### PR TITLE
fix(mcp): serialize in-flow OAuth refresh to stop Notion family revocation

### DIFF
--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -1400,6 +1400,90 @@ async def _oauth_refresh_lock(server_url: str):
         os.close(fd)
 
 
+def _refresh_user_agent() -> str:
+    """A stable ``local-operator/<version>`` identifier for the refresh POST.
+
+    See the header comment in :func:`_refresh_oauth_token_locked`: Cloudflare
+    blocks a no-UA refresh to mcp.notion.com. The version is looked up from the
+    installed distribution metadata and degrades to a bare product token when
+    running from a source checkout with no metadata, so this can never raise
+    into a refresh.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            return f"local-operator/{version('local-operator')}"
+        except PackageNotFoundError:
+            return "local-operator"
+    except Exception:  # noqa: BLE001 — a UA lookup must never break a refresh
+        return "local-operator"
+
+
+def _is_invalid_grant(body: bytes) -> bool:
+    """True when an OAuth error response body is an ``invalid_grant`` (RFC 6749).
+
+    A revoked or reused refresh token comes back as HTTP 400 with a JSON body
+    ``{\"error\": \"invalid_grant\", ...}``. Distinguishing it from a generic
+    400 is what lets the caller log the actionable \"run /mcp login\" meaning
+    (and never treat it as retriable). Any parse failure returns False so an
+    unexpected body is handled as an ordinary rejection, never crashes.
+    """
+    import json
+
+    try:
+        payload = json.loads(body)
+    except (ValueError, TypeError):
+        return False
+    return isinstance(payload, dict) and payload.get("error") == "invalid_grant"
+
+
+def _fallback_endpoints_for(server_url: str) -> "DiscoveredOAuthEndpoints":
+    """Synthesize the endpoint the SDK itself would refresh against.
+
+    When metadata discovery failed at startup (``endpoints is None``), the SDK's
+    ``_refresh_token`` falls back to ``urljoin(<scheme>://<netloc>, \"/token\")``
+    — the authorization base URL with its path stripped (see
+    ``OAuthContext.get_authorization_base_url``). Building a minimal
+    :class:`DiscoveredOAuthEndpoints` that targets exactly that URL lets the
+    coordinating provider perform the refresh UNDER THE LOCK with a fresh
+    re-read even without discovery, instead of falling through to the SDK's own
+    UNLOCKED refresh. That closes the residual reuse window: the SDK's unlocked
+    path spends whatever refresh token ``_initialize`` loaded at boot, which a
+    sibling may have already rotated away — presenting it a second time is the
+    reuse-detection trigger that revokes the whole family.
+
+    ``protected_resource_metadata`` is left None: with no discovery we have no
+    PRM, so the refresh omits the RFC 8707 ``resource`` parameter — matching the
+    SDK's own fallback path, whose ``should_include_resource_param`` is likewise
+    False without PRM (barring a 2025-06-18 protocol header, which the proactive
+    refresh does not carry).
+    """
+    from urllib.parse import urljoin, urlparse
+
+    from mcp.shared.auth import OAuthMetadata
+
+    parsed = urlparse(server_url)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    token_url = urljoin(base, "/token")
+    return DiscoveredOAuthEndpoints(
+        oauth_metadata=OAuthMetadata.model_validate(
+            {
+                "issuer": base,
+                # authorization_endpoint is a required field on OAuthMetadata
+                # but is unused by the refresh path (refresh only reads
+                # token_endpoint); the SDK's own fallback derives it the same
+                # way, so a synthesized value keeps the model valid without
+                # affecting behaviour.
+                "authorization_endpoint": urljoin(base, "/authorize"),
+                "token_endpoint": token_url,
+            }
+        ),
+        protected_resource_metadata=None,
+        auth_server_url=base,
+    )
+
+
 async def _refresh_oauth_token_locked(
     server_url: str,
     storage: McpTokenStorage,
@@ -1436,7 +1520,17 @@ async def _refresh_oauth_token_locked(
     if endpoints.protected_resource_metadata is not None:
         data["resource"] = resource_url_from_server_url(server_url)
 
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    headers = {
+        "Content-Type": "application/x-www-form-urlencoded",
+        # Explicit UA, not httpx's default. mcp.notion.com sits behind
+        # Cloudflare, whose bot heuristics return HTTP 403 "error code 1010"
+        # to a refresh POST carrying NO User-Agent (observed live this cycle:
+        # httpx's built-in UA slips through, a missing one is blocked). Pinning
+        # our own identifier means a future httpx default change or a stricter
+        # Cloudflare rule cannot silently turn every refresh into a 403 and
+        # force a browser grant on the whole fleet.
+        "User-Agent": _refresh_user_agent(),
+    }
     auth_method = client_info.token_endpoint_auth_method
     if auth_method == "client_secret_post" and client_info.client_secret:
         data["client_secret"] = client_info.client_secret
@@ -1453,6 +1547,23 @@ async def _refresh_oauth_token_locked(
         logger.debug("MCP token refresh request failed for %s", server_url, exc_info=True)
         return False
     if response.status_code != 200:
+        # A revoked-grant rejection is qualitatively different from a transient
+        # one and must be logged as such: for a rotating provider that runs
+        # refresh-token REUSE DETECTION (Notion), presenting an already-rotated
+        # refresh token returns HTTP 400 {"error":"invalid_grant"} and revokes
+        # the ENTIRE token family, logging out every session at once. When that
+        # happens the only recovery is an interactive login, so the log names
+        # that action instead of implying a retry will heal it. We never
+        # auto-retry here regardless: returning False lets the connect surface
+        # McpAuthRequiredError, which the manager turns into a suspended
+        # reconnect (see manager._reconnect's McpAuthRequiredError arm) rather
+        # than hammering a dead grant.
+        if response.status_code == 400 and _is_invalid_grant(response.content):
+            logger.info(
+                "MCP OAuth grant revoked for %s (invalid_grant); run /mcp login to restore it",
+                server_url,
+            )
+            return False
         # Informational, not debug: a rejected refresh is the thing that turns
         # into a login prompt, so its cause belongs in the readable log.
         logger.info("MCP token refresh rejected for %s: HTTP %s", server_url, response.status_code)
@@ -1677,11 +1788,18 @@ def _make_refresh_coordinating_provider(
     token endpoint is not ``<server_base>/token`` (Datadog) refreshes rather
     than 404-ing into a browser grant.
 
-    Degradation is honest: with no discovered ``endpoints`` (metadata discovery
-    failed at startup) the re-read/adopt step still runs — which alone removes
-    the common case, where a sibling already refreshed — and only the
-    self-performed exchange falls back to the SDK's own unlocked refresh, i.e.
-    exactly the pre-fix behaviour for that one provider.
+    The invariant, enforced on EVERY path: the SDK's own (unlocked)
+    ``_refresh_token`` must never run with an in-memory refresh token older than
+    what storage holds. With no discovered ``endpoints`` (metadata discovery
+    failed at startup) the coordinator no longer falls through to that unlocked
+    refresh — it synthesizes the SDK's own fallback token endpoint
+    (``<scheme>://<netloc>/token``) and performs the exchange UNDER THE LOCK
+    with a fresh re-read, so even without discovery a stale boot-time refresh
+    token is never presented a second time. Presenting one to a reuse-detecting
+    provider (Notion) is what returns ``invalid_grant`` and revokes the whole
+    token family. If the coordinated refresh itself raises, a final under-lock
+    re-read still adopts the freshest persisted token before the SDK runs, so
+    the invariant survives the exception fall-through too.
 
     The subclass additionally intercepts the FIRST 401 the resource server
     returns for the original request. The coordination step above only fires
@@ -1723,37 +1841,88 @@ def _make_refresh_coordinating_provider(
                     # Re-read under the lock: a sibling process may have rotated
                     # the token while we waited. Adopting its result is what
                     # turns a double-spend into a no-op.
-                    stored = await ctx.storage.get_tokens()
-                    if stored is not None and stored.access_token:
-                        ctx.current_tokens = stored
-                        ctx.token_expiry_time = self._refresh_coord_storage.stored_token_expiry()
+                    await self._resync_from_store(ctx)
                     if ctx.is_token_valid():
                         return  # a peer already refreshed; do not spend again
+                    # The invariant this whole block exists to guarantee: the
+                    # SDK's own ``_refresh_token`` must NEVER run with an
+                    # in-memory refresh token older than the one in storage. The
+                    # SDK loads the token once at ``_initialize`` and spends it
+                    # unlocked; a sibling that rotated it in between leaves us
+                    # holding a stale refresh token, and presenting that to a
+                    # reuse-detecting provider (Notion) returns
+                    # ``invalid_grant`` and revokes the ENTIRE token family —
+                    # logging out every session at once. So we always perform
+                    # the refresh ourselves, UNDER THE LOCK, with a fresh
+                    # re-read; the SDK's unlocked path is never reached with a
+                    # stale token.
                     endpoints = self._refresh_coord_endpoints
                     if endpoints is None:
-                        # No discovered endpoint: leave the stale token in place
-                        # and let the SDK's own (unlocked) in-flow refresh run —
-                        # the pre-fix path for this one provider. The re-read
-                        # above already handled the common racing case.
-                        return
+                        # Discovery failed at startup, but we must still refresh
+                        # under the lock rather than fall through to the SDK's
+                        # UNLOCKED refresh (which would spend the possibly-stale
+                        # boot-time token and risk the family revocation above).
+                        # Synthesize the exact endpoint the SDK itself would
+                        # fall back to (``<scheme>://<netloc>/token``) so the
+                        # locked, re-reading refresh targets the same URL the
+                        # unlocked path would have.
+                        endpoints = _fallback_endpoints_for(self._refresh_coord_server_url)
                     refreshed = await _refresh_oauth_token_locked(
                         self._refresh_coord_server_url,
                         self._refresh_coord_storage,
                         endpoints,
                     )
                     if refreshed:
-                        new_tokens = await ctx.storage.get_tokens()
-                        if new_tokens is not None:
-                            ctx.current_tokens = new_tokens
-                            ctx.token_expiry_time = (
-                                self._refresh_coord_storage.stored_token_expiry()
-                            )
+                        await self._resync_from_store(ctx)
             except Exception:  # noqa: BLE001 — coordination is best-effort
-                # A failed re-read/refresh must never break the request: fall
-                # through to the SDK's own auth flow, which will refresh (or, if
-                # that fails, surface the non-interactive McpAuthRequiredError).
+                # A failed re-read/refresh must never break the request. But we
+                # must NOT let the SDK's unlocked refresh then spend a stale
+                # boot-time token: re-read storage one final time under the lock
+                # and overwrite the in-memory token with whatever is persisted,
+                # so whatever the SDK spends next is at least the freshest
+                # stored refresh token, never an older one a sibling already
+                # rotated away. This upholds the same invariant on the exception
+                # fall-through path (a raised locked-refresh, a transient store
+                # error) as the success path does.
                 logger.debug(
                     "MCP in-flight refresh coordination failed for %s",
+                    self._refresh_coord_server_url,
+                    exc_info=True,
+                )
+                await self._adopt_freshest_stored_token(ctx)
+
+        async def _resync_from_store(self, ctx: Any) -> None:
+            """Overwrite the in-memory token with the persisted one.
+
+            Called under :func:`_oauth_refresh_lock`. Reads the store's current
+            token through the same storage the provider persists through and,
+            when present, adopts it into the context along with its recomputed
+            expiry. Both the success path and the exception fall-through share
+            this one definition of "sync from store" so the invariant (in-memory
+            refresh token never older than storage) is enforced identically on
+            every path.
+            """
+            stored = await ctx.storage.get_tokens()
+            if stored is not None and stored.access_token:
+                ctx.current_tokens = stored
+                ctx.token_expiry_time = self._refresh_coord_storage.stored_token_expiry()
+
+        async def _adopt_freshest_stored_token(self, ctx: Any) -> None:
+            """Final under-lock re-read on the exception fall-through path.
+
+            Guarantees the invariant even when the coordinated refresh raised:
+            re-read storage under the refresh lock and adopt the freshest
+            persisted token, so the SDK's subsequent unlocked refresh can never
+            spend an in-memory refresh token older than what is on disk. Best
+            effort — a failure here just leaves the pre-fix behaviour, never a
+            raise into the request.
+            """
+            try:
+                async with _oauth_refresh_lock(self._refresh_coord_server_url):
+                    await self._resync_from_store(ctx)
+            except Exception:  # noqa: BLE001 — best-effort; never break the request
+                logger.debug(
+                    "MCP in-flight refresh final re-read failed for %s",
                     self._refresh_coord_server_url,
                     exc_info=True,
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.1"
+version = "0.42.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/repro_notion_reuse.py
+++ b/scripts/repro_notion_reuse.py
@@ -1,0 +1,534 @@
+#!/usr/bin/env python3
+"""Two-process repro for the RESIDUAL Notion MCP OAuth reuse-detection window.
+
+Sibling of ``repro_notion_401.py``. That script proves the 401-ADOPTION path
+(PR #340): a session holding a locally-valid but server-side-revoked ACCESS
+token recovers by adopting a peer's token on the 401. This script proves the
+remaining hole that adoption does not cover: the SDK's own in-flow REFRESH,
+which spends the refresh token the provider loaded ONCE at ``_initialize`` and
+never re-reads, under no cross-process lock.
+
+Why that hole is fatal for Notion specifically: Notion rotates its refresh
+token on every use AND runs REFRESH-TOKEN REUSE DETECTION. Presenting an
+already-rotated refresh token returns HTTP 400 ``{"error":"invalid_grant"}``
+and revokes the ENTIRE token family — every one of the ~15 concurrent
+local-operator sessions sharing the one grant is logged out at once. So a
+sibling that boots with a now-stale in-memory refresh token must NEVER let the
+SDK spend it: it has to re-read storage under the lock and spend the freshest
+persisted refresh token instead.
+
+The invariant under test: the SDK's ``_refresh_token`` must never run with a
+``context.current_tokens.refresh_token`` older than what is in storage.
+
+Scenario (two OS processes, one shared auth.db, one fake reuse-detecting AS):
+
+- A fake authorization server rotates the refresh token on every refresh and
+  RETIRES the spent one. Presenting a retired refresh token revokes the whole
+  family (sets ``family_revoked`` and returns 400 invalid_grant), exactly like
+  Notion. State lives in an flock'd JSON file so two processes agree.
+- Process A boots with the original grant, REFRESHES once (rotating
+  ``r-old`` -> ``r-new`` and retiring ``r-old``), and persists ``r-new`` to the
+  shared store. Its access token is then aged to EXPIRED — modelling the real
+  steady state where the whole fleet booted together and has crossed the 8h
+  access-token boundary, so even the freshest STORED access token needs a
+  refresh (this is what makes coordination proceed to refresh rather than
+  simply adopt a still-valid access token).
+- Process B boots (SEPARATE process) holding the PRE-rotation refresh token
+  ``r-old`` in memory with an EXPIRED access token, and with metadata discovery
+  FAILED (``endpoints=None``) — the exact fall-through the fix closes. It makes
+  a request, which triggers the in-flow refresh. With the bug, the SDK spends
+  the stale in-memory ``r-old`` unlocked -> the AS detects reuse -> the family
+  is revoked (every session logged out). With the fix, B refreshes UNDER THE
+  LOCK against the SDK's own synthesized fallback endpoint, re-reads storage,
+  and spends the fresh ``r-new`` -> the family survives.
+
+Usage:
+    .venv/bin/python scripts/repro_notion_reuse.py <scratch_dir>
+
+Prints PASS/FAIL lines and exits non-zero on failure. A pre-fix tree FAILs:
+process B spends the retired token and the AS revokes the family.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+# Ensure the repo is importable regardless of the caller's cwd.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+SERVER_URL = "https://mcp.notion-reuse.test/mcp"
+
+REGISTRY_NAME = "as_reuse_registry.json"
+REGISTRY_LOCK_NAME = "as_reuse_registry.lock"
+
+
+def _registry_paths(scratch: str):
+    return os.path.join(scratch, REGISTRY_NAME), os.path.join(scratch, REGISTRY_LOCK_NAME)
+
+
+def _with_registry(scratch: str, mutate) -> Any:
+    """Read-modify-write the fake AS registry under an flock'd sidecar file.
+
+    Cross-process safe the same way production's ``_oauth_refresh_lock`` is: a
+    byte-range flock on a sidecar file, never on the data file itself.
+    """
+    import fcntl
+
+    reg_path, lock_path = _registry_paths(scratch)
+    os.makedirs(scratch, exist_ok=True)
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            with open(reg_path) as fh:
+                data = json.load(fh)
+        except (FileNotFoundError, json.JSONDecodeError):
+            # current_refresh: the ONLY refresh token the AS will honour.
+            # retired: refresh tokens already spent (presenting one = reuse).
+            # family_revoked: set once reuse is detected — the whole grant dies.
+            data = {
+                "counter": 0,
+                "current_refresh": None,
+                "retired": [],
+                "live_access": [],
+                "family_revoked": False,
+            }
+        result = mutate(data)
+        with open(reg_path, "w") as fh:
+            json.dump(data, fh)
+        return result
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def _as_issue_initial(scratch: str) -> dict[str, Any]:
+    """The AS issues the ORIGINAL grant (access + refresh)."""
+
+    def mutate(data):
+        data["counter"] += 1
+        access = f"access-{data['counter']}"
+        refresh = f"refresh-{data['counter']}"
+        data["current_refresh"] = refresh
+        data["live_access"] = [access]
+        return {"access_token": access, "refresh_token": refresh}
+
+    return _with_registry(scratch, mutate)
+
+
+def _as_refresh(scratch: str, presented_refresh: str) -> dict[str, Any]:
+    """Rotate the grant, with REUSE DETECTION.
+
+    - Presenting the CURRENT refresh token rotates: the spent token is retired,
+      a new access+refresh pair is issued, and all prior access tokens are
+      revoked (Notion's behaviour).
+    - Presenting a RETIRED refresh token is reuse: the entire family is revoked
+      and an ``invalid_grant`` error is signalled. This is the event that logs
+      every session out at once, and the thing the fix must prevent B from
+      triggering.
+    """
+
+    def mutate(data):
+        if presented_refresh in data["retired"] or data["family_revoked"]:
+            # Reuse detected (or the family is already dead from an earlier
+            # reuse): revoke everything and report invalid_grant.
+            data["family_revoked"] = True
+            data["current_refresh"] = None
+            data["live_access"] = []
+            return {"error": "invalid_grant", "error_description": "OAuth grant revoked"}
+        if presented_refresh != data["current_refresh"]:
+            # An unknown token: treat as a generic invalid_grant, not a rotation.
+            return {"error": "invalid_grant", "error_description": "unknown refresh token"}
+        data["retired"].append(data["current_refresh"])
+        data["counter"] += 1
+        access = f"access-{data['counter']}"
+        refresh = f"refresh-{data['counter']}"
+        data["current_refresh"] = refresh
+        data["live_access"] = [access]  # rotation revokes prior access tokens
+        return {"access_token": access, "refresh_token": refresh}
+
+    return _with_registry(scratch, mutate)
+
+
+def _as_family_revoked(scratch: str) -> bool:
+    reg_path, _ = _registry_paths(scratch)
+    try:
+        with open(reg_path) as fh:
+            data = json.load(fh)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return False
+    return bool(data.get("family_revoked"))
+
+
+def _as_token_live(scratch: str, access_token: str) -> bool:
+    reg_path, _ = _registry_paths(scratch)
+    try:
+        with open(reg_path) as fh:
+            data = json.load(fh)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return False
+    return access_token in data.get("live_access", [])
+
+
+def _refresh_lock_is_held(scratch: str) -> bool:
+    """True when another holder owns the REAL ``_oauth_refresh_lock`` right now.
+
+    Probes the exact lock file production uses (``config_dir()/
+    mcp_oauth_refresh.lock``) with a NON-BLOCKING exclusive flock: if the
+    acquire fails, some code path is inside the lock; if it succeeds, we release
+    immediately and report "unheld". This is how the repro tells the fix's
+    coordinated (locked) refresh apart from the SDK's unlocked one without
+    instrumenting the code under test.
+    """
+    import fcntl
+
+    from local_operator.paths import config_dir
+
+    lock_path = os.path.join(str(config_dir()), "mcp_oauth_refresh.lock")
+    try:
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    except OSError:
+        return False
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return True  # someone else holds it -> the refresh IS locked
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        return False
+    finally:
+        os.close(fd)
+
+
+def _inject_concurrent_sibling_rotation(scratch: str, about_to_present: str) -> None:
+    """Simulate a peer rotating the grant in the unlocked seam.
+
+    Called only when a refresh POST arrives with the refresh lock UNHELD — i.e.
+    the SDK's unlocked in-flow refresh, the residual window. If the token this
+    POST is about to present is still the current one, a sibling process rotates
+    it away first (retiring it), so this POST then presents a RETIRED token and
+    trips reuse detection. That is the real multi-process race: 15 sessions, one
+    grant, and any unlocked spend can be overtaken.
+    """
+
+    def mutate(data):
+        if data["family_revoked"]:
+            return None
+        if about_to_present == data.get("current_refresh"):
+            data["retired"].append(data["current_refresh"])
+            data["counter"] += 1
+            data["current_refresh"] = f"refresh-{data['counter']}"
+            data["live_access"] = [f"access-{data['counter']}"]
+        return None
+
+    _with_registry(scratch, mutate)
+
+
+def _make_fake_as_handler(scratch: str, browser_events: list[str], role: str):
+    """Build the single request handler standing in for the reuse-detecting AS.
+
+    It answers every URL the flow can reach: any ``/token`` endpoint (the SDK's
+    fallback OR a discovered one), the authorization endpoint (a full browser
+    grant, which must never be reached), metadata discovery (forced 404 so the
+    provider runs with ``endpoints=None`` — the fall-through the fix closes),
+    and the resource server (200 a live token, 401 a revoked one).
+    """
+    import httpx
+    from mcp.shared.auth import OAuthToken
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if url.rstrip("/").endswith("/token"):
+            body = request.content.decode()
+            presented = ""
+            for part in body.split("&"):
+                if part.startswith("refresh_token="):
+                    presented = part.split("=", 1)[1]
+            # MODEL THE RESIDUAL WINDOW. The bug is not "spend a stale token
+            # loaded at boot" — coordination's re-read already adopts the
+            # freshest STORED token before falling through. The bug is the SEAM:
+            # coordination releases ``_oauth_refresh_lock``, and only THEN does
+            # the SDK's unlocked ``_refresh_token`` POST — so one of the other
+            # ~15 sessions can rotate the grant in that gap, retiring the token
+            # this POST is about to present. We detect which path issued this
+            # POST by probing the real refresh lock: if it is UNHELD, the POST is
+            # the SDK's unlocked path (the bug), and we inject exactly that
+            # concurrent sibling rotation before processing — retiring the
+            # presented token so reuse detection fires. If the lock is HELD, the
+            # POST is the fix's coordinated path and no sibling can slip in.
+            if not _refresh_lock_is_held(scratch):
+                _inject_concurrent_sibling_rotation(scratch, presented)
+            result = _as_refresh(scratch, presented)
+            if "error" in result:
+                # Reuse / revoked grant: HTTP 400 invalid_grant, exactly Notion.
+                return httpx.Response(400, json=result, request=request)
+            token = OAuthToken(
+                access_token=result["access_token"],
+                refresh_token=result["refresh_token"],
+                expires_in=3600,
+            )
+            return httpx.Response(200, json=token.model_dump(mode="json"), request=request)
+        if "authorize" in url:
+            browser_events.append(f"{role}: AUTHORIZATION-GRANT request to {url}")
+            return httpx.Response(200, json={}, request=request)
+        if "oauth-protected-resource" in url or "oauth-authorization-server" in url:
+            return httpx.Response(404, request=request)
+        auth = request.headers.get("Authorization", "")
+        token_val = auth.removeprefix("Bearer ").strip()
+        if _as_token_live(scratch, token_val):
+            return httpx.Response(200, json={"ok": True}, request=request)
+        return httpx.Response(401, request=request)
+
+    return handler
+
+
+def _install_fake_as_transport(handler) -> None:
+    """Route this process's ``httpx.AsyncClient`` through ``handler``.
+
+    The fix's ``_refresh_oauth_token_locked`` opens its OWN ``httpx.AsyncClient``
+    to POST the refresh, so that internal client must also hit the fake AS.
+    Patching ``AsyncClient`` process-wide with a MockTransport covers it. The
+    yielded-request path (the SDK's in-flow refresh and the resource request) is
+    driven by hand against the SAME handler in ``_process_b`` — never through a
+    real client, which would nest a second auth flow.
+    """
+    import httpx
+
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.AsyncClient
+
+    def patched_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs.setdefault("transport", transport)
+        return real_client(*args, **kwargs)
+
+    httpx.AsyncClient = patched_client  # type: ignore[misc, assignment]
+
+
+def _build_provider(scratch: str):
+    """A refresh-coordinating provider over the SHARED auth.db, built with
+    ``endpoints=None`` (discovery failed) and NON-INTERACTIVE so a stray full
+    grant raises instead of opening a browser."""
+    from local_operator.mcp.auth import build_oauth_provider
+    from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+    from local_operator.providers.auth_store import AuthStore
+
+    store = AuthStore(db_path=os.path.join(scratch, "auth.db"))
+    cfg = MCPHttpServerConfig(url=SERVER_URL, auth=MCPAuthConfig(type="oauth"))
+    return build_oauth_provider(SERVER_URL, cfg, store=store, endpoints=None, interactive=False)
+
+
+def _seed(scratch: str) -> None:
+    """Seed the fake AS and the shared store with the ORIGINAL grant."""
+    import asyncio
+
+    from mcp.shared.auth import OAuthToken
+
+    from local_operator.mcp.auth import McpTokenStorage
+    from local_operator.providers.auth_store import AuthStore
+
+    token = _as_issue_initial(scratch)
+    store = AuthStore(db_path=os.path.join(scratch, "auth.db"))
+    storage = McpTokenStorage(SERVER_URL, store)
+    asyncio.run(
+        storage.set_tokens(
+            OAuthToken(
+                access_token=token["access_token"],
+                refresh_token=token["refresh_token"],
+                expires_in=3600,
+            )
+        )
+    )
+    print(f"seed: issued original grant {token}", flush=True)
+
+
+async def _process_a(scratch: str) -> None:
+    """Process A: REFRESH once (rotating the grant), persist, then age it.
+
+    A rotates ``r-old`` -> ``r-new`` at the AS (retiring ``r-old``) and persists
+    ``r-new`` to the shared store, then ages the stored access token to EXPIRED.
+    The ageing models the real steady state: the whole fleet booted together, so
+    by the time B refreshes even the freshest STORED access token has crossed
+    the 8h boundary and needs a refresh — which is precisely what makes B's
+    coordination proceed to a refresh rather than adopt a still-valid token."""
+    import time
+
+    from mcp.shared.auth import OAuthToken
+
+    from local_operator.mcp.auth import TOKENS_OBTAINED_AT_KEY, McpTokenStorage
+    from local_operator.providers.auth_store import AuthStore
+
+    store = AuthStore(db_path=os.path.join(scratch, "auth.db"))
+    storage = McpTokenStorage(SERVER_URL, store)
+    current = await storage.get_tokens()
+    assert current is not None and current.refresh_token is not None
+    rotated = _as_refresh(scratch, current.refresh_token)
+    assert "error" not in rotated, f"A's own refresh should succeed: {rotated}"
+    await storage.set_tokens(
+        OAuthToken(
+            access_token=rotated["access_token"],
+            refresh_token=rotated["refresh_token"],
+            expires_in=3600,
+        )
+    )
+    # Age the stored access token so B's coordination proceeds to a refresh.
+    creds = storage._read() or {}
+    creds[TOKENS_OBTAINED_AT_KEY] = time.time() - 100000
+    storage._write(creds)
+    print(
+        f"A: rotated r-old -> {rotated['refresh_token']}, persisted (access aged to expired)",
+        flush=True,
+    )
+
+
+async def _process_b(scratch: str) -> int:
+    """Process B: hold the PRE-rotation refresh token, refresh, must not reuse.
+
+    Returns 0 on success (family survives, B spent the fresh token), 1 on the
+    bug (B spent the retired token and the AS revoked the whole family)."""
+    import time
+
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+    from local_operator.mcp.auth import McpAuthRequiredError, McpTokenStorage
+    from local_operator.providers.auth_store import AuthStore
+
+    browser_events: list[str] = []
+    handler = _make_fake_as_handler(scratch, browser_events, "B")
+    _install_fake_as_transport(handler)
+
+    provider = _build_provider(scratch)
+
+    # Client info is needed for can_refresh_token() to be True.
+    store = AuthStore(db_path=os.path.join(scratch, "auth.db"))
+    storage = McpTokenStorage(SERVER_URL, store)
+    await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+
+    # Reconstruct B's multi-process state: B BOOTED before A's rotation, so its
+    # in-memory refresh token is the ORIGINAL ``refresh-1`` (now RETIRED at the
+    # AS), and its access token is EXPIRED (the fleet crossed the 8h boundary).
+    # This is the session that, pre-fix, spends the retired refresh token via
+    # the SDK's unlocked in-flow refresh and kills the whole family.
+    original_refresh = "refresh-1"
+    provider.context.current_tokens = OAuthToken(
+        access_token="access-1", refresh_token=original_refresh, expires_in=3600
+    )
+    provider.context.token_expiry_time = time.time() - 10  # EXPIRED -> refresh fires
+    provider.context.client_info = OAuthClientInformationFull(client_id="cid")
+    provider._initialized = True
+
+    stored_now = await storage.get_tokens()
+    print(
+        f"B: booted with in-memory refresh '{original_refresh}' (retired), "
+        f"store holds refresh '{stored_now.refresh_token if stored_now else None}'",
+        flush=True,
+    )
+
+    # Drive the auth flow the way httpx does — but answer each yielded request
+    # by calling the fake-AS handler DIRECTLY, never through a real client
+    # (which would nest a second auth flow). This is exactly how the SDK's own
+    # tests pump an httpx Auth: the provider only YIELDS requests, and the
+    # caller supplies the responses.
+    import httpx
+
+    gen = provider.async_auth_flow(httpx.Request("POST", SERVER_URL, content=b'{"q":1}'))
+    final_status = None
+    try:
+        request = await gen.__anext__()
+        while True:
+            response = handler(request)
+            try:
+                request = await gen.asend(response)
+            except StopAsyncIteration:
+                final_status = response.status_code
+                break
+    except McpAuthRequiredError as exc:
+        print(f"B: full authorization grant ran (McpAuthRequiredError): {exc}", flush=True)
+    finally:
+        await gen.aclose()
+
+    if _as_family_revoked(scratch):
+        print(
+            "B: FAIL — reuse DETECTED: B spent the retired refresh token and the "
+            "AS revoked the ENTIRE token family (every session logged out)",
+            flush=True,
+        )
+        return 1
+    if browser_events:
+        print(f"B: FAIL — browser/authorization grant ran: {browser_events}", flush=True)
+        return 1
+    if final_status != 200:
+        print(f"B: FAIL — final status {final_status}, expected 200", flush=True)
+        return 1
+    current = provider.context.current_tokens
+    spent = current.refresh_token if current else None
+    if spent == original_refresh:
+        print(f"B: FAIL — still holding the retired token '{spent}'", flush=True)
+        return 1
+    print(
+        f"B: PASS — refreshed under the lock without reusing the retired token; "
+        f"now holds '{spent}', family intact, final status 200",
+        flush=True,
+    )
+    return 0
+
+
+def _run_role(scratch: str, role: str) -> int:
+    import asyncio
+
+    if role == "A":
+        asyncio.run(_process_a(scratch))
+        return 0
+    return asyncio.run(_process_b(scratch))
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+    scratch = sys.argv[1]
+
+    if len(sys.argv) >= 4 and sys.argv[2] == "child":
+        # Isolate config so _oauth_refresh_lock and AuthStore resolve under the
+        # scratch dir, never the developer's real ~/.local-operator.
+        os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = scratch
+        return _run_role(scratch, sys.argv[3])
+
+    import subprocess
+
+    os.makedirs(scratch, exist_ok=True)
+    os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = scratch
+    _seed(scratch)
+
+    env = dict(os.environ, LOCAL_OPERATOR_CONFIG_DIR=scratch)
+    a = subprocess.run(
+        [sys.executable, os.path.abspath(__file__), scratch, "child", "A"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    sys.stdout.write(a.stdout)
+    sys.stderr.write(a.stderr)
+    if a.returncode != 0:
+        print("ORCH: FAIL — process A errored", flush=True)
+        return 1
+
+    b = subprocess.run(
+        [sys.executable, os.path.abspath(__file__), scratch, "child", "B"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    sys.stdout.write(b.stdout)
+    sys.stderr.write(b.stderr)
+    if b.returncode != 0:
+        print("ORCH: FAIL — process B triggered reuse detection / did not recover", flush=True)
+        return 1
+    print("ORCH: PASS — the whole token family survived a stale sibling refresh", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -1831,12 +1831,19 @@ class TestInflightRefreshCoordination:
         assert not provider.context.lock.locked(), "SDK context.lock leaked after early close"
 
     @pytest.mark.asyncio
-    async def test_no_endpoints_falls_back_to_sdk_refresh(
+    async def test_no_endpoints_still_refreshes_under_the_lock(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """With no discovered endpoint the re-read still runs (so a racing peer
-        is still adopted), but a self-performed refresh is left to the SDK — the
-        pre-fix path for that one provider, never a crash."""
+        """With no discovered endpoint we STILL perform the refresh under the
+        lock (against the SDK's synthesized fallback token endpoint) rather than
+        falling through to the SDK's UNLOCKED refresh.
+
+        This is the residual reuse window the fix closes: the SDK's unlocked
+        path would spend the possibly-stale boot-time refresh token, which a
+        reuse-detecting provider (Notion) punishes by revoking the whole token
+        family. The synthesized endpoint must be ``<scheme>://<netloc>/token`` —
+        exactly what the SDK itself falls back to — so the locked, re-reading
+        refresh targets the same URL."""
         import time
 
         from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
@@ -1852,20 +1859,24 @@ class TestInflightRefreshCoordination:
         await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
         store.rows[0].data["tokens_obtained_at"] = time.time() - 600
 
-        # endpoints=None: no self-performed refresh possible.
+        # endpoints=None: discovery failed, but we must still refresh under the
+        # lock against the synthesized fallback endpoint.
         provider = build_oauth_provider(self.URL, self._cfg(), store=store, endpoints=None)
 
-        refresh_calls = {"n": 0}
+        refresh_calls: dict[str, Any] = {"n": 0, "endpoint": None}
 
-        async def fake_refresh(*args: Any, **kwargs: Any) -> bool:
+        async def fake_refresh(server_url: str, storage_arg: Any, endpoints: Any) -> bool:
             refresh_calls["n"] += 1
+            refresh_calls["endpoint"] = str(endpoints.oauth_metadata.token_endpoint)
             return True
 
         monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", fake_refresh)
 
-        # Must not raise; our own locked refresh is never called (no endpoint).
         await self._drive_auth_flow(provider)
-        assert refresh_calls["n"] == 0
+        # Exactly one locked refresh happened, against the SDK's own fallback
+        # token endpoint (server base with the path stripped, plus ``/token``).
+        assert refresh_calls["n"] == 1
+        assert refresh_calls["endpoint"] == "https://mcp.example.com/token"
 
     async def _drive_401_flow(self, provider, responder) -> list[Any]:
         """Pump ``async_auth_flow`` the way httpx does, recording every request
@@ -2084,3 +2095,234 @@ class TestInflightRefreshCoordination:
         # A looping adoption would show a third.
         to_resource = [y for y in yields if str(y[0].url) == self.URL]
         assert len(to_resource) == 2
+
+    @pytest.mark.asyncio
+    async def test_no_endpoints_spends_the_fresh_stored_refresh_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The residual reuse window, closed: with discovery failed
+        (endpoints=None) the coordinated refresh must spend the token CURRENTLY
+        in storage, never the stale one the provider loaded at boot.
+
+        Presenting an already-rotated refresh token to a reuse-detecting
+        provider (Notion) revokes the entire token family. We seed a rotated
+        token into storage AFTER the provider initialized, then drive the flow
+        and assert the refresh token the locked exchange actually reads is the
+        FRESH one — proof the SDK's unlocked, boot-time-token path was never
+        reached."""
+        import time
+
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        # Provider boots holding the STALE token (this is what _initialize
+        # loads into memory and the SDK would spend unlocked).
+        await storage.set_tokens(
+            OAuthToken(access_token="stale", refresh_token="r-old", expires_in=60)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+        store.rows[0].data["tokens_obtained_at"] = time.time() - 600  # age past expiry
+
+        provider = build_oauth_provider(self.URL, self._cfg(), store=store, endpoints=None)
+        # Force the in-memory boot-time view, THEN rotate storage underneath it.
+        async with provider.context.lock:
+            await provider._initialize()
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.refresh_token == "r-old"
+
+        # A sibling process rotated the grant in the shared store to a fresh but
+        # still-expired token (so coordination proceeds to refresh, not adopt).
+        await storage.set_tokens(
+            OAuthToken(access_token="stale2", refresh_token="r-new", expires_in=60)
+        )
+        store.rows[0].data["tokens_obtained_at"] = time.time() - 600
+
+        # The locked exchange reads its refresh token from STORAGE, not from the
+        # provider's in-memory context, so capturing what it reads proves which
+        # token would actually be spent on the wire.
+        spent: dict[str, Any] = {}
+
+        async def spy_refresh(server_url: str, storage_arg: Any, endpoints: Any) -> bool:
+            tokens = await storage_arg.get_tokens()
+            spent["refresh_token"] = tokens.refresh_token if tokens else None
+            spent["endpoint"] = str(endpoints.oauth_metadata.token_endpoint)
+            return True
+
+        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", spy_refresh)
+
+        await self._drive_auth_flow(provider)
+
+        # The refresh spent the FRESH stored token, against the SDK's fallback
+        # endpoint — never the stale boot-time "r-old".
+        assert spent["refresh_token"] == "r-new"
+        assert spent["endpoint"] == "https://mcp.example.com/token"
+
+    @pytest.mark.asyncio
+    async def test_locked_refresh_raise_still_adopts_freshest_before_sdk(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The exception fall-through upholds the invariant too: if the locked
+        refresh RAISES, a final under-lock re-read adopts the freshest persisted
+        token, so the SDK's subsequent unlocked refresh cannot spend an
+        in-memory refresh token older than storage."""
+        import time
+
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        await storage.set_tokens(
+            OAuthToken(access_token="stale", refresh_token="r-old", expires_in=60)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+        store.rows[0].data["tokens_obtained_at"] = time.time() - 600
+
+        provider = build_oauth_provider(
+            self.URL, self._cfg(), store=store, endpoints=self._endpoints()
+        )
+        async with provider.context.lock:
+            await provider._initialize()
+
+        # Sibling rotated storage to a fresh-but-expired token after boot.
+        await storage.set_tokens(
+            OAuthToken(access_token="stale2", refresh_token="r-new", expires_in=60)
+        )
+        store.rows[0].data["tokens_obtained_at"] = time.time() - 600
+
+        async def boom(*args: Any, **kwargs: Any) -> bool:
+            raise RuntimeError("token endpoint unreachable")
+
+        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", boom)
+
+        await provider._coordinate_inflight_refresh()
+
+        # Even though the refresh raised, the in-memory token is now the freshest
+        # persisted one — the SDK will not spend the stale "r-old".
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.refresh_token == "r-new"
+
+
+class TestRefreshOAuthTokenLocked:
+    """The locked refresh exchange: revoked-grant handling and the pinned UA.
+
+    ``_refresh_oauth_token_locked`` is the one place local-operator performs the
+    refresh POST itself (the coordinated, cross-process-serialized path). Two
+    behaviours matter beyond a happy-path 200: an ``invalid_grant`` rejection
+    must be recognised as a DEAD grant (not retried, logged with the login
+    remedy), and the request must carry an explicit User-Agent so Cloudflare
+    cannot bot-block a no-UA refresh to mcp.notion.com.
+    """
+
+    URL = "https://mcp.notion.test/mcp"
+
+    def _endpoints(self):
+        from mcp.shared.auth import OAuthMetadata
+
+        from local_operator.mcp.auth import DiscoveredOAuthEndpoints
+
+        return DiscoveredOAuthEndpoints(
+            oauth_metadata=OAuthMetadata.model_validate(
+                {
+                    "issuer": self.URL,
+                    "authorization_endpoint": "https://a/authorize",
+                    "token_endpoint": "https://a/token",
+                }
+            )
+        )
+
+    async def _seed(self) -> McpTokenStorage:
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        await storage.set_tokens(
+            OAuthToken(access_token="a-old", refresh_token="r-old", expires_in=60)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+        return storage
+
+    @pytest.mark.asyncio
+    async def test_invalid_grant_is_a_dead_grant_not_retried(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A revoked/reused refresh token (HTTP 400 invalid_grant) returns False
+        with ONE actionable log line and no retry — the manager turns the
+        resulting McpAuthRequiredError into a suspended reconnect."""
+        import logging
+
+        import httpx
+
+        from local_operator.mcp import auth as auth_mod
+
+        storage = await self._seed()
+
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(
+                400,
+                json={"error": "invalid_grant", "error_description": "OAuth grant revoked"},
+                request=request,
+            )
+
+        transport = httpx.MockTransport(handler)
+        real_client = httpx.AsyncClient
+
+        def patched_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+            kwargs["transport"] = transport
+            return real_client(*args, **kwargs)
+
+        monkeypatch.setattr(httpx, "AsyncClient", patched_client)
+
+        with caplog.at_level(logging.INFO, logger="local_operator.mcp.auth"):
+            ok = await auth_mod._refresh_oauth_token_locked(self.URL, storage, self._endpoints())
+
+        assert ok is False
+        # Exactly one POST — no auto-retry of a dead grant.
+        assert calls["n"] == 1
+        revoked_logs = [r for r in caplog.records if "revoked" in r.getMessage().lower()]
+        assert len(revoked_logs) == 1
+        assert "login" in revoked_logs[0].getMessage().lower()
+
+    @pytest.mark.asyncio
+    async def test_refresh_post_carries_an_explicit_user_agent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The refresh POST must send a non-empty User-Agent (Cloudflare 1010
+        blocks a no-UA refresh to mcp.notion.com)."""
+        import httpx
+
+        from local_operator.mcp import auth as auth_mod
+
+        storage = await self._seed()
+
+        seen: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["ua"] = request.headers.get("User-Agent", "")
+            from mcp.shared.auth import OAuthToken
+
+            token = OAuthToken(access_token="a-new", refresh_token="r-new", expires_in=3600)
+            return httpx.Response(200, json=token.model_dump(mode="json"), request=request)
+
+        transport = httpx.MockTransport(handler)
+        real_client = httpx.AsyncClient
+
+        def patched_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+            kwargs["transport"] = transport
+            return real_client(*args, **kwargs)
+
+        monkeypatch.setattr(httpx, "AsyncClient", patched_client)
+
+        ok = await auth_mod._refresh_oauth_token_locked(self.URL, storage, self._endpoints())
+        assert ok is True
+        assert seen["ua"]  # non-empty
+        assert seen["ua"].startswith("local-operator")


### PR DESCRIPTION
## Summary

Stops rotating-refresh-token providers (Notion) from revoking the whole OAuth token family and logging every concurrent `local-operator` session out at once. This is the residual reuse window left open after #242 (cross-process startup lock) and #340 (401 access-token adoption).

## Verified root cause (proven against Notion's live API this cycle)

Notion rotates its refresh token on every refresh AND revokes prior access tokens, and it additionally runs **refresh-token reuse detection**: presenting an already-rotated refresh token returns `HTTP 400 {"error":"invalid_grant","error_description":"OAuth grant revoked"}` and revokes the **entire token family** — logging out every session sharing the grant (this machine runs ~15 concurrent processes sharing one row: `auth.db`, `provider='mcp-oauth'`, `identity_key='https://mcp.notion.com/mcp'`).

Three concrete defects combined into the residual window:

1. **Unlocked in-flow refresh (the important one).** The mcp SDK's `OAuthClientProvider._refresh_token` spends `context.current_tokens.refresh_token` — loaded once at `_initialize` and never re-read from storage — under **no** cross-process lock. `_RefreshCoordinatingOAuthProvider._coordinate_inflight_refresh` re-reads and adopts a peer-rotated token first, but it **returned early** into the SDK's unlocked refresh in two cases: (a) `endpoints is None` (discovery failed), and (b) the coordinated refresh raised. In those fall-through cases the SDK's POST fires *after* our lock is released, so a sibling can rotate the grant in that seam and the SDK then presents the now-retired token → `invalid_grant` → whole family dead.

2. **`invalid_grant` treated as an ordinary rejection.** `_refresh_oauth_token_locked` returned `False` on any non-200 without distinguishing a dead grant from a transient failure, so the readable log gave no actionable signal.

3. **No explicit User-Agent on the refresh POST.** A refresh POST with **no** `User-Agent` header gets Cloudflare `HTTP 403 error code 1010` (bot block) from `mcp.notion.com`; httpx's default UA currently escapes it, but `_refresh_oauth_token_locked` set no explicit UA, so a future httpx default change or a stricter Cloudflare rule would silently 403 the whole fleet into a browser grant.

## The fix (`local_operator/mcp/auth.py`)

**Part A — close the reuse window.** `_coordinate_inflight_refresh` now *always* performs the refresh itself, under `_oauth_refresh_lock` with a fresh re-read, so the SDK's unlocked path is never reached with a stale token. The invariant enforced on **every** path: the SDK's `_refresh_token` must never run with an in-memory refresh token older than storage.
- `endpoints is None` no longer falls through — it synthesizes the SDK's own fallback token endpoint (`<scheme>://<netloc>/token`, via `_fallback_endpoints_for`) and refreshes under the lock against exactly the URL the SDK would have used.
- On an exception in the coordinated refresh, a final under-lock re-read (`_adopt_freshest_stored_token`) adopts the freshest persisted token before control returns to the SDK, upholding the invariant on the fall-through path too.
- The success and both fall-through paths share one `_resync_from_store` helper so "sync from store" has a single definition.

**Part B — `invalid_grant` is a dead grant.** `_refresh_oauth_token_locked` parses the 400 body (`_is_invalid_grant`) and, on `invalid_grant`, logs once at INFO with the actionable "grant revoked; run `/mcp login`" meaning and never auto-retries. The connect then surfaces `McpAuthRequiredError`, which the manager already turns into a durably-suspended reconnect (`_reconnect_suspended`) rather than hammering a revoked grant.

**Part C — pinned User-Agent.** The refresh POST now sends `local-operator/<version>` (`_refresh_user_agent`, from installed distribution metadata, degrading to a bare product token in a source checkout), with a comment citing the observed Cloudflare 1010 block on no-UA requests to `mcp.notion.com`.

## Testing evidence (real execution)

### Unit — `tests/unit/mcp/test_auth.py`

Four new tests plus one rewritten to encode the new invariant:

- **`test_no_endpoints_still_refreshes_under_the_lock`** (rewritten): with `endpoints=None` a locked refresh now runs against the synthesized fallback endpoint `https://mcp.example.com/token`, instead of falling through to the SDK's unlocked refresh.
- **`test_no_endpoints_spends_the_fresh_stored_refresh_token`**: seeds a rotated token into storage *after* the provider initialized, drives the flow, and asserts the refresh token the locked exchange actually reads is the **fresh** `r-new`, never the stale boot-time `r-old`.
- **`test_locked_refresh_raise_still_adopts_freshest_before_sdk`**: when the coordinated refresh raises, the in-memory token is still resynced to the freshest persisted one before the SDK runs.
- **`test_invalid_grant_is_a_dead_grant_not_retried`**: a 400 `invalid_grant` returns `False`, logs the revoked/login meaning exactly once, and issues exactly one POST (no retry).
- **`test_refresh_post_carries_an_explicit_user_agent`**: the outgoing refresh POST carries a non-empty `User-Agent` starting `local-operator`.

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/mcp/test_auth.py -q
86 passed in 3.61s
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/mcp -q
261 passed in 5.02s
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
7273 passed, 7 skipped in 170.80s
```

### Two-process reuse-detection repro — `scripts/repro_notion_reuse.py`

A new sibling of `repro_notion_401.py`, modeling the reuse-detection family revocation across **two OS processes** sharing one `auth.db` and one fake reuse-detecting authorization server. The AS rotates and retires refresh tokens; presenting a retired token revokes the whole family. Process A refreshes (rotating `r-old` → `r-new`, retiring `r-old`) and ages the stored access token to expired; process B boots holding the pre-rotation `r-old` with `endpoints=None`. The fake AS probes the **real** `_oauth_refresh_lock`: a refresh POST arriving with the lock **unheld** (the SDK's unlocked path) triggers a concurrent sibling rotation in the seam, retiring the token B is about to present — exactly the multi-process race.

**Pre-fix (origin/main):** B's unlocked SDK refresh presents the retired token, reuse detection fires, the SDK clears tokens and escalates to a full browser grant:

```
seed: issued original grant {'access_token': 'access-1', 'refresh_token': 'refresh-1'}
A: rotated r-old -> refresh-2, persisted (access aged to expired)
B: booted with in-memory refresh 'refresh-1' (retired), store holds refresh 'refresh-2'
B: full authorization grant ran (McpAuthRequiredError): MCP OAuth authorization required for https://mcp.notion-reuse.test/mcp
B: FAIL — reuse DETECTED: B spent the retired refresh token and the AS revoked the ENTIRE token family (every session logged out)
ORCH: FAIL — process B triggered reuse detection / did not recover
(exit 1)
```

**Post-fix (this branch):** B refreshes under the lock, re-reads storage, and spends the fresh token — the family survives:

```
seed: issued original grant {'access_token': 'access-1', 'refresh_token': 'refresh-1'}
A: rotated r-old -> refresh-2, persisted (access aged to expired)
B: booted with in-memory refresh 'refresh-1' (retired), store holds refresh 'refresh-2'
B: PASS — refreshed under the lock without reusing the retired token; now holds 'refresh-3', family intact, final status 200
ORCH: PASS — the whole token family survived a stale sibling refresh
(exit 0)
```

### CI gates (all clean, run exactly as `.github/workflows/ci.yml`)

```
$ .venv/bin/python -m flake8 .                         # clean
$ uvx --from black==26.1.0 black --check .             # 561 files unchanged
$ uvx isort==5.13.2 --check .                          # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python local_operator/mcp/auth.py tests/unit/mcp/test_auth.py
  0 errors, 0 warnings, 0 informations
```

Full-tree pyright is running in CI; changed files are clean above.

## Version

Patch bump `0.42.1` → `0.42.2` — a reliability fix to the existing OAuth refresh path, no new user-facing capability.
