### PR TITLE
chore(release): bump version to 0.42.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.2"
+version = "0.42.3"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Release bump to `0.42.3`. Publishes the eval render-loop fix from #344, which merged to `main` after `v0.42.2` had already been tagged (a concurrent Notion-MCP release, #345, claimed `0.42.2`), leaving #344 merged but unreleased.

This PR is the version bump only — the fix itself is already on `main` (`0f77c668`).

## What ships

**#344 — `fix(eval): offload result rendering off the render loop`.** The TUI could freeze for up to ~1.2s on an `eval` call. Root cause: `_render` ran `spill_truncate` inline on the Textual render loop, and any result over the 8 KiB budget triggers the spill store's LRU eviction sweep — one synchronous `stat`+read per stored entry (O(entries) disk I/O). With a populated store that stalled rendering for 800–1240 ms. The success-path result assembly is now offloaded via `asyncio.to_thread`, matching what the `bash` tool already did; only the bounded `display()` join stays on the loop. Timeout/abort/crash/lost-state/cancel semantics are unchanged.

## Testing evidence

Full agent review across two rounds on #344 (0 blockers; the one major — a regression test that didn't actually guard the fix — was remediated with a deterministic heartbeat test that provably FAILS on the inline path and PASSES with the offload).

Stall measurements (longest synchronous gap on the render loop):
- 900 KB eval result: **813–1240 ms → 22 ms**
- 30 KB result, 1.5k-entry spill store: **84 ms → 28 ms** (target <50 ms met)

Wall time unchanged — same work, moved off the loop.

Gates on head: flake8, `black==26.1.0 --check`, `isort==5.13.2 --check`, pyright all clean; `tests/unit/tools/test_eval_tool.py` 47 passed.

This bump PR carries no code change beyond `pyproject.toml`; CI re-runs the suite against the merged fix.
