### PR TITLE
fix(browser): wake suspended MV3 worker via 1-min reconnect alarm

### DIFF
--- a/extension/src/reconnect.ts
+++ b/extension/src/reconnect.ts
@@ -1,0 +1,69 @@
+// Two-tier reconnection timing for the MV3 service worker (finding A13).
+//
+// WHY two tiers, and why the split matters:
+//
+// An MV3 service worker is torn down after ~30s idle. A pending `setTimeout`
+// does NOT survive that teardown and does NOT wake a suspended worker — the
+// timer is simply lost when the worker dies (Chrome MV3 lifecycle). So any
+// reconnection that bottoms out on `setTimeout` never happens once the worker
+// has idle-suspended: the socket stays down until a real event (a page load,
+// the toolbar icon) happens to wake the worker. That is the observed defect —
+// `extension connected: no` sticking for minutes with no automatic recovery.
+//
+// `chrome.alarms` is the ONLY timer Chrome will use to wake a suspended worker,
+// so reconnection after suspension MUST bottom out on an alarm, never on a
+// `setTimeout`. The two tiers:
+//
+//   - ALARM (guaranteed floor): a periodic alarm re-dials whenever the socket
+//     is down. It survives suspension and wakes the worker. Chrome clamps alarm
+//     periods to a 30s minimum and, per the chrome.alarms docs, "may delay them
+//     an arbitrary amount more"; periods below 0.5 min "will not be honored and
+//     will cause a warning". The previous 0.5-min period sat exactly on that
+//     clamp edge, where Chrome delays or drops the tick — which is why the
+//     automatic rewake never fired. One minute is comfortably above the clamp
+//     where the alarm reliably fires, at the cost of up to ~1 min to rewake
+//     after idle suspension. That worst case is acceptable for a bridge that is
+//     idle by definition when suspended; instant rewake still happens on the
+//     real events that already work (page load, toolbar click).
+//
+//   - setTimeout (fast path, best-effort): while the worker is still ALIVE, a
+//     transient mid-session socket drop should reconnect in ~seconds, not wait
+//     up to a minute for the next alarm. An exponential backoff `setTimeout`
+//     handles that. It is best-effort ONLY: if the worker suspends before it
+//     fires the timer dies with the worker, and the alarm floor picks
+//     reconnection back up on the next tick. Nothing may depend on it running.
+
+export const RECONNECT_ALARM_NAME = "lop-bridge-reconnect";
+
+// Guaranteed-wake period. Kept at/above Chrome's 30s alarm clamp so the tick
+// actually fires on a suspended worker (see module header). Do not lower below
+// 1 without evidence the shorter period is honored in RELEASED Chrome — the
+// unpacked-dev build has no floor and will mislead a local test.
+export const RECONNECT_ALARM_PERIOD_MINUTES = 1;
+
+// Ceiling on the alive-only fast-path backoff. A capped exponential keeps a
+// dead daemon from being hammered while still recovering a live socket quickly.
+export const MAX_BACKOFF_MS = 30_000;
+
+export function backoffDelayMs(attempt: number): number {
+  return Math.min(MAX_BACKOFF_MS, 1_000 * 2 ** attempt);
+}
+
+// Whether to arm the best-effort `setTimeout` fast path. Only while the worker
+// is ALIVE and no fast-path timer is already pending: a suspended worker cannot
+// run a `setTimeout` at all (the alarm floor covers that case), and a second
+// concurrent timer would just double-dial into the connecting guard.
+export function shouldArmFastPath(input: { alive: boolean; fastPathPending: boolean }): boolean {
+  return input.alive && !input.fastPathPending;
+}
+
+// Whether an alarm tick (the guaranteed wake) should dial. On a cold wake after
+// suspension the globals have reset to false, so this returns true and
+// reconnection proceeds without any page interaction — the whole point of the
+// fix. When the worker is alive and already connected or mid-dial it stays a
+// no-op; connect()'s own guard is authoritative, this just avoids a pointless
+// call (and a redundant one right after the top-level `void connect()` that a
+// cold wake already kicked off, which will have set connecting=true).
+export function shouldDialOnAlarm(input: { connected: boolean; connecting: boolean }): boolean {
+  return !input.connected && !input.connecting;
+}

--- a/extension/src/worker.ts
+++ b/extension/src/worker.ts
@@ -9,6 +9,13 @@ import { logs } from "./commands/logs";
 import { BridgeCommandError } from "./cdp";
 import { expireAccessRequest, resolveOrigin, setPendingObserver } from "./origins";
 import { DEFAULT_PORT, getLocal } from "./state";
+import {
+  RECONNECT_ALARM_NAME,
+  RECONNECT_ALARM_PERIOD_MINUTES,
+  backoffDelayMs,
+  shouldArmFastPath,
+  shouldDialOnAlarm,
+} from "./reconnect";
 import { ErrorCode, type DaemonMessage, type ExtensionEvent, type Response } from "./protocol.gen";
 
 const HANDLERS: Record<
@@ -48,7 +55,10 @@ let attempt = 0;
 let connected = false;
 let connecting = false;
 let alive = false;
-let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+// Best-effort fast-path timer (see reconnect.ts). Only meaningful while the
+// worker is alive; it dies with a suspending worker and the alarm floor takes
+// over — nothing may depend on it firing.
+let fastPathTimer: ReturnType<typeof setTimeout> | undefined;
 // The request id currently being handled, so an origin pause can tell the
 // daemon WHICH command to keep alive past the base timeout (finding A3).
 let activeRequestId = "";
@@ -233,19 +243,35 @@ async function connect(): Promise<void> {
   };
 }
 
+// FAST PATH ONLY — see reconnect.ts for the two-tier design. This recovers a
+// transient socket drop in seconds WHILE THE WORKER IS ALIVE. It is best-effort:
+// a `setTimeout` does not survive worker suspension, so if the worker suspends
+// before it fires the timer is lost and the reconnect alarm (the guaranteed
+// floor) rewakes the worker and re-dials instead. Reconnection therefore never
+// DEPENDS on this — it only makes the alive case faster than the ~1-min alarm.
 function scheduleReconnect(): void {
-  if (!alive || reconnectTimer) return;
-  const delay = Math.min(30_000, 1_000 * 2 ** attempt);
+  if (!shouldArmFastPath({ alive, fastPathPending: fastPathTimer !== undefined })) return;
+  const delay = backoffDelayMs(attempt);
   attempt += 1;
-  reconnectTimer = setTimeout(() => {
-    reconnectTimer = undefined;
+  fastPathTimer = setTimeout(() => {
+    fastPathTimer = undefined;
     void connect();
   }, delay);
 }
 
-chrome.alarms.create("lop-bridge-reconnect", { periodInMinutes: 0.5 });
+// GUARANTEED WAKE — the alarm is the only timer Chrome uses to wake a suspended
+// MV3 worker, so it is the reconnection FLOOR. Period is kept at Chrome's
+// reliable minimum (see RECONNECT_ALARM_PERIOD_MINUTES); the old 0.5-min period
+// sat on the clamp edge where Chrome delayed or dropped the tick, which is why
+// the automatic rewake never fired after idle suspension. `create` re-arms an
+// existing alarm idempotently, so calling it at every worker start (top level +
+// onStartup + onInstalled) guards against a lost alarm without stacking copies.
+function ensureReconnectAlarm(): void {
+  chrome.alarms.create(RECONNECT_ALARM_NAME, { periodInMinutes: RECONNECT_ALARM_PERIOD_MINUTES });
+}
+ensureReconnectAlarm();
 chrome.alarms.onAlarm.addListener((alarm) => {
-  if (alarm.name === "lop-bridge-reconnect" && !connected) void connect();
+  if (alarm.name === RECONNECT_ALARM_NAME && shouldDialOnAlarm({ connected, connecting })) void connect();
   // TTL sweep for an async access request nobody is polling: without it an
   // abandoned request would leave the "!" badge and popup prompt up until the
   // next access RPC happened to run the lazy sweep. The alarm is created by
@@ -254,12 +280,20 @@ chrome.alarms.onAlarm.addListener((alarm) => {
 });
 chrome.runtime.onStartup.addListener(() => {
   alive = true;
+  ensureReconnectAlarm();
   void connect();
 });
 chrome.runtime.onInstalled.addListener(() => {
   alive = true;
+  ensureReconnectAlarm();
   void connect();
 });
+// Cold-start convergence: on every worker start (including a rewake from
+// suspension, when the globals have reset to their false initializers) the
+// top-level dial runs immediately, the alarm is (re)armed as the floor, and
+// both funnel through connect()'s connecting/connected guard onto ONE stable
+// socket. `connecting` is never persisted, so a suspend can never leave it
+// wedged true across a restart — a fresh worker always starts able to dial.
 alive = true;
 void connect();
 

--- a/extension/tests/pure.test.mjs
+++ b/extension/tests/pure.test.mjs
@@ -323,3 +323,43 @@ test("redacted handles are recognizable by their owner but not driveable", async
     assert.equal(ownsRedacted(token, token), true);
   } finally { await module.close(); }
 });
+
+test("reconnect timing: alarm is the guaranteed floor, setTimeout the alive-only fast path", async () => {
+  const module = await load("src/reconnect.ts");
+  try {
+    const {
+      RECONNECT_ALARM_PERIOD_MINUTES,
+      MAX_BACKOFF_MS,
+      backoffDelayMs,
+      shouldArmFastPath,
+      shouldDialOnAlarm,
+    } = module.loaded;
+
+    // The alarm period must stay at/above Chrome's 30s clamp. Below 0.5 min
+    // Chrome refuses to honour the period (the old 0.5-min bug sat on the edge
+    // where the tick was delayed/dropped and the automatic rewake never fired).
+    assert.ok(RECONNECT_ALARM_PERIOD_MINUTES >= 0.5, "alarm period below Chrome's 30s clamp");
+
+    // Fast-path backoff is exponential and capped so a dead daemon is not
+    // hammered while a live socket still recovers in seconds.
+    assert.equal(backoffDelayMs(0), 1_000);
+    assert.equal(backoffDelayMs(3), 8_000);
+    assert.equal(backoffDelayMs(99), MAX_BACKOFF_MS);
+
+    // The setTimeout fast path arms ONLY while the worker is alive (a suspended
+    // worker cannot run it — the alarm covers that) and never stacks a second
+    // pending timer.
+    assert.equal(shouldArmFastPath({ alive: true, fastPathPending: false }), true);
+    assert.equal(shouldArmFastPath({ alive: true, fastPathPending: true }), false);
+    assert.equal(shouldArmFastPath({ alive: false, fastPathPending: false }), false);
+
+    // The guaranteed-wake alarm dials whenever the socket is neither connected
+    // nor mid-dial. This is the cold-wake-after-suspension case: globals have
+    // reset to false, so the alarm re-dials with NO page interaction — the fix.
+    assert.equal(shouldDialOnAlarm({ connected: false, connecting: false }), true);
+    // ...but stays a no-op when a socket is up or a dial is already in flight,
+    // so the alarm never storms a second socket past connect()'s own guard.
+    assert.equal(shouldDialOnAlarm({ connected: true, connecting: false }), false);
+    assert.equal(shouldDialOnAlarm({ connected: false, connecting: true }), false);
+  } finally { await module.close(); }
+});

--- a/extension/tests/pure.test.mjs
+++ b/extension/tests/pure.test.mjs
@@ -335,10 +335,11 @@ test("reconnect timing: alarm is the guaranteed floor, setTimeout the alive-only
       shouldDialOnAlarm,
     } = module.loaded;
 
-    // The alarm period must stay at/above Chrome's 30s clamp. Below 0.5 min
-    // Chrome refuses to honour the period (the old 0.5-min bug sat on the edge
-    // where the tick was delayed/dropped and the automatic rewake never fired).
-    assert.ok(RECONNECT_ALARM_PERIOD_MINUTES >= 0.5, "alarm period below Chrome's 30s clamp");
+    // The alarm period must sit ABOVE Chrome's 30s clamp. Below 0.5 min Chrome
+    // refuses to honour the period, and 0.5 min itself sits exactly on the clamp
+    // edge where the tick can be dropped/delayed (the original bug) — so a
+    // `>= 0.5` assertion would re-admit the buggy edge. Require strictly above.
+    assert.ok(RECONNECT_ALARM_PERIOD_MINUTES > 0.5, "alarm period not strictly above Chrome's 30s clamp edge");
 
     // Fast-path backoff is exponential and capped so a dead daemon is not
     // hammered while a live socket still recovers in seconds.

--- a/local_operator/guides/browser/GUIDE.md
+++ b/local_operator/guides/browser/GUIDE.md
@@ -291,8 +291,10 @@ Every failure is one actionable string; act on it rather than retrying blindly:
      or other debug flags — the extension IS the debugger; a debug-port
      browser on a real profile is a security hole.
   2. **Browser running but still disconnected?** The service worker may be
-     idle-suspended and (known defect) does not always rewake on its own
-     alarm. Opening any page in that browser wakes it:
+     idle-suspended. It rewakes and reconnects on its own within ~1 minute
+     (a periodic reconnect alarm is the guaranteed wake — wait a minute
+     before intervening), but Chrome may delay alarms arbitrarily, so when
+     it matters now open any page in that browser:
      `open -g -a "Google Chrome" "https://example.com"` — or ask the user to
      click the extension's toolbar icon (opening the popup wakes the worker
      instantly). Reconnection then happens within seconds.

--- a/local_operator/guides/browser/GUIDE.md
+++ b/local_operator/guides/browser/GUIDE.md
@@ -291,10 +291,11 @@ Every failure is one actionable string; act on it rather than retrying blindly:
      or other debug flags — the extension IS the debugger; a debug-port
      browser on a real profile is a security hole.
   2. **Browser running but still disconnected?** The service worker may be
-     idle-suspended. It rewakes and reconnects on its own within ~1 minute
-     (a periodic reconnect alarm is the guaranteed wake — wait a minute
-     before intervening), but Chrome may delay alarms arbitrarily, so when
-     it matters now open any page in that browser:
+     idle-suspended. A periodic reconnect alarm rewakes and reconnects it on
+     its own — up to ~1 minute in a packed/released build (Chrome clamps
+     sub-30s alarm periods; a developer/unpacked load fires sooner), but
+     Chrome may delay alarms arbitrarily, so when it matters now open any
+     page in that browser:
      `open -g -a "Google Chrome" "https://example.com"` — or ask the user to
      click the extension's toolbar icon (opening the popup wakes the worker
      instantly). Reconnection then happens within seconds.


### PR DESCRIPTION
## Summary

The bridge showed `extension connected: no` **indefinitely** after the extension's service worker idle-suspended (observed live 3x tonight in the user's real paired Chrome; RPCs failed `extension_disconnected` for 4+ minutes until a page load or toolbar click happened to wake the worker).

### Root cause — both reconnection drivers were unreliable after suspension

1. **The reconnect alarm ran at `periodInMinutes: 0.5`** — exactly on Chrome's clamp edge. Per the [chrome.alarms docs](https://developer.chrome.com/docs/extensions/reference/api/alarms): *"Chrome limits alarms to at most once every 30 seconds but may delay them an arbitrary amount more. That is, setting delayInMinutes or periodInMinutes to less than 0.5 will not be honored and will cause a warning."* The tick was delayed/dropped, so the automatic rewake never fired.
2. **`scheduleReconnect()`'s `setTimeout` cannot survive worker teardown and cannot wake a suspended worker** — the timer dies with the worker, so any reconnection bottoming out on it never happened after suspension.

### Fix — two-tier reconnection design (`extension/src/reconnect.ts`)

| Tier | Mechanism | Purpose |
|---|---|---|
| **Alarm** (guaranteed floor) | `chrome.alarms.create("lop-bridge-reconnect", { periodInMinutes: 1 })`, re-armed at every worker start | The only timer Chrome uses to **wake** a suspended MV3 worker. Period raised above the 30s clamp so the tick actually fires. |
| **setTimeout** (fast path, best-effort) | Exponential backoff (1s to 30s cap), armed **only while the worker is alive** | A transient mid-session socket drop still recovers in ~seconds instead of waiting up to a minute. If the worker suspends first, the timer dies and the alarm floor takes over. |

- Alarm re-armed at top level + `onStartup` + `onInstalled` (`create` is idempotent, so a lost alarm can't strand the bridge).
- Alarm handler skips a redundant dial when one is already in flight (`shouldDialOnAlarm`).
- Cold-start convergence: top-level `connect` + `onStartup` + `onInstalled` + alarm all funnel through `connect()`'s existing `connecting`/`connected` guard onto one stable socket. `connecting` is never persisted, so no path can leave it wedged true across a restart (the A11 concern — verified closed).
- Resource model (documented in code): idle suspension is allowed (no keep-alive churn); rewake guaranteed within ~1 min by the alarm, instant on events that already work (page load, toolbar click). The extension can't be pushed to while its socket is down, so the alarm floor is the mechanism. A sub-minute *guaranteed* rewake is impossible with `chrome.alarms` in released Chrome (30s clamp + arbitrary delay) — noted as a tradeoff.

## Testing evidence

### Live headful Chrome — forced service-worker suspension, automatic reconnect, 2/2 cycles ✅

Setup (fully isolated from the user's real environment):

- Throwaway Chrome profile, launched **backgrounded** (`open -g`) and **off-screen** (`--window-position=-3000,-3000`) — never foregrounded, never stole focus.
- Built extension loaded via CDP `Extensions.loadUnpacked` (Chrome 151 blocks `--load-extension` from the command line) — extension id `gohljamgppdcpklikjdfdhpgkmfinlfi`.
- Throwaway daemon on isolated port **4177** with `LOCAL_OPERATOR_CONFIG_DIR=/tmp/lop-rewake-test/config`, so the user's real 4099 daemon/pairing was **never touched** (verified untouched after teardown).
- A copy of the built worker was retargeted to port 4177 (`DEFAULT_PORT` rewrite in the bundle) so the test extension could never dial the user's live daemon.

Steps and actual observations:

```
baseline:                  extension_connected: True   (SW target present)
CDP Target.closeTarget(SW) -> worker fully dead: SW target GONE, connected=False
                           (all globals and setTimeout timers lost with it)
NO page/toolbar interaction at any point during recovery.

cycle 1: t+40s  RECONNECTED  (SW back: True)
cycle 2: t+46s  RECONNECTED  (pre-kill connected: True -> post-kill False -> auto-reconnect)
```

Daemon log (2nd socket opens after the kill; nothing but health checks in between):

```
INFO:     127.0.0.1:64702 - "WebSocket /extension" [accepted]
INFO:     connection open
INFO:     127.0.0.1:64858 - "WebSocket /extension" [accepted]
INFO:     connection open
```

Since the worker was fully terminated (SW target gone), no `setTimeout` survived — only the **alarm** could have rewoken it and re-dialed.

**Honest caveats, clearly labeled:**

- **Unpacked-extension caveat:** an unpacked extension has *no* 30s alarm clamp ("when you've loaded it unpacked, there's no limit to how often the alarm can fire" — chrome.alarms docs). This test proves the alarm path rewakes a fully-terminated worker and re-dials, **not** the released-build 1-min period timing. The period choice itself is evidenced by the docs (sub-0.5-min periods "will not be honored").
- **Forced kill vs idle suspend:** CDP `Target.closeTarget` terminates the worker abruptly; an idle suspend has the same teardown semantics for our purposes (globals lost, timers lost) but is not literally the same trigger.

### Unit tests ✅

New test in `extension/tests/pure.test.mjs` covers the extracted timer-selection logic:

- alarm period >= 0.5 min (Chrome's clamp floor),
- capped exponential backoff (1s / 8s / 30s cap),
- fast path arms only while alive and never stacks a second pending timer,
- alarm dials unless `connected`/`connecting` (cold-wake-after-suspension case: globals reset to false, so dial).

### Gates ✅

- `pnpm typecheck` clean
- `pnpm test` — **36/36 pass**
- `pnpm build` clean (verified `RECONNECT_ALARM_PERIOD_MINUTES = 1` and `lop-bridge-reconnect` in the bundle)

Protocol/Python untouched, so `gen_ts --check` and the bridge pytest slice were not required.

## Guide

`local_operator/guides/browser/GUIDE.md` — "extension not connected" troubleshooting step 2 now says rewake happens automatically within ~1 min (wait before intervening), keeping the manual page-open/toolbar fallback since Chrome may still delay alarms. Frontmatter untouched.
