### PR TITLE
chore(release): bump version to 0.42.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.8"
+version = "0.42.9"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## What

Bumps Local Operator from 0.42.8 to 0.42.9 for the merged browser-extension feature batch:

- #353 native session tab groups
- #352 explicit loopback all-port grants and exact-port cleanup
- #355 concurrent approval queue, cancellation, numbered action badge, and robust notifications

Extension package remains v0.1.4 and was built/validated separately from merged main.

## Testing

- parsed project metadata: `0.42.9`
- `pytest tests/unit/test_update.py tests/unit/test_import_graph.py tests/unit/test_cli_style.py`: 56 passed
- feature PRs individually passed full CI, current-head agent code review, and user-visible design/UX gates; requester manually validated the combined build in real Chrome

The shared editable `.venv/bin/local-operator` shebang currently points at a deleted unrelated performance worktree, so that checkout-local console launcher cannot be used for the smoke. The stable global `lop` install is independent and will be rebuilt/smoked after merge per AGENTS.md.