### PR TITLE
fix(tui): keep compacted context reading settled

### DIFF
--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -895,6 +895,10 @@ class AgentEndEvent(AgentEvent[Literal["agent_end"]]):
     aborted: bool = False
     error: str | None = None
     generation: int = 0
+    # A post-turn compaction happens after the loop creates this event but before
+    # the session releases it. Keep the billed messages intact while letting the
+    # session replace their now-invalid pre-compaction occupancy reading.
+    context_tokens: int | None = None
 
 
 class TurnStartEvent(AgentEvent[Literal["turn_start"]]):

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -1096,6 +1096,21 @@ class FrontendStateStore:
         # breakdown on every unrelated mutation would serialize the unbounded
         # tool inventory on the session loop.
         context_breakdown = current.context_breakdown
+        # A compaction creates a newer occupancy estimate than the last provider
+        # receipt while that receipt remains authoritative for billing. Generic
+        # source refreshes run after `agent_end`; replaying the unchanged receipt
+        # there caused every frontend to paint `tokens_after` and then rebound to
+        # the pre-pass level. Only a genuinely newer receipt may supersede it.
+        receipt_context = getattr(last_usage, "context_tokens", None) if last_usage else None
+        current_receipt_context = (
+            current.last_usage.context_tokens if current.last_usage is not None else None
+        )
+        preserve_settled_context = bool(
+            current.context_is_estimate
+            and current.context_tokens
+            and receipt_context
+            and receipt_context == current_receipt_context
+        )
         changes = dict(
             cwd=str(getattr(session, "cwd", "") or getattr(session, "_cwd", "") or os.getcwd()),
             conversation_title=title,
@@ -1112,15 +1127,12 @@ class FrontendStateStore:
             last_usage=(
                 last_usage.model_dump(mode="json") if isinstance(last_usage, Usage) else last_usage
             ),
-            context_tokens=(
-                getattr(last_usage, "context_tokens", None)
-                if last_usage
-                else current.context_tokens
-            ),
+            context_tokens=(current.context_tokens if preserve_settled_context else receipt_context)
+            or current.context_tokens,
             context_is_estimate=(
-                False
-                if isinstance(last_usage, Usage) and last_usage.context_tokens
-                else current.context_is_estimate
+                current.context_is_estimate
+                if preserve_settled_context
+                else False if receipt_context else current.context_is_estimate
             ),
             context_window=(
                 getattr(effective, "context_window", None) if effective is not None else None
@@ -1295,11 +1307,18 @@ class FrontendStateStore:
                 elif any(u.input_tokens or u.output_tokens for u in usages):
                     changes["cost_knowledge"] = CostKnowledge.PARTIAL
                     changes["current_turn_accrued_cost"] = 0.0
+                # `messages` remain the billing authority even when a post-turn
+                # compaction invalidates their occupancy. The session stamps the
+                # settled level separately so this late boundary cannot rebound a
+                # frontend to the provider reading from before the rewrite.
+                settled_context = event.context_tokens or aggregate.context_tokens
                 changes.update(
                     last_usage=aggregate.model_dump(mode="json"),
-                    context_tokens=aggregate.context_tokens,
+                    context_tokens=settled_context,
                     context_is_estimate=(
-                        False if aggregate.context_tokens else state.context_is_estimate
+                        True
+                        if event.context_tokens is not None
+                        else False if aggregate.context_tokens else state.context_is_estimate
                     ),
                 )
         elif (

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1455,6 +1455,10 @@ class Session:
         # whether the run continues, `_logical_generation` remembers which
         # agent_start the eventual end belongs to. Both are None outside a run.
         self._held_end: AgentEndEvent | None = None
+        # The loop's held end owns billing, but a later post-turn compaction owns
+        # occupancy. Carry that newer level to the boundary without rewriting the
+        # usage objects that lifetime cost and analytics still need.
+        self._held_context_tokens: int | None = None
         self._abort_requested = False  # sticky across the continuation gap
         # Last completed provider request (epoch ms). Distinct from
         # _last_activity_ms: the idle-flush pruning must measure provider-cache
@@ -4038,15 +4042,18 @@ class Session:
         """Emit the boundary event the pipeline was holding, if any."""
         held = self._held_end
         self._held_end = None
+        context_tokens = self._held_context_tokens
+        self._held_context_tokens = None
         if held is None:
             return
         generation = self._logical_generation or held.generation
         self._logical_generation = None
-        await self._emit(
-            held
-            if held.generation == generation
-            else held.model_copy(update={"generation": generation})
-        )
+        changes: dict[str, Any] = {}
+        if held.generation != generation:
+            changes["generation"] = generation
+        if context_tokens is not None:
+            changes["context_tokens"] = context_tokens
+        await self._emit(held if not changes else held.model_copy(update=changes))
 
     async def _run_turn(
         self,
@@ -5043,6 +5050,11 @@ class Session:
         outcome = await self._run_compaction(planned, reason="context-window")
         if not outcome.ran:
             return
+        # The provider usage in `_held_end.messages` remains authoritative for
+        # BILLING, but its occupancy predates this pass. If it is allowed to win
+        # the later agent-end reduction, every frontend briefly paints `after`
+        # from compaction_end and then rebounds to `before` at turn settlement.
+        self._held_context_tokens = outcome.tokens_after
 
         # (5) Recovery band: only schedule a continuation when the pass
         # actually created headroom (an anti-thrash guard).

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -4162,6 +4162,12 @@ class Session:
                         # end. Continuation runs re-enter here and are silent.
                         self._logical_generation = event.generation
                         await self._emit(event)
+                    else:
+                        # A continuation's provider receipt is newer than the
+                        # estimate produced between runs. Demote that estimate
+                        # as soon as the later request begins so the eventual
+                        # held end can expose its own authoritative occupancy.
+                        self._held_context_tokens = None
                     continue
                 if isinstance(event, AgentEndEvent):
                     new_messages = list(event.messages)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -14467,10 +14467,11 @@ class OperatorApp(App[None]):
         self._status.update(
             streaming=False,
             context_tokens=context_tokens,
-            # The provider's own prompt_tokens: exact, and it supersedes the
-            # boot estimate permanently. `None` leaves the flag alone, so a turn
-            # that reported no usage does not demote a standing estimate.
-            context_is_estimate=None if context_tokens is None else False,
+            # Ordinarily this is the provider's exact prompt_tokens. A post-turn
+            # compaction replaces that now-invalid occupancy with its local
+            # settled estimate while preserving the turn's provider bill.
+            # `None` leaves the flag alone when the turn reported no usage.
+            context_is_estimate=(None if context_tokens is None else message.context_is_estimate),
             context_window=_context_window(self._session),
             cost=cost_text,
         )

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -97,12 +97,14 @@ class TurnEnded(Message):
         *,
         context_tokens: int = 0,
         usage: Any = None,
+        context_is_estimate: bool = False,
     ) -> None:
         super().__init__()
         self.aborted = aborted
         self.error = error
         self.context_tokens = context_tokens
         self.usage = usage
+        self.context_is_estimate = context_is_estimate
 
 
 class ContextUsageReported(Message):
@@ -540,12 +542,16 @@ class EventController:
                 context_tokens=context_tokens or None,
                 cost_components=cost_components,
             )
+        # The aggregate still prices the calls. A post-turn compaction can stamp
+        # a newer occupancy level on the boundary without corrupting that bill.
+        settled_context = getattr(event, "context_tokens", None)
         self._post(
             TurnEnded(
                 getattr(event, "aborted", False),
                 getattr(event, "error", None),
-                context_tokens=context_tokens,
+                context_tokens=(settled_context if settled_context is not None else context_tokens),
                 usage=usage,
+                context_is_estimate=settled_context is not None,
             )
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.9"
+version = "0.42.10"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.8"
+version = "0.42.9"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/session/test_frontend_state.py
+++ b/tests/unit/session/test_frontend_state.py
@@ -193,6 +193,36 @@ def test_compaction_semantics_replace_context_and_preserve_lifetime_cost() -> No
     assert store.state.cumulative_parent_cost == 8.5
 
 
+def test_post_compaction_agent_end_keeps_settled_occupancy_and_provider_bill() -> None:
+    """A held boundary is emitted after automatic compaction, so its message
+    usage is older than the context it closes. Occupancy follows the stamped
+    post-pass level while billing still consumes the provider's real receipt.
+    """
+    store = FrontendStateStore(
+        _state(
+            cumulative_parent_cost=8.5,
+            context_tokens=590_400,
+            last_usage=Usage(context_tokens=590_400),
+        )
+    )
+    usage = Usage(context_tokens=590_400, input_tokens=590_400, output_tokens=1_000, usd_cost=2.5)
+    session = SimpleNamespace(effective_model=_spec(), restored_usage=lambda: usage)
+
+    store.observe_event(
+        session,
+        AgentEndEvent(
+            messages=[Message.assistant("done", usage=usage)],
+            context_tokens=131_100,
+        ),
+    )
+
+    assert store.state.context_tokens == 131_100
+    assert store.state.context_is_estimate is True
+    assert store.state.last_usage is not None
+    assert store.state.last_usage.context_tokens == 590_400
+    assert store.state.cumulative_parent_cost == pytest.approx(11.0)
+
+
 def test_real_async_job_roundtrips_progress_trajectory_and_accounting() -> None:
     job = AsyncJob(
         id="child-1",

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -1477,6 +1477,62 @@ async def test_compaction_continuation_emits_one_run_boundary(tmp_path, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_continuation_provider_usage_supersedes_compaction_estimate(tmp_path, monkeypatch):
+    """Exercise the production boundary order: the first provider run ends,
+    post-turn compaction stamps its estimate, and default auto-continuation runs
+    the provider again before the one logical agent end is released. The later
+    receipt must own occupancy; the estimate only bridges the gap between runs.
+    """
+    stream = ScriptedStream(
+        [
+            [
+                StreamTextDelta(delta="first"),
+                StreamEndEvent(
+                    stop_reason="stop",
+                    usage=Usage(input_tokens=590_400, context_tokens=590_400),
+                ),
+            ],
+            [
+                StreamTextDelta(delta="resumed"),
+                StreamEndEvent(
+                    stop_reason="stop",
+                    usage=Usage(input_tokens=171_000, context_tokens=171_000),
+                ),
+            ],
+        ]
+    )
+    session = make_session(tmp_path, stream)
+    compactions = 0
+
+    async def fake_compact() -> None:
+        nonlocal compactions
+        compactions += 1
+        if compactions == 1:
+            session._held_context_tokens = 131_100
+            session._continuation_queue.append(Message.user("continue"))
+
+    monkeypatch.setattr(session, "_maybe_compact", fake_compact)
+    ends: list[AgentEndEvent] = []
+    session.subscribe(
+        lambda event: ends.append(event) if isinstance(event, AgentEndEvent) else None
+    )
+
+    await session.prompt("do the thing")
+
+    assert len(stream.requests) == 2
+    assert len(ends) == 1
+    assert ends[0].context_tokens is None
+    continuation = next(
+        message
+        for message in reversed(ends[0].messages)
+        if isinstance(message, Message) and message.usage is not None
+    )
+    assert continuation.usage is not None
+    assert continuation.usage.context_tokens == 171_000
+    await session.dispose()
+
+
+@pytest.mark.asyncio
 async def test_the_auto_continuation_prompt_is_never_announced_as_user(tmp_path, monkeypatch):
     """The post-compaction continuation is harness chrome, not the user's words.
 

--- a/tests/unit/tui/test_compact_command.py
+++ b/tests/unit/tui/test_compact_command.py
@@ -365,6 +365,36 @@ async def test_the_receipt_falls_back_when_there_are_no_figures() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_post_compaction_turn_end_cannot_rebound_the_band() -> None:
+    """Automatic compaction settles before the held agent end. That boundary
+    must carry the post-pass occupancy while retaining the pre-pass usage for
+    billing; otherwise the footer visibly jumps back to 53.7% after showing
+    11.9% and the canonical state teaches attached terminals the same lie.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        assert app._status is not None
+        app._status.update(context_tokens=131_100, context_is_estimate=True)
+        app.on_turn_ended(
+            TurnEnded(
+                False,
+                None,
+                context_tokens=131_100,
+                context_is_estimate=True,
+                usage=None,
+            )
+        )
+        await pilot.pause()
+        tokens = app._status.context_tokens
+        estimated = app._status.context_is_estimate
+
+    assert tokens == 131_100
+    assert estimated is True
+
+
+@pytest.mark.asyncio
 async def test_the_band_reading_drops_by_what_the_pass_saved() -> None:
     """The band reports the next request's size, and a compaction changes only
     the history — so the saving transfers exactly. Left alone the reading would


### PR DESCRIPTION
## Summary

Fix the context footer rebounding to its pre-compaction occupancy after an automatic compaction. The compaction result now remains authoritative for occupancy while the provider's earlier usage receipt remains authoritative for billing.

The root cause was event ordering: `compaction_end` correctly painted the settled estimate, then the held `agent_end` replayed the completed turn's pre-compaction provider context count. The canonical frontend refresh repeated the same rollback from `restored_usage()`.

Bumps the patch version to `0.42.10`. The branch now includes current `origin/main` at `f7648577` (`0.42.9`), with the conflict resolved to the next available patch, `0.42.10`.

## Testing

### Real rendered reproduction

Driven through the real `OperatorApp` with `run_test`, canonical engine events, the production stylesheet, and Textual SVG export at `120x36`.

Before the fix, the receipt showed `590.4k → 131.1k`, then the settled footer rebounded to `590.4k`:

- `/tmp/compaction-before-compacted.svg`
- `/tmp/compaction-before-settled.svg`
- rendered PNG inspected at `/tmp/compaction-png/compaction-before-settled.svg.png`

After the fix, both the compacted and settled frames remain at `131.1k`:

- `/tmp/compaction-fixed-compacted.svg`
- `/tmp/compaction-fixed-settled.svg`
- rendered PNG inspected at `/tmp/compaction-png/compaction-fixed-settled.svg.png`

Actual output:

```text
# before
compacted_status='... ▦ 131.1k/— ...'
settled_status='... ▦ 590.4k/— ...'
status_tokens=590400 estimate=False

# after
compacted_status='... ▦ 131.1k/— ...'
settled_status='... ▦ 131.1k/— ...'
status_tokens=131100 estimate=True
```

Geometry was unchanged and healthy in both captures:

```text
screen_size=Size(width=118, height=34)
virtual=Size(width=118, height=34)
scrollbar=False
```

### Production-order auto-continuation regression

The session regression now exercises the real controller order: provider receipt at `590.4k` → post-turn compaction estimate at `131.1k` → default auto-continuation → newer provider receipt at `171.0k` → one final `agent_end`. The final boundary leaves `AgentEndEvent.context_tokens` unset so the canonical reducer selects the continuation message's authoritative `171.0k` usage rather than stamping the older compaction estimate.

A real `OperatorApp` rendered capture of the continuation-settled state confirmed the receipt stays visible while the footer settles to exact `171.0k`, with unchanged geometry:

```text
tokens=171000 estimate=False
screen=Size(width=118, height=34)
virtual=Size(width=118, height=34)
scrollbar=False
```

Artifacts: `/tmp/compaction-r1-compacted.svg`, `/tmp/compaction-r1-continuation-settled.svg`, and the inspected browser screenshot `/tmp/compaction-r1-continuation-settled.png`.

### Automated validation

```text
env -u NO_COLOR TERM=xterm-256color PYTHONPATH=/tmp/lop-compaction-readout \
  .venv/bin/python -m pytest tests/unit -q
7338 passed, 7 skipped; 6 resource-sensitive tests failed while full-tree pyright was consuming ~3.2 GB concurrently

env -u NO_COLOR TERM=xterm-256color PYTHONPATH=/tmp/lop-compaction-readout \
  .venv/bin/python -m pytest <the six failed node IDs> -q
6 passed in 15.52s

.venv/bin/python -m flake8 .
pass

uvx --from black==26.1.0 black --check .
566 files unchanged

uvx isort==5.13.2 --check .
pass

.venv/bin/python -m pyright --pythonpath .venv/bin/python \
  local_operator/session/session.py tests/unit/session/test_session.py
0 errors, 0 warnings, 0 informations
```

The exact full-tree pyright gate was also started and remained CPU-bound at about 100% with ~3.2 GB RSS while this evidence was prepared; changed-file pyright is clean and CI runs the same full-tree gate independently.


### Round 2 conflict remediation

Merged current `origin/main` (`f7648577`, released as `v0.42.9`) into the feature branch and resolved the sole `pyproject.toml` conflict to `0.42.10`. The compaction implementation and regression tests remain unchanged.

```text
env -u NO_COLOR TERM=xterm-256color PYTHONPATH=/private/tmp/lop-compaction-readout \
  .venv/bin/python -m pytest -q -n 0 \
  tests/unit/session/test_frontend_state.py::test_post_compaction_agent_end_keeps_settled_occupancy_and_provider_bill \
  tests/unit/session/test_session.py::test_continuation_provider_usage_supersedes_compaction_estimate \
  tests/unit/tui/test_compact_command.py::test_a_post_compaction_turn_end_cannot_rebound_the_band
3 passed in 0.94s

.venv/bin/python -m flake8 .
pass
uvx --from black==26.1.0 black --check .
566 files unchanged
uvx isort==5.13.2 --check .
pass
```

A broader focused run completed `322 passed` with four unrelated TUI timing/state failures under concurrent full-tree pyright load. Three passed immediately in serial; the remaining replayed-bang test is outside this PR's diff and is left to CI while full-tree pyright continues locally.
