### PR TITLE
docs(agents): versioning policy keyed to materiality, not commit type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,39 @@ change to `main`, run `lop-update`, verify the `.lop-source` marker, then smoke
 test `lop` from outside the repository. Never repoint `lop` at the editable
 `.venv`; doing so couples the stable command back to in-progress work.
 
+## Versioning: choose the bump by materiality, not commit type
+
+The version in `pyproject.toml` and the `vX.Y.Z` release tag are chosen by the
+**user-facing materiality** of the change, **not** by its conventional-commit
+type. A `feat:` commit is *not* automatically a minor. Using the commit type as
+the version signal is how a run of bug-fix and reliability releases inflates the
+minor number and drains its meaning — a minor should mark a step-function
+improvement a user would notice and adopt, so that going from `0.N.x` to
+`0.(N+1).0` still tells them something.
+
+- **Patch (`0.N.x` → `0.N.(x+1)`) — the default; most releases are patches.**
+  Bug fixes, performance and reliability improvements (backoff, retries,
+  timeouts, tuning), refactors, internal cleanups, docs, and small
+  self-contained features that do not change what the product can fundamentally
+  do. A single small `feat:` commit is a patch. **When in doubt, patch.**
+
+- **Minor (`0.N.x` → `0.(N+1).0`) — a material, step-function capability.**
+  Reserve it for a new surface or subsystem a user would notice and adopt: the
+  browser extension, the mobile relay, peer-to-peer session messaging. The test
+  is simple — if you cannot name the step-function capability in the release
+  title (`X.Y.0: <the new thing>`), it is a patch, not a minor. Several small
+  features bundled together are still patches unless one of them clears this
+  bar on its own.
+
+- **Major (`0.x` → higher, or `1.0`) — only on explicit request.** Bump the
+  major version *only* when the developer explicitly asks for it, in the rare
+  case where the new version is considered a distinct product from its
+  predecessor. Never decide a major bump on your own judgement.
+
+Because releases run frequently here, err toward patch: an under-called bump is
+trivially corrected by the next release, while an over-called minor permanently
+misreports how much changed.
+
 ## Visual validation: how to actually look at a UI change
 
 This is a terminal UI. **A passing test is not evidence that a visual change

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ improvement a user would notice and adopt, so that going from `0.N.x` to
   features bundled together are still patches unless one of them clears this
   bar on its own.
 
-- **Major (`0.x` → higher, or `1.0`) — only on explicit request.** Bump the
+- **Major (`X.y.z` → `(X+1).0.0`) — only on explicit request.** Bump the
   major version *only* when the developer explicitly asks for it, in the rare
   case where the new version is considered a distinct product from its
   predecessor. Never decide a major bump on your own judgement.


### PR DESCRIPTION
## What

Adds an authoritative **Versioning** section to `AGENTS.md` that keys the `pyproject.toml` / `vX.Y.Z` bump to **user-facing materiality**, not conventional-commit type.

## Why

Recent releases over-used minor bumps. Auditing the last 8 minors against a step-function bar:

| Tag | Contents | Should have been |
|---|---|---|
| v0.40.0 | 1 `fix(subagent)` | patch |
| v0.39.0 | 4 `fix(...)` | patch |
| v0.38.0 | crash-resume fix framed as feat | patch |
| v0.37.0 | mobile full-screen + p2p `lop send` + store automation | minor ✓ |
| v0.36.0 | small feat: restore team/agent on resume | patch (borderline) |
| v0.35.0 | browser extension + bridge | minor ✓ |
| v0.34.0 | feat: patient backoff on connectivity loss | patch |
| v0.33.0 | unify subagent transcript views (refactor) | patch (borderline) |

Roughly 5 of 8 were patch-grade shipped as minors. Root cause: the only version rule lived in the harness team brief ("patch for fixes, minor for features"), mapping the commit *type* straight onto the semver level. The repo docs (`AGENTS.md`, `CONTRIBUTING.md`) stated no versioning policy at all — `CONTRIBUTING.md` covers only release *mechanics*.

## Change

New `## Versioning` section in `AGENTS.md`:
- **Patch** is the default (fixes, perf/reliability, refactors, docs, small self-contained feats). When in doubt, patch.
- **Minor** only for a material step-function capability a user would notice and adopt. Naming test: if you can't name the capability in the release title, it's a patch.
- **Major** only on explicit developer request.

The harness `lopdev` team brief was updated in the same pass so future releases follow this policy.

## Testing evidence

Docs-only change (`AGENTS.md`, +33 lines, no code). No runtime behaviour affected; the standard code quality gates (flake8/black/isort/pyright/pytest) have no docs surface to exercise. Rendered the new section to confirm Markdown formatting:

\`\`\`
$ sed -n '/## Versioning/,/misreports how much changed/p' AGENTS.md | head -5
## Versioning: choose the bump by materiality, not commit type
...
\`\`\`

## Review

Agent review round to follow on this PR before merge.