### PR TITLE
chore(release): 0.41.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.41.7"
+version = "0.41.8"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Version bump to 0.41.8 for the mobile multi-part ask fix (#333). 0.41.7 was already taken by the Goal next-step updates release that landed from main while #333 was in flight. Version-string-only change; substantive review is on #333.