### PR TITLE
chore(release): bump runtime to 0.42.13 and extension to 0.1.5

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Local Operator",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Connect Local Operator to the browser you already use, entirely on your machine.",
   "permissions": ["debugger", "tabs", "tabGroups", "scripting", "storage", "alarms", "webNavigation", "notifications"],
   "host_permissions": ["<all_urls>"],

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-operator-browser-extension",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "packageManager": "pnpm@11.22.0",
   "scripts": {

--- a/extension/tests/origins.integration.test.mjs
+++ b/extension/tests/origins.integration.test.mjs
@@ -81,7 +81,7 @@ function installChromeStub(actionFailures = new Set(), notificationFailures = ne
     },
     runtime: {
       getURL: (path) => `chrome-extension://test/${path}`,
-      getManifest: () => ({ version: "0.1.4" }),
+      getManifest: () => ({ version: "0.1.5" }),
       onStartup: { addListener: () => {} }, onInstalled: { addListener: () => {} },
       onMessage: { addListener: () => {} }, sendMessage: async () => {},
     },

--- a/extension/tests/release.test.mjs
+++ b/extension/tests/release.test.mjs
@@ -56,7 +56,7 @@ async function runRelease(args, handlers) {
 
 test("manifest requests tabGroups exactly once", async () => {
   const manifest = JSON.parse(await readFile(new URL("../manifest.json", import.meta.url), "utf8"));
-  assert.equal(manifest.version, "0.1.4");
+  assert.equal(manifest.version, "0.1.5");
   assert.equal(manifest.permissions.filter((permission) => permission === "tabGroups").length, 1);
 });
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.12"
+version = "0.42.13"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## What

Runtime 0.42.12→0.42.13 ships the merged stale-approval-loop fix (#363) on top of 0.42.12; extension 0.1.4→0.1.5 ships the same fix to the Chrome Web Store package:

- Approval decisions on a generation-less fallback render now apply to the single live matching entry instead of looping on "Request changed."
- The daemon stops echoing dead prompts via awaiting_origin_cleared.
- Expired/cancelled requests get a consequence-stating notice; true replacements keep the original copy.
- Retried in-command navigations no longer enqueue duplicate requests (multimap waiters).

## Testing

- Extension gates on head: typecheck clean, 67/67 node tests (release.test.mjs pins 0.1.5), build clean.
- #363 carried clean terminal code (rounds 1-2) and design (rounds 1-2) review rounds with remediation.
- Runtime metadata parses as 0.42.13; targeted release/CLI tests pass.