### PR TITLE
fix(extension): walk through ignored AX wrapper nodes in snapshot compaction

### DIFF
--- a/extension/src/ax-compact.ts
+++ b/extension/src/ax-compact.ts
@@ -20,7 +20,23 @@ export function compactAX(nodes: AXNode[], epoch: number): { snapshot: string; r
   const lines: string[] = [];
   let sequence = 0;
   function visit(node: AXNode, depth: number): void {
-    if (node.ignored) return;
+    // An ignored node is excluded from the accessible tree but its subtree is
+    // NOT: Chrome wraps every real page in ignored generic containers (html and
+    // body surface as role "none", ignored: true) sitting directly under the
+    // RootWebArea. Returning early here therefore pruned the ENTIRE page and
+    // produced the live one-line snapshots ('- RootWebArea "…" [e1]') that
+    // survived the Accessibility.enable fix — confirmed against real headful
+    // Chrome 151 and Chrome for Testing 145, where getFullAXTree returns a
+    // full tree (48 nodes on the repro page) whose nodes 2..3 are ignored
+    // wrappers. Treat ignored nodes as transparent: skip the line, keep the
+    // depth, and walk through to their children.
+    if (node.ignored) {
+      for (const child of node.childIds ?? []) {
+        const found = byId.get(child);
+        if (found) visit(found, depth);
+      }
+      return;
+    }
     const role = String(node.role?.value ?? "");
     const name = String(node.name?.value ?? "").trim();
     const focusable = node.properties?.some((property) => property.name === "focusable" && property.value.value === true);

--- a/extension/src/ax-compact.ts
+++ b/extension/src/ax-compact.ts
@@ -19,7 +19,13 @@ export function compactAX(nodes: AXNode[], epoch: number): { snapshot: string; r
   const refs: Record<string, SnapshotRef> = {};
   const lines: string[] = [];
   let sequence = 0;
+  // Guard against cyclic or duplicated childIds in a malformed AX payload:
+  // the walk trusts protocol data, and without this a cycle would recurse
+  // forever inside the extension's service worker (review round 1, MINOR-1).
+  const visited = new Set<string>();
   function visit(node: AXNode, depth: number): void {
+    if (visited.has(node.nodeId)) return;
+    visited.add(node.nodeId);
     // An ignored node is excluded from the accessible tree but its subtree is
     // NOT: Chrome wraps every real page in ignored generic containers (html and
     // body surface as role "none", ignored: true) sitting directly under the
@@ -29,7 +35,10 @@ export function compactAX(nodes: AXNode[], epoch: number): { snapshot: string; r
     // Chrome 151 and Chrome for Testing 145, where getFullAXTree returns a
     // full tree (48 nodes on the repro page) whose nodes 2..3 are ignored
     // wrappers. Treat ignored nodes as transparent: skip the line, keep the
-    // depth, and walk through to their children.
+    // depth, and walk through to their children. This is deliberate even for
+    // an ignored node carrying `focusable` (e.g. inside aria-hidden): ignored
+    // means excluded from the accessible tree, so it emits no line and no ref
+    // despite focusable being a ref trigger for rendered nodes below.
     if (node.ignored) {
       for (const child of node.childIds ?? []) {
         const found = byId.get(child);

--- a/extension/src/commands/snapshot.ts
+++ b/extension/src/commands/snapshot.ts
@@ -5,8 +5,8 @@ import { setRefs } from "../state";
 // Serializes the enable→read→disable window below. The worker dispatches
 // daemon frames fire-and-forget (worker.ts onmessage), so two concurrent
 // snapshots could otherwise interleave as enable/enable/read/DISABLE/read —
-// the second read then hits a disabled a11y engine, the exact one-node bug
-// this file fixes. The daemon pipelines commands per tab today, so this is
+// the second read then hits a disabled a11y engine and risks a degraded
+// tree. The daemon pipelines commands per tab today, so this is
 // latent, but the extension should not depend on that scheduling promise.
 // A promise chain (not a refcount) keeps it simple: snapshots are rare and
 // heavy, so serializing them costs nothing observable. Failures are swallowed
@@ -15,12 +15,15 @@ let axQueue: Promise<unknown> = Promise.resolve();
 
 export async function snapshot(params: Record<string, unknown>): Promise<Record<string, unknown>> {
   const surface = await requireSurface(params.tab);
-  // Accessibility.getFullAXTree only returns a populated tree once
-  // Accessibility.enable has run on THIS debugger session; without it Chrome
-  // answers with just the root node (observed live: one-line snapshots). We
-  // disable again after the read so the a11y engine is not kept hot on the tab
-  // between snapshots — the stored refs are backendDOMNodeIds, which belong to
-  // the DOM (not the AX tree) and remain resolvable after disable.
+  // Enable the a11y domain for the read window as documented CDP hygiene.
+  // NOTE: the live one-line snapshots previously blamed on a missing enable
+  // were actually compactAX pruning the subtrees of ignored wrapper nodes
+  // (see ax-compact.ts) — verified in headful Chrome 151/145 where bare
+  // getFullAXTree on a hidden tab returns a full tree even without enable.
+  // We keep the enable→read→disable window anyway: it is cheap, matches the
+  // documented contract, and disable ensures the a11y engine is not kept hot
+  // on the tab between snapshots — the stored refs are backendDOMNodeIds,
+  // which belong to the DOM (not the AX tree) and remain resolvable after.
   const run = async (): Promise<{ nodes: AXNode[] }> => {
     await cdp(surface.tabId, "Accessibility.enable");
     try {

--- a/extension/tests/pure.test.mjs
+++ b/extension/tests/pure.test.mjs
@@ -36,6 +36,31 @@ test("AX compaction assigns epoch-scoped click refs", async () => {
   } finally { await module.close(); }
 });
 
+test("AX compaction walks through ignored wrapper nodes", async () => {
+  const module = await load("src/ax-compact.ts");
+  try {
+    // Real headful Chrome wraps every page's content in ignored generic
+    // containers (html/body render as role "none", ignored: true) directly
+    // under the RootWebArea. Pruning ignored subtrees therefore drops the
+    // whole page — the live one-line-snapshot bug. This mirrors the exact
+    // shape captured from Chrome 151 on http://127.0.0.1 test pages.
+    const rendered = module.loaded.compactAX([
+      { nodeId: "1", role: { value: "RootWebArea" }, name: { value: "Page" }, backendDOMNodeId: 1, childIds: ["2"], properties: [{ name: "focusable", value: { value: true } }] },
+      { nodeId: "2", role: { value: "none" }, ignored: true, childIds: ["3"] },
+      { nodeId: "3", role: { value: "none" }, ignored: true, childIds: ["4", "5"] },
+      { nodeId: "4", role: { value: "heading" }, name: { value: "Title" } },
+      { nodeId: "5", role: { value: "link" }, name: { value: "More" }, backendDOMNodeId: 9 },
+    ], 3);
+    const lines = rendered.snapshot.split("\n");
+    assert.equal(lines.length, 3, "ignored wrappers must not hide the page");
+    // Children of an ignored wrapper indent relative to the last RENDERED
+    // ancestor, not the wrapper chain: depth stays flat through them.
+    assert.match(lines[1], /^  - heading "Title"$/);
+    assert.match(lines[2], /^  - link "More" \[e2\]$/);
+    assert.deepEqual(rendered.refs.e2, { backendNodeId: 9, epoch: 3 });
+  } finally { await module.close(); }
+});
+
 test("scroll expressions force instant behavior in every mode", async () => {
   const module = await load("src/scroll-expressions.ts");
   try {

--- a/extension/tests/pure.test.mjs
+++ b/extension/tests/pure.test.mjs
@@ -61,6 +61,25 @@ test("AX compaction walks through ignored wrapper nodes", async () => {
   } finally { await module.close(); }
 });
 
+test("AX compaction terminates on cyclic and duplicated childIds", async () => {
+  const module = await load("src/ax-compact.ts");
+  try {
+    // The walk trusts protocol data; a malformed payload with a cycle
+    // (2 -> 3 -> 2) or the same child listed twice must neither hang the
+    // service worker nor emit duplicate lines (review round 1, MINOR-1).
+    const rendered = module.loaded.compactAX([
+      { nodeId: "1", role: { value: "RootWebArea" }, name: { value: "Page" }, childIds: ["2", "2"] },
+      { nodeId: "2", role: { value: "heading" }, name: { value: "Loop" }, childIds: ["3"] },
+      { nodeId: "3", role: { value: "link" }, name: { value: "Back" }, backendDOMNodeId: 4, childIds: ["2"] },
+    ], 1);
+    assert.deepEqual(rendered.snapshot.split("\n"), [
+      '- RootWebArea "Page"',
+      '  - heading "Loop"',
+      '    - link "Back" [e1]',
+    ]);
+  } finally { await module.close(); }
+});
+
 test("scroll expressions force instant behavior in every mode", async () => {
   const module = await load("src/scroll-expressions.ts");
   try {


### PR DESCRIPTION
## What

Fixes the still-broken live snapshot: on the real paired Chrome (0.1.1 build, post-#313), `snapshot` returned exactly one AX line — `- RootWebArea "…" [e1]` — on every page, twice in a row.

**Root cause is not tree population and not the hidden tab.** Reproduced against throwaway headful Chrome (Chrome for Testing 145 with the production `chrome.debugger` path in an MV3 probe extension, plus branded Chrome 151 over raw CDP): a hidden `active:false` tab's `Accessibility.getFullAXTree` returns the **full tree** — 48 nodes on a rich local page, 14 on example.com — with or without `Accessibility.enable`, immediately, even in a minimized window and even mid-load on a 52k-node page. The hidden-tab/deferred-a11y hypothesis is dead: `ProgressiveAccessibility` (incl. `disable_on_hide`) changed nothing.

The actual bug is in `compactAX` (`extension/src/ax-compact.ts`): Chrome wraps every real page's content in **ignored generic containers** (html/body surface as `role: "none", ignored: true`) directly under the RootWebArea, and the early `if (node.ignored) return` pruned those wrappers' **entire subtrees** — the whole page. PR #313's headless validation counted *raw protocol nodes* (19), never the compacted output, which is why it looked fixed.

Fix: treat ignored nodes as transparent — emit no line, keep the depth, walk through to children. Refs stay `backendDOMNodeId`s, the `axQueue` serialization (c628cee4) and the enable→read→disable window are unchanged (enable kept as documented CDP hygiene; comments corrected to stop attributing the one-line bug to it).

## Testing evidence

`pnpm typecheck` clean, `pnpm test` 16/16 (new pure test mirrors the exact ignored-wrapper shape captured from Chrome 151), `pnpm build` clean.

Live before/after in throwaway **headful** Chrome (`/tmp` profile, launched backgrounded and off-screen; the paired Chrome and bridge daemon untouched), production CDP sequence — `tabs.create({active:false})` → attach → `Runtime`/`Log` enable → navigate → webNavigation settle → `Accessibility.enable` → `getFullAXTree` → `disable` — run inside an MV3 service worker via `chrome.debugger`, then both the pre-fix and post-fix `compactAX` bundles applied to the same live tree (tab confirmed `active: false`):

| Page | Raw nodes | Before | After |
|---|---|---|---|
| https://example.com | 14 | 1 line / 1 ref | **6 lines / 2 refs** (heading, text, `link "Learn more" [e2]`) |
| Local rich page (headings/nav/form/footer over `python3 -m http.server`) | 48 | 1 line / 1 ref | **26 lines / 10 refs** (banner/nav/main/contentinfo landmarks; links, textbox, checkbox, combobox+options, `button "Submit Button" [e10]`) |

Second consecutive snapshot cycle (disable → enable → read) returns the identical tree — matches the live "two snapshots, same single node" symptom being deterministic, not a warmup race.

## Not in this PR

- Live re-verification on the paired Chrome (requires the user's bridge; deliberately untouched — the fix is in `compactAX`, which the live probes exercised byte-for-byte via the compiled bundle).
- Extension version bump / store release.
