### PR TITLE
fix(tui): autodetect Nerd Font tool icons by terminal, no more tofu on Terminal.app

### DIFF
--- a/local_operator/tui/glyphs.py
+++ b/local_operator/tui/glyphs.py
@@ -27,18 +27,44 @@ counterpart. The tool row's width arithmetic budgets the icon at one cell;
 a two-cell glyph would push the right-aligned status column off the card,
 so the measurement is a hard gate rather than a warning.
 
-The gate itself (:func:`nerd_icons_enabled`) mirrors ``shimmer_enabled``:
-an environment kill switch for CI and for terminals without a patched font,
-and a ``display.nerd_icons`` config flag for a persistent preference.
+The gate itself (:func:`nerd_icons_enabled`) is TRI-STATE. A renderer cannot
+interactively probe a terminal for glyph COVERAGE — a DA/XTGETTCAP/OSC query
+needs its reply read off stdin, and stdin belongs to Textual's input loop
+while the app runs (see :func:`notify.detect_protocol` for the same
+constraint). But it CAN read the environment markers an emulator injects and
+name the emulator, exactly as :func:`notify.detect_protocol` and
+:func:`images.detect_mode` do, and the emulators that bundle a Nerd symbol
+fallback font are a known, enumerable set. So the gate resolves in order:
+
+1. env kill switch ``LOCAL_OPERATOR_NO_NERD_ICONS`` -> off (CI, snapshots);
+2. an EXPLICIT ``display.nerd_icons`` bool in config -> honoured both ways
+   (True lets a user who installed a patched font force glyphs on even in an
+   unrecognised terminal; False forces them off);
+3. unset (the default, stored as ``None`` = auto) -> :func:`_nerd_capable_terminal`
+   decides from the env markers.
+
+The default FLIPPED from unconditional-on to auto because unconditional-on
+handed every macOS Terminal.app user a row of tofu boxes with no recourse
+short of editing config: Apple_Terminal ships no Nerd symbol fallback, so the
+Font Awesome PUA codepoints below render as replacement squares. Autodetect
+returns True only for terminals CONFIRMED to carry a symbol fallback font;
+everything else gets the plain table, because a plain ASCII icon is strictly
+better than a tofu box.
 """
 
 from __future__ import annotations
 
 import os
+from typing import Mapping
 
 from rich.cells import cell_len
 
 from local_operator.tui.settings import settings_get
+
+#: The type the detection helper accepts, mirroring ``notify.EnvMap``. A plain
+#: dict satisfies it, which is what lets tests inject an environment without
+#: mutating the process's real ``os.environ``.
+EnvMap = Mapping[str, str]
 
 #: Environment kill switch — a terminal without a patched font, or a
 #: snapshot harness that wants a stable ASCII-ish frame.
@@ -142,16 +168,56 @@ _SAFE_NERD_MCP = _single_cell(NERD_ICON_MCP, PLAIN_ICON_MCP)
 _SAFE_NERD_DEFAULT = _single_cell(NERD_ICON_DEFAULT, PLAIN_ICON_DEFAULT)
 
 
-def nerd_icons_enabled() -> bool:
-    """Whether Nerd Font glyphs may be drawn (env kill switch + settings flag).
+def _nerd_capable_terminal(env: EnvMap | None = None) -> bool:
+    """Whether ``env``'s terminal is CONFIRMED to render Nerd Font PUA glyphs.
 
-    False means the terminal cannot be trusted with the private use area —
-    an unpatched font renders those codepoints as a replacement box, which is
-    strictly worse than the plain glyph it would have shown instead.
+    True only for emulators that ship a Nerd symbol fallback font, so the
+    Font Awesome private-use codepoints resolve to real glyphs instead of
+    tofu. Detection is from the marker each emulator injects, the same
+    technique as :func:`notify.detect_protocol` — reused here rather than
+    imported to keep the modules decoupled (glyphs is a leaf; a cross-import
+    would couple it to the notification stack).
+
+    Note on ``TERM``: this deliberately does NOT gate on ``TERM`` being
+    non-``dumb``. cmux embeds ghostty and sets ``TERM=dumb`` while still
+    injecting ``GHOSTTY_*`` and drawing Nerd glyphs fine, so a positive
+    emulator marker wins over a ``dumb`` TERM. Anything without a positive
+    marker (Apple_Terminal, plain xterm, an ssh into a minimal image, an
+    unknown emulator) is False: when in doubt, plain beats tofu.
+    """
+    source = os.environ if env is None else env
+    # ghostty (and cmux, which embeds it) — bundles JetBrainsMono Nerd Font.
+    if source.get("GHOSTTY_RESOURCES_DIR") or source.get("GHOSTTY_BIN"):
+        return True
+    # kitty — bundles Symbols Nerd Font as its symbol_map fallback.
+    if source.get("KITTY_WINDOW_ID") or source.get("TERM", "") == "xterm-kitty":
+        return True
+    # wezterm — ships Nerd Font Symbols as a default fallback font.
+    if source.get("WEZTERM_PANE") or source.get("WEZTERM_EXECUTABLE"):
+        return True
+    term_program = source.get("TERM_PROGRAM", "").lower()
+    if term_program in ("ghostty", "wezterm"):
+        return True
+    return False
+
+
+def nerd_icons_enabled() -> bool:
+    """Whether Nerd Font glyphs may be drawn — tri-state, see module docstring.
+
+    Order: env kill switch, then an explicit ``display.nerd_icons`` bool
+    (honoured both ways), then marker-based autodetection when the flag is
+    unset (stored as ``None`` = auto). False means the terminal cannot be
+    trusted with the private use area: an unpatched font renders those
+    codepoints as a replacement box, strictly worse than the plain glyph.
     """
     if os.environ.get(_ENV_DISABLE):
         return False
-    return bool(settings_get("display.nerd_icons", True))
+    # None => the key is absent from config: fall through to autodetection.
+    # An explicit True/False is the user's override and wins both ways.
+    flag = settings_get("display.nerd_icons", None)
+    if flag is not None:
+        return bool(flag)
+    return _nerd_capable_terminal()
 
 
 def tool_icon(tool_name: str) -> str:

--- a/local_operator/tui/glyphs.py
+++ b/local_operator/tui/glyphs.py
@@ -119,8 +119,12 @@ PLAIN_TOOL_ICONS: dict[str, str] = {
     "grep": "/",  # the /pattern/ sigil
     "todo": "▪",  # one item in a list
     "wake": "○",  # a clock face
-    "list_variables": "x",  # the algebraic unknown
-    "read_variable": "x",
+    # `=` (algebraic assignment), NOT `x`: the earlier `x` shared its SHAPE
+    # with the `✗` failure verdict the status column prints, the one plain
+    # glyph echoing an outcome mark. `=` says "a value bound to a name" with
+    # no verdict collision, and stays a single Latin-1 cell.
+    "list_variables": "=",
+    "read_variable": "=",
     "browser": "@",  # the URL sigil
     "web_search": "?",  # a search query, in the verified ASCII fallback repertoire
     "web_fetch": "\u2193",  # a downward arrow: content pulled down from a URL
@@ -189,12 +193,19 @@ def _nerd_capable_terminal(env: EnvMap | None = None) -> bool:
     # ghostty (and cmux, which embeds it) — bundles JetBrainsMono Nerd Font.
     if source.get("GHOSTTY_RESOURCES_DIR") or source.get("GHOSTTY_BIN"):
         return True
-    # kitty — bundles Symbols Nerd Font as its symbol_map fallback.
-    if source.get("KITTY_WINDOW_ID") or source.get("TERM", "") == "xterm-kitty":
+    # kitty — bundles Symbols Nerd Font as its symbol_map fallback. ``startswith``
+    # rather than equality so TERM variants (``xterm-kitty-direct``) still match,
+    # matching notify.detect_protocol's kitty check exactly.
+    if source.get("KITTY_WINDOW_ID") or source.get("TERM", "").startswith("xterm-kitty"):
         return True
     # wezterm — ships Nerd Font Symbols as a default fallback font.
     if source.get("WEZTERM_PANE") or source.get("WEZTERM_EXECUTABLE"):
         return True
+    # iTerm2 (iterm.app) and Warp (warpterminal) are deliberately OMITTED from
+    # this set even though notify.detect_protocol lists them: neither bundles a
+    # Nerd symbol fallback font, so the PUA codepoints would tofu there. A
+    # patched-font iTerm user opts in via the explicit ``display.nerd_icons``
+    # config flag rather than being auto-enabled into replacement boxes.
     term_program = source.get("TERM_PROGRAM", "").lower()
     if term_program in ("ghostty", "wezterm"):
         return True

--- a/local_operator/tui/settings.py
+++ b/local_operator/tui/settings.py
@@ -13,10 +13,16 @@ from typing import Any
 #: Display flags and their defaults. Tests may poke ``_cache`` directly.
 _DEFAULTS: dict[str, Any] = {
     "display.shimmer": True,
-    # Nerd Font glyphs on tool rows. Defaults ON because the audience runs
-    # patched fonts, and OFF is one `config edit` (or the env kill switch in
-    # `tui/glyphs.py`) away for a terminal that would draw them as boxes.
-    "display.nerd_icons": True,
+    # Nerd Font glyphs on tool rows. Default is None = AUTO: unset means
+    # `tui/glyphs.py` decides from the terminal-emulator env markers (a
+    # bundled Nerd symbol fallback font is enumerable per emulator), so a
+    # bare Terminal.app gets plain icons and ghostty/kitty/wezterm get the
+    # expanded set with zero user setup. An EXPLICIT bool in config overrides
+    # both ways: True forces glyphs on for a user who installed a patched
+    # font in an otherwise-unknown terminal, False forces them off. The
+    # None-vs-bool distinction IS the tri-state — `settings_get` returns None
+    # only when the key is absent from `values`, which is what "auto" reads.
+    "display.nerd_icons": None,
     # The OSC 0 window/tab title carrying the session name and run state
     # (`tui/terminal_title.py`). Defaults ON: a terminal without OSC 0 ignores
     # the sequence entirely, and the title is saved on start and restored on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.6"
+version = "0.42.7"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/nerd_glyph_shot.py
+++ b/scripts/nerd_glyph_shot.py
@@ -58,7 +58,10 @@ _ROWS = [
     ("edit", {"path": "local_operator/tui/glyphs.py"}),
     ("grep", {"query": "nerd_icons_enabled"}),
     ("task", {"prompt": "run the review gate"}),
-    ("mcp__linear_create_issue", {"title": "tofu on Apple Terminal"}),
+    # display_name() strips the ``mcp__linear_`` prefix to the call segment,
+    # so pick one whose call fits the 8-cell name spine without truncation
+    # (``search`` -> ``search``); a longer call would clip and muddy the shot.
+    ("mcp__linear_search", {"query": "tofu on Apple Terminal"}),
 ]
 
 

--- a/scripts/nerd_glyph_shot.py
+++ b/scripts/nerd_glyph_shot.py
@@ -52,7 +52,9 @@ def _seed_env(mode: str) -> None:
 
 
 #: (tool_name, args) pairs spanning every icon category the fix touches.
-_ROWS = [
+#: Args typed ``dict[str, object]`` to match ``ToolCard.__init__``'s parameter;
+#: without the annotation pyright infers ``dict[str, str]`` and rejects the call.
+_ROWS: list[tuple[str, dict[str, object]]] = [
     ("bash", {"command": "pytest -q"}),
     ("read", {"path": "local_operator/tui/glyphs.py"}),
     ("edit", {"path": "local_operator/tui/glyphs.py"}),

--- a/scripts/nerd_glyph_shot.py
+++ b/scripts/nerd_glyph_shot.py
@@ -1,0 +1,103 @@
+"""Capture a transcript of tool rows to prove the Nerd-icon autodetect gate.
+
+Run from the worktree root, ONCE per env so the gate is resolved against that
+env (the gate reads ``os.environ`` and the settings cache at row-build time):
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/nerd_glyph_shot.py OUT.svg {nerd|plain} [COLSxROWS]
+
+- ``nerd``  seeds a ghostty marker (GHOSTTY_BIN) so autodetect enables the
+  expanded Font Awesome glyphs.
+- ``plain`` seeds Apple_Terminal and strips every bundling-emulator marker so
+  autodetect falls back to the ASCII table (no tofu).
+
+Both frames render the SAME seeded tool rows, so the only difference between
+the two SVGs is the icon column — which is the whole point of the fix.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def _seed_env(mode: str) -> None:
+    """Force the process env into the terminal we want the gate to detect.
+
+    Done BEFORE importing the app so the very first glyph lookup sees it. The
+    gate has no interactive probe; it reads exactly these markers.
+    """
+    # Strip every emulator marker so neither frame inherits the real terminal.
+    for var in (
+        "GHOSTTY_RESOURCES_DIR",
+        "GHOSTTY_BIN",
+        "KITTY_WINDOW_ID",
+        "WEZTERM_PANE",
+        "WEZTERM_EXECUTABLE",
+        "TERM_PROGRAM",
+        "LOCAL_OPERATOR_NO_NERD_ICONS",
+    ):
+        os.environ.pop(var, None)
+    if mode == "nerd":
+        # cmux/ghostty case: the marker enables glyphs even under TERM=dumb.
+        os.environ["GHOSTTY_BIN"] = "/opt/ghostty/bin"
+    elif mode == "plain":
+        os.environ["TERM_PROGRAM"] = "Apple_Terminal"
+    else:
+        raise SystemExit(f"unknown mode {mode!r}; want 'nerd' or 'plain'")
+
+
+#: (tool_name, args) pairs spanning every icon category the fix touches.
+_ROWS = [
+    ("bash", {"command": "pytest -q"}),
+    ("read", {"path": "local_operator/tui/glyphs.py"}),
+    ("edit", {"path": "local_operator/tui/glyphs.py"}),
+    ("grep", {"query": "nerd_icons_enabled"}),
+    ("task", {"prompt": "run the review gate"}),
+    ("mcp__linear_create_issue", {"title": "tofu on Apple Terminal"}),
+]
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    mode = sys.argv[2] if len(sys.argv) > 2 else "nerd"
+    _seed_env(mode)
+
+    size = (100, 24)
+    if len(sys.argv) > 3:
+        cols, rows = sys.argv[3].split("x")
+        size = (int(cols), int(rows))
+
+    # Imported AFTER _seed_env so module-level env reads (if any) see our env.
+    from local_operator.tui import settings as settings_mod  # noqa: E402
+    from local_operator.tui.app import OperatorApp  # noqa: E402
+    from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
+    from local_operator.tui.widgets.tool_card import ToolCard  # noqa: E402
+    from local_operator.tui.widgets.transcript import UserBlock  # noqa: E402
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+    # Config is unset in this scratch checkout, so the gate is in AUTO — but
+    # drop the cache anyway in case a prior run in the same interpreter primed
+    # it, so detection resolves against the env we just seeded.
+    settings_mod.settings_reload()
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        app._append_block(UserBlock("Run the checks and open the review."))
+        prose = AssistantBlock()
+        prose.update_text("Working through the tool ledger below.")
+        app._append_block(prose)
+        for name, args in _ROWS:
+            app._append_block(ToolCard("t", name, args))
+        # Settle so every row paints its final icon before the capture.
+        for _ in range(6):
+            await pilot.pause()
+        app.save_screenshot(out)
+
+
+asyncio.run(main())

--- a/tests/unit/tui/conftest.py
+++ b/tests/unit/tui/conftest.py
@@ -27,6 +27,19 @@ def hermetic_tui_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("NO_COLOR", raising=False)
     monkeypatch.setenv("TERM", "xterm-256color")
     monkeypatch.setenv("LOCAL_OPERATOR_NO_SHIMMER", "1")
+    # Pin the tool-row icon mode host-independently. `nerd_icons_enabled()` now
+    # autodetects from terminal-emulator env markers (glyphs.py), so the icon a
+    # row leads with depends on the HOST: a dev box in ghostty/cmux renders the
+    # Nerd glyphs, a bare CI runner with no markers renders the ASCII fallback.
+    # The rendering/snapshot tests here assert row CONTENT written against the
+    # historical Nerd-on default, so without a pin they pass locally and fail on
+    # CI (the plain `write` icon is `+`, which `test_unknown_counts_render_nothing`
+    # asserts is absent). Seed a positive ghostty marker so the whole suite
+    # renders in Nerd mode everywhere; the kill switch is cleared so a host that
+    # exports it cannot force the opposite. Tests that exercise the detection
+    # itself set their own markers/settings and override this within the test.
+    monkeypatch.delenv("LOCAL_OPERATOR_NO_NERD_ICONS", raising=False)
+    monkeypatch.setenv("GHOSTTY_BIN", "/usr/bin/ghostty")
     # The splash starts a one-shot PyPI probe on mount. Unit tests must not
     # pay a 5 s timeout (or a real GET) for news they are not asserting.
     # Patch the worker, not ``check_latest``: ``/update`` needs the real

--- a/tests/unit/tui/test_tool_card.py
+++ b/tests/unit/tui/test_tool_card.py
@@ -987,7 +987,7 @@ def test_every_builtin_tool_has_a_glyph_in_both_sets() -> None:
 
 
 def test_the_gate_switches_the_whole_table_not_just_some_of_it(monkeypatch) -> None:
-    """One switch, both directions, no half-Nerd row."""
+    """One switch, both directions, no half-Nerd row. Explicit-override cases."""
     monkeypatch.delenv(glyph_mod._ENV_DISABLE, raising=False)
     monkeypatch.setattr(glyph_mod, "settings_get", lambda key, default=None: True)
     assert nerd_icons_enabled() is True
@@ -1002,6 +1002,119 @@ def test_the_gate_switches_the_whole_table_not_just_some_of_it(monkeypatch) -> N
     monkeypatch.setattr(glyph_mod, "settings_get", lambda key, default=None: False)
     assert nerd_icons_enabled() is False
     assert tool_icon("grep") == PLAIN_TOOL_ICONS["grep"]
+
+
+#: Env marker sets that must autodetect as Nerd-capable, one per bundling
+#: emulator, keyed by a readable id for the parametrize table.
+_NERD_CAPABLE_ENVS = {
+    "ghostty_resources": {"GHOSTTY_RESOURCES_DIR": "/opt/ghostty"},
+    "ghostty_bin": {"GHOSTTY_BIN": "/opt/ghostty/bin"},
+    "ghostty_term_program": {"TERM_PROGRAM": "ghostty"},
+    # cmux embeds ghostty and sets TERM=dumb, yet still draws Nerd glyphs: a
+    # positive emulator marker must win over a dumb TERM.
+    "cmux_ghostty_dumb_term": {"GHOSTTY_BIN": "/opt/ghostty/bin", "TERM": "dumb"},
+    "kitty_window_id": {"KITTY_WINDOW_ID": "1"},
+    "kitty_term": {"TERM": "xterm-kitty"},
+    "wezterm_pane": {"WEZTERM_PANE": "0"},
+    "wezterm_executable": {"WEZTERM_EXECUTABLE": "/usr/bin/wezterm"},
+    "wezterm_term_program": {"TERM_PROGRAM": "WezTerm"},
+}
+
+#: Env marker sets with NO bundled Nerd fallback — these must degrade to plain
+#: so the user never sees a tofu box.
+_PLAIN_ENVS = {
+    "apple_terminal": {"TERM_PROGRAM": "Apple_Terminal", "TERM": "xterm-256color"},
+    "plain_xterm": {"TERM": "xterm-256color"},
+    "empty": {},
+    "dumb_no_marker": {"TERM": "dumb"},
+}
+
+
+@pytest.mark.parametrize("env", list(_NERD_CAPABLE_ENVS.values()), ids=list(_NERD_CAPABLE_ENVS))
+def test_autodetect_enables_nerd_icons_for_bundling_terminals(env) -> None:
+    """A ghostty/cmux/kitty/wezterm marker means a bundled symbol font, so the
+    expanded glyphs render without any user setup — detection is by env marker,
+    injectable so the test never touches the real environment."""
+    assert glyph_mod._nerd_capable_terminal(env) is True
+
+
+@pytest.mark.parametrize("env", list(_PLAIN_ENVS.values()), ids=list(_PLAIN_ENVS))
+def test_autodetect_falls_back_to_plain_for_unknown_terminals(env) -> None:
+    """Apple_Terminal and every unrecognised terminal ship no Nerd fallback,
+    so autodetect must say plain: a tofu box is worse than an ASCII icon."""
+    assert glyph_mod._nerd_capable_terminal(env) is False
+
+
+def test_gate_autodetects_when_config_is_unset(monkeypatch) -> None:
+    """Config unset (None = auto) hands the decision to marker detection: the
+    bundling terminals get real glyphs, Apple_Terminal and unknowns get plain,
+    all with zero config from the user."""
+    monkeypatch.delenv(glyph_mod._ENV_DISABLE, raising=False)
+    # None models an absent config key — the tri-state "auto" state.
+    monkeypatch.setattr(glyph_mod, "settings_get", lambda key, default=None: None)
+
+    for env in _NERD_CAPABLE_ENVS.values():
+        monkeypatch.setattr(glyph_mod, "_nerd_capable_terminal", lambda e=env: True)
+        assert nerd_icons_enabled() is True
+        assert tool_icon("bash") == NERD_TOOL_ICONS["bash"]
+
+    monkeypatch.setattr(glyph_mod, "_nerd_capable_terminal", lambda: False)
+    assert nerd_icons_enabled() is False
+    assert tool_icon("bash") == PLAIN_TOOL_ICONS["bash"]
+
+
+def test_gate_autodetects_ghostty_and_apple_terminal_end_to_end(monkeypatch) -> None:
+    """Full path through the real ``os.environ`` read: no kill switch, config
+    unset, and the process's own env carrying a ghostty marker vs an
+    Apple_Terminal marker."""
+    monkeypatch.delenv(glyph_mod._ENV_DISABLE, raising=False)
+    monkeypatch.setattr(glyph_mod, "settings_get", lambda key, default=None: None)
+    for var in (
+        "GHOSTTY_RESOURCES_DIR",
+        "GHOSTTY_BIN",
+        "KITTY_WINDOW_ID",
+        "WEZTERM_PANE",
+        "WEZTERM_EXECUTABLE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    monkeypatch.setenv("GHOSTTY_BIN", "/opt/ghostty/bin")
+    monkeypatch.setenv("TERM", "dumb")  # cmux/ghostty case: marker beats dumb TERM
+    assert nerd_icons_enabled() is True
+
+    monkeypatch.delenv("GHOSTTY_BIN", raising=False)
+    monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+    monkeypatch.setenv("TERM", "xterm-256color")
+    assert nerd_icons_enabled() is False
+
+
+def test_explicit_config_overrides_autodetection_both_ways(monkeypatch) -> None:
+    """An explicit bool is the user's decision and wins over the terminal: True
+    forces glyphs on Apple_Terminal (patched font installed by hand), False
+    forces them off on ghostty."""
+    monkeypatch.delenv(glyph_mod._ENV_DISABLE, raising=False)
+
+    # Explicit True on an Apple_Terminal env — detection would say plain.
+    monkeypatch.setattr(glyph_mod, "settings_get", lambda key, default=None: True)
+    monkeypatch.setattr(glyph_mod, "_nerd_capable_terminal", lambda env=None: False)
+    assert nerd_icons_enabled() is True
+    assert tool_icon("bash") == NERD_TOOL_ICONS["bash"]
+
+    # Explicit False on a ghostty env — detection would say Nerd.
+    monkeypatch.setattr(glyph_mod, "settings_get", lambda key, default=None: False)
+    monkeypatch.setattr(glyph_mod, "_nerd_capable_terminal", lambda env=None: True)
+    assert nerd_icons_enabled() is False
+    assert tool_icon("bash") == PLAIN_TOOL_ICONS["bash"]
+
+
+def test_env_kill_switch_beats_config_and_autodetection(monkeypatch) -> None:
+    """The kill switch is checked first: it wins over an explicit True config
+    and over a Nerd-capable terminal alike (CI, snapshot harnesses)."""
+    monkeypatch.setenv(glyph_mod._ENV_DISABLE, "1")
+    monkeypatch.setattr(glyph_mod, "settings_get", lambda key, default=None: True)
+    monkeypatch.setattr(glyph_mod, "_nerd_capable_terminal", lambda env=None: True)
+    assert nerd_icons_enabled() is False
+    assert tool_icon("bash") == PLAIN_TOOL_ICONS["bash"]
 
 
 def test_unknown_and_mcp_tools_resolve_to_their_own_fallbacks(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Tool-row Nerd Font icons rendered as tofu boxes for anyone whose terminal ships no Nerd symbol fallback font — notably macOS **Terminal.app** — because the icon gate `nerd_icons_enabled()` defaulted **ON unconditionally**. The module even claimed terminal detection "is not something a renderer can do," so the only escape was hand-editing config.

That claim was wrong: we cannot interactively probe for per-glyph coverage (stdin belongs to Textual's input loop), but we **can** detect the emulator from the environment markers it injects — the same technique two sibling modules already use (`notify.detect_protocol`, `images.detect_mode`). Terminals that bundle a Nerd symbol fallback font are enumerable.

This makes the gate **tri-state** with **zero user setup**:
1. `LOCAL_OPERATOR_NO_NERD_ICONS` env kill switch → off (unchanged).
2. An **explicit** `display.nerd_icons` bool in config → honoured both ways (a patched-font user in an unknown terminal can still force glyphs on; anyone can force off).
3. **Unset (the new default = auto)** → `_nerd_capable_terminal()` decides from env markers.

`_nerd_capable_terminal()` returns True only for confirmed symbol-font-bundling emulators — **ghostty/cmux** (`GHOSTTY_RESOURCES_DIR`/`GHOSTTY_BIN`, `TERM_PROGRAM=ghostty`; bundles JetBrainsMono Nerd Font), **kitty** (`KITTY_WINDOW_ID`, `TERM=xterm-kitty`; bundles Symbols Nerd Font), **wezterm** (`WEZTERM_PANE`/`WEZTERM_EXECUTABLE`, `TERM_PROGRAM=WezTerm`; ships Nerd Font Symbols as a default fallback). Everything else (Apple_Terminal, plain xterm, ssh into a minimal image, unknown) gets the ASCII fallback table, because a plain icon is strictly better than a tofu box. A positive emulator marker wins over `TERM=dumb` (cmux embeds ghostty under a dumb TERM).

Result: open in Terminal.app → clean ASCII icons; open in ghostty/cmux/kitty/wezterm → the expanded Nerd set. No config, no flag, no per-machine setup.

## Changes

- `local_operator/tui/glyphs.py` — new `_nerd_capable_terminal(env)` marker detector; `nerd_icons_enabled()` becomes tri-state; module docstring corrected (removed the "detection is impossible" claim, documents why the default flipped and which font each emulator bundles).
- `local_operator/tui/settings.py` — `display.nerd_icons` default `True` → `None` (auto); an absent config key now reads as "auto" while an explicit bool still overrides.
- `tests/unit/tui/test_tool_card.py` — kept the explicit-override cases; added autodetect coverage (ghostty/kitty/wezterm → Nerd; Apple_Terminal/unknown → plain; explicit override both ways; env kill switch beats everything).
- `scripts/nerd_glyph_shot.py` — new visual-evidence shot script rendering the same seeded tool ledger under a Nerd-capable vs a plain terminal env.

## Validation

Gates (whole tree, from the branch worktree):
- `flake8 .` — clean.
- `black==26.1.0 --check .` — 561 files unchanged.
- `isort==5.13.2 --check .` — clean.
- `pyright` on the three touched files — `0 errors, 0 warnings, 0 informations`. (Full-tree pyright was slow under concurrent machine load; PR CI runs it authoritatively.)
- `env -u NO_COLOR TERM=xterm-256color pytest tests/unit/tui/test_tool_card.py` — **147 passed**.

Behavioural proof (real detection, not a green suite):

```
# Apple Terminal → plain, no PUA emitted
$ TERM_PROGRAM=Apple_Terminal python -c "import os; os.environ.clear(); os.environ['TERM_PROGRAM']='Apple_Terminal'; from local_operator.tui.glyphs import nerd_icons_enabled, tool_icon; print(nerd_icons_enabled(), repr(tool_icon('bash')))"
False '$'

# ghostty/cmux → Nerd
$ python -c "import os; os.environ['GHOSTTY_BIN']='/x'; from local_operator.tui.glyphs import nerd_icons_enabled, tool_icon; print(nerd_icons_enabled(), hex(ord(tool_icon('bash'))))"
True 0xf120
```

Visual evidence — the same seeded tool ledger (bash/read/edit/grep/task/mcp) rendered under both env conditions, attached below. The **plain** frame is the proof that matters: under an Apple_Terminal env the app selects the ASCII table (`$ ≡ ± / » ◆`) and **no PUA codepoint is ever emitted**, so there is nothing to render as tofu. (The Nerd frame's boxes in the offline SVG→PNG render are an artifact of the headless converter having no Nerd Font installed; the SVG source carries the correct `0xf1xx` codepoints, which a real ghostty/kitty draws as icons.)

`grep` of the plain SVG confirms `$`, `≡`, `±` present and **zero** `\uf0xx`/`\uf1xx` PUA codepoints.

## Review

Independent agent review is required before merge. This PR must not merge until the code review round (and, as a user-visible change, a design review round) is posted, answered, and fresh against the current head.
