### PR TITLE
feat(browser): group tabs by session

### DIFF
--- a/docs/evidence/session-tab-groups/README.md
+++ b/docs/evidence/session-tab-groups/README.md
@@ -1,0 +1,20 @@
+# Session tab groups evidence
+
+Captured 2026-08-27 from the built 0.1.4 extension loaded with
+`Extensions.loadUnpacked` into a temporary Google Chrome profile. The bridge ran
+on port 4199 with `LOCAL_OPERATOR_CONFIG_DIR=/tmp/lop-tab-groups-e2e/config`, so
+neither the paired browser daemon nor its state was touched.
+
+`e2e-output.txt` records real bridge responses for five separately identified
+sessions, duplicate labels, rename, explicit resume, close/prune, and the
+redacted multi-tab listing. `native-state.json` is Chrome's own `tabs.query`,
+`tabGroups.get`, and `windows.getAll` response after those calls. It proves the
+cyan native groups and titles, inactive tabs, and `focused: false` window.
+
+A native browser-chrome screenshot was attempted with non-activating
+`screencapture -x` after moving the test window via `chrome.windows.update`
+without changing `focused:false`. macOS denied Screen Recording to this process:
+`could not create image from display`. CoreGraphics window enumeration was also
+empty for the same privacy gate. No synthetic tab-strip image was substituted.
+The JSON is retained as truthful rendered-surface state; a still requires the
+operator to grant Screen Recording and rerun the capture.

--- a/docs/evidence/session-tab-groups/collapsed-after-restart.json
+++ b/docs/evidence/session-tab-groups/collapsed-after-restart.json
@@ -1,0 +1,7 @@
+[
+  {
+    "title": "LO \u00b7 Release planning",
+    "collapsed": true,
+    "color": "cyan"
+  }
+]

--- a/docs/evidence/session-tab-groups/e2e-output.txt
+++ b/docs/evidence/session-tab-groups/e2e-output.txt
@@ -1,0 +1,10 @@
+open {"tab": "bridge:279508589:6a2c8c…", "title": "Example Domain", "url": "https://example.com/"}
+open {"tab": "bridge:279508590:11580f…", "title": "Example Domain", "url": "https://example.com/"}
+open {"tab": "bridge:279508591:bc19e5…", "title": "Example Domain", "url": "https://example.com/"}
+open {"tab": "bridge:279508592:d9a1ff…", "title": "Example Domain", "url": "https://example.com/"}
+open {"tab": "bridge:279508593:c56d62…", "title": "Example Domain", "url": "https://example.com/"}
+tabs {"limit": 8, "tabs": [{"createdAt": 1787868058978, "lastUsedAt": 1787868058978, "tab": "bridge:279508593:c56d62…", "title": "Example Domain", "url": "https://example.com/"}, {"createdAt": 1787868058803, "lastUsedAt": 1787868058803, "tab": "bridge:279508592:d9a1ff…", "title": "Example Domain", "url": "https://example.com/"}, {"createdAt": 1787868058772, "lastUsedAt": 1787868058772, "tab": "bridge:279508591:bc19e5…", "title": "Example Domain", "url": "https://example.com/"}, {"createdAt": 1787868058310, "lastUsedAt": 1787868058310, "tab": "bridge:279508590:11580f…", "title": "Example Domain", "url": "https://example.com/"}, {"createdAt": 1787868058158, "lastUsedAt": 1787868058158, "tab": "bridge:279508589:6a2c8c…", "title": "Example Domain", "url": "https://example.com/"}]}
+goto {"title": "Example Domain", "url": "https://example.com/"}
+open {"tab": "bridge:279508589:6a2c8c…", "title": "Example Domain", "url": "https://example.com/"}
+close {}
+tabs {"limit": 8, "tabs": [{"createdAt": 1787868058158, "lastUsedAt": 1787868059057, "tab": "bridge:279508589:6a2c8c…", "title": "Example Domain", "url": "https://example.com/"}, {"createdAt": 1787868058310, "lastUsedAt": 1787868059040, "tab": "bridge:279508590:11580f…", "title": "Example Domain", "url": "https://example.com/"}, {"createdAt": 1787868058978, "lastUsedAt": 1787868058978, "tab": "bridge:279508593:c56d62…", "title": "Example Domain", "url": "https://example.com/"}, {"createdAt": 1787868058803, "lastUsedAt": 1787868058803, "tab": "bridge:279508592:d9a1ff…", "title": "Example Domain", "url": "https://example.com/"}]}

--- a/docs/evidence/session-tab-groups/native-state.json
+++ b/docs/evidence/session-tab-groups/native-state.json
@@ -1,0 +1,94 @@
+{
+  "tabs": [
+    {
+      "id": 279508587,
+      "active": true,
+      "windowId": 279508586,
+      "groupId": -1,
+      "title": "about:blank"
+    },
+    {
+      "id": 279508588,
+      "active": false,
+      "windowId": 279508586,
+      "groupId": -1,
+      "title": "chrome-extension://pjkjoopobkiogkempoolmhcjfdommhcj/popup/popup.html"
+    },
+    {
+      "id": 279508589,
+      "active": false,
+      "windowId": 279508586,
+      "groupId": 1294515474,
+      "title": "Example Domain"
+    },
+    {
+      "id": 279508590,
+      "active": false,
+      "windowId": 279508586,
+      "groupId": 770862595,
+      "title": "Example Domain"
+    },
+    {
+      "id": 279508592,
+      "active": false,
+      "windowId": 279508586,
+      "groupId": 1943256257,
+      "title": "Example Domain"
+    },
+    {
+      "id": 279508593,
+      "active": false,
+      "windowId": 279508586,
+      "groupId": 1785666623,
+      "title": "Example Domain"
+    }
+  ],
+  "groups": [
+    {
+      "collapsed": false,
+      "color": "cyan",
+      "id": 1294515474,
+      "shared": false,
+      "title": "LO · Release planning",
+      "windowId": 279508586
+    },
+    {
+      "collapsed": false,
+      "color": "cyan",
+      "id": 770862595,
+      "shared": false,
+      "title": "LO · Renamed review",
+      "windowId": 279508586
+    },
+    {
+      "collapsed": false,
+      "color": "cyan",
+      "id": 1943256257,
+      "shared": false,
+      "title": "LO · Session",
+      "windowId": 279508586
+    },
+    {
+      "collapsed": false,
+      "color": "cyan",
+      "id": 1785666623,
+      "shared": false,
+      "title": "LO · 世界 launch notes with a…",
+      "windowId": 279508586
+    }
+  ],
+  "windows": [
+    {
+      "alwaysOnTop": false,
+      "focused": false,
+      "height": 900,
+      "id": 279508586,
+      "incognito": false,
+      "left": 0,
+      "state": "normal",
+      "top": 100,
+      "type": "normal",
+      "width": 1400
+    }
+  ]
+}

--- a/docs/evidence/session-tab-groups/restart-output.txt
+++ b/docs/evidence/session-tab-groups/restart-output.txt
@@ -1,0 +1,39 @@
+{
+  "goto_after_worker_restart": {
+    "url": "https://example.com/",
+    "title": "Example Domain"
+  },
+  "tabs_after_worker_restart": {
+    "tabs": [
+      {
+        "tab": "bridge:279508589:6a2c8c…",
+        "url": "https://example.com/",
+        "title": "Example Domain",
+        "createdAt": 1787868058158,
+        "lastUsedAt": 1787868196920
+      },
+      {
+        "tab": "bridge:279508590:11580f…",
+        "url": "https://example.com/",
+        "title": "Example Domain",
+        "createdAt": 1787868058310,
+        "lastUsedAt": 1787868059040
+      },
+      {
+        "tab": "bridge:279508593:c56d62…",
+        "url": "https://example.com/",
+        "title": "Example Domain",
+        "createdAt": 1787868058978,
+        "lastUsedAt": 1787868058978
+      },
+      {
+        "tab": "bridge:279508592:d9a1ff…",
+        "url": "https://example.com/",
+        "title": "Example Domain",
+        "createdAt": 1787868058803,
+        "lastUsedAt": 1787868058803
+      }
+    ],
+    "limit": 8
+  }
+}

--- a/docs/store/permissions.md
+++ b/docs/store/permissions.md
@@ -28,6 +28,10 @@ boundary. Do not shorten it to “browser automation.”
 
 > Local Operator uses `chrome.tabs` to create, navigate, inspect, and close one tab dedicated to the user's agent. Reading that tab's URL and title lets the extension confirm the page actually reached after navigation or a redirect. The extension does not read, modify, or close the user's other tabs.
 
+### `tabGroups`
+
+> Used only to title and visually group tabs created and owned by Local Operator. The extension does not enumerate or alter unrelated tab groups, move groups between windows, or use group membership for browsing-history collection.
+
 ### `scripting`
 
 > Local Operator uses `chrome.scripting.executeScript` in the agent-owned tab to return that page's rendered text content to the agent when the user asks it to read a page. The injected function is bundled with the extension, performs text extraction only, and neither loads remote code nor persists on the page.
@@ -55,7 +59,7 @@ boundary. Do not shorten it to “browser automation.”
 **Submission check (finding N2):** before uploading, diff this file against the
 **built** `extension/dist/manifest.json`, not the source list. The built name is
 `Local Operator`, and the permission set that must match here is
-`debugger, tabs, scripting, storage, alarms, webNavigation, notifications` plus
+`debugger, tabs, tabGroups, scripting, storage, alarms, webNavigation, notifications` plus
 host `<all_urls>`. Any implementation change to the manifest updates this file,
 not the reverse.
 

--- a/docs/store/submission-checklist.md
+++ b/docs/store/submission-checklist.md
@@ -48,6 +48,10 @@ workflows documented below; no long-lived Google credential is stored.
       law fields, and supply any required business address/D-U-N-S details.
       This is a legal/account-owner decision, not defined by the product design.
 
+## 0.1.4 permission handoff
+
+- [ ] **Damian must add the NEW `tabGroups` permission justification in the Chrome Web Store dashboard when uploading the next package.** Use the exact paste-ready rationale in `permissions.md`; the package will request a new permission and must not be submitted against the old seven-permission declaration.
+
 ## 1. Developer account and publisher identity
 
 - [ ] Sign in to the Chrome Web Store Developer Dashboard with a company-owned,

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 3,
   "name": "Local Operator",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Connect Local Operator to the browser you already use, entirely on your machine.",
-  "permissions": ["debugger", "tabs", "scripting", "storage", "alarms", "webNavigation", "notifications"],
+  "permissions": ["debugger", "tabs", "tabGroups", "scripting", "storage", "alarms", "webNavigation", "notifications"],
   "host_permissions": ["<all_urls>"],
   "background": {"service_worker": "worker.js", "type": "module"},
   "action": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-operator-browser-extension",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "packageManager": "pnpm@11.22.0",
   "scripts": {

--- a/extension/src/commands/nav.ts
+++ b/extension/src/commands/nav.ts
@@ -8,6 +8,7 @@ import {
   type OriginAdmission,
 } from "../origins";
 import { settle } from "../settle";
+import { reconcileTabGroup } from "../tab-groups";
 import {
   atSurfaceCap,
   getSurfaces,
@@ -107,6 +108,9 @@ export async function open(params: Record<string, unknown>, requestId: string): 
   const admission = await ensureTopLevelAccess(url, requestId, sessionRequester(params));
   if (params.tab !== undefined && params.tab !== null && params.tab !== "") {
     const surface = await requireSurface(params.tab);
+    // Explicit resume refreshes trusted metadata and is the one command that
+    // may rejoin a tab the user manually ungrouped.
+    await reconcileTabGroup(surface, params, true);
     // Re-arm log capture on the resumed surface: after a worker restart the
     // ring buffer was lost and the domains may need re-enabling, and
     // startLogCapture is idempotent when they are already on.
@@ -155,12 +159,16 @@ export async function open(params: Record<string, unknown>, requestId: string): 
   // navigating, so the `logs` command captures output from the destination
   // page's very first script (finding: logs must be "since the surface opened").
   await startLogCapture(tab.id, cdp);
+  // Security-sensitive ordering stays intact: blank tab persisted, debugger
+  // attached, and log capture armed before presentation, then navigation.
+  await reconcileTabGroup(surface, params, true);
   const live = await navigate(tab.id, url, requestId, admission);
   return { tab: surfaceToken(surface), ...live };
 }
 
 export async function goto(params: Record<string, unknown>, requestId: string): Promise<Record<string, unknown>> {
   const surface = await requireSurface(params.tab);
+  await reconcileTabGroup(surface, params, false);
   const url = safeHttpUrl(params.url);
   // Same early refusal as open — see the comment there. Consumption likewise
   // happens HERE, once, bound to this command's request id.

--- a/extension/src/state.ts
+++ b/extension/src/state.ts
@@ -24,6 +24,10 @@ export interface StoredSurface {
   groupBaseLabel?: string;
   groupOrdinal?: number;
   groupAppliedLabel?: string;
+  // Advisory ownership proof for the current browser lifetime. Group IDs are
+  // ephemeral, so a mismatch is never repaired on an ordinary command; only
+  // explicit open/resume may establish and persist a fresh LO-owned group.
+  appliedGroupId?: number;
 }
 
 export interface SnapshotRef {

--- a/extension/src/state.ts
+++ b/extension/src/state.ts
@@ -18,6 +18,12 @@ export interface StoredSurface {
   // chrome.tabs at list time so the listing can never show a stale page.
   createdAt: number;
   lastUsedAt: number;
+  // Optional for seamless upgrade from 0.1.3 session storage. Identity and the
+  // stable collision ordinal persist; native group ids do not survive Chrome.
+  ownerKey?: string;
+  groupBaseLabel?: string;
+  groupOrdinal?: number;
+  groupAppliedLabel?: string;
 }
 
 export interface SnapshotRef {

--- a/extension/src/tab-groups.ts
+++ b/extension/src/tab-groups.ts
@@ -50,6 +50,19 @@ async function tabOrUndefined(tabId: number): Promise<chrome.tabs.Tab | undefine
   try { return await chrome.tabs.get(tabId); } catch { return undefined; }
 }
 
+async function isAppliedGroup(surface: StoredSurface, groupId: number): Promise<boolean> {
+  if (surface.appliedGroupId !== groupId || !surface.groupAppliedLabel) return false;
+  try {
+    const group = await chrome.tabGroups.get(groupId);
+    // IDs can be recycled after browser/worker churn. Matching the exact title
+    // and colour LO last applied prevents a recycled personal group with the
+    // same numeric ID from becoming writable through stale session storage.
+    return group.title === surface.groupAppliedLabel && group.color === "cyan";
+  } catch {
+    return false;
+  }
+}
+
 async function allocateTitle(
   surface: StoredSurface,
   ownerKey: string,
@@ -94,7 +107,12 @@ async function existingSiblingGroup(
   for (const candidate of Object.values(await getSurfaces())) {
     if (candidate.tabId === surface.tabId || candidate.ownerKey !== ownerKey) continue;
     const tab = await tabOrUndefined(candidate.tabId);
-    if (tab?.windowId === windowId && typeof tab.groupId === "number" && tab.groupId !== NO_GROUP) {
+    if (
+      tab?.windowId === windowId
+      && typeof tab.groupId === "number"
+      && tab.groupId !== NO_GROUP
+      && await isAppliedGroup(candidate, tab.groupId)
+    ) {
       return tab.groupId;
     }
   }
@@ -115,9 +133,12 @@ export async function reconcileCommandTab(params: Record<string, unknown>): Prom
 /** Reconcile trusted session metadata with native browser chrome.
  *
  * `explicit` is reserved for open/resume. Ordinary commands update the title
- * of a still-grouped tab but respect manual ungrouping; open/resume is the
- * user's explicit rejoin point. Native group ids are deliberately rediscovered
- * from live tabs and never persisted because Chromium recycles them.
+ * only while the live group still matches the advisory ID LO persisted when it
+ * created/joined that group. A mismatch means the user moved the tab into a
+ * personal group, which must remain untouched. Open/resume may remove the tab
+ * from that personal group by creating/joining an LO-owned group, but it never
+ * updates the personal group itself. IDs remain advisory because Chromium can
+ * recycle them; a stale mismatch therefore fails safely until explicit resume.
  */
 export function reconcileTabGroup(
   surface: StoredSurface,
@@ -138,12 +159,15 @@ export function reconcileTabGroup(
       surface.groupOrdinal = allocation.ordinal;
 
       const grouped = typeof tab.groupId === "number" && tab.groupId !== NO_GROUP;
-      if (!grouped && !explicit && surface.groupAppliedLabel) {
+      const stillOwned = grouped && await isAppliedGroup(surface, tab.groupId);
+      if (!explicit && !stillOwned) {
+        // Covers both manual ungrouping and a move into a personal group. Never
+        // infer ownership from an LO-looking title: titles are user-controlled.
         await putSurface(surface);
         return;
       }
 
-      let groupId = grouped ? tab.groupId : undefined;
+      let groupId = stillOwned ? tab.groupId : undefined;
       let created = false;
       if (groupId === undefined) {
         const sibling = await existingSiblingGroup(surface, ownerKey, tab.windowId);
@@ -160,6 +184,7 @@ export function reconcileTabGroup(
         ...(created ? { collapsed: false } : {}),
       });
       surface.groupAppliedLabel = allocation.title;
+      surface.appliedGroupId = groupId;
       await putSurface(surface);
     } catch {
       // Grouping is never part of the browsing success contract. This also

--- a/extension/src/tab-groups.ts
+++ b/extension/src/tab-groups.ts
@@ -1,0 +1,169 @@
+import { getSurfaces, putSurface, resolveSurfaceToken, type StoredSurface } from "./state";
+
+const GROUP_PREFIX = "LO · ";
+const FALLBACK_LABEL = "Session";
+const MAX_LABEL_CLUSTERS = 30;
+const NO_GROUP = -1;
+
+/** Browser grouping is presentation only: every failure is swallowed so a
+ * missing, partial, or policy-disabled Chromium API can never block browsing. */
+let groupQueue: Promise<unknown> = Promise.resolve();
+function serialize<T>(op: () => Promise<T>): Promise<T> {
+  const run = groupQueue.catch(() => {}).then(op);
+  groupQueue = run;
+  return run;
+}
+
+function cleanLabel(value: unknown): string {
+  const raw = typeof value === "string" ? value : "";
+  // Defense in depth for older or non-Python bridge clients. C0/C1/DEL,
+  // direction controls, and zero-width format controls are all Unicode Cc/Cf.
+  const clean = raw
+    .replace(/\p{Cf}/gu, "")
+    .replace(/\p{Cc}/gu, (character) => (/\s/u.test(character) ? " " : ""))
+    .replace(/\s+/gu, " ")
+    .trim();
+  if (!clean) return FALLBACK_LABEL;
+  const segments = typeof Intl.Segmenter === "function"
+    ? [...new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(clean)].map((part) => part.segment)
+    : [...clean];
+  if (segments.length <= MAX_LABEL_CLUSTERS) return clean;
+  const hard = segments.slice(0, MAX_LABEL_CLUSTERS).join("").trimEnd();
+  const boundary = hard.lastIndexOf(" ");
+  return `${boundary >= 8 ? hard.slice(0, boundary).trimEnd() : hard}…`;
+}
+
+function trustedOwner(params: Record<string, unknown>): string {
+  const requester = typeof params.requester === "string" ? params.requester.trim() : "";
+  return requester.startsWith("session:") ? requester : "";
+}
+
+function baseTitle(params: Record<string, unknown>): string {
+  return `${GROUP_PREFIX}${cleanLabel(params.session_label)}`;
+}
+
+function appliedTitle(base: string, ordinal: number): string {
+  return ordinal > 1 ? `${base} (${ordinal})` : base;
+}
+
+async function tabOrUndefined(tabId: number): Promise<chrome.tabs.Tab | undefined> {
+  try { return await chrome.tabs.get(tabId); } catch { return undefined; }
+}
+
+async function allocateTitle(
+  surface: StoredSurface,
+  ownerKey: string,
+  wantedBase: string,
+): Promise<{ base: string; ordinal: number; title: string }> {
+  if (surface.ownerKey === ownerKey && surface.groupBaseLabel === wantedBase && surface.groupOrdinal) {
+    return {
+      base: wantedBase,
+      ordinal: surface.groupOrdinal,
+      title: appliedTitle(wantedBase, surface.groupOrdinal),
+    };
+  }
+
+  const surfaces = Object.values(await getSurfaces());
+  const sameOwner = surfaces.find((candidate) =>
+    candidate !== surface && candidate.ownerKey === ownerKey && candidate.groupBaseLabel === wantedBase && candidate.groupOrdinal
+  );
+  if (sameOwner?.groupOrdinal) {
+    return {
+      base: wantedBase,
+      ordinal: sameOwner.groupOrdinal,
+      title: appliedTitle(wantedBase, sameOwner.groupOrdinal),
+    };
+  }
+
+  const used = new Set(
+    surfaces
+      .filter((candidate) => candidate.ownerKey !== ownerKey && candidate.groupBaseLabel === wantedBase)
+      .map((candidate) => candidate.groupOrdinal)
+      .filter((ordinal): ordinal is number => typeof ordinal === "number" && ordinal > 0),
+  );
+  let ordinal = 1;
+  while (used.has(ordinal)) ordinal += 1;
+  return { base: wantedBase, ordinal, title: appliedTitle(wantedBase, ordinal) };
+}
+
+async function existingSiblingGroup(
+  surface: StoredSurface,
+  ownerKey: string,
+  windowId: number,
+): Promise<number | undefined> {
+  for (const candidate of Object.values(await getSurfaces())) {
+    if (candidate.tabId === surface.tabId || candidate.ownerKey !== ownerKey) continue;
+    const tab = await tabOrUndefined(candidate.tabId);
+    if (tab?.windowId === windowId && typeof tab.groupId === "number" && tab.groupId !== NO_GROUP) {
+      return tab.groupId;
+    }
+  }
+  return undefined;
+}
+
+/** Best-effort ordinary-command hook. Exact token lookup preserves the same
+ * capability boundary as command dispatch without changing recency or errors. */
+export async function reconcileCommandTab(params: Record<string, unknown>): Promise<void> {
+  try {
+    const surface = resolveSurfaceToken(params.tab, await getSurfaces());
+    if (surface) await reconcileTabGroup(surface, params, false);
+  } catch {
+    // The real command remains authoritative for stale-handle diagnostics.
+  }
+}
+
+/** Reconcile trusted session metadata with native browser chrome.
+ *
+ * `explicit` is reserved for open/resume. Ordinary commands update the title
+ * of a still-grouped tab but respect manual ungrouping; open/resume is the
+ * user's explicit rejoin point. Native group ids are deliberately rediscovered
+ * from live tabs and never persisted because Chromium recycles them.
+ */
+export function reconcileTabGroup(
+  surface: StoredSurface,
+  params: Record<string, unknown>,
+  explicit: boolean,
+): Promise<void> {
+  return serialize(async () => {
+    try {
+      if (typeof chrome.tabs.group !== "function" || typeof chrome.tabGroups?.update !== "function") return;
+      const ownerKey = trustedOwner(params);
+      if (!ownerKey) return;
+      const tab = await tabOrUndefined(surface.tabId);
+      if (!tab || tab.windowId === undefined) return;
+
+      const allocation = await allocateTitle(surface, ownerKey, baseTitle(params));
+      surface.ownerKey = ownerKey;
+      surface.groupBaseLabel = allocation.base;
+      surface.groupOrdinal = allocation.ordinal;
+
+      const grouped = typeof tab.groupId === "number" && tab.groupId !== NO_GROUP;
+      if (!grouped && !explicit && surface.groupAppliedLabel) {
+        await putSurface(surface);
+        return;
+      }
+
+      let groupId = grouped ? tab.groupId : undefined;
+      let created = false;
+      if (groupId === undefined) {
+        const sibling = await existingSiblingGroup(surface, ownerKey, tab.windowId);
+        groupId = sibling === undefined
+          ? await chrome.tabs.group({ tabIds: [surface.tabId] })
+          : await chrome.tabs.group({ groupId: sibling, tabIds: [surface.tabId] });
+        created = sibling === undefined;
+      }
+
+      // Omitting `collapsed` on updates preserves a user's collapsed group.
+      await chrome.tabGroups.update(groupId, {
+        title: allocation.title,
+        color: "cyan",
+        ...(created ? { collapsed: false } : {}),
+      });
+      surface.groupAppliedLabel = allocation.title;
+      await putSurface(surface);
+    } catch {
+      // Grouping is never part of the browsing success contract. This also
+      // covers group success followed by update rejection on managed browsers.
+    }
+  });
+}

--- a/extension/src/worker.ts
+++ b/extension/src/worker.ts
@@ -9,6 +9,7 @@ import { logs } from "./commands/logs";
 import { BridgeCommandError } from "./cdp";
 import { expireAccessRequest, resolveOrigin, setPendingObserver } from "./origins";
 import { DEFAULT_PORT, getLocal } from "./state";
+import { reconcileCommandTab } from "./tab-groups";
 import {
   RECONNECT_ALARM_NAME,
   RECONNECT_ALARM_PERIOD_MINUTES,
@@ -125,6 +126,9 @@ async function dispatch(request: { id: string; method: string; params: Record<st
   }
   activeRequestId = request.id;
   try {
+    // Rename propagation is presentation-only and deliberately precedes every
+    // owned-tab command; failures never mask the command's real result.
+    if (request.method !== "open") await reconcileCommandTab(request.params);
     const result = await handler(request.params, request.id);
     // Push the driven page so the daemon (and the Connected popup) can show
     // the human what the agent is on (finding U3).

--- a/extension/tests/release.test.mjs
+++ b/extension/tests/release.test.mjs
@@ -54,6 +54,12 @@ async function runRelease(args, handlers) {
   }
 }
 
+test("manifest requests tabGroups exactly once", async () => {
+  const manifest = JSON.parse(await readFile(new URL("../manifest.json", import.meta.url), "utf8"));
+  assert.equal(manifest.version, "0.1.4");
+  assert.equal(manifest.permissions.filter((permission) => permission === "tabGroups").length, 1);
+});
+
 test("store zip is allowlisted, source-map-free, and version-aligned", async () => {
   await run("node", ["build.mjs", "--zip"], { cwd: import.meta.dirname + "/.." });
   const validated = await run("bash", ["scripts/validate-store-zip.sh", "local-operator-extension.zip", VERSION], {

--- a/extension/tests/tab-groups.integration.test.mjs
+++ b/extension/tests/tab-groups.integration.test.mjs
@@ -36,18 +36,25 @@ function installChrome({ groupReject = false, updateReject = false, APIs = true 
         return id;
       } } : {}),
     },
-    ...(APIs ? { tabGroups: { update: async (id, options) => {
-      updateCalls.push([id, structuredClone(options)]);
-      if (updateReject) throw new Error("managed browser rejected title");
-      groups.set(id, { ...(groups.get(id) ?? { id }), ...options });
-      return groups.get(id);
-    } } } : {}),
+    ...(APIs ? { tabGroups: {
+      get: async (id) => { if (!groups.has(id)) throw new Error("dead group"); return { ...groups.get(id) }; },
+      update: async (id, options) => {
+        updateCalls.push([id, structuredClone(options)]);
+        if (updateReject) throw new Error("managed browser rejected title");
+        groups.set(id, { ...(groups.get(id) ?? { id }), ...options });
+        return groups.get(id);
+      },
+    } } : {}),
   };
   return {
     tabs, groups, groupCalls, updateCalls,
     seed: (surface, tab) => { surfaces[`bridge:${surface.tabId}:${surface.nonce}`] = structuredClone(surface); tabs.set(tab.id, { groupId: -1, ...tab }); },
     surface: (tabId) => Object.values(surfaces).find((surface) => surface.tabId === tabId),
     ungroup: (tabId) => { tabs.get(tabId).groupId = -1; },
+    moveToGroup: (tabId, groupId, group = { title: "Personal", color: "red", collapsed: true }) => {
+      tabs.get(tabId).groupId = groupId;
+      groups.set(groupId, { id: groupId, ...group });
+    },
     restore: () => { delete globalThis.chrome; },
   };
 }
@@ -135,6 +142,96 @@ test("defensive sanitizer never exposes requester or invisible controls", async 
     );
     assert.equal(chrome.groups.get(10).title, "LO · Session");
     assert.doesNotMatch(chrome.groups.get(10).title, /full-secret-uuid/);
+  } finally { await bundle.close(); chrome.restore(); }
+});
+
+test("ordinary rename never mutates a personal group after manual regrouping", async () => {
+  const chrome = installChrome();
+  const bundle = await loadModule();
+  try {
+    const owned = surface(1); chrome.seed(owned, { id: 1, windowId: 1 });
+    await bundle.loaded.reconcileTabGroup(owned, params("A", "Name"), true);
+    chrome.moveToGroup(1, 77);
+    const updatesBefore = chrome.updateCalls.length;
+
+    await bundle.loaded.reconcileTabGroup(chrome.surface(1), params("A", "Renamed"), false);
+
+    assert.equal(chrome.updateCalls.length, updatesBefore, "ordinary command must not update personal group");
+    assert.deepEqual(chrome.groups.get(77), {
+      id: 77,
+      title: "Personal",
+      color: "red",
+      collapsed: true,
+    });
+  } finally { await bundle.close(); chrome.restore(); }
+});
+
+test("explicit resume rejoins an LO group without mutating the personal group", async () => {
+  const chrome = installChrome();
+  const bundle = await loadModule();
+  try {
+    const owned = surface(1); chrome.seed(owned, { id: 1, windowId: 1 });
+    await bundle.loaded.reconcileTabGroup(owned, params("A", "Name"), true);
+    chrome.moveToGroup(1, 77);
+    const updatesBefore = chrome.updateCalls.length;
+
+    await bundle.loaded.reconcileTabGroup(chrome.surface(1), params("A", "Renamed"), true);
+
+    assert.deepEqual(chrome.groups.get(77), {
+      id: 77,
+      title: "Personal",
+      color: "red",
+      collapsed: true,
+    });
+    assert.equal(chrome.updateCalls.length, updatesBefore + 1);
+    assert.deepEqual(chrome.groupCalls.at(-1), { tabIds: [1] });
+    assert.equal(chrome.groups.get(11).title, "LO · Renamed");
+    assert.equal(chrome.surface(1).appliedGroupId, 11);
+  } finally { await bundle.close(); chrome.restore(); }
+});
+
+test("recycled advisory group id with personal metadata fails safe", async () => {
+  const chrome = installChrome();
+  const bundle = await loadModule();
+  try {
+    const stale = surface(1, {
+      ownerKey: "session:A",
+      groupBaseLabel: "LO · Name",
+      groupOrdinal: 1,
+      groupAppliedLabel: "LO · Name",
+      appliedGroupId: 88,
+    });
+    chrome.seed(stale, { id: 1, windowId: 1, groupId: 88 });
+    chrome.moveToGroup(1, 88);
+
+    await bundle.loaded.reconcileTabGroup(stale, params("A", "Renamed"), false);
+
+    assert.equal(chrome.updateCalls.length, 0);
+    assert.equal(chrome.groups.get(88).title, "Personal");
+  } finally { await bundle.close(); chrome.restore(); }
+});
+
+test("stale advisory group id fails safe until explicit resume", async () => {
+  const chrome = installChrome();
+  const bundle = await loadModule();
+  try {
+    const stale = surface(1, {
+      ownerKey: "session:A",
+      groupBaseLabel: "LO · Name",
+      groupOrdinal: 1,
+      groupAppliedLabel: "LO · Name",
+      appliedGroupId: 404,
+    });
+    chrome.seed(stale, { id: 1, windowId: 1, groupId: 88 });
+    chrome.moveToGroup(1, 88);
+
+    await bundle.loaded.reconcileTabGroup(stale, params("A", "Renamed"), false);
+    assert.equal(chrome.updateCalls.length, 0);
+    assert.equal(chrome.groups.get(88).title, "Personal");
+
+    await bundle.loaded.reconcileTabGroup(chrome.surface(1), params("A", "Renamed"), true);
+    assert.deepEqual(chrome.groupCalls, [{ tabIds: [1] }]);
+    assert.equal(chrome.groups.get(10).title, "LO · Renamed");
   } finally { await bundle.close(); chrome.restore(); }
 });
 

--- a/extension/tests/tab-groups.integration.test.mjs
+++ b/extension/tests/tab-groups.integration.test.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+async function loadModule() {
+  const dir = await mkdtemp(join(tmpdir(), "lop-tab-groups-it-"));
+  const outfile = join(dir, "module.mjs");
+  await build({ entryPoints: ["src/tab-groups.ts"], bundle: true, platform: "node", format: "esm", outfile });
+  return { loaded: await import(pathToFileURL(outfile) + `?${Date.now()}`), close: () => rm(dir, { recursive: true, force: true }) };
+}
+
+function installChrome({ groupReject = false, updateReject = false, APIs = true } = {}) {
+  let surfaces = {};
+  const tabs = new Map();
+  const groups = new Map();
+  const groupCalls = [];
+  const updateCalls = [];
+  let nextGroup = 10;
+  globalThis.chrome = {
+    storage: { session: {
+      get: async () => ({ surfaces }),
+      set: async (value) => { if (value.surfaces) surfaces = structuredClone(value.surfaces); },
+    } },
+    tabs: {
+      get: async (id) => { if (!tabs.has(id)) throw new Error("dead"); return { ...tabs.get(id) }; },
+      ...(APIs ? { group: async (options) => {
+        groupCalls.push(structuredClone(options));
+        if (groupReject) throw new Error("unsupported by policy");
+        const id = options.groupId ?? nextGroup++;
+        for (const tabId of options.tabIds) tabs.get(tabId).groupId = id;
+        groups.set(id, groups.get(id) ?? { id, collapsed: false });
+        return id;
+      } } : {}),
+    },
+    ...(APIs ? { tabGroups: { update: async (id, options) => {
+      updateCalls.push([id, structuredClone(options)]);
+      if (updateReject) throw new Error("managed browser rejected title");
+      groups.set(id, { ...(groups.get(id) ?? { id }), ...options });
+      return groups.get(id);
+    } } } : {}),
+  };
+  return {
+    tabs, groups, groupCalls, updateCalls,
+    seed: (surface, tab) => { surfaces[`bridge:${surface.tabId}:${surface.nonce}`] = structuredClone(surface); tabs.set(tab.id, { groupId: -1, ...tab }); },
+    surface: (tabId) => Object.values(surfaces).find((surface) => surface.tabId === tabId),
+    ungroup: (tabId) => { tabs.get(tabId).groupId = -1; },
+    restore: () => { delete globalThis.chrome; },
+  };
+}
+
+const surface = (tabId, extra = {}) => ({ tabId, nonce: `nonce${tabId}`, epoch: 1, createdAt: tabId, lastUsedAt: tabId, ...extra });
+const params = (owner, label) => ({ requester: `session:${owner}`, session_label: label });
+
+for (const options of [{ APIs: false }, { groupReject: true }, { updateReject: true }]) {
+  test(`group API failure stays best-effort ${JSON.stringify(options)}`, async () => {
+    const chrome = installChrome(options);
+    const bundle = await loadModule();
+    try {
+      const owned = surface(1); chrome.seed(owned, { id: 1, windowId: 1, active: false });
+      await assert.doesNotReject(bundle.loaded.reconcileTabGroup(owned, params("A", "Planning"), true));
+      assert.equal((await chrome.tabs.get(1)).active, false); // grouping never activates the tab
+    } finally { await bundle.close(); chrome.restore(); }
+  });
+}
+
+test("same owner joins per-window groups without expanding existing groups", async () => {
+  const chrome = installChrome();
+  const bundle = await loadModule();
+  try {
+    const one = surface(1); const two = surface(2); const otherWindow = surface(3);
+    chrome.seed(one, { id: 1, windowId: 7, active: false });
+    chrome.seed(two, { id: 2, windowId: 7, active: false });
+    chrome.seed(otherWindow, { id: 3, windowId: 8, active: false });
+    await bundle.loaded.reconcileTabGroup(one, params("A", "Planning"), true);
+    chrome.groups.get(10).collapsed = true;
+    await bundle.loaded.reconcileTabGroup(two, params("A", "Planning"), true);
+    await bundle.loaded.reconcileTabGroup(otherWindow, params("A", "Planning"), true);
+    assert.deepEqual(chrome.groupCalls, [
+      { tabIds: [1] },
+      { groupId: 10, tabIds: [2] },
+      { tabIds: [3] },
+    ]);
+    assert.equal(chrome.groups.get(10).collapsed, true);
+    assert.equal(chrome.groups.get(11).title, "LO · Planning");
+    assert.equal(chrome.updateCalls[1][1].collapsed, undefined, "joining must preserve collapsed state");
+  } finally { await bundle.close(); chrome.restore(); }
+});
+
+test("duplicate labels get stable owner ordinals and rename updates in place", async () => {
+  const chrome = installChrome();
+  const bundle = await loadModule();
+  try {
+    const a = surface(1); const b = surface(2);
+    chrome.seed(a, { id: 1, windowId: 1 }); chrome.seed(b, { id: 2, windowId: 1 });
+    await bundle.loaded.reconcileTabGroup(a, params("A", "Same"), true);
+    await bundle.loaded.reconcileTabGroup(b, params("B", "Same"), true);
+    assert.equal(chrome.groups.get(10).title, "LO · Same");
+    assert.equal(chrome.groups.get(11).title, "LO · Same (2)");
+    assert.equal(chrome.surface(2).groupOrdinal, 2);
+    await bundle.loaded.reconcileTabGroup(b, params("B", "Renamed"), false);
+    assert.equal(chrome.groups.get(11).title, "LO · Renamed");
+    assert.equal(chrome.groupCalls.length, 2, "rename must not create/rejoin a group");
+  } finally { await bundle.close(); chrome.restore(); }
+});
+
+test("old stored surfaces backfill metadata and ignore dead siblings", async () => {
+  const chrome = installChrome();
+  const bundle = await loadModule();
+  try {
+    const old = surface(1); // exact 0.1.3 shape: no owner/group fields
+    const dead = surface(99, { ownerKey: "session:A", groupBaseLabel: "LO · Name", groupOrdinal: 1 });
+    chrome.seed(old, { id: 1, windowId: 1 });
+    chrome.seed(dead, { id: 99, windowId: 1 });
+    chrome.tabs.delete(99);
+    await bundle.loaded.reconcileTabGroup(old, params("A", "Name"), true);
+    assert.equal(chrome.surface(1).ownerKey, "session:A");
+    assert.equal(chrome.surface(1).groupAppliedLabel, "LO · Name");
+    assert.deepEqual(chrome.groupCalls, [{ tabIds: [1] }]);
+  } finally { await bundle.close(); chrome.restore(); }
+});
+
+test("defensive sanitizer never exposes requester or invisible controls", async () => {
+  const chrome = installChrome();
+  const bundle = await loadModule();
+  try {
+    const owned = surface(1); chrome.seed(owned, { id: 1, windowId: 1 });
+    await bundle.loaded.reconcileTabGroup(
+      owned,
+      { requester: "session:full-secret-uuid", session_label: " \u202e\u200b  " },
+      true,
+    );
+    assert.equal(chrome.groups.get(10).title, "LO · Session");
+    assert.doesNotMatch(chrome.groups.get(10).title, /full-secret-uuid/);
+  } finally { await bundle.close(); chrome.restore(); }
+});
+
+test("ordinary command respects manual ungrouping while resume rejoins", async () => {
+  const chrome = installChrome();
+  const bundle = await loadModule();
+  try {
+    const owned = surface(1); chrome.seed(owned, { id: 1, windowId: 1 });
+    await bundle.loaded.reconcileTabGroup(owned, params("A", "Name"), true);
+    chrome.ungroup(1);
+    await bundle.loaded.reconcileTabGroup(chrome.surface(1), params("A", "Renamed"), false);
+    assert.equal(chrome.groupCalls.length, 1, "ordinary commands respect manual ungrouping");
+    await bundle.loaded.reconcileTabGroup(chrome.surface(1), params("A", "Renamed"), true);
+    assert.equal(chrome.groupCalls.length, 2, "explicit resume is the rejoin point");
+  } finally { await bundle.close(); chrome.restore(); }
+});

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -600,6 +600,9 @@ class ToolContext(BaseModel):
 
     cwd: str = "."
     session_id: str = ""
+    # Human-readable title is display metadata only. Security-sensitive tools
+    # must continue using ``session_id`` for identity and authorization.
+    session_name: str = ""
     agent_id: str = ""
     # Which BACKGROUND JOB this execution belongs to, so a host can scope an
     # approval decision to the work that provoked it instead of to every

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -4364,6 +4364,9 @@ class Session:
         return ToolContext(
             cwd=self._cwd,
             session_id=self._session_id,
+            # Re-read the live holder every turn so generated, user-set, and
+            # resumed titles reach display-only browser metadata after renames.
+            session_name=self.conversation_name,
             agent_id=self._agent_id,
             has_ui=self._has_ui,
             resolve_internal_url=self._skill_resolver,

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -54,6 +54,7 @@ import signal as signal_module
 import threading
 import time
 import traceback
+import unicodedata
 from collections.abc import Awaitable, Callable, Iterator
 from datetime import UTC, datetime
 from pathlib import Path
@@ -5650,6 +5651,54 @@ def _browser_requester(context: ToolContext | None, tool_call_id: str) -> str:
     return f"call:{tool_call_id}"
 
 
+_BROWSER_SESSION_LABEL_CLUSTERS = 30
+
+
+def _browser_session_label(context: ToolContext | None) -> str:
+    """Display-only session title safe for compact browser chrome.
+
+    The extension receives identity separately, so this value may never fall
+    back to a UUID or request token. Removing all control/format characters is
+    intentionally broader than the known bidi and zero-width set: browser tab
+    chrome is too small to make invisible direction changes attributable.
+    """
+    raw = context.session_name if context is not None else ""
+    cleaned = "".join(
+        " " if char.isspace() else char
+        for char in raw
+        if unicodedata.category(char) not in {"Cf"}
+        and not (unicodedata.category(char) == "Cc" and not char.isspace())
+    )
+    cleaned = " ".join(cleaned.split())
+    if not cleaned:
+        return "Session"
+
+    clusters: list[str] = []
+    for char in cleaned:
+        if clusters and (unicodedata.combining(char) or unicodedata.category(char) == "Sk"):
+            clusters[-1] += char
+        else:
+            clusters.append(char)
+    if len(clusters) <= _BROWSER_SESSION_LABEL_CLUSTERS:
+        return cleaned
+
+    clipped = "".join(clusters[:_BROWSER_SESSION_LABEL_CLUSTERS]).rstrip()
+    # Prefer a complete word when that still leaves a useful title; long words
+    # fall back to the grapheme-safe hard boundary rather than an empty label.
+    word_boundary = clipped.rfind(" ")
+    if word_boundary >= 8:
+        clipped = clipped[:word_boundary].rstrip()
+    return f"{clipped}…" if clipped else "Session"
+
+
+def _browser_identity_params(context: ToolContext | None, tool_call_id: str) -> dict[str, str]:
+    """Trusted wire metadata; model/browser arguments cannot override it."""
+    return {
+        "requester": _browser_requester(context, tool_call_id),
+        "session_label": _browser_session_label(context),
+    }
+
+
 async def _bridge_call(
     tool_call_id: str,
     action: str,
@@ -5694,10 +5743,9 @@ async def _bridge_open(
     # hijack another's tab mid-task when agents ran in parallel.
     params: dict[str, Any] = {
         "url": raw_url.strip(),
-        # The approval-binding identity — see _browser_requester. The
-        # extension uses it to decide whether a stored once-grant belongs to
-        # THIS navigation's session.
-        "requester": _browser_requester(context, tool_call_id),
+        # Identity and display metadata are both host-derived. The requester
+        # remains the only authorization key; the label is untrusted display.
+        **_browser_identity_params(context, tool_call_id),
     }
     resuming = state.surface_id.startswith("bridge:")
     if resuming:
@@ -5712,7 +5760,11 @@ async def _bridge_open(
         # the recovery verb — same contract as the cmux path — so drop the
         # dead handle and create a fresh tab instead of surfacing the error.
         state.surface_id = ""
-        result, problem = await _bridge_call(tool_call_id, "open", {"url": raw_url.strip()})
+        result, problem = await _bridge_call(
+            tool_call_id,
+            "open",
+            {"url": raw_url.strip(), **_browser_identity_params(context, tool_call_id)},
+        )
     if problem is not None:
         return problem
     assert result is not None
@@ -5800,10 +5852,10 @@ async def _bridge_access(
     would deadlock the recovery path."""
     url = params.url.strip()
     # The approval-binding identity — see _browser_requester.
-    requester = _browser_requester(context, tool_call_id)
+    identity = _browser_identity_params(context, tool_call_id)
     if action == "request_access":
         result, problem = await _bridge_call(
-            tool_call_id, "request_access", {"url": url, "requester": requester}
+            tool_call_id, "request_access", {"url": url, **identity}
         )
         if problem is not None:
             return problem
@@ -5837,7 +5889,7 @@ async def _bridge_access(
         wire = {
             "url": url,
             "timeout_ms": min(remaining_ms, _BRIDGE_AWAIT_SLICE_MS),
-            "requester": requester,
+            **identity,
         }
         result, problem = await _bridge_call(tool_call_id, "await_access", wire)
         if problem is not None:
@@ -5986,9 +6038,9 @@ async def _bridge_action(
     surface = state.surface_id
     wire: dict[str, Any] = {
         "tab": surface,
-        # Approval-binding identity (see _browser_requester): goto's
-        # top-level admission consults it for once-grants.
-        "requester": _browser_requester(context, tool_call_id),
+        # Approval identity and display metadata stay host-derived on every
+        # command so a rename can update an existing native group in place.
+        **_browser_identity_params(context, tool_call_id),
     }
     if action == "goto":
         wire["url"] = params.url.strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.7"
+version = "0.42.8"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/browser_bridge/test_tool_selection.py
+++ b/tests/unit/browser_bridge/test_tool_selection.py
@@ -174,6 +174,7 @@ async def test_scroll_wire_params_only_set_fields(monkeypatch) -> None:
     assert captured["params"] == {
         "tab": "bridge:9:nonce",
         "requester": "call:t",
+        "session_label": "Session",
         "y": 400.0,
     }
     # Result reports the landing position and that more remains below.
@@ -389,7 +390,11 @@ async def test_request_access_works_without_a_surface(monkeypatch) -> None:
         assert action == "request_access"
         # The tool binds the approval to an identity (session when the host
         # provides one, else the tool call id — never anonymous).
-        assert params == {"url": "https://example.com", "requester": "call:t"}
+        assert params == {
+            "url": "https://example.com",
+            "requester": "call:t",
+            "session_label": "Session",
+        }
         return {"origin": "https://example.com", "state": "pending"}, None
 
     monkeypatch.setattr(builtin, "_bridge_call", fake_call)
@@ -510,6 +515,74 @@ async def test_session_identity_is_stable_across_the_whole_flow(monkeypatch) -> 
     assert [entry[0] for entry in seen] == ["request_access", "await_access", "open"]
     identities = {entry[1] for entry in seen}
     assert identities == {"session:sess-42"}, f"identity drifted: {seen}"
+
+
+@pytest.mark.asyncio
+async def test_browser_session_label_is_sanitized_and_host_derived(monkeypatch) -> None:
+    monkeypatch.setattr(builtin, "cmux_browser_available", lambda: False)
+    monkeypatch.setattr(builtin, "bridge_browser_available", lambda: True)
+    seen: list[dict[str, Any]] = []
+
+    async def fake_call(tool_call_id, action, params, *, surface=""):
+        seen.append(dict(params))
+        return {"tab": "bridge:5:n0nce", "url": "https://example.com/", "title": "x"}, None
+
+    monkeypatch.setattr(builtin, "_bridge_call", fake_call)
+    context = ToolContext(
+        session_id="secret-session-uuid",
+        session_name="  Q1\u202e launch\u200b   notes " + "🙂" * 40,
+        browser=BrowserSurface(),
+    )
+    result = await builtin.execute_browser(
+        "call-1",
+        {
+            "action": "open",
+            "url": "https://example.com",
+            # BrowserParams forbids these model-controlled overrides entirely.
+        },
+        None,
+        None,
+        context,
+    )
+    assert not result.is_error
+    assert seen[0]["requester"] == "session:secret-session-uuid"
+    assert seen[0]["session_label"] == "Q1 launch notes…"
+    assert "secret-session-uuid" not in seen[0]["session_label"]
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("", "Session"),
+        ("\x00\x7f\x85\u202d\u2066\ufeff", "Session"),
+        ("  one\t two\nthree  ", "one two three"),
+        ("e\u0301" * 31, "e\u0301" * 30 + "…"),
+    ],
+)
+def test_browser_session_label_edge_cases(name: str, expected: str) -> None:
+    assert builtin._browser_session_label(ToolContext(session_name=name)) == expected
+
+
+@pytest.mark.asyncio
+async def test_rename_changes_label_without_changing_requester(monkeypatch) -> None:
+    monkeypatch.setattr(builtin, "cmux_browser_available", lambda: False)
+    monkeypatch.setattr(builtin, "bridge_browser_available", lambda: True)
+    seen: list[tuple[str, str]] = []
+
+    async def fake_call(tool_call_id, action, params, *, surface=""):
+        seen.append((str(params["requester"]), str(params["session_label"])))
+        return {"origin": "https://example.com", "state": "pending"}, None
+
+    monkeypatch.setattr(builtin, "_bridge_call", fake_call)
+    context = ToolContext(session_id="same", session_name="Before", browser=BrowserSurface())
+    await builtin.execute_browser(
+        "t1", {"action": "request_access", "url": "https://example.com"}, None, None, context
+    )
+    context.session_name = "After"
+    await builtin.execute_browser(
+        "t2", {"action": "request_access", "url": "https://example.com"}, None, None, context
+    )
+    assert seen == [("session:same", "Before"), ("session:same", "After")]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -469,6 +469,16 @@ async def test_abort_emits_aborted_agent_end(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_tool_context_carries_live_conversation_name(tmp_path) -> None:
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream)
+    assert session._build_tool_context().session_name == ""
+    session.set_conversation_name("Release planning")
+    assert session._build_tool_context().session_name == "Release planning"
+    await session.dispose()
+
+
+@pytest.mark.asyncio
 async def test_yolo_disables_approval(tmp_path):
     stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")]])
     approvals: list[str] = []


### PR DESCRIPTION
## Summary

- groups extension-created tabs in native Chromium tab groups by trusted Local Operator session identity
- titles groups from the live conversation name through a twice-sanitized, display-only label; duplicate names receive stable browser-lifetime ordinals
- keeps grouping best-effort and focus-neutral, preserves manually collapsed groups, respects manual ungrouping until explicit resume, and leaves existing multi-session isolation/redaction/cleanup behavior intact
- bumps Local Operator to `0.42.8` and the browser extension to `0.1.4`

## Delivery contract

Fresh extension opens still create `about:blank` with `active:false`, persist the nonce-bearing surface, attach CDP, and start log capture before grouping and destination navigation. Group API absence or rejection is swallowed, including `tabGroups.update` rejection after `tabs.group` succeeds. The implementation adds no focus-capable API and never calls `tabs.update({active:true})`, `windows.update({focused:true})`, `tabGroups.move`, or global title-based group adoption.

Group ownership uses only the host-derived `requester=session:<session_id>`. The visible `session_label` comes only from `ToolContext.session_name`, is sanitized in Python and again in the extension, and never falls back to a nonce, UUID, request id, cwd, prompt, or URL. Existing 0.1.3 stored surfaces backfill optional metadata in place; native group IDs are not persisted.

## Non-goals

- no popup management UI
- no grouping or enumeration of unrelated tabs/groups
- no change to the site approval, surface capability, or redacted `tabs` listing contracts
- no release, merge, or local runtime update in this PR

## Chrome Web Store impact

Extension 0.1.4 adds exactly one permission: `tabGroups`.

> Used only to title and visually group tabs created and owned by Local Operator. The extension does not enumerate or alter unrelated tab groups, move groups between windows, or use group membership for browsing-history collection.

`docs/store/permissions.md` contains the paste-ready declaration, and `docs/store/submission-checklist.md` explicitly calls out that Damian must add the new justification when uploading the next package.

## Testing

### Extension

- `pnpm --dir extension typecheck` ✅
- `pnpm --dir extension test` ✅ 45 tests
- `pnpm --dir extension build` ✅
- `pnpm --dir extension build:zip` ✅
- `bash extension/scripts/validate-store-zip.sh extension/local-operator-extension.zip 0.1.4` ✅, 12 files, no source maps
- `.venv/bin/python -m local_operator.browser_bridge.gen_ts --check` ✅ protocol unchanged

Coverage includes absent/rejecting group APIs, update rejection after group creation, inactive tabs, same-owner same-window joining, separate windows, duplicate-name ordinals, rename-in-place, collapsed-state preservation, 0.1.3 backfill, manual ungroup/rejoin policy, dead siblings, and defensive title sanitization.

### Python

- focused browser/session tests: `136 passed`
- targeted pyright on changed Python modules/tests: `0 errors, 0 warnings, 0 informations`
- full `flake8 .`, Black 26.1.0 check, and isort 5.13.2 check ✅
- whole-tree pyright was terminated after 24 minutes of sustained CPU while another worktree also ran pyright; this was shared-machine contention, not a diagnostic result. The parent will serialize the final whole-tree run.
- full unit suite completed: `7301 passed, 7 skipped`; 25 unrelated environment failures came from the shared `.venv` launcher retaining a deleted worktree shebang (`ModuleNotFoundError: local_operator` in eval-worker subprocesses) plus one pre-existing TUI shell-card race. Changed focused suites are green.

## Real browser E2E

Loaded the built 0.1.4 extension via `Extensions.loadUnpacked` into a temporary Google Chrome profile, paired it to a temporary daemon on port 4199, and exercised real bridge calls for:

- five separately identified sessions
- two distinct names
- duplicate `Release planning` collision
- generic empty-label fallback
- long Unicode label
- rename through ordinary `goto`
- explicit resume
- close/dead prune
- service-worker target termination, wake, reconnect, and subsequent `goto`
- redacted `tabs` listings before and after close

Chrome's native API state showed cyan groups titled `LO · Release planning`, `LO · Renamed review`, `LO · Session`, and `LO · 世界 launch notes with a…`; every driven tab remained `active:false`, the browser window remained `focused:false`, and the collapsed `Release planning` group stayed collapsed after worker restart and ordinary navigation. Raw responses and Chrome-native state are in `docs/evidence/session-tab-groups/`.

### Native browser-chrome still limitation

A non-activating `screencapture -x` still was attempted after confirming `focused:false`. macOS denied Screen Recording to this process (`could not create image from display`), and CoreGraphics window enumeration was empty under the same privacy gate. No fake tab strip was fabricated. `native-state.json` records Chrome's real native groups and window focus state; a visual still requires granting this process Screen Recording and rerunning capture.

## Rollback

Revert this PR and publish a subsequent patch. Stored grouping fields are optional and ignored by 0.1.3; Chromium removes empty groups natively, and no authoritative native group IDs or data migrations are introduced.
