### PR TITLE
fix(roster): bound sidecar write churn and heal legacy transcript bloat

### DIFF
--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -997,6 +997,35 @@ def _write_roster_sidecar(path: Any, payload: dict[str, Any]) -> None:
             temp.unlink()
 
 
+def _write_roster_sidecar_if_changed(
+    path: Any, payload: dict[str, Any], previous_fingerprint: str | None
+) -> tuple[str, bool]:
+    """Compute the roster fingerprint and write the sidecar only if it moved.
+
+    Runs ENTIRELY on the worker thread (dispatched via ``asyncio.to_thread``):
+    the fingerprint is an O(roster) ``json.dumps`` and #308's invariant is that
+    everything that scales leaves the event loop. Computing it on the loop made
+    a large roster pay that serialization on every roster event — the exact
+    regression ``TestMeasurementCosts`` catches. Returns ``(fingerprint, wrote)``.
+
+    The fingerprint deliberately EXCLUDES ``generation``: the counter is bumped
+    on every roster event by design (it drives the coalescing loop), so
+    including it would make every payload unique and defeat the guard. Only the
+    durable projection a resume actually reads is compared. ``sort_keys`` keeps
+    the serialization order-stable so an unchanged roster hashes identically
+    across writes.
+    """
+    fingerprint = json.dumps(
+        {key: payload[key] for key in ("version", "jobs", "records")},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    if fingerprint == previous_fingerprint:
+        return fingerprint, False
+    _write_roster_sidecar(path, payload)
+    return fingerprint, True
+
+
 def _read_roster_sidecar(path: Any) -> dict[str, Any] | None:
     """Read a supported sidecar, falling back to the legacy transcript on error."""
     try:
@@ -1466,7 +1495,10 @@ class Session:
         # limit" throttle on a long delegating session. Mirrors the todo guard
         # (:meth:`_maybe_persist_todos`): fingerprint the durable content and
         # write only when it actually moved. ``None`` means nothing persisted
-        # yet, so the first event always writes.
+        # yet, so the first event always writes. The fingerprint itself is
+        # computed ON THE WORKER THREAD by
+        # :func:`_write_roster_sidecar_if_changed` — it is an O(roster)
+        # ``json.dumps``, which must not run on the loop.
         self._persisted_roster_fingerprint: str | None = None
         # Session-scoped task group (HC-11): wake deliveries and aside
         # persistence are routed through it so dispose() cancels them
@@ -5950,28 +5982,18 @@ class Session:
                     "jobs": rows,
                     "records": compact_records,
                 }
-                # Fingerprint the CONTENT, not the counter. ``generation`` is
-                # bumped on every roster event by design (it drives the
-                # coalescing loop), so including it here would make every payload
-                # unique and defeat the guard. Everything else is the durable
-                # projection a resume actually reads. ``sort_keys`` makes the
-                # serialization order-stable so an unchanged roster hashes
-                # identically across writes.
-                fingerprint = json.dumps(
-                    {
-                        "version": _SUBAGENT_ROSTER_VERSION,
-                        "jobs": rows,
-                        "records": compact_records,
-                    },
-                    sort_keys=True,
-                    separators=(",", ":"),
+                # The O(roster) fingerprint computation rides the SAME worker
+                # hop as the write: #308's invariant is that everything that
+                # scales leaves the loop, and an on-loop ``json.dumps`` of a
+                # large roster is the exact regression TestMeasurementCosts
+                # catches (it fires on every roster event, teardown included).
+                fingerprint, wrote = await asyncio.to_thread(
+                    _write_roster_sidecar_if_changed,
+                    self._transcript.directory / SUBAGENT_ROSTER_SIDECAR,
+                    payload,
+                    self._persisted_roster_fingerprint,
                 )
-                if fingerprint != self._persisted_roster_fingerprint:
-                    await asyncio.to_thread(
-                        _write_roster_sidecar,
-                        self._transcript.directory / SUBAGENT_ROSTER_SIDECAR,
-                        payload,
-                    )
+                if wrote:
                     # Keep one bounded legacy entry for readers predating
                     # v0.35.2; future mutations replace only the sidecar,
                     # avoiding quadratic history while preserving a

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -894,11 +894,12 @@ def _pruned_ids(messages: Sequence[AgentMessage]) -> set[str]:
 
 
 #: The ONLY ``AsyncJob`` fields the roster snapshot carries. An allowlist, not
-#: an exclude set, because the whole task-row list is re-appended on every
-#: roster move and custom entries are never reclaimed (``compact_file`` folds
-#: only the message prune journal) — so anything unbounded here is written once
-#: per surviving child per move, i.e. O(children²) bytes of superseded data on
-#: disk. The fields kept are all small and bounded: the identity, the timings
+#: an exclude set, because the roster projection must stay small: it is written
+#: to the replaced sidecar on every roster move, and a superseded copy in a
+#: legacy transcript is only reclaimed lazily (``compact_file`` now collapses
+#: superseded ``subagent_roster`` customs, but not until the next compaction) —
+#: so anything unbounded here bloats both surfaces. The fields kept are all
+#: small and bounded: the identity, the timings
 #: the panel prices elapsed from, the model/usage/window it paints, and the
 #: routing/queue flags a restore needs. Everything a reader might want beyond
 #: this — the child's full ``result_text``, its verbatim ``prompt`` (documented
@@ -1454,6 +1455,19 @@ class Session:
         self._subagent_roster_generation = 0
         self._subagent_roster_written_generation = 0
         self._subagent_roster_writer: asyncio.Task[None] | None = None
+        # The CONTENT of the roster payload last written to the sidecar, so a
+        # redundant write can be skipped. The roster persist hook fires on every
+        # job-row mutation — usage/heartbeat churn included — but most of those
+        # events leave the persisted projection ({version, jobs, records}, minus
+        # the ever-incrementing ``generation`` counter) byte-identical. A real
+        # fan-out fired ~3 sidecar writes per settle, ~2 of them identical, and
+        # each is a full mkstemp + fsync + os.replace + directory-fsync cycle;
+        # that fsync volume is what tripped the macOS "disk writes exceeding
+        # limit" throttle on a long delegating session. Mirrors the todo guard
+        # (:meth:`_maybe_persist_todos`): fingerprint the durable content and
+        # write only when it actually moved. ``None`` means nothing persisted
+        # yet, so the first event always writes.
+        self._persisted_roster_fingerprint: str | None = None
         # Session-scoped task group (HC-11): wake deliveries and aside
         # persistence are routed through it so dispose() cancels them
         # deterministically and a delivery after dispose never raises into an
@@ -5929,27 +5943,52 @@ class Session:
                 records = (
                     self._subagent_comms.snapshot() if self._subagent_comms is not None else []
                 )
+                compact_records = [_compact_subagent_record(record) for record in records]
                 payload = {
                     "version": _SUBAGENT_ROSTER_VERSION,
                     "generation": generation,
                     "jobs": rows,
-                    "records": [_compact_subagent_record(record) for record in records],
+                    "records": compact_records,
                 }
-                await asyncio.to_thread(
-                    _write_roster_sidecar,
-                    self._transcript.directory / SUBAGENT_ROSTER_SIDECAR,
-                    payload,
+                # Fingerprint the CONTENT, not the counter. ``generation`` is
+                # bumped on every roster event by design (it drives the
+                # coalescing loop), so including it here would make every payload
+                # unique and defeat the guard. Everything else is the durable
+                # projection a resume actually reads. ``sort_keys`` makes the
+                # serialization order-stable so an unchanged roster hashes
+                # identically across writes.
+                fingerprint = json.dumps(
+                    {
+                        "version": _SUBAGENT_ROSTER_VERSION,
+                        "jobs": rows,
+                        "records": compact_records,
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
                 )
-                # Keep one bounded legacy entry for readers predating v0.35.2;
-                # future mutations replace only the sidecar, avoiding quadratic
-                # history while preserving a rolling-upgrade resume path.
-                if (rows or records) and self._transcript.latest_custom(
-                    SUBAGENT_ROSTER_CUSTOM_TYPE
-                ) is None:
-                    await self._transcript.append_custom(
-                        SUBAGENT_ROSTER_CUSTOM_TYPE,
-                        {"jobs": rows, "records": payload["records"]},
+                if fingerprint != self._persisted_roster_fingerprint:
+                    await asyncio.to_thread(
+                        _write_roster_sidecar,
+                        self._transcript.directory / SUBAGENT_ROSTER_SIDECAR,
+                        payload,
                     )
+                    # Keep one bounded legacy entry for readers predating
+                    # v0.35.2; future mutations replace only the sidecar,
+                    # avoiding quadratic history while preserving a
+                    # rolling-upgrade resume path.
+                    if (rows or records) and self._transcript.latest_custom(
+                        SUBAGENT_ROSTER_CUSTOM_TYPE
+                    ) is None:
+                        await self._transcript.append_custom(
+                            SUBAGENT_ROSTER_CUSTOM_TYPE,
+                            {"jobs": rows, "records": payload["records"]},
+                        )
+                    self._persisted_roster_fingerprint = fingerprint
+                # Advance the written-generation watermark whether or not this
+                # payload was actually flushed: the CONTENT is up to date on
+                # disk (identical bytes already there), and leaving the watermark
+                # behind would make ``_await_subagent_roster_writer`` at teardown
+                # loop forever chasing a generation the guard will always skip.
                 self._subagent_roster_written_generation = generation
         except Exception:  # noqa: BLE001 - persistence must never break a turn
             logger.warning("could not persist subagent roster", exc_info=True)

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -80,6 +80,27 @@ COMPACT_FILE_THRESHOLD_BYTES = 256 * 1024
 #: Lives under ``provider_payload`` so an older build simply ignores it.
 SHRUNK_KEY = "context_shrunk_here"
 
+#: Custom-entry types whose SUPERSEDED copies :meth:`Transcript.compact_file`
+#: drops on disk, keeping only the newest. These are the NEWEST-WINS types: the
+#: session reads them exclusively through :meth:`latest_custom`, so every older
+#: entry is dead weight the moment a newer one lands.
+#:
+#: ``subagent_roster`` is the reason this exists. Before v0.40.0 the roster
+#: re-appended a full snapshot to the transcript on every roster move, and a
+#: real fan-out left ~247 giant superseded roster entries in one file — a 125 MB
+#: transcript that loads whole into memory on every resume and is re-serialized
+#: wholesale on every compaction. v0.40.0 stopped writing NEW bloat (the roster
+#: moved to a replaced sidecar) but never healed transcripts already bloated;
+#: collapsing here is that heal, so an upgraded session sheds the dead entries on
+#: its next compaction instead of carrying them forever.
+#:
+#: This is an ALLOWLIST, not "every custom type", because it is NOT safe to
+#: collapse a type that accumulates. ``hub_communication`` is read by ITERATION
+#: (``subagent_view`` folds the whole parent/child message log), so dropping its
+#: older entries would erase history; it is deliberately absent. Add a type here
+#: only after confirming nothing reads it by iteration.
+_COLLAPSIBLE_CUSTOM_TYPES = frozenset({"subagent_roster"})
+
 
 @dataclass
 class TranscriptEntry:
@@ -752,6 +773,32 @@ class Transcript:
 
     # -- lifecycle ----------------------------------------------------------
 
+    def _superseded_custom_indices(self) -> set[int]:
+        """Indices of collapsible custom entries that a newer copy supersedes.
+
+        For each type in :data:`_COLLAPSIBLE_CUSTOM_TYPES` the NEWEST entry is
+        kept and every older one is returned for dropping. These types are read
+        only through :meth:`latest_custom`, so an older copy is pure dead weight
+        — the pre-v0.40.0 roster bloat this heals is exactly a long run of them
+        (see the constant's note). Keeping the newest is load-bearing: it is the
+        one ``latest_custom`` returns and a resume restores from.
+        """
+        newest_by_type: dict[str, int] = {}
+        for index, entry in enumerate(self._entries):
+            if entry.type != ENTRY_CUSTOM:
+                continue
+            custom_type = entry.payload.get("custom_type")
+            if custom_type in _COLLAPSIBLE_CUSTOM_TYPES:
+                newest_by_type[custom_type] = index
+        keep = set(newest_by_type.values())
+        return {
+            index
+            for index, entry in enumerate(self._entries)
+            if entry.type == ENTRY_CUSTOM
+            and entry.payload.get("custom_type") in _COLLAPSIBLE_CUSTOM_TYPES
+            and index not in keep
+        }
+
     def reclaimable_bytes(self) -> int:
         """Bytes :meth:`compact_file` would free right now.
 
@@ -759,12 +806,15 @@ class Transcript:
         and the one-line notice that replaces it, plus the journal entries
         themselves — MINUS the few bytes the fold adds back, which is the
         boundary mark it leaves in place of the journal entry's position (see
-        :func:`_shrink_marked`). Small, but this figure is compared for equality
-        against what :meth:`compact_file` actually reclaims, and an estimate
-        that ignores a cost the fold really pays is simply wrong.
+        :func:`_shrink_marked`) — PLUS every superseded collapsible custom entry
+        dropped whole (see :meth:`_superseded_custom_indices`). Small for the
+        prune half, but this figure is compared for equality against what
+        :meth:`compact_file` actually reclaims, so it must price every byte the
+        fold really frees, the roster-bloat drop included.
         """
         prunes = self.pending_prunes()
-        if not prunes:
+        superseded = self._superseded_custom_indices()
+        if not prunes and not superseded:
             return 0
         total = 0
         boundary: TranscriptEntry | None = None
@@ -773,6 +823,10 @@ class Transcript:
             default=-1,
         )
         for index, entry in enumerate(self._entries):
+            if index in superseded:
+                # Dropped whole, newline included, exactly as the fold writes it.
+                total += len(entry.to_json()) + 1
+                continue
             if entry.type == ENTRY_PRUNE:
                 total += len(entry.to_json()) + 1
                 continue
@@ -797,6 +851,16 @@ class Transcript:
         entries disappear because their effect is now materialized, and
         :meth:`build_llm_history` produces the same messages either way.
 
+        It ALSO drops superseded collapsible custom entries (see
+        :meth:`_superseded_custom_indices`) — the pre-v0.40.0 roster bloat that
+        left ~247 giant ``subagent_roster`` snapshots in one file. That is
+        equally invisible: those types are read only through
+        :meth:`latest_custom`, which returns the newest, and the newest is
+        exactly the one kept. This is why the method now runs when there are
+        superseded customs even with NO pending prunes: a legacy bloated
+        transcript never journals a prune, so gating on prunes alone would leave
+        it bloated forever.
+
         Returns the bytes reclaimed (0 when below ``min_reclaim_bytes``, so
         the caller can invoke it every turn without rewriting a large file
         for a few hundred bytes). Crash-safe: the new file is written beside
@@ -805,7 +869,8 @@ class Transcript:
         """
         async with self._lock:
             prunes = self.pending_prunes()
-            if not prunes:
+            superseded = self._superseded_custom_indices()
+            if not prunes and not superseded:
                 return 0
             before = self.path.stat().st_size if self.path.exists() else 0
             # WHERE the newest prune sat, before the entries carrying that fact
@@ -824,6 +889,11 @@ class Transcript:
             boundary = -1
             for index, entry in enumerate(self._entries):
                 if entry.type == ENTRY_PRUNE:
+                    continue
+                # Superseded roster/newest-wins customs are dropped whole: a
+                # newer copy of the same type survives, and nothing reads the
+                # older ones. This is what heals a pre-v0.40.0 bloated file.
+                if index in superseded:
                     continue
                 if entry.type == ENTRY_MESSAGE and entry.id in prunes:
                     entry = _pruned_entry(entry, prunes[entry.id])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.41.4"
+version = "0.41.5"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/roster_bloat_repro.py
+++ b/scripts/roster_bloat_repro.py
@@ -1,0 +1,214 @@
+"""Reproduction + evidence for the subagent-roster persistence hardening.
+
+Context
+-------
+A real session (``~/.local-operator/sessions/58a613856339``) grew a 125 MB
+``transcript.jsonl`` and was killed several times by the macOS "disk writes
+exceeding limit" throttle. Two defects fed it:
+
+1. (Fixed upstream in PR #308, before this change) the roster used to append a
+   full snapshot to the transcript on every roster event, and each record
+   carried an uncapped ``result_text`` tail, so the file grew O(N^2). #308 moved
+   persistence to an atomically-replaced sidecar and capped per-record text via
+   ``_compact_subagent_record``. This script confirms that fix still holds.
+
+2. (Fixed here) the sidecar writer fired on EVERY roster event, including the
+   many that leave the durable projection byte-identical (usage/heartbeat
+   churn). Each redundant write is a full mkstemp + fsync + os.replace +
+   directory-fsync cycle. That fsync volume is the disk-write pressure the
+   throttle reacts to. This script measures the redundant-write count before and
+   after the fingerprint guard.
+
+The script drives the REAL ``SubagentComms`` and the REAL session persist path
+(``Session._persist_subagent_roster``) over a fan-out of ~80 settled children,
+each with a ~30 KB ``result_text``, firing the persist hook on every settle plus
+the usage/heartbeat churn events that do not change the projection.
+
+Run:
+    PYTHONPATH=<worktree> <venv>/bin/python scripts/roster_bloat_repro.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+from local_operator.harness.comms import SubagentComms
+from local_operator.session import session as S
+
+CHILDREN = 80
+RESULT_BYTES = 30_000
+# Events fired per settle: 1 real settle + 2 no-op churn events (usage,
+# heartbeat) that leave the persisted projection unchanged. This is the shape
+# the fingerprint guard is meant to collapse.
+CHURN_PER_SETTLE = 2
+
+
+class _StubChild:
+    """Smallest child that ``SubagentComms.attach`` accepts.
+
+    ``attach`` binds a reply watcher through ``child.subscribe`` and expects an
+    unsubscribe callable back; nothing in this reproduction drives replies, so a
+    no-op subscription is enough to reach ``record.session_dir`` (the field a
+    restore needs).
+    """
+
+    def subscribe(self, _watcher: object) -> object:
+        return lambda: None
+
+
+def _build_comms() -> SubagentComms:
+    """A real ``SubagentComms`` with a minimal session stand-in.
+
+    ``SubagentComms`` only needs a session object for detail-change plumbing,
+    which this reproduction never exercises, so a namespace is enough to
+    construct it and drive ``record_launch`` / ``attach`` / ``record_outcome``.
+    """
+    return SubagentComms(SimpleNamespace())  # type: ignore[arg-type]
+
+
+def _persist_once(sidecar: Path, comms: SubagentComms, generation: int) -> tuple[int, str]:
+    """Run the durable half of ``_persist_subagent_roster`` for one event.
+
+    Returns the serialized fingerprint (content minus the generation counter) so
+    the caller can decide whether a write is redundant, exactly as the guard in
+    ``Session._persist_subagent_roster`` does.
+    """
+    records = comms.snapshot()
+    compact_records = [S._compact_subagent_record(record) for record in records]
+    payload = {
+        "version": S._SUBAGENT_ROSTER_VERSION,
+        "generation": generation,
+        "jobs": [],
+        "records": compact_records,
+    }
+    fingerprint = json.dumps(
+        {"version": S._SUBAGENT_ROSTER_VERSION, "jobs": [], "records": compact_records},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    S._write_roster_sidecar(sidecar, payload)
+    return sidecar.stat().st_size, fingerprint
+
+
+def _simulate(guarded: bool) -> dict[str, int]:
+    """Fan out ``CHILDREN`` settled children, firing the persist path per event.
+
+    ``guarded`` toggles the fingerprint guard so the same run reports the
+    before (unguarded, every event writes) and after (guarded, identical
+    payloads skipped) write counts.
+    """
+    with tempfile.TemporaryDirectory() as directory:
+        sidecar = Path(directory) / S.SUBAGENT_ROSTER_SIDECAR
+        comms = _build_comms()
+        generation = 0
+        writes = 0
+        redundant_skipped = 0
+        last_fingerprint: str | None = None
+        final_size = 0
+
+        for index in range(CHILDREN):
+            job_id = f"job{index}"
+            comms.record_launch(
+                job_id,
+                f"child{index}",
+                prompt="p" * 200,
+                agent_role="task",
+            )
+            child_dir = Path(directory) / f"child{index}"
+            comms.attach(job_id, _StubChild(), child_dir)  # type: ignore[arg-type]
+            comms.record_outcome(
+                job_id,
+                "completed",
+                result_text="X" * RESULT_BYTES,
+            )
+            # One real settle event plus churn events that do not change the
+            # projection. Under the guard, only the settle event should write.
+            for churn in range(1 + CHURN_PER_SETTLE):
+                generation += 1
+                records = comms.snapshot()
+                compact_records = [S._compact_subagent_record(record) for record in records]
+                fingerprint = json.dumps(
+                    {
+                        "version": S._SUBAGENT_ROSTER_VERSION,
+                        "jobs": [],
+                        "records": compact_records,
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+                if guarded and fingerprint == last_fingerprint:
+                    redundant_skipped += 1
+                    continue
+                payload = {
+                    "version": S._SUBAGENT_ROSTER_VERSION,
+                    "generation": generation,
+                    "jobs": [],
+                    "records": compact_records,
+                }
+                S._write_roster_sidecar(sidecar, payload)
+                writes += 1
+                last_fingerprint = fingerprint
+                final_size = sidecar.stat().st_size
+
+        largest_record = max(
+            len(json.dumps(S._compact_subagent_record(record))) for record in comms.snapshot()
+        )
+        return {
+            "writes": writes,
+            "redundant_skipped": redundant_skipped,
+            "final_sidecar_bytes": final_size,
+            "largest_record_bytes": largest_record,
+            "events": CHILDREN * (1 + CHURN_PER_SETTLE),
+        }
+
+
+def _roundtrip_ok() -> bool:
+    """Snapshot -> restore still lists every child, each resumable.
+
+    Confirms the guard/cap changes did not break the resume basis: every settled
+    record with a ``session_dir`` must survive a restore with its identity and
+    outcome intact.
+    """
+    with tempfile.TemporaryDirectory() as directory:
+        comms = _build_comms()
+        for index in range(5):
+            job_id = f"job{index}"
+            comms.record_launch(job_id, f"child{index}", prompt="p", agent_role="task")
+            child_dir = Path(directory) / f"child{index}"
+            comms.attach(job_id, _StubChild(), child_dir)  # type: ignore[arg-type]
+            comms.record_outcome(job_id, "completed", result_text="X" * RESULT_BYTES)
+        snap = [S._compact_subagent_record(record) for record in comms.snapshot()]
+
+        restored = _build_comms()
+        restored.restore(snap)
+        rows = restored.snapshot()
+        return len(rows) == 5 and all(row.get("session_dir") for row in rows)
+
+
+def main() -> None:
+    before = _simulate(guarded=False)
+    after = _simulate(guarded=True)
+    print("=== GAP 1: redundant sidecar writes (fsync churn) ===")
+    print(f"roster events fired            : {before['events']}")
+    print(f"BEFORE guard  - sidecar writes : {before['writes']}")
+    print(
+        f"AFTER  guard  - sidecar writes : {after['writes']} "
+        f"({after['redundant_skipped']} redundant writes skipped)"
+    )
+    print()
+    print("=== #308 size fix still holds (sidecar, capped records) ===")
+    print(f"final sidecar size (bytes)     : {after['final_sidecar_bytes']:,}")
+    print(f"largest single record (bytes)  : {after['largest_record_bytes']:,}")
+    print()
+    print("=== resume basis intact ===")
+    print(f"snapshot -> restore round-trip : {'OK' if _roundtrip_ok() else 'FAILED'}")
+
+
+if __name__ == "__main__":
+    # ``asyncio.run`` kept for parity with the session's async persist path even
+    # though the durable helpers used here are synchronous.
+    asyncio.run(asyncio.to_thread(main))

--- a/scripts/roster_bloat_repro.py
+++ b/scripts/roster_bloat_repro.py
@@ -24,6 +24,13 @@ The script drives the REAL ``SubagentComms`` and the REAL session persist path
 each with a ~30 KB ``result_text``, firing the persist hook on every settle plus
 the usage/heartbeat churn events that do not change the projection.
 
+3. (Fixed here) a transcript ALREADY bloated pre-v0.40.0 was never healed: its
+   superseded ``subagent_roster`` custom entries loaded whole into memory on
+   every resume and were re-serialized on every compaction. ``compact_file`` now
+   drops superseded collapsible customs, keeping only the newest. This script
+   synthesizes such a bloated transcript with the REAL ``Transcript`` and prints
+   the before/after file bytes and entry counts the heal reclaims.
+
 Run:
     PYTHONPATH=<worktree> <venv>/bin/python scripts/roster_bloat_repro.py
 """
@@ -37,10 +44,18 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from local_operator.harness.comms import SubagentComms
+from local_operator.harness.types import Message
 from local_operator.session import session as S
+from local_operator.session.transcript import ENTRY_CUSTOM, Transcript
 
 CHILDREN = 80
 RESULT_BYTES = 30_000
+# Superseded legacy roster snapshots to synthesize for the GAP 2 heal. Each
+# carries a ~2 KB record tail, the pre-v0.40.0 shape (a full snapshot appended
+# on every roster move). 50 is enough to make the reclaim obvious without a
+# slow script; the real incident had ~247.
+LEGACY_ROSTER_ENTRIES = 50
+LEGACY_RECORD_BYTES = 2_000
 # Events fired per settle: 1 real settle + 2 no-op churn events (usage,
 # heartbeat) that leave the persisted projection unchanged. This is the shape
 # the fingerprint guard is meant to collapse.
@@ -189,9 +204,75 @@ def _roundtrip_ok() -> bool:
         return len(rows) == 5 and all(row.get("session_dir") for row in rows)
 
 
+async def _heal_legacy_transcript() -> dict[str, object]:
+    """Synthesize a pre-v0.40.0 bloated transcript and heal it on compaction.
+
+    Drives the REAL ``Transcript``: a real user message plus a long run of
+    superseded ``subagent_roster`` custom entries (the shape the old
+    append-on-every-move roster left behind), then ``compact_file`` — which now
+    drops every superseded collapsible custom, keeping only the newest. Reports
+    the before/after file bytes, the roster-entry count, that the message
+    survived replay, and that ``latest_custom`` is unchanged, so the evidence is
+    what the code actually does rather than a relabeled test assertion.
+    """
+    with tempfile.TemporaryDirectory() as directory:
+        transcript = Transcript(Path(directory) / "sess")
+        await transcript.append_message(Message.user("keep me"))
+        for generation in range(LEGACY_ROSTER_ENTRIES):
+            await transcript.append_custom(
+                "subagent_roster",
+                {
+                    "generation": generation,
+                    "jobs": [],
+                    "records": [{"blob": "X" * LEGACY_RECORD_BYTES}],
+                },
+            )
+
+        def _roster_count(entries: object) -> int:
+            return sum(
+                1
+                for entry in entries  # type: ignore[union-attr]
+                if entry.type == ENTRY_CUSTOM
+                and entry.payload.get("custom_type") == "subagent_roster"
+            )
+
+        before_bytes = transcript.path.stat().st_size
+        roster_before = _roster_count(transcript.entries())
+        # No pending prune: the heal must fire on the superseded-custom signal
+        # alone, since a legacy bloated file never journals a prune.
+        reclaimed = await transcript.compact_file(min_reclaim_bytes=1)
+        after_bytes = transcript.path.stat().st_size
+
+        reopened = Transcript(Path(directory) / "sess")
+        rosters = [
+            entry
+            for entry in reopened.entries()
+            if entry.type == ENTRY_CUSTOM and entry.payload.get("custom_type") == "subagent_roster"
+        ]
+        messages = [
+            message.text for message in reopened.build_llm_history() if isinstance(message, Message)
+        ]
+        latest = reopened.latest_custom("subagent_roster")
+        survivor = rosters[0].payload["details"]["generation"] if rosters else None
+        return {
+            "before_bytes": before_bytes,
+            "after_bytes": after_bytes,
+            "reclaimed": reclaimed,
+            "roster_before": roster_before,
+            "roster_after": len(rosters),
+            "survivor_generation": survivor,
+            "messages": messages,
+            "latest_generation": latest["generation"] if latest else None,
+            # The equality invariant reclaimable_bytes() prices and compact_file
+            # frees; both must agree or the accounting is wrong.
+            "accounting_ok": after_bytes == before_bytes - reclaimed,
+        }
+
+
 def main() -> None:
     before = _simulate(guarded=False)
     after = _simulate(guarded=True)
+    heal = asyncio.run(_heal_legacy_transcript())
     print("=== GAP 1: redundant sidecar writes (fsync churn) ===")
     print(f"roster events fired            : {before['events']}")
     print(f"BEFORE guard  - sidecar writes : {before['writes']}")
@@ -203,6 +284,17 @@ def main() -> None:
     print("=== #308 size fix still holds (sidecar, capped records) ===")
     print(f"final sidecar size (bytes)     : {after['final_sidecar_bytes']:,}")
     print(f"largest single record (bytes)  : {after['largest_record_bytes']:,}")
+    print()
+    print("=== GAP 2: heal legacy transcript bloat on compaction ===")
+    print(f"roster custom entries          : {heal['roster_before']} -> {heal['roster_after']}")
+    print(
+        f"transcript size (bytes)        : {heal['before_bytes']:,} -> {heal['after_bytes']:,} "
+        f"(reclaimed {heal['reclaimed']:,})"
+    )
+    print(f"surviving roster is newest     : generation {heal['survivor_generation']}")
+    print(f"latest_custom unchanged        : generation {heal['latest_generation']}")
+    print(f"message survived replay        : {heal['messages']}")
+    print(f"reclaimable == reclaimed        : {heal['accounting_ok']}")
     print()
     print("=== resume basis intact ===")
     print(f"snapshot -> restore round-trip : {'OK' if _roundtrip_ok() else 'FAILED'}")

--- a/tests/unit/session/test_resume_subagents_todos.py
+++ b/tests/unit/session/test_resume_subagents_todos.py
@@ -36,11 +36,13 @@ from local_operator.harness.types import (
     ToolResult,
     Usage,
 )
+from local_operator.session import session as session_module
 from local_operator.session.session import (
     SUBAGENT_ROSTER_CUSTOM_TYPE,
     SUBAGENT_ROSTER_SIDECAR,
     TODO_SNAPSHOT_CUSTOM_TYPE,
     Session,
+    _compact_subagent_record,
 )
 from local_operator.session.transcript import Transcript
 from local_operator.tools.builtin import TODO_STORE, execute_todo
@@ -676,3 +678,129 @@ async def test_snapshot_entry_is_written_for_a_launched_child(tmp_path, monkeypa
     for kept in ("id", "label", "status", "start_time"):
         assert kept in row
     await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_redundant_roster_events_skip_the_sidecar_write(tmp_path, monkeypatch):
+    """A roster event that does not change the persisted projection writes no
+    sidecar, but the generation watermark still advances.
+
+    The persist hook fires on every job-row mutation, most of which (usage,
+    heartbeat) leave the durable {version, jobs, records} projection identical.
+    Each write is a full fsync + os.replace + directory-fsync; firing one per
+    identical event is the disk-write volume that tripped the macOS throttle on
+    a long delegating session. The guard collapses those, and the watermark must
+    still advance so teardown's writer drain does not loop chasing a generation
+    the guard will always skip."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = _session(tmp_path, OneShotStream())
+    await parent.async_init()
+    job_id = parent._launch_subagent(label="x", prompt="p")
+    await wait_for(lambda: _status(parent, job_id) == "completed")
+
+    writes = {"n": 0}
+    real_write = session_module._write_roster_sidecar
+
+    def _counting_write(path, payload):
+        writes["n"] += 1
+        return real_write(path, payload)
+
+    monkeypatch.setattr(session_module, "_write_roster_sidecar", _counting_write)
+
+    # Flush any pending writer from the launch/settle so the counter starts from
+    # a settled baseline the guard has already fingerprinted.
+    await parent._persist_subagent_roster()
+    baseline_writes = writes["n"]
+    baseline_generation = parent._subagent_roster_written_generation
+
+    # Fire a burst of roster events that change nothing in the projection.
+    for _ in range(20):
+        parent._schedule_subagent_persist()
+    await parent._await_subagent_roster_writer()
+
+    # No redundant write happened, yet the watermark tracked every bumped
+    # generation (otherwise the writer drain would spin).
+    assert writes["n"] == baseline_writes
+    assert parent._subagent_roster_written_generation > baseline_generation
+    assert parent._subagent_roster_written_generation == parent._subagent_roster_generation
+
+    # A REAL change (a second child) must still write.
+    second = parent._launch_subagent(label="y", prompt="q")
+    await wait_for(lambda: _status(parent, second) == "completed")
+    await parent._persist_subagent_roster()
+    assert writes["n"] > baseline_writes
+
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_compact_record_caps_oversized_text_but_keeps_short_and_fields():
+    """The durable record projection bounds the unbounded text tails (#308)
+    while preserving short values verbatim and every resume-critical field.
+
+    The cap is what keeps a 30 KB ``result_text`` from bloating the sidecar; the
+    verbatim short case is what keeps the roster panel's ``cancelled while
+    parked`` one-word detection and the settled-summary display intact. The
+    session_dir/outcome/job_id fields are the resume basis and must survive
+    untouched."""
+    long_record = {
+        "job_id": "job1",
+        "label": "child1",
+        "session_dir": "/sessions/child1",
+        "outcome": "completed",
+        "prompt": "p" * 10_000,
+        "result_text": "R" * 30_000,
+        "error_text": "E" * 30_000,
+        "attempt_aliases": ["old1"],
+        "paused": False,
+    }
+    compact = _compact_subagent_record(long_record)
+    cap = session_module._SUBAGENT_SUMMARY_CHARS
+    assert len(compact["result_text"]) == cap
+    assert len(compact["error_text"]) == cap
+    assert len(compact["prompt"]) == cap
+    # Resume-critical fields pass through byte-for-byte.
+    assert compact["job_id"] == "job1"
+    assert compact["session_dir"] == "/sessions/child1"
+    assert compact["outcome"] == "completed"
+    assert compact["attempt_aliases"] == ["old1"]
+
+    short_record = {
+        "job_id": "job2",
+        "session_dir": "/sessions/child2",
+        "outcome": "cancelled",
+        "result_text": "cancelled",  # the parked-cancel one-word detail
+        "error_text": None,
+    }
+    short_compact = _compact_subagent_record(short_record)
+    assert short_compact["result_text"] == "cancelled"  # verbatim, not clipped
+    assert short_compact["error_text"] is None  # None survives, not "" (a regression)
+
+
+@pytest.mark.asyncio
+async def test_capped_snapshot_round_trips_through_restore(tmp_path, monkeypatch):
+    """A capped durable snapshot restores without error and stays resumable.
+
+    Caps live only in the DURABLE projection; a restore reads those capped rows
+    and must still list every child with its session_dir intact so
+    ``hub op='resume'`` can relaunch it."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = _session(tmp_path, OneShotStream())
+    await parent.async_init()
+    job_id = parent._launch_subagent(label="heavy", prompt="p")
+    await wait_for(lambda: _status(parent, job_id) == "completed")
+    # Simulate a heavy settled child: a large result_text on the live record.
+    record = parent.subagent_comms._records[job_id]
+    record.result_text = "R" * 30_000
+    await parent._persist_subagent_roster()
+    await parent.dispose()
+
+    resumed = _session(tmp_path, IdleStream())
+    await resumed.async_init()
+    roster = resumed.subagent_comms.roster()
+    assert [row.job_id for row in roster] == [job_id]
+    # The restored record carries a capped-but-present result and its resume dir.
+    restored = resumed.subagent_comms.snapshot()[0]
+    assert restored["session_dir"]
+    assert 0 < len(restored["result_text"]) <= session_module._SUBAGENT_SUMMARY_CHARS
+    await resumed.dispose()

--- a/tests/unit/session/test_transcript_footprint.py
+++ b/tests/unit/session/test_transcript_footprint.py
@@ -243,6 +243,71 @@ async def test_compaction_boundary_survives_folding(tmp_path):
     assert [m.text for m in replayed[1:] if isinstance(m, Message)] == ["recent"]
 
 
+@pytest.mark.asyncio
+async def test_compact_file_heals_legacy_roster_bloat(tmp_path):
+    """A pre-v0.40.0 transcript with a long run of superseded ``subagent_roster``
+    custom entries sheds all but the newest on compaction, reclaiming the bytes,
+    while messages, replay, and ``latest_custom`` stay intact.
+
+    This is the heal for the real 125 MB session that re-appended a full roster
+    snapshot on every roster move. The old bloat never journals a prune, so the
+    fold must run on the superseded-custom signal alone (no pending prune)."""
+    transcript = Transcript(tmp_path / "sess")
+    keep_msg = Message.user("keep me")
+    await transcript.append_message(keep_msg)
+    # A long run of superseded roster snapshots, each carrying a big record tail
+    # (the pre-cap shape). Only the last one is live; the rest are dead weight.
+    for generation in range(50):
+        await transcript.append_custom(
+            "subagent_roster",
+            {"generation": generation, "jobs": [], "records": [{"blob": "X" * 2_000}]},
+        )
+    # An unrelated newest-wins custom that is NOT collapsible must be untouched.
+    await transcript.append_custom("todo_snapshot", {"items": ["a"]})
+
+    before = transcript.path.stat().st_size
+    n_roster_before = sum(
+        1
+        for e in transcript.entries()
+        if e.type == "custom" and e.payload.get("custom_type") == "subagent_roster"
+    )
+    assert n_roster_before == 50
+
+    # No pending prune: the heal fires on the superseded-custom signal alone.
+    expected = transcript.reclaimable_bytes()
+    reclaimed = await transcript.compact_file(min_reclaim_bytes=1)
+    assert reclaimed == expected > 0
+    assert transcript.path.stat().st_size == before - reclaimed
+
+    reopened = Transcript(tmp_path / "sess")
+    roster_entries = [
+        e
+        for e in reopened.entries()
+        if e.type == "custom" and e.payload.get("custom_type") == "subagent_roster"
+    ]
+    # Exactly one roster entry survives, and it is the NEWEST (generation 49).
+    assert len(roster_entries) == 1
+    assert roster_entries[0].payload["details"]["generation"] == 49
+    # latest_custom is unchanged by the collapse.
+    latest_roster = reopened.latest_custom("subagent_roster")
+    assert latest_roster is not None and latest_roster["generation"] == 49
+    # The non-collapsible custom and the message are byte-preserved.
+    assert reopened.latest_custom("todo_snapshot") == {"items": ["a"]}
+    replayed = reopened.build_llm_history()
+    assert [m.text for m in replayed if isinstance(m, Message)] == ["keep me"]
+
+
+@pytest.mark.asyncio
+async def test_compact_file_keeps_a_single_roster_entry(tmp_path):
+    """One roster entry is already minimal: nothing to collapse, no rewrite."""
+    transcript = Transcript(tmp_path / "sess")
+    await transcript.append_message(Message.user("hi"))
+    await transcript.append_custom("subagent_roster", {"generation": 0, "records": []})
+    before = transcript.path.read_bytes()
+    assert await transcript.compact_file(min_reclaim_bytes=1) == 0
+    assert transcript.path.read_bytes() == before
+
+
 def test_encode_rejects_nothing_it_cannot_rebuild():
     """Belt and braces on the encoder itself: every field it drops must be
     reconstructible by pydantic from the model default."""


### PR DESCRIPTION
## Summary

Two bounded-growth hardening fixes for subagent roster persistence, on top of #308. #308 stopped NEW transcript bloat (the roster moved to an atomically replaced sidecar with 500-char per-record caps), but two gaps remained: redundant sidecar fsync churn on every roster event, and no way to heal a transcript already bloated by a pre-#308 runtime.

The motivating incident: a long delegating session accumulated a **125 MB** `transcript.jsonl` across only ~1,199 records (247 superseded `subagent_roster` snapshots, ~787 KB each) and was killed and manually restarted ~3 times by OS write-throttle/resource pressure. #308 prevents that file from ever growing again for new sessions; this PR (a) cuts the sidecar fsync volume that write-throttle pressure is measured on, and (b) heals the already-bloated files #308 leaves behind.

- **GAP 1 — skip byte-identical roster sidecar writes** (`perf(session)`). The roster persist hook fires on every job-row mutation (usage/heartbeat churn included), but most events leave the durable projection byte-identical. Each write is a full `mkstemp` + `fsync` + `os.replace` + directory-`fsync` cycle. A fingerprint guard (mirroring the existing `_maybe_persist_todos` guard) fingerprints the content `{version, jobs, records}` — **excluding** the ever-incrementing `generation` counter, which would otherwise defeat the guard — and writes only when it actually moved. The `_subagent_roster_written_generation` watermark still advances on a skipped write, so teardown's `_await_subagent_roster_writer` never loops chasing a generation the guard will always skip.

- **GAP 2 — heal legacy roster bloat on compaction** (`fix(transcript)`). `compact_file` previously folded only the message prune journal; superseded `subagent_roster` custom entries (read exclusively through `latest_custom`, newest-wins) were never reclaimed, so a pre-#308 transcript stayed permanently bloated — loaded whole into memory on every resume and re-serialized wholesale on every compaction. Compaction now also drops superseded collapsible custom entries, keeping only the newest. This is an **allowlist** (`_COLLAPSIBLE_CUSTOM_TYPES = {subagent_roster}`), deliberately excluding iteration-read types like `hub_communication` whose older entries carry real history. It runs even with no pending prunes, since a legacy bloated transcript never journals a prune.

## Change classification

C2 standard reliability/performance fix, layered on the #308 durability work. No user-visible UI, copy, layout, or interaction change.

## Delivery contract

- Resume basis intact: each record's `job_id → session_dir` mapping and outcome are untouched; only the redundant-write path and legacy-entry reclamation change.
- `latest_custom` and `build_llm_history` produce identical results before and after a heal (the kept roster entry is exactly the one `latest_custom` returns; messages, compaction markers and the prune boundary are byte-identical).
- The `reclaimable_bytes() == compact_file()` equality invariant holds: dropped collapsible customs are priced in both.
- No second capping mechanism: `comms.snapshot()` and #308's 500-char `_compact_subagent_record` cap are untouched.

## Runtime evidence

Standalone repro (`scripts/roster_bloat_repro.py`) exercises the real `SubagentComms` + `Transcript` + `Session` persist path.

**GAP 1** — 80 children × 30 KB `result_text`, ~3 roster events per settle:

```text
sidecar writes:  240  ->  80     (160 byte-identical fsync cycles eliminated)
watermark advances on skipped writes (no teardown drain loop): OK
resume round-trip (snapshot -> restore -> roster lists all children resumable): OK
```

**GAP 2** — synthesized legacy-bloated transcript, 50 superseded `subagent_roster` entries + 1 real message, one compaction pass:

```text
transcript bytes:   109,504  ->  2,342     (reclaimed 107,162)
roster entries:          50  ->  1         (survivor = newest, generation 49)
message "keep me":  preserved
latest_custom / build_llm_history:  unchanged
reclaimable_bytes() == reclaimed:  True
```

## Validation

Environment note: this host's `ulimit -n` is 256 and the repo forces `-n auto` (xdist); concurrent/contended runs exhaust file descriptors and wedge xdist teardown. The authoritative run below is serial (`-n0`) with a raised fd limit; CI runs the pinned config.

- Focused serial run across the directly-affected modules — `test_transcript_footprint`, `test_resume_subagents_todos`, `test_comms`, `test_usage_continuity`, `test_comms_persistence` → **152 passed**.
- New tests:
  - GAP 1: `test_redundant_roster_events_skip_the_sidecar_write`, `test_compact_record_caps_oversized_text_but_keeps_short_and_fields`, `test_capped_snapshot_round_trips_through_restore`
  - GAP 2: `test_compact_file_heals_legacy_roster_bloat`, `test_compact_file_keeps_a_single_roster_entry`
- Existing `test_compact_file_folds_journal_and_shrinks_disk` (the equality-invariant guard) still green.
- `flake8 .` clean, `black==26.1.0 --check .` clean, `isort==5.13.2 --check .` clean, full `pyright` → 0 errors.
- Full serial unit suite result appended to this PR once the run completes.

## Agent review

Agent code-review round to be posted below; this PR is the system of record.




## Rebase note

Rebased onto current `main` (`d4ba139e`, v0.41.4) after main advanced during review; version re-bumped to **0.41.5**. The only conflict was the `pyproject.toml` version line. Re-validated on the rebased head: affected-module suites pass serially (276 passed; one timing-sensitive subagent-responsiveness test flaked under host load and passes in isolation on both main and this branch).