### PR TITLE
chore(release): 0.41.6 (version collision fix for #325)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.41.5"
+version = "0.41.6"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Mechanical version bump: #325 (roster sidecar write churn + legacy transcript bloat heal) merged to main carrying `version = "0.41.5"`, but a concurrent mobile-relay PR (#323) tagged and published **0.41.5** to PyPI first (~19:32Z). Main's pyproject now names a version already taken on PyPI, so #325's roster fixes have no releasable version.

This bumps main to **0.41.6** so the roster fixes get their own tag and PyPI release. One line, no code change.

## Change classification

C1 mechanical release-hygiene fix. No functional change; the code being released was fully reviewed and CI-green under #325 (three agent review rounds, all clean).

## Validation

- Diff is exactly the `pyproject.toml` version line `0.41.5` → `0.41.6`.
- CI on this branch validates the tree builds and imports at the new version.
- The substantive roster code shipping under this version is #325's, already merged and green.

## Agent review

Lightweight agent review round to follow (no code delta beyond the version line).