### PR TITLE
chore(extension): bump version to 0.1.2

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Local Operator",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Connect Local Operator to the browser you already use, entirely on your machine.",
   "permissions": ["debugger", "tabs", "scripting", "storage", "alarms", "webNavigation", "notifications"],
   "host_permissions": ["<all_urls>"],

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-operator-browser-extension",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "packageManager": "pnpm@11.22.0",
   "scripts": {

--- a/extension/src/origins.ts
+++ b/extension/src/origins.ts
@@ -269,7 +269,9 @@ async function recordAccessDecisionLocked(
  * resolved only after that atomic validation succeeds. A duplicate delivery
  * of the CURRENT generation is idempotent: the record already carries the
  * decision, so the re-read sees `live.decision` set and nothing re-applies
- * (still `applied:true` — the user's click did land, it just already landed). */
+ * (`applied:false` — the click already landed once; a second landing must be
+ * a no-op, and the caller distinguishes "this delivery did something" from
+ * "the decision exists" via the record, not the return value). */
 export function resolveOrigin(
   origin: string,
   decision: OriginDecision,


### PR DESCRIPTION
## What

Bumps the extension 0.1.1 → 0.1.2 and corrects the round-4 review nit (a stale `resolveOrigin` docstring parenthetical; code and tests already said `applied:false`).

## Why 0.1.2

The 0.1.1 package was built before three merges landed. 0.1.2 carries the full beta-test hardening batch, every piece live-verified in a real paired Chrome:

- **#319** snapshot walks through ignored AX wrappers (1 node → 228 nodes/52 refs live)
- **#324** ref-resolution `DOM.getDocument` fix (ref click/type proven live)
- **#320** honest bridge client timeouts (60 < 65 < 90/100 s chain from protocol.py)
- **#321** multi-tab surfaces — parallel sessions own tabs, `tabs` list with nonce redaction
- **#329** async origin-approval flow — `request_access`/`await_access`, fail-early teaching errors, requester-bound grants, prompt generations, atomic once-grant consumption (four review rounds)

## Testing

- `pnpm typecheck` clean, `pnpm test` 35/35, `pnpm build:zip` + `validate-store-zip.sh … 0.1.2` pass (validated package: 0.1.2, no source maps)