### PR TITLE
chore(release): bump version to 0.42.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.11"
+version = "0.42.12"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Problem

`v0.42.11` was published by #360 while #359 was held on a provider rate limit. When #359 and #361 merged afterwards, `main` still carried `version = "0.42.11"` — a collision with the already-published tag. Releasing the unreleased perf (#359) and browser (#361) fixes under that stamp would either fail the PyPI upload (version exists) or overwrite the published release.

## Change

Bump `pyproject.toml` to `0.42.12` so the unreleased commits ship under a fresh, unambiguous version.

## Change classification

**C0, chore.** One-line version bump; no code, schema, or behaviour change.

## Testing evidence

- `grep '^version' pyproject.toml` → `0.42.12`.
- No source files touched; CI gates cover the tree.

## Risk and rollback

Trivial revert. No migration or persistent format changes.