### PR TITLE
feat(tui): goal-driven /loop <goal> mode with a judge-gated completion loop

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -690,8 +690,15 @@ def _parse_loop_verdict(text: str) -> tuple[bool | None, str]:
                 # word that merely CONTAINS "not"/"n't" (nothing, cannot, another)
                 # no longer causes an unbounded false-continue.
                 tokens = _NEGATION_TOKEN_RE.findall(payload)
+                # The contraction suffix is checked for BOTH apostrophe forms:
+                # the tokeniser accepts a curly apostrophe (U+2019), which most
+                # editors and phones autocorrect a straight one into, so
+                # `can't`/`can’t` must both count as a negator. Missing the curly
+                # form would let `VERDICT: ACHIEVED but can’t verify` read as a
+                # false RELEASE — the one trust-breaking outcome R2 closed.
                 negated = any(
-                    tok in ("NOT", "NOT_ACHIEVED") or tok.endswith("N'T") for tok in tokens
+                    tok in ("NOT", "NOT_ACHIEVED") or tok.endswith(("N'T", "N\u2019T"))
+                    for tok in tokens
                 )
                 achieved = not negated
             continue
@@ -11218,7 +11225,7 @@ class OperatorApp(App[None]):
         # directly with `/loop <goal text>` instead of only via `/goal` first.
         if not getattr(session, "goal", ""):
             notice(
-                "set a goal first with /goal <text>, or loop toward one now: " "/loop <goal text>",
+                "set a goal first with /goal <text>, or loop toward one now: /loop <goal text>",
                 "warning",
             )
             return

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import sys
 import time
 from collections.abc import Mapping, Sequence
@@ -469,7 +470,14 @@ SLASH_COMMANDS: list[SlashCommand] = [
     # session's user MessageStartEvent is consumed silently rather than
     # painted — two different receipts for two different events (the typed
     # command, and the prompt the turn later announces).
-    SlashCommand("loop", "Iterate autonomously toward the goal", consumes_prompt=True),
+    SlashCommand(
+        "loop",
+        # Advertises BOTH forms so the goal mode is discoverable from the palette
+        # without reading the source: free text is a goal a judge decides is met,
+        # a number is a bounded iteration count.
+        "Loop toward a goal: /loop <goal text>, or /loop <n> for n turns",
+        consumes_prompt=True,
+    ),
     # NOT an exception, and the reason IS the feature. The question does reach
     # the model, but only for one off-the-record request that never joins the
     # conversation (`SessionProtocol.complete_aside`) — so a user row in the
@@ -579,6 +587,64 @@ def slash_command_for(text: str) -> SlashCommand | None:
     return next((entry for entry in SLASH_COMMANDS if name in entry.names), None)
 
 
+#: Recognises a `/loop` argument that is number-SHAPED but not a clean integer
+#: — a fat-fingered count like `3e`, `5x`, `3.5`, `12.`, `1e3`. Deliberately
+#: NARROW: a single whitespace-free token that starts with a digit and contains
+#: only digits, letters, or a dot. A real goal written in words ("2fa the login
+#: flow") has spaces and so is never caught; a clean integer is parsed before
+#: this is ever consulted. The point is that a mistyped count must not silently
+#: launch an unbounded, judge-gated loop toward the literal typo as its goal.
+_BOTCHED_COUNT_RE = re.compile(r"\d[A-Za-z0-9.]*$")
+
+
+#: Longest goal string echoed into the launch notice. Independent of the
+#: session's `MAX_GOAL_CHARS` (2000, for the model-facing tail): this is a
+#: single terminal receipt line, so a multi-hundred-char goal is truncated to
+#: stay readable. The FULL goal still drives the loop and the judge; only the
+#: on-screen label is clipped.
+_LOOP_GOAL_LABEL_CHARS = 120
+
+
+def _loop_goal_label(goal: str) -> str:
+    """A safe, bounded rendering of the goal for the launch notice.
+
+    The goal is untrusted user text that never gets sanitised elsewhere in goal
+    mode (it is not stored via `set_goal`), so the one place it reaches the
+    screen must strip control/escape sequences — a pasted `\\x1b[2J` must not
+    clear the terminal — and collapse whitespace so a multi-line paste stays one
+    notice line. Over-long goals are truncated with an ellipsis; the loop still
+    pursues the whole string.
+    """
+    cleaned = " ".join(strip_control_sequences(goal).split())
+    if len(cleaned) > _LOOP_GOAL_LABEL_CHARS:
+        cleaned = cleaned[: _LOOP_GOAL_LABEL_CHARS - 1].rstrip() + "…"
+    return cleaned
+
+
+def _looks_like_botched_count(arg: str) -> bool:
+    """Whether ``arg`` reads as a mistyped integer count rather than a goal.
+
+    Called only after ``int(arg)`` has already failed, so a clean integer never
+    reaches here. Returns ``True`` for a single number-shaped token (starts with
+    a digit, no spaces, only alphanumerics/dot) so `/loop 3e` and `/loop 3.5`
+    are rejected with a disambiguating hint instead of starting an uncapped run.
+    """
+    token = arg.strip()
+    # A goal is written in words; anything with whitespace is not a botched count.
+    if not token or " " in token or "\t" in token:
+        return False
+    return bool(_BOTCHED_COUNT_RE.fullmatch(token))
+
+
+#: Tokeniser for the negation check in `_parse_loop_verdict`. Splits the
+#: uppercased verdict payload into words made of letters, digits, and an
+#: internal apostrophe (straight or curly), so a whole-word negator is testable
+#: as a token rather than a substring — the fix for the `NOTHING`/`CANNOT`
+#: false-continue. `NOT_ACHIEVED` (with an underscore) survives as one token so
+#: the spec's compound negative reads as a single negator.
+_NEGATION_TOKEN_RE = re.compile(r"[A-Z0-9_]+(?:['\u2019][A-Z]+)?")
+
+
 def _parse_loop_verdict(text: str) -> tuple[bool | None, str]:
     """Parse a goal-mode judge answer into ``(achieved, reason)``.
 
@@ -593,10 +659,18 @@ def _parse_loop_verdict(text: str) -> tuple[bool | None, str]:
       "not achieved" style answer (or any line that names both tokens) reads as
       continue, never as a false release. A false release is the one
       trust-breaking error under the notify-once contract.
-    - The tokens are matched on the payload AFTER ``VERDICT:``, and because
-      ``ACHIEVED`` is not a substring of ``CONTINUE`` (nor vice versa) the two
-      cannot collide. We do NOT infer a verdict from free prose: an answer with
-      no ``VERDICT:`` line at all is a judge failure, not a guess.
+    - Negation is matched at the TOKEN level, not as a substring. `NOT` is a
+      substring of ordinary words a model naturally writes on the verdict line
+      (`NOTHING`, `ANOTHER`, `CANNOT`, `NOTE`), and `N'T` of `CAN'T`/`DON'T`;
+      an unbounded substring scan turned `VERDICT: ACHIEVED, nothing else
+      remains` into a false CONTINUE, spinning the loop forever (goal mode has
+      no iteration ceiling and a readable CONTINUE resets the failure breaker).
+      So we split the payload into alphanumeric-plus-apostrophe tokens and only
+      treat a WHOLE-word negator (`NOT`, a contraction ending in `N'T`, or the
+      compound `NOT_ACHIEVED`) as flipping ACHIEVED to CONTINUE.
+
+    We do NOT infer a verdict from free prose: an answer with no ``VERDICT:``
+    line at all is a judge failure (``None``), not a guess.
     """
     reason = ""
     achieved: bool | None = None
@@ -611,12 +685,15 @@ def _parse_loop_verdict(text: str) -> tuple[bool | None, str]:
             if "CONTINUE" in payload:
                 achieved = False
             elif "ACHIEVED" in payload:
-                # Defensive against an off-spec "VERDICT: NOT ACHIEVED": the two
-                # spec tokens are ACHIEVED / CONTINUE, but a model that ignores
-                # the instruction and negates ACHIEVED must read as CONTINUE, not
-                # as a false release (the one trust-breaking error). A legitimate
-                # "ACHIEVED" payload never carries a negation word.
-                achieved = "NOT" not in payload and "N'T" not in payload
+                # Token-level negation check (see docstring): only a whole-word
+                # negator flips a genuine ACHIEVED to CONTINUE, so an ordinary
+                # word that merely CONTAINS "not"/"n't" (nothing, cannot, another)
+                # no longer causes an unbounded false-continue.
+                tokens = _NEGATION_TOKEN_RE.findall(payload)
+                negated = any(
+                    tok in ("NOT", "NOT_ACHIEVED") or tok.endswith("N'T") for tok in tokens
+                )
+                achieved = not negated
             continue
         # The first non-empty line after a readable verdict is the reason.
         if achieved is not None and not reason:
@@ -655,11 +732,13 @@ LOOP_GOAL_PROMPT = (
 #: The off-the-record judge prompt asked (via `complete_aside`) after each
 #: goal-mode turn settles. It forces a machine-parseable verdict on its own
 #: line. The two verdict tokens are lexically DISTINCT on purpose: `ACHIEVED`
-#: is a substring of `NOT_ACHIEVED`, so a "not achieved" style answer would be
-#: misread as achieved by a naive substring match. `CONTINUE` shares no such
-#: prefix with `ACHIEVED`, so the parser cannot confuse them. Judge strictly:
-#: a false release notifies "done" when it is not, which is the one
-#: trust-breaking outcome under the notify-once contract, so bias to CONTINUE.
+#: and `CONTINUE` share no prefix, so `_parse_loop_verdict` can tell them apart
+#: even when a model appends prose to the verdict line. The parser matches the
+#: tokens (and any negator) at the WORD level, not as substrings — a genuine
+#: `VERDICT: ACHIEVED, nothing remains` must not read as CONTINUE just because
+#: an ordinary word contains "not". Judge strictly: a false release notifies
+#: "done" when it is not, the one trust-breaking outcome under the notify-once
+#: contract, so the prompt biases to CONTINUE when unsure.
 LOOP_JUDGE_PROMPT = (
     "You are judging whether a standing goal has been fully achieved, based on "
     "the conversation above (the work done so far).\n\n"
@@ -11105,6 +11184,22 @@ class OperatorApp(App[None]):
             try:
                 iterations = int(arg)
             except ValueError:
+                # A number-shaped argument that is NOT a clean integer is almost
+                # certainly a fat-fingered count (`3e`, `5x`, `3.5`), not a goal
+                # written in words. Launching an UNBOUNDED, judge-gated loop
+                # toward the goal "3e" on a typo is a real token-budget footgun,
+                # so refuse with a hint that disambiguates the two forms rather
+                # than silently starting an uncapped run. A genuine goal that
+                # happens to begin with a digit (`2fa work`) is written as more
+                # than one token and so is not caught here.
+                if _looks_like_botched_count(arg):
+                    self._system_notice(
+                        f"'{arg.strip()}' looks like a mistyped count — "
+                        f"use /loop <n> (1..{MAX_LOOP_ITERATIONS}) for a bounded run, "
+                        "or /loop <goal in words> for a goal",
+                        "warning",
+                    )
+                    return
                 # Non-integer text is the goal. Goal mode carries its own
                 # ephemeral goal, so the "set a goal first" guard below (which
                 # gates numeric mode) deliberately does NOT apply here.
@@ -11118,9 +11213,14 @@ class OperatorApp(App[None]):
         else:
             iterations = DEFAULT_LOOP_ITERATIONS
         # Numeric mode still reads the STANDING goal (the tail it works toward),
-        # so it keeps refusing when none is set. Goal mode never reaches here.
+        # so it keeps refusing when none is set. The message surfaces the inline
+        # goal form too — a user with no standing goal can loop toward one
+        # directly with `/loop <goal text>` instead of only via `/goal` first.
         if not getattr(session, "goal", ""):
-            notice("set a goal first: /goal <text>", "warning")
+            notice(
+                "set a goal first with /goal <text>, or loop toward one now: " "/loop <goal text>",
+                "warning",
+            )
             return
         self._loop_cancelled = False
         notice(f"looping toward the goal ({iterations} iteration(s)) — /loop stop to cancel")
@@ -11137,7 +11237,16 @@ class OperatorApp(App[None]):
         so the `_loop_running` guard still enforces one loop at a time.
         """
         self._loop_cancelled = False
-        notice("looping toward the goal — /loop stop to cancel")
+        # NAME the goal in the launch notice. Goal mode deliberately does not
+        # paint a user row or set the band (it never calls `set_goal`), so
+        # without this line there is NO on-screen record of what the loop is
+        # pursuing — a user who scrolls up cannot answer "what is this loop
+        # doing?". It is also the anchor that makes a number-shaped typo
+        # recoverable: the launch line reads back the literal goal. The goal is
+        # untrusted user text, so it is control-char-stripped (a pasted escape
+        # sequence must not rewrite the terminal) and length-capped for the
+        # notice only — the full string still drives the loop.
+        notice(f"looping toward: {_loop_goal_label(goal)} — /loop stop to cancel")
         self.run_worker(self._loop_goal_worker(goal), thread=False, group="loop")
 
     async def _loop_worker(self, iterations: int) -> None:
@@ -11287,19 +11396,30 @@ class OperatorApp(App[None]):
                 try:
                     await session.prompt(prompt)
                 except Exception as error:  # surface and stop; never spin
+                    if self._status is not None:
+                        self._status.update(streaming=False)
                     notice(f"loop stopped: {error}", "error")
                     # A failed prompt never announces, so take the stale echo
                     # entry back out (same hazard as numeric mode / `_start_turn`).
                     self._consume_user_echo(prompt)
                     break
-                finally:
-                    if self._status is not None:
-                        self._status.update(streaming=False)
+                # NOTE: the status is deliberately NOT reset to idle here — it
+                # stays in a working state across the judge call below so the
+                # loop never looks frozen while the verdict is being computed.
                 completed += 1
                 # --- yield boundary reached: judge the settled turn ---
                 if self._loop_cancelled or session is not self._session:
+                    if self._status is not None:
+                        self._status.update(streaming=False)
                     break
+                # Keep the status in a working state ACROSS the judge call. The
+                # judge is a real `complete_aside` network round-trip that can
+                # take seconds; without this the surface looks frozen between
+                # `loop N` and `loop N+1` while it is in fact spending tokens on
+                # the verdict. Cleared once the verdict is in hand (below).
                 achieved, reason = await self._judge_goal(session, goal)
+                if self._status is not None:
+                    self._status.update(streaming=False)
                 if achieved is True:
                     released = True
                     break
@@ -11315,14 +11435,36 @@ class OperatorApp(App[None]):
                     # is for consecutive MALFUNCTION, not for a judge that is
                     # healthily telling us to keep going.
                     judge_failures = 0
+                    # A low-key receipt so the judge gate is LEGIBLE on the happy
+                    # path: without it, goal mode looks identical to a dumb
+                    # N-times loop. `note` level (same channel as `loop N`), not
+                    # a toast — the notify-once contract is about the RELEASE,
+                    # while this just shows the loop is judged, not blind. Only
+                    # when the judge gave a reason, to avoid an empty line.
+                    if reason:
+                        notice(f"continuing: {reason}", "note")
         finally:
-            # All three fields reset here, unconditionally. A worker that
-            # crashed with `_loop_suppress_completion` still True would silently
-            # mute the completion toast for the rest of the process (and the next
-            # session on a reload) — the `finally` is the only correct place.
+            # `_loop_running`/`_loop_goal` reset synchronously and
+            # unconditionally: the next `/loop` reads them immediately to answer
+            # "already running", and a crash must never leave them stuck.
+            #
+            # `_loop_suppress_completion` is DIFFERENT and its clear is DEFERRED
+            # (see `_release_loop_completion_suppression`). The live controller
+            # posts `TurnEnded` via `post_message` (queued to the pump, not
+            # delivered synchronously), so when a cancel/reload/breaker/error
+            # `break` exits right after `await session.prompt(...)` returns, the
+            # final turn's `TurnEnded` is still sitting in the queue. Clearing
+            # the flag here would let that queued event dispatch into
+            # `on_turn_ended` with suppression already off, firing a spurious
+            # "task complete" toast on a loop the user cancelled — a false
+            # release, the one trust-breaking outcome. `call_later` posts the
+            # clear as a `Callback` to the SAME FIFO queue, so it runs only
+            # AFTER any already-queued `TurnEnded` has been suppressed. The
+            # release path is unaffected: it calls `_notify` directly, and its
+            # own `await _judge_goal` already drained the final `TurnEnded`.
             self._loop_running = False
             self._loop_goal = ""
-            self._loop_suppress_completion = False
+            self.call_later(self._release_loop_completion_suppression)
         # Terminal outcome (mirrors the numeric worker's tail). Only the release
         # path fires the toast — one notification, exactly when the judge said
         # the goal was met, which is the whole notify-once contract.
@@ -11340,6 +11482,21 @@ class OperatorApp(App[None]):
             notice(f"goal achieved after {completed} turn(s): {reason}", "info")
             self._notify("complete", running_children=self._outstanding_delegated_jobs())
         # (judge-failure and turn-error paths already emitted their own notice.)
+
+    def _release_loop_completion_suppression(self) -> None:
+        """Clear the goal-loop completion-toast suppression, deferred one pump
+        cycle past the worker's exit so a still-queued final ``TurnEnded``
+        cannot fire a spurious "task complete" on a cancelled/reloaded loop.
+
+        Guarded on ``_loop_running``: if a NEW goal loop has already started in
+        the interval (it re-sets the flag ``True``), this stale callback from
+        the previous worker must not clear the new loop's suppression — the new
+        worker owns the flag now and will post its own deferred clear when it
+        ends. Without the guard, a `/loop` typed within one pump cycle of the
+        last one ending could unmute the fresh loop's per-turn toasts.
+        """
+        if not self._loop_running:
+            self._loop_suppress_completion = False
 
     # -- providers / accounts / usage --------------------------------------
     def _cmd_search(self, arg: str, notice: NoticeFn) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -579,6 +579,51 @@ def slash_command_for(text: str) -> SlashCommand | None:
     return next((entry for entry in SLASH_COMMANDS if name in entry.names), None)
 
 
+def _parse_loop_verdict(text: str) -> tuple[bool | None, str]:
+    """Parse a goal-mode judge answer into ``(achieved, reason)``.
+
+    ``achieved`` is ``True`` (ACHIEVED), ``False`` (CONTINUE), or ``None`` when
+    no ``VERDICT:`` line is readable — which the caller treats as a fail-safe
+    CONTINUE plus a judge-failure strike, never as a release. A pure module-level
+    function so a unit test can hammer it with garbage without standing up the app.
+
+    Two robustness rules are load-bearing:
+
+    - ``CONTINUE`` is checked BEFORE ``ACHIEVED`` on the verdict payload, so a
+      "not achieved" style answer (or any line that names both tokens) reads as
+      continue, never as a false release. A false release is the one
+      trust-breaking error under the notify-once contract.
+    - The tokens are matched on the payload AFTER ``VERDICT:``, and because
+      ``ACHIEVED`` is not a substring of ``CONTINUE`` (nor vice versa) the two
+      cannot collide. We do NOT infer a verdict from free prose: an answer with
+      no ``VERDICT:`` line at all is a judge failure, not a guess.
+    """
+    reason = ""
+    achieved: bool | None = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        upper = stripped.upper()
+        if "VERDICT:" in upper:
+            payload = upper.split("VERDICT:", 1)[1]
+            # CONTINUE first: a stray "not achieved" must never read as achieved.
+            if "CONTINUE" in payload:
+                achieved = False
+            elif "ACHIEVED" in payload:
+                # Defensive against an off-spec "VERDICT: NOT ACHIEVED": the two
+                # spec tokens are ACHIEVED / CONTINUE, but a model that ignores
+                # the instruction and negates ACHIEVED must read as CONTINUE, not
+                # as a false release (the one trust-breaking error). A legitimate
+                # "ACHIEVED" payload never carries a negation word.
+                achieved = "NOT" not in payload and "N'T" not in payload
+            continue
+        # The first non-empty line after a readable verdict is the reason.
+        if achieved is not None and not reason:
+            reason = stripped
+    return achieved, reason
+
+
 #: ``/loop`` defaults and hard ceiling. A loop spends real tokens per
 #: iteration, so it is bounded by construction — an unbounded "keep going"
 #: is how an agent burns a budget unattended.
@@ -593,6 +638,48 @@ LOOP_PROMPT = (
     "the tools available, then briefly state what advanced and what remains. "
     "If the goal is already fully met, say so plainly and stop."
 )
+
+#: The prompt each GOAL-mode iteration (`/loop <goal text>`) submits. Unlike
+#: `LOOP_PROMPT`, it EMBEDS the goal text directly rather than referencing "the
+#: standing goal": goal mode deliberately does not call `set_goal`, so the
+#: system prompt's volatile tail is untouched and there is no standing goal in
+#: the context to reference. The goal is user text, so we format the TEMPLATE
+#: with the goal as the argument (`str.format` on the template) — braces inside
+#: the goal are then opaque replacement values, never format directives.
+LOOP_GOAL_PROMPT = (
+    "Work toward this goal:\n\n{goal}\n\n"
+    "Make concrete progress with the tools available, then briefly state what "
+    "advanced and what remains. If the goal is already fully met, say so plainly."
+)
+
+#: The off-the-record judge prompt asked (via `complete_aside`) after each
+#: goal-mode turn settles. It forces a machine-parseable verdict on its own
+#: line. The two verdict tokens are lexically DISTINCT on purpose: `ACHIEVED`
+#: is a substring of `NOT_ACHIEVED`, so a "not achieved" style answer would be
+#: misread as achieved by a naive substring match. `CONTINUE` shares no such
+#: prefix with `ACHIEVED`, so the parser cannot confuse them. Judge strictly:
+#: a false release notifies "done" when it is not, which is the one
+#: trust-breaking outcome under the notify-once contract, so bias to CONTINUE.
+LOOP_JUDGE_PROMPT = (
+    "You are judging whether a standing goal has been fully achieved, based on "
+    "the conversation above (the work done so far).\n\n"
+    "GOAL: {goal}\n\n"
+    "Answer with a single line, exactly one of:\n"
+    "  VERDICT: ACHIEVED\n"
+    "  VERDICT: CONTINUE\n"
+    "Then, on the next line, one short sentence of reason. Judge strictly: "
+    "answer ACHIEVED only if the goal is fully and verifiably met, not merely "
+    "in progress. If unsure, answer CONTINUE."
+)
+
+#: Consecutive-judge-failure breaker for goal mode. There is deliberately NO
+#: hard iteration ceiling in goal mode (a healthy judge answering CONTINUE runs
+#: unbounded, by design — `/loop stop`/Esc are the user's escape), but a judge
+#: that never returns a READABLE verdict (provider error, or unparseable
+#: output) would otherwise spin forever with no way out but a manual stop. This
+#: ceiling is on consecutive judge MALFUNCTION, not on progress: it trips only
+#: after this many unreadable verdicts in a row, and resets on any readable one.
+MAX_LOOP_JUDGE_FAILURES = 3
 
 #: How often the band re-counts running background jobs. Nothing emits an
 #: event when a job settles, so the subagent segment either polls or goes
@@ -1583,6 +1670,21 @@ class OperatorApp(App[None]):
         # the turn boundary (never mid-turn, so a turn is never half-applied).
         self._loop_running: bool = False
         self._loop_cancelled: bool = False
+        #: Goal-mode state for `/loop <goal text>`. `_loop_goal` is BOTH the
+        #: mode flag and the payload: goal mode is active iff it is truthy while
+        #: `_loop_running`. Carrying the goal here (not via `set_goal`) keeps the
+        #: standing `/goal` and the system prompt's tail untouched — a `/loop do
+        #: X` must not silently overwrite a goal the user set for the session.
+        self._loop_goal: str = ""
+        #: While a held goal loop is running, the per-turn completion toast that
+        #: the `TurnEnded` handler fires on every clean turn is SUPPRESSED — the
+        #: loop owns a single release toast fired only when the judge says the
+        #: goal is achieved, so an unbounded goal loop does not spam a toast per
+        #: turn (the fatigue this feature exists to remove). Cleared in the
+        #: worker's `finally`; a stuck-True flag would mute completions for the
+        #: rest of the process (and across sessions), so that reset is
+        #: load-bearing, never best-effort.
+        self._loop_suppress_completion: bool = False
         #: AbortSignal for the in-flight bang-mode command, if any. Owned by
         #: the app rather than the session because bang-mode is a TUI gesture
         #: — the session's abort stops a TURN, and a user-typed `sleep 30`
@@ -10996,24 +11098,47 @@ class OperatorApp(App[None]):
         if self._loop_running:
             notice("a loop is already running — /loop stop to cancel", "warning")
             return
-        if not getattr(session, "goal", ""):
-            notice("set a goal first: /goal <text>", "warning")
-            return
-        iterations = DEFAULT_LOOP_ITERATIONS
+        # Dispatch on the argument SHAPE: an integer (or empty) is numeric mode,
+        # unchanged; any other non-empty text is a GOAL, not a typo. Goal mode is
+        # additive — `/loop`, `/loop <n>`, `/loop stop` behave exactly as before.
         if arg:
             try:
                 iterations = int(arg)
             except ValueError:
-                self._system_notice(f"usage: /loop [n] (1..{MAX_LOOP_ITERATIONS})", "warning")
+                # Non-integer text is the goal. Goal mode carries its own
+                # ephemeral goal, so the "set a goal first" guard below (which
+                # gates numeric mode) deliberately does NOT apply here.
+                self._start_goal_loop(arg, notice)
                 return
-        if iterations < 1 or iterations > MAX_LOOP_ITERATIONS:
-            self._system_notice(
-                f"iterations must be between 1 and {MAX_LOOP_ITERATIONS}", "warning"
-            )
+            if iterations < 1 or iterations > MAX_LOOP_ITERATIONS:
+                self._system_notice(
+                    f"iterations must be between 1 and {MAX_LOOP_ITERATIONS}", "warning"
+                )
+                return
+        else:
+            iterations = DEFAULT_LOOP_ITERATIONS
+        # Numeric mode still reads the STANDING goal (the tail it works toward),
+        # so it keeps refusing when none is set. Goal mode never reaches here.
+        if not getattr(session, "goal", ""):
+            notice("set a goal first: /goal <text>", "warning")
             return
         self._loop_cancelled = False
         notice(f"looping toward the goal ({iterations} iteration(s)) — /loop stop to cancel")
         self.run_worker(self._loop_worker(iterations), thread=False, group="loop")
+
+    def _start_goal_loop(self, goal: str, notice: NoticeFn) -> None:
+        """Launch goal mode (`/loop <goal text>`) — loop turns until a judge
+        says the goal is achieved, then notify once.
+
+        Kept separate from `_cmd_loop`'s numeric path because the two modes
+        differ in almost everything (unbounded vs bounded, judge vs count,
+        embedded goal vs standing goal, suppressed vs per-turn toast); a shared
+        launcher would only obscure that. Reuses the same worker `group="loop"`
+        so the `_loop_running` guard still enforces one loop at a time.
+        """
+        self._loop_cancelled = False
+        notice("looping toward the goal — /loop stop to cancel")
+        self.run_worker(self._loop_goal_worker(goal), thread=False, group="loop")
 
     async def _loop_worker(self, iterations: int) -> None:
         """Run up to ``iterations`` goal-advancing turns, sequentially."""
@@ -11076,6 +11201,145 @@ class OperatorApp(App[None]):
             notice(f"loop stopped by reload after {completed} iteration(s)", "warning")
         else:
             notice(f"loop finished after {completed} iteration(s)")
+
+    async def _judge_goal(self, session: Any, goal: str) -> tuple[bool | None, str]:
+        """Ask the off-the-record judge whether ``goal`` is achieved.
+
+        Runs ONE `complete_aside` — the same no-trace primitive `/btw` uses:
+        it reads the live conversation (so the judge sees what the last turn
+        actually did), writes nothing to the transcript, runs no tools, and
+        bills through `_charge_aside` so the judge's tokens fold into the
+        session cost exactly as an aside does (a forked call is not free).
+
+        Returns `(achieved, reason)` where `achieved is None` means the verdict
+        was unreadable — the caller's fail-safe CONTINUE plus a failure strike.
+        A provider error is caught and reported the same way: `CancelledError`
+        is a `BaseException`, so an Esc mid-judge is NOT swallowed here and the
+        worker unwinds cleanly through its `finally` (same reasoning as the
+        aside worker). We do not pass `on_delta`: the judge answer must not
+        stream to any visible surface.
+        """
+        # Belt-and-suspenders: `/loop` already routes to the session OWNER,
+        # where `complete_aside` is the real implementation (a follower's raises),
+        # but guard in case a future path reaches the worker on a session lacking
+        # it — treat a missing primitive as a judge failure, not a crash.
+        if not hasattr(session, "complete_aside"):
+            return None, ""
+        turns = [Message.user(LOOP_JUDGE_PROMPT.format(goal=goal))]
+        try:
+            answer = await session.complete_aside(turns, on_usage=self._charge_aside)
+        except Exception as error:  # noqa: BLE001 — any provider failure is a judge failure
+            self._append_block(NoticeBlock(f"judge unavailable, continuing: {error}", "warning"))
+            return None, ""
+        achieved, reason = _parse_loop_verdict(answer)
+        if achieved is None:
+            self._append_block(NoticeBlock("judge returned no verdict, continuing", "warning"))
+        return achieved, reason
+
+    async def _loop_goal_worker(self, goal: str) -> None:
+        """Run goal mode: loop turns toward ``goal`` until the judge releases.
+
+        Separate from `_loop_worker` on purpose — the two share only their
+        guards, and a single worker branching on mode at five points would be
+        harder to read than two workers that each do one thing. There is no hard
+        iteration ceiling (decision: a healthy judge answering CONTINUE runs
+        unbounded); the only stops are `/loop stop`/Esc, a reload, a turn error,
+        the judge saying ACHIEVED, or the consecutive-judge-failure breaker.
+        """
+
+        def notice(body: str, kind: NoticeKind = "info") -> None:
+            self._append_block(NoticeBlock(body, kind))
+
+        session = self._session
+        if session is None:
+            return
+        self._loop_running = True
+        self._loop_goal = goal
+        # Suppress the per-turn completion toast for the whole held loop; the
+        # release path below fires the single toast. Set here, cleared in the
+        # `finally` — the reset is load-bearing (see the field's init comment).
+        self._loop_suppress_completion = True
+        completed = 0
+        judge_failures = 0
+        released = False
+        reason = ""
+        try:
+            while True:
+                if self._loop_cancelled:
+                    break
+                # Re-checked every iteration, not captured once: `/reload`
+                # replaces `self._session` underneath a running loop, and the
+                # captured reference would go on driving the DISPOSED session.
+                # Same guard the numeric worker documents.
+                if session is not self._session:
+                    break
+                # A NOTICE, not a UserBlock: the per-turn prompt is app-authored
+                # chrome, exactly as in numeric mode.
+                notice(f"loop {completed + 1} (goal mode)", "note")
+                if self._status is not None:
+                    self._status.update(streaming=True)
+                # Format ONCE and reuse the exact string for both the echo
+                # registration and the prompt: the echo registry matches on the
+                # submitted string byte-for-byte, so a second `.format` here
+                # could drift and leave the user MessageStartEvent unconsumed.
+                prompt = LOOP_GOAL_PROMPT.format(goal=goal)
+                self._pending_user_echoes.append(prompt)
+                try:
+                    await session.prompt(prompt)
+                except Exception as error:  # surface and stop; never spin
+                    notice(f"loop stopped: {error}", "error")
+                    # A failed prompt never announces, so take the stale echo
+                    # entry back out (same hazard as numeric mode / `_start_turn`).
+                    self._consume_user_echo(prompt)
+                    break
+                finally:
+                    if self._status is not None:
+                        self._status.update(streaming=False)
+                completed += 1
+                # --- yield boundary reached: judge the settled turn ---
+                if self._loop_cancelled or session is not self._session:
+                    break
+                achieved, reason = await self._judge_goal(session, goal)
+                if achieved is True:
+                    released = True
+                    break
+                if achieved is None:
+                    # Unreadable verdict: fail-safe CONTINUE, but count the
+                    # strike so a permanently broken judge cannot spin forever.
+                    judge_failures += 1
+                    if judge_failures >= MAX_LOOP_JUDGE_FAILURES:
+                        notice("loop stopped: judge could not decide", "error")
+                        break
+                else:
+                    # A readable CONTINUE clears the strike counter — the breaker
+                    # is for consecutive MALFUNCTION, not for a judge that is
+                    # healthily telling us to keep going.
+                    judge_failures = 0
+        finally:
+            # All three fields reset here, unconditionally. A worker that
+            # crashed with `_loop_suppress_completion` still True would silently
+            # mute the completion toast for the rest of the process (and the next
+            # session on a reload) — the `finally` is the only correct place.
+            self._loop_running = False
+            self._loop_goal = ""
+            self._loop_suppress_completion = False
+        # Terminal outcome (mirrors the numeric worker's tail). Only the release
+        # path fires the toast — one notification, exactly when the judge said
+        # the goal was met, which is the whole notify-once contract.
+        if self._loop_cancelled:
+            notice(f"loop cancelled after {completed} turn(s)")
+        elif session is not self._session:
+            notice(f"loop stopped by reload after {completed} turn(s)", "warning")
+        elif released:
+            # The NoticeBlock is the unconditional in-transcript receipt (visible
+            # whether or not the terminal is focused); `_notify` is the
+            # focus-gated attention-grab, and it passes the real outstanding-child
+            # count so a loop that spun up subagents does not fire a false finish
+            # while they are still working (the existing deferral machinery then
+            # delivers it when the last child lands).
+            notice(f"goal achieved after {completed} turn(s): {reason}", "info")
+            self._notify("complete", running_children=self._outstanding_delegated_jobs())
+        # (judge-failure and turn-error paths already emitted their own notice.)
 
     # -- providers / accounts / usage --------------------------------------
     def _cmd_search(self, arg: str, notice: NoticeFn) -> None:
@@ -14039,7 +14303,16 @@ class OperatorApp(App[None]):
             # gate has not started at all, and a backgrounded bash job also
             # re-enters the conversation when it settles.
             outstanding = self._outstanding_delegated_jobs()
-            if self._notify("complete", running_children=outstanding):
+            if self._loop_suppress_completion:
+                # A held goal loop (`/loop <goal text>`) owns the SINGLE release
+                # toast, fired only when the judge says the goal is achieved (see
+                # `_loop_goal_worker`). Every goal-mode turn reaches this handler,
+                # so without this short-circuit an unbounded loop would fire a
+                # completion toast per turn — the notification fatigue the goal
+                # mode exists to remove. Numeric mode does not set the flag, so
+                # its per-turn behaviour is unchanged.
+                pass
+            elif self._notify("complete", running_children=outstanding):
                 self._completion_deferred = False
             elif outstanding:
                 # A fresh deferral starts with an empty handled-set, or ids

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.3"
+version = "0.42.4"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -3705,6 +3705,19 @@ class GoalSession(FakeSession):
         super().__init__()
         self._goal = ""
         self.fail_on_prompt = False
+        #: Verdicts the goal-mode judge returns, consumed one per call. Default
+        #: (empty list) => after the staged verdicts run out, answer ACHIEVED,
+        #: so a test that stages nothing terminates rather than spinning the
+        #: pilot forever.
+        self.judge_verdicts: list[str] = []
+        #: Number of consecutive `complete_aside` calls that should RAISE before
+        #: any staged verdict is returned — exercises the judge-error path.
+        self.judge_raises = 0
+        self.judge_calls = 0
+        #: When set, `prompt` awaits it before recording — lets a test observe
+        #: the loop mid-flight (the fake is otherwise instantaneous and the
+        #: worker settles before the test can look at `_loop_running`).
+        self.prompt_gate: asyncio.Event | None = None
 
     @property
     def goal(self) -> str:
@@ -3717,7 +3730,28 @@ class GoalSession(FakeSession):
     async def prompt(self, text: str, images: Sequence[ImageContent] | None = None) -> None:
         if self.fail_on_prompt:
             raise RuntimeError("boom")
+        if self.prompt_gate is not None:
+            await self.prompt_gate.wait()
         self.prompts.append(text)
+
+    async def complete_aside(
+        self,
+        turns: list[Any],
+        *,
+        on_delta: Callable[[str], None] | None = None,
+        on_usage: Callable[[Any], None] | None = None,
+    ) -> str:
+        # Scriptable judge: raise `judge_raises` times, then serve staged
+        # verdicts, then default to ACHIEVED so an unstaged test terminates.
+        self.judge_calls += 1
+        if on_usage is not None:
+            on_usage(SimpleNamespace())
+        if self.judge_raises > 0:
+            self.judge_raises -= 1
+            raise RuntimeError("judge boom")
+        if self.judge_verdicts:
+            return self.judge_verdicts.pop(0)
+        return "VERDICT: ACHIEVED\ndefault stop"
 
 
 async def _type_command(pilot, app, command: str) -> None:
@@ -3772,17 +3806,18 @@ async def test_loop_runs_bounded_iterations() -> None:
 
 
 @pytest.mark.asyncio
-async def test_loop_rejects_out_of_range_and_garbage() -> None:
+async def test_loop_rejects_out_of_range() -> None:
+    # An out-of-range INTEGER is still an error. Non-integer text is no longer
+    # an error at all — it is a goal (see the goal-mode dispatch tests below),
+    # the one user-facing behaviour this feature removes.
     session = GoalSession()
     session.set_goal("g")
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         await _type_command(pilot, app, "loop 99")
-        await _type_command(pilot, app, "loop abc")
         text = _transcript_text(app)
     assert "between 1 and" in text
-    assert "usage: /loop" in text
     assert session.prompts == []
 
 
@@ -3813,6 +3848,277 @@ async def test_interrupt_cancels_running_loop() -> None:
         app._loop_running = True
         app.action_interrupt()
         assert app._loop_cancelled is True
+
+
+# -- /loop goal mode ---------------------------------------------------------
+
+
+async def _settle_loop(pilot, app, limit: int = 60) -> None:
+    """Pump the pilot until the loop worker settles.
+
+    Bounded so a regression that never releases fails as a timeout in the
+    assertions rather than hanging the suite forever.
+    """
+    for _ in range(limit):
+        await pilot.pause()
+        if not app._loop_running:
+            return
+
+
+@pytest.mark.asyncio
+async def test_loop_goal_dispatch_is_not_numeric() -> None:
+    # `/loop <non-integer>` is a GOAL, not a usage error — the whole feature.
+    session = GoalSession()
+    # Hold the first turn so the loop is observable mid-flight.
+    session.prompt_gate = asyncio.Event()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await _type_command(pilot, app, "loop finish the parser")
+        # The goal is captured before the worker exits; assert while it runs.
+        assert app._loop_running is True
+        assert app._loop_goal == "finish the parser"
+        # Release the turn; the default ACHIEVED verdict then ends the loop.
+        session.prompt_gate.set()
+        await _settle_loop(pilot, app)
+        text = _transcript_text(app)
+    assert "usage: /loop" not in text
+    assert session.prompts  # at least one turn ran
+
+
+@pytest.mark.asyncio
+async def test_loop_goal_releases_when_judge_says_achieved() -> None:
+    session = GoalSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        session.judge_verdicts = [
+            "VERDICT: CONTINUE\nnot yet",
+            "VERDICT: ACHIEVED\ndone",
+        ]
+        await _type_command(pilot, app, "loop do the thing")
+        await _settle_loop(pilot, app)
+        text = _transcript_text(app)
+    assert len(session.prompts) == 2
+    assert session.judge_calls == 2
+    assert "goal achieved after 2" in text
+    # All three fields reset by the worker's finally.
+    assert app._loop_running is False
+    assert app._loop_goal == ""
+    assert app._loop_suppress_completion is False
+
+
+@pytest.mark.asyncio
+async def test_loop_goal_suppresses_turn_ended_toast() -> None:
+    # The crux, tested at the seam: while the suppress flag is set, a settling
+    # TurnEnded fires NO completion notify; with it clear, the same event does.
+    session = GoalSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        completion_notifies: list[int | None] = []
+        real_notify = app._notify
+
+        def _record_notify(kind: str, *, running_children: int | None = None) -> bool:
+            if kind == "complete":
+                completion_notifies.append(running_children)
+            return real_notify(kind, running_children=running_children)
+
+        app._notify = _record_notify  # type: ignore[assignment]
+        # Held loop: a per-turn settle must not notify.
+        app._loop_suppress_completion = True
+        app.post_message(TurnEnded(aborted=False, error=None, context_tokens=1_000))
+        await pilot.pause()
+        await pilot.pause()
+        assert completion_notifies == []
+        # Not held: the same event notifies as usual (numeric mode / normal turns).
+        app._loop_suppress_completion = False
+        app.post_message(TurnEnded(aborted=False, error=None, context_tokens=1_000))
+        await pilot.pause()
+        await pilot.pause()
+    assert len(completion_notifies) == 1
+
+
+@pytest.mark.asyncio
+async def test_loop_goal_notifies_once_on_release() -> None:
+    # End to end: N held turns produce exactly one completion notify, on release.
+    session = GoalSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        completion_notifies: list[int | None] = []
+        real_notify = app._notify
+
+        def _record_notify(kind: str, *, running_children: int | None = None) -> bool:
+            if kind == "complete":
+                completion_notifies.append(running_children)
+            return real_notify(kind, running_children=running_children)
+
+        app._notify = _record_notify  # type: ignore[assignment]
+        session.judge_verdicts = [
+            "VERDICT: CONTINUE\nnot yet",
+            "VERDICT: CONTINUE\nstill not",
+            "VERDICT: ACHIEVED\ndone",
+        ]
+        await _type_command(pilot, app, "loop do the thing")
+        await _settle_loop(pilot, app)
+    assert len(session.prompts) == 3
+    # Exactly one completion notify — the release toast, not a per-turn toast.
+    assert len(completion_notifies) == 1
+
+
+@pytest.mark.asyncio
+async def test_loop_goal_ignores_standing_goal_guard() -> None:
+    # Goal mode starts with NO standing goal set; numeric mode still refuses.
+    session = GoalSession()
+    session.prompt_gate = asyncio.Event()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        assert session.goal == ""
+        await _type_command(pilot, app, "loop do the thing")
+        assert app._loop_running is True
+        session.prompt_gate.set()
+        await _settle_loop(pilot, app)
+        # Numeric with no goal still refuses.
+        await _type_command(pilot, app, "loop 2")
+        text = _transcript_text(app)
+    assert "set a goal first" in text
+
+
+@pytest.mark.asyncio
+async def test_loop_goal_does_not_clobber_standing_goal() -> None:
+    session = GoalSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await _type_command(pilot, app, "goal keep me")
+        assert session.goal == "keep me"
+        session.judge_verdicts = ["VERDICT: ACHIEVED\ndone"]
+        await _type_command(pilot, app, "loop something else")
+        await _settle_loop(pilot, app)
+    assert session.goal == "keep me"
+
+
+@pytest.mark.asyncio
+async def test_loop_goal_judge_error_continues_with_warning() -> None:
+    # A judge that raises once must NOT stop or release; it continues with a
+    # visible warning, then releases on the next readable verdict.
+    session = GoalSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        session.judge_raises = 1
+        session.judge_verdicts = ["VERDICT: ACHIEVED\ndone"]
+        await _type_command(pilot, app, "loop do the thing")
+        await _settle_loop(pilot, app)
+        text = _transcript_text(app)
+    # Turn 1 -> judge raises (continue), turn 2 -> ACHIEVED release.
+    assert len(session.prompts) == 2
+    assert "judge unavailable, continuing" in text
+    assert "goal achieved after 2" in text
+
+
+@pytest.mark.asyncio
+async def test_loop_goal_judge_failure_breaker() -> None:
+    # A judge that never returns a readable verdict trips the breaker after
+    # MAX_LOOP_JUDGE_FAILURES, rather than spinning forever.
+    from local_operator.tui.app import MAX_LOOP_JUDGE_FAILURES
+
+    session = GoalSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        # Empty string => no VERDICT line => unreadable => failure strike.
+        session.judge_verdicts = [""] * (MAX_LOOP_JUDGE_FAILURES + 5)
+        await _type_command(pilot, app, "loop do the thing")
+        await _settle_loop(pilot, app)
+        text = _transcript_text(app)
+    assert len(session.prompts) == MAX_LOOP_JUDGE_FAILURES
+    assert "judge could not decide" in text
+    assert app._loop_suppress_completion is False
+
+
+@pytest.mark.asyncio
+async def test_loop_goal_stop_cancels() -> None:
+    session = GoalSession()
+    # Hold the first turn so the stop lands while the loop is genuinely running.
+    session.prompt_gate = asyncio.Event()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        session.judge_verdicts = ["VERDICT: CONTINUE\nnot yet"] * 50
+        await _type_command(pilot, app, "loop do the thing")
+        assert app._loop_running is True
+        await _type_command(pilot, app, "loop stop")
+        session.prompt_gate.set()
+        await _settle_loop(pilot, app)
+        text = _transcript_text(app)
+    assert "loop cancelled" in text
+    assert app._loop_running is False
+    assert app._loop_goal == ""
+    assert app._loop_suppress_completion is False
+
+
+@pytest.mark.asyncio
+async def test_loop_goal_reload_safety() -> None:
+    # Swapping app._session mid-loop must stop the worker cleanly and reset all
+    # three fields (esp. the suppress flag, which would otherwise mute the NEXT
+    # session's completion toasts).
+    session = GoalSession()
+    session.prompt_gate = asyncio.Event()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        session.judge_verdicts = ["VERDICT: CONTINUE\nnot yet"] * 50
+        await _type_command(pilot, app, "loop do the thing")
+        assert app._loop_running is True
+        # Simulate a reload: the session the worker captured is no longer live.
+        app._session = GoalSession()
+        session.prompt_gate.set()
+        await _settle_loop(pilot, app)
+        text = _transcript_text(app)
+    assert "stopped by reload" in text
+    assert app._loop_running is False
+    assert app._loop_goal == ""
+    assert app._loop_suppress_completion is False
+
+
+@pytest.mark.asyncio
+async def test_loop_goal_turn_error_stops() -> None:
+    session = GoalSession()
+    session.fail_on_prompt = True
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await _type_command(pilot, app, "loop do the thing")
+        await _settle_loop(pilot, app)
+        text = _transcript_text(app)
+    assert "loop stopped" in text
+    assert app._loop_running is False
+    assert app._loop_goal == ""
+    assert app._loop_suppress_completion is False
+
+
+def test_parse_loop_verdict_units() -> None:
+    from local_operator.tui.app import _parse_loop_verdict
+
+    # Clean verdicts.
+    assert _parse_loop_verdict("VERDICT: ACHIEVED\nall done") == (True, "all done")
+    assert _parse_loop_verdict("VERDICT: CONTINUE\nnot yet") == (False, "not yet")
+    # Lowercase / mixed case is fine (parser upper-cases).
+    assert _parse_loop_verdict("verdict: achieved\nok")[0] is True
+    # A "not achieved" phrasing must NOT read as achieved — the substring trap.
+    assert _parse_loop_verdict("VERDICT: NOT ACHIEVED\nnope")[0] is not True
+    # CONTINUE wins even if both tokens somehow appear.
+    assert _parse_loop_verdict("VERDICT: CONTINUE ACHIEVED")[0] is False
+    # Leading prose before the verdict line is tolerated.
+    assert _parse_loop_verdict("thinking...\nVERDICT: ACHIEVED\nreason")[0] is True
+    # No verdict line at all => unreadable => None.
+    assert _parse_loop_verdict("") == (None, "")
+    assert _parse_loop_verdict("just some prose\nno verdict here") == (None, "")
+    # A verdict with no reason line => (bool, "").
+    assert _parse_loop_verdict("VERDICT: ACHIEVED") == (True, "")
 
 
 # -- MCP status band + startup toast -----------------------------------------

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -3718,6 +3718,13 @@ class GoalSession(FakeSession):
         #: the loop mid-flight (the fake is otherwise instantaneous and the
         #: worker settles before the test can look at `_loop_running`).
         self.prompt_gate: asyncio.Event | None = None
+        #: When set to the running app, `prompt` POSTS a real `TurnEnded` via
+        #: `post_message` on settle, exactly like the live controller
+        #: (`tui/events.py` `_post`). This reproduces the queued-dispatch
+        #: ordering that the plain fake could not — the R1 regression relies on
+        #: it, because the completion toast fires from `on_turn_ended` off that
+        #: queued event, not synchronously from `prompt`.
+        self.post_turn_ended_to: Any = None
 
     @property
     def goal(self) -> str:
@@ -3733,6 +3740,13 @@ class GoalSession(FakeSession):
         if self.prompt_gate is not None:
             await self.prompt_gate.wait()
         self.prompts.append(text)
+        if self.post_turn_ended_to is not None:
+            # Mirror the live controller: a settled turn is announced through the
+            # message pump, not returned inline, so the completion notify races
+            # the worker's suppress-flag reset.
+            self.post_turn_ended_to.post_message(
+                TurnEnded(aborted=False, error=None, context_tokens=1000)
+            )
 
     async def complete_aside(
         self,
@@ -3822,6 +3836,72 @@ async def test_loop_rejects_out_of_range() -> None:
 
 
 @pytest.mark.asyncio
+async def test_loop_botched_count_does_not_launch_goal_loop() -> None:
+    # U2 — a number-shaped typo (`3e`, `5x`, `3.5`) must NOT silently start an
+    # unbounded goal loop toward the literal typo; it errors with a hint.
+    for typo in ("3e", "5x", "3.5", "12."):
+        session = GoalSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            await _type_command(pilot, app, f"loop {typo}")
+            # Give any (erroneously launched) worker a chance to run a turn.
+            for _ in range(6):
+                await pilot.pause()
+            text = _transcript_text(app)
+        assert app._loop_running is False, f"{typo!r} launched a loop"
+        assert session.prompts == [], f"{typo!r} ran a turn"
+        assert "mistyped count" in text, f"{typo!r} gave no disambiguating hint"
+
+
+@pytest.mark.asyncio
+async def test_loop_goal_with_digit_prefix_words_still_launches() -> None:
+    # A real goal that merely begins with a digit ("2fa the login flow") is
+    # written in words and must still start goal mode, not hit the typo guard.
+    session = GoalSession()
+    session.prompt_gate = asyncio.Event()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await _type_command(pilot, app, "loop 2fa the login flow")
+        assert app._loop_running is True
+        assert app._loop_goal == "2fa the login flow"
+        session.prompt_gate.set()
+        await _settle_loop(pilot, app)
+
+
+@pytest.mark.asyncio
+async def test_loop_goal_launch_notice_names_the_goal() -> None:
+    # U1 — the goal text must appear on screen at launch so there is a record of
+    # what the loop is pursuing.
+    session = GoalSession()
+    session.prompt_gate = asyncio.Event()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await _type_command(pilot, app, "loop finish the parser")
+        text = _transcript_text(app)
+        assert "looping toward: finish the parser" in text
+        session.prompt_gate.set()
+        await _settle_loop(pilot, app)
+
+
+@pytest.mark.asyncio
+async def test_loop_no_goal_hint_surfaces_inline_form() -> None:
+    # U3 — bare `/loop` with no standing goal should point at the inline goal
+    # form, not only at `/goal`.
+    session = GoalSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await _type_command(pilot, app, "loop")
+        # Collapse wrap so an 80-col line break inside the hint doesn't matter.
+        text = " ".join(_transcript_text(app).split())
+    assert "loop toward one now: /loop <goal text>" in text
+    assert session.prompts == []
+
+
+@pytest.mark.asyncio
 async def test_loop_stops_on_turn_error() -> None:
     session = GoalSession()
     session.set_goal("g")
@@ -3863,6 +3943,24 @@ async def _settle_loop(pilot, app, limit: int = 60) -> None:
         await pilot.pause()
         if not app._loop_running:
             return
+
+
+def _record_completion_notifies(app) -> list[int | None]:
+    """Wrap `app._notify` so a test can count 'complete' notifications.
+
+    Returns the list the wrapper appends to; the real notify still runs (it is a
+    no-op headless, but the call is what a test asserts on).
+    """
+    fired: list[int | None] = []
+    real_notify = app._notify
+
+    def rec(kind: str, *, running_children: int | None = None) -> bool:
+        if kind == "complete":
+            fired.append(running_children)
+        return real_notify(kind, running_children=running_children)
+
+    app._notify = rec  # type: ignore[assignment]
+    return fired
 
 
 @pytest.mark.asyncio
@@ -3946,15 +4044,10 @@ async def test_loop_goal_notifies_once_on_release() -> None:
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
-        completion_notifies: list[int | None] = []
-        real_notify = app._notify
-
-        def _record_notify(kind: str, *, running_children: int | None = None) -> bool:
-            if kind == "complete":
-                completion_notifies.append(running_children)
-            return real_notify(kind, running_children=running_children)
-
-        app._notify = _record_notify  # type: ignore[assignment]
+        # Post a real TurnEnded per turn (live-controller ordering) so the per-
+        # turn toasts would fire if suppression leaked — they must not.
+        session.post_turn_ended_to = app
+        completion_notifies = _record_completion_notifies(app)
         session.judge_verdicts = [
             "VERDICT: CONTINUE\nnot yet",
             "VERDICT: CONTINUE\nstill not",
@@ -3962,6 +4055,8 @@ async def test_loop_goal_notifies_once_on_release() -> None:
         ]
         await _type_command(pilot, app, "loop do the thing")
         await _settle_loop(pilot, app)
+        for _ in range(6):
+            await pilot.pause()
     assert len(session.prompts) == 3
     # Exactly one completion notify — the release toast, not a per-turn toast.
     assert len(completion_notifies) == 1
@@ -4047,17 +4142,26 @@ async def test_loop_goal_stop_cancels() -> None:
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
+        # R1 regression: the fake POSTS a real TurnEnded on settle like the live
+        # controller, so a spurious completion toast after the suppress-flag
+        # reset would fire here. Assert exactly ZERO 'complete' notifies.
+        session.post_turn_ended_to = app
+        completion_notifies = _record_completion_notifies(app)
         session.judge_verdicts = ["VERDICT: CONTINUE\nnot yet"] * 50
         await _type_command(pilot, app, "loop do the thing")
         assert app._loop_running is True
         await _type_command(pilot, app, "loop stop")
         session.prompt_gate.set()
         await _settle_loop(pilot, app)
+        # Extra pumps so any still-queued TurnEnded has dispatched.
+        for _ in range(6):
+            await pilot.pause()
         text = _transcript_text(app)
     assert "loop cancelled" in text
     assert app._loop_running is False
     assert app._loop_goal == ""
     assert app._loop_suppress_completion is False
+    assert completion_notifies == []  # no false "task complete" on a cancelled loop
 
 
 @pytest.mark.asyncio
@@ -4070,6 +4174,10 @@ async def test_loop_goal_reload_safety() -> None:
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
+        # R1 regression on the reload path too: a queued TurnEnded from the
+        # disposed session must not fire a completion toast after reset.
+        session.post_turn_ended_to = app
+        completion_notifies = _record_completion_notifies(app)
         session.judge_verdicts = ["VERDICT: CONTINUE\nnot yet"] * 50
         await _type_command(pilot, app, "loop do the thing")
         assert app._loop_running is True
@@ -4077,11 +4185,14 @@ async def test_loop_goal_reload_safety() -> None:
         app._session = GoalSession()
         session.prompt_gate.set()
         await _settle_loop(pilot, app)
+        for _ in range(6):
+            await pilot.pause()
         text = _transcript_text(app)
     assert "stopped by reload" in text
     assert app._loop_running is False
     assert app._loop_goal == ""
     assert app._loop_suppress_completion is False
+    assert completion_notifies == []  # no false "task complete" on a reloaded loop
 
 
 @pytest.mark.asyncio
@@ -4119,6 +4230,18 @@ def test_parse_loop_verdict_units() -> None:
     assert _parse_loop_verdict("just some prose\nno verdict here") == (None, "")
     # A verdict with no reason line => (bool, "").
     assert _parse_loop_verdict("VERDICT: ACHIEVED") == (True, "")
+
+    # R2 — token-level negation. An ordinary word that merely CONTAINS "not"/
+    # "n't" (nothing, cannot, another, note) must NOT flip a genuine ACHIEVED to
+    # CONTINUE: substring matching did exactly that and spun the loop forever.
+    assert _parse_loop_verdict("VERDICT: ACHIEVED, nothing else remains")[0] is True
+    assert _parse_loop_verdict("VERDICT: ACHIEVED - on to another goal")[0] is True
+    assert _parse_loop_verdict("VERDICT: ACHIEVED. Cannot do more.")[0] is True
+    assert _parse_loop_verdict("VERDICT: ACHIEVED, note the caveat")[0] is True
+    # But a real whole-word negator still reads as CONTINUE.
+    assert _parse_loop_verdict("VERDICT: NOT ACHIEVED")[0] is False
+    assert _parse_loop_verdict("VERDICT: NOT_ACHIEVED")[0] is False
+    assert _parse_loop_verdict("VERDICT: ACHIEVED but can't verify")[0] is False
 
 
 # -- MCP status band + startup toast -----------------------------------------

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -4242,6 +4242,10 @@ def test_parse_loop_verdict_units() -> None:
     assert _parse_loop_verdict("VERDICT: NOT ACHIEVED")[0] is False
     assert _parse_loop_verdict("VERDICT: NOT_ACHIEVED")[0] is False
     assert _parse_loop_verdict("VERDICT: ACHIEVED but can't verify")[0] is False
+    # R6 — a curly apostrophe (U+2019, what editors/phones autocorrect to) in
+    # the contraction must count as a negator too, or `can’t` reads as a false
+    # RELEASE. False-continue is the safe side; a false release is the bug.
+    assert _parse_loop_verdict("VERDICT: ACHIEVED but can\u2019t verify")[0] is False
 
 
 # -- MCP status band + startup toast -----------------------------------------


### PR DESCRIPTION
## Summary

Adds a goal-driven mode to the `/loop` slash command. Today `/loop` accepts only a number: `/loop 5` runs five fixed iterations of a canned "advance the standing goal" prompt, and any non-integer argument (e.g. `/loop finish the parser`) fails with `usage: /loop [n] (1..25)`. That mismatched the way loops work in other agent harnesses, where you type the goal directly and the agent keeps going until it is met.

Now `/loop <goal text>` starts a **judge-gated** loop: it runs turns toward the goal, and after each turn a forked, off-the-record judge call (same session model, via `complete_aside`) decides whether the goal is achieved. Not-achieved force-continues; achieved releases the loop and notifies the user **once**. Intermediate yields do not notify — that is the whole point, to avoid a completion toast on every iteration.

Fully **additive**: `/loop [n]` (numeric, still 1..25), `/loop stop`, and `/goal` are unchanged.

## Behaviour

Dispatch on the argument shape in `_cmd_loop`:
- `/loop stop|cancel|abort` → cancels a running loop (unchanged).
- `/loop` (no arg) → `DEFAULT_LOOP_ITERATIONS` numeric run (unchanged).
- `/loop 5` (integer) → five bounded iterations, 1..25 guard + standing-goal guard (unchanged).
- `/loop <non-integer text>` → **new** goal mode with that text as the goal.

Goal mode:
- Carries an **ephemeral** `self._loop_goal` — it does **not** call `session.set_goal`, so a `/loop do X` never clobbers a standing `/goal` the user set for the session, and restores nothing on exit because it changed nothing.
- **No hard iteration ceiling** (runs until the judge releases), but is cooperatively cancellable via `/loop stop`, reload-safe (`session is not self._session`), and protected by a **3-consecutive-judge-failure breaker** so a broken judge cannot spin forever.
- The judge verdict is parsed from distinct `VERDICT: ACHIEVED` / `VERDICT: CONTINUE` tokens by a pure `_parse_loop_verdict`; CONTINUE is checked before ACHIEVED and a negated "NOT ACHIEVED" never reads as a false release. An unreadable or errored verdict **fails safe to CONTINUE** with a surfaced warning (a false "done" that breaks user trust is worse than one extra loop).
- **Notify-once gating:** a `_loop_suppress_completion` flag short-circuits the per-turn completion toast in `on_turn_ended` while the loop is held; the worker fires exactly one `_notify("complete", ...)` on release. All three new state fields reset in the worker's `finally` (load-bearing — a stuck suppress flag would mute completions process-wide).
- Judge cost is charged via `_charge_aside`, so each goal turn's judge tokens are accounted, not silently free. Note: a goal turn costs roughly one extra full-context judge call on top of the turn.

### One intentional behaviour change
`/loop abc` no longer prints a usage error — it is now a goal. This is the point of the feature. The out-of-range **integer** error (`/loop 99`) is retained.

## Validation

All gates run over the whole tree from the branch (editable venv):

- `flake8 .` → clean.
- `black==26.1.0 --check .` → `560 files would be left unchanged`.
- `isort==5.13.2 --check .` → clean.
- `pyright` on the changed files (`local_operator/tui/app.py`, `tests/unit/tui/test_app_pilot.py`) → `0 errors, 0 warnings, 0 informations`. CI runs the authoritative tree-wide pyright.
- `pytest tests/unit/tui -q` → **2574 passed, 4 skipped**; loop subset **18 passed**.
- `pytest tests/unit -q` → the only failures are 23 in `tests/unit/tools/test_eval_tool.py`, pre-existing and environmental (the eval-worker subprocess cannot import `local_operator` under a symlinked-venv worktree); they fail **identically in a clean `~/local-operator` checkout** and are untouched by this change. CI's real install runs them green.

### Real-path execution evidence

Driven against the real `OperatorApp` via `run_test` with a scripted judge (no live model call), exercising the actual `_cmd_loop` + goal worker + `on_turn_ended` path:

```
=== Scenario A: CONTINUE, CONTINUE, ACHIEVED ===
  turns run (session.prompts) : 3
  judge calls                 : 3
  completion notifies fired   : 1 (expect 1, only on release)
  goal-achieved receipt       : True
  suppress flag reset         : True
  loop_goal reset             : True
  loop_running reset          : True
=== Scenario B: suppress flag gates TurnEnded completion toast ===
  completion notifies while suppressed : 0 (expect 0)
  completion notifies after clear      : 1 (expect 1)
=== Scenario C: /loop stop cancels a running goal loop ===
  running when stop issued : True
  'loop cancelled' receipt : True
  all three fields reset   : True
=== Scenario D: verdict parser ===
  'VERDICT: ACHIEVED\nall done'  -> (True, 'all done')  OK
  'VERDICT: CONTINUE\nnot yet'   -> (False, 'not yet')  OK
  'verdict: achieved\nok'        -> (True, 'ok')         OK
  'VERDICT: NOT ACHIEVED\nnope'  -> (False, 'nope')      OK
  ''                             -> (None, '')           OK
  'just prose\nno verdict'       -> (None, '')           OK
  'VERDICT: ACHIEVED'            -> (True, '')            OK
```

This confirms the core contract: N turns then release, zero intermediate notifications and exactly one on release, `/loop stop` cancels mid-loop, and all loop state resets.

## Review

Independent agent review is required before merge. This PR must not merge until that round is posted, answered, and fresh against the current head. As a user-visible interaction change (new command behaviour + notify-once flow), it also carries a UX round; the Scenario A/B/C evidence above is the real-run flow proof. No new painted widget, so no design round.
