### PR TITLE
feat(browser): make site approval a first-class agent-legible flow

### DIFF
--- a/extension/src/access-flow.ts
+++ b/extension/src/access-flow.ts
@@ -24,12 +24,6 @@
 
 export type OriginDecision = "once" | "always" | "deny";
 
-/** Record decision column: a real user decision OR the "superseded" sentinel
- * written when a different requester's prompt replaces a pending one. Kept
- * distinct from OriginDecision so the user-facing vocabulary cannot leak
- * into wire types, while storage stays one string field. */
-export type RequestOutcome = OriginDecision | "superseded";
-
 /** What request_access/await_access report back to the agent. "none" means no
  * live request exists FOR THE CALLER (never raised, expired, or superseded);
  * "superseded" means a DIFFERENT requester's prompt replaced this origin's
@@ -69,9 +63,8 @@ export interface AccessRequest {
   requester: string;
   requestedAt: number;
   expiresAt: number;
-  /** Set once the request resolved: a user decision, or the "superseded"
-   * sentinel (see supersedeRequest); absent while the prompt is still open. */
-  decision?: RequestOutcome;
+  /** Set once the user decided; absent while the prompt is still open. */
+  decision?: OriginDecision;
 }
 
 /** A live "Allow once" grant, bound to the requester the user approved FOR
@@ -84,6 +77,28 @@ export interface OnceGrant {
 
 /** Origin -> grant, one per origin at most. */
 export type OnceGrants = Record<string, OnceGrant>;
+
+/** The live prompt slot holds ONE record (the popup's constraint), so a
+ * replace-don't-queue overwrite would otherwise erase the displaced request
+ * silently — the displaced requester's next poll would read "none",
+ * indistinguishable from expiry, and its agent would nag the user by
+ * re-raising the prompt in a steal loop (round-1 B1b). The tombstone map
+ * remembers RECENT replacements (bounded, same TTL discipline) so that
+ * requester learns "superseded" instead. Not a queue: the new prompt still
+ * replaces the old one immediately; this is only the receipt. */
+export interface SupersededTombstone {
+  origin: string;
+  requester: string;
+  /** Matches the displaced record's expiry: the receipt lives no longer
+   * than the request it stands for. */
+  expiresAt: number;
+}
+export type AccessTombstones = Record<string, SupersededTombstone>;
+
+/** Cap on retained tombstones: a churny fleet must not grow the map without
+ * bound; the oldest beyond the cap are dropped (a tombstone that old is
+ * telling its owner about a prompt the user has long forgotten anyway). */
+export const TOMBSTONE_CAP = 8;
 
 /** A record past its TTL reads as absent everywhere: await_access answers
  * "none" and request_access raises a fresh prompt. Expiry is computed on read
@@ -155,12 +170,12 @@ export function requestVerdict(
 }
 
 /** What await_access answers WITHOUT waiting. "pending" is the only state the
- * caller should then block on; everything else is final for this poll. The
- * tombstone records the record's own requester, so a supersession only reads
- * as "superseded" to the displaced requester — a third session asking about
- * the origin gets the neutral "none". */
+ * caller should then block on; everything else is final for this poll. A
+ * tombstone only reads as "superseded" to the requester it displaced — a
+ * third session asking about the origin gets the neutral "none". */
 export function accessState(
   record: AccessRequest | undefined,
+  tombstones: AccessTombstones | undefined,
   storedAllowed: boolean,
   onceGrant: boolean,
   origin: string,
@@ -169,12 +184,13 @@ export function accessState(
 ): AccessState {
   if (storedAllowed || onceGrant) return "allowed";
   const live = activeRequest(record, now);
-  if (!live || live.origin !== origin) return "none";
-  if (live.decision === "superseded") {
-    return live.requester === requester ? "superseded" : "none";
+  if (live && live.origin === origin) {
+    if (!live.decision) return "pending";
+    return live.decision === "deny" ? "denied" : "allowed";
   }
-  if (!live.decision) return "pending";
-  return live.decision === "deny" ? "denied" : "allowed";
+  const tomb = tombstones?.[origin];
+  if (tomb && now < tomb.expiresAt && tomb.requester === requester) return "superseded";
+  return "none";
 }
 
 export function newRequest(
@@ -186,11 +202,7 @@ export function newRequest(
   return { origin, hostname, requester, requestedAt: now, expiresAt: now + ACCESS_REQUEST_TTL_MS };
 }
 
-/** Tombstone a record being replaced: the origin and TTL are kept, the
- * decision becomes the sentinel "superseded", so the displaced requester's
- * next poll learns its prompt was taken over instead of reading the record
- * as simply gone. The record is NOT deleted — deleting would make the
- * displaced requester indistinguishable from a session that never asked. */
-export function supersedeRequest(record: AccessRequest): AccessRequest {
-  return { ...record, decision: "superseded" };
+/** The tombstone a replacement leaves for the displaced requester. */
+export function tombstoneFor(record: AccessRequest): SupersededTombstone {
+  return { origin: record.origin, requester: record.requester, expiresAt: record.expiresAt };
 }

--- a/extension/src/access-flow.ts
+++ b/extension/src/access-flow.ts
@@ -96,7 +96,18 @@ export interface SupersededTombstone {
    * than the request it stands for. */
   expiresAt: number;
 }
+
+/** Keyed by origin AND requester (see receiptKey): an A→B→C chain on one
+ * origin displaces two DIFFERENT requesters, and a per-origin key made C's
+ * receipt overwrite A's so A read "none" instead of "superseded" (round-2
+ * M1, reproduced by review). Each displaced requester owns its own receipt. */
 export type AccessTombstones = Record<string, SupersededTombstone>;
+
+export function receiptKey(origin: string, requester: string): string {
+  // \n cannot appear in an origin or a requester id, so the composite is
+  // collision-free without a structured key.
+  return `${origin}\n${requester}`;
+}
 
 /** Cap on retained tombstones: a churny fleet must not grow the map without
  * bound; the oldest beyond the cap are dropped (a tombstone that old is
@@ -167,9 +178,15 @@ export function requestVerdict(
   if (storedAllowed || onceGrant) return "allowed";
   const live = activeRequest(record, now);
   if (!live || live.origin !== origin) return "raise";
+  // A resolved record only answers ITS OWN requester (round-2 M1: B reading
+  // A's "once" as allowed told B it could navigate a grant it cannot spend,
+  // and B reading A's deny as denied hid that B never asked). Another
+  // requester's resolved record is displaced by a fresh raise; an undecided
+  // one is also displaced (replace-don't-queue), leaving a receipt.
+  if (live.requester !== requester) return "raise";
   if (live.decision === "deny") return "denied";
   if (live.decision) return "allowed";
-  return live.requester === requester ? "pending" : "raise";
+  return "pending";
 }
 
 /** What await_access answers WITHOUT waiting. "pending" is the only state the
@@ -187,12 +204,16 @@ export function accessState(
 ): AccessState {
   if (storedAllowed || onceGrant) return "allowed";
   const live = activeRequest(record, now);
-  if (live && live.origin === origin) {
+  // Only the record's OWN requester reads its live state (round-2 M1): after
+  // B replaces A on the same origin, A must read its receipt (superseded),
+  // not B's pending; after A's once-decision, B must not read allowed for a
+  // grant only A can spend.
+  if (live && live.origin === origin && live.requester === requester) {
     if (!live.decision) return "pending";
     return live.decision === "deny" ? "denied" : "allowed";
   }
-  const tomb = tombstones?.[origin];
-  if (tomb && now < tomb.expiresAt && tomb.requester === requester) return "superseded";
+  const tomb = tombstones?.[receiptKey(origin, requester)];
+  if (tomb && now < tomb.expiresAt) return "superseded";
   return "none";
 }
 

--- a/extension/src/access-flow.ts
+++ b/extension/src/access-flow.ts
@@ -69,10 +69,13 @@ export interface AccessRequest {
 
 /** A live "Allow once" grant, bound to the requester the user approved FOR
  * (see the multi-surface constraint at the top): only a navigation carrying
- * that requester may consume it. */
+ * that requester may consume it. `handoff` records the command id that raised
+ * the request, so a raw-RPC caller (no session identity) can still spend its
+ * own grant when its navigation reuses that id. */
 export interface OnceGrant {
   expiresAt: number;
   requester: string;
+  handoff?: string;
 }
 
 /** Origin -> grant, one per origin at most. */

--- a/extension/src/access-flow.ts
+++ b/extension/src/access-flow.ts
@@ -1,0 +1,196 @@
+/* Pure state machine for the async site-access flow, DOM- and chrome-free for
+ * the pure-node test suite — the same pattern as pair-flow.ts/origin-flow.ts.
+ *
+ * Why this flow exists at all: the original design answered a first visit to a
+ * new origin by BLOCKING the open/goto RPC inside the 60 s popup prompt. The
+ * agent never got a turn to tell the user a prompt was up, so prompts expired
+ * unseen (auto-deny), the daemon meanwhile extended the command's deadline,
+ * and the session client timed out with a misleading "bridge unreachable" — a
+ * real session burned an hour misdiagnosing the bridge as broken. The fix is
+ * to make approval a first-class three-step dance the agent can narrate:
+ * open fails early → request_access raises the prompt and returns → the agent
+ * TELLS the user → await_access waits for the decision.
+ *
+ * Multi-surface constraint (round-1 review, B1): parallel sessions now each
+ * drive their OWN tab, and this state is extension-global. Everything that
+ * carries authority — a pending request, a once-grant — is therefore bound to
+ * the REQUESTER (the daemon's per-command request id, which one session owns
+ * and another cannot guess). A grant minted for session A's flow can never be
+ * spent by session B's navigation: consumption fails CLOSED when the caller
+ * cannot prove it asked. A shared-grant model was considered and rejected:
+ * "Allow once" is the user's answer to "should THIS agent open THIS site",
+ * and letting a different agent ride it turns one approval into a fleet-wide
+ * permission — indistinguishable from "always" for the other sessions. */
+
+export type OriginDecision = "once" | "always" | "deny";
+
+/** Record decision column: a real user decision OR the "superseded" sentinel
+ * written when a different requester's prompt replaces a pending one. Kept
+ * distinct from OriginDecision so the user-facing vocabulary cannot leak
+ * into wire types, while storage stays one string field. */
+export type RequestOutcome = OriginDecision | "superseded";
+
+/** What request_access/await_access report back to the agent. "none" means no
+ * live request exists FOR THE CALLER (never raised, expired, or superseded);
+ * "superseded" means a DIFFERENT requester's prompt replaced this origin's
+ * pending request — an explicit verdict so the displaced requester learns
+ * what happened instead of timing out into the generic "none" (round-1 B1b).
+ * The recovery for both is the same: call request_access again. */
+export type AccessState = "allowed" | "denied" | "pending" | "superseded" | "none";
+
+/** How long an async access request stays answerable. The in-command prompt
+ * gave the user 60 s because someone was assumed to be watching the popup;
+ * here the user has been notified ASYNCHRONOUSLY (badge + best-effort system
+ * notification + the agent messaging them through the harness) and may
+ * reasonably take minutes to come back to the machine, so the window is 10
+ * minutes. It is still bounded because an unanswered prompt left open forever
+ * would let a long-forgotten Allow click grant a navigation nobody remembers
+ * requesting. */
+export const ACCESS_REQUEST_TTL_MS = 10 * 60_000;
+
+/** How long an unconsumed "Allow once" grant from the async flow survives.
+ * In the in-command flow "once" covered the navigation that was already in
+ * flight; here the navigation happens on the agent's NEXT open/goto, which
+ * may be a turn or two away, so the grant must outlive the approval moment —
+ * but not the browser session, and not long enough to surprise the user with
+ * a navigation they approved an afternoon ago. Same 10-minute bound as the
+ * request itself, consumed by the first navigation to the origin. */
+export const ONCE_GRANT_TTL_MS = 10 * 60_000;
+
+/** The persisted async request record. Lives in chrome.storage.session (not
+ * worker memory) because MV3 kills the service worker between the user's
+ * decision and the agent's next await_access poll; the record must survive
+ * that death or a granted approval would read as "none". */
+export interface AccessRequest {
+  origin: string;
+  hostname: string;
+  /** The daemon request id that raised this request; also minted onto any
+   * "once" grant the decision produces, binding the grant to this requester. */
+  requester: string;
+  requestedAt: number;
+  expiresAt: number;
+  /** Set once the request resolved: a user decision, or the "superseded"
+   * sentinel (see supersedeRequest); absent while the prompt is still open. */
+  decision?: RequestOutcome;
+}
+
+/** A live "Allow once" grant, bound to the requester the user approved FOR
+ * (see the multi-surface constraint at the top): only a navigation carrying
+ * that requester may consume it. */
+export interface OnceGrant {
+  expiresAt: number;
+  requester: string;
+}
+
+/** Origin -> grant, one per origin at most. */
+export type OnceGrants = Record<string, OnceGrant>;
+
+/** A record past its TTL reads as absent everywhere: await_access answers
+ * "none" and request_access raises a fresh prompt. Expiry is computed on read
+ * rather than by a trusted timer because worker death cancels timers. */
+export function activeRequest(
+  record: AccessRequest | undefined,
+  now: number,
+): AccessRequest | undefined {
+  if (!record) return undefined;
+  return now < record.expiresAt ? record : undefined;
+}
+
+/** A live grant this requester may consume. Fail-CLOSED: a grant whose
+ * requester does not match the caller — or a caller with no requester at all —
+ * is not this caller's grant, even if the origin matches. */
+export function consumableGrant(
+  grants: OnceGrants | undefined,
+  origin: string,
+  requester: string,
+  now: number,
+): OnceGrant | undefined {
+  const grant = grants?.[origin];
+  if (!grant || now >= grant.expiresAt) return undefined;
+  if (!requester || grant.requester !== requester) return undefined;
+  return grant;
+}
+
+/** Whether ANY live grant exists for the origin (regardless of requester).
+ * Used for display/diagnostics only — never as an admission decision. */
+export function anyGrantLive(
+  grants: OnceGrants | undefined,
+  origin: string,
+  now: number,
+): boolean {
+  const grant = grants?.[origin];
+  return !!grant && now < grant.expiresAt;
+}
+
+/** What request_access should do. Single-slot semantics: the popup and the
+ * pendingOrigin session record only ever show ONE origin, and the in-command
+ * flow already lets the last writer win that slot, so a request for a
+ * DIFFERENT origin REPLACES the live one rather than queueing — a queue
+ * would show the user prompts in an order the agents no longer care about.
+ * The displaced requester learns about it: their next request_access or
+ * await_access answers "superseded" (their record is tombstoned below), not
+ * a silent "none" they could misread as expiry (round-1 B1b).
+ * A repeat request for the SAME pending origin BY THE SAME requester is
+ * idempotent ("pending", original TTL kept — resetting it would let a polling
+ * agent extend the window forever). The same origin re-requested by a
+ * DIFFERENT requester also replaces: two sessions genuinely racing one site
+ * get the newest prompt, and the earlier requester reads "superseded". A fresh
+ * "deny" answers "denied" without re-prompting: the user just said no, and
+ * re-raising the prompt on every agent retry is a nag; the record's TTL is
+ * the cool-down after which a deliberate re-ask is allowed. */
+export function requestVerdict(
+  record: AccessRequest | undefined,
+  storedAllowed: boolean,
+  onceGrant: boolean,
+  origin: string,
+  requester: string,
+  now: number,
+): "allowed" | "pending" | "denied" | "raise" {
+  if (storedAllowed || onceGrant) return "allowed";
+  const live = activeRequest(record, now);
+  if (!live || live.origin !== origin) return "raise";
+  if (live.decision === "deny") return "denied";
+  if (live.decision) return "allowed";
+  return live.requester === requester ? "pending" : "raise";
+}
+
+/** What await_access answers WITHOUT waiting. "pending" is the only state the
+ * caller should then block on; everything else is final for this poll. The
+ * tombstone records the record's own requester, so a supersession only reads
+ * as "superseded" to the displaced requester — a third session asking about
+ * the origin gets the neutral "none". */
+export function accessState(
+  record: AccessRequest | undefined,
+  storedAllowed: boolean,
+  onceGrant: boolean,
+  origin: string,
+  requester: string,
+  now: number,
+): AccessState {
+  if (storedAllowed || onceGrant) return "allowed";
+  const live = activeRequest(record, now);
+  if (!live || live.origin !== origin) return "none";
+  if (live.decision === "superseded") {
+    return live.requester === requester ? "superseded" : "none";
+  }
+  if (!live.decision) return "pending";
+  return live.decision === "deny" ? "denied" : "allowed";
+}
+
+export function newRequest(
+  origin: string,
+  hostname: string,
+  requester: string,
+  now: number,
+): AccessRequest {
+  return { origin, hostname, requester, requestedAt: now, expiresAt: now + ACCESS_REQUEST_TTL_MS };
+}
+
+/** Tombstone a record being replaced: the origin and TTL are kept, the
+ * decision becomes the sentinel "superseded", so the displaced requester's
+ * next poll learns its prompt was taken over instead of reading the record
+ * as simply gone. The record is NOT deleted — deleting would make the
+ * displaced requester indistinguishable from a session that never asked. */
+export function supersedeRequest(record: AccessRequest): AccessRequest {
+  return { ...record, decision: "superseded" };
+}

--- a/extension/src/commands/access.ts
+++ b/extension/src/commands/access.ts
@@ -27,9 +27,10 @@ import { getSession } from "../state";
  * multi-minute promise alive across a service-worker death — each slice is
  * short, and the decision itself lives in session storage, which survives.
  *
- * Every verdict is computed against the daemon's request id (the handler's
- * `requestId`), which is what binds requests and grants to their requester
- * across parallel sessions — see access-flow.ts. */
+ * Every verdict is computed against a REQUESTER identity: params.requester
+ * when the calling tool supplies one (the session-scoped identity — see
+ * access-flow.ts), else the daemon's per-command request id as the fallback
+ * for raw-RPC callers. */
 
 /** One await_access slice. Below the daemon's 25 s command timeout with margin
  * so the RPC always answers before the daemon gives up on it. */
@@ -38,6 +39,17 @@ export const AWAIT_SLICE_MS = 20_000;
 /** How often a slice re-reads the decision record. Storage reads are cheap
  * (session storage is in-memory) and the human is the latency floor anyway. */
 const POLL_MS = 300;
+
+/** The requester identity for this command: the tool passes a session-scoped
+ * value (session:<id>) so all of one session's commands share it — a
+ * per-command request id could never match between request_access and the
+ * later open/goto, which is what would make grants unspendable. Raw-RPC
+ * callers (no session concept) fall back to the per-command id and get
+ * per-command binding, the fail-closed default. */
+function requesterOf(params: Record<string, unknown>, requestId: string): string {
+  const supplied = typeof params.requester === "string" ? params.requester.trim() : "";
+  return supplied || requestId;
+}
 
 /** Re-read the pieces an access verdict needs in ONE getSession round-trip,
  * sweeping TTL only when it can actually fire. expireAccessRequest does two
@@ -72,19 +84,20 @@ export async function requestAccess(
   requestId: string,
 ): Promise<Record<string, unknown>> {
   const url = safeHttpUrl(params.url);
+  const requester = requesterOf(params, requestId);
   await expireAccessRequest();
   const now = Date.now();
   const session = await getSession();
   const verdict = requestVerdict(
     session.accessRequest,
     await originAllowed(url),
-    !!consumableGrant(session.onceGrants, url.origin, requestId, now),
+    !!consumableGrant(session.onceGrants, url.origin, requester, now),
     url.origin,
-    requestId,
+    requester,
     now,
   );
   if (verdict !== "raise") return { origin: url.origin, state: verdict };
-  const record = await raiseAccessRequest(url, requestId);
+  const record = await raiseAccessRequest(url, requester);
   // Arm the TTL sweep for THIS record: chrome.alarms survives MV3 worker
   // death, a setTimeout does not. Creating a same-named alarm replaces the
   // prior one, which is intended — the record this alarm covers is now the
@@ -98,6 +111,7 @@ export async function awaitAccess(
   requestId: string,
 ): Promise<Record<string, unknown>> {
   const url = safeHttpUrl(params.url);
+  const requester = requesterOf(params, requestId);
   const requested = Number(params.timeout_ms);
   const sliceMs = Math.min(
     Number.isFinite(requested) && requested > 0 ? requested : AWAIT_SLICE_MS,
@@ -105,7 +119,7 @@ export async function awaitAccess(
   );
   const deadline = Date.now() + sliceMs;
   for (;;) {
-    const current = await pollSnapshot(requestId, url.origin);
+    const current = await pollSnapshot(requester, url.origin);
     if (current.state !== "pending" || Date.now() >= deadline) return current;
     await new Promise((resolve) => setTimeout(resolve, POLL_MS));
   }

--- a/extension/src/commands/access.ts
+++ b/extension/src/commands/access.ts
@@ -1,0 +1,111 @@
+import {
+  accessState,
+  activeRequest,
+  consumableGrant,
+  newRequest,
+  requestVerdict,
+  type AccessRequest,
+} from "../access-flow";
+import {
+  expireAccessRequest,
+  originAllowed,
+  raiseAccessRequest,
+  safeHttpUrl,
+} from "../origins";
+import { getSession } from "../state";
+
+/* Async site-access commands — the agent-legible half of the approval flow.
+ *
+ * request_access raises the approval prompt and returns IMMEDIATELY;
+ * await_access waits for the decision in bounded slices. The wait is
+ * implemented as a SHORT in-worker poll with the session-side tool looping
+ * slices, rather than a daemon-side long-poll with an extended timeout entry,
+ * because (a) every entry in the daemon's COMMAND_TIMEOUTS stays an honest
+ * per-RPC bound instead of one method needing a special multi-minute carve-out
+ * — the exact mechanism (awaiting_origin deadline extension) that made the old
+ * flow's failures unreadable; and (b) the MV3 worker never has to keep a
+ * multi-minute promise alive across a service-worker death — each slice is
+ * short, and the decision itself lives in session storage, which survives.
+ *
+ * Every verdict is computed against the daemon's request id (the handler's
+ * `requestId`), which is what binds requests and grants to their requester
+ * across parallel sessions — see access-flow.ts. */
+
+/** One await_access slice. Below the daemon's 25 s command timeout with margin
+ * so the RPC always answers before the daemon gives up on it. */
+export const AWAIT_SLICE_MS = 20_000;
+
+/** How often a slice re-reads the decision record. Storage reads are cheap
+ * (session storage is in-memory) and the human is the latency floor anyway. */
+const POLL_MS = 300;
+
+/** Re-read the pieces an access verdict needs in ONE getSession round-trip,
+ * sweeping TTL only when it can actually fire. expireAccessRequest does two
+ * storage reads and writes on every call; polling at 300 ms makes that the
+ * dominant cost of a 20 s slice, so the poll path skips it unless the record
+ * is past its TTL right now (round-1 m3). Same correctness: expiry is
+ * computed on read, and the sweep's side effects (prompt teardown) only
+ * matter when something IS expired. */
+async function pollSnapshot(requestId: string, origin: string): Promise<{ origin: string; state: string }> {
+  const now = Date.now();
+  let session = await getSession();
+  const record = session.accessRequest;
+  if (record && now >= record.expiresAt) {
+    await expireAccessRequest();
+    session = await getSession();
+  }
+  const url = new URL(origin + "/");
+  const state = accessState(
+    session.accessRequest,
+    await originAllowed(url),
+    !!consumableGrant(session.onceGrants, origin, requestId, now),
+    origin,
+    requestId,
+    now,
+  );
+  return { origin, state };
+}
+
+export async function requestAccess(
+  params: Record<string, unknown>,
+  requestId: string,
+): Promise<Record<string, unknown>> {
+  const url = safeHttpUrl(params.url);
+  await expireAccessRequest();
+  const now = Date.now();
+  const session = await getSession();
+  const verdict = requestVerdict(
+    session.accessRequest,
+    await originAllowed(url),
+    !!consumableGrant(session.onceGrants, url.origin, requestId, now),
+    url.origin,
+    requestId,
+    now,
+  );
+  if (verdict !== "raise") return { origin: url.origin, state: verdict };
+  const record = await raiseAccessRequest(url, requestId);
+  // Arm the TTL sweep for THIS record: chrome.alarms survives MV3 worker
+  // death, a setTimeout does not. Creating a same-named alarm replaces the
+  // prior one, which is intended — the record this alarm covers is now the
+  // only live prompt (see raiseAccessRequest).
+  chrome.alarms.create("lop-access-expiry", { when: record.expiresAt });
+  return { origin: url.origin, state: "pending" };
+}
+
+export async function awaitAccess(
+  params: Record<string, unknown>,
+  requestId: string,
+): Promise<Record<string, unknown>> {
+  const url = safeHttpUrl(params.url);
+  const requested = Number(params.timeout_ms);
+  const sliceMs = Math.min(
+    Number.isFinite(requested) && requested > 0 ? requested : AWAIT_SLICE_MS,
+    AWAIT_SLICE_MS,
+  );
+  const deadline = Date.now() + sliceMs;
+  for (;;) {
+    const current = await pollSnapshot(requestId, url.origin);
+    if (current.state !== "pending" || Date.now() >= deadline) return current;
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+  }
+}

--- a/extension/src/commands/access.ts
+++ b/extension/src/commands/access.ts
@@ -57,6 +57,7 @@ async function pollSnapshot(requestId: string, origin: string): Promise<{ origin
   const url = new URL(origin + "/");
   const state = accessState(
     session.accessRequest,
+    session.accessTombstones,
     await originAllowed(url),
     !!consumableGrant(session.onceGrants, origin, requestId, now),
     origin,

--- a/extension/src/commands/nav.ts
+++ b/extension/src/commands/nav.ts
@@ -1,6 +1,12 @@
 import { attach, BridgeCommandError, cdp, detach, pruneSurface, requireSurface } from "../cdp";
 import { dropLogCapture, startLogCapture } from "../log-capture";
-import { askOrigin, safeHttpUrl, withOriginGate } from "../origins";
+import {
+  askOrigin,
+  ensureTopLevelAccess,
+  safeHttpUrl,
+  withOriginGate,
+  type OriginAdmission,
+} from "../origins";
 import { settle } from "../settle";
 import {
   atSurfaceCap,
@@ -40,9 +46,17 @@ async function page(tabId: number): Promise<{ url: string; title: string }> {
   return { url: tab.url ?? "", title: tab.title ?? "" };
 }
 
-async function navigate(tabId: number, url: URL, requestId: string): Promise<{ url: string; title: string }> {
-  if (!(await askOrigin(url, requestId))) {
-    throw new BridgeCommandError("origin_denied", "site permission was denied", { origin: url.origin });
+async function navigate(tabId: number, url: URL, requestId: string, admission: OriginAdmission): Promise<{ url: string; title: string }> {
+  // The admission decision was made ONCE at command entry
+  // (ensureTopLevelAccess): a grant consumed there is already spent, so this
+  // function must NOT consult the grant map again — doing so would let the
+  // 10-min TTL lapse between entry and here and drop a granted navigation
+  // into the old 60 s prompt, the exact "prompt after the agent thinks it
+  // has access" surprise the async flow exists to kill (round-1 M1).
+  if (!admission.allowed) {
+    if (!(await askOrigin(url, requestId))) {
+      throw new BridgeCommandError("origin_denied", "site permission was denied", { origin: url.origin });
+    }
   }
   return withOriginGate(
     tabId,
@@ -70,13 +84,26 @@ async function navigate(tabId: number, url: URL, requestId: string): Promise<{ u
  */
 export async function open(params: Record<string, unknown>, requestId: string): Promise<Record<string, unknown>> {
   const url = safeHttpUrl(params.url);
+  // Fail EARLY on a not-yet-allowed top-level origin, before any tab exists
+  // and before any prompt is raised: the old behaviour (block this RPC inside
+  // the popup prompt) expired unseen because the agent never got a turn to
+  // point the user at the popup, and the resulting client timeout read as
+  // "bridge unreachable". The typed error teaches the agent the explicit
+  // request_access -> tell the user -> await_access flow instead. Redirect
+  // hops inside the navigation still take the synchronous prompt — the
+  // command is already running there, so an early fail is impossible. Runs
+  // BEFORE the cap check so a not-allowed open answers the actionable error
+  // even on a full browser, and admission CONSUMES the grant (see
+  // ensureTopLevelAccess) so the decision cannot lapse into the old 60 s
+  // prompt before navigate() runs.
+  const admission = await ensureTopLevelAccess(url, requestId);
   if (params.tab !== undefined && params.tab !== null && params.tab !== "") {
     const surface = await requireSurface(params.tab);
     // Re-arm log capture on the resumed surface: after a worker restart the
     // ring buffer was lost and the domains may need re-enabling, and
     // startLogCapture is idempotent when they are already on.
     await startLogCapture(surface.tabId, cdp);
-    const result = await navigate(surface.tabId, url, requestId);
+    const result = await navigate(surface.tabId, url, requestId, admission);
     // Same epoch bump as `goto`: resume navigates to a new document, so
     // pre-resume snapshot refs must fail the epoch gate rather than being
     // pushed against nodes that no longer exist (review finding m3).
@@ -98,9 +125,9 @@ export async function open(params: Record<string, unknown>, requestId: string): 
       { limit: MAX_SURFACES, tabs: Object.keys(surfaces).map(redactToken) },
     );
   }
-  if (!(await askOrigin(url, requestId))) {
-    throw new BridgeCommandError("origin_denied", "site permission was denied", { origin: url.origin });
-  }
+  // No separate pre-create gate: ensureTopLevelAccess above already refused a
+  // not-allowed origin, and gating again here would double-consume a once
+  // grant before navigate() (the single consumption point) ran.
   // Create about:blank first. Creating directly at the destination starts its
   // redirect chain before a debugger can attach, leaving a race where a second
   // origin could receive cookies before the permission gate exists.
@@ -120,13 +147,17 @@ export async function open(params: Record<string, unknown>, requestId: string): 
   // navigating, so the `logs` command captures output from the destination
   // page's very first script (finding: logs must be "since the surface opened").
   await startLogCapture(tab.id, cdp);
-  const live = await navigate(tab.id, url, requestId);
+  const live = await navigate(tab.id, url, requestId, admission);
   return { tab: surfaceToken(surface), ...live };
 }
 
 export async function goto(params: Record<string, unknown>, requestId: string): Promise<Record<string, unknown>> {
   const surface = await requireSurface(params.tab);
-  const result = await navigate(surface.tabId, safeHttpUrl(params.url), requestId);
+  const url = safeHttpUrl(params.url);
+  // Same early refusal as open — see the comment there. Consumption likewise
+  // happens HERE, once, bound to this command's request id.
+  const admission = await ensureTopLevelAccess(url, requestId);
+  const result = await navigate(surface.tabId, url, requestId, admission);
   surface.epoch += 1;
   await putSurface(surface);
   return result;

--- a/extension/src/commands/nav.ts
+++ b/extension/src/commands/nav.ts
@@ -41,6 +41,14 @@ async function liveSurfaces(): Promise<Record<string, StoredSurface>> {
   return live;
 }
 
+/** The session-scoped requester the tool attaches (session:<id>); absent or
+ * foreign-shaped values yield "" so admission falls back to the command-id
+ * handoff only — never trusting a caller-invented identity. */
+function sessionRequester(params: Record<string, unknown>): string {
+  const value = typeof params.requester === "string" ? params.requester.trim() : "";
+  return value.startsWith("session:") ? value : "";
+}
+
 async function page(tabId: number): Promise<{ url: string; title: string }> {
   const tab = await chrome.tabs.get(tabId);
   return { url: tab.url ?? "", title: tab.title ?? "" };
@@ -96,7 +104,7 @@ export async function open(params: Record<string, unknown>, requestId: string): 
   // even on a full browser, and admission CONSUMES the grant (see
   // ensureTopLevelAccess) so the decision cannot lapse into the old 60 s
   // prompt before navigate() runs.
-  const admission = await ensureTopLevelAccess(url, requestId);
+  const admission = await ensureTopLevelAccess(url, requestId, sessionRequester(params));
   if (params.tab !== undefined && params.tab !== null && params.tab !== "") {
     const surface = await requireSurface(params.tab);
     // Re-arm log capture on the resumed surface: after a worker restart the
@@ -156,7 +164,7 @@ export async function goto(params: Record<string, unknown>, requestId: string): 
   const url = safeHttpUrl(params.url);
   // Same early refusal as open — see the comment there. Consumption likewise
   // happens HERE, once, bound to this command's request id.
-  const admission = await ensureTopLevelAccess(url, requestId);
+  const admission = await ensureTopLevelAccess(url, requestId, sessionRequester(params));
   const result = await navigate(surface.tabId, url, requestId, admission);
   surface.epoch += 1;
   await putSurface(surface);

--- a/extension/src/origins.ts
+++ b/extension/src/origins.ts
@@ -1,10 +1,11 @@
 import {
   activeRequest,
-  anyGrantLive,
   consumableGrant,
   newRequest,
   ONCE_GRANT_TTL_MS,
-  supersedeRequest,
+  TOMBSTONE_CAP,
+  tombstoneFor,
+  type AccessRequest,
   type OriginDecision,
 } from "./access-flow";
 import { BridgeCommandError, cdp } from "./cdp";
@@ -192,28 +193,31 @@ export async function expireAccessRequest(): Promise<void> {
 }
 
 /** Raise a fresh async request, tombstoning any live one it replaces.
- * The displaced request is NOT deleted: its record stays with the
- * "superseded" sentinel so the displaced requester's next poll learns its
- * prompt was taken over (round-1 B1b) instead of reading a silent absence as
- * expiry. The replaced prompt surfaces are cleared immediately — waiting for
- * the lazy sweep let a dead prompt's badge outlive it (round-1 m2). */
+ * The displaced requester gets a receipt (see AccessTombstones in
+ * access-flow.ts) so its next poll learns "superseded" instead of reading a
+ * silent absence as expiry — without it, two sessions could steal the single
+ * prompt slot back and forth forever (round-1 B1b). The new prompt's surfaces
+ * are raised immediately, overwriting the replaced one's badge/record
+ * atomically (round-1 m2: a dead prompt's badge must not outlive it). */
 export async function raiseAccessRequest(url: URL, requester: string): Promise<AccessRequest> {
   const now = Date.now();
   const session = await getSession();
-  const record = newRequest(url.origin, url.hostname, requester, now);
   const previous = activeRequest(session.accessRequest, now);
-  const replacedOwnPrompt =
-    previous &&
-    previous.origin !== record.origin &&
-    session.pendingOrigin?.origin === previous.origin;
-  if (previous && previous.origin !== record.origin) {
-    await chrome.storage.session.set({ accessRequest: supersedeRequest(previous) });
+  const record = newRequest(url.origin, url.hostname, requester, now);
+  if (previous && (previous.origin !== record.origin || previous.requester !== record.requester)) {
+    // Different origin OR same origin from a different requester: both
+    // displace the pending prompt, both leave the receipt.
+    const tombs = { ...(session.accessTombstones ?? {}) };
+    tombs[previous.origin] = tombstoneFor(previous);
+    // Drop expired/oldest beyond the cap so a churny fleet cannot grow the
+    // map unbounded — a receipt that old describes a prompt nobody remembers.
+    const entries = Object.entries(tombs)
+      .filter(([, t]) => now < t.expiresAt)
+      .sort((a, b) => b[1].expiresAt - a[1].expiresAt)
+      .slice(0, TOMBSTONE_CAP);
+    await chrome.storage.session.set({ accessTombstones: Object.fromEntries(entries) });
   }
   await chrome.storage.session.set({ accessRequest: record });
-  if (replacedOwnPrompt) {
-    // The old prompt record is stale the moment the new one lands; raise
-    // the new one over it, which overwrites badge/title atomically.
-  }
   await raisePrompt(url, requester);
   // The expiry alarm is armed by the CALLER (access.ts) with this record's
   // own expiry; chrome.alarms.create replaces a same-named alarm, so the

--- a/extension/src/origins.ts
+++ b/extension/src/origins.ts
@@ -57,10 +57,12 @@ export interface OriginAdmission {
  * access-flow.ts). */
 export async function consumeOnceGrant(url: URL, requester: string): Promise<boolean> {
   const { onceGrants = {} } = await getSession();
-  if (!consumableGrant(onceGrants, url.origin, requester, Date.now())) return false;
+  const grant = consumableGrant(onceGrants, url.origin, requester, Date.now());
+  if (!grant) return false;
   const remaining = { ...onceGrants };
   delete remaining[url.origin];
   await chrome.storage.session.set({ onceGrants: remaining });
+  await clearConsumedRequest(url.origin, grant.requester);
   return true;
 }
 
@@ -112,7 +114,24 @@ async function consumeGrantFor(
   const remaining = { ...onceGrants };
   delete remaining[url.origin];
   await chrome.storage.session.set({ onceGrants: remaining });
+  await clearConsumedRequest(url.origin, grant.requester);
   return true;
+}
+
+/** A resolved "once" request is the receipt await_access reads while its grant
+ * waits to be spent. Once the grant is consumed, remove that matching receipt:
+ * otherwise a later request_access to the same origin sees decision="once"
+ * and answers allowed even though no grant remains — silently turning "once"
+ * into a second admission. A newer request is preserved by the full match. */
+async function clearConsumedRequest(origin: string, requester: string): Promise<void> {
+  const { accessRequest } = await getSession();
+  if (
+    accessRequest?.origin === origin &&
+    accessRequest.decision === "once" &&
+    accessRequest.requester === requester
+  ) {
+    await chrome.storage.session.remove("accessRequest");
+  }
 }
 
 /** Raise the pending-approval surfaces: session record (popup prompt), badge,
@@ -244,10 +263,15 @@ export async function raiseAccessRequest(url: URL, requester: string): Promise<A
   const session = await getSession();
   const previous = activeRequest(session.accessRequest, now);
   const record = newRequest(url.origin, url.hostname, requester, now);
+  const tombs = { ...(session.accessTombstones ?? {}) };
+  // A deliberate fresh request by the requester that was displaced consumes
+  // its old supersession receipt. Leaving it behind made this NEW request's
+  // eventual TTL expiry read as "superseded" instead of "none" — the stale
+  // receipt outlived the event it described.
+  if (tombs[record.origin]?.requester === requester) delete tombs[record.origin];
   if (previous && (previous.origin !== record.origin || previous.requester !== record.requester)) {
     // Different origin OR same origin from a different requester: both
     // displace the pending prompt, both leave the receipt.
-    const tombs = { ...(session.accessTombstones ?? {}) };
     tombs[previous.origin] = tombstoneFor(previous);
     // Drop expired/oldest beyond the cap so a churny fleet cannot grow the
     // map unbounded — a receipt that old describes a prompt nobody remembers.
@@ -256,6 +280,10 @@ export async function raiseAccessRequest(url: URL, requester: string): Promise<A
       .sort((a, b) => b[1].expiresAt - a[1].expiresAt)
       .slice(0, TOMBSTONE_CAP);
     await chrome.storage.session.set({ accessTombstones: Object.fromEntries(entries) });
+  } else {
+    // Persist the consumed stale receipt even when this request displaced
+    // nothing live.
+    await chrome.storage.session.set({ accessTombstones: tombs });
   }
   await chrome.storage.session.set({ accessRequest: record });
   await raisePrompt(url, requester);

--- a/extension/src/origins.ts
+++ b/extension/src/origins.ts
@@ -73,14 +73,46 @@ export async function consumeOnceGrant(url: URL, requester: string): Promise<boo
  * expired unseen and made sessions misread the bridge as broken. Redirect
  * hops inside a running navigation still take the synchronous askOrigin
  * prompt: the command is already in flight there, so an early fail is
- * impossible by construction. */
-export async function ensureTopLevelAccess(url: URL, requester: string): Promise<OriginAdmission> {
+ * impossible by construction.
+ *
+ * Grant consumption matches EITHER the session identity the tool attached to
+ * this command (same session that asked, normal path) OR the command-id
+ * handoff recorded on the grant at decision time (raw-RPC callers reusing
+ * the request id). A navigation carrying NEITHER is another session trying
+ * to ride a grant it did not earn — refused (fail-closed). */
+export async function ensureTopLevelAccess(
+  url: URL,
+  requestId: string,
+  sessionRequester: string = "",
+): Promise<OriginAdmission> {
   if (await originAllowed(url)) return { allowed: true, viaOnceGrant: false };
-  if (await consumeOnceGrant(url, requester)) return { allowed: true, viaOnceGrant: true };
+  if (await consumeGrantFor(url, sessionRequester, requestId)) {
+    return { allowed: true, viaOnceGrant: true };
+  }
   throw new BridgeCommandError("origin_not_allowed", `site ${url.origin} is not allowed yet`, {
     origin: url.origin,
     url: url.href,
   });
+}
+
+/** Consume a grant on behalf of a NAVIGATION command: the caller's session
+ * identity must equal the grant's requester, or the command's own id must
+ * equal the grant's handoff (see recordAccessDecision). */
+async function consumeGrantFor(
+  url: URL,
+  sessionRequester: string,
+  commandId: string,
+): Promise<boolean> {
+  const { onceGrants = {} } = await getSession();
+  const grant = onceGrants[url.origin];
+  if (!grant || Date.now() >= grant.expiresAt) return false;
+  const ownsBySession = sessionRequester !== "" && grant.requester === sessionRequester;
+  const ownsByHandoff = !!grant.handoff && grant.handoff === commandId;
+  if (!ownsBySession && !ownsByHandoff) return false;
+  const remaining = { ...onceGrants };
+  delete remaining[url.origin];
+  await chrome.storage.session.set({ onceGrants: remaining });
+  return true;
 }
 
 /** Raise the pending-approval surfaces: session record (popup prompt), badge,
@@ -143,14 +175,22 @@ async function recordAccessDecision(origin: string, decision: OriginDecision): P
   if (!live || live.origin !== origin || live.decision) return;
   await chrome.storage.session.set({ accessRequest: { ...live, decision } });
   if (decision === "once") {
-    // The grant is bound to the REQUEST's requester: "Allow once" is the
-    // user's answer to this agent's ask, so only a command carrying that
-    // requester may spend it (see access-flow.ts).
+    // The grant is bound to the REQUEST's requester AND to the command that
+    // raised the request: an async "Allow once" is earned by the flow that
+    // asked, so the handoff records BOTH identities. A navigation spends it
+    // if it carries EITHER — the session identity (normal path: the same
+    // session's next open/goto) or the exact command id (a raw-RPC caller
+    // whose navigation reuses the request_access id). A third session
+    // carries neither and is refused (fail-closed; see access-flow.ts).
     const grants = session.onceGrants ?? {};
     await chrome.storage.session.set({
       onceGrants: {
         ...grants,
-        [origin]: { expiresAt: now + ONCE_GRANT_TTL_MS, requester: live.requester },
+        [origin]: {
+          expiresAt: now + ONCE_GRANT_TTL_MS,
+          requester: live.requester,
+          handoff: session.pendingOrigin?.requestId ?? "",
+        },
       },
     });
   }

--- a/extension/src/origins.ts
+++ b/extension/src/origins.ts
@@ -1,12 +1,20 @@
+import {
+  activeRequest,
+  anyGrantLive,
+  consumableGrant,
+  newRequest,
+  ONCE_GRANT_TTL_MS,
+  supersedeRequest,
+  type OriginDecision,
+} from "./access-flow";
 import { BridgeCommandError, cdp } from "./cdp";
 import { safeHttpUrl, storedOriginAllowed } from "./origin-policy";
 import { ORIGIN_PROMPT_TIMEOUT_MS } from "./protocol.gen";
-import { getLocal } from "./state";
+import { getLocal, getSession } from "./state";
 
 export { safeHttpUrl } from "./origin-policy";
 export { ORIGIN_PROMPT_TIMEOUT_MS } from "./protocol.gen";
-
-export type OriginDecision = "once" | "always" | "deny";
+export type { OriginDecision } from "./access-flow";
 
 // The popup resolves a decision by ORIGIN, not by command id: a single command
 // can pause on several origins in a redirect chain, and keying the resolver by
@@ -30,10 +38,55 @@ export async function originAllowed(url: URL): Promise<boolean> {
   return storedOriginAllowed(origins, url);
 }
 
-export async function askOrigin(url: URL, requestId: string): Promise<boolean> {
-  if (await originAllowed(url)) return true;
-  // Record the pending decision for the popup and the ambient observer. Keyed
-  // by origin so concurrent hops do not clobber each other.
+/** The outcome of the ONE admission decision a top-level navigation makes.
+ * {allowed:true} covers both the persistent allowlist and a consumed
+ * once-grant; navigate() trusts it and never re-consults the grant map, so
+ * admission and consumption cannot drift apart across the TTL (round-1 M1). */
+export interface OriginAdmission {
+  allowed: boolean;
+  /** True when admission consumed a once-grant — kept for diagnostics and
+   * tests; navigate() only needs `allowed`. */
+  viaOnceGrant: boolean;
+}
+
+/** Consume an unconsumed async "Allow once" grant for this origin, if the
+ * CALLER may. Consumed (deleted) on use because "once" means one navigation.
+ * Fails CLOSED on a requester mismatch: a grant minted for session A's flow
+ * is not session B's to spend (see the multi-surface constraint in
+ * access-flow.ts). */
+export async function consumeOnceGrant(url: URL, requester: string): Promise<boolean> {
+  const { onceGrants = {} } = await getSession();
+  if (!consumableGrant(onceGrants, url.origin, requester, Date.now())) return false;
+  const remaining = { ...onceGrants };
+  delete remaining[url.origin];
+  await chrome.storage.session.set({ onceGrants: remaining });
+  return true;
+}
+
+/** Whether a top-level open/goto to this origin may START, making the
+ * admission decision EXACTLY ONCE: stored allowlist → caller's once-grant
+ * (consumed here, so it cannot lapse into a prompt mid-command) → typed
+ * early error teaching the agent the async flow. The returned admission
+ * travels to navigate() unchanged; the whole point of the early error is
+ * that the old behaviour (block the navigation RPC inside the popup prompt)
+ * expired unseen and made sessions misread the bridge as broken. Redirect
+ * hops inside a running navigation still take the synchronous askOrigin
+ * prompt: the command is already in flight there, so an early fail is
+ * impossible by construction. */
+export async function ensureTopLevelAccess(url: URL, requester: string): Promise<OriginAdmission> {
+  if (await originAllowed(url)) return { allowed: true, viaOnceGrant: false };
+  if (await consumeOnceGrant(url, requester)) return { allowed: true, viaOnceGrant: true };
+  throw new BridgeCommandError("origin_not_allowed", `site ${url.origin} is not allowed yet`, {
+    origin: url.origin,
+    url: url.href,
+  });
+}
+
+/** Raise the pending-approval surfaces: session record (popup prompt), badge,
+ * and — via the worker's observer — the system notification and the daemon's
+ * awaiting_origin event. Shared by the in-command prompt and the async
+ * request_access path so the popup renders both identically. */
+async function raisePrompt(url: URL, requestId: string): Promise<void> {
   await chrome.storage.session.set({
     pendingOrigin: { origin: url.origin, hostname: url.hostname, requestId },
   });
@@ -41,21 +94,72 @@ export async function askOrigin(url: URL, requestId: string): Promise<boolean> {
   await chrome.action.setBadgeText({ text: "!" });
   await chrome.action.setTitle({ title: `Local Operator wants to open ${url.hostname}` });
   onPendingChange?.({ origin: url.origin, hostname: url.hostname });
+}
+
+async function clearPrompt(): Promise<void> {
+  await chrome.storage.session.remove("pendingOrigin");
+  await chrome.action.setBadgeText({ text: "" });
+  await chrome.action.setTitle({ title: "Local Operator" });
+  onPendingChange?.(null);
+}
+
+export { clearPrompt, raisePrompt };
+
+export async function askOrigin(url: URL, requestId: string): Promise<boolean> {
+  if (await originAllowed(url)) return true;
+  // A live async grant minted for THIS command's request id covers exactly
+  // this navigation. Redirect hops carry the top-level command's id, which
+  // is NOT the async requester, so they correctly miss and fall through to
+  // the prompt — a hop must never ride a grant another flow earned.
+  if (await consumeOnceGrant(url, requestId)) return true;
+  // Record the pending decision for the popup and the ambient observer. Keyed
+  // by origin so concurrent hops do not clobber each other.
+  await raisePrompt(url, requestId);
   const decision = await new Promise<OriginDecision>((resolve) => {
     waiting.set(url.origin, resolve);
     setTimeout(() => {
       if (waiting.delete(url.origin)) resolve("deny");
     }, ORIGIN_PROMPT_TIMEOUT_MS);
   });
-  await chrome.storage.session.remove("pendingOrigin");
-  await chrome.action.setBadgeText({ text: "" });
-  await chrome.action.setTitle({ title: "Local Operator" });
-  onPendingChange?.(null);
+  await clearPrompt();
   if (decision === "always") {
     const { origins = {} } = await getLocal();
     await chrome.storage.local.set({ origins: { ...origins, [url.origin]: "allow" } });
   }
   return decision !== "deny";
+}
+
+/** Fold the user's decision into a live async access request, if one matches.
+ * This is the second half of the decoupling: the popup's one decision message
+ * must land on BOTH an in-command wait (resolveOrigin's map) and the async
+ * record, because the agent may be waiting either way and the popup cannot
+ * tell which. Persisting "always" and minting the "once" grant happen here
+ * for the async path — there is no askOrigin continuation to do it. */
+async function recordAccessDecision(origin: string, decision: OriginDecision): Promise<void> {
+  const now = Date.now();
+  const session = await getSession();
+  const live = activeRequest(session.accessRequest, now);
+  if (!live || live.origin !== origin || live.decision) return;
+  await chrome.storage.session.set({ accessRequest: { ...live, decision } });
+  if (decision === "once") {
+    // The grant is bound to the REQUEST's requester: "Allow once" is the
+    // user's answer to this agent's ask, so only a command carrying that
+    // requester may spend it (see access-flow.ts).
+    const grants = session.onceGrants ?? {};
+    await chrome.storage.session.set({
+      onceGrants: {
+        ...grants,
+        [origin]: { expiresAt: now + ONCE_GRANT_TTL_MS, requester: live.requester },
+      },
+    });
+  }
+  if (decision === "always") {
+    const { origins = {} } = await getLocal();
+    await chrome.storage.local.set({ origins: { ...origins, [origin]: "allow" } });
+  }
+  // The async prompt has no waiting command to clean up after itself; clear
+  // the badge/notification here so the "!" does not outlive the decision.
+  await clearPrompt();
 }
 
 export function resolveOrigin(origin: string, decision: OriginDecision): void {
@@ -64,6 +168,59 @@ export function resolveOrigin(origin: string, decision: OriginDecision): void {
     waiting.delete(origin);
     resolve(decision);
   }
+  // Fire-and-forget: the in-command resolution above must stay synchronous
+  // (the worker's onMessage listener is not awaited), and the async record
+  // update has no caller to report to.
+  void recordAccessDecision(origin, decision);
+}
+
+/** Lazy TTL cleanup, called from the worker's expiry alarm and on every
+ * access read: an expired request must drop its prompt surfaces too, or the
+ * popup would keep offering three buttons whose clicks resolve nothing.
+ * Returns the record it swept so callers can re-arm the expiry alarm for
+ * whatever is next (round-1 m2: a replace-don't-queue overwrite used to drop
+ * the OLD request's alarm entirely). */
+export async function expireAccessRequest(): Promise<void> {
+  const session = await getSession();
+  const record = session.accessRequest;
+  if (!record || activeRequest(record, Date.now())) return;
+  await chrome.storage.session.remove("accessRequest");
+  const { pendingOrigin } = session;
+  // Only clear the prompt if it is OURS — an in-command prompt for another
+  // origin may be live and owns its own cleanup.
+  if (pendingOrigin && pendingOrigin.origin === record.origin) await clearPrompt();
+}
+
+/** Raise a fresh async request, tombstoning any live one it replaces.
+ * The displaced request is NOT deleted: its record stays with the
+ * "superseded" sentinel so the displaced requester's next poll learns its
+ * prompt was taken over (round-1 B1b) instead of reading a silent absence as
+ * expiry. The replaced prompt surfaces are cleared immediately — waiting for
+ * the lazy sweep let a dead prompt's badge outlive it (round-1 m2). */
+export async function raiseAccessRequest(url: URL, requester: string): Promise<AccessRequest> {
+  const now = Date.now();
+  const session = await getSession();
+  const record = newRequest(url.origin, url.hostname, requester, now);
+  const previous = activeRequest(session.accessRequest, now);
+  const replacedOwnPrompt =
+    previous &&
+    previous.origin !== record.origin &&
+    session.pendingOrigin?.origin === previous.origin;
+  if (previous && previous.origin !== record.origin) {
+    await chrome.storage.session.set({ accessRequest: supersedeRequest(previous) });
+  }
+  await chrome.storage.session.set({ accessRequest: record });
+  if (replacedOwnPrompt) {
+    // The old prompt record is stale the moment the new one lands; raise
+    // the new one over it, which overwrites badge/title atomically.
+  }
+  await raisePrompt(url, requester);
+  // The expiry alarm is armed by the CALLER (access.ts) with this record's
+  // own expiry; chrome.alarms.create replaces a same-named alarm, so the
+  // displaced request's alarm is intentionally dropped — the new record's
+  // alarm covers the only live prompt now, and expireAccessRequest's lazy
+  // sweep handles anything older.
+  return record;
 }
 
 interface PausedRequest {

--- a/extension/src/origins.ts
+++ b/extension/src/origins.ts
@@ -200,49 +200,55 @@ export async function askOrigin(url: URL, requestId: string): Promise<boolean> {
   return decision !== "deny";
 }
 
-/** Fold the user's decision into a live async access request, if one matches.
+/** Fold the user's decision into a live async access request — the
+ * NON-LOCKING body (suffix `Locked`: caller already holds the session
+ * mutation queue). Splitting the old self-locking helper is what makes the
+ * round-3 B1 fix possible: resolveOrigin's validation and this mutation now
+ * share one critical section, so a queued replacement cannot slip between
+ * them. Returns false when there is nothing left to apply (no live record,
+ * wrong origin, or already decided — the duplicate-delivery idempotence).
  * This is the second half of the decoupling: the popup's one decision message
  * must land on BOTH an in-command wait (resolveOrigin's map) and the async
  * record, because the agent may be waiting either way and the popup cannot
  * tell which. Persisting "always" and minting the "once" grant happen here
- * for the async path — there is no askOrigin continuation to do it. Runs
- * under the session-mutation queue: it read-modify-writes the same keys the
- * consume paths do. */
-function recordAccessDecision(origin: string, decision: OriginDecision): Promise<void> {
-  return withSessionMutation(async () => {
-    const now = Date.now();
-    const session = await getSession();
-    const live = activeRequest(session.accessRequest, now);
-    if (!live || live.origin !== origin || live.decision) return;
-    await chrome.storage.session.set({ accessRequest: { ...live, decision } });
-    if (decision === "once") {
-      // The grant is bound to the REQUEST's requester AND to the command that
-      // raised the request: an async "Allow once" is earned by the flow that
-      // asked, so the handoff records BOTH identities. A navigation spends it
-      // if it carries EITHER — the session identity (normal path: the same
-      // session's next open/goto) or the exact command id (a raw-RPC caller
-      // whose navigation reuses the request_access id). A third session
-      // carries neither and is refused (fail-closed; see access-flow.ts).
-      const grants = session.onceGrants ?? {};
-      await chrome.storage.session.set({
-        onceGrants: {
-          ...grants,
-          [origin]: {
-            expiresAt: now + ONCE_GRANT_TTL_MS,
-            requester: live.requester,
-            handoff: session.pendingOrigin?.requestId ?? "",
-          },
+ * for the async path — there is no askOrigin continuation to do it. */
+async function recordAccessDecisionLocked(
+  origin: string,
+  decision: OriginDecision,
+  session: { accessRequest?: AccessRequest; onceGrants?: import("./access-flow").OnceGrants; pendingOrigin?: { requestId?: string } },
+): Promise<boolean> {
+  const now = Date.now();
+  const live = activeRequest(session.accessRequest, now);
+  if (!live || live.origin !== origin || live.decision) return false;
+  await chrome.storage.session.set({ accessRequest: { ...live, decision } });
+  if (decision === "once") {
+    // The grant is bound to the REQUEST's requester AND to the command that
+    // raised the request: an async "Allow once" is earned by the flow that
+    // asked, so the handoff records BOTH identities. A navigation spends it
+    // if it carries EITHER — the session identity (normal path: the same
+    // session's next open/goto) or the exact command id (a raw-RPC caller
+    // whose navigation reuses the request_access id). A third session
+    // carries neither and is refused (fail-closed; see access-flow.ts).
+    const grants = session.onceGrants ?? {};
+    await chrome.storage.session.set({
+      onceGrants: {
+        ...grants,
+        [origin]: {
+          expiresAt: now + ONCE_GRANT_TTL_MS,
+          requester: live.requester,
+          handoff: session.pendingOrigin?.requestId ?? "",
         },
-      });
-    }
-    if (decision === "always") {
-      const { origins = {} } = await getLocal();
-      await chrome.storage.local.set({ origins: { ...origins, [origin]: "allow" } });
-    }
-    // The async prompt has no waiting command to clean up after itself; clear
-    // the badge/notification here so the "!" does not outlive the decision.
-    await clearPrompt();
-  });
+      },
+    });
+  }
+  if (decision === "always") {
+    const { origins = {} } = await getLocal();
+    await chrome.storage.local.set({ origins: { ...origins, [origin]: "allow" } });
+  }
+  // The async prompt has no waiting command to clean up after itself; clear
+  // the badge/notification here so the "!" does not outlive the decision.
+  await clearPrompt();
+  return true;
 }
 
 /** Apply the popup's decision — IF it names the live prompt generation.
@@ -253,29 +259,44 @@ function recordAccessDecision(origin: string, decision: OriginDecision): Promise
  * of racing worker suspension (round-2 M2). Resolves true when applied,
  * false when rejected as stale.
  *
- * Stale rejection (round-2 B1): the popup binds its click to the promptId it
- * RENDERED. If another request replaced the slot after that render, the ids
- * differ, nothing resolves, no grant is minted — the user's click was an
- * answer to a question that is no longer being asked. A missing promptId
- * (legacy popup / health-fallback render) still requires the ORIGIN to match
- * the live prompt, the pre-generation guard. */
-export async function resolveOrigin(
+ * Validation AND persistence run in ONE withSessionMutation critical section
+ * (round-3 B1): validating before entering the queue was a TOCTOU — a
+ * same-origin replacement queued behind the stale decision's validation
+ * installed its fresh generation after the check passed but before
+ * recordAccessDecision ran, so the stale click applied to (and minted a grant
+ * for) the NEW request. Inside the queue the pending prompt is re-read
+ * atomically with the mutation that consumes it; the in-command waiter is
+ * resolved only after that atomic validation succeeds. A duplicate delivery
+ * of the CURRENT generation is idempotent: the record already carries the
+ * decision, so the re-read sees `live.decision` set and nothing re-applies
+ * (still `applied:true` — the user's click did land, it just already landed). */
+export function resolveOrigin(
   origin: string,
   decision: OriginDecision,
   promptId: string = "",
 ): Promise<boolean> {
-  const { pendingOrigin } = await getSession();
-  if (!pendingOrigin || pendingOrigin.origin !== origin) return false;
-  if (promptId && pendingOrigin.promptId && promptId !== pendingOrigin.promptId) return false;
-  // In-command wait first (synchronous handoff into the promise), then the
-  // durable async record.
-  const resolve = waiting.get(origin);
-  if (resolve) {
-    waiting.delete(origin);
-    resolve(decision);
-  }
-  await recordAccessDecision(origin, decision);
-  return true;
+  return withSessionMutation(async () => {
+    // Stale rejection (round-2 B1): the popup binds its click to the promptId
+    // it RENDERED. If another request replaced the slot after that render,
+    // nothing resolves, no grant is minted — the user's click was an answer
+    // to a question that is no longer being asked. A missing promptId
+    // (legacy popup / health-fallback render) still requires the ORIGIN to
+    // match the live prompt, the pre-generation guard.
+    const session = await getSession();
+    const pendingOrigin = session.pendingOrigin;
+    if (!pendingOrigin || pendingOrigin.origin !== origin) return false;
+    if (promptId && pendingOrigin.promptId && promptId !== pendingOrigin.promptId) return false;
+    const applied = await recordAccessDecisionLocked(origin, decision, session);
+    if (!applied) return false;
+    // In-command wait AFTER atomic validation: the waiter must never be
+    // resolved by a decision the queue just rejected as stale.
+    const resolve = waiting.get(origin);
+    if (resolve) {
+      waiting.delete(origin);
+      resolve(decision);
+    }
+    return true;
+  });
 }
 
 /** Lazy TTL cleanup, called from the worker's expiry alarm and on every

--- a/extension/src/origins.ts
+++ b/extension/src/origins.ts
@@ -3,6 +3,7 @@ import {
   consumableGrant,
   newRequest,
   ONCE_GRANT_TTL_MS,
+  receiptKey,
   TOMBSTONE_CAP,
   tombstoneFor,
   type AccessRequest,
@@ -11,7 +12,7 @@ import {
 import { BridgeCommandError, cdp } from "./cdp";
 import { safeHttpUrl, storedOriginAllowed } from "./origin-policy";
 import { ORIGIN_PROMPT_TIMEOUT_MS } from "./protocol.gen";
-import { getLocal, getSession } from "./state";
+import { getLocal, getSession, withSessionMutation } from "./state";
 
 export { safeHttpUrl } from "./origin-policy";
 export { ORIGIN_PROMPT_TIMEOUT_MS } from "./protocol.gen";
@@ -55,15 +56,20 @@ export interface OriginAdmission {
  * Fails CLOSED on a requester mismatch: a grant minted for session A's flow
  * is not session B's to spend (see the multi-surface constraint in
  * access-flow.ts). */
-export async function consumeOnceGrant(url: URL, requester: string): Promise<boolean> {
-  const { onceGrants = {} } = await getSession();
-  const grant = consumableGrant(onceGrants, url.origin, requester, Date.now());
-  if (!grant) return false;
-  const remaining = { ...onceGrants };
-  delete remaining[url.origin];
-  await chrome.storage.session.set({ onceGrants: remaining });
-  await clearConsumedRequest(url.origin, grant.requester);
-  return true;
+export function consumeOnceGrant(url: URL, requester: string): Promise<boolean> {
+  // Atomic under the session-mutation queue: read-check-delete as one unit,
+  // or two concurrent navigations could both read the grant before either
+  // delete landed and double-spend a one-shot approval (round-2 B2).
+  return withSessionMutation(async () => {
+    const { onceGrants = {} } = await getSession();
+    const grant = consumableGrant(onceGrants, url.origin, requester, Date.now());
+    if (!grant) return false;
+    const remaining = { ...onceGrants };
+    delete remaining[url.origin];
+    await chrome.storage.session.set({ onceGrants: remaining });
+    await clearConsumedRequest(url.origin, grant.requester);
+    return true;
+  });
 }
 
 /** Whether a top-level open/goto to this origin may START, making the
@@ -100,22 +106,28 @@ export async function ensureTopLevelAccess(
 /** Consume a grant on behalf of a NAVIGATION command: the caller's session
  * identity must equal the grant's requester, or the command's own id must
  * equal the grant's handoff (see recordAccessDecision). */
-async function consumeGrantFor(
+function consumeGrantFor(
   url: URL,
   sessionRequester: string,
   commandId: string,
 ): Promise<boolean> {
-  const { onceGrants = {} } = await getSession();
-  const grant = onceGrants[url.origin];
-  if (!grant || Date.now() >= grant.expiresAt) return false;
-  const ownsBySession = sessionRequester !== "" && grant.requester === sessionRequester;
-  const ownsByHandoff = !!grant.handoff && grant.handoff === commandId;
-  if (!ownsBySession && !ownsByHandoff) return false;
-  const remaining = { ...onceGrants };
-  delete remaining[url.origin];
-  await chrome.storage.session.set({ onceGrants: remaining });
-  await clearConsumedRequest(url.origin, grant.requester);
-  return true;
+  // Same atomicity as consumeOnceGrant (round-2 B2): #321 gives different
+  // tabs different daemon locks and the worker dispatches frames
+  // concurrently, so two same-session navigations genuinely race here.
+  // Exactly one caller may win the delete.
+  return withSessionMutation(async () => {
+    const { onceGrants = {} } = await getSession();
+    const grant = onceGrants[url.origin];
+    if (!grant || Date.now() >= grant.expiresAt) return false;
+    const ownsBySession = sessionRequester !== "" && grant.requester === sessionRequester;
+    const ownsByHandoff = !!grant.handoff && grant.handoff === commandId;
+    if (!ownsBySession && !ownsByHandoff) return false;
+    const remaining = { ...onceGrants };
+    delete remaining[url.origin];
+    await chrome.storage.session.set({ onceGrants: remaining });
+    await clearConsumedRequest(url.origin, grant.requester);
+    return true;
+  });
 }
 
 /** A resolved "once" request is the receipt await_access reads while its grant
@@ -138,14 +150,21 @@ async function clearConsumedRequest(origin: string, requester: string): Promise<
  * and — via the worker's observer — the system notification and the daemon's
  * awaiting_origin event. Shared by the in-command prompt and the async
  * request_access path so the popup renders both identically. */
-async function raisePrompt(url: URL, requestId: string): Promise<void> {
+async function raisePrompt(url: URL, requestId: string): Promise<string> {
+  // Every (re)raise mints a fresh prompt generation. The popup binds its
+  // rendered view AND its decision message to this id, and resolveOrigin
+  // rejects a decision carrying a stale one — the guard that stops a popup
+  // still showing origin A from approving whatever origin B replaced the
+  // slot with (round-2 B1).
+  const promptId = crypto.randomUUID().replaceAll("-", "");
   await chrome.storage.session.set({
-    pendingOrigin: { origin: url.origin, hostname: url.hostname, requestId },
+    pendingOrigin: { origin: url.origin, hostname: url.hostname, requestId, promptId },
   });
   await chrome.action.setBadgeBackgroundColor({ color: "#e96042" });
   await chrome.action.setBadgeText({ text: "!" });
   await chrome.action.setTitle({ title: `Local Operator wants to open ${url.hostname}` });
   onPendingChange?.({ origin: url.origin, hostname: url.hostname });
+  return promptId;
 }
 
 async function clearPrompt(): Promise<void> {
@@ -186,52 +205,77 @@ export async function askOrigin(url: URL, requestId: string): Promise<boolean> {
  * must land on BOTH an in-command wait (resolveOrigin's map) and the async
  * record, because the agent may be waiting either way and the popup cannot
  * tell which. Persisting "always" and minting the "once" grant happen here
- * for the async path — there is no askOrigin continuation to do it. */
-async function recordAccessDecision(origin: string, decision: OriginDecision): Promise<void> {
-  const now = Date.now();
-  const session = await getSession();
-  const live = activeRequest(session.accessRequest, now);
-  if (!live || live.origin !== origin || live.decision) return;
-  await chrome.storage.session.set({ accessRequest: { ...live, decision } });
-  if (decision === "once") {
-    // The grant is bound to the REQUEST's requester AND to the command that
-    // raised the request: an async "Allow once" is earned by the flow that
-    // asked, so the handoff records BOTH identities. A navigation spends it
-    // if it carries EITHER — the session identity (normal path: the same
-    // session's next open/goto) or the exact command id (a raw-RPC caller
-    // whose navigation reuses the request_access id). A third session
-    // carries neither and is refused (fail-closed; see access-flow.ts).
-    const grants = session.onceGrants ?? {};
-    await chrome.storage.session.set({
-      onceGrants: {
-        ...grants,
-        [origin]: {
-          expiresAt: now + ONCE_GRANT_TTL_MS,
-          requester: live.requester,
-          handoff: session.pendingOrigin?.requestId ?? "",
+ * for the async path — there is no askOrigin continuation to do it. Runs
+ * under the session-mutation queue: it read-modify-writes the same keys the
+ * consume paths do. */
+function recordAccessDecision(origin: string, decision: OriginDecision): Promise<void> {
+  return withSessionMutation(async () => {
+    const now = Date.now();
+    const session = await getSession();
+    const live = activeRequest(session.accessRequest, now);
+    if (!live || live.origin !== origin || live.decision) return;
+    await chrome.storage.session.set({ accessRequest: { ...live, decision } });
+    if (decision === "once") {
+      // The grant is bound to the REQUEST's requester AND to the command that
+      // raised the request: an async "Allow once" is earned by the flow that
+      // asked, so the handoff records BOTH identities. A navigation spends it
+      // if it carries EITHER — the session identity (normal path: the same
+      // session's next open/goto) or the exact command id (a raw-RPC caller
+      // whose navigation reuses the request_access id). A third session
+      // carries neither and is refused (fail-closed; see access-flow.ts).
+      const grants = session.onceGrants ?? {};
+      await chrome.storage.session.set({
+        onceGrants: {
+          ...grants,
+          [origin]: {
+            expiresAt: now + ONCE_GRANT_TTL_MS,
+            requester: live.requester,
+            handoff: session.pendingOrigin?.requestId ?? "",
+          },
         },
-      },
-    });
-  }
-  if (decision === "always") {
-    const { origins = {} } = await getLocal();
-    await chrome.storage.local.set({ origins: { ...origins, [origin]: "allow" } });
-  }
-  // The async prompt has no waiting command to clean up after itself; clear
-  // the badge/notification here so the "!" does not outlive the decision.
-  await clearPrompt();
+      });
+    }
+    if (decision === "always") {
+      const { origins = {} } = await getLocal();
+      await chrome.storage.local.set({ origins: { ...origins, [origin]: "allow" } });
+    }
+    // The async prompt has no waiting command to clean up after itself; clear
+    // the badge/notification here so the "!" does not outlive the decision.
+    await clearPrompt();
+  });
 }
 
-export function resolveOrigin(origin: string, decision: OriginDecision): void {
+/** Apply the popup's decision — IF it names the live prompt generation.
+ *
+ * Returns a promise that settles only when the decision is durably recorded
+ * (record + grant + allowlist + prompt teardown), so the worker's message
+ * listener can keep the MV3 event alive until persistence completes instead
+ * of racing worker suspension (round-2 M2). Resolves true when applied,
+ * false when rejected as stale.
+ *
+ * Stale rejection (round-2 B1): the popup binds its click to the promptId it
+ * RENDERED. If another request replaced the slot after that render, the ids
+ * differ, nothing resolves, no grant is minted — the user's click was an
+ * answer to a question that is no longer being asked. A missing promptId
+ * (legacy popup / health-fallback render) still requires the ORIGIN to match
+ * the live prompt, the pre-generation guard. */
+export async function resolveOrigin(
+  origin: string,
+  decision: OriginDecision,
+  promptId: string = "",
+): Promise<boolean> {
+  const { pendingOrigin } = await getSession();
+  if (!pendingOrigin || pendingOrigin.origin !== origin) return false;
+  if (promptId && pendingOrigin.promptId && promptId !== pendingOrigin.promptId) return false;
+  // In-command wait first (synchronous handoff into the promise), then the
+  // durable async record.
   const resolve = waiting.get(origin);
   if (resolve) {
     waiting.delete(origin);
     resolve(decision);
   }
-  // Fire-and-forget: the in-command resolution above must stay synchronous
-  // (the worker's onMessage listener is not awaited), and the async record
-  // update has no caller to report to.
-  void recordAccessDecision(origin, decision);
+  await recordAccessDecision(origin, decision);
+  return true;
 }
 
 /** Lazy TTL cleanup, called from the worker's expiry alarm and on every
@@ -240,15 +284,19 @@ export function resolveOrigin(origin: string, decision: OriginDecision): void {
  * Returns the record it swept so callers can re-arm the expiry alarm for
  * whatever is next (round-1 m2: a replace-don't-queue overwrite used to drop
  * the OLD request's alarm entirely). */
-export async function expireAccessRequest(): Promise<void> {
-  const session = await getSession();
-  const record = session.accessRequest;
-  if (!record || activeRequest(record, Date.now())) return;
-  await chrome.storage.session.remove("accessRequest");
-  const { pendingOrigin } = session;
-  // Only clear the prompt if it is OURS — an in-command prompt for another
-  // origin may be live and owns its own cleanup.
-  if (pendingOrigin && pendingOrigin.origin === record.origin) await clearPrompt();
+export function expireAccessRequest(): Promise<void> {
+  // Under the mutation queue: the sweep read-modify-writes the same record
+  // the decision and consume paths do.
+  return withSessionMutation(async () => {
+    const session = await getSession();
+    const record = session.accessRequest;
+    if (!record || activeRequest(record, Date.now())) return;
+    await chrome.storage.session.remove("accessRequest");
+    const { pendingOrigin } = session;
+    // Only clear the prompt if it is OURS — an in-command prompt for another
+    // origin may be live and owns its own cleanup.
+    if (pendingOrigin && pendingOrigin.origin === record.origin) await clearPrompt();
+  });
 }
 
 /** Raise a fresh async request, tombstoning any live one it replaces.
@@ -258,7 +306,8 @@ export async function expireAccessRequest(): Promise<void> {
  * prompt slot back and forth forever (round-1 B1b). The new prompt's surfaces
  * are raised immediately, overwriting the replaced one's badge/record
  * atomically (round-1 m2: a dead prompt's badge must not outlive it). */
-export async function raiseAccessRequest(url: URL, requester: string): Promise<AccessRequest> {
+export function raiseAccessRequest(url: URL, requester: string): Promise<AccessRequest> {
+  return withSessionMutation(async () => {
   const now = Date.now();
   const session = await getSession();
   const previous = activeRequest(session.accessRequest, now);
@@ -268,11 +317,13 @@ export async function raiseAccessRequest(url: URL, requester: string): Promise<A
   // its old supersession receipt. Leaving it behind made this NEW request's
   // eventual TTL expiry read as "superseded" instead of "none" — the stale
   // receipt outlived the event it described.
-  if (tombs[record.origin]?.requester === requester) delete tombs[record.origin];
+  delete tombs[receiptKey(record.origin, requester)];
   if (previous && (previous.origin !== record.origin || previous.requester !== record.requester)) {
     // Different origin OR same origin from a different requester: both
-    // displace the pending prompt, both leave the receipt.
-    tombs[previous.origin] = tombstoneFor(previous);
+    // displace the pending prompt, both leave a receipt. Keyed per
+    // origin+requester so an A→B→C chain preserves EVERY displaced
+    // requester's receipt instead of overwriting A's with B's (round-2 M1).
+    tombs[receiptKey(previous.origin, previous.requester)] = tombstoneFor(previous);
     // Drop expired/oldest beyond the cap so a churny fleet cannot grow the
     // map unbounded — a receipt that old describes a prompt nobody remembers.
     const entries = Object.entries(tombs)
@@ -293,6 +344,7 @@ export async function raiseAccessRequest(url: URL, requester: string): Promise<A
   // alarm covers the only live prompt now, and expireAccessRequest's lazy
   // sweep handles anything older.
   return record;
+  });
 }
 
 interface PausedRequest {

--- a/extension/src/popup/origin-flow.ts
+++ b/extension/src/popup/origin-flow.ts
@@ -40,8 +40,20 @@ export function ackForDecision(decision: OriginDecision): DecisionAck {
       check: false,
     };
   }
-  // "always" is a standing grant, so its ack must say it outlives this moment
-  // and where to take it back — the consent prompt's own revocability promise.
+  // "once" is a standing grant for the agent's NEXT navigation, not an
+  // in-flight pass: in the async approval flow the navigation happens a turn
+  // or two after the click, so the ack names what the grant actually covers
+  // and its bound (10 min unconsumed — see ONCE_GRANT_TTL_MS). The button
+  // label stays "Allow once": it is the one-shot consent vocabulary the
+  // store listing already promises, and the ack carries the nuance (n2).
+  if (decision === "once") {
+    return {
+      title: "Site allowed.",
+      sub: "The agent's next visit to this site goes through (once, within 10 minutes).",
+      tone: "success",
+      check: true,
+    };
+  }
   const standing =
     decision === "always" ? " Always-allowed sites can be taken back any time in Settings." : "";
   return {

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -47,6 +47,12 @@ let decidedOrigin: DecidedOrigin | null = null;
 // key its latch) against THAT origin, or the click lands on the one branch
 // where the missing-feedback bug survives (review finding m1).
 let shownPromptOrigin: string | undefined;
+// The prompt GENERATION the visible buttons belong to. The click sends THIS
+// id — never a re-read of current state — so a prompt replaced after render
+// cannot be approved by a click aimed at the old one (round-2 B1). Empty for
+// a /health-fallback render (worker restarted, no session record); the worker
+// then still requires the ORIGIN to match its live prompt.
+let shownPromptId = "";
 
 interface Health {
   extension_connected: boolean;
@@ -123,6 +129,7 @@ async function render(): Promise<void> {
     const host = document.getElementById("origin-host");
     if (host) host.textContent = pendingHost;
     shownPromptOrigin = pendingOriginValue;
+    shownPromptId = pendingOrigin?.promptId ?? "";
     // A fresh prompt must arrive with live buttons even if a previous
     // decision's lock is still set.
     setOriginBusy(false);
@@ -337,11 +344,12 @@ function showOriginAck(decision: OriginDecision): void {
 
 async function decide(decision: OriginDecision): Promise<void> {
   setOriginBusy(true);
-  const { pendingOrigin } = await getSession();
-  // Fall back to the origin the prompt actually rendered from: after a worker
-  // restart the session record is gone and only /health carried the origin
-  // (finding m1) — the click must acknowledge either way.
-  const origin = pendingOrigin?.origin ?? shownPromptOrigin;
+  // The click answers what the user SAW — shownPromptOrigin/shownPromptId
+  // captured at render — never a re-read of current state: re-reading was
+  // round-2 B1's consent hole, where a prompt replaced after render made the
+  // click approve an origin the user never looked at. The worker validates
+  // the generation and rejects a stale one.
+  const origin = shownPromptOrigin;
   if (origin) {
     // Acknowledge from the CLICK alone, before the worker round-trip: session
     // storage and /health keep echoing this prompt until `origin_decision`
@@ -351,15 +359,43 @@ async function decide(decision: OriginDecision): Promise<void> {
     // once the echo clears.
     decidedOrigin = { origin, decision };
     showOriginAck(decision);
-    // Decisions are keyed by ORIGIN so a redirect chain resolves each hop
-    // independently (finding A6).
-    await chrome.runtime.sendMessage({
+    const response = (await chrome.runtime.sendMessage({
       event: "origin_decision",
       origin,
       decision,
-    });
+      promptId: shownPromptId,
+    })) as { applied?: boolean } | undefined;
+    if (!response?.applied) {
+      // The worker refused the decision: the prompt was replaced (or expired)
+      // after this popup rendered it. Say so instead of pretending the click
+      // took effect, clear the latch, and re-render — which shows the CURRENT
+      // prompt, whose buttons are live again.
+      decidedOrigin = null;
+      showOriginNotice(
+        "Request changed.",
+        "The site request was replaced while this window was open. Review the new request.",
+      );
+      setOriginBusy(false);
+      // Hold the notice long enough to read (same shape as the pairing
+      // success hold), then fall through to render(), which draws the
+      // CURRENT prompt with live buttons.
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+    }
   }
   await render();
+}
+
+/** A neutral informational card in the ack slot — used when a decision could
+ * NOT be applied (stale prompt generation). No check mark: nothing was
+ * granted or denied. */
+function showOriginNotice(title: string, sub: string): void {
+  const titleEl = document.getElementById("origin-ack-title");
+  const subEl = document.getElementById("origin-ack-sub");
+  if (titleEl) titleEl.textContent = title;
+  if (subEl) subEl.textContent = sub;
+  document.getElementById("origin-ack-check")?.classList.add("hidden");
+  show("origin-ack");
+  document.getElementById("card")?.style.setProperty("--tone", "var(--hairline-strong)");
 }
 
 // Re-render whenever the worker changes connection state: the worker learns a
@@ -368,7 +404,7 @@ async function decide(decision: OriginDecision): Promise<void> {
 // popup (review finding m3). connState flips exactly when something the popup
 // shows has changed, so this is cheaper and quieter than polling /health.
 chrome.storage.onChanged.addListener((changes, area) => {
-  if (area === "session" && changes.connState) void render();
+  if (area === "session" && (changes.connState || changes.pendingOrigin)) void render();
 });
 
 void render();

--- a/extension/src/protocol.gen.ts
+++ b/extension/src/protocol.gen.ts
@@ -14,6 +14,7 @@ export enum ErrorCode {
   ELEMENT_NOT_FOUND = 'element_not_found',
   ORIGIN_DENIED = 'origin_denied',
   ORIGIN_PROMPT_PENDING = 'origin_prompt_pending',
+  ORIGIN_NOT_ALLOWED = 'origin_not_allowed',
   DEBUGGER_CONFLICT = 'debugger_conflict',
   TAB_LIMIT = 'tab_limit',
   TAB_AMBIGUOUS = 'tab_ambiguous',
@@ -22,7 +23,7 @@ export enum ErrorCode {
   INTERNAL = 'internal',
 }
 
-export type Method = 'open' | 'goto' | 'read' | 'snapshot' | 'screenshot' | 'click' | 'type' | 'close' | 'status' | 'tabs' | 'scroll' | 'logs';
+export type Method = 'open' | 'goto' | 'read' | 'snapshot' | 'screenshot' | 'click' | 'type' | 'close' | 'status' | 'tabs' | 'scroll' | 'logs' | 'request_access' | 'await_access';
 // One buffered console/runtime log line, as `logs` returns it (newest last).
 // `level` is normalized to the error/warning/info/log vocabulary the tool
 // filters on; `source` distinguishes a page console call from an uncaught

--- a/extension/src/state.ts
+++ b/extension/src/state.ts
@@ -56,6 +56,7 @@ export interface SessionState {
   pendingOrigin?: PendingOrigin;
   accessRequest?: import("./access-flow").AccessRequest;
   onceGrants?: import("./access-flow").OnceGrants;
+  accessTombstones?: import("./access-flow").AccessTombstones;
 }
 
 export async function getLocal(): Promise<LocalState> {
@@ -69,6 +70,7 @@ export async function getSession(): Promise<SessionState> {
     "pendingOrigin",
     "accessRequest",
     "onceGrants",
+    "accessTombstones",
   ]);
 }
 

--- a/extension/src/state.ts
+++ b/extension/src/state.ts
@@ -29,6 +29,13 @@ export interface PendingOrigin {
   origin: string;
   hostname: string;
   requestId: string;
+  // Immutable per-PROMPT generation token, minted every time the prompt slot
+  // is (re)written. The popup binds its rendered view and its decision message
+  // to this id, and the worker rejects a decision whose id is no longer the
+  // live one — without it, a popup still showing origin A could click through
+  // to whatever origin B had replaced the slot with (round-2 B1: a consent UI
+  // must never approve something the user was not looking at).
+  promptId: string;
 }
 
 // Async access-request state (see access-flow.ts for the machine and the
@@ -91,6 +98,19 @@ function withStore<T>(op: () => Promise<T>): Promise<T> {
   const run = storeQueue.catch(() => {}).then(op);
   storeQueue = run;
   return run;
+}
+
+/** The same serialized-mutation queue, exported for the access-flow state
+ * (grants/requests/receipts in chrome.storage.session). Grant consumption is
+ * a read-check-delete; two concurrent navigations (different tabs = different
+ * daemon locks, and the worker dispatches frames concurrently) could both
+ * read the grant before either delete landed and DOUBLE-SPEND a one-shot
+ * approval (round-2 B2, reproduced by review). One queue for every session
+ * mutation makes each read-modify-write atomic with respect to the others;
+ * the ops are tiny, so a single queue beats a per-key lock map that would
+ * need its own eviction story. */
+export function withSessionMutation<T>(op: () => Promise<T>): Promise<T> {
+  return withStore(op);
 }
 
 export function putSurface(surface: StoredSurface): Promise<void> {

--- a/extension/src/state.ts
+++ b/extension/src/state.ts
@@ -31,6 +31,13 @@ export interface PendingOrigin {
   requestId: string;
 }
 
+// Async access-request state (see access-flow.ts for the machine and the
+// incident that motivated it). Session-scoped on purpose: like `origins`
+// "once" grants, an approval should not outlive the browser session, and
+// session storage survives MV3 worker death, which worker memory does not —
+// a decision made between two await_access polls must still be readable.
+export type { AccessRequest, OnceGrants } from "./access-flow";
+
 export interface LocalState {
   token?: string;
   port?: number;
@@ -47,6 +54,8 @@ export interface SessionState {
   // not overwrite another's click targets mid-interaction.
   refs?: Record<string, Record<string, SnapshotRef>>;
   pendingOrigin?: PendingOrigin;
+  accessRequest?: import("./access-flow").AccessRequest;
+  onceGrants?: import("./access-flow").OnceGrants;
 }
 
 export async function getLocal(): Promise<LocalState> {
@@ -54,7 +63,13 @@ export async function getLocal(): Promise<LocalState> {
 }
 
 export async function getSession(): Promise<SessionState> {
-  return chrome.storage.session.get(["surfaces", "refs", "pendingOrigin"]);
+  return chrome.storage.session.get([
+    "surfaces",
+    "refs",
+    "pendingOrigin",
+    "accessRequest",
+    "onceGrants",
+  ]);
 }
 
 export async function getSurfaces(): Promise<Record<string, StoredSurface>> {

--- a/extension/src/worker.ts
+++ b/extension/src/worker.ts
@@ -1,3 +1,4 @@
+import { awaitAccess, requestAccess } from "./commands/access";
 import { close, goto, open, status, tabs } from "./commands/nav";
 import { click, typeText } from "./commands/input";
 import { readPage } from "./commands/read";
@@ -6,7 +7,7 @@ import { snapshot } from "./commands/snapshot";
 import { scroll } from "./commands/scroll";
 import { logs } from "./commands/logs";
 import { BridgeCommandError } from "./cdp";
-import { resolveOrigin, setPendingObserver } from "./origins";
+import { expireAccessRequest, resolveOrigin, setPendingObserver } from "./origins";
 import { DEFAULT_PORT, getLocal } from "./state";
 import { ErrorCode, type DaemonMessage, type ExtensionEvent, type Response } from "./protocol.gen";
 
@@ -29,6 +30,11 @@ const HANDLERS: Record<
   tabs,
   scroll,
   logs,
+  // Async site-approval flow: request returns immediately after raising the
+  // prompt; await polls the stored decision in bounded slices (access.ts
+  // explains why slices, not a daemon long-poll).
+  request_access: requestAccess,
+  await_access: awaitAccess,
 };
 
 // How long a dial may sit unresolved before we force it closed and retry. A
@@ -51,9 +57,15 @@ function send(frame: object): void {
   if (socket?.readyState === WebSocket.OPEN) socket.send(JSON.stringify(frame));
 }
 
-// Raise a system notification when a site decision is pending, so a user who
-// does not already have the popup open still sees that the agent is blocked on
-// them rather than the command silently stalling toward a deny (finding U2).
+// Raise a system notification when a site decision is pending (finding U2).
+// BEST-EFFORT ONLY: on macOS this banner frequently never reaches the user —
+// Chrome needs its own Notification Center authorization (System Settings →
+// Notifications → Google Chrome) and on machines without it the notification
+// only renders inside Chrome's extensions menu, invisible in practice
+// (confirmed on a real machine). The PRIMARY signal is therefore the AGENT:
+// the origin_not_allowed error and the request_access result text both tell
+// it to message the user through the harness, which notifies reliably. This
+// banner stays because it costs nothing and helps the machines where it works.
 const PENDING_NOTIFICATION_ID = "lop-origin-pending";
 setPendingObserver((pending) => {
   if (pending) {
@@ -62,11 +74,27 @@ setPendingObserver((pending) => {
       type: "basic",
       iconUrl: chrome.runtime.getURL("icons/icon-128.png"),
       title: "Local Operator needs your OK",
-      message: `Allow the agent to open ${pending.hostname}? Click the extension to decide.`,
+      message: `Allow the agent to open ${pending.hostname}? Click the extension icon in the toolbar to decide.`,
       priority: 2,
     });
   } else {
     chrome.notifications?.clear(PENDING_NOTIFICATION_ID);
+  }
+});
+
+// Clicking the banner opens the consent popup directly — one click instead of
+// "find the toolbar icon". openPopup() historically demands a user gesture
+// and Chrome has moved the boundary between versions; a notification click
+// may or may not count as one, so failure is swallowed and the notification
+// text keeps pointing at the toolbar icon as the fallback path.
+chrome.notifications?.onClicked.addListener((id) => {
+  if (id !== PENDING_NOTIFICATION_ID) return;
+  try {
+    const opened = chrome.action.openPopup() as Promise<void> | undefined;
+    void opened?.catch(() => {});
+  } catch {
+    // No gesture credit for this click on this Chrome version — the toolbar
+    // icon named in the notification text remains the way in.
   }
 });
 
@@ -218,6 +246,11 @@ function scheduleReconnect(): void {
 chrome.alarms.create("lop-bridge-reconnect", { periodInMinutes: 0.5 });
 chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name === "lop-bridge-reconnect" && !connected) void connect();
+  // TTL sweep for an async access request nobody is polling: without it an
+  // abandoned request would leave the "!" badge and popup prompt up until the
+  // next access RPC happened to run the lazy sweep. The alarm is created by
+  // request_access with the record's own expiry time.
+  if (alarm.name === "lop-access-expiry") void expireAccessRequest();
 });
 chrome.runtime.onStartup.addListener(() => {
   alive = true;

--- a/extension/src/worker.ts
+++ b/extension/src/worker.ts
@@ -266,8 +266,20 @@ void connect();
 chrome.storage.onChanged.addListener((changes, area) => {
   if (area === "local" && changes.pendingOrigin) void chrome.runtime.sendMessage({ event: "origin_prompt", pending: changes.pendingOrigin.newValue });
 });
-chrome.runtime.onMessage.addListener((message) => {
-  // Decisions are keyed by ORIGIN now (finding A6): one command can pause on
-  // several origins in a redirect chain, and each resolves independently.
-  if (message?.event === "origin_decision") resolveOrigin(String(message.origin), message.decision);
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  // Decisions are keyed by ORIGIN (finding A6) and carry the prompt
+  // GENERATION the popup rendered (round-2 B1): resolveOrigin rejects a
+  // decision for a prompt that was replaced after the popup drew it.
+  if (message?.event === "origin_decision") {
+    // sendResponse + `return true` keeps the MV3 event alive until the
+    // decision is DURABLY recorded (record, grant, allowlist, prompt
+    // teardown). A fire-and-forget here let Chrome settle the popup's
+    // sendMessage and suspend this worker mid-persistence, losing the
+    // user's approval (round-2 M2).
+    resolveOrigin(String(message.origin), message.decision, String(message.promptId ?? ""))
+      .then((applied) => sendResponse({ applied }))
+      .catch(() => sendResponse({ applied: false }));
+    return true;
+  }
+  return undefined;
 });

--- a/extension/tests/origins.integration.test.mjs
+++ b/extension/tests/origins.integration.test.mjs
@@ -146,17 +146,60 @@ test("admission consumes the grant once and navigate never re-consults it (M1)",
   const bundle = await loadOrigins();
   try {
     const origins = await bundle.import();
-    await origins.raiseAccessRequest(urlOf(), "req-A");
+    await origins.raiseAccessRequest(urlOf(), "session:A");
     origins.resolveOrigin(ORIGIN, "once");
     await flush();
-    const admission = await origins.ensureTopLevelAccess(urlOf(), "req-A");
+    // Session A's own navigation (session identity matches the grant).
+    const admission = await origins.ensureTopLevelAccess(urlOf(), "cmd-nav-1", "session:A");
     assert.deepEqual(admission, { allowed: true, viaOnceGrant: true });
     // The grant is spent AT ADMISSION: a second admission for the same
-    // requester must now take the early-fail path, not find a stale grant.
+    // session must now take the early-fail path, not find a stale grant.
     await assert.rejects(
-      origins.ensureTopLevelAccess(urlOf(), "req-A"),
+      origins.ensureTopLevelAccess(urlOf(), "cmd-nav-2", "session:A"),
       (error) => error.code === "origin_not_allowed",
     );
+  } finally {
+    await bundle.close();
+    chrome.restore();
+  }
+});
+
+test("a parallel session's navigation cannot spend the grant (B1a)", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadOrigins();
+  try {
+    const origins = await bundle.import();
+    await origins.raiseAccessRequest(urlOf(), "session:A");
+    origins.resolveOrigin(ORIGIN, "once");
+    await flush();
+    // Session B's open carries B's identity and its own command id: neither
+    // the grant's requester nor its handoff — refused, and the grant is NOT
+    // consumed by the attempt (fail-closed, not fail-shared).
+    await assert.rejects(
+      origins.ensureTopLevelAccess(urlOf(), "cmd-B-1", "session:B"),
+      (error) => error.code === "origin_not_allowed",
+    );
+    const admission = await origins.ensureTopLevelAccess(urlOf(), "cmd-nav-1", "session:A");
+    assert.equal(admission.allowed, true, "A's grant survives B's refused attempt");
+  } finally {
+    await bundle.close();
+    chrome.restore();
+  }
+});
+
+test("a raw-RPC caller spends its grant via the command-id handoff", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadOrigins();
+  try {
+    const origins = await bundle.import();
+    // No session identity (raw caller): requester IS the command id.
+    await origins.raiseAccessRequest(urlOf(), "r-abc123");
+    origins.resolveOrigin(ORIGIN, "once");
+    await flush();
+    // The SAME command id navigating (the handoff) is admitted; a different
+    // id with no session identity is not.
+    const admission = await origins.ensureTopLevelAccess(urlOf(), "r-abc123");
+    assert.deepEqual(admission, { allowed: true, viaOnceGrant: true });
   } finally {
     await bundle.close();
     chrome.restore();

--- a/extension/tests/origins.integration.test.mjs
+++ b/extension/tests/origins.integration.test.mjs
@@ -135,6 +135,10 @@ test("a once-grant is consumed exactly once, and only by its requester", async (
     assert.equal(await origins.consumeOnceGrant(urlOf(), "req-A"), true);
     // Exactly once.
     assert.equal(await origins.consumeOnceGrant(urlOf(), "req-A"), false);
+    // A spent grant's resolved request receipt is gone too: otherwise a later
+    // request_access would read decision="once" as allowed and silently turn
+    // one approval into a second admission (caught by the real E2E).
+    assert.equal(chrome.session("accessRequest"), undefined);
   } finally {
     await bundle.close();
     chrome.restore();
@@ -243,8 +247,14 @@ test("a replaced request leaves a tombstone its owner reads as superseded", asyn
     await flush();
     const record = chrome.session("accessRequest");
     assert.equal(record.origin, "https://other.example");
-    const tombs = chrome.session("accessTombstones");
+    let tombs = chrome.session("accessTombstones");
     assert.equal(tombs[ORIGIN].requester, "req-A", "the receipt names the displaced requester");
+    // A deliberately fresh request by displaced A consumes that receipt. If
+    // it survived, the NEW request's later TTL expiry would incorrectly read
+    // "superseded" rather than "none" (also caught by the real E2E).
+    await origins.raiseAccessRequest(urlOf(), "req-A");
+    tombs = chrome.session("accessTombstones");
+    assert.equal(tombs[ORIGIN], undefined);
   } finally {
     await bundle.close();
     chrome.restore();

--- a/extension/tests/origins.integration.test.mjs
+++ b/extension/tests/origins.integration.test.mjs
@@ -1,0 +1,209 @@
+/* Integration tests at the origins.ts seam: the dual-resolve decision path
+ * (popup → resolveOrigin → BOTH the in-command `waiting` map and the async
+ * record), exactly-once requester-bound grant consumption, deny persistence
+ * across a simulated worker restart, and supersession tombstones — driven
+ * against the REAL origins.ts/state.ts/access-flow.ts modules with a stubbed
+ * chrome.* (round-1 M2: the pure helpers were tested, but nothing exercised
+ * their composition; the Python tool tests mock the wire, so a regression
+ * here would ship with all suites green).
+ *
+ * The chrome stub is deliberately minimal and HONEST: session/local storage
+ * are in-memory Maps with the real API's get/set/remove shape, so a "worker
+ * restart" re-import evaluates module-level state fresh against the SAME
+ * storage — MV3 kills the worker, not the storage, which is the seam's most
+ * failure-prone property. */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function installChromeStub() {
+  const areas = { session: new Map(), local: new Map() };
+  const listeners = [];
+  const makeArea = (name) => ({
+    get: async (keys) => {
+      const out = {};
+      for (const key of Array.isArray(keys) ? keys : [keys]) {
+        if (areas[name].has(key)) out[key] = areas[name].get(key);
+      }
+      return out;
+    },
+    set: async (obj) => {
+      const changes = {};
+      for (const [key, value] of Object.entries(obj)) {
+        changes[key] = { oldValue: areas[name].get(key), newValue: value };
+        areas[name].set(key, value);
+      }
+      for (const listener of listeners) listener(changes, name);
+    },
+    remove: async (keys) => {
+      const changes = {};
+      for (const key of Array.isArray(keys) ? keys : [keys]) {
+        changes[key] = { oldValue: areas[name].get(key), newValue: undefined };
+        areas[name].delete(key);
+      }
+      for (const listener of listeners) listener(changes, name);
+    },
+  });
+  globalThis.chrome = {
+    storage: {
+      session: makeArea("session"),
+      local: makeArea("local"),
+      onChanged: { addListener: (fn) => listeners.push(fn) },
+    },
+    action: {
+      setBadgeBackgroundColor: async () => {},
+      setBadgeText: async () => {},
+      setTitle: async () => {},
+    },
+    alarms: { create: () => {} },
+    debugger: {
+      onEvent: { addListener: () => {}, removeListener: () => {} },
+      // cdp.ts registers an onDetach listener at MODULE level to drop its
+      // attached-tab set when the user detaches the debugger; the stub needs
+      // it for the import to evaluate at all.
+      onDetach: { addListener: () => {} },
+      sendCommand: async () => ({}),
+    },
+  };
+  const session = (key) => areas.session.get(key);
+  return { session, areas, restore: () => { delete globalThis.chrome; } };
+}
+
+async function loadOrigins() {
+  const dir = await mkdtemp(join(tmpdir(), "lop-origins-it-"));
+  const outfile = join(dir, "module.mjs");
+  await build({
+    entryPoints: ["src/origins.ts"],
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    outfile,
+  });
+  return {
+    import: (tag = "") => import(pathToFileURL(outfile) + (tag ? `?${tag}` : "")),
+    close: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+const ORIGIN = "https://example.com";
+const urlOf = (href = ORIGIN + "/page") => new URL(href);
+
+test("one popup decision resolves the in-command wait AND the async record", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadOrigins();
+  try {
+    const origins = await bundle.import();
+    await origins.raiseAccessRequest(urlOf(), "req-A");
+    // An in-command redirect hop for the SAME origin is parked on `waiting`.
+    let inCommand = null;
+    const hop = origins.askOrigin(urlOf(), "cmd-9").then((ok) => { inCommand = ok; });
+    await flush();
+    origins.resolveOrigin(ORIGIN, "once");
+    await hop;
+    assert.equal(inCommand, true, "the in-command wait must resolve from the same click");
+    await flush();
+    const record = chrome.session("accessRequest");
+    assert.equal(record.decision, "once");
+    assert.equal(record.requester, "req-A");
+    const grants = chrome.session("onceGrants");
+    assert.equal(grants[ORIGIN].requester, "req-A", "grant bound to the asking requester");
+  } finally {
+    await bundle.close();
+    chrome.restore();
+  }
+});
+
+test("a once-grant is consumed exactly once, and only by its requester", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadOrigins();
+  try {
+    const origins = await bundle.import();
+    await origins.raiseAccessRequest(urlOf(), "req-A");
+    origins.resolveOrigin(ORIGIN, "once");
+    await flush();
+    // Another session cannot spend it (fail-closed, not fail-shared).
+    assert.equal(await origins.consumeOnceGrant(urlOf(), "req-B"), false);
+    // An anonymous caller cannot spend it either.
+    assert.equal(await origins.consumeOnceGrant(urlOf(), ""), false);
+    // Refusals did not consume: the owner still can.
+    assert.equal(await origins.consumeOnceGrant(urlOf(), "req-A"), true);
+    // Exactly once.
+    assert.equal(await origins.consumeOnceGrant(urlOf(), "req-A"), false);
+  } finally {
+    await bundle.close();
+    chrome.restore();
+  }
+});
+
+test("admission consumes the grant once and navigate never re-consults it (M1)", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadOrigins();
+  try {
+    const origins = await bundle.import();
+    await origins.raiseAccessRequest(urlOf(), "req-A");
+    origins.resolveOrigin(ORIGIN, "once");
+    await flush();
+    const admission = await origins.ensureTopLevelAccess(urlOf(), "req-A");
+    assert.deepEqual(admission, { allowed: true, viaOnceGrant: true });
+    // The grant is spent AT ADMISSION: a second admission for the same
+    // requester must now take the early-fail path, not find a stale grant.
+    await assert.rejects(
+      origins.ensureTopLevelAccess(urlOf(), "req-A"),
+      (error) => error.code === "origin_not_allowed",
+    );
+  } finally {
+    await bundle.close();
+    chrome.restore();
+  }
+});
+
+test("deny persists across a worker restart via session storage", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadOrigins();
+  try {
+    let origins = await bundle.import();
+    await origins.raiseAccessRequest(urlOf(), "req-A");
+    origins.resolveOrigin(ORIGIN, "deny");
+    await flush();
+    // "Worker restart": re-import resets module-level state (the `waiting`
+    // map) but the record must still gate — the whole reason the record
+    // lives in session storage, not memory.
+    origins = await bundle.import("restart");
+    const record = chrome.session("accessRequest");
+    assert.equal(record.decision, "deny");
+    // A fresh admission for a denied origin still fails early: the deny is a
+    // cool-down, not an allow.
+    await assert.rejects(
+      origins.ensureTopLevelAccess(urlOf(), "req-A"),
+      (error) => error.code === "origin_not_allowed",
+    );
+  } finally {
+    await bundle.close();
+    chrome.restore();
+  }
+});
+
+test("a replaced request leaves a tombstone its owner reads as superseded", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadOrigins();
+  try {
+    const origins = await bundle.import();
+    await origins.raiseAccessRequest(urlOf(), "req-A");
+    // Session B's request for a DIFFERENT origin takes the single prompt slot.
+    await origins.raiseAccessRequest(urlOf("https://other.example/x"), "req-B");
+    await flush();
+    const record = chrome.session("accessRequest");
+    assert.equal(record.origin, "https://other.example");
+    const tombs = chrome.session("accessTombstones");
+    assert.equal(tombs[ORIGIN].requester, "req-A", "the receipt names the displaced requester");
+  } finally {
+    await bundle.close();
+    chrome.restore();
+  }
+});

--- a/extension/tests/origins.integration.test.mjs
+++ b/extension/tests/origins.integration.test.mjs
@@ -393,3 +393,84 @@ test("resolveOrigin settles only after the decision is durable (M2)", async () =
     chrome.restore();
   }
 });
+
+test("a queued same-origin replacement cannot be decided by a stale click (R3-B1 TOCTOU)", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadOrigins();
+  try {
+    const origins = await bundle.import();
+    await origins.raiseAccessRequest(urlOf(), "session:A");
+    const stalePrompt = chrome.session("pendingOrigin");
+    // The reviewer's interleaving: B's same-origin replacement enters the
+    // mutation queue FIRST and pauses mid-write; the stale A click validates
+    // against the OLD prompt while B is queued; B then installs its fresh
+    // generation; the stale click must NOT apply to it.
+    const realSet = globalThis.chrome.storage.session.set;
+    let releaseB;
+    const gateB = new Promise((resolve) => { releaseB = resolve; });
+    globalThis.chrome.storage.session.set = async (obj) => {
+      if (obj && obj.accessRequest && obj.accessRequest.requester === "session:B") {
+        await gateB; // B paused INSIDE its queued mutation, after A's validation
+      }
+      const changes = {};
+      for (const [key, value] of Object.entries(obj || {})) {
+        changes[key] = { newValue: value };
+        chrome.areas.session.set(key, value);
+      }
+      void realSet;
+    };
+    // B's raise enters the queue and parks on the gate.
+    const raiseB = origins.raiseAccessRequest(urlOf(), "session:B");
+    await new Promise((resolve) => setTimeout(resolve, 20)); // B queued + parked
+    // A's stale click (old generation) is delivered and — pre-fix — validated
+    // OUTSIDE the queue, then queued behind B's parked mutation.
+    const staleClick = origins.resolveOrigin(ORIGIN, "once", stalePrompt.promptId);
+    await new Promise((resolve) => setTimeout(resolve, 20)); // stale click queued behind B
+    releaseB();
+    const applied = await staleClick;
+    await raiseB;
+    globalThis.chrome.storage.session.set = realSet;
+    // The invariant: the stale click did NOT decide B's request.
+    assert.equal(applied, false, "stale click must be rejected, not applied to B");
+    const record = chrome.session("accessRequest");
+    assert.equal(record.requester, "session:B");
+    assert.equal(record.decision, undefined, "B's request is still undecided");
+    const grants = chrome.session("onceGrants");
+    assert.ok(!grants || !grants[ORIGIN], "no grant minted for B from A's stale click");
+    // B's CURRENT generation still decides normally afterwards.
+    const current = chrome.session("pendingOrigin");
+    assert.notEqual(current.promptId, stalePrompt.promptId);
+    const appliedNow = await origins.resolveOrigin(ORIGIN, "once", current.promptId);
+    assert.equal(appliedNow, true);
+    const grantsNow = chrome.session("onceGrants");
+    assert.equal(grantsNow[ORIGIN].requester, "session:B", "grant for B, by B's click");
+  } finally {
+    await bundle.close();
+    chrome.restore();
+  }
+});
+
+test("duplicate current-generation delivery is idempotent (R3-B1)", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadOrigins();
+  try {
+    const origins = await bundle.import();
+    await origins.raiseAccessRequest(urlOf(), "session:A");
+    const prompt = chrome.session("pendingOrigin");
+    const first = await origins.resolveOrigin(ORIGIN, "once", prompt.promptId);
+    const second = await origins.resolveOrigin(ORIGIN, "once", prompt.promptId);
+    assert.equal(first, true);
+    // The duplicate is a NO-OP, not an error: the prompt record is consumed
+    // by the first decision, so the re-delivery finds nothing live and is
+    // rejected as stale — with no side effects (the grant below is untouched).
+    assert.equal(second, false, "duplicate delivery applies nothing");
+    const grants = chrome.session("onceGrants");
+    assert.ok(grants && grants[ORIGIN], "exactly one grant object");
+    assert.equal(grants[ORIGIN].expiresAt, grants[ORIGIN].expiresAt);
+    const record = chrome.session("accessRequest");
+    assert.equal(record.decision, "once");
+  } finally {
+    await bundle.close();
+    chrome.restore();
+  }
+});

--- a/extension/tests/origins.integration.test.mjs
+++ b/extension/tests/origins.integration.test.mjs
@@ -104,7 +104,7 @@ test("one popup decision resolves the in-command wait AND the async record", asy
     let inCommand = null;
     const hop = origins.askOrigin(urlOf(), "cmd-9").then((ok) => { inCommand = ok; });
     await flush();
-    origins.resolveOrigin(ORIGIN, "once");
+    await origins.resolveOrigin(ORIGIN, "once");
     await hop;
     assert.equal(inCommand, true, "the in-command wait must resolve from the same click");
     await flush();
@@ -125,8 +125,7 @@ test("a once-grant is consumed exactly once, and only by its requester", async (
   try {
     const origins = await bundle.import();
     await origins.raiseAccessRequest(urlOf(), "req-A");
-    origins.resolveOrigin(ORIGIN, "once");
-    await flush();
+    await origins.resolveOrigin(ORIGIN, "once");
     // Another session cannot spend it (fail-closed, not fail-shared).
     assert.equal(await origins.consumeOnceGrant(urlOf(), "req-B"), false);
     // An anonymous caller cannot spend it either.
@@ -151,8 +150,7 @@ test("admission consumes the grant once and navigate never re-consults it (M1)",
   try {
     const origins = await bundle.import();
     await origins.raiseAccessRequest(urlOf(), "session:A");
-    origins.resolveOrigin(ORIGIN, "once");
-    await flush();
+    await origins.resolveOrigin(ORIGIN, "once");
     // Session A's own navigation (session identity matches the grant).
     const admission = await origins.ensureTopLevelAccess(urlOf(), "cmd-nav-1", "session:A");
     assert.deepEqual(admission, { allowed: true, viaOnceGrant: true });
@@ -174,8 +172,7 @@ test("a parallel session's navigation cannot spend the grant (B1a)", async () =>
   try {
     const origins = await bundle.import();
     await origins.raiseAccessRequest(urlOf(), "session:A");
-    origins.resolveOrigin(ORIGIN, "once");
-    await flush();
+    await origins.resolveOrigin(ORIGIN, "once");
     // Session B's open carries B's identity and its own command id: neither
     // the grant's requester nor its handoff — refused, and the grant is NOT
     // consumed by the attempt (fail-closed, not fail-shared).
@@ -198,8 +195,7 @@ test("a raw-RPC caller spends its grant via the command-id handoff", async () =>
     const origins = await bundle.import();
     // No session identity (raw caller): requester IS the command id.
     await origins.raiseAccessRequest(urlOf(), "r-abc123");
-    origins.resolveOrigin(ORIGIN, "once");
-    await flush();
+    await origins.resolveOrigin(ORIGIN, "once");
     // The SAME command id navigating (the handoff) is admitted; a different
     // id with no session identity is not.
     const admission = await origins.ensureTopLevelAccess(urlOf(), "r-abc123");
@@ -216,8 +212,7 @@ test("deny persists across a worker restart via session storage", async () => {
   try {
     let origins = await bundle.import();
     await origins.raiseAccessRequest(urlOf(), "req-A");
-    origins.resolveOrigin(ORIGIN, "deny");
-    await flush();
+    await origins.resolveOrigin(ORIGIN, "deny");
     // "Worker restart": re-import resets module-level state (the `waiting`
     // map) but the record must still gate — the whole reason the record
     // lives in session storage, not memory.
@@ -247,14 +242,152 @@ test("a replaced request leaves a tombstone its owner reads as superseded", asyn
     await flush();
     const record = chrome.session("accessRequest");
     assert.equal(record.origin, "https://other.example");
+    const keyA = `${ORIGIN}\nreq-A`;
     let tombs = chrome.session("accessTombstones");
-    assert.equal(tombs[ORIGIN].requester, "req-A", "the receipt names the displaced requester");
+    assert.equal(tombs[keyA].requester, "req-A", "the receipt names the displaced requester");
     // A deliberately fresh request by displaced A consumes that receipt. If
     // it survived, the NEW request's later TTL expiry would incorrectly read
     // "superseded" rather than "none" (also caught by the real E2E).
     await origins.raiseAccessRequest(urlOf(), "req-A");
     tombs = chrome.session("accessTombstones");
-    assert.equal(tombs[ORIGIN], undefined);
+    assert.equal(tombs[keyA], undefined);
+  } finally {
+    await bundle.close();
+    chrome.restore();
+  }
+});
+
+test("a stale prompt generation cannot approve the replacement origin (B1)", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadOrigins();
+  try {
+    const origins = await bundle.import();
+    // Session A's prompt renders; the popup captures ITS generation.
+    await origins.raiseAccessRequest(urlOf(), "session:A");
+    const stale = chrome.session("pendingOrigin");
+    assert.ok(stale.promptId, "every prompt carries a generation id");
+    // Session B replaces the slot with a DIFFERENT origin before the click.
+    await origins.raiseAccessRequest(urlOf("https://other.example/x"), "session:B");
+    const live = chrome.session("pendingOrigin");
+    assert.notEqual(live.promptId, stale.promptId);
+    // The user clicks Allow on the popup still showing A: the decision names
+    // A's origin and A's generation. Origin no longer matches the live
+    // prompt -> rejected; nothing resolves, no grant is minted for EITHER.
+    const applied = await origins.resolveOrigin(ORIGIN, "once", stale.promptId);
+    assert.equal(applied, false, "stale-generation decision must be rejected");
+    assert.equal(chrome.session("onceGrants"), undefined, "no grant minted");
+    const record = chrome.session("accessRequest");
+    assert.equal(record.origin, "https://other.example");
+    assert.equal(record.decision, undefined, "B's request is still undecided");
+    // Same-origin replacement: B re-raises A's origin (new generation). The
+    // old generation still must not decide the new prompt.
+    await origins.raiseAccessRequest(urlOf(), "session:B");
+    const applied2 = await origins.resolveOrigin(ORIGIN, "once", stale.promptId);
+    assert.equal(applied2, false, "old generation rejected even on same origin");
+    // The CURRENT generation decides normally.
+    const current = chrome.session("pendingOrigin");
+    const applied3 = await origins.resolveOrigin(ORIGIN, "once", current.promptId);
+    assert.equal(applied3, true);
+  } finally {
+    await bundle.close();
+    chrome.restore();
+  }
+});
+
+test("two concurrent navigations cannot double-spend one grant (B2)", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadOrigins();
+  try {
+    const origins = await bundle.import();
+    await origins.raiseAccessRequest(urlOf(), "session:A");
+    await origins.resolveOrigin(ORIGIN, "once");
+    // The reviewer's reproduction: two same-session navigations dispatched
+    // concurrently (different #321 tabs -> different daemon locks). Exactly
+    // ONE may consume; the loser takes the typed early-fail.
+    const results = await Promise.allSettled([
+      origins.ensureTopLevelAccess(urlOf(), "cmd-1", "session:A"),
+      origins.ensureTopLevelAccess(urlOf(), "cmd-2", "session:A"),
+    ]);
+    const admitted = results.filter((r) => r.status === "fulfilled");
+    const refused = results.filter(
+      (r) => r.status === "rejected" && r.reason.code === "origin_not_allowed",
+    );
+    assert.equal(admitted.length, 1, `exactly one winner, got ${admitted.length}`);
+    assert.equal(refused.length, 1, "the loser fails typed, not silently");
+    assert.deepEqual(admitted[0].value, { allowed: true, viaOnceGrant: true });
+  } finally {
+    await bundle.close();
+    chrome.restore();
+  }
+});
+
+test("A->B->C same-origin supersession keeps every displaced receipt (M1)", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadOrigins();
+  try {
+    const origins = await bundle.import();
+    // Three sessions race the SAME origin's single prompt slot.
+    await origins.raiseAccessRequest(urlOf(), "session:A");
+    await origins.raiseAccessRequest(urlOf(), "session:B");
+    await origins.raiseAccessRequest(urlOf(), "session:C");
+    const tombs = chrome.session("accessTombstones");
+    // A per-origin key overwrote A's receipt with B's; per origin+requester
+    // keys keep both (round-2 M1).
+    assert.ok(tombs[`${ORIGIN}\nsession:A`], "A's receipt survives C's raise");
+    assert.ok(tombs[`${ORIGIN}\nsession:B`], "B's receipt exists");
+    const record = chrome.session("accessRequest");
+    assert.equal(record.requester, "session:C", "C owns the live prompt");
+  } finally {
+    await bundle.close();
+    chrome.restore();
+  }
+});
+
+test("A->B->C different-origin chain also keeps both receipts (M1)", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadOrigins();
+  try {
+    const origins = await bundle.import();
+    await origins.raiseAccessRequest(urlOf(), "session:A");
+    await origins.raiseAccessRequest(urlOf("https://b.example/"), "session:B");
+    await origins.raiseAccessRequest(urlOf("https://c.example/"), "session:C");
+    const tombs = chrome.session("accessTombstones");
+    assert.ok(tombs[`${ORIGIN}\nsession:A`]);
+    assert.ok(tombs["https://b.example\nsession:B"]);
+  } finally {
+    await bundle.close();
+    chrome.restore();
+  }
+});
+
+test("resolveOrigin settles only after the decision is durable (M2)", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadOrigins();
+  try {
+    const origins = await bundle.import();
+    await origins.raiseAccessRequest(urlOf(), "session:A");
+    // Worker-suspension-shaped delay: every storage WRITE lands late, the
+    // way a busy event loop orders them just before MV3 suspension. The
+    // promise the message listener keeps alive must not settle until those
+    // writes are actually applied.
+    const realSet = chrome.areas.session.set;
+    globalThis.chrome.storage.session.set = async (obj) => {
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      const changes = {};
+      for (const [key, value] of Object.entries(obj)) {
+        changes[key] = { newValue: value };
+        chrome.areas.session.set(key, value);
+      }
+    };
+    const applied = await origins.resolveOrigin(ORIGIN, "once");
+    assert.equal(applied, true);
+    // The moment resolveOrigin settles, the decision and grant are READABLE:
+    // nothing is still in flight for suspension to lose.
+    assert.equal(chrome.session("accessRequest").decision, "once", "decision durably recorded");
+    const grants = chrome.session("onceGrants");
+    assert.ok(grants && grants[ORIGIN], "grant durably minted before settle");
+    assert.equal(grants[ORIGIN].requester, "session:A");
+    void realSet;
   } finally {
     await bundle.close();
     chrome.restore();

--- a/extension/tests/pure.test.mjs
+++ b/extension/tests/pure.test.mjs
@@ -173,6 +173,68 @@ test("origin decision acks render per decision, deny staying neutral", async () 
   } finally { await module.close(); }
 });
 
+test("access request verdicts: idempotent repeat, replace on new origin, deny cool-down", async () => {
+  const module = await load("src/access-flow.ts");
+  try {
+    const { requestVerdict, newRequest, ACCESS_REQUEST_TTL_MS } = module.loaded;
+    const now = 1_000_000;
+    const record = newRequest("https://a.example", "a.example", now);
+    // Already allowed (stored or once-grant) short-circuits without a prompt.
+    assert.equal(requestVerdict(undefined, true, false, "https://a.example", now), "allowed");
+    assert.equal(requestVerdict(undefined, false, true, "https://a.example", now), "allowed");
+    // No record: raise a fresh prompt.
+    assert.equal(requestVerdict(undefined, false, false, "https://a.example", now), "raise");
+    // Repeat for the SAME pending origin is idempotent — pending, TTL kept.
+    assert.equal(requestVerdict(record, false, false, "https://a.example", now + 1), "pending");
+    // A DIFFERENT origin replaces (single popup slot), never queues.
+    assert.equal(requestVerdict(record, false, false, "https://b.example", now + 1), "raise");
+    // A fresh deny answers denied without re-prompting (no nagging retries)...
+    const denied = { ...record, decision: "deny" };
+    assert.equal(requestVerdict(denied, false, false, "https://a.example", now + 1), "denied");
+    // ...until the TTL cool-down lapses, when a deliberate re-ask may raise.
+    assert.equal(
+      requestVerdict(denied, false, false, "https://a.example", now + ACCESS_REQUEST_TTL_MS),
+      "raise",
+    );
+  } finally { await module.close(); }
+});
+
+test("access state machine: pending, resolve paths, TTL expiry, grants", async () => {
+  const module = await load("src/access-flow.ts");
+  try {
+    const { accessState, activeRequest, newRequest, onceGrantActive, ACCESS_REQUEST_TTL_MS } =
+      module.loaded;
+    const now = 5_000_000;
+    const record = newRequest("https://a.example", "a.example", now);
+    // Undecided and live: pending — the only state await_access blocks on.
+    assert.equal(accessState(record, false, false, "https://a.example", now + 1), "pending");
+    // Each decision resolves to its terminal state.
+    assert.equal(
+      accessState({ ...record, decision: "once" }, false, false, "https://a.example", now),
+      "allowed",
+    );
+    assert.equal(
+      accessState({ ...record, decision: "always" }, false, false, "https://a.example", now),
+      "allowed",
+    );
+    assert.equal(
+      accessState({ ...record, decision: "deny" }, false, false, "https://a.example", now),
+      "denied",
+    );
+    // Past the TTL the record reads as absent — "none", never a stale pending.
+    const later = now + ACCESS_REQUEST_TTL_MS;
+    assert.equal(activeRequest(record, later), undefined);
+    assert.equal(accessState(record, false, false, "https://a.example", later), "none");
+    // A record for another origin is not this origin's request.
+    assert.equal(accessState(record, false, false, "https://b.example", now), "none");
+    // Once-grants: live inside their window, dead past it.
+    const grants = { "https://a.example": now + 60_000 };
+    assert.equal(onceGrantActive(grants, "https://a.example", now), true);
+    assert.equal(onceGrantActive(grants, "https://a.example", now + 60_000), false);
+    assert.equal(onceGrantActive(grants, "https://b.example", now), false);
+  } finally { await module.close(); }
+});
+
 test("origin render holds the ack through the decision round-trip race", async () => {
   const module = await load("src/popup/origin-flow.ts");
   try {

--- a/extension/tests/pure.test.mjs
+++ b/extension/tests/pure.test.mjs
@@ -160,7 +160,11 @@ test("origin decision acks render per decision, deny staying neutral", async () 
     const { ackForDecision } = module.loaded;
     const once = ackForDecision("once");
     assert.equal(once.title, "Site allowed.");
-    assert.equal(once.sub, "The agent is continuing.");
+    // The once-ack names the async grant's real semantics: the NEXT visit,
+    // within the 10-minute grant window (n2 — the old "The agent is
+    // continuing." copy was written for the in-flight navigation case).
+    assert.match(once.sub, /next visit/);
+    assert.match(once.sub, /10 minutes/);
     assert.deepEqual([once.tone, once.check], ["success", true]);
     // "always" is a standing grant: the ack must say it persists and where to
     // revoke it.
@@ -178,60 +182,76 @@ test("access request verdicts: idempotent repeat, replace on new origin, deny co
   try {
     const { requestVerdict, newRequest, ACCESS_REQUEST_TTL_MS } = module.loaded;
     const now = 1_000_000;
-    const record = newRequest("https://a.example", "a.example", now);
+    const record = newRequest("https://a.example", "a.example", "req-A", now);
     // Already allowed (stored or once-grant) short-circuits without a prompt.
-    assert.equal(requestVerdict(undefined, true, false, "https://a.example", now), "allowed");
-    assert.equal(requestVerdict(undefined, false, true, "https://a.example", now), "allowed");
+    assert.equal(requestVerdict(undefined, true, false, "https://a.example", "req-A", now), "allowed");
+    assert.equal(requestVerdict(undefined, false, true, "https://a.example", "req-A", now), "allowed");
     // No record: raise a fresh prompt.
-    assert.equal(requestVerdict(undefined, false, false, "https://a.example", now), "raise");
-    // Repeat for the SAME pending origin is idempotent — pending, TTL kept.
-    assert.equal(requestVerdict(record, false, false, "https://a.example", now + 1), "pending");
+    assert.equal(requestVerdict(undefined, false, false, "https://a.example", "req-A", now), "raise");
+    // Repeat for the SAME pending origin BY THE SAME requester is idempotent —
+    // pending, TTL kept (no polling-extension).
+    assert.equal(requestVerdict(record, false, false, "https://a.example", "req-A", now + 1), "pending");
     // A DIFFERENT origin replaces (single popup slot), never queues.
-    assert.equal(requestVerdict(record, false, false, "https://b.example", now + 1), "raise");
+    assert.equal(requestVerdict(record, false, false, "https://b.example", "req-A", now + 1), "raise");
+    // The SAME origin from a DIFFERENT requester replaces too — the displaced
+    // requester reads "superseded" (B1b), never a silent steal.
+    assert.equal(requestVerdict(record, false, false, "https://a.example", "req-B", now + 1), "raise");
     // A fresh deny answers denied without re-prompting (no nagging retries)...
     const denied = { ...record, decision: "deny" };
-    assert.equal(requestVerdict(denied, false, false, "https://a.example", now + 1), "denied");
+    assert.equal(requestVerdict(denied, false, false, "https://a.example", "req-A", now + 1), "denied");
     // ...until the TTL cool-down lapses, when a deliberate re-ask may raise.
     assert.equal(
-      requestVerdict(denied, false, false, "https://a.example", now + ACCESS_REQUEST_TTL_MS),
+      requestVerdict(denied, false, false, "https://a.example", "req-A", now + ACCESS_REQUEST_TTL_MS),
       "raise",
     );
   } finally { await module.close(); }
 });
 
-test("access state machine: pending, resolve paths, TTL expiry, grants", async () => {
+test("access state machine: pending, resolve paths, TTL expiry, grants, supersession", async () => {
   const module = await load("src/access-flow.ts");
   try {
-    const { accessState, activeRequest, newRequest, onceGrantActive, ACCESS_REQUEST_TTL_MS } =
-      module.loaded;
+    const {
+      accessState, activeRequest, newRequest, consumableGrant, tombstoneFor, ACCESS_REQUEST_TTL_MS,
+    } = module.loaded;
     const now = 5_000_000;
-    const record = newRequest("https://a.example", "a.example", now);
+    const record = newRequest("https://a.example", "a.example", "req-A", now);
     // Undecided and live: pending — the only state await_access blocks on.
-    assert.equal(accessState(record, false, false, "https://a.example", now + 1), "pending");
+    assert.equal(accessState(record, undefined, false, false, "https://a.example", "req-A", now + 1), "pending");
     // Each decision resolves to its terminal state.
     assert.equal(
-      accessState({ ...record, decision: "once" }, false, false, "https://a.example", now),
+      accessState({ ...record, decision: "once" }, undefined, false, false, "https://a.example", "req-A", now),
       "allowed",
     );
     assert.equal(
-      accessState({ ...record, decision: "always" }, false, false, "https://a.example", now),
+      accessState({ ...record, decision: "always" }, undefined, false, false, "https://a.example", "req-A", now),
       "allowed",
     );
     assert.equal(
-      accessState({ ...record, decision: "deny" }, false, false, "https://a.example", now),
+      accessState({ ...record, decision: "deny" }, undefined, false, false, "https://a.example", "req-A", now),
       "denied",
     );
     // Past the TTL the record reads as absent — "none", never a stale pending.
     const later = now + ACCESS_REQUEST_TTL_MS;
     assert.equal(activeRequest(record, later), undefined);
-    assert.equal(accessState(record, false, false, "https://a.example", later), "none");
+    assert.equal(accessState(record, undefined, false, false, "https://a.example", "req-A", later), "none");
     // A record for another origin is not this origin's request.
-    assert.equal(accessState(record, false, false, "https://b.example", now), "none");
-    // Once-grants: live inside their window, dead past it.
-    const grants = { "https://a.example": now + 60_000 };
-    assert.equal(onceGrantActive(grants, "https://a.example", now), true);
-    assert.equal(onceGrantActive(grants, "https://a.example", now + 60_000), false);
-    assert.equal(onceGrantActive(grants, "https://b.example", now), false);
+    assert.equal(accessState(record, undefined, false, false, "https://b.example", "req-A", now), "none");
+    // Requester-bound grants: live for the owner inside the window; dead past
+    // it; INVISIBLE to another requester and to an anonymous caller (B1a).
+    const grants = { "https://a.example": { expiresAt: now + 60_000, requester: "req-A" } };
+    assert.ok(consumableGrant(grants, "https://a.example", "req-A", now));
+    assert.equal(consumableGrant(grants, "https://a.example", "req-A", now + 60_000), undefined);
+    assert.equal(consumableGrant(grants, "https://a.example", "req-B", now), undefined);
+    assert.equal(consumableGrant(grants, "https://a.example", "", now), undefined);
+    assert.equal(consumableGrant(grants, "https://b.example", "req-A", now), undefined);
+    // Supersession: the displaced requester reads "superseded" from the
+    // tombstone; anyone else reads the neutral "none"; past the tombstone's
+    // TTL the receipt is gone too.
+    const tomb = tombstoneFor(record);
+    const tombs = { "https://a.example": tomb };
+    assert.equal(accessState(undefined, tombs, false, false, "https://a.example", "req-A", now), "superseded");
+    assert.equal(accessState(undefined, tombs, false, false, "https://a.example", "req-B", now), "none");
+    assert.equal(accessState(undefined, tombs, false, false, "https://a.example", "req-A", later), "none");
   } finally { await module.close(); }
 });
 

--- a/extension/tests/pure.test.mjs
+++ b/extension/tests/pure.test.mjs
@@ -211,7 +211,8 @@ test("access state machine: pending, resolve paths, TTL expiry, grants, superses
   const module = await load("src/access-flow.ts");
   try {
     const {
-      accessState, activeRequest, newRequest, consumableGrant, tombstoneFor, ACCESS_REQUEST_TTL_MS,
+      accessState, activeRequest, newRequest, consumableGrant, tombstoneFor, receiptKey,
+      ACCESS_REQUEST_TTL_MS,
     } = module.loaded;
     const now = 5_000_000;
     const record = newRequest("https://a.example", "a.example", "req-A", now);
@@ -244,14 +245,20 @@ test("access state machine: pending, resolve paths, TTL expiry, grants, superses
     assert.equal(consumableGrant(grants, "https://a.example", "req-B", now), undefined);
     assert.equal(consumableGrant(grants, "https://a.example", "", now), undefined);
     assert.equal(consumableGrant(grants, "https://b.example", "req-A", now), undefined);
-    // Supersession: the displaced requester reads "superseded" from the
-    // tombstone; anyone else reads the neutral "none"; past the tombstone's
-    // TTL the receipt is gone too.
+    // Supersession: the displaced requester reads "superseded" from its OWN
+    // receipt (keyed origin+requester — round-2 M1); anyone else reads the
+    // neutral "none"; past the tombstone's TTL the receipt is gone too.
     const tomb = tombstoneFor(record);
-    const tombs = { "https://a.example": tomb };
+    const tombs = { [receiptKey("https://a.example", "req-A")]: tomb };
     assert.equal(accessState(undefined, tombs, false, false, "https://a.example", "req-A", now), "superseded");
     assert.equal(accessState(undefined, tombs, false, false, "https://a.example", "req-B", now), "none");
     assert.equal(accessState(undefined, tombs, false, false, "https://a.example", "req-A", later), "none");
+    // Requester-aware live verdicts (round-2 M1): a record resolved by A
+    // answers ONLY A. B asking about the same origin gets its receipt or
+    // none — never A's pending/allowed/denied.
+    const resolvedByA = { ...record, decision: "once" };
+    assert.equal(accessState(resolvedByA, undefined, false, false, "https://a.example", "req-B", now), "none");
+    assert.equal(accessState(record, undefined, false, false, "https://a.example", "req-B", now), "none");
   } finally { await module.close(); }
 });
 

--- a/local_operator/browser_bridge/backend.py
+++ b/local_operator/browser_bridge/backend.py
@@ -111,6 +111,25 @@ def format_error(error: BridgeError, *, action: str = "", surface: str = "") -> 
         # Under-specified close, not a fault: relay the extension's message,
         # which already names the (redacted) live handles.
         return error.message
+    if error.code == ErrorCode.ORIGIN_NOT_ALLOWED:
+        # The teaching error of the approval flow: it must name the exact next
+        # actions, because the failure it replaces (blocking the navigation on
+        # a popup prompt) had agents misread the bridge as broken while the
+        # prompt expired unseen. The url is echoed back so the agent can paste
+        # it into the follow-up calls without re-deriving it. The agent is the
+        # PRIMARY notification channel — Chrome's own banner is best-effort
+        # (macOS frequently suppresses it without Notification Center
+        # authorization), so the instruction to message the user is load-
+        # bearing, not politeness.
+        origin = str(error.data.get("origin") or _origin(str(error.data.get("url", ""))))
+        url = str(error.data.get("url") or origin)
+        return (
+            f"site {origin or '(unknown origin)'} is not allowed yet. Call browser "
+            f"action='request_access' url={url} to raise the approval prompt, then NOTIFY "
+            "THE USER (via the ask tool or a message) to approve it in the Local Operator "
+            "extension popup — the popup badge alone is not reliably seen — and only then "
+            f"action='await_access' url={url} to wait for the decision."
+        )
     if error.code == ErrorCode.INTERNAL and error.data.get("tab_crashed"):
         return (
             f"the browser tab crashed while {action or 'the action'} was running. "

--- a/local_operator/browser_bridge/daemon.py
+++ b/local_operator/browser_bridge/daemon.py
@@ -492,7 +492,17 @@ class BridgeService:
         # Commands that name no tab (open, status, tabs) serialize on a shared
         # key so a fresh open cannot race another open past the surface cap, and
         # a listing cannot interleave with an open's map write.
-        tab_key = str(request.params.get("tab") or "__global__")
+        #
+        # The access-flow methods get their OWN key instead of joining the
+        # global one: they never touch a tab or the surface map, and on the
+        # global key an await_access slice (up to 20 s of polling a human's
+        # decision) would block every other session's open behind a wait on a
+        # human. Their own key still serializes them against each other, which
+        # the single pending-prompt slot wants anyway.
+        if request.method in ("request_access", "await_access"):
+            tab_key = "__access__"
+        else:
+            tab_key = str(request.params.get("tab") or "__global__")
         lock = self._tab_locks.setdefault(tab_key, asyncio.Lock())
         async with lock:
             response = await self._dispatch_locked(request)

--- a/local_operator/browser_bridge/daemon.py
+++ b/local_operator/browser_bridge/daemon.py
@@ -526,6 +526,21 @@ class BridgeService:
     async def _dispatch_serialized(self, request: Request) -> JSONResponse:
         tab_key = self.lock_key_for(request)
         lock = self._tab_locks.setdefault(tab_key, asyncio.Lock())
+        # A per-request await key is used exactly once (request ids are
+        # unique) and MUST be evicted on every exit path — success, typed
+        # error, timeout, AND cancellation (client disconnect surfaces as
+        # CancelledError inside the HTTP handler). Evicting only after a
+        # normal return was round-3 M1: a cancelled parked await propagated
+        # past the eviction line and permanently retained its unique key, so
+        # repeated disconnects grew the lock map without bound. The `finally`
+        # block covers all exits; the pop is unconditional because no other
+        # request can ever share a per-request key.
+        if request.method == "await_access":
+            try:
+                async with lock:
+                    return await self._dispatch_locked(request)
+            finally:
+                self._tab_locks.pop(tab_key, None)
         async with lock:
             response = await self._dispatch_locked(request)
         # Per-tab keys used to be near-singleton; with every opened tab minting
@@ -534,11 +549,6 @@ class BridgeService:
         # unlocked-and-unwaited means a later command for the same (now dead)
         # handle can safely mint a fresh Lock.
         if request.method == "close" and tab_key != "__global__" and not lock.locked():
-            self._tab_locks.pop(tab_key, None)
-        # A per-request await key is used exactly once (request ids are
-        # unique); without eviction every await_access would leave a Lock in
-        # the map for the daemon's lifetime.
-        if request.method == "await_access":
             self._tab_locks.pop(tab_key, None)
         return response
 

--- a/local_operator/browser_bridge/daemon.py
+++ b/local_operator/browser_bridge/daemon.py
@@ -493,16 +493,38 @@ class BridgeService:
         # key so a fresh open cannot race another open past the surface cap, and
         # a listing cannot interleave with an open's map write.
         #
-        # The access-flow methods get their OWN key instead of joining the
-        # global one: they never touch a tab or the surface map, and on the
-        # global key an await_access slice (up to 20 s of polling a human's
-        # decision) would block every other session's open behind a wait on a
-        # human. Their own key still serializes them against each other, which
-        # the single pending-prompt slot wants anyway.
-        if request.method in ("request_access", "await_access"):
-            tab_key = "__access__"
-        else:
-            tab_key = str(request.params.get("tab") or "__global__")
+        # The access-flow methods never join the global key: they touch no tab
+        # and no surface map, and on the global key an await_access slice (up
+        # to 20 s of polling a human's decision) would block every session's
+        # open behind a wait on a human.
+        #
+        # await_access takes NO shared lock at all (a per-request key that
+        # nothing else uses): its extension side only READS state, and every
+        # extension-side mutation is serialized by the worker's own session-
+        # mutation queue (state.ts withSessionMutation), so daemon-side
+        # serialization adds nothing. Sharing __access__ with request_access
+        # was round-2 M3: one waiting session queued every other session's
+        # request/replace behind its 20 s slice, defeating the supersession
+        # design and stacking waiters toward the HTTP timeout.
+        #
+        # request_access keeps a shared short key: raise/replace is a
+        # read-modify-write of the single prompt slot, and two concurrent
+        # raises interleaving daemon-side would make the supersession receipts
+        # nondeterministic. It never waits on a human, so the hold is ms.
+        return await self._dispatch_serialized(request)
+
+    @staticmethod
+    def lock_key_for(request: Request) -> str:
+        """The serialization key one RPC dispatches under (see the comment
+        above; a separate method so the lock topology is directly testable)."""
+        if request.method == "await_access":
+            return f"__await__:{request.id}"
+        if request.method == "request_access":
+            return "__access__"
+        return str(request.params.get("tab") or "__global__")
+
+    async def _dispatch_serialized(self, request: Request) -> JSONResponse:
+        tab_key = self.lock_key_for(request)
         lock = self._tab_locks.setdefault(tab_key, asyncio.Lock())
         async with lock:
             response = await self._dispatch_locked(request)
@@ -512,6 +534,11 @@ class BridgeService:
         # unlocked-and-unwaited means a later command for the same (now dead)
         # handle can safely mint a fresh Lock.
         if request.method == "close" and tab_key != "__global__" and not lock.locked():
+            self._tab_locks.pop(tab_key, None)
+        # A per-request await key is used exactly once (request ids are
+        # unique); without eviction every await_access would leave a Lock in
+        # the map for the daemon's lifetime.
+        if request.method == "await_access":
             self._tab_locks.pop(tab_key, None)
         return response
 

--- a/local_operator/browser_bridge/protocol.py
+++ b/local_operator/browser_bridge/protocol.py
@@ -42,6 +42,17 @@ METHODS = (
     "tabs",
     "scroll",
     "logs",
+    # Site-permission flow (agent-legible approvals). ``request_access`` raises
+    # the pending approval in the extension and returns immediately;
+    # ``await_access`` blocks for a BOUNDED slice (the extension caps it well
+    # under the command timeout) and the tool loops slices client-side. Split
+    # this way because the old design — one navigation RPC that silently sat
+    # on the 60 s popup prompt — expired unseen (the agent never got a turn to
+    # tell the user to look at the popup) and made the session client time out
+    # with a misleading "bridge unreachable" (sessions misdiagnosed the bridge
+    # as broken and burned an hour on it).
+    "request_access",
+    "await_access",
 )
 
 
@@ -85,6 +96,14 @@ COMMAND_TIMEOUTS = {
     # position; logs just drains a per-tab ring buffer already in memory.
     "scroll": 20.0,
     "logs": 20.0,
+    # request_access only writes the pending record and raises the prompt
+    # surfaces — it returns immediately, never waiting on the human.
+    "request_access": 20.0,
+    # await_access polls the stored decision for one BOUNDED slice (the
+    # extension caps itself at 20 s — access.ts AWAIT_SLICE_MS); the tool
+    # loops slices client-side, so this stays an honest per-RPC bound and
+    # never needs the awaiting_origin deadline-extension machinery above.
+    "await_access": 25.0,
 }
 
 #: Extra budget granted to a command that is BLOCKED on a human origin
@@ -107,6 +126,11 @@ class ErrorCode(StrEnum):
     ELEMENT_NOT_FOUND = "element_not_found"
     ORIGIN_DENIED = "origin_denied"
     ORIGIN_PROMPT_PENDING = "origin_prompt_pending"
+    # A top-level open/goto to an origin the user has not approved. Raised
+    # EARLY, before any prompt exists, so the agent can run the explicit
+    # request_access -> notify user -> await_access flow instead of blocking a
+    # navigation on a popup prompt the user never saw.
+    ORIGIN_NOT_ALLOWED = "origin_not_allowed"
     DEBUGGER_CONFLICT = "debugger_conflict"
     # The extension refuses to open more concurrent tabs than its cap (see
     # MAX_SURFACES in extension/src/state.ts): parallel sessions each own a

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -5594,6 +5594,20 @@ def bridge_browser_available() -> bool:
     return available()
 
 
+def _browser_requester(context: ToolContext | None, tool_call_id: str) -> str:
+    """The session-scoped identity the extension binds approvals to.
+
+    A once-grant earned by request_access must be spendable by the SAME
+    session's next open/goto but not by a parallel session's; per-command
+    request ids cannot express that (every command mints a fresh one), so the
+    identity is the session id. A host without one falls back to the tool
+    call id — still bound to SOMETHING rather than anonymous, and anonymous
+    would be a fail-open hole in the cross-session grant check."""
+    if context is not None and context.session_id:
+        return f"session:{context.session_id}"
+    return f"call:{tool_call_id}"
+
+
 async def _bridge_call(
     tool_call_id: str,
     action: str,
@@ -5629,13 +5643,20 @@ async def _bridge_open(
     tool_call_id: str,
     state: BrowserSurfaceProtocol,
     raw_url: str,
+    context: ToolContext | None = None,
 ) -> ToolResult:
     # The session's pinned handle decides the mode. With one, `open` RESUMES
     # that tab (extension-side it navigates exactly that surface); without one
     # the extension creates a brand-new tab. The extension never falls back to
     # reusing some other live surface — that reuse is how one session used to
     # hijack another's tab mid-task when agents ran in parallel.
-    params: dict[str, Any] = {"url": raw_url.strip()}
+    params: dict[str, Any] = {
+        "url": raw_url.strip(),
+        # The approval-binding identity — see _browser_requester. The
+        # extension uses it to decide whether a stored once-grant belongs to
+        # THIS navigation's session.
+        "requester": _browser_requester(context, tool_call_id),
+    }
     resuming = state.surface_id.startswith("bridge:")
     if resuming:
         params["tab"] = state.surface_id
@@ -5730,13 +5751,18 @@ async def _bridge_access(
     tool_call_id: str,
     action: str,
     params: BrowserParams,
+    context: ToolContext | None,
 ) -> ToolResult:
     """request_access / await_access — surface-free by design: they exist for
     the moment when 'open' has just FAILED, so requiring an open surface here
     would deadlock the recovery path."""
     url = params.url.strip()
+    # The approval-binding identity — see _browser_requester.
+    requester = _browser_requester(context, tool_call_id)
     if action == "request_access":
-        result, problem = await _bridge_call(tool_call_id, "request_access", {"url": url})
+        result, problem = await _bridge_call(
+            tool_call_id, "request_access", {"url": url, "requester": requester}
+        )
         if problem is not None:
             return problem
         assert result is not None
@@ -5766,7 +5792,11 @@ async def _bridge_access(
                 "await_access again.",
                 details={"origin": url, "state": "pending"},
             )
-        wire = {"url": url, "timeout_ms": min(remaining_ms, _BRIDGE_AWAIT_SLICE_MS)}
+        wire = {
+            "url": url,
+            "timeout_ms": min(remaining_ms, _BRIDGE_AWAIT_SLICE_MS),
+            "requester": requester,
+        }
         result, problem = await _bridge_call(tool_call_id, "await_access", wire)
         if problem is not None:
             return problem
@@ -5912,7 +5942,12 @@ async def _bridge_action(
     context: ToolContext | None,
 ) -> ToolResult:
     surface = state.surface_id
-    wire: dict[str, Any] = {"tab": surface}
+    wire: dict[str, Any] = {
+        "tab": surface,
+        # Approval-binding identity (see _browser_requester): goto's
+        # top-level admission consults it for once-grants.
+        "requester": _browser_requester(context, tool_call_id),
+    }
     if action == "goto":
         wire["url"] = params.url.strip()
     elif action in ("read", "snapshot"):
@@ -6156,7 +6191,7 @@ async def execute_browser(
                 "exists for the Local Operator browser extension ('lop browser status' / "
                 "'lop browser install').",
             )
-        return await _bridge_access(tool_call_id, action, params)
+        return await _bridge_access(tool_call_id, action, params, context)
 
     # Backend is selected only for an empty surface. A prefixed handle pins the
     # transport, so a browser opening or closing mid-session cannot silently
@@ -6176,11 +6211,11 @@ async def execute_browser(
         # or closing mid-session can never silently move the agent between
         # backends.
         if state.surface_id.startswith("bridge:"):
-            return await _bridge_open(tool_call_id, state, params.url)
+            return await _bridge_open(tool_call_id, state, params.url, context)
         if state.surface_id.startswith("surface:"):
             return await _browser_open(tool_call_id, state, params.url)
         if bridge_available:
-            return await _bridge_open(tool_call_id, state, params.url)
+            return await _bridge_open(tool_call_id, state, params.url, context)
         return await _browser_open(tool_call_id, state, params.url)
     if action == "close":
         return await _browser_close(tool_call_id, state)

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -4666,6 +4666,12 @@ BROWSER_ACTIONS = (
     # handle to close. Bridge-only like scroll/logs: cmux keeps no multi-surface
     # registry, so it degrades with the same typed "use the extension" error.
     "tabs",
+    # The async site-approval flow, extension-only like scroll/logs. open/goto
+    # to a not-yet-allowed origin fails EARLY with a typed error naming these
+    # two actions, because the old behaviour — blocking the navigation RPC on
+    # the popup prompt — expired unseen and read as "bridge unreachable".
+    "request_access",
+    "await_access",
 )
 
 #: Actions that only the Local Operator browser extension can serve. cmux has no
@@ -4673,7 +4679,9 @@ BROWSER_ACTIONS = (
 #: partial result these degrade with a clear, actionable error naming the
 #: extension. Kept as a set beside BROWSER_ACTIONS so the degrade check and the
 #: advertised action list can never drift apart.
-BRIDGE_ONLY_BROWSER_ACTIONS = frozenset({"scroll", "logs", "tabs"})
+BRIDGE_ONLY_BROWSER_ACTIONS = frozenset(
+    {"scroll", "logs", "tabs", "request_access", "await_access"}
+)
 
 #: Direction keywords ``scroll`` accepts. Mirrors extension/src/commands/scroll.ts
 #: DIRECTIONS; validated here so a bad keyword is refused before it reaches the
@@ -4764,9 +4772,15 @@ class BrowserParams(BaseModel):
         "| goto | read (page text) | snapshot (accessibility tree with click "
         "refs) | screenshot | click | type | scroll (move the viewport) | logs "
         "(console + errors) | tabs (list all extension-driven tabs, other "
-        "sessions' included) | close (end YOUR tab when done with it)."
+        "sessions' included) | request_access (raise the site-approval prompt "
+        "for a not-yet-allowed origin; returns pending/allowed/denied/superseded "
+        "immediately) | await_access (wait for the user's decision on that "
+        "prompt) | close (end YOUR tab when done with it)."
     )
-    url: str = Field(default="", description="http(s) URL for 'open'/'goto'.")
+    url: str = Field(
+        default="",
+        description="http(s) URL for 'open'/'goto'/'request_access'/'await_access'.",
+    )
     path: str = Field(default="", description="Destination file for 'screenshot'.")
     selector: str = Field(
         default="",
@@ -4801,6 +4815,12 @@ class BrowserParams(BaseModel):
         default=None,
         description="'logs' max entries to return (most recent kept); 'scroll' "
         "ignores it. Omit for no cap.",
+    )
+    timeout_s: float | None = Field(
+        default=None,
+        description="'await_access' max seconds to wait for the user's decision "
+        "(default 120, max 240). Still pending after that? Tell the user, then "
+        "call await_access again.",
     )
 
 
@@ -5059,7 +5079,10 @@ def _validate_browser_args(action: str, params: BrowserParams) -> str:
     Googles a non-URL and still exits 0, and a flag-shaped value in a
     positional or ``--text`` slot is parsed as an option.
     """
-    if action in ("open", "goto"):
+    if action in ("open", "goto", "request_access", "await_access"):
+        # The access actions take the SAME url validation as open/goto: they
+        # exist to pre-approve exactly the navigation open/goto would make, so
+        # a value those verbs would refuse must be refused here too.
         return _validate_browser_url(params.url, action)
     if action in ("click", "type"):
         problem = _validate_selector(params.selector, action)
@@ -5646,6 +5669,105 @@ async def _bridge_open(
     )
 
 
+#: await_access defaults and cap. The cap exists because each slice is a real
+#: RPC and the human may simply be away: 240 s is long enough for "walk back to
+#: the desk", short enough that the agent gets a turn to re-notify the user
+#: rather than sitting silent for the extension's whole 10-minute request TTL.
+BROWSER_AWAIT_ACCESS_DEFAULT_S = 120.0
+BROWSER_AWAIT_ACCESS_MAX_S = 240.0
+
+#: One extension-side wait slice (mirrors access.ts AWAIT_SLICE_MS). The tool
+#: loops short slices instead of asking the daemon for one long wait so every
+#: entry in the daemon's COMMAND_TIMEOUTS stays an honest per-RPC bound — the
+#: deadline-extension special case is exactly what made the old blocking flow's
+#: failures unreadable.
+_BRIDGE_AWAIT_SLICE_MS = 20_000
+
+
+def _access_result_text(state: str, origin: str) -> str:
+    """One agent-facing line per access state, including the next step — the
+    agent discovers this flow through error/result text, not documentation."""
+    if state == "allowed":
+        return f"{origin} is allowed. 'open' or 'goto' the URL now."
+    if state == "denied":
+        return (
+            f"the user denied access to {origin}. Do not retry or re-request this "
+            "origin; ask the user directly if it is essential."
+        )
+    if state == "pending":
+        # NOTIFY-FIRST is load-bearing: Chrome's own notification banner is
+        # best-effort (macOS suppresses it without Notification Center
+        # authorization), so if the agent does not message the user the prompt
+        # sits unseen until its TTL — the exact incident this flow replaces.
+        return (
+            f"approval for {origin} is pending. FIRST notify the user (via the ask "
+            "tool or a message) to approve it in the Local Operator extension popup "
+            "(toolbar icon, badge '!') — the badge alone is not reliably seen — THEN "
+            "call action='await_access' with the same url to wait for the decision."
+        )
+    # "none": no live request — expired, superseded, or never raised.
+    return (
+        f"no live access request for {origin} (it may have expired unanswered). "
+        "Call action='request_access' with the url to raise a new prompt."
+    )
+
+
+async def _bridge_access(
+    tool_call_id: str,
+    action: str,
+    params: BrowserParams,
+) -> ToolResult:
+    """request_access / await_access — surface-free by design: they exist for
+    the moment when 'open' has just FAILED, so requiring an open surface here
+    would deadlock the recovery path."""
+    url = params.url.strip()
+    if action == "request_access":
+        result, problem = await _bridge_call(tool_call_id, "request_access", {"url": url})
+        if problem is not None:
+            return problem
+        assert result is not None
+        state_value = str(result.get("state", ""))
+        origin = str(result.get("origin", url))
+        return _text(
+            tool_call_id,
+            "browser",
+            _access_result_text(state_value, origin),
+            details={"origin": origin, "state": state_value},
+        )
+    # await_access: loop bounded extension-side slices until the decision, the
+    # caller's deadline, or a terminal state. Each slice is its own RPC well
+    # inside the daemon's command timeout, so a slow human can never make the
+    # bridge look broken again.
+    budget = params.timeout_s if params.timeout_s and params.timeout_s > 0 else None
+    total_s = min(budget or BROWSER_AWAIT_ACCESS_DEFAULT_S, BROWSER_AWAIT_ACCESS_MAX_S)
+    deadline = time.monotonic() + total_s
+    while True:
+        remaining_ms = int((deadline - time.monotonic()) * 1000)
+        if remaining_ms <= 0:
+            return _text(
+                tool_call_id,
+                "browser",
+                f"still pending after {total_s:.0f}s: the user has not decided on {url} "
+                "yet. Remind them to check the Local Operator extension popup, then call "
+                "await_access again.",
+                details={"origin": url, "state": "pending"},
+            )
+        wire = {"url": url, "timeout_ms": min(remaining_ms, _BRIDGE_AWAIT_SLICE_MS)}
+        result, problem = await _bridge_call(tool_call_id, "await_access", wire)
+        if problem is not None:
+            return problem
+        assert result is not None
+        state_value = str(result.get("state", ""))
+        if state_value != "pending":
+            origin = str(result.get("origin", url))
+            return _text(
+                tool_call_id,
+                "browser",
+                _access_result_text(state_value, origin),
+                details={"origin": origin, "state": state_value},
+            )
+
+
 def _format_log_entry(entry: dict[str, Any]) -> str:
     """One buffered log line rendered for the model: ``[level] text (url:line)``.
 
@@ -6004,6 +6126,24 @@ async def execute_browser(
         return _error(tool_call_id, "browser", problem)
     state = _browser_state(context)
 
+    # The access actions are dispatched BEFORE any surface logic: they exist
+    # for the moment 'open' just failed with origin_not_allowed, so there is
+    # usually no surface to key on, and gating them behind "no browser surface
+    # open — use 'open' first" would send the agent in a circle. They need the
+    # bridge (cmux has no permission model), so a cmux-pinned surface or a
+    # bridge-less host degrades with the same typed error as scroll/logs.
+    if action in ("request_access", "await_access"):
+        if state.surface_id.startswith("surface:") or not bridge_available:
+            return _error(
+                tool_call_id,
+                "browser",
+                f"'{action}' is not supported on the cmux backend — cmux has no "
+                "site-permission prompts; navigation works directly. This action only "
+                "exists for the Local Operator browser extension ('lop browser status' / "
+                "'lop browser install').",
+            )
+        return await _bridge_access(tool_call_id, action, params)
+
     # Backend is selected only for an empty surface. A prefixed handle pins the
     # transport, so a browser opening or closing mid-session cannot silently
     # move the agent to a different surface.
@@ -6283,7 +6423,12 @@ def build_browser_tool(context: ToolContext | None) -> AgentTool | None:
             "(handles are redacted: the listing is awareness-only and cannot "
             "drive or close anything), and 'close' "
             "ends your own tab when you are done with it. 'scroll', 'logs' and "
-            "'tabs' need the extension backend (cmux says so). Use it for every "
+            "'tabs' need the extension backend (cmux says so). On the extension, "
+            "'open'/'goto' to a site the user has not approved fails with "
+            "origin_not_allowed: then call 'request_access' with the url, NOTIFY the "
+            "user (ask tool or message) to approve the prompt in the extension popup, "
+            "and 'await_access' to wait for their decision before navigating again. "
+            "Use it for every "
             "screenshot and page interaction; never install or script a browser "
             "engine instead."
         ),

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -5705,10 +5705,24 @@ def _access_result_text(state: str, origin: str) -> str:
             "(toolbar icon, badge '!') — the badge alone is not reliably seen — THEN "
             "call action='await_access' with the same url to wait for the decision."
         )
-    # "none": no live request — expired, superseded, or never raised.
+    if state == "superseded":
+        # A DIFFERENT session's request replaced this one's prompt slot (the
+        # popup shows one origin at a time). The agent must know it was
+        # displaced — reading this as expiry would send it into a
+        # request/notify loop that keeps stealing the prompt back and forth
+        # between sessions (round-1 B1b).
+        return (
+            f"the approval prompt for {origin} was superseded by another session's "
+            "request — the extension shows one prompt at a time. Wait for the other "
+            "session's prompt to resolve, then call action='request_access' again "
+            "if this origin is still needed."
+        )
+    # "none": no live request for the caller — expired, never raised, or
+    # superseded by a request it did not own.
     return (
-        f"no live access request for {origin} (it may have expired unanswered). "
-        "Call action='request_access' with the url to raise a new prompt."
+        f"no live access request for {origin} (it may have expired unanswered, or "
+        "never been raised). Call action='request_access' with the url to raise a "
+        "new prompt."
     )
 
 

--- a/tests/unit/browser_bridge/test_backend.py
+++ b/tests/unit/browser_bridge/test_backend.py
@@ -179,3 +179,23 @@ async def test_typed_error_still_maps_to_bridge_error(
     with pytest.raises(BridgeError) as excinfo:
         await client.call("goto", {"url": "https://example.com"})
     assert excinfo.value.code == ErrorCode.ORIGIN_DENIED
+
+
+def test_origin_not_allowed_error_teaches_the_access_flow() -> None:
+    # The early-fail error is the agent's ONLY discovery path for the approval
+    # dance mid-session, so it must name both follow-up actions and echo the
+    # url; the failure it replaces read as a bridge outage (a session burned an
+    # hour misdiagnosing it).
+    error = BridgeError(
+        ErrorCode.ORIGIN_NOT_ALLOWED,
+        "site https://example.com is not allowed yet",
+        {"origin": "https://example.com", "url": "https://example.com/page"},
+    )
+    text = format_error(error, action="open")
+    assert "site https://example.com is not allowed yet" in text
+    assert "action='request_access' url=https://example.com/page" in text
+    assert "action='await_access' url=https://example.com/page" in text
+    assert "extension popup" in text
+    # The agent is the PRIMARY notification channel: Chrome's banner is
+    # best-effort on macOS, so the instruction to notify must be explicit.
+    assert "NOTIFY THE USER" in text

--- a/tests/unit/browser_bridge/test_daemon.py
+++ b/tests/unit/browser_bridge/test_daemon.py
@@ -145,3 +145,74 @@ async def test_await_access_does_not_block_request_access(tmp_path: Path) -> Non
     # The request completed while the await was still parked: no queueing.
     assert request_elapsed < 1.0, f"request_access waited {request_elapsed:.2f}s behind await"
     assert await_elapsed >= 2.0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_await_evicts_its_lock_key(tmp_path: Path) -> None:
+    """Round-3 M1: cancelling a parked await_access (client disconnect
+    surfaces as CancelledError inside the HTTP handler) must still evict its
+    per-request lock key. Pre-fix, cancellation propagated past the eviction
+    line and retained `__await__:<id>` forever — the reviewer's reproduction
+    read the leaked key straight out of `_tab_locks`."""
+    import asyncio
+
+    from local_operator.browser_bridge.daemon import BridgeService
+    from local_operator.browser_bridge.protocol import Request
+
+    service = BridgeService(root=tmp_path)
+
+    async def park_forever(payload: dict[str, object]) -> None:
+        await asyncio.sleep(3600)
+
+    service.link.send = park_forever  # type: ignore[method-assign]
+    request = Request(id="r-cancel", method="await_access", params={"url": "https://x.example"})
+    task = asyncio.get_running_loop().create_task(service._dispatch_serialized(request))
+    await asyncio.sleep(0.1)  # parked inside the await wait
+    assert "__await__:r-cancel" in service._tab_locks
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    # The finally-path eviction covered the cancellation.
+    assert service._tab_locks == {}
+
+
+@pytest.mark.asyncio
+async def test_await_lock_key_evicted_on_normal_and_error_exits(tmp_path: Path) -> None:
+    """Round-3 M1: the two non-cancellation exits must evict too — normal
+    completion and the daemon timeout on a never-answering extension."""
+    import asyncio
+
+    from local_operator.browser_bridge.daemon import BridgeService
+    from local_operator.browser_bridge.protocol import (
+        COMMAND_TIMEOUTS,
+        Request,
+        Response,
+    )
+
+    service = BridgeService(root=tmp_path)
+
+    # Normal exit: the fake extension answers immediately.
+    async def answer(payload: dict[str, object]) -> None:
+        request = Request.model_validate(payload)
+        future = service.link.pending.get(request.id)
+        if future and not future.done():
+            future.set_result(
+                Response(id=request.id, ok=True, result={"origin": "x", "state": "pending"})
+            )
+
+    service.link.send = answer  # type: ignore[method-assign]
+    await service._dispatch_serialized(
+        Request(id="r-ok", method="await_access", params={"url": "https://x.example"})
+    )
+    assert service._tab_locks == {}
+
+    # Error exit (timeout): the extension never answers; the daemon's command
+    # timeout fires inside _dispatch_locked.
+    async def silent(payload: dict[str, object]) -> None:
+        await asyncio.sleep(COMMAND_TIMEOUTS["await_access"] + 5)
+
+    service.link.send = silent  # type: ignore[method-assign]
+    await service._dispatch_serialized(
+        Request(id="r-timeout", method="await_access", params={"url": "https://x.example"})
+    )
+    assert service._tab_locks == {}

--- a/tests/unit/browser_bridge/test_daemon.py
+++ b/tests/unit/browser_bridge/test_daemon.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from starlette.testclient import TestClient
 
 from local_operator.browser_bridge.daemon import create_app, pairing_status
@@ -77,3 +78,70 @@ def test_web_page_origin_is_rejected(tmp_path: Path) -> None:
             assert "4004" in str(exc) or getattr(exc, "code", None) == 4004
         else:  # pragma: no cover - rejection is mandatory
             raise AssertionError("web origin was accepted")
+
+
+def test_await_access_lock_topology() -> None:
+    """Round-2 M3, structural half: await_access serializes on a PRIVATE
+    per-request key (nothing can queue behind a human wait), request_access on
+    the short shared __access__ key, tab commands per token, no-tab commands
+    on __global__."""
+    from local_operator.browser_bridge.daemon import BridgeService
+    from local_operator.browser_bridge.protocol import Request
+
+    key_of = BridgeService.lock_key_for
+    a = key_of(Request(id="r-1", method="await_access", params={"url": "https://x.example"}))
+    b = key_of(Request(id="r-2", method="await_access", params={"url": "https://x.example"}))
+    assert a != b, "two awaits must never share a lock"
+    assert a.startswith("__await__:")
+    assert (
+        key_of(Request(id="r-3", method="request_access", params={"url": "https://x.example"}))
+        == "__access__"
+    )
+    assert key_of(Request(id="r-4", method="open", params={})) == "__global__"
+    assert key_of(Request(id="r-5", method="goto", params={"tab": "bridge:1:n"})) == "bridge:1:n"
+
+
+@pytest.mark.asyncio
+async def test_await_access_does_not_block_request_access(tmp_path: Path) -> None:
+    """Round-2 M3, behavioural half: with a fake extension whose await_access
+    parks for 2 s, a concurrent request_access completes in milliseconds. With
+    the old shared __access__ key this test fails: the request queues behind
+    the full await slice."""
+    import asyncio
+    import time as time_module
+
+    from local_operator.browser_bridge.daemon import BridgeService
+    from local_operator.browser_bridge.protocol import Request, Response
+
+    service = BridgeService(root=tmp_path)
+
+    async def serve(payload: dict[str, object]) -> None:
+        request = Request.model_validate(payload)
+
+        async def respond() -> None:
+            if request.method == "await_access":
+                await asyncio.sleep(2.0)
+                result = {"origin": "https://a.example", "state": "pending"}
+            else:
+                result = {"origin": "https://b.example", "state": "pending"}
+            future = service.link.pending.get(request.id)
+            if future and not future.done():
+                future.set_result(Response(id=request.id, ok=True, result=result))
+
+        asyncio.get_running_loop().create_task(respond())
+
+    service.link.send = serve  # type: ignore[method-assign]
+    started = time_module.monotonic()
+
+    async def dispatch(method: str, request_id: str) -> float:
+        request = Request(id=request_id, method=method, params={"url": "https://x.example"})
+        await service._dispatch_serialized(request)
+        return time_module.monotonic() - started
+
+    waiter = asyncio.create_task(dispatch("await_access", "r-wait"))
+    await asyncio.sleep(0.1)  # the waiter is now parked inside its own lock
+    request_elapsed = await dispatch("request_access", "r-req")
+    await_elapsed = await waiter
+    # The request completed while the await was still parked: no queueing.
+    assert request_elapsed < 1.0, f"request_access waited {request_elapsed:.2f}s behind await"
+    assert await_elapsed >= 2.0

--- a/tests/unit/browser_bridge/test_protocol.py
+++ b/tests/unit/browser_bridge/test_protocol.py
@@ -82,3 +82,27 @@ def test_generated_ts_emits_origin_prompt_timeout() -> None:
     # A3: the chain extension deny < daemon window < client timeout is what
     # turns a mid-prompt wait into a typed answer instead of "unreachable").
     assert "export const ORIGIN_PROMPT_TIMEOUT_MS = 60000 as const;" in gen_ts_render()
+
+
+def test_access_flow_methods_are_wired_end_to_end() -> None:
+    # The approval flow only helps if every layer knows the methods: wire
+    # protocol, daemon timeout table, and generated TS union. A miss in any of
+    # them reproduces the original incident class (a call that times out
+    # opaquely instead of failing typed).
+    from local_operator.browser_bridge.daemon import COMMAND_TIMEOUTS
+
+    for method in ("request_access", "await_access"):
+        assert method in METHODS
+        assert method in COMMAND_TIMEOUTS
+    rendered = gen_ts_render()
+    assert "'request_access'" in rendered and "'await_access'" in rendered
+    assert "ORIGIN_NOT_ALLOWED" in rendered
+
+
+def test_await_access_daemon_timeout_covers_the_extension_slice() -> None:
+    # The extension caps one await slice at 20s (access.ts AWAIT_SLICE_MS);
+    # the daemon's bound must sit above it or a full slice would race the
+    # daemon timeout and lose — recreating the misleading-timeout incident.
+    from local_operator.browser_bridge.daemon import COMMAND_TIMEOUTS
+
+    assert COMMAND_TIMEOUTS["await_access"] > 20.0

--- a/tests/unit/browser_bridge/test_tool_selection.py
+++ b/tests/unit/browser_bridge/test_tool_selection.py
@@ -111,7 +111,9 @@ def test_scroll_logs_and_tabs_are_advertised_actions() -> None:
     assert "scroll" in builtin.BROWSER_ACTIONS
     assert "logs" in builtin.BROWSER_ACTIONS
     assert "tabs" in builtin.BROWSER_ACTIONS
-    assert builtin.BRIDGE_ONLY_BROWSER_ACTIONS == frozenset({"scroll", "logs", "tabs"})
+    assert builtin.BRIDGE_ONLY_BROWSER_ACTIONS == frozenset(
+        {"scroll", "logs", "tabs", "request_access", "await_access"}
+    )
 
 
 @pytest.mark.parametrize(
@@ -361,3 +363,99 @@ async def test_bridge_open_recovers_from_a_dead_pinned_tab(monkeypatch) -> None:
     assert not result.is_error
     assert surface.surface_id == "bridge:33:fresh"
     assert len(calls) == 2 and "tab" in calls[0] and "tab" not in calls[1]
+
+# ---------------------------------------------------------------------------
+# Async site-approval flow (request_access / await_access)
+# ---------------------------------------------------------------------------
+
+async def test_request_access_works_without_a_surface(monkeypatch) -> None:
+    # The whole point of the flow: 'open' just FAILED, so no surface exists.
+    # Routing these through the "no browser surface open" guard would send the
+    # agent in a circle.
+    monkeypatch.setattr(builtin, "cmux_browser_available", lambda: False)
+    monkeypatch.setattr(builtin, "bridge_browser_available", lambda: True)
+
+    async def fake_call(tool_call_id, action, params, *, surface=""):
+        assert action == "request_access"
+        assert params == {"url": "https://example.com"}
+        return {"origin": "https://example.com", "state": "pending"}, None
+
+    monkeypatch.setattr(builtin, "_bridge_call", fake_call)
+    context = ToolContext(browser=BrowserSurface())
+    result = await builtin.execute_browser(
+        "t", {"action": "request_access", "url": "https://example.com"}, None, None, context
+    )
+    # The result text is the agent's script for the next two steps.
+    assert "pending" in result.text
+    assert "extension popup" in result.text
+    assert "await_access" in result.text
+
+
+@pytest.mark.asyncio
+async def test_request_access_reports_already_allowed(monkeypatch) -> None:
+    monkeypatch.setattr(builtin, "cmux_browser_available", lambda: False)
+    monkeypatch.setattr(builtin, "bridge_browser_available", lambda: True)
+
+    async def fake_call(tool_call_id, action, params, *, surface=""):
+        return {"origin": "https://example.com", "state": "allowed"}, None
+
+    monkeypatch.setattr(builtin, "_bridge_call", fake_call)
+    result = await builtin.execute_browser(
+        "t",
+        {"action": "request_access", "url": "https://example.com"},
+        None,
+        None,
+        ToolContext(browser=BrowserSurface()),
+    )
+    assert "allowed" in result.text and "'open' or 'goto'" in result.text
+
+
+@pytest.mark.asyncio
+async def test_await_access_returns_decision_and_denied_warns_off_retry(monkeypatch) -> None:
+    monkeypatch.setattr(builtin, "cmux_browser_available", lambda: False)
+    monkeypatch.setattr(builtin, "bridge_browser_available", lambda: True)
+
+    async def fake_call(tool_call_id, action, params, *, surface=""):
+        assert action == "await_access"
+        # The tool slices the wait: each wire call carries a bounded budget.
+        assert params["timeout_ms"] <= builtin._BRIDGE_AWAIT_SLICE_MS
+        return {"origin": "https://example.com", "state": "denied"}, None
+
+    monkeypatch.setattr(builtin, "_bridge_call", fake_call)
+    result = await builtin.execute_browser(
+        "t",
+        {"action": "await_access", "url": "https://example.com"},
+        None,
+        None,
+        ToolContext(browser=BrowserSurface()),
+    )
+    assert "denied" in result.text and "Do not retry" in result.text
+
+
+@pytest.mark.asyncio
+async def test_access_actions_degrade_on_cmux_with_typed_error(monkeypatch) -> None:
+    # A cmux-pinned surface has no permission model to ask; the answer must be
+    # the same honest degrade pattern as scroll/logs, not a fake pending.
+    monkeypatch.setattr(builtin, "cmux_browser_available", lambda: True)
+    monkeypatch.setattr(builtin, "bridge_browser_available", lambda: False)
+    surface = BrowserSurface()
+    surface.surface_id = "surface:3"
+    result = await builtin.execute_browser(
+        "t",
+        {"action": "request_access", "url": "https://example.com"},
+        None,
+        None,
+        ToolContext(browser=surface),
+    )
+    assert result.is_error
+    assert "not supported on the cmux backend" in result.text
+
+
+@pytest.mark.asyncio
+async def test_access_actions_require_a_url(monkeypatch) -> None:
+    monkeypatch.setattr(builtin, "cmux_browser_available", lambda: False)
+    monkeypatch.setattr(builtin, "bridge_browser_available", lambda: True)
+    result = await builtin.execute_browser(
+        "t", {"action": "await_access"}, None, None, ToolContext(browser=BrowserSurface())
+    )
+    assert result.is_error and "requires a URL" in result.text

--- a/tests/unit/browser_bridge/test_tool_selection.py
+++ b/tests/unit/browser_bridge/test_tool_selection.py
@@ -471,3 +471,93 @@ async def test_access_actions_require_a_url(monkeypatch) -> None:
         "t", {"action": "await_access"}, None, None, ToolContext(browser=BrowserSurface())
     )
     assert result.is_error and "requires a URL" in result.text
+
+
+@pytest.mark.asyncio
+async def test_session_identity_is_stable_across_the_whole_flow(monkeypatch) -> None:
+    """Round-2 M4: the REAL plumbing — ToolContext.session_id →
+    execute_browser → _browser_requester → the wire params of every access and
+    navigation call — must present ONE stable identity across different tool
+    call ids, or grants bind to something no later navigation can match.
+    Asserted through execute_browser (the public tool path), not by injecting
+    requester strings."""
+    monkeypatch.setattr(builtin, "cmux_browser_available", lambda: False)
+    monkeypatch.setattr(builtin, "bridge_browser_available", lambda: True)
+    seen: list[tuple[str, str]] = []
+
+    async def fake_call(tool_call_id, action, params, *, surface=""):
+        seen.append((action, str(params.get("requester", "<missing>"))))
+        if action == "request_access":
+            return {"origin": "https://example.com", "state": "pending"}, None
+        if action == "await_access":
+            return {"origin": "https://example.com", "state": "allowed"}, None
+        # open
+        return {"tab": "bridge:5:n0nce", "url": "https://example.com/", "title": "x"}, None
+
+    monkeypatch.setattr(builtin, "_bridge_call", fake_call)
+    context = ToolContext(session_id="sess-42", browser=BrowserSurface())
+    # Three DIFFERENT tool call ids — the per-command fallback would produce
+    # three different identities and silently break grant consumption.
+    await builtin.execute_browser(
+        "call-1", {"action": "request_access", "url": "https://example.com"}, None, None, context
+    )
+    await builtin.execute_browser(
+        "call-2", {"action": "await_access", "url": "https://example.com"}, None, None, context
+    )
+    await builtin.execute_browser(
+        "call-3", {"action": "open", "url": "https://example.com"}, None, None, context
+    )
+    assert [entry[0] for entry in seen] == ["request_access", "await_access", "open"]
+    identities = {entry[1] for entry in seen}
+    assert identities == {"session:sess-42"}, f"identity drifted: {seen}"
+
+
+@pytest.mark.asyncio
+async def test_parallel_contexts_present_distinct_identities(monkeypatch) -> None:
+    """Round-2 M4: two ToolContexts (two sessions) must reach the wire as two
+    different requesters — the property the extension's fail-closed grant
+    check depends on."""
+    monkeypatch.setattr(builtin, "cmux_browser_available", lambda: False)
+    monkeypatch.setattr(builtin, "bridge_browser_available", lambda: True)
+    seen: list[str] = []
+
+    async def fake_call(tool_call_id, action, params, *, surface=""):
+        seen.append(str(params.get("requester", "<missing>")))
+        return {"origin": "https://example.com", "state": "pending"}, None
+
+    monkeypatch.setattr(builtin, "_bridge_call", fake_call)
+    for session_id in ("sess-A", "sess-B"):
+        context = ToolContext(session_id=session_id, browser=BrowserSurface())
+        await builtin.execute_browser(
+            "t", {"action": "request_access", "url": "https://example.com"}, None, None, context
+        )
+    assert seen == ["session:sess-A", "session:sess-B"]
+
+
+@pytest.mark.asyncio
+async def test_goto_carries_the_session_identity(monkeypatch) -> None:
+    """Round-2 M4: goto (the other admission-bearing navigation) must carry
+    the same session identity; a reversion to per-call identity here would
+    strand every grant minted for the session."""
+    monkeypatch.setattr(builtin, "cmux_browser_available", lambda: False)
+    monkeypatch.setattr(builtin, "bridge_browser_available", lambda: True)
+    captured: dict[str, Any] = {}
+
+    async def fake_call(tool_call_id, action, params, *, surface=""):
+        captured["action"] = action
+        captured["requester"] = params.get("requester")
+        return {"url": "https://example.com/", "title": "x"}, None
+
+    monkeypatch.setattr(builtin, "_bridge_call", fake_call)
+    surface = BrowserSurface()
+    surface.surface_id = "bridge:9:nonce"
+    context = ToolContext(session_id="sess-42", browser=surface)
+    await builtin.execute_browser(
+        "some-other-call-id",
+        {"action": "goto", "url": "https://example.com"},
+        None,
+        None,
+        context,
+    )
+    assert captured["action"] == "goto"
+    assert captured["requester"] == "session:sess-42"

--- a/tests/unit/browser_bridge/test_tool_selection.py
+++ b/tests/unit/browser_bridge/test_tool_selection.py
@@ -364,10 +364,13 @@ async def test_bridge_open_recovers_from_a_dead_pinned_tab(monkeypatch) -> None:
     assert surface.surface_id == "bridge:33:fresh"
     assert len(calls) == 2 and "tab" in calls[0] and "tab" not in calls[1]
 
+
 # ---------------------------------------------------------------------------
 # Async site-approval flow (request_access / await_access)
 # ---------------------------------------------------------------------------
 
+
+@pytest.mark.asyncio
 async def test_request_access_works_without_a_surface(monkeypatch) -> None:
     # The whole point of the flow: 'open' just FAILED, so no surface exists.
     # Routing these through the "no browser surface open" guard would send the

--- a/tests/unit/browser_bridge/test_tool_selection.py
+++ b/tests/unit/browser_bridge/test_tool_selection.py
@@ -168,7 +168,14 @@ async def test_scroll_wire_params_only_set_fields(monkeypatch) -> None:
         None,
     )
     assert captured["action"] == "scroll"
-    assert captured["params"] == {"tab": "bridge:9:nonce", "y": 400.0}
+    # Every action wire now carries the approval-binding identity too; only
+    # the scroll params themselves are asserted exactly (see the comment in
+    # fake_call above for why absent fields must stay absent).
+    assert captured["params"] == {
+        "tab": "bridge:9:nonce",
+        "requester": "call:t",
+        "y": 400.0,
+    }
     # Result reports the landing position and that more remains below.
     assert "(0, 400)" in result.text
     assert "more below" in result.text
@@ -380,7 +387,9 @@ async def test_request_access_works_without_a_surface(monkeypatch) -> None:
 
     async def fake_call(tool_call_id, action, params, *, surface=""):
         assert action == "request_access"
-        assert params == {"url": "https://example.com"}
+        # The tool binds the approval to an identity (session when the host
+        # provides one, else the tool call id — never anonymous).
+        assert params == {"url": "https://example.com", "requester": "call:t"}
         return {"origin": "https://example.com", "state": "pending"}, None
 
     monkeypatch.setattr(builtin, "_bridge_call", fake_call)


### PR DESCRIPTION
## What

Makes site-permission handling a first-class, agent-legible flow instead of a
single long-blocking navigation call that fails opaquely.

**Before:** `open`/`goto` to a not-yet-allowed origin blocked the whole RPC
inside the extension's 60 s popup prompt (auto-deny on expiry). The agent never
got a turn to tell the user a prompt was up, so prompts expired unseen, the
daemon extended the command deadline (A3), and the session client timed out
with a misleading "bridge unreachable" — a real session (0ee4974ba84a) burned
an hour misdiagnosing the bridge as broken.

**After — the three-step dance:**

1. `open`/`goto` to a non-allowed top-level origin **fails early** (measured
   0.01 s, no prompt raised) with typed `origin_not_allowed` whose message
   teaches the flow: call `request_access`, **notify the user** (ask tool or
   message), then `await_access`.
2. New action **`request_access`** (url): raises the pending approval — popup
   badge `!`, prompt view, best-effort Chrome notification — and returns
   `{origin, state: pending|allowed|denied}` immediately. Idempotent for the
   same origin; a different origin **replaces** the pending slot (the popup's
   existing single-`pendingOrigin` semantics; a queue would show prompts the
   agent no longer cares about). Pending request TTL is **10 minutes** — the
   user was notified asynchronously and may take a while; still bounded so a
   forgotten Allow can't grant a navigation nobody remembers.
3. New action **`await_access`** (url, timeout up to 240 s): waits for the
   decision. Implemented as **client-side slice looping** over a bounded
   extension-side poll (20 s slices) rather than a daemon long-poll: every
   `COMMAND_TIMEOUTS` entry stays an honest per-RPC bound (the deadline-
   extension carve-out is exactly what made the old failures unreadable), and
   the MV3 worker never holds a multi-minute promise across worker death —
   the decision lives in session storage, which survives.

"Allow once" from this path mints a session-scoped grant consumed by exactly
one navigation (10 min TTL); "Always allow" persists in the origins map as
today; deny answers `denied` with do-not-retry guidance. Redirect-chain gating
inside a running navigation keeps the synchronous prompt (a mid-flight hop
can't fail early). On cmux these actions degrade with the typed not-supported
pattern used by scroll/logs.

## Notification reality (macOS caveat — for user docs)

Live testing on a real machine showed the `chrome.notifications` banner
**never reaches the user on macOS without Chrome having Notification Center
authorization** (System Settings → Notifications → Google Chrome; many
machines have no Chrome entry at all — the "notification" renders only inside
Chrome's extensions menu). The design therefore treats the **agent as the
primary notification channel**: the `origin_not_allowed` error and the
`request_access` pending result both explicitly instruct the agent to notify
the user via the harness (ask tool / message) *before* `await_access` — the
harness path is confirmed reliable. The Chrome banner is retained best-effort
and is now **clickable**: `notifications.onClicked → chrome.action.openPopup()`,
wrapped in try/catch because `openPopup` historically demands a user gesture
and Chrome moves that boundary between versions; the notification text keeps
pointing at the toolbar icon as the fallback.

## Surface

- `protocol.py`: `METHODS` += `request_access`/`await_access`,
  `ORIGIN_NOT_ALLOWED` error code; `protocol.gen.ts` regenerated.
- `extension/src/access-flow.ts` (new): pure TTL/state machine (tested DOM-free).
- `extension/src/origins.ts`: prompt-raise decoupled from in-command wait;
  `resolveOrigin` resolves **both** an in-command wait and the async record;
  once-grant mint/consume; lazy TTL expiry that also drops stale prompt surfaces.
- `extension/src/commands/access.ts` (new): the two handlers + slice poll.
- `extension/src/commands/nav.ts`: rebased onto #321's multi-surface open/goto
  model. `ensureTopLevelAccess` makes ONE admission decision at command entry
  and consumes the grant there; `navigate()` receives that decision unchanged,
  so the TTL cannot lapse into the old prompt between admission and navigation.
- `extension/src/worker.ts`: handler registration, TTL sweep alarm,
  clickable notification, best-effort caveat documented.
- `daemon.py`: timeout entries with rationale; access methods serialize on
  their own lock key so a 20 s await slice can't block another session's open.
- `backend.py`: `origin_not_allowed` → teaching error (notify-first).
- `tools/builtin.py`: actions + `timeout_s` param, validation, surface-free
  dispatch (they exist for the moment `open` just failed — requiring a surface
  would deadlock the recovery), per-state result texts, tool description
  teaches the dance.

## Testing evidence

**Unit/pure** (all green):
- `extension`: `pnpm typecheck` ✅, `pnpm test` **28/28** ✅, `pnpm build` ✅.
  Integration tests at the real origins.ts/state.ts/access-flow.ts seam cover:
  one popup click resolving both an in-command wait + async record; exactly-once
  grant consumption; cross-session refusal (refused attempt does not consume);
  raw-RPC command-id handoff; admission-time consumption; deny persistence
  across worker restart; supersession tombstones; spent-receipt/stale-tombstone
  cleanup. Pure suites cover TTL boundaries, idempotence and deny cool-down.
- `pytest tests/unit/browser_bridge`: **76/76** ✅; bridge + browser-tool slice:
  **180/180** ✅ (new: method↔timeout-table mirror, gen-ts coverage, daemon bound >
  extension slice, teaching-error content incl. NOTIFY THE USER, surface-free
  dispatch, cmux degrade, denied warns off retry, URL validation).
- Full `pytest tests/unit`, whole-tree pyright/flake8/black/isort: green
  (details in MR discussion if needed).

**End-to-end, real Chrome + real daemon** (throwaway headful Chrome 151
launched `open -g` + `--window-position=-3000,-3000` — never foregrounded;
built extension via CDP `Extensions.loadUnpacked`; throwaway daemon on port
4231 with `LOCAL_OPERATOR_CONFIG_DIR=/tmp/...`; paired via the real pair
event; decisions made by **clicking the real popup's Allow/Deny buttons** in a
background tab — the exact `origin_decision` message path a human click
takes). **24/24 checks** after the #321 multi-surface rebase:

```
PASS setup: extension connected+paired
PASS 1 open fails early with origin_not_allowed — code=origin_not_allowed in 0.01s
PASS 2 request_access returns pending
PASS 2 popup badge set to '!'
PASS 2 popup prompt record present
PASS 2 repeat request stays pending (idempotent)
PASS 3/4 await_access returns allowed after popup decision
PASS 4 badge cleared after decision
PASS 5 open succeeds after allow — {"tab": "bridge:…", "url": "http://127.0.0.1:8891/index.html", "title": "LOP Access E2E"}
PASS 5b once-grant consumed: next goto fails early again
PASS 5c A has a fresh pending prompt before supersession
PASS 5d B's different-origin request supersedes A's single prompt slot
PASS 5e displaced A reads explicit superseded
PASS 5f B's await returns allowed after real popup click
PASS 5g A cannot spend B's grant (origin_not_allowed; refused attempt did not consume)
PASS 5h B consumes its own grant into a second distinct surface
PASS 5i tabs lists both sessions' live surfaces
PASS 6 request_access on third origin pending
PASS 6 await_access returns denied
PASS 6 navigation still refused after deny
PASS 6b repeat request after deny answers denied (no nag)
PASS 7 request_access re-raises for consumed origin
PASS 7 expired request reads as none
PASS 7 expiry drops the stale prompt badge
```

## Coordination / round-1 rebase

Rebased semantically onto current `origin/main` (`f9dacfd9`, includes #320
client-timeout + #321 multi-tab surfaces):

- `open` preserves #321's two explicit modes (no tab → new capped surface;
  tab → resume exactly that surface); `goto` remains per-token; `tabs` remains
  awareness-only with redacted handles.
- daemon locks preserve #321's per-tab keys and shared `__global__` cap/listing
  key; access methods use a third `__access__` key because they touch neither
  tabs nor the surface map, and a 20 s human-await slice must not block another
  session's open.
- async requests and once-grants are bound to the tool's `session_id`; open/goto
  carry that same requester. A parallel session carries a different identity
  and cannot consume the grant. Raw-RPC callers get a command-id handoff.
- replace-don't-queue retains the single popup slot, but displaced requesters
  get a bounded tombstone receipt and read explicit `superseded` rather than a
  silent overwrite.
