### PR TITLE
fix(extension): request the document before resolving snapshot refs

### DIFF
--- a/extension/src/commands/input.ts
+++ b/extension/src/commands/input.ts
@@ -35,6 +35,14 @@ async function nodeIdFor(tabId: number, selector: unknown, epoch: number): Promi
   const ref = /^e\d+$/.test(selector) ? refs[selector] : undefined;
   if (ref) {
     if (ref.epoch !== epoch) throw new BridgeCommandError("element_not_found", "the page navigated since that snapshot");
+    // DOM.pushNodesByBackendIdsToFrontend requires the DOM agent to hold the
+    // document for this session first, or Chrome rejects with -32000
+    // "Document needs to be requested first". The CSS-selector branch below
+    // gets this for free from its own getDocument call; the ref branch must
+    // request it explicitly. Found live: every ref-based click failed while
+    // selector-based clicks worked (the pre-#319 snapshot bug meant refs were
+    // never exercised before). depth:0 keeps the payload minimal.
+    await cdp<DocumentResult>(tabId, "DOM.getDocument", { depth: 0 });
     const pushed = await cdp<PushResult>(tabId, "DOM.pushNodesByBackendIdsToFrontend", { backendNodeIds: [ref.backendNodeId] });
     const node = pushed.nodeIds[0];
     if (!node) throw new BridgeCommandError("element_not_found", "snapshot ref is stale");

--- a/extension/src/commands/scroll.ts
+++ b/extension/src/commands/scroll.ts
@@ -67,6 +67,11 @@ async function nodeObjectId(tabId: number, selector: string, epoch: number): Pro
     if (ref.epoch !== epoch) {
       throw new BridgeCommandError("element_not_found", "the page navigated since that snapshot");
     }
+    // Same constraint as input.ts nodeIdFor: pushNodesByBackendIdsToFrontend
+    // rejects with -32000 "Document needs to be requested first" unless this
+    // debugger session has requested the document. See input.ts for the full
+    // rationale (found live once #319 made refs reachable at all).
+    await cdp<DocumentResult>(tabId, "DOM.getDocument", { depth: 0 });
     const pushed = await cdp<PushResult>(tabId, "DOM.pushNodesByBackendIdsToFrontend", {
       backendNodeIds: [ref.backendNodeId],
     });


### PR DESCRIPTION
## What

Ref-based element resolution (`e5`-style handles from snapshot) failed on every call with CDP error -32000 "Document needs to be requested first". Both ref branches (input.ts nodeIdFor, scroll.ts nodeObjectId) now issue `DOM.getDocument {depth:0}` before `DOM.pushNodesByBackendIdsToFrontend`, which the CSS-selector branch always got for free from its own getDocument call.

## Why it was invisible until now

Before #319, snapshot returned a single node with no usable refs, so the ref path had never been exercised against live Chrome. Live verification of #319 (228-node tree, 52 refs) exposed this on the first ref click.

## Testing

- Reproduced live in the user's real paired Chrome: `click e6` → -32000; after fix → navigates (evidence in follow-up comment after rebuild+reload)
- `pnpm typecheck` / `pnpm test` 17/17 / `pnpm build` clean