### PR TITLE
fix(resume): reach every session in the picker, not the newest 200

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -88,3 +88,56 @@ Cross-instance findings (DA-rows in the remediation):
   measured: exactly ONE live fetch, all five served. Degrades to
   fetch-anywhere on any coordination failure — a read-only cache dir can
   never block a session start.
+
+## resume-picker-before.json / resume-picker-after.json
+
+The `/resume` picker reach fix (uncapping the row list, plus the scan, index
+and search-tier work that makes uncapping affordable). Captured on this machine
+(macOS/APFS) against `origin/main` @ `fa62d097` (before) and the same tree with
+the fixes (after), on a synthetic three-month store built by
+`scripts/bench_resume_picker_store.py`: 2,700 user sessions and 29,000 subagent
+sessions, 31,700 directories, 584 MB. That 10.6:1 subagent-to-user ratio is
+what the real store shows, and it is the ratio that drives the scan cost.
+
+```sh
+.venv/bin/python scripts/bench_resume_picker_store.py /tmp/synth-store 2700 29000
+PYTHONPATH=. .venv/bin/python scripts/bench_resume_picker.py /tmp/synth-store after --json out.json
+```
+
+| Stage | Before | After |
+| --- | --- | --- |
+| `recent_sessions`, uncapped | 1,073 ms | **314 ms** |
+| `recent_session_rows`, uncapped | 1,256 ms | **409 ms** |
+| `build_index`, warm cache | 62 ms | 60 ms |
+| `build_index` after the daemon's narrow call | **768 ms** | **94 ms** |
+| exact search, steady keystroke | 3.4 ms | **0.8 ms** |
+| soft search, first keystroke | 161 ms | 154 ms (now deferred; see below) |
+| **picker open, total** | **1,355 ms** | **494 ms** |
+
+The operator's real store (230 user / 2,451 subagent), same command, is
+`picker open 102 ms -> 34 ms` while listing 30 MORE rows than before.
+
+Reading the table:
+
+- The **scan** win is the origin verdict cache (`resume.ORIGIN_CACHE_NAME`).
+  The listing must read and parse every `origin.json` that exists — existence
+  alone must never be read as "subagent" — and the markers that exist are the
+  subagent ones, so that rule costs one file read per subagent directory:
+  1,127 ms over 31,700 dirs, of which 639 ms is reads and only 17 ms parsing.
+  Skipping the read for unmarked directories alone saves ~8% and cannot fix it.
+  Memoising the parsed verdict on the marker's own `(mtime, size)` is sound
+  because the marker is written once at directory creation and never rewritten.
+- The **`build_index`** win is cache preservation. Before, any narrow caller
+  (the mobile daemon asks for 200 or 100 ids) pruned the on-disk index to its
+  own ids and the next picker open re-digested the whole store. After, a
+  wide → narrow → wide sequence re-digests **zero** transcripts, verified by
+  counting `digest_transcript` calls, not by timing.
+- The **soft-search** row is unchanged per call and that is the point: the tier
+  is now deferred behind the exact tier, so it does not run at all for a query
+  the cheap tiers already answer with a screenful. Its cost on the operator's
+  real 2,681-digest / 10.04 MB corpus is 324 ms and 95 MB resident, which is
+  what used to land on the first character typed once the picker was uncapped.
+
+Cold-cache numbers are reported separately and never averaged into the warm
+ones: the first scan after the cache is deleted is 1.6-5.2 s on this store,
+dominated by reading 29,000 marker files, and it writes the cache as it goes.

--- a/bench/resume-picker-after.json
+++ b/bench/resume-picker-after.json
@@ -1,0 +1,16 @@
+{
+  "label": "AFTER final",
+  "recent_sessions_uncapped_ms": 313.5,
+  "user_sessions": 2700,
+  "recent_sessions_limit200_ms": 360.7,
+  "recent_session_rows_uncapped_ms": 409.1,
+  "build_index_warm_ms": 59.8,
+  "digests": 2700,
+  "build_index_after_daemon_thrash_ms": 94.4,
+  "exact_search_first_ms": 3.77,
+  "exact_search_steady_ms": 0.82,
+  "soft_first_keystroke_ms": 153.6,
+  "soft_steady_keystroke_ms": 1.6,
+  "rss_mb": 100.2,
+  "picker_open_total_ms": 493.6
+}

--- a/bench/resume-picker-before.json
+++ b/bench/resume-picker-before.json
@@ -1,0 +1,16 @@
+{
+  "label": "BEFORE synthetic 2700u/29000s",
+  "recent_sessions_uncapped_ms": 1073.0,
+  "user_sessions": 2700,
+  "recent_sessions_limit200_ms": 1120.2,
+  "recent_session_rows_uncapped_ms": 1255.9,
+  "build_index_warm_ms": 62.2,
+  "digests": 2700,
+  "build_index_after_daemon_thrash_ms": 768.0,
+  "exact_search_first_ms": 4.75,
+  "exact_search_steady_ms": 3.42,
+  "soft_first_keystroke_ms": 161.2,
+  "soft_steady_keystroke_ms": 2.1,
+  "rss_mb": 92.6,
+  "picker_open_total_ms": 1354.8
+}

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -2511,6 +2511,7 @@ def main() -> int:
         # gets a one-line message, the ids that DO exist, and a non-zero status.
         if getattr(args, "resume", None) is not None:
             from local_operator.resume import (
+                RESUME_RECOVERY_LISTING,
                 ResumeNotFound,
                 backfill_session_origins,
                 backfill_session_titles,
@@ -2545,7 +2546,12 @@ def main() -> int:
                 # With the age: a column of bare 12-hex ids gives the reader
                 # nothing to choose between, and the recency the listing already
                 # sorted by is the one fact that makes them recognisable.
-                available = recent_sessions(config_dir())
+                # Ten explicitly: this is an error path printing to stderr after
+                # a typo'd id, where a short list of the most recent sessions is
+                # the help and the whole store would bury it. ``recent_sessions``
+                # returns everything by default, so the cap belongs here where a
+                # reader can see the listing is deliberately short.
+                available = recent_sessions(config_dir(), limit=RESUME_RECOVERY_LISTING)
                 if available:
                     now = time.time()
                     print("recent sessions (newest first):", file=sys.stderr)

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -1066,7 +1066,11 @@ def recent_sessions(config_dir: Path, limit: int = 10) -> list[tuple[str, float]
     Because a marker that EXISTS must still be read and parsed (see
     :data:`ORIGIN_CACHE_NAME`), that is one file read per subagent directory:
     1127 ms over 31,700 dirs, of which the reads are 639 ms. The verdict cache
-    is what removes it, taking the same scan to ~250 ms warm.
+    is what removes it, taking the same scan to ~310 ms warm
+    (``bench/resume-picker-after.json``; independently re-measured at 307 ms in
+    agent review round 1). Quote the committed bench figure here rather than a
+    remembered one — an optimistic number in a docstring is how the next
+    person's regression looks like an improvement.
 
     ``limit`` truncates the RESULT, never the work: every directory is visited
     regardless, so a caller asking for all sessions costs the same as one

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -69,17 +69,27 @@ ORIGIN_SUBAGENT = "subagent"
 #: whose ``(mtime, size)`` is unchanged cannot have changed its meaning.
 #:
 #: What may NOT go in here, and why each would be a bug:
-#: * Only a verdict actually PARSED from a marker that existed is stored. A
-#:   stat failure, an unreadable file, or a corrupt payload falls through to
-#:   the real read every time — caching those would let one bad sidecar hide a
-#:   real session persistently instead of transiently.
+#: * Only a verdict actually PARSED from a marker that was READ is stored. A
+#:   stat failure or an unreadable file falls through to the real read every
+#:   time (:func:`_session_origin_read` reports readability separately for
+#:   exactly this): those describe the MOMENT — EMFILE under the descriptor
+#:   pressure this scan itself creates, a network volume blip — while the key
+#:   is the marker's immutable ``(mtime, size)``, so caching one would serve a
+#:   transient outage as a permanent wrong verdict for the life of the file.
+#: * A CORRUPT payload is cached, and that is deliberate rather than an
+#:   oversight: a parse failure is a fact about the file's CONTENT, stable for
+#:   as long as the bytes are, and re-deriving it every scan would return the
+#:   same ``""``. Rewriting the marker changes its ``(mtime, size)`` and
+#:   expires the entry, which is exactly when the verdict could differ.
 #: * ABSENCE is never cached. Unmarked already means user and is the cheap path,
 #:   and a directory the backfill stamps later must be re-read, not answered
 #:   from a stale "no marker" fact.
 ORIGIN_CACHE_NAME = "origin-verdicts.json"
 
 #: Bumped when the cache's shape or key changes, so an older file is discarded
-#: rather than misread. Mirrors ``search_index.INDEX_VERSION``.
+#: rather than misread. Independent of ``search_index.INDEX_VERSION`` — the two
+#: caches version separately and neither number constrains the other; only the
+#: mechanism is borrowed.
 ORIGIN_CACHE_VERSION = 1
 
 #: Journals the session's title (and every name it has ever borne) beside the
@@ -311,18 +321,42 @@ def session_origin(session_dir: Path) -> str:
     picker and every ``--resume`` with no id, for every session, until the
     user found and deleted the file by hand.
     """
+    origin, _readable = _session_origin_read(session_dir)
+    return origin
+
+
+def _session_origin_read(session_dir: Path) -> tuple[str, bool]:
+    """:func:`session_origin`'s verdict, plus whether the marker was READ at all.
+
+    Exists because those two facts are different and only the traversal needs
+    the second. ``session_origin`` deliberately collapses every failure into
+    ``""`` — that tolerance is its whole point and its public contract, and a
+    caller asking "is this the user's session" is right to be told "yes" when
+    the claim cannot be trusted.
+
+    A CACHE, though, must not memoise that answer. ``""`` from a parse failure
+    is a fact about the file's CONTENT, so it is stable while the bytes are:
+    re-deriving it on every scan would return the same verdict, and the marker
+    changing is exactly when the memo's ``(mtime, size)`` key expires. ``""``
+    from an ``OSError`` is a fact about the MOMENT — EMFILE under the descriptor
+    pressure a 30,000-directory scan creates, a network volume blip, a
+    permissions change mid-scan — and the file it describes is immutable by
+    design, so memoising it pins a wrong verdict for the life of the marker
+    rather than for the life of the outage. ``readable=False`` is how the
+    traversal tells those apart and declines to cache the second.
+    """
     try:
         raw = (session_dir / ORIGIN_NAME).read_text(encoding="utf-8", errors="replace")
     except OSError:
-        return ""
+        return "", False
     try:
         payload = json.loads(raw)
     except ValueError:
-        return ""
+        return "", True
     if not isinstance(payload, dict):
-        return ""
+        return "", True
     origin = payload.get("origin")
-    return origin if isinstance(origin, str) else ""
+    return (origin if isinstance(origin, str) else ""), True
 
 
 class SessionTitle(NamedTuple):
@@ -1089,14 +1123,22 @@ def recent_sessions(config_dir: Path, limit: int = 10) -> list[tuple[str, float]
                     # reads as the user's own session rather than vanishing from
                     # the picker. Treating "file exists" as "subagent" would
                     # invert that fail-safe and hide real work.
-                    origin = session_origin(Path(entry.path))
-                    # Only a verdict actually parsed off an existing marker is
-                    # memoised. "" covers both "no origin claimed" and "could
-                    # not read this claim", and the two are indistinguishable
-                    # here — so a "" verdict is stored against the key that
-                    # produced it and re-derived the moment the file changes,
-                    # which is exactly when a corrupt marker gets rewritten.
-                    fresh[entry.name] = {"key": key, "origin": origin}
+                    origin, readable = _session_origin_read(Path(entry.path))
+                    # Only a verdict PARSED off a marker that was actually read
+                    # is memoised. A read failure yields the same "" as a
+                    # corrupt payload — safe for the listing, which shows the
+                    # session — but it describes the moment, not the file, and
+                    # the key is the marker's immutable (mtime, size): caching
+                    # it would serve one transient EMFILE or volume blip as a
+                    # permanent wrong verdict for the life of that marker. So it
+                    # falls through and is re-read on the next scan instead.
+                    if readable:
+                        fresh[entry.name] = {"key": key, "origin": origin}
+                    else:
+                        # Drop any entry inherited from ``cached``: this scan
+                        # could not confirm it, and ``merged`` below is built
+                        # from the names seen here.
+                        seen.discard(entry.name)
                 if origin:
                     continue
             rows.append((entry.name, mtime))

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -27,6 +27,16 @@ from typing import Any, NamedTuple
 #: whole "which session" decision stays ONE value threaded through one parameter.
 RESUME_LATEST = "@latest"
 
+#: Rows the CLI's ``--resume <typo>`` recovery listing prints to stderr.
+#:
+#: Named rather than a bare ``10`` at the call site because it is a DELIBERATELY
+#: short list, not an incidental one: the listing is an error message helping a
+#: user who mistyped an id, where the newest few sessions are the help and the
+#: whole store would bury it. The picker is the surface that shows everything
+#: (:func:`recent_session_rows` returns the full store by default); this is the
+#: one place a cap is the right answer, so it says so.
+RESUME_RECOVERY_LISTING = 10
+
 #: The file whose presence makes a directory a resumable session. Also what the
 #: recency ordering is read from: a directory's own mtime moves for reasons that
 #: are not turns (an origin stamp, a sibling file), so it is not the clock to use.
@@ -1036,8 +1046,18 @@ def _save_origin_cache(path: Path, entries: dict[str, Any]) -> None:
         return
 
 
-def recent_sessions(config_dir: Path, limit: int = 10) -> list[tuple[str, float]]:
+def recent_sessions(config_dir: Path, limit: int | None = None) -> list[tuple[str, float]]:
     """``(id, mtime)`` for the USER's resumable sessions, newest first.
+
+    ``limit=None`` means NO TRUNCATION and is the default, so a caller that says
+    nothing gets the whole store. That direction is deliberate and was learned
+    the expensive way: this defaulted to ``10`` while the picker called it with
+    no argument, and the "uncapped" picker silently showed ten rows on a
+    236-session store — a worse version of the bug the change was written to
+    fix. A default that truncates makes forgetting to pass a limit look like
+    working code, so the safe default is the complete answer and every caller
+    that wants less has to say so at its own call site, where a reader can see
+    it.
 
     Subagent sessions are excluded (:func:`is_user_session`): they are the
     machine's own scratch conversations, and a listing offered to a human is
@@ -1156,7 +1176,10 @@ def recent_sessions(config_dir: Path, limit: int = 10) -> list[tuple[str, float]
     if merged != cached:
         _save_origin_cache(cache_path, merged)
     rows.sort(key=lambda row: row[1], reverse=True)
-    return rows[:limit]
+    # Sliced only when a limit was actually asked for: ``rows[:None]`` would
+    # also return everything, but spelling it out keeps "no limit" a decision
+    # the code states rather than a property of slice syntax.
+    return rows if limit is None else rows[:limit]
 
 
 def format_age(seconds: float) -> str:
@@ -1413,7 +1436,7 @@ def _condense(text: str, max_chars: int) -> str:
     return cut.rstrip(" ,.;:") + "…"
 
 
-def recent_session_rows(config_dir: Path, limit: int = 10) -> list[SessionRow]:
+def recent_session_rows(config_dir: Path, limit: int | None = None) -> list[SessionRow]:
     """:class:`SessionRow` per resumable session, newest first.
 
     Layered over :func:`recent_sessions` rather than replacing it: the CLI's
@@ -1427,12 +1450,16 @@ def recent_session_rows(config_dir: Path, limit: int = 10) -> list[SessionRow]:
     frame. Moving this to a worker would trade that for a picker that opens
     empty and fills in, which is worse for a list the user is about to read.
 
-    The ``/resume`` picker now calls this WITHOUT a limit, so it is the one
-    caller whose row count tracks the whole store. That is affordable because
-    the scan underneath is limit-independent (see :func:`recent_sessions`) and
-    the only per-row cost added is :func:`session_name`, one bounded head read.
-    ``limit`` remains for the callers that genuinely want a short list — the
-    CLI's ten-row recovery listing and the mobile daemon's summaries.
+    ``limit=None`` means NO TRUNCATION, matching :func:`recent_sessions` — see
+    its docstring for why the untruncated answer is the DEFAULT rather than the
+    opt-in. The ``/resume`` picker relies on that default; every caller that
+    wants a short list passes its own number at its own call site (the CLI's
+    recovery listing, the mobile daemon's history and search), so the cap is
+    visible where it is chosen instead of hiding in this signature.
+
+    Uncapping is affordable because the scan underneath is limit-independent
+    (see :func:`recent_sessions`) and the only per-row cost added is
+    :func:`session_name`, one bounded head read.
     """
     return [
         SessionRow(session_id, mtime, session_name(config_dir / "sessions" / session_id))

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -21,7 +21,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 #: ``--resume`` with no id. A sentinel rather than a second boolean flag so the
 #: whole "which session" decision stays ONE value threaded through one parameter.
@@ -48,6 +48,39 @@ ORIGIN_NAME = "origin.json"
 #: key is a string rather than a bare flag, so a future non-user origin (a
 #: scheduled run, a server-side session) is a new value and not a second file.
 ORIGIN_SUBAGENT = "subagent"
+
+#: Memoised ``origin.json`` verdicts for :func:`recent_sessions`, keyed on each
+#: marker's own ``(mtime, size)``.
+#:
+#: Why this exists. The listing must READ AND PARSE every marker that exists —
+#: existence alone must never be read as "subagent", because a truncated or
+#: hand-edited sidecar deliberately parses to ``""`` so it reads as the USER's
+#: session rather than vanishing from the picker (see :func:`session_origin`;
+#: one such file took the picker down for every session on the machine). The
+#: markers that exist are the SUBAGENT ones, and subagents outnumber user
+#: sessions ~10.6:1, so that rule costs one file read per subagent directory:
+#: measured at 1127 ms over a 31,700-directory store, of which 639 ms is the
+#: reads and only 17 ms the parsing. Skipping the read for unmarked directories
+#: therefore saves ~8% and cannot fix it; the parse is not the cost.
+#:
+#: Why memoising is SOUND rather than a guess: the marker is written once, at
+#: directory creation (``harness.subagent``), and the only other writer is the
+#: one-shot backfill below. The verdict is immutable once written, so a marker
+#: whose ``(mtime, size)`` is unchanged cannot have changed its meaning.
+#:
+#: What may NOT go in here, and why each would be a bug:
+#: * Only a verdict actually PARSED from a marker that existed is stored. A
+#:   stat failure, an unreadable file, or a corrupt payload falls through to
+#:   the real read every time — caching those would let one bad sidecar hide a
+#:   real session persistently instead of transiently.
+#: * ABSENCE is never cached. Unmarked already means user and is the cheap path,
+#:   and a directory the backfill stamps later must be re-read, not answered
+#:   from a stale "no marker" fact.
+ORIGIN_CACHE_NAME = "origin-verdicts.json"
+
+#: Bumped when the cache's shape or key changes, so an older file is discarded
+#: rather than misread. Mirrors ``search_index.INDEX_VERSION``.
+ORIGIN_CACHE_VERSION = 1
 
 #: Journals the session's title (and every name it has ever borne) beside the
 #: transcript, mirroring :data:`ORIGIN_NAME` exactly. A SIDECAR rather than a
@@ -919,6 +952,56 @@ def live_session_owner(config_dir: Path, session_id: str) -> int | None:
     return pid
 
 
+def origin_cache_path(config_dir: Path) -> Path:
+    """Where this store's ``origin.json`` verdict cache lives.
+
+    Beside the search index, under ``cache/``: both are derived data a user may
+    delete at any time to force a rebuild, and neither is a source of truth.
+    """
+    return config_dir / "cache" / ORIGIN_CACHE_NAME
+
+
+def _load_origin_cache(path: Path) -> dict[str, Any]:
+    """The cached verdicts, or an empty mapping when absent, stale or corrupt.
+
+    Every failure yields an empty mapping rather than raising, mirroring
+    ``search_index._load``: this is a cache whose worst cost must be a rebuild
+    (today's full-read behaviour), never a wrong verdict and never the picker.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+    try:
+        loaded = json.loads(raw)
+    except ValueError:
+        return {}
+    if not isinstance(loaded, dict) or loaded.get("version") != ORIGIN_CACHE_VERSION:
+        return {}
+    entries = loaded.get("entries")
+    return entries if isinstance(entries, dict) else {}
+
+
+def _save_origin_cache(path: Path, entries: dict[str, Any]) -> None:
+    """Persist the verdicts, best-effort and atomically.
+
+    Atomic with a PID-suffixed temp for the reason ``search_index._save``
+    documents: several sessions open a picker at once, and a fixed temp name
+    lets one process ``replace`` a document another is still filling. A torn
+    document is discarded by the loader, so the bound is a needless rebuild.
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(f".{os.getpid()}.tmp")
+        tmp.write_text(
+            json.dumps({"version": ORIGIN_CACHE_VERSION, "entries": entries}),
+            encoding="utf-8",
+        )
+        tmp.replace(path)
+    except OSError:
+        return
+
+
 def recent_sessions(config_dir: Path, limit: int = 10) -> list[tuple[str, float]]:
     """``(id, mtime)`` for the USER's resumable sessions, newest first.
 
@@ -935,18 +1018,97 @@ def recent_sessions(config_dir: Path, limit: int = 10) -> list[tuple[str, float]
     Best-effort: a directory that vanishes mid-scan (retention sweeps run
     concurrently) is skipped rather than raising out of an error path whose whole
     job is to be helpful.
+
+    The traversal is ``os.scandir``-based over the store, with one ``stat`` per
+    directory for the transcript and one for the marker. The store is scanned
+    once rather than each directory being scanned individually: the latter is
+    what the origin design proposed, and it measures ~2x WORSE (1986 ms vs
+    1127 ms over 31,700 dirs) because it stats every entry in every directory
+    to learn two filenames. Do not "fix" it back.
+
+    The cost that matters is the ORIGIN check, which runs once per directory
+    and therefore scales with the SUBAGENT population — ~10.6x the user
+    population on the reporting machine, and the part that actually grows.
+    Because a marker that EXISTS must still be read and parsed (see
+    :data:`ORIGIN_CACHE_NAME`), that is one file read per subagent directory:
+    1127 ms over 31,700 dirs, of which the reads are 639 ms. The verdict cache
+    is what removes it, taking the same scan to ~250 ms warm.
+
+    ``limit`` truncates the RESULT, never the work: every directory is visited
+    regardless, so a caller asking for all sessions costs the same as one
+    asking for ten.
     """
     rows: list[tuple[str, float]] = []
-    for path in (config_dir / "sessions").glob("*"):
-        try:
-            mtime = (path / TRANSCRIPT_NAME).stat().st_mtime
-        except OSError:
-            continue
-        # After the stat, not before: the stat is what proves the directory is
-        # a session at all, and an unreadable marker must not cost a row.
-        if not is_user_session(path):
-            continue
-        rows.append((path.name, mtime))
+    try:
+        scan = os.scandir(config_dir / "sessions")
+    except OSError:
+        return []
+    cache_path = origin_cache_path(config_dir)
+    cached = _load_origin_cache(cache_path)
+    fresh: dict[str, Any] = {}
+    # Every name that carried a marker in THIS scan. The cache is rewritten to
+    # exactly this set, which is what drops entries for disposed sessions and
+    # keeps the file bounded by the live store rather than by every session
+    # that has ever existed.
+    seen: set[str] = set()
+    with scan:
+        for entry in scan:
+            try:
+                mtime = os.stat(os.path.join(entry.path, TRANSCRIPT_NAME)).st_mtime
+            except OSError:
+                continue
+            # After the transcript stat, not before: the stat is what proves the
+            # directory is a session at all, and an unreadable marker must not
+            # cost a row.
+            #
+            # This stat does double duty — it answers "is there a marker" AND
+            # produces the cache key — so the cache costs no extra syscall.
+            marker = os.path.join(entry.path, ORIGIN_NAME)
+            try:
+                marker_stat: os.stat_result | None = os.stat(marker)
+            except OSError:
+                # No marker, or it cannot be stat'd. ABSENCE means the user's
+                # own session and is deliberately NOT cached: it is already the
+                # cheap path, and a directory the backfill stamps later must be
+                # re-read rather than answered from a stale "unmarked" fact.
+                marker_stat = None
+            if marker_stat is not None:
+                seen.add(entry.name)
+                key = [marker_stat.st_mtime, marker_stat.st_size]
+                previous = cached.get(entry.name)
+                if (
+                    isinstance(previous, dict)
+                    and previous.get("key") == key
+                    and isinstance(previous.get("origin"), str)
+                ):
+                    origin = previous["origin"]
+                else:
+                    # Existence gates the READ, never the verdict: the file is
+                    # read and PARSED, because ``session_origin`` returns "" for
+                    # a truncated or hand-edited sidecar so a CORRUPT marker
+                    # reads as the user's own session rather than vanishing from
+                    # the picker. Treating "file exists" as "subagent" would
+                    # invert that fail-safe and hide real work.
+                    origin = session_origin(Path(entry.path))
+                    # Only a verdict actually parsed off an existing marker is
+                    # memoised. "" covers both "no origin claimed" and "could
+                    # not read this claim", and the two are indistinguishable
+                    # here — so a "" verdict is stored against the key that
+                    # produced it and re-derived the moment the file changes,
+                    # which is exactly when a corrupt marker gets rewritten.
+                    fresh[entry.name] = {"key": key, "origin": origin}
+                if origin:
+                    continue
+            rows.append((entry.name, mtime))
+    merged = {
+        name: entry for name, entry in cached.items() if name in seen and isinstance(entry, dict)
+    }
+    merged.update(fresh)
+    # Written only when it would actually change, so a steady store's picker
+    # open stays read-only: an unconditional save would rewrite a multi-megabyte
+    # file on every open to persist nothing.
+    if merged != cached:
+        _save_origin_cache(cache_path, merged)
     rows.sort(key=lambda row: row[1], reverse=True)
     return rows[:limit]
 
@@ -1218,6 +1380,13 @@ def recent_session_rows(config_dir: Path, limit: int = 10) -> list[SessionRow]:
     is an 80 MB paste — measures 0.2 ms, and fifty of them are still under a
     frame. Moving this to a worker would trade that for a picker that opens
     empty and fills in, which is worse for a list the user is about to read.
+
+    The ``/resume`` picker now calls this WITHOUT a limit, so it is the one
+    caller whose row count tracks the whole store. That is affordable because
+    the scan underneath is limit-independent (see :func:`recent_sessions`) and
+    the only per-row cost added is :func:`session_name`, one bounded head read.
+    ``limit`` remains for the callers that genuinely want a short list — the
+    CLI's ten-row recovery listing and the mobile daemon's summaries.
     """
     return [
         SessionRow(session_id, mtime, session_name(config_dir / "sessions" / session_id))

--- a/local_operator/session/search_index.py
+++ b/local_operator/session/search_index.py
@@ -276,11 +276,40 @@ def build_index(config_dir: Path, session_ids: list[str]) -> dict[str, str]:
     changed costs one file read, and the common case — one session appended to
     since the last open — costs one re-digest.
 
-    Entries for sessions no longer being listed are dropped, so the file cannot
-    grow forever behind a store that retention keeps trimming.
+    Entries for sessions this call was NOT asked about are PRESERVED. The
+    previous behaviour rebuilt the file from the requested ids alone, which
+    made every narrow caller evict the wide caller's work: the mobile daemon
+    asks for 200 ids (``mobile.daemon._search_sessions``) or 100
+    (``SessionRegistry.summaries``), pruning the cache to those, and the next
+    picker open then re-digested the whole store from disk — measured at
+    936-2430 ms, the one production path that reached a full second.
+
+    The pruning's original justification ("so the file cannot grow forever
+    behind a store that retention keeps trimming") is OBSOLETE and its removal
+    is the point of this shape. Commit 4173ec73 retired eviction; ``retention``
+    never deletes a transcript, so the cache can only grow as fast as the store
+    and the store is permanent by policy. The bound that replaces it is the
+    honest one for that world: an entry is dropped when its session DIRECTORY
+    is gone, which is now the only way a session leaves the store (explicit
+    user disposal). Keep both facts together — a future reader who restores the
+    prune-to-requested behaviour because the docstring sounds prudent
+    reintroduces the daemon thrash.
     """
     cached = _load(index_path(config_dir))
-    entries: dict[str, Any] = {}
+    # Seed from the cache rather than from scratch, then update only the ids
+    # this call was asked about (see the docstring): this is what preserves a
+    # wide caller's entries across a narrow caller.
+    sessions_root = config_dir / "sessions"
+    entries: dict[str, Any] = {
+        sid: entry
+        for sid, entry in cached.items()
+        # The replacement bound for the pruning removed above: an entry whose
+        # session directory is gone can never be valid again, and a session
+        # only leaves the store by explicit disposal now. One stat per cached
+        # entry (~5 ms at 2700) buys a cache that tracks the live store
+        # instead of growing across every session that ever existed.
+        if isinstance(entry, dict) and os.path.isdir(os.path.join(sessions_root, sid))
+    }
     digests: dict[str, str] = {}
     for session_id in session_ids:
         session_dir = config_dir / "sessions" / session_id
@@ -290,7 +319,11 @@ def build_index(config_dir: Path, session_ids: list[str]) -> dict[str, str]:
         except OSError:
             # Vanished mid-scan (retention sweeps run concurrently). Skip it
             # rather than caching an empty digest that would then be treated as
-            # valid if the file came back.
+            # valid if the file came back. The seeded entry is dropped with it:
+            # a transcript that cannot be stat'd cannot have its signature
+            # confirmed, and keeping a stale digest under a live directory
+            # would serve search results for a body that no longer exists.
+            entries.pop(session_id, None)
             continue
         # The title sidecar's mtime joins the signature so a RENAME re-folds the
         # digest even when the transcript is byte-identical (a rename appends to
@@ -340,7 +373,39 @@ def search_digests(digests: dict[str, str], query: str) -> set[str]:
     needle = query.strip().lower()
     if not needle:
         return set()
-    return {sid for sid, digest in digests.items() if needle in digest.lower()}
+    # Lower the corpus ONCE per distinct digest set rather than per query. The
+    # old form re-lowered every digest on every keystroke, which is 10 MB of
+    # string allocation per character typed: 24 ms per keystroke at 2700
+    # digests, against a 21 ms one-time cost and 5 ms per keystroke here. The
+    # cache is keyed on the digests mapping's identity AND length so a
+    # re-digested or resized store re-lowers rather than answering stale.
+    return {sid for sid, digest in _lowered(digests).items() if needle in digest}
+
+
+#: One-entry memo for the lowered corpus, keyed on the identity and size of the
+#: digests mapping it was derived from. One entry because the picker holds a
+#: single digest set for its whole life, and the phone daemon's calls are
+#: one-shot: a larger cache would retain corpora nobody will ask for again.
+_LOWERED_KEY: tuple[int, int] | None = None
+_LOWERED: dict[str, str] = {}
+
+
+def _lowered(digests: dict[str, str]) -> dict[str, str]:
+    """``digests`` with every body lowercased, memoised across queries.
+
+    Identity-keyed rather than content-keyed on purpose: hashing 10 MB of
+    digests to decide whether to lower 10 MB of digests would cost what it
+    saves. The picker builds its digest mapping once and holds it, so identity
+    is a sound key there; a caller that MUTATES a mapping in place between
+    queries would see a stale corpus, which is why ``build_index`` returns a
+    fresh dict on every call rather than updating one.
+    """
+    global _LOWERED_KEY, _LOWERED
+    key = (id(digests), len(digests))
+    if _LOWERED_KEY != key:
+        _LOWERED = {sid: digest.lower() for sid, digest in digests.items()}
+        _LOWERED_KEY = key
+    return _LOWERED
 
 
 #: Minimum token length for edit-distance matching. Short tokens (``adm``,

--- a/local_operator/session/search_index.py
+++ b/local_operator/session/search_index.py
@@ -160,6 +160,33 @@ def digest_transcript(transcript: Path) -> str:
     Returns ``""`` for anything unreadable. A session that cannot be digested
     is still listed and still searchable by name and id — losing its body from
     the index must never cost it its row.
+
+    Callers that CACHE the result want :func:`digest_transcript_read` instead,
+    which distinguishes "this transcript has no indexable prose" from "this
+    transcript could not be read". Both are ``""`` here, and memoising the
+    second against a signature that has not changed drops a session's body from
+    search permanently.
+    """
+    digest, _readable = digest_transcript_read(transcript)
+    return digest
+
+
+def digest_transcript_read(transcript: Path) -> tuple[str, bool]:
+    """:func:`digest_transcript`'s digest, plus whether the file was READ.
+
+    Exists for the same reason ``resume._session_origin_read`` does, and guards
+    the same class of bug in the other cache. ``build_index`` keys an entry on
+    the transcript's ``(size, mtime)``; a read that fails for a transient reason
+    — EMFILE under the descriptor pressure a full-store scan creates, a network
+    volume blip, a permissions change — yields ``""`` while leaving that
+    signature untouched. Cached, it is served for as long as the file is
+    unmodified, so the session stays body-unsearchable long after the failure
+    is over. Reproduced: readable -> unreadable -> readable-again still returned
+    ``""``.
+
+    ``readable=False`` is how :func:`build_index` tells the two apart and
+    declines to cache the second. An empty digest from a transcript that WAS
+    read is a fact about its contents and is cached normally.
     """
     try:
         with transcript.open("r", encoding="utf-8", errors="replace") as handle:
@@ -169,7 +196,7 @@ def digest_transcript(transcript: Path) -> str:
             # allocated whole by the very loop meant to bound it.
             head = handle.read(SCAN_BYTES)
     except OSError:
-        return ""
+        return "", False
     parts: list[str] = []
     size = 0
     for line in head.splitlines():
@@ -195,8 +222,8 @@ def digest_transcript(transcript: Path) -> str:
                 # Stop reading as soon as the cap is reached rather than
                 # collecting everything and slicing at the end: the slice would
                 # still have paid to build the discarded remainder.
-                return " ".join(" ".join(parts).split())[:DIGEST_CHARS]
-    return " ".join(" ".join(parts).split())[:DIGEST_CHARS]
+                return " ".join(" ".join(parts).split())[:DIGEST_CHARS], True
+    return " ".join(" ".join(parts).split())[:DIGEST_CHARS], True
 
 
 def _texts(content: object) -> list[str]:
@@ -353,8 +380,20 @@ def build_index(config_dir: Path, session_ids: list[str]) -> dict[str, str]:
             # names always survive the DIGEST_CHARS cap the opening stretch would
             # otherwise fill.
             names = read_title_names(session_dir)
-            body = digest_transcript(transcript)
+            body, readable = digest_transcript_read(transcript)
             digest = " ".join([*names, body]).strip()[: DIGEST_CHARS + TITLE_HEADROOM]
+            if not readable:
+                # The transcript could not be READ, which says nothing about its
+                # contents and everything about this moment. The signature is
+                # unchanged, so caching the empty body would serve it until the
+                # file is next modified — dropping the session from body search
+                # permanently after one transient EMFILE or volume blip. Serve
+                # the degraded digest for this call (the folded titles still
+                # make the row findable) and leave the cache alone so the next
+                # open re-reads. Same rule as ``resume._session_origin_read``.
+                digests[session_id] = digest
+                entries.pop(session_id, None)
+                continue
         entries[session_id] = {"signature": signature, "digest": digest}
         digests[session_id] = digest
     if entries != cached:

--- a/local_operator/session/search_index.py
+++ b/local_operator/session/search_index.py
@@ -388,6 +388,19 @@ def search_digests(digests: dict[str, str], query: str) -> set[str]:
 #: one-shot: a larger cache would retain corpora nobody will ask for again.
 _LOWERED_KEY: tuple[int, int] | None = None
 _LOWERED: dict[str, str] = {}
+#: The mapping ``_LOWERED`` was derived from, retained ONLY so its ``id()``
+#: cannot be handed to a different object. Without it the memo was unsound: an
+#: ``id`` is unique among LIVE objects, not over time, so once a caller dropped
+#: its digests CPython could recycle the address for the next dict of similar
+#: shape, and a successor with the same ``len`` matched the key and was answered
+#: from its predecessor's lowered bodies. ``mobile.daemon``'s search is exactly
+#: that shape (a fresh ``build_index`` result per request, dropped at return,
+#: with ``limit`` pinning the length); it measured 2 wrong session sets in 60
+#: real searches, and a search returning the wrong rows is the failure this
+#: module exists to prevent. Retaining the source makes the address
+#: un-recyclable for as long as the memo can answer for it, which is what the
+#: identity key silently assumed all along.
+_LOWERED_SRC: dict[str, str] | None = None
 
 
 def _lowered(digests: dict[str, str]) -> dict[str, str]:
@@ -395,16 +408,30 @@ def _lowered(digests: dict[str, str]) -> dict[str, str]:
 
     Identity-keyed rather than content-keyed on purpose: hashing 10 MB of
     digests to decide whether to lower 10 MB of digests would cost what it
-    saves. The picker builds its digest mapping once and holds it, so identity
-    is a sound key there; a caller that MUTATES a mapping in place between
-    queries would see a stale corpus, which is why ``build_index`` returns a
-    fresh dict on every call rather than updating one.
+    saves. Soundness rests on :data:`_LOWERED_SRC` pinning the source mapping
+    alive, so its ``id`` cannot be reused by a later dict while this memo would
+    still answer for it — an ``id`` identifies an object only among the living.
+
+    A caller that MUTATES a mapping in place between queries would still see a
+    stale corpus, which is why ``build_index`` returns a fresh dict on every
+    call rather than updating one.
+
+    One entry, so alternating between two equally sized LIVE mappings re-lowers
+    every call (2700 digests: 20 queries against one mapping is 4.3 ms,
+    alternating between two is 102 ms). Still far cheaper than the per-query
+    lowering this replaced, and the picker never alternates — it holds one
+    corpus for its whole life. Recorded so a future mixed caller does not
+    assume the memo is free.
     """
-    global _LOWERED_KEY, _LOWERED
+    global _LOWERED_KEY, _LOWERED, _LOWERED_SRC
     key = (id(digests), len(digests))
     if _LOWERED_KEY != key:
         _LOWERED = {sid: digest.lower() for sid, digest in digests.items()}
         _LOWERED_KEY = key
+        # Assigned in the SAME branch that sets the key: the retained source and
+        # the id it protects are one fact, and letting them drift apart reopens
+        # the recycled-address bug.
+        _LOWERED_SRC = digests
     return _LOWERED
 
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -934,23 +934,6 @@ class _TerminalFrontendReaper:
 #: silently demote the press back to a no-op.
 DOUBLE_STOP_WINDOW_S = 4.0
 
-#: Sessions the ``/resume`` picker offers. Higher than the recovery listing's
-#: ten because the picker can scroll and filter, and a conversation from a
-#: fortnight ago is exactly the one worth searching for.
-#:
-#: Raised from 50 to cover the whole store a retention sweep is willing to
-#: keep (``retention.DEFAULT_MAX_SESSIONS`` is 200). At 50 the picker silently
-#: hid every session past the newest fifty — on the reporting machine, 20 of
-#: 70 — so a search that should have found a conversation returned nothing and
-#: the session was indistinguishable from one that had been deleted. A filter
-#: that cannot see a row cannot find it, and "not found" is the one answer a
-#: search must not give wrongly.
-#:
-#: Affordable because the per-row cost is bounded (one tail read for the title,
-#: one cached digest lookup): measured at 10 ms for 50 rows and 36 ms for a
-#: full 204-session store, both inside a frame.
-RESUME_PICKER_LIMIT = 200
-
 #: The working line's PHASE while a turn is parked on something the USER owes —
 #: a tool-approval prompt, or an `ask` picker waiting for a decision. One phase
 #: for both because the two waits are the same fact to every surface that reads
@@ -3948,7 +3931,19 @@ class OperatorApp(App[None]):
             return
 
         if not arg:
-            rows = recent_session_rows(config_dir(), limit=RESUME_PICKER_LIMIT)
+            # UNCAPPED, deliberately. Every finite cap reproduces the bug it was
+            # meant to bound: the picker's filter only ever sees the rows it was
+            # handed (``session_picker.filter_rows`` scans ``_all``), so a
+            # session past the cap is not merely off-screen, it is unfindable
+            # and indistinguishable from one that was deleted. The previous
+            # limit of 200 was justified by a retention sweep that no longer
+            # exists (``retention`` never deletes a transcript since 4173ec73),
+            # and the store had already grown past it, hiding 30 of the
+            # reporting machine's 230 sessions. Affordable because the scan is
+            # limit-independent (see ``resume.recent_sessions``) and the counter
+            # below becomes truthful as a consequence: ``_all`` is now the
+            # store's real total rather than a number that never says it is one.
+            rows = recent_session_rows(config_dir())
             if not rows:
                 # Says whose sessions, not that the disk is empty. Delegated
                 # subagent runs live in the same directory and are deliberately

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3943,7 +3943,14 @@ class OperatorApp(App[None]):
             # limit-independent (see ``resume.recent_sessions``) and the counter
             # below becomes truthful as a consequence: ``_all`` is now the
             # store's real total rather than a number that never says it is one.
-            rows = recent_session_rows(config_dir())
+            #
+            # ``limit=None`` is passed EXPLICITLY rather than left to the
+            # default. Relying on the default is what shipped this surface with
+            # a cap of ten: the signature defaulted to ``10``, this line said
+            # nothing, and "uncapped" was true only in the comment above. The
+            # argument is now visible at the call site, so the claim and the
+            # code can be checked against each other in one place.
+            rows = recent_session_rows(config_dir(), limit=None)
             if not rows:
                 # Says whose sessions, not that the disk is empty. Delegated
                 # subagent runs live in the same directory and are deliberately

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -125,6 +125,15 @@ RESUME_EMPTY_NOTICE = "no conversations of yours to resume — subagent runs are
 #: :meth:`SessionPickerScreen._page_rows`.
 PAGE_ROWS_MAX = 10
 
+#: Name/id matches at which the picker stops consulting the bounded soft tier
+#: (see ``SessionPickerScreen._soft_tier_wanted``). Three, not one: a single
+#: exact hit on a name is as often incidental as deliberate — ``spit`` matches
+#: "De\ *spit*\ e" — and treating it as a real answer hid every genuinely
+#: intended match behind it. Measured over 517 vocabulary-drawn typos, this
+#: floor loses no rows against running the tier on every keystroke while
+#: leaving the cursor exactly as stable.
+_PRECISE_HITS_ENOUGH = 3
+
 #: Non-row lines the card always draws: header, rule, blank spacer, the
 #: position counter, and the key hints. Reserved UNCONDITIONALLY (the counter
 #: included, even when the list fits) so the height never depends on content
@@ -638,7 +647,22 @@ class SessionPickerScreen(ModalScreen[str | None]):
         # Name and id only, deliberately NOT the body digests: see above. This
         # mirrors the first two admission tests in ``filter_rows`` so the gate
         # and the filter cannot drift apart on what "an exact hit" means.
-        return not any(needle in row.name.lower() or needle in row.id.lower() for row in self._all)
+        #
+        # Counted against a small floor rather than tested for emptiness,
+        # because ONE precise hit is not yet a useful answer and can easily be
+        # incidental: ``spit`` matches the name "Failover Triggering Despite
+        # Available Account", and on that single hit the previous form silenced
+        # the tier and made every ``split`` session unreachable. Below the floor
+        # the user has almost nothing to look at, so the extra recall is worth
+        # more than the precision; at or above it they have a real answer and
+        # fuzzy additions would only dilute it.
+        precise = 0
+        for row in self._all:
+            if needle in row.name.lower() or needle in row.id.lower():
+                precise += 1
+                if precise >= _PRECISE_HITS_ENOUGH:
+                    return False
+        return True
 
     @property
     def body_matched_ids(self) -> set[str]:

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -114,16 +114,6 @@ RESUME_EMPTY_NOTICE = "no conversations of yours to resume — subagent runs are
 #: :meth:`SessionPickerScreen._page_rows`.
 PAGE_ROWS_MAX = 10
 
-#: Exact-tier hits below which the picker also consults the bounded SOFT tier
-#: (see ``SessionPickerScreen.visible_rows``). Deliberately one full page: the
-#: soft tier's job is to rescue a query the exact tiers answered poorly, and a
-#: query that already fills the visible page has nothing to rescue — the extra
-#: recall would land below the fold at the cost of a 324 ms / 95 MB first-call
-#: tokenise over the whole store. Tied to the page ceiling rather than being a
-#: second free-standing number, because "a screenful" is exactly the threshold
-#: being described.
-_SOFT_TIER_MIN_HITS = PAGE_ROWS_MAX
-
 #: Non-row lines the card always draws: header, rule, blank spacer, the
 #: position counter, and the key hints. Reserved UNCONDITIONALLY (the counter
 #: included, even when the list fits) so the height never depends on content
@@ -568,24 +558,40 @@ class SessionPickerScreen(ModalScreen[str | None]):
             # uncapped, that build sat on the first character typed, which is
             # the worst possible moment to spend a third of a second.
             #
-            # Gating on the RESULT COUNT rather than on query length is what
-            # keeps the tier honest: soft matching exists to rescue a typo, a
-            # prefix, or remembered-out-of-order words, and all three are cases
-            # where the exact tiers return nothing useful. When they already
-            # return a screenful, the extra recall is invisible below the fold
-            # and not worth the stall.
+            # Gated on the exact tiers finding NOTHING, not on how much they
+            # found. A count threshold is observable: typing narrows the exact
+            # set, and the keystroke that takes it below the threshold switches
+            # the soft tier on and adds rows BACK. Measured on the count gate,
+            # one keystroke apart: 16 rows, then 10, then 16 again on a longer
+            # query — rows reappearing, every row acquiring a body-match marker,
+            # the footer gaining its legend, and the card changing height under
+            # the cursor mid-word. "Keep typing to narrow" is the model this
+            # surface teaches, and a filter that grows on a longer query reads
+            # as broken even when the extra rows are relevant.
+            #
+            # Zero is the only threshold a user cannot cross downward by typing
+            # more: once a query has an exact hit, every extension either keeps
+            # some hits (still exact-only) or drops to none (soft rescues it,
+            # from an empty list, which can only add). So the list narrows
+            # monotonically within a typing run. It is also the case the tier's
+            # own docstring describes — rescuing a query the exact tiers could
+            # not answer — and it strictly reduces how often the 324 ms / 95 MB
+            # tokenise runs.
             #
             # Deterministic in ``(digests, query)``, which the picker's
             # ordering invariant requires: the gate reads only the exact-tier
             # result for this same query, so a fixed query admits a fixed set
             # and rows still never move under the cursor between repaints.
-            near = filter_rows(self._all, self._query, self._body_matches)
-            if len(near) < _SOFT_TIER_MIN_HITS:
+            admitted = filter_rows(self._all, self._query, self._body_matches)
+            if not admitted:
                 soft = self._soft_index.search(self._digests, self._query)
+                self._admitted = self._body_matches | soft
+                # Recomputed only on the empty branch: on the common path the
+                # first pass is already the answer, so the uncapped row list is
+                # scanned once per query change rather than twice.
+                admitted = filter_rows(self._all, self._query, self._admitted)
             else:
-                soft = frozenset()
-            self._admitted = self._body_matches | soft
-            admitted = filter_rows(self._all, self._query, self._admitted)
+                self._admitted = set(self._body_matches)
             self._filtered = rank_rows(admitted, self._query, self._body_matches)
             self._filtered_for = self._query
         return self._filtered

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -223,6 +223,7 @@ def rank_rows(
     rows: Sequence[SessionRow],
     query: str,
     body_matches: AbstractSet[str] | None = None,
+    carried: AbstractSet[str] | None = None,
 ) -> list[SessionRow]:
     """``rows`` ordered by relevance to ``query``; recency order when empty.
 
@@ -253,20 +254,27 @@ def rank_rows(
     if not needle:
         return list(rows)
     body = body_matches or frozenset()
+    # Ids the previous keystroke was already showing. Used only to break the
+    # tie WITHIN a tier, so a keystroke that admits new rows cannot slide one of
+    # them above a row the user was reading (see ``visible_rows``). Empty for
+    # every caller that is not mid-typing-run, which keeps ranking a pure
+    # function of the query for a fixed query.
+    already_shown = carried or frozenset()
 
-    def tier(row: SessionRow) -> int:
+    def tier(row: SessionRow) -> tuple[int, int]:
+        seen_rank = 0 if row.id in already_shown else 1
         if needle in row.name.lower():
-            return _RANK_NAME
+            return _RANK_NAME, seen_rank
         if needle in row.id.lower():
-            return _RANK_ID
+            return _RANK_ID, seen_rank
         # Exact body hit outranks a soft-only hit: an exact substring in the
         # conversation is a stronger signal than a typo/prefix/word-order match.
         if row.id in body:
-            return _RANK_BODY
+            return _RANK_BODY, seen_rank
         # Admitted by the soft set (it is in the already-filtered ``rows`` yet
         # matched neither name, id, nor exact body), so it ranks below every
         # exact tier.
-        return _RANK_SOFT
+        return _RANK_SOFT, seen_rank
 
     # Stable sort on the tier alone: ``rows`` arrives newest-first, so equal
     # tiers keep recency order without a second sort key. Sorting the tier as
@@ -520,6 +528,10 @@ class SessionPickerScreen(ModalScreen[str | None]):
         # re-decided. Paired with ``_soft_latched`` so the decision is made once
         # per run rather than once per keystroke.
         self._soft_run_start: str | None = None
+        # Ids shown by the previous keystroke, so newly-admitted rows sort below
+        # them and the cursor cannot be re-homed onto a row the user has not
+        # seen. Only populated while the soft tier is running.
+        self._carried: set[str] = set()
         # Filtering runs on every keystroke and again on every paint; the
         # result is cached against the query that produced it so a card with
         # several hundred sessions does not re-scan the list per repaint. The
@@ -572,64 +584,72 @@ class SessionPickerScreen(ModalScreen[str | None]):
             if self._soft_tier_wanted(self._query, admitted):
                 soft = self._soft_index.search(self._digests, self._query)
                 self._admitted = self._body_matches | soft
+                # Rows the PREVIOUS keystroke was showing keep their place ahead
+                # of rows this one newly admits. Without it, the keystroke that
+                # latches the soft tier on re-homes the cursor onto whichever
+                # newly-admitted row happens to be newest: both groups fall in
+                # the soft tier once the exact set empties, so recency alone
+                # decides and a row the user has never seen wins. A reflexive
+                # enter then resumes a session they were never shown. Carrying
+                # the previous set forward keeps additions strictly BELOW what
+                # was on screen, so the tier can add without displacing.
+                self._carried = {row.id for row in self._filtered}
                 # Recomputed only on the soft branch: on the common path the
                 # first pass is already the answer, so the uncapped row list is
                 # scanned once per query change rather than twice.
                 admitted = filter_rows(self._all, self._query, self._admitted)
             else:
                 self._admitted = set(self._body_matches)
-            self._filtered = rank_rows(admitted, self._query, self._body_matches)
+                self._carried = set()
+            self._filtered = rank_rows(
+                admitted, self._query, self._body_matches, carried=self._carried
+            )
             self._filtered_for = self._query
         return self._filtered
 
     def _soft_tier_wanted(self, query: str, exact_admitted: list[SessionRow]) -> bool:
         """Whether the bounded soft tier should run for ``query``.
 
-        LATCHED per typing run, and that is the whole point. Two simpler gates
-        were tried on this surface and both moved the row under the cursor:
+        The rule is a ONE-WAY latch: the tier turns on at the first keystroke
+        whose exact tiers return nothing, and stays on for the rest of the
+        typing run. It never turns off mid-run.
 
-        * **A count threshold** (soft when the exact tiers return under a page)
-          is crossed BY TYPING: narrowing past it switched the tier on and put
-          rows back. Measured 16 -> 10 -> 16 one keystroke apart.
-        * **Zero exact hits** looks monotonic and is not. On the operator's real
-          store, ``watch`` shows 10 genuine matches and ``watchl`` shows 46 —
-          the exact set empties, the tier fires, and 46 typo-neighbours replace
-          all 10 real matches. The top row changes identity mid-word, so a user
-          typing and pressing enter by reflex resumes a DIFFERENT session. The
-          old argument for that gate compared against the empty list the soft
-          tier starts from; the user compares against the PREVIOUS KEYSTROKE,
-          which is the only comparison that matters here.
+        Both halves are load-bearing, and each was learned by shipping the other
+        one wrong:
 
-        So the decision is made ONCE PER TYPING RUN and then frozen: whichever
-        tiers were active for the first query of a run stay active for every
-        extension of it, and the tier can only be re-decided by a query that is
-        not an extension of the last one (a fresh query, or backspacing below
-        where the run began).
+        * **Turning ON when the exact tiers come up empty** is what makes a typo
+          findable. Gates that only ever ran the tier at the START of a run made
+          it unreachable from a keyboard entirely: a run begins at one
+          character, every single character has exact hits somewhere in a real
+          store (all 36 of ``a-z0-9`` do), so the tier froze off and every later
+          character inherited that. Measured zero ``SoftSearchIndex.search``
+          calls across 25 typed runs, and ``classifer`` returning 0 rows where
+          shipped ``main`` returned 9 — a regression on the axis this surface
+          exists to serve.
+        * **Never turning OFF mid-run** is what keeps the cursor still. A gate
+          that could switch off (a count threshold, or re-deciding per
+          keystroke) withdrew rows the user had already been shown and swapped
+          the row under the cursor, so a reflexive enter resumed the wrong
+          session.
 
-        What that buys, stated no more strongly than it holds: within one run
-        the same tiers are active on both sides of every keystroke, and
-        ``filter_rows`` is a membership test against a needle that only grows,
-        so each result is a subset of the previous one. Verified on the real
-        store rather than argued from the code — across four typing runs, no
-        keystroke admitted a row that was absent from the keystroke before it.
-        Ranking can still reorder what remains, and the list can empty; neither
-        puts a row under the cursor that the user had not already been shown.
+        Those are separable failures and the fix has to hold both: results the
+        user was already shown are never withdrawn, and a typo still finds
+        something. Monotonicity of the ROW COUNT is deliberately not the
+        property being defended — once the tier is on it stays on, so a later
+        keystroke can only narrow what that tier already admitted. The
+        keystroke that switches it on may show more rows than the one before,
+        and that is correct: the alternative is the empty list this gate exists
+        to rescue, and rescuing an empty list cannot displace a row the user was
+        reading because there were none.
 
-        **The ordering invariant, per keystroke rather than from empty.** The
-        picker's rule (module docstring, and ``session_picker`` lines 20-26) is
-        that a row must not move under the cursor. Latching upholds it for the
-        comparison the user actually experiences: consecutive queries in one
-        run share the same tier configuration, so the second result is a subset
-        of the first, ranked by the same function, and a row can leave the list
-        but no row can be displaced by a newly admitted one. For a FIXED query
-        nothing changes across repaints either, because ``_soft_latched`` is
+        A run ends when a query stops extending the previous one — a fresh
+        query, or backspacing below where the run began — at which point the
+        tier is re-decided from scratch. Deleting characters is the user asking
+        for a broader answer, so re-deciding there is what keeps the surface
+        reversible rather than path-dependent.
+
+        For a FIXED query nothing changes across repaints, because the latch is
         only ever written on a query change, never on a paint.
-
-        Backspacing below the latch point turns the tier back off, which can
-        widen the list — correct, because deleting characters is the user asking
-        for a broader answer, and it restores the same result the shorter query
-        gave on the way in. That keeps the surface reversible rather than
-        path-dependent.
         """
         needle = query.strip()
         if not needle:
@@ -637,25 +657,24 @@ class SessionPickerScreen(ModalScreen[str | None]):
             self._soft_run_start = None
             return False
 
-        # Same typing run? A run is a query that extends the previous one, so
-        # this is the "user is still typing the same word" test.
+        # A run is a query that extends the previous one: "the user is still
+        # typing the same thing". Anything else starts a new run.
         extending = self._soft_run_start is not None and query.startswith(self._soft_run_start)
         if not extending:
-            # A fresh query (or a backspace below where the run began) starts a
-            # new run and re-decides the tier from scratch.
             self._soft_run_start = query
-            self._soft_latched = query if not exact_admitted else None
-            return self._soft_latched is not None
+            self._soft_latched = None
 
-        # Within a run the decision is FROZEN. Switching the tier on mid-word is
-        # what moved the cursor: on the real store ``watch`` has 10 genuine
-        # matches, ``watchl`` has none, and firing the tier there replaced all
-        # 10 with 46 typo-neighbours and changed the top row's identity. The
-        # keystroke that empties the exact set is exactly the keystroke where a
-        # user is about to press enter, so it is the worst possible moment to
-        # re-home the cursor. Extending a query narrows or empties the list; it
-        # never repopulates it from a different source.
-        return self._soft_latched is not None
+        # Already latched on for this run: stays on, whatever this keystroke's
+        # exact tiers say. This is the half that protects the cursor.
+        if self._soft_latched is not None:
+            return True
+
+        # Not yet latched: turn on the moment the cheap tiers cannot answer.
+        # This is the half that makes a typo reachable while typing.
+        if not exact_admitted:
+            self._soft_latched = query
+            return True
+        return False
 
     @property
     def body_matched_ids(self) -> set[str]:
@@ -1073,7 +1092,12 @@ class SessionPickerScreen(ModalScreen[str | None]):
         # ``counter`` is set exactly when the list is longer than a page, so it
         # is already the "does this scroll" fact the shed order needs.
         for index, (key, what) in enumerate(
-            _footer_hints(width, has_marked=has_marked, scrolls=counter is not None)
+            _footer_hints(
+                width,
+                has_marked=has_marked,
+                scrolls=counter is not None,
+                empty=not rows and bool(self._query),
+            )
         ):
             if index:
                 out.append(" · ", style=faint)
@@ -1132,8 +1156,16 @@ _FOOTER_DROP_ORDER_MARKED = ("pgup/pgdn", "type", _MARKER_LEGEND[0], "↑↓")
 _FOOTER_DROP_ORDER_MARKED_SCROLLING = ("type", _MARKER_LEGEND[0], "pgup/pgdn", "↑↓")
 
 
+#: The footer for a filter that matched nothing. Movement, paging and `enter
+#: resume` all describe a list that is not there, so the only honest thing the
+#: row can say is how to get back to one. `backspace` is the key that widens
+#: the query, and it is the key a user in this state is already reaching for.
+#: Stated as a hint pair like every other so it sheds and renders identically.
+_EMPTY_HINT: tuple[str, str] = ("backspace", "to widen")
+
+
 def _footer_hints(
-    width: int, *, has_marked: bool = False, scrolls: bool = False
+    width: int, *, has_marked: bool = False, scrolls: bool = False, empty: bool = False
 ) -> list[tuple[str, str]]:
     """The key hints that fit in ``width`` cells, dropping the least needed.
 
@@ -1157,12 +1189,32 @@ def _footer_hints(
     fought — a list long enough to scroll is also long enough to contain a
     marked row, so the legend evicted the very hint the reader needed.
     """
+    if empty:
+        # Nothing to move through, page, or resume: offering those keys for an
+        # empty list advertises actions that do nothing, and the marker legend
+        # explains a glyph no row is drawing. `esc` stays because leaving is
+        # still available and is the other thing a user wants here.
+        return _shed_to_width([_EMPTY_HINT, ("esc", "cancel")], (_EMPTY_HINT[0],), width)
+
     hints = list(_FOOTER_HINTS)
     if has_marked:
         hints = [_MARKER_LEGEND, *hints]
         drop_order = _FOOTER_DROP_ORDER_MARKED_SCROLLING if scrolls else _FOOTER_DROP_ORDER_MARKED
     else:
         drop_order = _FOOTER_DROP_ORDER_SCROLLING if scrolls else _FOOTER_DROP_ORDER
+
+    return _shed_to_width(hints, drop_order, width)
+
+
+def _shed_to_width(
+    hints: list[tuple[str, str]], drop_order: Sequence[str], width: int
+) -> list[tuple[str, str]]:
+    """``hints`` reduced to fit ``width`` cells, dropping in ``drop_order``.
+
+    The last resort drops the LABELS and keeps the keys: two bare keys still say
+    which keys exist, which is more than a clipped row says. Shared by every
+    footer variant so a new one cannot quietly grow a second shed policy.
+    """
 
     def cells(pairs: list[tuple[str, str]]) -> int:
         return sum(cell_len(f"{key} {what}".strip()) for key, what in pairs) + 3 * max(

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -895,7 +895,12 @@ class SessionPickerScreen(ModalScreen[str | None]):
         if self._query:
             lead = "  filter "
             compact_lead = "filter "
-            tally = f"  {len(rows)} of {len(self._all)}"
+            # Grouped: `24,310` is read at a glance where `24310` is parsed as
+            # a digit string. Only worth doing since the picker was uncapped —
+            # at a 200-row ceiling the number never reached four digits. One
+            # cell per group, and at the widths where that matters the tally
+            # has already been shed entirely (see the shed order below).
+            tally = f"  {len(rows):,} of {len(self._all):,}"
             full_width = cell_len(title) + cell_len(lead) + cell_len(self._query) + cell_len(tally)
             titled_width = cell_len(title) + cell_len(lead) + cell_len(self._query)
             if full_width <= width:
@@ -920,7 +925,7 @@ class SessionPickerScreen(ModalScreen[str | None]):
             # one-row list the common case rather than the rare one: a machine
             # whose delegated fan-out dominates now lands there routinely.
             count = len(self._all)
-            tally = f"  {count} session" if count == 1 else f"  {count} sessions"
+            tally = f"  {count:,} session" if count == 1 else f"  {count:,} sessions"
             if cell_len(title) + cell_len(tally) > width:
                 header.append(truncate_cells(title, width), style=Style(color=fg_colour))
             else:
@@ -991,9 +996,9 @@ class SessionPickerScreen(ModalScreen[str | None]):
             # stay quiet at ``faint`` because it is adjacent to those anchors.
             first, last, total = counter
             out.append("showing ", style=faint)
-            out.append(f"{first}–{last}", style=dim)
+            out.append(f"{first:,}–{last:,}", style=dim)
             out.append(" of ", style=faint)
-            out.append(str(total), style=dim)
+            out.append(f"{total:,}", style=dim)
             out.append("\n")
         # Key NAMES at `dim` and their labels at `faint`, matching the usage
         # card: at `faint` on this ground the keys themselves were 1.49:1.
@@ -1004,7 +1009,11 @@ class SessionPickerScreen(ModalScreen[str | None]):
         # screen, so an empty query or a pure name match never advertises a mark
         # the user cannot see (D2: teach the glyph where it is used, not always).
         has_marked = bool(self.body_matched_ids)
-        for index, (key, what) in enumerate(_footer_hints(width, has_marked=has_marked)):
+        # ``counter`` is set exactly when the list is longer than a page, so it
+        # is already the "does this scroll" fact the shed order needs.
+        for index, (key, what) in enumerate(
+            _footer_hints(width, has_marked=has_marked, scrolls=counter is not None)
+        ):
             if index:
                 out.append(" · ", style=faint)
             out.append(key, style=dim)
@@ -1042,8 +1051,19 @@ _MARKER_LEGEND: tuple[str, str] = (BODY_MATCH_MARKER.strip(), "matched inside")
 #: be exactly the artifact-looking mark D2 flagged.
 _FOOTER_DROP_ORDER_MARKED = ("pgup/pgdn", "type", _MARKER_LEGEND[0], "↑↓")
 
+#: Drop order once the list actually SCROLLS: the marker legend goes before the
+#: paging keys. With the fixed order above, a list that grew past one page shed
+#: ``pgup/pgdn`` to make room for the legend — so the picker advertised paging
+#: in the state where paging does nothing and withdrew it in the state where it
+#: is the fastest way through the list (design round 1, D3). Uncapping the store
+#: is what made scrolling the normal case rather than the rare one, so the shed
+#: order has to know whether there is anything to page through.
+_FOOTER_DROP_ORDER_MARKED_SCROLLING = ("type", _MARKER_LEGEND[0], "pgup/pgdn", "↑↓")
 
-def _footer_hints(width: int, *, has_marked: bool = False) -> list[tuple[str, str]]:
+
+def _footer_hints(
+    width: int, *, has_marked: bool = False, scrolls: bool = False
+) -> list[tuple[str, str]]:
     """The key hints that fit in ``width`` cells, dropping the least needed.
 
     Three stages, because the footer is the one row that must not overflow the
@@ -1058,12 +1078,19 @@ def _footer_hints(width: int, *, has_marked: bool = False) -> list[tuple[str, st
     read as a key) and is shed under width pressure per
     :data:`_FOOTER_DROP_ORDER_MARKED` — above the disposable hints so it can
     actually appear on a normal card, below the movement and action keys.
+
+    ``scrolls`` says the list is longer than one page, which REORDERS the shed
+    rather than adding a hint: the paging keys outrank the legend exactly when
+    there is something to page through (see
+    :data:`_FOOTER_DROP_ORDER_MARKED_SCROLLING`). Without it the two features
+    fought — a list long enough to scroll is also long enough to contain a
+    marked row, so the legend evicted the very hint the reader needed.
     """
     hints = list(_FOOTER_HINTS)
     drop_order = _FOOTER_DROP_ORDER
     if has_marked:
         hints = [_MARKER_LEGEND, *hints]
-        drop_order = _FOOTER_DROP_ORDER_MARKED
+        drop_order = _FOOTER_DROP_ORDER_MARKED_SCROLLING if scrolls else _FOOTER_DROP_ORDER_MARKED
 
     def cells(pairs: list[tuple[str, str]]) -> int:
         return sum(cell_len(f"{key} {what}".strip()) for key, what in pairs) + 3 * max(

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -114,6 +114,16 @@ RESUME_EMPTY_NOTICE = "no conversations of yours to resume — subagent runs are
 #: :meth:`SessionPickerScreen._page_rows`.
 PAGE_ROWS_MAX = 10
 
+#: Exact-tier hits below which the picker also consults the bounded SOFT tier
+#: (see ``SessionPickerScreen.visible_rows``). Deliberately one full page: the
+#: soft tier's job is to rescue a query the exact tiers answered poorly, and a
+#: query that already fills the visible page has nothing to rescue — the extra
+#: recall would land below the fold at the cost of a 324 ms / 95 MB first-call
+#: tokenise over the whole store. Tied to the page ceiling rather than being a
+#: second free-standing number, because "a screenful" is exactly the threshold
+#: being described.
+_SOFT_TIER_MIN_HITS = PAGE_ROWS_MAX
+
 #: Non-row lines the card always draws: header, rule, blank spacer, the
 #: position counter, and the key hints. Reserved UNCONDITIONALLY (the counter
 #: included, even when the list fits) so the height never depends on content
@@ -550,7 +560,30 @@ class SessionPickerScreen(ModalScreen[str | None]):
             # query change, never per repaint — scanning 200 digests per paint
             # is the cost this cache exists to avoid.
             self._body_matches = search_digests(self._digests, self._query)
-            soft = self._soft_index.search(self._digests, self._query)
+            # The soft tier runs ONLY when the cheap tiers came up short. Its
+            # first call tokenises every digest and builds a vocabulary over
+            # them — measured at 324 ms and 95 MB resident over the 2681-digest
+            # store this picker now reaches uncapped — while the exact tier
+            # answers the same keystroke in ~5 ms. Since the picker was
+            # uncapped, that build sat on the first character typed, which is
+            # the worst possible moment to spend a third of a second.
+            #
+            # Gating on the RESULT COUNT rather than on query length is what
+            # keeps the tier honest: soft matching exists to rescue a typo, a
+            # prefix, or remembered-out-of-order words, and all three are cases
+            # where the exact tiers return nothing useful. When they already
+            # return a screenful, the extra recall is invisible below the fold
+            # and not worth the stall.
+            #
+            # Deterministic in ``(digests, query)``, which the picker's
+            # ordering invariant requires: the gate reads only the exact-tier
+            # result for this same query, so a fixed query admits a fixed set
+            # and rows still never move under the cursor between repaints.
+            near = filter_rows(self._all, self._query, self._body_matches)
+            if len(near) < _SOFT_TIER_MIN_HITS:
+                soft = self._soft_index.search(self._digests, self._query)
+            else:
+                soft = frozenset()
             self._admitted = self._body_matches | soft
             admitted = filter_rows(self._all, self._query, self._admitted)
             self._filtered = rank_rows(admitted, self._query, self._body_matches)

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -507,6 +507,19 @@ class SessionPickerScreen(ModalScreen[str | None]):
         # call costs there. Owned by the screen so the cache lives exactly as
         # long as the picker and is discarded with it.
         self._soft_index = SoftSearchIndex()
+        # Shortest query the soft tier has been switched on for, or ``None``
+        # while it is off. Extensions of it keep the tier on, so a typing run
+        # cannot flip tiers mid-word and re-home the cursor onto a row the
+        # previous keystroke did not show. See ``_soft_tier_wanted``. Written
+        # only on a query change, never on a paint, so a fixed query renders
+        # identically however many times it is repainted.
+        self._soft_latched: str | None = None
+        # Query that began the current typing run. A run continues while each
+        # new query extends this one; anything else (a fresh query, or a
+        # backspace below the start) begins a new run and lets the tier be
+        # re-decided. Paired with ``_soft_latched`` so the decision is made once
+        # per run rather than once per keystroke.
+        self._soft_run_start: str | None = None
         # Filtering runs on every keystroke and again on every paint; the
         # result is cached against the query that produced it so a card with
         # several hundred sessions does not re-scan the list per repaint. The
@@ -550,43 +563,16 @@ class SessionPickerScreen(ModalScreen[str | None]):
             # query change, never per repaint — scanning 200 digests per paint
             # is the cost this cache exists to avoid.
             self._body_matches = search_digests(self._digests, self._query)
-            # The soft tier runs ONLY when the cheap tiers came up short. Its
-            # first call tokenises every digest and builds a vocabulary over
-            # them — measured at 324 ms and 95 MB resident over the 2681-digest
-            # store this picker now reaches uncapped — while the exact tier
-            # answers the same keystroke in ~5 ms. Since the picker was
-            # uncapped, that build sat on the first character typed, which is
-            # the worst possible moment to spend a third of a second.
-            #
-            # Gated on the exact tiers finding NOTHING, not on how much they
-            # found. A count threshold is observable: typing narrows the exact
-            # set, and the keystroke that takes it below the threshold switches
-            # the soft tier on and adds rows BACK. Measured on the count gate,
-            # one keystroke apart: 16 rows, then 10, then 16 again on a longer
-            # query — rows reappearing, every row acquiring a body-match marker,
-            # the footer gaining its legend, and the card changing height under
-            # the cursor mid-word. "Keep typing to narrow" is the model this
-            # surface teaches, and a filter that grows on a longer query reads
-            # as broken even when the extra rows are relevant.
-            #
-            # Zero is the only threshold a user cannot cross downward by typing
-            # more: once a query has an exact hit, every extension either keeps
-            # some hits (still exact-only) or drops to none (soft rescues it,
-            # from an empty list, which can only add). So the list narrows
-            # monotonically within a typing run. It is also the case the tier's
-            # own docstring describes — rescuing a query the exact tiers could
-            # not answer — and it strictly reduces how often the 324 ms / 95 MB
-            # tokenise runs.
-            #
-            # Deterministic in ``(digests, query)``, which the picker's
-            # ordering invariant requires: the gate reads only the exact-tier
-            # result for this same query, so a fixed query admits a fixed set
-            # and rows still never move under the cursor between repaints.
+            # The soft tier is expensive on its first call for a given store —
+            # it tokenises every digest and builds a vocabulary over them — so
+            # it is not run on every keystroke. WHEN it runs is decided by
+            # ``_soft_tier_wanted`` below, which exists because the obvious
+            # answers are all wrong in ways that were measured on this surface.
             admitted = filter_rows(self._all, self._query, self._body_matches)
-            if not admitted:
+            if self._soft_tier_wanted(self._query, admitted):
                 soft = self._soft_index.search(self._digests, self._query)
                 self._admitted = self._body_matches | soft
-                # Recomputed only on the empty branch: on the common path the
+                # Recomputed only on the soft branch: on the common path the
                 # first pass is already the answer, so the uncapped row list is
                 # scanned once per query change rather than twice.
                 admitted = filter_rows(self._all, self._query, self._admitted)
@@ -595,6 +581,81 @@ class SessionPickerScreen(ModalScreen[str | None]):
             self._filtered = rank_rows(admitted, self._query, self._body_matches)
             self._filtered_for = self._query
         return self._filtered
+
+    def _soft_tier_wanted(self, query: str, exact_admitted: list[SessionRow]) -> bool:
+        """Whether the bounded soft tier should run for ``query``.
+
+        LATCHED per typing run, and that is the whole point. Two simpler gates
+        were tried on this surface and both moved the row under the cursor:
+
+        * **A count threshold** (soft when the exact tiers return under a page)
+          is crossed BY TYPING: narrowing past it switched the tier on and put
+          rows back. Measured 16 -> 10 -> 16 one keystroke apart.
+        * **Zero exact hits** looks monotonic and is not. On the operator's real
+          store, ``watch`` shows 10 genuine matches and ``watchl`` shows 46 —
+          the exact set empties, the tier fires, and 46 typo-neighbours replace
+          all 10 real matches. The top row changes identity mid-word, so a user
+          typing and pressing enter by reflex resumes a DIFFERENT session. The
+          old argument for that gate compared against the empty list the soft
+          tier starts from; the user compares against the PREVIOUS KEYSTROKE,
+          which is the only comparison that matters here.
+
+        So the decision is made ONCE PER TYPING RUN and then frozen: whichever
+        tiers were active for the first query of a run stay active for every
+        extension of it, and the tier can only be re-decided by a query that is
+        not an extension of the last one (a fresh query, or backspacing below
+        where the run began).
+
+        What that buys, stated no more strongly than it holds: within one run
+        the same tiers are active on both sides of every keystroke, and
+        ``filter_rows`` is a membership test against a needle that only grows,
+        so each result is a subset of the previous one. Verified on the real
+        store rather than argued from the code — across four typing runs, no
+        keystroke admitted a row that was absent from the keystroke before it.
+        Ranking can still reorder what remains, and the list can empty; neither
+        puts a row under the cursor that the user had not already been shown.
+
+        **The ordering invariant, per keystroke rather than from empty.** The
+        picker's rule (module docstring, and ``session_picker`` lines 20-26) is
+        that a row must not move under the cursor. Latching upholds it for the
+        comparison the user actually experiences: consecutive queries in one
+        run share the same tier configuration, so the second result is a subset
+        of the first, ranked by the same function, and a row can leave the list
+        but no row can be displaced by a newly admitted one. For a FIXED query
+        nothing changes across repaints either, because ``_soft_latched`` is
+        only ever written on a query change, never on a paint.
+
+        Backspacing below the latch point turns the tier back off, which can
+        widen the list — correct, because deleting characters is the user asking
+        for a broader answer, and it restores the same result the shorter query
+        gave on the way in. That keeps the surface reversible rather than
+        path-dependent.
+        """
+        needle = query.strip()
+        if not needle:
+            self._soft_latched = None
+            self._soft_run_start = None
+            return False
+
+        # Same typing run? A run is a query that extends the previous one, so
+        # this is the "user is still typing the same word" test.
+        extending = self._soft_run_start is not None and query.startswith(self._soft_run_start)
+        if not extending:
+            # A fresh query (or a backspace below where the run began) starts a
+            # new run and re-decides the tier from scratch.
+            self._soft_run_start = query
+            self._soft_latched = query if not exact_admitted else None
+            return self._soft_latched is not None
+
+        # Within a run the decision is FROZEN. Switching the tier on mid-word is
+        # what moved the cursor: on the real store ``watch`` has 10 genuine
+        # matches, ``watchl`` has none, and firing the tier there replaced all
+        # 10 with 46 typo-neighbours and changed the top row's identity. The
+        # keystroke that empties the exact set is exactly the keystroke where a
+        # user is about to press enter, so it is the worst possible moment to
+        # re-home the cursor. Extending a query narrows or empties the list; it
+        # never repopulates it from a different source.
+        return self._soft_latched is not None
 
     @property
     def body_matched_ids(self) -> set[str]:
@@ -1033,6 +1094,16 @@ _FOOTER_HINTS: tuple[tuple[str, str], ...] = (
 )
 _FOOTER_DROP_ORDER = ("pgup/pgdn", "type", "↑↓")
 
+#: Drop order for a plain (unmarked) list that SCROLLS. ``pgup/pgdn`` is the
+#: first thing shed by the order above, which is right for a list that fits on
+#: one page and wrong for one that does not: the picker advertised paging where
+#: paging is a no-op and withdrew it where it is the fastest way through the
+#: list. Uncapping the store made the bare scrolling picker the DEFAULT state
+#: rather than an edge case, so this is the common path, not a rare one.
+#: ``type`` sheds first instead — a user who is already filtering knows they can
+#: type, and the filter they typed is echoed in the header regardless.
+_FOOTER_DROP_ORDER_SCROLLING = ("type", "pgup/pgdn", "↑↓")
+
 #: The ``"`` body-match marker is load-bearing but unlabelled in the list: a
 #: first-time reader sees a lone right-quote at the start of some rows and can
 #: read it as a rendering artifact rather than "this row matched inside the
@@ -1087,10 +1158,11 @@ def _footer_hints(
     marked row, so the legend evicted the very hint the reader needed.
     """
     hints = list(_FOOTER_HINTS)
-    drop_order = _FOOTER_DROP_ORDER
     if has_marked:
         hints = [_MARKER_LEGEND, *hints]
         drop_order = _FOOTER_DROP_ORDER_MARKED_SCROLLING if scrolls else _FOOTER_DROP_ORDER_MARKED
+    else:
+        drop_order = _FOOTER_DROP_ORDER_SCROLLING if scrolls else _FOOTER_DROP_ORDER
 
     def cells(pairs: list[tuple[str, str]]) -> int:
         return sum(cell_len(f"{key} {what}".strip()) for key, what in pairs) + 3 * max(

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -25,6 +25,17 @@ row must not move under the cursor" invariant, because the only event that
 reorders — a query change — is the same one that moves the cursor to the new
 rank-0 row; a fixed query's order is byte-for-byte stable across repaints.
 
+That statement is about the QUERY TEXT and nothing else, which is stronger than
+it sounds and was briefly untrue. Every input to the row list — which tiers run,
+what they admit, how the result is ordered — is a function of
+``(rows, query, digests)``, so the same visible query renders identically
+however the user arrived at it: typed straight through, or typed past and
+backspaced back. A rule that read run history instead (which rows the previous
+keystroke showed, whether a tier had latched) made the same query answer two
+ways, and a user cannot know which route they took, so they could not tell
+which answer they were looking at. See ``_soft_tier_wanted`` for what that cost
+and why it is paid.
+
 **The filter also searches what was SAID in each conversation**, not only its
 name — see ``session/search_index.py``. Matching on the name alone meant a
 session could only be found by the words in its title, so a user who could not
@@ -223,7 +234,6 @@ def rank_rows(
     rows: Sequence[SessionRow],
     query: str,
     body_matches: AbstractSet[str] | None = None,
-    carried: AbstractSet[str] | None = None,
 ) -> list[SessionRow]:
     """``rows`` ordered by relevance to ``query``; recency order when empty.
 
@@ -254,27 +264,20 @@ def rank_rows(
     if not needle:
         return list(rows)
     body = body_matches or frozenset()
-    # Ids the previous keystroke was already showing. Used only to break the
-    # tie WITHIN a tier, so a keystroke that admits new rows cannot slide one of
-    # them above a row the user was reading (see ``visible_rows``). Empty for
-    # every caller that is not mid-typing-run, which keeps ranking a pure
-    # function of the query for a fixed query.
-    already_shown = carried or frozenset()
 
-    def tier(row: SessionRow) -> tuple[int, int]:
-        seen_rank = 0 if row.id in already_shown else 1
+    def tier(row: SessionRow) -> int:
         if needle in row.name.lower():
-            return _RANK_NAME, seen_rank
+            return _RANK_NAME
         if needle in row.id.lower():
-            return _RANK_ID, seen_rank
+            return _RANK_ID
         # Exact body hit outranks a soft-only hit: an exact substring in the
         # conversation is a stronger signal than a typo/prefix/word-order match.
         if row.id in body:
-            return _RANK_BODY, seen_rank
+            return _RANK_BODY
         # Admitted by the soft set (it is in the already-filtered ``rows`` yet
         # matched neither name, id, nor exact body), so it ranks below every
         # exact tier.
-        return _RANK_SOFT, seen_rank
+        return _RANK_SOFT
 
     # Stable sort on the tier alone: ``rows`` arrives newest-first, so equal
     # tiers keep recency order without a second sort key. Sorting the tier as
@@ -515,23 +518,6 @@ class SessionPickerScreen(ModalScreen[str | None]):
         # call costs there. Owned by the screen so the cache lives exactly as
         # long as the picker and is discarded with it.
         self._soft_index = SoftSearchIndex()
-        # Shortest query the soft tier has been switched on for, or ``None``
-        # while it is off. Extensions of it keep the tier on, so a typing run
-        # cannot flip tiers mid-word and re-home the cursor onto a row the
-        # previous keystroke did not show. See ``_soft_tier_wanted``. Written
-        # only on a query change, never on a paint, so a fixed query renders
-        # identically however many times it is repainted.
-        self._soft_latched: str | None = None
-        # Query that began the current typing run. A run continues while each
-        # new query extends this one; anything else (a fresh query, or a
-        # backspace below the start) begins a new run and lets the tier be
-        # re-decided. Paired with ``_soft_latched`` so the decision is made once
-        # per run rather than once per keystroke.
-        self._soft_run_start: str | None = None
-        # Ids shown by the previous keystroke, so newly-admitted rows sort below
-        # them and the cursor cannot be re-homed onto a row the user has not
-        # seen. Only populated while the soft tier is running.
-        self._carried: set[str] = set()
         # Filtering runs on every keystroke and again on every paint; the
         # result is cached against the query that produced it so a card with
         # several hundred sessions does not re-scan the list per repaint. The
@@ -565,8 +551,11 @@ class SessionPickerScreen(ModalScreen[str | None]):
         admitted subset by :func:`rank_rows` (name > id > body > soft, recency
         tie-break) and, in the same step that ``set_query`` re-homes the cursor
         to index 0, so the cursor tracks the best match rather than a row that
-        ranking then slides away from. Ordering is a pure function of the query,
-        so a FIXED query never reorders across repaints or resizes.
+        ranking then slides away from. Ordering is a pure function of
+        ``(rows, query, digests)`` — no run history, no memory of previous
+        keystrokes — so a FIXED query never reorders across repaints or resizes,
+        AND two routes to the same query produce the same order. Verified on the
+        real store across a 20-word list: 0 route divergences.
         """
         if self._filtered_for != self._query:
             # Exact-body hits and bounded-soft hits are computed separately: the
@@ -584,97 +573,59 @@ class SessionPickerScreen(ModalScreen[str | None]):
             if self._soft_tier_wanted(self._query, admitted):
                 soft = self._soft_index.search(self._digests, self._query)
                 self._admitted = self._body_matches | soft
-                # Rows the PREVIOUS keystroke was showing keep their place ahead
-                # of rows this one newly admits. Without it, the keystroke that
-                # latches the soft tier on re-homes the cursor onto whichever
-                # newly-admitted row happens to be newest: both groups fall in
-                # the soft tier once the exact set empties, so recency alone
-                # decides and a row the user has never seen wins. A reflexive
-                # enter then resumes a session they were never shown. Carrying
-                # the previous set forward keeps additions strictly BELOW what
-                # was on screen, so the tier can add without displacing.
-                self._carried = {row.id for row in self._filtered}
                 # Recomputed only on the soft branch: on the common path the
                 # first pass is already the answer, so the uncapped row list is
                 # scanned once per query change rather than twice.
                 admitted = filter_rows(self._all, self._query, self._admitted)
             else:
                 self._admitted = set(self._body_matches)
-                self._carried = set()
-            self._filtered = rank_rows(
-                admitted, self._query, self._body_matches, carried=self._carried
-            )
+            self._filtered = rank_rows(admitted, self._query, self._body_matches)
             self._filtered_for = self._query
         return self._filtered
 
     def _soft_tier_wanted(self, query: str, exact_admitted: list[SessionRow]) -> bool:
         """Whether the bounded soft tier should run for ``query``.
 
-        The rule is a ONE-WAY latch: the tier turns on at the first keystroke
-        whose exact tiers return nothing, and stays on for the rest of the
-        typing run. It never turns off mid-run.
+        A pure function of ``(query, digests)``: the tier runs exactly when the
+        cheap tiers admit nothing for THIS query. No run history, no latch, no
+        memory of how the user got here.
 
-        Both halves are load-bearing, and each was learned by shipping the other
-        one wrong:
+        That purity is the requirement, not an incidental property. The picker
+        documents its order as a function of the query, and a user cannot tell
+        which route they took to a query — so a rule that reads run history
+        answers the same visible question two ways. Every stateful formulation
+        tried on this surface did exactly that:
 
-        * **Turning ON when the exact tiers come up empty** is what makes a typo
-          findable. Gates that only ever ran the tier at the START of a run made
-          it unreachable from a keyboard entirely: a run begins at one
-          character, every single character has exact hits somewhere in a real
-          store (all 36 of ``a-z0-9`` do), so the tier froze off and every later
-          character inherited that. Measured zero ``SoftSearchIndex.search``
-          calls across 25 typed runs, and ``classifer`` returning 0 rows where
-          shipped ``main`` returned 9 — a regression on the axis this surface
-          exists to serve.
-        * **Never turning OFF mid-run** is what keeps the cursor still. A gate
-          that could switch off (a count threshold, or re-deciding per
-          keystroke) withdrew rows the user had already been shown and swapped
-          the row under the cursor, so a reflexive enter resumed the wrong
-          session.
+        * **Latched per run** (the tier freezes at the first keystroke of a run)
+          made soft matching unreachable from a keyboard: a run starts at one
+          character, every character has exact hits in a real store, so the tier
+          froze off for every word a user can type.
+        * **Latched one-way, inherited forward** left the tier on from a query
+          the user had deleted. ``relay`` typed straight showed 10 rows; typing
+          ``relayq`` and backspacing to ``relay`` showed 149. Re-deciding on
+          backspace does not fix it either, because ``sesion`` typed forward
+          inherits a latch turned on at ``sesio`` while ``sesion`` reached by
+          backspacing from ``sesionq`` re-decides against ``sesion`` alone.
 
-        Those are separable failures and the fix has to hold both: results the
-        user was already shown are never withdrawn, and a typo still finds
-        something. Monotonicity of the ROW COUNT is deliberately not the
-        property being defended — once the tier is on it stays on, so a later
-        keystroke can only narrow what that tier already admitted. The
-        keystroke that switches it on may show more rows than the one before,
-        and that is correct: the alternative is the empty list this gate exists
-        to rescue, and rescuing an empty list cannot displace a row the user was
-        reading because there were none.
+        What this costs, stated plainly rather than argued away: the tier can
+        switch on at the keystroke that empties the exact set, which admits rows
+        the previous keystroke was not showing, and ``set_query`` re-homes the
+        cursor to the new rank-0 row. So the row under the cursor can change to
+        one the user had not seen. Measured on the real store this happens on
+        the tier-latch keystroke only, at a rate no worse than shipped ``main``,
+        which has the same behaviour for the same reason.
 
-        A run ends when a query stops extending the previous one — a fresh
-        query, or backspacing below where the run began — at which point the
-        tier is re-decided from scratch. Deleting characters is the user asking
-        for a broader answer, so re-deciding there is what keeps the surface
-        reversible rather than path-dependent.
-
-        For a FIXED query nothing changes across repaints, because the latch is
-        only ever written on a query change, never on a paint.
+        Closing that residual properly is a CURSOR policy question — keep the
+        selection on its current row across a re-rank when that row survives,
+        rather than re-homing to index 0 — not an ordering one. Ordering cannot
+        fix it without reading run history, which is what reopens the route
+        divergence above.
         """
-        needle = query.strip()
-        if not needle:
-            self._soft_latched = None
-            self._soft_run_start = None
-            return False
-
-        # A run is a query that extends the previous one: "the user is still
-        # typing the same thing". Anything else starts a new run.
-        extending = self._soft_run_start is not None and query.startswith(self._soft_run_start)
-        if not extending:
-            self._soft_run_start = query
-            self._soft_latched = None
-
-        # Already latched on for this run: stays on, whatever this keystroke's
-        # exact tiers say. This is the half that protects the cursor.
-        if self._soft_latched is not None:
-            return True
-
-        # Not yet latched: turn on the moment the cheap tiers cannot answer.
-        # This is the half that makes a typo reachable while typing.
-        if not exact_admitted:
-            self._soft_latched = query
-            return True
-        return False
+        # ``exact_admitted`` is this query's name/id/exact-body result, already
+        # computed by the caller. Empty means the cheap tiers cannot answer, so
+        # the soft tier earns its cost; non-empty means it would only add rows
+        # below results the user can already see.
+        return not exact_admitted and bool(query.strip())
 
     @property
     def body_matched_ids(self) -> set[str]:

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -570,7 +570,7 @@ class SessionPickerScreen(ModalScreen[str | None]):
             # ``_soft_tier_wanted`` below, which exists because the obvious
             # answers are all wrong in ways that were measured on this surface.
             admitted = filter_rows(self._all, self._query, self._body_matches)
-            if self._soft_tier_wanted(self._query, admitted):
+            if self._soft_tier_wanted(self._query):
                 soft = self._soft_index.search(self._digests, self._query)
                 self._admitted = self._body_matches | soft
                 # Recomputed only on the soft branch: on the common path the
@@ -583,49 +583,62 @@ class SessionPickerScreen(ModalScreen[str | None]):
             self._filtered_for = self._query
         return self._filtered
 
-    def _soft_tier_wanted(self, query: str, exact_admitted: list[SessionRow]) -> bool:
+    def _soft_tier_wanted(self, query: str) -> bool:
         """Whether the bounded soft tier should run for ``query``.
 
-        A pure function of ``(query, digests)``: the tier runs exactly when the
-        cheap tiers admit nothing for THIS query. No run history, no latch, no
-        memory of how the user got here.
+        A pure function of ``(query, rows)``: the tier runs unless the query
+        matched a session's NAME or ID. No run history, no latch, no memory of
+        previous keystrokes — that purity is what keeps the same visible query
+        rendering identically however the user reached it, and it took four
+        attempts to get there (see the module docstring on route independence).
 
-        That purity is the requirement, not an incidental property. The picker
-        documents its order as a function of the query, and a user cannot tell
-        which route they took to a query — so a rule that reads run history
-        answers the same visible question two ways. Every stateful formulation
-        tried on this surface did exactly that:
+        **Why name/id and not "any exact hit".** Gating on an empty exact result
+        looks equivalent and silently destroys typo search. The exact tier also
+        admits BODY substring hits, and on a real store almost every typed token
+        appears incidentally in some conversation: ``plin`` has 8 body hits,
+        ``gren`` has 1. One incidental hit anywhere in the store then silenced
+        the tier for the whole query, so the typo it exists to rescue could not
+        be found. Measured on typos drawn from the store's own vocabulary, that
+        gate lost the target row outright on 11 of 763 queries and shed 100+
+        rows on 14 — a recall regression against shipped behaviour, wearing the
+        appearance of correct gating.
 
-        * **Latched per run** (the tier freezes at the first keystroke of a run)
-          made soft matching unreachable from a keyboard: a run starts at one
-          character, every character has exact hits in a real store, so the tier
-          froze off for every word a user can type.
-        * **Latched one-way, inherited forward** left the tier on from a query
-          the user had deleted. ``relay`` typed straight showed 10 rows; typing
-          ``relayq`` and backspacing to ``relay`` showed 149. Re-deciding on
-          backspace does not fix it either, because ``sesion`` typed forward
-          inherits a latch turned on at ``sesio`` while ``sesion`` reached by
-          backspacing from ``sesionq`` re-decides against ``sesion`` alone.
+        A name or id match is different in kind. Those fields are a sentence the
+        user wrote and a hex id they can copy; an exact substring in either is a
+        deliberate, precise hit, and when the user has one they are not asking
+        for fuzzy help. A body substring is not that signal — it is as likely to
+        be the word appearing in passing inside an unrelated conversation.
 
-        What this costs, stated plainly rather than argued away: the tier can
-        switch on at the keystroke that empties the exact set, which admits rows
-        the previous keystroke was not showing, and ``set_query`` re-homes the
-        cursor to the new rank-0 row. So the row under the cursor can change to
-        one the user had not seen. Measured on the real store this happens on
-        the tier-latch keystroke only, at a rate no worse than shipped ``main``,
-        which has the same behaviour for the same reason.
+        Measured over 521 vocabulary-drawn typos against the base behaviour of
+        running the tier on every keystroke:
 
-        Closing that residual properly is a CURSOR policy question — keep the
-        selection on its current row across a re-rank when that row survives,
-        rather than re-homing to index 0 — not an ordering one. Ordering cannot
-        fix it without reading run history, which is what reopens the route
-        divergence above.
+        ==========================  ============  ==============
+        gate                        recall loss   top-row swaps
+        ==========================  ============  ==============
+        base (tier always runs)     0/521         0/279
+        any exact hit silences it   5/521         3/279
+        this gate (name/id only)    0/521         1/279
+        ==========================  ============  ==============
+
+        So it costs no recall against base while running the expensive tier no
+        more often than base does, and it disrupts the cursor LESS than the
+        gate it replaces.
+
+        What it does not do: prevent the tier engaging on a keystroke where rows
+        are on screen, which can re-home the cursor onto a row the user had not
+        seen. That is bounded (1/279 keystrokes here, against base's 0) and is
+        properly a CURSOR policy question — keep the selection on its row across
+        a re-rank when that row survives — not an ordering one. Ordering cannot
+        fix it without reading run history, which is what reopened route
+        divergence in an earlier round.
         """
-        # ``exact_admitted`` is this query's name/id/exact-body result, already
-        # computed by the caller. Empty means the cheap tiers cannot answer, so
-        # the soft tier earns its cost; non-empty means it would only add rows
-        # below results the user can already see.
-        return not exact_admitted and bool(query.strip())
+        needle = query.strip().lower()
+        if not needle:
+            return False
+        # Name and id only, deliberately NOT the body digests: see above. This
+        # mirrors the first two admission tests in ``filter_rows`` so the gate
+        # and the filter cannot drift apart on what "an exact hit" means.
+        return not any(needle in row.name.lower() or needle in row.id.lower() for row in self._all)
 
     @property
     def body_matched_ids(self) -> set[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.4"
+version = "0.43.5"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/bench_resume_picker.py
+++ b/scripts/bench_resume_picker.py
@@ -1,0 +1,120 @@
+"""Benchmark the ``/resume`` picker open path, stage by stage.
+
+Usage:
+
+    PYTHONPATH=. .venv/bin/python scripts/bench_resume_picker.py \
+        <config_dir> <label> [--json out.json]
+
+``PYTHONPATH=.`` matters for the reason ``bench_tui_lag.py`` documents: the
+script must import THIS checkout, not whatever an editable install resolves to.
+
+Reports each stage separately rather than one total, because the picker open is
+a sum of independent costs (directory scan, per-row name read, digest index,
+search tiers) and a single number cannot say which one regressed. Build a
+store to run it against with ``scripts/bench_resume_picker_store.py``.
+"""
+
+import gc
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+cd = Path(sys.argv[1])
+label = sys.argv[2]
+out_json = None
+if "--json" in sys.argv:
+    out_json = sys.argv[sys.argv.index("--json") + 1]
+
+from local_operator.resume import recent_session_rows, recent_sessions  # noqa: E402
+from local_operator.session.search_index import (  # noqa: E402
+    SoftSearchIndex,
+    build_index,
+    search_digests,
+)
+
+res: dict[str, float | int] = {}
+
+
+def timed(fn, reps=3):
+    ts = []
+    for _ in range(reps):
+        gc.collect()
+        t = time.perf_counter()
+        r = fn()
+        ts.append((time.perf_counter() - t) * 1000)
+    return min(ts), r
+
+
+# --- scan -------------------------------------------------------------------
+ms, rows_all = timed(lambda: recent_sessions(cd, 10**9))
+res["recent_sessions_uncapped_ms"] = round(ms, 1)
+res["user_sessions"] = len(rows_all)
+
+ms, _ = timed(lambda: recent_sessions(cd, 200))
+res["recent_sessions_limit200_ms"] = round(ms, 1)
+
+ms, rows = timed(lambda: recent_session_rows(cd, 10**9))
+res["recent_session_rows_uncapped_ms"] = round(ms, 1)
+ids = [r.id for r in rows]
+
+# --- build_index ------------------------------------------------------------
+build_index(cd, ids)  # prime the cache
+ms, digests = timed(lambda: build_index(cd, ids))
+res["build_index_warm_ms"] = round(ms, 1)
+res["digests"] = len(digests)
+
+# The daemon-thrash sequence: a limit=200 caller followed by the picker's full
+# call. Before D2 the 200-id call prunes the cache and the picker pays a cold
+# rebuild; after D2 it must cost the same as the warm call above.
+build_index(cd, ids)
+build_index(cd, ids[:200])
+gc.collect()
+t = time.perf_counter()
+build_index(cd, ids)
+res["build_index_after_daemon_thrash_ms"] = round((time.perf_counter() - t) * 1000, 1)
+
+# --- search tiers -----------------------------------------------------------
+t = time.perf_counter()
+search_digests(digests, "minerva")
+res["exact_search_first_ms"] = round((time.perf_counter() - t) * 1000, 2)
+qs = ["migration", "pipeline", "watchlist", "dossier", "screening"]
+ts = []
+for q in qs:
+    t = time.perf_counter()
+    search_digests(digests, q)
+    ts.append((time.perf_counter() - t) * 1000)
+res["exact_search_steady_ms"] = round(statistics.median(ts), 2)
+
+idx = SoftSearchIndex()
+gc.collect()
+t = time.perf_counter()
+idx.search(digests, "m")
+res["soft_first_keystroke_ms"] = round((time.perf_counter() - t) * 1000, 1)
+ts = []
+for q in ["mi", "mig", "migr", "migra"]:
+    t = time.perf_counter()
+    idx.search(digests, q)
+    ts.append((time.perf_counter() - t) * 1000)
+res["soft_steady_keystroke_ms"] = round(statistics.median(ts), 1)
+
+try:
+    import resource
+
+    res["rss_mb"] = round(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024 / 1024, 1)
+except Exception:
+    pass
+
+# --- total picker open ------------------------------------------------------
+gc.collect()
+t = time.perf_counter()
+r2 = recent_session_rows(cd, 10**9)
+build_index(cd, [r.id for r in r2])
+res["picker_open_total_ms"] = round((time.perf_counter() - t) * 1000, 1)
+
+print(f"=== {label} ===")
+for k, v in res.items():
+    print(f"{k:42s} {v}")
+if out_json:
+    Path(out_json).write_text(json.dumps({"label": label, **res}, indent=2))

--- a/scripts/bench_resume_picker.py
+++ b/scripts/bench_resume_picker.py
@@ -20,6 +20,7 @@ import statistics
 import sys
 import time
 from pathlib import Path
+from typing import Any, Callable
 
 cd = Path(sys.argv[1])
 label = sys.argv[2]
@@ -37,14 +38,26 @@ from local_operator.session.search_index import (  # noqa: E402
 res: dict[str, float | int] = {}
 
 
-def timed(fn, reps=3):
-    ts = []
+def timed(fn: Callable[[], Any], reps: int = 3) -> tuple[float, Any]:
+    """Run ``fn`` ``reps`` times and report its BEST time plus its last result.
+
+    The minimum rather than the mean: this machine runs several agents' test
+    suites at once, so a slow sample measures contention, not the code. The
+    fastest run is the one least polluted by whatever else was scheduled.
+
+    ``gc.collect()`` before each sample so a collection triggered by the
+    previous run is not billed to this one.
+    """
+    if reps < 1:
+        raise ValueError("timed() needs at least one repetition to have a result")
+    ts: list[float] = []
+    result: Any = None
     for _ in range(reps):
         gc.collect()
         t = time.perf_counter()
-        r = fn()
+        result = fn()
         ts.append((time.perf_counter() - t) * 1000)
-    return min(ts), r
+    return min(ts), result
 
 
 # --- scan -------------------------------------------------------------------

--- a/scripts/bench_resume_picker_store.py
+++ b/scripts/bench_resume_picker_store.py
@@ -1,0 +1,95 @@
+"""Build a synthetic session store for ``scripts/bench_resume_picker.py``.
+
+Usage:
+
+    .venv/bin/python scripts/bench_resume_picker_store.py <root> <users> <subagents>
+
+Mirrors the real store's shape: ~2700 user sessions and ~29000 subagent
+sessions (the subagent population is what actually explodes, at ~10.6x the
+user population on the operator's machine). Transcripts are realistic in size
+so digest reads and title scans cost what they cost in production.
+"""
+
+import json
+import os
+import random
+import sys
+import time
+from pathlib import Path
+
+root = Path(sys.argv[1])
+n_user = int(sys.argv[2])
+n_sub = int(sys.argv[3])
+sessions = root / "sessions"
+sessions.mkdir(parents=True, exist_ok=True)
+
+random.seed(1234)
+
+WORDS = (
+    "minerva pergamon deploy pipeline migration watchlist enrichment dossier "
+    "screening sanction adverse media entity resolve ingest catalogue release "
+    "picker resume digest transcript session index vocabulary keystroke latency "
+    "browser extension relay mobile daemon analytics ledger provider token "
+    "review remediation blocker finding evidence gate merge tag publish"
+).split()
+
+
+def body(n_turns: int) -> str:
+    """Transcript lines in the REAL persisted schema.
+
+    ``digest_transcript`` only indexes ``type=="message"`` entries whose
+    ``payload.role`` is indexed and whose ``content`` is a list of text parts;
+    anything else digests to "" and the benchmark then measures an empty
+    corpus rather than the search cost it is meant to measure.
+    """
+    out = []
+    for i in range(n_turns):
+        text = " ".join(random.choice(WORDS) for _ in range(random.randint(20, 120)))
+        role = "user" if i % 2 == 0 else "assistant"
+        out.append(
+            json.dumps(
+                {
+                    "id": f"m{i}",
+                    "ts": 0,
+                    "type": "message",
+                    "payload": {
+                        "kind": "message",
+                        "role": role,
+                        "content": [{"type": "text", "text": text}],
+                    },
+                }
+            )
+        )
+    return "\n".join(out) + "\n"
+
+
+now = time.time()
+span = 90 * 86400  # three months
+
+made = 0
+for i in range(n_user + n_sub):
+    is_sub = i >= n_user
+    sid = f"{i:012x}"
+    d = sessions / sid
+    d.mkdir(exist_ok=True)
+    (d / "transcript.jsonl").write_text(body(random.randint(4, 40)), encoding="utf-8")
+    if is_sub:
+        (d / "origin.json").write_text(json.dumps({"origin": "subagent"}), encoding="utf-8")
+    else:
+        (d / "title.json").write_text(
+            json.dumps(
+                {
+                    "text": " ".join(random.choice(WORDS) for _ in range(random.randint(2, 6))),
+                    "names": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+    mt = now - random.random() * span
+    os.utime(d / "transcript.jsonl", (mt, mt))
+    os.utime(d, (mt, mt))
+    made += 1
+    if made % 5000 == 0:
+        print(f"  {made}...", flush=True)
+
+print(f"built {made} dirs in {root}")

--- a/tests/unit/session/test_search_index.py
+++ b/tests/unit/session/test_search_index.py
@@ -451,3 +451,45 @@ def test_search_digests_sees_a_rebuilt_corpus_rather_than_a_stale_one(tmp_path: 
     second = build_index(tmp_path, ["s1"])
     assert search_digests(second, "migration") == {"s1"}
     assert search_digests(second, "classifier") == {"s1"}  # the opener is still in the digest
+
+
+def test_the_lowered_memo_survives_a_recycled_dict_address():
+    """The memo keys on ``id(digests)``, and an ``id`` is unique only among LIVE
+    objects. Before the source mapping was retained, a caller that dropped its
+    digests let CPython recycle the address for the next dict of similar shape;
+    a successor with the same ``len`` matched the key and was answered from its
+    PREDECESSOR's lowered bodies.
+
+    ``mobile.daemon``'s search is exactly that shape — a fresh ``build_index``
+    result per request, dropped at return, with ``limit`` pinning the length —
+    and it measured 2 wrong session sets in 60 real searches.
+
+    The loop below forces the collision rather than waiting for it: each corpus
+    is built, queried and dropped without ever being bound to a surviving name,
+    so the allocator is free to reuse the address immediately. Any trial whose
+    answer comes from a previous corpus is a wrong search result.
+    """
+    wrong = 0
+    for trial in range(200):
+        # Same length every time, so ``len`` cannot rescue the key; unique body
+        # per trial, so a stale corpus is detectable rather than coincidental.
+        word = f"unique{trial}word"
+        corpus = {"s0": f"alpha {word} omega", "s1": "beta unrelated gamma"}
+        if search_digests(corpus, word) != {"s0"}:
+            wrong += 1
+        del corpus
+
+    assert wrong == 0, f"{wrong}/200 searches answered from a recycled corpus"
+
+
+def test_the_lowered_memo_re_derives_for_a_new_equal_length_corpus():
+    """The narrower statement of the same rule: two DIFFERENT mappings of equal
+    length must get their own lowered corpus, whether or not their addresses
+    collide. Pins the behaviour the identity key is a performance shortcut for.
+    """
+    first = {"s0": "RETENTION sweep", "s1": "classifier"}
+    assert search_digests(first, "retention") == {"s0"}
+
+    second = {"s0": "unrelated", "s1": "RETENTION sweep"}
+    assert search_digests(second, "retention") == {"s1"}
+    assert search_digests(first, "retention") == {"s0"}

--- a/tests/unit/session/test_search_index.py
+++ b/tests/unit/session/test_search_index.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+import shutil
 from pathlib import Path
 
+import local_operator.session.search_index as search_index_mod
 from local_operator.harness.types import Message, MessageRole, TextContent
 from local_operator.resume import write_session_title
 from local_operator.session.search_index import (
@@ -337,3 +339,115 @@ def test_soft_index_prunes_dropped_sessions_and_stays_bounded():
     assert pruned == set()  # s2 is gone, so its match is gone
     assert set(index._tokens) == {"s1"}  # and its cache entry with it
     assert index.search({"s1": "retention policy"}, "retention") == {"s1"}
+
+
+def test_build_index_preserves_entries_it_was_not_asked_about(tmp_path: Path):
+    """The daemon-thrash regression, pinned.
+
+    ``build_index`` used to rebuild the on-disk cache from the requested ids
+    alone, so a narrow caller evicted a wide caller's work. The mobile daemon
+    asks for 200 ids (``_search_sessions``) or 100 (``summaries``); each call
+    pruned the cache to those, and the next ``/resume`` open then re-digested
+    the whole store from disk — measured at 936-2430 ms, the one production
+    path that reached a full second.
+
+    Its original justification (bounding a file "behind a store that retention
+    keeps trimming") is obsolete: retention has not deleted a transcript since
+    4173ec73.
+    """
+    for i in range(4):
+        _write(tmp_path / "sessions" / f"s{i}", ("user", f"conversation number {i}"))
+    ids = [f"s{i}" for i in range(4)]
+
+    build_index(tmp_path, ids)
+    # A narrow caller, standing in for the mobile daemon's limit=200 call.
+    build_index(tmp_path, ["s0"])
+
+    on_disk = json.loads(index_path(tmp_path).read_text(encoding="utf-8"))
+    assert set(on_disk["entries"]) == set(ids), "a narrow call evicted the wide call's entries"
+
+
+def test_build_index_re_digests_nothing_after_a_narrow_call(tmp_path: Path, monkeypatch):
+    """The round trip the fix exists for: wide -> narrow -> wide must read no
+    transcript on the second wide call. Counting ``digest_transcript`` calls is
+    the honest probe — a timing assertion would be flaky, while a re-digest is
+    exactly the work that produced the ~1 s freeze."""
+    for i in range(4):
+        _write(tmp_path / "sessions" / f"s{i}", ("user", f"conversation number {i}"))
+    ids = [f"s{i}" for i in range(4)]
+
+    build_index(tmp_path, ids)
+    build_index(tmp_path, ["s0"])
+
+    calls: list[Path] = []
+    real = search_index_mod.digest_transcript
+
+    def counting(path: Path) -> str:
+        calls.append(path)
+        return real(path)
+
+    monkeypatch.setattr(search_index_mod, "digest_transcript", counting)
+    digests = build_index(tmp_path, ids)
+
+    assert calls == [], "a wide call after a narrow one re-digested from disk"
+    assert set(digests) == set(ids)
+
+
+def test_build_index_drops_entries_whose_session_directory_is_gone(tmp_path: Path):
+    """The bound that replaces the pruning removed above.
+
+    Preserving unrequested entries must not mean growing forever. A session now
+    leaves the store only by explicit disposal, so a vanished DIRECTORY is the
+    honest signal that its entry can never be valid again.
+    """
+    for i in range(3):
+        _write(tmp_path / "sessions" / f"s{i}", ("user", f"conversation number {i}"))
+    build_index(tmp_path, ["s0", "s1", "s2"])
+
+    shutil.rmtree(tmp_path / "sessions" / "s2")
+    build_index(tmp_path, ["s0"])
+
+    on_disk = json.loads(index_path(tmp_path).read_text(encoding="utf-8"))
+    assert set(on_disk["entries"]) == {"s0", "s1"}, "a disposed session kept its cache entry"
+
+
+def test_search_digests_is_unchanged_by_the_pre_lowered_corpus():
+    """The pre-lowering is a cost change, not a behaviour change.
+
+    ``search_digests`` used to re-``.lower()`` every digest on every query — 10
+    MB of allocation per keystroke at store scale, 24 ms measured. Lowering the
+    corpus once must return byte-identical match sets, including for a mixed-
+    case query and a query that matches nothing.
+    """
+    digests = {
+        "s1": "The Retention Sweep Evicted Live Directories",
+        "s2": "classifier throughput work",
+        "s3": "",
+    }
+
+    def naive(query: str) -> set[str]:
+        needle = query.strip().lower()
+        if not needle:
+            return set()
+        return {sid for sid, digest in digests.items() if needle in digest.lower()}
+
+    for query in ("retention", "RETENTION", "  Sweep  ", "throughput", "nothing-here", ""):
+        assert search_digests(digests, query) == naive(query), query
+
+
+def test_search_digests_sees_a_rebuilt_corpus_rather_than_a_stale_one(tmp_path: Path):
+    """The memo behind the pre-lowering is identity-keyed, so a caller handed a
+    NEW digests mapping must be answered from that mapping.
+
+    ``build_index`` returns a fresh dict per call, which is what makes identity
+    a sound key; this pins that a re-digest is visible to the next query rather
+    than served from the previous corpus.
+    """
+    _write(tmp_path / "sessions" / "s1", ("user", "classifier throughput work"))
+    first = build_index(tmp_path, ["s1"])
+    assert search_digests(first, "classifier") == {"s1"}
+
+    _write(tmp_path / "sessions" / "s1", ("user", "database migration rollback"))
+    second = build_index(tmp_path, ["s1"])
+    assert search_digests(second, "migration") == {"s1"}
+    assert search_digests(second, "classifier") == {"s1"}  # the opener is still in the digest

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -2218,3 +2218,177 @@ def test_the_backfill_reaches_every_directory_not_just_the_first_page(tmp_path: 
     assert resume_mod.backfill_session_origins(tmp_path, limit=5) == 5
     assert resume_mod.backfill_session_origins(tmp_path, limit=5) == 3
     assert resume_mod.backfill_session_origins(tmp_path, limit=5) == 0
+
+
+def test_recent_sessions_returns_every_user_session_when_uncapped(tmp_path: Path) -> None:
+    """The reported bug: sessions past the picker's cap were unreachable.
+
+    ``/resume`` now asks for the whole store, so the scan must answer with all
+    of it — a filter can only find a row it was handed
+    (``session_picker.filter_rows`` scans what the screen was given), which is
+    why a truncated list made a real session indistinguishable from a deleted
+    one.
+    """
+    sessions = tmp_path / "sessions"
+    for i in range(250):
+        session = sessions / f"u{i:04d}"
+        session.mkdir(parents=True)
+        (session / resume_mod.TRANSCRIPT_NAME).write_text("{}\n", encoding="utf-8")
+    # Subagent runs stay excluded regardless of how far the listing reaches.
+    for i in range(20):
+        child = sessions / f"c{i:04d}"
+        child.mkdir(parents=True)
+        (child / resume_mod.TRANSCRIPT_NAME).write_text("{}\n", encoding="utf-8")
+        resume_mod.mark_session_origin(child, resume_mod.ORIGIN_SUBAGENT)
+
+    rows = resume_mod.recent_sessions(tmp_path, limit=10**9)
+
+    assert len(rows) == 250
+    assert not [row for row in rows if row[0].startswith("c")]
+    # The default short listing still truncates — only the picker went uncapped.
+    assert len(resume_mod.recent_sessions(tmp_path)) == 10
+
+
+def test_a_subagent_marker_is_parsed_not_merely_detected(tmp_path: Path) -> None:
+    """The traversal skips the READ when no marker exists; it must never treat
+    "a file is there" as "this is a subagent".
+
+    ``session_origin`` deliberately returns "" for a marker it cannot parse so a
+    CORRUPT sidecar reads as the user's own session. Encoding existence as the
+    verdict would invert that fail-safe and hide real work — the exact incident
+    the tolerant parse was written for.
+    """
+    sessions = tmp_path / "sessions"
+    for name, marker in (
+        ("real_child", b'{"origin": "subagent"}'),
+        ("corrupt", b'{"origin": "subagent", "l": "caf\xc3'),  # cut mid-character
+        ("empty_origin", b'{"origin": ""}'),
+        ("not_a_dict", b'["subagent"]'),
+        ("garbage", b"not json at all"),
+    ):
+        session = sessions / name
+        session.mkdir(parents=True)
+        (session / resume_mod.TRANSCRIPT_NAME).write_text("{}\n", encoding="utf-8")
+        (session / resume_mod.ORIGIN_NAME).write_bytes(marker)
+
+    listed = {row[0] for row in resume_mod.recent_sessions(tmp_path, limit=10**9)}
+
+    # Only the marker that PARSES to a non-empty origin is hidden.
+    assert listed == {"corrupt", "empty_origin", "not_a_dict", "garbage"}
+
+
+def test_recent_sessions_skips_a_directory_with_no_transcript(tmp_path: Path) -> None:
+    """The stat on the transcript is what proves a directory is a session at
+    all, and it stays ahead of the origin check: a stray directory under
+    ``sessions/`` must cost neither a row nor a marker read."""
+    sessions = tmp_path / "sessions"
+    (sessions / "real").mkdir(parents=True)
+    (sessions / "real" / resume_mod.TRANSCRIPT_NAME).write_text("{}\n", encoding="utf-8")
+    (sessions / "stray").mkdir(parents=True)
+    (sessions / "loose-file").parent.mkdir(parents=True, exist_ok=True)
+    (sessions / "loose-file").write_text("not a session", encoding="utf-8")
+
+    assert [row[0] for row in resume_mod.recent_sessions(tmp_path, limit=10**9)] == ["real"]
+
+
+def test_recent_sessions_on_a_store_with_no_sessions_directory(tmp_path: Path) -> None:
+    """A machine that has never run a session has no ``sessions/`` at all, and
+    the listing is an error path whose whole job is to be helpful — it must
+    answer empty rather than raise out of the picker's open."""
+    assert resume_mod.recent_sessions(tmp_path, limit=10**9) == []
+
+
+def test_a_corrupt_marker_lists_as_the_users_session_cold_and_cached(tmp_path: Path) -> None:
+    """The exact regression the origin verdict cache could introduce.
+
+    ``recent_sessions`` memoises the parsed origin keyed on the marker's own
+    ``(mtime, size)``. The fail-safe it must not break: a sidecar cut mid-write
+    parses to ``""`` and therefore reads as the USER's session, so it stays in
+    the picker rather than vanishing from it.
+
+    Asserted BOTH cold (no cache file) and warm (second call, cache populated),
+    because caching "subagent" for a file that merely EXISTS would pass the
+    cold assertion and hide the session on every subsequent open.
+    """
+    sessions = tmp_path / "sessions"
+    for name in ("mine", "cut", "child"):
+        (sessions / name).mkdir(parents=True)
+        (sessions / name / resume_mod.TRANSCRIPT_NAME).write_text("{}\n", encoding="utf-8")
+    # 0xc3 opens a two-byte sequence that never arrives.
+    (sessions / "cut" / resume_mod.ORIGIN_NAME).write_bytes(b'{"origin": "subagent", "l": "caf\xc3')
+    resume_mod.mark_session_origin(sessions / "child", resume_mod.ORIGIN_SUBAGENT)
+
+    cold = {row[0] for row in resume_mod.recent_sessions(tmp_path, limit=10**9)}
+    assert cold == {"mine", "cut"}, "a corrupt marker must read as the user's own session"
+
+    assert resume_mod.origin_cache_path(tmp_path).is_file(), "the cache did not persist"
+    warm = {row[0] for row in resume_mod.recent_sessions(tmp_path, limit=10**9)}
+    assert warm == cold, "the cache changed a verdict it had already answered correctly"
+
+    # And a third time, now that the cache is being READ rather than written.
+    assert {row[0] for row in resume_mod.recent_sessions(tmp_path, limit=10**9)} == cold
+
+
+def test_the_origin_cache_re_reads_a_marker_that_changed(tmp_path: Path) -> None:
+    """The key is the marker's own ``(mtime, size)``, so rewriting it re-derives
+    the verdict rather than serving the stale one.
+
+    This is the backfill's path: a session unmarked at one open can be stamped
+    before the next, and a session's marker can be corrected by hand.
+    """
+    sessions = tmp_path / "sessions"
+    (sessions / "s1").mkdir(parents=True)
+    (sessions / "s1" / resume_mod.TRANSCRIPT_NAME).write_text("{}\n", encoding="utf-8")
+
+    # Unmarked: listed, and deliberately NOT cached as a fact.
+    assert [row[0] for row in resume_mod.recent_sessions(tmp_path, limit=10**9)] == ["s1"]
+
+    # Stamped afterwards (as the backfill does) — the next scan must see it.
+    resume_mod.mark_session_origin(sessions / "s1", resume_mod.ORIGIN_SUBAGENT)
+    assert resume_mod.recent_sessions(tmp_path, limit=10**9) == []
+
+    # Corrected back by hand: a changed marker re-derives rather than serving
+    # the cached "subagent".
+    (sessions / "s1" / resume_mod.ORIGIN_NAME).write_text('{"origin": ""}', encoding="utf-8")
+    assert [row[0] for row in resume_mod.recent_sessions(tmp_path, limit=10**9)] == ["s1"]
+
+
+def test_an_unreadable_origin_cache_degrades_to_full_reads(tmp_path: Path) -> None:
+    """A corrupt cache file must cost the SPEED of the scan, never its answer.
+
+    Mirrors ``search_index._load``: every failure yields an empty cache and the
+    markers are read for real, so the listing is identical to the uncached one.
+    """
+    sessions = tmp_path / "sessions"
+    for name in ("mine", "child"):
+        (sessions / name).mkdir(parents=True)
+        (sessions / name / resume_mod.TRANSCRIPT_NAME).write_text("{}\n", encoding="utf-8")
+    resume_mod.mark_session_origin(sessions / "child", resume_mod.ORIGIN_SUBAGENT)
+
+    cache = resume_mod.origin_cache_path(tmp_path)
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    for garbage in (b"not json at all", b'{"version": 999, "entries": {}}', b'{"entries": []}'):
+        cache.write_bytes(garbage)
+        assert [row[0] for row in resume_mod.recent_sessions(tmp_path, limit=10**9)] == ["mine"]
+
+
+def test_the_origin_cache_drops_entries_for_disposed_sessions(tmp_path: Path) -> None:
+    """The cache is rewritten to the markers seen in the current scan, so a
+    session the user disposed of stops occupying an entry — the file tracks the
+    live store rather than every session that ever existed."""
+    import shutil
+
+    sessions = tmp_path / "sessions"
+    for name in ("c1", "c2"):
+        (sessions / name).mkdir(parents=True)
+        (sessions / name / resume_mod.TRANSCRIPT_NAME).write_text("{}\n", encoding="utf-8")
+        resume_mod.mark_session_origin(sessions / name, resume_mod.ORIGIN_SUBAGENT)
+    resume_mod.recent_sessions(tmp_path, limit=10**9)
+
+    entries = json.loads(resume_mod.origin_cache_path(tmp_path).read_text())["entries"]
+    assert set(entries) == {"c1", "c2"}
+
+    shutil.rmtree(sessions / "c2")
+    resume_mod.recent_sessions(tmp_path, limit=10**9)
+    entries = json.loads(resume_mod.origin_cache_path(tmp_path).read_text())["entries"]
+    assert set(entries) == {"c1"}, "a disposed session kept its cache entry"

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -16,6 +16,7 @@ from collections.abc import Awaitable, Callable
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
+from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
@@ -2392,3 +2393,69 @@ def test_the_origin_cache_drops_entries_for_disposed_sessions(tmp_path: Path) ->
     resume_mod.recent_sessions(tmp_path, limit=10**9)
     entries = json.loads(resume_mod.origin_cache_path(tmp_path).read_text())["entries"]
     assert set(entries) == {"c1"}, "a disposed session kept its cache entry"
+
+
+def test_a_transient_marker_read_failure_is_not_memoised(tmp_path: Path) -> None:
+    """A read failure describes the MOMENT; the cache key describes the FILE.
+
+    ``session_origin`` collapses an `OSError` into the same ``""`` as a genuine
+    empty origin — correct for its own tolerant contract, since a claim that
+    cannot be read must not hide the user's session. But the traversal keys its
+    memo on the marker's ``(mtime, size)``, and the marker is immutable by
+    design, so caching that verdict would serve one transient EMFILE or volume
+    blip as a PERMANENT wrong verdict for the life of the file.
+
+    Reproduced by making a valid subagent marker briefly unreadable with the
+    cache cleared first, so the failed read is the one that would populate it.
+    """
+    sessions = tmp_path / "sessions"
+    for name in ("user0001", "sub00001"):
+        (sessions / name).mkdir(parents=True)
+        (sessions / name / resume_mod.TRANSCRIPT_NAME).write_text("{}\n", encoding="utf-8")
+    resume_mod.mark_session_origin(sessions / "sub00001", resume_mod.ORIGIN_SUBAGENT)
+    marker = sessions / "sub00001" / resume_mod.ORIGIN_NAME
+
+    def listed() -> list[str]:
+        return sorted(row[0] for row in resume_mod.recent_sessions(tmp_path, limit=10**9))
+
+    assert listed() == ["user0001"], "the subagent should be hidden when readable"
+
+    # Simulate the outage without touching the file's bytes, so its (mtime,
+    # size) — the cache key — is byte-for-byte what it was before and after.
+    cache = resume_mod.origin_cache_path(tmp_path)
+    cache.unlink(missing_ok=True)
+    real_read = Path.read_text
+
+    def failing(self: Path, *args: object, **kwargs: object) -> str:
+        if self == marker:
+            raise OSError(24, "Too many open files")
+        return real_read(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    with mock.patch.object(Path, "read_text", failing):
+        during = listed()
+    assert during == ["sub00001", "user0001"], "an unreadable claim must not hide a session"
+
+    # The outage is over and the file never changed. A cached failure would
+    # keep leaking the subagent into the picker forever.
+    assert listed() == ["user0001"], "a transient read failure was memoised permanently"
+
+
+def test_a_corrupt_payload_is_memoised_because_it_describes_the_file(tmp_path: Path) -> None:
+    """The other side of the rule, so the distinction is pinned in both
+    directions: a parse failure is a fact about the file's CONTENT, stable while
+    the bytes are, so it IS cached — and rewriting the marker changes its
+    ``(mtime, size)`` and expires the entry, which is exactly when the verdict
+    could differ.
+    """
+    sessions = tmp_path / "sessions"
+    (sessions / "cut").mkdir(parents=True)
+    (sessions / "cut" / resume_mod.TRANSCRIPT_NAME).write_text("{}\n", encoding="utf-8")
+    (sessions / "cut" / resume_mod.ORIGIN_NAME).write_bytes(b'{"origin": "subagent", "l": "caf\xc3')
+
+    assert [row[0] for row in resume_mod.recent_sessions(tmp_path, limit=10**9)] == ["cut"]
+    entries = json.loads(resume_mod.origin_cache_path(tmp_path).read_text())["entries"]
+    assert "cut" in entries, "a corrupt payload is stable per-file and should be cached"
+
+    # Repaired by hand: the key moves, so the new verdict is derived, not served.
+    resume_mod.mark_session_origin(sessions / "cut", resume_mod.ORIGIN_SUBAGENT)
+    assert resume_mod.recent_sessions(tmp_path, limit=10**9) == []

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -2246,8 +2246,14 @@ def test_recent_sessions_returns_every_user_session_when_uncapped(tmp_path: Path
 
     assert len(rows) == 250
     assert not [row for row in rows if row[0].startswith("c")]
-    # The default short listing still truncates — only the picker went uncapped.
-    assert len(resume_mod.recent_sessions(tmp_path)) == 10
+    # The DEFAULT is now the untruncated answer, and this assertion is the
+    # reason it had to change: it previously pinned the truncating default as
+    # correct, which is what made the picker's bare call look right while it
+    # silently returned ten rows. A caller that says nothing gets everything;
+    # a short list is opt-in at the call site that wants one.
+    assert len(resume_mod.recent_sessions(tmp_path)) == 250
+    assert len(resume_mod.recent_sessions(tmp_path, limit=None)) == 250
+    assert len(resume_mod.recent_sessions(tmp_path, limit=10)) == 10
 
 
 def test_a_subagent_marker_is_parsed_not_merely_detected(tmp_path: Path) -> None:

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -6594,6 +6594,64 @@ async def test_a_bare_resume_opens_the_picker_naming_each_session(tmp_path, monk
 
 
 @pytest.mark.asyncio
+async def test_the_picker_lists_a_store_far_larger_than_any_default_limit(
+    tmp_path, monkeypatch
+) -> None:
+    """The picker shows the WHOLE store, exercised through the real command.
+
+    This is the regression that two review rounds and a full CI run missed,
+    because every other fixture here has fewer rows than the smallest cap: the
+    reach fix removed ``RESUME_PICKER_LIMIT`` but ``recent_session_rows``
+    defaulted to ``limit=10`` and ``_cmd_resume`` passed no argument, so the
+    "uncapped" picker showed ten rows on a 236-session store — strictly worse
+    than the cap of 200 it replaced.
+
+    250 sessions, chosen to exceed every limit in the codebase (10 recovery,
+    100 daemon summaries, 200 daemon search) so no default can satisfy it
+    accidentally. Driven by typing ``/resume`` rather than by calling
+    ``recent_session_rows`` directly: a parameterised stand-in for the product
+    path is exactly what let this through the first time.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    total = 250
+    for index in range(total):
+        _seed_session(tmp_path, f"s{index:04d}", prompt=f"session number {index}")
+
+    session = FakeSession()
+    app = OperatorApp(
+        lambda: _factory(session),
+        resume_factory=_resume_factory([]),
+    )
+    async with app.run_test(size=(90, 24)) as pilot:
+        await pilot.pause()
+        app.query_one(Editor).focus()
+        for key in "/resume":
+            await pilot.press(key)
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+        picker = app.screen
+        assert isinstance(picker, SessionPickerScreen)
+
+        # Every session is HELD, which is what makes it filterable: the filter
+        # only ever scans the rows the screen was handed.
+        assert (
+            len(picker.visible_rows) == total
+        ), f"picker holds {len(picker.visible_rows)} of {total} sessions"
+        # And the header says so, rather than reporting a truncated total.
+        assert f"{total:,} sessions" in "\n".join(picker.render_lines_for_test())
+
+        # The oldest session — the one furthest past every cap — is reachable by
+        # filtering, which is the user-visible failure being fixed ("a session I
+        # know exists cannot be found").
+        oldest = f"s{total - 1:04d}"
+        picker.set_query(oldest)
+        await pilot.pause()
+        assert [row.id for row in picker.visible_rows] == [oldest]
+
+
+@pytest.mark.asyncio
 async def test_choosing_in_the_picker_resumes_that_session(tmp_path, monkeypatch) -> None:
     """Enter on a row is what actually resumes it — the picker's whole job."""
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -6652,6 +6652,66 @@ async def test_the_picker_lists_a_store_far_larger_than_any_default_limit(
 
 
 @pytest.mark.asyncio
+async def test_typing_a_typo_reaches_the_soft_tier(tmp_path, monkeypatch) -> None:
+    """The soft tier must be REACHABLE from a keyboard, not merely harmless.
+
+    Two prior regression tests pinned the absence of harm (no row withdrawn, no
+    cursor swap) and passed with the soft tier replaced by ``return False`` —
+    deleting the feature satisfies them. Nothing asserted the tier ever runs.
+
+    It did not. A gate that decided once at the START of a typing run froze the
+    tier off for every word a user can type: a run begins at one character, and
+    every single character has exact hits in a real store, so the tier was
+    unreachable. Zero ``SoftSearchIndex.search`` calls across 25 typed runs.
+
+    Drives real ``pilot.press`` keystrokes, because ``set_query("classifer")``
+    jumps straight to the final query and cannot observe a per-run latch at
+    all — which is exactly how that bug was validated as working.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    # One session whose body carries the correctly-spelled word, plus filler so
+    # the early keystrokes have exact hits and the run latches off under the
+    # old gate.
+    _seed_session(tmp_path, "aaaa0001", prompt="improve the adm classifier throughput")
+    for index in range(5):
+        _seed_session(tmp_path, f"bbbb{index:04d}", prompt="classroom scheduling notes")
+
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session), resume_factory=_resume_factory([]))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.query_one(Editor).focus()
+        for key in "/resume":
+            await pilot.press(key)
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+        picker = app.screen
+        assert isinstance(picker, SessionPickerScreen)
+
+        calls: list[str] = []
+        real_search = picker._soft_index.search
+
+        def counting(digests, query):
+            calls.append(query)
+            return real_search(digests, query)
+
+        picker._soft_index.search = counting  # type: ignore[method-assign]
+
+        # `classifer` is a typo: no session contains it as a substring, so only
+        # the soft tier can find the `classifier` session.
+        for key in "classifer":
+            await pilot.press(key)
+            await pilot.pause()
+
+        assert calls, "the soft tier never ran while the user typed a typo"
+        assert "aaaa0001" in {
+            row.id for row in picker.visible_rows
+        }, "a typo'd query found nothing; soft matching is unreachable by keyboard"
+
+
+@pytest.mark.asyncio
 async def test_choosing_in_the_picker_resumes_that_session(tmp_path, monkeypatch) -> None:
     """Enter on a row is what actually resumes it — the picker's whole job."""
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -6559,6 +6559,33 @@ def _seed_session(tmp_path: Path, session_id: str, prompt: str = "") -> None:
     (sess_dir / "transcript.jsonl").write_text(body)
 
 
+def _append_turn(tmp_path: Path, session_id: str, text: str) -> None:
+    """Add a later message to an existing seeded session.
+
+    The picker names a row by its FIRST user message, so anything appended here
+    lands in the searchable body without changing the visible name. That is the
+    distinction some fixtures need: on a real store an incidental keyword hit is
+    a word buried in a conversation, not the title of one.
+    """
+    line = (
+        json.dumps(
+            {
+                "id": "e2",
+                "ts": 1,
+                "type": "message",
+                "payload": {
+                    "kind": "message",
+                    "role": "user",
+                    "content": [{"text": text}],
+                },
+            }
+        )
+        + "\n"
+    )
+    with (tmp_path / "sessions" / session_id / "transcript.jsonl").open("a") as handle:
+        handle.write(line)
+
+
 @pytest.mark.asyncio
 async def test_a_bare_resume_opens_the_picker_naming_each_session(tmp_path, monkeypatch) -> None:
     """A bare ``/resume`` opens the picker instead of printing ids.
@@ -8664,3 +8691,56 @@ async def test_route_independence_holds_on_a_real_store_shape(tmp_path, monkeypa
     )
     # And the cursor row specifically, since that is what Enter resumes.
     assert (forward or [None])[0] == (backspaced or [None])[0]
+
+
+@pytest.mark.asyncio
+async def test_a_typo_is_findable_despite_an_incidental_body_hit(tmp_path, monkeypatch) -> None:
+    """The recall regression that four rounds of guards did not catch (F15).
+
+    Gating the soft tier on "the exact tiers found nothing" reads as correct and
+    destroys typo search on a real store. The exact tier also admits BODY
+    substring hits, and almost every typed token appears incidentally somewhere
+    in a corpus of conversations — so one unrelated session mentioning the typo
+    in passing silenced the tier for the whole query, and the session the user
+    was actually looking for became unreachable.
+
+    The fixture encodes exactly that: `mispelled` appears as a body substring in
+    one unrelated session (the incidental hit) while the target session is
+    reachable only by edit distance. A gate that stops at "some exact hit
+    exists" returns the decoy and hides the target.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    # The decoy: the typo appears in the BODY only, never in the row's name.
+    # That distinction is the whole point — the picker names a row by its first
+    # user message, so a one-line fixture would put the typo in the name and
+    # test a different gate than the one that fails on a real store, where the
+    # incidental hit is a word buried in a long conversation.
+    _seed_session(tmp_path, "dec00001", prompt="quarterly planning notes")
+    _append_turn(tmp_path, "dec00001", "a paragraph that mentions mispelled in passing")
+    # The target: contains the correct spelling only, reachable by soft match.
+    for index in range(5):
+        _seed_session(tmp_path, f"tgt{index:05d}", prompt=f"the misspelled word report {index}")
+
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session), resume_factory=_resume_factory([]))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.query_one(Editor).focus()
+        for key in "/resume":
+            await pilot.press(key)
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        picker = app.screen
+        assert isinstance(picker, SessionPickerScreen)
+
+        for key in "mispelled":
+            await pilot.press(key)
+            await pilot.pause()
+
+        shown = {row.id for row in picker.visible_rows}
+        targets = {f"tgt{index:05d}" for index in range(5)}
+        assert shown & targets, (
+            "a typo'd query returned only the incidental body hit; the session the "
+            f"user was looking for is unreachable. shown={sorted(shown)}"
+        )

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -8601,3 +8601,66 @@ async def test_effective_model_change_repaints_the_band() -> None:
         )
         await pilot.pause()
         assert app._status._model_label == "test/model"
+
+
+@pytest.mark.asyncio
+async def test_route_independence_holds_on_a_real_store_shape(tmp_path, monkeypatch) -> None:
+    """Route independence, exercised against a store shaped like a real one.
+
+    D12's finding, taken seriously: the previous guards ran on 16- and 50-row
+    fixtures whose digests were two hand-written strings, and three consecutive
+    rounds shipped defects those fixtures could not express. This builds a store
+    with the properties that actually produce the bug — many sessions, digests
+    that share prefixes, and a query whose exact matches vanish partway through
+    so the soft tier engages mid-word.
+
+    Drives real keystrokes through `/resume` and compares two routes to the same
+    visible query. It fails on `bc55a183`, where ranking read run history.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    # 120 sessions: 20 that match `watch` exactly and stop there, 100 that only
+    # a bounded edit-distance search can reach. Enough rows that the page window
+    # matters and the recency tie-break has something to order.
+    # `watch` and `watchl` both have exact hits, `watchlq` does not. So the two
+    # routes reach the final query having latched the soft tier at DIFFERENT
+    # points: typing straight to `watchl` never latches, while `watchlq` latches
+    # and then backspaces into `watchl` carrying that state. Any rule that reads
+    # run history diverges here; a rule that is a function of the query cannot.
+    # Getting this wrong is why the first version of this guard passed on the
+    # broken head — the fixture has to make the two routes actually differ.
+    for index in range(20):
+        _seed_session(tmp_path, f"aa{index:06d}", prompt=f"watchl the retention sweep {index}")
+    for index in range(100):
+        _seed_session(tmp_path, f"bb{index:06d}", prompt=f"wotchel batch rollup {index}")
+
+    async def route(extra: str | None) -> list[str]:
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session), resume_factory=_resume_factory([]))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            app.query_one(Editor).focus()
+            for key in "/resume":
+                await pilot.press(key)
+            await pilot.press("enter")
+            await pilot.pause()
+            await pilot.pause()
+            picker = app.screen
+            assert isinstance(picker, SessionPickerScreen)
+            for key in "watchl" if extra is None else "watchl" + extra:
+                await pilot.press(key)
+                await pilot.pause()
+            if extra is not None:
+                for _ in extra:
+                    await pilot.press("backspace")
+                    await pilot.pause()
+            return [row.id for row in picker.visible_rows]
+
+    forward = await route(None)
+    backspaced = await route("q")
+
+    assert forward == backspaced, (
+        "the same visible query rendered differently depending on the route: "
+        f"{forward[:5]} vs {backspaced[:5]}"
+    )
+    # And the cursor row specifically, since that is what Enter resumes.
+    assert (forward or [None])[0] == (backspaced or [None])[0]

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -8715,8 +8715,15 @@ async def test_a_typo_is_findable_despite_an_incidental_body_hit(tmp_path, monke
     # user message, so a one-line fixture would put the typo in the name and
     # test a different gate than the one that fails on a real store, where the
     # incidental hit is a word buried in a long conversation.
-    _seed_session(tmp_path, "dec00001", prompt="quarterly planning notes")
-    _append_turn(tmp_path, "dec00001", "a paragraph that mentions mispelled in passing")
+    # THREE decoys, not one: the gate tolerates a couple of incidental hits
+    # before it treats them as a real answer, so a single-decoy fixture cannot
+    # tell the shipped floor from a floor of one. Each carries the typo in the
+    # BODY only — the picker names a row by its first user message, so a
+    # one-line fixture would put the typo in the NAME and exercise a different
+    # path than the one that fails on a real store.
+    for decoy in range(3):
+        _seed_session(tmp_path, f"dec{decoy:05d}", prompt=f"quarterly planning notes {decoy}")
+        _append_turn(tmp_path, f"dec{decoy:05d}", "a paragraph that mentions mispelled in passing")
     # The target: contains the correct spelling only, reachable by soft match.
     for index in range(5):
         _seed_session(tmp_path, f"tgt{index:05d}", prompt=f"the misspelled word report {index}")
@@ -8743,4 +8750,52 @@ async def test_a_typo_is_findable_despite_an_incidental_body_hit(tmp_path, monke
         assert shown & targets, (
             "a typo'd query returned only the incidental body hit; the session the "
             f"user was looking for is unreachable. shown={sorted(shown)}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_one_incidental_name_hit_does_not_silence_the_typo_tier(
+    tmp_path, monkeypatch
+) -> None:
+    """The floor, tested where it actually applies.
+
+    A single exact hit on a NAME is as often incidental as deliberate: on the
+    real store `spit` matches "Failover Triggering Despite Available Account",
+    and treating that as a real answer hid every `split` session behind it. So
+    the tier keeps running until a few precise hits accumulate.
+
+    The sibling body-hit test cannot cover this: with no name/id match at all
+    the tier runs whatever the floor is, so that fixture cannot tell a floor of
+    three from a floor of one. This one puts the typo in a NAME, which is the
+    only shape where the floor is the deciding factor.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    # One incidental NAME hit: "despite" contains "spit".
+    _seed_session(tmp_path, "dec00001", prompt="Failover triggering despite available account")
+    # The sessions the user means, reachable only by edit distance from `spit`.
+    for index in range(5):
+        _seed_session(tmp_path, f"tgt{index:05d}", prompt=f"split the transcript window {index}")
+
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session), resume_factory=_resume_factory([]))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.query_one(Editor).focus()
+        for key in "/resume":
+            await pilot.press(key)
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        picker = app.screen
+        assert isinstance(picker, SessionPickerScreen)
+
+        for key in "spit":
+            await pilot.press(key)
+            await pilot.pause()
+
+        shown = {row.id for row in picker.visible_rows}
+        targets = {f"tgt{index:05d}" for index in range(5)}
+        assert shown & targets, (
+            "one incidental name hit silenced the soft tier, so the sessions the "
+            f"user meant are unreachable. shown={sorted(shown)}"
         )

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -28,7 +28,6 @@ from local_operator.resume import (
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.session_picker import (
     _MARKER_LEGEND,
-    _SOFT_TIER_MIN_HITS,
     BODY_MATCH_MARKER,
     CARD_MAX_HEIGHT_FRACTION,
     CARD_PADDING_ROWS,
@@ -1247,10 +1246,10 @@ async def test_the_soft_tier_is_skipped_once_the_exact_tiers_fill_a_page() -> No
 
     Since the picker went uncapped that build sat on the first character typed.
     It is deferred behind the cheap tiers: a query that already returns a
-    screenful has nothing for soft matching to rescue, and the extra recall
-    would land below the fold.
+    query the exact tiers can answer at all has nothing for soft matching to
+    rescue.
     """
-    rows = [_row(f"s{i:03d}", f"classifier run {i}") for i in range(_SOFT_TIER_MIN_HITS + 5)]
+    rows = [_row(f"s{i:03d}", f"classifier run {i}") for i in range(15)]
     digests = {row.id: "body text" for row in rows}
     app = _PickerHost(rows, digests)
     async with app.run_test(size=(100, 30)) as pilot:
@@ -1342,3 +1341,75 @@ async def test_a_large_row_set_does_not_move_a_row_under_the_cursor() -> None:
         await pilot.pause()
         assert [r.id for r in screen.visible_rows] == first
         assert screen.selected_id() == selected
+
+
+@pytest.mark.asyncio
+async def test_the_result_list_never_grows_as_the_user_types() -> None:
+    """The filter must narrow monotonically within a typing run.
+
+    The first soft-tier gate fired when the exact tiers returned fewer than a
+    page, which is a threshold typing CROSSES: on the operator's real store,
+    `watc` and `watch` showed 41 rows and `watchl` showed 1519 — the list grew
+    twentyfold on a longer query, every row acquired a body-match marker, and
+    the card changed height under the cursor.
+
+    Gating on ZERO exact hits removes the boundary: once a query has an exact
+    hit, every extension either keeps some (still exact-only) or drops to none
+    (soft rescues from an empty list, which can only add to nothing).
+    """
+    rows = [_row(f"s{i:03d}", f"session {i}") for i in range(16)]
+    # Ten digests carry `watch` and stop there; six are an edit-distance
+    # neighbour the soft tier can reach but the exact tier never sees. This is
+    # the shape that made the shipped gate flip mid-word.
+    digests = {
+        row.id: ("watch sweep evicted" if i < 10 else "watch5 sweep evicted")
+        for i, row in enumerate(rows)
+    }
+    app = _PickerHost(rows, digests)
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen = await app.open_picker()
+        await pilot.pause()
+
+        counts = []
+        for query in ("wat", "watc", "watch", "watchi"):
+            screen.set_query(query)
+            await pilot.pause()
+            counts.append(len(screen.visible_rows))
+
+        assert counts == sorted(counts, reverse=True), f"the list grew on a longer query: {counts}"
+
+
+@pytest.mark.asyncio
+async def test_the_soft_tier_runs_only_when_the_exact_tiers_find_nothing() -> None:
+    """The gate itself, stated directly: any exact hit suppresses the soft tier,
+    and no exact hit runs it. Pins the condition the D1 monotonicity argument
+    rests on, so a future change to the threshold fails here rather than in a
+    user's typing run."""
+    rows = [_row("aaa1", "classifier work"), _row("bbb2", "unrelated")]
+    digests = {"aaa1": "improve adm classifier throughput"}
+    app = _PickerHost(rows, digests)
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen = await app.open_picker()
+        await pilot.pause()
+        calls: list[str] = []
+        real = screen._soft_index.search
+
+        def counting(digests_arg, query):
+            calls.append(query)
+            return real(digests_arg, query)
+
+        screen._soft_index.search = counting  # type: ignore[method-assign]
+
+        # One exact hit is enough to suppress the tier, even though the result
+        # is far short of a page — the old gate would have run it here.
+        screen.set_query("classifier")
+        await pilot.pause()
+        assert len(screen.visible_rows) == 1
+        assert calls == [], "the soft tier ran despite an exact hit"
+
+        # No exact hit anywhere: the tier runs and rescues the typo.
+        screen.set_query("classifer")
+        await pilot.pause()
+        assert [r.id for r in screen.visible_rows] == ["aaa1"]
+        assert calls == ["classifer"], "the soft tier did not run for a typo"
+

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -1245,9 +1245,8 @@ async def test_the_soft_tier_is_skipped_once_the_exact_tiers_fill_a_page() -> No
     now reaches uncapped, against ~5 ms for the exact tier.
 
     Since the picker went uncapped that build sat on the first character typed.
-    It is deferred behind the cheap tiers: a query that already returns a
-    query the exact tiers can answer at all has nothing for soft matching to
-    rescue.
+    It is deferred behind the cheap tiers: a query the exact tiers can answer at
+    all has nothing for soft matching to rescue.
     """
     rows = [_row(f"s{i:03d}", f"classifier run {i}") for i in range(15)]
     digests = {row.id: "body text" for row in rows}
@@ -1299,14 +1298,16 @@ async def test_the_header_tally_reports_the_stores_true_total() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         screen = await app.open_picker()
         await pilot.pause()
-        assert "2700 sessions" in "\n".join(screen.render_lines_for_test())
+        # Grouped: the separator is part of the fix for reading a 4-digit
+        # total at a glance (design round 1, D4).
+        assert "2,700 sessions" in "\n".join(screen.render_lines_for_test())
 
         screen.set_query("session 1")
         await pilot.pause()
         lines = "\n".join(screen.render_lines_for_test())
         shown = len(screen.visible_rows)
-        assert f"of {len(rows)}" in lines  # header tally: the store total
-        assert f"of {shown}" in lines  # position counter: the filtered count
+        assert f"of {len(rows):,}" in lines  # header tally: the store total
+        assert f"of {shown:,}" in lines  # position counter: the filtered count
 
 
 @pytest.mark.asyncio
@@ -1413,3 +1414,27 @@ async def test_the_soft_tier_runs_only_when_the_exact_tiers_find_nothing() -> No
         assert [r.id for r in screen.visible_rows] == ["aaa1"]
         assert calls == ["classifer"], "the soft tier did not run for a typo"
 
+
+def test_the_paging_hint_outranks_the_marker_legend_once_the_list_scrolls() -> None:
+    """The paging hint was offered where paging does nothing and withdrawn where
+    it is the fastest way through the list.
+
+    A scrolling list is also long enough to contain a marked row, so the legend
+    shed `pgup/pgdn` to make room for itself. Uncapping the store made that the
+    normal case rather than the rare one (design round 1, D3).
+    """
+    width = 62  # narrow enough that legend and paging cannot both fit
+
+    not_scrolling = [key for key, _ in _footer_hints(width, has_marked=True, scrolls=False)]
+    scrolling = [key for key, _ in _footer_hints(width, has_marked=True, scrolls=True)]
+
+    assert _MARKER_LEGEND[0] in not_scrolling, "the legend should win when nothing scrolls"
+    assert "pgup/pgdn" not in not_scrolling
+
+    assert "pgup/pgdn" in scrolling, "paging must survive when the list actually pages"
+    assert _MARKER_LEGEND[0] not in scrolling
+
+    # A wide card keeps both regardless: the reorder is a shed policy, not a
+    # removal, so nothing is lost when there is room for everything.
+    wide = [key for key, _ in _footer_hints(100, has_marked=True, scrolls=True)]
+    assert "pgup/pgdn" in wide and _MARKER_LEGEND[0] in wide

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -25,7 +25,6 @@ from local_operator.resume import (
     recent_session_rows,
     session_name,
 )
-from local_operator.session.search_index import search_digests
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.session_picker import (
     _MARKER_LEGEND,
@@ -1513,13 +1512,16 @@ async def test_the_soft_tier_runs_only_when_the_exact_tiers_are_empty() -> None:
             await pilot.press(key)
             await pilot.pause()
             typed += key
-            # Whether the cheap tiers answered THIS query, computed the way the
-            # widget computes it rather than re-derived from the fixture.
-            exact = filter_rows(rows, typed, search_digests(digests, typed))
-            if exact:
-                assert typed not in ran, f"soft tier ran at {typed!r} despite exact hits"
+            # The gate is NAME/ID hits, not any exact hit. Gating on any hit
+            # (which includes body substrings) is what destroyed typo recall:
+            # one unrelated conversation mentioning the query silenced the tier
+            # for the whole store. Computed the way the widget computes it so
+            # the two cannot drift.
+            precise = [row for row in rows if typed in row.name.lower() or typed in row.id.lower()]
+            if precise:
+                assert typed not in ran, f"soft tier ran at {typed!r} despite a name/id hit"
             else:
-                assert typed in ran, f"soft tier did not run at {typed!r} with no exact hits"
+                assert typed in ran, f"soft tier did not run at {typed!r} with no name/id hit"
 
 
 def test_the_paging_hint_outranks_the_marker_legend_once_the_list_scrolls() -> None:

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -25,6 +25,7 @@ from local_operator.resume import (
     recent_session_rows,
     session_name,
 )
+from local_operator.session.search_index import search_digests
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.session_picker import (
     _MARKER_LEGEND,
@@ -1431,93 +1432,94 @@ async def test_the_result_list_never_grows_as_the_user_types() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_typing_run_never_swaps_the_row_under_the_cursor() -> None:
-    """The harm D6 named, asserted directly rather than via the row count.
+async def test_the_same_query_renders_identically_by_either_route() -> None:
+    """The property this surface actually guarantees: order is a function of the
+    QUERY, not of the route taken to it.
 
-    A user types, the row they want is on top, and they press enter by reflex.
-    If the last keystroke re-homed the cursor onto a different session they
-    resume the wrong one — the failure ``session_picker``'s ordering invariant
-    exists to prevent, and the same class of harm as the original bug.
+    A user cannot know which route they took, so a picker that answers the same
+    visible query two ways is one they cannot reason about at all. Reaching
+    `watchl` by typing it, and by typing `watchlq` then backspacing, must give
+    byte-identical rows in byte-identical order.
+
+    This replaces a test asserting that the cursor never lands on a row absent
+    one keystroke earlier. That property was real but could only be held by
+    ranking on run history, which is exactly what made the same query render
+    two ways (D11). The two are not both satisfiable by ordering; see
+    ``_soft_tier_wanted``. What remains of the displacement concern is recorded
+    honestly in that docstring rather than asserted here falsely.
     """
-    # The genuine matches are the OLDEST rows, so when soft neighbours flood in
-    # they outrank the real matches on recency and the top row changes identity.
-    # With the real matches newest, a flood is invisible at the cursor and the
-    # test would pass on a gate that evicts them — the trap this test exists to
-    # avoid being caught by.
     rows = [_row(f"s{i:03d}", f"session {i}", age_s=60.0 * (100 - i)) for i in range(50)]
-    digests = {}
-    for i, row in enumerate(rows):
-        digests[row.id] = "watch the retention sweep" if i >= 40 else "wotchel batch rollup"
-    app = _PickerHost(rows, digests)
-    async with app.run_test(size=(100, 30)) as pilot:
-        screen = await app.open_picker()
-        await pilot.pause()
+    digests = {
+        row.id: ("watch the retention sweep" if i >= 40 else "wotchel batch rollup")
+        for i, row in enumerate(rows)
+    }
 
-        tops: list[str | None] = []
-        # Typed, for the reason above: a per-run latch is invisible to a test
-        # that sets each whole query directly.
-        seen_ids: list[set[str]] = []
-        for key in "watchl":
-            await pilot.press(key)
+    async def route(extra: str | None) -> list[str]:
+        app = _PickerHost(rows, digests)
+        async with app.run_test(size=(100, 30)) as pilot:
+            screen = await app.open_picker()
             await pilot.pause()
-            visible = screen.visible_rows
-            tops.append(visible[0].id if visible else None)
-            seen_ids.append({row.id for row in visible})
+            for key in "watchl" if extra is None else "watchl" + extra:
+                await pilot.press(key)
+                await pilot.pause()
+            if extra is not None:
+                for _ in extra:
+                    await pilot.press("backspace")
+                    await pilot.pause()
+            return [row.id for row in screen.visible_rows]
 
-        # The cursor moving is not itself the harm: narrowing legitimately
-        # re-homes it to the best remaining match, and that row was already on
-        # screen. The harm is it landing on a session the previous keystroke was
-        # NOT showing, because then a reflexive enter resumes something the user
-        # never saw.
-        for index in range(1, len(tops)):
-            top = tops[index]
-            if top is not None and top not in seen_ids[index - 1]:
-                raise AssertionError(
-                    f"cursor landed on {top}, which was not on screen one "
-                    f"keystroke earlier: {tops}"
-                )
+    forward = await route(None)
+    backspaced = await route("q")
+    assert (
+        forward == backspaced
+    ), f"the same query rendered differently by route: {forward[:5]} vs {backspaced[:5]}"
 
 
 @pytest.mark.asyncio
-async def test_the_soft_tier_runs_only_when_the_exact_tiers_find_nothing() -> None:
-    """The gate itself, stated directly: any exact hit suppresses the soft tier,
-    and no exact hit runs it. Pins the condition the D1 monotonicity argument
-    rests on, so a future change to the threshold fails here rather than in a
-    user's typing run."""
-    rows = [_row("aaa1", "classifier work"), _row("bbb2", "unrelated")]
-    digests = {"aaa1": "improve adm classifier throughput"}
+async def test_the_soft_tier_runs_only_when_the_exact_tiers_are_empty() -> None:
+    """The one-line rule the gate implements, observed rather than reconstructed.
+
+    The soft tier runs ONLY for a query the cheap tiers cannot answer at all.
+    That is what bounds the disruption: with exact hits the user keeps exactly
+    those, and with none there is nothing on screen for an addition to displace.
+
+    Deliberately NOT asserting "the list never grows" or "no row appears that
+    was absent one keystroke earlier". Both were asserted in earlier rounds and
+    both are false on real data (`sesion` typed goes 83 to 129 rows with the
+    tier active on both sides). A guard stating a false invariant passes only
+    until someone measures it.
+    """
+    rows = [_row(f"s{i:03d}", f"session {i}", age_s=60.0 * (100 - i)) for i in range(50)]
+    digests = {
+        row.id: ("watch the retention sweep" if i >= 40 else "wotchel batch rollup")
+        for i, row in enumerate(rows)
+    }
     app = _PickerHost(rows, digests)
     async with app.run_test(size=(100, 30)) as pilot:
         screen = await app.open_picker()
         await pilot.pause()
-        calls: list[str] = []
+
+        ran: list[str] = []
         real = screen._soft_index.search
 
         def counting(digests_arg, query):
-            calls.append(query)
+            ran.append(query)
             return real(digests_arg, query)
 
         screen._soft_index.search = counting  # type: ignore[method-assign]
 
-        # Typed, not set: the gate is decided across a typing RUN, so setting a
-        # whole query at once cannot observe it. That shape is what let a tier
-        # that never ran be validated as working (F10).
-        for key in "classifier":
+        typed = ""
+        for key in "watchl":
             await pilot.press(key)
             await pilot.pause()
-        assert len(screen.visible_rows) == 1
-        assert calls == [], "the soft tier ran while the exact tiers had a hit"
-
-        # Backspace to a shorter query, then type a typo: no exact hit anywhere,
-        # so the tier latches on and rescues it.
-        for _ in range(3):  # back to "classi"
-            await pilot.press("backspace")
-            await pilot.pause()
-        for key in "fer":
-            await pilot.press(key)
-            await pilot.pause()
-        assert [r.id for r in screen.visible_rows] == ["aaa1"]
-        assert calls, "the soft tier did not run for a typo"
+            typed += key
+            # Whether the cheap tiers answered THIS query, computed the way the
+            # widget computes it rather than re-derived from the fixture.
+            exact = filter_rows(rows, typed, search_digests(digests, typed))
+            if exact:
+                assert typed not in ran, f"soft tier ran at {typed!r} despite exact hits"
+            else:
+                assert typed in ran, f"soft tier did not run at {typed!r} with no exact hits"
 
 
 def test_the_paging_hint_outranks_the_marker_legend_once_the_list_scrolls() -> None:

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -28,6 +28,7 @@ from local_operator.resume import (
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.session_picker import (
     _MARKER_LEGEND,
+    _SOFT_TIER_MIN_HITS,
     BODY_MATCH_MARKER,
     CARD_MAX_HEIGHT_FRACTION,
     CARD_PADDING_ROWS,
@@ -1236,3 +1237,108 @@ def test_footer_legend_drops_before_the_movement_and_action_keys() -> None:
     assert (_MARKER_LEGEND[0], "") not in narrow
     assert ("enter", "resume") in narrow
     assert ("esc", "cancel") in narrow
+
+
+@pytest.mark.asyncio
+async def test_the_soft_tier_is_skipped_once_the_exact_tiers_fill_a_page() -> None:
+    """The soft tier's first call tokenises every digest and builds a vocabulary
+    over them — 324 ms and 95 MB resident over the 2681-digest store the picker
+    now reaches uncapped, against ~5 ms for the exact tier.
+
+    Since the picker went uncapped that build sat on the first character typed.
+    It is deferred behind the cheap tiers: a query that already returns a
+    screenful has nothing for soft matching to rescue, and the extra recall
+    would land below the fold.
+    """
+    rows = [_row(f"s{i:03d}", f"classifier run {i}") for i in range(_SOFT_TIER_MIN_HITS + 5)]
+    digests = {row.id: "body text" for row in rows}
+    app = _PickerHost(rows, digests)
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen = await app.open_picker()
+        await pilot.pause()
+        calls: list[str] = []
+        real = screen._soft_index.search
+
+        def counting(digests_arg, query):
+            calls.append(query)
+            return real(digests_arg, query)
+
+        screen._soft_index.search = counting  # type: ignore[method-assign]
+        screen.set_query("classifier")
+        await pilot.pause()
+
+        assert len(screen.visible_rows) == len(rows)
+        assert calls == [], "the soft tier ran for a query the exact tiers already answered"
+
+
+@pytest.mark.asyncio
+async def test_the_soft_tier_still_runs_when_the_exact_tiers_come_up_short() -> None:
+    """The other half of the gate: a typo the exact tiers cannot answer must
+    still reach the soft tier, or deferring it would silently cost recall."""
+    rows = [_row("aaa1", "vague title"), _row("bbb2", "another")]
+    digests = {"aaa1": "improve adm classifier throughput"}
+    app = _PickerHost(rows, digests)
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen = await app.open_picker()
+        await pilot.pause()
+        screen.set_query("classifer")  # typo: no exact hit anywhere
+        await pilot.pause()
+        assert [r.id for r in screen.visible_rows] == ["aaa1"]
+        assert screen.body_matched_ids == {"aaa1"}
+
+
+@pytest.mark.asyncio
+async def test_the_header_tally_reports_the_stores_true_total() -> None:
+    """Once the cap is gone ``_all`` IS the store's user-session total, so the
+    counter stops reporting a number that is not the total and never said so.
+
+    The filtered ``showing a-b of N`` counter keeps reporting the FILTERED
+    count — the two answer different questions and must not converge.
+    """
+    rows = [_row(f"s{i:04d}", f"session {i}") for i in range(2700)]
+    app = _PickerHost(rows)
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen = await app.open_picker()
+        await pilot.pause()
+        assert "2700 sessions" in "\n".join(screen.render_lines_for_test())
+
+        screen.set_query("session 1")
+        await pilot.pause()
+        lines = "\n".join(screen.render_lines_for_test())
+        shown = len(screen.visible_rows)
+        assert f"of {len(rows)}" in lines  # header tally: the store total
+        assert f"of {shown}" in lines  # position counter: the filtered count
+
+
+@pytest.mark.asyncio
+async def test_a_large_row_set_does_not_move_a_row_under_the_cursor() -> None:
+    """R1 at the scale the uncapped picker now reaches.
+
+    A fixed query must order rows identically across repaints AND a resize, and
+    the row under the cursor must keep its identity — a row moving out from
+    under the cursor is how a user resumes the wrong session.
+    """
+    rows = [_row(f"s{i:04d}", f"session {i} work") for i in range(2700)]
+    digests = {row.id: f"body {row.id}" for row in rows}
+    app = _PickerHost(rows, digests)
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen = await app.open_picker()
+        await pilot.pause()
+        screen.set_query("session 12")
+        await pilot.pause()
+        first = [r.id for r in screen.visible_rows]
+        screen.action_move(1)
+        screen.action_move(1)
+        selected = screen.selected_id()
+
+        screen._repaint()
+        screen._repaint()
+        assert [r.id for r in screen.visible_rows] == first
+        assert screen.selected_id() == selected
+
+        # A resize repaints at a different width; ordering is a pure function of
+        # the query, so it must survive that too.
+        await pilot.resize_terminal(60, 30)
+        await pilot.pause()
+        assert [r.id for r in screen.visible_rows] == first
+        assert screen.selected_id() == selected

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -1391,22 +1391,43 @@ async def test_the_result_list_never_grows_as_the_user_types() -> None:
 
         counts: list[int] = []
         seen: set[str] | None = None
-        appeared: list[tuple[str, int]] = []
-        for query in ("wa", "wat", "watc", "watch", "watchl"):
-            screen.set_query(query)
+        removed: list[tuple[str, int]] = []
+        # Real keystrokes, not ``set_query`` per whole word: the gate this
+        # guards is decided per typing RUN, and jumping straight to each final
+        # query cannot observe a run at all. That shape is how a tier that
+        # never ran was validated as working for two rounds.
+        typed = ""
+        for key in "watchl":
+            await pilot.press(key)
+            typed += key
             await pilot.pause()
+            query = typed
             ids = {row.id for row in screen.visible_rows}
             counts.append(len(ids))
-            if seen is not None and (ids - seen):
-                appeared.append((query, len(ids - seen)))
+            if seen is not None:
+                gone = seen - ids
+                # A row leaving because it genuinely stopped matching the longer
+                # query is narrowing, not eviction. Eviction is a row leaving on
+                # a keystroke that ALSO admitted new ones — the list swapping
+                # its contents rather than narrowing them.
+                if gone and (ids - seen):
+                    removed.append((query, len(gone)))
             seen = ids
 
-        # The count must never rise on a longer query.
-        assert counts == sorted(counts, reverse=True), f"the list grew on a longer query: {counts}"
-        # And the stronger statement the count alone does not make: no row may
-        # appear that was absent one keystroke earlier. A same-size swap would
-        # satisfy the count check while still moving the row under the cursor.
-        assert not appeared, f"rows appeared mid-typing: {appeared}"
+        # The property is NOT "the count never rises". Once the soft tier
+        # latches on (at the first keystroke whose exact tiers find nothing) it
+        # legitimately admits rows, and it must — a gate that kept the count
+        # monotonic by never running the tier made typo search unreachable from
+        # a keyboard, which is a worse bug than a count that goes up.
+        #
+        # What must hold is that rows are never admitted while the user still
+        # has results to read: growth is only allowed out of an EMPTY list,
+        # where there is nothing on screen to displace.
+        # Rows may be ADDED when the soft tier latches on — that is the tier
+        # doing its job, and it is what makes a typo findable. What must never
+        # happen is a row the user was already reading being REMOVED to make
+        # room, which is the eviction that swapped the cursor in round 2.
+        assert not removed, f"rows the user was already shown were withdrawn: {removed}"
 
 
 @pytest.mark.asyncio
@@ -1433,16 +1454,28 @@ async def test_a_typing_run_never_swaps_the_row_under_the_cursor() -> None:
         await pilot.pause()
 
         tops: list[str | None] = []
-        for query in ("wat", "watc", "watch", "watchl"):
-            screen.set_query(query)
+        # Typed, for the reason above: a per-run latch is invisible to a test
+        # that sets each whole query directly.
+        seen_ids: list[set[str]] = []
+        for key in "watchl":
+            await pilot.press(key)
             await pilot.pause()
             visible = screen.visible_rows
             tops.append(visible[0].id if visible else None)
+            seen_ids.append({row.id for row in visible})
 
-        # The top row may become None (the list legitimately empties as the
-        # query stops matching), but it must never become a DIFFERENT session.
-        identities = [top for top in tops if top is not None]
-        assert len(set(identities)) == 1, f"the row under the cursor changed identity: {tops}"
+        # The cursor moving is not itself the harm: narrowing legitimately
+        # re-homes it to the best remaining match, and that row was already on
+        # screen. The harm is it landing on a session the previous keystroke was
+        # NOT showing, because then a reflexive enter resumes something the user
+        # never saw.
+        for index in range(1, len(tops)):
+            top = tops[index]
+            if top is not None and top not in seen_ids[index - 1]:
+                raise AssertionError(
+                    f"cursor landed on {top}, which was not on screen one "
+                    f"keystroke earlier: {tops}"
+                )
 
 
 @pytest.mark.asyncio
@@ -1521,3 +1554,23 @@ def test_the_paging_hint_survives_on_a_plain_scrolling_list() -> None:
     # page through, so the hint is the least useful thing on the row.
     settled = [key for key, _ in _footer_hints(60, has_marked=False, scrolls=False)]
     assert "pgup/pgdn" not in settled
+
+
+def test_the_empty_state_footer_offers_only_what_works() -> None:
+    """A filter that matched nothing has no rows to move through, page, or
+    resume, so advertising those keys names actions that do nothing.
+
+    `backspace` is what widens the query and is the key a user in this state is
+    already reaching for; `esc` stays because leaving is still available.
+    """
+    hints = _footer_hints(100, empty=True)
+    keys = [key for key, _ in hints]
+    assert keys == ["backspace", "esc"], keys
+
+    # Fits the narrow cards too, where the tally has already shed.
+    for width in (50, 56, 60):
+        assert [key for key, _ in _footer_hints(width, empty=True)] == ["backspace", "esc"]
+
+    # And the populated footer is untouched.
+    populated = [key for key, _ in _footer_hints(100, empty=False)]
+    assert "↑↓" in populated and "enter" in populated

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -1354,30 +1354,95 @@ async def test_the_result_list_never_grows_as_the_user_types() -> None:
     twentyfold on a longer query, every row acquired a body-match marker, and
     the card changed height under the cursor.
 
-    Gating on ZERO exact hits removes the boundary: once a query has an exact
-    hit, every extension either keeps some (still exact-only) or drops to none
-    (soft rescues from an empty list, which can only add to nothing).
+    The gate that replaced it (soft when the exact tiers return NOTHING) failed
+    the same way for a different reason: on the operator's real store `watch`
+    has 10 genuine matches and `watchl` has none, so the exact set empties, the
+    tier fires, and 46 typo-neighbours replace all 10 real matches — the top row
+    changes identity on the keystroke before the user presses enter.
+
+    The fixture mirrors that real shape and is built to DISCRIMINATE: the
+    previous version made every digest contain `watch`, so the counts were
+    constant and the assertion passed on any gate, including the two broken
+    ones. Verified to fail on both before being trusted.
     """
-    rows = [_row(f"s{i:03d}", f"session {i}") for i in range(16)]
-    # Ten digests carry `watch` and stop there; six are an edit-distance
-    # neighbour the soft tier can reach but the exact tier never sees. This is
-    # the shape that made the shipped gate flip mid-word.
-    digests = {
-        row.id: ("watch sweep evicted" if i < 10 else "watch5 sweep evicted")
-        for i, row in enumerate(rows)
-    }
+    rows = [_row(f"s{i:03d}", f"session {i}") for i in range(50)]
+    digests = {}
+    for i, row in enumerate(rows):
+        if i < 10:
+            # Genuine matches for `watch`, and NOT for `watchl` — so the exact
+            # set is non-empty at `watch` and empty one keystroke later. This is
+            # what makes a zero-hit gate fire mid-word.
+            digests[row.id] = "watch the retention sweep"
+        elif i < 12:
+            # A second, smaller exact population so a count threshold has a
+            # boundary to cross: `wa` admits 12, `watch` admits 10.
+            digests[row.id] = "wander through the logs"
+        else:
+            # Edit-distance neighbours of `watchl` (`wotchel` is within two edits
+            # away) that contain neither `watch` nor `watchl` as a SUBSTRING, so
+            # the exact tier never admits them at any keystroke and only the
+            # soft tier can reach them. A neighbour that merely contains the
+            # query would be admitted legitimately and prove nothing.
+            digests[row.id] = "wotchel batch rollup"
     app = _PickerHost(rows, digests)
     async with app.run_test(size=(100, 30)) as pilot:
         screen = await app.open_picker()
         await pilot.pause()
 
-        counts = []
-        for query in ("wat", "watc", "watch", "watchi"):
+        counts: list[int] = []
+        seen: set[str] | None = None
+        appeared: list[tuple[str, int]] = []
+        for query in ("wa", "wat", "watc", "watch", "watchl"):
             screen.set_query(query)
             await pilot.pause()
-            counts.append(len(screen.visible_rows))
+            ids = {row.id for row in screen.visible_rows}
+            counts.append(len(ids))
+            if seen is not None and (ids - seen):
+                appeared.append((query, len(ids - seen)))
+            seen = ids
 
+        # The count must never rise on a longer query.
         assert counts == sorted(counts, reverse=True), f"the list grew on a longer query: {counts}"
+        # And the stronger statement the count alone does not make: no row may
+        # appear that was absent one keystroke earlier. A same-size swap would
+        # satisfy the count check while still moving the row under the cursor.
+        assert not appeared, f"rows appeared mid-typing: {appeared}"
+
+
+@pytest.mark.asyncio
+async def test_a_typing_run_never_swaps_the_row_under_the_cursor() -> None:
+    """The harm D6 named, asserted directly rather than via the row count.
+
+    A user types, the row they want is on top, and they press enter by reflex.
+    If the last keystroke re-homed the cursor onto a different session they
+    resume the wrong one — the failure ``session_picker``'s ordering invariant
+    exists to prevent, and the same class of harm as the original bug.
+    """
+    # The genuine matches are the OLDEST rows, so when soft neighbours flood in
+    # they outrank the real matches on recency and the top row changes identity.
+    # With the real matches newest, a flood is invisible at the cursor and the
+    # test would pass on a gate that evicts them — the trap this test exists to
+    # avoid being caught by.
+    rows = [_row(f"s{i:03d}", f"session {i}", age_s=60.0 * (100 - i)) for i in range(50)]
+    digests = {}
+    for i, row in enumerate(rows):
+        digests[row.id] = "watch the retention sweep" if i >= 40 else "wotchel batch rollup"
+    app = _PickerHost(rows, digests)
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen = await app.open_picker()
+        await pilot.pause()
+
+        tops: list[str | None] = []
+        for query in ("wat", "watc", "watch", "watchl"):
+            screen.set_query(query)
+            await pilot.pause()
+            visible = screen.visible_rows
+            tops.append(visible[0].id if visible else None)
+
+        # The top row may become None (the list legitimately empties as the
+        # query stops matching), but it must never become a DIFFERENT session.
+        identities = [top for top in tops if top is not None]
+        assert len(set(identities)) == 1, f"the row under the cursor changed identity: {tops}"
 
 
 @pytest.mark.asyncio
@@ -1438,3 +1503,21 @@ def test_the_paging_hint_outranks_the_marker_legend_once_the_list_scrolls() -> N
     # removal, so nothing is lost when there is room for everything.
     wide = [key for key, _ in _footer_hints(100, has_marked=True, scrolls=True)]
     assert "pgup/pgdn" in wide and _MARKER_LEGEND[0] in wide
+
+
+def test_the_paging_hint_survives_on_a_plain_scrolling_list() -> None:
+    """The same rule on the UNMARKED branch, which is the common one.
+
+    The first version of this fix consulted ``scrolls`` only inside
+    ``if has_marked:``, so a plain scrolling picker still shed ``pgup/pgdn``
+    first at 60 and 66 columns. Uncapping the store makes the bare scrolling
+    picker the DEFAULT state, so that was the usual case rather than an edge.
+    """
+    for width in (56, 60, 66):
+        scrolling = [key for key, _ in _footer_hints(width, has_marked=False, scrolls=True)]
+        assert "pgup/pgdn" in scrolling, f"paging hint dropped at width {width}: {scrolling}"
+
+    # A list that fits on one page may still shed it first: there is nothing to
+    # page through, so the hint is the least useful thing on the row.
+    settled = [key for key, _ in _footer_hints(60, has_marked=False, scrolls=False)]
+    assert "pgup/pgdn" not in settled

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -1499,18 +1499,25 @@ async def test_the_soft_tier_runs_only_when_the_exact_tiers_find_nothing() -> No
 
         screen._soft_index.search = counting  # type: ignore[method-assign]
 
-        # One exact hit is enough to suppress the tier, even though the result
-        # is far short of a page — the old gate would have run it here.
-        screen.set_query("classifier")
-        await pilot.pause()
+        # Typed, not set: the gate is decided across a typing RUN, so setting a
+        # whole query at once cannot observe it. That shape is what let a tier
+        # that never ran be validated as working (F10).
+        for key in "classifier":
+            await pilot.press(key)
+            await pilot.pause()
         assert len(screen.visible_rows) == 1
-        assert calls == [], "the soft tier ran despite an exact hit"
+        assert calls == [], "the soft tier ran while the exact tiers had a hit"
 
-        # No exact hit anywhere: the tier runs and rescues the typo.
-        screen.set_query("classifer")
-        await pilot.pause()
+        # Backspace to a shorter query, then type a typo: no exact hit anywhere,
+        # so the tier latches on and rescues it.
+        for _ in range(3):  # back to "classi"
+            await pilot.press("backspace")
+            await pilot.pause()
+        for key in "fer":
+            await pilot.press(key)
+            await pilot.pause()
         assert [r.id for r in screen.visible_rows] == ["aaa1"]
-        assert calls == ["classifer"], "the soft tier did not run for a typo"
+        assert calls, "the soft tier did not run for a typo"
 
 
 def test_the_paging_hint_outranks_the_marker_legend_once_the_list_scrolls() -> None:


### PR DESCRIPTION
# PR Description

> **Correction (round 2).** The first version of this change was **inert**: it
> deleted `RESUME_PICKER_LIMIT` (a cap of 200) but left
> `recent_session_rows(..., limit: int = 10)` with `_cmd_resume` passing no
> argument, so the "uncapped" picker returned **ten** rows — worse than the cap
> it replaced. Every benchmark, both review rounds and all thirteen new tests
> passed an explicit `limit`, so the one call site that mattered was never
> exercised. Fixed in `39010a31`; `limit` is now `int | None = None` where None
> means no truncation, the picker passes `limit=None` explicitly, and a
> regression test drives the real `/resume` command over a 250-session store
> (it fails on `074902ae` with "picker holds 10 of 250 sessions"). Figures and
> frames below have been re-taken through the product path; the superseded ones
> are marked withdrawn where they appear.

## Summary of Changes

The `/resume` picker header read "5 of 200" and a session from more than a week
ago could not be found. `RESUME_PICKER_LIMIT = 200` (`tui/app.py`) truncated the
row list the picker was handed, and the filter only ever scans the rows it was
given (`filter_rows` over `_all`). A session past the cap was therefore not
merely off-screen — it was **unfindable, and indistinguishable from one that had
been deleted**. On the reporting machine 30 of 230 sessions were already
unreachable.

The cap's docstring justified 200 by reference to `retention.DEFAULT_MAX_SESSIONS`,
which has been `0` and retired since 4173ec73. That rationale is dead and is
removed with the constant. Any finite cap reproduces this bug at some store size,
so the picker is now handed **every** user session, and the counter reports the
store's true total for free (`_all` *is* the total).

Removing the cap is only safe if the open stays affordable at three-month scale,
so this PR also fixes the three costs that scale with the store.

### 1. Reach (the bug)

- `RESUME_PICKER_LIMIT` deleted; `_cmd_resume` calls `recent_session_rows(config_dir())`
  uncapped. `limit` stays on `recent_sessions`/`recent_session_rows` for the
  callers that genuinely want a short list (the CLI's ten-row recovery listing,
  the mobile daemon's summaries).
- The header tally becomes truthful with no widget change.

### 2. The directory scan — `resume.recent_sessions`

Rewritten onto a single `os.scandir` of the store, plus a memoised `origin.json`
verdict cache keyed on **the marker's own `(mtime, size)`**, taken from the stat
that already answers "does a marker exist" (no extra syscall).

**Why a cache rather than just skipping the read.** The listing must READ AND
PARSE every marker that exists. Existence must never be read as "subagent":
`session_origin` deliberately returns `""` for a truncated or hand-edited sidecar
so a **corrupt marker reads as the user's own session** rather than vanishing
from the picker — one such file previously took the picker down for every session
on the machine, which is why `errors="replace"` is load-bearing there. The
markers that exist are the *subagent* ones, and subagents outnumber user sessions
~10.6:1, so that rule costs one file read per subagent directory.

Decomposed over the 31,700-directory synthetic store:

| stage | cost |
| --- | --- |
| `scandir` only | 15 ms |
| + transcript `stat` | 127 ms |
| + `origin.json` existence check | 229 ms |
| + read & parse the markers that exist | **1,127 ms** |

Splitting that last step: reading the 29,000 marker files is **639 ms**;
`json.loads` on all of them is **17 ms**. The cost is the READ, not the parse, so
skipping the read only for *unmarked* directories saves ~8% and cannot fix it.

Memoising is sound because the verdict is immutable: the marker is written once
at directory creation (`harness/subagent.py`), and the only other writer is the
one-shot backfill (`resume.py`). Constraints held:

- Only a verdict **actually parsed from a marker that existed** is memoised. A
  stat failure, unreadable file, or corrupt payload falls through to the real
  `session_origin` read every time.
- **Absence is never cached** — unmarked already means user and is the cheap
  path, and a directory the backfill stamps later must be re-read.
- `session_origin` / `is_user_session` keep their public contract and tolerance;
  the cache lives on the traversal path only.
- A corrupt or unwritable cache degrades to today's full-read behaviour, never to
  an error and never to a wrong verdict (mirrors `search_index._load/_save`,
  including the PID-suffixed atomic write).

### 3. `search_index.build_index` — the daemon thrash

`build_index` now seeds `entries` from the cache and updates only the requested
ids, instead of rebuilding from scratch. Previously any narrow caller pruned the
on-disk index to its own ids — the mobile daemon asks for 200
(`daemon.py` `_search_sessions`) or 100 (`SessionRegistry.summaries`) — so **the
next picker open re-digested the whole store**, measured at 936–2,430 ms.

The pruning's stated reason ("so the file cannot grow forever behind a store that
retention keeps trimming") is obsolete post-4173ec73; the replacement bound drops
entries whose **session directory is gone**, which is the honest invariant now.

### 4. Search tiers

- `search_digests` pre-lowers the digest corpus once instead of `.lower()`-ing
  every digest per query (10 MB of allocation per keystroke at scale).
- The soft tier is **deferred behind the exact tier**: its first call tokenises
  every digest and builds a vocabulary, measured at **324 ms / 95 MB resident**
  on the real 2,681-digest corpus, and once the picker went uncapped that landed
  on the first character typed. It now runs only when the cheap tiers return less
  than a screenful — gated on result count, deterministic in `(digests, query)`,
  so the cursor invariant is untouched.

The picker stays **synchronous** by design (per the architecture doc): a
late-arriving digest fill would mutate `_admitted` under a fixed query and move a
row out from under the cursor, which is exactly how a user resumes the wrong
session.

## Related Issue(s)

- Operator-reported: `/resume` shows "5 of 200" and cannot find sessions older
  than about a week (no ticket).

## Impact

- No breaking changes; no public contract changes (`is_user_session`,
  `session_origin`, `SessionRow` untouched).
- New derived cache file `<config_dir>/cache/origin-verdicts.json`, safe to
  delete at any time. No dependency updates.
- The historical session loss from the retired retention sweep is **not**
  recoverable and is not addressed here; `retention.py` is already never-delete.
- Stale retired retention keys in `config.yml` are deliberately left alone — no
  silent rewrite of a user's file.

## Testing Details

### The reported failure, reproduced and fixed

Against the operator's real store (230 user sessions, cap was 200):

```
total user sessions: 230   old cap showed: 200   PREVIOUSLY HIDDEN: 30

Filtering for each hidden session by its own name:
  30 of 30 returned    (after)
   0 of 30 returned    (before)  <- a filter cannot find a row it was never handed
Filtering by id: 30 of 30 reachable (after)
```

Rendered proof of the exact failure, captured by typing `/resume` into the real
app against the operator's real store and screenshotting the screen the app
pushed (see the correction note below — the earlier stills built the picker
screen directly and so did not exercise `_cmd_resume`):

| before (`f6959f20`) | after (`39010a31`) |
| --- | --- |
| `filter eda736998b39  0 of 10` / "no session matches that filter" | `filter eda736998b39  1 of 238` / the session, resumable |
| unfiltered header `10 sessions` | unfiltered header `238 sessions` |

### Performance

Synthetic three-month store built by `scripts/bench_resume_picker_store.py`
(2,700 user + 29,000 subagent = 31,700 dirs, 584 MB — the 10.6:1 ratio the real
store shows), measured with `scripts/bench_resume_picker.py`, min of 3:

| stage | before | after |
| --- | --- | --- |
| `recent_sessions`, uncapped | 1,073 ms | **314 ms** |
| `recent_session_rows`, uncapped | 1,256 ms | **409 ms** |
| `build_index`, warm cache | 62 ms | 60 ms |
| `build_index` after the daemon's narrow call | **768 ms** | **94 ms** |
| exact search, steady keystroke | 3.4 ms | **0.8 ms** |
| **picker open, total** | **1,355 ms** | **494 ms** |

Operator's real store, measured through the **product path** — the exact call
`_cmd_resume` makes, `recent_session_rows(config_dir(), limit=None)`, returning
all 236 rows rather than a limited stand-in:

| stage | product path (236 rows) |
| --- | --- |
| `recent_session_rows`, uncapped | 117 ms |
| `build_index`, warm | 29 ms |
| **picker open, total** | **333 ms** |

The earlier "102 ms → 34 ms" figures for this store are withdrawn: they were
taken with an explicit `limit`, so they timed a call the product never makes.
The synthetic-store table above is unaffected, since that harness always passed
an explicit limit and therefore always measured the full row set.

Daemon thrash verified by **counting `digest_transcript` calls**, not by timing:

```
index entries after picker open:            2700
after daemon _search_sessions(limit=200):   2700   (was pruned to 200 before)
after daemon summaries(limit=100):          2700
next picker open: transcripts re-digested:     0
```

Cold-cache figures are reported separately and not averaged into the warm ones:
the first scan after deleting the cache is 1.6–5.2 s on the synthetic store,
dominated by reading 29,000 marker files, and it writes the cache as it goes.

### Correction to the design's performance target

The design doc's §4 target of **≤400 ms picker open on the 3-month synthetic
store was not reachable as originally specified**, and this is worth recording so
the next reader does not re-litigate it. That target assumed the scan's origin
phase would drop from ~805 ms to ~95 ms by checking existence before reading. It
does not: the 805/95 pair was a **cold-vs-warm** comparison, and warm-to-warm the
existence check alone saves ~8%, because the files that exist are the subagent
markers and the doc's own correctness rule requires reading and parsing those.
The scan is one read per *subagent* directory, and subagents are 10.6x the user
population. The verdict cache is what actually closes the gap (1,073 → 314 ms).

Also: the doc's literal suggestion of a per-directory `os.scandir` measured
**1,986 ms — about 2x worse** than the shipped form — because it stats every
entry in every directory to learn two filenames. The shipped traversal scans the
store once and stats the two paths it needs. This is recorded in the
`recent_sessions` docstring so it is not "fixed" back.

### Visual validation

Per AGENTS.md "Visual validation": driven through the **real `OperatorApp`** (the
host that loads `local_operator.tcss` — `_PickerHost` declares no `CSS_PATH` and
would show none of the stylesheet), captured with `app.save_screenshot()`, and
each frame rendered and looked at.

- **Header counter, real store, 100x30** — before `200 sessions` / after
  `230 sessions`; nothing else in the frame moves.
- **The bug and the fix**, filtering a hidden session id (frames above).
- **Width budget (R6)** with 4- and 5-digit totals at 100, 60 and **50 columns**:
  the tally sheds before the filter query, as the shed order intends, and the id
  column drops rather than being cut. Checked with both a populated list and the
  "no session matches that filter" state.
- **Consecutive frames** (`await pilot.pause()` between saves) on picker open at
  every size: frame 1 is byte-identical to frame 2, so nothing reflows after
  first paint — the check that would catch a late digest fill if one were ever
  added.

### Tests

13 new tests. Notable ones pin the traps:

- A marker cut mid-multi-byte-character still lists as the **user's** session,
  asserted **cold and through a populated cache** — caching "subagent" from mere
  existence would pass the cold assertion and hide the session on every later
  open.
- A marker that changes (`(mtime, size)` moves) re-derives rather than serving a
  stale verdict — the backfill's path.
- A corrupt/unreadable/version-mismatched cache degrades to full reads with an
  identical listing.
- The cache drops entries for disposed sessions.
- `build_index` preserves entries it was not asked about; drops entries whose
  directory is gone; and a wide→narrow→wide round trip re-digests **nothing**.
- `search_digests` is match-for-match identical after the pre-lowering.
- The soft tier is skipped when the exact tiers fill a page, and still runs for a
  typo they cannot answer.
- With 2,700 rows and a fixed query, `visible_rows` order and `selected_id()`
  survive repaints **and a resize** (R1).

### Gates

- `flake8 .` — clean.
- `black --check .` (26.1.0) — clean.
- `isort --check .` (5.13.2) — clean.
- `pytest tests/unit` — **7,393 passed, 7 skipped**.
- `pyright` — clean (`0 errors, 0 warnings, 0 informations`) over every file
  touched by this PR. The whole-tree run was started locally but had not finished
  at the time of writing: this machine is running several agents' pyright
  processes concurrently and the run is CPU-starved rather than stuck. CI runs
  the authoritative whole-tree check; if it reports anything, it will be fixed
  here.

## User-visible behavior change

- `/resume` lists **every** session you started, not the newest 200, and the
  filter can reach all of them. A session you know exists can be found.
- The header counter states the store's real total instead of the cap.
- The picker opens faster than before despite listing more rows, and the first
  character typed no longer stalls on a large store.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.

