### PR TITLE
fix(harness,tui): stop two real bugs behind the flaky suite

### DIFF
--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -175,26 +175,76 @@ async def _get_before_timeout(queue: asyncio.Queue[_QueueItemT], timeout: float)
     final queue flush. Racing explicit tasks lets delivery win every tie; if the
     timer wins alone, the getter is cancelled and joined before control returns,
     so it cannot consume a later item in the background.
+
+    THE INVARIANT, on every exit path including the caller being cancelled: an
+    item this call took off the queue is either returned to the caller or put
+    back. Nothing is consumed and dropped. The first version of this helper held
+    only the timeout half of that promise, which made it a silent behavioural
+    divergence from the ``wait_for`` it replaced — ``wait_for`` never touches an
+    already-completed getter, so a caller cancelled in the delivery turn left
+    the item in the queue, while this helper's cleanup discarded it (R1-1, agent
+    review round 1). In a helper whose entire reason to exist is event loss at a
+    cancellation boundary, only the full invariant is worth stating.
+
+    A reclaimed item returns at the TAIL. The promise is that it is still in the
+    queue for the next reader, not that FIFO order survives a cancelled read;
+    the abort drain that calls this abandons the queue on that path anyway.
     """
     getter = asyncio.create_task(queue.get())
     timer = asyncio.create_task(asyncio.sleep(timeout))
+
+    def reclaim() -> None:
+        """Hand back an item the getter dequeued that no caller will receive.
+
+        A completed, uncancelled getter is the ONLY shape that can strand an
+        item: ``Queue.get`` removes nothing until its task has run to
+        completion, and a getter cancelled while still suspended re-wakes the
+        next waiter on its way out, so the item never left the queue.
+        """
+        if getter.done() and not getter.cancelled() and getter.exception() is None:
+            queue.put_nowait(getter.result())
+
+    # Decided INSIDE the try, because the cleanup below runs before any return
+    # and has to know whether a dequeued item is still on its way to the caller
+    # or has been stranded. Computing it after the fact would reclaim the item
+    # on the success path too, handing the caller a copy that is also back in
+    # the queue. ``not cancelled`` rather than a result check so a getter that
+    # somehow failed re-raises its own exception below, as ``wait_for`` did.
+    delivered = False
     try:
         await asyncio.wait({getter, timer}, return_when=asyncio.FIRST_COMPLETED)
-        if getter.done():
-            return getter.result()
-        getter.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await getter
-        raise TimeoutError
+        delivered = getter.done() and not getter.cancelled()
     finally:
-        # Caller cancellation must not leave either contestant alive: a leaked
-        # getter could silently consume an event after this drain has unwound.
+        # Stop both contestants SYNCHRONOUSLY, before any await in this block.
+        # A join is a suspension point, so a contestant still running while we
+        # are parked in one could take a further item off the queue.
         for task in (getter, timer):
             if not task.done():
                 task.cancel()
-        for task in (getter, timer):
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
+        # A caller cancelled during ``wait`` lands here with ``delivered``
+        # still False and the getter possibly already holding an item nobody
+        # will receive. Hand it back before the joins, since a join is also
+        # where a pending cancellation gets delivered and the rest of this
+        # block skipped. On the timeout path the getter is still suspended and
+        # holds nothing, so ``reclaim`` is a no-op.
+        if not delivered:
+            reclaim()
+        try:
+            for task in (getter, timer):
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+        except BaseException:
+            # Cancelled DURING the join, after the success path below was
+            # already committed to returning this item. The joins are the only
+            # awaits between taking the item and the caller receiving it, so
+            # this is the last window in which the item can be stranded.
+            if delivered:
+                reclaim()
+            raise
+
+    if delivered:
+        return getter.result()
+    raise TimeoutError
 
 
 def _consume_claim(claimed: Counter[str], call_id: str) -> bool:

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -28,7 +28,7 @@ import time
 from collections import Counter
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, TypeVar
 
 from pydantic import TypeAdapter, ValidationError
 
@@ -162,6 +162,39 @@ def _lower_effort(model: "ModelSpec") -> str | None:
 # (a process group refusing to die) keeps unwinding in the background while the
 # turn it belonged to is already over.
 ABORT_DRAIN_TIMEOUT_S = 2.0
+
+_QueueItemT = TypeVar("_QueueItemT")
+
+
+async def _get_before_timeout(queue: asyncio.Queue[_QueueItemT], timeout: float) -> _QueueItemT:
+    """Get one queue item before ``timeout`` without losing a boundary item.
+
+    The timeout and a queue delivery can become ready in the same event-loop
+    turn. ``wait_for(queue.get())`` may report the timeout after the getter has
+    already dequeued an item, orphaning that event from both this drain and its
+    final queue flush. Racing explicit tasks lets delivery win every tie; if the
+    timer wins alone, the getter is cancelled and joined before control returns,
+    so it cannot consume a later item in the background.
+    """
+    getter = asyncio.create_task(queue.get())
+    timer = asyncio.create_task(asyncio.sleep(timeout))
+    try:
+        await asyncio.wait({getter, timer}, return_when=asyncio.FIRST_COMPLETED)
+        if getter.done():
+            return getter.result()
+        getter.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await getter
+        raise TimeoutError
+    finally:
+        # Caller cancellation must not leave either contestant alive: a leaked
+        # getter could silently consume an event after this drain has unwound.
+        for task in (getter, timer):
+            if not task.done():
+                task.cancel()
+        for task in (getter, timer):
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
 
 
 def _consume_claim(claimed: Counter[str], call_id: str) -> bool:
@@ -1478,9 +1511,8 @@ class AgentLoop:
                                 ABORT_DRAIN_TIMEOUT_S,
                             )
                             break
-                        getter = asyncio.ensure_future(queue.get())
                         try:
-                            event = await asyncio.wait_for(getter, timeout=remaining)
+                            event = await _get_before_timeout(queue, remaining)
                         except TimeoutError:
                             # The tasks are left running: they own their own
                             # resources, log their own failures, and the

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4807,6 +4807,21 @@ class OperatorApp(App[None]):
         bottom until the two met. That is the "logo and screen coming together"
         effect; it was never an animation anyone declared.
         """
+        # There is no layout to reconcile once the screen stack is gone, and
+        # every pass below reaches `self.screen`, which RAISES on an empty
+        # stack rather than returning None. Guarded here because this is the
+        # single funnel all three passes go through.
+        #
+        # A teardown race reaches it, not a hypothetical one: the splash
+        # resizes ASYNCHRONOUSLY — `WelcomeView._poll` posts `BlockResized`
+        # when the model label lands, which is exactly when the session factory
+        # resolves — so a quit that beats the factory home leaves that message
+        # queued against a torn-down stack, and `ScreenStackError: No screens
+        # on stack` comes out of the message pump. A fast quit during boot is
+        # ordinary use, and the crash lands at the one moment nothing can
+        # report it usefully.
+        if not self.screen_stack:
+            return
         size = self.size if size is None else size
         # Card first: the shell's width decides how tall the shell measures, which
         # is a term in the composition below.

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -2006,18 +2006,37 @@ class TranscriptView(ScrollableContainer):
         """Mount older blocks above the viewport without moving its content.
 
         History paging is the only prepend path. Textual cannot preserve the
-        visual anchor automatically because mounting changes ``virtual_size``
-        before the next layout pass, so remember the old virtual height and add
-        exactly its growth to ``scroll_y`` after refresh. The optional offset is
-        captured by the caller before asynchronous I/O starts; using the later
-        value would apply the prepend to wherever the user moved meanwhile.
+        visual anchor automatically, so the anchor is restored explicitly here.
+        The optional offset is captured by the caller before asynchronous I/O
+        starts; using the later value would apply the prepend to wherever the
+        user moved meanwhile.
+
+        The anchor is expressed as a BLOCK and that block's offset from the top
+        of the viewport, not as ``virtual_size`` growth. Growth is the obvious
+        formulation and it is subtly wrong: the batch is mounted with its gaps
+        decided while its blocks were still unmounted, where
+        ``spans_multiple_rows()`` has no width to measure against and falls back
+        to 80 columns, and :meth:`_settle_gaps` then re-decides them against real
+        widths. Re-deciding rewrites margin classes, which changes the heights of
+        the blocks ABOVE the anchor, which changes ``virtual_size`` on a LATER
+        layout pass than the one that restored the scroll. Any offset derived
+        from a height sampled before that pass is stale by exactly the rows the
+        settle reclaimed, so the reader's row came to rest up to 2 rows off
+        (measured on a 140-message history page: 142 rows pre-settle, 140 after).
+        A block's own ``virtual_region`` is re-derived by the same layout pass
+        that resizes it, so reading the position back afterwards is correct
+        whichever pass wins the race.
         """
         additions = list(blocks)
         if not additions:
             return
-        old_height = self.virtual_size.height
         old_scroll = self.scroll_y if anchor_offset is None else anchor_offset
         before = self._blocks[0] if self._blocks else None
+        # The row the reader is looking at, and where it sits in the viewport.
+        # Prepending never moves this block within the ledger, so it survives
+        # the mount and every gap re-decision above it.
+        anchor_block = before
+        anchor_gap = (before.virtual_region.y - old_scroll) if before is not None else 0.0
         if before is None:
             self.mount(*additions)
         else:
@@ -2025,13 +2044,21 @@ class TranscriptView(ScrollableContainer):
         self._blocks[0:0] = additions
         self._name_col_cache = None
 
-        def restore_anchor() -> None:
-            growth = max(0, self.virtual_size.height - old_height)
-            self.scroll_to(y=max(0, old_scroll + growth), animate=False)
+        def settle_then_restore() -> None:
+            # Settle FIRST so the heights above the anchor are final, then let
+            # the layout pass that applied them publish new positions before the
+            # anchor is read back.
             self._settle_gaps(additions)
             self._remeasure_empty_state()
 
-        self.call_after_refresh(restore_anchor)
+            def restore_anchor() -> None:
+                if anchor_block is None or anchor_block.parent is not self:
+                    return
+                self.scroll_to(y=max(0, anchor_block.virtual_region.y - anchor_gap), animate=False)
+
+            self.call_after_refresh(restore_anchor)
+
+        self.call_after_refresh(settle_then_restore)
 
     def append_block(self, block: TranscriptBlock) -> None:
         """Mount ``block`` at the bottom.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,20 @@ fetch = ["markdownify"]
 all = ["local-operator[server,mcp,images,tokenizer,fetch]"]
 dev = [
     "local-operator[all]",
-    "ruff",
+    # PINNED TO THE VERSION CI RUNS (`.github/workflows/ci.yml` lint job). The
+    # documented gate — `.venv/bin/python -m flake8 .` in AGENTS.md, `make lint`
+    # in the Makefile — used to fail with `No module named flake8` on a fresh
+    # venv, because the dev extra shipped `ruff` instead while every other
+    # reference in the repo (CI, Makefile, CONTRIBUTING, SECURITY, the PR
+    # template) named flake8. `ruff` was invoked by nothing: no CI step, no make
+    # target, no `[tool.ruff]` config. A lint gate you cannot run locally is one
+    # you first meet as a red CI job, so the dev extra installs the real one and
+    # the unused one is gone (R1-2, agent review round 1).
+    #
+    # Unpinned it would drift from CI: a newer pycodestyle can flag code CI
+    # accepts, or accept code CI flags, and either way the local gate stops
+    # predicting the remote one. Bump this and the ci.yml pin together.
+    "flake8==7.1.0",
     "pyright",
     "pytest",
     "pytest-asyncio",

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -59,6 +59,36 @@ async def wait_for(predicate, timeout: float = 10.0) -> None:
         await asyncio.sleep(0.01)
 
 
+def has_complete_tool_round(session_dir) -> bool:
+    """Whether a child's transcript already holds one FINISHED tool round.
+
+    "Finished" means an assistant message carrying tool calls plus a tool
+    result for every one of them. A round that is only half written is the
+    thing the cancel tests must not act on: cancelling there leaves a dangling
+    tool-use block, which ``_answered_prefix`` then trims away, and the test
+    asserting the child "kept the work it had already done" would be asserting
+    against an empty prefix.
+
+    Reading the file mid-append is safe by construction: the transcript is
+    JSONL and ``TranscriptEntry.from_json`` drops a malformed line on its own
+    rather than failing the parse, so a torn final row simply reads as not
+    there yet and the next poll sees it.
+    """
+    history = Transcript(session_dir).build_llm_history()
+    answered = {
+        message.tool_call_id
+        for message in history
+        if isinstance(message, Message) and message.role == "tool"
+    }
+    return any(
+        isinstance(message, Message)
+        and message.role == "assistant"
+        and message.tool_calls
+        and all(call.id in answered for call in message.tool_calls)
+        for message in history
+    )
+
+
 # --- unit level: comms against a stand-in child -------------------------------
 
 
@@ -1244,11 +1274,15 @@ async def test_a_resumed_child_replays_the_stopped_ones_transcript(tmp_path, mon
     job_id = parent._launch_subagent(label="docs", prompt="Update the docs.")
     comms = parent.subagent_comms
     await wait_for(lambda: comms.session_dir_of(job_id) is not None)
-    # Let it do some work, then stop it. A running turn's messages are
-    # persisted when the turn ENDS (Session.prompt writes them after its loop
-    # finishes, and a hard cancel pre-empts that), so the stopped child's
-    # transcript only settles after cancel — the state resume has to read.
-    await asyncio.sleep(0.3)
+    # Let it finish real work before stopping it, and wait on THAT rather than
+    # on a duration: the child persists each tool round at its loop boundary
+    # (``Session._persist_progress``) roughly 0.29s after launch, so the fixed
+    # 0.3s sleep this replaced was inside one standard deviation of the thing
+    # it was betting against and lost the coin flip about a third of the time.
+    # Resume is only meaningful over a child that got somewhere, so the
+    # condition to wait for is a completed round, with seconds of headroom so
+    # this fails only if the child genuinely never runs a tool.
+    await wait_for(lambda: has_complete_tool_round(comms.session_dir_of(job_id)), timeout=30.0)
     await comms.cancel(job_id)
     await wait_for(lambda: status_of(parent, job_id) == "cancelled")
     await wait_for(lambda: len(Transcript(comms.session_dir_of(job_id)).build_llm_history()) >= 2)
@@ -1278,7 +1312,11 @@ async def test_a_cancelled_child_keeps_the_work_it_had_already_done(tmp_path, mo
     job_id = parent._launch_subagent(label="docs", prompt="Update the docs.")
     comms = parent.subagent_comms
     await wait_for(lambda: comms.session_dir_of(job_id) is not None)
-    await asyncio.sleep(0.3)  # let it complete at least one tool round
+    # Wait for the round itself, not for how long a round usually takes. The
+    # assertions below are entirely about work the child had ALREADY completed
+    # before the cancel, so cancelling early does not fail loudly — it silently
+    # asserts over a transcript holding only the launch prompt.
+    await wait_for(lambda: has_complete_tool_round(comms.session_dir_of(job_id)), timeout=30.0)
 
     await comms.cancel(job_id)
     await wait_for(lambda: len(Transcript(comms.session_dir_of(job_id)).build_llm_history()) > 1)

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -2033,6 +2033,67 @@ async def test_queue_timeout_cancels_and_awaits_its_pending_getter():
     assert queue.get_nowait() is item
 
 
+@pytest.mark.asyncio
+async def test_caller_cancellation_leaves_a_dequeued_item_in_the_queue():
+    """A cancelled caller must not consume an item and drop it.
+
+    The helper's whole purpose is that an item it takes off the queue is either
+    returned or put back. The first version held that only for the TIMEOUT
+    path: its cleanup cancelled and joined both contestants unconditionally, so
+    a caller cancelled in the same turn a delivery landed discarded the item the
+    getter had already dequeued. That is a silent divergence from the
+    ``wait_for`` this replaced, which never touches an already-completed getter
+    and so leaves the item in the queue (R1-1, agent review round 1).
+
+    Unreachable as damage from today's sole caller — the abort drain is already
+    unwinding and abandons the queue — but the divergence is exactly the class
+    of bug this helper exists to prevent, so the invariant gets a test rather
+    than an argument about reachability.
+
+    Deterministic, not probabilistic: the loop below advances the event loop one
+    turn at a time and cancels only once the getter has provably dequeued the
+    item (``queue.empty()``), which is the precise state the old cleanup
+    mishandled. Against the pre-fix helper this fails 200/200; after, 200/200
+    preserve the item.
+    """
+    queue: asyncio.Queue[object] = asyncio.Queue()
+    item = object()
+    current = asyncio.current_task()
+    tasks_before = {task for task in asyncio.all_tasks() if task is not current}
+
+    # A timeout far past any scheduling jitter: the timer must never be the
+    # reason this call ends, or the test would prove the already-covered path.
+    caller = asyncio.create_task(_get_before_timeout(queue, timeout=30))
+    await asyncio.sleep(0)  # Let the helper create and register its contestants.
+    await asyncio.sleep(0)
+    queue.put_nowait(item)
+
+    # Spin until the getter has taken the item but the caller has not yet
+    # resumed to receive it. Bounded so a helper that never dequeues fails here
+    # rather than hanging.
+    for _ in range(50):
+        if queue.empty():
+            break
+        await asyncio.sleep(0)
+    else:  # pragma: no cover - a helper that never dequeues is already broken
+        pytest.fail("the getter never dequeued the item")
+    assert not caller.done(), "caller resumed before it could be cancelled mid-delivery"
+
+    caller.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    # The item is back, and it is THE item: a reclaim that put back something
+    # else would satisfy a bare length check.
+    assert queue.qsize() == 1
+    assert queue.get_nowait() is item
+
+    # And the reclaim did not come at the cost of the property the timeout path
+    # already had: no contestant survives this call.
+    tasks_after = {task for task in asyncio.all_tasks() if task is not current}
+    assert tasks_after == tasks_before
+
+
 # ---------------------------------------------------------------------------
 # Refusal terminal: the model said no, and the run must end saying WHY
 # ---------------------------------------------------------------------------

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -12,12 +12,14 @@ from typing import Any, Literal
 
 import pytest
 
+import local_operator.harness.loop as loop_module
 from local_operator.harness.loop import (
     ABORT_DRAIN_TIMEOUT_S,
     STEERING_INTERRUPT_POLL_S,
     AgentLoop,
     LoopContext,
     _consume_claim,
+    _get_before_timeout,
     validate_tool_arguments,
 )
 from local_operator.harness.types import (
@@ -46,6 +48,26 @@ from local_operator.harness.types import (
 from local_operator.providers.failover import ProviderError
 
 MODEL = ModelSpec(provider="test", model_id="m")
+
+
+class _ControlledDeadline:
+    """Keep the abort drain live until a test-controlled parking boundary."""
+
+    def __init__(self, parked: asyncio.Event) -> None:
+        self.parked = parked
+
+    def __sub__(self, _now: float) -> float:
+        return -1.0 if self.parked.is_set() else 60.0
+
+
+class ControlledDrainBudget:
+    """Replace the numeric drain budget without adding a production test seam."""
+
+    def __init__(self, parked: asyncio.Event) -> None:
+        self.parked = parked
+
+    def __radd__(self, _now: float) -> _ControlledDeadline:
+        return _ControlledDeadline(self.parked)
 
 
 class ScriptedStream:
@@ -1644,82 +1666,67 @@ async def test_a_slow_unwind_still_reports_the_tool_as_ENDED():
 
 
 @pytest.mark.asyncio
-async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill():
-    """Review round 3, R3-1. The backfill must decide before it emits.
+async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill(monkeypatch):
+    """The final flush must emit an end parked after the drain has expired.
 
-    A generator suspends at every ``yield``, handing control to a consumer that
-    may await. A runner whose cleanup lands in one of those windows parks its
-    own result — writing its end event to the queue nobody reads any more — and
-    an interleaved backfill then saw the filled slot and emitted nothing. That
-    call kept its start event and never got an end, which is the exact damage
-    the backfill exists to prevent.
-
-    Needs BOTH a multi-call batch (so there is an earlier slot to suspend on)
-    and a consumer that actually awaits. The single-tool guard above cannot
-    reach it: with one slot there is nothing to suspend on before it.
+    Two calls make the boundary observable: c1 parks immediately on abort, while
+    c2 cannot finish cancellation until the consumer is suspended on c1's end.
+    At that exact yield, c2 parks synchronously and the controlled budget expires.
+    The backfill sees c2's filled slot and owes no synthetic end, leaving the
+    final queue flush as the only path that can emit c2's real end event.
     """
     started = asyncio.Event()
     parked = asyncio.Event()
+    allow_park = asyncio.Event()
+    started_count = 0
+    monkeypatch.setattr(loop_module, "ABORT_DRAIN_TIMEOUT_S", ControlledDrainBudget(parked))
 
-    async def never_parks(tool_call_id, args, signal, on_update, context) -> ToolResult:
-        started.set()
+    async def parks_immediately(tool_call_id, args, signal, on_update, context) -> ToolResult:
+        nonlocal started_count
+        started_count += 1
+        if started_count == 2:
+            started.set()
         await asyncio.sleep(30)
         return ToolResult(
-            tool_call_id=tool_call_id, tool_name="stuck", content=[TextContent(text="late")]
+            tool_call_id=tool_call_id, tool_name="first", content=[TextContent(text="late")]
         )
 
-    async def parks_late(tool_call_id, args, signal, on_update, context) -> ToolResult:
+    async def parks_at_flush_boundary(tool_call_id, args, signal, on_update, context) -> ToolResult:
+        nonlocal started_count
+        started_count += 1
+        if started_count == 2:
+            started.set()
         try:
             await asyncio.sleep(30)
         except asyncio.CancelledError:
-            # Settles just past the drain budget: the batch has given up
-            # waiting, so this lands while the backfill is mid-emit.
             with contextlib.suppress(asyncio.CancelledError):
-                # Parks past the drain budget by enough that the event lands on
-                # a queue the drain loop has already abandoned — which is the
-                # window the FLUSH exists to cover, and the only window in which
-                # this test can detect the flush going missing.
-                #
-                # A RIDGE, NOT A FLOOR: moving this value in EITHER direction
-                # blinds the test. Swept against a tree with the flush deleted,
-                # it detects at +0.30 and is blind at +0.15, +0.35, +0.40, +0.45
-                # and +0.60 (R10/R11).
-                #
-                # Detection is PROBABILISTIC — roughly 3 runs in 4 (measured
-                # 7/8, 9/12, 11/16, 12/16 red). Anyone spot-checking by deleting
-                # the flush must repeat the run: a single green one proves
-                # nothing and would wrongly suggest the test is already dead.
-                #
-                # Too short and the park lands in the range the
-                # backfill already handles; too long and it lands after the
-                # batch has stopped emitting. Both ends pass with the flush
-                # gone, which means the test silently stops testing the thing it
-                # is named for. The flakiness this once had is fixed by the
-                # `parked` gate below, not by moving this.
-                await asyncio.sleep(ABORT_DRAIN_TIMEOUT_S + 0.3)
+                await allow_park.wait()
+            # No await may separate this signal from the runner's synchronous
+            # park: the consumer must resume only after c2 has filled its slot
+            # and queued the end event that solely the final flush can emit.
             parked.set()
             raise
         return ToolResult(
-            tool_call_id=tool_call_id, tool_name="slow", content=[TextContent(text="late")]
+            tool_call_id=tool_call_id, tool_name="second", content=[TextContent(text="late")]
         )
 
     tools = [
         AgentTool(
-            name="stuck",
+            name="first",
             parameters={"type": "object", "properties": {}},
-            execute=never_parks,
+            execute=parks_immediately,
         ),
         AgentTool(
-            name="slow",
+            name="second",
             parameters={"type": "object", "properties": {}},
-            execute=parks_late,
+            execute=parks_at_flush_boundary,
         ),
     ]
     stream = ScriptedStream(
         [
             [
-                tool_call_delta(0, id="c1", name="stuck", args="{}"),
-                tool_call_delta(1, id="c2", name="slow", args="{}"),
+                tool_call_delta(0, id="c1", name="first", args="{}"),
+                tool_call_delta(1, id="c2", name="second", args="{}"),
                 StreamEndEvent(stop_reason="toolUse"),
             ],
             [StreamEndEvent(stop_reason="stop")],
@@ -1729,47 +1736,22 @@ async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill()
     config = make_config(stream, interrupt_mode="immediate", has_steering_messages=lambda: False)
     signal = AbortSignal()
     loop = AgentLoop()
-
     events: list[Any] = []
 
     async def run() -> None:
         async for event in loop.run([Message.user("go")], context, config, signal):
             events.append(event)
-            # A consumer that awaits — the TUI paints, the API server writes.
-            # Without this the generator never suspends and the loss is not
-            # reachable at all.
-            #
-            # The duration is deliberate and must not be shortened to settle a
-            # flake: the tool has to park AFTER the drain gives up at
-            # ABORT_DRAIN_TIMEOUT_S but while the consumer still owes the
-            # generator a resume, and that window is what the flush covers.
-            # Moving either number moves the park out of that window — see the
-            # ridge measurements on the tool's own sleep above — and the test
-            # then passes with the flush deleted, i.e. it stops testing the
-            # thing it is named for. Waiting on the park event instead was tried
-            # and is worse (3/40): it lets the generator finish before the park
-            # it is supposed to be racing.
-            #
-            # The IDENTICAL literal `ABORT_DRAIN_TIMEOUT_S + 0.3` appears once
-            # more in this file, in the duplicate-call-id suppression test —
-            # grep `does_not_suppress_the_real_calls` — and that is the copy a
-            # search-and-replace would collide with. It is INDEPENDENT of this
-            # one: it exercises the suppression rule, not the flush window, so
-            # nothing about it needs to move if this does.
-            #
-            # (The slow-unwind test — grep `still_reports_the_tool_as_ENDED` —
-            # overshoots by `+ 2` and is independent for the same reason. Only
-            # the identical literal is a real hazard.)
-            await asyncio.sleep(0.3)
+            if isinstance(event, ToolExecutionEndEvent) and event.tool_call_id == "c1":
+                # Every yielded event reaches an awaiting consumer, matching the
+                # TUI paint/API write shape rather than draining synchronously.
+                allow_park.set()
+                await asyncio.wait_for(parked.wait(), timeout=5)
+            await asyncio.sleep(0)
 
-    task = asyncio.ensure_future(run())
+    task = asyncio.create_task(run())
     await asyncio.wait_for(started.wait(), timeout=5)
     signal.abort("interrupted")
-    await asyncio.wait_for(task, timeout=ABORT_DRAIN_TIMEOUT_S + 15)
-    # The scenario only exists once the slow tool has actually parked. Without
-    # this the assertion sometimes ran against a turn that ended BEFORE the
-    # cleanup finished — a different shape, and the source of a ~1-in-8 flake.
-    await asyncio.wait_for(parked.wait(), timeout=5)
+    await asyncio.wait_for(task, timeout=15)
 
     started_ids = [e.tool_call_id for e in events if isinstance(e, ToolExecutionStartEvent)]
     ended_ids = [e.tool_call_id for e in events if isinstance(e, ToolExecutionEndEvent)]
@@ -1779,7 +1761,7 @@ async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill()
             f"{call_id} was announced as started and ended {ended_ids.count(call_id)} "
             f"times; every started call needs exactly one end (ends={ended_ids})"
         )
-    # And the wire is still legal: one tool_result per tool_use.
+
     tool_messages = [m for m in context.messages if isinstance(m, Message) and m.role == "tool"]
     assert sorted(str(m.tool_call_id) for m in tool_messages) == ["c1", "c2"]
 
@@ -1976,6 +1958,79 @@ def test_the_flush_suppression_counts_rather_than_matching():
     assert _consume_claim(claimed, "dup") is False
     # An id nobody claimed is never suppressed.
     assert _consume_claim(Counter(), "other") is False
+
+
+@pytest.mark.asyncio
+async def test_wait_for_can_lose_an_item_delivered_at_its_timeout_boundary(monkeypatch):
+    """Pin the production race that requires an explicit getter/timer race."""
+
+    class ControlledTimeout:
+        def __init__(self) -> None:
+            self.armed = asyncio.Event()
+            self.task: asyncio.Task[Any] | None = None
+            self.expiring = False
+
+        async def __aenter__(self):
+            self.task = asyncio.current_task()
+            self.armed.set()
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            if self.expiring and exc_type is asyncio.CancelledError:
+                raise TimeoutError from exc
+            return None
+
+        def fire(self) -> None:
+            self.expiring = True
+            assert self.task is not None
+            self.task.cancel()
+
+    queue: asyncio.Queue[object] = asyncio.Queue()
+    item = object()
+    getter = asyncio.create_task(queue.get())
+    await asyncio.sleep(0)  # Register the getter before arranging the boundary.
+    controlled = ControlledTimeout()
+    monkeypatch.setattr(asyncio.timeouts, "timeout", lambda _delay: controlled)
+    waiting = asyncio.create_task(asyncio.wait_for(getter, timeout=30))
+    await controlled.armed.wait()
+
+    # Queue delivery runs first and dequeues the item; timeout cancellation then
+    # wins before wait_for observes that result, reproducing the lost-item race.
+    queue.put_nowait(item)
+    asyncio.get_running_loop().call_soon(controlled.fire)
+
+    with pytest.raises(TimeoutError):
+        await waiting
+    assert queue.empty()
+    assert getter.done() and not getter.cancelled()
+    assert getter.result() is item
+
+
+@pytest.mark.asyncio
+async def test_queue_get_wins_when_it_ties_the_timeout():
+    queue = asyncio.Queue()
+    item = object()
+    queue.put_nowait(item)
+
+    assert await _get_before_timeout(queue, timeout=0) is item
+    assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_queue_timeout_cancels_and_awaits_its_pending_getter():
+    queue = asyncio.Queue()
+    current = asyncio.current_task()
+    tasks_before = {task for task in asyncio.all_tasks() if task is not current}
+
+    with pytest.raises(TimeoutError):
+        await _get_before_timeout(queue, timeout=0)
+
+    tasks_after = {task for task in asyncio.all_tasks() if task is not current}
+    assert tasks_after == tasks_before
+    item = object()
+    queue.put_nowait(item)
+    await asyncio.sleep(0)
+    assert queue.get_nowait() is item
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/tui/test_ask_picker.py
+++ b/tests/unit/tui/test_ask_picker.py
@@ -1343,6 +1343,18 @@ async def test_a_held_key_never_answers_a_question_the_card_moved_on_from() -> N
 
     Reachable by one ordinary mouse click, since a single-select click both
     answers and advances.
+
+    The property under test is the ``still_aimed_at`` guard in
+    ``_commit_held_answer_key``, NOT the length of the hold window — so the
+    window is stretched here and the commit is fired by hand at the point the
+    test cares about. Racing the real 180 ms timer was the flake: under CPU
+    contention the timer fired BEFORE ``action_accept()`` advanced the card,
+    the key committed while still legitimately aimed at question 1, and the
+    test failed reporting the very bug it exists to catch
+    (``{'drop_table': ['Keep it'], 'rollout': ['Canary']}``) when nothing was
+    wrong. Stretching the hold makes "the key is still parked when the card
+    advances" a fact rather than a bet; calling the timer's own callback
+    afterwards exercises the identical guard the real timer would reach.
     """
     from local_operator.tui.widgets.editor import Editor
 
@@ -1364,27 +1376,37 @@ async def test_a_held_key_never_answers_a_question_the_card_moved_on_from() -> N
         card = app._ask_screen
         assert card is not None
 
-        # The fixed pauses in THIS test are deliberate and must not be converted
-        # to idle-waits. It probes a wall-clock ordering race: a key parked in the
-        # composer must not commit once the card has advanced past the question it
-        # was aimed at. The `pause(0.1)` after the click lets focus/routing settle
-        # so the press is held rather than dropped; `action_accept()` must run
-        # while the key is still parked (before the ~180 ms ANSWER_KEY_HOLD_S timer
-        # fires); and the trailing pump outlasts that window so any wrong commit
-        # would already have happened. An idle-wait cannot express "before a real
-        # timer fires" and made this test commit the stale key under CPU
-        # contention — the exact bug it exists to catch.
         await pilot.click(Editor)
-        await pilot.pause(0.1)
+        # Wait for the click's focus/routing to settle, so the press below is
+        # HELD by the composer rather than dropped, instead of betting a fixed
+        # 0.1s that it has.
+        for _ in range(100):
+            if isinstance(app.screen.focused, Editor):
+                break
+            await pilot.pause()
+
         await pilot.press("2")  # aimed at question 1: "Canary"
-        assert app._held_answer_key is not None, "the key was not held"
+        held = app._held_answer_key
+        assert held is not None, "the key was not held"
+        # Take the real timer out of the race entirely. Stopping it cannot mask
+        # a regression: the commit path is invoked explicitly below, so the
+        # guard still runs — it just runs at a moment the test controls.
+        held.timer.stop()
 
         # The card advances to question 2 while the key is still parked.
         card.focus()
-        await pilot.pause(0.02)
-        card.action_accept()
-        for _ in range(20):
-            await pilot.pause(0.03)
+        for _ in range(100):
+            if app._live_prompt() is card and card.question_index == 1:
+                break
+            if card.question_index == 0:
+                card.action_accept()
+            await pilot.pause()
+        assert card.question_index == 1, "the card never advanced to question 2"
+        assert app._held_answer_key is held, "the key was released before the advance"
+
+        # Now fire exactly what the expired hold would have called.
+        app._commit_held_answer_key()
+        await pilot.pause()
 
         # The stale key answered nothing: question 2 is still being asked.
         assert not asked.done(), "a parked key answered a question it was not aimed at"

--- a/tests/unit/tui/test_boot_layout.py
+++ b/tests/unit/tui/test_boot_layout.py
@@ -1144,3 +1144,47 @@ async def test_the_splash_holds_completely_still_under_the_animation_gate() -> N
             await asyncio.sleep(0.5)
             await pilot.pause()
             assert _styled_rows(app) == before
+
+
+@pytest.mark.asyncio
+async def test_a_late_splash_resize_does_not_crash_a_torn_down_app() -> None:
+    """Quitting during boot must not raise out of the message pump.
+
+    The splash resizes asynchronously: ``WelcomeView._poll`` posts
+    ``BlockResized`` once the model label is known, and the model label lands
+    when the session factory resolves. A quit that beats the factory home
+    therefore leaves that message queued against a screen stack that is already
+    gone, and every boot-layout pass reaches ``self.screen``, which RAISES
+    ``ScreenStackError`` on an empty stack instead of returning ``None``.
+
+    Observed as a real crash on exit, from the pump rather than from anything
+    the user did: ``on_welcome_view_block_resized`` -> ``_sync_boot_layout`` ->
+    ``_sync_boot_card`` -> ``ScreenStackError: No screens on stack``.
+
+    Driven by emptying the stack and dispatching the handler exactly as the
+    pump would, because reproducing the wall-clock ordering by racing a real
+    quit against a real poll is the coin flip that hid the bug in the first
+    place. The state is what matters, and the state is "this message arrived
+    with no screens left".
+    """
+    app = _make_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _settle(pilot)
+        screen = app.screen
+        card_up_before = screen.has_class(BOOT_CARD_CLASS)
+
+        # Exactly the teardown state: a BlockResized is in the pump's hand and
+        # the screen stack has already been emptied.
+        stack = app._screen_stacks[app._current_mode]
+        stack.clear()
+        assert not app.screen_stack, "the race under test needs an empty stack"
+
+        app.on_welcome_view_block_resized(WelcomeView.BlockResized())
+
+        # The guard skips the pass; it does not swallow a failure. Put the
+        # screen back and the identical message reconciles the layout as
+        # before, so what was added is a teardown check and not a mute.
+        stack.append(screen)
+        app.on_welcome_view_block_resized(WelcomeView.BlockResized())
+        assert app.screen.has_class(BOOT_CARD_CLASS) == card_up_before

--- a/tests/unit/tui/test_command_picker.py
+++ b/tests/unit/tui/test_command_picker.py
@@ -1372,7 +1372,16 @@ async def test_clicking_a_login_row_runs_it() -> None:
         app.set_editor_text("/login ")
         await pilot.pause()
         await pilot.click(CommandPicker, offset=(4, 1))
-        await pilot.pause()
+        # Wait for the SUBMISSION, not for one tick. A click travels through the
+        # picker's row handler and is submitted by a posted message, so the
+        # single ``pause()`` this replaced was a bet on that landing within one
+        # idle tick — a bet the census watched lose on a contended xdist worker
+        # (``assert [] == ['/login alibaba']``). The ceiling is a deadlock
+        # guard: a click that never runs the row still fails the assertion below.
+        for _ in range(200):
+            if app.submissions:
+                break
+            await pilot.pause()
         assert app.submissions == ["/login alibaba"]
 
 

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -190,6 +190,28 @@ async def _settled_rows(pilot: Any, app: OperatorApp, ceiling: int = 200) -> lis
     return previous
 
 
+async def _wait_for_row(pilot: Any, app: OperatorApp, needle: str, ceiling: int = 200) -> None:
+    """Wait until ``needle`` appears in the painted frame.
+
+    A settled approval future does NOT mean its receipt is on screen. The card
+    resolves its own future first and the transcript row is written by a later
+    frame, so a test that presses a key, awaits the future and then reads
+    ``rows(app)`` is asserting one frame too early. It usually wins that race
+    and loses it under load: the census caught exactly this as
+    ``assert any("denied" in row ...)`` failing on a contended xdist worker,
+    where the sibling ``y`` test survived only because its focus poll happened
+    to spend the extra ticks.
+
+    The ceiling is a deadlock guard rather than a timing assumption, so a slow
+    machine costs nothing while a receipt that never paints still fails.
+    """
+    for _ in range(ceiling):
+        if any(needle in row for row in rows(app)):
+            return
+        await pilot.pause()
+    raise AssertionError(f"{needle!r} never appeared in the painted frame")
+
+
 async def _boot(pilot: Any, app: OperatorApp) -> None:
     """Wait for the session to be ADOPTED, rather than for a fixed duration.
 
@@ -374,12 +396,18 @@ async def test_n_denies_one_tool_and_lets_the_turn_continue() -> None:
         ask = await _booted_gate(pilot, session)
         session.streaming = True
         pending = asyncio.ensure_future(ask("write", "write: /etc/hosts"))
-        await pilot.pause()
+        # Same condition wait the ``y`` sibling makes: mounting the card and
+        # moving focus to it is a mount round trip, so a single pause is a bet
+        # on that costing one frame. Pressing early types into the composer.
+        for _ in range(100):
+            if isinstance(app.screen.focused, ApprovalPrompt):
+                break
+            await pilot.pause(0.02)
 
         await pilot.press("n")
         assert await asyncio.wait_for(pending, 2) is False
         assert session.aborts == []  # only the tool was refused
-        assert any("denied" in row for row in rows(app))
+        await _wait_for_row(pilot, app, "denied")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_stream_anchor.py
+++ b/tests/unit/tui/test_stream_anchor.py
@@ -31,14 +31,17 @@ from local_operator.tui.events import (
     AssistantMessageEnd,
     AssistantMessageStart,
 )
+from local_operator.tui.widgets.assistant import AssistantBlock
 from local_operator.tui.widgets.subagent_view import SubagentView
 from local_operator.tui.widgets.transcript import (
+    GAP_CLASS,
     TAIL_TOLERANCE_ROWS,
     TailAnchor,
     TranscriptView,
     UserBlock,
 )
 
+from .conftest import StyledTranscriptApp
 from .test_app_pilot import FakeSession, _factory
 from .test_band_panels import FakeSession as BandFakeSession
 from .test_band_panels import _async_factory, _fake_jobs, _Job
@@ -501,3 +504,73 @@ async def test_paging_the_subagent_body_by_its_hint_arrow_releases_the_anchor() 
             await pilot.pause()
             await pilot.pause()
         assert float(body.scroll_offset.y) == parked
+
+
+# --- history prepend: the anchor survives gap settlement --------------------
+
+
+def _prose(text: str) -> AssistantBlock:
+    """An assistant block whose source text is set directly.
+
+    ``spans_multiple_rows`` is answered from ``_full_text`` rather than by
+    rendering, so this is the whole of what adaptive spacing reads.
+    """
+    block = AssistantBlock()
+    block._full_text = text
+    return block
+
+
+@pytest.mark.asyncio
+async def test_a_history_prepend_holds_the_readers_row_through_gap_settlement() -> None:
+    """The reader's row must not move when older history is mounted above it.
+
+    This pins the mechanism that made history paging drift, not merely that
+    *some* restoration happens. ``prepend_blocks`` mounts its batch while the
+    blocks are still unmounted, so ``spans_multiple_rows()`` has no width and
+    falls back to 80 columns; ``_settle_gaps`` then re-decides those gaps
+    against the real width on a LATER layout pass. Re-deciding removes margin
+    rows ABOVE the anchor, so any offset derived from ``virtual_size`` growth
+    sampled before that pass is stale by exactly the rows the settle reclaimed
+    — the reader came to rest up to 2 rows off their line.
+
+    The provisional gap classes are set here explicitly rather than raced for.
+    Waiting for the layout passes to interleave the wrong way reproduces the
+    drift only intermittently (measured 2/10 through the subagent view), which
+    is the timing bet this suite exists to remove. Setting the class states the
+    same precondition the 80-column fallback produces, so the settle-time
+    correction — and therefore the regression — is deterministic.
+
+    Two-sided by construction: with the fix the gap is held exactly, and with
+    the pre-fix growth formula restored it drifts by the reclaimed 2 rows.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(90, 20)) as pilot:
+        view = app.query_one(TranscriptView)
+        for index in range(60):
+            view.append_block(_prose(f"tail {index}"))
+        for _ in range(20):
+            await pilot.pause()
+
+        # Mid-history, so the anchor is NOT flush with the top of the viewport:
+        # a gap of zero cannot show a drift of two rows.
+        view.scroll_to(y=25, animate=False)
+        for _ in range(20):
+            await pilot.pause()
+
+        anchor = view._blocks[0]
+        before_gap = anchor.virtual_region.y - view.scroll_y
+
+        older = [_prose(f"older {index}") for index in range(40)]
+        # The provisional decision an unmounted batch makes for itself, which
+        # `_settle_gaps` then reclaims once real widths exist.
+        for block in older[:2]:
+            block.add_class(GAP_CLASS)
+
+        view.prepend_blocks(older)
+        for _ in range(60):
+            await pilot.pause()
+
+        # The settle really did reclaim the provisional rows: without this the
+        # assertion below could pass on a batch that never moved.
+        assert not any(block.has_class(GAP_CLASS) for block in older)
+        assert anchor.virtual_region.y - view.scroll_y == before_gap

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -304,6 +304,28 @@ async def _wait_history(pilot: Any, view: SubagentView) -> None:
     raise AssertionError("history worker did not settle")
 
 
+async def _wait_geometry_settled(
+    pilot: Any, body: Any, *, cycles: int = 4, limit: int = 200
+) -> None:
+    """Pause until the body's geometry stops changing for ``cycles`` cycles.
+
+    A prepend restores the anchor across TWO layout passes: gap settlement
+    re-decides margins against real widths, and the pass that applies them
+    republishes positions. A fixed number of pauses bets on which pass wins and
+    loses that bet under parallel load, so the wait is on the observable itself.
+    """
+    last: tuple[int, float] | None = None
+    stable = 0
+    for _ in range(limit):
+        await pilot.pause()
+        current = (body.virtual_size.height, body.scroll_y)
+        stable = stable + 1 if current == last else 0
+        last = current
+        if stable >= cycles:
+            return
+    raise AssertionError("body geometry never settled")
+
+
 @pytest.mark.asyncio
 async def test_durable_history_opens_at_tail_and_pages_to_the_start(tmp_path) -> None:
     transcript = Transcript(tmp_path / "child")
@@ -395,18 +417,21 @@ async def test_history_prepend_preserves_anchor_and_home_dedupes_requests(
         monkeypatch.setattr(view.__module__ + ".read_transcript_page", slow)
         view._initial_tail_pending = True
         view._body.scroll_home(animate=False)
-        await pilot.pause()
+        await _wait_geometry_settled(pilot, view._body)
         view._initial_tail_pending = False
-        before_max = view._body.max_scroll_y
-        before = view._body.scroll_y
+        # The row the reader is on, and where it sits in the viewport. This is
+        # the invariant a prepend must hold: the SAME entry stays put. Asserting
+        # it via `max_scroll_y` growth instead approximates it with a number that
+        # gap settlement legitimately changes after the anchor is restored, which
+        # is what made this test flake by 2 rows under load.
+        anchor_block = view._body._blocks[0]
+        before_gap = anchor_block.virtual_region.y - view._body.scroll_y
         view.action_home()
         view.action_home()
         await _wait_history(pilot, view)
-        for _ in range(5):
-            await pilot.pause()
+        await _wait_geometry_settled(pilot, view._body)
         assert calls == 1
-        growth = view._body.max_scroll_y - before_max
-        assert abs(view._body.scroll_y - (before + growth)) <= 1
+        assert anchor_block.virtual_region.y - view._body.scroll_y == before_gap
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

A census of 12 full-suite runs found only 2 fully green. Investigating the "flaky" tests turned up **two real product bugs** that the tests were intermittently catching and being blamed for, plus one real crash guard. This fixes the products, then removes the timing bets that made the failures look like noise.

- `harness/loop.py` — an event queued at the abort-drain timeout boundary could be dequeued and then thrown away, leaving a tool call with a start event and no end.
- `tui/widgets/transcript.py` — a history prepend restored the reader's scroll position from a stale height, leaving them up to 2 rows off their line.
- `tui/app.py` — `_sync_boot_card` dereferenced `self.screen` unguarded, so quitting during boot raised `ScreenStackError` out of the message pump.
- Seven test files trade fixed sleeps for polls on the condition the assertion actually depends on.

**No version bump. This is not a release.**

## The first real bug: an event lost at the abort-drain timeout

`AgentLoop` drained its event queue after an abort with:

```python
getter = asyncio.ensure_future(queue.get())
event = await asyncio.wait_for(getter, timeout=remaining)
```

A queue delivery and the timeout can become ready in the same event-loop turn. When they do, `wait_for` can raise `TimeoutError` *after* the getter has already dequeued an item. That item is then in neither place: not processed by the drain, and not left in the queue for the final flush. When the lost item is a `ToolExecutionEndEvent`, the tool call keeps its start event and never gets an end — the UI shows a card that never completes.

A standalone probe of the old pattern lost **43 of 2000** items at the boundary.

The fix races the getter and the timer as explicit tasks, gives the getter every same-turn tie, and cancels *and joins* a timer-only getter so a leaked getter cannot silently consume a later event after the drain unwinds.

### Evidence

The boundary is pinned by three tests, one of which reconstructs the exact interleaving (`test_wait_for_can_lose_an_item_delivered_at_its_timeout_boundary`) by driving a controlled timeout so the race is forced rather than raced for.

Mutation proof, run on this branch: **deleting the post-drain flush makes the harness suite red 10/10**, deterministically, always on the same test:

```text
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/harness/test_loop.py -q   # flush deleted
1 failed, 60 passed          (x10 runs, identical)

FAILED tests/unit/harness/test_loop.py::test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill
AssertionError: c2 was announced as started and ended 0 times; every started
call needs exactly one end (ends=['c1'])
```

With the fix in place the file is **61 passed**, 3/3 runs.

The late-parking test itself was rebuilt on a test-only `ControlledDrainBudget` that monkeypatches the existing `ABORT_DRAIN_TIMEOUT_S`, replacing a documented timing "ridge" that only detected the bug at exactly +0.30s.

## The second real bug: a history prepend restored the anchor from a stale height

`prepend_blocks` remembered `virtual_size.height`, mounted the older blocks, and added the growth to `scroll_y`.

The batch is mounted with its gaps decided while its blocks are still **unmounted**, where `spans_multiple_rows()` has no width to measure against and falls back to 80 columns. `_settle_gaps` then re-decides those gaps against real widths on a **later** layout pass, which rewrites margin classes, which changes the heights of blocks *above* the anchor — after the scroll was already restored. The restored offset was stale by exactly the rows the settle reclaimed.

Traced on a 140-message page: `virtual_size.height` was 142 at scroll-restore time and settled to 140 four pauses later, leaving the reader 2 rows off the line they were reading.

The fix expresses the anchor as **a block plus that block's offset from the top of the viewport**. A block's `virtual_region` is re-derived by the same layout pass that resizes it, so reading it back afterwards is correct whichever pass wins, and gap settlement is ordered before the measurement.

### Evidence

The flake is real and this fixes it. On clean `origin/main` (`c61b58ac`), the existing test fails **5 of 12** runs with exactly the signature recorded in earlier full-suite logs:

```text
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
    tests/unit/tui/test_subagent_view.py -k history_prepend -q     # on origin/main
assert calls == 1
> assert abs(view._body.scroll_y - (before + growth)) <= 1
E AssertionError: assert 2.0 <= 1
run 1 FAIL | 2 pass | 3 pass | 4 pass | 5 FAIL | 6 FAIL | 7 FAIL | 8 pass
run 9 pass | 10 pass | 11 pass | 12 FAIL      ->  5/12 failed
```

On this branch the rewritten test is **12/12 green**.

Mutation A, removing the restoration entirely: **3/3 red**. Bypassing the `_history_loading` dedup: **6/6 red** on `assert 2 == 1`, so the one-read-per-edge half still discriminates.

### A fourth commit, because the rewritten test did not actually discriminate

Re-running the mutations rather than trusting them showed the rewritten anchor test **passes against the verbatim pre-fix `prepend_blocks`** — 10/10 isolated, 8/8 in-file. Instrumenting it showed why: its anchor sits at gap 0 and `virtual_size` is already settled by the time the gap is read back, so the stale-height window is never entered. It passes for reasons unrelated to the fix.

A regression test that cannot fail on the regression is the exact failure mode this branch exists to end, so `test_stream_anchor.py` gains a deterministic one that drives `prepend_blocks` directly under the real stylesheet:

- the anchor is **mid-history**, not flush with the viewport top, since a gap of zero cannot express a drift of two rows;
- the batch's provisional gap classes are **set rather than raced for** — they are what an unmounted batch decides for itself under the 80-column fallback, and `_settle_gaps` reclaims them once real widths exist. Waiting for the layout passes to interleave the wrong way reproduces the drift only 2/10 through the subagent view, which is precisely the timing bet being removed elsewhere in this branch;
- the reclamation is asserted, so the anchor assertion cannot pass vacuously on a batch whose gaps never moved.

Two-sided and deterministic, measured on this tree:

| | isolated | in-file |
|---|---|---|
| fixed product | **12/12 pass** | 5/5 pass (18 passed) |
| verbatim pre-fix `prepend_blocks` | **12/12 FAIL** | 5/5 FAIL |

The pre-fix failure is the drift itself, not a proxy:

```text
>       assert anchor.virtual_region.y - view.scroll_y == before_gap
E       AssertionError: assert (40 - 67) == -25
```

`-27` against an expected `-25`: the reader left exactly 2 rows off, which is the originally traced error.

**One thing worth flagging for review:** the OLD assertion necessarily fails against the fixed product (11/12). It measured `max_scroll_y` growth, which the fix deliberately stops preserving, so that is the intended behaviour change rather than a regression. It is called out here because "old test red, new test green" is not by itself evidence, and the deterministic test above is what carries the claim.

## The crash guard

`_sync_boot_card` reached `self.screen`, which raises on an empty stack rather than returning `None`. The splash resizes asynchronously — `WelcomeView._poll` posts `BlockResized` when the model label lands, which is exactly when the session factory resolves — so a quit that beats the factory home left that message queued against a torn-down stack:

```text
ScreenStackError: No screens on stack
```

A fast quit during boot is ordinary use, and the crash landed at the one moment nothing could report it usefully. Guarded at the single funnel all three layout passes go through.

## Test-side: conditions instead of durations

Each of these waited on how long something usually takes, which is a bet that is lost under parallel load.

- **`test_comms.py`** (two tests) polled for a persisted, *complete* tool round instead of `sleep(0.3)`. The child persists its round at a loop boundary measured at mean **0.2917s** against a 0.3s bet — **0.91 sigma**, with **4 of 18** samples already over. These tests assert over work the child had *already* completed, so losing the bet did not fail loudly; it asserted against a transcript holding only the launch prompt.
- **Three TUI tests** poll for painted state instead of a single `pilot.pause()`.
- **The ask-picker test** now controls the real `ANSWER_KEY_HOLD_S=0.18` timer rather than trying to outrun it.
- **`_boot`/`_booted_gate`** wait on session adoption and handler installation. Measured: adoption takes ~0.03s warm and **2.3s** cold (first import of the session graph), so the old flat `pause(0.25)` failed deterministically on a cold cache and passed on a warm one.

## Validation

Full unit suite on this branch, three consecutive runs:

```text
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
6881 passed, 7 skipped, 441 warnings in 167.70s
6881 passed, 7 skipped, 441 warnings in 203.50s
6881 passed, 7 skipped, 441 warnings in 171.38s
```

Gates, run over the whole tree exactly as CI does:

```text
$ .venv/bin/python -m flake8 .                       # clean
$ black --check .                                    # 531 files unchanged (pinned 26.1.0)
$ isort --check .                                    # clean (repo config, not --profile black)
```

`black`/`isort` were run from a dedicated venv at the pinned versions because `uvx` could not spawn on this host (`error: Failed to spawn: black`); versions verified as `black, 26.1.0` and `isort 5.13.2`.

**pyright was deferred locally and is covered by the CI `type-check` gate.** This host has been at load average 50-150 all night with several concurrent peer sessions; two attempts each ran past 30 minutes at ~99% CPU without completing, and a third was still running when this PR was opened. CI runs the same check on a quiet machine and is the authoritative signal.

## Known remaining, out of scope

Two pre-existing flakes were observed in the full-suite logs and are **not** introduced here, both load-sensitive and unrelated to these commits: `test_launch_subagent.py::test_the_loop_stays_responsive_while_several_subagents_run` (a wall-clock 1000 ms budget, observed at 1262 ms under load average 90+) and `test_auth.py::TestBrowserLaunchContainment::test_silenced_console_keeps_the_browser_off_the_terminal`. They are left alone rather than silently worked around, since this PR is already large.

## Scope

Deliberately unchanged: the accepted boundary where a cleanup outruns the whole turn rather than just the drain budget (documented in `loop.py`; closing it means holding the turn open, which is what `ABORT_DRAIN_TIMEOUT_S` exists to refuse), the `claimed` counter kept as defence in depth, and the two flakes named above.
