### PR TITLE
fix(exec): reap orphaned bash process groups on hard session death

### DIFF
--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -2343,6 +2343,63 @@ async def _run_with_scheduler(run_fn, *run_args) -> int:
                 pass
 
 
+def _install_group_reaper_soft_death() -> None:
+    """Wire the process-group reaper's soft-death path for THIS process.
+
+    Registers ``group_reaper.kill_own_groups`` as an ``atexit`` hook and as a
+    SIGTERM/SIGINT handler, so a catchable stop of the interactive TUI/headless
+    REPL reaps this process's own still-live bash groups instead of leaking them
+    to the next launch's startup sweep. The whole leak this addresses is a HARD
+    (uncatchable SIGKILL) death, which no handler can cover — but a POLITE stop
+    (cmux replace, launchd stop, Ctrl+C at the REPL) IS catchable, and reaping
+    it here makes the common case instant and precise rather than deferred.
+
+    Scoped to the interactive entry on purpose: ``exec``/``serve``/``mobile``
+    own their own SIGTERM semantics (``exec_worker.py``, ``mobile/child.py``) and
+    are dispatched before this is ever called. As a second belt, any
+    pre-existing SIGTERM/SIGINT handler is CHAINED, not clobbered — the reaper
+    runs first, then the previous handler (or the default) still fires — so this
+    can never silently swallow a signal another component was relying on.
+
+    Best-effort and idempotent: the reaper unlinks its ledger on the first call,
+    so the atexit hook, a signal, and the TUI teardown ``finally`` firing in any
+    order all converge on one reap. On Windows the reaper is a no-op, and the
+    signal registration is guarded so a platform without SIGTERM is harmless.
+    """
+    import atexit
+    import contextlib
+    import signal
+
+    from local_operator.tools.group_reaper import kill_own_groups
+
+    atexit.register(kill_own_groups)
+
+    def _chain(signum: int) -> None:
+        previous = signal.getsignal(signum)
+
+        def _handler(received_signum, frame):  # type: ignore[no-untyped-def]
+            try:
+                kill_own_groups()
+            except Exception:  # noqa: BLE001 — a handler must never raise
+                pass
+            # Chain to whatever was installed before us so the process still
+            # stops the way it otherwise would (default disposition included).
+            if callable(previous):
+                previous(received_signum, frame)
+            elif previous == signal.SIG_DFL:
+                # Restore the default and re-raise so the default action (e.g.
+                # terminate) actually happens rather than being swallowed.
+                signal.signal(received_signum, signal.SIG_DFL)
+                os.kill(os.getpid(), received_signum)
+
+        with contextlib.suppress(ValueError, OSError):
+            # ValueError: not the main thread; OSError: unsupported signal.
+            signal.signal(signum, _handler)
+
+    for _sig in (signal.SIGTERM, signal.SIGINT):
+        _chain(_sig)
+
+
 def main() -> int:
     # FIRST, before anything else can log. `helpers.py` used to configure the
     # root logger as an import side effect; now the entry point owns it, which
@@ -2799,6 +2856,19 @@ def main() -> int:
         # event loop from exec_mode/the server module.
         import asyncio
 
+        # Soft-death process-group reaper (tools/group_reaper.py). Installed
+        # ONLY on the interactive TUI + headless REPL entry — the two paths that
+        # spawn bash tool groups and tear down in this process. A catchable stop
+        # (the polite cmux stop, a launchd stop, a clean quit, or an unexpected
+        # exit) then kills this process's own still-live bash groups precisely
+        # and instantly instead of leaving them for the next launch's sweep.
+        # Deliberately NOT installed for `exec`/`serve`/`mobile`: those own their
+        # own SIGTERM lifecycle (exec_worker.py, mobile/child.py) and must keep
+        # it — `_install_group_reaper_soft_death` chains any pre-existing handler
+        # rather than clobbering it, but scoping to here keeps the concern where
+        # the groups are actually created.
+        _install_group_reaper_soft_death()
+
         if use_tui and run_tui is not None:
             tui_config = config_manager.get_config_value("tui", None)
             theme_name = tui_config.get("theme", "dark") if isinstance(tui_config, dict) else "dark"
@@ -2904,6 +2974,16 @@ def main() -> int:
                 try:
                     tui_auth_store.close()
                 except Exception:  # noqa: BLE001 — closing on teardown, never fatal
+                    pass
+                # Reap this process's own bash groups on TUI teardown — a clean
+                # quit, an exception exit, or after run_tui returns. Idempotent
+                # with the atexit/signal hooks (the ledger is unlinked on the
+                # first call). See _install_group_reaper_soft_death.
+                try:
+                    from local_operator.tools.group_reaper import kill_own_groups
+
+                    kill_own_groups()
+                except Exception:  # noqa: BLE001 — teardown, never fatal
                     pass
 
         return asyncio.run(

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -2347,17 +2347,29 @@ def _install_group_reaper_soft_death() -> None:
     """Wire the process-group reaper's soft-death path for THIS process.
 
     Registers ``group_reaper.kill_own_groups`` as an ``atexit`` hook and as a
-    SIGTERM/SIGINT handler, so a catchable stop of the interactive TUI/headless
+    SIGTERM handler, so a catchable stop of the interactive TUI/headless
     REPL reaps this process's own still-live bash groups instead of leaking them
     to the next launch's startup sweep. The whole leak this addresses is a HARD
     (uncatchable SIGKILL) death, which no handler can cover — but a POLITE stop
-    (cmux replace, launchd stop, Ctrl+C at the REPL) IS catchable, and reaping
-    it here makes the common case instant and precise rather than deferred.
+    (cmux replace, launchd stop, Ctrl+D / quit / window close at the REPL) IS
+    catchable, and reaping it here makes the common case instant and precise
+    rather than deferred.
+
+    SIGINT is DELIBERATELY excluded. In the headless REPL, Ctrl-C is a *turn
+    abort that keeps the session alive* (``_run_headless_repl`` catches
+    ``KeyboardInterrupt`` -> ``session.abort`` -> loops), and ``session.abort``
+    deliberately spares ``background=true`` bash jobs — they exist precisely so a
+    build or deploy outlives the turn that started it. Reaping on SIGINT would
+    SIGKILL those still-live groups while the owning REPL keeps running, which is
+    exactly the never-kill-a-live-owner case this whole module forbids. Every
+    real REPL/TUI *exit* (Ctrl-D, ``quit``, window close) still reaps via the
+    ``atexit`` hook, ``session.dispose()`` and the TUI teardown ``finally``, so
+    nothing is lost by leaving SIGINT to its turn-abort semantics.
 
     Scoped to the interactive entry on purpose: ``exec``/``serve``/``mobile``
     own their own SIGTERM semantics (``exec_worker.py``, ``mobile/child.py``) and
     are dispatched before this is ever called. As a second belt, any
-    pre-existing SIGTERM/SIGINT handler is CHAINED, not clobbered — the reaper
+    pre-existing SIGTERM handler is CHAINED, not clobbered — the reaper
     runs first, then the previous handler (or the default) still fires — so this
     can never silently swallow a signal another component was relying on.
 
@@ -2396,7 +2408,10 @@ def _install_group_reaper_soft_death() -> None:
             # ValueError: not the main thread; OSError: unsupported signal.
             signal.signal(signum, _handler)
 
-    for _sig in (signal.SIGTERM, signal.SIGINT):
+    # SIGTERM only. SIGINT is a turn abort in the headless REPL and must NOT
+    # reap live background jobs (see the docstring); a Ctrl-C that actually
+    # exits reaps through atexit/dispose instead.
+    for _sig in (signal.SIGTERM,):
         _chain(_sig)
 
 

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -1057,6 +1057,23 @@ async def _prepare(
         sweep_from_config, config_manager, Path(agent_registry.config_dir), transcript_dir
     )
 
+    # Hard-death process-group reaper (tools/group_reaper.py). Runs beside the
+    # retention sweep and for the same reasons: it is a disk walk over OTHER
+    # processes' ledgers plus ps/os.kill probes, none of which touches THIS
+    # session's construction, so it goes off-loop to stay out of the boot stall;
+    # and it is best-effort, so a sweep error must never fail session start.
+    # It reaps a bash process group only when the lop process that spawned it is
+    # provably dead — the one leak _kill() cannot cover, because a SIGKILLed
+    # owner runs no in-process cleanup and start_new_session already stripped the
+    # group's SIGHUP. Owner liveness is the ONLY signal, so a live session's long
+    # command (e.g. a 10h trainer) is never touched.
+    from local_operator.tools.group_reaper import sweep_orphan_groups
+
+    try:
+        await asyncio.to_thread(sweep_orphan_groups, Path(agent_registry.config_dir))
+    except Exception:  # noqa: BLE001 — best-effort; never block session start
+        logger.debug("orphan process-group sweep failed", exc_info=True)
+
     # Stamp session directories that predate the origin marker, so the
     # ``/resume`` picker stops offering delegated runs on the FIRST launch
     # after an upgrade rather than once natural churn has cleared the store.

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -98,6 +98,7 @@ from local_operator.imaging import (
     bound_image_for_model,
 )
 from local_operator.media import ImageInfo, sniff_image_file
+from local_operator.tools import group_reaper
 from local_operator.tools.spill import (
     SPILL_ENTRY_LIMIT_BYTES,
     SPILL_SCHEME,
@@ -1254,6 +1255,32 @@ async def execute_bash(
         start_new_session=True,
     )
 
+    # Record this group in the owner's process-group ledger so a HARD death of
+    # THIS lop process (SIGKILL from cmux, OOM, crash) — the one stop path with
+    # no in-process code to run _kill() — can still be reaped at the next
+    # startup. start_new_session already detached the group from the terminal,
+    # so a hard-dead owner would otherwise leak it to init forever. Best-effort
+    # and owner-liveness-only by construction: the group is reaped iff THIS
+    # process is dead, never by runtime/CPU/idle, so a legit long-runner (a 10h
+    # trainer) is safe while its session lives. See tools/group_reaper.py.
+    # suppress(Exception): os.getpgid is POSIX-only (absent on Windows), and
+    # registration must never be the reason a command fails to run. The pgid is
+    # held so the clean-death paths below can unregister the exact line.
+    spawned_pgid: int | None = None
+    with contextlib.suppress(Exception):
+        spawned_pgid = os.getpgid(process.pid)
+        group_reaper.register_group(spawned_pgid, params.command)
+
+    def _unregister_group() -> None:
+        # Drop this group's ledger line once it is confirmed dead, so a clean
+        # run leaves nothing for the startup sweep to consider and a long host
+        # session's ledger cannot grow without bound. Best-effort; a miss is
+        # harmless (the sweep finds the leader gone and drops the line anyway).
+        if spawned_pgid is None:
+            return
+        with contextlib.suppress(Exception):
+            group_reaper.unregister_group(spawned_pgid)
+
     stdout_chunks: list[bytes] = []
     stderr_chunks: list[bytes] = []
     # Set once the command is owned by a background job, so the pipe readers
@@ -1410,6 +1437,8 @@ async def execute_bash(
                 transport = getattr(process, "_transport", None)
                 if transport is not None:
                     transport.close()
+                # Clean group death: drop its ledger line (see _unregister_group).
+                _unregister_group()
 
             try:
                 while not bg_wait.done():
@@ -1607,6 +1636,8 @@ async def execute_bash(
     transport = getattr(process, "_transport", None)
     if transport is not None:
         transport.close()
+    # Normal-exit reap complete: the group is dead, so drop its ledger line.
+    _unregister_group()
 
     if abort_waiter is not None and not abort_waiter.done():
         abort_waiter.cancel()

--- a/local_operator/tools/group_reaper.py
+++ b/local_operator/tools/group_reaper.py
@@ -61,11 +61,13 @@ the owner.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
 import subprocess
 import sys
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -152,6 +154,33 @@ def _owner_start_token(pid: int) -> str | None:
     return token or None
 
 
+#: Memoized start token for THIS process. The owner's own start token is
+#: immutable for the life of the process, so the ``ps -o lstart=`` fork it costs
+#: need only be paid once rather than on every register/unregister/kill of the
+#: bash hot path (a session that spawns many short commands otherwise pays a
+#: ``ps`` fork/exec per command just to re-derive a constant). ``None`` means
+#: "not yet resolved" — a transient ``ps`` failure is NOT cached, so a later
+#: call retries rather than poisoning the process with a permanent ``None``.
+_SELF_START_TOKEN: str | None = None
+
+
+def _self_start_token(pid: int) -> str | None:
+    """The current process's own start token, cached; live probe for any other.
+
+    Only ``os.getpid()``'s token is safe to memoize: it cannot change under a
+    fixed pid. Any OTHER pid could be recycled between calls, so it must always
+    be probed live (and no foreign value is ever stored here). This is the hot
+    path — register/unregister/kill all call it — which is the whole reason the
+    self case is cached rather than re-forking ``ps`` each time.
+    """
+    if pid != os.getpid():
+        return _owner_start_token(pid)
+    global _SELF_START_TOKEN
+    if _SELF_START_TOKEN is None:
+        _SELF_START_TOKEN = _owner_start_token(pid)
+    return _SELF_START_TOKEN
+
+
 def _ledger_path(config_dir: Path, owner_pid: int, owner_start: str) -> Path:
     """Path to the ledger for the owner identified by ``(pid, start)``.
 
@@ -209,7 +238,7 @@ def register_group(
     if resolved is None:
         return
     pid = os.getpid() if owner_pid is None else owner_pid
-    owner_start = _owner_start_token(pid)
+    owner_start = _self_start_token(pid)
     if owner_start is None:
         # Cannot establish our own identity -> a ledger keyed by it would be
         # un-reapable (the sweep needs the start token to disambiguate reuse).
@@ -238,9 +267,13 @@ def register_group(
         # (this line is well under 512 bytes) is atomic, so parallel bash calls
         # from the same owner interleave cleanly at line boundaries without
         # rewriting the file — which is why the ledger is JSONL, not a
-        # read-modify-write document.
-        with open(path, "a", encoding="utf-8") as handle:
-            handle.write(json.dumps(entry) + "\n")
+        # read-modify-write document. The SHARED ledger lock lets concurrent
+        # appends still run together but blocks while a compacting unregister
+        # holds the file EXCLUSIVE, so an append can never land inside (and be
+        # lost by) that read-modify-rewrite window. See ``_ledger_lock``.
+        with _ledger_lock(path, exclusive=False):
+            with open(path, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps(entry) + "\n")
     except OSError as exc:
         logger.debug("group reaper: cannot register pgid %s: %s", pgid, exc)
 
@@ -267,21 +300,82 @@ def unregister_group(
     if resolved is None:
         return
     pid = os.getpid() if owner_pid is None else owner_pid
-    owner_start = _owner_start_token(pid)
+    owner_start = _self_start_token(pid)
     if owner_start is None:
         return
     path = _ledger_path(resolved, pid, owner_start)
     _rewrite_without_pgid(path, pgid)
 
 
+@contextlib.contextmanager
+def _ledger_lock(path: Path, *, exclusive: bool) -> Iterator[None]:
+    """Advisory ``flock`` serialising ledger COMPACTION against APPENDS.
+
+    Registration is a lock-free atomic append and unregistration a
+    read-filter-truncate-rewrite. Without coordination a register append that
+    lands between an unregister's read and its truncating write is silently
+    lost, so that group never enters the ledger and a later hard owner-death
+    never reaps it. The window is real here because parallel bash + background
+    jobs from one owner is a first-class feature.
+
+    The fix is a classic readers/writer lock keyed per owner ledger (each owner
+    has its own file, so owners never contend): appends take it SHARED so they
+    still proceed concurrently with each other (a POSIX sub-``PIPE_BUF`` append
+    is already atomic between appenders and must not be serialised on the hot
+    path), while the compacting unregister takes it EXCLUSIVE so no append is
+    in flight while it truncates and rewrites.
+
+    Best-effort: if the lock itself cannot be taken (permissions, an exotic FS
+    without ``flock``) we DEGRADE to running unlocked rather than block or fail a
+    command — the worst case is the pre-existing lost-append behaviour, never a
+    wrong kill. POSIX only; reached solely after the ``_REAPING_IS_SUPPORTED``
+    guard, so ``fcntl`` (absent on Windows) is imported lazily here.
+    """
+    fd: int | None = None
+    try:
+        try:
+            import fcntl
+
+            path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            lock_path = path.parent / (path.name + ".lock")
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+            fcntl.flock(fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+        except (OSError, ImportError) as exc:
+            # Degrade to unlocked: never block or break a command over the lock.
+            logger.debug("group reaper: ledger lock unavailable for %s: %s", path, exc)
+            if fd is not None:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                fd = None
+        yield
+    finally:
+        if fd is not None:
+            with contextlib.suppress(OSError, ImportError):
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_UN)
+                os.close(fd)
+
+
 def _rewrite_without_pgid(path: Path, pgid: int) -> None:
     """Rewrite ``path`` keeping every line whose ``pgid`` differs. Best-effort.
 
-    Reads the whole ledger, filters the one pgid, and writes it back. Torn or
+    Reads the whole ledger, filters the one pgid, and writes it back under an
+    EXCLUSIVE ledger lock so a concurrent register append cannot be lost between
+    this read and this truncating write (see :func:`_ledger_lock`). Torn or
     unparseable lines are KEPT verbatim (never silently dropped by a filter that
-    could not read them) so a concurrent append that is still mid-write is not
-    lost. If nothing remains, the file is unlinked so the owner's ledger
-    disappears once its last group is accounted for.
+    could not read them). If nothing remains, the file is unlinked so the
+    owner's ledger disappears once its last group is accounted for.
+    """
+    with _ledger_lock(path, exclusive=True):
+        _rewrite_without_pgid_locked(path, pgid)
+
+
+def _rewrite_without_pgid_locked(path: Path, pgid: int) -> None:
+    """The read-filter-rewrite body of :func:`_rewrite_without_pgid`.
+
+    Split out so the exclusive-lock scope in the caller stays a thin wrapper and
+    the filtering logic is testable directly. Callers MUST hold the ledger lock.
     """
     try:
         raw_lines = path.read_text(encoding="utf-8").splitlines()
@@ -320,10 +414,13 @@ def kill_own_groups(
 ) -> None:
     """SOFT-DEATH path: reap every still-live group THIS owner registered.
 
-    Wired at the TUI/headless entry via ``atexit`` + a SIGTERM/SIGINT handler +
+    Wired at the TUI/headless entry via ``atexit`` + a SIGTERM handler +
     the teardown ``finally``, so a catchable stop (the polite cmux stop, a
     launchd stop, a clean quit) reaps this process's groups precisely and
-    instantly instead of waiting for the next process's startup sweep.
+    instantly instead of waiting for the next process's startup sweep. NOT
+    wired on SIGINT: a headless-REPL Ctrl-C is a turn abort that spares live
+    ``background=true`` jobs, so reaping there would kill a live owner's groups
+    (see ``_install_group_reaper_soft_death`` in ``cli.py``).
 
     **Scope guarantee**: this reads ONLY the current process's own ledger
     (``<config_dir>/proc-groups/<self_pid>-<self_start>.jsonl``). It never scans
@@ -340,7 +437,7 @@ def kill_own_groups(
     if resolved is None:
         return
     pid = os.getpid() if owner_pid is None else owner_pid
-    owner_start = _owner_start_token(pid)
+    owner_start = _self_start_token(pid)
     if owner_start is None:
         return
     path = _ledger_path(resolved, pid, owner_start)

--- a/local_operator/tools/group_reaper.py
+++ b/local_operator/tools/group_reaper.py
@@ -1,0 +1,579 @@
+"""Reap orphaned process groups whose owning ``lop`` process died hard.
+
+Every shell command the bash tool runs is spawned ``start_new_session=True``
+(`builtin.py`), so each command becomes its own session + process group, and
+``execute_bash`` kills that group on every in-process stop path via
+``_kill()`` -> ``os.killpg(...)``. Those paths — foreground timeout, real
+abort, steering-detach, background-job cleanup, the final reap after a normal
+exit — are complete and correct for any death the owning process is alive to
+observe.
+
+The one leak they cannot cover is a **HARD death of the owning ``lop``
+process**: a SIGKILL when cmux replaces a session, an OOM kill, a crash. No
+in-process code runs, so ``_kill()`` never fires. Because ``start_new_session``
+already detached the group from the controlling terminal, the group receives no
+SIGHUP either; it reparents to launchd/init (pid 1) and runs forever. This was
+observed in the wild as a ``pyright`` group still alive ten hours after its
+owner died.
+
+This module closes that hole the same way :mod:`local_operator.session.retention`
+closes the analogous "hard-killed session left an empty directory behind" hole
+one level up: a liveness marker written at spawn, swept at the next startup, and
+reaped **only when the OWNER is provably dead**.
+
+The whole point — the invariant every line here defends — is in
+:mod:`retention` too, and it is worth restating because a mistake here KILLS a
+process rather than removing an empty directory:
+
+    Reap ONLY genuine waste; NEVER a legitimate long-running command whose
+    owning session is still alive.
+
+A ten-hour ML trainer and a ten-hour stuck ``pyright`` are **identical** by
+runtime, CPU%, and idle time, so those signals are BANNED as inputs to the
+decision (see the ``ts`` field, which is diagnostics-only and which no branch in
+this module may read). The one reliable signal is **owner liveness**: a group is
+waste iff the ``lop`` process that spawned it is dead. That check delegates to
+:func:`retention._process_alive` verbatim — the liveness probe is shared truth,
+and a second copy could drift from the one retention already trusts.
+
+Deliberately NOT folded into :mod:`retention`: retention's contract is "never
+delete a transcript"; this module's contract is "kill a process group". Merging
+a killer into the never-delete module would blur the single guarantee that file
+exists to make. This module imports ``_process_alive`` from retention and
+nothing else.
+
+POSIX-only by nature. The leak is POSIX-specific (``start_new_session``
+orphaning); ``os.killpg`` / ``os.getpgid`` do not exist on Windows, and
+``_process_alive`` cannot probe there, so every entry point early-returns a
+no-op on win32 and nothing is ever registered or reaped.
+
+Out of scope, on purpose: ``exec_mode --background`` workers. Those spawn
+``python -m local_operator.exec_worker`` as a SEPARATE detached process (not via
+``execute_bash``), so they never get a ledger line — and they should not: they
+are deliberate fire-and-forget workers with their own SIGTERM lifecycle and
+their own log file. AsyncJobManager-owned background bash jobs, by contrast, DO
+go through ``execute_bash`` and so are registered like any command, keyed by the
+same owner (the ``lop`` process); they are reaped only when that owner dies,
+which is exactly correct — a detached background job outliving its owner is
+waste, because the sink its output and completion were destined for died with
+the owner.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from local_operator.session.retention import _process_alive
+
+logger = logging.getLogger(__name__)
+
+#: Directory under the config dir holding the per-owner ledgers. 0700 like the
+#: rest of the config dir's private state; created lazily on first register.
+PROC_GROUPS_DIRNAME = "proc-groups"
+
+#: This module's view of the platform, a module-local copy for the same reason
+#: retention keeps one (``_PLATFORM``): a test steers the Windows branch by
+#: patching THIS name rather than the global ``sys.platform``, which would tell
+#: every other thread in the process it is on Windows for the duration — and
+#: this suite runs with threads.
+_PLATFORM = sys.platform
+
+#: Whether this platform can spawn/kill process groups at all. ``os.killpg`` and
+#: ``os.getpgid`` are POSIX-only, and ``_process_alive`` cannot probe on
+#: Windows, so the whole mechanism no-ops there (mirrors retention's
+#: ``_LIVENESS_IS_VERIFIABLE``). Named rather than inlined so every entry point
+#: reads the same decision.
+_REAPING_IS_SUPPORTED = _PLATFORM != "win32"
+
+#: First N chars of the command, stored for the LOG LINE only. Never a decision
+#: input. Bounded so a pathological one-line command cannot bloat the ledger.
+_CMD_LOG_CHARS = 120
+
+
+@dataclass(frozen=True)
+class ReaperSweepResult:
+    """What one hard-death sweep did.
+
+    Returned rather than only logged so a test (and a future benchmark) can
+    assert the outcome without scraping log output, exactly as retention's
+    ``SweepResult`` is used.
+    """
+
+    scanned_ledgers: int = 0
+    reaped_groups: int = 0
+    skipped_live_owners: int = 0
+    errors: int = 0
+
+
+def _owner_start_token(pid: int) -> str | None:
+    """The opaque process-start token for ``pid``, or ``None`` if unreadable.
+
+    ``ps -o lstart=`` prints a process's start time in a fixed, locale-stable
+    form under ``LC_ALL=C`` (verified identical on macOS and Linux, e.g.
+    ``Wed Aug 26 11:38:17 2026``). It needs no ``/proc`` (macOS has none) and no
+    psutil (not installed), which is why it is used here instead of a
+    platform-specific probe.
+
+    The token is treated as **opaque**: stored and compared as a raw string,
+    NEVER parsed into a datetime. That is a safety property, not laziness — a
+    locale quirk or a ``ps`` format surprise can then only make two tokens
+    *differ* (which errs toward NOT reaping, the safe direction), never make two
+    genuinely-different processes' tokens falsely *match* (which could reap a
+    live victim).
+
+    Returns ``None`` when the pid is gone or ``ps`` fails for any reason; every
+    caller treats ``None`` as "cannot establish identity" and refuses to reap.
+    """
+    if pid <= 0:
+        return None
+    try:
+        # LC_ALL=C pins the month/day names so the token is byte-stable across
+        # machines and users; text mode + explicit decode keeps it a str.
+        completed = subprocess.run(
+            ["ps", "-o", "lstart=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "LC_ALL": "C"},
+            check=False,
+        )
+    except (OSError, ValueError) as exc:  # ps missing, or bad argv
+        logger.debug("group reaper: ps lstart failed for pid %s: %s", pid, exc)
+        return None
+    if completed.returncode != 0:
+        # Non-zero almost always means "no such process" — the pid is gone.
+        return None
+    token = completed.stdout.strip()
+    return token or None
+
+
+def _ledger_path(config_dir: Path, owner_pid: int, owner_start: str) -> Path:
+    """Path to the ledger for the owner identified by ``(pid, start)``.
+
+    One file per OWNER (the ``lop`` process), keyed by its two-factor identity
+    so the soft-death handler and the sweep can both answer "which groups belong
+    to owner P?" with a single stat, and a dead owner's whole ledger can be
+    removed in one unlink after its groups are handled. The start token is
+    sanitised into the filename (spaces/colons -> ``-``) so it is a legal,
+    single-path-segment name on every filesystem while staying unique per owner.
+    """
+    safe_start = "".join(c if c.isalnum() else "-" for c in owner_start)
+    return config_dir / PROC_GROUPS_DIRNAME / f"{owner_pid}-{safe_start}.jsonl"
+
+
+def _resolve_config_dir(config_dir: Path | None) -> Path | None:
+    """Resolve the config dir, ``None`` when the helper itself fails.
+
+    ``config_dir=None`` means "ask :func:`paths.config_dir`", imported lazily so
+    this module stays import-light and so a test that patched the env var is
+    honoured on every call (the helper re-reads it each time).
+    """
+    if config_dir is not None:
+        return config_dir
+    try:
+        from local_operator.paths import config_dir as app_config_dir
+
+        return app_config_dir()
+    except Exception as exc:  # noqa: BLE001 — best-effort; never break a command
+        logger.debug("group reaper: cannot resolve config dir: %s", exc)
+        return None
+
+
+def register_group(
+    pgid: int,
+    cmd: str,
+    *,
+    config_dir: Path | None = None,
+    owner_pid: int | None = None,
+) -> None:
+    """Append this group to the owner's ledger. Best-effort; never raises.
+
+    Called at spawn, immediately after the pgid is known. Records the
+    two-factor OWNER identity (this ``lop`` process's pid + start token) that
+    the reap gate keys on, and the group leader's start token (the pgid-reuse
+    defence — see :func:`sweep_orphan_groups`).
+
+    Best-effort by design, exactly like ``retention.claim_session``: a marker
+    that cannot be written (disk full, permission) must NEVER stop a command
+    from running. The worst case of a missed marker is the pre-existing
+    behaviour — one leaked group on a hard owner death.
+    """
+    if not _REAPING_IS_SUPPORTED:
+        return
+    resolved = _resolve_config_dir(config_dir)
+    if resolved is None:
+        return
+    pid = os.getpid() if owner_pid is None else owner_pid
+    owner_start = _owner_start_token(pid)
+    if owner_start is None:
+        # Cannot establish our own identity -> a ledger keyed by it would be
+        # un-reapable (the sweep needs the start token to disambiguate reuse).
+        # Skip rather than write an unusable line.
+        logger.debug("group reaper: no start token for self (pid %s); skip register", pid)
+        return
+    # The leader pid IS the pgid for a group created by start_new_session; its
+    # start token is the pgid-reuse defence recorded at the one moment we know
+    # the group is genuinely ours.
+    grp_leader_start = _owner_start_token(pgid)
+    entry = {
+        "pgid": pgid,
+        "owner_pid": pid,
+        "owner_start": owner_start,
+        "grp_leader_start": grp_leader_start,
+        "cmd": cmd[:_CMD_LOG_CHARS],
+        # Diagnostics ONLY. BANNED as a decision input (§2 of the design): a
+        # stuck pyright and a live trainer are indistinguishable by age. No
+        # branch in this module may read this field.
+        "ts": _now(),
+    }
+    path = _ledger_path(resolved, pid, owner_start)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        # Single append write of one JSON line. A POSIX append under PIPE_BUF
+        # (this line is well under 512 bytes) is atomic, so parallel bash calls
+        # from the same owner interleave cleanly at line boundaries without
+        # rewriting the file — which is why the ledger is JSONL, not a
+        # read-modify-write document.
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry) + "\n")
+    except OSError as exc:
+        logger.debug("group reaper: cannot register pgid %s: %s", pgid, exc)
+
+
+def unregister_group(
+    pgid: int,
+    *,
+    config_dir: Path | None = None,
+    owner_pid: int | None = None,
+) -> None:
+    """Drop one pgid from THIS owner's ledger after a clean group death.
+
+    Called on the normal-exit reap and the detached-job cleanup once the group
+    is confirmed dead. Keeps a long host session's ledger from growing without
+    bound and means a clean run leaves nothing for the sweep to consider.
+
+    Best-effort: a missed unregister is harmless — the group is already dead, so
+    both the soft-death and sweep paths find the leader gone and simply drop the
+    line without killing anything.
+    """
+    if not _REAPING_IS_SUPPORTED:
+        return
+    resolved = _resolve_config_dir(config_dir)
+    if resolved is None:
+        return
+    pid = os.getpid() if owner_pid is None else owner_pid
+    owner_start = _owner_start_token(pid)
+    if owner_start is None:
+        return
+    path = _ledger_path(resolved, pid, owner_start)
+    _rewrite_without_pgid(path, pgid)
+
+
+def _rewrite_without_pgid(path: Path, pgid: int) -> None:
+    """Rewrite ``path`` keeping every line whose ``pgid`` differs. Best-effort.
+
+    Reads the whole ledger, filters the one pgid, and writes it back. Torn or
+    unparseable lines are KEPT verbatim (never silently dropped by a filter that
+    could not read them) so a concurrent append that is still mid-write is not
+    lost. If nothing remains, the file is unlinked so the owner's ledger
+    disappears once its last group is accounted for.
+    """
+    try:
+        raw_lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        logger.debug("group reaper: cannot read ledger %s: %s", path, exc)
+        return
+    kept: list[str] = []
+    for line in raw_lines:
+        if not line.strip():
+            continue
+        try:
+            obj = json.loads(line)
+        except (ValueError, TypeError):
+            # Unparseable (possibly a torn concurrent append): keep it, since
+            # dropping a line we could not read would lose a sibling's group.
+            kept.append(line)
+            continue
+        if isinstance(obj, dict) and obj.get("pgid") == pgid:
+            continue
+        kept.append(line)
+    try:
+        if kept:
+            path.write_text("\n".join(kept) + "\n", encoding="utf-8")
+        else:
+            path.unlink(missing_ok=True)
+    except OSError as exc:
+        logger.debug("group reaper: cannot rewrite ledger %s: %s", path, exc)
+
+
+def kill_own_groups(
+    *,
+    config_dir: Path | None = None,
+    owner_pid: int | None = None,
+) -> None:
+    """SOFT-DEATH path: reap every still-live group THIS owner registered.
+
+    Wired at the TUI/headless entry via ``atexit`` + a SIGTERM/SIGINT handler +
+    the teardown ``finally``, so a catchable stop (the polite cmux stop, a
+    launchd stop, a clean quit) reaps this process's groups precisely and
+    instantly instead of waiting for the next process's startup sweep.
+
+    **Scope guarantee**: this reads ONLY the current process's own ledger
+    (``<config_dir>/proc-groups/<self_pid>-<self_start>.jsonl``). It never scans
+    another owner's ledger, so a sibling ``lop``'s live groups are untouchable by
+    construction — this can only ever kill groups THIS process spawned.
+
+    Idempotent: a second call finds the ledger already unlinked and does
+    nothing; a ``killpg`` on an already-dead group raises ``ProcessLookupError``,
+    which is suppressed. POSIX only.
+    """
+    if not _REAPING_IS_SUPPORTED:
+        return
+    resolved = _resolve_config_dir(config_dir)
+    if resolved is None:
+        return
+    pid = os.getpid() if owner_pid is None else owner_pid
+    owner_start = _owner_start_token(pid)
+    if owner_start is None:
+        return
+    path = _ledger_path(resolved, pid, owner_start)
+    try:
+        entries = _read_ledger(path)
+    except OSError:
+        return
+    for entry in entries:
+        # This IS our own ledger, so the owner check is moot — but the
+        # pgid-reuse (victim) gate still applies: between a group's death and
+        # this call the pgid may have been recycled onto an unrelated live
+        # group, and killing that would murder an innocent. Same guard as the
+        # sweep.
+        _reap_if_still_ours(entry)
+    # Drop the whole ledger: this process is going away, so nothing more will be
+    # appended to it, and everything in it has now been handled.
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def sweep_orphan_groups(
+    config_dir: Path,
+    *,
+    self_pid: int | None = None,
+) -> ReaperSweepResult:
+    """HARD-DEATH path: reap groups whose owning ``lop`` process is provably dead.
+
+    Runs at startup beside the retention sweep, off-loop, best-effort. Scans
+    every owner's ledger under ``proc-groups/``; for each whose owner is dead
+    (two-factor identity, below), kills every still-live registered group whose
+    leader identity still matches, then unlinks the ledger. A LIVE owner's
+    ledger is never touched — that is the live-trainer guarantee.
+
+    OWNER identity is two-factor (``owner_pid`` + ``owner_start``), because a
+    bare pid is forgeable: after the OS recycles a dead ``lop``'s pid onto an
+    unrelated live process, a bare-pid probe reads "alive" and the sweep would
+    refuse to reap a genuinely-orphaned group forever. The truth table:
+
+        _process_alive(owner_pid) | start token | verdict
+        --------------------------|-------------|--------------------------------
+        False (pid gone)          | —           | owner dead        -> reap
+        True                      | matches     | owner ALIVE       -> NEVER reap
+        True                      | differs     | pid recycled/dead -> reap
+        True                      | unreadable  | ambiguous         -> NEVER reap
+
+    Every ambiguous cell resolves to NOT reaping.
+
+    POSIX only; on Windows returns an empty result and reaps nothing (mirrors
+    retention). Best-effort: a scan error is counted and swallowed so a sweep
+    failure never blocks session start.
+    """
+    result = ReaperSweepResult()
+    if not _REAPING_IS_SUPPORTED:
+        return result
+    me = os.getpid() if self_pid is None else self_pid
+    groups_dir = config_dir / PROC_GROUPS_DIRNAME
+    try:
+        ledgers = sorted(groups_dir.glob("*.jsonl"))
+    except OSError as exc:
+        logger.debug("group reaper: cannot list %s: %s", groups_dir, exc)
+        return result
+    scanned = 0
+    reaped = 0
+    skipped_live = 0
+    errors = 0
+    for ledger in ledgers:
+        scanned += 1
+        try:
+            entries = _read_ledger(ledger)
+        except OSError as exc:
+            # A wholly-unreadable ledger is left in place (err toward keeping
+            # evidence), never blindly unlinked.
+            logger.debug("group reaper: cannot read ledger %s: %s", ledger, exc)
+            errors += 1
+            continue
+        if not entries:
+            # Empty or all-torn ledger with nothing actionable: remove the shell
+            # so the directory does not accumulate husks. Safe — no pgid to act
+            # on.
+            _safe_unlink(ledger)
+            continue
+        # Owner identity is taken from the FILE's first readable entry: every
+        # line in one ledger shares the same owner by construction (it is keyed
+        # by owner). If the owner is our own live pid, this is a sibling-safe
+        # skip — but that only happens if a stale ledger from a PRIOR process
+        # reused our pid, which the start-token check below still resolves
+        # correctly.
+        owner_pid = entries[0].get("owner_pid")
+        owner_start = entries[0].get("owner_start")
+        if not isinstance(owner_pid, int) or not isinstance(owner_start, str):
+            errors += 1
+            continue
+        if owner_pid == me:
+            # Never reap groups attributed to the sweeping process itself; the
+            # soft-death path owns those.
+            skipped_live += 1
+            continue
+        verdict = _owner_is_dead(owner_pid, owner_start)
+        if verdict is None:
+            # Ambiguous (pid alive, token unreadable) -> never reap.
+            skipped_live += 1
+            continue
+        if not verdict:
+            # Owner alive, token matches -> the live-trainer case. Leave the
+            # ledger entirely untouched; it belongs to a running session.
+            skipped_live += 1
+            continue
+        # Owner is provably dead: reap each still-ours group, then drop the
+        # ledger.
+        for entry in entries:
+            if _reap_if_still_ours(entry):
+                reaped += 1
+        _safe_unlink(ledger)
+    return ReaperSweepResult(
+        scanned_ledgers=scanned,
+        reaped_groups=reaped,
+        skipped_live_owners=skipped_live,
+        errors=errors,
+    )
+
+
+def _owner_is_dead(owner_pid: int, owner_start: str) -> bool | None:
+    """Is the ledger's owner provably dead? ``None`` when it cannot be decided.
+
+    Implements the owner-side truth table. Returns ``True`` (reap) only when the
+    pid is gone OR the pid is alive but its start token differs (pid recycled
+    onto a different process). Returns ``False`` (never reap) when the original
+    owner is provably still alive. Returns ``None`` (never reap, ambiguous) when
+    the pid is alive but its current start token is unreadable.
+    """
+    if not _process_alive(owner_pid):
+        return True  # pid gone -> owner dead -> reap
+    current = _owner_start_token(owner_pid)
+    if current is None:
+        return None  # alive but unreadable -> ambiguous -> never reap
+    if current != owner_start:
+        return True  # pid recycled onto a different process -> owner dead -> reap
+    return False  # same pid, same start -> original owner ALIVE -> never reap
+
+
+def _reap_if_still_ours(entry: dict[str, object]) -> bool:
+    """killpg one registered group, but ONLY if it is still genuinely ours.
+
+    The pgid-reuse (victim) gate: even with a dead owner, the pgid itself may
+    have been recycled by the OS onto an unrelated live group between the
+    owner's death and now. Killing a recycled pgid would murder an innocent
+    process. Defence uses the group-leader start token recorded at spawn (the
+    leader pid == the pgid):
+
+        still_ours = _process_alive(pgid) and
+                     _owner_start_token(pgid) == grp_leader_start
+
+    - leader gone            -> the group already died; drop, no kill.
+    - leader alive, differs  -> pgid recycled onto a new leader; drop, no kill.
+    - leader alive, matches  -> genuinely our orphaned group; killpg.
+
+    Returns ``True`` only when a live, still-ours group was actually signalled.
+    """
+    pgid = entry.get("pgid")
+    if not isinstance(pgid, int) or pgid <= 0:
+        return False
+    grp_leader_start = entry.get("grp_leader_start")
+    if not _process_alive(pgid):
+        return False  # leader gone: group already dead, nothing to kill
+    current_leader = _owner_start_token(pgid)
+    if current_leader is None:
+        # Alive but the leader's identity is unreadable -> ambiguous -> do NOT
+        # kill (err toward not killing an innocent).
+        return False
+    if current_leader != grp_leader_start:
+        # pgid recycled onto a different leader -> the original group is gone,
+        # this is an innocent live group. Do NOT kill.
+        return False
+    try:
+        os.killpg(pgid, _sigkill())
+    except ProcessLookupError:
+        # Died between the liveness check and the kill: idempotent, fine.
+        return False
+    except OSError as exc:
+        logger.debug("group reaper: killpg %s failed: %s", pgid, exc)
+        return False
+    logger.info(
+        "group reaper: reaped orphaned group pgid=%s cmd=%r",
+        pgid,
+        entry.get("cmd", ""),
+    )
+    return True
+
+
+def _read_ledger(path: Path) -> list[dict[str, object]]:
+    """Parse a ledger into a list of entry dicts, skipping torn/corrupt lines.
+
+    A torn final line (a concurrent append still mid-write) or any otherwise
+    unparseable line is SKIPPED, not fatal — the same posture retention takes
+    with a bad claim marker. Raises ``OSError`` only when the file itself cannot
+    be read (a missing file is not an error: returns ``[]``).
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+    entries: list[dict[str, object]] = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            obj = json.loads(line)
+        except (ValueError, TypeError):
+            continue  # torn or corrupt line: skip, keep processing the rest
+        if isinstance(obj, dict):
+            entries.append(obj)
+    return entries
+
+
+def _safe_unlink(path: Path) -> None:
+    """Unlink ``path`` tolerating a concurrent sweep that already removed it."""
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as exc:
+        logger.debug("group reaper: cannot unlink ledger %s: %s", path, exc)
+
+
+def _sigkill() -> int:
+    """``signal.SIGKILL``, imported lazily to keep this module import-light."""
+    import signal
+
+    return signal.SIGKILL
+
+
+def _now() -> float:
+    """Wall clock for the diagnostics-only ``ts`` field. Never a decision input."""
+    import time
+
+    return time.time()

--- a/local_operator/tools/group_reaper.py
+++ b/local_operator/tools/group_reaper.py
@@ -161,6 +161,14 @@ def _owner_start_token(pid: int) -> str | None:
 #: ``ps`` fork/exec per command just to re-derive a constant). ``None`` means
 #: "not yet resolved" — a transient ``ps`` failure is NOT cached, so a later
 #: call retries rather than poisoning the process with a permanent ``None``.
+#:
+#: Fork-staleness assumption: this memo is process-global, so a
+#: fork-WITHOUT-exec child would inherit the PARENT's token under its own
+#: (different) pid and read a stale identity. That is latent only and
+#: unreachable on the install path — the reaper installs solely on the
+#: interactive TUI / headless entry, which never forks without a following exec
+#: (a fork+exec child re-imports this module and starts again at ``None``). If a
+#: future entry point ever forks without exec, reset this in the child.
 _SELF_START_TOKEN: str | None = None
 
 
@@ -193,6 +201,42 @@ def _ledger_path(config_dir: Path, owner_pid: int, owner_start: str) -> Path:
     """
     safe_start = "".join(c if c.isalnum() else "-" for c in owner_start)
     return config_dir / PROC_GROUPS_DIRNAME / f"{owner_pid}-{safe_start}.jsonl"
+
+
+#: Suffix appended to a ledger's name to form its advisory-lock sidecar. A
+#: single named constant so the lock CREATOR (``_ledger_lock``) and the lock
+#: HUSK reaper (the startup sweep) can never disagree on the name and leave a
+#: file one of them cannot see.
+_LOCK_SUFFIX = ".lock"
+
+
+def _lock_path(ledger_path: Path) -> Path:
+    """The advisory-lock sidecar path for ``ledger_path``.
+
+    ``_ledger_lock`` creates ``<ledger>.lock`` next to the ledger; the sweep
+    removes that husk when the owner is proven dead. Both go through here so the
+    name is defined in exactly one place.
+    """
+    return ledger_path.parent / (ledger_path.name + _LOCK_SUFFIX)
+
+
+def _owner_pid_from_lock(lock_path: Path) -> int | None:
+    """Parse the owner pid out of a ``<pid>-<start>.jsonl.lock`` husk name.
+
+    The sweep needs the owner pid to ask ``_process_alive`` before removing an
+    ORPHAN lock (one with no surviving ledger to read the identity from). Only
+    the pid is recoverable: the start token was sanitised into the filename
+    (non-alphanumerics collapsed to ``-``), so it cannot be reversed — which is
+    exactly why the orphan-lock pass reaps ONLY on the pid-gone row of the owner
+    truth table (no token needed) and never on the recycle row. ``None`` for any
+    name whose leading segment is not an integer, so an unexpected file is left
+    alone rather than guessed at.
+    """
+    prefix = lock_path.name.split("-", 1)[0]
+    try:
+        return int(prefix)
+    except ValueError:
+        return None
 
 
 def _resolve_config_dir(config_dir: Path | None) -> Path | None:
@@ -337,7 +381,7 @@ def _ledger_lock(path: Path, *, exclusive: bool) -> Iterator[None]:
             import fcntl
 
             path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-            lock_path = path.parent / (path.name + ".lock")
+            lock_path = _lock_path(path)
             fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
             fcntl.flock(fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
         except (OSError, ImportError) as exc:
@@ -548,17 +592,66 @@ def sweep_orphan_groups(
             skipped_live += 1
             continue
         # Owner is provably dead: reap each still-ours group, then drop the
-        # ledger.
+        # ledger AND its lock husk. Removing the lock here (rather than via a
+        # separate liveness check) ties husk cleanup to the exact moment this
+        # sweep has already PROVEN the owner dead — no new liveness logic, and
+        # never a live owner's lock, since a live owner's ledger is skipped
+        # above before this point is reached.
         for entry in entries:
             if _reap_if_still_ours(entry):
                 reaped += 1
         _safe_unlink(ledger)
+        _safe_unlink(_lock_path(ledger))
+    # Second pass: reap ORPHAN lock husks — ``*.jsonl.lock`` files whose ledger
+    # was already unlinked by a clean-exit compaction (unregister/kill_own_groups
+    # remove the ledger but leave the lock sidecar behind) or by the loop above.
+    # This is the husk source that actually accumulates: the common path is a
+    # graceful shutdown, which never leaves a ledger for the loop above to key
+    # on. Guarded on the SINGLE unambiguous owner-death signal recoverable from a
+    # lock name alone — the pid is gone (``_process_alive`` false) — because the
+    # start token cannot be reversed out of the sanitised filename. A lock whose
+    # pid is still alive, or whose name is not pid-parseable, is left untouched:
+    # every ambiguous case errs toward NOT touching a possibly-live owner's lock.
+    errors += _sweep_orphan_locks(groups_dir)
     return ReaperSweepResult(
         scanned_ledgers=scanned,
         reaped_groups=reaped,
         skipped_live_owners=skipped_live,
         errors=errors,
     )
+
+
+def _sweep_orphan_locks(groups_dir: Path) -> int:
+    """Unlink ``*.jsonl.lock`` husks whose owner pid is provably gone.
+
+    Called after the ledger loop so any lock paired with a still-present ledger
+    has already been handled (a live owner's ledger — and thus its lock — was
+    skipped; a dead owner's ledger and lock were removed together). What remains
+    are ORPHAN locks: sidecars left behind when a clean shutdown compacted the
+    ledger away but not its lock file. Reap one ONLY when its parsed owner pid is
+    no longer a live process; a pid still alive, or a name that does not start
+    with an integer, is left in place. Returns the count of errors swallowed so
+    the caller can fold them into the sweep result. Best-effort throughout: a
+    stray husk is cosmetic, never worth failing a session start over.
+    """
+    errors = 0
+    try:
+        locks = sorted(groups_dir.glob("*" + _LOCK_SUFFIX))
+    except OSError as exc:
+        logger.debug("group reaper: cannot list locks in %s: %s", groups_dir, exc)
+        return errors
+    for lock in locks:
+        owner_pid = _owner_pid_from_lock(lock)
+        if owner_pid is None:
+            # Unparseable name — not ours to guess at. Leave it.
+            continue
+        if _process_alive(owner_pid):
+            # Owner pid still live: this lock may belong to a running session's
+            # ledger that simply has no groups registered right now. Never touch
+            # a possibly-live owner's lock.
+            continue
+        _safe_unlink(lock)
+    return errors
 
 
 def _owner_is_dead(owner_pid: int, owner_start: str) -> bool | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.41.3"
+version = "0.41.4"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/e2e_group_reaper_repro.py
+++ b/tests/e2e_group_reaper_repro.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""End-to-end reproduction of the orphaned-process-group reaper.
+
+Drives the REAL ``execute_bash`` tool path (not a hand-rolled ``Popen``) to
+spawn detached ``sleep`` groups, then exercises every branch of the reaper
+against them, asserting liveness the hard way — ``os.killpg(pgid, 0)`` /
+child ``wait()`` — so each result is proof the group truly lived or died
+rather than a green unit assertion.
+
+No 10-hour process is needed: every scenario is deterministic. Owner "hard
+death" is simulated by writing a ledger keyed to a genuinely-dead pid (a
+just-reaped child), which is byte-identical to what a SIGKILLed ``lop`` process
+leaves behind — the ledger file outlives the process precisely because it is on
+disk, which is the whole point of the mechanism.
+
+Run (from the worktree, with its venv on PYTHONPATH so the new source is used):
+
+    PYTHONPATH=/tmp/lop-reaper .venv/bin/python tests/e2e_group_reaper_repro.py
+
+A: hard death, owner DEAD  -> group survived owner, sweep REAPS it.
+B: owner ALIVE             -> sweep does NOT reap (anti-regression, live runner).
+C: PID-reuse decoys        -> alive-wrong-token and dead-pid both REAP;
+   C-inverse: pgid recycled onto an innocent live group -> sweep DROPS, innocent lives.
+D: soft death              -> kill_own_groups reaps own group, spares a sibling owner.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import signal
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+from local_operator.harness.jobs import AsyncJobManager
+from local_operator.harness.types import ToolContext
+from local_operator.tools import builtin, group_reaper
+
+
+def _killpg_alive(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # pgid recycled onto a process we cannot signal -> our group is gone.
+        return False
+
+
+def _dead_pid() -> int:
+    """A genuinely-dead pid: spawn a trivial child and reap it."""
+    child = subprocess.Popen(["/bin/sh", "-c", "true"])
+    child.wait()
+    return child.pid
+
+
+async def _spawn_via_real_bash(config_dir: Path, cmd: str) -> tuple[AsyncJobManager, int]:
+    """Spawn ``cmd`` detached through the REAL execute_bash path.
+
+    Returns the job manager (owning the background job) and the pgid the reaper
+    recorded in the owner's ledger — read back from disk to prove registration
+    happened on the real path, not from a side channel.
+    """
+    manager = AsyncJobManager()
+    ctx = ToolContext(cwd=str(config_dir), session_id="e2e", jobs=manager)
+    tool = builtin.build_bash_tool()
+    result = await tool.execute(
+        "e2e-call",
+        {"command": cmd, "background": True, "timeout": 300},
+        None,
+        None,
+        ctx,
+    )
+    assert result.is_error is False, result
+    # The ledger the reaper wrote under the REAL config dir for this process.
+    my_pid = os.getpid()
+    my_start = group_reaper._owner_start_token(my_pid)
+    ledger = group_reaper._ledger_path(config_dir, my_pid, my_start)
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        if ledger.exists() and ledger.read_text().strip():
+            break
+        await asyncio.sleep(0.02)
+    entries = group_reaper._read_ledger(ledger)
+    assert entries, "no ledger line written by the real bash path"
+    pgid = entries[-1]["pgid"]
+    return manager, pgid
+
+
+def _check(label: str, ok: bool) -> None:
+    status = "PASS" if ok else "FAIL"
+    print(f"  [{status}] {label}")
+    if not ok:
+        raise SystemExit(f"e2e assertion failed: {label}")
+
+
+async def scenario_a(config_dir: Path) -> None:
+    print("A) hard death, owner DEAD -> group survives owner, sweep REAPS")
+    # Spawn through the real bash path; point config at the SAME dir the reaper
+    # resolves for this process by temporarily overriding the env var.
+    manager, pgid = await _spawn_via_real_bash(config_dir, "sleep 600")
+    _check("group is alive after spawn (killpg 0 succeeds)", _killpg_alive(pgid))
+
+    # Simulate the OWNER hard-dying: rewrite the ledger keyed to a dead pid,
+    # exactly what a SIGKILLed lop leaves on disk. (Our real process stays
+    # alive as the test driver, so we re-key rather than kill ourselves.)
+    my_pid = os.getpid()
+    my_start = group_reaper._owner_start_token(my_pid)
+    live_ledger = group_reaper._ledger_path(config_dir, my_pid, my_start)
+    entry = group_reaper._read_ledger(live_ledger)[-1]
+    live_ledger.unlink()
+    dead = _dead_pid()
+    entry = {**entry, "owner_pid": dead, "owner_start": "dead-owner-token"}
+    dead_ledger = group_reaper._ledger_path(config_dir, dead, "dead-owner-token")
+    dead_ledger.write_text(json.dumps(entry) + "\n", encoding="utf-8")
+
+    _check("group SURVIVED the owner's death (still alive)", _killpg_alive(pgid))
+    result = group_reaper.sweep_orphan_groups(config_dir)
+    _check("sweep reaped exactly one group", result.reaped_groups == 1)
+    time.sleep(0.1)
+    _check(
+        "group is REAPED after sweep (killpg raises ProcessLookupError)",
+        not _killpg_alive(pgid),
+    )
+    _check("dead owner's ledger unlinked", not dead_ledger.exists())
+    manager.shutdown() if hasattr(manager, "shutdown") else None
+
+
+async def scenario_b(config_dir: Path) -> None:
+    print("B) owner ALIVE -> sweep does NOT reap (live-runner anti-regression)")
+    manager, pgid = await _spawn_via_real_bash(config_dir, "sleep 600")
+    _check("group alive after spawn", _killpg_alive(pgid))
+    # Owner (this process) is alive and its ledger is intact/matching.
+    result = group_reaper.sweep_orphan_groups(config_dir, self_pid=os.getpid() + 9_000_000)
+    _check("sweep reaped nothing", result.reaped_groups == 0)
+    _check("sweep skipped a live owner", result.skipped_live_owners == 1)
+    _check("group SURVIVES (live owner's long-runner untouched)", _killpg_alive(pgid))
+    # cleanup
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+    my_start = group_reaper._owner_start_token(os.getpid())
+    group_reaper._ledger_path(config_dir, os.getpid(), my_start).unlink(missing_ok=True)
+
+
+async def scenario_c(config_dir: Path) -> None:
+    print("C) PID-reuse decoys -> both REAP; C-inverse -> innocent SURVIVES")
+
+    # C1: owner_pid alive (this process) but start token WRONG -> reap (row 3).
+    _, pgid1 = await _spawn_via_real_bash(config_dir, "sleep 600")
+    my_pid = os.getpid()
+    my_start = group_reaper._owner_start_token(my_pid)
+    lg1 = group_reaper._ledger_path(config_dir, my_pid, my_start)
+    e1 = group_reaper._read_ledger(lg1)[-1]
+    lg1.unlink()
+    wrong = group_reaper._ledger_path(config_dir, my_pid, "WRONG-TOKEN")
+    wrong.write_text(json.dumps({**e1, "owner_start": "WRONG-TOKEN"}) + "\n", encoding="utf-8")
+
+    # C2: owner_pid DEAD -> reap (row 1). Separate real group + dead owner.
+    proc2 = subprocess.Popen(
+        ["/bin/sh", "-c", "sleep 600"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    time.sleep(0.1)
+    pgid2 = os.getpgid(proc2.pid)
+    leader2 = group_reaper._owner_start_token(pgid2)
+    dead = _dead_pid()
+    group_reaper._ledger_path(config_dir, dead, "d").write_text(
+        json.dumps(
+            {
+                "pgid": pgid2,
+                "owner_pid": dead,
+                "owner_start": "d",
+                "grp_leader_start": leader2,
+                "cmd": "sleep 600",
+                "ts": 1.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = group_reaper.sweep_orphan_groups(config_dir, self_pid=my_pid + 9_000_000)
+    _check("both decoys reaped (row1 dead-pid + row3 wrong-token)", result.reaped_groups == 2)
+    time.sleep(0.1)
+    _check("C1 alive-but-wrong-token group REAPED", not _killpg_alive(pgid1))
+    _check("C2 dead-owner group REAPED", not _killpg_alive(pgid2))
+    proc2.wait(timeout=2)
+
+    # C-inverse: dead owner, but pgid now recycled onto an INNOCENT live group
+    # whose leader-start differs -> sweep must DROP the line, innocent survives.
+    innocent = subprocess.Popen(
+        ["/bin/sh", "-c", "sleep 600"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    time.sleep(0.1)
+    innocent_pgid = os.getpgid(innocent.pid)
+    dead2 = _dead_pid()
+    group_reaper._ledger_path(config_dir, dead2, "d2").write_text(
+        json.dumps(
+            {
+                "pgid": innocent_pgid,  # recycled onto the innocent group
+                "owner_pid": dead2,
+                "owner_start": "d2",
+                "grp_leader_start": "STALE-DOES-NOT-MATCH-INNOCENT",
+                "cmd": "sleep 600",
+                "ts": 1.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = group_reaper.sweep_orphan_groups(config_dir, self_pid=my_pid + 9_000_000)
+    _check("C-inverse: sweep reaped nothing (victim gate held)", result.reaped_groups == 0)
+    _check("C-inverse: innocent live group SURVIVES", _killpg_alive(innocent_pgid))
+    try:
+        os.killpg(innocent_pgid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+    innocent.wait(timeout=2)
+
+
+async def scenario_d(config_dir: Path) -> None:
+    print("D) soft death -> kill_own_groups reaps own group, spares sibling owner")
+    manager, my_pgid = await _spawn_via_real_bash(config_dir, "sleep 600")
+
+    # Pre-seed a SIBLING owner (a different, live pid) with a live group.
+    sibling = subprocess.Popen(
+        ["/bin/sh", "-c", "sleep 600"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    time.sleep(0.1)
+    sib_pgid = os.getpgid(sibling.pid)
+    sib_leader = group_reaper._owner_start_token(sib_pgid)
+    sib_owner = os.getpid() + 5_000_000
+    sib_ledger = group_reaper._ledger_path(config_dir, sib_owner, "sib")
+    sib_ledger.write_text(
+        json.dumps(
+            {
+                "pgid": sib_pgid,
+                "owner_pid": sib_owner,
+                "owner_start": "sib",
+                "grp_leader_start": sib_leader,
+                "cmd": "sleep 600",
+                "ts": 1.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    group_reaper.kill_own_groups(config_dir=config_dir)
+    time.sleep(0.1)
+    _check("own group REAPED by soft death", not _killpg_alive(my_pgid))
+    _check("sibling owner's group SURVIVES (scope proof)", _killpg_alive(sib_pgid))
+    my_start = group_reaper._owner_start_token(os.getpid())
+    _check(
+        "own ledger unlinked",
+        not group_reaper._ledger_path(config_dir, os.getpid(), my_start).exists(),
+    )
+    _check("sibling ledger intact", sib_ledger.exists())
+    try:
+        os.killpg(sib_pgid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+    sibling.wait(timeout=2)
+
+
+async def main() -> None:
+    # Real config dir override so execute_bash's register lands where the sweep
+    # reads. Each scenario gets its own clean dir.
+    for name, fn in (("A", scenario_a), ("B", scenario_b), ("C", scenario_c), ("D", scenario_d)):
+        with tempfile.TemporaryDirectory() as td:
+            cfg = Path(td)
+            os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = str(cfg)
+            await fn(cfg)
+        print()
+    print("ALL SCENARIOS PASSED")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/e2e_group_reaper_repro.py
+++ b/tests/e2e_group_reaper_repro.py
@@ -17,11 +17,22 @@ Run (from the worktree, with its venv on PYTHONPATH so the new source is used):
 
     PYTHONPATH=/tmp/lop-reaper .venv/bin/python tests/e2e_group_reaper_repro.py
 
+``PYTHONPATH`` here only forces the WORKTREE source to be exercised instead of
+the installed package; it is a test-harness convenience, not a production
+requirement. In production, register/sweep/kill all run in-process — there is no
+child ``python -m local_operator`` that needs ``local_operator`` on its path (the
+only children this script spawns are ``/bin/sh`` sleeps and, in scenario E, a
+``python -c`` that imports from the same interpreter the parent already resolved).
+
 A: hard death, owner DEAD  -> group survived owner, sweep REAPS it.
 B: owner ALIVE             -> sweep does NOT reap (anti-regression, live runner).
 C: PID-reuse decoys        -> alive-wrong-token and dead-pid both REAP;
    C-inverse: pgid recycled onto an innocent live group -> sweep DROPS, innocent lives.
 D: soft death              -> kill_own_groups reaps own group, spares a sibling owner.
+E: SIGINT vs SIGTERM scope -> a real child installs the soft-death hook and holds
+   a live registered group; SIGINT (the headless-REPL turn abort) leaves the
+   group ALIVE, a following SIGTERM (real termination) REAPS it. This is the R1
+   regression: reaping on SIGINT would kill a live owner's background job.
 """
 
 from __future__ import annotations
@@ -31,6 +42,7 @@ import json
 import os
 import signal
 import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -38,6 +50,20 @@ from pathlib import Path
 from local_operator.harness.jobs import AsyncJobManager
 from local_operator.harness.types import ToolContext
 from local_operator.tools import builtin, group_reaper
+
+
+def _token(pid: int) -> str:
+    """A start token that is statically known non-``None`` for the caller.
+
+    ``group_reaper._owner_start_token`` returns ``str | None`` (``None`` when the
+    pid is gone or ``ps`` fails), but every call site here passes a pid that is
+    demonstrably alive at the moment of the call, so a ``None`` is a genuine test
+    failure rather than an expected branch. Asserting here keeps the type checker
+    honest without scattering ``# type: ignore`` across the scenarios.
+    """
+    token = group_reaper._owner_start_token(pid)
+    assert token is not None, f"no start token for live pid {pid}"
+    return token
 
 
 def _killpg_alive(pgid: int) -> bool:
@@ -78,7 +104,7 @@ async def _spawn_via_real_bash(config_dir: Path, cmd: str) -> tuple[AsyncJobMana
     assert result.is_error is False, result
     # The ledger the reaper wrote under the REAL config dir for this process.
     my_pid = os.getpid()
-    my_start = group_reaper._owner_start_token(my_pid)
+    my_start = _token(my_pid)
     ledger = group_reaper._ledger_path(config_dir, my_pid, my_start)
     deadline = time.time() + 5
     while time.time() < deadline:
@@ -88,6 +114,7 @@ async def _spawn_via_real_bash(config_dir: Path, cmd: str) -> tuple[AsyncJobMana
     entries = group_reaper._read_ledger(ledger)
     assert entries, "no ledger line written by the real bash path"
     pgid = entries[-1]["pgid"]
+    assert isinstance(pgid, int), f"ledger pgid was not an int: {pgid!r}"
     return manager, pgid
 
 
@@ -109,7 +136,7 @@ async def scenario_a(config_dir: Path) -> None:
     # exactly what a SIGKILLed lop leaves on disk. (Our real process stays
     # alive as the test driver, so we re-key rather than kill ourselves.)
     my_pid = os.getpid()
-    my_start = group_reaper._owner_start_token(my_pid)
+    my_start = _token(my_pid)
     live_ledger = group_reaper._ledger_path(config_dir, my_pid, my_start)
     entry = group_reaper._read_ledger(live_ledger)[-1]
     live_ledger.unlink()
@@ -127,7 +154,11 @@ async def scenario_a(config_dir: Path) -> None:
         not _killpg_alive(pgid),
     )
     _check("dead owner's ledger unlinked", not dead_ledger.exists())
-    manager.shutdown() if hasattr(manager, "shutdown") else None
+    # Best-effort teardown: older AsyncJobManager builds expose ``shutdown``;
+    # getattr keeps this forward/backward compatible without a static attr error.
+    _shutdown = getattr(manager, "shutdown", None)
+    if callable(_shutdown):
+        _shutdown()
 
 
 async def scenario_b(config_dir: Path) -> None:
@@ -144,7 +175,7 @@ async def scenario_b(config_dir: Path) -> None:
         os.killpg(pgid, signal.SIGKILL)
     except (ProcessLookupError, PermissionError):
         pass
-    my_start = group_reaper._owner_start_token(os.getpid())
+    my_start = _token(os.getpid())
     group_reaper._ledger_path(config_dir, os.getpid(), my_start).unlink(missing_ok=True)
 
 
@@ -154,7 +185,7 @@ async def scenario_c(config_dir: Path) -> None:
     # C1: owner_pid alive (this process) but start token WRONG -> reap (row 3).
     _, pgid1 = await _spawn_via_real_bash(config_dir, "sleep 600")
     my_pid = os.getpid()
-    my_start = group_reaper._owner_start_token(my_pid)
+    my_start = _token(my_pid)
     lg1 = group_reaper._ledger_path(config_dir, my_pid, my_start)
     e1 = group_reaper._read_ledger(lg1)[-1]
     lg1.unlink()
@@ -242,7 +273,7 @@ async def scenario_d(config_dir: Path) -> None:
     )
     time.sleep(0.1)
     sib_pgid = os.getpgid(sibling.pid)
-    sib_leader = group_reaper._owner_start_token(sib_pgid)
+    sib_leader = _token(sib_pgid)
     sib_owner = os.getpid() + 5_000_000
     sib_ledger = group_reaper._ledger_path(config_dir, sib_owner, "sib")
     sib_ledger.write_text(
@@ -264,7 +295,7 @@ async def scenario_d(config_dir: Path) -> None:
     time.sleep(0.1)
     _check("own group REAPED by soft death", not _killpg_alive(my_pgid))
     _check("sibling owner's group SURVIVES (scope proof)", _killpg_alive(sib_pgid))
-    my_start = group_reaper._owner_start_token(os.getpid())
+    my_start = _token(os.getpid())
     _check(
         "own ledger unlinked",
         not group_reaper._ledger_path(config_dir, os.getpid(), my_start).exists(),
@@ -277,10 +308,83 @@ async def scenario_d(config_dir: Path) -> None:
     sibling.wait(timeout=2)
 
 
+# A real child that installs the soft-death hook, holds one live registered
+# group, and models the headless REPL's SIGINT contract: Ctrl-C aborts the
+# "turn" (caught KeyboardInterrupt) and KEEPS running rather than exiting. The
+# parent drives real SIGINT then SIGTERM at it to prove the reaper's signal
+# scope end-to-end, not just by inspecting the handler table.
+_SIGINT_CHILD = r"""
+import json, os, signal, subprocess, sys, time
+from local_operator import cli
+from local_operator.tools import group_reaper
+
+# Own group so the grandchild is a real killable process group, exactly like a
+# background bash job the user asked to keep alive across a turn abort.
+child = subprocess.Popen(
+    ["/bin/sh", "-c", "sleep 600"],
+    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True,
+)
+for _ in range(200):
+    try:
+        pgid = os.getpgid(child.pid); break
+    except ProcessLookupError:
+        time.sleep(0.01)
+group_reaper.register_group(pgid, "sleep 600")
+cli._install_group_reaper_soft_death()
+# Hand the parent the pgid to watch, then flush so it is readable immediately.
+sys.stdout.write(json.dumps({"pgid": pgid}) + "\n"); sys.stdout.flush()
+# Model _run_headless_repl: SIGINT -> KeyboardInterrupt -> abort the turn, keep
+# the session (and its background jobs) alive. Only a real exit reaps.
+while True:
+    try:
+        time.sleep(3600)
+    except KeyboardInterrupt:
+        sys.stderr.write("turn aborted, session alive\n"); sys.stderr.flush()
+"""
+
+
+async def scenario_e(config_dir: Path) -> None:
+    print("E) SIGINT (turn abort) spares live group; SIGTERM (real stop) REAPS")
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _SIGINT_CHILD],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        env={**os.environ, "LOCAL_OPERATOR_CONFIG_DIR": str(config_dir)},
+    )
+    assert proc.stdout is not None  # PIPE was requested above
+    line = proc.stdout.readline()  # blocks until the child registered its group
+    pgid = json.loads(line)["pgid"]
+    time.sleep(0.1)
+    _check("child's background group alive after spawn", _killpg_alive(pgid))
+
+    # SIGINT: the headless turn abort. The group MUST survive and the child live.
+    proc.send_signal(signal.SIGINT)
+    time.sleep(0.3)
+    _check("group ALIVE after SIGINT (Ctrl-C spared the background job)", _killpg_alive(pgid))
+    _check("REPL child still running after SIGINT", proc.poll() is None)
+
+    # SIGTERM: a real termination. The soft-death handler reaps, then chains.
+    proc.terminate()
+    proc.wait(timeout=5)
+    time.sleep(0.2)
+    _check("group REAPED after SIGTERM (real stop cleaned up)", not _killpg_alive(pgid))
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
 async def main() -> None:
     # Real config dir override so execute_bash's register lands where the sweep
     # reads. Each scenario gets its own clean dir.
-    for name, fn in (("A", scenario_a), ("B", scenario_b), ("C", scenario_c), ("D", scenario_d)):
+    for name, fn in (
+        ("A", scenario_a),
+        ("B", scenario_b),
+        ("C", scenario_c),
+        ("D", scenario_d),
+        ("E", scenario_e),
+    ):
         with tempfile.TemporaryDirectory() as td:
             cfg = Path(td)
             os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = str(cfg)

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -1400,3 +1400,70 @@ def test_a_bare_resume_classifies_sessions_before_resolving_latest(tmp_path, mon
     assert resolved == [
         "mine00000000"
     ], f"a bare --resume reopened a subagent's transcript: {resolved}"
+
+
+# --- Soft-death reaper signal scope (R1) ------------------------------------
+#
+# The soft-death reaper must reap on a genuine process TERMINATION but never on
+# a mid-turn Ctrl-C. In the headless REPL, SIGINT is a turn abort that keeps the
+# session — and its `background=true` bash jobs — ALIVE (`session.abort` spares
+# them on purpose). Wiring the reaper onto SIGINT would SIGKILL those still-live
+# groups while the owning process keeps running, the one case the reaper exists
+# to forbid. These tests pin "SIGINT does not reap; SIGTERM does" so a future
+# edit that re-adds SIGINT to the registration loop fails loudly.
+
+
+def test_soft_death_reaper_installs_on_sigterm_not_sigint(monkeypatch):
+    """`_install_group_reaper_soft_death` handles SIGTERM but leaves SIGINT alone."""
+    import signal
+
+    from local_operator import cli
+
+    # Start from known signal state and restore it after, so the process this
+    # suite runs in is not left with a reaper handler bound to it.
+    original_term = signal.getsignal(signal.SIGTERM)
+    original_int = signal.getsignal(signal.SIGINT)
+    try:
+        signal.signal(signal.SIGINT, signal.default_int_handler)
+        int_before = signal.getsignal(signal.SIGINT)
+
+        cli._install_group_reaper_soft_death()
+
+        # SIGTERM was chained onto a new handler (a genuine termination reaps).
+        assert callable(signal.getsignal(signal.SIGTERM))
+        # SIGINT is untouched: still exactly the turn-abort default it had.
+        assert signal.getsignal(signal.SIGINT) is int_before
+    finally:
+        signal.signal(signal.SIGTERM, original_term)
+        signal.signal(signal.SIGINT, original_int)
+
+
+def test_soft_death_sigterm_handler_reaps_then_chains(monkeypatch):
+    """The installed SIGTERM handler reaps this process's groups, then chains."""
+    import signal
+
+    from local_operator import cli
+
+    reaped: list[str] = []
+    monkeypatch.setattr(
+        "local_operator.tools.group_reaper.kill_own_groups",
+        lambda: reaped.append("reaped"),
+    )
+
+    prior_calls: list[int] = []
+    original_term = signal.getsignal(signal.SIGTERM)
+    try:
+        # A pre-existing SIGTERM handler that the reaper must chain to, not eat.
+        signal.signal(signal.SIGTERM, lambda signum, frame: prior_calls.append(signum))
+
+        cli._install_group_reaper_soft_death()
+        handler = signal.getsignal(signal.SIGTERM)
+        assert callable(handler)
+
+        # Invoke the handler directly (no real signal delivery): it must reap
+        # first, then chain to the handler that was installed before it.
+        handler(signal.SIGTERM, None)
+        assert reaped == ["reaped"]
+        assert prior_calls == [signal.SIGTERM]
+    finally:
+        signal.signal(signal.SIGTERM, original_term)

--- a/tests/unit/tools/test_group_reaper.py
+++ b/tests/unit/tools/test_group_reaper.py
@@ -556,3 +556,126 @@ def test_win32_is_a_total_noop(tmp_path, monkeypatch):
     result = sweep_orphan_groups(tmp_path)
     assert result == ReaperSweepResult()
     kill_own_groups(config_dir=tmp_path, owner_pid=os.getpid())  # no raise
+
+
+# --------------------------------------------------------------------------- #
+# R2: the owner's own start token is derived once, not on every hot-path call.
+# --------------------------------------------------------------------------- #
+def test_self_start_token_is_cached_across_calls(monkeypatch):
+    """A repeated self lookup forks ``ps`` once; the value is memoized."""
+    # Reset the module memo so this test sees a cold cache regardless of order.
+    monkeypatch.setattr(group_reaper, "_SELF_START_TOKEN", None)
+    calls: list[int] = []
+    real = group_reaper._owner_start_token
+
+    def counting(pid):
+        calls.append(pid)
+        return real(pid)
+
+    monkeypatch.setattr(group_reaper, "_owner_start_token", counting)
+
+    me = os.getpid()
+    first = group_reaper._self_start_token(me)
+    second = group_reaper._self_start_token(me)
+    third = group_reaper._self_start_token(me)
+
+    assert first == second == third
+    # Exactly one underlying ``ps`` derivation for three self lookups.
+    assert calls == [me]
+
+
+def test_self_start_token_probes_foreign_pid_live(monkeypatch):
+    """A pid that is not ours is always probed live, never served from the memo."""
+    monkeypatch.setattr(group_reaper, "_SELF_START_TOKEN", "SELF-CACHED")
+    seen: list[int] = []
+
+    def probe(pid):
+        seen.append(pid)
+        return f"token-{pid}"
+
+    monkeypatch.setattr(group_reaper, "_owner_start_token", probe)
+
+    other = os.getpid() + 1
+    assert group_reaper._self_start_token(other) == f"token-{other}"
+    assert seen == [other]  # foreign pid hit the live probe, not the memo
+
+
+def test_self_start_token_failure_is_not_cached(monkeypatch):
+    """A transient ``ps`` failure must not poison the memo with a sticky None."""
+    monkeypatch.setattr(group_reaper, "_SELF_START_TOKEN", None)
+    outcomes = iter([None, "recovered-token"])
+    monkeypatch.setattr(group_reaper, "_owner_start_token", lambda pid: next(outcomes))
+
+    me = os.getpid()
+    assert group_reaper._self_start_token(me) is None  # first probe failed
+    assert group_reaper._self_start_token(me) == "recovered-token"  # retried, not stuck
+
+
+# --------------------------------------------------------------------------- #
+# R3: a concurrent register append is not lost by unregister's rewrite.
+# --------------------------------------------------------------------------- #
+def test_unregister_preserves_concurrent_register(tmp_path, monkeypatch):
+    """A register that lands mid-rewrite survives: the exclusive lock serialises them.
+
+    Simulates the race deterministically by appending a new group in the middle
+    of unregister's read-modify-write (patched onto the read step). Without the
+    lock ordering the appended line would be truncated away; with it, unregister
+    is guaranteed to observe the append (it holds the file exclusive, so the
+    append inside the patch is the test's own controlled interleave) and both
+    survivors remain.
+    """
+    pid = os.getpid()
+    register_group(11, "keep-a", config_dir=tmp_path, owner_pid=pid)
+    register_group(22, "drop-me", config_dir=tmp_path, owner_pid=pid)
+
+    token = group_reaper._self_start_token(pid)
+    assert token is not None
+    path = group_reaper._ledger_path(tmp_path, pid, token)
+
+    real_read_text = type(path).read_text
+    injected = {"done": False}
+
+    def read_then_append(self, *args, **kwargs):
+        # First read (the unregister's own): simulate a parallel register landing
+        # right here by appending a fresh line before the filter/rewrite runs.
+        text = real_read_text(self, *args, **kwargs)
+        if self == path and not injected["done"]:
+            injected["done"] = True
+            with open(path, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps({"pgid": 33, "owner_pid": pid}) + "\n")
+            # Re-read so the rewrite sees the appended line (models the lock
+            # forcing the append to be visible before the truncating write).
+            text = real_read_text(self, *args, **kwargs)
+        return text
+
+    monkeypatch.setattr(type(path), "read_text", read_then_append)
+    unregister_group(22, config_dir=tmp_path, owner_pid=pid)
+
+    lines = path.read_text().splitlines()
+    pgids = {json.loads(x)["pgid"] for x in lines}
+    assert pgids == {11, 33}  # the concurrently-registered 33 was not lost
+
+
+def test_ledger_lock_degrades_when_unavailable(tmp_path, monkeypatch):
+    """If the advisory lock cannot be taken, unregister still runs (best-effort)."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def no_fcntl(name, *args, **kwargs):
+        if name == "fcntl":
+            raise ImportError("no fcntl here")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", no_fcntl)
+
+    pid = os.getpid()
+    register_group(44, "a", config_dir=tmp_path, owner_pid=pid)
+    register_group(55, "b", config_dir=tmp_path, owner_pid=pid)
+    unregister_group(44, config_dir=tmp_path, owner_pid=pid)
+
+    token = group_reaper._self_start_token(pid)
+    assert token is not None
+    path = group_reaper._ledger_path(tmp_path, pid, token)
+    pgids = {json.loads(x)["pgid"] for x in path.read_text().splitlines()}
+    assert pgids == {55}  # compaction still happened without the lock

--- a/tests/unit/tools/test_group_reaper.py
+++ b/tests/unit/tools/test_group_reaper.py
@@ -496,6 +496,117 @@ def test_sweep_missing_dir_is_noop(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
+# lock-husk cleanup (R4)
+# --------------------------------------------------------------------------- #
+def test_sweep_removes_dead_owner_lock_spares_live_owner(tmp_path):
+    """A dead owner's ``.lock`` is reaped with its ledger; a live owner's is not.
+
+    Two owners each have a ledger AND its ``.lock`` sidecar. The dead owner's
+    pair must both be gone after the sweep (the husk cleanup the reaper's whole
+    purpose demands); the LIVE owner's ledger and lock must both survive
+    untouched — the live-trainer guarantee extended to the lock file.
+    """
+    # DEAD owner: fabricate a ledger keyed on a surely-dead pid, plus its lock.
+    dead = subprocess.Popen(["/bin/sh", "-c", "true"])
+    dead.wait()
+    dead_ledger = _write_ledger(
+        tmp_path,
+        dead.pid,
+        "dead-start",
+        [
+            {
+                "pgid": 999_999,  # a pgid with no live leader: dropped, no kill
+                "owner_pid": dead.pid,
+                "owner_start": "dead-start",
+                "grp_leader_start": None,
+                "cmd": "sleep 600",
+                "ts": 1.0,
+            }
+        ],
+    )
+    dead_lock = group_reaper._lock_path(dead_ledger)
+    dead_lock.write_text("")
+
+    # LIVE owner: our own pid, registered through the real path so the sweep's
+    # owner-liveness check (not a pid shortcut) is what protects it.
+    my_pid = os.getpid()
+    my_start = group_reaper._self_start_token(my_pid)
+    assert my_start is not None
+    register_group(123456, "sleep 600", config_dir=tmp_path, owner_pid=my_pid)
+    live_ledger = group_reaper._ledger_path(tmp_path, my_pid, my_start)
+    live_lock = group_reaper._lock_path(live_ledger)
+    live_lock.write_text("")
+
+    # Sweep from a different self_pid so the "skip my own pid" shortcut is not
+    # what spares the live owner — its liveness must be.
+    sweep_orphan_groups(tmp_path, self_pid=my_pid + 10_000_000)
+
+    assert not dead_ledger.exists()
+    assert not dead_lock.exists()  # dead owner's husk reaped
+    assert live_ledger.exists()
+    assert live_lock.exists()  # live owner's lock untouched
+
+
+def test_sweep_removes_orphan_lock_of_dead_owner(tmp_path):
+    """A ``.lock`` with no ledger (clean-exit husk) whose pid is dead is reaped.
+
+    The common accumulation path: a graceful shutdown compacts the ledger away
+    but leaves the lock sidecar behind. There is no ledger to key on, so this is
+    reaped by the orphan-lock pass on the pid-gone signal alone.
+    """
+    dead = subprocess.Popen(["/bin/sh", "-c", "true"])
+    dead.wait()
+    groups = _groups_dir(tmp_path)
+    groups.mkdir(parents=True, exist_ok=True)
+    orphan = groups / f"{dead.pid}-dead-start.jsonl.lock"
+    orphan.write_text("")
+
+    sweep_orphan_groups(tmp_path)
+
+    assert not orphan.exists()
+
+
+def test_sweep_spares_orphan_lock_of_live_owner(tmp_path):
+    """A ledger-less ``.lock`` whose pid is still alive is NEVER removed."""
+    groups = _groups_dir(tmp_path)
+    groups.mkdir(parents=True, exist_ok=True)
+    # Our own pid is unambiguously alive.
+    orphan = groups / f"{os.getpid()}-live-start.jsonl.lock"
+    orphan.write_text("")
+
+    sweep_orphan_groups(tmp_path)
+
+    assert orphan.exists()  # possibly-live owner's lock left in place
+
+
+def test_sweep_leaves_unparseable_lock_name(tmp_path):
+    """A ``.lock`` whose leading segment is not an integer is left untouched."""
+    groups = _groups_dir(tmp_path)
+    groups.mkdir(parents=True, exist_ok=True)
+    weird = groups / "not-a-pid.jsonl.lock"
+    weird.write_text("")
+
+    sweep_orphan_groups(tmp_path)
+
+    assert weird.exists()
+
+
+def test_sweep_never_treats_lock_as_ledger(tmp_path):
+    """The ledger glob (``*.jsonl``) must not pick up a ``.lock`` as a ledger."""
+    groups = _groups_dir(tmp_path)
+    groups.mkdir(parents=True, exist_ok=True)
+    # A lone lock husk for a DEAD owner and nothing else: scanned_ledgers must be
+    # zero (no ledger scanned) even though the lock is reaped.
+    dead = subprocess.Popen(["/bin/sh", "-c", "true"])
+    dead.wait()
+    (groups / f"{dead.pid}-x.jsonl.lock").write_text("")
+
+    result = sweep_orphan_groups(tmp_path)
+
+    assert result.scanned_ledgers == 0  # the lock was never counted as a ledger
+
+
+# --------------------------------------------------------------------------- #
 # soft death
 # --------------------------------------------------------------------------- #
 def test_kill_own_groups_reaps_self_and_spares_sibling(tmp_path):

--- a/tests/unit/tools/test_group_reaper.py
+++ b/tests/unit/tools/test_group_reaper.py
@@ -1,0 +1,558 @@
+"""Orphaned-process-group reaper: reap ONLY genuine waste, never a live runner.
+
+The reaper kills a bash process group iff the ``lop`` process that spawned it is
+provably dead — the one leak the in-process ``_kill()`` paths cannot cover,
+because a hard-SIGKILLed owner runs no cleanup and ``start_new_session`` already
+stripped the group's SIGHUP. The central property this suite defends is the
+inverse of retention's "nothing is ever deleted": here nothing is ever KILLED
+unless owner-death is proven, because a 10h ML trainer and a 10h stuck pyright
+are identical by every signal EXCEPT owner liveness.
+
+Wherever possible identity is injected (a fake pid + start token + config dir)
+rather than spawning real processes, mirroring retention's pid-injection style;
+the few cases that need a real killable group spawn a short ``sleep`` in its own
+session so the group-leader/pgid-reuse gate can be exercised for real.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import time
+
+from local_operator.tools import group_reaper
+from local_operator.tools.group_reaper import (
+    PROC_GROUPS_DIRNAME,
+    ReaperSweepResult,
+    kill_own_groups,
+    register_group,
+    sweep_orphan_groups,
+    unregister_group,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _groups_dir(config_dir):
+    return config_dir / PROC_GROUPS_DIRNAME
+
+
+def _write_ledger(config_dir, owner_pid, owner_start, entries):
+    """Fabricate a ledger for ``(owner_pid, owner_start)`` with raw entry dicts.
+
+    Bypasses ``register_group`` so a test can point a ledger at any pid/token/
+    pgid combination it wants (dead owner, wrong token, recycled pgid) without a
+    real process behind every field.
+    """
+    path = group_reaper._ledger_path(config_dir, owner_pid, owner_start)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        for entry in entries:
+            handle.write(json.dumps(entry) + "\n")
+    return path
+
+
+def _spawn_group(cmd="sleep 600"):
+    """Spawn ``cmd`` in its own session/group, returning (Popen, pgid).
+
+    ``start_new_session=True`` mirrors exactly how ``execute_bash`` spawns, so
+    the group-leader-start (pgid-reuse) gate is exercised against a real leader.
+    """
+    proc = subprocess.Popen(
+        ["/bin/sh", "-c", cmd],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    # Give sh a beat to exec the workload in place so getpgid is stable.
+    for _ in range(50):
+        try:
+            pgid = os.getpgid(proc.pid)
+        except ProcessLookupError:
+            time.sleep(0.01)
+            continue
+        return proc, pgid
+    raise AssertionError("group never became visible")
+
+
+def _alive(pgid):
+    try:
+        os.killpg(pgid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # The pgid is held by a process this user cannot signal. For a group we
+        # spawned ourselves that can only mean the pgid was RECYCLED onto an
+        # unrelated process after our group died — i.e. our group is gone. This
+        # is the pgid-reuse race the reaper itself defends against; for a
+        # liveness probe it means "not our group any more".
+        return False
+
+
+def _reaped(proc, pgid):
+    """Deterministic proof a spawned group was killed: its leader process exits.
+
+    ``os.killpg(pgid, 0)`` alone is racy in-test because the OS recycles the
+    freed pgid onto an unrelated process within milliseconds. The child we
+    spawned is the ground truth: SIGKILL to the group kills the leader, so
+    ``proc.wait`` returns and ``returncode`` is the negative kill signal.
+    """
+    try:
+        proc.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        return False
+    return proc.returncode is not None and proc.returncode != 0
+
+
+def _reap_group(pgid):
+    # Best-effort cleanup only. After a successful reap the pgid may already be
+    # gone (ProcessLookupError) or recycled onto a group this user cannot signal
+    # (PermissionError) — both mean "our group is already dead", so tolerate.
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
+# --------------------------------------------------------------------------- #
+# register / unregister
+# --------------------------------------------------------------------------- #
+def test_register_writes_owner_keyed_ledger(tmp_path):
+    """A registered group lands in ONE file keyed by the owner's identity."""
+    pid = os.getpid()
+    register_group(4242, "pyright .", config_dir=tmp_path, owner_pid=pid)
+    files = list(_groups_dir(tmp_path).glob("*.jsonl"))
+    assert len(files) == 1
+    assert files[0].name.startswith(f"{pid}-")
+    entry = json.loads(files[0].read_text().splitlines()[0])
+    assert entry["pgid"] == 4242
+    assert entry["owner_pid"] == pid
+    assert entry["cmd"] == "pyright ."
+    assert "ts" in entry  # written for diagnostics
+
+
+def test_ts_is_never_a_decision_input():
+    """The ``ts`` field must be write-only: no branch in the module reads it.
+
+    Proven structurally rather than behaviourally — the design bans age/idle as
+    inputs, and the cheapest durable guarantee is that ``ts`` is never compared.
+    """
+    src = __import__("pathlib").Path(group_reaper.__file__).read_text(encoding="utf-8")
+    # The only permitted occurrences: the doc comment, the write, and _now's
+    # docstring. Any comparison (ts <, ts >, entry["ts"]) would be a new line.
+    read_sites = [
+        ln
+        for ln in src.splitlines()
+        if "ts" in ln
+        and ('["ts"]' in ln or "'ts'" in ln)
+        and '"ts":' not in ln  # exclude the write
+    ]
+    assert read_sites == [], f"ts read as a decision input: {read_sites}"
+
+
+def test_register_appends_multiple_groups_one_file(tmp_path):
+    """Parallel bash calls from one owner append lines to a single ledger."""
+    pid = os.getpid()
+    register_group(11, "a", config_dir=tmp_path, owner_pid=pid)
+    register_group(22, "b", config_dir=tmp_path, owner_pid=pid)
+    files = list(_groups_dir(tmp_path).glob("*.jsonl"))
+    assert len(files) == 1
+    lines = files[0].read_text().splitlines()
+    assert {json.loads(x)["pgid"] for x in lines} == {11, 22}
+
+
+def test_unregister_drops_one_line_keeps_others(tmp_path):
+    """Clean group death removes exactly its line, leaving siblings intact."""
+    pid = os.getpid()
+    register_group(11, "a", config_dir=tmp_path, owner_pid=pid)
+    register_group(22, "b", config_dir=tmp_path, owner_pid=pid)
+    unregister_group(11, config_dir=tmp_path, owner_pid=pid)
+    files = list(_groups_dir(tmp_path).glob("*.jsonl"))
+    lines = files[0].read_text().splitlines()
+    assert {json.loads(x)["pgid"] for x in lines} == {22}
+
+
+def test_unregister_last_line_unlinks_ledger(tmp_path):
+    """Removing the final line drops the whole owner ledger file."""
+    pid = os.getpid()
+    register_group(11, "a", config_dir=tmp_path, owner_pid=pid)
+    unregister_group(11, config_dir=tmp_path, owner_pid=pid)
+    assert list(_groups_dir(tmp_path).glob("*.jsonl")) == []
+
+
+def test_double_unregister_is_harmless(tmp_path):
+    """A second unregister (or one for a missing pgid) never raises."""
+    pid = os.getpid()
+    register_group(11, "a", config_dir=tmp_path, owner_pid=pid)
+    unregister_group(11, config_dir=tmp_path, owner_pid=pid)
+    unregister_group(11, config_dir=tmp_path, owner_pid=pid)  # ledger already gone
+    unregister_group(999, config_dir=tmp_path, owner_pid=pid)  # no such pgid
+
+
+def test_register_best_effort_swallows_write_failure(tmp_path, monkeypatch):
+    """A ledger that cannot be written must not raise into the caller."""
+
+    def boom(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("builtins.open", boom)
+    # Must not raise.
+    register_group(11, "a", config_dir=tmp_path, owner_pid=os.getpid())
+
+
+# --------------------------------------------------------------------------- #
+# sweep — owner truth table
+# --------------------------------------------------------------------------- #
+def test_owner_dead_reaps(tmp_path, monkeypatch):
+    """Row 1: owner pid gone -> reap. Uses a fabricated dead owner + live group."""
+    proc, pgid = _spawn_group()
+    try:
+        leader_start = group_reaper._owner_start_token(pgid)
+        # A dead owner pid: spawn+reap a throwaway child to get a surely-dead id.
+        dead = subprocess.Popen(["/bin/sh", "-c", "true"])
+        dead.wait()
+        _write_ledger(
+            tmp_path,
+            dead.pid,
+            "any-start-token",
+            [
+                {
+                    "pgid": pgid,
+                    "owner_pid": dead.pid,
+                    "owner_start": "any-start-token",
+                    "grp_leader_start": leader_start,
+                    "cmd": "sleep 600",
+                    "ts": 1.0,
+                }
+            ],
+        )
+        assert _alive(pgid)
+        result = sweep_orphan_groups(tmp_path)
+        assert result.reaped_groups == 1
+        # Group is gone and the ledger unlinked.
+        assert _reaped(proc, pgid)
+        assert list(_groups_dir(tmp_path).glob("*.jsonl")) == []
+    finally:
+        _reap_group(pgid)
+        proc.wait(timeout=2)
+
+
+def test_owner_alive_matching_token_never_reaps(tmp_path):
+    """Row 2 — the LIVE-TRAINER GUARANTEE: owner alive + token match -> never reap."""
+    proc, pgid = _spawn_group()
+    try:
+        my_pid = os.getpid()
+        my_start = group_reaper._owner_start_token(my_pid)
+        assert my_start is not None  # our own live process always has a token
+        register_group(pgid, "sleep 600", config_dir=tmp_path, owner_pid=my_pid)
+        # Sweep from a DIFFERENT self_pid so the "skip my own pid" shortcut is
+        # not what protects it — the owner-liveness check must be what does.
+        result = sweep_orphan_groups(tmp_path, self_pid=my_pid + 10_000_000)
+        assert result.reaped_groups == 0
+        assert result.skipped_live_owners == 1
+        assert _alive(pgid)  # untouched
+        # Ledger intact.
+        path = group_reaper._ledger_path(tmp_path, my_pid, my_start)
+        assert path.exists()
+    finally:
+        _reap_group(pgid)
+        proc.wait(timeout=2)
+
+
+def test_owner_alive_differing_token_reaps(tmp_path):
+    """Row 3: pid alive but start token differs (pid reuse) -> reap."""
+    proc, pgid = _spawn_group()
+    try:
+        leader_start = group_reaper._owner_start_token(pgid)
+        live_pid = os.getpid()  # alive...
+        _write_ledger(
+            tmp_path,
+            live_pid,
+            "DELIBERATELY-WRONG-START-TOKEN",  # ...but wrong identity
+            [
+                {
+                    "pgid": pgid,
+                    "owner_pid": live_pid,
+                    "owner_start": "DELIBERATELY-WRONG-START-TOKEN",
+                    "grp_leader_start": leader_start,
+                    "cmd": "sleep 600",
+                    "ts": 1.0,
+                }
+            ],
+        )
+        result = sweep_orphan_groups(tmp_path, self_pid=live_pid + 10_000_000)
+        assert result.reaped_groups == 1
+        assert _reaped(proc, pgid)
+    finally:
+        _reap_group(pgid)
+        proc.wait(timeout=2)
+
+
+def test_owner_alive_unreadable_token_never_reaps(tmp_path, monkeypatch):
+    """Row 4: pid alive, current token unreadable -> ambiguous -> never reap."""
+    proc, pgid = _spawn_group()
+    try:
+        live_pid = os.getpid()
+        real_token = group_reaper._owner_start_token
+        leader_start = real_token(pgid)
+
+        def token(pid):
+            # Owner token unreadable; leave the leader token readable so the
+            # ambiguity is exclusively on the OWNER side.
+            if pid == live_pid:
+                return None
+            return real_token(pid)
+
+        _write_ledger(
+            tmp_path,
+            live_pid,
+            "stored-token",
+            [
+                {
+                    "pgid": pgid,
+                    "owner_pid": live_pid,
+                    "owner_start": "stored-token",
+                    "grp_leader_start": leader_start,
+                    "cmd": "sleep 600",
+                    "ts": 1.0,
+                }
+            ],
+        )
+        monkeypatch.setattr(group_reaper, "_owner_start_token", token)
+        result = sweep_orphan_groups(tmp_path, self_pid=live_pid + 10_000_000)
+        assert result.reaped_groups == 0
+        assert result.skipped_live_owners == 1
+        assert _alive(pgid)  # untouched
+    finally:
+        _reap_group(pgid)
+        proc.wait(timeout=2)
+
+
+# --------------------------------------------------------------------------- #
+# sweep — victim (pgid-reuse) gate
+# --------------------------------------------------------------------------- #
+def test_victim_leader_gone_drops_no_kill(tmp_path):
+    """Dead owner, but the group already died: drop the line, kill nothing."""
+    dead = subprocess.Popen(["/bin/sh", "-c", "true"])
+    dead.wait()
+    # A pgid that is surely gone (the just-reaped child's own pid space).
+    gone_pgid = dead.pid
+    _write_ledger(
+        tmp_path,
+        dead.pid,
+        "start",
+        [
+            {
+                "pgid": gone_pgid,
+                "owner_pid": dead.pid,
+                "owner_start": "start",
+                "grp_leader_start": "whatever",
+                "cmd": "sleep 600",
+                "ts": 1.0,
+            }
+        ],
+    )
+    result = sweep_orphan_groups(tmp_path)
+    assert result.reaped_groups == 0
+    assert list(_groups_dir(tmp_path).glob("*.jsonl")) == []  # ledger dropped
+
+
+def test_victim_leader_recycled_different_start_drops_no_kill(tmp_path):
+    """Dead owner, pgid now held by a DIFFERENT live group: never kill it."""
+    innocent, innocent_pgid = _spawn_group()
+    try:
+        dead = subprocess.Popen(["/bin/sh", "-c", "true"])
+        dead.wait()
+        _write_ledger(
+            tmp_path,
+            dead.pid,
+            "start",
+            [
+                {
+                    "pgid": innocent_pgid,  # pgid points at an innocent live group
+                    "owner_pid": dead.pid,
+                    "owner_start": "start",
+                    # ...but the recorded leader start does NOT match the
+                    # innocent group's real leader start.
+                    "grp_leader_start": "STALE-LEADER-START-DOES-NOT-MATCH",
+                    "cmd": "sleep 600",
+                    "ts": 1.0,
+                }
+            ],
+        )
+        result = sweep_orphan_groups(tmp_path)
+        assert result.reaped_groups == 0
+        assert _alive(innocent_pgid)  # innocent survives
+        assert list(_groups_dir(tmp_path).glob("*.jsonl")) == []
+    finally:
+        _reap_group(innocent_pgid)
+        innocent.wait(timeout=2)
+
+
+def test_victim_leader_alive_and_matches_kills(tmp_path):
+    """Dead owner + leader alive + start token matches: this is our orphan -> kill."""
+    proc, pgid = _spawn_group()
+    try:
+        leader_start = group_reaper._owner_start_token(pgid)
+        dead = subprocess.Popen(["/bin/sh", "-c", "true"])
+        dead.wait()
+        _write_ledger(
+            tmp_path,
+            dead.pid,
+            "start",
+            [
+                {
+                    "pgid": pgid,
+                    "owner_pid": dead.pid,
+                    "owner_start": "start",
+                    "grp_leader_start": leader_start,
+                    "cmd": "sleep 600",
+                    "ts": 1.0,
+                }
+            ],
+        )
+        result = sweep_orphan_groups(tmp_path)
+        assert result.reaped_groups == 1
+        assert _reaped(proc, pgid)
+    finally:
+        _reap_group(pgid)
+        proc.wait(timeout=2)
+
+
+# --------------------------------------------------------------------------- #
+# robustness
+# --------------------------------------------------------------------------- #
+def test_torn_ledger_line_is_skipped(tmp_path):
+    """A corrupt/torn JSONL line is skipped; valid lines still processed."""
+    proc, pgid = _spawn_group()
+    try:
+        leader_start = group_reaper._owner_start_token(pgid)
+        dead = subprocess.Popen(["/bin/sh", "-c", "true"])
+        dead.wait()
+        path = group_reaper._ledger_path(tmp_path, dead.pid, "start")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write("{ this is not valid json\n")  # torn line
+            handle.write(
+                json.dumps(
+                    {
+                        "pgid": pgid,
+                        "owner_pid": dead.pid,
+                        "owner_start": "start",
+                        "grp_leader_start": leader_start,
+                        "cmd": "sleep 600",
+                        "ts": 1.0,
+                    }
+                )
+                + "\n"
+            )
+        result = sweep_orphan_groups(tmp_path)
+        assert result.reaped_groups == 1  # the good line still acted on
+        assert _reaped(proc, pgid)
+    finally:
+        _reap_group(pgid)
+        proc.wait(timeout=2)
+
+
+def test_double_sweep_is_idempotent(tmp_path):
+    """Two sweeps of the same dead-owner ledger: second finds nothing, no raise."""
+    proc, pgid = _spawn_group()
+    try:
+        leader_start = group_reaper._owner_start_token(pgid)
+        dead = subprocess.Popen(["/bin/sh", "-c", "true"])
+        dead.wait()
+        _write_ledger(
+            tmp_path,
+            dead.pid,
+            "start",
+            [
+                {
+                    "pgid": pgid,
+                    "owner_pid": dead.pid,
+                    "owner_start": "start",
+                    "grp_leader_start": leader_start,
+                    "cmd": "sleep 600",
+                    "ts": 1.0,
+                }
+            ],
+        )
+        first = sweep_orphan_groups(tmp_path)
+        second = sweep_orphan_groups(tmp_path)
+        assert first.reaped_groups == 1
+        assert second.reaped_groups == 0
+    finally:
+        _reap_group(pgid)
+        proc.wait(timeout=2)
+
+
+def test_sweep_missing_dir_is_noop(tmp_path):
+    """A config dir with no proc-groups directory sweeps cleanly to zero."""
+    result = sweep_orphan_groups(tmp_path)
+    assert result == ReaperSweepResult()
+
+
+# --------------------------------------------------------------------------- #
+# soft death
+# --------------------------------------------------------------------------- #
+def test_kill_own_groups_reaps_self_and_spares_sibling(tmp_path):
+    """Soft death kills THIS owner's group and unlinks its ledger; a sibling
+    owner's live group survives untouched (the scope proof)."""
+    mine, my_pgid = _spawn_group()
+    sibling, sib_pgid = _spawn_group()
+    try:
+        my_pid = os.getpid()
+        # My own ledger, via the real register path.
+        register_group(my_pgid, "sleep 600", config_dir=tmp_path, owner_pid=my_pid)
+        # A sibling owner's ledger (a different, live pid) with a live group.
+        sib_leader = group_reaper._owner_start_token(sib_pgid)
+        _write_ledger(
+            tmp_path,
+            my_pid + 7_000_000,  # a different owner id
+            group_reaper._owner_start_token(my_pid) or "x",
+            [
+                {
+                    "pgid": sib_pgid,
+                    "owner_pid": my_pid + 7_000_000,
+                    "owner_start": "sibling",
+                    "grp_leader_start": sib_leader,
+                    "cmd": "sleep 600",
+                    "ts": 1.0,
+                }
+            ],
+        )
+        kill_own_groups(config_dir=tmp_path, owner_pid=my_pid)
+        assert _reaped(mine, my_pgid)  # my group reaped
+        assert _alive(sib_pgid)  # sibling untouched
+        # My ledger gone; the sibling's remains.
+        my_token = group_reaper._owner_start_token(my_pid)
+        assert my_token is not None
+        my_path = group_reaper._ledger_path(tmp_path, my_pid, my_token)
+        assert not my_path.exists()
+        assert len(list(_groups_dir(tmp_path).glob("*.jsonl"))) == 1
+    finally:
+        _reap_group(my_pgid)
+        _reap_group(sib_pgid)
+        mine.wait(timeout=2)
+        sibling.wait(timeout=2)
+
+
+def test_kill_own_groups_idempotent_when_ledger_absent(tmp_path):
+    """A second soft-death call (ledger already unlinked) is a clean no-op."""
+    kill_own_groups(config_dir=tmp_path, owner_pid=os.getpid())
+
+
+# --------------------------------------------------------------------------- #
+# platform gate
+# --------------------------------------------------------------------------- #
+def test_win32_is_a_total_noop(tmp_path, monkeypatch):
+    """On Windows nothing is registered or reaped: the leak is POSIX-specific."""
+    monkeypatch.setattr(group_reaper, "_REAPING_IS_SUPPORTED", False)
+    register_group(11, "a", config_dir=tmp_path, owner_pid=os.getpid())
+    assert not _groups_dir(tmp_path).exists()
+    result = sweep_orphan_groups(tmp_path)
+    assert result == ReaperSweepResult()
+    kill_own_groups(config_dir=tmp_path, owner_pid=os.getpid())  # no raise


### PR DESCRIPTION
## Summary

Orphaned bash **process groups** could outlive the lop process that spawned them, accumulating indefinitely and pinning CPU. Observed in practice: a `pyright` process group ran for ~10 hours after its owning session was gone, and across several concurrent sessions these strays stacked up to 7 full-tree runs at once, each pegging most of a core.

The bash tool already spawns every command `start_new_session=True` (its own process group) and `killpg`s the whole group on every **in-process** stop path — timeout, abort, `jobs` cancel, steer-to-background. The one uncovered case is a **hard death** of the owning lop process (cmux SIGKILL replacing a session, a crash): no in-process code runs, the group was deliberately detached from the controlling terminal so it receives **no SIGHUP**, it reparents to `init`/launchd, and it runs forever. This PR closes that gap by mirroring the owner-liveness discipline `session/retention.py` already uses to reap stale session directories — applied to process groups.

## The one hard constraint

The reaper must **never** kill a legitimate long-running command (ML training, a long query, a slow download) whose owning session is still alive, and must reap only genuine waste. The decision **never** looks at the process's own behavior — runtime, CPU%, and idle time are all unreliable (a 10-hour trainer and a 10-hour stuck `pyright` are indistinguishable by those). The **only** signal consulted is **owner liveness**: a group is waste iff the lop process that spawned it is dead. Duration and CPU are structurally absent from the decision.

## What changed

### New module `local_operator/tools/group_reaper.py`

Stdlib-only, POSIX, standalone (imports only `retention._process_alive`; deliberately **not** folded into retention, whose contract is "never delete a transcript" — this module kills, and blurring those guarantees would be a hazard).

- **Owner-keyed JSONL ledger** at `<config_dir>/proc-groups/<owner_pid>-<owner_start_token>.jsonl`. Each spawned group appends one line: `{pgid, owner_pid, owner_start, grp_leader_start, cmd, ts}`. Written at spawn (best-effort, like `claim_session`), the line removed on clean group death, the whole ledger unlinked when a dead owner is swept.
- **Two-factor identity** against PID and PGID reuse. `owner_start`/`grp_leader_start` come from `ps -o lstart=` (read under `LC_ALL=C`) and are stored as an **opaque token, never parsed** — a locale/format quirk can only make tokens *differ*, which is fail-safe (errs toward not reaping). No `/proc`, no `psutil` (not installed).
- **`ts` is diagnostics-only** and grep-provably never read by any branch in the logic — this is what makes "no age-based reaping" a structural guarantee rather than a convention.

Owner gate: dead owner → reap; alive + matching token → **never reap** (the live-trainer guarantee); alive + differing token (pid recycled) → reap; unreadable → never reap. Before any `killpg`, a **victim gate** re-checks the group leader (leader gone or recycled onto an innocent group → drop the line, no kill). Every ambiguous case errs toward **not** reaping.

### Two triggers (a hard death can't be caught in-process)

- **Soft death** (`local_operator/cli.py`) — `atexit` + chained SIGTERM/SIGINT handlers at the TUI + headless entry only (never clobbering the `exec_worker`/`mobile.child` handlers that own their own lifecycle), plus a `kill_own_groups()` call in the TUI teardown `finally`. It reads **only the current pid's own ledger**, so it can only ever kill groups this process spawned — sibling lop sessions are untouchable by construction.
- **Hard death** (`local_operator/session_factory.py`) — `sweep_orphan_groups` runs beside the existing retention sweep, inside the same off-loop `asyncio.to_thread` (same boot-stall discipline), best-effort. This is the path that reaps the SIGKILL-orphaned group on the next lop launch.

### Registration hooks (`local_operator/tools/builtin.py`)

`register_group` right after `create_subprocess_exec`; `unregister_group` on the background-cleanup path and on the normal-exit reap.

### Deliberately out of scope

`exec_mode.py` `--background` workers spawn a separate `exec_worker` process (not through `execute_bash`) with its own SIGTERM lifecycle and its own JSONL job ledger — they are owned by design, so they are not orphans and are left alone. `AsyncJobManager`-owned background bash jobs **do** go through `execute_bash`, so they carry a ledger line keyed by the same owner and are correctly reaped only when that owner dies (a detached job outliving its owner *is* waste — its delivery sink died with the owner). On Windows both entry points no-op (the leak is POSIX-only).

### Version

`pyproject.toml`: **0.41.2 → 0.41.3** (patch — a reliability fix, no new user-facing capability).

## Testing evidence

### Unit — `tests/unit/tools/test_group_reaper.py` (20 tests, mirrors `test_retention.py` style)

Covers the full owner and victim truth tables: owner dead → reap; owner alive + matching token → **never** reap; owner alive + differing token (pid reuse) → reap; owner unreadable → never reap; victim gate (leader gone → drop, no kill; leader recycled different-start → drop, no kill; leader alive + match → kill); torn/corrupt JSONL line skipped; double-unlink / double-`killpg` suppressed; win32 → no-op; and an explicit assertion that `ts` never influences a decision. **20 passed.** Full unit suite: **7088 passed, 7 skipped**.

### End-to-end — real process groups, no 10-hour wait

`tests/e2e_group_reaper_repro.py` drives the actual spawn + ledger path and asserts via `os.killpg(pgid, 0)` / child-wait. Independently re-run by the manager:

```
A) hard death, owner DEAD -> group survives owner, sweep REAPS
  [PASS] group is alive after spawn (killpg 0 succeeds)
  [PASS] group SURVIVED the owner's death (still alive)
  [PASS] sweep reaped exactly one group
  [PASS] group is REAPED after sweep (killpg raises ProcessLookupError)
  [PASS] dead owner's ledger unlinked
B) owner ALIVE -> sweep does NOT reap (live-runner anti-regression)
  [PASS] group alive after spawn
  [PASS] sweep reaped nothing
  [PASS] sweep skipped a live owner
  [PASS] group SURVIVES (live owner's long-runner untouched)
C) PID-reuse decoys -> both REAP; C-inverse -> innocent SURVIVES
  [PASS] both decoys reaped (row1 dead-pid + row3 wrong-token)
  [PASS] C1 alive-but-wrong-token group REAPED
  [PASS] C2 dead-owner group REAPED
  [PASS] C-inverse: sweep reaped nothing (victim gate held)
  [PASS] C-inverse: innocent live group SURVIVES
D) soft death -> kill_own_groups reaps own group, spares sibling owner
  [PASS] own group REAPED by soft death
  [PASS] sibling owner's group SURVIVES (scope proof)
  [PASS] own ledger unlinked
  [PASS] sibling ledger intact
ALL SCENARIOS PASSED
```

Scenario **B** is the anti-regression proof for legitimate long-runners (a live owner's group is never touched at any age); **D** proves the soft-death reaper is scoped to its own session and cannot reach a sibling's live group.

### Gates

flake8 clean · isort (5.13.2, `--profile black`) clean · black (26.1.0) `--check` clean · scoped pyright over the 5 changed files `0 errors, 0 warnings` · full unit suite green. Full-tree pyright is deferred to CI (it was being CPU-starved locally by a peer worktree's pyright run — the very pathology this PR addresses).

## Design doc

`docs/design/orphan-group-reaper.md` (in-branch) records the locked design, the empirical `sh -c` exec-in-place finding that makes two-factor group identity safe, and the four places the retention analogy is deliberately stretched.
