### PR TITLE
fix(tui): pin subagent prompt to top, stop view tearing, let children poll background bash

### DIFF
--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -65,6 +65,17 @@ the child-shaped tool — one peer, its parent — which is how it answers a
 question the parent asked and how it reports being blocked without waiting
 for its final result. See :mod:`local_operator.harness.comms`.
 
+``jobs`` is a SECOND, CONDITIONAL exception, on a different principle. It
+observes and cancels the child's OWN background jobs — it spawns nothing
+(that is ``task``) and dies with the child's job manager — so it crosses no
+boundary the prune protects. But a child can only produce a background job
+while its ``bash`` retains ``background``, and the bash receipt tells the
+model to poll such a job with ``jobs(op='peek')``. So the invariant is: a
+child keeps ``jobs`` IFF it can still background a bash command. The prune
+below re-adds ``jobs`` exactly under that condition (:func:`_can_background`),
+which is what stops a non-delegating role or grandchild that backgrounds a
+long command from looping forever on ``Tool not found: jobs``.
+
 Approvals the child asks for carry ``ToolContext.job_id`` — the id of the job
 this child IS — so a host can scope an approval decision to the delegated
 work that provoked it. Live failure it exists for: a subagent outliving its
@@ -145,6 +156,24 @@ TRAJECTORY_CAP = 500
 #: being present. Role guidance generally lives in
 #: :mod:`local_operator.agent_profiles`.
 SCOUT_TOOL_ALLOWLIST = frozenset({"read", "glob", "grep", "list_variables", "read_variable"})
+
+
+def _can_background(tools: "list[AgentTool]") -> bool:
+    """Whether this toolset can PRODUCE a background job.
+
+    Only ``bash`` spawns background jobs, and only while its schema still
+    carries the ``background`` parameter. A toolset with no such ``bash`` (a
+    scout, an allowlist that omits it) cannot register a job, so it has
+    nothing for ``jobs`` to observe. Deriving the answer from the actual
+    schema — rather than hard-coding which roles background — is what keeps
+    the ``jobs``-retention rule below tied to reality if the bash schema or a
+    role's allowlist later changes.
+    """
+    bash = next((tool for tool in tools if tool.name == "bash"), None)
+    if bash is None:
+        return False
+    return "background" in bash.parameters.get("properties", {})
+
 
 #: Preamble stamped onto a scout prompt when no profile resolves. The tool
 #: filter enforces the letter; this states the intent, so the scout REPORTS
@@ -1153,6 +1182,26 @@ async def _build_child_session(
         drop = merged_in
     else:
         drop = {name for name in merged_in if name == "wake"}
+    # ``jobs`` is the OBSERVE/CONTROL surface over this child's OWN background
+    # jobs (peek at output, cancel) — it spawns nothing (that's ``task``) and
+    # dies with the child's job manager, so it crosses no boundary the prune
+    # protects. Meanwhile the ``bash`` tool's ``background=true`` receipt tells
+    # the model to "follow it with jobs(op='peek')". When the branch above
+    # dropped the whole ``merged_in`` set (non-delegating role, grandchild),
+    # that advice pointed at a tool that no longer existed, so a child that
+    # backgrounded a long command (a coder polling a 10-min pyright) spun
+    # forever emitting ``Tool not found: jobs``. Invariant, encoded here rather
+    # than as two edits that can silently drift: a child keeps ``jobs`` IFF it
+    # can still produce a background job (its ``bash`` retains ``background``).
+    # Un-pruning ``jobs`` (not stripping ``bash``'s ``background``) preserves a
+    # real capability — a child genuinely benefits from backgrounding a long
+    # build and polling it — while killing the loop; stripping the schema
+    # per-session would be more invasive and would remove that capability.
+    # ``task``/``wait``/``wake`` keep their treatment: ``jobs`` polling is
+    # non-blocking and is the advertised path, so sparing ``jobs`` alone is the
+    # minimal correct fix, and a child that must not fan out still cannot.
+    if _can_background(tools):
+        drop = drop - {"jobs"}
     child.refresh_tools([tool for tool in child._tools if tool.name not in drop])
     if mcp is not None:
         mcp.attach(child)

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -1230,9 +1230,18 @@ Screen.subagent-compact #band {
  * four-row panel. It cannot come from the body's `TranscriptView` padding,
  * which the class below deliberately zeroes — the hint row is BELOW the body,
  * so the row has to be the page's. */
+/* An OPAQUE ground on the scrolling page. Without a fill the container is
+ * transparent, and a transparent scrolling region lets Textual's compositor
+ * skip clearing cells on a partial repaint: a hover on an `.actionable` hint
+ * plus the 8Hz working spinner then painted new cells over stale ones and the
+ * page appeared to tear on mouse-move. The `$lo-bg` token matches the Screen's
+ * own baseline ground on purpose — subagent mode is "the same app looking
+ * elsewhere" (see `_open_subagent_view`), so the fill must read as the app's own
+ * ground and not as an elevated slab the way the surface elevation would. */
 .subagent-view {
     height: 1fr;
     padding: 1 1 1 1;
+    background: $lo-bg;
 }
 
 .subagent-view-title {

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -1362,13 +1362,34 @@ class SubagentView(Vertical):
                 if previous != current:
                     break
                 common_suffix += 1
+            # The pinned delegation prompt (see `_merge_body`) is a STABLE
+            # PREFIX: it sits at index 0 in both the old and new body and is not
+            # part of the paged history. Older rows page in AFTER it, so the
+            # freshly-prepended set is the slice BETWEEN that prefix and the
+            # common suffix. Counting from index 0 instead (the old accounting)
+            # folded the prompt into the "new rows" set and remounted it a
+            # second time, because the prompt is no longer a pure front to
+            # prepend against once history rows exist below it.
+            common_prefix = 0
+            for previous, current in zip(self._entries, entries):
+                if previous != current:
+                    break
+                common_prefix += 1
             count = len(entries) - common_suffix
-            if count > 0:
-                new_entries = entries[:count]
+            # Clamp the prefix inside the newly-prepended window: an entry can
+            # be both leading-stable and trailing-stable only when nothing
+            # changed, which `count > common_prefix` already excludes.
+            common_prefix = min(common_prefix, count)
+            if count > common_prefix and common_prefix < len(self._blocks):
+                new_entries = entries[common_prefix:count]
                 new_blocks = [entry_block(entry) for entry in new_entries]
-                self._body.prepend_blocks(new_blocks, anchor_offset=anchor)
-                self._blocks[0:0] = new_blocks
-                self._entries[0:0] = new_entries
+                # Mount ahead of the current first post-prefix block (the first
+                # durable-history row) so the prompt above it stays put and the
+                # reader's anchor, further down, is untouched.
+                before_block = self._blocks[common_prefix]
+                self._body.prepend_blocks(new_blocks, anchor_offset=anchor, before=before_block)
+                self._blocks[common_prefix:common_prefix] = new_blocks
+                self._entries[common_prefix:common_prefix] = new_entries
                 self._pending = entries
                 return
         self._pending = entries

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -1166,9 +1166,7 @@ class SubagentView(Vertical):
                 self._known[entry.key] = entry
             elif _supersedes(entry, known):
                 self._known[entry.key] = entry
-        live = [self._known[key] for key in self._order]
-        durable_keys = {entry.key for entry in self._history_entries}
-        body = [*self._history_entries, *(entry for entry in live if entry.key not in durable_keys)]
+        body = self._merge_body()
 
         tail = self._tail_entry(gone, progress)
         if tail is not None:
@@ -1354,12 +1352,7 @@ class SubagentView(Vertical):
     def _reconcile_current_body(
         self, *, anchor: float | None = None, prepend: bool = False
     ) -> None:
-        live = [self._known[key] for key in self._order]
-        durable_keys = {entry.key for entry in self._history_entries}
-        entries = [
-            *self._history_entries,
-            *(entry for entry in live if entry.key not in durable_keys),
-        ]
+        entries = self._merge_body()
         tail = self._tail_entry(self._status == "gone", "")
         if tail is not None:
             entries.append(tail)
@@ -1380,6 +1373,36 @@ class SubagentView(Vertical):
                 return
         self._pending = entries
         self._sync_body(entries, self._pending_head)
+
+    def _merge_body(self) -> list[SubagentEntry]:
+        """The page body: prompt, then disk history, then surviving live rows.
+
+        The `"__prompt__"` entry is PINNED to the head of the merged body, ahead
+        of `self._history_entries`, and both assembly sites (`show` and
+        `_reconcile_current_body`) go through here so they cannot drift apart.
+
+        Why the pin is load-bearing: the prompt is the delegation instruction,
+        recorded at REGISTRATION (`harness/subagent.py`), so it is always the
+        first message chronologically — the USER turn of this conversation. But
+        `self._history_entries` is the child's real transcript paged in from
+        disk, and every live trajectory key matches a durable key and folds out,
+        leaving `"__prompt__"` as the one live key disk history never produces.
+        A naive `[*history, *live]` merge therefore stranded the prompt AFTER
+        all durable rows — at the bottom of the page — the moment async history
+        loaded and reconciled (the two-frame "prompt jumps to the bottom" bug).
+        Separating it out and prepending keeps it first whether or not durable
+        history is present and whether the job is running or settled, and it
+        stays deduped: it is one keyed entry in `self._order`, mounted once by
+        the same keyed diff as every other row.
+        """
+        live = [self._known[key] for key in self._order]
+        durable_keys = {entry.key for entry in self._history_entries}
+        prompt = next((entry for entry in live if entry.key == "__prompt__"), None)
+        rest = [
+            entry for entry in live if entry.key != "__prompt__" and entry.key not in durable_keys
+        ]
+        head: list[SubagentEntry] = [prompt] if prompt is not None else []
+        return [*head, *self._history_entries, *rest]
 
     def _tail_entry(self, gone: bool, progress: str) -> SubagentEntry | None:
         """The row that TERMINATES the page, when the page needs one.

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -2001,7 +2001,11 @@ class TranscriptView(ScrollableContainer):
         self._remeasure_empty_state()
 
     def prepend_blocks(
-        self, blocks: Sequence[TranscriptBlock], *, anchor_offset: float | None = None
+        self,
+        blocks: Sequence[TranscriptBlock],
+        *,
+        anchor_offset: float | None = None,
+        before: TranscriptBlock | None = None,
     ) -> None:
         """Mount older blocks above the viewport without moving its content.
 
@@ -2010,6 +2014,17 @@ class TranscriptView(ScrollableContainer):
         The optional offset is captured by the caller before asynchronous I/O
         starts; using the later value would apply the prepend to wherever the
         user moved meanwhile.
+
+        ``before`` names the block the additions mount ahead of, and it doubles
+        as the anchor. It defaults to the current first block — the true front
+        — which is the plain history-paging case. But the subagent view PINS a
+        delegation-prompt block at index 0 (a STABLE PREFIX that is not part of
+        the paged history), so older rows there must land AFTER that prompt, not
+        at the true front, or the prefix accounting double-counts and the prompt
+        remounts. Passing the current first *history* block as ``before`` keeps
+        the insertion below the pin and picks an anchor at or below the fold
+        rather than the pinned prompt (which sits above the viewport and must
+        not be treated as the reader's row).
 
         The anchor is expressed as a BLOCK and that block's offset from the top
         of the viewport, not as ``virtual_size`` growth. Growth is the obvious
@@ -2031,7 +2046,13 @@ class TranscriptView(ScrollableContainer):
         if not additions:
             return
         old_scroll = self.scroll_y if anchor_offset is None else anchor_offset
-        before = self._blocks[0] if self._blocks else None
+        if before is None:
+            before = self._blocks[0] if self._blocks else None
+        # Splice at the anchor's ledger position, not always 0: with a pinned
+        # prefix above it the additions belong after that prefix, and
+        # ``.index`` is robust to any block (e.g. the truncation note) mounted
+        # outside the caller's own list.
+        insert_index = self._blocks.index(before) if before is not None else len(self._blocks)
         # The row the reader is looking at, and where it sits in the viewport.
         # Prepending never moves this block within the ledger, so it survives
         # the mount and every gap re-decision above it.
@@ -2041,7 +2062,7 @@ class TranscriptView(ScrollableContainer):
             self.mount(*additions)
         else:
             self.mount(*additions, before=before)
-        self._blocks[0:0] = additions
+        self._blocks[insert_index:insert_index] = additions
         self._name_col_cache = None
 
         def settle_then_restore() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.41.0"
+version = "0.41.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -1110,9 +1110,14 @@ async def test_child_of_top_level_session_keeps_delegation_but_not_wake(tmp_path
 
 
 @pytest.mark.asyncio
-async def test_grandchild_never_advertises_session_capability_tools(tmp_path, monkeypatch):
-    """One level deeper the whole set goes: a grandchild's children would
-    register on a job manager nothing observes and that dies mid-turn."""
+async def test_grandchild_cannot_fan_out_but_polls_its_own_background_bash(tmp_path, monkeypatch):
+    """One level deeper the SPAWN/PERSIST tools go: a grandchild's children
+    would register on a job manager nothing observes and that dies mid-turn.
+    But ``jobs`` stays, because the grandchild keeps ``bash`` with
+    ``background`` — so it can still poll and cancel the background command it
+    is told to (the bash receipt advertises ``jobs(op='peek')``), and without
+    ``jobs`` that advice loops forever on ``Tool not found: jobs``. The
+    invariant: ``jobs`` survives IFF ``bash`` can still background."""
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
     parent = make_session(tmp_path, OneShotStream())
     # A parent that is itself a child is recognisable by its _job_id.
@@ -1121,7 +1126,10 @@ async def test_grandchild_never_advertises_session_capability_tools(tmp_path, mo
     child = await build_child(parent)
 
     names = {tool.name for tool in child._tools}
-    assert names.isdisjoint({"task", "wait", "jobs", "wake"})
+    # No fan-out and no cross-boundary persistence from a grandchild.
+    assert names.isdisjoint({"task", "wait", "wake"})
+    # ...but it can observe/cancel its OWN background job.
+    assert "jobs" in names
     assert {"bash", "read", "edit", "write"} <= names
     await child.dispose()
     await parent.dispose()
@@ -1186,10 +1194,54 @@ async def test_a_tool_restricted_role_keeps_hub_so_it_can_answer(tmp_path, monke
     )
 
     names = {tool.name for tool in child._tools}
-    assert names <= {"read", "glob", "grep", "bash", "todo", "hub"}
+    assert names <= {"read", "glob", "grep", "bash", "todo", "hub", "jobs"}
     assert "hub" in names
-    # The boundary itself is intact: nothing the allowlist denies survived.
-    assert {"edit", "write", "eval"}.isdisjoint(names)
+    # It keeps ``bash`` with ``background``, so it must keep ``jobs`` to poll
+    # and cancel that background job — otherwise the bash receipt's advice to
+    # ``jobs(op='peek')`` loops on ``Tool not found: jobs``.
+    assert "jobs" in names
+    # The boundary itself is intact: nothing the allowlist denies survived,
+    # and a role that must not fan out still has no spawn/persist tools.
+    assert {"edit", "write", "eval", "task", "wait", "wake"}.isdisjoint(names)
+    await child.dispose()
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_non_delegating_role_keeps_jobs_to_poll_its_background_bash(tmp_path, monkeypatch):
+    """The bug this fixes: a non-delegating role (coder/reviewer) that
+    backgrounds a long ``bash`` command spun forever emitting ``Tool not
+    found: jobs``. Such a role loses the SPAWN/PERSIST capability tools
+    (``task``/``wait``/``wake``) — a slice that fans out is a fan-out nobody
+    watches — but it keeps ``bash`` with ``background``, so it must keep
+    ``jobs`` to observe and cancel the job that ``bash`` receipt tells it to
+    poll. Invariant: ``jobs`` survives IFF ``bash`` can still background."""
+    from local_operator.agent_profiles import AgentProfile
+    from local_operator.harness import subagent as subagent_mod
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = make_session(tmp_path, OneShotStream())
+
+    # A coder-shaped profile: full toolset (no allowlist), does not delegate.
+    profile = AgentProfile(
+        name="coder",
+        description="implements a slice",
+        may_delegate=False,
+    )
+    child = await subagent_mod._build_child_session(
+        label="sub",
+        prompt="implement the slice",
+        parent_session=parent,
+        model_spec=None,
+        job_id="job-1",
+        agent="coder",
+        profile=profile,
+    )
+
+    names = {tool.name for tool in child._tools}
+    assert "bash" in names
+    assert "jobs" in names
+    assert {"task", "wait", "wake"}.isdisjoint(names)
     await child.dispose()
     await parent.dispose()
 

--- a/tests/unit/session/test_role_subagents.py
+++ b/tests/unit/session/test_role_subagents.py
@@ -89,7 +89,13 @@ async def test_a_reviewer_child_cannot_edit_but_can_run_commands(tmp_path, monke
 @pytest.mark.asyncio
 async def test_a_non_delegating_role_gets_no_task_tool(tmp_path, monkeypatch) -> None:
     """A reviewer spawning its own children turns one review into a fan-out
-    nobody is watching."""
+    nobody is watching, so the SPAWN/persist tools stay pruned.
+
+    ``jobs`` is the deliberate exception: it only observes and cancels the
+    child's OWN background bash jobs, and the reviewer keeps ``bash`` (hence
+    ``background``), so pruning ``jobs`` would leave a reviewer that
+    backgrounded a long command looping on ``Tool not found: jobs``. See the
+    ``_can_background`` invariant in ``harness/subagent.py``."""
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
     stream = RecordingStream()
     parent = make_parent(tmp_path, stream)
@@ -97,7 +103,13 @@ async def test_a_non_delegating_role_gets_no_task_tool(tmp_path, monkeypatch) ->
     await run_role(parent, "reviewer")
 
     names = {tool.name for tool in stream.requests[0].tools}
-    assert not names & {"task", "wait", "jobs", "wake"}
+    # The fan-out and persistence tools stay gone: a non-delegating role must
+    # not start its own children or arm a wake its one-prompt session can't keep.
+    assert not names & {"task", "wait", "wake"}
+    # But it keeps ``jobs`` to poll/cancel the background bash jobs it can
+    # still produce (it has ``bash``), which is what stops the poll loop.
+    assert "jobs" in names
+    assert "bash" in names
     await parent.dispose()
 
 

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -400,6 +400,62 @@ async def test_prompt_leads_the_body_ahead_of_durable_history(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_prompt_stays_single_when_paging_multipage_history_to_the_start(
+    tmp_path,
+) -> None:
+    """Paging durable history to its very start must not re-mount the prompt.
+
+    The single-page guard above passes vacuously against the double-mount bug:
+    one page never exercises the prepend fast-path in `_reconcile_current_body`.
+    With the prompt PINNED at index 0, that path's prefix accounting has to
+    exclude the pinned head, or each paged-in older page treats index 0 as a
+    freshly-prepended row and mounts a SECOND prompt UserBlock. A settled child
+    has no 1Hz poll to self-heal it, so the duplicate persists on screen. This
+    seeds >100 rows (2+ pages) and pages to the start, asserting exactly one
+    prompt entry, one prompt block, and one instruction occurrence."""
+    instruction = "Audit the ingest path and report the retry-budget regression."
+    transcript = Transcript(tmp_path / "child")
+    for index in range(130):
+        await transcript.append_message(Message.assistant(f"durable {index}"))
+    job = _job_with(TRAJECTORY, status="completed")
+    job.prompt = instruction
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, job)
+        await _wait_history(pilot, view)
+
+        # Page all the way back to the transcript start, one disk read per edge.
+        while not view._history_exhausted:
+            view.action_home()
+            await _wait_history(pilot, view)
+        for _ in range(5):
+            await pilot.pause()
+
+        prompt_entries = [e for e in view._entries if e.key == "__prompt__"]
+        assert len(prompt_entries) == 1, [e.key for e in view._entries]
+        assert view._entries[0].key == "__prompt__", [e.key for e in view._entries]
+
+        prompt_blocks = [
+            b
+            for b in view._body.blocks()
+            if isinstance(b, UserBlock) and b.text().startswith("Audit the ingest path")
+        ]
+        assert len(prompt_blocks) == 1, [type(b).__name__ for b in view._body.blocks()]
+
+        rows = view.rendered_rows()
+        occurrences = sum(1 for row in rows if row.startswith("Audit the ingest path"))
+        assert occurrences == 1, rows
+        # The full window really did page in, so the guard ran against 2+ pages.
+        assert "durable 0" in " ".join(rows)
+        assert len(view._history_ids) == 130
+
+
+@pytest.mark.asyncio
 async def test_history_home_key_lands_on_newly_loaded_page(tmp_path) -> None:
     """The binding path must not sample the old tail before Home settles."""
     transcript = Transcript(tmp_path / "child")

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -361,6 +361,45 @@ async def test_durable_history_opens_at_tail_and_pages_to_the_start(tmp_path) ->
 
 
 @pytest.mark.asyncio
+async def test_prompt_leads_the_body_ahead_of_durable_history(tmp_path) -> None:
+    """The delegated instruction is the first message chronologically, so it
+    must lead the merged body even after async disk history loads.
+
+    Regression guard: `_merge_body` used to append surviving live entries AFTER
+    all of `self._history_entries`, and the prompt is the one live key disk
+    history never produces, so it was stranded at the BOTTOM of the page the
+    moment `_apply_history_page` reconciled the body. The instruction must sit
+    at index 0, ahead of every durable row."""
+    transcript = Transcript(tmp_path / "child")
+    for index in range(8):
+        await transcript.append_message(Message.assistant(f"durable {index}"))
+    job = _job_with(TRAJECTORY, status="completed")
+    job.prompt = "Audit the ingest path and report the retry-budget regression."
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, job)
+        await _wait_history(pilot, view)
+        # Both the model (_entries) and the mounted blocks must agree: prompt
+        # first, then the disk-loaded rows.
+        assert view._entries[0].key == "__prompt__"
+        assert view._history_entries, "durable history must be present for the guard"
+        durable_keys = {entry.key for entry in view._history_entries}
+        prompt_pos = next(i for i, e in enumerate(view._entries) if e.key == "__prompt__")
+        first_durable = next(i for i, e in enumerate(view._entries) if e.key in durable_keys)
+        assert prompt_pos < first_durable, [e.key for e in view._entries]
+        first = view._body.blocks()[0]
+        assert isinstance(first, UserBlock), [type(b).__name__ for b in view._body.blocks()]
+        assert first.text().startswith("Audit the ingest path")
+        # Deduped: the instruction is mounted exactly once across the reconcile.
+        assert sum(1 for b in view._body.blocks() if isinstance(b, UserBlock)) == 1
+
+
+@pytest.mark.asyncio
 async def test_history_home_key_lands_on_newly_loaded_page(tmp_path) -> None:
     """The binding path must not sample the old tail before Home settles."""
     transcript = Transcript(tmp_path / "child")


### PR DESCRIPTION
## Summary

Three fixes to the subagent transcript viewer and to subagent tool provisioning, all surfaced from real use.

1. **The delegated prompt rendered at the bottom of a subagent's transcript instead of the top.** The prompt is the delegation instruction — chronologically the first message — but it kept landing under all of the child's durable history, and jumped to the bottom the moment the async disk history loaded.
2. **The subagent view tore on mouse-move** — the current frame's interactive elements painted over a frozen previous frame, worst while the working spinner ticked and the pointer moved over the hint row.
3. **A subagent that ran `bash(background=true)` looped forever emitting `Tool not found: jobs`** — backgrounding succeeded and the receipt told the model to poll with `jobs(op='peek')`, but `jobs` had been pruned from that child's toolset.

## What changed

### 1. Prompt pinned to the head of the body (`local_operator/tui/widgets/subagent_view.py`)

The page body was assembled independently in two places (`show` and `_reconcile_current_body`) as `[*history, *surviving_live]`. The prompt is a live entry keyed `"__prompt__"`; every other live key matches a durable-history key and folds out, so `"__prompt__"` was the sole live survivor and landed **after** all durable rows — at the bottom. On first paint (before disk history loaded) it showed high up; once `_apply_history_page` reconciled and `scroll_end`'d, it was pinned to the bottom. That is the two-state behaviour the bug reporter saw.

Both sites now route through one `_merge_body()` helper that separates `"__prompt__"` out of the live list and prepends it ahead of durable history, so the prompt leads the page whether or not history is present and whether the job is running or settled. It stays a single keyed entry, mounted exactly once by the existing keyed diff.

### 2. Opaque ground on the page (`local_operator/tui/local_operator.tcss`)

`.subagent-view` had no `background` and resolved to transparent at runtime, unlike every other block widget. A transparent scrolling region lets Textual's compositor skip clearing cells on a partial repaint, so a hover on an `.actionable` hint plus the 8 Hz spinner painted new cells over stale ones — the tearing. Added `background: $lo-bg`, matching the Screen's own baseline so subagent mode still reads as "the same app looking elsewhere" (per `_open_subagent_view`) rather than an elevated slab.

### 3. A child can poll and cancel its own background bash jobs (`local_operator/harness/subagent.py`)

`bash(background=true)` works for a child (its `context.jobs` is the child's own live `Session.jobs`), and the success receipt says to follow up with `jobs(op='peek')`. But the depth-aware prune dropped the whole capability set — `jobs` included — for non-delegating roles (coder/reviewer), scouts, and grandchildren, so that advice pointed at a tool that no longer existed and the model looped on `Tool not found: jobs`. The child's work still completed (the result auto-delivers through the owner sink), but the poll loop burned turns and budget.

`jobs` only **observes/cancels** the child's own jobs — it spawns nothing (that's `task`) and dies with the child's job manager — so it crosses no boundary the prune protects. It's now spared from the prune under a **derived invariant**: a child keeps `jobs` iff it can still produce a background job (`_can_background(tools)` reads the actual `bash` schema for the `background` parameter rather than hard-coding roles, so the rule can't drift from reality). `task`/`wait`/`wake` keep their existing treatment — a child that must not fan out still can't, and a scout (no `bash`) still gets no `jobs`. The rejected alternative (stripping `bash`'s `background` per child) was more invasive and would remove a genuinely useful capability.

### Version

`pyproject.toml`: **0.41.0 → 0.41.1** (patch — three user-facing bug fixes, no new step-function capability).

## Testing evidence

### Bug 1 — visual proof (before/after)

Rendered the real `OperatorApp` with a subagent view opened over a job carrying both a delegated prompt and 12 durable disk rows, captured with `app.save_screenshot`, then rasterised and viewed:

- **Before:** `DELEGATED PROMPT` sits at the bottom, below `durable history row 0..11`, even scrolled home (`prompt index: 12 of 17`).
- **After:** `DELEGATED PROMPT` leads, then `durable history row 0..11`, then trajectory (`prompt index: 0 of 17`).

Regression guard: `tests/unit/tui/test_subagent_view.py::test_prompt_leads_the_body_ahead_of_durable_history` — seeds a prompt + 8 durable rows, waits for the async history worker, asserts `_entries[0].key == "__prompt__"`, prompt index < first durable index, the first mounted block is the instruction `UserBlock`, and exactly one such block (deduped). Fails on old code, passes on the fix.

### Bug 2 — root cause + fix confirmed; motion artifact not directly captured

The tearing is motion-driven (hover + 8 Hz spinner over a transparent region) and does not appear in a static still, so the artifact itself is not screenshot-captured. Confirmed instead: (1) `.subagent-view` resolved to a **transparent** background at runtime, unlike every other block widget; (2) after the change it resolves opaque to `$lo-bg`; (3) no appearance regression — the after-still is identical apart from the bug-1 reordering. An opaque container is the standard compositor-clears-the-region remedy. Full mouse-move confirmation needs a live interactive session; flagged honestly rather than claimed.

### Bug 3 — real construction + tests

Built real `coder` and `scout` children and asserted the resulting toolsets directly: the coder has `jobs` + `bash` and no `task`/`wait`/`wake`; the scout (no `bash`) has neither `jobs` nor the spawn tools. Tests:

- `tests/unit/session/test_launch_subagent.py` — grandchild test updated (`jobs` now kept, `task`/`wait`/`wake` gone); restricted-role test tightened; added `test_non_delegating_role_keeps_jobs_to_poll_its_background_bash`.
- `tests/unit/session/test_role_subagents.py::test_a_non_delegating_role_gets_no_task_tool` — updated: a reviewer keeps `jobs` + `bash` but still gets none of `task`/`wait`/`wake`.

### Gates (whole tree, as CI runs them)

```
$ .venv/bin/python -m flake8 .                          # exit 0
$ black --check .   (black 26.1.0)                        # 551 files unchanged
$ isort --check-only .   (isort 5.13.2, repo config)      # exit 0
$ pyright  (touched .py files)                            # 0 errors, 0 warnings
$ pytest tests/unit/tui tests/unit/session tests/unit/harness -q   # all pass
```

Notes: full-tree `pyright` cannot complete on the dev host (it times out under contention; CI runs it in its own runner), so pyright was scoped to the touched files. `uvx isort==5.13.2` cannot spawn in this sandbox (an environment issue, not a lint failure); validated with the identically pinned isort 5.13.2 module. One suite failure — `test_esc_with_no_children_says_nothing_about_subagents` — is a worktree-path artifact: the footer renders the CWD `/private/tmp/lop-subagent-fixes`, whose path contains the substring `subagent`, and the test asserts no row contains it. Proven by running the test from a renamed copy dir (passes); CI's checkout path is `local-operator` and won't trigger it.

## Full changelog

https://github.com/damianvtran/local-operator/compare/v0.41.0...dev-subagent-fixes
