### PR TITLE
fix(mcp): adopt peer-rotated token on 401 to avoid Notion logout

### DIFF
--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -59,11 +59,6 @@ from local_operator.callback_page import callback_response
 if TYPE_CHECKING:
     # The SDK is an optional extra: these names are needed for annotations
     # only, so importing them here keeps this module importable without it.
-    # NOTE: the SDK's auth flow is typed against its own vendored ``httpx2``
-    # (a separate distribution from ``httpx``), and ``gen.asend`` for the inner
-    # generator only accepts ``httpx2.Response`` — so the adoption retry's
-    # response annotation must be ``httpx2``'s, not ``httpx``'s.
-    import httpx2
     from mcp.shared.auth import (
         AuthorizationCodeResult,
         OAuthClientInformationFull,
@@ -1798,17 +1793,20 @@ def _make_refresh_coordinating_provider(
             # path when httpx closes the OUTER flow (its ``finally:
             # await auth_flow.aclose()``).
             inner = super().async_auth_flow(request)
-            # One 401-driven token adoption is allowed per flow invocation;
-            # ``None`` = the first yield has not arrived yet (the SDK re-auth
-            # machinery never yields the ORIGINAL request object again, so the
-            # guard can latch on identity), and anything True means the adoption
-            # budget is spent — a second 401 must pass through untouched.
-            original_request: Any = None
+            # One 401-driven token adoption is allowed per flow invocation.
+            # ``original_request`` is the caller's request object itself (NOT
+            # the first yield: when the loaded token is expired the SDK yields
+            # a refresh request first, and latching on the first yield would
+            # point the identity guard at the wrong object). The SDK re-auth
+            # machinery never yields this object again except its own end-of-flow
+            # retry, so ``outgoing is original_request`` reliably identifies the
+            # caller's request; ``adoption_attempted`` spends the one-retry
+            # budget — a second 401 must pass through untouched.
+            original_request: Any = request
             adoption_attempted = False
             try:
                 try:
                     outgoing = await inner.__anext__()
-                    original_request = outgoing
                 except StopAsyncIteration:
                     return
                 while True:
@@ -1863,16 +1861,33 @@ def _make_refresh_coordinating_provider(
                         # (stored token identical to ours, or none) also passes
                         # through unchanged on this first 401.
                         adoption_attempted = True
-                        retry_response = await self._adopt_peer_token_once(
-                            request, original_request
-                        )
-                        if retry_response is not None:
-                            # A peer's fresh token answered the request: feed the
-                            # retry's response into the SDK generator INSTEAD of
-                            # the 401, so its full browser-authorization branch
-                            # never sees a challenge. Mirrors the SDK's own
-                            # end-of-flow retry, which re-sends the same request
-                            # object after ``_add_auth_header`` mutates it.
+                        retry_request = await self._adopt_peer_token_once(original_request)
+                        if retry_request is not None:
+                            # Re-yield the retry request: the SAME httpx client
+                            # that sent the original sends this one (same
+                            # proxies, TLS, and event hooks), exactly matching
+                            # the SDK's own end-of-flow 401 retry, which
+                            # re-yields the request after ``_add_auth_header``.
+                            # Then feed the retry's response into the SDK
+                            # generator INSTEAD of the 401, so its full
+                            # browser-authorization branch never sees a
+                            # challenge.
+                            try:
+                                retry_response = yield retry_request
+                            except GeneratorExit:
+                                # The outer flow is closing: re-raise so the
+                                # ``finally`` below closes the inner generator
+                                # and the SDK unwinds its lock.
+                                raise
+                            except BaseException as exc:  # noqa: BLE001
+                                # A transport fault on the retry: deliver it into
+                                # the SDK generator so its ``finally`` runs and
+                                # the lock is released, then relay what it yields.
+                                try:
+                                    outgoing = await inner.athrow(exc)
+                                except StopAsyncIteration:
+                                    return
+                                continue
                             try:
                                 outgoing = await inner.asend(retry_response)
                             except StopAsyncIteration:
@@ -1894,24 +1909,22 @@ def _make_refresh_coordinating_provider(
                 # never left suspended. Idempotent if already exhausted/closed.
                 await inner.aclose()
 
-        async def _adopt_peer_token_once(
-            self, request: Any, original_request: Any
-        ) -> "httpx2.Response | None":
-            """Re-send the original request once with a peer-rotated token, if any.
+        async def _adopt_peer_token_once(self, original_request: Any) -> Any:
+            """Adopt a peer-rotated token and return the request to retry, if any.
 
-            Returns the retry's ``httpx.Response`` when the store held an access
-            token DIFFERENT from the one in memory and the re-send completed —
-            whatever status it came back with, success or failure, so the SDK
-            sees the truth about the adopted token. Returns ``None`` when there
-            is nothing to adopt (stored token identical to ours, or no row), in
-            which case the caller passes the original 401 through to the SDK.
+            Returns the ORIGINAL request with its Authorization header rewritten
+            to the adopted token when the store held an access token DIFFERENT
+            from the one in memory — the caller re-yields it so the SAME httpx
+            client that sent the original sends the retry (same proxies, TLS,
+            and event hooks). Returns ``None`` when there is nothing to adopt
+            (stored token identical to ours, or no row), in which case the
+            caller passes the original 401 through to the SDK.
 
-            ``request`` is the request object the SDK is driving; the adopted
-            token is installed into the context AND into that object's
-            Authorization header, because the SDK's end-of-flow retry re-sends
-            this same object after ``_add_auth_header`` — mutating it here keeps
-            the retry (and any later one) on the adopted token rather than
-            stamping the revoked one back over it.
+            Mutating the request object in place (rather than building a new
+            one) matches the SDK's own end-of-flow 401 retry contract:
+            ``_add_auth_header`` rewrites the same object's Authorization header
+            and re-yields it. Header mutation never touches the request
+            body/stream, so the re-send is body-safe.
             """
             try:
                 async with _oauth_refresh_lock(self._refresh_coord_server_url):
@@ -1928,8 +1941,9 @@ def _make_refresh_coordinating_provider(
                     self.context.token_expiry_time = (
                         self._refresh_coord_storage.stored_token_expiry()
                     )
-                    retry = original_request
-                    retry.headers["Authorization"] = f"Bearer {stored.access_token}"
+                    original_request.headers["Authorization"] = (
+                        f"Bearer {stored.access_token}"
+                    )
             except Exception:  # noqa: BLE001 — adoption is best-effort
                 # A failed re-read must not break the request: defer to the
                 # SDK's own 401 handling rather than inventing a new failure.
@@ -1939,39 +1953,11 @@ def _make_refresh_coordinating_provider(
                     exc_info=True,
                 )
                 return None
-            if retry is request:
-                # The SDK's first yield IS the request it was given, so this is
-                # the normal case and there is nothing to clone. A subclass that
-                # ever yielded a DIFFERENT object would make mutating it here an
-                # observable side effect; skipping the retry then is deliberate
-                # — the 401 passes through, which is the safe pre-fix behaviour.
-                logger.debug(
-                    "MCP 401 adoption retrying %s with a peer-rotated token",
-                    self._refresh_coord_server_url,
-                )
-                return await self._send_401_adoption_retry(retry)
-            return None
-
-        async def _send_401_adoption_retry(self, request: Any) -> "httpx2.Response | None":
-            """Send the re-authorized request through the SDK's own transport.
-
-            The auth flow only ever YIELDS requests for the caller to send, so
-            re-sending needs a real send path. The SDK wires its httpx transport
-            onto the provider as ``_transport`` (used by its internal discovery
-            and token-endpoint posts); routing the retry through the same
-            transport keeps proxies, TLS, and event hooks identical to the send
-            that produced the 401. The body is replay-safe: httpx ``Request``
-            content is materialized at construction, so a re-send re-reads the
-            bytes — the SDK's own end-of-flow retry relies on exactly this.
-            """
-            transport = getattr(self, "_transport", None)
-            if transport is None:
-                logger.debug(
-                    "MCP 401 adoption has no transport for %s; passing the 401 through",
-                    self._refresh_coord_server_url,
-                )
-                return None
-            return await transport.handle_async_request(request)
+            logger.debug(
+                "MCP 401 adoption retrying %s with a peer-rotated token",
+                self._refresh_coord_server_url,
+            )
+            return original_request
 
     return _RefreshCoordinatingOAuthProvider(**kwargs)
 

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -59,6 +59,11 @@ from local_operator.callback_page import callback_response
 if TYPE_CHECKING:
     # The SDK is an optional extra: these names are needed for annotations
     # only, so importing them here keeps this module importable without it.
+    # NOTE: the SDK's auth flow is typed against its own vendored ``httpx2``
+    # (a separate distribution from ``httpx``), and ``gen.asend`` for the inner
+    # generator only accepts ``httpx2.Response`` — so the adoption retry's
+    # response annotation must be ``httpx2``'s, not ``httpx``'s.
+    import httpx2
     from mcp.shared.auth import (
         AuthorizationCodeResult,
         OAuthClientInformationFull,
@@ -1682,6 +1687,17 @@ def _make_refresh_coordinating_provider(
     the common case, where a sibling already refreshed — and only the
     self-performed exchange falls back to the SDK's own unlocked refresh, i.e.
     exactly the pre-fix behaviour for that one provider.
+
+    The subclass additionally intercepts the FIRST 401 the resource server
+    returns for the original request. The coordination step above only fires
+    when the loaded token is EXPIRED, but a rotating provider (Notion) revokes
+    every previously issued access token when a sibling refreshes — so a
+    session can hold a locally-valid, server-side-revoked token that sails
+    past coordination and gets a 401. Before that 401 reaches the SDK's full
+    browser-authorization branch, the flow re-reads the store under the lock
+    and, if a peer's different token is already there, adopts it and re-sends
+    the request once. See ``async_auth_flow`` for the bound and the pass-through
+    rule for genuinely dead grants.
     """
     from mcp.client.auth import OAuthClientProvider
 
@@ -1782,9 +1798,17 @@ def _make_refresh_coordinating_provider(
             # path when httpx closes the OUTER flow (its ``finally:
             # await auth_flow.aclose()``).
             inner = super().async_auth_flow(request)
+            # One 401-driven token adoption is allowed per flow invocation;
+            # ``None`` = the first yield has not arrived yet (the SDK re-auth
+            # machinery never yields the ORIGINAL request object again, so the
+            # guard can latch on identity), and anything True means the adoption
+            # budget is spent — a second 401 must pass through untouched.
+            original_request: Any = None
+            adoption_attempted = False
             try:
                 try:
                     outgoing = await inner.__anext__()
+                    original_request = outgoing
                 except StopAsyncIteration:
                     return
                 while True:
@@ -1805,6 +1829,61 @@ def _make_refresh_coordinating_provider(
                         except StopAsyncIteration:
                             return
                         continue
+                    if (
+                        response is not None
+                        and response.status_code == 401
+                        and not adoption_attempted
+                        and outgoing is original_request
+                    ):
+                        # The coordination step above only fires when the loaded
+                        # token is EXPIRED, but Notion revokes every previously
+                        # issued access token the moment any sibling process
+                        # rotates the grant. Every other live session then holds
+                        # a locally-VALID, server-side-REVOKED token: it skips
+                        # coordination, sends the corpse, and this 401 is what
+                        # comes back. The SDK's answer to a 401 is the FULL
+                        # browser authorization (non-interactive connects turn
+                        # that into McpAuthRequiredError and suspend
+                        # auto-reconnect), even though the shared store already
+                        # holds the sibling's fresh token. So before the 401
+                        # reaches the SDK, re-read the store under the refresh
+                        # lock and adopt a DIFFERENT token if a peer wrote one.
+                        #
+                        # Adoption is race-free without spending anything: it
+                        # copies a token a sibling already paid a refresh for,
+                        # so it cannot invalidate anything and cannot double-
+                        # spend the rotating refresh token. The lock only
+                        # serializes the re-read against a concurrent rotation
+                        # so the adopted value is not mid-write. It is bounded
+                        # to ONE attempt per flow: if the adopted token ALSO
+                        # 401s (a genuinely dead grant, e.g. the user revoked
+                        # access server-side), the second 401 passes through to
+                        # the SDK's own full-flow branch exactly as before —
+                        # adoption never loops. A grant that is truly dead
+                        # (stored token identical to ours, or none) also passes
+                        # through unchanged on this first 401.
+                        adoption_attempted = True
+                        retry_response = await self._adopt_peer_token_once(
+                            request, original_request
+                        )
+                        if retry_response is not None:
+                            # A peer's fresh token answered the request: feed the
+                            # retry's response into the SDK generator INSTEAD of
+                            # the 401, so its full browser-authorization branch
+                            # never sees a challenge. Mirrors the SDK's own
+                            # end-of-flow retry, which re-sends the same request
+                            # object after ``_add_auth_header`` mutates it.
+                            try:
+                                outgoing = await inner.asend(retry_response)
+                            except StopAsyncIteration:
+                                return
+                            continue
+                        # No peer token to adopt: fall through and hand the 401
+                        # to the SDK unchanged (existing dead-grant behaviour).
+                    # ``response`` is whatever the caller sent into the flow;
+                    # httpx always sends a real Response, so the None case is a
+                    # type-narrowing artifact, not a reachable state.
+                    assert response is not None  # noqa: S101 — httpx never sends None
                     try:
                         outgoing = await inner.asend(response)
                     except StopAsyncIteration:
@@ -1814,6 +1893,85 @@ def _make_refresh_coordinating_provider(
                 # pass through here, so the SDK generator (and its held lock) is
                 # never left suspended. Idempotent if already exhausted/closed.
                 await inner.aclose()
+
+        async def _adopt_peer_token_once(
+            self, request: Any, original_request: Any
+        ) -> "httpx2.Response | None":
+            """Re-send the original request once with a peer-rotated token, if any.
+
+            Returns the retry's ``httpx.Response`` when the store held an access
+            token DIFFERENT from the one in memory and the re-send completed —
+            whatever status it came back with, success or failure, so the SDK
+            sees the truth about the adopted token. Returns ``None`` when there
+            is nothing to adopt (stored token identical to ours, or no row), in
+            which case the caller passes the original 401 through to the SDK.
+
+            ``request`` is the request object the SDK is driving; the adopted
+            token is installed into the context AND into that object's
+            Authorization header, because the SDK's end-of-flow retry re-sends
+            this same object after ``_add_auth_header`` — mutating it here keeps
+            the retry (and any later one) on the adopted token rather than
+            stamping the revoked one back over it.
+            """
+            try:
+                async with _oauth_refresh_lock(self._refresh_coord_server_url):
+                    stored = await self.context.storage.get_tokens()
+                    if stored is None or not stored.access_token:
+                        return None
+                    current = self.context.current_tokens
+                    if current is not None and stored.access_token == current.access_token:
+                        # The store still holds exactly the token that just 401'd:
+                        # this grant is dead everywhere, not merely revoked for
+                        # us. The SDK's full flow is the right answer.
+                        return None
+                    self.context.current_tokens = stored
+                    self.context.token_expiry_time = (
+                        self._refresh_coord_storage.stored_token_expiry()
+                    )
+                    retry = original_request
+                    retry.headers["Authorization"] = f"Bearer {stored.access_token}"
+            except Exception:  # noqa: BLE001 — adoption is best-effort
+                # A failed re-read must not break the request: defer to the
+                # SDK's own 401 handling rather than inventing a new failure.
+                logger.debug(
+                    "MCP 401 token adoption failed for %s",
+                    self._refresh_coord_server_url,
+                    exc_info=True,
+                )
+                return None
+            if retry is request:
+                # The SDK's first yield IS the request it was given, so this is
+                # the normal case and there is nothing to clone. A subclass that
+                # ever yielded a DIFFERENT object would make mutating it here an
+                # observable side effect; skipping the retry then is deliberate
+                # — the 401 passes through, which is the safe pre-fix behaviour.
+                logger.debug(
+                    "MCP 401 adoption retrying %s with a peer-rotated token",
+                    self._refresh_coord_server_url,
+                )
+                return await self._send_401_adoption_retry(retry)
+            return None
+
+        async def _send_401_adoption_retry(self, request: Any) -> "httpx2.Response | None":
+            """Send the re-authorized request through the SDK's own transport.
+
+            The auth flow only ever YIELDS requests for the caller to send, so
+            re-sending needs a real send path. The SDK wires its httpx transport
+            onto the provider as ``_transport`` (used by its internal discovery
+            and token-endpoint posts); routing the retry through the same
+            transport keeps proxies, TLS, and event hooks identical to the send
+            that produced the 401. The body is replay-safe: httpx ``Request``
+            content is materialized at construction, so a re-send re-reads the
+            bytes — the SDK's own end-of-flow retry relies on exactly this.
+            """
+            transport = getattr(self, "_transport", None)
+            if transport is None:
+                logger.debug(
+                    "MCP 401 adoption has no transport for %s; passing the 401 through",
+                    self._refresh_coord_server_url,
+                )
+                return None
+            return await transport.handle_async_request(request)
 
     return _RefreshCoordinatingOAuthProvider(**kwargs)
 

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -1941,9 +1941,7 @@ def _make_refresh_coordinating_provider(
                     self.context.token_expiry_time = (
                         self._refresh_coord_storage.stored_token_expiry()
                     )
-                    original_request.headers["Authorization"] = (
-                        f"Bearer {stored.access_token}"
-                    )
+                    original_request.headers["Authorization"] = f"Bearer {stored.access_token}"
             except Exception:  # noqa: BLE001 — adoption is best-effort
                 # A failed re-read must not break the request: defer to the
                 # SDK's own 401 handling rather than inventing a new failure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.0"
+version = "0.42.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/repro_notion_401.py
+++ b/scripts/repro_notion_401.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Two-process repro for the residual Notion MCP OAuth logout bug.
+
+Proves the 401-adoption fix end to end across PROCESS boundaries, which is
+where the bug lives: several long-lived local-operator sessions share ONE
+stored grant row, Notion rotates the refresh token on every use, and rotating
+REVOKES every previously issued access token. A session holding a locally-
+valid but server-side-revoked token must recover by adopting a sibling's
+fresh token on the 401 — NOT by running the full browser authorization grant
+(the "Notion logged out again" the user saw several times a day).
+
+Scenario (two OS processes, one shared auth.db, one fake Notion-like AS):
+
+- A fake authorization server issues 8h access tokens, rotates the refresh
+  token on every refresh, and revokes all prior access tokens when it rotates
+  (exactly Notion's behaviour). Revocation state is kept in a small registry
+  guarded by an flock'd file, mirroring how production already coordinates
+  cross-process with ``fcntl.flock`` in ``_oauth_refresh_lock``.
+- Process A boots with the original token, REFRESHES (rotates), and persists
+  the fresh token to the shared store.
+- Process B boots (in a SEPARATE process) with the token it loaded BEFORE the
+  rotation — locally valid (unexpired), but revoked server-side by A's
+  rotation. It makes a request, gets a 401, and must succeed by adopting A's
+  token from the shared store WITHOUT any browser grant / discovery request.
+
+Usage:
+    .venv/bin/python scripts/repro_notion_401.py <scratch_dir>
+
+Prints PASS/FAIL lines and exits non-zero on failure. A pre-fix tree FAILs:
+process B runs the full authorization grant instead of adopting the token.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+# Ensure the repo is importable regardless of the caller's cwd.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+SERVER_URL = "https://mcp.notion.test/mcp"
+
+# The access-token "registry" the fake AS consults. Kept as a JSON file under
+# an flock'd lock so two processes agree on which tokens are revoked without
+# any extra dependency (aiosqlite is not installed).
+REGISTRY_NAME = "as_registry.json"
+REGISTRY_LOCK_NAME = "as_registry.lock"
+
+
+def _registry_paths(scratch: str):
+    return os.path.join(scratch, REGISTRY_NAME), os.path.join(scratch, REGISTRY_LOCK_NAME)
+
+
+def _with_registry(scratch: str, mutate) -> Any:
+    """Read-modify-write the fake AS's token registry under an flock'd file.
+
+    Cross-process safe the same way production's ``_oauth_refresh_lock`` is:
+    a byte-range flock on a sidecar file, never on the data file itself.
+    """
+    import fcntl
+
+    reg_path, lock_path = _registry_paths(scratch)
+    os.makedirs(scratch, exist_ok=True)
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            with open(reg_path) as fh:
+                data = json.load(fh)
+        except (FileNotFoundError, json.JSONDecodeError):
+            data = {"live": [], "counter": 0}
+        result = mutate(data)
+        with open(reg_path, "w") as fh:
+            json.dump(data, fh)
+        return result
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def _as_issue_initial(scratch: str) -> dict[str, Any]:
+    """The authorization server issues the ORIGINAL grant (access + refresh)."""
+
+    def mutate(data):
+        data["counter"] += 1
+        token = {
+            "access_token": f"access-{data['counter']}",
+            "refresh_token": f"refresh-{data['counter']}",
+        }
+        data["live"] = [token["access_token"]]
+        return token
+
+    return _with_registry(scratch, mutate)
+
+
+def _as_refresh(scratch: str, presented_refresh: str) -> dict[str, Any]:
+    """The AS rotates: a refresh REVOKES every prior access token (Notion).
+
+    The presented refresh token must match the CURRENT one — a stale refresh
+    (a second process spending the token it loaded at boot) is rejected, which
+    is exactly the double-spend Notion punishes."""
+
+    def mutate(data):
+        current_refresh = f"refresh-{data['counter']}"
+        if presented_refresh != current_refresh:
+            raise RuntimeError(
+                f"stale refresh token presented: {presented_refresh} != {current_refresh}"
+            )
+        data["counter"] += 1
+        token = {
+            "access_token": f"access-{data['counter']}",
+            "refresh_token": f"refresh-{data['counter']}",
+        }
+        # Rotation revokes ALL previously issued access tokens.
+        data["live"] = [token["access_token"]]
+        return token
+
+    return _with_registry(scratch, mutate)
+
+
+def _as_token_live(scratch: str, access_token: str) -> bool:
+    reg_path, _ = _registry_paths(scratch)
+    try:
+        with open(reg_path) as fh:
+            data = json.load(fh)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return False
+    return access_token in data.get("live", [])
+
+
+def _endpoints():
+    from mcp.shared.auth import OAuthMetadata
+
+    from local_operator.mcp.auth import DiscoveredOAuthEndpoints
+
+    return DiscoveredOAuthEndpoints(
+        oauth_metadata=OAuthMetadata.model_validate(
+            {
+                "issuer": SERVER_URL,
+                "authorization_endpoint": "https://a/authorize",
+                "token_endpoint": "https://a/token",
+            }
+        )
+    )
+
+
+def _build_provider(scratch: str, role: str, browser_events: list[str]):
+    """A refresh-coordinating provider over the SHARED auth.db.
+
+    ``role`` is "A" (refresher) or "B" (adopter); only A's transport performs
+    the rotation. The provider is built NON-INTERACTIVE, so if the 401 ever
+    reaches the SDK's full authorization branch it raises McpAuthRequiredError
+    instead of opening a browser — which is precisely the bug being proven
+    absent for B."""
+    import httpx
+
+    from local_operator.mcp.auth import build_oauth_provider
+    from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+    from local_operator.providers.auth_store import AuthStore
+
+    store = AuthStore(db_path=os.path.join(scratch, "auth.db"))
+    cfg = MCPHttpServerConfig(url=SERVER_URL, auth=MCPAuthConfig(type="oauth"))
+    provider = build_oauth_provider(
+        SERVER_URL, cfg, store=store, endpoints=_endpoints(), interactive=False
+    )
+
+    async def fake_send(request):
+        url = str(request.url)
+        # The fake AS's token endpoint: only process A refreshes here.
+        if url.rstrip("/").endswith("/token"):
+            from mcp.shared.auth import OAuthToken
+
+            # Pull the presented refresh token out of the form body.
+            body = request.content.decode()
+            presented = ""
+            for part in body.split("&"):
+                if part.startswith("refresh_token="):
+                    presented = part.split("=", 1)[1]
+            new = _as_refresh(scratch, presented)
+            token = OAuthToken(
+                access_token=new["access_token"],
+                refresh_token=new["refresh_token"],
+                expires_in=3600,
+            )
+            return httpx.Response(200, json=token.model_dump(mode="json"), request=request)
+
+        # The authorization endpoint: reaching it means the FULL browser grant
+        # ran — the bug. Record it so the assertion can name the culprit.
+        if "authorize" in url:
+            browser_events.append(f"{role}: AUTHORIZATION-GRANT request to {url}")
+            return httpx.Response(200, json={}, request=request)
+
+        # The resource server: 401 any REVOKED token, 200 a live one.
+        auth = request.headers.get("Authorization", "")
+        token = auth.removeprefix("Bearer ").strip()
+        if _as_token_live(scratch, token):
+            return httpx.Response(200, json={"ok": True}, request=request)
+        return httpx.Response(401, request=request)
+
+    provider._transport = httpx.AsyncHTTPTransport()
+    provider._transport.handle_async_request = fake_send
+    return provider
+
+
+async def _process_a(scratch: str) -> None:
+    """Process A: load the original token, then REFRESH (rotating the grant).
+
+    A's token was loaded at boot before the refresh; the refresh exchange is
+    emulated by calling the fake AS's rotation directly and persisting the
+    result through the SAME storage the provider uses, which is what the real
+    in-flow refresh does. The point is the SIDE EFFECT on the shared store and
+    on the AS's revocation registry, not which coroutine spent the token."""
+    from mcp.shared.auth import OAuthToken
+
+    from local_operator.mcp.auth import McpTokenStorage
+    from local_operator.providers.auth_store import AuthStore
+
+    store = AuthStore(db_path=os.path.join(scratch, "auth.db"))
+    storage = McpTokenStorage(SERVER_URL, store)
+    current = await storage.get_tokens()
+    assert current is not None and current.refresh_token is not None
+    # Rotate at the AS (revokes the original access token) and persist the
+    # fresh pair, exactly as a successful refresh would.
+    new = _as_refresh(scratch, current.refresh_token)
+    await storage.set_tokens(
+        OAuthToken(
+            access_token=new["access_token"], refresh_token=new["refresh_token"], expires_in=3600
+        )
+    )
+    print(f"A: rotated grant; live access token is now {new['access_token']}", flush=True)
+
+
+async def _process_b(scratch: str) -> int:
+    """Process B: hold the PRE-ROTATION token, request, get 401, must adopt.
+
+    Returns 0 on success (adopted, no browser grant), 1 on the bug (a full
+    authorization grant ran or the request failed)."""
+    import httpx
+
+    from local_operator.mcp.auth import McpAuthRequiredError, McpTokenStorage
+    from local_operator.providers.auth_store import AuthStore
+
+    browser_events: list[str] = []
+
+    provider = _build_provider(scratch, "B", browser_events)
+
+    # Reconstruct B's exact multi-process state: B BOOTED before A's rotation,
+    # so its in-memory token is the ORIGINAL one — locally valid (unexpired),
+    # but revoked server-side by A's rotation. The provider's ``_initialize``
+    # would load the CURRENT (rotated) store token, so we pin the in-memory
+    # state to the pre-rotation view directly: the original token, an unexpired
+    # deadline, and the initialized flag. This is precisely the session that,
+    # pre-fix, sent the revoked token, got a 401, and ran a full browser grant.
+    import time as _time
+
+    from mcp.shared.auth import OAuthToken
+
+    original_access = "access-1"
+    provider.context.current_tokens = OAuthToken(
+        access_token=original_access, refresh_token="refresh-1", expires_in=3600
+    )
+    provider.context.token_expiry_time = _time.time() + 3600  # locally valid
+    provider._initialized = True
+
+    # The shared store already holds A's rotated token; note it for the log.
+    store = AuthStore(db_path=os.path.join(scratch, "auth.db"))
+    storage = McpTokenStorage(SERVER_URL, store)
+    stored_now = await storage.get_tokens()
+    print(
+        f"B: booted holding '{original_access}' (locally valid, revoked by A); "
+        f"store holds '{stored_now.access_token if stored_now else None}'",
+        flush=True,
+    )
+
+    # Trace the adoption helper so we can see whether the 401 branch fires and
+    # what it returns, inside the real flow. The retry's response IS the
+    # request's final outcome when adoption ran — httpx hands THAT response
+    # (not the 401) to the caller — so capture it here.
+    outcome: dict[str, Any] = {}
+    _orig_adopt = getattr(provider, "_adopt_peer_token_once", None)
+    if _orig_adopt is not None:
+        # Post-fix: the retry's response IS the request's final outcome when
+        # adoption ran — httpx hands THAT response (not the 401) to the caller.
+        async def _traced_adopt(req, orig):
+            res = await _orig_adopt(req, orig)
+            if res is not None:
+                outcome["status"] = res.status_code
+                outcome["adopted"] = provider.context.current_tokens.access_token
+            return res
+
+        provider._adopt_peer_token_once = _traced_adopt
+    # Pre-fix there is no adoption helper: B's 401 drives the SDK's full
+    # authorization grant, which (non-interactive) raises McpAuthRequiredError —
+    # the bug this repro demonstrates.
+
+    # Drive the auth flow the way httpx does: send each yielded request through
+    # the provider's transport and feed the response back in.
+    gen = provider.async_auth_flow(httpx.Request("POST", SERVER_URL, content=b'{"q":1}'))
+    try:
+        request = await gen.__anext__()
+        final_status = None
+        while True:
+            response = await provider._transport.handle_async_request(request)
+            try:
+                request = await gen.asend(response)
+            except StopAsyncIteration:
+                final_status = response.status_code
+                break
+    except McpAuthRequiredError as exc:
+        print(f"B: FAIL — full authorization grant ran (McpAuthRequiredError): {exc}", flush=True)
+        return 1
+    finally:
+        await gen.aclose()
+
+    # When adoption ran, its retry response is the request's true outcome (what
+    # httpx would hand the caller); otherwise the last response stands.
+    if "status" in outcome:
+        final_status = outcome["status"]
+
+    if browser_events:
+        print(f"B: FAIL — browser/authorization grant ran: {browser_events}", flush=True)
+        return 1
+    if final_status != 200:
+        print(f"B: FAIL — final status {final_status}, expected 200 via adoption", flush=True)
+        return 1
+
+    current = provider.context.current_tokens
+    adopted = current.access_token if current else None
+    if adopted == original_access:
+        print(f"B: FAIL — still on the revoked token '{adopted}'", flush=True)
+        return 1
+    print(
+        f"B: PASS — 401 recovered by ADOPTING sibling token '{adopted}', "
+        f"no browser grant, final status 200",
+        flush=True,
+    )
+    return 0
+
+
+def _seed(scratch: str) -> None:
+    """Seed the fake AS and the shared store with the ORIGINAL grant."""
+    import asyncio
+
+    from mcp.shared.auth import OAuthToken
+
+    from local_operator.mcp.auth import McpTokenStorage
+    from local_operator.providers.auth_store import AuthStore
+
+    token = _as_issue_initial(scratch)
+    store = AuthStore(db_path=os.path.join(scratch, "auth.db"))
+    storage = McpTokenStorage(SERVER_URL, store)
+    asyncio.run(
+        storage.set_tokens(
+            OAuthToken(
+                access_token=token["access_token"],
+                refresh_token=token["refresh_token"],
+                expires_in=3600,
+            )
+        )
+    )
+    print(f"seed: issued original grant {token}", flush=True)
+
+
+def _run_role(scratch: str, role: str) -> int:
+    import asyncio
+
+    if role == "A":
+        asyncio.run(_process_a(scratch))
+        return 0
+    return asyncio.run(_process_b(scratch))
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+    scratch = sys.argv[1]
+
+    # Subprocess entry point: `repro_notion_401.py <scratch> child <A|B>`.
+    if len(sys.argv) >= 4 and sys.argv[2] == "child":
+        # Isolate the child's config dir so _oauth_refresh_lock and AuthStore
+        # resolve under the scratch dir, never the developer's real ~/.local-operator.
+        os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = scratch
+        return _run_role(scratch, sys.argv[3])
+
+    # Orchestrator: seed, then run A and B as SEPARATE OS processes sharing the
+    # one scratch dir (one auth.db, one AS registry) — the multi-process state
+    # the bug lives in.
+    import subprocess
+
+    os.makedirs(scratch, exist_ok=True)
+    os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = scratch
+    _seed(scratch)
+
+    env = dict(os.environ, LOCAL_OPERATOR_CONFIG_DIR=scratch)
+    a = subprocess.run(
+        [sys.executable, os.path.abspath(__file__), scratch, "child", "A"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    sys.stdout.write(a.stdout)
+    sys.stderr.write(a.stderr)
+    if a.returncode != 0:
+        print("ORCH: FAIL — process A errored", flush=True)
+        return 1
+
+    b = subprocess.run(
+        [sys.executable, os.path.abspath(__file__), scratch, "child", "B"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    sys.stdout.write(b.stdout)
+    sys.stderr.write(b.stderr)
+    if b.returncode != 0:
+        print("ORCH: FAIL — process B did not recover via adoption", flush=True)
+        return 1
+
+    print("ORCH: PASS — two-process 401 adoption recovered without a browser grant", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repro_notion_401.py
+++ b/scripts/repro_notion_401.py
@@ -147,13 +147,17 @@ def _endpoints():
 
 
 def _build_provider(scratch: str, role: str, browser_events: list[str]):
-    """A refresh-coordinating provider over the SHARED auth.db.
+    """A refresh-coordinating provider over the SHARED auth.db, plus a fake
+    httpx send function standing in for the caller's client.
 
-    ``role`` is "A" (refresher) or "B" (adopter); only A's transport performs
-    the rotation. The provider is built NON-INTERACTIVE, so if the 401 ever
-    reaches the SDK's full authorization branch it raises McpAuthRequiredError
-    instead of opening a browser — which is precisely the bug being proven
-    absent for B."""
+    The provider is an httpx Auth: it only ever YIELDS requests; the CALLER's
+    httpx client sends them. Nothing in the SDK or local-operator sets a
+    transport on the provider, so this repro drives the flow exactly the way
+    httpx does — sending each yielded request through ``fake_send`` and feeding
+    the response back in. The provider is built NON-INTERACTIVE, so if the 401
+    ever reaches the SDK's full authorization branch it raises
+    McpAuthRequiredError instead of opening a browser — which is precisely the
+    bug being proven absent for B."""
     import httpx
 
     from local_operator.mcp.auth import build_oauth_provider
@@ -199,9 +203,7 @@ def _build_provider(scratch: str, role: str, browser_events: list[str]):
             return httpx.Response(200, json={"ok": True}, request=request)
         return httpx.Response(401, request=request)
 
-    provider._transport = httpx.AsyncHTTPTransport()
-    provider._transport.handle_async_request = fake_send
-    return provider
+    return provider, fake_send
 
 
 async def _process_a(scratch: str) -> None:
@@ -244,7 +246,7 @@ async def _process_b(scratch: str) -> int:
 
     browser_events: list[str] = []
 
-    provider = _build_provider(scratch, "B", browser_events)
+    provider, send = _build_provider(scratch, "B", browser_events)
 
     # Reconstruct B's exact multi-process state: B BOOTED before A's rotation,
     # so its in-memory token is the ORIGINAL one — locally valid (unexpired),
@@ -274,35 +276,17 @@ async def _process_b(scratch: str) -> int:
         flush=True,
     )
 
-    # Trace the adoption helper so we can see whether the 401 branch fires and
-    # what it returns, inside the real flow. The retry's response IS the
-    # request's final outcome when adoption ran — httpx hands THAT response
-    # (not the 401) to the caller — so capture it here.
-    outcome: dict[str, Any] = {}
-    _orig_adopt = getattr(provider, "_adopt_peer_token_once", None)
-    if _orig_adopt is not None:
-        # Post-fix: the retry's response IS the request's final outcome when
-        # adoption ran — httpx hands THAT response (not the 401) to the caller.
-        async def _traced_adopt(req, orig):
-            res = await _orig_adopt(req, orig)
-            if res is not None:
-                outcome["status"] = res.status_code
-                outcome["adopted"] = provider.context.current_tokens.access_token
-            return res
-
-        provider._adopt_peer_token_once = _traced_adopt
-    # Pre-fix there is no adoption helper: B's 401 drives the SDK's full
-    # authorization grant, which (non-interactive) raises McpAuthRequiredError —
-    # the bug this repro demonstrates.
-
     # Drive the auth flow the way httpx does: send each yielded request through
-    # the provider's transport and feed the response back in.
+    # the fake client and feed the response back in. With the fix, the adoption
+    # retry appears as a SECOND yield of the same request object bearing the
+    # adopted token; without it, the 401 drives the SDK's full authorization
+    # grant, which (non-interactive) raises McpAuthRequiredError — the bug.
     gen = provider.async_auth_flow(httpx.Request("POST", SERVER_URL, content=b'{"q":1}'))
     try:
         request = await gen.__anext__()
         final_status = None
         while True:
-            response = await provider._transport.handle_async_request(request)
+            response = await send(request)
             try:
                 request = await gen.asend(response)
             except StopAsyncIteration:
@@ -313,11 +297,6 @@ async def _process_b(scratch: str) -> int:
         return 1
     finally:
         await gen.aclose()
-
-    # When adoption ran, its retry response is the request's true outcome (what
-    # httpx would hand the caller); otherwise the last response stands.
-    if "status" in outcome:
-        final_status = outcome["status"]
 
     if browser_events:
         print(f"B: FAIL — browser/authorization grant ran: {browser_events}", flush=True)

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -1866,3 +1866,250 @@ class TestInflightRefreshCoordination:
         # Must not raise; our own locked refresh is never called (no endpoint).
         await self._drive_auth_flow(provider)
         assert refresh_calls["n"] == 0
+
+    async def _drive_401_flow(self, provider, responder) -> list[Any]:
+        """Pump ``async_auth_flow`` the way httpx does, recording every request
+        the flow yields and answering each with ``responder(request)``.
+
+        The responder's return value for the ORIGINAL request is normally a
+        401 (that is the case under test); the adoption retry is sent by the
+        provider itself through its ``_transport``, so it never appears in the
+        recorded yields.
+        """
+        import httpx
+
+        yielded: list[httpx.Request] = []
+        gen = provider.async_auth_flow(httpx.Request("POST", self.URL, content=b"payload"))
+        try:
+            request = await gen.__anext__()
+            while True:
+                yielded.append(request)
+                response = responder(request)
+                try:
+                    request = await gen.asend(response)
+                except StopAsyncIteration:
+                    return yielded
+        finally:
+            await gen.aclose()
+
+    def _adoption_transport(self, monkeypatch: pytest.MonkeyPatch, provider, records):
+        """Give the provider an httpx transport that emulates a resource server
+        which revokes the OLD token: a request bearing the revoked token gets a
+        401, one bearing the adopted token gets a 200. Returns the transport's
+        call log."""
+        import httpx
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            records.append(dict(request.headers))
+            if request.headers.get("Authorization") == "Bearer fresh-by-peer":
+                return httpx.Response(200, request=request)
+            return httpx.Response(401, request=request)
+
+        # A dedicated transport instance: patching ``handle_async_request`` on
+        # the CLASS-level ``_transport`` the SDK set would race other tests in
+        # this xdist worker — monkeypatch.undo() restores the class attribute
+        # but cannot remove the leaked lambda from a SHARED instance's
+        # ``__dict__``, and a stale lambda there would intercept this retry.
+        provider._transport = httpx.AsyncHTTPTransport()
+        monkeypatch.setattr(provider._transport, "handle_async_request", handler)
+        return records
+
+    @pytest.mark.asyncio
+    async def test_401_adopts_peer_token_and_retries_original_request(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The residual Notion bug: a sibling process rotated the grant, which
+        REVOKED our still-unexpired access token server-side. Our request 401s;
+        the flow must adopt the peer's token from the store and re-send the
+        ORIGINAL request with it — never yielding a discovery/registration/
+        browser-grant request to the caller."""
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        # Our in-memory token is still VALID locally (unexpired) — coordination
+        # at the top of the flow correctly does nothing for it.
+        await storage.set_tokens(
+            OAuthToken(access_token="revoked-but-unexpired", refresh_token="r1", expires_in=3600)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+
+        provider = build_oauth_provider(
+            self.URL, self._cfg(), store=store, endpoints=self._endpoints()
+        )
+        # Force initialization NOW, while the store still holds OUR token: the
+        # SDK loads current_tokens once in _initialize, so rotating the store
+        # AFTER this point is what leaves the provider holding the revoked
+        # token in memory — the exact multi-process state under test. (Rotating
+        # before _initialize would just load the fresh token at boot, which is
+        # the already-working restart path.)
+        async with provider.context.lock:
+            await provider._initialize()
+
+        # The sibling process rotated the grant after we loaded: the shared
+        # store now holds a fresh token, and the old access token is revoked
+        # server-side (emulated by the transport below).
+        await storage.set_tokens(
+            OAuthToken(access_token="fresh-by-peer", refresh_token="r2", expires_in=3600)
+        )
+
+        transport_calls: list[dict[str, str]] = []
+        self._adoption_transport(monkeypatch, provider, transport_calls)
+
+        import httpx
+
+        def responder(request: httpx.Request) -> httpx.Response:
+            # The resource server answers the original (revoked-token) request
+            # with a 401; nothing else should be yielded to us at all.
+            return httpx.Response(401, request=request)
+
+        yielded = await self._drive_401_flow(provider, responder)
+
+        # Exactly ONE request was yielded to the caller (the original): the 401
+        # never reached the SDK, so its full-flow machinery (discovery,
+        # registration, authorization) never produced a request.
+        assert len(yielded) == 1
+        # The provider re-sent the request itself through the transport with the
+        # ADOPTED token, and the flow completed on that retry's 200. (Filter the
+        # log: other tests in this xdist worker can leak calls through a stale
+        # monkeypatch on the shared class transport. Header dict keys are
+        # lowercased by httpx.)
+        adopted = [h for h in transport_calls if h.get("authorization") == "Bearer fresh-by-peer"]
+        assert adopted, f"no adoption retry carried the peer's token: {transport_calls}"
+        # The adopted token is now the in-memory token too, so a later request
+        # (or the SDK's own end-of-flow retry) uses it rather than the corpse.
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.access_token == "fresh-by-peer"
+
+    @pytest.mark.asyncio
+    async def test_401_with_identical_stored_token_passes_through_to_sdk(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The store holds exactly the token that just 401'd: the grant is dead
+        everywhere, not merely revoked for us. The 401 must pass through to the
+        SDK unchanged (its full-flow branch becomes reachable, as before the
+        fix) and NO adoption retry may be sent."""
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        await storage.set_tokens(
+            OAuthToken(access_token="dead-token", refresh_token="r1", expires_in=3600)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+
+        # interactive=False: if the 401 wrongly reaches the SDK's full-flow
+        # branch and gets as far as authorization, the flow must RAISE
+        # (McpAuthRequiredError) rather than open a browser in the test run.
+        provider = build_oauth_provider(
+            self.URL, self._cfg(), store=store, endpoints=self._endpoints(), interactive=False
+        )
+
+        # A DEDICATED transport instance (see _adoption_transport): nothing may
+        # be sent on it, because no adoption retry may happen — but a leaked
+        # class-level monkeypatch from another test must not be able to send
+        # either and confuse the assertion.
+        import httpx
+
+        transport_calls: list[dict[str, str]] = []
+
+        async def counting_handler(request: httpx.Request) -> httpx.Response:
+            transport_calls.append(dict(request.headers))
+            return httpx.Response(200, request=request)
+
+        provider._transport = httpx.AsyncHTTPTransport()
+        monkeypatch.setattr(provider._transport, "handle_async_request", counting_handler)
+
+        sdk_yields_after_401: list[str] = []
+        seen_401 = {"done": False}
+
+        def responder(request: httpx.Request) -> httpx.Response:
+            if not seen_401["done"]:
+                # The original request: answer with the 401 challenge.
+                seen_401["done"] = True
+                return httpx.Response(401, request=request)
+            # Anything yielded AFTER the 401 is the SDK's full-flow machinery
+            # (protected-resource discovery first) — proof the challenge
+            # reached the SDK rather than being answered by an adoption retry.
+            # Fail it so the flow terminates without a browser grant.
+            sdk_yields_after_401.append(str(request.url))
+            return httpx.Response(404, request=request)
+
+        with contextlib.suppress(Exception):
+            # The failed discovery may or may not raise out of the flow (SDK
+            # version dependent); the yields above are the assertion.
+            await self._drive_401_flow(provider, responder)
+
+        assert sdk_yields_after_401, "the 401 never reached the SDK's full-flow branch"
+        assert transport_calls == []  # no adoption retry was attempted
+
+    @pytest.mark.asyncio
+    async def test_second_401_after_adoption_retry_passes_through(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Adoption is bounded to ONE retry per flow: when the adopted token
+        ALSO 401s (the grant is genuinely dead server-side), that second 401
+        passes through to the SDK's full-flow branch — adoption never loops."""
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        await storage.set_tokens(
+            OAuthToken(access_token="revoked-but-unexpired", refresh_token="r1", expires_in=3600)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+
+        # interactive=False: the second 401 passing through must RAISE out of
+        # the SDK's authorization step, never open a browser in the test run.
+        provider = build_oauth_provider(
+            self.URL, self._cfg(), store=store, endpoints=self._endpoints(), interactive=False
+        )
+        # Load OUR token into memory first (see the adoption test above for why
+        # the rotation must come after _initialize).
+        async with provider.context.lock:
+            await provider._initialize()
+
+        # A peer rotated the grant, but the resource server 401s EVERY bearer
+        # token (emulating a grant the user revoked server-side).
+        await storage.set_tokens(
+            OAuthToken(access_token="also-dead", refresh_token="r2", expires_in=3600)
+        )
+
+        import httpx
+
+        transport_calls: list[dict[str, str]] = []
+
+        async def always_401(request: httpx.Request) -> httpx.Response:
+            transport_calls.append(dict(request.headers))
+            return httpx.Response(401, request=request)
+
+        provider._transport = httpx.AsyncHTTPTransport()
+        monkeypatch.setattr(provider._transport, "handle_async_request", always_401)
+
+        sdk_yields_after_401: list[str] = []
+        seen_401 = {"done": False}
+
+        def responder(request: httpx.Request) -> httpx.Response:
+            if not seen_401["done"]:
+                seen_401["done"] = True
+                return httpx.Response(401, request=request)
+            # The SDK's full-flow branch (reached only if the retry's second
+            # 401 passed through): fail its discovery so the flow terminates.
+            sdk_yields_after_401.append(str(request.url))
+            return httpx.Response(404, request=request)
+
+        with contextlib.suppress(Exception):
+            await self._drive_401_flow(provider, responder)
+
+        # Exactly ONE adoption retry was sent (with the adopted token); the
+        # retry's 401 then passed through to the SDK, whose full-flow branch
+        # yielded its discovery request.
+        assert len(transport_calls) == 1
+        assert transport_calls[0]["authorization"] == "Bearer also-dead"
+        assert sdk_yields_after_401, "the second 401 never reached the SDK's full-flow branch"

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -1872,9 +1872,12 @@ class TestInflightRefreshCoordination:
         the flow yields and answering each with ``responder(request)``.
 
         The responder's return value for the ORIGINAL request is normally a
-        401 (that is the case under test); the adoption retry is sent by the
-        provider itself through its ``_transport``, so it never appears in the
-        recorded yields.
+        401 (that is the case under test). With the fix, the flow RE-YIELDS the
+        original request (Authorization rewritten to an adopted token) as the
+        retry — the responder sees it as a second yield, exactly as the real
+        httpx client would. Without anything to adopt, the 401 passes through
+        to the SDK and its full-flow machinery (discovery etc.) shows up as
+        further yields.
         """
         import httpx
 
@@ -1892,37 +1895,13 @@ class TestInflightRefreshCoordination:
         finally:
             await gen.aclose()
 
-    def _adoption_transport(self, monkeypatch: pytest.MonkeyPatch, provider, records):
-        """Give the provider an httpx transport that emulates a resource server
-        which revokes the OLD token: a request bearing the revoked token gets a
-        401, one bearing the adopted token gets a 200. Returns the transport's
-        call log."""
-        import httpx
-
-        async def handler(request: httpx.Request) -> httpx.Response:
-            records.append(dict(request.headers))
-            if request.headers.get("Authorization") == "Bearer fresh-by-peer":
-                return httpx.Response(200, request=request)
-            return httpx.Response(401, request=request)
-
-        # A dedicated transport instance: patching ``handle_async_request`` on
-        # the CLASS-level ``_transport`` the SDK set would race other tests in
-        # this xdist worker — monkeypatch.undo() restores the class attribute
-        # but cannot remove the leaked lambda from a SHARED instance's
-        # ``__dict__``, and a stale lambda there would intercept this retry.
-        provider._transport = httpx.AsyncHTTPTransport()
-        monkeypatch.setattr(provider._transport, "handle_async_request", handler)
-        return records
-
     @pytest.mark.asyncio
-    async def test_401_adopts_peer_token_and_retries_original_request(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_401_adopts_peer_token_and_retries_original_request(self) -> None:
         """The residual Notion bug: a sibling process rotated the grant, which
         REVOKED our still-unexpired access token server-side. Our request 401s;
-        the flow must adopt the peer's token from the store and re-send the
-        ORIGINAL request with it — never yielding a discovery/registration/
-        browser-grant request to the caller."""
+        the flow must adopt the peer's token from the store and RE-YIELD the
+        original request with it (for the same httpx client to send) — never
+        yielding a discovery/registration/browser-grant request."""
         from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 
         from local_operator.mcp.auth import build_oauth_provider
@@ -1950,47 +1929,47 @@ class TestInflightRefreshCoordination:
 
         # The sibling process rotated the grant after we loaded: the shared
         # store now holds a fresh token, and the old access token is revoked
-        # server-side (emulated by the transport below).
+        # server-side (emulated by the responder below).
         await storage.set_tokens(
             OAuthToken(access_token="fresh-by-peer", refresh_token="r2", expires_in=3600)
         )
 
-        transport_calls: list[dict[str, str]] = []
-        self._adoption_transport(monkeypatch, provider, transport_calls)
-
         import httpx
 
+        calls: list[tuple[httpx.Request, str]] = []
+
         def responder(request: httpx.Request) -> httpx.Response:
-            # The resource server answers the original (revoked-token) request
-            # with a 401; nothing else should be yielded to us at all.
+            calls.append((request, request.headers.get("Authorization", "")))
+            # The resource server 401s the revoked token; the retry carrying the
+            # adopted token succeeds.
+            if request.headers.get("Authorization") == "Bearer fresh-by-peer":
+                return httpx.Response(200, request=request)
             return httpx.Response(401, request=request)
 
         yielded = await self._drive_401_flow(provider, responder)
 
-        # Exactly ONE request was yielded to the caller (the original): the 401
-        # never reached the SDK, so its full-flow machinery (discovery,
-        # registration, authorization) never produced a request.
-        assert len(yielded) == 1
-        # The provider re-sent the request itself through the transport with the
-        # ADOPTED token, and the flow completed on that retry's 200. (Filter the
-        # log: other tests in this xdist worker can leak calls through a stale
-        # monkeypatch on the shared class transport. Header dict keys are
-        # lowercased by httpx.)
-        adopted = [h for h in transport_calls if h.get("authorization") == "Bearer fresh-by-peer"]
-        assert adopted, f"no adoption retry carried the peer's token: {transport_calls}"
+        # Exactly TWO requests reached the caller: the original (401) and the
+        # adoption retry. Nothing else — the 401 never reached the SDK, so its
+        # full-flow machinery (discovery, registration, authorization) never
+        # produced a request.
+        assert len(yielded) == 2
+        # The retry is the SAME request object re-yielded with the adopted
+        # token — the SDK's own end-of-flow retry contract, sent by the same
+        # httpx client that sent the original.
+        assert yielded[1] is yielded[0]
+        assert calls[0][1] == "Bearer revoked-but-unexpired"
+        assert calls[1][1] == "Bearer fresh-by-peer"
         # The adopted token is now the in-memory token too, so a later request
         # (or the SDK's own end-of-flow retry) uses it rather than the corpse.
         assert provider.context.current_tokens is not None
         assert provider.context.current_tokens.access_token == "fresh-by-peer"
 
     @pytest.mark.asyncio
-    async def test_401_with_identical_stored_token_passes_through_to_sdk(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_401_with_identical_stored_token_passes_through_to_sdk(self) -> None:
         """The store holds exactly the token that just 401'd: the grant is dead
         everywhere, not merely revoked for us. The 401 must pass through to the
         SDK unchanged (its full-flow branch becomes reachable, as before the
-        fix) and NO adoption retry may be sent."""
+        fix) and NO adoption retry may be re-yielded."""
         from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 
         from local_operator.mcp.auth import build_oauth_provider
@@ -2009,25 +1988,13 @@ class TestInflightRefreshCoordination:
             self.URL, self._cfg(), store=store, endpoints=self._endpoints(), interactive=False
         )
 
-        # A DEDICATED transport instance (see _adoption_transport): nothing may
-        # be sent on it, because no adoption retry may happen — but a leaked
-        # class-level monkeypatch from another test must not be able to send
-        # either and confuse the assertion.
         import httpx
 
-        transport_calls: list[dict[str, str]] = []
-
-        async def counting_handler(request: httpx.Request) -> httpx.Response:
-            transport_calls.append(dict(request.headers))
-            return httpx.Response(200, request=request)
-
-        provider._transport = httpx.AsyncHTTPTransport()
-        monkeypatch.setattr(provider._transport, "handle_async_request", counting_handler)
-
-        sdk_yields_after_401: list[str] = []
+        yields: list[tuple[httpx.Request, str]] = []
         seen_401 = {"done": False}
 
         def responder(request: httpx.Request) -> httpx.Response:
+            yields.append((request, request.headers.get("Authorization", "")))
             if not seen_401["done"]:
                 # The original request: answer with the 401 challenge.
                 seen_401["done"] = True
@@ -2036,21 +2003,28 @@ class TestInflightRefreshCoordination:
             # (protected-resource discovery first) — proof the challenge
             # reached the SDK rather than being answered by an adoption retry.
             # Fail it so the flow terminates without a browser grant.
-            sdk_yields_after_401.append(str(request.url))
             return httpx.Response(404, request=request)
 
         with contextlib.suppress(Exception):
             # The failed discovery may or may not raise out of the flow (SDK
-            # version dependent); the yields above are the assertion.
+            # version dependent); the yields below are the assertion.
             await self._drive_401_flow(provider, responder)
 
-        assert sdk_yields_after_401, "the 401 never reached the SDK's full-flow branch"
-        assert transport_calls == []  # no adoption retry was attempted
+        # The FIRST yield is the original request, still bearing the dead token
+        # (adoption did NOT rewrite it — the stored token was identical).
+        assert yields[0][1] == "Bearer dead-token"
+        # The 401 reached the SDK: its full-flow branch yielded at least one
+        # discovery/registration request after the original.
+        assert len(yields) >= 2, "the 401 never reached the SDK's full-flow branch"
+        # No adoption retry: exactly ONE request went to the resource URL (the
+        # original). Everything after it is the SDK's own machinery on other
+        # URLs (discovery/registration), which the SDK may yield several of.
+        to_resource = [y for y in yields if str(y[0].url) == self.URL]
+        assert len(to_resource) == 1
+        assert yields[1][0].url != yields[0][0].url
 
     @pytest.mark.asyncio
-    async def test_second_401_after_adoption_retry_passes_through(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_second_401_after_adoption_retry_passes_through(self) -> None:
         """Adoption is bounded to ONE retry per flow: when the adopted token
         ALSO 401s (the grant is genuinely dead server-side), that second 401
         passes through to the SDK's full-flow branch — adoption never loops."""
@@ -2083,33 +2057,30 @@ class TestInflightRefreshCoordination:
 
         import httpx
 
-        transport_calls: list[dict[str, str]] = []
-
-        async def always_401(request: httpx.Request) -> httpx.Response:
-            transport_calls.append(dict(request.headers))
-            return httpx.Response(401, request=request)
-
-        provider._transport = httpx.AsyncHTTPTransport()
-        monkeypatch.setattr(provider._transport, "handle_async_request", always_401)
-
-        sdk_yields_after_401: list[str] = []
-        seen_401 = {"done": False}
+        yields: list[tuple[httpx.Request, str]] = []
 
         def responder(request: httpx.Request) -> httpx.Response:
-            if not seen_401["done"]:
-                seen_401["done"] = True
+            yields.append((request, request.headers.get("Authorization", "")))
+            # The resource server 401s every bearer token on this URL; the
+            # SDK's discovery sub-requests (a different URL) get a 404 so the
+            # flow terminates without a browser grant.
+            if str(request.url) == self.URL:
                 return httpx.Response(401, request=request)
-            # The SDK's full-flow branch (reached only if the retry's second
-            # 401 passed through): fail its discovery so the flow terminates.
-            sdk_yields_after_401.append(str(request.url))
             return httpx.Response(404, request=request)
 
         with contextlib.suppress(Exception):
             await self._drive_401_flow(provider, responder)
 
-        # Exactly ONE adoption retry was sent (with the adopted token); the
-        # retry's 401 then passed through to the SDK, whose full-flow branch
-        # yielded its discovery request.
-        assert len(transport_calls) == 1
-        assert transport_calls[0]["authorization"] == "Bearer also-dead"
-        assert sdk_yields_after_401, "the second 401 never reached the SDK's full-flow branch"
+        # The caller saw: the original (401), the ONE adoption retry (same
+        # object, adopted token, 401 again), and then the SDK's full-flow
+        # machinery (discovery requests on other URLs — possibly several) —
+        # proof the second 401 passed through and adoption did not loop.
+        assert yields[0][1] == "Bearer revoked-but-unexpired"
+        assert yields[1][0] is yields[0][0]  # the retry re-yields the original
+        assert yields[1][1] == "Bearer also-dead"
+        assert len(yields) >= 3
+        assert yields[2][0].url != yields[0][0].url  # SDK discovery, not a retry
+        # Exactly TWO requests went to the resource URL: original + one retry.
+        # A looping adoption would show a third.
+        to_resource = [y for y in yields if str(y[0].url) == self.URL]
+        assert len(to_resource) == 2


### PR DESCRIPTION
## Summary

Fixes the residual Notion MCP OAuth logout bug: after one session rotates the shared grant, every OTHER live session still holds a locally-valid but server-side-revoked access token, sends it, gets a 401, and the SDK runs the full browser authorization grant — surfacing as `McpAuthRequiredError` ("run /mcp login notion") and suspending auto-reconnect.

## Root cause

Notion rotates its refresh token on every use and revokes ALL previously issued access tokens when a refresh happens (access tokens live 8h). local-operator runs one long-lived process per cmux workspace, all sharing ONE stored grant row (`auth.db`, `provider='mcp-oauth'`, `identity_key='https://mcp.notion.com/mcp'`).

PR #242 added `_make_refresh_coordinating_provider` in `local_operator/mcp/auth.py`: before the SDK's in-flow refresh, it re-reads storage under `_oauth_refresh_lock` and adopts a peer-rotated token. BUT its gate is `if ctx.is_token_valid() or not ctx.can_refresh_token(): return` — it only coordinates when the IN-MEMORY token is EXPIRED. The residual gap: after one session rotates the grant, every other live session still holds a locally-VALID (unexpired) but server-side-REVOKED access token. That session skips coordination, sends the revoked token, gets 401, and the SDK's `async_auth_flow` 401 branch runs the FULL browser authorization grant.

Empirical timeline on this machine: one successful rotation at 16:43, then cascading "OAuth authorization expired" incidents in OTHER sessions 16:52-17:07. The stored row is healthy (fresh token + refresh token) — the failure is purely the revoked-but-unexpired in-memory token.

## The fix

In `_RefreshCoordinatingOAuthProvider.async_auth_flow`, intercept a 401 response ONCE per flow invocation:

- When the response is a 401 on the ORIGINAL request and no adoption-retry has happened yet in this flow: under `_oauth_refresh_lock(server_url)`, re-read `stored = await ctx.storage.get_tokens()`. If `stored` has an access_token DIFFERENT from `ctx.current_tokens.access_token`: adopt it (`ctx.current_tokens = stored`, `ctx.token_expiry_time = storage.stored_token_expiry()`), rewrite the original request's Authorization header to the adopted token IN PLACE, and RE-YIELD the request so the SAME httpx client that sent the original sends the retry (same proxies, TLS, and event hooks). The retry's response is fed into the SDK generator instead of the 401, so the SDK's full browser-authorization branch never sees a challenge.
- The retry goes through the caller's client by RE-YIELDING, matching the SDK's own end-of-flow 401 retry contract (`_add_auth_header` rewrites the same request object and re-yields it). The provider is an httpx Auth: it only ever YIELDS requests; nothing in the SDK or local-operator sets a transport on it, so an internal send is not possible. Header mutation never touches the request body/stream, so the re-send is body-safe.
- Adoption never spends a refresh token, so no rotation race; the lock still serializes the re-read against a concurrent rotation.
- If NOT adopted (stored token identical to in-memory, or absent): pass the 401 through unchanged — existing behaviour for genuinely dead grants.
- Bounded to one adoption-retry per flow: a second 401 (the adopted token also rejected, i.e. a genuinely dead grant) passes through to the SDK's full-flow branch.

## Testing evidence

### Unit — `tests/unit/mcp/test_auth.py::TestInflightRefreshCoordination` (9 tests)

Three new tests extend the existing coordinating-provider class, driving the flow purely through yields (no transport injection — the responder observes the re-yielded retry request exactly as the real httpx client would):

- **(a) 401 with a DIFFERENT fresh stored token** → the original request is re-yielded with the adopted Authorization header (same object), the SDK never yields a discovery/registration request, and the flow completes on the retry's 200.
- **(b) 401 with IDENTICAL stored token** → 401 passed through to SDK (full-flow branch reachable as before; exactly one request to the resource URL, the rest are SDK discovery).
- **(c) second 401 after an adoption retry** → passes through (bounded to one retry; exactly two requests to the resource URL, then SDK discovery).

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/mcp/test_auth.py -q -k "InflightRefreshCoordination"
.........                                                                [100%]
9 passed in 1.81s
```

### Two-process integration repro — `scripts/repro_notion_401.py`

A scripted repro with a fake Notion-like authorization server (rotating refresh token; on rotation, revokes prior access tokens; 401 for revoked tokens) and TWO provider instances in SEPARATE OS processes sharing one `McpTokenStorage`-backed auth store (tmp sqlite `auth.db`). Process A refreshes (rotates). Process B (holding the old unexpired token) makes a request, gets 401, and must succeed via adoption WITHOUT any browser-grant/discovery request. The repro drives each flow purely through yields — the adoption retry appears as a second yield of the same request object bearing the adopted token.

**Pre-fix (origin/main, no wrapper change):** process B's 401 drives the SDK into the full registration/authorization branch and fails:

```
$ .venv/bin/python scripts/repro_notion_401.py /tmp/notion-repro-pre
seed: issued original grant {'access_token': 'access-1', 'refresh_token': 'refresh-1'}
A: rotated grant; live access token is now access-2
B: booted holding 'access-1' (locally valid, revoked by A); store holds 'access-2'
...
mcp.client.auth.exceptions.OAuthRegistrationError: Registration failed: 401
ORCH: FAIL — process B did not recover via adoption
(exit 1)
```

**Post-fix (this branch):** process B recovers by adopting the sibling's token, no browser grant:

```
$ .venv/bin/python scripts/repro_notion_401.py /tmp/notion-repro
seed: issued original grant {'access_token': 'access-1', 'refresh_token': 'refresh-1'}
A: rotated grant; live access token is now access-2
B: booted holding 'access-1' (locally valid, revoked by A); store holds 'access-2'
B: PASS — 401 recovered by ADOPTING sibling token 'access-2', no browser grant, final status 200
ORCH: PASS — two-process 401 adoption recovered without a browser grant
(exit 0)
```

### Gates

```
$ .venv/bin/python -m flake8 local_operator/mcp/auth.py tests/unit/mcp/test_auth.py scripts/repro_notion_401.py
(clean)
$ uvx --from black==26.1.0 black --check local_operator/mcp/auth.py tests/unit/mcp/test_auth.py scripts/repro_notion_401.py
3 files would be left unchanged.
$ uvx isort==5.13.2 --check local_operator/mcp/auth.py tests/unit/mcp/test_auth.py scripts/repro_notion_401.py
(clean)
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python local_operator/mcp/auth.py tests/unit/mcp/test_auth.py scripts/repro_notion_401.py
0 errors, 0 warnings, 0 informations
```

Full unit suite: 7140 passed, 7 skipped, plus 8 pre-existing failures in `tests/unit/server/test_server_models.py` (`AttributeError: 'State' object has no attribute 'env_config'`) that reproduce identically on clean origin/main and are unrelated to this change.

## Version

Bumped to 0.42.1 (patch: bug fix per AGENTS.md versioning). Note: the task originally targeted 0.41.7, but 0.41.7 through 0.41.10 and 0.42.0 were released while this work was in progress, so this bumps to the next available patch.
