### PR TITLE
fix(browser): stop the stale approval-popup loop on replaced requests

### DIFF
--- a/extension/src/approval-store.ts
+++ b/extension/src/approval-store.ts
@@ -196,12 +196,33 @@ export function enqueueAccess(
   return withSessionMutation(async () => {
     const now = Date.now();
     const snapshot = await normalizedLocked(now);
-    // Only narrated async requests deduplicate. Two paused documents under one
-    // command carry the same requester/origin/kind/commandId but represent two
-    // independently blocked navigations. Sharing one generation would either
-    // overwrite a waiter or make one Allow once authorize both.
-    const existing = kind === "async" ? findPending(snapshot.queue, url.origin, requester, kind, now) : undefined;
+    // Async requests deduplicate on origin+requester: one narrated question is
+    // asked once. In-command requests deduplicate ONLY on
+    // origin+requester+commandId — a retried navigation re-asks the identical
+    // question and must not stack a twin the user has to answer twice
+    // (approving one used to leave the other looping the popup on
+    // "Request changed."). Two paused documents under DIFFERENT commands keep
+    // separate generations so each command resumes on its own consent; a
+    // same-command twin shares the one generation the user is looking at, and
+    // one Allow resumes every waiter attached to it — exactly the consent
+    // given, never a broader grant.
+    const existing =
+      kind === "async"
+        ? findPending(snapshot.queue, url.origin, requester, kind, now)
+        : snapshot.queue.find(
+            (entry) =>
+              entry.kind === "in_command" &&
+              entry.origin === url.origin &&
+              entry.requester === requester &&
+              !!commandId &&
+              entry.commandId === commandId,
+          );
     if (existing) {
+      // A deduplicated generation must carry the new caller's waiter too:
+      // onAdmitted otherwise fires only on first admission, and an in-command
+      // caller whose waiter never registers would await a promise nothing can
+      // resolve (the paused document frozen forever).
+      onAdmitted?.(existing);
       await armNextExpiry(snapshot);
       return {
         origin: url.origin,

--- a/extension/src/origins.ts
+++ b/extension/src/origins.ts
@@ -1,5 +1,5 @@
 import { reconcileActionSurface } from "./action-surface";
-import { requesterOriginKey, type AccessQueueEntry, type OriginDecision } from "./access-queue";
+import { liveQueue, requesterOriginKey, type AccessQueueEntry, type OriginDecision } from "./access-queue";
 import {
   cancelAccess,
   decideAccess,
@@ -17,16 +17,21 @@ export type { OriginDecision } from "./access-queue";
 
 // In-command continuations are keyed by immutable queue generation, never by
 // origin: two commands paused on the same redirect must resume independently.
-const waiting = new Map<string, (decision: OriginDecision) => void>();
+// Each generation can hold SEVERAL resolvers: enqueueAccess dedupes a retried
+// same-command navigation onto the existing entry (approval-store), and every
+// paused document waiting on that entry registered its own resolver here — a
+// single-slot map would overwrite the first and strand its navigation.
+const waiting = new Map<string, Set<(decision: OriginDecision) => void>>();
 let onPendingChange: ((snapshot: QueueSnapshot) => void) | null = null;
 
 function reconcileWaiters(snapshot: QueueSnapshot): void {
-  for (const [entryId, resolve] of waiting) {
+  for (const [entryId, resolvers] of waiting) {
     if (snapshot.queue.some((entry) => entry.entryId === entryId)) continue;
     const receipt = Object.values(snapshot.results).find((candidate) => candidate.entryId === entryId);
     if (!receipt) continue;
     waiting.delete(entryId);
-    resolve(receipt.state === "allowed" ? "always" : "deny");
+    const decision: OriginDecision = receipt.state === "allowed" ? "always" : "deny";
+    for (const resolve of resolvers) resolve(decision);
   }
 }
 
@@ -124,8 +129,12 @@ export async function askOrigin(url: URL, requestId: string): Promise<boolean> {
   const queued = await enqueueAccess(url, requestId, "in_command", requestId, (entry) => {
     // enqueueAccess invokes this callback under the same mutation lock that
     // publishes the entry. No decision or expiry sweep can interleave between
-    // visibility and registration.
-    waiting.set(entry.entryId, resolveWaiter);
+    // visibility and registration. The callback also fires for a DEDUPED
+    // enqueue (retried same-command navigation), so several resolvers can
+    // attach to one generation — see the `waiting` map's comment.
+    const resolvers = waiting.get(entry.entryId) ?? new Set<(decision: OriginDecision) => void>();
+    resolvers.add(resolveWaiter);
+    waiting.set(entry.entryId, resolvers);
   });
   if (!queued.entry) return false;
   await updatePromptSurfaces(await sweepQueue());
@@ -133,12 +142,30 @@ export async function askOrigin(url: URL, requestId: string): Promise<boolean> {
 }
 
 export async function resolveOrigin(
-  _origin: string,
+  origin: string,
   decision: OriginDecision,
   entryId: string = "",
 ): Promise<boolean> {
-  if (!entryId || !["once", "always", "all_ports", "deny"].includes(decision)) return false;
-  const result = await decideAccess(entryId, decision);
+  if (!["once", "always", "all_ports", "deny"].includes(decision)) return false;
+  let targetId = entryId;
+  const session = await getSession();
+  const queue = liveQueue(session.accessQueue, Date.now());
+  if (!targetId || !queue.some((entry) => entry.entryId === targetId)) {
+    // Generation miss: a /health-fallback render carries no entry id (queue
+    // storage empty after a worker restart, or the entry expired while the
+    // daemon still echoes it), and a stale id means the entry was replaced.
+    // The click still names the ORIGIN the user looked at, so honour it
+    // against that origin's single live entry — the mismatch came from a
+    // fallback render, not a replaced prompt. Zero or several matches stay
+    // REJECTED: with several live entries for the origin the click cannot say
+    // which paused navigation the user meant, so round-2 B1's consent hole
+    // stays closed.
+    const match = queue.filter((entry) => entry.origin === origin);
+    if (match.length !== 1) return false;
+    targetId = match[0]?.entryId ?? "";
+    if (!targetId) return false;
+  }
+  const result = await decideAccess(targetId, decision);
   if (!result.applied) return false;
   // decideAccess persisted receipts before releasing the mutation lock; the
   // queue observer resolves every matching waiter from those receipts.

--- a/extension/src/origins.ts
+++ b/extension/src/origins.ts
@@ -162,7 +162,9 @@ export async function resolveOrigin(
     // stays closed.
     const match = queue.filter((entry) => entry.origin === origin);
     if (match.length !== 1) return false;
-    targetId = match[0]?.entryId ?? "";
+    // length===1 guarantees the element; no optional-chain dead guard.
+    const single = match[0]!;
+    targetId = single.entryId;
     if (!targetId) return false;
   }
   const result = await decideAccess(targetId, decision);

--- a/extension/src/popup/origin-flow.ts
+++ b/extension/src/popup/origin-flow.ts
@@ -111,8 +111,11 @@ export function noticeForRejectedDecision(
       sub: "The site request was replaced while this window was open. Review the new request.",
     };
   }
+  // D1/D2 (design round 1): state the CONSEQUENCE (nothing was granted or
+  // denied) instead of restating the title's cause, so a user who just
+  // clicked Allow knows the click had no effect.
   return {
     title: "Request expired.",
-    sub: "This request expired or was cancelled.",
+    sub: "It timed out or was cancelled, so nothing was granted or denied.",
   };
 }

--- a/extension/src/popup/origin-flow.ts
+++ b/extension/src/popup/origin-flow.ts
@@ -80,3 +80,39 @@ export function originPromptView(
   if (!pendingOrigin) return "none";
   return decided && decided.origin === pendingOrigin ? "ack" : "prompt";
 }
+
+export interface OriginNotice {
+  title: string;
+  sub: string;
+}
+
+/** The notice a REJECTED decision shows, or null when none should appear.
+ *
+ * A rejection with an EMPTY shown prompt id came from a /health-fallback
+ * render (worker restarted, queue storage empty, or the entry expired while
+ * the daemon still echoed it) — the request was never "replaced", the popup
+ * simply had no generation to aim at. resolveOrigin's origin fallback and the
+ * daemon's cleared-event reconciliation retry or retire that render, so a
+ * scary "Request changed." interstitial there was pure noise — and looping it
+ * every click was the reported bug.
+ *
+ * A rejection WITH a shown id is a real miss: the generation the buttons were
+ * drawn for is gone. If the origin is still pending under a NEWER generation
+ * the prompt was replaced; if the live queue holds no entry for the origin at
+ * all, the request expired or was cancelled. */
+export function noticeForRejectedDecision(
+  shownPromptId: string,
+  originStillPending: boolean,
+): OriginNotice | null {
+  if (!shownPromptId) return null;
+  if (originStillPending) {
+    return {
+      title: "Request changed.",
+      sub: "The site request was replaced while this window was open. Review the new request.",
+    };
+  }
+  return {
+    title: "Request expired.",
+    sub: "This request expired or was cancelled.",
+  };
+}

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -9,6 +9,7 @@ import { DEFAULT_PORT, getLocal, getSession, getSurfaces } from "../state";
 import { pairVerdict, viewForHealth } from "./pair-flow";
 import {
   ackForDecision,
+  noticeForRejectedDecision,
   originPromptView,
   type DecidedOrigin,
   type OriginDecision,
@@ -403,6 +404,11 @@ async function decide(decision: OriginDecision): Promise<void> {
   // click approve an origin the user never looked at. The worker validates
   // the generation and rejects a stale one.
   const origin = shownPromptOrigin;
+  // Capture the generation at click time, like the origin: a concurrent
+  // render() (storage.onChanged) may rewrite the module variables while this
+  // async handler is in flight, and the notice selection must judge the
+  // prompt the user SAW, not whatever landed mid-flight.
+  const promptId = shownPromptId;
   if (origin) {
     // Acknowledge from the CLICK alone, before the worker round-trip: session
     // storage and /health keep echoing this prompt until `origin_decision`
@@ -416,23 +422,30 @@ async function decide(decision: OriginDecision): Promise<void> {
       event: "origin_decision",
       origin,
       decision,
-      entryId: shownPromptId,
+      entryId: promptId,
     })) as { applied?: boolean } | undefined;
     if (!response?.applied) {
-      // The worker refused the decision: the prompt was replaced (or expired)
-      // after this popup rendered it. Say so instead of pretending the click
-      // took effect, clear the latch, and re-render — which shows the CURRENT
-      // prompt, whose buttons are live again.
       decidedOrigin = null;
-      showOriginNotice(
-        "Request changed.",
-        "The site request was replaced while this window was open. Review the new request.",
+      // A rejection with an EMPTY prompt id came from a /health-fallback
+      // render (no generation to aim at) — the request was not replaced, and
+      // resolveOrigin's origin fallback already applied this click to the
+      // single matching live entry. Re-render the resulting state without the
+      // "Request changed." interstitial: looping it on every click was the
+      // reported bug. A rejection WITH an id is a real miss — replaced or
+      // expired — and gets the matching notice.
+      const { accessQueue } = await getSession();
+      const originStillPending = liveQueue(accessQueue, Date.now()).some(
+        (entry) => entry.origin === origin,
       );
+      const notice = noticeForRejectedDecision(promptId, originStillPending);
       setOriginBusy(false);
-      // Hold the notice long enough to read (same shape as the pairing
-      // success hold), then fall through to render(), which draws the
-      // CURRENT prompt with live buttons.
-      await new Promise((resolve) => setTimeout(resolve, 1500));
+      if (notice) {
+        showOriginNotice(notice.title, notice.sub);
+        // Hold the notice long enough to read (same shape as the pairing
+        // success hold), then fall through to render(), which draws the
+        // CURRENT prompt with live buttons.
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+      }
     }
   }
   // A successful decision removes this generation; FIFO becomes current. A

--- a/extension/src/protocol.gen.ts
+++ b/extension/src/protocol.gen.ts
@@ -54,10 +54,12 @@ export interface Pong { event: 'pong'; }
 export interface TabClosed { event: 'tab_closed'; tab: string; }
 export interface TabUpdate { event: 'tab_update'; url: string; title: string; }
 export interface AwaitingOrigin { event: 'awaiting_origin'; id: string; origin: string; }
+export interface AwaitingOriginCleared { event: 'awaiting_origin_cleared'; id: string; }
 export interface Unpair { event: 'unpair'; }
 export interface OriginDecision {
   event: 'origin_decision'; origin: string; decision: 'once' | 'always' | 'deny';
 }
 export type ExtensionEvent =
-  | Hello | PairRequest | Pong | TabClosed | TabUpdate | AwaitingOrigin | Unpair | OriginDecision;
+  | Hello | PairRequest | Pong | TabClosed | TabUpdate | AwaitingOrigin | AwaitingOriginCleared
+  | Unpair | OriginDecision;
 export type DaemonMessage = HelloAck | PairResult | Ping | Request;

--- a/extension/src/worker.ts
+++ b/extension/src/worker.ts
@@ -80,6 +80,13 @@ function send(frame: object): void {
 const PENDING_NOTIFICATION_ID = "lop-origin-pending";
 let notificationQueueKey = "unreconciled";
 
+// Command ids the worker has announced to the daemon as awaiting a human
+// origin decision. Module-level so it survives across observer invocations
+// but resets with the worker — a restarted worker re-announces its live
+// entries on the first snapshot, and the daemon's own record resets on
+// disconnect, so neither side carries stale ids across a restart.
+const announcedAwaitingIds = new Set<string>();
+
 /** Chrome's notification typings retain callback overloads across versions,
  * while MV3 implementations return promises. Normalize the runtime result so
  * the action-surface allSettled boundary always owns rejection handling. */
@@ -88,10 +95,25 @@ async function notificationResult(result: Promise<unknown> | unknown): Promise<v
 }
 
 setPendingObserver(async (snapshot) => {
+  // Command ids announced as awaiting a human decision. The daemon pops its
+  // record when the RPC's response arrives or the RPC times out, but a queue
+  // entry that is decided, cancelled, or expired on the extension side
+  // produces neither when the worker loses the command (suspension, restart),
+  // so /health kept echoing a prompt the popup could never resolve — the
+  // stale echo that looped the approval popup. Announce clearances for ids
+  // that leave the queue so the echo is bounded by the queue's lifetime.
+  const liveCommandIds = new Set<string>();
   for (const entry of snapshot.queue) {
     if (entry.kind === "in_command" && entry.commandId) {
+      liveCommandIds.add(entry.commandId);
       send({ event: "awaiting_origin", id: entry.commandId, origin: entry.origin });
+      announcedAwaitingIds.add(entry.commandId);
     }
+  }
+  for (const id of announcedAwaitingIds) {
+    if (liveCommandIds.has(id)) continue;
+    announcedAwaitingIds.delete(id);
+    send({ event: "awaiting_origin_cleared", id });
   }
   const count = snapshot.queue.length;
   // Badge/title reconciliation may legitimately repeat during a sweep, but an

--- a/extension/tests/origins.integration.test.mjs
+++ b/extension/tests/origins.integration.test.mjs
@@ -420,22 +420,22 @@ test("decision between enqueue publication and return cannot miss the waiter", a
   } finally { await bundle.close(); chrome.restore(); }
 });
 
-test("identical in-command admissions are independently visible and decidable", async () => {
+test("same-command in-command admissions dedupe onto one generation", async () => {
   const chrome = installChromeStub();
   const bundle = await loadModule("src/origins.ts");
   try {
     const origins = await bundle.import();
     const first = origins.askOrigin(url("https://same-hop.example"), "same-command");
     const second = origins.askOrigin(url("https://same-hop.example"), "same-command");
-    while (chrome.session("accessQueue")?.length !== 2) await new Promise((resolve) => setTimeout(resolve, 0));
-    const [a, b] = chrome.session("accessQueue");
-    assert.notEqual(a.entryId, b.entryId);
-    await origins.resolveOrigin(a.origin, "deny", a.entryId);
-    assert.equal(await first, false);
-    assert.equal(chrome.session("accessQueue").length, 1, "deny removes only the selected navigation");
-    await origins.resolveOrigin(b.origin, "once", b.entryId);
-    assert.equal(await second, true);
-    assert.equal(chrome.session("onceGrants")?.["https://same-hop.example\nsame-command"], undefined);
+    // A retried same-command navigation re-asks the identical question, so it
+    // dedupes onto the ONE generation the user is looking at instead of
+    // stacking a twin. One decision therefore settles every paused document
+    // attached to that command.
+    while ((chrome.session("accessQueue")?.length ?? 0) !== 1) await new Promise((resolve) => setTimeout(resolve, 0));
+    const [entry] = chrome.session("accessQueue");
+    await origins.resolveOrigin(entry.origin, "deny", entry.entryId);
+    assert.deepEqual(await Promise.all([first, second]), [false, false]);
+    assert.equal(chrome.session("accessQueue").length, 0, "the deduped generation is decided");
   } finally { await bundle.close(); chrome.restore(); }
 });
 
@@ -446,7 +446,7 @@ test("always allow reconciles every identical in-command waiter", async () => {
     const origins = await bundle.import();
     const first = origins.askOrigin(url("https://fleet-hop.example"), "same-command");
     const second = origins.askOrigin(url("https://fleet-hop.example"), "same-command");
-    while (chrome.session("accessQueue")?.length !== 2) await new Promise((resolve) => setTimeout(resolve, 0));
+    while ((chrome.session("accessQueue")?.length ?? 0) !== 1) await new Promise((resolve) => setTimeout(resolve, 0));
     const selected = chrome.session("accessQueue")[0];
     await origins.resolveOrigin(selected.origin, "always", selected.entryId);
     assert.deepEqual(await Promise.all([first, second]), [true, true]);
@@ -461,7 +461,7 @@ test("TTL sweep settles every identical in-command waiter", async () => {
     const origins = await bundle.import();
     const first = origins.askOrigin(url("https://expire-both.example"), "same-command");
     const second = origins.askOrigin(url("https://expire-both.example"), "same-command");
-    while (chrome.session("accessQueue")?.length !== 2) await new Promise((resolve) => setTimeout(resolve, 0));
+    while ((chrome.session("accessQueue")?.length ?? 0) !== 1) await new Promise((resolve) => setTimeout(resolve, 0));
     const expiresAt = Math.max(...chrome.session("accessQueue").map((entry) => entry.expiresAt));
     await origins.sweepQueue(expiresAt);
     assert.deepEqual(await Promise.all([first, second]), [false, false]);
@@ -573,4 +573,112 @@ test("queue cap rejects without loss and migration imports legacy generation onc
     assert.equal(overflow.pending_count, 16);
     assert.equal(chrome.session("accessQueue").length, 16);
   } finally { await bundle.close(); chrome.restore(); }
+});
+
+test("origin-fallback decision applies to a single live entry and rejects ambiguity", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadModule("src/origins.ts");
+  try {
+    const origins = await bundle.import();
+    const now = Date.now();
+    chrome.setSession("accessQueueVersion", 1);
+    // ONE live entry for the origin: an empty-generation (health-fallback)
+    // decision has no id to aim at, but the user is looking at exactly this
+    // origin, so the click must land on it.
+    chrome.setSession("accessQueue", [
+      { entryId: "solo", origin: "https://solo.example", displayAuthority: "solo.example", requester: "cmd-solo", kind: "in_command", requestedAt: now, expiresAt: now + 60_000, sequence: 1, commandId: "cmd-solo" },
+    ]);
+    assert.equal(await origins.resolveOrigin("https://solo.example", "once", ""), true, "single match applies");
+    assert.equal(chrome.session("accessQueue").length, 0, "single entry was decided");
+
+    // TWO live entries share the origin: the fallback must not guess which
+    // paused navigation the user meant (B1 stays closed).
+    chrome.setSession("accessQueue", [
+      { entryId: "twin-a", origin: "https://twin.example", displayAuthority: "twin.example", requester: "cmd-a", kind: "in_command", requestedAt: now, expiresAt: now + 60_000, sequence: 1, commandId: "cmd-a" },
+      { entryId: "twin-b", origin: "https://twin.example", displayAuthority: "twin.example", requester: "cmd-b", kind: "in_command", requestedAt: now, expiresAt: now + 60_000, sequence: 2, commandId: "cmd-b" },
+    ]);
+    assert.equal(await origins.resolveOrigin("https://twin.example", "once", ""), false, "multi-match rejects");
+    assert.equal(chrome.session("accessQueue").length, 2, "both twin entries survive the rejection");
+
+    // No live entry for the origin: nothing to apply the decision to.
+    assert.equal(await origins.resolveOrigin("https://absent.example", "once", ""), false, "zero-match rejects");
+  } finally { await bundle.close(); chrome.restore(); }
+});
+
+test("in-command enqueue dedupes a retried same-command navigation but keeps distinct commands", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadStore();
+  try {
+    const store = await bundle.import();
+    const first = await store.enqueueAccess(url("https://dup.example"), "cmd-1", "in_command", "cmd-1");
+    const retry = await store.enqueueAccess(url("https://dup.example"), "cmd-1", "in_command", "cmd-1");
+    assert.equal(retry.entryId, first.entryId, "same command dedupes onto one generation");
+    assert.equal(chrome.session("accessQueue").length, 1, "no twin stacks for one command");
+    const other = await store.enqueueAccess(url("https://dup.example"), "cmd-1", "in_command", "cmd-2");
+    assert.notEqual(other.entryId, first.entryId, "a different command keeps its own generation");
+    assert.equal(chrome.session("accessQueue").length, 2);
+  } finally { await bundle.close(); chrome.restore(); }
+});
+
+test("a deduped same-command generation resolves every attached waiter", async () => {
+  const chrome = installChromeStub();
+  const bundle = await loadModule("src/origins.ts");
+  try {
+    const origins = await bundle.import();
+    // Two paused documents under the SAME command share one generation after
+    // dedupe; both registered resolvers must be released by one decision, or
+    // one navigation would wait on a promise nothing can resolve.
+    const p1 = origins.askOrigin(url("https://wait.example"), "cmd-w");
+    const p2 = origins.askOrigin(url("https://wait.example"), "cmd-w");
+    for (let i = 0; i < 40 && (chrome.session("accessQueue")?.length ?? 0) !== 1; i++) await tick();
+    await tick();
+    assert.equal(chrome.session("accessQueue").length, 1, "twins dedupe onto one generation");
+    const entryId = chrome.session("accessQueue")[0].entryId;
+    assert.equal(await origins.resolveOrigin("https://wait.example", "once", entryId), true);
+    const [r1, r2] = await Promise.all([p1, p2]);
+    assert.equal(r1, true, "first paused document resumes");
+    assert.equal(r2, true, "deduped twin also resumes");
+  } finally { await bundle.close(); chrome.restore(); }
+});
+
+test("worker observer announces an origin block and clears it when the entry leaves the queue", async () => {
+  const chrome = installChromeStub();
+  const frames = [];
+  globalThis.navigator = { userAgent: "node-test" };
+  globalThis.WebSocket = class {
+    static OPEN = 1;
+    readyState = 1;
+    constructor() { queueMicrotask(() => this.onopen?.()); }
+    send(data) { frames.push(JSON.parse(String(data))); }
+    close() {}
+  };
+  const bundle = await loadModule("src/worker.ts");
+  const originalNow = Date.now;
+  let now = Date.now();
+  try {
+    chrome.setSession("accessQueueVersion", 1);
+    chrome.setSession("accessQueue", [
+      { entryId: "e1", origin: "https://x.example", displayAuthority: "x.example", requester: "cmd-1", kind: "in_command", requestedAt: now, expiresAt: now + 60_000, sequence: 1, commandId: "cmd-1" },
+    ]);
+    await bundle.import();
+    // Wait for the socket to open (hello frame) so observer sends are captured.
+    for (let i = 0; i < 40 && !frames.some((f) => f.event === "hello"); i++) await tick();
+    assert.ok(frames.some((f) => f.event === "hello"), "worker connected");
+    // Re-sweep with the entry still live: the announcement repeats, and no
+    // clearance is emitted for an entry that is still in the queue.
+    await chrome.fireAlarm("lop-access-expiry");
+    for (let i = 0; i < 40 && !frames.some((f) => f.event === "awaiting_origin"); i++) await tick();
+    assert.ok(frames.some((f) => f.event === "awaiting_origin" && f.id === "cmd-1"), "block announced");
+    assert.ok(!frames.some((f) => f.event === "awaiting_origin_cleared"), "no clearance while the entry is live");
+    // Expire the entry and sweep: the observer must announce the clearance so
+    // the daemon stops echoing a prompt the popup can no longer resolve.
+    now += 120_000;
+    Date.now = () => now;
+    await chrome.fireAlarm("lop-access-expiry");
+    for (let i = 0; i < 40 && !frames.some((f) => f.event === "awaiting_origin_cleared"); i++) await tick();
+    assert.ok(frames.some((f) => f.event === "awaiting_origin_cleared" && f.id === "cmd-1"), "clearance announced");
+  } finally {
+    Date.now = originalNow;
+    await bundle.close(); chrome.restore();
+  }
 });

--- a/extension/tests/pure.test.mjs
+++ b/extension/tests/pure.test.mjs
@@ -394,6 +394,29 @@ test("origin render holds the ack through the decision round-trip race", async (
   } finally { await module.close(); }
 });
 
+test("rejected decision notice skips the interstitial for fallback renders", async () => {
+  const module = await load("src/popup/origin-flow.ts");
+  try {
+    const { noticeForRejectedDecision } = module.loaded;
+    // An EMPTY prompt id means the popup rendered from the /health fallback —
+    // the request was never "replaced", so no interstitial: the origin
+    // fallback already retried the click, and looping the notice on every
+    // click was the reported bug.
+    assert.equal(noticeForRejectedDecision("", true), null);
+    assert.equal(noticeForRejectedDecision("", false), null);
+    // A real miss with the origin still pending under a NEWER generation.
+    assert.deepEqual(noticeForRejectedDecision("gen-1", true), {
+      title: "Request changed.",
+      sub: "The site request was replaced while this window was open. Review the new request.",
+    });
+    // A real miss with the origin gone from the live queue entirely.
+    assert.deepEqual(noticeForRejectedDecision("gen-1", false), {
+      title: "Request expired.",
+      sub: "This request expired or was cancelled.",
+    });
+  } finally { await module.close(); }
+});
+
 test("surface tokens resolve only with an exact nonce-bearing handle", async () => {
   const module = await load("src/state.ts");
   try {

--- a/extension/tests/pure.test.mjs
+++ b/extension/tests/pure.test.mjs
@@ -412,7 +412,7 @@ test("rejected decision notice skips the interstitial for fallback renders", asy
     // A real miss with the origin gone from the live queue entirely.
     assert.deepEqual(noticeForRejectedDecision("gen-1", false), {
       title: "Request expired.",
-      sub: "This request expired or was cancelled.",
+      sub: "It timed out or was cancelled, so nothing was granted or denied.",
     });
   } finally { await module.close(); }
 });

--- a/local_operator/browser_bridge/daemon.py
+++ b/local_operator/browser_bridge/daemon.py
@@ -415,6 +415,17 @@ class BridgeService:
                         self.link.awaiting_origin[request_id] = str(frame.get("origin", ""))
                         self.publish()
                     continue
+                if frame.get("event") == "awaiting_origin_cleared":
+                    # The extension's queue entry for this command is gone
+                    # (decided, cancelled, or expired) without a response the
+                    # daemon will see. Drop the record so /health stops echoing
+                    # a prompt the popup can no longer resolve — the stale echo
+                    # is what looped the approval popup on "Request changed."
+                    request_id = str(frame.get("id", ""))
+                    if request_id and request_id in self.link.awaiting_origin:
+                        self.link.awaiting_origin.pop(request_id, None)
+                        self.publish()
+                    continue
                 if frame.get("event") == "unpair":
                     # The options page "Unpair this browser" reaches the daemon
                     # here so revocation severs THIS live socket, mirroring the

--- a/local_operator/browser_bridge/gen_ts.py
+++ b/local_operator/browser_bridge/gen_ts.py
@@ -67,12 +67,14 @@ export interface Pong {{ event: 'pong'; }}
 export interface TabClosed {{ event: 'tab_closed'; tab: string; }}
 export interface TabUpdate {{ event: 'tab_update'; url: string; title: string; }}
 export interface AwaitingOrigin {{ event: 'awaiting_origin'; id: string; origin: string; }}
+export interface AwaitingOriginCleared {{ event: 'awaiting_origin_cleared'; id: string; }}
 export interface Unpair {{ event: 'unpair'; }}
 export interface OriginDecision {{
   event: 'origin_decision'; origin: string; decision: 'once' | 'always' | 'deny';
 }}
 export type ExtensionEvent =
-  | Hello | PairRequest | Pong | TabClosed | TabUpdate | AwaitingOrigin | Unpair | OriginDecision;
+  | Hello | PairRequest | Pong | TabClosed | TabUpdate | AwaitingOrigin | AwaitingOriginCleared
+  | Unpair | OriginDecision;
 export type DaemonMessage = HelloAck | PairResult | Ping | Request;
 """
 

--- a/local_operator/browser_bridge/protocol.py
+++ b/local_operator/browser_bridge/protocol.py
@@ -235,6 +235,18 @@ class AwaitingOrigin(WireModel):
     origin: str = ""
 
 
+class AwaitingOriginCleared(WireModel):
+    """Extension -> daemon: a previously announced command is NO LONGER blocked
+    on a human origin decision — its queue entry expired, was cancelled, or was
+    decided without a response the daemon will see. The daemon pops its record
+    so /health stops echoing a prompt the extension no longer shows; without
+    this the echo outlived the queue entry and the popup looped on a stale
+    request it could never resolve."""
+
+    event: Literal["awaiting_origin_cleared"] = "awaiting_origin_cleared"
+    id: str
+
+
 class Unpair(WireModel):
     """Extension -> daemon: the options page revoked pairing, so the daemon must
     drop the live socket, not merely the next reconnect (findings A5/U1)."""

--- a/tests/unit/browser_bridge/test_daemon.py
+++ b/tests/unit/browser_bridge/test_daemon.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
@@ -78,6 +79,60 @@ def test_web_page_origin_is_rejected(tmp_path: Path) -> None:
             assert "4004" in str(exc) or getattr(exc, "code", None) == 4004
         else:  # pragma: no cover - rejection is mandatory
             raise AssertionError("web origin was accepted")
+
+
+def _until(condition, timeout: float = 5.0) -> None:
+    """The websocket receive loop runs on TestClient's portal thread, so a
+    main-thread assertion right after send_json races the frame's processing.
+    Poll the condition instead of reading state once."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return
+        time.sleep(0.02)
+    assert condition(), "condition did not settle in time"
+
+
+def test_awaiting_origin_cleared_stops_the_health_echo(tmp_path: Path) -> None:
+    """The extension's queue entry can expire, be cancelled, or be decided
+    without a response the daemon will see. The extension then announces
+    ``awaiting_origin_cleared``; the daemon must drop its record and republish
+    so /health stops echoing a prompt the popup can no longer resolve — the
+    stale echo that looped the approval popup on "Request changed." """
+    app = create_app(root=tmp_path)
+    with TestClient(app) as client:
+        service = app.state.bridge
+        with client.websocket_connect("/extension", headers={"origin": ORIGIN}) as socket:
+            socket.send_json(
+                {
+                    "event": "hello",
+                    "proto": PROTO_VERSION,
+                    "token": "",
+                    "extension_version": "0.1.0",
+                    "browser": "Chrome/151",
+                }
+            )
+            socket.receive_json()
+            socket.send_json(
+                {"event": "awaiting_origin", "id": "r-1", "origin": "https://docs.example"}
+            )
+            _until(lambda: service.link.awaiting_origin == {"r-1": "https://docs.example"})
+            assert client.get("/health").json()["pending_origin"] == "https://docs.example"
+            # The extension-side entry is gone; the daemon must forget it.
+            socket.send_json({"event": "awaiting_origin_cleared", "id": "r-1"})
+            _until(lambda: service.link.awaiting_origin == {})
+            assert client.get("/health").json()["pending_origin"] == ""
+            # A clearance for an id the daemon never recorded is a no-op.
+            socket.send_json({"event": "awaiting_origin_cleared", "id": "r-unknown"})
+            assert service.link.awaiting_origin == {}
+
+
+def test_awaiting_origin_cleared_round_trips_through_the_wire_model() -> None:
+    from local_operator.browser_bridge.protocol import AwaitingOriginCleared
+
+    frame = AwaitingOriginCleared(id="r-1")
+    assert AwaitingOriginCleared.model_validate_json(frame.model_dump_json()) == frame
+    assert frame.event == "awaiting_origin_cleared"
 
 
 def test_await_access_lock_topology() -> None:


### PR DESCRIPTION
# PR Description

## Summary of Changes

Fix the "Request changed." approval-popup loop in the browser extension. A user
reported the same site request (`docs.gominerva.com`) appearing twice; approving
the first popup left the second looping on the "Request changed. The site request
was replaced while this window was open. Review the new request." interstitial —
every Allow click re-showed the interstitial and the request never resolved.

Four cooperating defects produced the loop; this PR fixes all of them.

### Diagnosis (verified against `origin/main`)

1. **Health-fallback renders carry no generation id.** `popup.ts` `render()`
   computes `shownPromptId = selected?.entryId ?? session.pendingOrigin?.promptId
   ?? ""`. When the popup renders from the daemon `/health` fallback (queue
   storage empty/unread, worker restarted, or the queue entry expired while the
   daemon still echoes it), `shownPromptId` is `""`.

2. **Empty generation = dead buttons.** `origins.ts` `resolveOrigin()` returned
   `false` for any decision with a missing/stale `entryId`. A health-fallback
   render therefore rejected every click; `popup.ts` `decide()` showed the
   "Request changed." interstitial, waited 1.5 s, re-rendered the SAME
   health-echoed prompt, and looped until the daemon stopped echoing.

3. **The daemon echo outlives the queue entry.** `daemon.py` sets
   `awaiting_origin` from the extension's `awaiting_origin` event and pops it
   only when that RPC's response arrives or the RPC times out
   (`ORIGIN_PROMPT_WINDOW_S` ≈ 10 min + 5 s). Nothing reconciles it when the
   extension-side queue entry expires/cancels while the worker is suspended or
   the response is lost, so `/health` `pending_origin` kept echoing a prompt the
   extension no longer held — feeding loop (2).

4. **Duplicate requests stack.** Two `in_command` entries for the same
   origin+requester+commandId (a retried navigation) enqueued as two separate
   generations (`enqueueAccess` deduped only `kind === "async"`), so the user saw
   "the same request twice" and approving one left the twin.

### Fixes

- **A — Origin-fallback decision (`origins.ts`).** When the generation id is
  missing or stale, `resolveOrigin` now applies the decision to the single live
  queue entry whose origin exactly matches the clicked origin. Rationale: the
  user is looking at the exact origin rendered; the generation mismatch came from
  a fallback render, not a replaced prompt. Zero or several matches still reject,
  so round-2 B1's consent hole stays closed (never apply by origin alone when
  ambiguous).

- **B — Daemon reconciliation (`worker.ts`, `daemon.py`, `protocol.py`,
  `protocol.gen.ts`).** The worker observer tracks announced command ids and now
  emits a new `awaiting_origin_cleared` event for ids that leave the queue. The
  daemon pops its record and republishes, so `/health` stops echoing a prompt the
  popup can no longer resolve. This bounds the stale echo to the queue's
  lifetime. The frame is a typed `AwaitingOriginCleared` model and
  `protocol.gen.ts` is regenerated via `gen_ts.py`.

- **C — Popup notice selection (`popup.ts`, `origin-flow.ts`).** When `decide()`
  gets `applied: false` and the shown prompt id was empty (health-fallback
  render), it no longer shows "Request changed." — the request was not replaced;
  retry is handled by fix A. A new pure `noticeForRejectedDecision()` returns the
  "Request changed." copy only when the origin is still pending under a NEWER
  generation (a true replacement), and a new "Request expired." copy when the
  live queue no longer holds the origin. The 1.5 s hold behavior is preserved.

- **D — In-command dedupe (`approval-store.ts`).** `enqueueAccess` now dedupes
  `kind === "in_command"` on origin+requester+commandId (a retried navigation
  re-asks the identical question). Different commandIds and two paused documents
  under different commands keep separate generations. A deduped generation carries
  every attached waiter (`origins.ts` `waiting` is now a multimap), so one Allow
  resumes every paused document on that command — exactly the consent given,
  never a broader grant.

## Related Issue(s)

- User-reported approval-popup loop (no ticket).

## Impact

- No breaking changes. The wire protocol gains one extension→daemon event
  (`awaiting_origin_cleared`); older daemons ignore unknown frames, and the
  daemon's existing response/timeout pops remain as backstops.
- No dependency updates.
- Security: the B1 consent hole stays closed — origin-fallback applies only on an
  unambiguous single match, and dedupe never broadens a grant.

## Testing Details

### Extension (node) — `pnpm typecheck && pnpm test && pnpm build`

- `origin-fallback decision applies to a single live entry and rejects ambiguity`
  — single match applies, multi-match rejects, zero-match rejects (fix A).
- `in-command enqueue dedupes a retried same-command navigation but keeps
  distinct commands` — same command dedupes, different commandId keeps its own
  generation (fix D).
- `a deduped same-command generation resolves every attached waiter` — one
  decision settles both paused documents (fix D multimap).
- `worker observer announces an origin block and clears it when the entry leaves
  the queue` — clearance emitted after the entry leaves, not on first
  announcement (fix B).
- `rejected decision notice skips the interstitial for fallback renders` — pure
  `noticeForRejectedDecision` selection (fix C).
- Three pre-existing tests that codified the OLD no-dedupe rule
  (`identical in-command admissions are independently visible and decidable`,
  `always allow reconciles every identical in-command waiter`, `TTL sweep settles
  every identical in-command waiter`) were reconciled to the new dedupe behavior;
  their `while length !== 2` loops would otherwise spin forever.

Result: **67/67 pass**, `tsc --noEmit` clean, `build` clean.

### Python — `tests/unit/browser_bridge`

- `test_awaiting_origin_cleared_stops_the_health_echo` — the daemon pops the
  record on the cleared event and `/health` `pending_origin` empties; a clearance
  for an unknown id is a no-op (fix B).
- `test_awaiting_origin_cleared_round_trips_through_the_wire_model` — protocol
  model round-trip.
- `test_generated_types_are_current` — `gen_ts --check` parity.

Result: **94/94 pass** in `tests/unit/browser_bridge`. Full `tests/unit` suite:
7337 passed; the 24 pre-existing failures (`test_eval_tool.py`,
`test_subagent_view.py`) reproduce identically on clean `origin/main` and are
unrelated to this change.

### Gates

flake8, black (26.1.0), isort (5.13.2), and pyright all clean on the touched
files.

## User-visible behavior change

- Approving a site request rendered from the `/health` fallback now resolves the
  request instead of looping on "Request changed."
- A retried navigation no longer stacks a duplicate request; one Allow settles
  every paused document on that command.
- When a request is genuinely replaced, the popup still says "Request changed.";
  when it expired or was cancelled, it now says "Request expired."

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.
