### PR TITLE
chore(release): bump version to 0.41.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.41.8"
+version = "0.41.9"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Mechanical version correction after concurrent publishing: `v0.41.8` was published from `cfa4cbaf`, then #334 merged at `7ace5fb4` while still carrying `version = "0.41.8"`. PyPI versions are immutable, so the newly merged subagents-panel change needs a fresh release version.

This bumps only `pyproject.toml` from **0.41.8** to **0.41.9**. There is no lockfile in this repository and no functional code change.

## Validation

- Confirmed `v0.41.8` resolves to `cfa4cbaf19ec841899e8e16954113704ebf75d4d` while current `origin/main` is `7ace5fb4ac3824857b251adc9c63b182d9472f23`.
- Confirmed PyPI currently reports `local-operator` **0.41.8**.
- Built `local_operator-0.41.9-py3-none-any.whl`; wheel metadata reports `Version: 0.41.9`.
- `flake8 .` passed.
- `black==26.1.0 --check .` passed (556 files unchanged).
- `isort==5.13.2 --check .` passed.
- `pyright --pythonpath .venv/bin/python .` passed with 0 errors, 0 warnings.
- Full unit run: 7,157 passed, 7 skipped; seven unrelated failures remain on the unchanged tree. The timing-sensitive mobile failure passed in isolation. The server-model failures reproduce in their own file because `app.state.env_config` is absent and are outside this one-line version-only diff.

## Review

Independent agent review is required before merge. This PR must not merge until that review round is posted, answered, and fresh against the current head.
