### PR TITLE
fix(tui): stop subagent view tearing and let children poll their background bash jobs

### DIFF
--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -65,6 +65,17 @@ the child-shaped tool — one peer, its parent — which is how it answers a
 question the parent asked and how it reports being blocked without waiting
 for its final result. See :mod:`local_operator.harness.comms`.
 
+``jobs`` is a SECOND, CONDITIONAL exception, on a different principle. It
+observes and cancels the child's OWN background jobs — it spawns nothing
+(that is ``task``) and dies with the child's job manager — so it crosses no
+boundary the prune protects. But a child can only produce a background job
+while its ``bash`` retains ``background``, and the bash receipt tells the
+model to poll such a job with ``jobs(op='peek')``. So the invariant is: a
+child keeps ``jobs`` IFF it can still background a bash command. The prune
+below re-adds ``jobs`` exactly under that condition (:func:`_can_background`),
+which is what stops a non-delegating role or grandchild that backgrounds a
+long command from looping forever on ``Tool not found: jobs``.
+
 Approvals the child asks for carry ``ToolContext.job_id`` — the id of the job
 this child IS — so a host can scope an approval decision to the delegated
 work that provoked it. Live failure it exists for: a subagent outliving its
@@ -145,6 +156,24 @@ TRAJECTORY_CAP = 500
 #: being present. Role guidance generally lives in
 #: :mod:`local_operator.agent_profiles`.
 SCOUT_TOOL_ALLOWLIST = frozenset({"read", "glob", "grep", "list_variables", "read_variable"})
+
+
+def _can_background(tools: "list[AgentTool]") -> bool:
+    """Whether this toolset can PRODUCE a background job.
+
+    Only ``bash`` spawns background jobs, and only while its schema still
+    carries the ``background`` parameter. A toolset with no such ``bash`` (a
+    scout, an allowlist that omits it) cannot register a job, so it has
+    nothing for ``jobs`` to observe. Deriving the answer from the actual
+    schema — rather than hard-coding which roles background — is what keeps
+    the ``jobs``-retention rule below tied to reality if the bash schema or a
+    role's allowlist later changes.
+    """
+    bash = next((tool for tool in tools if tool.name == "bash"), None)
+    if bash is None:
+        return False
+    return "background" in bash.parameters.get("properties", {})
+
 
 #: Preamble stamped onto a scout prompt when no profile resolves. The tool
 #: filter enforces the letter; this states the intent, so the scout REPORTS
@@ -1152,6 +1181,26 @@ async def _build_child_session(
         drop = merged_in
     else:
         drop = {name for name in merged_in if name == "wake"}
+    # ``jobs`` is the OBSERVE/CONTROL surface over this child's OWN background
+    # jobs (peek at output, cancel) — it spawns nothing (that's ``task``) and
+    # dies with the child's job manager, so it crosses no boundary the prune
+    # protects. Meanwhile the ``bash`` tool's ``background=true`` receipt tells
+    # the model to "follow it with jobs(op='peek')". When the branch above
+    # dropped the whole ``merged_in`` set (non-delegating role, grandchild),
+    # that advice pointed at a tool that no longer existed, so a child that
+    # backgrounded a long command (a coder polling a 10-min pyright) spun
+    # forever emitting ``Tool not found: jobs``. Invariant, encoded here rather
+    # than as two edits that can silently drift: a child keeps ``jobs`` IFF it
+    # can still produce a background job (its ``bash`` retains ``background``).
+    # Un-pruning ``jobs`` (not stripping ``bash``'s ``background``) preserves a
+    # real capability — a child genuinely benefits from backgrounding a long
+    # build and polling it — while killing the loop; stripping the schema
+    # per-session would be more invasive and would remove that capability.
+    # ``task``/``wait``/``wake`` keep their treatment: ``jobs`` polling is
+    # non-blocking and is the advertised path, so sparing ``jobs`` alone is the
+    # minimal correct fix, and a child that must not fan out still cannot.
+    if _can_background(tools):
+        drop = drop - {"jobs"}
     child.refresh_tools([tool for tool in child._tools if tool.name not in drop])
     if mcp is not None:
         mcp.attach(child)

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -1230,9 +1230,18 @@ Screen.subagent-compact #band {
  * four-row panel. It cannot come from the body's `TranscriptView` padding,
  * which the class below deliberately zeroes — the hint row is BELOW the body,
  * so the row has to be the page's. */
+/* An OPAQUE ground on the scrolling page. Without a fill the container is
+ * transparent, and a transparent scrolling region lets Textual's compositor
+ * skip clearing cells on a partial repaint: a hover on an `.actionable` hint
+ * plus the 8Hz working spinner then painted new cells over stale ones and the
+ * page appeared to tear on mouse-move. The `$lo-bg` token matches the Screen's
+ * own baseline ground on purpose — subagent mode is "the same app looking
+ * elsewhere" (see `_open_subagent_view`), so the fill must read as the app's own
+ * ground and not as an elevated slab the way the surface elevation would. */
 .subagent-view {
     height: 1fr;
     padding: 1 1 1 1;
+    background: $lo-bg;
 }
 
 .subagent-view-title {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.41.1"
+version = "0.41.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -1150,9 +1150,14 @@ async def test_child_of_top_level_session_keeps_delegation_but_not_wake(tmp_path
 
 
 @pytest.mark.asyncio
-async def test_grandchild_never_advertises_session_capability_tools(tmp_path, monkeypatch):
-    """One level deeper the whole set goes: a grandchild's children would
-    register on a job manager nothing observes and that dies mid-turn."""
+async def test_grandchild_cannot_fan_out_but_polls_its_own_background_bash(tmp_path, monkeypatch):
+    """One level deeper the SPAWN/PERSIST tools go: a grandchild's children
+    would register on a job manager nothing observes and that dies mid-turn.
+    But ``jobs`` stays, because the grandchild keeps ``bash`` with
+    ``background`` — so it can still poll and cancel the background command it
+    is told to (the bash receipt advertises ``jobs(op='peek')``), and without
+    ``jobs`` that advice loops forever on ``Tool not found: jobs``. The
+    invariant: ``jobs`` survives IFF ``bash`` can still background."""
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
     parent = make_session(tmp_path, OneShotStream())
     # A parent that is itself a child is recognisable by its _job_id.
@@ -1161,7 +1166,10 @@ async def test_grandchild_never_advertises_session_capability_tools(tmp_path, mo
     child = await build_child(parent)
 
     names = {tool.name for tool in child._tools}
-    assert names.isdisjoint({"task", "wait", "jobs", "wake"})
+    # No fan-out and no cross-boundary persistence from a grandchild.
+    assert names.isdisjoint({"task", "wait", "wake"})
+    # ...but it can observe/cancel its OWN background job.
+    assert "jobs" in names
     assert {"bash", "read", "edit", "write"} <= names
     await child.dispose()
     await parent.dispose()
@@ -1226,10 +1234,54 @@ async def test_a_tool_restricted_role_keeps_hub_so_it_can_answer(tmp_path, monke
     )
 
     names = {tool.name for tool in child._tools}
-    assert names <= {"read", "glob", "grep", "bash", "todo", "hub"}
+    assert names <= {"read", "glob", "grep", "bash", "todo", "hub", "jobs"}
     assert "hub" in names
-    # The boundary itself is intact: nothing the allowlist denies survived.
-    assert {"edit", "write", "eval"}.isdisjoint(names)
+    # It keeps ``bash`` with ``background``, so it must keep ``jobs`` to poll
+    # and cancel that background job — otherwise the bash receipt's advice to
+    # ``jobs(op='peek')`` loops on ``Tool not found: jobs``.
+    assert "jobs" in names
+    # The boundary itself is intact: nothing the allowlist denies survived,
+    # and a role that must not fan out still has no spawn/persist tools.
+    assert {"edit", "write", "eval", "task", "wait", "wake"}.isdisjoint(names)
+    await child.dispose()
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_non_delegating_role_keeps_jobs_to_poll_its_background_bash(tmp_path, monkeypatch):
+    """The bug this fixes: a non-delegating role (coder/reviewer) that
+    backgrounds a long ``bash`` command spun forever emitting ``Tool not
+    found: jobs``. Such a role loses the SPAWN/PERSIST capability tools
+    (``task``/``wait``/``wake``) — a slice that fans out is a fan-out nobody
+    watches — but it keeps ``bash`` with ``background``, so it must keep
+    ``jobs`` to observe and cancel the job that ``bash`` receipt tells it to
+    poll. Invariant: ``jobs`` survives IFF ``bash`` can still background."""
+    from local_operator.agent_profiles import AgentProfile
+    from local_operator.harness import subagent as subagent_mod
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = make_session(tmp_path, OneShotStream())
+
+    # A coder-shaped profile: full toolset (no allowlist), does not delegate.
+    profile = AgentProfile(
+        name="coder",
+        description="implements a slice",
+        may_delegate=False,
+    )
+    child = await subagent_mod._build_child_session(
+        label="sub",
+        prompt="implement the slice",
+        parent_session=parent,
+        model_spec=None,
+        job_id="job-1",
+        agent="coder",
+        profile=profile,
+    )
+
+    names = {tool.name for tool in child._tools}
+    assert "bash" in names
+    assert "jobs" in names
+    assert {"task", "wait", "wake"}.isdisjoint(names)
     await child.dispose()
     await parent.dispose()
 

--- a/tests/unit/session/test_role_subagents.py
+++ b/tests/unit/session/test_role_subagents.py
@@ -89,7 +89,13 @@ async def test_a_reviewer_child_cannot_edit_but_can_run_commands(tmp_path, monke
 @pytest.mark.asyncio
 async def test_a_non_delegating_role_gets_no_task_tool(tmp_path, monkeypatch) -> None:
     """A reviewer spawning its own children turns one review into a fan-out
-    nobody is watching."""
+    nobody is watching, so the SPAWN/persist tools stay pruned.
+
+    ``jobs`` is the deliberate exception: it only observes and cancels the
+    child's OWN background bash jobs, and the reviewer keeps ``bash`` (hence
+    ``background``), so pruning ``jobs`` would leave a reviewer that
+    backgrounded a long command looping on ``Tool not found: jobs``. See the
+    ``_can_background`` invariant in ``harness/subagent.py``."""
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
     stream = RecordingStream()
     parent = make_parent(tmp_path, stream)
@@ -97,7 +103,13 @@ async def test_a_non_delegating_role_gets_no_task_tool(tmp_path, monkeypatch) ->
     await run_role(parent, "reviewer")
 
     names = {tool.name for tool in stream.requests[0].tools}
-    assert not names & {"task", "wait", "jobs", "wake"}
+    # The fan-out and persistence tools stay gone: a non-delegating role must
+    # not start its own children or arm a wake its one-prompt session can't keep.
+    assert not names & {"task", "wait", "wake"}
+    # But it keeps ``jobs`` to poll/cancel the background bash jobs it can
+    # still produce (it has ``bash``), which is what stops the poll loop.
+    assert "jobs" in names
+    assert "bash" in names
     await parent.dispose()
 
 


### PR DESCRIPTION
## Summary

Two fixes to the subagent transcript viewer and subagent tool provisioning, both surfaced from real use. (A third fix originally in this work — the delegated prompt rendering at the bottom of a subagent's transcript — was independently fixed by #309, released as v0.41.1, so it's dropped here. See the note below.)

1. **The subagent view tore on mouse-move** — the current frame's interactive elements painted over a frozen previous frame, worst while the working spinner ticked and the pointer moved over the hint row.
2. **A subagent that ran `bash(background=true)` looped forever emitting `Tool not found: jobs`** — backgrounding succeeded and the receipt told the model to poll with `jobs(op='peek')`, but `jobs` had been pruned from that child's toolset.

## What changed

### 1. Opaque ground on the page (`local_operator/tui/local_operator.tcss`)

`.subagent-view` had no `background` and resolved to transparent at runtime, unlike every other block widget. A transparent scrolling region lets Textual's compositor skip clearing cells on a partial repaint, so a hover on an `.actionable` hint plus the 8 Hz spinner painted new cells over stale ones — the tearing. Added `background: $lo-bg`, matching the Screen's own baseline so subagent mode still reads as "the same app looking elsewhere" (per `_open_subagent_view`) rather than an elevated slab.

### 2. A child can poll and cancel its own background bash jobs (`local_operator/harness/subagent.py`)

`bash(background=true)` works for a child (its `context.jobs` is the child's own live `Session.jobs`), and the success receipt says to follow up with `jobs(op='peek')`. But the depth-aware prune dropped the whole capability set — `jobs` included — for non-delegating roles (coder/reviewer), scouts, and grandchildren, so that advice pointed at a tool that no longer existed and the model looped on `Tool not found: jobs`. The child's work still completed (the result auto-delivers through the owner sink), but the poll loop burned turns and budget.

`jobs` only **observes/cancels** the child's own jobs — it spawns nothing (that's `task`) and dies with the child's job manager — so it crosses no boundary the prune protects. It's now spared from the prune under a **derived invariant**: a child keeps `jobs` iff it can still produce a background job (`_can_background(tools)` reads the actual `bash` schema for the `background` parameter rather than hard-coding roles, so the rule can't drift from reality). `task`/`wait`/`wake` keep their existing treatment — a child that must not fan out still can't, and a scout (no `bash`) still gets no `jobs`.

### Version

`pyproject.toml`: **0.41.1 → 0.41.2** (patch — two user-facing bug fixes).

### Note on the dropped prompt-ordering fix

This work originally also fixed the delegated prompt rendering at the bottom of a subagent transcript instead of the top. While it was in review (closed PR #322), **#309** merged and released as v0.41.1; its `_chronological_entries()` + `_launch_prompts` reconciliation already places the prompt at the head, and its `insert_blocks(prefix, …)` API independently handles the multi-page-paging double-mount that a round-1 review had caught here. Verified against current main: opening a subagent view over a job with a delegated prompt and 12 durable disk rows renders the prompt at index 0. So those commits are redundant and were dropped; only the two orthogonal fixes above remain.

## Testing evidence

### Bug 1 (tearing) — root cause + fix confirmed

The tearing is motion-driven (hover + 8 Hz spinner over a transparent region) and does not appear in a static still, so the artifact itself isn't screenshot-captured. Confirmed instead on current main: `.subagent-view` resolves to `Color(20, 17, 12)` (`$lo-bg`) at runtime after the change (was transparent before), and an opaque container is the standard compositor-clears-the-region remedy. In the earlier review of this same one-line change, a design reviewer captured a fresh running frame (live spinner + tool cards, the actual tearing scenario) and confirmed the tool-card slabs sit over the opaque ground with no seam and no elevation error, and the title/rule/hint chrome and scrollbar are unregressed. Full mouse-move confirmation needs a live interactive session.

### Bug 2 (`jobs` prune) — real construction + tests

Built real `coder` and `scout` children and asserted the resulting toolsets directly: the coder has `jobs` + `bash` and no `task`/`wait`/`wake`; the scout (no `bash`) has neither `jobs` nor the spawn tools. Tests:

- `tests/unit/session/test_launch_subagent.py` — grandchild test updated (`jobs` now kept, `task`/`wait`/`wake` gone); restricted-role test tightened; added `test_non_delegating_role_keeps_jobs_to_poll_its_background_bash`.
- `tests/unit/session/test_role_subagents.py::test_a_non_delegating_role_gets_no_task_tool` — updated: a reviewer keeps `jobs` + `bash` but still gets none of `task`/`wait`/`wake`.

### Gates (whole tree, as CI runs them)

```
$ .venv/bin/python -m flake8 .                          # exit 0
$ black --check .   (black 26.1.0)                        # 552 files unchanged
$ isort --check-only .   (isort 5.13.2, repo config)      # exit 0
$ pyright  (touched .py files)                            # 0 errors, 0 warnings
$ pytest tests/unit/session/test_launch_subagent.py tests/unit/session/test_role_subagents.py tests/unit/tui/test_subagent_view.py -q   # all pass
```

Full-tree `pyright` cannot complete on the dev host (it times out under contention; CI runs it in its own runner), so pyright was scoped to the touched files. `uvx isort==5.13.2` cannot spawn in this sandbox (an environment issue, not a lint failure); validated with the identically pinned isort 5.13.2 module.

## Full changelog

https://github.com/damianvtran/local-operator/compare/v0.41.1...dev-subagent-fixes-v2
