### PR TITLE
fix(tui): guard fd 2 so macOS malloc diagnostics do not corrupt the frame

### DIFF
--- a/local_operator/logger.py
+++ b/local_operator/logger.py
@@ -302,6 +302,86 @@ def _open_rotating_handler(
     return handler, path
 
 
+def _redirect_fd_stderr(logfd: int) -> Optional[int]:
+    """Point the process's REAL stderr file descriptor (fd 2) at the log file.
+
+    :func:`file_logging` and Textual's own ``redirect_stderr`` only swap the
+    Python-level ``sys.stderr`` object and the logging handlers bound to it.
+    That is enough for anything written *through Python*, but it does nothing
+    about code below the interpreter that calls the raw ``write(2)`` syscall on
+    file descriptor 2 directly. Those bytes never pass through ``sys.stderr``,
+    so every Python-level redirect misses them and they land straight on top of
+    whatever Textual has painted on the alternate screen, smearing the frame
+    and the composer until the next full repaint.
+
+    The concrete offender on macOS is libmalloc: under memory pressure (and on
+    lock/unlock and sleep/wake, which churn the allocator the same way) it
+    emits ``MallocStackLogging: can't turn off malloc stack logging because it
+    was not enabled.`` by writing it to fd 2 itself, underneath CPython. We
+    have zero ``malloc`` references in the tree — this is the OS, not us — which
+    is exactly why no Python-level guard can catch it. Redirecting the OS-level
+    fd 2 into the rotating log file does: the native bytes are captured where
+    they can be grepped in ``local-operator.log`` (the operator's choice over
+    ``/dev/null`` — these diagnostics correlate with real RAM-pressure events
+    and are worth keeping), and the frame stays clean. This mirrors the fix in
+    openai/codex PR #24459 ("prevent macos stderr from corrupting composer").
+
+    macOS-only by design: Linux and Windows do not emit this, and moving fd 2
+    out from under them would be needless risk for no benefit. Returns the
+    saved original fd 2 (to restore on exit) or ``None`` when the guard did not
+    install — off-darwin, or a syscall failed and the caller should leave fd 2
+    untouched rather than send it somewhere invalid.
+
+    Rotation trade-off: ``dup2(logfd, 2)`` makes fd 2 share the log file's
+    *open file description* as it stands right now, independent of ``logfd``
+    itself. When ``RotatingFileHandler`` rolls over it closes and reopens its
+    own stream, but fd 2 keeps its reference to the install-time description, so
+    native bytes emitted after a mid-session rotation keep flowing to the
+    pre-rotation inode (the rolled ``.1`` file) until the block exits. That is
+    accepted deliberately: the bytes are still captured, just in the rolled
+    file, and mid-session rotation is rare. The alternative — re-pointing fd 2
+    on every rollover — would couple this allocator guard to logging internals
+    for a case that almost never happens.
+    """
+    # Guard: this defect is macOS-specific, so the fd surgery is too.
+    if sys.platform != "darwin":
+        return None
+    try:
+        # Preserve the real terminal (or whatever owns fd 2) so exit restores it
+        # exactly, including on exception.
+        saved_fd = os.dup(2)
+    except OSError:
+        return None
+    try:
+        os.dup2(logfd, 2)
+    except OSError:
+        # Could not redirect; do not leave a dangling saved fd behind.
+        try:
+            os.close(saved_fd)
+        except OSError:
+            pass
+        return None
+    return saved_fd
+
+
+def _restore_fd_stderr(saved_fd: Optional[int]) -> None:
+    """Undo :func:`_redirect_fd_stderr`, putting the original fd 2 back.
+
+    Best-effort and non-raising in both syscalls: this runs in ``file_logging``'s
+    ``finally``, where a teardown exception would mask the real one.
+    """
+    if saved_fd is None:
+        return
+    try:
+        os.dup2(saved_fd, 2)
+    except OSError:  # noqa: BLE001 — teardown must not raise
+        pass
+    try:
+        os.close(saved_fd)
+    except OSError:  # noqa: BLE001 — teardown must not raise
+        pass
+
+
 def _write_header(handler: logging.Handler, path: Path) -> None:
     """State the file's own path and bound as its first record.
 
@@ -360,6 +440,7 @@ def file_logging(
     state = _detach_console_handlers()
     handler, path = _open_rotating_handler(max_bytes, backup_count)
     root_logger = logging.getLogger()
+    saved_stderr_fd: Optional[int] = None
     if handler is not None and path is not None:
         # Passes the guard installed above by design: `_is_console_handler`
         # rejects FileHandler, so the file handler is the one thing that can
@@ -367,12 +448,32 @@ def file_logging(
         root_logger.addHandler(handler)
         _write_header(handler, path)
         _current_log_file = path
+        # Reuse the file the handler just opened for the fd-level stderr guard
+        # (see `_redirect_fd_stderr`): its underlying fd is our redirect target.
+        # Only the OUTER `file_logging` block reaches here — the re-entrancy
+        # early-return above means a nested block never re-installs the guard —
+        # so its lifetime is tied to the same ownership window as the handler.
+        # If no file could be opened (`handler is None`) fd 2 is left alone.
+        # `stream` is a FileHandler concretion, not on the base Handler type,
+        # so reach it defensively and treat a rolled/closed stream as "no fd".
+        stream = getattr(handler, "stream", None)
+        logfd: Optional[int] = None
+        if stream is not None:
+            try:
+                logfd = stream.fileno()
+            except (OSError, ValueError):
+                logfd = None
+        if logfd is not None:
+            saved_stderr_fd = _redirect_fd_stderr(logfd)
     _file_logging_active = True
     try:
         yield path
     finally:
         _file_logging_active = False
         _current_log_file = None
+        # Restore the real fd 2 first, before the handler that owns the redirect
+        # target is closed, so the terminal is back the instant the TUI exits.
+        _restore_fd_stderr(saved_stderr_fd)
         if handler is not None:
             root_logger.removeHandler(handler)
             try:

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import io
 import logging
 import logging.handlers
+import os
 import sys
 from pathlib import Path
 from typing import Any, cast
@@ -26,6 +27,8 @@ from local_operator.logger import (
     LOG_MAX_BYTES,
     LOG_TOTAL_MAX_BYTES,
     _is_console_handler,
+    _redirect_fd_stderr,
+    _restore_fd_stderr,
     configure_cli_logging,
     configure_console_logging,
     current_log_file,
@@ -344,3 +347,156 @@ def test_rotation_reaps_old_files_and_holds_the_ceiling(log_home: Path) -> None:
 
     # The newest data survived: reaping must drop the OLDEST file, not the live one.
     assert "x" in log_home.read_text(encoding="utf-8")
+
+
+# --- Native (fd-level) stderr guard -----------------------------------------
+#
+# macOS libmalloc writes `MallocStackLogging: ...` straight to OS fd 2 with a
+# raw write(2), underneath CPython, so no Python-level redirect (Textual's
+# `redirect_stderr`, our handler swap) can catch it. The guard redirects the
+# real fd 2 into the log file while the TUI owns the terminal. These verify the
+# fd LIFECYCLE (dup/dup2/restore) at the descriptor level, not by matching a
+# string — the platform diagnostic itself is not reproducible in CI, so
+# `sys.platform` is forced to "darwin" and a raw `os.write(2, ...)` stands in
+# for the allocator's native write.
+
+
+def _fd_identity(fd: int) -> tuple[int, int]:
+    """(device, inode) of whatever a file descriptor currently points at.
+
+    Two descriptors pointing at the same open file share this pair; a redirect
+    that repoints fd 2 changes it. Comparing identities is how a test sees the
+    guard move fd 2 without depending on any message text.
+    """
+    info = os.fstat(fd)
+    return (info.st_dev, info.st_ino)
+
+
+def test_redirect_fd_stderr_is_a_no_op_off_darwin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Linux and Windows do not emit the diagnostic; fd 2 must be left alone."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    target = tmp_path / "sink.log"
+    with open(target, "w", encoding="utf-8") as sink:
+        before = _fd_identity(2)
+        saved = _redirect_fd_stderr(sink.fileno())
+        try:
+            assert saved is None
+            assert _fd_identity(2) == before
+        finally:
+            _restore_fd_stderr(saved)
+
+
+def test_redirect_fd_stderr_moves_and_restores_fd_two_on_darwin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The helper in isolation: native writes land in the target, fd 2 restored.
+
+    Platform-independent by construction (``sys.platform`` forced), so the fd
+    surgery is exercised on the Linux CI host even though the real diagnostic
+    only occurs on macOS.
+    """
+    monkeypatch.setattr(sys, "platform", "darwin")
+    target = tmp_path / "sink.log"
+    with open(target, "w", encoding="utf-8") as sink:
+        before = _fd_identity(2)
+        saved = _redirect_fd_stderr(sink.fileno())
+        try:
+            assert saved is not None
+            # fd 2 now shares the sink's open file, not the pre-block target.
+            assert _fd_identity(2) != before
+            assert _fd_identity(2) == _fd_identity(sink.fileno())
+            os.write(2, b"native malloc noise\n")
+        finally:
+            _restore_fd_stderr(saved)
+        # Exactly the original target again, and nothing painted on it.
+        assert _fd_identity(2) == before
+    assert "native malloc noise" in target.read_text(encoding="utf-8")
+
+
+def test_file_logging_captures_native_fd2_writes_on_darwin(
+    log_home: Path, monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]
+) -> None:
+    """End to end through ``file_logging``: a raw ``write(2)`` lands in the log.
+
+    This is the real bug's shape: bytes written to fd 2 directly, bypassing
+    ``sys.stderr`` entirely. They must reach the rotating log file and never the
+    terminal, and fd 2 must differ from its pre-block target only inside the
+    block.
+    """
+    monkeypatch.setattr(sys, "platform", "darwin")
+    before = _fd_identity(2)
+
+    with file_logging() as path:
+        assert path == log_home
+        # Inside the block fd 2 is redirected away from the terminal.
+        assert _fd_identity(2) != before
+        os.write(2, b"native malloc noise\n")
+
+    # Restored the instant the block exits, so `exec`/REPL/server stderr works.
+    assert _fd_identity(2) == before
+    # The native bytes were captured in the log, not painted on the terminal.
+    assert "native malloc noise" in log_home.read_text(encoding="utf-8")
+    assert "native malloc noise" not in capfd.readouterr().err
+
+
+def test_file_logging_restores_fd2_after_an_exception_on_darwin(
+    log_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The restore lives in ``finally``; an app crash must still hand fd 2 back."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    before = _fd_identity(2)
+
+    with pytest.raises(ValueError):
+        with file_logging():
+            assert _fd_identity(2) != before
+            raise ValueError("app crashed")
+
+    assert _fd_identity(2) == before
+
+
+def test_nested_file_logging_does_not_reinstall_or_restore_fd2_early(
+    log_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard is tied to the OUTER block only, like the handler detach.
+
+    A nested ``file_logging`` early-returns before the redirect code, so it must
+    neither move fd 2 again nor hand it back when it exits — otherwise the inner
+    exit would restore the terminal while the TUI is still painting.
+    """
+    monkeypatch.setattr(sys, "platform", "darwin")
+    before = _fd_identity(2)
+
+    with file_logging():
+        redirected = _fd_identity(2)
+        assert redirected != before
+        with file_logging():
+            # Inner block must not repoint fd 2 to a second target.
+            assert _fd_identity(2) == redirected
+        # Inner exit must NOT have restored fd 2 early.
+        assert _fd_identity(2) == redirected
+
+    assert _fd_identity(2) == before
+
+
+def test_file_logging_leaves_fd2_alone_when_no_log_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No file handler means no redirect target; fd 2 must never move.
+
+    The guard is best-effort exactly like the file handler: sending fd 2 to a
+    closed or absent fd would be worse than the diagnostic it captures.
+    """
+    monkeypatch.setattr(sys, "platform", "darwin")
+    blocked = tmp_path / "cfg"
+    blocked.mkdir()
+    (blocked / "logs").write_text("not a directory", encoding="utf-8")
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(blocked))
+    before = _fd_identity(2)
+
+    with file_logging() as path:
+        assert path is None
+        assert _fd_identity(2) == before
+
+    assert _fd_identity(2) == before


### PR DESCRIPTION
## Problem

On macOS, lines like

```
python3(64653) MallocStackLogging: can't turn off malloc stack logging because it was not enabled.
```

periodically flood the TUI during/after RAM-pressure spikes (also lock/unlock, sleep/wake). A burst under memory pressure smears repeatedly across the frame and the composer until the next full repaint.

## Root cause

This is **not** from our logging — there are zero `malloc`/`MallocStackLogging` references in the tree. It is macOS `libmalloc` writing bytes **directly to OS file descriptor 2** via a raw `write(2)`, underneath CPython. Textual's `redirect_stderr` and our own `file_logging()` only swap the Python-level `sys.stderr` object and the logging handlers bound to it; **neither touches the real fd 2**. So those native bytes bypass every Python-level redirect and paint straight on top of whatever the renderer owns.

This is a known macOS quirk, not app-specific — the identical message is filed against k9s (Go), openai/codex (Rust), and amazon-q (Rust). Codex fixed it in PR #24459 ("prevent macos stderr from corrupting composer") with an fd-level stderr guard tied to terminal ownership; this change applies the same approach.

## Change

Add an **fd-level stderr guard** inside `file_logging()` (already the single authoritative "TUI owns the terminal" window — the codebase deliberately never calls `App.suspend()`, and `file_logging` is re-entrant with the ownership boundary as its enter/exit):

- While the TUI holds the terminal, `os.dup` the real fd 2 and `os.dup2` it onto the already-open rotating log file's fd, so native diagnostics are **captured** in `local-operator.log` (greppable) rather than discarded — the operator's choice over `/dev/null`, since these correlate with real RAM-pressure events.
- Restore the original fd 2 exactly on exit, including on exception, in the `finally` **before** the handler that owns the redirect target closes.
- **macOS-only** (`sys.platform == "darwin"`); a no-op elsewhere. If no log file can be opened, fd 2 is left untouched (never pointed at a closed/invalid fd).
- Only the **outer** `file_logging` block installs/removes it — the existing `_file_logging_active` early-return makes nested blocks no-ops, so the guard's lifetime is tied to the same ownership window as the handler.
- `sys.stderr` is untouched (Textual owns it); this only moves the underlying OS fd.

### Rotation trade-off

fd 2 is `dup`'d from the install-time log fd. When `RotatingFileHandler` rolls over it closes/reopens its own stream, but fd 2 keeps its reference to the install-time open file description, so post-rotation native bytes keep flowing to the pre-rotation inode (the rolled `.1` file) until block exit. Accepted deliberately: bytes are still captured, mid-session rotation is rare, and re-pointing fd 2 on every rollover would couple this allocator guard to logging internals. Documented in `_redirect_fd_stderr`.

## Files

- `local_operator/logger.py` (+101): `_redirect_fd_stderr`, `_restore_fd_stderr`, wiring in `file_logging`.
- `tests/unit/test_logger.py` (+156): 6 new fd-lifecycle tests.

## Testing evidence (real execution, not just a green suite)

The platform diagnostic is environment-dependent (RAM-pressure-triggered), so the deterministic regression is fd-level:

- **Mechanism, live on macOS**: a standalone script inside a `file_logging()` block does `os.write(2, b"MallocStackLogging: ...")`; the bytes land **in the log file**, while stderr captured to a separate file contains only the post-block marker — proving fd 2 was redirected in-block and restored after.
- **6 new tests** (platform-forced via `monkeypatch.setattr(sys, "platform", ...)`, so they run on any CI host): no-op off-darwin; fd 2 moved-and-restored on darwin (identity via `os.fstat` `(st_dev, st_ino)`, not string matching); raw `os.write(2, ...)` captured in log and absent from `capfd` stderr; restoration on exception; nested-block re-entrancy; fd 2 left alone when no log file.
- `tests/unit/test_logger.py` 20/20 and `tests/unit/tui/test_logger_silence.py` 5/5 passing.
- Gates (whole tree, as CI): flake8 clean, black 26.1.0 clean, isort 5.13.2 clean, pyright 0 errors. Broad unit suite green (two unrelated pre-existing env flakes reproduced on a clean checkout).

## Notes

Backend change, no user-visible UI alteration beyond "the flood is gone" — no design/UX round warranted. Bug fix → **patch** bump at release.
