### PR TITLE
chore(extension): bump version to 0.1.3

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Local Operator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Connect Local Operator to the browser you already use, entirely on your machine.",
   "permissions": ["debugger", "tabs", "scripting", "storage", "alarms", "webNavigation", "notifications"],
   "host_permissions": ["<all_urls>"],

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-operator-browser-extension",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "packageManager": "pnpm@11.22.0",
   "scripts": {


### PR DESCRIPTION
## What

Bumps the extension 0.1.2 → 0.1.3 to carry **#348 (MV3 service-worker rewake fix)** into the Chrome Web Store package.

## Why

0.1.2 closed the browser-extension arc except one live-verified defect: after idle suspension the service worker stayed disconnected until a manual page-open or toolbar poke. #348 makes reconnection automatic (~1 min, above Chrome's alarm clamp). The store package should not ship a build with that known defect.

## Testing

- `pnpm typecheck` clean, `pnpm test` 36/36, `pnpm build:zip` + `validate-store-zip.sh … 0.1.3` pass (validated package: 0.1.3, 12 files, no source maps)
- `dist/worker.js` verified to carry `periodInMinutes: 1`