### PR TITLE
chore(release): bump version to 0.41.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.41.9"
+version = "0.41.10"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Mechanical version correction after concurrent publishing: `v0.41.9` and PyPI `0.41.9` already target `fe3de126`, while current `origin/main` includes the later #338 version commit at `a35117b2`. PyPI versions are immutable, so the current main contents need a fresh release version.

This bumps only `pyproject.toml` from **0.41.9** to **0.41.10**. There is no functional code change.

## Validation

- Confirmed published `v0.41.9` targets `fe3de126e8cb5a22af236908cfcb60645b26509a`, while this branch starts from current `origin/main` at `a35117b2f626dbc5e0d8d7360fcc4841e72e2a19`.
- Built `local_operator-0.41.10-py3-none-any.whl` and `local_operator-0.41.10.tar.gz`; both package metadata records report `Name: local-operator` and `Version: 0.41.10`.
- `flake8 .` passed.
- `black==26.1.0 --check .` passed (556 files unchanged).
- `isort==5.13.2 --check .` passed.
- Full unit suite passed: 7,219 passed, 7 skipped.
- Full-tree pyright was started but made no progress for over nine minutes under concurrent machine resource contention and was stopped per release coordination. This is a one-line metadata-only diff over the same source that passed pyright before the collision; PR CI is the authoritative full pyright gate.

## Review

Independent agent review is required before merge. This PR must not merge until that review round is posted, answered, and fresh against the current head.
