### PR TITLE
fix(session): keep off-the-record asides on the working turn's cache prefix

### DIFF
--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -2095,6 +2095,23 @@ class GoogleClient:
                     ]
                 }
             ]
+            # Gemini has no per-request tool_choice field; it takes the mode
+            # under toolConfig.functionCallingConfig instead. It defaults to
+            # AUTO, so before an aside started sending the live tool schema this
+            # branch was never reached with tools present and the mode never
+            # mattered. Now that complete_aside sends tools with
+            # tool_choice="none" (to stay on the working turn's cache prefix),
+            # the mode MUST be pinned or the aside could newly call a tool — the
+            # opposite of the "reads the turn, calls nothing" contract. Map the
+            # cross-provider tool_choice onto Gemini's mode; unknown values fall
+            # back to AUTO, matching the other builders' safe default.
+            body["toolConfig"] = {
+                "functionCallingConfig": {
+                    "mode": {"auto": "AUTO", "none": "NONE", "required": "ANY"}.get(
+                        request.tool_choice, "AUTO"
+                    )
+                }
+            }
         return body
 
     @staticmethod

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -5747,10 +5747,10 @@ class Session:
         Gemini builder is taught to honour it, since it otherwise ignores
         ``tool_choice`` and non-empty tools would newly ALLOW a call).
 
-        Known caveat for the reviewer: on Anthropic a ``tool_choice`` that
-        differs from the turn's can still invalidate the growing MESSAGE-tail
-        cache while the tools+system HEAD stays warm — the head is the large,
-        stable win here; the tail delta is bounded by the turn's own tail.
+        Caveat: on Anthropic a ``tool_choice`` that differs from the turn's
+        can still invalidate the growing MESSAGE-tail cache while the
+        tools+system HEAD stays warm — the head is the large, stable win here;
+        the tail delta is bounded by the turn's own tail.
 
         Safe to call mid-turn, and the pairing below is what makes that true —
         see :meth:`_wire_legal_snapshot`.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -5731,9 +5731,26 @@ class Session:
         what owns cost accounting, so ``on_usage`` hands the provider's own
         figures back rather than this method guessing at them.
 
-        No tools, and ``tool_choice="none"``: an aside that could edit a file
-        would be a turn wearing a popup, and the answer is meant to come from
-        context the agent already has.
+        The live tool schema, with ``tool_choice="none"``: an aside that could
+        edit a file would be a turn wearing a popup, and the answer is meant to
+        come from context the agent already has, so nothing may be called. The
+        tools are still SENT because the tools block is the FRONT of the
+        provider cache prefix — tools -> system -> messages on Anthropic, and
+        part of the cached request body on the OpenAI-compatible and Gemini
+        wires. A real working turn sends ``list(context.tools)``
+        (``harness/loop.py``), so an aside that dropped them to ``[]`` would
+        change the prefix at position 0 and force the provider to re-process the
+        whole conversation at full/cache-write price instead of a cache READ.
+        Sending the SAME tool schema the turn sends is what keeps the aside
+        warm against the turn's cached prefix. ``tool_choice="none"`` preserves
+        the "reads the turn, calls nothing" contract on every wire (and the
+        Gemini builder is taught to honour it, since it otherwise ignores
+        ``tool_choice`` and non-empty tools would newly ALLOW a call).
+
+        Known caveat for the reviewer: on Anthropic a ``tool_choice`` that
+        differs from the turn's can still invalidate the growing MESSAGE-tail
+        cache while the tools+system HEAD stays warm — the head is the large,
+        stable win here; the tail delta is bounded by the turn's own tail.
 
         Safe to call mid-turn, and the pairing below is what makes that true —
         see :meth:`_wire_legal_snapshot`.
@@ -5745,7 +5762,10 @@ class Session:
             model=self._model,
             system_blocks=list(blocks),
             messages=self._render_history([*self._wire_legal_snapshot(), *turns]),
-            tools=[],
+            # Live tools (not []): keep the aside on the SAME cache prefix the
+            # working turn builds. See the docstring for why this is a cache
+            # read rather than a full re-process. tool_choice stays "none".
+            tools=list(self._context.tools),
             tool_choice="none",
         )
         parts: list[str] = []

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -12355,6 +12355,25 @@ class OperatorApp(App[None]):
         cost = self._cost_for(usage)
         if cost is not None:
             self._total_cost += cost
+        # Cache instrumentation (debug-only, off by default): an aside is meant
+        # to ride the working turn's cached prefix, so cache_read should be a
+        # large fraction of the prompt while input (the uncached remainder)
+        # stays small. When that inverts — high input, low cache_read — the
+        # aside has diverged from the turn's prefix and is re-processing the
+        # conversation at full price, which is exactly the regression the tools
+        # restoration fixes. Logged, not surfaced, so the "no extra row" aside
+        # contract holds; enable it with the module logger at DEBUG to measure.
+        if logger.isEnabledFor(logging.DEBUG):
+            cache_read = getattr(usage, "cache_read_tokens", 0)
+            cache_write = getattr(usage, "cache_write_tokens", 0)
+            uncached = getattr(usage, "input_tokens", 0)
+            logger.debug(
+                "aside usage: cache_read=%s cache_write=%s input=%s output=%s",
+                cache_read,
+                cache_write,
+                uncached,
+                getattr(usage, "output_tokens", 0),
+            )
 
     def _aside_can_fork(self) -> bool:
         """Whether ``^f`` would work right now — the card cannot know alone.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.4"
+version = "0.42.5"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/measure_aside_cache.py
+++ b/scripts/measure_aside_cache.py
@@ -1,0 +1,143 @@
+"""Live Anthropic measurement of the aside prompt-cache fix.
+
+Makes three REAL streamed calls against the configured Anthropic OAuth
+credential on ``claude-opus-4-8`` and reads the provider-reported cache tokens:
+
+1. WARM: a working-turn-shaped request (system + a real conversation + the
+   full tool schema). This writes the cache prefix (tools -> system -> messages).
+2. ASIDE-OLD: the same conversation with tools=[] and tool_choice="none"
+   (the regression). Its prefix diverges at position 0, so cache_read should be
+   low relative to the prompt.
+3. ASIDE-NEW: the same conversation with the live tools restored and
+   tool_choice="none" (the fix). Its tools+system head matches the warm turn,
+   so cache_read should be high.
+
+Prints cache_read / cache_write / input for each so the before/after is a
+measured number, not an assertion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from local_operator.harness.types import (
+    AgentTool,
+    ChatRequest,
+    Message,
+    StreamUsageEvent,
+)
+from local_operator.model.configure import build_model_spec
+from local_operator.providers.auth_store import AuthStore, default_db_path
+from local_operator.providers.clients import client_for_spec
+
+
+def _noop(*_a, **_k):
+    raise AssertionError("tool must not run")
+
+
+def _tools() -> list[AgentTool]:
+    # A handful of realistic schemas so the tools block is a meaningful chunk of
+    # the prefix (the real session ships ~a dozen core tools).
+    names = ["bash", "read", "write", "edit", "grep", "glob", "eval", "task"]
+    return [
+        AgentTool(
+            name=n,
+            description=f"{n} tool: does {n} things with useful parameters",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "target path"},
+                    "content": {"type": "string", "description": "payload"},
+                },
+            },
+            execute=_noop,
+        )
+        for n in names
+    ]
+
+
+def _conversation() -> list[Message]:
+    # A long-ish exchange so cache read/write token counts are clearly visible.
+    convo: list[Message] = []
+    for i in range(6):
+        convo.append(
+            Message.user((f"Step {i}: please explain concept number {i} in detail. " * 8).strip())
+        )
+        convo.append(Message.assistant((f"Concept {i} explained thoroughly. " * 40).strip()))
+    # End on a user message so the WARM request is a legal working turn (the
+    # model generates the reply). The asides append their own user question
+    # after this, so all three requests share the same long prefix.
+    convo.append(Message.user(("Now summarise everything above concisely. " * 6).strip()))
+    return convo
+
+
+SYSTEM = [
+    "You are a helpful coding agent. " * 30,
+    "Environment: macOS, python 3.14. " * 20,
+]
+
+
+async def _run(client, spec, oauth, request, label):
+    usage = None
+    async for event in client.stream(request, None, oauth_access=oauth):
+        if isinstance(event, StreamUsageEvent):
+            usage = event.usage
+    if usage is None:
+        print(f"{label}: no usage reported")
+        return None
+    print(
+        f"{label}: cache_read={usage.cache_read_tokens} "
+        f"cache_write={usage.cache_write_tokens} input={usage.input_tokens} "
+        f"output={usage.output_tokens} context={usage.context_tokens}"
+    )
+    return usage
+
+
+async def main() -> None:
+    spec = build_model_spec("anthropic", "claude-opus-4-8")
+    store = AuthStore(default_db_path())
+    oauth = await store.get_oauth_access("anthropic")
+    client = client_for_spec(spec)
+
+    tools = _tools()
+    convo = _conversation()
+
+    warm = ChatRequest(model=spec, system_blocks=list(SYSTEM), messages=list(convo), tools=tools)
+    aside_old = ChatRequest(
+        model=spec,
+        system_blocks=list(SYSTEM),
+        messages=[*convo, Message.user("why did you pick that?")],
+        tools=[],
+        tool_choice="none",
+    )
+    aside_new = ChatRequest(
+        model=spec,
+        system_blocks=list(SYSTEM),
+        messages=[*convo, Message.user("why did you pick that?")],
+        tools=tools,
+        tool_choice="none",
+    )
+
+    # 1) Warm the cache with a working-turn shape.
+    await _run(client, spec, oauth, warm, "WARM (turn, tools)")
+    await asyncio.sleep(1)
+    # 2) Old aside behaviour: tools dropped -> prefix diverges at position 0.
+    old = await _run(client, spec, oauth, aside_old, "ASIDE-OLD (tools=[])")
+    await asyncio.sleep(1)
+    # Re-warm so the aside-new measurement is not polluted by aside-old having
+    # written a no-tools prefix.
+    await _run(client, spec, oauth, warm, "RE-WARM (turn, tools)")
+    await asyncio.sleep(1)
+    # 3) New aside behaviour: tools restored -> tools+system head matches turn.
+    new = await _run(client, spec, oauth, aside_new, "ASIDE-NEW (tools restored)")
+
+    if old and new:
+        print(
+            f"\nRESULT: cache_read old={old.cache_read_tokens} "
+            f"new={new.cache_read_tokens} "
+            f"(delta={new.cache_read_tokens - old.cache_read_tokens})"
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 import pytest
@@ -3113,3 +3113,118 @@ async def test_codex_5_6_stream_skips_reasoning_items() -> None:
     texts = [e.delta for e in events if isinstance(e, StreamTextDelta)]
     assert texts == ["Answer"]  # the encrypted blob never became text
     assert events[-1].stop_reason == "stop"
+
+
+# ---------------------------------------------------------------------------
+# Aside cache-prefix regression: tools + tool_choice="none"
+#
+# `Session.complete_aside` (the /btw overlay and the /loop goal-mode judge)
+# sends the SAME live tool schema a working turn sends so the aside rides the
+# turn's cached prefix instead of re-processing the whole conversation. The
+# tools block is the FRONT of every provider's cache prefix, so a future
+# refactor that silently dropped `body["tools"]` for a `tool_choice="none"`
+# request would reintroduce the exact prompt-cache regression these tests
+# guard. Each of the three wires must emit the tools AND pin the choice to
+# "none" (the aside reads the turn and calls nothing).
+# ---------------------------------------------------------------------------
+
+
+async def _aside_execute(*_args: Any, **_kwargs: Any) -> ToolResult:
+    """Never invoked: an aside sends tools but calls none."""
+    raise AssertionError("aside tool must not be executed")
+
+
+def _aside_tools() -> list[AgentTool]:
+    return [
+        AgentTool(
+            name="bash",
+            description="Run a shell command",
+            parameters={"type": "object", "properties": {}},
+            execute=_aside_execute,
+        ),
+        AgentTool(
+            name="read",
+            description="Read a file",
+            parameters={"type": "object", "properties": {}},
+            execute=_aside_execute,
+        ),
+    ]
+
+
+def test_openai_compat_emits_tools_with_tool_choice_none() -> None:
+    request = ChatRequest(
+        model=_spec(provider="openai"),
+        messages=[Message.user("why?")],
+        tools=_aside_tools(),
+        tool_choice="none",
+    )
+    body = OpenAICompatClient("https://x")._build_body(request)
+    assert [t["function"]["name"] for t in body["tools"]] == ["bash", "read"]
+    assert body["tool_choice"] == "none"
+
+
+def test_openai_responses_emits_tools_with_tool_choice_none() -> None:
+    request = ChatRequest(
+        model=_spec(provider="openai"),
+        messages=[Message.user("why?")],
+        tools=_aside_tools(),
+        tool_choice="none",
+    )
+    body = OpenAICompatClient("https://x")._build_responses_body(request)
+    assert [t["name"] for t in body["tools"]] == ["bash", "read"]
+    assert body["tool_choice"] == "none"
+
+
+def test_anthropic_emits_tools_with_tool_choice_none_and_keeps_cache_control() -> None:
+    request = ChatRequest(
+        model=_spec(provider="anthropic"),
+        system_blocks=["instructions", "env"],
+        messages=[Message.user("first"), Message.assistant("mid"), Message.user("why?")],
+        tools=_aside_tools(),
+        tool_choice="none",
+    )
+    body = AnthropicClient()._build_body(request)
+    assert [t["name"] for t in body["tools"]] == ["bash", "read"]
+    assert body["tool_choice"] == {"type": "none"}
+    # The message-tail cache_control placement is unchanged by restoring tools:
+    # the tools block sits AHEAD of system+messages in the prefix, so the
+    # existing breakpoint policy (last block of the final message, and the
+    # prior user turn) must still hold.
+    assert "cache_control" in body["messages"][-1]["content"][-1]
+    assert "cache_control" in body["messages"][0]["content"][-1]
+
+
+def test_google_emits_tools_and_pins_function_calling_to_none() -> None:
+    """Gemini has no tool_choice field; it takes the mode under
+    toolConfig.functionCallingConfig. Before the aside sent tools this branch
+    was never reached with tools present, so the mode defaulted to AUTO. Now
+    that an aside sends the live tools with tool_choice="none", the mode MUST
+    be pinned to NONE or the aside could newly call a tool."""
+    request = ChatRequest(
+        model=_spec(provider="google", model_id="gemini-2.5-pro"),
+        messages=[Message.user("why?")],
+        tools=_aside_tools(),
+        tool_choice="none",
+    )
+    body = GoogleClient()._build_body(request)
+    decls = body["tools"][0]["function_declarations"]
+    assert [d["name"] for d in decls] == ["bash", "read"]
+    assert body["toolConfig"]["functionCallingConfig"]["mode"] == "NONE"
+
+
+def test_google_function_calling_mode_maps_auto_and_required() -> None:
+    cases: list[tuple[Literal["auto", "none", "required"], str]] = [
+        ("auto", "AUTO"),
+        ("required", "ANY"),
+        ("none", "NONE"),
+    ]
+    for choice, mode in cases:
+        body = GoogleClient()._build_body(
+            ChatRequest(
+                model=_spec(provider="google", model_id="gemini-2.5-pro"),
+                messages=[Message.user("hi")],
+                tools=_aside_tools(),
+                tool_choice=choice,
+            )
+        )
+        assert body["toolConfig"]["functionCallingConfig"]["mode"] == mode

--- a/tests/unit/session/test_aside.py
+++ b/tests/unit/session/test_aside.py
@@ -13,6 +13,7 @@ import pytest
 
 from local_operator.harness.types import (
     AbortSignal,
+    AgentTool,
     ChatRequest,
     Message,
     ModelSpec,
@@ -22,6 +23,7 @@ from local_operator.harness.types import (
     StreamUsageEvent,
     TextContent,
     ToolCall,
+    ToolResult,
     Usage,
 )
 from local_operator.session.session import Session
@@ -47,11 +49,26 @@ class RecordingStream:
         return gen()
 
 
+async def _noop_execute(*_args, **_kwargs) -> ToolResult:
+    """A tool body that is never invoked — asides send tools but call none."""
+    raise AssertionError("aside tool must not be executed")
+
+
+def _tool(name: str) -> AgentTool:
+    """A minimal live tool, so an aside request carries a real schema."""
+    return AgentTool(
+        name=name,
+        description=f"{name} tool",
+        parameters={"type": "object", "properties": {}},
+        execute=_noop_execute,
+    )
+
+
 def make_session(tmp_path, stream, **kwargs) -> Session:
     return Session(
         model=MODEL,
         stream_fn=stream,
-        tools=[],
+        tools=kwargs.pop("tools", []),
         transcript=Transcript(tmp_path / "sess"),
         system_blocks_provider=kwargs.pop("system_blocks_provider", lambda: ["stable", "env"]),
         **kwargs,
@@ -85,9 +102,19 @@ async def test_complete_aside_leaves_no_trace(tmp_path) -> None:
 
 @pytest.mark.asyncio
 async def test_complete_aside_sends_the_live_context_and_no_tools(tmp_path) -> None:
-    """It answers from the conversation, and cannot act on it."""
+    """It answers from the conversation, and cannot act on it.
+
+    The aside sends the SAME live tool schema a working turn sends, not ``[]``:
+    the tools block is the front of every provider's cache prefix, so dropping
+    it would push the aside off the turn's cached prefix and force a full
+    re-process (the regression this fixes). ``tool_choice="none"`` is what keeps
+    "reads the turn, calls nothing" true even though the tools are present.
+    """
+    tools = [_tool("bash"), _tool("read")]
     stream = RecordingStream()
-    session = make_session(tmp_path, stream, system_blocks_provider=lambda: ["stable", "goal: x"])
+    session = make_session(
+        tmp_path, stream, tools=tools, system_blocks_provider=lambda: ["stable", "goal: x"]
+    )
     session._context.messages.append(Message.user("port it"))
 
     await session.complete_aside([Message.user("why?")])
@@ -95,7 +122,13 @@ async def test_complete_aside_sends_the_live_context_and_no_tools(tmp_path) -> N
     request = stream.requests[-1]
     assert request.system_blocks == ["stable", "goal: x"]
     assert [m.text for m in request.messages] == ["port it", "why?"]
-    assert request.tools == []
+    # Tools mirror the session's live set (the working turn's prefix) exactly —
+    # this is the whole point: the aside must send what the turn sends. The
+    # session augments the caller's tools with its own built-ins (task, hub,
+    # ...), so assert identity with the live set rather than the literal input.
+    assert request.tools == session._context.tools
+    assert {"bash", "read"} <= {t.name for t in request.tools}
+    # And it still cannot call any of them.
     assert request.tool_choice == "none"
     await session.dispose()
 


### PR DESCRIPTION
## Summary

Off-the-record model calls — `/btw` and the new `/loop` goal-mode judge — were re-processing the entire conversation at full price instead of reading the working turn's warm prompt cache. Both go through `Session.complete_aside`, which built its request with `tools=[]` while a real turn sends the full tool schema (`harness/loop.py`). Since the tool block sits at the **front** of every provider's cache prefix (Anthropic caches `tools → system → messages`; OpenAI and Gemini include the tool array in the cached request), dropping it diverged the aside from the turn's prefix and forced a full re-read/re-write on every judge call and every `/btw`.

This restores the live tool set on `complete_aside` (keeping `tool_choice="none"`, so the aside still reads the turn and calls nothing), so the aside now shares the turn's cached prefix on all three provider families.

## What changed

- **`local_operator/session/session.py`** — `complete_aside` sends `tools=list(self._context.tools)` (was `tools=[]`); `tool_choice="none"` unchanged. Applied unconditionally, so both `/btw` and the loop judge benefit. Docstring + call-site comment explain the cache-prefix rationale and the message-tail caveat below.
- **`local_operator/providers/clients.py`** — `GoogleClient._build_body` now maps `tool_choice` onto `toolConfig.functionCallingConfig.mode` (AUTO/NONE/ANY). Gemini previously **ignored** `tool_choice` entirely, so restoring tools without this would have newly *allowed* an aside to call a tool. This closes that hole and is the widest-blast-radius part of the diff (it affects any Gemini request that sets `tool_choice`, not just asides — intended, maps to the documented mode).
- **`local_operator/tui/app.py`** — `_charge_aside` gains a debug-only (off by default) log of `cache_read / cache_write / input / output` for asides, so the cache behaviour is observable without shipping noise.
- **Tests** — the session aside test asserts `request.tools == session._context.tools` and `tool_choice == "none"`; 5 new client-builder regression tests (OpenAI chat-completions, OpenAI Responses, Anthropic incl. unchanged `cache_control` placement, Gemini NONE, Gemini mode map) so a future refactor can't silently drop the tools block for asides. `scripts/measure_aside_cache.py` is the live measurement harness.

The other off-the-record forks were audited and correctly left alone: `complete_once` (auto-naming, different cheap model + fresh single message) and `_one_shot_complete` (compaction, own system prompt + fresh message) share no prefix with the turn, so their `tools=[]` is right; the server-side one-shot in `server/utils/operator.py` is out of scope.

## Validation

### Measured cache evidence — live, real Anthropic OAuth, `claude-opus-4-8`

```
WARM (turn, tools):          cache_read=0     cache_write=5984
ASIDE-OLD (tools=[]):        cache_read=0     cache_write=4967   <- regression: full re-process
RE-WARM (turn, tools):       cache_read=5984  cache_write=0
ASIDE-NEW (tools restored):  cache_read=5984  cache_write=8      <- fix: reads the whole warm prefix
```

The aside goes from reading **0** cached tokens to reading the **entire 5984-token** prefix; cache_write collapses 4967 → 8. On this model cache reads bill at 0.1× input (`cache_reads_price` 0.50 vs `input_price` 25.0 /MTok), so a goal-loop judge (and every `/btw`) now costs a small fraction of what it did.

### Gates (worktree, symlinked `.venv`)

- `flake8 .` clean · `black==26.1.0 --check .` 562 files unchanged · `isort==5.13.2 --check .` clean · `pyright` on changed files: 0 errors.
- `pytest tests/unit/tui -q` → 2578 passed, 4 skipped. The 5 new builder/aside tests pass.
- `pytest tests/unit -q` → the only failures are the 24 pre-existing environmental `tests/unit/tools/test_eval_tool.py` cases (eval worker subprocess cannot import `local_operator` under a symlinked-venv worktree; identical on clean `origin/main`). CI's real install runs them green.

## Reviewer notes

- **`tool_choice="none"` message-tail caveat:** on Anthropic the aside's `tool_choice="none"` differs from the turn's `"auto"`, which can invalidate the growing message-*tail* cache while the tools+system head stays warm. The live numbers show that residual cost is tiny (cache_write=8), but it is real.
- **Gemini `toolConfig`** is a behaviour change on the Gemini wire for any `tool_choice`-bearing request with tools, not just asides — intended and safe, but the broadest surface in the diff.

## Review

Independent agent review is required before merge. This PR must not merge until that round is posted, answered, and fresh against the current head.
