### PR TITLE
feat(hub): fan resume out to multiple subagents

### DIFF
--- a/local_operator/prompts_md/system.md
+++ b/local_operator/prompts_md/system.md
@@ -137,8 +137,9 @@ doing without spending its attention, which is the fast way to check on a
 quiet child; `hub` also sends it a note, asks it a question and waits for its
 answer (a busy child finishes its current step before replying, so give it
 minutes, or peek instead of re-asking), steers it onto a different course,
-cancels it, or resumes a stopped one against its own transcript. Address them
-by job id, by label, or `"all"`. Inside a subagent, `hub` is how you reach the
+cancels it, or resumes a stopped one (or a batch of them at once) against its
+own transcript. Address them by job id, by label, or `"all"`. Inside a
+subagent, `hub` is how you reach the
 agent that delegated to you — answer its questions, and speak up unprompted
 when you are blocked or the task turns out to be wrong.
 

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -6943,7 +6943,7 @@ class HubParams(BaseModel):
             "(becomes part of its instructions). pause: stop it now but keep it "
             "resumable. cancel: stop it for good. resume: relaunch a stopped, paused or "
             "failed subagent against its own transcript so it continues where it left "
-            "off."
+            "off; names several targets to fan one message out to a whole batch at once."
         )
     )
     # A plain array, NOT ``str | list[str]``: pydantic renders a union as
@@ -6962,8 +6962,9 @@ class HubParams(BaseModel):
         description=(
             "Who to address: job ids from 'task'/'jobs'/'hub op=list', subagent "
             'labels, or ["all"] for every running subagent. Several ids address '
-            "several subagents. 'ask', 'resume' and 'peek' take exactly one. Omit "
-            "for op='list', which addresses nobody."
+            "several subagents. 'ask' and 'peek' take exactly one; 'resume' fans one "
+            "message out to every target you name, so a batch of failed subagents can "
+            "be resumed in a single call. Omit for op='list', which addresses nobody."
         ),
     )
 
@@ -7118,7 +7119,8 @@ def _hub_list(tool_call_id: str, comms: Any) -> ToolResult:
         lines.append("")
         lines.append(
             "Resume one with hub op='resume' and its JOB id, plus an instruction for "
-            "what to do next. The transcript id above is not a job id: it opens the "
+            "what to do next \u2014 or name several JOB ids to resume a whole batch in "
+            "one call. The transcript id above is not a job id: it opens the "
             "child's history for reading and starts no agent."
         )
     return _text(
@@ -7277,9 +7279,15 @@ async def _execute_hub_parent(
             "hub",
             "; ".join(errors) or "no subagent matched; use 'jobs' to list them.",
         )
-    # A question, a resume and a peek each have exactly one subject, so they
-    # refuse a fan-out rather than silently acting on the first match.
-    if params.op in ("ask", "resume", "peek") and len(ids) > 1:
+    # A question and a peek each have exactly one subject — one reply to read,
+    # one transcript window to render — so they refuse a fan-out rather than
+    # silently acting on the first match. Resume is deliberately NOT here: each
+    # resume spawns an INDEPENDENT new job replaying that target's own
+    # transcript, so N targets produce N separate children with no shared reply
+    # and no shared transcript to collide. Fanning one message out to a whole
+    # batch of stopped/failed children (e.g. after a provider stall) is exactly
+    # what resume should do, so it falls through to the loop below.
+    if params.op in ("ask", "peek") and len(ids) > 1:
         return _error(
             tool_call_id,
             "hub",
@@ -7312,15 +7320,59 @@ async def _execute_hub_parent(
         )
 
     if params.op == "resume":
-        new_job_id, error = comms.resume(ids[0], message)
-        if error is not None:
-            return _error(tool_call_id, "hub", error)
+        # Fan-out: resume every target in turn. Unlike ask/peek, each resume
+        # spawns an independent new job on its own transcript, so a batch of
+        # stopped/failed children can be relaunched in one call. ``comms.resume``
+        # returns a ``(new_job_id, error)`` tuple rather than a ``Delivery``, so
+        # we collect per-target receipts here and format them like the
+        # send/steer/cancel block below without borrowing the Delivery shape.
+        resumed: list[tuple[str, str | None, str | None]] = [
+            # (resumed-from id, new job id, error)
+            (job_id, *comms.resume(job_id, message))
+            for job_id in ids
+        ]
+        acted = [receipt for receipt in resumed if receipt[2] is None]
+        header = (
+            f"resume: {len(acted)}/{len(resumed)} subagent(s)"
+            if resumed
+            else "resume: nothing to do"
+        )
+        lines = [header]
+        for from_id, new_job_id, error in resumed:
+            label = comms.label_of(from_id)
+            if error is None:
+                # Each success carries the NEW job id it was resumed as; the
+                # transcript-replay guidance is stated once in the footer
+                # rather than repeated on every line.
+                lines.append(f"- {label} ({from_id}): resumed as job {new_job_id}")
+            else:
+                lines.append(f"- {label} ({from_id}): failed \u2014 {error}")
+        lines.extend(f"- {error}" for error in errors)
+        if acted:
+            # Kept from the single-target wording: a resumed child replays its
+            # own transcript before it reads this instruction, so the parent
+            # must 'wait' for it rather than assume it acted immediately.
+            lines.append(
+                "Each replays its own transcript before reading this instruction. "
+                "Await them with 'wait'."
+            )
         return _text(
             tool_call_id,
             "hub",
-            f"resumed {comms.label_of(ids[0])} as job {new_job_id}; it replays its own "
-            "transcript before reading this instruction. Await it with 'wait'.",
-            details={"op": "resume", "job_id": new_job_id, "resumed_from": ids[0]},
+            "\n".join(lines),
+            details={
+                "op": "resume",
+                "job_ids": [new_id for _from, new_id, error in resumed if error is None],
+                "resumed_from": [from_id for from_id, _new, error in resumed if error is None],
+                "acted": len(acted),
+                # Mirrored into details as well as the flag: every other useless
+                # site in this module carries the key, and compaction's pruning
+                # pass reads it from there.
+                "useless": not acted,
+            },
+            # Nothing was resumed: a receipt list of pure failures is not an
+            # observation the model should act on as if it had been heard.
+            useless=not acted,
         )
 
     deliveries = []
@@ -7392,8 +7444,9 @@ def build_hub_tool(context: ToolContext) -> AgentTool | None:
             "longer shows), send a note, ask one a question and get its answer (use "
             "this to find out whether a quiet child is stuck), steer one onto a "
             "different course, pause one so it can be picked up later, cancel one, or "
-            "resume a stopped, paused or failed one against its own transcript so it "
-            'continues where it left off. Address them by job id, by label, or "all".'
+            "resume a stopped, paused or failed one (or a whole batch of them at once) "
+            "against its own transcript so it continues where it left off. Address them "
+            'by job id, by label, or "all".'
         ),
         parameters=HubParams.model_json_schema(),
         # Write, like 'task' and 'wake': these ops redirect, kill and restart

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -7362,6 +7362,9 @@ async def _execute_hub_parent(
             "\n".join(lines),
             details={
                 "op": "resume",
+                # Unlike the send/steer/cancel block below, where "job_ids" is the
+                # target list, a resume spawns fresh jobs: "job_ids" here holds the
+                # NEW successfully-spawned ids, with their sources in "resumed_from".
                 "job_ids": [new_id for _from, new_id, error in resumed if error is None],
                 "resumed_from": [from_id for from_id, _new, error in resumed if error is None],
                 "acted": len(acted),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.40.0"
+version = "0.41.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -1147,6 +1147,141 @@ async def test_the_tool_refuses_to_ask_several_children_at_once():
 
 
 @pytest.mark.asyncio
+async def test_the_tool_refuses_to_peek_several_children_at_once():
+    """peek renders ONE transcript window, so like ask it stays single-subject
+    even though resume beside it now fans out."""
+    comms, jobs, _child, _parent = wire()
+    jobs.add("job-2")
+    comms.record_launch("job-2", "docs")
+    comms.attach("job-2", FakeChild(), tmp_dir())
+
+    result = await execute_hub(
+        "call-1",
+        {"op": "peek", "to": ["all"]},
+        None,
+        None,
+        ToolContext(cwd=".", subagent_comms=comms),
+    )
+
+    assert result.is_error
+    assert "one subagent at a time" in body(result)
+
+
+def _stopped_resumable(comms, jobs, tmp_path, job_id: str, label: str) -> None:
+    """Bring a child into the exact state ``comms.resume`` will act on: a
+    settled job row, a session dir with a transcript on disk, and detached so
+    no live twin blocks the resume."""
+    jobs.add(job_id, status="cancelled")
+    comms.record_launch(job_id, label)
+    session_dir = tmp_path / job_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / TRANSCRIPT_FILENAME).write_text("{}\n", encoding="utf-8")
+    comms.attach(job_id, FakeChild(), session_dir)
+    comms.detach(job_id)
+
+
+@pytest.mark.asyncio
+async def test_resume_fans_one_message_out_to_several_stopped_children(tmp_path, monkeypatch):
+    """The point of the fan-out: a batch that all stalled comes back in one
+    call, each as its own new job replaying its own transcript."""
+    spawned: list[str] = []
+
+    def spy(**kwargs):
+        new_id = f"resumed-{len(spawned) + 1}"
+        spawned.append(new_id)
+        return new_id
+
+    monkeypatch.setattr("local_operator.harness.subagent.run_subagent", spy)
+    jobs = FakeJobs()
+    comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+    _stopped_resumable(comms, jobs, tmp_path, "job-1", "parser")
+    _stopped_resumable(comms, jobs, tmp_path, "job-2", "docs")
+
+    result = await execute_hub(
+        "call-1",
+        {"op": "resume", "to": ["job-1", "job-2"], "message": "carry on"},
+        None,
+        None,
+        ToolContext(cwd=".", subagent_comms=comms),
+    )
+
+    text = body(result)
+    assert "resume: 2/2 subagent(s)" in text
+    # Both targets are named beside the NEW job id they were resumed as.
+    assert "parser (job-1): resumed as job resumed-1" in text
+    assert "docs (job-2): resumed as job resumed-2" in text
+    details = payload(result)
+    assert details["job_ids"] == ["resumed-1", "resumed-2"]
+    assert details["resumed_from"] == ["job-1", "job-2"]
+    assert details["acted"] == 2
+    assert result.useless is False
+
+
+@pytest.mark.asyncio
+async def test_resume_batch_reports_success_and_failure_side_by_side(tmp_path, monkeypatch):
+    """A mixed batch must not fail the whole call: the resumable child comes
+    back and the one that refuses carries its reason on its own line."""
+    monkeypatch.setattr(
+        "local_operator.harness.subagent.run_subagent",
+        lambda **kwargs: "resumed-1",
+    )
+    jobs = FakeJobs()
+    comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+    _stopped_resumable(comms, jobs, tmp_path, "job-1", "parser")
+    # A still-running child is not resumable and refuses with a reason.
+    jobs.add("job-2", status="running")
+    comms.record_launch("job-2", "docs")
+    comms.attach("job-2", FakeChild(), tmp_path / "job-2")
+
+    result = await execute_hub(
+        "call-1",
+        {"op": "resume", "to": ["job-1", "job-2"], "message": "carry on"},
+        None,
+        None,
+        ToolContext(cwd=".", subagent_comms=comms),
+    )
+
+    text = body(result)
+    assert "resume: 1/2 subagent(s)" in text
+    assert "parser (job-1): resumed as job resumed-1" in text
+    assert "docs (job-2): failed" in text
+    assert "still running" in text
+    details = payload(result)
+    assert details["job_ids"] == ["resumed-1"]
+    assert details["resumed_from"] == ["job-1"]
+    assert details["acted"] == 1
+    # One child was reached, so the receipt is a real observation, not useless.
+    assert result.useless is False
+
+
+@pytest.mark.asyncio
+async def test_a_resume_batch_that_reaches_nobody_is_flagged_useless(tmp_path):
+    """Pure-failure fan-out mirrors send/steer/cancel: nothing was resumed, so
+    the receipt is flagged useless for compaction to prune."""
+    jobs = FakeJobs()
+    comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+    # Two running children: both refuse, so the batch reaches nobody.
+    jobs.add("job-1", status="running")
+    comms.record_launch("job-1", "parser")
+    comms.attach("job-1", FakeChild(), tmp_path / "job-1")
+    jobs.add("job-2", status="running")
+    comms.record_launch("job-2", "docs")
+    comms.attach("job-2", FakeChild(), tmp_path / "job-2")
+
+    result = await execute_hub(
+        "call-1",
+        {"op": "resume", "to": ["job-1", "job-2"], "message": "carry on"},
+        None,
+        None,
+        ToolContext(cwd=".", subagent_comms=comms),
+    )
+
+    assert "resume: 0/2 subagent(s)" in body(result)
+    assert payload(result)["acted"] == 0
+    assert result.useless is True
+
+
+@pytest.mark.asyncio
 async def test_the_tool_accepts_the_string_forms_models_send_for_to():
     """Observed live (2026-08-19): a parent model retried ``op='ask'`` against
     a running reviewer and never once emitted a real array — a bare id, the


### PR DESCRIPTION
## Summary

`hub op='resume'` now fans **one** resume message out to **several** subagents in a single call. Previously resume shared the "exactly one subject" guard with `ask` and `peek` and refused whenever more than one target matched, so recovering a batch of failed children — the common case when a provider stall knocks out a whole `task` fan-out at once — meant one hub call per child, which is slow and wasteful.

The guard was wrong for resume specifically. `ask` has one reply to read and `peek` has one transcript window to render, so they genuinely address one subject. Resume does not: each resume spawns an **independent** new job replaying that target's own transcript, so N targets produce N separate children with no shared reply and no shared transcript to collide. Fanning out is exactly what resume should do.

## What changed

- `local_operator/tools/builtin.py` (`_execute_hub_parent`): dropped `"resume"` from the single-subject guard tuple (now `ask`/`peek` only). Replaced the single-target resume block with a loop over every target, building a per-target receipt modelled on the existing send/steer/cancel block: a `resume: N/M subagent(s)` header, one line per target naming the new job id on success or the reason on failure, `_hub_targets` errors appended, and the transcript-replay/`wait` guidance stated once in the footer. `details` now carries lists (`job_ids`, `resumed_from`, `acted`) plus the `useless` flag, mirroring the other multi-target ops. Single-target resume behaviour is preserved through the same loop (one clean receipt line).
- Copy updated to match the new capability: the `op` and `to` field descriptions, the tool-level description, the `_hub_list` roster hint, and the hub paragraph in `prompts_md/system.md` — each now states resume can address a whole batch.
- `pyproject.toml`: **0.40.0 → 0.41.0** (minor; new capability).

## Testing evidence

Backend change, no UI. Exercised the real path through `_execute_hub_parent` with the harness comms in `tests/unit/harness/test_comms.py` (5 new tests):

- Resuming two stopped children in one call spawns two new jobs and the receipt names both.
- A mixed batch (one resumable + one refusing) yields one success line and one failure line carrying the reason.
- A pure-failure batch is flagged `useless` so the model does not act on it as if heard.
- `peek` still refuses `len(ids) > 1` (guard regression); the matching `ask`-refuses test already existed.

Command outputs (whole tree, exactly as CI runs them, from the worktree with `local_operator.__file__` confirmed resolving into it):

```
$ .venv/bin/python -m flake8 .                        # exit 0
$ uvx --from black==26.1.0 black --check .            # 551 files unchanged
$ python -m isort --check .   (isort 5.13.2, repo cfg) # exit 0
$ python -m pyright --pythonpath .venv/bin/python .    # 0 errors, 0 warnings
$ python -m pytest tests/unit/harness/test_comms.py -q # 104 passed
```

Note: `uvx isort==5.13.2` cannot spawn isort in this sandbox (an environment issue, not a lint failure); validated with the identically-pinned isort 5.13.2 as a module and confirmed the version. CI runs `isort --check .` and will exercise the literal form.

## Full changelog

https://github.com/damianvtran/local-operator/compare/v0.40.0...dev-resume-fanout
