### PR TITLE
fix(tui): show each subagent failover once

### DIFF
--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -401,8 +401,8 @@ def fold_trajectory(events: Sequence[Any], *, settled: bool = False) -> list[Sub
     assistant messages accumulate per message id (start resets, update appends
     the delta, end adopts the authoritative text), tool rows are keyed by
     ``tool_call_id``, and compaction/retry/notice/agent_end produce the same
-    notice wording the live transcript produces. Turn boundaries are noise at
-    this zoom and dropped.
+    notice wording the live transcript produces. Turn boundaries and effective
+    model changes are display-state noise at this zoom and dropped.
 
     ``settled`` marks the job as no longer running, and is the only way to
     tell a tool that is STILL executing from one whose end event never
@@ -522,17 +522,11 @@ def fold_trajectory(events: Sequence[Any], *, settled: bool = False) -> list[Sub
                 body += f" → falling back to {event.get('fallback_model')}"
             note(index, body, "warning")
         elif etype == "model_change":
-            # The child's route moved (fallback pinned or primary recovered).
-            # One line either way: the page is a trajectory, and which model
-            # answered from this point on is part of what happened.
-            fell = bool(event.get("is_fallback"))
-            selector = f"{event.get('provider', '')}/{event.get('model_id', '')}"
-            # Same verb pairing as the parent's notices (design D2).
-            note(
-                index,
-                (f"fell back to {selector}" if fell else f"back to {selector}"),
-                "warning" if fell else "info",
-            )
+            # Route notices narrate the edge once; this event only keeps model
+            # labels and context limits truthful elsewhere in the subagent UI.
+            # Rendering it would recreate the main transcript's historical
+            # two-notices-for-one-transition defect.
+            continue
         elif etype == "agent_end":
             # The child's own failure, in the wording `on_turn_ended` uses for
             # the parent's. Without it a failed subagent's page simply stopped,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.41.5"
+version = "0.41.6"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -224,6 +224,75 @@ def test_fold_reports_the_childs_own_failure_and_its_retries() -> None:
     ]
 
 
+def test_fold_narrates_a_fallback_route_change_once() -> None:
+    events = [
+        {
+            "type": "notice",
+            "text": "provider failure — falling back to x/mini",
+            "kind": "warning",
+        },
+        {
+            "type": "model_change",
+            "provider": "x",
+            "model_id": "mini",
+            "is_fallback": True,
+        },
+    ]
+
+    entries = fold_trajectory(events, settled=False)
+
+    assert [(entry.text, entry.notice_kind) for entry in entries] == [
+        ("provider failure — falling back to x/mini", "warning")
+    ]
+
+
+def test_fold_keeps_each_notice_in_a_fallback_cascade_without_model_change_duplicates() -> None:
+    events: list[dict[str, Any]] = []
+    targets = ["x/mini", "y/medium", "z/max"]
+    for selector in targets:
+        provider, model_id = selector.split("/", 1)
+        events.extend(
+            [
+                {
+                    "type": "notice",
+                    "text": f"provider failure — falling back to {selector}",
+                    "kind": "warning",
+                },
+                {
+                    "type": "model_change",
+                    "provider": provider,
+                    "model_id": model_id,
+                    "is_fallback": True,
+                },
+            ]
+        )
+
+    entries = fold_trajectory(events, settled=False)
+
+    assert [entry.text for entry in entries] == [
+        f"provider failure — falling back to {selector}" for selector in targets
+    ]
+    assert [entry.notice_kind for entry in entries] == ["warning"] * len(targets)
+
+
+def test_fold_narrates_primary_recovery_once() -> None:
+    events = [
+        {"type": "notice", "text": "back to primary/model", "kind": "info"},
+        {
+            "type": "model_change",
+            "provider": "primary",
+            "model_id": "model",
+            "is_fallback": False,
+        },
+    ]
+
+    entries = fold_trajectory(events, settled=False)
+
+    assert [(entry.text, entry.notice_kind) for entry in entries] == [
+        ("back to primary/model", "info")
+    ]
+
+
 def test_fold_admits_that_the_engine_dropped_the_start_of_a_long_run() -> None:
     """At the retention cap the beginning of the run is GONE, and a transcript
     that hides that invites conclusions drawn from a deleted opening."""


### PR DESCRIPTION
## Summary

Opening a subagent's full transcript after it had already walked a provider failover cascade displayed every route transition twice:

```text
provider failure — falling back to alibaba-token-plan/qwen3.8-max
fell back to alibaba-token-plan/qwen3.8-max
provider failure — falling back to xai/grok-4-fast
fell back to xai/grok-4-fast
```

The child had not failed over again and its work was unaffected. The view was replaying two different events for one historical transition: the canonical `NoticeEvent` that narrates the failure edge, followed by the `ModelChangeEvent` whose job is to keep model labels and context limits truthful.

## Root cause

`local_operator/harness/subagent.py` correctly retains both events in `job.trajectory`:

1. `model/configure.py::_on_route_change` emits `provider failure — falling back to <target>` as the user-facing notice.
2. `session/session.py::_on_route_settled` emits `ModelChangeEvent` so the status band and job row follow the effective model.

`fold_trajectory()` in the subagent view rendered both as transcript notices. The main conversation already has the correct contract: `OperatorApp.on_effective_model_changed` updates the display but deliberately emits no transcript line because the route-change notice already narrated the edge. `ModelChangeEvent`'s own contract says the same thing.

## What changed

- `local_operator/tui/widgets/subagent_view.py`: `model_change` is now display-state noise at transcript zoom and produces no `SubagentEntry`. Canonical `NoticeEvent` rows remain visible, so every real fallback or recovery transition still appears exactly once.
- `retry_start` is deliberately unchanged. Retry/backoff rows remain useful even when no route edge occurs; this fix is semantic and event-type-based rather than adjacent-text deduplication that could hide a legitimate recurrence after recovery.
- `tests/unit/tui/test_subagent_view.py`: regressions for one fallback, a three-target cascade, primary recovery, and retained retry rendering.
- `pyproject.toml`: **0.41.4 → 0.41.5** (patch — a user-visible observability correction).

## Testing evidence

### Real rendered path — before / after

Drove the real `OperatorApp` with a subagent job containing assistant/tool activity plus three realistic route transitions, each represented by its actual `NoticeEvent` + `ModelChangeEvent` pair. Opened the full subagent view and captured it with `app.save_screenshot()`.

- **Before:** six warning rows for three transitions (canonical notice + `fell back to …` duplicate for each target).
- **After:** exactly three warning rows, one canonical notice per actual target.
- Geometry unchanged: screen `108×32`, screen virtual size `108×32`; body `105×16`; no vertical scrollbar.

Artifacts:
- `/tmp/lop-failover-shots/ql-before/before.svg.png`
- `/tmp/lop-failover-shots/ql-after/after.svg.png`

### Automated

```text
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui/test_subagent_view.py -q -p no:randomly -p no:cacheprovider
78 passed

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui -q -p no:randomly -p no:cacheprovider
2541 passed, 4 skipped, 3 unrelated parallel timing/render failures
$ pytest <the three failures> -q
3 passed
```

The three broad-suite failures are unrelated Textual pilot contention failures outside the touched surface and all pass serially.

### Quality gates

```text
$ .venv/bin/python -m flake8 .
clean
$ uvx --from black==26.1.0 black --check .
555 files unchanged
$ python -m isort --check .  # isort 5.13.2, repo config
clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python <touched files>
0 errors, 0 warnings
```

The exact full-tree pyright was also started locally but remained active for more than 11 minutes under shared-host contention; CI runs that exact command on an isolated runner and must be green before merge.

## Full changelog

https://github.com/damianvtran/local-operator/compare/v0.41.4...dev-subagent-failover-spam
