### PR TITLE
feat(tui): add /failovers and a packaged failover guide

### DIFF
--- a/docs/assets/pr-failovers/after-empty-80.svg
+++ b/docs/assets/pr-failovers/after-empty-80.svg
@@ -1,0 +1,133 @@
+<svg class="rich-terminal" viewBox="0 0 994 489.2" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-475064663-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-475064663-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-475064663-r1 { fill: #c5c8c6 }
+.terminal-475064663-r2 { fill: #e9e5db }
+.terminal-475064663-r3 { fill: #837c6d }
+.terminal-475064663-r4 { fill: #57c785 }
+.terminal-475064663-r5 { fill: #1e1a14 }
+.terminal-475064663-r6 { fill: #4a4539 }
+.terminal-475064663-r7 { fill: #b48cd6 }
+.terminal-475064663-r8 { fill: #6ea8d8 }
+.terminal-475064663-r9 { fill: #ef8078;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-475064663-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="438.2" />
+    </clipPath>
+    <clipPath id="terminal-475064663-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-475064663-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-475064663-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-475064663-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-475064663-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-475064663-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-475064663-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-475064663-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-475064663-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-475064663-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-475064663-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-475064663-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-475064663-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-475064663-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-475064663-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-475064663-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-475064663-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="487.2" rx="8"/><text class="terminal-475064663-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">Local&#160;Operator</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-475064663-clip-terminal)">
+    <rect fill="#14110c" x="0" y="1.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="25.9" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="50.3" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="244" y="50.3" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="74.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="170.8" y="74.7" width="549" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="719.8" y="74.7" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="99.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="99.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="183" y="99.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="915" y="99.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="123.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="123.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="146.4" y="123.5" width="695.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="841.8" y="123.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="147.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="147.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="122" y="147.9" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="658.8" y="147.9" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="172.3" width="939.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="196.7" width="939.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="221.1" width="939.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="245.5" width="939.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="269.9" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="294.3" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="36.6" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#e9e5db" x="61" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="73.2" y="318.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="353.8" y="318.7" width="585.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="939.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="951.6" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="343.1" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="951.6" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="367.5" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="207.4" y="367.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="244" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="268.4" y="367.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="317.2" y="367.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="353.8" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="378.2" y="367.5" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="695.4" y="367.5" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="927.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="939.4" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="951.6" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="391.9" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-475064663-matrix">
+    <text class="terminal-475064663-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-475064663-line-0)">
+</text><text class="terminal-475064663-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-475064663-line-1)">
+</text><text class="terminal-475064663-r3" x="48.8" y="68.8" textLength="195.2" clip-path="url(#terminal-475064663-line-2)">failover&#160;cascade</text><text class="terminal-475064663-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-475064663-line-2)">
+</text><text class="terminal-475064663-r3" x="48.8" y="93.2" textLength="36.6" clip-path="url(#terminal-475064663-line-3)">├─&#160;</text><text class="terminal-475064663-r4" x="85.4" y="93.2" textLength="85.4" clip-path="url(#terminal-475064663-line-3)">primary</text><text class="terminal-475064663-r3" x="170.8" y="93.2" textLength="549" clip-path="url(#terminal-475064663-line-3)">&#160;&#160;anthropic/claude-opus-5&#160;·&#160;high&#160;·&#160;4&#160;accounts</text><text class="terminal-475064663-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-475064663-line-3)">
+</text><text class="terminal-475064663-r3" x="48.8" y="117.6" textLength="36.6" clip-path="url(#terminal-475064663-line-4)">├─&#160;</text><text class="terminal-475064663-r4" x="85.4" y="117.6" textLength="97.6" clip-path="url(#terminal-475064663-line-4)">no&#160;chain</text><text class="terminal-475064663-r3" x="183" y="117.6" textLength="732" clip-path="url(#terminal-475064663-line-4)">&#160;&#160;no&#160;chain&#160;matches&#160;—&#160;set&#160;values.retry.fallbackChains.default</text><text class="terminal-475064663-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-475064663-line-4)">
+</text><text class="terminal-475064663-r3" x="48.8" y="142" textLength="36.6" clip-path="url(#terminal-475064663-line-5)">├─&#160;</text><text class="terminal-475064663-r4" x="85.4" y="142" textLength="61" clip-path="url(#terminal-475064663-line-5)">stale</text><text class="terminal-475064663-r3" x="146.4" y="142" textLength="695.4" clip-path="url(#terminal-475064663-line-5)">&#160;&#160;config.yml&#160;changed&#160;since&#160;this&#160;session&#160;started&#160;·&#160;/reload</text><text class="terminal-475064663-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-475064663-line-5)">
+</text><text class="terminal-475064663-r3" x="48.8" y="166.4" textLength="36.6" clip-path="url(#terminal-475064663-line-6)">└─&#160;</text><text class="terminal-475064663-r4" x="85.4" y="166.4" textLength="36.6" clip-path="url(#terminal-475064663-line-6)">tip</text><text class="terminal-475064663-r3" x="122" y="166.4" textLength="536.8" clip-path="url(#terminal-475064663-line-6)">&#160;&#160;ask&#160;the&#160;agent&#160;to&#160;set&#160;up&#160;a&#160;fallback&#160;cascade</text><text class="terminal-475064663-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-475064663-line-6)">
+</text><text class="terminal-475064663-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-475064663-line-7)">
+</text><text class="terminal-475064663-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-475064663-line-8)">
+</text><text class="terminal-475064663-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-475064663-line-9)">
+</text><text class="terminal-475064663-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-475064663-line-10)">
+</text><text class="terminal-475064663-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-475064663-line-11)">
+</text><text class="terminal-475064663-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-475064663-line-12)">
+</text><text class="terminal-475064663-r2" x="24.4" y="337.2" textLength="12.2" clip-path="url(#terminal-475064663-line-13)">❯</text><text class="terminal-475064663-r3" x="73.2" y="337.2" textLength="280.6" clip-path="url(#terminal-475064663-line-13)">Message&#160;Local&#160;Operator…</text><text class="terminal-475064663-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-475064663-line-13)">
+</text><text class="terminal-475064663-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-475064663-line-14)">
+</text><text class="terminal-475064663-r3" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-475064663-line-15)">◆&#160;</text><text class="terminal-475064663-r2" x="48.8" y="386" textLength="158.6" clip-path="url(#terminal-475064663-line-15)">Claude&#160;Opus&#160;5</text><text class="terminal-475064663-r6" x="207.4" y="386" textLength="36.6" clip-path="url(#terminal-475064663-line-15)">&#160;›&#160;</text><text class="terminal-475064663-r3" x="244" y="386" textLength="24.4" clip-path="url(#terminal-475064663-line-15)">▴&#160;</text><text class="terminal-475064663-r7" x="268.4" y="386" textLength="48.8" clip-path="url(#terminal-475064663-line-15)">high</text><text class="terminal-475064663-r6" x="317.2" y="386" textLength="36.6" clip-path="url(#terminal-475064663-line-15)">&#160;›&#160;</text><text class="terminal-475064663-r3" x="353.8" y="386" textLength="24.4" clip-path="url(#terminal-475064663-line-15)">⌂&#160;</text><text class="terminal-475064663-r8" x="378.2" y="386" textLength="317.2" clip-path="url(#terminal-475064663-line-15)">/private/tmp/lop-failovers</text><text class="terminal-475064663-r9" x="927.2" y="386" textLength="12.2" clip-path="url(#terminal-475064663-line-15)">!</text><text class="terminal-475064663-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-475064663-line-15)">
+</text><text class="terminal-475064663-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-475064663-line-16)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/assets/pr-failovers/after-fallback-serving-80.svg
+++ b/docs/assets/pr-failovers/after-fallback-serving-80.svg
@@ -1,0 +1,132 @@
+<svg class="rich-terminal" viewBox="0 0 994 489.2" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-1651858060-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-1651858060-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-1651858060-r1 { fill: #c5c8c6 }
+.terminal-1651858060-r2 { fill: #e9e5db }
+.terminal-1651858060-r3 { fill: #837c6d }
+.terminal-1651858060-r4 { fill: #57c785 }
+.terminal-1651858060-r5 { fill: #1e1a14 }
+.terminal-1651858060-r6 { fill: #4a4539 }
+.terminal-1651858060-r7 { fill: #6ea8d8 }
+.terminal-1651858060-r8 { fill: #ef8078;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-1651858060-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="438.2" />
+    </clipPath>
+    <clipPath id="terminal-1651858060-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1651858060-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1651858060-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1651858060-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1651858060-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1651858060-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1651858060-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1651858060-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1651858060-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1651858060-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1651858060-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1651858060-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1651858060-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1651858060-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1651858060-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1651858060-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1651858060-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="487.2" rx="8"/><text class="terminal-1651858060-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">Local&#160;Operator</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1651858060-clip-terminal)">
+    <rect fill="#14110c" x="0" y="1.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="25.9" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="50.3" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="244" y="50.3" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="74.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="170.8" y="74.7" width="549" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="719.8" y="74.7" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="99.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="99.1" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="244" y="99.1" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="353.8" y="99.1" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="123.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="123.5" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="488" y="123.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="622.2" y="123.5" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="147.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="147.9" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="488" y="147.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="622.2" y="147.9" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="172.3" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="172.3" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="488" y="172.3" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="768.6" y="172.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="196.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="196.7" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="488" y="196.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="622.2" y="196.7" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="221.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="221.1" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="488" y="221.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="622.2" y="221.1" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="245.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="245.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="122" y="245.5" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="829.6" y="245.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="269.9" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="294.3" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="36.6" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#e9e5db" x="61" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="73.2" y="318.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="353.8" y="318.7" width="585.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="939.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="951.6" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="343.1" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="951.6" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="367.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="183" y="367.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="219.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="244" y="367.5" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="561.2" y="367.5" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="927.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="939.4" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="951.6" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="391.9" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-1651858060-matrix">
+    <text class="terminal-1651858060-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-1651858060-line-0)">
+</text><text class="terminal-1651858060-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-1651858060-line-1)">
+</text><text class="terminal-1651858060-r3" x="48.8" y="68.8" textLength="195.2" clip-path="url(#terminal-1651858060-line-2)">failover&#160;cascade</text><text class="terminal-1651858060-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-1651858060-line-2)">
+</text><text class="terminal-1651858060-r3" x="48.8" y="93.2" textLength="36.6" clip-path="url(#terminal-1651858060-line-3)">├─&#160;</text><text class="terminal-1651858060-r4" x="85.4" y="93.2" textLength="85.4" clip-path="url(#terminal-1651858060-line-3)">primary</text><text class="terminal-1651858060-r3" x="170.8" y="93.2" textLength="549" clip-path="url(#terminal-1651858060-line-3)">&#160;&#160;anthropic/claude-opus-5&#160;·&#160;high&#160;·&#160;4&#160;accounts</text><text class="terminal-1651858060-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-1651858060-line-3)">
+</text><text class="terminal-1651858060-r3" x="48.8" y="117.6" textLength="36.6" clip-path="url(#terminal-1651858060-line-4)">├─&#160;</text><text class="terminal-1651858060-r4" x="85.4" y="117.6" textLength="158.6" clip-path="url(#terminal-1651858060-line-4)">matched&#160;chain</text><text class="terminal-1651858060-r3" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-1651858060-line-4)">&#160;&#160;default</text><text class="terminal-1651858060-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-1651858060-line-4)">
+</text><text class="terminal-1651858060-r3" x="48.8" y="142" textLength="36.6" clip-path="url(#terminal-1651858060-line-5)">├─&#160;</text><text class="terminal-1651858060-r4" x="85.4" y="142" textLength="402.6" clip-path="url(#terminal-1651858060-line-5)">1.&#160;zai/glm-5.3&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1651858060-r3" x="488" y="142" textLength="134.2" clip-path="url(#terminal-1651858060-line-5)">&#160;&#160;1&#160;account</text><text class="terminal-1651858060-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-1651858060-line-5)">
+</text><text class="terminal-1651858060-r3" x="48.8" y="166.4" textLength="36.6" clip-path="url(#terminal-1651858060-line-6)">├─&#160;</text><text class="terminal-1651858060-r4" x="85.4" y="166.4" textLength="402.6" clip-path="url(#terminal-1651858060-line-6)">2.&#160;kimi/k3&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1651858060-r3" x="488" y="166.4" textLength="134.2" clip-path="url(#terminal-1651858060-line-6)">&#160;&#160;1&#160;account</text><text class="terminal-1651858060-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-1651858060-line-6)">
+</text><text class="terminal-1651858060-r3" x="48.8" y="190.8" textLength="36.6" clip-path="url(#terminal-1651858060-line-7)">├─&#160;</text><text class="terminal-1651858060-r4" x="85.4" y="190.8" textLength="402.6" clip-path="url(#terminal-1651858060-line-7)">3.&#160;alibaba-token-plan/qwen3.8-max</text><text class="terminal-1651858060-r3" x="488" y="190.8" textLength="280.6" clip-path="url(#terminal-1651858060-line-7)">&#160;&#160;←&#160;serving&#160;&#160;3&#160;accounts</text><text class="terminal-1651858060-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-1651858060-line-7)">
+</text><text class="terminal-1651858060-r3" x="48.8" y="215.2" textLength="36.6" clip-path="url(#terminal-1651858060-line-8)">├─&#160;</text><text class="terminal-1651858060-r4" x="85.4" y="215.2" textLength="402.6" clip-path="url(#terminal-1651858060-line-8)">4.&#160;xai/grok-4.6&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1651858060-r3" x="488" y="215.2" textLength="134.2" clip-path="url(#terminal-1651858060-line-8)">&#160;&#160;1&#160;account</text><text class="terminal-1651858060-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-1651858060-line-8)">
+</text><text class="terminal-1651858060-r3" x="48.8" y="239.6" textLength="36.6" clip-path="url(#terminal-1651858060-line-9)">├─&#160;</text><text class="terminal-1651858060-r4" x="85.4" y="239.6" textLength="402.6" clip-path="url(#terminal-1651858060-line-9)">5.&#160;openai/gpt-5.6-sol&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1651858060-r3" x="488" y="239.6" textLength="134.2" clip-path="url(#terminal-1651858060-line-9)">&#160;&#160;1&#160;account</text><text class="terminal-1651858060-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-1651858060-line-9)">
+</text><text class="terminal-1651858060-r3" x="48.8" y="264" textLength="36.6" clip-path="url(#terminal-1651858060-line-10)">└─&#160;</text><text class="terminal-1651858060-r4" x="85.4" y="264" textLength="36.6" clip-path="url(#terminal-1651858060-line-10)">tip</text><text class="terminal-1651858060-r3" x="122" y="264" textLength="707.6" clip-path="url(#terminal-1651858060-line-10)">&#160;&#160;ask&#160;the&#160;agent&#160;to&#160;change&#160;models,&#160;effort&#160;or&#160;providers&#160;here</text><text class="terminal-1651858060-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-1651858060-line-10)">
+</text><text class="terminal-1651858060-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-1651858060-line-11)">
+</text><text class="terminal-1651858060-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-1651858060-line-12)">
+</text><text class="terminal-1651858060-r2" x="24.4" y="337.2" textLength="12.2" clip-path="url(#terminal-1651858060-line-13)">❯</text><text class="terminal-1651858060-r3" x="73.2" y="337.2" textLength="280.6" clip-path="url(#terminal-1651858060-line-13)">Message&#160;Local&#160;Operator…</text><text class="terminal-1651858060-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-1651858060-line-13)">
+</text><text class="terminal-1651858060-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-1651858060-line-14)">
+</text><text class="terminal-1651858060-r3" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-1651858060-line-15)">◆&#160;</text><text class="terminal-1651858060-r2" x="48.8" y="386" textLength="134.2" clip-path="url(#terminal-1651858060-line-15)">Qwen3.8&#160;Max</text><text class="terminal-1651858060-r6" x="183" y="386" textLength="36.6" clip-path="url(#terminal-1651858060-line-15)">&#160;›&#160;</text><text class="terminal-1651858060-r3" x="219.6" y="386" textLength="24.4" clip-path="url(#terminal-1651858060-line-15)">⌂&#160;</text><text class="terminal-1651858060-r7" x="244" y="386" textLength="317.2" clip-path="url(#terminal-1651858060-line-15)">/private/tmp/lop-failovers</text><text class="terminal-1651858060-r8" x="927.2" y="386" textLength="12.2" clip-path="url(#terminal-1651858060-line-15)">!</text><text class="terminal-1651858060-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-1651858060-line-15)">
+</text><text class="terminal-1651858060-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-1651858060-line-16)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/assets/pr-failovers/after-no-chains.svg
+++ b/docs/assets/pr-failovers/after-no-chains.svg
@@ -1,0 +1,107 @@
+<svg class="rich-terminal" viewBox="0 0 1238 342.79999999999995" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-804661481-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-804661481-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-804661481-r1 { fill: #c5c8c6 }
+.terminal-804661481-r2 { fill: #e9e5db }
+.terminal-804661481-r3 { fill: #837c6d }
+.terminal-804661481-r4 { fill: #57c785 }
+.terminal-804661481-r5 { fill: #1e1a14 }
+.terminal-804661481-r6 { fill: #4a4539 }
+.terminal-804661481-r7 { fill: #6ea8d8 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-804661481-clip-terminal">
+      <rect x="0" y="0" width="1219.0" height="291.79999999999995" />
+    </clipPath>
+    <clipPath id="terminal-804661481-line-0">
+    <rect x="0" y="1.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-804661481-line-1">
+    <rect x="0" y="25.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-804661481-line-2">
+    <rect x="0" y="50.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-804661481-line-3">
+    <rect x="0" y="74.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-804661481-line-4">
+    <rect x="0" y="99.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-804661481-line-5">
+    <rect x="0" y="123.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-804661481-line-6">
+    <rect x="0" y="147.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-804661481-line-7">
+    <rect x="0" y="172.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-804661481-line-8">
+    <rect x="0" y="196.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-804661481-line-9">
+    <rect x="0" y="221.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-804661481-line-10">
+    <rect x="0" y="245.5" width="1220" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="340.8" rx="8"/><text class="terminal-804661481-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">Local&#160;Operator</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-804661481-clip-terminal)">
+    <rect fill="#14110c" x="0" y="1.5" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="25.9" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="50.3" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="244" y="50.3" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="74.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="170.8" y="74.7" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="488" y="74.7" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="99.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="99.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="183" y="99.1" width="854" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1037" y="99.1" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="123.5" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="147.9" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="36.6" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#e9e5db" x="61" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="73.2" y="172.3" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="353.8" y="172.3" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1183.4" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1195.6" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="196.7" width="1171.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1195.6" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="221.1" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="170.8" y="221.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="207.4" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="231.8" y="221.1" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="549" y="221.1" width="634.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1183.4" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1195.6" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="245.5" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="269.9" width="1220" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-804661481-matrix">
+    <text class="terminal-804661481-r1" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-804661481-line-0)">
+</text><text class="terminal-804661481-r1" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-804661481-line-1)">
+</text><text class="terminal-804661481-r3" x="48.8" y="68.8" textLength="195.2" clip-path="url(#terminal-804661481-line-2)">failover&#160;cascade</text><text class="terminal-804661481-r1" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-804661481-line-2)">
+</text><text class="terminal-804661481-r3" x="48.8" y="93.2" textLength="36.6" clip-path="url(#terminal-804661481-line-3)">├─&#160;</text><text class="terminal-804661481-r4" x="85.4" y="93.2" textLength="85.4" clip-path="url(#terminal-804661481-line-3)">primary</text><text class="terminal-804661481-r3" x="170.8" y="93.2" textLength="317.2" clip-path="url(#terminal-804661481-line-3)">&#160;&#160;test/model&#160;·&#160;no&#160;accounts</text><text class="terminal-804661481-r1" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-804661481-line-3)">
+</text><text class="terminal-804661481-r3" x="48.8" y="117.6" textLength="36.6" clip-path="url(#terminal-804661481-line-4)">└─&#160;</text><text class="terminal-804661481-r4" x="85.4" y="117.6" textLength="97.6" clip-path="url(#terminal-804661481-line-4)">no&#160;chain</text><text class="terminal-804661481-r3" x="183" y="117.6" textLength="854" clip-path="url(#terminal-804661481-line-4)">&#160;&#160;nothing&#160;matches&#160;test/model&#160;—&#160;set&#160;values.retry.fallbackChains.default</text><text class="terminal-804661481-r1" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-804661481-line-4)">
+</text><text class="terminal-804661481-r1" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-804661481-line-5)">
+</text><text class="terminal-804661481-r1" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-804661481-line-6)">
+</text><text class="terminal-804661481-r2" x="24.4" y="190.8" textLength="12.2" clip-path="url(#terminal-804661481-line-7)">❯</text><text class="terminal-804661481-r3" x="73.2" y="190.8" textLength="280.6" clip-path="url(#terminal-804661481-line-7)">Message&#160;Local&#160;Operator…</text><text class="terminal-804661481-r1" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-804661481-line-7)">
+</text><text class="terminal-804661481-r1" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-804661481-line-8)">
+</text><text class="terminal-804661481-r3" x="24.4" y="239.6" textLength="24.4" clip-path="url(#terminal-804661481-line-9)">◆&#160;</text><text class="terminal-804661481-r2" x="48.8" y="239.6" textLength="122" clip-path="url(#terminal-804661481-line-9)">test/model</text><text class="terminal-804661481-r6" x="170.8" y="239.6" textLength="36.6" clip-path="url(#terminal-804661481-line-9)">&#160;›&#160;</text><text class="terminal-804661481-r3" x="207.4" y="239.6" textLength="24.4" clip-path="url(#terminal-804661481-line-9)">⌂&#160;</text><text class="terminal-804661481-r7" x="231.8" y="239.6" textLength="317.2" clip-path="url(#terminal-804661481-line-9)">/private/tmp/lop-failovers</text><text class="terminal-804661481-r1" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-804661481-line-9)">
+</text><text class="terminal-804661481-r1" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-804661481-line-10)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/assets/pr-failovers/after-populated-80.svg
+++ b/docs/assets/pr-failovers/after-populated-80.svg
@@ -1,0 +1,133 @@
+<svg class="rich-terminal" viewBox="0 0 994 489.2" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-2566537324-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-2566537324-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-2566537324-r1 { fill: #c5c8c6 }
+.terminal-2566537324-r2 { fill: #e9e5db }
+.terminal-2566537324-r3 { fill: #837c6d }
+.terminal-2566537324-r4 { fill: #57c785 }
+.terminal-2566537324-r5 { fill: #1e1a14 }
+.terminal-2566537324-r6 { fill: #4a4539 }
+.terminal-2566537324-r7 { fill: #b48cd6 }
+.terminal-2566537324-r8 { fill: #6ea8d8 }
+.terminal-2566537324-r9 { fill: #ef8078;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-2566537324-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="438.2" />
+    </clipPath>
+    <clipPath id="terminal-2566537324-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2566537324-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2566537324-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2566537324-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2566537324-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2566537324-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2566537324-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2566537324-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2566537324-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2566537324-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2566537324-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2566537324-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2566537324-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2566537324-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2566537324-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2566537324-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2566537324-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="487.2" rx="8"/><text class="terminal-2566537324-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">Local&#160;Operator</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-2566537324-clip-terminal)">
+    <rect fill="#14110c" x="0" y="1.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="25.9" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="50.3" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="244" y="50.3" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="74.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="170.8" y="74.7" width="695.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="866.2" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="99.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="99.1" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="244" y="99.1" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="353.8" y="99.1" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="123.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="123.5" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="488" y="123.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="622.2" y="123.5" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="147.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="147.9" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="488" y="147.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="622.2" y="147.9" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="172.3" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="172.3" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="488" y="172.3" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="634.4" y="172.3" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="196.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="196.7" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="488" y="196.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="622.2" y="196.7" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="221.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="221.1" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="488" y="221.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="622.2" y="221.1" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="245.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="245.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="122" y="245.5" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="829.6" y="245.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="269.9" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="294.3" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="36.6" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#e9e5db" x="61" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="73.2" y="318.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="353.8" y="318.7" width="585.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="939.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="951.6" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="343.1" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="951.6" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="367.5" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="207.4" y="367.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="244" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="268.4" y="367.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="317.2" y="367.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="353.8" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="378.2" y="367.5" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="695.4" y="367.5" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="927.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="939.4" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="951.6" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="391.9" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-2566537324-matrix">
+    <text class="terminal-2566537324-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2566537324-line-0)">
+</text><text class="terminal-2566537324-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2566537324-line-1)">
+</text><text class="terminal-2566537324-r3" x="48.8" y="68.8" textLength="195.2" clip-path="url(#terminal-2566537324-line-2)">failover&#160;cascade</text><text class="terminal-2566537324-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2566537324-line-2)">
+</text><text class="terminal-2566537324-r3" x="48.8" y="93.2" textLength="36.6" clip-path="url(#terminal-2566537324-line-3)">├─&#160;</text><text class="terminal-2566537324-r4" x="85.4" y="93.2" textLength="85.4" clip-path="url(#terminal-2566537324-line-3)">primary</text><text class="terminal-2566537324-r3" x="170.8" y="93.2" textLength="695.4" clip-path="url(#terminal-2566537324-line-3)">&#160;&#160;anthropic/claude-opus-5&#160;·&#160;high&#160;·&#160;4&#160;accounts&#160;&#160;&#160;←&#160;serving</text><text class="terminal-2566537324-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2566537324-line-3)">
+</text><text class="terminal-2566537324-r3" x="48.8" y="117.6" textLength="36.6" clip-path="url(#terminal-2566537324-line-4)">├─&#160;</text><text class="terminal-2566537324-r4" x="85.4" y="117.6" textLength="158.6" clip-path="url(#terminal-2566537324-line-4)">matched&#160;chain</text><text class="terminal-2566537324-r3" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-2566537324-line-4)">&#160;&#160;default</text><text class="terminal-2566537324-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2566537324-line-4)">
+</text><text class="terminal-2566537324-r3" x="48.8" y="142" textLength="36.6" clip-path="url(#terminal-2566537324-line-5)">├─&#160;</text><text class="terminal-2566537324-r4" x="85.4" y="142" textLength="402.6" clip-path="url(#terminal-2566537324-line-5)">1.&#160;zai/glm-5.3&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2566537324-r3" x="488" y="142" textLength="134.2" clip-path="url(#terminal-2566537324-line-5)">&#160;&#160;1&#160;account</text><text class="terminal-2566537324-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2566537324-line-5)">
+</text><text class="terminal-2566537324-r3" x="48.8" y="166.4" textLength="36.6" clip-path="url(#terminal-2566537324-line-6)">├─&#160;</text><text class="terminal-2566537324-r4" x="85.4" y="166.4" textLength="402.6" clip-path="url(#terminal-2566537324-line-6)">2.&#160;kimi/k3&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2566537324-r3" x="488" y="166.4" textLength="134.2" clip-path="url(#terminal-2566537324-line-6)">&#160;&#160;1&#160;account</text><text class="terminal-2566537324-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-2566537324-line-6)">
+</text><text class="terminal-2566537324-r3" x="48.8" y="190.8" textLength="36.6" clip-path="url(#terminal-2566537324-line-7)">├─&#160;</text><text class="terminal-2566537324-r4" x="85.4" y="190.8" textLength="402.6" clip-path="url(#terminal-2566537324-line-7)">3.&#160;alibaba-token-plan/qwen3.8-max</text><text class="terminal-2566537324-r3" x="488" y="190.8" textLength="146.4" clip-path="url(#terminal-2566537324-line-7)">&#160;&#160;3&#160;accounts</text><text class="terminal-2566537324-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-2566537324-line-7)">
+</text><text class="terminal-2566537324-r3" x="48.8" y="215.2" textLength="36.6" clip-path="url(#terminal-2566537324-line-8)">├─&#160;</text><text class="terminal-2566537324-r4" x="85.4" y="215.2" textLength="402.6" clip-path="url(#terminal-2566537324-line-8)">4.&#160;xai/grok-4.6&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2566537324-r3" x="488" y="215.2" textLength="134.2" clip-path="url(#terminal-2566537324-line-8)">&#160;&#160;1&#160;account</text><text class="terminal-2566537324-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-2566537324-line-8)">
+</text><text class="terminal-2566537324-r3" x="48.8" y="239.6" textLength="36.6" clip-path="url(#terminal-2566537324-line-9)">├─&#160;</text><text class="terminal-2566537324-r4" x="85.4" y="239.6" textLength="402.6" clip-path="url(#terminal-2566537324-line-9)">5.&#160;openai/gpt-5.6-sol&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2566537324-r3" x="488" y="239.6" textLength="134.2" clip-path="url(#terminal-2566537324-line-9)">&#160;&#160;1&#160;account</text><text class="terminal-2566537324-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-2566537324-line-9)">
+</text><text class="terminal-2566537324-r3" x="48.8" y="264" textLength="36.6" clip-path="url(#terminal-2566537324-line-10)">└─&#160;</text><text class="terminal-2566537324-r4" x="85.4" y="264" textLength="36.6" clip-path="url(#terminal-2566537324-line-10)">tip</text><text class="terminal-2566537324-r3" x="122" y="264" textLength="707.6" clip-path="url(#terminal-2566537324-line-10)">&#160;&#160;ask&#160;the&#160;agent&#160;to&#160;change&#160;models,&#160;effort&#160;or&#160;providers&#160;here</text><text class="terminal-2566537324-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-2566537324-line-10)">
+</text><text class="terminal-2566537324-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-2566537324-line-11)">
+</text><text class="terminal-2566537324-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-2566537324-line-12)">
+</text><text class="terminal-2566537324-r2" x="24.4" y="337.2" textLength="12.2" clip-path="url(#terminal-2566537324-line-13)">❯</text><text class="terminal-2566537324-r3" x="73.2" y="337.2" textLength="280.6" clip-path="url(#terminal-2566537324-line-13)">Message&#160;Local&#160;Operator…</text><text class="terminal-2566537324-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-2566537324-line-13)">
+</text><text class="terminal-2566537324-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-2566537324-line-14)">
+</text><text class="terminal-2566537324-r3" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-2566537324-line-15)">◆&#160;</text><text class="terminal-2566537324-r2" x="48.8" y="386" textLength="158.6" clip-path="url(#terminal-2566537324-line-15)">Claude&#160;Opus&#160;5</text><text class="terminal-2566537324-r6" x="207.4" y="386" textLength="36.6" clip-path="url(#terminal-2566537324-line-15)">&#160;›&#160;</text><text class="terminal-2566537324-r3" x="244" y="386" textLength="24.4" clip-path="url(#terminal-2566537324-line-15)">▴&#160;</text><text class="terminal-2566537324-r7" x="268.4" y="386" textLength="48.8" clip-path="url(#terminal-2566537324-line-15)">high</text><text class="terminal-2566537324-r6" x="317.2" y="386" textLength="36.6" clip-path="url(#terminal-2566537324-line-15)">&#160;›&#160;</text><text class="terminal-2566537324-r3" x="353.8" y="386" textLength="24.4" clip-path="url(#terminal-2566537324-line-15)">⌂&#160;</text><text class="terminal-2566537324-r8" x="378.2" y="386" textLength="317.2" clip-path="url(#terminal-2566537324-line-15)">/private/tmp/lop-failovers</text><text class="terminal-2566537324-r9" x="927.2" y="386" textLength="12.2" clip-path="url(#terminal-2566537324-line-15)">!</text><text class="terminal-2566537324-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-2566537324-line-15)">
+</text><text class="terminal-2566537324-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-2566537324-line-16)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/assets/pr-failovers/after-populated.svg
+++ b/docs/assets/pr-failovers/after-populated.svg
@@ -1,0 +1,133 @@
+<svg class="rich-terminal" viewBox="0 0 1287 489.2" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-1796101679-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-1796101679-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-1796101679-r1 { fill: #c5c8c6 }
+.terminal-1796101679-r2 { fill: #e9e5db }
+.terminal-1796101679-r3 { fill: #837c6d }
+.terminal-1796101679-r4 { fill: #57c785 }
+.terminal-1796101679-r5 { fill: #1e1a14 }
+.terminal-1796101679-r6 { fill: #4a4539 }
+.terminal-1796101679-r7 { fill: #b48cd6 }
+.terminal-1796101679-r8 { fill: #6ea8d8 }
+.terminal-1796101679-r9 { fill: #ef8078;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-1796101679-clip-terminal">
+      <rect x="0" y="0" width="1267.8" height="438.2" />
+    </clipPath>
+    <clipPath id="terminal-1796101679-line-0">
+    <rect x="0" y="1.5" width="1268.8" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1796101679-line-1">
+    <rect x="0" y="25.9" width="1268.8" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1796101679-line-2">
+    <rect x="0" y="50.3" width="1268.8" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1796101679-line-3">
+    <rect x="0" y="74.7" width="1268.8" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1796101679-line-4">
+    <rect x="0" y="99.1" width="1268.8" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1796101679-line-5">
+    <rect x="0" y="123.5" width="1268.8" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1796101679-line-6">
+    <rect x="0" y="147.9" width="1268.8" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1796101679-line-7">
+    <rect x="0" y="172.3" width="1268.8" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1796101679-line-8">
+    <rect x="0" y="196.7" width="1268.8" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1796101679-line-9">
+    <rect x="0" y="221.1" width="1268.8" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1796101679-line-10">
+    <rect x="0" y="245.5" width="1268.8" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1796101679-line-11">
+    <rect x="0" y="269.9" width="1268.8" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1796101679-line-12">
+    <rect x="0" y="294.3" width="1268.8" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1796101679-line-13">
+    <rect x="0" y="318.7" width="1268.8" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1796101679-line-14">
+    <rect x="0" y="343.1" width="1268.8" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1796101679-line-15">
+    <rect x="0" y="367.5" width="1268.8" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1796101679-line-16">
+    <rect x="0" y="391.9" width="1268.8" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1285" height="487.2" rx="8"/><text class="terminal-1796101679-title" fill="#c5c8c6" text-anchor="middle" x="642" y="27">Local&#160;Operator</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1796101679-clip-terminal)">
+    <rect fill="#14110c" x="0" y="1.5" width="1268.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="25.9" width="1244.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1256.6" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="50.3" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="244" y="50.3" width="1000.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1244.4" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1256.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="74.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="170.8" y="74.7" width="695.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="866.2" y="74.7" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1244.4" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1256.6" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="99.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="99.1" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="244" y="99.1" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="353.8" y="99.1" width="890.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1244.4" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1256.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="123.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="123.5" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="256.2" y="123.5" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="671" y="123.5" width="573.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1244.4" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1256.6" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="147.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="147.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="207.4" y="147.9" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="622.2" y="147.9" width="622.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1244.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1256.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="172.3" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="172.3" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="488" y="172.3" width="427" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="915" y="172.3" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1244.4" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1256.6" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="196.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="196.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="268.4" y="196.7" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="683.2" y="196.7" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1244.4" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1256.6" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="221.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="221.1" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="341.6" y="221.1" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="756.4" y="221.1" width="488" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1244.4" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1256.6" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="245.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="245.5" width="841.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="927.2" y="245.5" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1244.4" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1256.6" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="269.9" width="1244.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1256.6" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="294.3" width="1244.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1256.6" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="36.6" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#e9e5db" x="61" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="73.2" y="318.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="353.8" y="318.7" width="878.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1232.2" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1244.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1256.6" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="343.1" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1244.4" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1256.6" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="367.5" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="207.4" y="367.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="244" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="268.4" y="367.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="317.2" y="367.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="353.8" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="378.2" y="367.5" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="695.4" y="367.5" width="524.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1220" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1232.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1244.4" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1256.6" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="391.9" width="1244.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1256.6" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="416.3" width="1268.8" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-1796101679-matrix">
+    <text class="terminal-1796101679-r1" x="1268.8" y="20" textLength="12.2" clip-path="url(#terminal-1796101679-line-0)">
+</text><text class="terminal-1796101679-r1" x="1268.8" y="44.4" textLength="12.2" clip-path="url(#terminal-1796101679-line-1)">
+</text><text class="terminal-1796101679-r3" x="48.8" y="68.8" textLength="195.2" clip-path="url(#terminal-1796101679-line-2)">failover&#160;cascade</text><text class="terminal-1796101679-r1" x="1268.8" y="68.8" textLength="12.2" clip-path="url(#terminal-1796101679-line-2)">
+</text><text class="terminal-1796101679-r3" x="48.8" y="93.2" textLength="36.6" clip-path="url(#terminal-1796101679-line-3)">├─&#160;</text><text class="terminal-1796101679-r4" x="85.4" y="93.2" textLength="85.4" clip-path="url(#terminal-1796101679-line-3)">primary</text><text class="terminal-1796101679-r3" x="170.8" y="93.2" textLength="695.4" clip-path="url(#terminal-1796101679-line-3)">&#160;&#160;anthropic/claude-opus-5&#160;·&#160;high&#160;·&#160;4&#160;accounts&#160;&#160;&#160;←&#160;serving</text><text class="terminal-1796101679-r1" x="1268.8" y="93.2" textLength="12.2" clip-path="url(#terminal-1796101679-line-3)">
+</text><text class="terminal-1796101679-r3" x="48.8" y="117.6" textLength="36.6" clip-path="url(#terminal-1796101679-line-4)">├─&#160;</text><text class="terminal-1796101679-r4" x="85.4" y="117.6" textLength="158.6" clip-path="url(#terminal-1796101679-line-4)">matched&#160;chain</text><text class="terminal-1796101679-r3" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-1796101679-line-4)">&#160;&#160;default</text><text class="terminal-1796101679-r1" x="1268.8" y="117.6" textLength="12.2" clip-path="url(#terminal-1796101679-line-4)">
+</text><text class="terminal-1796101679-r3" x="48.8" y="142" textLength="36.6" clip-path="url(#terminal-1796101679-line-5)">├─&#160;</text><text class="terminal-1796101679-r4" x="85.4" y="142" textLength="170.8" clip-path="url(#terminal-1796101679-line-5)">1.&#160;zai/glm-5.3</text><text class="terminal-1796101679-r3" x="256.2" y="142" textLength="414.8" clip-path="url(#terminal-1796101679-line-5)">&#160;&#160;model&#160;default&#160;effort&#160;·&#160;1&#160;account</text><text class="terminal-1796101679-r1" x="1268.8" y="142" textLength="12.2" clip-path="url(#terminal-1796101679-line-5)">
+</text><text class="terminal-1796101679-r3" x="48.8" y="166.4" textLength="36.6" clip-path="url(#terminal-1796101679-line-6)">├─&#160;</text><text class="terminal-1796101679-r4" x="85.4" y="166.4" textLength="122" clip-path="url(#terminal-1796101679-line-6)">2.&#160;kimi/k3</text><text class="terminal-1796101679-r3" x="207.4" y="166.4" textLength="414.8" clip-path="url(#terminal-1796101679-line-6)">&#160;&#160;model&#160;default&#160;effort&#160;·&#160;1&#160;account</text><text class="terminal-1796101679-r1" x="1268.8" y="166.4" textLength="12.2" clip-path="url(#terminal-1796101679-line-6)">
+</text><text class="terminal-1796101679-r3" x="48.8" y="190.8" textLength="36.6" clip-path="url(#terminal-1796101679-line-7)">├─&#160;</text><text class="terminal-1796101679-r4" x="85.4" y="190.8" textLength="402.6" clip-path="url(#terminal-1796101679-line-7)">3.&#160;alibaba-token-plan/qwen3.8-max</text><text class="terminal-1796101679-r3" x="488" y="190.8" textLength="427" clip-path="url(#terminal-1796101679-line-7)">&#160;&#160;model&#160;default&#160;effort&#160;·&#160;3&#160;accounts</text><text class="terminal-1796101679-r1" x="1268.8" y="190.8" textLength="12.2" clip-path="url(#terminal-1796101679-line-7)">
+</text><text class="terminal-1796101679-r3" x="48.8" y="215.2" textLength="36.6" clip-path="url(#terminal-1796101679-line-8)">├─&#160;</text><text class="terminal-1796101679-r4" x="85.4" y="215.2" textLength="183" clip-path="url(#terminal-1796101679-line-8)">4.&#160;xai/grok-4.6</text><text class="terminal-1796101679-r3" x="268.4" y="215.2" textLength="414.8" clip-path="url(#terminal-1796101679-line-8)">&#160;&#160;model&#160;default&#160;effort&#160;·&#160;1&#160;account</text><text class="terminal-1796101679-r1" x="1268.8" y="215.2" textLength="12.2" clip-path="url(#terminal-1796101679-line-8)">
+</text><text class="terminal-1796101679-r3" x="48.8" y="239.6" textLength="36.6" clip-path="url(#terminal-1796101679-line-9)">├─&#160;</text><text class="terminal-1796101679-r4" x="85.4" y="239.6" textLength="256.2" clip-path="url(#terminal-1796101679-line-9)">5.&#160;openai/gpt-5.6-sol</text><text class="terminal-1796101679-r3" x="341.6" y="239.6" textLength="414.8" clip-path="url(#terminal-1796101679-line-9)">&#160;&#160;model&#160;default&#160;effort&#160;·&#160;1&#160;account</text><text class="terminal-1796101679-r1" x="1268.8" y="239.6" textLength="12.2" clip-path="url(#terminal-1796101679-line-9)">
+</text><text class="terminal-1796101679-r3" x="48.8" y="264" textLength="36.6" clip-path="url(#terminal-1796101679-line-10)">└─&#160;</text><text class="terminal-1796101679-r3" x="85.4" y="264" textLength="841.8" clip-path="url(#terminal-1796101679-line-10)">&#160;&#160;ask&#160;the&#160;agent&#160;to&#160;change&#160;models,&#160;effort&#160;or&#160;providers&#160;in&#160;this&#160;cascade</text><text class="terminal-1796101679-r1" x="1268.8" y="264" textLength="12.2" clip-path="url(#terminal-1796101679-line-10)">
+</text><text class="terminal-1796101679-r1" x="1268.8" y="288.4" textLength="12.2" clip-path="url(#terminal-1796101679-line-11)">
+</text><text class="terminal-1796101679-r1" x="1268.8" y="312.8" textLength="12.2" clip-path="url(#terminal-1796101679-line-12)">
+</text><text class="terminal-1796101679-r2" x="24.4" y="337.2" textLength="12.2" clip-path="url(#terminal-1796101679-line-13)">❯</text><text class="terminal-1796101679-r3" x="73.2" y="337.2" textLength="280.6" clip-path="url(#terminal-1796101679-line-13)">Message&#160;Local&#160;Operator…</text><text class="terminal-1796101679-r1" x="1268.8" y="337.2" textLength="12.2" clip-path="url(#terminal-1796101679-line-13)">
+</text><text class="terminal-1796101679-r1" x="1268.8" y="361.6" textLength="12.2" clip-path="url(#terminal-1796101679-line-14)">
+</text><text class="terminal-1796101679-r3" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-1796101679-line-15)">◆&#160;</text><text class="terminal-1796101679-r2" x="48.8" y="386" textLength="158.6" clip-path="url(#terminal-1796101679-line-15)">Claude&#160;Opus&#160;5</text><text class="terminal-1796101679-r6" x="207.4" y="386" textLength="36.6" clip-path="url(#terminal-1796101679-line-15)">&#160;›&#160;</text><text class="terminal-1796101679-r3" x="244" y="386" textLength="24.4" clip-path="url(#terminal-1796101679-line-15)">▴&#160;</text><text class="terminal-1796101679-r7" x="268.4" y="386" textLength="48.8" clip-path="url(#terminal-1796101679-line-15)">high</text><text class="terminal-1796101679-r6" x="317.2" y="386" textLength="36.6" clip-path="url(#terminal-1796101679-line-15)">&#160;›&#160;</text><text class="terminal-1796101679-r3" x="353.8" y="386" textLength="24.4" clip-path="url(#terminal-1796101679-line-15)">⌂&#160;</text><text class="terminal-1796101679-r8" x="378.2" y="386" textLength="317.2" clip-path="url(#terminal-1796101679-line-15)">/private/tmp/lop-failovers</text><text class="terminal-1796101679-r9" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-1796101679-line-15)">!</text><text class="terminal-1796101679-r1" x="1268.8" y="386" textLength="12.2" clip-path="url(#terminal-1796101679-line-15)">
+</text><text class="terminal-1796101679-r1" x="1268.8" y="410.4" textLength="12.2" clip-path="url(#terminal-1796101679-line-16)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/assets/pr-failovers/after-single-marker.svg
+++ b/docs/assets/pr-failovers/after-single-marker.svg
@@ -1,0 +1,133 @@
+<svg class="rich-terminal" viewBox="0 0 994 489.2" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-767168842-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-767168842-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-767168842-r1 { fill: #c5c8c6 }
+.terminal-767168842-r2 { fill: #e9e5db }
+.terminal-767168842-r3 { fill: #837c6d }
+.terminal-767168842-r4 { fill: #57c785 }
+.terminal-767168842-r5 { fill: #1e1a14 }
+.terminal-767168842-r6 { fill: #4a4539 }
+.terminal-767168842-r7 { fill: #b48cd6 }
+.terminal-767168842-r8 { fill: #6ea8d8 }
+.terminal-767168842-r9 { fill: #ef8078;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-767168842-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="438.2" />
+    </clipPath>
+    <clipPath id="terminal-767168842-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-767168842-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-767168842-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-767168842-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-767168842-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-767168842-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-767168842-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-767168842-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-767168842-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-767168842-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-767168842-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-767168842-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-767168842-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-767168842-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-767168842-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-767168842-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-767168842-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="487.2" rx="8"/><text class="terminal-767168842-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">Local&#160;Operator</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-767168842-clip-terminal)">
+    <rect fill="#14110c" x="0" y="1.5" width="976" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="25.9" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="50.3" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="244" y="50.3" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="74.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="74.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="170.8" y="74.7" width="549" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="719.8" y="74.7" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="99.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="99.1" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="244" y="99.1" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="353.8" y="99.1" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="123.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="123.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="123.5" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="402.6" y="123.5" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="841.8" y="123.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="147.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="147.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="146.4" y="147.9" width="695.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="841.8" y="147.9" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="172.3" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="85.4" y="172.3" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="122" y="172.3" width="756.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="878.4" y="172.3" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="196.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="134.2" y="196.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="221.1" width="939.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="245.5" width="939.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="269.9" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="294.3" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="36.6" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#e9e5db" x="61" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="73.2" y="318.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="353.8" y="318.7" width="585.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="939.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="951.6" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="343.1" width="927.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="951.6" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="367.5" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="207.4" y="367.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="244" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="268.4" y="367.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="305" y="367.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="341.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="366" y="367.5" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="683.2" y="367.5" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="927.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="939.4" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="951.6" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="391.9" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="416.3" width="976" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-767168842-matrix">
+    <text class="terminal-767168842-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-767168842-line-0)">
+</text><text class="terminal-767168842-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-767168842-line-1)">
+</text><text class="terminal-767168842-r3" x="48.8" y="68.8" textLength="195.2" clip-path="url(#terminal-767168842-line-2)">failover&#160;cascade</text><text class="terminal-767168842-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-767168842-line-2)">
+</text><text class="terminal-767168842-r3" x="48.8" y="93.2" textLength="36.6" clip-path="url(#terminal-767168842-line-3)">├─&#160;</text><text class="terminal-767168842-r4" x="85.4" y="93.2" textLength="85.4" clip-path="url(#terminal-767168842-line-3)">primary</text><text class="terminal-767168842-r3" x="170.8" y="93.2" textLength="549" clip-path="url(#terminal-767168842-line-3)">&#160;&#160;anthropic/claude-opus-5&#160;·&#160;high&#160;·&#160;4&#160;accounts</text><text class="terminal-767168842-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-767168842-line-3)">
+</text><text class="terminal-767168842-r3" x="48.8" y="117.6" textLength="36.6" clip-path="url(#terminal-767168842-line-4)">├─&#160;</text><text class="terminal-767168842-r4" x="85.4" y="117.6" textLength="158.6" clip-path="url(#terminal-767168842-line-4)">matched&#160;chain</text><text class="terminal-767168842-r3" x="244" y="117.6" textLength="109.8" clip-path="url(#terminal-767168842-line-4)">&#160;&#160;default</text><text class="terminal-767168842-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-767168842-line-4)">
+</text><text class="terminal-767168842-r3" x="48.8" y="142" textLength="36.6" clip-path="url(#terminal-767168842-line-5)">├─&#160;</text><text class="terminal-767168842-r4" x="85.4" y="142" textLength="317.2" clip-path="url(#terminal-767168842-line-5)">1.&#160;anthropic/claude-opus-5</text><text class="terminal-767168842-r3" x="402.6" y="142" textLength="439.2" clip-path="url(#terminal-767168842-line-5)">&#160;&#160;←&#160;serving&#160;&#160;low&#160;effort&#160;·&#160;4&#160;accounts</text><text class="terminal-767168842-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-767168842-line-5)">
+</text><text class="terminal-767168842-r3" x="48.8" y="166.4" textLength="36.6" clip-path="url(#terminal-767168842-line-6)">├─&#160;</text><text class="terminal-767168842-r4" x="85.4" y="166.4" textLength="61" clip-path="url(#terminal-767168842-line-6)">stale</text><text class="terminal-767168842-r3" x="146.4" y="166.4" textLength="695.4" clip-path="url(#terminal-767168842-line-6)">&#160;&#160;config.yml&#160;changed&#160;since&#160;this&#160;session&#160;started&#160;·&#160;/reload</text><text class="terminal-767168842-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-767168842-line-6)">
+</text><text class="terminal-767168842-r3" x="48.8" y="190.8" textLength="36.6" clip-path="url(#terminal-767168842-line-7)">└─&#160;</text><text class="terminal-767168842-r4" x="85.4" y="190.8" textLength="36.6" clip-path="url(#terminal-767168842-line-7)">tip</text><text class="terminal-767168842-r3" x="122" y="190.8" textLength="756.4" clip-path="url(#terminal-767168842-line-7)">&#160;&#160;ask&#160;the&#160;agent&#160;to&#160;change&#160;models,&#160;effort&#160;or&#160;providers&#160;in&#160;this&#160;</text><text class="terminal-767168842-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-767168842-line-7)">
+</text><text class="terminal-767168842-r3" x="48.8" y="215.2" textLength="85.4" clip-path="url(#terminal-767168842-line-8)">cascade</text><text class="terminal-767168842-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-767168842-line-8)">
+</text><text class="terminal-767168842-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-767168842-line-9)">
+</text><text class="terminal-767168842-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-767168842-line-10)">
+</text><text class="terminal-767168842-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-767168842-line-11)">
+</text><text class="terminal-767168842-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-767168842-line-12)">
+</text><text class="terminal-767168842-r2" x="24.4" y="337.2" textLength="12.2" clip-path="url(#terminal-767168842-line-13)">❯</text><text class="terminal-767168842-r3" x="73.2" y="337.2" textLength="280.6" clip-path="url(#terminal-767168842-line-13)">Message&#160;Local&#160;Operator…</text><text class="terminal-767168842-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-767168842-line-13)">
+</text><text class="terminal-767168842-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-767168842-line-14)">
+</text><text class="terminal-767168842-r3" x="24.4" y="386" textLength="24.4" clip-path="url(#terminal-767168842-line-15)">◆&#160;</text><text class="terminal-767168842-r2" x="48.8" y="386" textLength="158.6" clip-path="url(#terminal-767168842-line-15)">Claude&#160;Opus&#160;5</text><text class="terminal-767168842-r6" x="207.4" y="386" textLength="36.6" clip-path="url(#terminal-767168842-line-15)">&#160;›&#160;</text><text class="terminal-767168842-r3" x="244" y="386" textLength="24.4" clip-path="url(#terminal-767168842-line-15)">▴&#160;</text><text class="terminal-767168842-r7" x="268.4" y="386" textLength="36.6" clip-path="url(#terminal-767168842-line-15)">low</text><text class="terminal-767168842-r6" x="305" y="386" textLength="36.6" clip-path="url(#terminal-767168842-line-15)">&#160;›&#160;</text><text class="terminal-767168842-r3" x="341.6" y="386" textLength="24.4" clip-path="url(#terminal-767168842-line-15)">⌂&#160;</text><text class="terminal-767168842-r8" x="366" y="386" textLength="317.2" clip-path="url(#terminal-767168842-line-15)">/private/tmp/lop-failovers</text><text class="terminal-767168842-r9" x="927.2" y="386" textLength="12.2" clip-path="url(#terminal-767168842-line-15)">!</text><text class="terminal-767168842-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-767168842-line-15)">
+</text><text class="terminal-767168842-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-767168842-line-16)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/assets/pr-failovers/before.svg
+++ b/docs/assets/pr-failovers/before.svg
@@ -1,0 +1,133 @@
+<svg class="rich-terminal" viewBox="0 0 1238 489.2" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-870367775-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-870367775-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-870367775-r1 { fill: #c5c8c6 }
+.terminal-870367775-r2 { fill: #837c6d }
+.terminal-870367775-r3 { fill: #b5afa2 }
+.terminal-870367775-r4 { fill: #e0b04b }
+.terminal-870367775-r5 { fill: #e9e5db }
+.terminal-870367775-r6 { fill: #1e1a14 }
+.terminal-870367775-r7 { fill: #4a4539 }
+.terminal-870367775-r8 { fill: #6ea8d8 }
+.terminal-870367775-r9 { fill: #ef8078;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-870367775-clip-terminal">
+      <rect x="0" y="0" width="1219.0" height="438.2" />
+    </clipPath>
+    <clipPath id="terminal-870367775-line-0">
+    <rect x="0" y="1.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-870367775-line-1">
+    <rect x="0" y="25.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-870367775-line-2">
+    <rect x="0" y="50.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-870367775-line-3">
+    <rect x="0" y="74.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-870367775-line-4">
+    <rect x="0" y="99.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-870367775-line-5">
+    <rect x="0" y="123.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-870367775-line-6">
+    <rect x="0" y="147.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-870367775-line-7">
+    <rect x="0" y="172.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-870367775-line-8">
+    <rect x="0" y="196.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-870367775-line-9">
+    <rect x="0" y="221.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-870367775-line-10">
+    <rect x="0" y="245.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-870367775-line-11">
+    <rect x="0" y="269.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-870367775-line-12">
+    <rect x="0" y="294.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-870367775-line-13">
+    <rect x="0" y="318.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-870367775-line-14">
+    <rect x="0" y="343.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-870367775-line-15">
+    <rect x="0" y="367.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-870367775-line-16">
+    <rect x="0" y="391.9" width="1220" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="487.2" rx="8"/><text class="terminal-870367775-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">Local&#160;Operator</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-870367775-clip-terminal)">
+    <rect fill="#14110c" x="0" y="1.5" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="25.9" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="50.3" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="50.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="549" y="50.3" width="646.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="74.7" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="74.7" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="744.2" y="74.7" width="451.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="99.1" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="99.1" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="793" y="99.1" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="123.5" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="123.5" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="780.8" y="123.5" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="147.9" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="147.9" width="1171.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="172.3" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="172.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="549" y="172.3" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="719.8" y="172.3" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="196.7" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="196.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="549" y="196.7" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="695.4" y="196.7" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="221.1" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="221.1" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="549" y="221.1" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="597.8" y="221.1" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="245.5" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="269.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="158.6" y="269.9" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="366" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="390.4" y="269.9" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="866.2" y="269.9" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1073.6" y="269.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="294.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="146.4" y="294.3" width="915" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1061.4" y="294.3" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="318.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="146.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="158.6" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="170.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="183" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#e9e5db" x="195.2" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="207.4" y="318.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="488" y="318.7" width="549" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1037" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1049.2" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1061.4" y="318.7" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="343.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="146.4" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="158.6" y="343.1" width="890.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1049.2" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1061.4" y="343.1" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="367.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="146.4" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="158.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="183" y="367.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="305" y="367.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="341.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="366" y="367.5" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="683.2" y="367.5" width="341.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1024.8" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1037" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1049.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1061.4" y="367.5" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="391.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="146.4" y="391.9" width="915" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1061.4" y="391.9" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="416.3" width="1220" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-870367775-matrix">
+    <text class="terminal-870367775-r1" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-870367775-line-0)">
+</text><text class="terminal-870367775-r1" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-870367775-line-1)">
+</text><text class="terminal-870367775-r3" x="427" y="68.8" textLength="122" clip-path="url(#terminal-870367775-line-2)">test/model</text><text class="terminal-870367775-r1" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-870367775-line-2)">
+</text><text class="terminal-870367775-r2" x="427" y="93.2" textLength="317.2" clip-path="url(#terminal-870367775-line-3)">/private/tmp/lop-failovers</text><text class="terminal-870367775-r1" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-870367775-line-3)">
+</text><text class="terminal-870367775-r4" x="427" y="117.6" textLength="366" clip-path="url(#terminal-870367775-line-4)">!&#160;latest&#160;is&#160;v0.42.10&#160;—&#160;/update</text><text class="terminal-870367775-r1" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-870367775-line-4)">
+</text><text class="terminal-870367775-r4" x="427" y="142" textLength="353.8" clip-path="url(#terminal-870367775-line-5)">!&#160;not&#160;logged&#160;in&#160;—&#160;/login&#160;test</text><text class="terminal-870367775-r1" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-870367775-line-5)">
+</text><text class="terminal-870367775-r1" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-870367775-line-6)">
+</text><text class="terminal-870367775-r5" x="427" y="190.8" textLength="122" clip-path="url(#terminal-870367775-line-7)">/&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-870367775-r3" x="549" y="190.8" textLength="170.8" clip-path="url(#terminal-870367775-line-7)">command&#160;picker</text><text class="terminal-870367775-r1" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-870367775-line-7)">
+</text><text class="terminal-870367775-r5" x="427" y="215.2" textLength="122" clip-path="url(#terminal-870367775-line-8)">/help&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-870367775-r3" x="549" y="215.2" textLength="146.4" clip-path="url(#terminal-870367775-line-8)">all&#160;commands</text><text class="terminal-870367775-r1" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-870367775-line-8)">
+</text><text class="terminal-870367775-r5" x="427" y="239.6" textLength="122" clip-path="url(#terminal-870367775-line-9)">ctrl+d&#160;&#160;&#160;&#160;</text><text class="terminal-870367775-r3" x="549" y="239.6" textLength="48.8" clip-path="url(#terminal-870367775-line-9)">quit</text><text class="terminal-870367775-r1" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-870367775-line-9)">
+</text><text class="terminal-870367775-r1" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-870367775-line-10)">
+</text><text class="terminal-870367775-r4" x="366" y="288.4" textLength="24.4" clip-path="url(#terminal-870367775-line-11)">!&#160;</text><text class="terminal-870367775-r4" x="390.4" y="288.4" textLength="475.8" clip-path="url(#terminal-870367775-line-11)">unknown&#160;command:&#160;/failovers&#160;—&#160;try&#160;/help</text><text class="terminal-870367775-r1" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-870367775-line-11)">
+</text><text class="terminal-870367775-r1" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-870367775-line-12)">
+</text><text class="terminal-870367775-r5" x="158.6" y="337.2" textLength="12.2" clip-path="url(#terminal-870367775-line-13)">❯</text><text class="terminal-870367775-r2" x="207.4" y="337.2" textLength="280.6" clip-path="url(#terminal-870367775-line-13)">Message&#160;Local&#160;Operator…</text><text class="terminal-870367775-r1" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-870367775-line-13)">
+</text><text class="terminal-870367775-r1" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-870367775-line-14)">
+</text><text class="terminal-870367775-r2" x="158.6" y="386" textLength="24.4" clip-path="url(#terminal-870367775-line-15)">◆&#160;</text><text class="terminal-870367775-r5" x="183" y="386" textLength="122" clip-path="url(#terminal-870367775-line-15)">test/model</text><text class="terminal-870367775-r7" x="305" y="386" textLength="36.6" clip-path="url(#terminal-870367775-line-15)">&#160;›&#160;</text><text class="terminal-870367775-r2" x="341.6" y="386" textLength="24.4" clip-path="url(#terminal-870367775-line-15)">⌂&#160;</text><text class="terminal-870367775-r8" x="366" y="386" textLength="317.2" clip-path="url(#terminal-870367775-line-15)">/private/tmp/lop-failovers</text><text class="terminal-870367775-r9" x="1024.8" y="386" textLength="12.2" clip-path="url(#terminal-870367775-line-15)">!</text><text class="terminal-870367775-r1" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-870367775-line-15)">
+</text><text class="terminal-870367775-r1" x="1220" y="410.4" textLength="12.2" clip-path="url(#terminal-870367775-line-16)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/local_operator/guides/configuration/GUIDE.md
+++ b/local_operator/guides/configuration/GUIDE.md
@@ -96,54 +96,12 @@ local-operator login-status
 
 ## Configure quota-aware account and model fallback
 
-Fallback order lives under `values.retry.fallbackChains`. Use an exact
-`provider/model` key when only one primary should take the route, and list
-targets in priority order. A target can be a legacy `provider/model` string or
-a mapping with `provider`, `model`, and optional `effort`:
+Fallback order lives under `values.retry.fallbackChains`, and the routing engine
+around it — multi-account rotation, the quota reserve, cooldowns back to the
+primary — is documented in one place: read `guide://failover`. Two guides
+asserting cooldown semantics is how they drift apart.
 
-```yaml
-values:
-  retry:
-    enabled: true
-    maxRetries: 3
-    baseDelayMs: 500
-    modelFallback: true
-    usageAwareFallback: true
-    usageReservePercent: 10
-    fallbackChains:
-      anthropic/claude-opus-5:
-        - provider: anthropic
-          model: claude-opus-5
-          effort: low
-        - provider: openai
-          model: gpt-5.3-codex
-          effort: high
-```
-
-This route keeps the configured primary first. At a new user-message boundary,
-Local Operator checks a provider's live OAuth quota when that provider exposes
-one. It rotates through usable accounts on the same provider — including
-accounts whose remaining quota is under the reserve threshold — and only
-moves to the next listed provider once every account on the current one is
-at 0%. A model-tier cap (Anthropic's `7 day (Fable)` against `claude-fable-5`)
-is still per account: siblings on that provider are tried before the chain
-leaves it. Reserve quota can select a lower-effort route on the *same*
-provider without blocking the account; it is not a licence to hop providers
-while spendable quota remains. Fully exhausted account-wide quota skips
-same-provider effort changes because they cannot restore capacity. A
-fallback whose own provider is already at 0% is skipped so the cascade does
-not pin a maxed hop. Usage endpoints that are missing or unreachable fail
-open.
-
-Provider errors use the same ordered chain. A successful fallback stays pinned
-through tool calls and other model calls in that user message, and a cooldown
-prevents retrying a broken primary on every new message. Startup remains
-non-blocking: when quota preflight changes the route, the TUI prints a warning
-instead of failing launch.
-
-`fallbackChains.default` applies to any model without a more specific chain.
-Keys ending in `/*` match every model under that provider. Login credentials
-remain in the credential store; never put tokens or keys in this mapping.
+In the TUI, `/failovers` prints the live cascade and which provider is serving.
 
 
 ## Configuration sections

--- a/local_operator/guides/failover/GUIDE.md
+++ b/local_operator/guides/failover/GUIDE.md
@@ -54,6 +54,14 @@ to learn what was already known.
 
 ## Quota reserve
 
+**Everything in this section requires `usageAwareFallback: true`, which is NOT
+the shipped default.** With it false (the default), `preflight_usage` returns
+before any of it runs, so no quota is probed at message boundaries and neither
+rule below applies — the cascade still works, it just moves on provider errors
+rather than on quota forecasts. Turn it on to spend one lightweight quota
+request per user-message boundary in exchange for routing that leaves a
+provider before it fails.
+
 `usageReservePercent` (default 10) holds back a slice of quota. Two rules that
 are easy to get backwards:
 
@@ -116,11 +124,11 @@ Everything lives under `values.retry` in `config.yml`:
 values:
   retry:
     enabled: true
-    maxRetries: 3
-    baseDelayMs: 500
-    modelFallback: true
-    usageAwareFallback: true
-    usageReservePercent: 10
+    maxRetries: 10          # shipped default
+    baseDelayMs: 500        # shipped default
+    modelFallback: true     # shipped default
+    usageAwareFallback: true   # NOT the default (ships false); see below
+    usageReservePercent: 10 # shipped default
     fallbackChains:
       anthropic/claude-opus-5:
         - provider: zai
@@ -141,6 +149,13 @@ chain re-list the *current* model at a different effort as a real route.
 
 `enabled: false` or `modelFallback: false` switches the cascade off entirely —
 `/failovers` names whichever of the two did it.
+
+**An edit does not reach a running session.** The stream captures its settings
+once at session build and nothing watches `config.yml`, so after changing the
+cascade the user must run `/reload` (or start a new session) for the new routing
+to take effect. `/failovers` compares the two and prints a `stale` row naming
+`/reload` when they diverge, so the listing never shows a cascade the running
+session will not honour.
 
 **Never put tokens or API keys in this mapping.** Credentials live in the
 credential store (`local-operator login <provider>`); a chain entry names a

--- a/local_operator/guides/failover/GUIDE.md
+++ b/local_operator/guides/failover/GUIDE.md
@@ -1,0 +1,238 @@
+---
+name: failover
+description: Model failover and load balancing — why a request fell back, which provider serves now, fallbackChains cascade order and effort routing, multi-account quota rotation, cooldown.
+---
+
+# Model failover: the cascade, quota rotation, and what is serving
+
+Read this when a request went to a provider the user did not select, when the
+route keeps flipping to a model they do not want, when they ask which provider
+is answering right now, or when they want to change the order.
+
+The fast answer for "what is my cascade and what is serving it" is the
+`/failovers` command in the TUI. It prints the primary, which chain key matched,
+the ordered targets with their configured effort, how many accounts each
+provider has, and a `← serving` marker on the row actually answering. Everything
+below explains what that listing means and how to change it.
+
+## The shape of the thing
+
+Routing is two nested loops, and almost every confusing report comes from
+mistaking one for the other.
+
+1. **Within a provider**, requests rotate across every account stored for it.
+2. **Across providers**, the cascade descends the configured chain.
+
+The inner loop is exhausted before the outer one moves. A user with four
+Anthropic accounts does not leave Anthropic because one hit its limit — they
+leave when all four are spent.
+
+## Rotation within one provider
+
+Every credential for a provider is a candidate for every request. Selection
+order (`AuthStore._base_selection_order`) is: the session's sticky account
+first, then a per-session hash of the session id so concurrent sessions start on
+different accounts rather than stampeding one, then round-robin for callers with
+no session. An account that just failed on a provider-side fault is *demoted*
+(sorted last), never removed — a 500 is not the account's fault, so it stays
+available as a last resort.
+
+When a request fails on quota, `_recover_quota_blocked` (in
+`providers/failover.py`) probes the *other* accounts' own usage before the chain
+is allowed to leave the provider. This matters because **a model-tier cap is per
+account**: Anthropic's `7 day (Fable)` limit against `claude-fable-5` blocks one
+account for one model family while its shared windows still hold headroom, and
+while other accounts are untouched. A block is therefore a verdict about one
+account and one family, not about the provider, and siblings are tried first.
+
+## Descending the cascade
+
+Once no account on the current provider can serve, the chain's next target is
+tried, in configured order. A fallback whose own provider is already at 0% is
+skipped rather than pinned — hopping onto a maxed provider costs a full prompt
+to learn what was already known.
+
+## Quota reserve
+
+`usageReservePercent` (default 10) holds back a slice of quota. Two rules that
+are easy to get backwards:
+
+- Reserve quota can select a **lower-effort route on the same provider** without
+  blocking the account. Dropping from high to low effort on the model the user
+  chose is cheaper than leaving for another vendor, so the reserve buys a
+  cheaper route before it buys a different provider.
+- **Fully exhausted** account-wide quota skips same-provider effort changes
+  entirely: no effort level restores capacity that is gone, so trying one is a
+  wasted request.
+
+Usage endpoints that are missing or unreachable **fail open**. A provider with
+no usage API, or one whose usage call times out, is treated as usable — the
+alternative is refusing to route on a provider that was probably fine.
+
+## Sticky routing, and the way back up
+
+A successful fallback **stays pinned** for the rest of the user message: later
+tool calls and other model calls in that turn go to the same target. A turn that
+silently changed models halfway through would produce a transcript no one can
+reason about.
+
+Returning to the primary is three separate mechanisms:
+
+- **`primary_retry_at_ms`** — a cooldown after a transport failure. It is set
+  when the route **CHANGES**, and deliberately not bumped on every request that
+  uses the pinned route. Bumping it turned a fixed cooldown into a sliding
+  window: a user sending messages more often than the cooldown never reached the
+  deadline and stayed on the fallback for the entire session, long after the
+  primary recovered.
+- **`quota_pinned`** — a pin placed by a *quota* verdict is re-probed at every
+  message boundary **regardless of the cooldown**. Quota resets on a schedule
+  the usage endpoint can state definitively, so a cooldown sized to a 24-hour
+  advertised reset would glue the session to a fallback for a day after the
+  primary's 5-hour window reopened.
+- **`target_retry_at_ms`** — a per-target bench ("kimi 500'd 40s ago") so a
+  settled session does not replay a dead target's failure at every message
+  boundary. It is deliberately **not** cleared by `clear()`: it records facts
+  about the fallback providers, and neither a `/model` switch nor the primary
+  recovering changes those facts. Entries expire on their own, a target that
+  serves sheds its mark, and the bench is **advisory** — the stream driver's
+  loop-back sweep re-walks benched targets before declaring a turn exhausted, so
+  it can delay a target but never remove the last route to a served turn.
+
+## Retry and backoff
+
+`maxRetries` is the fast budget against a *reachable* provider (5xx, timeout);
+`baseDelayMs` seeds `backoff_delay_ms`, which is
+`min(base * 2^(attempt-1), 8000)` with 25% downward jitter. Connectivity loss —
+the machine itself offline, DNS or socket-connect failing before any HTTP — has
+its own patient budget (`connectivityMaxRetries`, `connectivityBackoffCapMs`) so
+an interactive session survives a laptop lid closing without burning the fast
+budget on a network that is not there.
+
+## Configuring it
+
+Everything lives under `values.retry` in `config.yml`:
+
+```yaml
+values:
+  retry:
+    enabled: true
+    maxRetries: 3
+    baseDelayMs: 500
+    modelFallback: true
+    usageAwareFallback: true
+    usageReservePercent: 10
+    fallbackChains:
+      anthropic/claude-opus-5:
+        - provider: zai
+          model: glm-5.3
+        - provider: openai
+          model: gpt-5.3-codex
+          effort: high
+```
+
+Chain keys are matched by specificity: an exact `provider/model` key wins, then
+the longest matching `provider/*` wildcard, then `default`. `default` applies to
+any model without a more specific chain, and a `provider/*` target keeps the
+failing model's id.
+
+A target is either a legacy `provider/model` string or a mapping with
+`provider`, `model`, and optional `effort`. The mapping form is what lets a
+chain re-list the *current* model at a different effort as a real route.
+
+`enabled: false` or `modelFallback: false` switches the cascade off entirely —
+`/failovers` names whichever of the two did it.
+
+**Never put tokens or API keys in this mapping.** Credentials live in the
+credential store (`local-operator login <provider>`); a chain entry names a
+route, never a secret.
+
+## Inspecting it without the network
+
+These run against the installed runtime and touch no provider API. The `LOP_PY`
+line resolves the interpreter that `lop` itself runs on, so they work from any
+directory:
+
+```bash
+LOP_PY="$(head -1 "$(command -v lop || command -v local-operator)" | sed 's|^#!||')"
+```
+
+**Which providers exist:**
+
+```bash
+"$LOP_PY" - <<'PY'
+from local_operator.providers.registry import list_login_providers
+for d in list_login_providers():
+    print(f"{d.id:26} {d.name}")
+PY
+```
+
+**Which models a provider serves.** Note the aggregator caveat: `static_models`
+returns `{}` for `openrouter`, `radient`, and `ollama` **by design** — their
+shipped entry describes the ROUTER, not a model, and for exactly those providers
+the live listing is authoritative. `STATIC_MODEL_HOSTINGS` names the providers
+this can answer for; for the others, use the live catalogue (`/model` in the
+TUI), which is the only source.
+
+```bash
+"$LOP_PY" - <<'PY'
+from local_operator.model.registry import STATIC_MODEL_HOSTINGS, static_models
+print("answerable statically:", ", ".join(sorted(STATIC_MODEL_HOSTINGS)))
+for model_id in sorted(static_models("anthropic")):
+    print(" ", model_id)
+print("openrouter ->", static_models("openrouter"))  # {} on purpose
+PY
+```
+
+**The resolved cascade** — the same walk the engine performs, so this is what
+would actually route:
+
+```bash
+"$LOP_PY" - <<'PY'
+from local_operator.config import ConfigManager
+from local_operator.paths import config_dir
+from local_operator.providers.failover import (
+    RetrySettings, expand_fallback_targets, resolve_chain, resolve_chain_key,
+)
+
+values = ConfigManager(config_dir()).get_config().values
+retry = RetrySettings.from_settings(values)
+primary = f"{values.get('hosting')}/{values.get('model_name')}"
+
+print(f"primary      {primary}")
+print(f"enabled      retry.enabled={retry.enabled} modelFallback={retry.model_fallback}")
+print(f"reserve      usageReservePercent={retry.usage_reserve_percent}")
+print(f"matched key  {resolve_chain_key(primary, retry.fallback_chains)}")
+chain = resolve_chain(primary, retry.fallback_chains) or []
+for i, target in enumerate(expand_fallback_targets(primary, chain), 1):
+    print(f"  {i}. {target.selector:38} effort={target.effort or 'model default'}")
+PY
+```
+
+**Account depth per provider** — how many accounts the inner loop can rotate
+through before the cascade leaves a provider:
+
+```bash
+"$LOP_PY" - <<'PY'
+# COUNTS AND PROVIDER IDS ONLY, never row.data: those rows carry live bearer
+# tokens and account emails, so one added field here is a credential printed
+# into a scrollback and a transcript.
+from local_operator.providers.auth_store import AuthStore
+from local_operator.providers.registry import credential_provider_id
+
+counts: dict[str, int] = {}
+for row in AuthStore().list_credentials():
+    pid = credential_provider_id(row.provider)  # xai-oauth and xai are ONE account
+    counts[pid] = counts.get(pid, 0) + 1
+for pid, total in sorted(counts.items()):
+    print(f"{pid:24} {total} account(s)")
+PY
+```
+
+## If this guide and the engine disagree
+
+`local_operator/providers/failover.py` is authoritative. It carries the routing
+loop, the cooldown rules, and the comments recording which regression each rule
+exists to prevent; this guide is a reading of it and can fall behind.
+
+For anything not answerable here, read the source on GitHub:
+<https://github.com/damianvtran/local-operator>.

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1699,6 +1699,23 @@ class SessionStreamFn:
             openai_api=_openai_api_mode(self._settings),
         )
 
+    @property
+    def routing_settings(self) -> Mapping[str, Any]:
+        """The settings mapping THIS stream will actually route on.
+
+        Captured once at session build (``session_factory``) and held for the
+        session's life, so it is not necessarily what is on disk: nothing
+        watches ``config.yml``, and the only ``ConfigManager.reload`` caller is
+        the first-run ``/login`` path. A read-only surface that wants to report
+        what the SESSION will do — rather than what a later edit intends — has
+        to read this rather than re-reading the file, or it shows a green light
+        for a cascade the running session will not honour.
+
+        Exposed read-only for exactly that reason; mutating routing mid-session
+        is not what this is for.
+        """
+        return self._settings if isinstance(self._settings, Mapping) else {}
+
     def set_notice_handler(
         self, handler: Callable[[str, str], Awaitable[None] | None] | None
     ) -> None:

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -831,9 +831,18 @@ def _chain_specificity(key: str, selector: str) -> int | None:
     return None
 
 
-def resolve_chain(selector: str, chains: Mapping[str, Sequence[Any]]) -> list[Any] | None:
-    """Pick the fallback chain for ``selector`` by specificity:
+def resolve_chain_key(selector: str, chains: Mapping[str, Sequence[Any]]) -> str | None:
+    """WHICH chain key serves ``selector``, by specificity:
     exact ``provider/model`` → longest matching wildcard prefix → ``default``.
+
+    ``None`` when nothing matches and no ``default`` is configured.
+
+    Split out of :func:`resolve_chain` because the key is an ANSWER, not just an
+    intermediate: a diagnostic that shows the user their cascade has to say
+    which of several plausible keys is actually in force (an exact entry
+    silently outranking a ``provider/*`` one is the whole confusion), and a
+    caller re-deriving that with its own matching loop is a second definition of
+    specificity that can disagree with the routing engine.
     """
     best_key: str | None = None
     best_score = -1
@@ -845,10 +854,19 @@ def resolve_chain(selector: str, chains: Mapping[str, Sequence[Any]]) -> list[An
             best_score = score
             best_key = key
     if best_key is None:
-        if DEFAULT_CHAIN_KEY in chains:
-            return list(chains[DEFAULT_CHAIN_KEY])
+        return DEFAULT_CHAIN_KEY if DEFAULT_CHAIN_KEY in chains else None
+    return best_key
+
+
+def resolve_chain(selector: str, chains: Mapping[str, Sequence[Any]]) -> list[Any] | None:
+    """The fallback chain for ``selector``, or ``None`` when none applies.
+
+    Selection lives in :func:`resolve_chain_key`; this is the entries behind it.
+    """
+    key = resolve_chain_key(selector, chains)
+    if key is None:
         return None
-    return list(chains[best_key])
+    return list(chains[key])
 
 
 def _fallback_target(entry: Any) -> FallbackTarget | None:

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -71,6 +71,10 @@ _FRONTEND_LOCAL_SLASHES = {
     "provider",
     "search",
     "accounts",
+    # Reads config.yml and the local credential COUNTS, and compares the
+    # frontend's own effective model — all of it available on a follower, so
+    # routing it to the owner would only add a hop.
+    "failovers",
     "usage",
     "analytics",
     "skills",

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2160,6 +2160,19 @@ class Session:
         return self._active_fallback
 
     @property
+    def routing_settings(self) -> Any:
+        """The settings this session's stream will ROUTE on, or ``None``.
+
+        The stream captured its settings mapping at session build and holds it
+        for the session's life, so a surface that re-reads ``config.yml`` is
+        answering a different question than "what will this session do". Kept
+        as a pass-through to the stream (rather than a second copy stored here)
+        so the two can never disagree; ``None`` when the stream predates the
+        accessor, which callers must treat as "cannot say", never as "empty".
+        """
+        return getattr(self._stream_fn, "routing_settings", None)
+
+    @property
     def effective_model(self) -> ModelSpec:
         """The spec ACTUALLY serving requests.
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -12020,12 +12020,16 @@ class OperatorApp(App[None]):
         # an exact entry or a wildcard that happened to expand. Tested on the
         # key's own SHAPE rather than "not equal to the primary", which called
         # every future match rule a wildcard.
-        if chain_key == DEFAULT_CHAIN_KEY:
+        # `chain_key` cannot be None here — a None key yields no targets and
+        # returned above — but the type does not carry that, and asserting it
+        # beats a cast that would hide a real None if the branch above moves.
+        matched_key = chain_key or DEFAULT_CHAIN_KEY
+        if matched_key == DEFAULT_CHAIN_KEY:
             matched = DEFAULT_CHAIN_KEY
-        elif chain_key.endswith("/*"):
-            matched = f"{chain_key} (wildcard)"
+        elif matched_key.endswith("/*"):
+            matched = f"{matched_key} (wildcard)"
         else:
-            matched = f"{chain_key} (exact)"
+            matched = f"{matched_key} (exact)"
         rows.append(("matched chain", matched))
 
         # ONE row is serving. The marker is a claim about a single route, and

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -443,6 +443,15 @@ SLASH_COMMANDS: list[SlashCommand] = [
     SlashCommand("accounts", "List stored credentials"),
     # The listing is the receipt — the cascade tree IS the whole answer, and
     # the command takes no argument to restate.
+    #
+    # NO `failover` singular alias, despite it being an equally natural spelling:
+    # the picker sizes its name column on the widest `/name  /alias` pair, and
+    # `/failovers  /failover` (21 cells) is 3 wider than the current widest, so
+    # the alias permanently narrows the DESCRIPTION column for every command at
+    # every width (it truncated `List all commands` on the 41-cell frame that
+    # `test_descriptions_come_back_above_the_collapse_width` pins). The singular
+    # still reaches this command through the picker's prefix match, which is the
+    # cheap half of what an alias would buy.
     SlashCommand("failovers", "Show the model failover cascade and what is serving"),
     # The panel is the receipt — the row the owner reported as noise.
     SlashCommand("usage", "Show provider usage quota"),
@@ -11799,15 +11808,45 @@ class OperatorApp(App[None]):
             counts[storage] = counts.get(storage, 0) + 1
         return counts
 
-    @staticmethod
-    def _account_detail(provider: str, counts: Mapping[str, int]) -> str:
-        """``2 accounts`` / ``1 account`` / ``no accounts`` for a provider."""
+    def _account_detail(self, provider: str, counts: Mapping[str, int]) -> str:
+        """What a ROUTING listing should say about ``provider``'s credentials.
+
+        Not the same question `/accounts` answers. That surface lists the
+        credential store, so "no accounts" is the literal truth there. Here the
+        row describes a hop the cascade may take, and a provider with a key in
+        the ENVIRONMENT — or one that needs no key at all, a local Ollama —
+        will serve perfectly well with zero stored rows. Printing "no accounts"
+        beside such a hop reads as "this hop will fail", which is the opposite
+        of the truth and sends the user to a pointless `login`.
+
+        So a zero count defers to ``is_usable`` (env key or
+        ``allows_missing_api_key``) before it reports an absence. A NON-zero
+        count still prints the number, because rotation depth is the thing this
+        column exists to show.
+        """
         from local_operator.providers.registry import credential_provider_id
 
         total = counts.get(credential_provider_id(provider), 0)
-        if total == 0:
+        if total:
+            return "1 account" if total == 1 else f"{total} accounts"
+        # Never let a credential-store read decide the row alone: `is_usable`
+        # is the wider question, and it is the one routing actually asks. The
+        # two usable-with-zero-rows cases are named apart because the user's
+        # next action differs — one is "your env var is doing the work", the
+        # other is "there is nothing to configure here".
+        if self._providers is None:
             return "no accounts"
-        return "1 account" if total == 1 else f"{total} accounts"
+        try:
+            definition = self._providers.provider(provider)
+            if definition is not None and definition.allows_missing_api_key:
+                return "no credential needed"
+            if self._providers.is_usable(provider):
+                return "env key"
+        except Exception:
+            # A locked store is not evidence the provider is broken; fall
+            # through to the honest count rather than inventing a verdict.
+            pass
+        return "no accounts"
 
     def _failover_rows(self, notice: NoticeFn) -> list[tuple[str, str]] | None:
         """The ``/failovers`` tree rows, or ``None`` when a notice was issued.
@@ -11825,6 +11864,15 @@ class OperatorApp(App[None]):
         Degrades rather than hides: the most likely caller is a default install
         with nothing configured at all, and "you have no cascade, here is the key
         that would create one" is the useful answer for them.
+
+        Reads the SESSION's captured routing settings, not ``config.yml``, for
+        the reason recorded on ``Session.routing_settings``: the stream snapshots
+        its settings at build time and nothing watches the file, so a listing
+        built from disk confirms cascade edits the running session will not
+        honour. That is worst for the user who followed this command's own
+        "ask the agent to change…" hint. The on-disk copy is still read, but
+        only to DETECT that divergence and say so; it never silently replaces
+        what the session will do.
         """
         from local_operator.config import ConfigManager
         from local_operator.paths import config_dir
@@ -11832,6 +11880,7 @@ class OperatorApp(App[None]):
             DEFAULT_CHAIN_KEY,
             RetrySettings,
             expand_fallback_targets,
+            parse_selector,
             resolve_chain,
             resolve_chain_key,
         )
@@ -11850,7 +11899,16 @@ class OperatorApp(App[None]):
             # model to have a cascade for until it attaches.
             notice("session is still starting…", "warning")
             return None
-        selected = _model_spec(session)
+        try:
+            selected = _model_spec(session)
+        except Exception:
+            # `RemoteSession.model` is a PROPERTY THAT RAISES when the owner has
+            # no selected spec yet, and `getattr(..., None)` does not suppress an
+            # exception raised inside a property. Unguarded, a follower attached
+            # before the owner's model syncs got `failover list failed: owner has
+            # no selected model spec` — an error notice, in developer vocabulary,
+            # for a state this function already has a warning phrasing for.
+            selected = None
         primary = str(getattr(session, "model_label", "") or "")
         if selected is not None:
             primary = f"{selected.provider}/{selected.model_id}"
@@ -11860,70 +11918,165 @@ class OperatorApp(App[None]):
 
         counts = self._account_counts()
         configured_effort = str(getattr(selected, "reasoning_effort", "") or "")
-        primary_accounts = self._account_detail(primary.split("/")[0], counts)
+        primary_provider, _ = parse_selector(primary)
         primary_detail = " · ".join(
-            part for part in (primary, configured_effort, primary_accounts) if part
+            part
+            for part in (
+                primary,
+                configured_effort,
+                self._account_detail(primary_provider, counts),
+            )
+            if part
         )
 
         # The model ACTUALLY serving, via `effective_model` rather than the
         # route's `active_fallback`: RemoteSession implements `effective_model`
         # but not the route state, so this is the one comparison that is correct
         # on both the owning terminal and an attached follower.
-        effective = _effective_spec(session)
+        try:
+            effective = _effective_spec(session)
+        except Exception:
+            effective = None  # same raising-property guard as `selected` above
         serving = ""
+        serving_effort = ""
         if effective is not None:
             serving = f"{effective.provider}/{effective.model_id}"
+            serving_effort = str(getattr(effective, "reasoning_effort", "") or "")
         else:
             serving = str(getattr(session, "effective_model_label", "") or "")
 
         rows: list[tuple[str, str]] = [("primary", primary_detail)]
 
-        retry = RetrySettings.from_settings(
-            ConfigManager(config_dir()).get_config().values,
-        )
+        # THE SESSION'S snapshot, with the file read only to detect drift.
+        session_settings = getattr(session, "routing_settings", None)
+        disk_settings = ConfigManager(config_dir()).get_config().values
+        if session_settings is None:
+            # A host that cannot say what it routes on (an older stream, a test
+            # double). Falling back to disk is the only answer available, and it
+            # is the answer this command shipped with.
+            session_settings = disk_settings
+            drifted = False
+        else:
+            # Compare only what routing reads. A `tui.theme` edit is not a
+            # routing change and must not raise a "/reload to apply" flag.
+            drifted = RetrySettings.from_settings(session_settings) != RetrySettings.from_settings(
+                disk_settings
+            )
+        retry = RetrySettings.from_settings(session_settings)
+
+        def close(extra: list[tuple[str, str]], hint: str) -> list[tuple[str, str]]:
+            """Finish the tree: drift flag, then the agent affordance.
+
+            Both belong in EVERY state, not just the populated one. The user
+            staring at "no chain" is the one who most needs to know the agent
+            will write the config for them, and a stale listing is most
+            misleading exactly when it shows a cascade that looks new.
+            """
+            out = rows + extra
+            if drifted:
+                # Named on its own row rather than folded into the hint: it is a
+                # fact about this listing's accuracy, and `/reload` is the step
+                # that makes the on-disk cascade the one that actually routes.
+                out.append(("stale", "config.yml changed since this session started · /reload"))
+            # The hint is an escape hatch, not a route. With an EMPTY name its
+            # text landed at the exact x of every row name while wearing the
+            # terminal `└─` glyph, so it read as one more cascade entry. Giving
+            # it a short label puts it in the same class as `primary` and
+            # `matched chain` — a named fact about the cascade rather than a
+            # numbered hop in it — for 5 cells instead of the 30+ that padding
+            # to the name column would cost (which re-wrapped the row it fixed).
+            out.append(("tip", hint))
+            return out
+
         if not retry.enabled or not retry.model_fallback:
             # Name the KEY, not just the state: "off" without the key leaves the
             # user hunting through config.yml for which of two switches did it.
             disabled_by = "retry.enabled" if not retry.enabled else "retry.modelFallback"
-            rows.append(("cascade off", f"{disabled_by} is false — no fallback route is used"))
-            return rows
+            return close(
+                [("cascade off", f"{disabled_by} is false — no fallback route is used")],
+                "ask the agent to turn the cascade back on",
+            )
 
         chain_key = resolve_chain_key(primary, retry.fallback_chains)
         chain = resolve_chain(primary, retry.fallback_chains) if chain_key else None
         targets = expand_fallback_targets(primary, chain) if chain else []
         if not targets:
-            rows.append(
-                (
-                    "no chain",
-                    f"nothing matches {primary} — set "
-                    f"values.retry.fallbackChains.{DEFAULT_CHAIN_KEY}",
-                )
-            )
-            return rows
+            # TWO different states, and collapsing them made the command assert
+            # the opposite of the engine's answer. A key can match and still
+            # yield nothing: `expand_fallback_targets` drops a legacy entry equal
+            # to the current selector, so `default: ["zai/glm-5.3"]` after
+            # `/model zai/glm-5.3` matched `default` and expanded to []. Telling
+            # that user to "set fallbackChains.default" names a key that is
+            # already set and suggests a no-op.
+            if chain_key is None:
+                detail = f"no chain matches — set values.retry.fallbackChains.{DEFAULT_CHAIN_KEY}"
+            else:
+                detail = f"{chain_key} matched but lists only the current model"
+            return close([("no chain", detail)], "ask the agent to set up a fallback cascade")
 
         # The key IS the answer to "which chain am I on"; the parenthetical only
         # earns its width when the key alone does not say how it was picked —
         # `default` is self-describing, `anthropic/claude-opus-5` could be either
-        # an exact entry or a wildcard that happened to expand.
+        # an exact entry or a wildcard that happened to expand. Tested on the
+        # key's own SHAPE rather than "not equal to the primary", which called
+        # every future match rule a wildcard.
         if chain_key == DEFAULT_CHAIN_KEY:
             matched = DEFAULT_CHAIN_KEY
+        elif chain_key.endswith("/*"):
+            matched = f"{chain_key} (wildcard)"
         else:
-            matched = f"{chain_key} ({'exact' if chain_key == primary else 'wildcard'})"
+            matched = f"{chain_key} (exact)"
         rows.append(("matched chain", matched))
 
-        if serving and serving == primary:
-            rows[0] = (rows[0][0], f"{rows[0][1]}   ← serving")
+        # ONE row is serving. The marker is a claim about a single route, and
+        # `FallbackTarget` is (selector, effort), so a chain that re-lists the
+        # current model at a different effort — which the guide documents as a
+        # real route — made both the primary and that target match on selector
+        # alone and printed the marker twice. Effort is part of the identity of
+        # the thing serving, so it is part of the comparison; the primary only
+        # keeps the marker when no target claims it, so the count can never
+        # exceed one.
+        target_rows: list[tuple[str, str, bool]] = []
+        served_by_target = False
         for index, target in enumerate(targets, start=1):
-            effort = f"{target.effort} effort" if target.effort else "model default effort"
-            detail = f"{effort} · {self._account_detail(target.selector.split('/')[0], counts)}"
-            if serving and serving == target.selector:
-                detail = f"{detail}   ← serving"
-            rows.append((f"{index}. {target.selector}", detail))
+            target_provider, _ = parse_selector(target.selector)
+            # Only what DIFFERS between rows. "model default effort" was
+            # identical on 5 of 5 rows on a real config — a column carrying no
+            # bits, and the width that pushed the serving marker into the wrap
+            # (`_removal_detail` rejects exactly this shape for the same reason).
+            parts = [f"{target.effort} effort"] if target.effort else []
+            parts.append(self._account_detail(target_provider, counts))
+            is_serving = (
+                not served_by_target
+                and bool(serving)
+                and serving == target.selector
+                and (target.effort or "") == (serving_effort if target.effort else "")
+            )
+            served_by_target = served_by_target or is_serving
+            target_rows.append((f"{index}. {target.selector}", " · ".join(parts), is_serving))
+
+        if serving and serving == primary and not served_by_target:
+            rows[0] = (rows[0][0], f"{rows[0][1]}   ← serving")
+
+        # Pad the name column so the details form a grid, the way the sibling
+        # `/mcp` listing does. This is the listing where down-column comparison
+        # matters most — "which of these hops has accounts" is read vertically —
+        # and D2's shortening is what makes the padding affordable.
+        name_column = max(len(name) for name, _, _ in target_rows)
+        for name, detail, is_serving in target_rows:
+            # The marker goes BEFORE the detail: it is the one element with no
+            # readable degraded form (a wrapped detail is still words; a wrapped
+            # `← serving` is an arrow at column 0 pointing at nothing), so it
+            # sits where the wrap reaches last rather than first.
+            marker = "← serving  " if is_serving else ""
+            rows.append((name.ljust(name_column), f"{marker}{detail}"))
 
         # House phrasing for "this is not a read-only wall": the agent owns the
         # config, so the user does not have to learn the YAML to change it.
-        rows.append(("", "ask the agent to change models, effort or providers in this cascade"))
-        return rows
+        # Trimmed to fit an 80-column terminal (a split pane) without wrapping:
+        # "in this cascade" restated the caption two rows up and cost the row
+        # its last line.
+        return close([], "ask the agent to change models, effort or providers here")
 
     def _cmd_failovers(self, notice: NoticeFn) -> None:
         """``/failovers`` — the model failover cascade and what is serving."""

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -441,6 +441,9 @@ SLASH_COMMANDS: list[SlashCommand] = [
     SlashCommand("search", "Configure web search providers and load balancing"),
     # The listing is the receipt.
     SlashCommand("accounts", "List stored credentials"),
+    # The listing is the receipt — the cascade tree IS the whole answer, and
+    # the command takes no argument to restate.
+    SlashCommand("failovers", "Show the model failover cascade and what is serving"),
     # The panel is the receipt — the row the owner reported as noise.
     SlashCommand("usage", "Show provider usage quota"),
     SlashCommand("context", "Show prompt, tool-schema and message token usage"),
@@ -9933,6 +9936,8 @@ class OperatorApp(App[None]):
             self._cmd_search(arg, notice)
         elif command == "/accounts":
             self._cmd_accounts(notice)
+        elif command == "/failovers":
+            self._cmd_failovers(notice)
         elif command == "/usage":
             self._cmd_usage(arg, notice)
         elif command == "/analytics":
@@ -11770,6 +11775,165 @@ class OperatorApp(App[None]):
                 self._append_block(block)
         except Exception as error:
             notice(f"accounts failed: {error}", "error")
+
+    def _account_counts(self) -> dict[str, int]:
+        """How many stored credentials each provider has, keyed by STORAGE id.
+
+        Grouped through ``credential_provider_id`` so a login flavour and the
+        provider it authenticates collapse into one number: ``xai-oauth`` writes
+        its row under ``xai``, and counting the literal ids would report the same
+        account twice under two names — the exact confusion
+        ``store_credentials_as`` exists to prevent.
+
+        COUNTS ONLY. Identities live in ``/accounts``, which is the one surface
+        that has thought about showing an email address; this tree must never
+        read ``row.data``.
+        """
+        from local_operator.providers.registry import credential_provider_id
+
+        counts: dict[str, int] = {}
+        if self._providers is None:
+            return counts
+        for row in self._providers.credentials():
+            storage = credential_provider_id(str(row.provider))
+            counts[storage] = counts.get(storage, 0) + 1
+        return counts
+
+    @staticmethod
+    def _account_detail(provider: str, counts: Mapping[str, int]) -> str:
+        """``2 accounts`` / ``1 account`` / ``no accounts`` for a provider."""
+        from local_operator.providers.registry import credential_provider_id
+
+        total = counts.get(credential_provider_id(provider), 0)
+        if total == 0:
+            return "no accounts"
+        return "1 account" if total == 1 else f"{total} accounts"
+
+    def _failover_rows(self, notice: NoticeFn) -> list[tuple[str, str]] | None:
+        """The ``/failovers`` tree rows, or ``None`` when a notice was issued.
+
+        NEVER resolves a model spec over the network. ``spec_for_target`` (and
+        anything else that resolves an unlisted model's metadata) can take ~10
+        seconds on a cold memo, and this runs on the paint path of a synchronous
+        slash command — a cascade listing that freezes the TUI for ten seconds is
+        a worse answer than no listing. The effort shown is therefore the
+        CONFIGURED effort from the chain entry, not the effort a resolved spec
+        would report; a future "let's show what it really resolves to" is exactly
+        the change that reintroduces the freeze, and it belongs on a worker if
+        anyone ever wants it.
+
+        Degrades rather than hides: the most likely caller is a default install
+        with nothing configured at all, and "you have no cascade, here is the key
+        that would create one" is the useful answer for them.
+        """
+        from local_operator.config import ConfigManager
+        from local_operator.paths import config_dir
+        from local_operator.providers.failover import (
+            DEFAULT_CHAIN_KEY,
+            RetrySettings,
+            expand_fallback_targets,
+            resolve_chain,
+            resolve_chain_key,
+        )
+
+        if self._providers is None:
+            # Same shape as `/accounts`: name the terminal command that answers
+            # the question this surface cannot, and warn rather than error —
+            # nothing is broken, this frontend just lacks the facade.
+            notice("run: local-operator config list (TUI lacks the provider facade)", "warning")
+            return None
+
+        session = self._session
+        if session is None:
+            # House phrasing for "ask again in a moment" (`_cmd_team`): the
+            # cascade is a property of the session's model, and there is no
+            # model to have a cascade for until it attaches.
+            notice("session is still starting…", "warning")
+            return None
+        selected = _model_spec(session)
+        primary = str(getattr(session, "model_label", "") or "")
+        if selected is not None:
+            primary = f"{selected.provider}/{selected.model_id}"
+        if not primary:
+            notice("no model selected yet", "warning")
+            return None
+
+        counts = self._account_counts()
+        configured_effort = str(getattr(selected, "reasoning_effort", "") or "")
+        primary_accounts = self._account_detail(primary.split("/")[0], counts)
+        primary_detail = " · ".join(
+            part for part in (primary, configured_effort, primary_accounts) if part
+        )
+
+        # The model ACTUALLY serving, via `effective_model` rather than the
+        # route's `active_fallback`: RemoteSession implements `effective_model`
+        # but not the route state, so this is the one comparison that is correct
+        # on both the owning terminal and an attached follower.
+        effective = _effective_spec(session)
+        serving = ""
+        if effective is not None:
+            serving = f"{effective.provider}/{effective.model_id}"
+        else:
+            serving = str(getattr(session, "effective_model_label", "") or "")
+
+        rows: list[tuple[str, str]] = [("primary", primary_detail)]
+
+        retry = RetrySettings.from_settings(
+            ConfigManager(config_dir()).get_config().values,
+        )
+        if not retry.enabled or not retry.model_fallback:
+            # Name the KEY, not just the state: "off" without the key leaves the
+            # user hunting through config.yml for which of two switches did it.
+            disabled_by = "retry.enabled" if not retry.enabled else "retry.modelFallback"
+            rows.append(("cascade off", f"{disabled_by} is false — no fallback route is used"))
+            return rows
+
+        chain_key = resolve_chain_key(primary, retry.fallback_chains)
+        chain = resolve_chain(primary, retry.fallback_chains) if chain_key else None
+        targets = expand_fallback_targets(primary, chain) if chain else []
+        if not targets:
+            rows.append(
+                (
+                    "no chain",
+                    f"nothing matches {primary} — set "
+                    f"values.retry.fallbackChains.{DEFAULT_CHAIN_KEY}",
+                )
+            )
+            return rows
+
+        # The key IS the answer to "which chain am I on"; the parenthetical only
+        # earns its width when the key alone does not say how it was picked —
+        # `default` is self-describing, `anthropic/claude-opus-5` could be either
+        # an exact entry or a wildcard that happened to expand.
+        if chain_key == DEFAULT_CHAIN_KEY:
+            matched = DEFAULT_CHAIN_KEY
+        else:
+            matched = f"{chain_key} ({'exact' if chain_key == primary else 'wildcard'})"
+        rows.append(("matched chain", matched))
+
+        if serving and serving == primary:
+            rows[0] = (rows[0][0], f"{rows[0][1]}   ← serving")
+        for index, target in enumerate(targets, start=1):
+            effort = f"{target.effort} effort" if target.effort else "model default effort"
+            detail = f"{effort} · {self._account_detail(target.selector.split('/')[0], counts)}"
+            if serving and serving == target.selector:
+                detail = f"{detail}   ← serving"
+            rows.append((f"{index}. {target.selector}", detail))
+
+        # House phrasing for "this is not a read-only wall": the agent owns the
+        # config, so the user does not have to learn the YAML to change it.
+        rows.append(("", "ask the agent to change models, effort or providers in this cascade"))
+        return rows
+
+    def _cmd_failovers(self, notice: NoticeFn) -> None:
+        """``/failovers`` — the model failover cascade and what is serving."""
+        try:
+            rows = self._failover_rows(notice)
+        except Exception as error:  # never crash the app on a config read
+            notice(f"failover list failed: {error}", "error")
+            return
+        if rows:
+            self._append_block(RichBlock(_tree_listing(rows, "failover cascade")))
 
     def _clock_ms(self) -> float:
         import time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.13"
+version = "0.42.14"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/guides/test_guides.py
+++ b/tests/unit/guides/test_guides.py
@@ -27,6 +27,7 @@ def test_packaged_catalog_is_small_and_descriptions_are_prompt_sized() -> None:
         "browser",
         "configuration",
         "extensions",
+        "failover",
         "mcp",
         "mobile",
         "peer-messaging",

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -52,6 +52,7 @@ from local_operator.providers.failover import (
     is_transient_error,
     is_usage_limit_error,
     resolve_chain,
+    resolve_chain_key,
     resolve_next_key,
     spec_for_selector,
     spec_for_target,
@@ -182,6 +183,33 @@ def test_resolve_chain_wildcard_specificity() -> None:
 def test_resolve_chain_none_without_default() -> None:
     assert resolve_chain("mistral/x", {"google/*": ["a/b"]}) is None
     assert resolve_chain("mistral/x", {}) is None
+
+
+def test_resolve_chain_key_reports_which_key_won() -> None:
+    """The KEY, by the same specificity that picks the entries.
+
+    `/failovers` shows the user which of several plausible keys is in force, and
+    it must be this function's answer rather than a second matching loop that
+    can disagree with routing.
+    """
+    assert resolve_chain_key("openrouter/anthropic/claude-opus", CHAINS) == (
+        "openrouter/anthropic/claude-opus"
+    )
+    assert resolve_chain_key("google/gemini-2.5-pro", CHAINS) == "google/*"
+    # No specific key matches, so the default chain is what actually serves.
+    assert resolve_chain_key("mistral/mistral-large", CHAINS) == "default"
+
+
+def test_resolve_chain_key_longest_wildcard_wins() -> None:
+    chains = {"a/*": ["x/y"], "a/b/*": ["z/w"]}
+    assert resolve_chain_key("a/b/c", chains) == "a/b/*"
+
+
+def test_resolve_chain_key_none_without_default() -> None:
+    # Same "nothing applies" verdict resolve_chain returns, so the two cannot
+    # disagree about whether a cascade exists at all.
+    assert resolve_chain_key("mistral/x", {"google/*": ["a/b"]}) is None
+    assert resolve_chain_key("mistral/x", {}) is None
 
 
 def test_expand_candidates_provider_wildcard_keeps_model_id() -> None:

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -3403,6 +3403,171 @@ async def test_accounts_command_renders_credentials() -> None:
     assert "api_key (login)" in texts
 
 
+def _failover_config(tmp_path, chains) -> None:
+    """Write a real config.yml with ``chains`` under ``values.retry``.
+
+    Through ConfigManager rather than a hand-written YAML file: the loader
+    validates the document, and a hand-rolled one missing a bookkeeping key
+    fails in the app as an unrelated error.
+    """
+    from local_operator.config import ConfigManager
+
+    manager = ConfigManager(tmp_path)
+    manager.set_config_value("hosting", "anthropic")
+    manager.set_config_value("model_name", "claude-opus-5")
+    retry = dict(manager.get_config_value("retry", {}) or {})
+    retry.update(chains)
+    manager.set_config_value("retry", retry)
+
+
+async def _failover_text(app) -> str:
+    """Run `/failovers` once the session has attached, and read the transcript.
+
+    The command reports the model's cascade, so running it before the session
+    lands captures the "still starting" degrade rather than the listing.
+    """
+    for _ in range(200):
+        if app._session is not None:
+            break
+        await asyncio.sleep(0.01)
+    app._run_slash_command("/failovers")
+    return _transcript_text(app)
+
+
+@pytest.mark.asyncio
+async def test_failovers_command_renders_the_cascade(monkeypatch, tmp_path) -> None:
+    """The populated case: order, matched key, accounts, and what is serving."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _failover_config(
+        tmp_path,
+        {
+            "fallbackChains": {
+                "test/*": [
+                    {"provider": "openrouter", "model": "deepseek/deepseek-chat", "effort": "high"},
+                    "deepseek/deepseek-reasoner",
+                ]
+            }
+        },
+    )
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=FakeProviderController())
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        text = await _failover_text(app)
+        await pilot.pause()
+
+    assert "failover cascade" in text
+    # The matched key AND how it matched: an exact entry silently outranking a
+    # wildcard is the confusion this row exists to end.
+    assert "test/* (wildcard)" in text
+    # Configured order is the routing order, numbered so it reads as a cascade.
+    assert "1. openrouter/deepseek/deepseek-chat" in text
+    assert "2. deepseek/deepseek-reasoner" in text
+    # CONFIGURED effort, never a resolved spec (that would be a network call on
+    # the paint path); a target without one says so rather than guessing.
+    assert "high effort" in text
+    assert "model default effort" in text
+    # The fake never falls back, so the primary is what serves.
+    assert "← serving" in text
+    assert text.index("← serving") < text.index("1. openrouter")
+    assert "ask the agent to change models, effort or providers" in text
+
+
+@pytest.mark.asyncio
+async def test_failovers_counts_accounts_without_printing_identities(monkeypatch, tmp_path) -> None:
+    """Counts collapse login flavours; `/accounts` keeps the identities.
+
+    The fake holds an openrouter key and a deepseek OAuth row carrying an email.
+    Printing `row.data` here would leak an address onto a surface that never
+    promised one.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _failover_config(tmp_path, {"fallbackChains": {"default": ["deepseek/deepseek-reasoner"]}})
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=FakeProviderController())
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        text = await _failover_text(app)
+        await pilot.pause()
+
+    assert "1 account" in text
+    assert "a@b.c" not in text
+
+
+@pytest.mark.asyncio
+async def test_failovers_without_a_chain_points_at_the_key_to_set(monkeypatch, tmp_path) -> None:
+    """The default install — nothing configured — is the most likely caller."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _failover_config(tmp_path, {"fallbackChains": {}})
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=FakeProviderController())
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        text = await _failover_text(app)
+        await pilot.pause()
+
+    # The primary is still shown: "you have no cascade" is only useful beside
+    # what would have had one.
+    assert "primary" in text
+    assert "values.retry.fallbackChains.default" in text
+
+
+@pytest.mark.asyncio
+async def test_failovers_names_the_key_that_disabled_the_cascade(monkeypatch, tmp_path) -> None:
+    """Switched off reads as switched off, and names WHICH switch."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _failover_config(
+        tmp_path,
+        {"modelFallback": False, "fallbackChains": {"default": ["deepseek/x"]}},
+    )
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=FakeProviderController())
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        text = await _failover_text(app)
+        await pilot.pause()
+
+    assert "retry.modelFallback is false" in text
+    # The configured chain must NOT be listed as a route: nothing would use it.
+    assert "deepseek/x" not in text
+
+
+@pytest.mark.asyncio
+async def test_failovers_without_a_provider_facade_warns(monkeypatch, tmp_path) -> None:
+    """Same shape as `/accounts`: name the terminal command that can answer."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _failover_config(tmp_path, {"fallbackChains": {}})
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        await _failover_text(app)
+        await pilot.pause()
+        notices = [b._text for b in app.query(NoticeBlock)]
+
+    assert any("local-operator config list" in n for n in notices)
+
+
+@pytest.mark.asyncio
+async def test_failovers_reports_an_unreadable_config_as_an_error(monkeypatch, tmp_path) -> None:
+    """A config read that raises is named, not swallowed into an empty tree."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _failover_config(tmp_path, {"fallbackChains": {}})
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=FakeProviderController())
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await asyncio.sleep(0.01)
+        import local_operator.config as config_mod
+
+        def explode(*args, **kwargs):
+            raise RuntimeError("database is locked")
+
+        monkeypatch.setattr(config_mod, "ConfigManager", explode)
+        app._run_slash_command("/failovers")
+        await pilot.pause()
+        notices = [b._text for b in app.query(NoticeBlock)]
+
+    assert any("failover list failed: database is locked" in n for n in notices)
+
+
 def _usage_reports(*, used: float = 5.0):
     from local_operator.providers.usage import UsageAmount, UsageLimit, UsageReport
 

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -3463,9 +3463,11 @@ async def test_failovers_command_renders_the_cascade(monkeypatch, tmp_path) -> N
     assert "1. openrouter/deepseek/deepseek-chat" in text
     assert "2. deepseek/deepseek-reasoner" in text
     # CONFIGURED effort, never a resolved spec (that would be a network call on
-    # the paint path); a target without one says so rather than guessing.
+    # the paint path). Only stated when it DIFFERS from the model default: the
+    # phrase was identical on every row of a real config, which is a column
+    # carrying no bits and the width that pushed the serving marker into a wrap.
     assert "high effort" in text
-    assert "model default effort" in text
+    assert "model default effort" not in text
     # The fake never falls back, so the primary is what serves.
     assert "← serving" in text
     assert text.index("← serving") < text.index("1. openrouter")
@@ -3566,6 +3568,242 @@ async def test_failovers_reports_an_unreadable_config_as_an_error(monkeypatch, t
         notices = [b._text for b in app.query(NoticeBlock)]
 
     assert any("failover list failed: database is locked" in n for n in notices)
+
+
+@pytest.mark.asyncio
+async def test_failovers_before_the_session_attaches_warns(monkeypatch, tmp_path) -> None:
+    """The pre-attach state, which the other tests deliberately wait past.
+
+    Reachable in practice: the command is typeable while the session is still
+    booting, and the cascade is a property of the session's model.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _failover_config(tmp_path, {"fallbackChains": {}})
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=FakeProviderController())
+    async with app.run_test(size=(100, 24)) as pilot:
+        # NO wait for attach — that is the state under test.
+        app._session = None
+        app._run_slash_command("/failovers")
+        await pilot.pause()
+        notices = [b._text for b in app.query(NoticeBlock)]
+
+    assert any("session is still starting" in n for n in notices)
+
+
+@pytest.mark.asyncio
+async def test_failovers_on_a_follower_whose_model_raises_warns(monkeypatch, tmp_path) -> None:
+    """`RemoteSession.model` is a property that RAISES before the owner syncs.
+
+    `getattr(session, "model", None)` does NOT suppress an exception raised
+    inside a property, so this used to surface as `failover list failed: owner
+    has no selected model spec` — an error notice carrying developer vocabulary
+    for a state that has a warning phrasing.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _failover_config(tmp_path, {"fallbackChains": {}})
+
+    class _RaisingSpec(FakeSession):
+        """A follower whose owner has not published a model spec yet.
+
+        Subclasses the fake so the session plumbing the app installs on adopt
+        (subscribe/dispose) still exists; only the spec accessors raise.
+        """
+
+        @property
+        def model_label(self) -> str:
+            return ""
+
+        @property
+        def model(self):
+            raise RuntimeError("owner has no selected model spec")
+
+        @property
+        def effective_model(self):
+            raise RuntimeError("owner has no effective model spec")
+
+        @property
+        def effective_model_label(self) -> str:
+            return ""
+
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=FakeProviderController())
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await asyncio.sleep(0.01)
+        # Swapped in AFTER attach: `_adopt_session` reads `.model` on the boot
+        # path too, and that unrelated call site is out of this slice's scope.
+        app._session = _RaisingSpec()
+        app._run_slash_command("/failovers")
+        await pilot.pause()
+        # `_token` is where NoticeBlock keeps the resolved kind; asserting on it
+        # is what pins the REGISTER rather than just the words.
+        notices = [(b._text, b._token) for b in app.query(NoticeBlock)]
+
+    matched = [(text, token) for text, token in notices if "no model selected yet" in text]
+    assert matched, notices
+    # Nothing is broken, so this must not be the error tier.
+    assert matched[0][1] != "error"
+    assert not any("failover list failed" in text for text, _ in notices)
+
+
+@pytest.mark.asyncio
+async def test_failovers_matched_key_with_only_the_current_model_is_not_no_match(
+    monkeypatch, tmp_path
+) -> None:
+    """A key CAN match and still expand to nothing, and that is not "no match".
+
+    `expand_fallback_targets` drops a legacy entry equal to the current
+    selector, so `default: ["test/model"]` on a `test/model` primary matched
+    `default` and produced []. Saying "set fallbackChains.default" there names a
+    key that is already set and suggests a no-op.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _failover_config(tmp_path, {"fallbackChains": {"default": ["test/model"]}})
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=FakeProviderController())
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        text = await _failover_text(app)
+        await pilot.pause()
+
+    assert "default matched but lists only the current model" in text
+    # The no-op suggestion must NOT be offered for a key that already matched.
+    assert "set values.retry.fallbackChains.default" not in text
+
+
+@pytest.mark.asyncio
+async def test_failovers_marks_exactly_one_serving_row(monkeypatch, tmp_path) -> None:
+    """Same model at a different effort is a real route, and only ONE serves.
+
+    `FallbackTarget` is (selector, effort), so a selector-only comparison put
+    the marker on both the primary and the target — worst in exactly the case
+    the marker exists to disambiguate ("am I on high or low?").
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _failover_config(
+        tmp_path,
+        {"fallbackChains": {"default": [{"provider": "test", "model": "model", "effort": "low"}]}},
+    )
+
+    class LowEffortSpec:
+        provider = "test"
+        model_id = "model"
+        reasoning_effort = "low"
+        display_name = ""
+
+    class ServingLowSession(FakeSession):
+        @property
+        def model(self):
+            spec = LowEffortSpec()
+            spec.reasoning_effort = "high"  # the SELECTION is high
+            return spec
+
+        @property
+        def effective_model(self):
+            return LowEffortSpec()  # the low-effort route is answering
+
+    app = OperatorApp(
+        lambda: _factory(ServingLowSession()), provider_controller=FakeProviderController()
+    )
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        text = await _failover_text(app)
+        await pilot.pause()
+
+    assert text.count("← serving") == 1, text
+    # It belongs to the low-effort TARGET, not the high-effort primary.
+    low_row = [line for line in text.splitlines() if "low effort" in line]
+    assert low_row and "← serving" in low_row[0], text
+
+
+@pytest.mark.asyncio
+async def test_failovers_does_not_call_a_usable_provider_accountless(monkeypatch, tmp_path) -> None:
+    """A routing listing must not report a working hop as `no accounts`.
+
+    The fake's `deepseek` has an OAuth row; `openrouter` has a key. A provider
+    that needs no credential at all (`allows_missing_api_key`) is a healthy
+    route, and calling it `no accounts` reads as "this hop will fail" and sends
+    the user to a pointless login.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _failover_config(tmp_path, {"fallbackChains": {"default": ["ollama/llama3"]}})
+
+    class OllamaDef:
+        id = "ollama"
+        name = "Ollama"
+        store_credentials_as = None
+        allows_missing_api_key = True
+        login = None
+        search_aliases = ()
+
+    class OllamaController(FakeProviderController):
+        def provider(self, pid):
+            return OllamaDef() if pid == "ollama" else super().provider(pid)
+
+        def is_usable(self, provider):
+            return provider == "ollama" or super().is_usable(provider)
+
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=OllamaController())
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        text = await _failover_text(app)
+        await pilot.pause()
+
+    ollama_row = [line for line in text.splitlines() if "ollama/llama3" in line]
+    assert ollama_row, text
+    assert "no credential needed" in ollama_row[0]
+    assert "no accounts" not in ollama_row[0]
+
+
+@pytest.mark.asyncio
+async def test_failovers_flags_config_edited_after_the_session_started(
+    monkeypatch, tmp_path
+) -> None:
+    """The listing must describe what the SESSION routes on, and flag drift.
+
+    The router captures its settings once at session build; nothing watches
+    config.yml. Without this the command confirmed cascade edits the running
+    session would not honour — a green light, and most wrong for the user who
+    followed this command's own "ask the agent to change…" hint.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    # On DISK: two targets. The session captured only the first.
+    _failover_config(tmp_path, {"fallbackChains": {"default": ["zai/glm-5.3", "kimi/k3"]}})
+
+    class SnapshotSession(FakeSession):
+        @property
+        def routing_settings(self):
+            return {"retry": {"fallbackChains": {"default": ["zai/glm-5.3"]}}}
+
+    app = OperatorApp(
+        lambda: _factory(SnapshotSession()), provider_controller=FakeProviderController()
+    )
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        text = await _failover_text(app)
+        await pilot.pause()
+
+    # What the SESSION will do, not what the file says.
+    assert "1. zai/glm-5.3" in text
+    assert "kimi/k3" not in text
+    # And it says so, naming the step that makes the edit real.
+    assert "config.yml changed since this session started" in text
+    assert "/reload" in text
+
+
+@pytest.mark.asyncio
+async def test_failovers_offers_the_agent_affordance_in_every_state(monkeypatch, tmp_path) -> None:
+    """The user with NO cascade needs the "ask the agent" hint most."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _failover_config(tmp_path, {"modelFallback": False, "fallbackChains": {}})
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=FakeProviderController())
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        disabled = await _failover_text(app)
+        await pilot.pause()
+
+    assert "ask the agent to turn the cascade back on" in disabled
 
 
 def _usage_reports(*, used: float = 5.0):

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -59,6 +59,8 @@ ECHO_POLICY = {
     "provider": False,
     "search": False,
     "accounts": False,
+    # The cascade tree IS the receipt, and there is no argument to restate.
+    "failovers": False,
     "usage": False,
     # The screen it opens IS the receipt (same rule as `/usage`); the argument
     # names a view, never words the model is told.
@@ -110,6 +112,7 @@ PROMPT_POLICY = {
     "provider": False,
     "search": False,
     "accounts": False,
+    "failovers": False,
     "usage": False,
     # A view selector, not a prompt: `/analytics [view]` names which screen to
     # open, so it splices-and-runs inline like `/usage` rather than reassembling.


### PR DESCRIPTION
## Summary

There was no way to answer "which provider is actually serving my requests, and what happens when this one runs out" without reading `config.yml` and then reading `providers/failover.py` to find out what the config meant. This adds the two surfaces that answer it: a read-only `/failovers` command, and a packaged `guide://failover` for the questions a listing cannot answer.

Ships as a **patch** (0.42.13 → 0.42.14): a diagnostic command plus a guide, no step-function capability.

## What `/failovers` shows

Primary, which chain key matched and how (exact / `provider/*` / `default`), the ordered targets with their configured effort, how many accounts each provider can rotate through, and a `← serving` marker on the row actually answering.

## Design constraints this had to respect

- **No spec resolution on the paint path.** `spec_for_target` can take ~10s on a cold memo for an unlisted model, and this is a synchronous slash command, so a "resolved effort" column would freeze the TUI. The listing shows **configured** effort; the reason is recorded in `_failover_rows`' docstring so a later "let's show what it really resolves to" does not reintroduce the freeze.
- **Serving is decided via `effective_model`**, not the route's `active_fallback`. `RemoteSession` implements the former and not the latter, so this is the one comparison correct on both the owning terminal and an attached follower. `failovers` is in `_FRONTEND_LOCAL_SLASHES` — it reads local config and local credential counts, so routing it to the owner would only add a hop.
- **Counts only, never identities.** Accounts are counted through `credential_provider_id`, so `xai-oauth` and `xai` collapse to one account rather than being double-counted. `row.data` is never read; `/accounts` owns identities.
- **`resolve_chain_key` is split out of `resolve_chain`** so the matched key is the engine's own answer. A caller re-deriving it with its own matching loop is a second definition of specificity that can disagree with routing.

## Visual evidence

Captured from the real `OperatorApp` (the lightweight test hosts declare no `CSS_PATH`, so they cannot show a stylesheet change), rendered and inspected as images. **All at 80 columns** — the width a split cmux pane produces, and the width at which the round-1 design review found the layout breaking.

| Populated | Fallback serving | Nothing configured |
|---|---|---|
| ![The cascade](https://raw.githubusercontent.com/damianvtran/local-operator/dev-failovers/docs/assets/pr-failovers/after-populated-80.svg) | ![Marker attached to its row](https://raw.githubusercontent.com/damianvtran/local-operator/dev-failovers/docs/assets/pr-failovers/after-fallback-serving-80.svg) | ![No chain matches](https://raw.githubusercontent.com/damianvtran/local-operator/dev-failovers/docs/assets/pr-failovers/after-empty-80.svg) |

The populated frame is this machine's **real** config and **real** credential counts — the 5-target `default` chain, not a fixture:

```
failover cascade
├─ primary        anthropic/claude-opus-5 · high · 4 accounts   ← serving
├─ matched chain  default
├─ 1. zai/glm-5.3                        1 account
├─ 2. kimi/k3                            1 account
├─ 3. alibaba-token-plan/qwen3.8-max     3 accounts
├─ 4. xai/grok-4.6                       1 account
├─ 5. openai/gpt-5.6-sol                 1 account
└─ tip  ask the agent to change models, effort or providers here
```

Details are padded into a column the way the sibling `/mcp` listing pads, so "which hop has accounts" reads vertically. The `← serving` marker sits **before** the detail, because it is the one element with no readable degraded form: a wrapped detail is still words, a wrapped `← serving` is an arrow at column 0 pointing at nothing.

The default install — nothing configured, which is the most likely caller — keeps its actionable key on one line at 80 columns, and offers the agent affordance rather than leaving a first-time user to author YAML:

```
failover cascade
├─ primary   anthropic/claude-opus-5 · high · 4 accounts
├─ no chain  no chain matches — set values.retry.fallbackChains.default
└─ tip       ask the agent to set up a fallback cascade
```

## Degrade behaviour

Six states, **each exercised by a test** (round 1 found the original table overstated this — two states had no test; they now do):

| State | Result |
|---|---|
| No provider facade | `warning`: `run: local-operator config list (TUI lacks the provider facade)` |
| Session not attached yet | `warning`: `session is still starting…` |
| Owner has not published a model (follower) | `warning`: `no model selected yet` — not an `error` |
| `retry.enabled` / `modelFallback` off | Primary plus a row naming **which** key disabled it |
| No chain matches / matched key lists only the current model | Distinct messages; the second no longer suggests a no-op |
| Config raises | `error`: `failover list failed: <error>` |

## The guide

`guide://failover` covers what the listing cannot: multi-account rotation *within* a provider before the chain leaves it (selection order, `_recover_quota_blocked`, and that a model-tier cap is per account so siblings are tried first), skipping a fallback whose provider is already at 0%, the quota reserve picking a lower-effort route on the same provider, sticky routing, and the three separate ways back up the cascade — the `primary_retry_at_ms` cooldown (set on route **change**, not bumped per use, because a sliding window pinned sessions for their whole life), `quota_pinned` re-probing at every message boundary regardless of cooldown, and the advisory per-target bench that `clear()` deliberately does not clear.

**Routing.** Five real user questions measured against the live index. Four previously selected **no guide at all**; all five now reach it:

| Question | Before | After |
|---|---|---|
| why did my model fall back to another provider | configuration | configuration, **failover** |
| failover keeps switching to kimi, how do I fix the cascade | *nothing* | **failover** |
| what models can I use for the fallback chain | *nothing* | **failover** |
| my anthropic account hit its quota and requests went to openai | *nothing* | **failover** |
| which provider is serving my requests right now | *nothing* | **failover** |

A guide's description costs context only in turns where it semantically routes (`skills/index.py` `render_block` emits one line per **selected** guide), so its resting footprint is zero. The description is 176 chars, inside the ≤180 contract pinned by `test_packaged_catalog_is_small_and_descriptions_are_prompt_sized`.

**Every bash recipe in the guide was extracted and run** before shipping, from a neutral directory, network-free:

```
=== RECIPE 1/2 (providers) ===   15 providers listed, openai … alibaba-token-plan-oauth
=== RECIPE 3 (models) ===        anthropic: 18 model ids; openrouter -> {} (the aggregator caveat, by design)
=== RECIPE 4 (cascade) ===       primary anthropic/claude-opus-5, matched key default, 5 targets in order
=== RECIPE 5 (account depth) ===  anthropic 4, alibaba-token-plan 3, zai/kimi/xai/openai 1 each
```

Recipe 4 imports `resolve_chain_key`, so it runs against this branch and will run against the installed runtime once released. The account recipe prints **counts and provider ids only** — that constraint is written into the snippet's own comment, since it is one edit away from printing bearer tokens.

The configuration guide's duplicate of these semantics is replaced by a three-line pointer; its `values.retry.*` key list stays. Two guides asserting cooldown rules is how they drift apart.

## Tests

- `tests/unit/providers/test_failover.py` — `resolve_chain_key` specificity (exact beats wildcard, longest wildcard wins), default fallthrough, and the `None` verdict matching `resolve_chain`'s.
- `tests/unit/tui/test_app_pilot.py` — **13** pilot tests: the populated render, counts-without-identities (asserts the fake's `a@b.c` never appears), every degrade state, and one regression test per round-1 major — matched-key-with-only-the-current-model, exactly-one-serving-marker, a usable provider never called `no accounts`, and the session-vs-disk drift flag.
- `tests/unit/tui/test_slash_echo.py` — the pinned echo/prompt policy entries.
- `tests/unit/guides/test_guides.py` — the packaged-guide inventory.

## Gates

Run over the whole tree, exactly as CI:

- `.venv/bin/python -m flake8 .` — clean
- `uvx --from black==26.1.0 black --check .` — clean, 569 files
- `uvx isort==5.13.2 --check .` — clean
- Unit suite — **7392 passed, 7 skipped**

Note for anyone reproducing locally: `tests/unit/tools/test_eval_tool.py` fails in **any** worktree (confirmed on unmodified `origin/main`) because the editable install resolves `local_operator` to the main checkout, so the eval worker subprocess cannot import from the worktree. `PYTHONPATH=$PWD` fixes it; CI is unaffected as it installs the package it tests.

## Review focus

Round 1 posted three independent rounds (code, design, UX); remediation is in the comment below. Two calls worth a second opinion:

- **No `failover` singular alias** (UX U2 suggested one). The picker sizes its name column on the widest `/name  /alias` pair, and `/failovers  /failover` is 21 cells against a previous max of 18 — it truncated `List all commands` on the 41-cell frame that `test_descriptions_come_back_above_the_collapse_width` pins. The singular still reaches the command through prefix matching. Rejected on cost, not on merit.
- **`/f` now ranks `failovers` above `effort`** (UX U2). That is correct prefix behaviour — `/f` is a prefix of `failovers` and not of `effort` — and the picker shows the row before Enter. Recorded as deliberate rather than special-cased.
