### PR TITLE
perf(tui): coalesce subagent progress updates

### DIFF
--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -458,12 +458,23 @@ class AsyncJobManager:
         self._invalidate_accounting()
 
     def _notify_roster_change(self) -> None:
-        """Signal a task-roster mutation to persistence and observers."""
-        self._notify_job_change(task_roster=True)
+        """Publish and persist a mutation of the durable task-row projection."""
+        self._notify_job_change(persist_roster=True)
 
-    def _notify_job_change(self, *, task_roster: bool) -> None:
-        """Publish every job mutation while persisting only resumable tasks."""
-        callbacks = ([self._on_roster_change] if task_roster else []) + [self._on_job_change]
+    def _notify_transient_job_change(self) -> None:
+        """Publish a live-only job mutation without scheduling durable I/O.
+
+        Progress is deliberately absent from the resume projection: after a
+        restart there is no live child behind that activity string, and the
+        restored row is stamped ``interrupted`` instead. Sending it through the
+        persistence callback made every tool/message boundary fingerprint the
+        entire historical child roster for bytes the sidecar never retained.
+        """
+        self._notify_job_change(persist_roster=False)
+
+    def _notify_job_change(self, *, persist_roster: bool) -> None:
+        """Publish every job mutation and persist only durable task fields."""
+        callbacks = ([self._on_roster_change] if persist_roster else []) + [self._on_job_change]
         for callback in callbacks:
             if callback is None:
                 continue
@@ -676,7 +687,7 @@ class AsyncJobManager:
         # only carry a resumable transcript, but the listener filters that).
         if type == "task":
             self._invalidate_accounting()
-        self._notify_job_change(task_roster=type == "task")
+        self._notify_job_change(persist_roster=type == "task")
         return job_id
 
     def start_queued(self, job_id: str) -> bool:
@@ -701,7 +712,7 @@ class AsyncJobManager:
         # in between would restore the row as if it were still parked.
         if job.type == "task":
             self._invalidate_accounting()
-        self._notify_job_change(task_roster=job.type == "task")
+        self._notify_job_change(persist_roster=job.type == "task")
         return True
 
     # -- delivery -----------------------------------------------------------
@@ -810,7 +821,7 @@ class AsyncJobManager:
         self._sweep_due()
         if job.type == "task":
             self._invalidate_accounting()
-        self._notify_job_change(task_roster=job.type == "task")
+        self._notify_job_change(persist_roster=job.type == "task")
         return True
 
     # -- lifecycle ----------------------------------------------------------
@@ -865,7 +876,9 @@ class AsyncJobManager:
         # recent end is the informative one (the current step, the error that
         # just landed), while the opening lines have usually already been read.
         job.output_tail = combined[-OUTPUT_TAIL_CHARS:]
-        self._notify_job_change(task_roster=job.type == "task")
+        # The durable result arrives at settlement; this rolling observation
+        # window is intentionally excluded from the resume projection.
+        self._notify_transient_job_change()
 
     def read_output(self, job_id: str, since: int = 0) -> tuple[str, int, bool] | None:
         """``(text, seq, gap)`` for a peek, or ``None`` when the job is unknown.
@@ -900,7 +913,7 @@ class AsyncJobManager:
             job = self._jobs.get(job_id)
             if job is not None:
                 job.latest_details = {"progress": details}
-                self._notify_job_change(task_roster=job.type == "task")
+                self._notify_transient_job_change()
 
         return report
 
@@ -926,7 +939,7 @@ class AsyncJobManager:
             self._settle(job)
             self._tasks.pop(job.id, None)
             self._sweep_due()
-            self._notify_job_change(task_roster=job.type == "task")
+            self._notify_job_change(persist_roster=job.type == "task")
             return
         except Exception as exc:
             job.status = "failed"
@@ -940,7 +953,7 @@ class AsyncJobManager:
         # leaves the outcome on disk for the next resume.
         if job.type == "task":
             self._invalidate_accounting()
-        self._notify_job_change(task_roster=job.type == "task")
+        self._notify_job_change(persist_roster=job.type == "task")
         try:
             await self._deliver(job)
         except Exception:

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -24,6 +24,7 @@ safe to call from any thread that serializes calls per session.
 from __future__ import annotations
 
 import time
+from collections.abc import Mapping
 from typing import Any
 
 from local_operator.harness.comms import HUB_MESSAGE_TYPE
@@ -857,7 +858,8 @@ class ProjectionFold:
                 )
                 if lifecycle.age_s is not None:
                     row.elapsed_s = max(0.0, float(lifecycle.age_s))
-            progress = str((getattr(job, "latest_details", None) or {}).get("progress") or "")
+            details = getattr(job, "latest_details", None)
+            progress = str(details.get("progress") or "") if isinstance(details, Mapping) else ""
             row.progress = progress if row.status == "running" else ""
             row.activity = row.progress or ("thinking" if row.status == "running" else "")
             # NOTE: no ``Transcript`` construction here. #298's full-screen

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -237,6 +237,18 @@ class _FrozenMapping(tuple[tuple[str, Any], ...]):
     def __len__(self) -> int:
         return tuple.__len__(self)
 
+    def get(self, key: str, default: Any = None) -> Any:
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def keys(self) -> Iterator[str]:
+        return self.__iter__()
+
+    def values(self) -> Iterator[Any]:
+        return (value for _key, value in tuple.__iter__(self))
+
     def items(self) -> Iterator[tuple[str, Any]]:
         return tuple.__iter__(self)
 
@@ -710,15 +722,17 @@ class SnapshotJobs:
         self.replace(values)
 
     def replace(self, values: Iterable[JobState]) -> None:
-        self._values = [value.model_copy(deep=True) for value in values]
+        # Canonical jobs already own recursively immutable retained payloads.
+        # Route copies through the public detacher instead of asking Pydantic to
+        # deep-copy tuple-backed Mapping/Sequence wrappers: the wrappers must
+        # stay immutable while consumers retain their abstract container API.
+        self._values = [_public_job(value) for value in values]
 
     def list(self) -> list[JobState]:
-        return [value.model_copy(deep=True) for value in self._values]
+        return [_public_job(value) for value in self._values]
 
     def get(self, job_id: str) -> JobState | None:
-        return next(
-            (value.model_copy(deep=True) for value in self._values if value.id == job_id), None
-        )
+        return next((_public_job(value) for value in self._values if value.id == job_id), None)
 
 
 class SnapshotWakeScheduler:

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -1357,11 +1357,14 @@ class FrontendStateStore:
         update = self.mutate(**changes) if changes else None
         # Expensive source snapshots are explicit mutation hooks. Turn edges and
         # tool/result boundaries are the defensive fallback; token deltas never
-        # rescan transcript/jobs or publish replacement state.
+        # rescan transcript/jobs or publish replacement state. Subagent progress
+        # is excluded too: the job manager already coalesces that live row onto
+        # ``refresh_jobs`` within 50 ms. Re-scanning the entire session here
+        # published a duplicate frame for every child boundary and made remote
+        # followers pay a second wire update for the same activity string.
         kind = str(getattr(event, "type", ""))
         if isinstance(event, (AgentEndEvent, MessageEndEvent)) or kind in {
             "tool_execution_end",
-            "subagent_progress",
             "subagent_end",
             "model_change",
         }:

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Callable
 
@@ -566,7 +566,7 @@ class RemoteSession:
         self.wake_scheduler.replace(state.wakes)
         self.mcp_manager.replace(state.mcp_servers)
         startup = state.mcp_startup
-        if isinstance(startup, dict):
+        if isinstance(startup, Mapping):
             from local_operator.session.mcp_status import McpStartupOutcome
 
             startup = McpStartupOutcome(
@@ -692,10 +692,12 @@ class RemoteSession:
                 return
             options = [
                 AskOption(
-                    label=(option.get("label", "") if isinstance(option, dict) else option.label),
+                    label=(
+                        option.get("label", "") if isinstance(option, Mapping) else option.label
+                    ),
                     description=(
                         option.get("description", "")
-                        if isinstance(option, dict)
+                        if isinstance(option, Mapping)
                         else option.description
                     ),
                 )

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1489,10 +1489,11 @@ class Session:
         self._subagent_roster_written_generation = 0
         self._subagent_roster_writer: asyncio.Task[None] | None = None
         # The CONTENT of the roster payload last written to the sidecar, so a
-        # redundant write can be skipped. The roster persist hook fires on every
-        # job-row mutation — usage/heartbeat churn included — but most of those
-        # events leave the persisted projection ({version, jobs, records}, minus
-        # the ever-incrementing ``generation`` counter) byte-identical. A real
+        # redundant write can be skipped. Live-only progress/output no longer
+        # reach this hook, but defensive duplicate lifecycle signals and usage
+        # updates can still leave the persisted projection ({version, jobs,
+        # records}, minus the ever-incrementing ``generation`` counter)
+        # byte-identical. A real
         # fan-out fired ~3 sidecar writes per settle, ~2 of them identical, and
         # each is a full mkstemp + fsync + os.replace + directory-fsync cycle;
         # that fsync volume is what tripped the macOS "disk writes exceeding

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15563,16 +15563,16 @@ class OperatorApp(App[None]):
         self._working_fallback = DEFAULT_ACTIVITY
         self._refresh_working_activity()
 
-    # Subagent events arrive through the Controller's `_post` on the shared
-    # stream; each is an immediate repaint trigger for the band, paired with
-    # the 1 Hz poll as the belt (see `_refresh_band`). The panel re-reads the
-    # manager itself, so the handlers only need to fire the refresh, never to
-    # carry job data.
+    # Start/end edges repaint immediately because they change the set or
+    # lifecycle of durable rows. Progress takes the canonical-state route only:
+    # the job manager coalesces it within 50 ms, and repainting this raw event as
+    # well made the owner perform the same band scan twice while a remote
+    # follower, which sees canonical updates only, behaved differently.
     def on_subagent_started(self, message: SubagentStarted) -> None:
         self._refresh_band()
 
     def on_subagent_progress(self, message: SubagentProgress) -> None:
-        self._refresh_band()
+        pass
 
     def on_subagent_ended(self, message: SubagentEnded) -> None:
         self._refresh_band()

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -9241,7 +9241,14 @@ class OperatorApp(App[None]):
         comms = getattr(session, "_subagent_comms", None) if session is not None else None
         try:
             lookup = getattr(comms, "job", None) if comms is not None else None
-            job = lookup(job_id) if callable(lookup) else manager.get(job_id) if manager else None
+            job = lookup(job_id) if callable(lookup) else None
+            # Owner comms resolves durable attempt aliases to a live job. The
+            # follower graph facade deliberately has no job objects of its own;
+            # its canonical SnapshotJobs ledger is authoritative instead. A
+            # callable lookup returning None must therefore fall through, not
+            # turn every follower child page into a false "no longer on ledger".
+            if job is None and manager is not None:
+                job = manager.get(job_id)
         except Exception:
             job = manager.get(job_id) if manager is not None else None
         # Comms accepts durable predecessor IDs, but the panel contains only the
@@ -9263,6 +9270,8 @@ class OperatorApp(App[None]):
             ancestors = comms.ancestors(job_id) if comms is not None else []
         except Exception:
             ancestors = []
+        details = getattr(job, "latest_details", None)
+        progress = details.get("progress") if isinstance(details, Mapping) else ""
         view.show(
             job_id=job_id,
             label=str(getattr(job, "label", "") or getattr(node, "label", "") or job_id),
@@ -9296,7 +9305,7 @@ class OperatorApp(App[None]):
                 or ""
             ),
             events=getattr(job, "trajectory", None) or [],
-            progress=str((getattr(job, "latest_details", None) or {}).get("progress") or ""),
+            progress=str(progress or ""),
             # Launch-time identity: the child's role and effort tier, recorded
             # on the job at registration (`AsyncJob.agent_role`/`effort`). The
             # title names them so the page says WHAT kind of child this is; the

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -18,7 +18,7 @@ not one of them. Settled rows follow the tool ledger's ink law: ✓ dim,
 from __future__ import annotations
 
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Callable, NamedTuple
 
@@ -379,7 +379,7 @@ def _read_row(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
     queued = bool(getattr(job, "queued", False))
     running = status == "running" and not queued
     details = getattr(job, "latest_details", None)
-    if not isinstance(details, dict):
+    if not isinstance(details, Mapping):
         details = {}
     if queued:
         # The word ``status_glyph`` already derived for this state, rather

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -49,7 +49,7 @@ from __future__ import annotations
 
 import asyncio
 import math
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Callable, Literal
 
@@ -151,14 +151,14 @@ HISTORY_UNAVAILABLE_NOTE = "history unavailable"
 HISTORY_ERROR_NOTE = "load failed · Home retry"
 
 
-def _as_dict(event: Any) -> dict[str, Any]:
+def _as_dict(event: Any) -> Mapping[str, Any]:
     """One trajectory entry as a dict.
 
     Entries are normally serialized dicts already; an engine that hands over
     live event objects is tolerated by dumping them, and anything neither is
     skipped (empty dict) rather than raised on.
     """
-    if isinstance(event, dict):
+    if isinstance(event, Mapping):
         return event
     dump = getattr(event, "model_dump", None)
     if callable(dump):
@@ -178,17 +178,17 @@ def _content_text(payload: Any) -> str:
     refresh timer — a repeating handler exception, not the skipped row this
     module promises.
     """
-    if not isinstance(payload, dict):
+    if not isinstance(payload, Mapping):
         return ""
     content = payload.get("content")
-    if not isinstance(content, (list, tuple)):
+    if not isinstance(content, Sequence) or isinstance(content, (str, bytes, bytearray)):
         return ""
     parts: list[str] = []
     for block in content:
         # Transcript encoding excludes pydantic defaults, including the text
         # block's ``type`` discriminator. The presence of ``text`` is therefore
         # the durable signal; trajectory events still carry the explicit type.
-        if isinstance(block, dict) and (
+        if isinstance(block, Mapping) and (
             block.get("type") == "text" or ("text" in block and "data" not in block)
         ):
             parts.append(str(block.get("text", "")))
@@ -298,7 +298,7 @@ def fold_transcript_entries(
             call_id = str(payload.get("tool_call_id") or "")
             if call_id:
                 provider_payload = payload.get("provider_payload")
-                metadata = provider_payload if isinstance(provider_payload, dict) else {}
+                metadata = provider_payload if isinstance(provider_payload, Mapping) else {}
                 details = metadata.get("details")
                 duration = _duration(metadata.get("duration_s"))
                 # Tool result text is the model-facing payload; presentation
@@ -307,7 +307,7 @@ def fold_transcript_entries(
                 results[call_id] = (
                     _content_text(payload),
                     bool(payload.get("is_error")),
-                    details if isinstance(details, dict) else None,
+                    dict(details) if isinstance(details, Mapping) else None,
                     duration,
                 )
     communication_ids: set[str] = set()
@@ -367,7 +367,7 @@ def fold_transcript_entries(
             if text:
                 folded.append(SubagentEntry(entry.id, "text", text=text))
             for raw_call in payload.get("tool_calls") or ():
-                if not isinstance(raw_call, dict):
+                if not isinstance(raw_call, Mapping):
                     continue
                 call_id = str(raw_call.get("id") or raw_call.get("tool_call_id") or "")
                 if not call_id:
@@ -448,7 +448,7 @@ def fold_trajectory(events: Sequence[Any], *, settled: bool = False) -> list[Sub
         etype = event.get("type")
         if etype in ("message_start", "message_update", "message_end"):
             message = event.get("message")
-            if not isinstance(message, dict) or message.get("role") != "assistant":
+            if not isinstance(message, Mapping) or message.get("role") != "assistant":
                 continue
             message_id = str(message.get("id") or f"m{index}")
             if etype == "message_start":
@@ -479,7 +479,7 @@ def fold_trajectory(events: Sequence[Any], *, settled: bool = False) -> list[Sub
                 key=call_id,
                 kind="tool",
                 tool_name=str(event.get("tool_name") or "tool"),
-                tool_args=args if isinstance(args, dict) else {},
+                tool_args=dict(args) if isinstance(args, Mapping) else {},
                 intent=intent if isinstance(intent, str) and intent else None,
             )
             remember("tool", call_id)
@@ -489,7 +489,7 @@ def fold_trajectory(events: Sequence[Any], *, settled: bool = False) -> list[Sub
             if started is None:
                 continue  # an end without a start: nothing to settle
             result = event.get("result")
-            result = result if isinstance(result, dict) else {}
+            result = result if isinstance(result, Mapping) else {}
             details = result.get("details")
             event_duration = _duration(event.get("duration_s"))
             tools[call_id] = SubagentEntry(
@@ -500,7 +500,7 @@ def fold_trajectory(events: Sequence[Any], *, settled: bool = False) -> list[Sub
                 intent=started.intent,
                 outcome="error" if (event.get("is_error") or result.get("is_error")) else "success",
                 result_text=_content_text(result),
-                details=details if isinstance(details, dict) else None,
+                details=dict(details) if isinstance(details, Mapping) else None,
                 duration_s=(
                     event_duration
                     if event_duration is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.10"
+version = "0.42.11"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/benchmark_residual_child_lag.py
+++ b/scripts/benchmark_residual_child_lag.py
@@ -1,0 +1,342 @@
+"""Measure parent TUI latency while a bounded child trajectory streams.
+
+This benchmark uses synthetic content with the same shape as the reported long
+session. It never opens or writes a retained user session.
+
+Run from the checkout with its interpreter:
+
+    env -u NO_COLOR TERM=xterm-256color \
+      .venv/bin/python scripts/benchmark_residual_child_lag.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import statistics
+import sys
+import time
+from collections import defaultdict
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from local_operator.harness.jobs import (  # noqa: E402
+    AsyncJob,
+    AsyncJobManager,
+    JobStatus,
+)
+from local_operator.harness.types import SubagentProgressEvent  # noqa: E402
+from local_operator.session.frontend_state import (  # noqa: E402
+    FrontendSessionState,
+    FrontendStateStore,
+    JobState,
+)
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.events import SubagentProgress  # noqa: E402
+from local_operator.tui.widgets.transcript import NoticeBlock  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+TRANSCRIPT_BLOCKS = 1_457
+RETAINED_TRAJECTORY = 500
+STREAM_INTERVAL_S = 0.05
+STREAM_UPDATES = 80
+
+
+def _summary(samples: list[float]) -> str:
+    if not samples:
+        return "n=0"
+    ordered = sorted(samples)
+    p95 = ordered[int(0.95 * (len(ordered) - 1))]
+    return (
+        f"n={len(samples)} median={statistics.median(ordered) * 1_000:.3f}ms "
+        f"p95={p95 * 1_000:.3f}ms max={max(ordered) * 1_000:.3f}ms"
+    )
+
+
+def _events(count: int) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    index = 0
+    while len(events) + 5 <= count:
+        text = f"child message {index} " + "x" * 240
+        events.extend(
+            [
+                {"type": "message_start", "message": {"role": "assistant", "id": f"m{index}"}},
+                {
+                    "type": "message_update",
+                    "message": {"role": "assistant", "id": f"m{index}"},
+                    "delta": text,
+                },
+                {
+                    "type": "message_end",
+                    "message": {
+                        "role": "assistant",
+                        "id": f"m{index}",
+                        "content": [{"type": "text", "text": text}],
+                    },
+                },
+                {
+                    "type": "tool_execution_start",
+                    "tool_call_id": f"t{index}",
+                    "tool_name": "read",
+                    "args": {"path": f"fixture/module_{index}.py"},
+                },
+                {
+                    "type": "tool_execution_end",
+                    "tool_call_id": f"t{index}",
+                    "tool_name": "read",
+                    "result": {"content": [{"type": "text", "text": "ok"}]},
+                },
+            ]
+        )
+        index += 1
+    return events[:count]
+
+
+class CanonicalFakeSession(FakeSession):
+    """Fake provider/session edges around the production frontend-state contract."""
+
+    def __init__(self, *, running: bool) -> None:
+        super().__init__()
+        trajectory = _events(RETAINED_TRAJECTORY) if running else []
+        now = time.time()
+        jobs = [
+            JobState(
+                id=f"child-{index}",
+                type="task",
+                label=f"historical child {index}",
+                status="completed",
+                start_time=now - 600 - index,
+                started_at=now - 600 - index,
+                settled_at=now - 500 - index,
+                prompt="bounded historical instruction",
+                agent_role="coder",
+            )
+            for index in range(3)
+        ]
+        jobs.append(
+            JobState(
+                id="active-child",
+                type="task",
+                label="streaming child",
+                status="running" if running else "completed",
+                start_time=now - 300,
+                started_at=now - 300,
+                settled_at=None if running else now - 200,
+                latest_details={"progress": "responding"},
+                trajectory=trajectory,
+                prompt="bounded active instruction",
+                agent_role="architect",
+            )
+        )
+        self._jobs_refresh_scheduled = False
+
+        def job_changed() -> None:
+            if self._jobs_refresh_scheduled:
+                return
+            self._jobs_refresh_scheduled = True
+            asyncio.get_running_loop().call_later(0.05, self._flush_jobs)
+
+        self.jobs = AsyncJobManager(on_job_change=job_changed)
+        self.jobs._jobs = {
+            job.id: AsyncJob(
+                id=job.id,
+                type="task",
+                status=cast(JobStatus, job.status),
+                start_time=job.start_time,
+                started_at=job.started_at,
+                settled_at=job.settled_at,
+                label=job.label,
+                latest_details=(
+                    cast(dict[str, Any], dict(job.latest_details))
+                    if isinstance(job.latest_details, dict)
+                    else None
+                ),
+                trajectory=list(job.trajectory or []),
+                prompt=job.prompt,
+                agent_role=job.agent_role,
+            )
+            for job in jobs
+        }  # synthetic retained ledger
+        self._frontend_state_store = FrontendStateStore(
+            FrontendSessionState(
+                session_id=self.session_id,
+                epoch="benchmark",
+                jobs=jobs,
+                conversation_title="Residual child lag fixture",
+            )
+        )
+        self.raw_progress: Callable[[SubagentProgressEvent], None] | None = None
+
+    def _flush_jobs(self) -> None:
+        self._jobs_refresh_scheduled = False
+        self._frontend_state_store.refresh_jobs(self)
+
+    @property
+    def frontend_state(self) -> FrontendSessionState:
+        return self._frontend_state_store.state
+
+    def subscribe_frontend(self, callback: Callable[[Any], None]):  # noqa: ANN201
+        return self._frontend_state_store.subscribe(callback)
+
+    def refresh_frontend_usage(self) -> None:
+        return None
+
+    def stream_edge(self, index: int) -> None:
+        jobs = self.jobs.list()
+        active = jobs[-1]
+        event = {
+            "type": "message_update",
+            "message": {"role": "assistant", "id": "live"},
+            "delta": f" edge-{index}",
+        }
+        trajectory = [*(active.trajectory or []), event]
+        if len(trajectory) > RETAINED_TRAJECTORY:
+            trajectory = trajectory[-RETAINED_TRAJECTORY:]
+        changed = active.model_copy(
+            update={
+                "trajectory": trajectory,
+                "latest_details": {"progress": f"stream edge {index}"},
+            }
+        )
+        self.jobs._jobs[active.id] = changed
+        self.jobs._progress_fn(active.id)(f"stream edge {index}")
+        progress = SubagentProgressEvent(
+            job_id=active.id,
+            label=active.label,
+            progress=f"stream edge {index}",
+        )
+        # This is Session._emit's ordering: canonical observation first, then
+        # EventController fan-out to the owner TUI's raw event handler.
+        self._frontend_state_store.observe_event(self, progress)
+        if self.raw_progress is not None:
+            self.raw_progress(progress)
+
+
+class Timings:
+    def __init__(self) -> None:
+        self.values: dict[str, list[float]] = defaultdict(list)
+
+    def wrap(self, owner: Any, name: str, label: str | None = None) -> None:
+        original = getattr(owner, name)
+
+        def measured(*args: Any, **kwargs: Any) -> Any:
+            started = time.perf_counter()
+            try:
+                return original(*args, **kwargs)
+            finally:
+                self.values[label or name].append(time.perf_counter() - started)
+
+        setattr(owner, name, measured)
+
+
+async def _event_loop_probe(stop: asyncio.Event, samples: list[float]) -> None:
+    target = time.perf_counter() + 0.01
+    while not stop.is_set():
+        await asyncio.sleep(max(0.0, target - time.perf_counter()))
+        now = time.perf_counter()
+        samples.append(max(0.0, now - target))
+        target += 0.01
+
+
+async def _stream(session: CanonicalFakeSession, edge_costs: list[float]) -> None:
+    for index in range(STREAM_UPDATES):
+        await asyncio.sleep(STREAM_INTERVAL_S)
+        started = time.perf_counter()
+        session.stream_edge(index)
+        edge_costs.append(time.perf_counter() - started)
+
+
+async def scenario(name: str, *, running: bool, child_visible: bool) -> None:
+    session = CanonicalFakeSession(running=running)
+    app = OperatorApp(lambda: _factory(session))
+    timings = Timings()
+    loop_lag: list[float] = []
+    edge_costs: list[float] = []
+    input_costs: list[float] = []
+    frame_costs: list[float] = []
+    async with app.run_test(size=(120, 40)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is session:
+                break
+        view = app._transcript_view()
+        with view.batch_append():
+            for index in range(TRANSCRIPT_BLOCKS):
+                view.append_block(NoticeBlock(f"retained event {index} " + "word " * 12, "info"))
+        await pilot.pause()
+        await pilot.pause()
+
+        panel = app._subagent_panel
+        if panel is not None:
+            timings.wrap(panel, "sync", "panel.sync")
+            timings.wrap(panel, "_tick", "panel.tick")
+            timings.wrap(panel, "_paint_all", "panel.paint_all")
+        timings.wrap(app, "_apply_frontend_state", "app.apply_frontend_state")
+        timings.wrap(app, "_refresh_band", "app.refresh_band")
+        timings.wrap(session._frontend_state_store, "mutate", "store.mutate")
+        timings.wrap(
+            session._frontend_state_store,
+            "refresh_from_session",
+            "store.refresh_from_session",
+        )
+        timings.wrap(session._frontend_state_store, "refresh_jobs", "store.refresh_jobs")
+        session.raw_progress = lambda event: app.on_subagent_progress(
+            SubagentProgress(event.job_id, event.label, event.progress)
+        )
+
+        if child_visible:
+            app._open_subagent_view("active-child")
+            await pilot.pause()
+            await pilot.pause()
+            child = app._subagent_view
+            if child is not None:
+                timings.wrap(child, "show", "child.show")
+                timings.wrap(child, "_tick", "child.tick")
+
+        stop = asyncio.Event()
+        probe = asyncio.create_task(_event_loop_probe(stop, loop_lag))
+        streamer = asyncio.create_task(_stream(session, edge_costs)) if running else None
+
+        for index in range(50):
+            started = time.perf_counter()
+            await pilot.pause()
+            frame_costs.append(time.perf_counter() - started)
+            if not child_visible:
+                started = time.perf_counter()
+                await pilot.press(chr(ord("a") + index % 26))
+                input_costs.append(time.perf_counter() - started)
+            await asyncio.sleep(0.05)
+
+        if streamer is not None:
+            await streamer
+        else:
+            await asyncio.sleep(STREAM_INTERVAL_S * STREAM_UPDATES - 2.5)
+        stop.set()
+        await probe
+        await pilot.pause()
+
+    print(f"\n{name}")
+    print("  event_loop_lag:", _summary(loop_lag))
+    print("  pilot_frame:", _summary(frame_costs))
+    if input_costs:
+        print("  keypress_roundtrip:", _summary(input_costs))
+    if edge_costs:
+        print("  stream_edge_sync:", _summary(edge_costs))
+    for label in sorted(timings.values):
+        print(f"  {label}:", _summary(timings.values[label]))
+
+
+async def main() -> None:
+    print(
+        f"fixture transcript_blocks={TRANSCRIPT_BLOCKS} jobs=4 "
+        f"trajectory={RETAINED_TRAJECTORY} edges={STREAM_UPDATES}@{STREAM_INTERVAL_S:.2f}s"
+    )
+    await scenario("idle parent visible", running=False, child_visible=False)
+    await scenario("running child, parent visible", running=True, child_visible=False)
+    await scenario("running child, child visible", running=True, child_visible=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/probe_child_update_scheduling.py
+++ b/scripts/probe_child_update_scheduling.py
@@ -1,0 +1,180 @@
+"""Count redundant parent work for relayed child progress boundaries."""
+
+from __future__ import annotations
+
+import asyncio
+import statistics
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from local_operator.harness.jobs import AsyncJobManager  # noqa: E402
+from local_operator.harness.subagent import _make_relay  # noqa: E402
+from local_operator.harness.types import (  # noqa: E402
+    Message,
+    MessageStartEvent,
+    SubagentProgressEvent,
+    ToolExecutionEndEvent,
+    ToolExecutionStartEvent,
+    ToolResult,
+)
+from local_operator.session.frontend_state import (  # noqa: E402
+    FrontendSessionState,
+    FrontendStateStore,
+)
+
+EVENTS = 60
+
+
+def _summary(values: list[float]) -> str:
+    if not values:
+        return "n=0"
+    values = sorted(values)
+    return (
+        f"n={len(values)} median={statistics.median(values) * 1000:.3f}ms "
+        f"p95={values[int(.95 * (len(values) - 1))] * 1000:.3f}ms "
+        f"max={max(values) * 1000:.3f}ms"
+    )
+
+
+async def main() -> None:
+    counts = {
+        "job_change_callback": 0,
+        "persist_callback": 0,
+        "coalesce_scheduled": 0,
+        "parent_progress_emitted": 0,
+        "observe_event": 0,
+        "refresh_from_session": 0,
+        "refresh_jobs_delayed": 0,
+        "frontend_updates": 0,
+        "ui_event_band_refresh": 0,
+        "ui_frontend_apply_band_refresh": 0,
+    }
+    scheduled = False
+
+    def persist() -> None:
+        counts["persist_callback"] += 1
+
+    def job_change() -> None:
+        nonlocal scheduled
+        counts["job_change_callback"] += 1
+        if not scheduled:
+            scheduled = True
+            counts["coalesce_scheduled"] += 1
+
+    manager = AsyncJobManager(on_roster_change=persist, on_job_change=job_change)
+    job_id = manager.register("task", "streaming child", lambda *_: asyncio.sleep(3600))
+    # Enter the registered coroutine before the synchronous burst so cancelling
+    # it at teardown cannot leave an un-awaited coroutine object behind.
+    await asyncio.sleep(0)
+    job = manager.get(job_id)
+    assert job is not None
+    job.prompt = "bounded instruction"
+    job.trajectory = []
+    store = FrontendStateStore(FrontendSessionState(session_id="bench", epoch="bench", jobs=[]))
+    session = SimpleNamespace(
+        jobs=manager,
+        _subagent_comms=None,
+        model=None,
+        effective_model=None,
+        session_id="bench",
+        cwd="/tmp",
+        queued_steering=lambda: [],
+        conversation_name="benchmark",
+        goal="",
+        active_agent="",
+        active_team_name="",
+        wake_scheduler=None,
+        mcp_manager=None,
+        mcp_startup=None,
+    )
+    store.refresh_from_session(session, initial=True)
+    store.subscribe(
+        lambda _update: counts.__setitem__("frontend_updates", counts["frontend_updates"] + 1)
+    )
+
+    original_refresh = store.refresh_from_session
+    fallback_costs: list[float] = []
+
+    def measured_refresh(*args: Any, **kwargs: Any):  # noqa: ANN201
+        counts["refresh_from_session"] += 1
+        started = time.perf_counter()
+        try:
+            return original_refresh(*args, **kwargs)
+        finally:
+            fallback_costs.append(time.perf_counter() - started)
+
+    store.refresh_from_session = measured_refresh  # type: ignore[method-assign]
+
+    async def emit(event: Any) -> None:
+        counts["parent_progress_emitted"] += 1
+        if isinstance(event, SubagentProgressEvent):
+            counts["observe_event"] += 1
+            before = store.state.sequence
+            store.observe_event(session, event)
+            after = store.state.sequence
+            # EventController still posts the raw edge, but the owner handler is
+            # intentionally a no-op; the delayed canonical jobs publication is
+            # the owner/follower-common visual invalidation.
+            if after != before:
+                counts["ui_frontend_apply_band_refresh"] += 1
+
+    relay = _make_relay(
+        job_id,
+        "streaming child",
+        job,
+        manager,
+        emit,
+        manager._progress_fn(job_id),
+        {},
+    )
+
+    relay_costs: list[float] = []
+    for index in range(EVENTS):
+        phase = index % 3
+        if phase == 0:
+            event = MessageStartEvent(message=Message(role="assistant", content=[], id=f"m{index}"))
+        elif phase == 1:
+            event = ToolExecutionStartEvent(
+                tool_call_id=f"t{index}", tool_name="read", args={"path": "fixture.py"}
+            )
+        else:
+            prior = index - 1
+            event = ToolExecutionEndEvent(
+                tool_call_id=f"t{prior}",
+                tool_name="read",
+                result=ToolResult(tool_call_id=f"t{prior}", tool_name="read", content=[]),
+            )
+        started = time.perf_counter()
+        await relay(event)
+        relay_costs.append(time.perf_counter() - started)
+
+    # One 50 ms coalesced callback services the whole same-loop burst. It still
+    # rebuilds the job projection even though observe_event's defensive fallback
+    # already refreshed canonical state once per progress event.
+    if scheduled:
+        scheduled = False
+        counts["refresh_jobs_delayed"] += 1
+        started = time.perf_counter()
+        before = store.state.sequence
+        store.refresh_jobs(session)
+        delayed_cost = time.perf_counter() - started
+        if store.state.sequence != before:
+            counts["ui_frontend_apply_band_refresh"] += 1
+    else:
+        delayed_cost = 0.0
+
+    manager._tasks[job_id].cancel()
+    await asyncio.gather(manager._tasks[job_id], return_exceptions=True)
+    print(f"events={EVENTS} counts={counts}")
+    print("relay_total:", _summary(relay_costs))
+    print("fallback_refresh_from_session:", _summary(fallback_costs))
+    print(f"delayed_refresh_jobs: {delayed_cost * 1000:.3f}ms")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/probe_spinner_invalidation.py
+++ b/scripts/probe_spinner_invalidation.py
@@ -1,0 +1,195 @@
+"""Inspect Textual invalidation from one running subagent spinner row."""
+
+from __future__ import annotations
+
+import asyncio
+import statistics
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from textual._compositor import ChopsUpdate, LayoutUpdate  # noqa: E402
+
+from local_operator.harness.jobs import AsyncJob  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.transcript import NoticeBlock  # noqa: E402
+from scripts.benchmark_residual_child_lag import CanonicalFakeSession  # noqa: E402
+from tests.unit.tui.test_app_pilot import _factory  # noqa: E402
+
+BLOCKS = 1_457
+TICKS = 40
+
+
+def _summary(values: list[float]) -> str:
+    if not values:
+        return "n=0"
+    values = sorted(values)
+    return (
+        f"n={len(values)} median={statistics.median(values) * 1000:.3f}ms "
+        f"p95={values[int(.95 * (len(values) - 1))] * 1000:.3f}ms "
+        f"max={max(values) * 1000:.3f}ms"
+    )
+
+
+class Probe:
+    def __init__(self, app: OperatorApp) -> None:
+        self.app = app
+        self.counts: Counter[str] = Counter()
+        self.bytes: list[int] = []
+        self.spans: list[int] = []
+        self.rows: list[int] = []
+        self.layout_times: list[float] = []
+        self.display_times: list[float] = []
+        self._install()
+
+    def _install(self) -> None:
+        screen = self.app.screen
+        original_layout = screen._refresh_layout
+
+        def layout(*args: Any, **kwargs: Any) -> Any:
+            started = time.perf_counter()
+            try:
+                return original_layout(*args, **kwargs)
+            finally:
+                self.counts["layout"] += 1
+                self.layout_times.append(time.perf_counter() - started)
+
+        screen._refresh_layout = layout  # type: ignore[method-assign]
+        original_display = self.app._display
+
+        def display(screen_arg: Any, renderable: Any) -> None:
+            started = time.perf_counter()
+            try:
+                if isinstance(renderable, ChopsUpdate):
+                    self.counts["partial"] += 1
+                    self.spans.append(len(renderable.spans))
+                    self.rows.append(len({y for y, _x1, _x2 in renderable.spans}))
+                    self.bytes.append(len(renderable.render_segments(self.app.console).encode()))
+                elif isinstance(renderable, LayoutUpdate):
+                    self.counts["full"] += 1
+                    self.rows.append(renderable.region.height)
+                    self.bytes.append(len(renderable.render_segments(self.app.console).encode()))
+                elif renderable is None:
+                    self.counts["none"] += 1
+                else:
+                    self.counts[type(renderable).__name__] += 1
+            finally:
+                self.display_times.append(time.perf_counter() - started)
+            original_display(screen_arg, renderable)
+
+        self.app._display = display  # type: ignore[method-assign]
+
+    def reset(self) -> None:
+        self.counts.clear()
+        self.bytes.clear()
+        self.spans.clear()
+        self.rows.clear()
+        self.layout_times.clear()
+        self.display_times.clear()
+
+    def report(self) -> str:
+        return (
+            f"counts={dict(self.counts)} bytes={self.bytes} spans={self.spans} rows={self.rows} "
+            f"layout={_summary(self.layout_times)} display={_summary(self.display_times)}"
+        )
+
+
+async def _mounted_app(job_count: int) -> tuple[OperatorApp, Any, Any]:
+    session = CanonicalFakeSession(running=True)
+    now = time.time()
+    if job_count > len(session.jobs.list()):
+        historical = [
+            AsyncJob(
+                id=f"history-{index}",
+                type="task",
+                label=f"historical child {index}",
+                status="completed",
+                start_time=now - 10_000 + index,
+                started_at=now - 10_000 + index,
+                settled_at=now - 9_000 + index,
+                agent_role="coder",
+            )
+            for index in range(job_count - 1)
+        ]
+        active = session.jobs.list()[-1]
+        session.jobs._jobs = {job.id: job for job in [*historical, active]}
+    app = OperatorApp(lambda: _factory(session))
+    context = app.run_test(size=(120, 40))
+    pilot = await context.__aenter__()
+    for _ in range(80):
+        await pilot.pause()
+        if app._session is session:
+            break
+    view = app._transcript_view()
+    with view.batch_append():
+        for index in range(BLOCKS):
+            view.append_block(NoticeBlock(f"retained event {index} " + "word " * 12, "info"))
+    await pilot.pause()
+    await pilot.pause()
+    app._refresh_band()
+    await pilot.pause()
+    panel = app._subagent_panel
+    assert panel is not None
+    panel._stop_spinner()
+    # Prevent the app's 1 Hz poll from rearming the native timer while this
+    # probe drives exact manual ticks; queued UI work is drained before capture.
+    panel._start_spinner = lambda: None  # type: ignore[method-assign]
+    await pilot.pause()
+    await pilot.pause()
+    return app, pilot, context
+
+
+async def scenario(name: str, *, mode: str, job_count: int = 4) -> None:
+    app, pilot, context = await _mounted_app(job_count)
+    panel = app._subagent_panel
+    assert panel is not None
+    try:
+        if mode == "hidden":
+            panel.display = False
+        elif mode == "unmounted":
+            await panel.remove()
+        if mode in {"hidden", "unmounted"}:
+            # Display/remove changes post several resize/layout messages. Drain
+            # the transition fully so capture contains steady-state ticks only.
+            for _settle in range(30):
+                await asyncio.sleep(0)
+                app.screen._on_timer_update()
+        # Flush the transition before installing capture. Each measured sample
+        # then consists of exactly one explicit tick and one compositor drain;
+        # wall-clock Textual timers cannot add unrelated cursor/status frames.
+        app.screen._on_timer_update()
+        probe = Probe(app)
+        probe.reset()
+        tick_times: list[float] = []
+        for _ in range(TICKS):
+            started = time.perf_counter()
+            if mode != "disabled":
+                panel._tick()
+            # Static.update posts Prompt to the row pump; a few zero-time yields
+            # drain row → screen invalidation without Pilot.pause's 50 ms sleep.
+            for _yield in range(5):
+                await asyncio.sleep(0)
+            app.screen._on_timer_update()
+            tick_times.append(time.perf_counter() - started)
+        print(
+            f"{name}: jobs={job_count} transcript_blocks={BLOCKS} ticks={TICKS} "
+            f"tick_roundtrip={_summary(tick_times)} {probe.report()}"
+        )
+    finally:
+        await context.__aexit__(None, None, None)
+
+
+async def main() -> None:
+    await scenario("spinner-visible-exact", mode="visible", job_count=4)
+    await scenario("spinner-disabled-exact", mode="disabled", job_count=4)
+    await scenario("spinner-hidden-exact", mode="hidden", job_count=4)
+    await scenario("spinner-unmounted-exact", mode="unmounted", job_count=4)
+    await scenario("spinner-visible-100-jobs", mode="visible", job_count=100)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/harness/test_jobs.py
+++ b/tests/unit/harness/test_jobs.py
@@ -47,6 +47,87 @@ async def quick_runner(job_id, signal, report_progress):
     return f"done:{job_id}"
 
 
+@pytest.mark.asyncio
+async def test_task_notification_callers_classify_transient_and_durable_mutations() -> None:
+    """Only fields retained by the resume projection schedule persistence.
+
+    This enumerates every public manager mutation that notifies while a task is
+    alive: registration, queue promotion, progress, output, and settlement.
+    Launch metadata/model/usage use ``_notify_roster_change`` directly in the
+    subagent runner and are covered by the same durable callback below.
+    """
+    durable: list[str] = []
+    live: list[str] = []
+    release_running = asyncio.Event()
+    release_queued = asyncio.Event()
+    started = asyncio.Event()
+    queued = ""
+
+    async def blocked(job_id, signal, report_progress):  # noqa: ANN001, ANN202
+        started.set()
+        await (release_queued if job_id == queued else release_running).wait()
+        return "settled result"
+
+    manager = AsyncJobManager(
+        max_running=1,
+        on_roster_change=lambda: durable.append("persist"),
+        on_job_change=lambda: live.append("publish"),
+    )
+    running = manager.register("task", "running", blocked)
+    queued = manager.register("task", "queued", blocked, queued=True)
+    assert (len(durable), len(live)) == (2, 2)  # both registrations
+    await started.wait()
+
+    manager._progress_fn(running)("reading files")
+    manager.append_output(running, "one live line\n")
+    assert (len(durable), len(live)) == (2, 4)
+
+    release_running.set()
+    await manager.settled_event(running).wait()
+    # Settlement frees capacity and atomically promotes the queued row: both are
+    # durable lifecycle moves, so each publishes and persists once.
+    assert (len(durable), len(live)) == (4, 6)
+    assert manager.start_queued(queued) is False  # already auto-promoted
+    release_queued.set()
+    await manager.settled_event(queued).wait()
+    assert (len(durable), len(live)) == (5, 7)  # second settlement
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_progress_burst_publishes_every_edge_without_persisting() -> None:
+    """Live activity stays smooth while the durable writer remains untouched."""
+    durable = 0
+    live = 0
+    release = asyncio.Event()
+
+    def persisted() -> None:
+        nonlocal durable
+        durable += 1
+
+    def published() -> None:
+        nonlocal live
+        live += 1
+
+    async def blocked(job_id, signal, report_progress):  # noqa: ANN001, ANN202
+        await release.wait()
+        return "done"
+
+    manager = AsyncJobManager(on_roster_change=persisted, on_job_change=published)
+    job_id = manager.register("task", "streaming", blocked)
+    durable = live = 0
+    report = manager._progress_fn(job_id)
+    for index in range(60):
+        report(f"edge {index}")
+    assert (durable, live) == (0, 60)
+
+    release.set()
+    await manager.settled_event(job_id).wait()
+    assert (durable, live) == (1, 61)
+    assert require_job(manager, job_id).result_text == "done"
+    await manager.dispose()
+
+
 def test_accumulate_usage_preserves_provider_reported_calls() -> None:
     """A tool-using child's receipts stay attached to their original calls."""
     from local_operator.harness.subagent import _accumulate_usage

--- a/tests/unit/session/test_frontend_state.py
+++ b/tests/unit/session/test_frontend_state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import pickle
 from collections import deque, namedtuple
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, cast
@@ -104,6 +105,32 @@ def test_state_json_roundtrip_preserves_full_model_usage_and_future_fields() -> 
     assert wire["future_owner_field"] == {"new": True}
     assert wire["selected_model"]["future_model_field"] == "kept"
     assert wire["last_usage"]["future_usage_field"] == 7
+
+
+def test_snapshot_jobs_preserve_immutable_mapping_and_sequence_interfaces() -> None:
+    state = FrontendStateStore(
+        _state(
+            jobs=[
+                JobState(
+                    id="child",
+                    type="task",
+                    latest_details={"progress": "reading files"},
+                    trajectory=[{"type": "message_update", "delta": "hello"}],
+                )
+            ]
+        )
+    ).state
+    jobs = SnapshotJobs(state.jobs)
+
+    for job in [*jobs.list(), jobs.get("child")]:
+        assert job is not None
+        assert isinstance(job.latest_details, Mapping)
+        assert job.latest_details.get("progress") == "reading files"
+        with pytest.raises((AttributeError, TypeError)):
+            job.latest_details["progress"] = "corrupted"  # type: ignore[index]
+        assert isinstance(job.trajectory, Sequence)
+        assert isinstance(job.trajectory[0], Mapping)
+        assert job.trajectory[0].get("delta") == "hello"
 
 
 def test_missing_model_and_cost_remain_explicit_unknowns() -> None:

--- a/tests/unit/session/test_frontend_state.py
+++ b/tests/unit/session/test_frontend_state.py
@@ -17,6 +17,7 @@ from local_operator.harness.types import (
     AgentStartEvent,
     Message,
     ModelSpec,
+    SubagentProgressEvent,
     Usage,
 )
 from local_operator.session.frontend_state import (
@@ -166,6 +167,64 @@ def test_usage_join_and_turn_end_does_not_double_count_mixed_calls() -> None:
         ("openrouter", "fallback-a", 0.4),
         ("openai", "gpt-5.6-sol", 0.6),
     ]
+
+
+def test_subagent_progress_defers_job_publication_to_the_coalescer(monkeypatch) -> None:
+    """A raw progress edge neither rescans nor publishes canonical state itself.
+
+    The manager's 50 ms ``refresh_jobs`` callback is the one owner publication;
+    followers receive that same update, so owner and follower visual cadence are
+    identical without a duplicate full-session fallback on every boundary.
+    """
+    job = AsyncJob(
+        id="child",
+        type="task",
+        status="running",
+        start_time=1.0,
+        label="child",
+        latest_details={"progress": "reading files"},
+    )
+    session = SimpleNamespace(
+        jobs=SimpleNamespace(list=lambda: [job]),
+        _subagent_comms=None,
+        model=None,
+        effective_model=None,
+        session_id="s1",
+        cwd="/repo",
+        queued_steering=lambda: [],
+        conversation_name="Canonical state",
+        goal="",
+        active_agent="",
+        active_team_name="",
+        wake_scheduler=None,
+        mcp_manager=None,
+        mcp_startup=None,
+    )
+    store = FrontendStateStore(_state(jobs=[]))
+    updates: list[FrontendUpdate] = []
+    store.subscribe(updates.append)
+    rescans = 0
+    original = store.refresh_from_session
+
+    def counted(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        nonlocal rescans
+        rescans += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(store, "refresh_from_session", counted)
+    assert (
+        store.observe_event(
+            session,
+            SubagentProgressEvent(job_id="child", label="child", progress="reading files"),
+        )
+        is None
+    )
+    assert (rescans, updates) == (0, [])
+
+    update = store.refresh_jobs(session)
+    assert update is not None
+    assert len(updates) == 1
+    assert updates[0].changes["jobs"][0]["latest_details"] == {"progress": "reading files"}
 
 
 def test_slash_capabilities_classify_every_advertised_command_and_images() -> None:

--- a/tests/unit/session/test_frontend_sync.py
+++ b/tests/unit/session/test_frontend_sync.py
@@ -72,6 +72,102 @@ async def test_owner_two_followers_share_full_1m_state_and_live_updates(
 
 
 @pytest.mark.asyncio
+async def test_real_socket_follower_consumes_immutable_subagent_progress_and_settlement(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Registrant → RemoteSession keeps the follower's full child ledger usable."""
+    import time
+
+    from local_operator.session.frontend_state import JobState
+    from local_operator.tui.app import OperatorApp
+    from local_operator.tui.widgets.subagent_panel import SubagentPanel
+    from local_operator.tui.widgets.subagent_view import LEDGER_GONE_NOTE, SubagentView
+    from tests.unit.tui.test_reconnect_parity import _boot, _remote_factory
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = FakeHandle()
+    started = time.time() - 2
+    running = JobState(
+        id="child",
+        type="task",
+        label="streaming child",
+        status="running",
+        start_time=started,
+        started_at=started,
+        latest_details={"progress": "reading files"},
+        trajectory=[
+            {"type": "message_start", "message": {"role": "assistant", "id": "m1"}},
+            {
+                "type": "message_update",
+                "message": {"role": "assistant", "id": "m1"},
+                "delta": "Inspecting the follower path.",
+            },
+        ],
+    )
+    handle._frontend.mutate(jobs=[running])
+    registrant = Registrant(handle, kind="tui")
+    registrant.start()
+    remote = None
+    try:
+        record = await _record(tmp_path)
+        remote = await RemoteSession.connect(
+            record, "s1", config_dir=tmp_path, takeover_factory=_never
+        )
+        app = OperatorApp(_remote_factory(remote))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _boot(app, pilot)
+            panel = app.query_one(SubagentPanel)
+            app._refresh_band()
+            panel._tick()
+            await pilot.pause()
+            assert "reading files" in str(getattr(panel._rows["child"], "content", ""))
+
+            app._open_subagent_view("child")
+            for _ in range(20):
+                await pilot.pause()
+                if "Inspecting the follower path." in " ".join(
+                    app.query_one(SubagentView).rendered_rows()
+                ):
+                    break
+            view = app.query_one(SubagentView)
+            assert "Inspecting the follower path." in " ".join(view.rendered_rows())
+
+            completed = running.model_copy(
+                update={
+                    "status": "completed",
+                    "settled_at": time.time(),
+                    "result_text": "follower path complete",
+                    "latest_details": {"progress": "thinking"},
+                }
+            )
+            handle._frontend.mutate(jobs=[completed])
+            for _ in range(100):
+                await pilot.pause()
+                row = remote.jobs.get("child")
+                if row is not None and row.status == "completed":
+                    break
+            assert remote.jobs.get("child") is not None
+            assert remote.jobs.get("child").status == "completed"  # type: ignore[union-attr]
+            assert "completed" in view.rendered_rows()[0]
+
+            await pilot.press("escape")
+            await pilot.pause()
+            app._open_subagent_view("child")
+            for _ in range(10):
+                await pilot.pause()
+            reopened = app.query_one(SubagentView)
+            rendered = " ".join(reopened.rendered_rows())
+            assert LEDGER_GONE_NOTE not in rendered
+            assert "completed" in rendered
+            assert remote.jobs.get("child") is not None
+    finally:
+        if remote is not None:
+            await remote.dispose()
+        registrant.close()
+
+
+@pytest.mark.asyncio
 async def test_daemon_never_receives_frontend_frames(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
     handle = FakeHandle()

--- a/tests/unit/session/test_resume_subagents_todos.py
+++ b/tests/unit/session/test_resume_subagents_todos.py
@@ -681,12 +681,50 @@ async def test_snapshot_entry_is_written_for_a_launched_child(tmp_path, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_live_progress_never_schedules_the_roster_writer(tmp_path, monkeypatch):
+    """Transient activity publishes to frontends without touching durability."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = _session(tmp_path, OneShotStream())
+    await parent.async_init()
+    job_id = parent._launch_subagent(label="x", prompt="p")
+    await wait_for(lambda: _status(parent, job_id) == "completed")
+    await parent._await_subagent_roster_writer()
+    generation = parent._subagent_roster_generation
+    updates = []
+    subscription = parent.subscribe_frontend(updates.append)
+    updates.clear()  # discard the join-time source reconciliation
+
+    report = parent.jobs._progress_fn(job_id)
+    started = asyncio.get_running_loop().time()
+    for index in range(60):
+        report(f"boundary {index}")
+    assert updates == []  # publication waits for the one 50 ms coalescer
+    assert parent._subagent_roster_generation == generation
+    assert parent._subagent_roster_writer is None
+    await wait_for(lambda: bool(updates), timeout=0.25)
+    assert asyncio.get_running_loop().time() - started <= 0.25
+    assert len(updates) == 1
+    assert updates[0].changes["jobs"][0]["latest_details"] == {"progress": "boundary 59"}
+    subscription.unsubscribe()
+
+    # Settlement remains durable even though progress is not. A fresh task must
+    # advance the generation at registration and again at its terminal outcome.
+    before_second = parent._subagent_roster_generation
+    second = parent._launch_subagent(label="y", prompt="q")
+    await wait_for(lambda: _status(parent, second) == "completed")
+    await parent._await_subagent_roster_writer()
+    assert parent._subagent_roster_generation > before_second
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
 async def test_redundant_roster_events_skip_the_sidecar_write(tmp_path, monkeypatch):
     """A roster event that does not change the persisted projection writes no
     sidecar, but the generation watermark still advances.
 
-    The persist hook fires on every job-row mutation, most of which (usage,
-    heartbeat) leave the durable {version, jobs, records} projection identical.
+    Defensive/manual persist signals can still repeat without a projection
+    change. Transient progress never reaches this hook; this test guards the
+    fingerprint fallback for the remaining redundant durable notifications.
     Each write is a full fsync + os.replace + directory-fsync; firing one per
     identical event is the disk-write volume that tripped the macOS throttle on
     a long delegating session. The guard collapses those, and the watermark must

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -1380,6 +1380,44 @@ async def test_frontend_update_burst_coalesces_to_latest_snapshot() -> None:
 
 
 @pytest.mark.asyncio
+async def test_raw_subagent_progress_waits_for_canonical_band_update() -> None:
+    """Owner progress has the same single visual invalidation as a follower."""
+    from local_operator.session.frontend_state import FrontendSessionState, JobState
+    from local_operator.tui.events import SubagentProgress
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 28)) as pilot:
+        await pilot.pause()
+        refreshes = 0
+
+        def refreshed() -> None:
+            nonlocal refreshes
+            refreshes += 1
+
+        app._refresh_band = refreshed
+        app.on_subagent_progress(SubagentProgress("child", "child", "reading files"))
+        assert refreshes == 0
+
+        # The canonical apply is the owner/follower-common route and owns the
+        # one repaint after the manager's <=50 ms coalescing window.
+        app._apply_frontend_state(
+            FrontendSessionState(
+                session_id="sess",
+                epoch="owner",
+                jobs=[
+                    JobState(
+                        id="child",
+                        type="task",
+                        status="running",
+                        latest_details={"progress": "reading files"},
+                    )
+                ],
+            )
+        )
+        assert refreshes == 1
+
+
+@pytest.mark.asyncio
 async def test_pending_frontend_update_cannot_repaint_after_session_adoption() -> None:
     """An old queued callback is retired before a replacement snapshot paints."""
     from local_operator.session.frontend_state import FrontendSessionState

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -139,7 +139,11 @@ def _job_with(trajectory: list[dict[str, Any]], status: str = "completed") -> An
 
 def test_fold_accepts_immutable_mapping_and_sequence_contracts() -> None:
     """Canonical follower trajectories stay tuple-backed and fully renderable."""
-    from local_operator.session.frontend_state import FrontendSessionState, FrontendStateStore, JobState
+    from local_operator.session.frontend_state import (
+        FrontendSessionState,
+        FrontendStateStore,
+        JobState,
+    )
     from local_operator.tui.widgets.subagent_panel import row_facts
 
     state = FrontendStateStore(

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -17,6 +17,7 @@ test there is.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 import pytest
@@ -134,6 +135,35 @@ def _job_with(trajectory: list[dict[str, Any]], status: str = "completed") -> An
 
 
 # -- the fold ---------------------------------------------------------------
+
+
+def test_fold_accepts_immutable_mapping_and_sequence_contracts() -> None:
+    """Canonical follower trajectories stay tuple-backed and fully renderable."""
+    from local_operator.session.frontend_state import FrontendSessionState, FrontendStateStore, JobState
+    from local_operator.tui.widgets.subagent_panel import row_facts
+
+    state = FrontendStateStore(
+        FrontendSessionState(
+            session_id="follower",
+            epoch="owner",
+            jobs=[
+                JobState(
+                    id="sub-1",
+                    type="task",
+                    label="immutable child",
+                    latest_details={"progress": "reading files"},
+                    trajectory=TRAJECTORY,
+                )
+            ],
+        )
+    ).state
+    job = state.jobs[0]
+    assert isinstance(job.latest_details, Mapping)
+    assert isinstance(job.trajectory, Sequence)
+    assert row_facts(job, fallback_id=job.id, current=False).activity == "reading files"
+    entries = fold_trajectory(job.trajectory, settled=False)
+    assert [entry.kind for entry in entries] == ["text", "tool", "tool", "text"]
+    assert entries[0].text == "Reading the ingest path."
 
 
 def test_fold_produces_prose_and_tool_rows_in_call_order() -> None:

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -1173,6 +1173,42 @@ async def test_leaving_restores_the_conversation_and_the_composer() -> None:
 
 
 @pytest.mark.asyncio
+async def test_canonical_progress_refresh_keeps_child_page_live() -> None:
+    """The single canonical invalidation updates an already-open child page."""
+    from local_operator.session.frontend_state import FrontendSessionState, JobState
+
+    job = _Job("sub-1", "audit the ingest path", status="running")
+    job.trajectory = [*_text("m1", "Reading the ingest path.")]
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        view = await _open(pilot, app, job)
+        prose = view._body.blocks()[0]
+        job.trajectory.append(_call("c1", "bash", command="pytest -q"))
+
+        # This is the frame the 50 ms jobs coalescer publishes to both owner and
+        # follower. No raw SubagentProgress repaint participates any more.
+        app._apply_frontend_state(
+            FrontendSessionState(
+                session_id="sess",
+                epoch="owner",
+                jobs=[
+                    JobState.from_job(job).model_copy(
+                        update={"latest_details": {"progress": "running pytest"}}
+                    )
+                ],
+            )
+        )
+        await pilot.pause()
+        blocks = view._body.blocks()
+        assert blocks[0] is prose
+        assert isinstance(blocks[1], ToolCard)
+        assert blocks[1]._state == "running"
+        assert isinstance(blocks[2], WorkingBlock)
+
+
+@pytest.mark.asyncio
 async def test_the_page_follows_a_running_subagent() -> None:
     """A running child keeps working after the page opens. The old modal
     snapshotted the trajectory at open and then sat still."""


### PR DESCRIPTION
## Problem

After v0.42.8 bounded long-session state work, a retained parent session could still lag while it was visibly parked on `wait` and one child streamed. The remaining path duplicated each throttled child progress boundary:

- `report_progress` notified both frontend publication and durable roster persistence, even though `latest_details` and rolling output are intentionally absent from the resume projection;
- `observe_event(SubagentProgressEvent)` performed a full `refresh_from_session` before the existing 50 ms jobs coalescer published the same row;
- the owner TUI repainted immediately from the raw progress event and then repainted again from canonical state, while remote followers used canonical state only.

Actual retained-session evidence was inspected read-only and sanitized to structural identifiers and sizes: parent session `835fbcafdc27` had a roughly 2.34 MiB transcript, 101 retained child records, a roughly 1.19 MiB roster sidecar, and one active child whose transcript was 98 entries / roughly 391 KiB at capture time. No retained session data was mutated.

## Change

- Split job notifications into durable roster changes and transient live changes.
  - Registration, queue transitions, model/usage changes, cancellation, and terminal status/outcome still publish and schedule roster persistence.
  - Progress strings and rolling output publish to frontends without incrementing the roster generation or scheduling sidecar fingerprint/write work.
- Remove `subagent_progress` from the full-session fallback in `FrontendStateStore.observe_event`; the existing 50 ms jobs coalescer owns canonical progress publication.
- Make raw owner-side `SubagentProgress` a no-op for repaint. The canonical jobs update is now the single visual invalidation for both owner and remote follower, with measured visibility under 250 ms.
- Keep the existing spinner cadence. Direct invalidation profiling showed it already repaints one row only and does not lay out the transcript.
- Add portable OSWorld-shaped benchmark and scheduling/spinner probes.
- Bump the patch version from `0.42.9` to `0.42.10`.

## Change classification

**C2, standard/pre-authorized.** This is a bounded performance and reliability correction with no schema migration, security-boundary change, or irreversible rollout. The PR is the system of record; no RFC or tracker was requested.

## Delivery contract

- Child activity remains perceptibly live on both the owner and remote followers through the same canonical update, within 250 ms.
- Transient progress/output never schedules durable roster fingerprint or write work.
- Durable launch, queue, model, usage, cancellation, settlement, and outcome state still survives resume.
- A burst produces one canonical jobs publication per 50 ms coalescing window and no raw owner-only repaint.
- Parent-view progress work remains bounded as transcripts and historical child records grow.
- Existing child-page reconciliation, scroll/widget identity, completion handling, and spinner rendering remain behaviorally unchanged.

## Non-goals

- Textual transcript virtualization or a compositor/reflow redesign.
- Changing progress cadence or hiding live child activity.
- Redesigning the full-page child view.
- Eliminating the separate child-visible Textual frame-settle tail documented below.

## Testing evidence

### Exact progress scheduling counts

`env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/probe_child_update_scheduling.py`

A 60-boundary burst through the real relay/state ownership seams measured:

| Work per burst | Before | After |
| --- | ---: | ---: |
| Roster persistence callbacks | 62 | 2 (registration/settlement only) |
| Full `refresh_from_session` fallbacks | 60 | 0 |
| Canonical frontend updates | 60 | 1 |
| Raw owner band refreshes | 60 | 0 |
| Canonical visual applies | 60 | 1 |
| Relay p95 | 0.745 ms | 0.203 ms |

The delayed `refresh_jobs` remains one call for the burst. Real-session regression coverage additionally asserts that 60 progress reports leave `_subagent_roster_generation` unchanged and schedule no writer, then proves a later task registration and settlement still advance and flush durable state.

### OSWorld-shaped real `OperatorApp` benchmark

`env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/benchmark_residual_child_lag.py`

The portable fixture uses 1,457 transcript blocks, four current jobs, a 500-event active child trajectory, and 80 child boundaries at 50 ms. Before and after used the same benchmark script on the same machine, with `origin/main` at `f7648577` as the baseline.

Stable synchronous and parent-frame evidence:

| Scenario | Before | After |
| --- | ---: | ---: |
| Child boundary synchronous p95 | 5.99 ms | 0.061 ms |
| Parent band refresh calls | 174 | 94 |
| Parent-visible frame p95 | 184 ms | 144 ms |
| Child-page `show` p95 | 4.83 ms | 4.91 ms |
| Child-page canonical apply p95 | 3.49 ms | 5.61 ms |

Keyboard round-trip timing was noisy and did **not** show a stable improvement: one directly comparable run measured parent idle/running p95 at 118/201 ms before and 201/231 ms after. A less-loaded post-change run measured 115/177 ms. The reliable improvement is removal of duplicate synchronous work and parent frame p95; all observed running-parent samples remained within the 250 ms visibility target apart from occasional machine-contention maxima.

The child-visible Textual frame-settle tail remains separate: p95 was roughly 924 ms before and 1,056 ms after in comparable runs, while the synchronous child-page path stayed under 10 ms. This PR does not claim to fix or materially improve that compositor/layout tail.

### Spinner isolation

`env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/probe_spinner_invalidation.py`

At 100 current jobs over 1,457 transcript blocks, spinner p95 was 1.49 ms. Every measured tick emitted exactly one row/span and 561 terminal bytes with zero layout passes. The cadence was therefore retained rather than degrading progress animation for an unrelated cost.

### Rendered real-app evidence

`scripts/tui_lag_shot.py` drove the real `OperatorApp` at 120x40 with 92 retained blocks and a screen-full tool ledger. Before and after SVGs were rendered in a real browser and visually inspected.

Stable geometry:

```text
screen size=118x38
screen virtual size=118x38
transcript virtual size=116x105
transcript vertical scrollbar=true
```

The transcript content box width remained 117. Its sampled height varied from 27 on the initial baseline capture to 33 after timer settling; two consecutive post-change captures were stable at 117x33. No stylesheet, layout, copy, or interaction changed in this PR.

### Automated verification

- `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest <focused paths>`: 7 focused scheduling/durability/owner-follower/child-view tests passed.
- `env -u NO_COLOR PYTHONPATH="$PWD" TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q`: 7,347 passed, 7 skipped.
- `.venv/bin/python -m flake8 .`: clean.
- `uvx --from black==26.1.0 black --check .`: 569 files unchanged, one notebook skipped because Jupyter extras are not installed.
- `uvx isort==5.13.2 --check .`: clean.
- Changed-file Pyright: 0 errors, 0 warnings.
- Whole-tree Pyright hit the known local long-running stall and was stopped after roughly 12 minutes rather than waiting indefinitely; GitHub CI remains authoritative for the complete type gate.

## Persistence and rollback

Progress and rolling output are not part of `_ROSTER_ROW_FIELDS`; after process loss a formerly active child restores as `interrupted`, so persisting its last transient activity string is neither useful nor truthful. Durable state still follows the existing roster generation, fingerprint, atomic replace, and transcript compatibility paths. Rollback is a normal code revert with no data migration or sidecar format change.

## Version

`0.42.10` (patch)
