### PR TITLE
chore(release): 0.41.9 (version collision fix for #336)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.41.8"
+version = "0.41.9"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Mechanical version bump: **0.41.8 was concurrently tagged before #336 merged**, so the MCP routing changes merged in #336 need a fresh version for release.

This bumps main to **0.41.9**. One line, no code change.

## Change classification

C1 mechanical release hygiene. The substantive code was reviewed in #336 with a clean agent-review round 5 against its current head and green CI.

## Validation

- Confirmed `origin/main` contains #336's merge commit `0046f2562bcc290ca87badc84484de7fed0216ab` and still declares `0.41.8`.
- Confirmed `v0.41.8` points to the earlier concurrent release at `cfa4cbaf19ec841899e8e16954113704ebf75d4d`.
- Diff is exactly the `pyproject.toml` version line `0.41.8` → `0.41.9`.
- Built the wheel with `uv build --wheel`; filename and wheel metadata both report `0.41.9`.

## Agent review

A fresh agent-review round for this mechanical version-only PR is required before merge. The substantive MCP routing code was reviewed in #336.
