### PR TITLE
feat(browser): multi-tab surfaces so parallel sessions each own a tab

### DIFF
--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -1,4 +1,4 @@
-import { getSession, parseSurface, type StoredSurface } from "./state";
+import { getSurfaces, putSurface, removeSurface, resolveSurfaceToken, type StoredSurface } from "./state";
 
 const attached = new Set<number>();
 
@@ -13,16 +13,28 @@ export class BridgeCommandError extends Error {
 }
 
 export async function requireSurface(token: unknown): Promise<StoredSurface> {
-  const parsed = parseSurface(token);
-  const { surface } = await getSession();
-  if (!parsed || !surface || parsed.tabId !== surface.tabId || parsed.nonce !== surface.nonce) {
+  // Exact-token lookup in the surfaces map: the nonce is part of the key, so a
+  // handle from another session (or a guessed tab id) resolves to nothing and
+  // keeps the same tab_closed shape callers already handle. This is what lets
+  // parallel sessions share the map without being able to drive each other's
+  // tabs by accident.
+  const surface = resolveSurfaceToken(token, await getSurfaces());
+  if (!surface) {
     throw new BridgeCommandError("tab_closed", "the browser tab handle is stale");
   }
   try {
     await chrome.tabs.get(surface.tabId);
   } catch {
+    // The Chrome tab is gone; drop the map entry so `tabs` never lists it and
+    // the map cannot fill with dead surfaces while their handles count toward
+    // the surface cap.
+    await removeSurface(String(token));
     throw new BridgeCommandError("tab_closed", "the browser tab was closed");
   }
+  // Recency for the `tabs` listing; best-effort, never on the command's
+  // critical path for correctness.
+  surface.lastUsedAt = Date.now();
+  await putSurface(surface);
   return surface;
 }
 

--- a/extension/src/cdp.ts
+++ b/extension/src/cdp.ts
@@ -1,4 +1,5 @@
-import { getSurfaces, putSurface, removeSurface, resolveSurfaceToken, type StoredSurface } from "./state";
+import { dropLogCapture } from "./log-capture";
+import { getSurfaces, removeSurface, resolveSurfaceToken, touchSurface, type StoredSurface } from "./state";
 
 const attached = new Set<number>();
 
@@ -25,17 +26,31 @@ export async function requireSurface(token: unknown): Promise<StoredSurface> {
   try {
     await chrome.tabs.get(surface.tabId);
   } catch {
-    // The Chrome tab is gone; drop the map entry so `tabs` never lists it and
-    // the map cannot fill with dead surfaces while their handles count toward
-    // the surface cap.
-    await removeSurface(String(token));
+    // The Chrome tab is gone: full prune, identical to the `tabs` prune site
+    // (review finding m1) — dropping only the map entry leaked the log ring
+    // buffer and left the dead tabId in the `attached` set for the worker's
+    // lifetime.
+    await pruneSurface(String(token), surface.tabId);
     throw new BridgeCommandError("tab_closed", "the browser tab was closed");
   }
   // Recency for the `tabs` listing; best-effort, never on the command's
-  // critical path for correctness.
+  // critical path for correctness. Conditional on the entry still existing so
+  // it cannot resurrect a concurrently-pruned surface (finding m5).
   surface.lastUsedAt = Date.now();
-  await putSurface(surface);
+  await touchSurface(String(token), surface.lastUsedAt);
   return surface;
+}
+
+/**
+ * The ONE dead-surface cleanup: map entry, log ring buffer, debugger session.
+ * Every prune site (requireSurface, status, tabs) must go through this — the
+ * three previously diverged and two of them leaked buffers/attachments
+ * (finding m1).
+ */
+export async function pruneSurface(token: string, tabId: number): Promise<void> {
+  dropLogCapture(tabId);
+  await detach(tabId);
+  await removeSurface(token);
 }
 
 export async function attach(tabId: number): Promise<void> {

--- a/extension/src/commands/input.ts
+++ b/extension/src/commands/input.ts
@@ -1,7 +1,7 @@
 import { BridgeCommandError, cdp, requireSurface } from "../cdp";
 import { withOriginGate } from "../origins";
 import { settle } from "../settle";
-import { getSession } from "../state";
+import { getRefs, surfaceToken, type StoredSurface } from "../state";
 
 interface QueryResult { nodeId?: number }
 interface PushResult { nodeIds: number[] }
@@ -29,12 +29,15 @@ async function callOnNode<T>(
   return out.result?.value as T;
 }
 
-async function nodeIdFor(tabId: number, selector: unknown, epoch: number): Promise<number> {
+async function nodeIdFor(surface: StoredSurface, selector: unknown): Promise<number> {
+  const tabId = surface.tabId;
   if (typeof selector !== "string" || !selector) throw new BridgeCommandError("element_not_found", "selector is required");
-  const { refs = {} } = await getSession();
+  // Refs are read from THIS surface's own map: a snapshot taken on another
+  // concurrently-driven tab must never supply the click target here.
+  const refs = await getRefs(surfaceToken(surface));
   const ref = /^e\d+$/.test(selector) ? refs[selector] : undefined;
   if (ref) {
-    if (ref.epoch !== epoch) throw new BridgeCommandError("element_not_found", "the page navigated since that snapshot");
+    if (ref.epoch !== surface.epoch) throw new BridgeCommandError("element_not_found", "the page navigated since that snapshot");
     // DOM.pushNodesByBackendIdsToFrontend requires the DOM agent to hold the
     // document for this session first, or Chrome rejects with -32000
     // "Document needs to be requested first". The CSS-selector branch below
@@ -66,7 +69,7 @@ export async function click(
 ): Promise<Record<string, unknown>> {
   const surface = await requireSurface(params.tab);
   const before = (await chrome.tabs.get(surface.tabId)).url ?? "";
-  const nodeId = await nodeIdFor(surface.tabId, params.selector ?? params.ref, surface.epoch);
+  const nodeId = await nodeIdFor(surface, params.selector ?? params.ref);
   await cdp(surface.tabId, "DOM.scrollIntoViewIfNeeded", { nodeId });
   const objectId = await objectIdFor(surface.tabId, nodeId);
   // Race a short grace window for a navigation the click may start. A click is
@@ -125,7 +128,7 @@ export async function click(
 export async function typeText(params: Record<string, unknown>): Promise<Record<string, unknown>> {
   const surface = await requireSurface(params.tab);
   const selector = params.selector ?? params.ref;
-  const nodeId = await nodeIdFor(surface.tabId, selector, surface.epoch);
+  const nodeId = await nodeIdFor(surface, selector);
   await cdp(surface.tabId, "DOM.scrollIntoViewIfNeeded", { nodeId });
   const objectId = await objectIdFor(surface.tabId, nodeId);
   // Replace-not-append (the cmux fill-vs-type lesson): focus, set the value on

--- a/extension/src/commands/nav.ts
+++ b/extension/src/commands/nav.ts
@@ -2,7 +2,15 @@ import { attach, BridgeCommandError, cdp, detach, requireSurface } from "../cdp"
 import { dropLogCapture, startLogCapture } from "../log-capture";
 import { askOrigin, safeHttpUrl, withOriginGate } from "../origins";
 import { settle } from "../settle";
-import { getSession, setSurface, surfaceToken, type StoredSurface } from "../state";
+import {
+  atSurfaceCap,
+  getSurfaces,
+  MAX_SURFACES,
+  putSurface,
+  removeSurface,
+  surfaceToken,
+  type StoredSurface,
+} from "../state";
 
 async function page(tabId: number): Promise<{ url: string; title: string }> {
   const tab = await chrome.tabs.get(tabId);
@@ -26,21 +34,38 @@ async function navigate(tabId: number, url: URL, requestId: string): Promise<{ u
   );
 }
 
+/**
+ * Open a surface. Two explicit modes, decided by the caller's `tab` param:
+ *
+ * - no `tab` → a brand-NEW tab and surface. Never reuses an existing one:
+ *   the old "reuse whatever surface exists" behaviour meant a second
+ *   session's open silently stole the first session's tab mid-task (the
+ *   parallelism-breaking hijack this multi-surface model exists to fix).
+ * - `tab` set → navigate THAT surface (the resume path). Same effect the old
+ *   reuse had, but explicit and scoped to the caller's own handle, so it can
+ *   only ever re-drive a tab the caller already owns.
+ */
 export async function open(params: Record<string, unknown>, requestId: string): Promise<Record<string, unknown>> {
   const url = safeHttpUrl(params.url);
-  const previous = (await getSession()).surface;
-  if (previous) {
-    try {
-      await chrome.tabs.get(previous.tabId);
-      // Re-arm log capture on the reused surface: after a worker restart the
-      // ring buffer was lost and the domains may need re-enabling, and
-      // startLogCapture is idempotent when they are already on.
-      await startLogCapture(previous.tabId, cdp);
-      const result = await navigate(previous.tabId, url, requestId);
-      return { tab: surfaceToken(previous), ...result };
-    } catch (error) {
-      if (!(error instanceof BridgeCommandError && error.code === "tab_closed")) throw error;
-    }
+  if (params.tab !== undefined && params.tab !== null && params.tab !== "") {
+    const surface = await requireSurface(params.tab);
+    // Re-arm log capture on the resumed surface: after a worker restart the
+    // ring buffer was lost and the domains may need re-enabling, and
+    // startLogCapture is idempotent when they are already on.
+    await startLogCapture(surface.tabId, cdp);
+    const result = await navigate(surface.tabId, url, requestId);
+    return { tab: surfaceToken(surface), ...result };
+  }
+  const surfaces = await getSurfaces();
+  if (atSurfaceCap(surfaces)) {
+    // Typed refusal, not silent reuse: each parallel session opens its own
+    // tab now, so an unbounded map would let an agent fleet spray tabs into
+    // the user's real browser. See MAX_SURFACES for the cap rationale.
+    throw new BridgeCommandError(
+      "tab_limit",
+      `already driving ${MAX_SURFACES} tabs — close one (action 'close' with its handle) before opening another`,
+      { limit: MAX_SURFACES, tabs: Object.keys(surfaces) },
+    );
   }
   if (!(await askOrigin(url, requestId))) {
     throw new BridgeCommandError("origin_denied", "site permission was denied", { origin: url.origin });
@@ -50,12 +75,15 @@ export async function open(params: Record<string, unknown>, requestId: string): 
   // origin could receive cookies before the permission gate exists.
   const tab = await chrome.tabs.create({ active: false, url: "about:blank" });
   if (tab.id === undefined) throw new BridgeCommandError("internal", "Chrome created no tab id");
+  const now = Date.now();
   const surface: StoredSurface = {
     tabId: tab.id,
     nonce: crypto.randomUUID().replaceAll("-", ""),
     epoch: 1,
+    createdAt: now,
+    lastUsedAt: now,
   };
-  await setSurface(surface);
+  await putSurface(surface);
   await attach(tab.id);
   // Start buffering console/runtime logs immediately after attach and BEFORE
   // navigating, so the `logs` command captures output from the destination
@@ -69,21 +97,97 @@ export async function goto(params: Record<string, unknown>, requestId: string): 
   const surface = await requireSurface(params.tab);
   const result = await navigate(surface.tabId, safeHttpUrl(params.url), requestId);
   surface.epoch += 1;
-  await setSurface(surface);
+  await putSurface(surface);
   return result;
 }
 
 export async function status(params: Record<string, unknown>): Promise<Record<string, unknown>> {
-  const surface = params.tab ? await requireSurface(params.tab) : (await getSession()).surface;
-  if (!surface) return { origin_mode: "default-deny" };
-  return { tab: surfaceToken(surface), ...(await page(surface.tabId)), origin_mode: "default-deny" };
+  if (params.tab) {
+    const surface = await requireSurface(params.tab);
+    return { tab: surfaceToken(surface), ...(await page(surface.tabId)), origin_mode: "default-deny" };
+  }
+  // No handle: report the most recently driven live surface, if any. With
+  // several sessions each owning a tab there is no single "the" surface any
+  // more, so recency is the most honest one-line answer.
+  const surfaces = Object.values(await getSurfaces()).sort((a, b) => b.lastUsedAt - a.lastUsedAt);
+  for (const surface of surfaces) {
+    try {
+      return { tab: surfaceToken(surface), ...(await page(surface.tabId)), origin_mode: "default-deny" };
+    } catch {
+      await removeSurface(surfaceToken(surface));
+    }
+  }
+  return { origin_mode: "default-deny" };
 }
 
-export async function close(params: Record<string, unknown>): Promise<Record<string, unknown>> {
-  const surface = await requireSurface(params.tab);
+/**
+ * List every live extension-owned surface, pruning entries whose Chrome tab
+ * is gone (detaching leftover debugger sessions best-effort as we go).
+ *
+ * URL/title come from chrome.tabs at call time, never from storage, so the
+ * listing cannot show a page the tab has since left. This is the discovery
+ * verb for parallel sessions: read-only awareness of ALL surfaces, including
+ * other sessions' — driving one still requires its exact token (nonce and
+ * all), so listing does not grant control.
+ */
+export async function tabs(_params: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const surfaces = await getSurfaces();
+  const live: Record<string, unknown>[] = [];
+  for (const [token, surface] of Object.entries(surfaces)) {
+    try {
+      const tab = await chrome.tabs.get(surface.tabId);
+      live.push({
+        tab: token,
+        url: tab.url ?? "",
+        title: tab.title ?? "",
+        createdAt: surface.createdAt,
+        lastUsedAt: surface.lastUsedAt,
+      });
+    } catch {
+      // Tab gone (user closed it, browser restarted): prune so the map cannot
+      // fill with dead entries that count toward the surface cap.
+      dropLogCapture(surface.tabId);
+      await detach(surface.tabId);
+      await removeSurface(token);
+    }
+  }
+  live.sort((a, b) => Number(b.lastUsedAt) - Number(a.lastUsedAt));
+  return { tabs: live, limit: MAX_SURFACES };
+}
+
+async function closeSurface(token: string, surface: StoredSurface): Promise<void> {
   dropLogCapture(surface.tabId);
   await detach(surface.tabId);
   try { await chrome.tabs.remove(surface.tabId); } catch { /* already gone is success */ }
-  await setSurface();
+  await removeSurface(token);
+}
+
+/**
+ * Close ONE surface. With a `tab` param, exactly that surface (each session
+ * closes its own tab when done). Without one — the pre-multi-tab call shape —
+ * close the sole surface if exactly one exists; with several, refuse and name
+ * the live handles, because guessing which tab another session still needs is
+ * precisely the hijack this model removes.
+ */
+export async function close(params: Record<string, unknown>): Promise<Record<string, unknown>> {
+  if (params.tab !== undefined && params.tab !== null && params.tab !== "") {
+    const surface = await requireSurface(params.tab);
+    await closeSurface(surfaceToken(surface), surface);
+    return {};
+  }
+  const surfaces = await getSurfaces();
+  const entries = Object.entries(surfaces);
+  if (entries.length === 0) {
+    throw new BridgeCommandError("tab_closed", "no browser tab is open");
+  }
+  if (entries.length > 1) {
+    throw new BridgeCommandError(
+      "internal",
+      `several tabs are open (${entries.map(([token]) => token).join(", ")}) — pass the handle of the one to close`,
+      { tabs: entries.map(([token]) => token) },
+    );
+  }
+  const [token, surface] = entries[0]!;
+  await closeSurface(token, surface);
   return {};
 }

--- a/extension/src/commands/nav.ts
+++ b/extension/src/commands/nav.ts
@@ -1,4 +1,4 @@
-import { attach, BridgeCommandError, cdp, detach, requireSurface } from "../cdp";
+import { attach, BridgeCommandError, cdp, detach, pruneSurface, requireSurface } from "../cdp";
 import { dropLogCapture, startLogCapture } from "../log-capture";
 import { askOrigin, safeHttpUrl, withOriginGate } from "../origins";
 import { settle } from "../settle";
@@ -7,10 +7,33 @@ import {
   getSurfaces,
   MAX_SURFACES,
   putSurface,
+  redactToken,
   removeSurface,
   surfaceToken,
   type StoredSurface,
 } from "../state";
+
+/**
+ * The surfaces map with dead entries pruned (full cleanup via pruneSurface).
+ *
+ * Called before the cap check and by `tabs`: counting stale entries against
+ * the cap refused fresh opens after a browser restart until something else
+ * happened to prune (review finding m2), and every prune site must do the
+ * same buffer/debugger cleanup (finding m1).
+ */
+async function liveSurfaces(): Promise<Record<string, StoredSurface>> {
+  const surfaces = await getSurfaces();
+  const live: Record<string, StoredSurface> = {};
+  for (const [token, surface] of Object.entries(surfaces)) {
+    try {
+      await chrome.tabs.get(surface.tabId);
+      live[token] = surface;
+    } catch {
+      await pruneSurface(token, surface.tabId);
+    }
+  }
+  return live;
+}
 
 async function page(tabId: number): Promise<{ url: string; title: string }> {
   const tab = await chrome.tabs.get(tabId);
@@ -54,17 +77,25 @@ export async function open(params: Record<string, unknown>, requestId: string): 
     // startLogCapture is idempotent when they are already on.
     await startLogCapture(surface.tabId, cdp);
     const result = await navigate(surface.tabId, url, requestId);
+    // Same epoch bump as `goto`: resume navigates to a new document, so
+    // pre-resume snapshot refs must fail the epoch gate rather than being
+    // pushed against nodes that no longer exist (review finding m3).
+    surface.epoch += 1;
+    await putSurface(surface);
     return { tab: surfaceToken(surface), ...result };
   }
-  const surfaces = await getSurfaces();
+  const surfaces = await liveSurfaces();
   if (atSurfaceCap(surfaces)) {
     // Typed refusal, not silent reuse: each parallel session opens its own
     // tab now, so an unbounded map would let an agent fleet spray tabs into
     // the user's real browser. See MAX_SURFACES for the cap rationale.
+    // Handles are REDACTED: the full token is the drive capability, and an
+    // error surface must not hand one session control of another's tab
+    // (finding M1).
     throw new BridgeCommandError(
       "tab_limit",
       `already driving ${MAX_SURFACES} tabs — close one (action 'close' with its handle) before opening another`,
-      { limit: MAX_SURFACES, tabs: Object.keys(surfaces) },
+      { limit: MAX_SURFACES, tabs: Object.keys(surfaces).map(redactToken) },
     );
   }
   if (!(await askOrigin(url, requestId))) {
@@ -108,47 +139,48 @@ export async function status(params: Record<string, unknown>): Promise<Record<st
   }
   // No handle: report the most recently driven live surface, if any. With
   // several sessions each owning a tab there is no single "the" surface any
-  // more, so recency is the most honest one-line answer.
-  const surfaces = Object.values(await getSurfaces()).sort((a, b) => b.lastUsedAt - a.lastUsedAt);
-  for (const surface of surfaces) {
-    try {
-      return { tab: surfaceToken(surface), ...(await page(surface.tabId)), origin_mode: "default-deny" };
-    } catch {
-      await removeSurface(surfaceToken(surface));
-    }
+  // more, so recency is the most honest one-line answer. The handle is
+  // REDACTED: without a tab param the caller has not proven ownership, and a
+  // full token here would hand it control of another session's tab (M1).
+  const surfaces = Object.entries(await liveSurfaces()).sort(
+    (a, b) => b[1].lastUsedAt - a[1].lastUsedAt,
+  );
+  const first = surfaces[0];
+  if (first) {
+    return { tab: redactToken(first[0]), ...(await page(first[1].tabId)), origin_mode: "default-deny" };
   }
   return { origin_mode: "default-deny" };
 }
 
 /**
  * List every live extension-owned surface, pruning entries whose Chrome tab
- * is gone (detaching leftover debugger sessions best-effort as we go).
+ * is gone (full cleanup via pruneSurface).
  *
  * URL/title come from chrome.tabs at call time, never from storage, so the
  * listing cannot show a page the tab has since left. This is the discovery
  * verb for parallel sessions: read-only awareness of ALL surfaces, including
- * other sessions' — driving one still requires its exact token (nonce and
- * all), so listing does not grant control.
+ * other sessions'. Handles are REDACTED (nonce truncated) because the full
+ * token IS the drive capability — listing it would grant every session
+ * control of every tab (review finding M1). A caller recognises its own tab
+ * by prefix-matching the full token it received at open; driving any tab
+ * still requires that full token.
  */
 export async function tabs(_params: Record<string, unknown>): Promise<Record<string, unknown>> {
-  const surfaces = await getSurfaces();
+  const surfaces = await liveSurfaces();
   const live: Record<string, unknown>[] = [];
   for (const [token, surface] of Object.entries(surfaces)) {
     try {
       const tab = await chrome.tabs.get(surface.tabId);
       live.push({
-        tab: token,
+        tab: redactToken(token),
         url: tab.url ?? "",
         title: tab.title ?? "",
         createdAt: surface.createdAt,
         lastUsedAt: surface.lastUsedAt,
       });
     } catch {
-      // Tab gone (user closed it, browser restarted): prune so the map cannot
-      // fill with dead entries that count toward the surface cap.
-      dropLogCapture(surface.tabId);
-      await detach(surface.tabId);
-      await removeSurface(token);
+      // Closed between the liveness pass and this read — rare; prune now.
+      await pruneSurface(token, surface.tabId);
     }
   }
   live.sort((a, b) => Number(b.lastUsedAt) - Number(a.lastUsedAt));
@@ -175,16 +207,21 @@ export async function close(params: Record<string, unknown>): Promise<Record<str
     await closeSurface(surfaceToken(surface), surface);
     return {};
   }
-  const surfaces = await getSurfaces();
+  const surfaces = await liveSurfaces();
   const entries = Object.entries(surfaces);
   if (entries.length === 0) {
     throw new BridgeCommandError("tab_closed", "no browser tab is open");
   }
   if (entries.length > 1) {
+    // Typed as tab_ambiguous (not internal — finding n1): this is the caller
+    // holding an under-specified request, not a bridge fault. Handles are
+    // redacted for the same reason as the listing: naming full tokens here
+    // would let any session close (or adopt) any tab (M1).
+    const redacted = entries.map(([token]) => redactToken(token));
     throw new BridgeCommandError(
-      "internal",
-      `several tabs are open (${entries.map(([token]) => token).join(", ")}) — pass the handle of the one to close`,
-      { tabs: entries.map(([token]) => token) },
+      "tab_ambiguous",
+      `several tabs are open (${redacted.join(", ")}) — pass the handle of the one to close`,
+      { tabs: redacted },
     );
   }
   const [token, surface] = entries[0]!;

--- a/extension/src/commands/scroll.ts
+++ b/extension/src/commands/scroll.ts
@@ -5,7 +5,7 @@ import {
   SCROLL_INTO_VIEW_FN,
   scrollExpressionFor,
 } from "../scroll-expressions";
-import { getSession } from "../state";
+import { getRefs, surfaceToken, type StoredSurface } from "../state";
 
 interface CallResult { result: { value?: unknown } }
 interface PushResult { nodeIds: number[] }
@@ -57,14 +57,17 @@ async function readMetrics(tabId: number): Promise<Metrics> {
   };
 }
 
-async function nodeObjectId(tabId: number, selector: string, epoch: number): Promise<string> {
+async function nodeObjectId(surface: StoredSurface, selector: string): Promise<string> {
   // Resolve a snapshot ref (e5) exactly as click/type do so the two ways of
   // naming an element stay consistent; otherwise treat it as a CSS selector.
-  const { refs = {} } = await getSession();
+  // Refs come from THIS surface's own map (see state.ts): another tab's
+  // snapshot must not supply the scroll target.
+  const tabId = surface.tabId;
+  const refs = await getRefs(surfaceToken(surface));
   const ref = /^e\d+$/.test(selector) ? refs[selector] : undefined;
   let nodeId: number;
   if (ref) {
-    if (ref.epoch !== epoch) {
+    if (ref.epoch !== surface.epoch) {
       throw new BridgeCommandError("element_not_found", "the page navigated since that snapshot");
     }
     // Same constraint as input.ts nodeIdFor: pushNodesByBackendIdsToFrontend
@@ -126,7 +129,7 @@ export async function scroll(params: Record<string, unknown>): Promise<Record<st
   if (selector) {
     // scrollIntoView on the resolved node, centered so the element is usable
     // after the scroll rather than jammed against the viewport edge.
-    const objectId = await nodeObjectId(tabId, selector, surface.epoch);
+    const objectId = await nodeObjectId(surface, selector);
     await cdp(tabId, "Runtime.callFunctionOn", {
       objectId,
       functionDeclaration: SCROLL_INTO_VIEW_FN,

--- a/extension/src/commands/snapshot.ts
+++ b/extension/src/commands/snapshot.ts
@@ -1,6 +1,6 @@
 import { compactAX, type AXNode } from "../ax-compact";
 import { cdp, requireSurface } from "../cdp";
-import { setRefs } from "../state";
+import { setRefs, surfaceToken } from "../state";
 
 // Serializes the enable→read→disable window below. The worker dispatches
 // daemon frames fire-and-forget (worker.ts onmessage), so two concurrent
@@ -36,7 +36,10 @@ export async function snapshot(params: Record<string, unknown>): Promise<Record<
   };
   const result = await (axQueue = axQueue.catch(() => {}).then(run)) as { nodes: AXNode[] };
   const rendered = compactAX(result.nodes, surface.epoch);
-  await setRefs(rendered.refs);
+  // Refs are stored under THIS surface's token: with several tabs driven in
+  // parallel, a global ref map would let one tab's snapshot silently repoint
+  // another tab's click targets.
+  await setRefs(surfaceToken(surface), rendered.refs);
   const tab = await chrome.tabs.get(surface.tabId);
   return { snapshot: rendered.snapshot, url: tab.url ?? "", title: tab.title ?? "" };
 }

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_PORT, getLocal, getSession } from "../state";
+import { DEFAULT_PORT, getLocal, getSession, getSurfaces } from "../state";
 import { pairVerdict, viewForHealth } from "./pair-flow";
 import {
   ackForDecision,
@@ -159,8 +159,13 @@ async function render(): Promise<void> {
     const detail = document.getElementById("connected-detail");
     if (detail && label) {
       const url = health.current_url;
+      // Parallel sessions can each drive their own tab now; the card stays a
+      // one-line status (no list, no redesign), so with several surfaces the
+      // label carries the count and the trough the most recently driven URL.
+      const surfaceCount = Object.keys(await getSurfaces()).length;
       if (url) {
-        label.textContent = health.current_title || "Driving";
+        label.textContent =
+          surfaceCount > 1 ? `Driving ${surfaceCount} tabs` : health.current_title || "Driving";
         detail.textContent = url;
         label.classList.remove("hidden");
       } else {

--- a/extension/src/protocol.gen.ts
+++ b/extension/src/protocol.gen.ts
@@ -16,6 +16,7 @@ export enum ErrorCode {
   ORIGIN_PROMPT_PENDING = 'origin_prompt_pending',
   DEBUGGER_CONFLICT = 'debugger_conflict',
   TAB_LIMIT = 'tab_limit',
+  TAB_AMBIGUOUS = 'tab_ambiguous',
   BUSY = 'busy',
   PROTO_MISMATCH = 'proto_mismatch',
   INTERNAL = 'internal',

--- a/extension/src/protocol.gen.ts
+++ b/extension/src/protocol.gen.ts
@@ -15,12 +15,13 @@ export enum ErrorCode {
   ORIGIN_DENIED = 'origin_denied',
   ORIGIN_PROMPT_PENDING = 'origin_prompt_pending',
   DEBUGGER_CONFLICT = 'debugger_conflict',
+  TAB_LIMIT = 'tab_limit',
   BUSY = 'busy',
   PROTO_MISMATCH = 'proto_mismatch',
   INTERNAL = 'internal',
 }
 
-export type Method = 'open' | 'goto' | 'read' | 'snapshot' | 'screenshot' | 'click' | 'type' | 'close' | 'status' | 'scroll' | 'logs';
+export type Method = 'open' | 'goto' | 'read' | 'snapshot' | 'screenshot' | 'click' | 'type' | 'close' | 'status' | 'tabs' | 'scroll' | 'logs';
 // One buffered console/runtime log line, as `logs` returns it (newest last).
 // `level` is normalized to the error/warning/info/log vocabulary the tool
 // filters on; `source` distinguishes a page console call from an uncaught

--- a/extension/src/state.ts
+++ b/extension/src/state.ts
@@ -97,6 +97,25 @@ export function removeSurface(token: string): Promise<void> {
   });
 }
 
+/**
+ * Refresh a surface's ``lastUsedAt`` — only if it is still in the map.
+ *
+ * An unconditional put could resurrect an entry a concurrent prune (tabs /
+ * status run under a different daemon lock key) just removed, leaving a dead
+ * surface counting toward the cap until the next prune (review finding m5).
+ * The presence check runs inside the store queue, so it cannot interleave
+ * with the prune's own read-modify-write.
+ */
+export function touchSurface(token: string, at: number): Promise<void> {
+  return withStore(async () => {
+    const surfaces = await getSurfaces();
+    const surface = surfaces[token];
+    if (!surface) return;
+    surface.lastUsedAt = at;
+    await chrome.storage.session.set({ surfaces });
+  });
+}
+
 export function setRefs(token: string, forSurface: Record<string, SnapshotRef>): Promise<void> {
   return withStore(async () => {
     const { refs = {} } = (await chrome.storage.session.get(["refs"])) as SessionState;
@@ -112,6 +131,37 @@ export async function getRefs(token: string): Promise<Record<string, SnapshotRef
 
 export function surfaceToken(surface: StoredSurface): string {
   return `bridge:${surface.tabId}:${surface.nonce}`;
+}
+
+// How many nonce characters a redacted handle shows. Enough to prefix-match a
+// session's own full token against a listing entry, far too few to reconstruct
+// the 32-hex-char nonce (26 chars of entropy stay hidden).
+const REDACTED_NONCE_CHARS = 6;
+
+/**
+ * A display-safe form of a surface handle: `bridge:<tabId>:<nonce[0..6]>…`.
+ *
+ * Every surface that leaves the extension OTHER than the caller's own `open`
+ * response uses this — the `tabs` listing, the tab_limit refusal, the
+ * ambiguous-close refusal, the no-handle `status`. The full token IS the
+ * drive capability (review finding M1): listing it would hand every session
+ * control of every tab and make the "listing does not grant control" claim
+ * false. The redacted prefix still lets a caller recognise its OWN tab
+ * (prefix-match against the full token it received at open) without being
+ * able to drive anyone else's.
+ */
+export function redactToken(token: string): string {
+  const parsed = parseSurface(token);
+  if (!parsed) return token;
+  return `bridge:${parsed.tabId}:${parsed.nonce.slice(0, REDACTED_NONCE_CHARS)}…`;
+}
+
+/** Whether ``fullToken`` (a caller's own handle) names the surface a redacted
+ * listing entry describes. The trailing ellipsis marks redaction; matching is
+ * a plain prefix test on the un-ellipsised part. */
+export function ownsRedacted(fullToken: string, redacted: string): boolean {
+  if (!redacted.endsWith("…")) return fullToken === redacted;
+  return fullToken.startsWith(redacted.slice(0, -1));
 }
 
 export function parseSurface(token: unknown): { tabId: number; nonce: string } | undefined {

--- a/extension/src/state.ts
+++ b/extension/src/state.ts
@@ -1,9 +1,23 @@
 export const DEFAULT_PORT = 4099;
 
+// Hard ceiling on concurrently-driven tabs. Parallel sessions each open their
+// own surface now, and nothing else bounds how many an agent fleet can spray
+// into the user's real browser — each one costs a debugger banner, a log
+// buffer and the user's attention to close by hand if a session dies without
+// cleanup. Eight comfortably covers a parallel batch while keeping the worst
+// case something a human can recover from in seconds. The refusal is a typed
+// tab_limit error telling the agent to close one, not a silent reuse.
+export const MAX_SURFACES = 8;
+
 export interface StoredSurface {
   tabId: number;
   nonce: string;
   epoch: number;
+  // For the `tabs` listing: when the surface was created and last driven. The
+  // live URL/title are deliberately NOT stored — they are fetched from
+  // chrome.tabs at list time so the listing can never show a stale page.
+  createdAt: number;
+  lastUsedAt: number;
 }
 
 export interface SnapshotRef {
@@ -24,8 +38,14 @@ export interface LocalState {
 }
 
 export interface SessionState {
-  surface?: StoredSurface;
-  refs?: Record<string, SnapshotRef>;
+  // Keyed by surface token (bridge:<tabId>:<nonce>) so each parallel session's
+  // tab has its own nonce/epoch and one session cannot address another's tab
+  // without knowing its nonce. Replaces the old single `surface` slot, whose
+  // open-time reuse let a second session silently steal the first's tab.
+  surfaces?: Record<string, StoredSurface>;
+  // Snapshot refs are per-surface for the same reason: one tab's snapshot must
+  // not overwrite another's click targets mid-interaction.
+  refs?: Record<string, Record<string, SnapshotRef>>;
   pendingOrigin?: PendingOrigin;
 }
 
@@ -34,25 +54,89 @@ export async function getLocal(): Promise<LocalState> {
 }
 
 export async function getSession(): Promise<SessionState> {
-  return chrome.storage.session.get(["surface", "refs", "pendingOrigin"]);
+  return chrome.storage.session.get(["surfaces", "refs", "pendingOrigin"]);
 }
 
-export async function setSurface(surface?: StoredSurface): Promise<void> {
-  if (surface) await chrome.storage.session.set({ surface });
-  else await chrome.storage.session.remove(["surface", "refs"]);
+export async function getSurfaces(): Promise<Record<string, StoredSurface>> {
+  const { surfaces = {} } = (await chrome.storage.session.get(["surfaces"])) as SessionState;
+  return surfaces;
 }
 
-export async function setRefs(refs: Record<string, SnapshotRef>): Promise<void> {
-  await chrome.storage.session.set({ refs });
+// Serializes read-modify-write mutations of the surfaces/refs maps. The daemon
+// serializes commands per TAB, so two different tabs' commands run truly
+// concurrently in this worker — two interleaved map writes would lose one
+// tab's update (the same lost-update shape the old single-surface model never
+// had to face). Same promise-chain pattern as snapshot's axQueue: mutations
+// are rare and tiny, and each link swallows its predecessor's failure so the
+// chain cannot poison later calls.
+let storeQueue: Promise<unknown> = Promise.resolve();
+function withStore<T>(op: () => Promise<T>): Promise<T> {
+  const run = storeQueue.catch(() => {}).then(op);
+  storeQueue = run;
+  return run;
+}
+
+export function putSurface(surface: StoredSurface): Promise<void> {
+  return withStore(async () => {
+    const surfaces = await getSurfaces();
+    surfaces[surfaceToken(surface)] = surface;
+    await chrome.storage.session.set({ surfaces });
+  });
+}
+
+/** Remove one surface and its snapshot refs; other surfaces are untouched. */
+export function removeSurface(token: string): Promise<void> {
+  return withStore(async () => {
+    const { surfaces = {}, refs = {} } = (await chrome.storage.session.get([
+      "surfaces",
+      "refs",
+    ])) as SessionState;
+    delete surfaces[token];
+    delete refs[token];
+    await chrome.storage.session.set({ surfaces, refs });
+  });
+}
+
+export function setRefs(token: string, forSurface: Record<string, SnapshotRef>): Promise<void> {
+  return withStore(async () => {
+    const { refs = {} } = (await chrome.storage.session.get(["refs"])) as SessionState;
+    refs[token] = forSurface;
+    await chrome.storage.session.set({ refs });
+  });
+}
+
+export async function getRefs(token: string): Promise<Record<string, SnapshotRef>> {
+  const { refs = {} } = (await chrome.storage.session.get(["refs"])) as SessionState;
+  return refs[token] ?? {};
 }
 
 export function surfaceToken(surface: StoredSurface): string {
   return `bridge:${surface.tabId}:${surface.nonce}`;
 }
 
-export function parseSurface(token: unknown): StoredSurface | undefined {
+export function parseSurface(token: unknown): { tabId: number; nonce: string } | undefined {
   if (typeof token !== "string") return undefined;
   const match = /^bridge:(\d+):([a-z0-9_-]+)$/i.exec(token);
   if (!match?.[1] || !match[2]) return undefined;
-  return { tabId: Number(match[1]), nonce: match[2], epoch: 0 };
+  return { tabId: Number(match[1]), nonce: match[2] };
+}
+
+/**
+ * Resolve a caller-supplied handle against the surfaces map.
+ *
+ * The map is keyed by the FULL token, nonce included, so this is an exact
+ * lookup: a caller that knows only a tab id (or guesses a nonce) simply
+ * misses, which is the whole anti-guessing property the nonce exists for —
+ * unchanged from the single-surface model, now enforced per surface.
+ */
+export function resolveSurfaceToken(
+  token: unknown,
+  surfaces: Record<string, StoredSurface>,
+): StoredSurface | undefined {
+  if (!parseSurface(token)) return undefined;
+  return surfaces[token as string];
+}
+
+export function atSurfaceCap(surfaces: Record<string, StoredSurface>): boolean {
+  return Object.keys(surfaces).length >= MAX_SURFACES;
 }

--- a/extension/src/worker.ts
+++ b/extension/src/worker.ts
@@ -1,4 +1,4 @@
-import { close, goto, open, status } from "./commands/nav";
+import { close, goto, open, status, tabs } from "./commands/nav";
 import { click, typeText } from "./commands/input";
 import { readPage } from "./commands/read";
 import { screenshot } from "./commands/shot";
@@ -26,6 +26,7 @@ const HANDLERS: Record<
   type: typeText,
   close,
   status,
+  tabs,
   scroll,
   logs,
 };

--- a/extension/tests/pure.test.mjs
+++ b/extension/tests/pure.test.mjs
@@ -189,3 +189,27 @@ test("origin render holds the ack through the decision round-trip race", async (
     assert.equal(originPromptView("https://example.com", null), "prompt");
   } finally { await module.close(); }
 });
+
+test("surface tokens resolve only with an exact nonce-bearing handle", async () => {
+  const module = await load("src/state.ts");
+  try {
+    const { surfaceToken, parseSurface, resolveSurfaceToken, atSurfaceCap, MAX_SURFACES } = module.loaded;
+    const surface = { tabId: 42, nonce: "abc123", epoch: 3, createdAt: 1, lastUsedAt: 2 };
+    const token = surfaceToken(surface);
+    assert.equal(token, "bridge:42:abc123");
+    assert.deepEqual(parseSurface(token), { tabId: 42, nonce: "abc123" });
+    const surfaces = { [token]: surface };
+    // Exact token resolves; a guessed nonce or the bare tab id does not — the
+    // nonce is the anti-guessing property that keeps parallel sessions from
+    // driving each other's tabs.
+    assert.equal(resolveSurfaceToken(token, surfaces), surface);
+    assert.equal(resolveSurfaceToken("bridge:42:guessed", surfaces), undefined);
+    assert.equal(resolveSurfaceToken("bridge:42", surfaces), undefined);
+    assert.equal(resolveSurfaceToken(42, surfaces), undefined);
+    // Cap math: at MAX_SURFACES entries a fresh open must be refused.
+    const many = {};
+    for (let i = 0; i < MAX_SURFACES; i += 1) many[`bridge:${i}:n${i}`] = { ...surface, tabId: i };
+    assert.equal(atSurfaceCap(surfaces), false);
+    assert.equal(atSurfaceCap(many), true);
+  } finally { await module.close(); }
+});

--- a/extension/tests/pure.test.mjs
+++ b/extension/tests/pure.test.mjs
@@ -213,3 +213,24 @@ test("surface tokens resolve only with an exact nonce-bearing handle", async () 
     assert.equal(atSurfaceCap(many), true);
   } finally { await module.close(); }
 });
+
+test("redacted handles are recognizable by their owner but not driveable", async () => {
+  const module = await load("src/state.ts");
+  try {
+    const { surfaceToken, redactToken, ownsRedacted, resolveSurfaceToken } = module.loaded;
+    const surface = { tabId: 42, nonce: "abcdef0123456789abcdef0123456789", epoch: 1, createdAt: 1, lastUsedAt: 2 };
+    const token = surfaceToken(surface);
+    const redacted = redactToken(token);
+    // Truncated to a 6-char prefix + ellipsis: enough to prefix-match, far
+    // too little to reconstruct the 32-char nonce (finding M1).
+    assert.equal(redacted, "bridge:42:abcdef…");
+    // The owner (holding the full token) recognises the listing entry...
+    assert.equal(ownsRedacted(token, redacted), true);
+    // ...another session's token does not...
+    assert.equal(ownsRedacted("bridge:42:ffffff0123456789abcdef0123456789", redacted), false);
+    // ...and the redacted form itself resolves NOTHING: it is not a handle.
+    assert.equal(resolveSurfaceToken(redacted, { [token]: surface }), undefined);
+    // Unredacted comparison still exact-matches (defensive path).
+    assert.equal(ownsRedacted(token, token), true);
+  } finally { await module.close(); }
+});

--- a/local_operator/browser_bridge/backend.py
+++ b/local_operator/browser_bridge/backend.py
@@ -100,8 +100,17 @@ def format_error(error: BridgeError, *, action: str = "", surface: str = "") -> 
         return "the extension is waiting for the user to approve this site in its popup."
     if error.code == ErrorCode.TAB_LIMIT:
         # The extension's message already names the cap and the remedy; append
-        # the discovery verb so the agent knows how to find a tab to close.
-        return f"{error.message}. Use 'tabs' to list the open tabs and their handles."
+        # the discovery verb. A session that owns none of the capped tabs
+        # cannot close one (handles in the listing are redacted, deliberately);
+        # its remedy is asking the other sessions — or the user — to close.
+        return (
+            f"{error.message}. Use 'tabs' to see what is open; if none is yours, "
+            "another session (or the user) must close one."
+        )
+    if error.code == ErrorCode.TAB_AMBIGUOUS:
+        # Under-specified close, not a fault: relay the extension's message,
+        # which already names the (redacted) live handles.
+        return error.message
     if error.code == ErrorCode.INTERNAL and error.data.get("tab_crashed"):
         return (
             f"the browser tab crashed while {action or 'the action'} was running. "

--- a/local_operator/browser_bridge/backend.py
+++ b/local_operator/browser_bridge/backend.py
@@ -98,6 +98,10 @@ def format_error(error: BridgeError, *, action: str = "", surface: str = "") -> 
         )
     if error.code == ErrorCode.ORIGIN_PROMPT_PENDING:
         return "the extension is waiting for the user to approve this site in its popup."
+    if error.code == ErrorCode.TAB_LIMIT:
+        # The extension's message already names the cap and the remedy; append
+        # the discovery verb so the agent knows how to find a tab to close.
+        return f"{error.message}. Use 'tabs' to list the open tabs and their handles."
     if error.code == ErrorCode.INTERNAL and error.data.get("tab_crashed"):
         return (
             f"the browser tab crashed while {action or 'the action'} was running. "

--- a/local_operator/browser_bridge/daemon.py
+++ b/local_operator/browser_bridge/daemon.py
@@ -487,9 +487,11 @@ class BridgeService:
         if request.id in self.link.pending:
             return self._error_response(request.id, ErrorCode.BUSY, "request id already in flight")
         # Serialize per tab so concurrent sessions cannot interleave commands on
-        # the one shared surface (finding A4). Commands that name no tab (open,
-        # status) serialize on a shared key so a second open cannot race the
-        # first into a duplicate surface.
+        # the same surface (finding A4); commands on DIFFERENT tabs run in
+        # parallel, which is what lets each session drive its own surface.
+        # Commands that name no tab (open, status, tabs) serialize on a shared
+        # key so a fresh open cannot race another open past the surface cap, and
+        # a listing cannot interleave with an open's map write.
         tab_key = str(request.params.get("tab") or "__global__")
         lock = self._tab_locks.setdefault(tab_key, asyncio.Lock())
         async with lock:

--- a/local_operator/browser_bridge/daemon.py
+++ b/local_operator/browser_bridge/daemon.py
@@ -495,7 +495,15 @@ class BridgeService:
         tab_key = str(request.params.get("tab") or "__global__")
         lock = self._tab_locks.setdefault(tab_key, asyncio.Lock())
         async with lock:
-            return await self._dispatch_locked(request)
+            response = await self._dispatch_locked(request)
+        # Per-tab keys used to be near-singleton; with every opened tab minting
+        # a token the map would now grow for the daemon's lifetime. Evict the
+        # key once its tab is closed and nothing is waiting on the lock —
+        # unlocked-and-unwaited means a later command for the same (now dead)
+        # handle can safely mint a fresh Lock.
+        if request.method == "close" and tab_key != "__global__" and not lock.locked():
+            self._tab_locks.pop(tab_key, None)
+        return response
 
     async def _dispatch_locked(self, request: Request) -> JSONResponse:
         future: asyncio.Future[Response] = asyncio.get_running_loop().create_future()

--- a/local_operator/browser_bridge/protocol.py
+++ b/local_operator/browser_bridge/protocol.py
@@ -32,6 +32,12 @@ METHODS = (
     "type",
     "close",
     "status",
+    # tabs lists every live extension-owned surface. It exists because parallel
+    # sessions now each open their OWN tab (open no longer reuses another
+    # session's surface), so agents need read-only discovery of what is being
+    # driven; control of a listed tab still requires its exact nonce-bearing
+    # handle. Bridge-only, like scroll/logs: cmux has no multi-surface registry.
+    "tabs",
     "scroll",
     "logs",
 )
@@ -68,6 +74,11 @@ COMMAND_TIMEOUTS = {
     "screenshot": 20.0,
     "close": 20.0,
     "status": 20.0,
+    # tabs, like status, names no tab and does no navigation: it enumerates the
+    # extension's surface map and prunes dead entries, a handful of chrome.tabs
+    # calls. It rides the same global lock key (no ``tab`` param) so a listing
+    # cannot interleave with an in-flight open's map write.
+    "tabs": 20.0,
     # scroll waits briefly for the wheel/scrollIntoView to settle and re-reads
     # position; logs just drains a per-tab ring buffer already in memory.
     "scroll": 20.0,
@@ -95,6 +106,11 @@ class ErrorCode(StrEnum):
     ORIGIN_DENIED = "origin_denied"
     ORIGIN_PROMPT_PENDING = "origin_prompt_pending"
     DEBUGGER_CONFLICT = "debugger_conflict"
+    # The extension refuses to open more concurrent tabs than its cap (see
+    # MAX_SURFACES in extension/src/state.ts): parallel sessions each own a
+    # tab now, and without a bound an agent fleet could spray tabs into the
+    # user's real browser. Typed so the tool can tell the agent to close one.
+    TAB_LIMIT = "tab_limit"
     BUSY = "busy"
     PROTO_MISMATCH = "proto_mismatch"
     INTERNAL = "internal"

--- a/local_operator/browser_bridge/protocol.py
+++ b/local_operator/browser_bridge/protocol.py
@@ -35,8 +35,10 @@ METHODS = (
     # tabs lists every live extension-owned surface. It exists because parallel
     # sessions now each open their OWN tab (open no longer reuses another
     # session's surface), so agents need read-only discovery of what is being
-    # driven; control of a listed tab still requires its exact nonce-bearing
-    # handle. Bridge-only, like scroll/logs: cmux has no multi-surface registry.
+    # driven. Listed handles are REDACTED (nonce truncated): the full token is
+    # the drive capability, granted only by the surface's own `open` response,
+    # so the listing is genuinely awareness-only. Bridge-only, like
+    # scroll/logs: cmux has no multi-surface registry.
     "tabs",
     "scroll",
     "logs",
@@ -111,6 +113,11 @@ class ErrorCode(StrEnum):
     # tab now, and without a bound an agent fleet could spray tabs into the
     # user's real browser. Typed so the tool can tell the agent to close one.
     TAB_LIMIT = "tab_limit"
+    # A bare `close` while several tabs are open: the request is
+    # under-specified, not a bridge fault, so it must not render as an
+    # "internal" bridge error (review finding n1). The message carries the
+    # REDACTED live handles so the caller can pick its own.
+    TAB_AMBIGUOUS = "tab_ambiguous"
     BUSY = "busy"
     PROTO_MISMATCH = "proto_mismatch"
     INTERNAL = "internal"

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -5588,11 +5588,16 @@ async def _bridge_call(
     try:
         return await BridgeClient().call(action, params), None
     except BridgeError as exc:
-        return None, _error(
+        problem = _error(
             tool_call_id,
             "browser",
             format_error(exc, action=action, surface=surface),
         )
+        # Carry the TYPED wire code so callers can branch on it (dead-pin
+        # recovery, handle-drop) instead of substring-matching the human
+        # diagnostic, which broke silently on any rewording (finding m4).
+        problem.details = {"error_code": exc.code.value}
+        return None, problem
     except BridgeUnreachable as exc:
         return None, _error(tool_call_id, "browser", str(exc))
 
@@ -5612,7 +5617,11 @@ async def _bridge_open(
     if resuming:
         params["tab"] = state.surface_id
     result, problem = await _bridge_call(tool_call_id, "open", params, surface=state.surface_id)
-    if problem is not None and resuming and "is gone" in problem.text:
+    if (
+        problem is not None
+        and resuming
+        and (problem.details or {}).get("error_code") == "tab_closed"
+    ):
         # The pinned tab died (user closed it, browser restarted). 'open' is
         # the recovery verb — same contract as the cmux path — so drop the
         # dead handle and create a fresh tab instead of surfacing the error.
@@ -5691,23 +5700,37 @@ def _bridge_logs_result(
     )
 
 
+def _owns_redacted_tab(own_surface: str, redacted: str) -> bool:
+    """Whether the session's full pinned handle names a REDACTED listing entry.
+
+    The extension truncates listed nonces (`bridge:<tabId>:<prefix>…`) so a
+    listing cannot hand out drive capabilities (review finding M1); a session
+    recognises its own tab by prefix-matching the full token it was given at
+    open. Mirrors ownsRedacted in extension/src/state.ts.
+    """
+    if not own_surface or not redacted:
+        return False
+    if redacted.endswith("…"):
+        return own_surface.startswith(redacted[:-1])
+    return own_surface == redacted
+
+
 def _format_bridge_tab(entry: dict[str, Any], own_surface: str) -> str:
-    """One listed tab: handle, page, recency — with the caller's own marked.
+    """One listed tab: redacted handle, page, recency — the caller's own marked.
 
     The "(yours)" marker matters because the listing shows EVERY session's
     tabs: an agent must close its own when done, and must treat the rest as
-    read-only awareness rather than handles to adopt.
+    read-only awareness. The handles are redacted by the extension and are NOT
+    driveable — driving needs the full token 'open' returned to its owner.
     """
     token = str(entry.get("tab", ""))
     title = str(entry.get("title", "")).strip() or "(untitled)"
     url = str(entry.get("url", "")).strip() or "(no URL)"
-    mine = " (yours)" if token and token == own_surface else ""
+    mine = " (yours)" if _owns_redacted_tab(own_surface, token) else ""
     when = ""
     last_used = entry.get("lastUsedAt")
     if isinstance(last_used, (int, float)) and last_used > 0:
-        from datetime import datetime, timezone
-
-        stamp = datetime.fromtimestamp(last_used / 1000, tz=timezone.utc)
+        stamp = datetime.fromtimestamp(last_used / 1000, tz=UTC)
         when = f" — last used {stamp.strftime('%H:%M:%S')} UTC"
     return f"{token}{mine}: {title} — {url}{when}"
 
@@ -5737,8 +5760,10 @@ async def _bridge_tabs(tool_call_id: str, state: BrowserSurfaceProtocol) -> Tool
         tool_call_id,
         "browser",
         f"{len(entries)} extension-driven tab{'s' if len(entries) != 1 else ''} "
-        "(most recently used first; tabs without '(yours)' belong to other "
-        "sessions — do not drive or close them):\n\n" + "\n".join(lines),
+        "(most recently used first; handles are redacted — the listing is "
+        "awareness-only and cannot drive or close a tab. Your own tab is "
+        "marked '(yours)'; drive it with the handle your session already "
+        "holds):\n\n" + "\n".join(lines),
         details={"tab_count": len(entries), "surface_id": state.surface_id},
     )
 
@@ -5781,7 +5806,8 @@ async def _bridge_action(
     if problem is not None:
         # A nonce-invalid or user-closed tab must be forgotten immediately;
         # retaining it would make even the recovery verb target stale state.
-        if "is gone; dropped the handle" in problem.text:
+        # Branch on the typed code, not the diagnostic's wording (finding m4).
+        if (problem.details or {}).get("error_code") == "tab_closed":
             state.surface_id = ""
         return problem
     assert result is not None
@@ -6254,7 +6280,8 @@ def build_browser_tool(context: ToolContext | None) -> AgentTool | None:
             "sessions each drive their own tab: a fresh 'open' creates a NEW "
             "extension tab pinned to this session (later opens navigate it), "
             "'tabs' lists every extension-driven tab including other sessions' "
-            "(read-only awareness — never drive or close those), and 'close' "
+            "(handles are redacted: the listing is awareness-only and cannot "
+            "drive or close anything), and 'close' "
             "ends your own tab when you are done with it. 'scroll', 'logs' and "
             "'tabs' need the extension backend (cmux says so). Use it for every "
             "screenshot and page interaction; never install or script a browser "

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -4661,6 +4661,11 @@ BROWSER_ACTIONS = (
     # approval tier and dispatch as everything else.
     "scroll",
     "logs",
+    # tabs lists every live extension-owned tab (all sessions', read-only
+    # awareness) so parallel agents can see what is being driven and know which
+    # handle to close. Bridge-only like scroll/logs: cmux keeps no multi-surface
+    # registry, so it degrades with the same typed "use the extension" error.
+    "tabs",
 )
 
 #: Actions that only the Local Operator browser extension can serve. cmux has no
@@ -4668,7 +4673,7 @@ BROWSER_ACTIONS = (
 #: partial result these degrade with a clear, actionable error naming the
 #: extension. Kept as a set beside BROWSER_ACTIONS so the degrade check and the
 #: advertised action list can never drift apart.
-BRIDGE_ONLY_BROWSER_ACTIONS = frozenset({"scroll", "logs"})
+BRIDGE_ONLY_BROWSER_ACTIONS = frozenset({"scroll", "logs", "tabs"})
 
 #: Direction keywords ``scroll`` accepts. Mirrors extension/src/commands/scroll.ts
 #: DIRECTIONS; validated here so a bad keyword is refused before it reaches the
@@ -4754,9 +4759,12 @@ class BrowserParams(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     action: str = Field(
-        description="open (start a surface at a URL) | goto | read (page text) | "
-        "snapshot (accessibility tree with click refs) | screenshot | click | "
-        "type | scroll (move the viewport) | logs (console + errors) | close."
+        description="open (start a surface at a URL; on the extension backend a "
+        "fresh open creates a NEW tab — your session then owns it and reuses it) "
+        "| goto | read (page text) | snapshot (accessibility tree with click "
+        "refs) | screenshot | click | type | scroll (move the viewport) | logs "
+        "(console + errors) | tabs (list all extension-driven tabs, other "
+        "sessions' included) | close (end YOUR tab when done with it)."
     )
     url: str = Field(default="", description="http(s) URL for 'open'/'goto'.")
     path: str = Field(default="", description="Destination file for 'screenshot'.")
@@ -5594,10 +5602,22 @@ async def _bridge_open(
     state: BrowserSurfaceProtocol,
     raw_url: str,
 ) -> ToolResult:
+    # The session's pinned handle decides the mode. With one, `open` RESUMES
+    # that tab (extension-side it navigates exactly that surface); without one
+    # the extension creates a brand-new tab. The extension never falls back to
+    # reusing some other live surface — that reuse is how one session used to
+    # hijack another's tab mid-task when agents ran in parallel.
     params: dict[str, Any] = {"url": raw_url.strip()}
-    if state.surface_id.startswith("bridge:"):
+    resuming = state.surface_id.startswith("bridge:")
+    if resuming:
         params["tab"] = state.surface_id
     result, problem = await _bridge_call(tool_call_id, "open", params, surface=state.surface_id)
+    if problem is not None and resuming and "is gone" in problem.text:
+        # The pinned tab died (user closed it, browser restarted). 'open' is
+        # the recovery verb — same contract as the cmux path — so drop the
+        # dead handle and create a fresh tab instead of surfacing the error.
+        state.surface_id = ""
+        result, problem = await _bridge_call(tool_call_id, "open", {"url": raw_url.strip()})
     if problem is not None:
         return problem
     assert result is not None
@@ -5668,6 +5688,58 @@ def _bridge_logs_result(
         "browser",
         f"{len(lines)} log entr{'y' if len(lines) == 1 else 'ies'} " f"(newest last):\n\n{body}",
         details={**details, "log_count": len(lines)},
+    )
+
+
+def _format_bridge_tab(entry: dict[str, Any], own_surface: str) -> str:
+    """One listed tab: handle, page, recency — with the caller's own marked.
+
+    The "(yours)" marker matters because the listing shows EVERY session's
+    tabs: an agent must close its own when done, and must treat the rest as
+    read-only awareness rather than handles to adopt.
+    """
+    token = str(entry.get("tab", ""))
+    title = str(entry.get("title", "")).strip() or "(untitled)"
+    url = str(entry.get("url", "")).strip() or "(no URL)"
+    mine = " (yours)" if token and token == own_surface else ""
+    when = ""
+    last_used = entry.get("lastUsedAt")
+    if isinstance(last_used, (int, float)) and last_used > 0:
+        from datetime import datetime, timezone
+
+        stamp = datetime.fromtimestamp(last_used / 1000, tz=timezone.utc)
+        when = f" — last used {stamp.strftime('%H:%M:%S')} UTC"
+    return f"{token}{mine}: {title} — {url}{when}"
+
+
+async def _bridge_tabs(tool_call_id: str, state: BrowserSurfaceProtocol) -> ToolResult:
+    """List every live extension-driven tab (all sessions').
+
+    Discovery deliberately needs no open surface of our own: its main use is a
+    session deciding whether to resume, or being told the surface cap is hit
+    and needing to see what is already open. The extension prunes dead tabs as
+    part of answering, so the list is live by construction.
+    """
+    result, problem = await _bridge_call(tool_call_id, "tabs", {}, surface=state.surface_id)
+    if problem is not None:
+        return problem
+    assert result is not None
+    entries = [entry for entry in result.get("tabs") or [] if isinstance(entry, dict)]
+    if not entries:
+        return _text(
+            tool_call_id,
+            "browser",
+            "No extension-driven browser tabs are open. Use 'open' with a URL to start one.",
+            details={"tab_count": 0},
+        )
+    lines = [_format_bridge_tab(entry, state.surface_id) for entry in entries]
+    return _text(
+        tool_call_id,
+        "browser",
+        f"{len(entries)} extension-driven tab{'s' if len(entries) != 1 else ''} "
+        "(most recently used first; tabs without '(yours)' belong to other "
+        "sessions — do not drive or close them):\n\n" + "\n".join(lines),
+        details={"tab_count": len(entries), "surface_id": state.surface_id},
     )
 
 
@@ -5932,6 +6004,20 @@ async def execute_browser(
         return await _browser_open(tool_call_id, state, params.url)
     if action == "close":
         return await _browser_close(tool_call_id, state)
+    if action == "tabs":
+        # Discovery works without an owned surface (its point is finding out
+        # what is open), but it is extension-only: cmux keeps no multi-surface
+        # registry, so a cmux-pinned session degrades exactly like scroll/logs.
+        if state.surface_id.startswith("surface:") or not bridge_available:
+            return _error(
+                tool_call_id,
+                "browser",
+                "'tabs' is not supported on the cmux backend — use the Local Operator "
+                "browser extension (run 'lop browser status' / 'lop browser install' to "
+                "set it up). cmux has no multi-tab surface registry, so this action only "
+                "works through the extension bridge.",
+            )
+        return await _bridge_tabs(tool_call_id, state)
     if not state.surface_id:
         return _error(tool_call_id, "browser", "no browser surface open — use 'open' first")
     if state.surface_id.startswith("bridge:"):
@@ -6164,8 +6250,13 @@ def build_browser_tool(context: ToolContext | None) -> AgentTool | None:
             "cannot. 'scroll' pages the view (default one screen down, or by "
             "x/y pixels, a direction keyword, or a selector to reveal) and reports "
             "whether more content remains; 'logs' returns the page's console "
-            "output and uncaught exceptions for debugging web apps. 'scroll' and "
-            "'logs' need the extension backend (cmux says so). Use it for every "
+            "output and uncaught exceptions for debugging web apps. Parallel "
+            "sessions each drive their own tab: a fresh 'open' creates a NEW "
+            "extension tab pinned to this session (later opens navigate it), "
+            "'tabs' lists every extension-driven tab including other sessions' "
+            "(read-only awareness — never drive or close those), and 'close' "
+            "ends your own tab when you are done with it. 'scroll', 'logs' and "
+            "'tabs' need the extension backend (cmux says so). Use it for every "
             "screenshot and page interaction; never install or script a browser "
             "engine instead."
         ),

--- a/tests/unit/browser_bridge/test_protocol.py
+++ b/tests/unit/browser_bridge/test_protocol.py
@@ -44,6 +44,26 @@ def test_scroll_and_logs_requests_round_trip() -> None:
     assert Request.model_validate_json(logs.model_dump_json()) == logs
 
 
+def test_tabs_is_a_protocol_method_with_a_daemon_timeout() -> None:
+    # `tabs` is the multi-surface discovery verb: parallel sessions each own a
+    # tab now, so agents need to list what is being driven. A METHODS entry
+    # without a daemon timeout would pass the allowlist and then die as
+    # "unknown method", so the two tables are pinned together here.
+    from local_operator.browser_bridge.daemon import COMMAND_TIMEOUTS
+
+    assert "tabs" in METHODS
+    assert "tabs" in COMMAND_TIMEOUTS
+    # Every advertised method must have a timeout, and vice versa — the ONE
+    # source of truth contract METHODS documents.
+    assert set(METHODS) == set(COMMAND_TIMEOUTS)
+
+
+def test_tab_limit_is_a_typed_error() -> None:
+    # The surface cap refusal must arrive as a typed code the tool can map to
+    # "close one first", not a generic internal error.
+    assert ErrorCode.TAB_LIMIT.value == "tab_limit"
+
+
 def test_generated_method_union_and_types_cover_new_methods() -> None:
     # The generated TS is the extension's only view of the method set; a method
     # added to METHODS without regenerating would let the extension ship a

--- a/tests/unit/browser_bridge/test_tool_selection.py
+++ b/tests/unit/browser_bridge/test_tool_selection.py
@@ -270,17 +270,19 @@ async def test_tabs_lists_surfaces_and_marks_own(monkeypatch) -> None:
     async def fake_call(tool_call_id, action, params, *, surface=""):
         assert action == "tabs"
         assert params == {}
+        # The extension REDACTS listed handles (finding M1): truncated nonce
+        # plus ellipsis, so the listing cannot hand out drive capabilities.
         return {
             "tabs": [
                 {
-                    "tab": "bridge:9:mine",
+                    "tab": "bridge:9:aaaaaa\u2026",
                     "url": "https://example.com/a",
                     "title": "Mine",
                     "createdAt": 1000,
                     "lastUsedAt": 2000,
                 },
                 {
-                    "tab": "bridge:12:theirs",
+                    "tab": "bridge:12:bbbbbb\u2026",
                     "url": "https://example.com/b",
                     "title": "Theirs",
                     "createdAt": 1000,
@@ -294,16 +296,29 @@ async def test_tabs_lists_surfaces_and_marks_own(monkeypatch) -> None:
     monkeypatch.setattr(builtin, "bridge_browser_available", lambda: True)
     monkeypatch.setattr(builtin, "_bridge_call", fake_call)
     surface = BrowserSurface()
-    surface.surface_id = "bridge:9:mine"
+    surface.surface_id = "bridge:9:aaaaaa0123456789aaaaaa0123456789"
     context = ToolContext(browser=surface)
     result = await builtin.execute_browser("t", {"action": "tabs"}, None, None, context)
     assert not result.is_error
-    # The caller's own tab is marked; another session's is listed but flagged
-    # as not theirs to drive.
-    assert "bridge:9:mine (yours)" in result.text
-    assert "bridge:12:theirs:" in result.text
-    assert "do not drive or close them" in result.text
+    # The caller's own tab is recognised by PREFIX-matching its full pinned
+    # token against the redacted entry; the other session's is listed as
+    # awareness only.
+    assert "bridge:9:aaaaaa\u2026 (yours)" in result.text
+    assert "bridge:12:bbbbbb\u2026:" in result.text
+    assert "awareness-only" in result.text
     assert result.details is not None and result.details["tab_count"] == 2
+
+
+def test_redacted_ownership_prefix_matching() -> None:
+    own = "bridge:9:aaaaaa0123456789aaaaaa0123456789"
+    assert builtin._owns_redacted_tab(own, "bridge:9:aaaaaa\u2026")
+    # Another session's redacted entry does not match.
+    assert not builtin._owns_redacted_tab(own, "bridge:9:bbbbbb\u2026")
+    # Same tab id alone is not ownership — the nonce prefix must agree.
+    assert not builtin._owns_redacted_tab("bridge:9:cccccc\u2026", "bridge:9:aaaaaa\u2026")
+    assert not builtin._owns_redacted_tab("", "bridge:9:aaaaaa\u2026")
+    # Defensive exact-match path for an unredacted value.
+    assert builtin._owns_redacted_tab(own, own)
 
 
 @pytest.mark.asyncio
@@ -332,9 +347,11 @@ async def test_bridge_open_recovers_from_a_dead_pinned_tab(monkeypatch) -> None:
     async def fake_call(tool_call_id, action, params, *, surface=""):
         calls.append(params)
         if "tab" in params:
-            return None, builtin._error(
-                "t", "browser", "browser tab bridge:9:dead is gone; dropped the handle."
-            )
+            # Recovery keys on the TYPED wire code carried in details, not on
+            # the diagnostic's wording (finding m4).
+            problem = builtin._error("t", "browser", "browser tab bridge:9:dead is gone.")
+            problem.details = {"error_code": "tab_closed"}
+            return None, problem
         return {"tab": "bridge:33:fresh", "url": "https://example.com/", "title": "E"}, None
 
     monkeypatch.setattr(builtin, "_bridge_call", fake_call)

--- a/tests/unit/browser_bridge/test_tool_selection.py
+++ b/tests/unit/browser_bridge/test_tool_selection.py
@@ -107,10 +107,11 @@ async def test_bridge_fallback_and_token_routing(monkeypatch) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_scroll_and_logs_are_advertised_actions() -> None:
+def test_scroll_logs_and_tabs_are_advertised_actions() -> None:
     assert "scroll" in builtin.BROWSER_ACTIONS
     assert "logs" in builtin.BROWSER_ACTIONS
-    assert builtin.BRIDGE_ONLY_BROWSER_ACTIONS == frozenset({"scroll", "logs"})
+    assert "tabs" in builtin.BROWSER_ACTIONS
+    assert builtin.BRIDGE_ONLY_BROWSER_ACTIONS == frozenset({"scroll", "logs", "tabs"})
 
 
 @pytest.mark.parametrize(
@@ -251,7 +252,95 @@ async def test_scroll_and_logs_degrade_on_cmux(monkeypatch) -> None:
     surface = BrowserSurface()
     surface.surface_id = "surface:cmux-open"
     context = ToolContext(browser=surface)
-    for action in ("scroll", "logs"):
+    for action in ("scroll", "logs", "tabs"):
         result = await builtin.execute_browser("t", {"action": action}, None, None, context)
         assert "not supported on the cmux backend" in result.text
         assert "Local Operator browser extension" in result.text
+
+
+# ---------------------------------------------------------------------------
+# tabs — multi-surface discovery. Parallel sessions each own a tab, so agents
+# need to list what is being driven, spot their own handle, and know which
+# handle to close when the surface cap refuses a fresh open.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tabs_lists_surfaces_and_marks_own(monkeypatch) -> None:
+    async def fake_call(tool_call_id, action, params, *, surface=""):
+        assert action == "tabs"
+        assert params == {}
+        return {
+            "tabs": [
+                {
+                    "tab": "bridge:9:mine",
+                    "url": "https://example.com/a",
+                    "title": "Mine",
+                    "createdAt": 1000,
+                    "lastUsedAt": 2000,
+                },
+                {
+                    "tab": "bridge:12:theirs",
+                    "url": "https://example.com/b",
+                    "title": "Theirs",
+                    "createdAt": 1000,
+                    "lastUsedAt": 1500,
+                },
+            ],
+            "limit": 8,
+        }, None
+
+    monkeypatch.setattr(builtin, "cmux_browser_available", lambda: False)
+    monkeypatch.setattr(builtin, "bridge_browser_available", lambda: True)
+    monkeypatch.setattr(builtin, "_bridge_call", fake_call)
+    surface = BrowserSurface()
+    surface.surface_id = "bridge:9:mine"
+    context = ToolContext(browser=surface)
+    result = await builtin.execute_browser("t", {"action": "tabs"}, None, None, context)
+    assert not result.is_error
+    # The caller's own tab is marked; another session's is listed but flagged
+    # as not theirs to drive.
+    assert "bridge:9:mine (yours)" in result.text
+    assert "bridge:12:theirs:" in result.text
+    assert "do not drive or close them" in result.text
+    assert result.details is not None and result.details["tab_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_tabs_works_without_an_owned_surface(monkeypatch) -> None:
+    # Discovery must not require 'open' first: its main use is deciding
+    # whether to resume an existing tab or seeing what fills the cap.
+    async def fake_call(tool_call_id, action, params, *, surface=""):
+        return {"tabs": []}, None
+
+    monkeypatch.setattr(builtin, "cmux_browser_available", lambda: False)
+    monkeypatch.setattr(builtin, "bridge_browser_available", lambda: True)
+    monkeypatch.setattr(builtin, "_bridge_call", fake_call)
+    context = ToolContext(browser=BrowserSurface())
+    result = await builtin.execute_browser("t", {"action": "tabs"}, None, None, context)
+    assert not result.is_error
+    assert "No extension-driven browser tabs" in result.text
+
+
+@pytest.mark.asyncio
+async def test_bridge_open_recovers_from_a_dead_pinned_tab(monkeypatch) -> None:
+    # 'open' is the recovery verb: when the session's pinned tab died, the
+    # resume attempt fails with tab-gone and the tool must fall back to
+    # creating a fresh tab instead of surfacing the error.
+    calls: list[dict[str, Any]] = []
+
+    async def fake_call(tool_call_id, action, params, *, surface=""):
+        calls.append(params)
+        if "tab" in params:
+            return None, builtin._error(
+                "t", "browser", "browser tab bridge:9:dead is gone; dropped the handle."
+            )
+        return {"tab": "bridge:33:fresh", "url": "https://example.com/", "title": "E"}, None
+
+    monkeypatch.setattr(builtin, "_bridge_call", fake_call)
+    surface = BrowserSurface()
+    surface.surface_id = "bridge:9:dead"
+    result = await builtin._bridge_open("t", surface, "https://example.com")
+    assert not result.is_error
+    assert surface.surface_id == "bridge:33:fresh"
+    assert len(calls) == 2 and "tab" in calls[0] and "tab" not in calls[1]


### PR DESCRIPTION
## Summary

The browser-extension bridge stored exactly ONE surface, and `open` silently reused it if its tab was alive — so a second Local Operator session's `open` **stole the first session's tab mid-task**. This PR makes the bridge multi-tab: each session's fresh `open` creates its own tab, sessions resume and close only their own tab, a new `tabs` verb lists everything being driven, and a cap stops tab-spray.

### Extension (`extension/src`)
- **state.ts** — `surfaces: Record<token, StoredSurface>` in session storage replaces the single `surface`; each surface keeps its own nonce/epoch plus `createdAt`/`lastUsedAt`. Snapshot `refs` are keyed per surface token so one tab's snapshot cannot repoint another tab's click targets. `MAX_SURFACES = 8` with a typed `tab_limit` refusal. Map mutations are serialized (the daemon locks per tab, so different tabs' commands genuinely interleave in the worker now).
- **nav.ts** — `open` with no `tab` param always creates a NEW tab (the hijack is gone); `open` with a `tab` navigates exactly that surface (explicit resume). New `tabs` handler lists live surfaces with URL/title fetched from `chrome.tabs` at call time and prunes dead entries (best-effort debugger detach). `close` with a `tab` closes that surface only; bare `close` still closes a sole surviving tab and refuses—naming the live handles—when several are open. about:blank-first attach, origin gate, and per-tab log-capture arming unchanged.
- **cdp.ts** — `requireSurface` resolves the caller's exact token against the map: nonce anti-guessing is preserved per surface, and the `tab_closed` error shape is unchanged for missing/stale handles.
- **popup.ts** — minimal change: the Connected card shows `Driving N tabs` when several surfaces exist (top-rule colour semantics untouched).

### Protocol / daemon / tool
- `protocol.py` `METHODS` += `tabs`, `ErrorCode` += `tab_limit`; `protocol.gen.ts` regenerated (diff is exactly the new method + code).
- `daemon.py` — `tabs` timeout entry (status-class, no-tab global lock key, so a listing can't interleave with an open's map write).
- `builtin.py` — `tabs` action in `BROWSER_ACTIONS` and the tool schema/description; marks the caller's own handle `(yours)` and warns other sessions' tabs are read-only awareness. `open` recovers from a dead pinned tab by creating a fresh one. `tab_limit` maps to a "close one first / use tabs" diagnostic. cmux degrades `tabs` with the same typed error pattern as scroll/logs. Description documents: open (no tab) = new tab, per-session pinning, close your own tab when done.

## Testing evidence

**Static gates** (full tree, per AGENTS.md): flake8 ✅, black ✅, isort ✅, pyright ✅ (0 errors), `gen_ts --check` ✅.

**Unit suites**: extension `pnpm typecheck` ✅, `pnpm test` 16/16 ✅ (new pure test pins exact-token resolution, nonce anti-guessing, cap math), `pnpm build` ✅. Python `tests/unit` full suite **7030 passed** (the 4 `tests/unit/server/test_server_models.py` failures reproduce on clean `origin/main` — pre-existing, unrelated). New tests pin: METHODS ⇔ COMMAND_TIMEOUTS parity, `tab_limit` typed code, `tabs` listing/own-marking, discovery without an owned surface, dead-pin recovery on `open`, cmux degradation for `tabs`.

**End-to-end** (throwaway headful Chrome 151 launched background/off-screen on a /tmp profile — `open -g` + `--window-position=-3000,-3000`, extension loaded via CDP `Extensions.loadUnpacked`; throwaway daemon on port **4599** with `LOCAL_OPERATOR_CONFIG_DIR=/tmp/lop-mtab-config`; paired over the real WS flow; RPC driven directly against `/rpc`). All 14 scenarios passed; transcript below is from the live run:

1. **Two fresh opens → two DISTINCT surfaces** (the hijack fix):
   `A → bridge:323108282:50fa79…  B → bridge:323108283:7c4de2…`
2. **Independent reads**: A returns `ALPHA-CONTENT-7431`, B returns `BETA-CONTENT-9182`, no cross-bleed.
3. **Independent goto**: navigating A leaves B's document untouched.
4. **`tabs` lists both** with live URL/title, `createdAt ≤ lastUsedAt`, `limit: 8`.
5. **Per-surface refs**: session storage shows `refs` keyed by both tokens with different epochs.
6. **Nonce anti-guessing**: correct tabId + wrong nonce → `tab_closed`.
7. **Ambiguous bare close refused**, naming both live handles.
8. **`close {tab: A}`** closes only A; `tabs` then lists just B; A's handle → `tab_closed`.
9. **Resume**: `open {tab: B, url}` navigates B — same token back, no new tab.
10. **Back-compat bare close** with exactly one tab → closes it; `tabs` → `[]`.
11. **Cap**: 8 opens succeed, the 9th → `tab_limit` "already driving 8 tabs — close one…".
12. **Prune**: killing a tab externally (user-close simulation) → `tabs` drops it.

Full JSON transcript captured at `/tmp/lop-mtab-e2e-evidence.md` during the run. The real `~/.local-operator` state, default-port daemon, and the user's own Chrome were untouched throughout.

## Deliberately not done
- No cmux-side `tabs` emulation (cmux has no multi-surface registry; it degrades with the established typed error).
- `commands/snapshot.ts` touched only for per-surface refs wiring (2 lines), to keep the in-flight `fix/snapshot-hidden-headful` rebase clean.
- Session-side `BrowserSurface` still pins ONE handle per session by design — multi-tab is across sessions, not within one.

## Review
Agent review round to follow on this PR before merge.
