### PR TITLE
fix(openai): restore gpt-5.6 prompt caching on the OAuth path

### DIFF
--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -512,6 +512,42 @@ def _sampling_params(request: ChatRequest, *, top_p_key: str = "top_p") -> dict[
     }
 
 
+# Matches an OpenAI ``gpt-5.<minor>`` model id, capturing the minor version. The
+# id may carry a suffix (``-sol``, ``-codex``, a date) which we ignore; only the
+# ``5.<minor>`` family number decides GPT-5.6-era cache semantics. A bare
+# ``gpt-5`` (no minor) is deliberately NOT matched: it predates the 5.6 implicit
+# caching change and must keep the older behaviour.
+_GPT_5_MINOR_RE = re.compile(r"^gpt-5\.(\d+)(?:[-.].*)?$")
+
+
+def _is_gpt_5_6_or_later(model_id: str) -> bool:
+    """Whether ``model_id`` is GPT-5.6 or a later 5.x that shares its caching.
+
+    GPT-5.6 changed OpenAI's implicit prompt-cache breakpoint to sit at the end
+    of the latest eligible user/tool message, which writes THROUGH the volatile
+    turn tail and loses hits on a large stable prefix followed by a changing
+    suffix (OpenAI Codex bug #35300). The remedies for that regression —
+    explicit ``prompt_cache_breakpoint`` markers and ``prompt_cache_options`` —
+    are GPT-5.6+ only; older Responses models (``gpt-5``, ``gpt-5.4`` …) 400 or
+    behave differently on them. This predicate gates those changes.
+
+    Conservative by construction: anything we cannot confidently parse as
+    ``gpt-5.N`` with ``N >= 6`` is treated as NOT 5.6+, which preserves today's
+    behaviour rather than risk sending a breakpoint to a model that rejects it.
+    """
+    match = _GPT_5_MINOR_RE.match(model_id.strip().lower())
+    if not match:
+        return False
+    return int(match.group(1)) >= 6
+
+
+# OpenAI caps a single request at four cache-WRITE breakpoints (guide: "Each
+# request can create up to four cache writes"). We spend one on the stable
+# system/developer prefix and reserve the rest for the most recent tool
+# results; never emit more than this many explicit markers in one body.
+_MAX_CACHE_BREAKPOINTS = 4
+
+
 def _reasoning_effort(request: ChatRequest) -> str | None:
     """The effort level to send, or ``None`` when the key must not appear.
 
@@ -772,6 +808,49 @@ def _messages_to_openai_responses(messages: Sequence[Message]) -> list[dict[str,
                 )
         items.append({"role": message.role, "content": content})
     return items
+
+
+def _mark_recent_tool_result_breakpoints(input_items: list[dict[str, Any]], budget: int) -> None:
+    """Add ``prompt_cache_breakpoint`` to the last ``budget`` tool results.
+
+    The guide's multi-turn-agent example marks each ``function_call_output``'s
+    last ``input_text`` block so a forked thread can reuse the shared prefix up
+    to that tool result. We only mark the MOST RECENT few, newest-first, to stay
+    within OpenAI's four-cache-write cap (the caller passes the remaining
+    budget after the implicit and stable-prefix writes). A string-valued output
+    is promoted to an ``input_text`` block so it can carry the marker; an
+    already-block output gets the marker on its final text block. Outputs with
+    no text block (image-only) are skipped rather than forced into a shape the
+    model would not read.
+    """
+    if budget <= 0:
+        return
+    marked = 0
+    for item in reversed(input_items):
+        if marked >= budget:
+            break
+        if item.get("type") != "function_call_output":
+            continue
+        output = item.get("output")
+        if isinstance(output, str):
+            item["output"] = [
+                {
+                    "type": "input_text",
+                    "text": output,
+                    "prompt_cache_breakpoint": {"mode": "explicit"},
+                }
+            ]
+            marked += 1
+            continue
+        if isinstance(output, list):
+            text_blocks = [
+                block
+                for block in output
+                if isinstance(block, dict) and block.get("type") == "input_text"
+            ]
+            if text_blocks:
+                text_blocks[-1]["prompt_cache_breakpoint"] = {"mode": "explicit"}
+                marked += 1
 
 
 EMPTY_TOOL_RESULT_TEXT = "[tool returned no output]"
@@ -1139,13 +1218,24 @@ class OpenAICompatClient:
         )
 
     def _build_responses_body(self, request: ChatRequest) -> dict[str, Any]:
-        """Public Responses body using native input items and flat tools."""
+        """Public Responses body using native input items and flat tools.
+
+        On GPT-5.6 and later this also carries the prompt-cache breakpoints the
+        model needs to stay warm; see ``_apply_gpt_5_6_prompt_cache`` for why.
+        """
+        # Gate the GPT-5.6-era cache controls once: ``prompt_cache_breakpoint``,
+        # ``prompt_cache_options`` and the developer-message prefix are 5.6+ only
+        # (older Responses models 400 or behave differently on them).
+        is_gpt_5_6 = _is_gpt_5_6_or_later(request.model.model_id)
         body: dict[str, Any] = {
             "model": request.model.model_id,
             "stream": True,
             "input": _messages_to_openai_responses(request.messages),
         }
-        if request.system_blocks:
+        if request.system_blocks and not is_gpt_5_6:
+            # Pre-5.6: the whole stable prefix rides top-level ``instructions``.
+            # It cannot carry a breakpoint, but pre-5.6 implicit caching does not
+            # write through the turn tail, so a breakpoint is unnecessary here.
             body["instructions"] = "\n\n".join(request.system_blocks)
         if request.tools:
             body["tools"] = _tools_to_openai_responses(request.tools)
@@ -1159,18 +1249,115 @@ class OpenAICompatClient:
         effort = _reasoning_effort(request)
         if effort is not None:
             body["reasoning"] = {"effort": effort}
+            # Defect #2: mirror OpenAI Codex (client.rs L720-724), which requests
+            # encrypted reasoning items whenever reasoning is enabled. On the
+            # ``store:false`` codex backend these ``reasoning.encrypted_content``
+            # items are what let the SAME response reuse its reasoning KV state,
+            # and they cost nothing when reasoning is off — so this is gated on
+            # reasoning being present, not on the model version. See
+            # ``_stream_responses`` for how the resulting reasoning items are
+            # handled on the wire (safely skipped; we do not yet replay them).
+            body["include"] = ["reasoning.encrypted_content"]
         if request.model.supports_prompt_cache and request.prompt_cache_key:
-            # The 24h policy is meaningful only with a stable key. SessionStreamFn
-            # supplies one per transcript, and retries preserve it on ChatRequest.
+            # A stable key routes same-prefix requests to the same warm cache.
+            # SessionStreamFn supplies one per transcript, and retries preserve
+            # it on ChatRequest.
             body["prompt_cache_key"] = request.prompt_cache_key
-            body["prompt_cache_retention"] = "24h"
+            if not is_gpt_5_6:
+                # Pre-5.6 lifetime control is ``prompt_cache_retention``. GPT-5.6
+                # replaced it with ``prompt_cache_options.ttl`` (guide migration),
+                # so 5.6+ must NOT send retention — it is set below instead.
+                body["prompt_cache_retention"] = "24h"
+        if is_gpt_5_6:
+            self._apply_gpt_5_6_prompt_cache(request, body)
         return body
 
+    def _apply_gpt_5_6_prompt_cache(self, request: ChatRequest, body: dict[str, Any]) -> None:
+        """Place GPT-5.6 explicit cache breakpoints on ``body`` (defect #3).
+
+        GPT-5.6 moved the implicit cache breakpoint to the end of the latest
+        eligible user/tool message (OpenAI Codex bug #35300), writing THROUGH
+        the volatile turn tail: a large stable prefix followed by a changing
+        suffix stops matching, collapsing the cache-read rate. The guide's fix
+        (0% -> 98.6% on a 9k-token prefix) is to end the stable prefix with an
+        explicit ``prompt_cache_breakpoint`` in an ``input_text`` block inside a
+        developer message — top-level ``instructions`` CANNOT carry a breakpoint,
+        which is exactly why the stable head has to move out of it here.
+
+        We mirror the guide's multi-turn-agent shape (reported >90%): implicit
+        mode kept on so the latest message still caches, plus explicit
+        breakpoints after the stable system prefix and after the most recent
+        tool results (helps forked threads reuse the shared prefix). Every
+        request is capped at four cache writes; implicit spends one slot, the
+        stable-prefix breakpoint one, leaving two for tool results.
+        """
+        # ``prompt_cache_options.mode = implicit`` keeps OpenAI's automatic
+        # breakpoint on the latest message while still honouring our explicit
+        # markers (guide: an implicit breakpoint uses one of the four write
+        # slots, leaving three for explicit ones).
+        body["prompt_cache_options"] = {"mode": "implicit"}
+
+        blocks = request.system_blocks
+        if blocks:
+            # system_blocks is ordered most-stable -> most-volatile (see
+            # prompts_api.build_system_blocks): block 0 instructions, tool
+            # inventory/skills next, the env/date/goal tail LAST. The breakpoint
+            # goes after the stable head but before the volatile tail, so a
+            # change in the tail never invalidates the stable prefix's cache.
+            if len(blocks) >= 2:
+                stable, volatile = blocks[:-1], blocks[-1]
+            else:
+                # A lone block has no stable/volatile split to exploit; treat it
+                # as the stable prefix and end it with the breakpoint.
+                stable, volatile = blocks, None
+            stable_content: list[dict[str, Any]] = [
+                {"type": "input_text", "text": text} for text in stable
+            ]
+            stable_content[-1]["prompt_cache_breakpoint"] = {"mode": "explicit"}
+            developer_items: list[dict[str, Any]] = [
+                {"role": "developer", "content": stable_content}
+            ]
+            if volatile is not None:
+                # The volatile tail rides its OWN developer message AFTER the
+                # breakpoint (no marker) so its churn stays out of the cached
+                # prefix — the guide's "keep changing content after the
+                # breakpoint" shape. It must sit in ``input`` rather than
+                # top-level ``instructions``, which would render BEFORE the
+                # breakpoint and pull the volatile bytes back into the prefix.
+                developer_items.append(
+                    {
+                        "role": "developer",
+                        "content": [{"type": "input_text", "text": volatile}],
+                    }
+                )
+            body["input"] = [*developer_items, *body["input"]]
+
+        # Explicit breakpoints after the most recent tool results, as in the
+        # guide's multi-turn-agent example. Budget: four total writes minus one
+        # for implicit and one for the stable-prefix breakpoint above = two.
+        stable_breakpoints = 1 if blocks else 0
+        tool_result_budget = max(0, _MAX_CACHE_BREAKPOINTS - 1 - stable_breakpoints)
+        _mark_recent_tool_result_breakpoints(body["input"], tool_result_budget)
+
     def _build_codex_responses_body(self, request: ChatRequest) -> dict[str, Any]:
-        """ChatGPT Codex body: Responses-shaped, with public-API-only keys removed."""
+        """ChatGPT Codex body: Responses-shaped, on the ``store:false`` backend.
+
+        Reuses the public Responses body, then strips the fields the codex
+        backend does not take. Note that ``prompt_cache_key`` is deliberately
+        NOT stripped any more: an earlier version popped it under a comment
+        calling it "public-API-only", which was a wrong assumption. Real Codex
+        (client.rs, ``build_responses_request``) sets ``prompt_cache_key``
+        UNCONDITIONALLY on this same ``store:false`` backend for routing
+        stickiness, and the model's ~89-90% cache-read rate versus ~97-98% for
+        OpenAI-shaped peers was traced to us stripping it. ``prompt_cache_key``,
+        ``include``, ``prompt_cache_options`` and the developer-message
+        breakpoints all flow through from ``_build_responses_body``. Only
+        ``prompt_cache_retention`` is popped: the codex backend is
+        ``store:false`` (public retention does not apply) and GPT-5.6 controls
+        lifetime through ``prompt_cache_options.ttl`` instead.
+        """
         body = self._build_responses_body(request)
         body["store"] = False
-        body.pop("prompt_cache_key", None)
         body.pop("prompt_cache_retention", None)
         body.pop("max_output_tokens", None)
         body.pop("temperature", None)
@@ -1370,8 +1557,26 @@ class OpenAICompatClient:
                 except json.JSONDecodeError:
                     continue
                 event_type = payload.get("type", "")
+                # Requesting ``include: ["reasoning.encrypted_content"]`` (defect
+                # #2) makes the stream carry ``reasoning`` output items and their
+                # ``response.reasoning*`` deltas that a non-reasoning include
+                # never produced. We deliberately DROP them: the harness has no
+                # channel to replay an OpenAI encrypted reasoning item back on
+                # the next turn's ``input`` (unlike Anthropic's thinking blocks,
+                # which ride ``provider_payload``), and wiring that state through
+                # the loop is out of this fix's scope. The include still earns
+                # its keep — encrypted reasoning improves SAME-response cache
+                # reuse — but cross-turn reasoning replay is intentionally not
+                # attempted here. Skipping is explicit rather than incidental so
+                # a future ``else`` branch cannot accidentally render a reasoning
+                # item's encrypted blob as assistant text. (Called out for review.)
+                if event_type.startswith("response.reasoning"):
+                    continue
                 if event_type == "response.output_item.added":
                     item = payload.get("item") or {}
+                    if item.get("type") == "reasoning":
+                        # Same rationale as above: acknowledge the item, drop it.
+                        continue
                     if item.get("type") == "function_call":
                         index = tool_call_count
                         tool_call_count += 1

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -1174,7 +1174,14 @@ class OpenAICompatClient:
             # reasoning being present, not on the model version. See
             # ``_stream_responses`` for how the resulting reasoning items are
             # handled on the wire (safely skipped; we do not yet replay them).
-            body["include"] = ["reasoning.encrypted_content"]
+            #
+            # Extend rather than assign: nothing else sets ``include`` on this
+            # path today, but a future include-bearing field must not be
+            # silently clobbered by this line (review round 1, N1). Dedupe so a
+            # re-entry cannot list the same value twice.
+            include = body.setdefault("include", [])
+            if "reasoning.encrypted_content" not in include:
+                include.append("reasoning.encrypted_content")
         if request.model.supports_prompt_cache and request.prompt_cache_key:
             # The 24h policy is meaningful only with a stable key. SessionStreamFn
             # supplies one per transcript, and retries preserve it on ChatRequest.

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -512,42 +512,6 @@ def _sampling_params(request: ChatRequest, *, top_p_key: str = "top_p") -> dict[
     }
 
 
-# Matches an OpenAI ``gpt-5.<minor>`` model id, capturing the minor version. The
-# id may carry a suffix (``-sol``, ``-codex``, a date) which we ignore; only the
-# ``5.<minor>`` family number decides GPT-5.6-era cache semantics. A bare
-# ``gpt-5`` (no minor) is deliberately NOT matched: it predates the 5.6 implicit
-# caching change and must keep the older behaviour.
-_GPT_5_MINOR_RE = re.compile(r"^gpt-5\.(\d+)(?:[-.].*)?$")
-
-
-def _is_gpt_5_6_or_later(model_id: str) -> bool:
-    """Whether ``model_id`` is GPT-5.6 or a later 5.x that shares its caching.
-
-    GPT-5.6 changed OpenAI's implicit prompt-cache breakpoint to sit at the end
-    of the latest eligible user/tool message, which writes THROUGH the volatile
-    turn tail and loses hits on a large stable prefix followed by a changing
-    suffix (OpenAI Codex bug #35300). The remedies for that regression —
-    explicit ``prompt_cache_breakpoint`` markers and ``prompt_cache_options`` —
-    are GPT-5.6+ only; older Responses models (``gpt-5``, ``gpt-5.4`` …) 400 or
-    behave differently on them. This predicate gates those changes.
-
-    Conservative by construction: anything we cannot confidently parse as
-    ``gpt-5.N`` with ``N >= 6`` is treated as NOT 5.6+, which preserves today's
-    behaviour rather than risk sending a breakpoint to a model that rejects it.
-    """
-    match = _GPT_5_MINOR_RE.match(model_id.strip().lower())
-    if not match:
-        return False
-    return int(match.group(1)) >= 6
-
-
-# OpenAI caps a single request at four cache-WRITE breakpoints (guide: "Each
-# request can create up to four cache writes"). We spend one on the stable
-# system/developer prefix and reserve the rest for the most recent tool
-# results; never emit more than this many explicit markers in one body.
-_MAX_CACHE_BREAKPOINTS = 4
-
-
 def _reasoning_effort(request: ChatRequest) -> str | None:
     """The effort level to send, or ``None`` when the key must not appear.
 
@@ -808,49 +772,6 @@ def _messages_to_openai_responses(messages: Sequence[Message]) -> list[dict[str,
                 )
         items.append({"role": message.role, "content": content})
     return items
-
-
-def _mark_recent_tool_result_breakpoints(input_items: list[dict[str, Any]], budget: int) -> None:
-    """Add ``prompt_cache_breakpoint`` to the last ``budget`` tool results.
-
-    The guide's multi-turn-agent example marks each ``function_call_output``'s
-    last ``input_text`` block so a forked thread can reuse the shared prefix up
-    to that tool result. We only mark the MOST RECENT few, newest-first, to stay
-    within OpenAI's four-cache-write cap (the caller passes the remaining
-    budget after the implicit and stable-prefix writes). A string-valued output
-    is promoted to an ``input_text`` block so it can carry the marker; an
-    already-block output gets the marker on its final text block. Outputs with
-    no text block (image-only) are skipped rather than forced into a shape the
-    model would not read.
-    """
-    if budget <= 0:
-        return
-    marked = 0
-    for item in reversed(input_items):
-        if marked >= budget:
-            break
-        if item.get("type") != "function_call_output":
-            continue
-        output = item.get("output")
-        if isinstance(output, str):
-            item["output"] = [
-                {
-                    "type": "input_text",
-                    "text": output,
-                    "prompt_cache_breakpoint": {"mode": "explicit"},
-                }
-            ]
-            marked += 1
-            continue
-        if isinstance(output, list):
-            text_blocks = [
-                block
-                for block in output
-                if isinstance(block, dict) and block.get("type") == "input_text"
-            ]
-            if text_blocks:
-                text_blocks[-1]["prompt_cache_breakpoint"] = {"mode": "explicit"}
-                marked += 1
 
 
 EMPTY_TOOL_RESULT_TEXT = "[tool returned no output]"
@@ -1218,24 +1139,20 @@ class OpenAICompatClient:
         )
 
     def _build_responses_body(self, request: ChatRequest) -> dict[str, Any]:
-        """Public Responses body using native input items and flat tools.
-
-        On GPT-5.6 and later this also carries the prompt-cache breakpoints the
-        model needs to stay warm; see ``_apply_gpt_5_6_prompt_cache`` for why.
-        """
-        # Gate the GPT-5.6-era cache controls once: ``prompt_cache_breakpoint``,
-        # ``prompt_cache_options`` and the developer-message prefix are 5.6+ only
-        # (older Responses models 400 or behave differently on them).
-        is_gpt_5_6 = _is_gpt_5_6_or_later(request.model.model_id)
+        """Public Responses body using native input items and flat tools."""
         body: dict[str, Any] = {
             "model": request.model.model_id,
             "stream": True,
             "input": _messages_to_openai_responses(request.messages),
         }
-        if request.system_blocks and not is_gpt_5_6:
-            # Pre-5.6: the whole stable prefix rides top-level ``instructions``.
-            # It cannot carry a breakpoint, but pre-5.6 implicit caching does not
-            # write through the turn tail, so a breakpoint is unnecessary here.
+        if request.system_blocks:
+            # The stable system prefix rides top-level ``instructions``, exactly
+            # as real Codex does (client.rs: ``instructions = base_instructions``).
+            # We deliberately do NOT move it into ``developer`` messages or attach
+            # ``prompt_cache_breakpoint`` markers: the ChatGPT-subscription Codex
+            # backend rejects both ``prompt_cache_breakpoint`` and
+            # ``prompt_cache_options`` with HTTP 400 (matches OpenAI Codex bug
+            # #35300), and that OAuth backend is the only path in use here.
             body["instructions"] = "\n\n".join(request.system_blocks)
         if request.tools:
             body["tools"] = _tools_to_openai_responses(request.tools)
@@ -1259,85 +1176,11 @@ class OpenAICompatClient:
             # handled on the wire (safely skipped; we do not yet replay them).
             body["include"] = ["reasoning.encrypted_content"]
         if request.model.supports_prompt_cache and request.prompt_cache_key:
-            # A stable key routes same-prefix requests to the same warm cache.
-            # SessionStreamFn supplies one per transcript, and retries preserve
-            # it on ChatRequest.
+            # The 24h policy is meaningful only with a stable key. SessionStreamFn
+            # supplies one per transcript, and retries preserve it on ChatRequest.
             body["prompt_cache_key"] = request.prompt_cache_key
-            if not is_gpt_5_6:
-                # Pre-5.6 lifetime control is ``prompt_cache_retention``. GPT-5.6
-                # replaced it with ``prompt_cache_options.ttl`` (guide migration),
-                # so 5.6+ must NOT send retention — it is set below instead.
-                body["prompt_cache_retention"] = "24h"
-        if is_gpt_5_6:
-            self._apply_gpt_5_6_prompt_cache(request, body)
+            body["prompt_cache_retention"] = "24h"
         return body
-
-    def _apply_gpt_5_6_prompt_cache(self, request: ChatRequest, body: dict[str, Any]) -> None:
-        """Place GPT-5.6 explicit cache breakpoints on ``body`` (defect #3).
-
-        GPT-5.6 moved the implicit cache breakpoint to the end of the latest
-        eligible user/tool message (OpenAI Codex bug #35300), writing THROUGH
-        the volatile turn tail: a large stable prefix followed by a changing
-        suffix stops matching, collapsing the cache-read rate. The guide's fix
-        (0% -> 98.6% on a 9k-token prefix) is to end the stable prefix with an
-        explicit ``prompt_cache_breakpoint`` in an ``input_text`` block inside a
-        developer message — top-level ``instructions`` CANNOT carry a breakpoint,
-        which is exactly why the stable head has to move out of it here.
-
-        We mirror the guide's multi-turn-agent shape (reported >90%): implicit
-        mode kept on so the latest message still caches, plus explicit
-        breakpoints after the stable system prefix and after the most recent
-        tool results (helps forked threads reuse the shared prefix). Every
-        request is capped at four cache writes; implicit spends one slot, the
-        stable-prefix breakpoint one, leaving two for tool results.
-        """
-        # ``prompt_cache_options.mode = implicit`` keeps OpenAI's automatic
-        # breakpoint on the latest message while still honouring our explicit
-        # markers (guide: an implicit breakpoint uses one of the four write
-        # slots, leaving three for explicit ones).
-        body["prompt_cache_options"] = {"mode": "implicit"}
-
-        blocks = request.system_blocks
-        if blocks:
-            # system_blocks is ordered most-stable -> most-volatile (see
-            # prompts_api.build_system_blocks): block 0 instructions, tool
-            # inventory/skills next, the env/date/goal tail LAST. The breakpoint
-            # goes after the stable head but before the volatile tail, so a
-            # change in the tail never invalidates the stable prefix's cache.
-            if len(blocks) >= 2:
-                stable, volatile = blocks[:-1], blocks[-1]
-            else:
-                # A lone block has no stable/volatile split to exploit; treat it
-                # as the stable prefix and end it with the breakpoint.
-                stable, volatile = blocks, None
-            stable_content: list[dict[str, Any]] = [
-                {"type": "input_text", "text": text} for text in stable
-            ]
-            stable_content[-1]["prompt_cache_breakpoint"] = {"mode": "explicit"}
-            developer_items: list[dict[str, Any]] = [
-                {"role": "developer", "content": stable_content}
-            ]
-            if volatile is not None:
-                # The volatile tail rides its OWN developer message AFTER the
-                # breakpoint (no marker) so its churn stays out of the cached
-                # prefix — the guide's "keep changing content after the
-                # breakpoint" shape. It must sit in ``input`` rather than
-                # top-level ``instructions``, which would render BEFORE the
-                # breakpoint and pull the volatile bytes back into the prefix.
-                developer_items.append(
-                    {
-                        "role": "developer",
-                        "content": [{"type": "input_text", "text": volatile}],
-                    }
-                )
-            body["input"] = [*developer_items, *body["input"]]
-
-        # Explicit breakpoints after the most recent tool results, as in the
-        # guide's multi-turn-agent example. Budget: four total writes minus one
-        # for implicit and one for the stable-prefix breakpoint above = two.
-        stable_breakpoints = 1 if blocks else 0
-        tool_result_budget = max(0, _MAX_CACHE_BREAKPOINTS - 1 - stable_breakpoints)
-        _mark_recent_tool_result_breakpoints(body["input"], tool_result_budget)
 
     def _build_codex_responses_body(self, request: ChatRequest) -> dict[str, Any]:
         """ChatGPT Codex body: Responses-shaped, on the ``store:false`` backend.
@@ -1349,12 +1192,11 @@ class OpenAICompatClient:
         (client.rs, ``build_responses_request``) sets ``prompt_cache_key``
         UNCONDITIONALLY on this same ``store:false`` backend for routing
         stickiness, and the model's ~89-90% cache-read rate versus ~97-98% for
-        OpenAI-shaped peers was traced to us stripping it. ``prompt_cache_key``,
-        ``include``, ``prompt_cache_options`` and the developer-message
-        breakpoints all flow through from ``_build_responses_body``. Only
-        ``prompt_cache_retention`` is popped: the codex backend is
-        ``store:false`` (public retention does not apply) and GPT-5.6 controls
-        lifetime through ``prompt_cache_options.ttl`` instead.
+        OpenAI-shaped peers was traced to us stripping it. ``prompt_cache_key``
+        and ``include`` (defect #2's encrypted reasoning) flow through from
+        ``_build_responses_body``. Only ``prompt_cache_retention`` is popped:
+        the codex backend is ``store:false``, so public retention does not
+        apply.
         """
         body = self._build_responses_body(request)
         body["store"] = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.41.2"
+version = "0.41.3"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/bench_openai_oauth_cache.py
+++ b/scripts/bench_openai_oauth_cache.py
@@ -98,6 +98,7 @@ REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO))
 
 from local_operator.harness.types import (  # noqa: E402
+    AgentTool,
     ChatRequest,
     Message,
     ModelSpec,
@@ -112,6 +113,7 @@ from local_operator.prompts_api import build_system_blocks  # noqa: E402
 from local_operator.providers.auth_store import AuthStore, OAuthAccess  # noqa: E402
 from local_operator.providers.clients import (  # noqa: E402
     CODEX_RESPONSES_URL,
+    OpenAICompatClient,
     client_for_spec,
 )
 from local_operator.tools.registry import create_tools  # noqa: E402
@@ -180,7 +182,7 @@ class ScenarioResult:
 # ---------------------------------------------------------------------------
 
 
-def _build_prefix() -> tuple[list, list[str]]:
+def _build_prefix() -> tuple[list[AgentTool], list[str]]:
     """The realistic (tools, system_blocks) prefix shared by every scenario.
 
     The tool inventory and system blocks are what dominate the cached prefix
@@ -210,7 +212,7 @@ def _resolve_spec(reasoning_effort: str | None) -> ModelSpec:
 def _make_request(
     spec: ModelSpec,
     system_blocks: list[str],
-    tools: list,
+    tools: list[AgentTool],
     messages: list[Message],
     session_id: str,
 ) -> ChatRequest:
@@ -460,7 +462,12 @@ def _dry_run() -> None:
     """
     spec = _resolve_spec("medium")
     tools, system_blocks = _build_prefix()
+    # ``client_for_spec`` is typed as the ``WireClient`` protocol; for an OpenAI
+    # spec it is concretely an ``OpenAICompatClient``, whose codex body builder
+    # and ``aclose`` this benchmark introspects. Assert the concrete type so the
+    # introspection type-checks (CI runs whole-tree pyright).
     client = client_for_spec(spec, openai_api="responses")
+    assert isinstance(client, OpenAICompatClient)
 
     print(f"Codex Responses URL: {CODEX_RESPONSES_URL}")
     print("prompt_cache_key set on ChatRequest: yes (= session id)\n")
@@ -547,7 +554,7 @@ def _print_scenario_table(results: list[ScenarioResult]) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
-_SCENARIO_RUNNERS: dict[str, Callable] = {
+_SCENARIO_RUNNERS: dict[str, Callable[..., Any]] = {
     "long_session": lambda c, o, t: run_long_session(c, o, t, None, "long_session"),
     "stable_prefix": run_stable_prefix,
     "tool_heavy": run_tool_heavy,
@@ -567,6 +574,7 @@ async def _run_live(scenario: str | None, turns: int) -> int:
 
     spec = _resolve_spec(None)
     client = client_for_spec(spec, openai_api="responses")
+    assert isinstance(client, OpenAICompatClient)
 
     names = [scenario] if scenario else list(_SCENARIO_RUNNERS.keys())
     results: list[ScenarioResult] = []

--- a/scripts/bench_openai_oauth_cache.py
+++ b/scripts/bench_openai_oauth_cache.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Live prompt-cache benchmark for the OpenAI OAuth (ChatGPT / Codex) path.
+
+This drives REAL multi-turn conversations through the harness' actual wire
+client (``OpenAICompatClient``) against the operator's ChatGPT-subscription
+OAuth credential for ``gpt-5.6-sol``, and reports the server-side prompt-cache
+hit rate the Codex Responses backend actually delivers. Its purpose is a
+before/after measurement: run the SAME script on ``origin/main`` and on a fix
+branch and compare the numbers. It deliberately hardcodes nothing about any
+fix -- it exercises whatever request the current code builds, so the delta is
+attributable to the code under test rather than to the harness.
+
+Why this exists
+---------------
+The Codex Responses path (``_build_codex_responses_body``) currently strips
+``prompt_cache_key`` from the body (it is popped as a "public-API-only" key).
+OpenAI's Responses cache keys off request-prefix identity, and a stable
+``prompt_cache_key`` is what pins diverging sessions that share a big system +
+tools prefix onto the same cache bucket (the failure mode OpenAI Codex issue
+#35300 targets). Without it, a large stable prefix reused across sessions that
+diverge at the first user turn caches far worse than it should. We need a live
+BEFORE number to prove the gap and an AFTER number to prove a fix.
+
+The cache-read rate and its subset semantics
+--------------------------------------------
+On OpenAI, ``usage.input_tokens_details.cached_tokens`` (mapped onto
+``Usage.cache_read_tokens``) is a SUBSET of ``usage.input_tokens`` -- the cached
+tokens are counted INSIDE the input total, not in addition to it. The Codex
+backend does not report a separate cache-WRITE count, so ``cache_write_tokens``
+is 0 on this path. To keep the rate comparable to the other providers' rate in
+``bench_cache_rate.py`` (where cached is reported OUTSIDE input), and to keep
+the denominator equal to the true prompt-side token volume, we compute:
+
+    cache_read_rate = sum(cache_read) / sum(input + cache_read + cache_write)
+
+Because ``cached ⊆ input`` here, ``input + cache_read`` double-counts the cached
+slice on purpose: the denominator is then "prompt tokens billed at full price
+(input - cached) + cached tokens counted once as input + cached counted again",
+which for OpenAI reduces to ``input + cached`` and makes the ratio directly the
+fraction of the prompt that was served from cache relative to a
+cached-outside-input convention. In practice ``cache_write`` is 0 here, so the
+denominator is ``input + cached`` and the rate is ``cached / (input + cached)``.
+The per-scenario table prints the raw sums so the semantics are auditable.
+
+What each scenario probes
+-------------------------
+1. ``long_session`` -- one session, 6-8 append-only turns that build on each
+   other. This is the operator's dominant usage; the whole prefix (system +
+   tools + growing history) is stable turn to turn, so it should show the
+   HIGHEST baseline cache rate even without the fix, because a single session
+   naturally reuses its own prefix.
+2. ``stable_prefix`` -- the same large system + tools prefix, but 5 SEPARATE
+   short sessions that diverge at the very first user turn. This is the issue
+   #35300 failure mode: the big shared prefix should hit cache across sessions,
+   and the ``prompt_cache_key`` is what makes that happen. Expect the biggest
+   before/after gap here.
+3. ``tool_heavy`` -- one session where each turn issues a tool call and feeds
+   the ``function_call`` / ``function_call_output`` back, 5-6 turns. Probes how
+   the cache behaves when the tail of the prefix is tool traffic rather than
+   plain user/assistant text (breakpoint-after-tool-result behavior).
+4. ``reasoning_on`` -- like scenario 1 but with reasoning effort set to
+   ``medium`` so the encrypted-reasoning-content path is exercised. Reasoning
+   items ride the Responses prefix; this checks caching still lands with them.
+
+Cost discipline
+---------------
+Model OUTPUT is the expensive part and it is capped hard: every prompt asks for
+a terse (<=15 word) answer, and turn counts are small and flag-tunable. The
+PREFIX (system + tools) is deliberately realistic (~10-15k tokens) so the cached
+prefix clears OpenAI's 1024-token cache floor -- a toy prefix would never cache
+and the measurement would be meaningless. Net: a full run spends a few thousand
+input tokens per turn (cached after the first) and a few hundred output tokens.
+
+Usage
+-----
+    .venv/bin/python scripts/bench_openai_oauth_cache.py --dry-run
+    .venv/bin/python scripts/bench_openai_oauth_cache.py --scenario long_session --turns 6
+    .venv/bin/python scripts/bench_openai_oauth_cache.py            # all scenarios, live
+
+``--dry-run`` prints the redacted request-body shape WITHOUT any network call so
+the codex routing (posts to the Codex URL, and -- on origin/main -- carries NO
+``prompt_cache_key``) can be inspected. Exit code is ALWAYS 0: this is a
+measurement tool, not a gate. A missing OAuth credential prints a skip line and
+exits 0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from local_operator.harness.types import (  # noqa: E402
+    ChatRequest,
+    Message,
+    ModelSpec,
+    StreamEndEvent,
+    StreamUsageEvent,
+    ToolCall,
+    ToolContext,
+    Usage,
+)
+from local_operator.model.configure import build_model_spec  # noqa: E402
+from local_operator.prompts_api import build_system_blocks  # noqa: E402
+from local_operator.providers.auth_store import AuthStore, OAuthAccess  # noqa: E402
+from local_operator.providers.clients import (  # noqa: E402
+    CODEX_RESPONSES_URL,
+    client_for_spec,
+)
+from local_operator.tools.registry import create_tools  # noqa: E402
+
+# The model under test. Resolved through the real registry so
+# supports_prompt_cache / supports_responses_api / context_window are the exact
+# values the app runs with, not guesses.
+MODEL_ID = "gpt-5.6-sol"
+
+# A terse-answer instruction appended to every user prompt. Output tokens are
+# the costly ones; the whole benchmark is about INPUT-side caching, so we cap
+# generation to a handful of tokens per turn without changing the prefix.
+TERSE = " Answer in 15 words or fewer, no code."
+
+# A small, realistic skills block so the frozen skills tail matches what a live
+# session carries. Kept byte-stable for a session exactly as the harness freezes
+# its selected skills block for the conversation.
+SKILLS_BLOCK = "<skills>\nminerva-observability: Datadog incident playbooks\n</skills>"
+
+ENV_DETAILS = "Platform: Darwin (arm64). Shell: /bin/zsh. Working on a Python project."
+DATE_STR = "2026-08-26"
+
+
+@dataclass
+class TurnUsage:
+    """One turn's prompt-side token accounting from the provider's usage event."""
+
+    input_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    output_tokens: int = 0
+
+
+@dataclass
+class ScenarioResult:
+    name: str
+    turns: list[TurnUsage] = field(default_factory=list)
+    error: str | None = None
+
+    @property
+    def total_input(self) -> int:
+        return sum(t.input_tokens for t in self.turns)
+
+    @property
+    def total_cache_read(self) -> int:
+        return sum(t.cache_read_tokens for t in self.turns)
+
+    @property
+    def total_cache_write(self) -> int:
+        return sum(t.cache_write_tokens for t in self.turns)
+
+    @property
+    def denom(self) -> int:
+        # See the module docstring: cached ⊆ input on OpenAI, so the denominator
+        # counts input + cache_read (+ cache_write, 0 here) to express the rate
+        # on the same "cached outside input" convention the other bench uses.
+        return self.total_input + self.total_cache_read + self.total_cache_write
+
+    @property
+    def cache_rate(self) -> float:
+        return self.total_cache_read / self.denom if self.denom else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Prefix construction (identical big prefix for every scenario)
+# ---------------------------------------------------------------------------
+
+
+def _build_prefix() -> tuple[list, list[str]]:
+    """The realistic (tools, system_blocks) prefix shared by every scenario.
+
+    The tool inventory and system blocks are what dominate the cached prefix
+    (~10-15k tokens together), so they are built once and reused: two scenarios
+    that share this prefix byte-for-byte are exactly what a server-side prefix
+    cache is supposed to reward.
+    """
+    tools = create_tools(ToolContext(cwd=str(REPO), session_id="bench-oauth-cache"))
+    system_blocks = build_system_blocks(tools, SKILLS_BLOCK, ENV_DETAILS, DATE_STR)
+    return tools, system_blocks
+
+
+def _resolve_spec(reasoning_effort: str | None) -> ModelSpec:
+    """The real ModelSpec for the model, optionally pinned to a reasoning level.
+
+    Resolved via ``build_model_spec`` (the same path the session uses) so
+    ``supports_prompt_cache`` and ``supports_responses_api`` are authoritative.
+    A reasoning level is only applied when the model's own ladder accepts it, so
+    the request never carries a level the provider would 400 on.
+    """
+    spec = build_model_spec("openai", MODEL_ID)
+    if reasoning_effort and reasoning_effort in spec.reasoning_efforts:
+        spec = spec.model_copy(update={"reasoning_effort": reasoning_effort})
+    return spec
+
+
+def _make_request(
+    spec: ModelSpec,
+    system_blocks: list[str],
+    tools: list,
+    messages: list[Message],
+    session_id: str,
+) -> ChatRequest:
+    """Build a ChatRequest exactly as the session host does.
+
+    Critically, ``prompt_cache_key`` is set to the session id, mirroring
+    ``SessionStreamFn.stream`` in ``model/configure.py`` (which copies the
+    session id onto the request when the field is unset). This is the realistic
+    behavior; whether the Codex body then FORWARDS it is the code under test.
+    """
+    return ChatRequest(
+        model=spec,
+        system_blocks=system_blocks,
+        messages=messages,
+        tools=tools,
+        prompt_cache_key=session_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario message builders
+# ---------------------------------------------------------------------------
+
+# Scenario 1 & 4: an append-only coding conversation. Each prompt builds on the
+# last so the whole history is a stable growing prefix.
+_LONG_PROMPTS = [
+    "I'm building a CLI todo app in Python. What single module layout do you suggest?",
+    "Name the dataclass fields for a Todo item.",
+    "What method signatures should the TodoList class expose?",
+    "How should completed todos be marked in storage?",
+    "Suggest one edge case my remove() method must handle.",
+    "What's a good name for the JSON persistence file?",
+    "One sentence: how should I test the add() path?",
+    "Summarize the design in one line.",
+]
+
+# Scenario 2: five short sessions that share the big prefix but DIVERGE at the
+# very first user turn. Each is a different domain question, so nothing but the
+# system + tools prefix is shared -- which is precisely what a stable
+# prompt_cache_key is supposed to keep warm across sessions.
+_DIVERGING_FIRST_TURNS = [
+    "In one line, what does a load balancer do?",
+    "In one line, what is a Python context manager?",
+    "In one line, what is TCP backpressure?",
+    "In one line, what is a database index?",
+    "In one line, what is idempotency?",
+]
+
+# Scenario 3: tool-heavy. Each turn asks for a lookup that the model answers
+# with a function_call; we synthesize the function_call_output and feed it back,
+# so the tail of the prefix is tool traffic rather than plain prose.
+_TOOL_PROMPTS = [
+    "Read the file config.yaml and tell me the port in one line.",
+    "Now read app.log and report the last error in one line.",
+    "Read version.txt and report the version in one line.",
+    "Read hosts.txt and report the first host in one line.",
+    "Read status.json and report the state in one line.",
+    "Read notes.md and report the title in one line.",
+]
+
+_TOOL_OUTPUTS = [
+    "port: 8080",
+    "ERROR connection reset by peer",
+    "v2.3.1",
+    "web-01.internal",
+    '{"state": "healthy"}',
+    "# Deployment notes",
+]
+
+
+def _long_messages(turn_idx: int, history: list[Message], prompt: str) -> list[Message]:
+    """Append-only: add a user turn, keep all prior assistant/user turns."""
+    history.append(Message.user(prompt + TERSE))
+    return list(history)
+
+
+def _tool_call_message(name: str, path: str) -> Message:
+    """An assistant turn requesting a single read tool call.
+
+    Uses a real ToolCall shape (id, name, arguments) so the Responses converter
+    emits a proper ``function_call`` input item, exercising the tool-result
+    breakpoint path rather than plain prose.
+    """
+    call = ToolCall(name=name, arguments={"path": path})
+    return Message(role="assistant", tool_calls=[call])
+
+
+def _tool_result_message(call_id: str, output: str) -> Message:
+    """A tool result answering a specific call id (=> ``function_call_output``)."""
+    from local_operator.harness.types import TextContent
+
+    return Message(
+        role="tool",
+        content=[TextContent(text=output)],
+        tool_call_id=call_id,
+        tool_name="read",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario runners
+# ---------------------------------------------------------------------------
+
+
+async def _stream_turn(
+    client: Any,
+    request: ChatRequest,
+    oauth_access: OAuthAccess | None,
+) -> TurnUsage:
+    """Drive one real provider turn and return its prompt-side usage.
+
+    Usage arrives on ``StreamUsageEvent`` and/or the terminal ``StreamEndEvent``;
+    we take the last non-empty usage seen. ``api_key`` is None because the OAuth
+    bearer is carried on ``oauth_access`` and injected by the client's headers.
+    """
+    last_usage: Usage | None = None
+    async for event in client.stream(request, None, oauth_access=oauth_access):
+        if isinstance(event, StreamUsageEvent) and event.usage is not None:
+            last_usage = event.usage
+        elif isinstance(event, StreamEndEvent) and event.usage is not None:
+            last_usage = event.usage
+    if last_usage is None:
+        return TurnUsage()
+    return TurnUsage(
+        input_tokens=last_usage.input_tokens,
+        cache_read_tokens=last_usage.cache_read_tokens,
+        cache_write_tokens=last_usage.cache_write_tokens,
+        output_tokens=last_usage.output_tokens,
+    )
+
+
+async def run_long_session(
+    client: Any,
+    oauth_access: OAuthAccess | None,
+    turns: int,
+    reasoning_effort: str | None,
+    scenario_name: str,
+) -> ScenarioResult:
+    """Scenario 1/4: one session, append-only turns."""
+    spec = _resolve_spec(reasoning_effort)
+    tools, system_blocks = _build_prefix()
+    session_id = f"bench-{scenario_name}"
+    result = ScenarioResult(name=scenario_name)
+    history: list[Message] = []
+    for i, prompt in enumerate(_LONG_PROMPTS[:turns]):
+        messages = _long_messages(i, history, prompt)
+        request = _make_request(spec, system_blocks, tools, messages, session_id)
+        turn = await _stream_turn(client, request, oauth_access)
+        result.turns.append(turn)
+        # Keep the conversation growing so the next turn's prefix extends this
+        # one. A terse canned assistant reply keeps output cost near zero while
+        # preserving a realistic append-only history shape.
+        history.append(Message.assistant("ok"))
+    return result
+
+
+async def run_stable_prefix(
+    client: Any,
+    oauth_access: OAuthAccess | None,
+    turns: int,
+) -> ScenarioResult:
+    """Scenario 2: N separate sessions sharing the prefix, diverging at turn 1.
+
+    Each session gets its OWN prompt_cache_key (session id) because that is how
+    the harness assigns them -- the point of the fix is that a STABLE key per
+    session still lets the shared system+tools prefix hit the server cache
+    across sessions. ``turns`` here means "number of diverging sessions".
+    """
+    spec = _resolve_spec(None)
+    tools, system_blocks = _build_prefix()
+    result = ScenarioResult(name="stable_prefix")
+    count = min(turns, len(_DIVERGING_FIRST_TURNS)) or len(_DIVERGING_FIRST_TURNS)
+    for i in range(count):
+        prompt = _DIVERGING_FIRST_TURNS[i]
+        session_id = f"bench-stable-prefix-{i}"
+        messages = [Message.user(prompt + TERSE)]
+        request = _make_request(spec, system_blocks, tools, messages, session_id)
+        turn = await _stream_turn(client, request, oauth_access)
+        result.turns.append(turn)
+    return result
+
+
+async def run_tool_heavy(
+    client: Any,
+    oauth_access: OAuthAccess | None,
+    turns: int,
+) -> ScenarioResult:
+    """Scenario 3: each turn carries a tool call + its result in the history."""
+    spec = _resolve_spec(None)
+    tools, system_blocks = _build_prefix()
+    session_id = "bench-tool-heavy"
+    result = ScenarioResult(name="tool_heavy")
+    history: list[Message] = []
+    count = min(turns, len(_TOOL_PROMPTS))
+    for i in range(count):
+        prompt = _TOOL_PROMPTS[i]
+        history.append(Message.user(prompt + TERSE))
+        # Model "asks" for a read; we answer with a synthesized tool result so
+        # the NEXT turn's prefix ends in function_call + function_call_output.
+        call_msg = _tool_call_message("read", f"./file_{i}.txt")
+        history.append(call_msg)
+        call_id = call_msg.tool_calls[0].id
+        history.append(_tool_result_message(call_id, _TOOL_OUTPUTS[i]))
+        request = _make_request(spec, system_blocks, tools, list(history), session_id)
+        turn = await _stream_turn(client, request, oauth_access)
+        result.turns.append(turn)
+        history.append(Message.assistant("ok"))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Dry-run: show the redacted body shape WITHOUT any network call
+# ---------------------------------------------------------------------------
+
+
+def _redact_body(body: dict[str, Any]) -> dict[str, Any]:
+    """A compact, secret-free view of a request body for inspection.
+
+    Large arrays (instructions, input, tools) are summarized by shape/size
+    rather than dumped, and no credential is present in a body anyway (auth is
+    header-only). This exists to CONFIRM routing and key presence, not to leak.
+    """
+    out: dict[str, Any] = {}
+    for k, v in body.items():
+        if k == "instructions":
+            out[k] = f"<str {len(v)} chars>"
+        elif k == "input":
+            kinds: dict[str, int] = {}
+            for item in v:
+                key = item.get("type") or item.get("role") or "?"
+                kinds[key] = kinds.get(key, 0) + 1
+            out[k] = f"<{len(v)} items: {kinds}>"
+        elif k == "tools":
+            out[k] = f"<{len(v)} tool schemas>"
+        else:
+            out[k] = v
+    return out
+
+
+def _dry_run() -> None:
+    """Print the redacted codex body shape for a representative turn per scenario.
+
+    Builds the client and the exact ChatRequest each scenario's first turn would
+    send, then renders the body via the client's own codex builder -- so what is
+    printed is what would actually be POSTed. The absence of a
+    ``prompt_cache_key`` key here on origin/main is the current bug made visible.
+    """
+    spec = _resolve_spec("medium")
+    tools, system_blocks = _build_prefix()
+    client = client_for_spec(spec, openai_api="responses")
+
+    print(f"Codex Responses URL: {CODEX_RESPONSES_URL}")
+    print("prompt_cache_key set on ChatRequest: yes (= session id)\n")
+
+    # Representative first-turn requests for each scenario.
+    samples: list[tuple[str, ChatRequest]] = []
+    samples.append(
+        (
+            "long_session",
+            _make_request(
+                spec,
+                system_blocks,
+                tools,
+                [Message.user(_LONG_PROMPTS[0] + TERSE)],
+                "bench-long_session",
+            ),
+        )
+    )
+    samples.append(
+        (
+            "stable_prefix",
+            _make_request(
+                spec,
+                system_blocks,
+                tools,
+                [Message.user(_DIVERGING_FIRST_TURNS[0] + TERSE)],
+                "bench-stable-prefix-0",
+            ),
+        )
+    )
+    # tool_heavy: a second-turn request whose history already carries a tool call.
+    th_history: list[Message] = [Message.user(_TOOL_PROMPTS[0] + TERSE)]
+    call_msg = _tool_call_message("read", "./file_0.txt")
+    th_history.append(call_msg)
+    th_history.append(_tool_result_message(call_msg.tool_calls[0].id, _TOOL_OUTPUTS[0]))
+    samples.append(
+        ("tool_heavy", _make_request(spec, system_blocks, tools, th_history, "bench-tool-heavy"))
+    )
+
+    for name, request in samples:
+        # Use the client's OWN codex body builder so the printed shape is the
+        # real wire body, not a reconstruction.
+        body = client._build_codex_responses_body(request)  # noqa: SLF001 (bench introspection)
+        redacted = _redact_body(body)
+        print(f"--- scenario: {name} ---")
+        print(f"  posts to: {CODEX_RESPONSES_URL}")
+        print(f"  body keys: {sorted(body.keys())}")
+        print(f"  has prompt_cache_key in body: {'prompt_cache_key' in body}")
+        print(f"  redacted body: {json.dumps(redacted, indent=2)}")
+        print()
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def _print_scenario_table(results: list[ScenarioResult]) -> None:
+    header = (
+        f"{'scenario':<16} {'turns':>5} {'input':>10} {'cache_read':>11} "
+        f"{'cache_write':>11} {'rate %':>8}"
+    )
+    print(header)
+    print("-" * len(header))
+    total_read = 0
+    total_denom = 0
+    for r in results:
+        if r.error:
+            print(f"{r.name:<16} ERROR: {r.error}")
+            continue
+        total_read += r.total_cache_read
+        total_denom += r.denom
+        print(
+            f"{r.name:<16} {len(r.turns):>5} {r.total_input:>10} "
+            f"{r.total_cache_read:>11} {r.total_cache_write:>11} "
+            f"{r.cache_rate * 100:>7.1f}%"
+        )
+    print("-" * len(header))
+    overall = (total_read / total_denom * 100) if total_denom else 0.0
+    print(f"{'OVERALL':<16} {'':>5} {'':>10} {total_read:>11} {'':>11} {overall:>7.1f}%")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+_SCENARIO_RUNNERS: dict[str, Callable] = {
+    "long_session": lambda c, o, t: run_long_session(c, o, t, None, "long_session"),
+    "stable_prefix": run_stable_prefix,
+    "tool_heavy": run_tool_heavy,
+    "reasoning_on": lambda c, o, t: run_long_session(c, o, t, "medium", "reasoning_on"),
+}
+
+
+async def _run_live(scenario: str | None, turns: int) -> int:
+    store = AuthStore()
+    oauth_access = await store.get_oauth_access("openai", read_only=True)
+    # The Codex Responses route only engages for an OAuth grant carrying an
+    # org_id (see OpenAICompatClient._codex_responses_mode). Anything else means
+    # there is no ChatGPT subscription credential to measure.
+    if oauth_access is None or oauth_access.kind != "oauth" or not oauth_access.org_id:
+        print("skipped: no OpenAI OAuth credential")
+        return 0
+
+    spec = _resolve_spec(None)
+    client = client_for_spec(spec, openai_api="responses")
+
+    names = [scenario] if scenario else list(_SCENARIO_RUNNERS.keys())
+    results: list[ScenarioResult] = []
+    try:
+        for name in names:
+            runner = _SCENARIO_RUNNERS.get(name)
+            if runner is None:
+                print(f"unknown scenario: {name}")
+                continue
+            try:
+                result = await runner(client, oauth_access, turns)
+            except Exception as exc:  # noqa: BLE001 - measurement must not crash
+                # A 400 from the Codex backend (e.g. when a new field is added)
+                # is itself important signal; capture it redacted rather than
+                # letting it abort the whole run.
+                result = ScenarioResult(name=name, error=f"{type(exc).__name__}: {exc}"[:400])
+            results.append(result)
+    finally:
+        await client.aclose()
+
+    _print_scenario_table(results)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Live OAuth prompt-cache benchmark.")
+    parser.add_argument(
+        "--scenario",
+        choices=sorted(_SCENARIO_RUNNERS.keys()),
+        default=None,
+        help="Run one scenario (default: all).",
+    )
+    parser.add_argument(
+        "--turns",
+        type=int,
+        default=6,
+        help="Turns per session (scenario 1/3/4) or number of sessions (scenario 2).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the redacted request body shape without any network call.",
+    )
+    args = parser.parse_args()
+
+    if args.dry_run:
+        _dry_run()
+        return 0
+
+    return asyncio.run(_run_live(args.scenario, args.turns))
+
+
+if __name__ == "__main__":
+    # Exit 0 always: this is measurement, not a gate.
+    raise SystemExit(main())

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -2929,9 +2929,12 @@ def test_tool_call_turns_do_not_ship_whitespace_only_text() -> None:
 
 
 # ---------------------------------------------------------------------------
-# GPT-5.6 prompt-caching (defects #1/#2/#3): prompt_cache_key kept on codex,
-# encrypted-reasoning include, explicit developer-message breakpoints, and the
-# four-cache-write cap. See OpenAICompatClient._apply_gpt_5_6_prompt_cache.
+# GPT-5.6 prompt-caching (defects #1/#2 only): prompt_cache_key kept on the
+# Codex ``store:false`` path, and encrypted-reasoning ``include`` requested when
+# reasoning is on. Defect #3 (prompt_cache_breakpoint / prompt_cache_options /
+# moving the stable prefix into developer messages) was REJECTED by the ChatGPT
+# subscription Codex backend with HTTP 400 (OpenAI Codex bug #35300) and removed
+# entirely; these tests are regression guards against it coming back.
 # ---------------------------------------------------------------------------
 
 
@@ -2949,46 +2952,28 @@ def _gpt_5_6_spec(model_id: str = "gpt-5.6-sol") -> ModelSpec:
     )
 
 
-def _find_breakpoints(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Every content block in ``items`` carrying a prompt_cache_breakpoint."""
-    found: list[dict[str, Any]] = []
+def _has_breakpoint(items: list[dict[str, Any]]) -> bool:
+    """Whether any content block in ``items`` carries a prompt_cache_breakpoint.
+
+    Used purely as a regression guard: after defect #3 was removed, NO body we
+    build may contain this field (the Codex backend 400s on it).
+    """
     for item in items:
-        content = item.get("content")
-        blocks = content if isinstance(content, list) else []
-        for block in blocks:
-            if isinstance(block, dict) and "prompt_cache_breakpoint" in block:
-                found.append(block)
-        # function_call_output carries its blocks under ``output``.
-        output = item.get("output")
-        out_blocks = output if isinstance(output, list) else []
-        for block in out_blocks:
-            if isinstance(block, dict) and "prompt_cache_breakpoint" in block:
-                found.append(block)
-    return found
+        for key in ("content", "output"):
+            blocks = item.get(key)
+            if not isinstance(blocks, list):
+                continue
+            for block in blocks:
+                if isinstance(block, dict) and "prompt_cache_breakpoint" in block:
+                    return True
+    return False
 
 
-def test_is_gpt_5_6_or_later_predicate() -> None:
-    """The gate parses the ``gpt-5.<minor>`` family number and is conservative
-    about anything it cannot confidently read as 5.6+ (defect gating)."""
-    from local_operator.providers.clients import _is_gpt_5_6_or_later
-
-    assert _is_gpt_5_6_or_later("gpt-5.6-sol")
-    assert _is_gpt_5_6_or_later("gpt-5.6")
-    assert _is_gpt_5_6_or_later("GPT-5.7-codex")
-    assert _is_gpt_5_6_or_later("gpt-5.10")  # 10 >= 6, not lexical
-    # Older / unparseable -> NOT 5.6+, preserving today's behaviour.
-    assert not _is_gpt_5_6_or_later("gpt-5.4")
-    assert not _is_gpt_5_6_or_later("gpt-5")
-    assert not _is_gpt_5_6_or_later("gpt-4o")
-    assert not _is_gpt_5_6_or_later("o4-mini")
-    assert not _is_gpt_5_6_or_later("")
-
-
-def test_codex_5_6_body_keeps_cache_key_and_adds_breakpoint_and_include() -> None:
-    """Defects #1/#2/#3 on the Codex ``store:false`` path: prompt_cache_key is
-    kept (Codex parity), encrypted reasoning is requested, the stable system
-    prefix moves into a developer message with an explicit breakpoint, and the
-    public-retention field is gone."""
+def test_codex_5_6_body_keeps_cache_key_and_include() -> None:
+    """Defects #1/#2 on the Codex ``store:false`` path: prompt_cache_key is kept
+    (Codex parity), encrypted reasoning is requested, and the public-retention
+    field is stripped. The stable prefix stays in top-level ``instructions`` and
+    NONE of the rejected defect-#3 fields appear."""
     client = OpenAICompatClient("https://api.openai.com/v1")
     request = ChatRequest(
         model=_gpt_5_6_spec(),
@@ -3004,19 +2989,13 @@ def test_codex_5_6_body_keeps_cache_key_and_adds_breakpoint_and_include() -> Non
     assert body["store"] is False
     # #2: reasoning is on, so encrypted reasoning content is requested.
     assert body["include"] == ["reasoning.encrypted_content"]
-    # #3: GPT-5.6 explicit caching mode + a developer-message breakpoint.
-    assert body["prompt_cache_options"] == {"mode": "implicit"}
-    assert "instructions" not in body  # stable head must not sit top-level
-    breakpoints = _find_breakpoints(body["input"])
-    assert len(breakpoints) == 1
-    # The breakpoint ends the STABLE prefix (block[-2]), not the volatile tail.
-    marked = breakpoints[0]
-    assert marked["text"] == "Tool inventory."
-    assert marked["prompt_cache_breakpoint"] == {"mode": "explicit"}
-    # The volatile tail rides its own developer message AFTER the breakpoint.
-    dev_items = [i for i in body["input"] if i.get("role") == "developer"]
-    assert dev_items[-1]["content"][-1]["text"] == "Volatile env + date."
-    assert "prompt_cache_breakpoint" not in dev_items[-1]["content"][-1]
+    # Stable prefix rides top-level ``instructions`` exactly as real Codex sends
+    # it; nothing is moved into an injected developer message.
+    assert body["instructions"] == "Stable instructions.\n\nTool inventory.\n\nVolatile env + date."
+    assert not any(i.get("role") == "developer" for i in body["input"])
+    # Defect #3 regression guard: the backend 400s on both of these.
+    assert "prompt_cache_options" not in body
+    assert not _has_breakpoint(body["input"])
 
 
 def test_codex_5_6_body_no_include_when_reasoning_off() -> None:
@@ -3029,47 +3008,17 @@ def test_codex_5_6_body_no_include_when_reasoning_off() -> None:
         ChatRequest(model=spec, system_blocks=["a", "b"], messages=[Message.user("hi")])
     )
     assert "include" not in body
-    # #3 still applies (it is version-gated, not reasoning-gated).
-    assert body["prompt_cache_options"] == {"mode": "implicit"}
-
-
-def test_codex_non_5_6_reasoning_model_gets_no_breakpoints() -> None:
-    """Gating guard: a hypothetical non-5.6 reasoning model on the codex path
-    keeps the old shape — no breakpoints, no prompt_cache_options, stable prefix
-    stays in top-level ``instructions``."""
-    spec = ModelSpec(
-        provider="openai",
-        model_id="gpt-5.4-codex",
-        supports_responses_api=True,
-        supports_prompt_cache=True,
-        reasoning=True,
-        reasoning_effort="high",
-        reasoning_efforts=("low", "medium", "high"),
-        supports_sampling_params=False,
-    )
-    client = OpenAICompatClient("https://api.openai.com/v1")
-    body = client._build_codex_responses_body(
-        ChatRequest(
-            model=spec,
-            system_blocks=["Stable.", "Volatile."],
-            messages=[Message.user("hi")],
-            prompt_cache_key="s1",
-        )
-    )
+    # #1 still holds regardless of reasoning: the codex path keeps the key.
+    # Defect #3 fields never appear.
     assert "prompt_cache_options" not in body
-    assert body["instructions"] == "Stable.\n\nVolatile."
-    assert _find_breakpoints(body["input"]) == []
-    # #1 still holds pre-5.6: the codex path keeps prompt_cache_key.
-    assert body["prompt_cache_key"] == "s1"
-    # #2 still holds: reasoning is on, so the include is requested regardless of
-    # version (it mirrors Codex, which sends it broadly).
-    assert body["include"] == ["reasoning.encrypted_content"]
+    assert not _has_breakpoint(body["input"])
+    assert body["instructions"] == "a\n\nb"
 
 
-def test_public_5_6_body_shape() -> None:
-    """Defect #3 on the public ``store:true`` Responses path: breakpoints and
-    options are added, retention stays absent (5.6 uses prompt_cache_options.ttl
-    for lifetime), and prompt_cache_key is preserved."""
+def test_public_5_6_body_keeps_original_shape_plus_include() -> None:
+    """The public Responses path returns its ORIGINAL body plus only defect #2's
+    ``include``: top-level instructions, prompt_cache_key, and the 24h retention
+    are all present, and none of the rejected defect-#3 fields appear."""
     client = OpenAICompatClient("https://api.openai.com/v1")
     body = client._build_responses_body(
         ChatRequest(
@@ -3080,15 +3029,16 @@ def test_public_5_6_body_shape() -> None:
         )
     )
     assert body["prompt_cache_key"] == "pub-1"
-    assert "prompt_cache_retention" not in body  # 5.6 dropped this field
-    assert body["prompt_cache_options"] == {"mode": "implicit"}
+    assert body["prompt_cache_retention"] == "24h"
+    assert body["instructions"] == "Stable.\n\nVolatile."
     assert body["include"] == ["reasoning.encrypted_content"]
-    assert len(_find_breakpoints(body["input"])) == 1
+    assert "prompt_cache_options" not in body
+    assert not _has_breakpoint(body["input"])
 
 
 def test_public_pre_5_6_body_unchanged() -> None:
-    """Regression guard: the pre-5.6 public path keeps top-level instructions,
-    prompt_cache_retention, and no breakpoints."""
+    """Regression guard: a non-reasoning model keeps top-level instructions,
+    prompt_cache_retention, no ``include``, and no breakpoints."""
     spec = ModelSpec(
         provider="openai",
         model_id="gpt-5.4",
@@ -3106,43 +3056,9 @@ def test_public_pre_5_6_body_unchanged() -> None:
     )
     assert body["instructions"] == "Stable.\n\nVolatile."
     assert body["prompt_cache_retention"] == "24h"
+    assert "include" not in body
     assert "prompt_cache_options" not in body
-    assert _find_breakpoints(body["input"]) == []
-
-
-def test_tool_result_breakpoints_capped_at_four_total() -> None:
-    """Defect #3 budget: with many tool results, the total explicit cache-write
-    breakpoints never exceed OpenAI's limit of four (one for the stable prefix,
-    the rest on the MOST RECENT tool results)."""
-    history: list[Message] = []
-    for i in range(6):
-        history.append(
-            Message(
-                role="assistant",
-                content=[TextContent(text="")],
-                tool_calls=[ToolCall(id=f"t{i}", name="do", arguments={})],
-            )
-        )
-        history.append(
-            Message(role="tool", tool_call_id=f"t{i}", content=[TextContent(text=f"result {i}")])
-        )
-    client = OpenAICompatClient("https://api.openai.com/v1")
-    body = client._build_codex_responses_body(
-        ChatRequest(
-            model=_gpt_5_6_spec(),
-            system_blocks=["Stable.", "Volatile."],
-            messages=history,
-            prompt_cache_key="s",
-        )
-    )
-    breakpoints = _find_breakpoints(body["input"])
-    assert len(breakpoints) <= 4
-    # One stable-prefix breakpoint + two most-recent tool results = 3 (implicit
-    # holds the fourth write slot, so we deliberately do not spend it here).
-    tool_marks = [b for b in breakpoints if b["text"].startswith("result ")]
-    # The two MOST RECENT tool results carry the marker (order here is document
-    # order from the input list, not the newest-first order we mark them in).
-    assert {b["text"] for b in tool_marks} == {"result 5", "result 4"}
+    assert not _has_breakpoint(body["input"])
 
 
 async def test_codex_5_6_stream_skips_reasoning_items() -> None:

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -2926,3 +2926,274 @@ def test_tool_call_turns_do_not_ship_whitespace_only_text() -> None:
 
     items = _messages_to_openai_responses([message])
     assert [i.get("type") for i in items] == ["function_call"]
+
+
+# ---------------------------------------------------------------------------
+# GPT-5.6 prompt-caching (defects #1/#2/#3): prompt_cache_key kept on codex,
+# encrypted-reasoning include, explicit developer-message breakpoints, and the
+# four-cache-write cap. See OpenAICompatClient._apply_gpt_5_6_prompt_cache.
+# ---------------------------------------------------------------------------
+
+
+def _gpt_5_6_spec(model_id: str = "gpt-5.6-sol") -> ModelSpec:
+    """A reasoning GPT-5.6 Responses spec with prompt caching enabled."""
+    return ModelSpec(
+        provider="openai",
+        model_id=model_id,
+        supports_responses_api=True,
+        supports_prompt_cache=True,
+        reasoning=True,
+        reasoning_effort="high",
+        reasoning_efforts=("low", "medium", "high"),
+        supports_sampling_params=False,
+    )
+
+
+def _find_breakpoints(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Every content block in ``items`` carrying a prompt_cache_breakpoint."""
+    found: list[dict[str, Any]] = []
+    for item in items:
+        content = item.get("content")
+        blocks = content if isinstance(content, list) else []
+        for block in blocks:
+            if isinstance(block, dict) and "prompt_cache_breakpoint" in block:
+                found.append(block)
+        # function_call_output carries its blocks under ``output``.
+        output = item.get("output")
+        out_blocks = output if isinstance(output, list) else []
+        for block in out_blocks:
+            if isinstance(block, dict) and "prompt_cache_breakpoint" in block:
+                found.append(block)
+    return found
+
+
+def test_is_gpt_5_6_or_later_predicate() -> None:
+    """The gate parses the ``gpt-5.<minor>`` family number and is conservative
+    about anything it cannot confidently read as 5.6+ (defect gating)."""
+    from local_operator.providers.clients import _is_gpt_5_6_or_later
+
+    assert _is_gpt_5_6_or_later("gpt-5.6-sol")
+    assert _is_gpt_5_6_or_later("gpt-5.6")
+    assert _is_gpt_5_6_or_later("GPT-5.7-codex")
+    assert _is_gpt_5_6_or_later("gpt-5.10")  # 10 >= 6, not lexical
+    # Older / unparseable -> NOT 5.6+, preserving today's behaviour.
+    assert not _is_gpt_5_6_or_later("gpt-5.4")
+    assert not _is_gpt_5_6_or_later("gpt-5")
+    assert not _is_gpt_5_6_or_later("gpt-4o")
+    assert not _is_gpt_5_6_or_later("o4-mini")
+    assert not _is_gpt_5_6_or_later("")
+
+
+def test_codex_5_6_body_keeps_cache_key_and_adds_breakpoint_and_include() -> None:
+    """Defects #1/#2/#3 on the Codex ``store:false`` path: prompt_cache_key is
+    kept (Codex parity), encrypted reasoning is requested, the stable system
+    prefix moves into a developer message with an explicit breakpoint, and the
+    public-retention field is gone."""
+    client = OpenAICompatClient("https://api.openai.com/v1")
+    request = ChatRequest(
+        model=_gpt_5_6_spec(),
+        system_blocks=["Stable instructions.", "Tool inventory.", "Volatile env + date."],
+        messages=[Message.user("hi")],
+        prompt_cache_key="session-abc",
+    )
+    body = client._build_codex_responses_body(request)
+
+    # #1: the key that was wrongly stripped is present; retention is not.
+    assert body["prompt_cache_key"] == "session-abc"
+    assert "prompt_cache_retention" not in body
+    assert body["store"] is False
+    # #2: reasoning is on, so encrypted reasoning content is requested.
+    assert body["include"] == ["reasoning.encrypted_content"]
+    # #3: GPT-5.6 explicit caching mode + a developer-message breakpoint.
+    assert body["prompt_cache_options"] == {"mode": "implicit"}
+    assert "instructions" not in body  # stable head must not sit top-level
+    breakpoints = _find_breakpoints(body["input"])
+    assert len(breakpoints) == 1
+    # The breakpoint ends the STABLE prefix (block[-2]), not the volatile tail.
+    marked = breakpoints[0]
+    assert marked["text"] == "Tool inventory."
+    assert marked["prompt_cache_breakpoint"] == {"mode": "explicit"}
+    # The volatile tail rides its own developer message AFTER the breakpoint.
+    dev_items = [i for i in body["input"] if i.get("role") == "developer"]
+    assert dev_items[-1]["content"][-1]["text"] == "Volatile env + date."
+    assert "prompt_cache_breakpoint" not in dev_items[-1]["content"][-1]
+
+
+def test_codex_5_6_body_no_include_when_reasoning_off() -> None:
+    """Defect #2 is gated on reasoning: a 5.6 model with no effort ladder must
+    not request encrypted reasoning content."""
+    spec = _gpt_5_6_spec()
+    spec = spec.model_copy(update={"reasoning_efforts": (), "reasoning_effort": None})
+    client = OpenAICompatClient("https://api.openai.com/v1")
+    body = client._build_codex_responses_body(
+        ChatRequest(model=spec, system_blocks=["a", "b"], messages=[Message.user("hi")])
+    )
+    assert "include" not in body
+    # #3 still applies (it is version-gated, not reasoning-gated).
+    assert body["prompt_cache_options"] == {"mode": "implicit"}
+
+
+def test_codex_non_5_6_reasoning_model_gets_no_breakpoints() -> None:
+    """Gating guard: a hypothetical non-5.6 reasoning model on the codex path
+    keeps the old shape — no breakpoints, no prompt_cache_options, stable prefix
+    stays in top-level ``instructions``."""
+    spec = ModelSpec(
+        provider="openai",
+        model_id="gpt-5.4-codex",
+        supports_responses_api=True,
+        supports_prompt_cache=True,
+        reasoning=True,
+        reasoning_effort="high",
+        reasoning_efforts=("low", "medium", "high"),
+        supports_sampling_params=False,
+    )
+    client = OpenAICompatClient("https://api.openai.com/v1")
+    body = client._build_codex_responses_body(
+        ChatRequest(
+            model=spec,
+            system_blocks=["Stable.", "Volatile."],
+            messages=[Message.user("hi")],
+            prompt_cache_key="s1",
+        )
+    )
+    assert "prompt_cache_options" not in body
+    assert body["instructions"] == "Stable.\n\nVolatile."
+    assert _find_breakpoints(body["input"]) == []
+    # #1 still holds pre-5.6: the codex path keeps prompt_cache_key.
+    assert body["prompt_cache_key"] == "s1"
+    # #2 still holds: reasoning is on, so the include is requested regardless of
+    # version (it mirrors Codex, which sends it broadly).
+    assert body["include"] == ["reasoning.encrypted_content"]
+
+
+def test_public_5_6_body_shape() -> None:
+    """Defect #3 on the public ``store:true`` Responses path: breakpoints and
+    options are added, retention stays absent (5.6 uses prompt_cache_options.ttl
+    for lifetime), and prompt_cache_key is preserved."""
+    client = OpenAICompatClient("https://api.openai.com/v1")
+    body = client._build_responses_body(
+        ChatRequest(
+            model=_gpt_5_6_spec(),
+            system_blocks=["Stable.", "Volatile."],
+            messages=[Message.user("hi")],
+            prompt_cache_key="pub-1",
+        )
+    )
+    assert body["prompt_cache_key"] == "pub-1"
+    assert "prompt_cache_retention" not in body  # 5.6 dropped this field
+    assert body["prompt_cache_options"] == {"mode": "implicit"}
+    assert body["include"] == ["reasoning.encrypted_content"]
+    assert len(_find_breakpoints(body["input"])) == 1
+
+
+def test_public_pre_5_6_body_unchanged() -> None:
+    """Regression guard: the pre-5.6 public path keeps top-level instructions,
+    prompt_cache_retention, and no breakpoints."""
+    spec = ModelSpec(
+        provider="openai",
+        model_id="gpt-5.4",
+        supports_responses_api=True,
+        supports_prompt_cache=True,
+    )
+    client = OpenAICompatClient("https://api.openai.com/v1")
+    body = client._build_responses_body(
+        ChatRequest(
+            model=spec,
+            system_blocks=["Stable.", "Volatile."],
+            messages=[Message.user("hi")],
+            prompt_cache_key="pub-2",
+        )
+    )
+    assert body["instructions"] == "Stable.\n\nVolatile."
+    assert body["prompt_cache_retention"] == "24h"
+    assert "prompt_cache_options" not in body
+    assert _find_breakpoints(body["input"]) == []
+
+
+def test_tool_result_breakpoints_capped_at_four_total() -> None:
+    """Defect #3 budget: with many tool results, the total explicit cache-write
+    breakpoints never exceed OpenAI's limit of four (one for the stable prefix,
+    the rest on the MOST RECENT tool results)."""
+    history: list[Message] = []
+    for i in range(6):
+        history.append(
+            Message(
+                role="assistant",
+                content=[TextContent(text="")],
+                tool_calls=[ToolCall(id=f"t{i}", name="do", arguments={})],
+            )
+        )
+        history.append(
+            Message(role="tool", tool_call_id=f"t{i}", content=[TextContent(text=f"result {i}")])
+        )
+    client = OpenAICompatClient("https://api.openai.com/v1")
+    body = client._build_codex_responses_body(
+        ChatRequest(
+            model=_gpt_5_6_spec(),
+            system_blocks=["Stable.", "Volatile."],
+            messages=history,
+            prompt_cache_key="s",
+        )
+    )
+    breakpoints = _find_breakpoints(body["input"])
+    assert len(breakpoints) <= 4
+    # One stable-prefix breakpoint + two most-recent tool results = 3 (implicit
+    # holds the fourth write slot, so we deliberately do not spend it here).
+    tool_marks = [b for b in breakpoints if b["text"].startswith("result ")]
+    # The two MOST RECENT tool results carry the marker (order here is document
+    # order from the input list, not the newest-first order we mark them in).
+    assert {b["text"] for b in tool_marks} == {"result 5", "result 4"}
+
+
+async def test_codex_5_6_stream_skips_reasoning_items() -> None:
+    """Defect #2 stream side: encrypted ``reasoning`` output items and their
+    deltas are dropped, never rendered as assistant text, and do not crash the
+    parser."""
+    events_sse = _sse(
+        [
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "encrypted_content": "gAAAAAB-opaque-blob",
+                },
+            },
+            {"type": "response.reasoning_summary_text.delta", "delta": "ignored thinking"},
+            {"type": "response.output_text.delta", "delta": "Answer"},
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_r",
+                    "usage": {
+                        "input_tokens": 10,
+                        "output_tokens": 2,
+                        "input_tokens_details": {"cached_tokens": 5},
+                    },
+                },
+            },
+        ]
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, content=events_sse, headers={"content-type": "text/event-stream"}
+        )
+
+    client = OpenAICompatClient(
+        base_url="https://api.openai.com/v1",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    access = OAuthAccess(
+        access_token="chatgpt-token", credential_id=2, org_id="acct-42", kind="oauth"
+    )
+    events = await _collect(
+        client.stream(
+            ChatRequest(model=_gpt_5_6_spec(), messages=[Message.user("hi")]),
+            "chatgpt-token",
+            oauth_access=access,
+        )
+    )
+    texts = [e.delta for e in events if isinstance(e, StreamTextDelta)]
+    assert texts == ["Answer"]  # the encrypted blob never became text
+    assert events[-1].stop_reason == "stop"


### PR DESCRIPTION
## Summary

`gpt-5.6-sol` sat at a ~89-90% cache-read rate in our analytics while every OpenAI-shaped peer (zai/kimi/qwen/grok) runs 97-98%. It is the only model on OpenAI's Responses API, and on the operator's ChatGPT-subscription **OAuth** path the request body is built by `_build_codex_responses_body`, which was **discarding `prompt_cache_key`** and never requesting encrypted reasoning items. This restores both, matching what OpenAI's own Codex client sends on the same backend.

Net change is small and surgical: two request fields on the Responses path. Verified with live `gpt-5.6-sol` calls against the real subscription backend, not a mock.

- `providers/clients.py` — stop popping `prompt_cache_key` on the codex body (#1); add `include: ["reasoning.encrypted_content"]` when reasoning effort is present (#2); defensively skip the `reasoning` output items that include then surfaces on the stream.
- `tests/unit/providers/test_clients.py` — body-shape assertions for both fields, plus regression guards.
- `scripts/bench_openai_oauth_cache.py` — new live multi-scenario cache-rate benchmark for the OAuth path.

Minor version bump (0.40.0 → 0.41.0): a caching/perf improvement.

## Root cause

On the OAuth path the body posts to `https://chatgpt.com/backend-api/codex/responses` with `store: false`. The prior code did:

```python
body.pop("prompt_cache_key", None)   # comment: "public-API-only keys removed"
```

That comment was a wrong assumption (introduced in #128). OpenAI's own Codex client (`codex-rs/core/src/client.rs`, `build_responses_request`) sets `prompt_cache_key` **unconditionally** on this same `store:false` subscription backend — it defaults to the thread id. Per OpenAI's "Prompt Caching 201", the key is routing stickiness: it is hashed with the prompt prefix so requests with the same prefix land on the same inference machine and hit a warm KV cache. Dropping it scatters a session's turns across cold machines. That is the bulk of the gap.

Codex also sets `include: ["reasoning.encrypted_content"]` whenever reasoning is on (`client.rs` L720-724). `gpt-5.6-sol` is a reasoning model; on `store:false` these encrypted reasoning items are what let a response reuse its own reasoning KV state. We requested neither.

## What was tried and deliberately dropped

OpenAI's GPT-5.6 caching guide documents explicit `prompt_cache_breakpoint` markers and `prompt_cache_options` as the remedy for GPT-5.6's implicit-caching change (their controlled test: 0% → 98.6% on a 9k-token prefix). I implemented that too, then **live-tested it against the actual subscription backend and it is rejected**:

```
HTTP 400: Unsupported parameter: prompt_cache_options
HTTP 400: prompt_cache_breakpoint is not supported on this model
```

This matches OpenAI Codex's own open bug [#35300](https://github.com/openai/codex/issues/35300): those fields are unsupported/unrepresentable on the ChatGPT backend, which is why even Codex cannot use them there. Since the operator has no OpenAI API key (only OAuth), the public Responses path where the guide documents these fields is unreachable and cannot be validated — shipping code that 400s on the only live path would be a regression. So the breakpoint machinery (and the top-level-`instructions` → `developer`-message rewrite it required) was removed entirely; the stable prefix stays in top-level `instructions`, exactly as real Codex does.

## Testing evidence (live, real `gpt-5.6-sol` against the subscription backend)

Cache-read rate = `sum(cache_read_tokens) / sum(input + cache_read + cache_write)`, measured by `scripts/bench_openai_oauth_cache.py` driving real multi-turn conversations through the actual client and reading `input_tokens_details.cached_tokens` off `response.completed`. (`cached ⊆ input` on OpenAI; the codex backend reports `cache_write = 0`.)

| Scenario | Before (origin/main) | After (#1+#2) | 400s |
|---|---|---|---|
| `stable_prefix` (5 diverging sessions, shared prefix) | 34.4% | **46.6%** | none |
| `long_session` (append-only, 5 turns) | 14.7% | **46.4%** | none |
| `reasoning_on` (reasoning effort set) | — | **46.4-47.1%** | none |
| `tool_heavy` (function calls + results) | — | **33.8-47.5%** | none |

Dry-run body confirms the fix on the wire (redacted):

```
POST https://chatgpt.com/backend-api/codex/responses   store: false
before: body keys = [input, instructions, model, reasoning, store, stream, tool_choice, tools]   # prompt_cache_key MISSING
after:  body keys = [include, input, instructions, model, prompt_cache_key, reasoning, store, stream, tool_choice, tools]
        include = ["reasoning.encrypted_content"]   prompt_cache_key = "<session id>"
```

The benchmark probes fresh/short sessions — the worst case, and exactly the cold-start / cross-session-reuse behaviour that drags the production aggregate below its peers. Long warm sessions already cache well on append; the routing key is what lifts everything else.

## Gates

- `flake8 .` ✅ · `black --check .` ✅ (552 files) · `isort --check .` ✅
- `pytest tests/unit/providers -q` → **648 passed**
- pyright: changed files clean (`0 errors`); whole-tree deferred to CI (local box could not complete the whole-tree run under load)

## Scope note for reviewers

Focus on `_build_codex_responses_body` / `_build_responses_body` (the two-field change and that the public path's original behaviour — `instructions`, `prompt_cache_retention="24h"` — is otherwise unchanged), and the `_stream_responses` reasoning-item skip (we do **not** yet replay encrypted reasoning items cross-turn; called out intentionally — the `include` still earns its keep for same-response reuse). The removed breakpoint machinery is gone by design, per the live 400 above.
