### PR TITLE
fix(tui): word-wise caret movement on every option+arrow encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,10 +205,11 @@ current session's cost live).
 - `shift+tab` — cycle reasoning effort.
 - `ctrl+l` — clear the transcript (history is untouched).
 - `option+←` / `option+→` (`ctrl+←` / `ctrl+→` on Linux and Windows) — move the
-  caret a word at a time in the composer; add `shift` to select by word. On
-  macOS this works whichever option-key mode your terminal is set to — the
-  default, "Use Option as Meta", and "Esc+" all behave the same, so there is
-  nothing to configure.
+  caret a word at a time in the composer; add `shift` to select by word. Works
+  the same in shell (`!`) mode and with a command list open, and `option+↑` /
+  `option+↓` behave as plain `↑` / `↓`. On macOS this works whichever
+  option-key mode your terminal is set to — the default, "Use Option as Meta",
+  and "Esc+" all behave the same, so there is nothing to configure.
 
 ## 🔌 Providers
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ current session's cost live).
   `ctrl+f` promotes the aside into the conversation.
 - `shift+tab` — cycle reasoning effort.
 - `ctrl+l` — clear the transcript (history is untouched).
+- `option+←` / `option+→` (`ctrl+←` / `ctrl+→` on Linux and Windows) — move the
+  caret a word at a time in the composer; add `shift` to select by word. On
+  macOS this works whichever option-key mode your terminal is set to — the
+  default, "Use Option as Meta", and "Esc+" all behave the same, so there is
+  nothing to configure.
 
 ## 🔌 Providers
 

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -14,6 +14,10 @@ submit-on-Enter. The subclass inverts that and takes the terminal key idioms:
   buffer, and inside the text they keep their cursor-move meaning
 - ``Tab`` completes the highlighted command WITHOUT submitting
 - ``Esc`` dismisses the picker, leaving the typed text alone
+- ``Option+←``/``Option+→`` (``Ctrl+←``/``Ctrl+→`` off macOS) move the caret by
+  WORD, and the ``Shift`` variants select by word. Every encoding a terminal
+  can emit for that chord works, including the ``Esc``-prefixed one that used
+  to abort the turn; see :meth:`_on_key`'s escape-coalescing block
 - ``!`` on an EMPTY composer enters shell mode (the bang is consumed, not
   typed). Enter then runs the buffer as a local shell command instead of
   sending a prompt; Esc or backspace on an empty shell-mode buffer leaves
@@ -76,6 +80,7 @@ from rich.segment import Segment
 from rich.style import Style as RichStyle
 from textual import events
 from textual.actions import SkipAction
+from textual.binding import Binding
 from textual.content import Content
 from textual.expand_tabs import expand_tabs_inline
 from textual.geometry import Offset
@@ -662,6 +667,46 @@ SHELL_PLACEHOLDER = "Run a command… — esc to leave"
 class Editor(TextArea):
     """Multiline prompt editor with submit-on-Enter, history, slash-completion."""
 
+    #: Word-wise caret movement on the macOS chord, ADDED to the ``ctrl+arrow``
+    #: bindings ``TextArea`` already ships rather than replacing them: the ctrl
+    #: chord is the Linux/Windows convention and costs nothing to keep, so both
+    #: platforms' muscle memory works in the same build.
+    #:
+    #: This half only covers terminals that encode option+arrow as a CSI
+    #: sequence with modifier 3 (``\x1b[1;3D``), which Textual's parser resolves
+    #: to the ``alt+left`` key name. The other two encodings are handled
+    #: elsewhere: ``\x1bb``/``\x1bf`` (readline meta) already parse to
+    #: ``ctrl+left``/``ctrl+right`` and hit the inherited bindings, and the
+    #: ``Esc``-prefixed form arrives as two separate events and is coalesced in
+    #: :meth:`_on_key`. All three are pinned in
+    #: ``tests/unit/tui/test_word_caret.py``.
+    #:
+    #: ``show=False`` to match every other binding in this app — the footer is
+    #: not a key reference here (see ``OperatorApp.BINDINGS``).
+    #:
+    #: Textual MERGES a subclass's ``BINDINGS`` with its bases' rather than
+    #: overriding them, so declaring this attribute does not cost the editor any
+    #: inherited key (verified against textual 8.2.8: the instance's resolved
+    #: binding map holds ``alt+left`` AND ``ctrl+left``).
+    BINDINGS = [
+        Binding("alt+left", "cursor_word_left", "Cursor word left", show=False),
+        Binding("alt+right", "cursor_word_right", "Cursor word right", show=False),
+        Binding("alt+shift+left", "cursor_word_left(True)", "Select word left", show=False),
+        Binding("alt+shift+right", "cursor_word_right(True)", "Select word right", show=False),
+    ]
+
+    #: The keys that, arriving on the message pump turn after an ``escape``,
+    #: mean that escape was the first half of an option+arrow chord rather
+    #: than a press of its own. Vertical arrows are deliberately absent: no
+    #: word-movement chord produces them, and ``up``/``down`` carry history
+    #: navigation, so swallowing an Esc for them would lose a stop.
+    ESCAPE_CHORD_KEYS = {
+        "left": ("cursor_word_left", False),
+        "right": ("cursor_word_right", False),
+        "shift+left": ("cursor_word_left", True),
+        "shift+right": ("cursor_word_right", True),
+    }
+
     #: Maximum remembered prompts.
     HISTORY_LIMIT = 200
 
@@ -798,6 +843,13 @@ class Editor(TextArea):
         # BEFORE ``super().__init__`` because TextArea's constructor loads the
         # initial document through ``load_text`` → ``_sync_picker``.
         self._suspend_picker_sync = False
+        # The escape action held for one pump turn, or ``None`` when no escape
+        # is in flight (the resting state). See the escape-coalescing block
+        # below :meth:`_on_key` for why an escape is ever held at all.
+        # Typed as returning ``object`` because the actions held here are
+        # usually ``post_message`` calls, which return ``bool``; the return is
+        # discarded either way.
+        self._pending_escape: Callable[[], object] | None = None
         # tab_behavior="indent": Tab NEVER moves focus (TUI-013). Command
         # completion consumes the key first; otherwise it indents.
         super().__init__(placeholder=placeholder, soft_wrap=True, tab_behavior="indent")
@@ -1314,6 +1366,24 @@ class Editor(TextArea):
     async def _on_key(self, event: events.Key) -> None:
         """Handle chat keys before TextArea's insert path sees them."""
         key = event.key
+        # FIRST, ahead of every other branch: an arrow completing a held escape
+        # is the second half of an option+arrow chord, and it must be read as
+        # that before any picker or history handler claims it. See the
+        # escape-coalescing block below `_on_key` for the whole rationale.
+        if self._pending_escape is not None and key in self.ESCAPE_CHORD_KEYS:
+            action, select = self.ESCAPE_CHORD_KEYS[key]
+            # The escape is DROPPED, not run: the user pressed one chord, so
+            # the turn must not also be stopped.
+            self._cancel_escape()
+            getattr(self, f"action_{action}")(select)
+            event.stop()
+            event.prevent_default()
+            return
+        # Any other key ends the chord window: the escape stood alone, so its
+        # action is owed now and must land BEFORE this key is handled (an Esc
+        # then a typed character must stop the turn, then type the character).
+        if self._pending_escape is not None:
+            self._flush_escape()
         # An advertised answer key, while a question is up and the buffer is
         # empty, answers the question instead of being typed.
         #
@@ -1498,7 +1568,14 @@ class Editor(TextArea):
             # keystrokes went nowhere) and only a LATER press, once focus had
             # already left, reached the app's stop. Consuming the key here keeps
             # focus put and gives Esc one meaning — stop what the agent is doing.
-            self.post_message(StopRequested())
+            #
+            # DEFERRED, not posted: on an Esc-prefixed terminal this same
+            # `escape` may be the first half of an option+arrow chord, and
+            # stopping the turn because the user moved the caret by a word is
+            # issue #370. The key is still consumed immediately (focus stays
+            # put); only the message is held. See the escape-coalescing block
+            # below `_on_key` for the window, the terminals, and the limits.
+            self._defer_escape(lambda: self.post_message(StopRequested()))
             event.stop()
             event.prevent_default()
             return
@@ -1570,6 +1647,131 @@ class Editor(TextArea):
             event.prevent_default()
             return
         await super()._on_key(event)
+
+    # -- escape/arrow chord coalescing ---------------------------------------
+    #
+    # WHY THIS EXISTS. There is no single byte sequence for option+arrow. Three
+    # encodings are in the field and which one a user gets is a terminal
+    # preference, not a platform fact:
+    #
+    #   \x1b[1;3D   CSI with modifier 3  -> parses to `alt+left`
+    #               (Ghostty, kitty, WezTerm, iTerm2 in CSI mode)
+    #   \x1bb       readline meta-b      -> parses to `ctrl+left`
+    #               (iTerm2's default ⌥← preset, Terminal.app "Option as Meta")
+    #   \x1b\x1b[D  Esc-prefixed         -> parses to TWO events: `escape`,
+    #               then `left` (iTerm2 and Terminal.app "Esc+", a very common
+    #               setting; also what the CSI form degrades to whenever
+    #               TEXTUAL_DISABLE_KITTY_KEY is set)
+    #
+    # The first two reach a binding on their own. The third does not, and before
+    # this code it was actively DESTRUCTIVE: the composer saw a bare `escape`,
+    # ran its escape action — which at the bottom of `_on_key` posts
+    # `StopRequested` — and then moved the caret one character. On that terminal
+    # config, pressing ⌥← to fix a typo ABORTED THE AGENT'S TURN (issue #370).
+    #
+    # THE KEY INSIGHT: THE PARSER HAS ALREADY RESOLVED THE TIMING AMBIGUITY.
+    # This widget does not need a wall-clock window at all, because by the time
+    # a key reaches `_on_key` the question "was anything typed after that Esc?"
+    # is settled. Measured against textual 8.2.8's `XTermParser.feed`:
+    #
+    #   feed("\x1b")       -> []                      nothing emitted at all
+    #   feed("\x1b\x1b[D") -> escape @+0.030ms,       both from ONE parse pass,
+    #                         left   @+0.060ms        ~30 MICROseconds apart
+    #
+    # A lone `\x1b` emits NOTHING until the parser has waited out its own
+    # `ESCAPE_DELAY` and concluded that no sequence followed. So a bare `escape`
+    # arriving here is already proof that nothing came after it. Conversely the
+    # chord's `escape` and `left` are emitted together and land on the message
+    # queue back to back, in order — when `_on_key` handles that `escape`, the
+    # `left` is ALREADY QUEUED behind it.
+    #
+    # Therefore the escape action is deferred by exactly ONE message-pump turn
+    # (`call_later`), not by a duration. That is sufficient by construction: a
+    # queued arrow overtakes the deferred callback and cancels it, and if no
+    # arrow was queued the callback runs on the very next turn. Esc-to-stop
+    # costs one loop turn instead of 100 ms of wall clock — measured at 9 ms
+    # mean / 14 ms worst case even with the event loop under sustained load,
+    # against 37 ms / 197 ms for `call_after_refresh`, which waits for a repaint
+    # and was rejected for exactly that reason. `set_timer(0, ...)` is not an
+    # option: it raises ZeroDivisionError in this version of Textual.
+    #
+    # WHAT BREAKS IF THE DEFERRAL IS REMOVED: ⌥←/⌥→ goes back to stopping the
+    # agent on every Esc-prefixed terminal. Replacing it with a wall-clock delay
+    # is a regression in the opposite direction — it makes the app's stop key
+    # perceptibly late to buy certainty the parser already provides for free.
+    #
+    # THE INHERENT LIMIT, stated plainly: a user who presses Esc and then an
+    # arrow so quickly that both land in one pump turn is byte-indistinguishable
+    # from the chord, and is read as the chord. That is a far tighter race than
+    # the old window (one event-loop turn, not a tenth of a second) and cannot
+    # realistically be hit by hand.
+    #
+    # ONLY THE BOTTOM BRANCH IS DEFERRED. The picker-dismiss, model-picker-close
+    # and shell-mode-exit branches return before reaching here and run
+    # SYNCHRONOUSLY, deliberately: those are direct manipulations of something
+    # visible on screen, and a tenth of a second between the key and the list
+    # closing reads as lag. They are also unambiguous — with a list open the
+    # user is dismissing the list, not word-moving through a buffer they cannot
+    # see the caret in — so there is nothing to disambiguate. Deferral is
+    # confined to the branch where Esc means "stop the turn"/"recall a steer",
+    # which is exactly the branch the chord was corrupting.
+
+    def _defer_escape(self, action: Callable[[], object]) -> None:
+        """Hold ``action`` for one pump turn, in case a queued arrow follows.
+
+        A second escape arriving while one is pending FLUSHES the first
+        immediately rather than replacing it: two presses must produce two
+        actions (Esc-Esc is the subagent-cancel escalation ladder, where
+        collapsing the pair would silently drop a rung).
+        """
+        self._flush_escape()
+        self._pending_escape = action
+        # `call_later`, not `call_after_refresh`: both order correctly behind a
+        # queued arrow, but `call_after_refresh` waits for a repaint, which under
+        # a busy loop pushed the stop out to ~197 ms — reintroducing the very
+        # latency this mechanism exists to avoid.
+        self.call_later(self._flush_escape)
+
+    def _flush_escape(self) -> None:
+        """Run a held escape action now, if one is still pending.
+
+        Safe to call more than once, and safe to call after
+        :meth:`_cancel_escape` has already dropped the action: the queued
+        ``call_later`` callback cannot be unscheduled, so it always arrives and
+        finds the pending slot empty when the chord claimed it.
+        """
+        action = self._pending_escape
+        # Cleared BEFORE the action runs: the action can post messages that
+        # re-enter the composer, and a half-cleared pending state would let the
+        # same escape fire twice.
+        self._pending_escape = None
+        if action is not None:
+            action()
+
+    def _cancel_escape(self) -> None:
+        """Drop a held escape action without running it — the chord case."""
+        self._pending_escape = None
+
+    # NO ``super()`` CALL IN EITHER HOOK BELOW, deliberately. Textual dispatches
+    # EVERY matching handler it finds walking the MRO (see
+    # ``MessagePump._get_dispatch_methods``), so ``Widget._on_blur`` already runs
+    # on its own — calling it here as well runs the base handler TWICE, which
+    # posts a second ``DescendantBlur`` and left the app mis-tracking focus (it
+    # showed "session is still starting" for a booted session). These override
+    # points ADD behaviour; they do not chain.
+
+    def _on_blur(self, event: events.Blur) -> None:
+        # A held escape must not outlive the composer's focus. Losing focus
+        # means the arrow that would have completed the chord is never coming,
+        # so the press was a real Esc and its action is owed now — a deferral
+        # resolving later would stop a turn the user started after looking away.
+        self._flush_escape()
+
+    def _on_unmount(self) -> None:
+        # Teardown (widget removal, app quit) is the one case where the action
+        # is DROPPED rather than flushed: there is no surface left for a stop or
+        # a steer-recall to act on.
+        self._cancel_escape()
 
     # -- submit -------------------------------------------------------------
     def _submit(self) -> None:

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -688,21 +688,42 @@ class Editor(TextArea):
     #: overriding them, so declaring this attribute does not cost the editor any
     #: inherited key (verified against textual 8.2.8: the instance's resolved
     #: binding map holds ``alt+left`` AND ``ctrl+left``).
-    #: The vertical entries carry no motion of their own — they exist so that
-    #: `⌥↑`/`⌥↓` on a CSI-modifier terminal (which parses to `alt+up`, a key
-    #: nothing binds) does the SAME thing as on an Esc-prefixed terminal (which
-    #: passes through as a plain `up`). Without them the two encodings diverge:
-    #: one recalls history, the other silently does nothing. See
-    #: :attr:`ESCAPE_CHORD_KEYS` for why the vertical chord is a pass-through
-    #: rather than a paragraph motion.
+    #: NOTE the vertical chords are deliberately ABSENT from this table. They
+    #: are handled in :meth:`_on_key` by :attr:`VERTICAL_CHORD_KEYS` instead,
+    #: because a ``Binding`` fires through the action system and never enters
+    #: ``_on_key`` — which is exactly how a previous revision destroyed a typed
+    #: slash command (code round 2 F5, ux round 2 U6). See that table.
     BINDINGS = [
         Binding("alt+left", "cursor_word_left", "Cursor word left", show=False),
         Binding("alt+right", "cursor_word_right", "Cursor word right", show=False),
         Binding("alt+shift+left", "cursor_word_left(True)", "Select word left", show=False),
         Binding("alt+shift+right", "cursor_word_right(True)", "Select word right", show=False),
-        Binding("alt+up", "composer_up", "Cursor up", show=False),
-        Binding("alt+down", "composer_down", "Cursor down", show=False),
     ]
+
+    #: The CSI-modifier spelling of every vertical option chord, mapped to the
+    #: plain key it must be INDISTINGUISHABLE from.
+    #:
+    #: Vertical chords are normalised to their plain arrow at the top of
+    #: :meth:`_on_key` rather than bound as actions, and the distinction is
+    #: load-bearing. ``up``/``down`` are claimed by FOUR handlers in this widget
+    #: — the model picker, the command picker, history navigation, and finally
+    #: TextArea's caret move — and every one of them lives inside ``_on_key``
+    #: and gates on the literal key name. A ``Binding`` bypasses ``_on_key``
+    #: entirely, so ``alt+up`` reached only a reimplementation of the last two
+    #: rungs and silently closed an open picker, overwriting a half-typed slash
+    #: command with a history entry on exactly the terminals where the key had
+    #: previously been a harmless no-op.
+    #:
+    #: Rewriting the key is therefore not a shortcut but the correctness
+    #: argument: there is ONE implementation of what ``up`` means, and the chord
+    #: cannot drift from it because it does not have its own. Anything added to
+    #: the plain-arrow path in future is inherited for free.
+    VERTICAL_CHORD_KEYS = {
+        "alt+up": "up",
+        "alt+down": "down",
+        "alt+shift+up": "shift+up",
+        "alt+shift+down": "shift+down",
+    }
 
     #: Every key that, arriving on the message pump turn after an ``escape``,
     #: proves that escape was the first half of an option+arrow chord rather
@@ -1401,6 +1422,20 @@ class Editor(TextArea):
     async def _on_key(self, event: events.Key) -> None:
         """Handle chat keys before TextArea's insert path sees them."""
         key = event.key
+        # A CSI-modifier vertical chord IS its plain arrow, and is rewritten to
+        # one here so that every handler below — both pickers, history, the
+        # caret — sees the key it already gates on. This is the whole fix for
+        # F5/U6: the alternative (binding `alt+up` to an action) skips `_on_key`
+        # and therefore skips the pickers, which is how `⌥↑` came to close an
+        # open list and overwrite a half-typed slash command from history.
+        #
+        # The Esc-prefixed encoding needs no rewrite: `ESCAPE_CHORD_KEYS` maps
+        # its arrows to a pass-through, so it arrives here already spelled
+        # `up`/`down`. Both encodings therefore converge on ONE implementation
+        # of what the arrow means, which is the property that stops them
+        # drifting apart again.
+        if key in self.VERTICAL_CHORD_KEYS:
+            key = self.VERTICAL_CHORD_KEYS[key]
         # FIRST, ahead of every other branch: an arrow completing a held escape
         # is the second half of an option+arrow chord, and it must be read as
         # that before any picker or history handler claims it. See the
@@ -1703,33 +1738,26 @@ class Editor(TextArea):
             event.stop()
             event.prevent_default()
             return
+        if key != event.key:
+            # A rewritten vertical chord that no branch above claimed. It cannot
+            # be handed to ``super()``, which would resolve the ORIGINAL
+            # `alt+up` against TextArea's bindings and find nothing — the silent
+            # no-op this rewrite exists to remove. Run the plain arrow's own
+            # action instead, which is where TextArea's `up`/`down` bindings
+            # would have landed anyway.
+            moves = {
+                "up": self.action_cursor_up,
+                "down": self.action_cursor_down,
+                "shift+up": lambda: self.action_cursor_up(True),
+                "shift+down": lambda: self.action_cursor_down(True),
+            }
+            move = moves.get(key)
+            if move is not None:
+                move()
+                event.stop()
+                event.prevent_default()
+                return
         await super()._on_key(event)
-
-    # -- vertical option chords ----------------------------------------------
-
-    def action_composer_up(self) -> None:
-        """``⌥↑`` — exactly what ``↑`` does in this composer.
-
-        Bound so the CSI-modifier encoding (`alt+up`, which nothing else binds)
-        matches the Esc-prefixed one (a plain `up` passed through by the chord
-        coalescing). Without this the same physical chord recalls history on one
-        terminal and does nothing on another.
-
-        Deliberately NOT macOS paragraph movement: ``↑`` here already means
-        history-at-the-edge and caret-move inside the text, and a second
-        competing meaning for the key would be a defect rather than a feature.
-        """
-        if self._caret_at_top_edge() and self._history:
-            self._navigate_history(-1)
-        else:
-            self.action_cursor_up()
-
-    def action_composer_down(self) -> None:
-        """``⌥↓`` — exactly what ``↓`` does in this composer. See above."""
-        if self._caret_at_bottom_edge() and (self._history_index is not None or self._history):
-            self._navigate_history(+1)
-        else:
-            self.action_cursor_down()
 
     # -- escape/arrow chord coalescing ---------------------------------------
     #

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -688,23 +688,58 @@ class Editor(TextArea):
     #: overriding them, so declaring this attribute does not cost the editor any
     #: inherited key (verified against textual 8.2.8: the instance's resolved
     #: binding map holds ``alt+left`` AND ``ctrl+left``).
+    #: The vertical entries carry no motion of their own — they exist so that
+    #: `⌥↑`/`⌥↓` on a CSI-modifier terminal (which parses to `alt+up`, a key
+    #: nothing binds) does the SAME thing as on an Esc-prefixed terminal (which
+    #: passes through as a plain `up`). Without them the two encodings diverge:
+    #: one recalls history, the other silently does nothing. See
+    #: :attr:`ESCAPE_CHORD_KEYS` for why the vertical chord is a pass-through
+    #: rather than a paragraph motion.
     BINDINGS = [
         Binding("alt+left", "cursor_word_left", "Cursor word left", show=False),
         Binding("alt+right", "cursor_word_right", "Cursor word right", show=False),
         Binding("alt+shift+left", "cursor_word_left(True)", "Select word left", show=False),
         Binding("alt+shift+right", "cursor_word_right(True)", "Select word right", show=False),
+        Binding("alt+up", "composer_up", "Cursor up", show=False),
+        Binding("alt+down", "composer_down", "Cursor down", show=False),
     ]
 
-    #: The keys that, arriving on the message pump turn after an ``escape``,
-    #: mean that escape was the first half of an option+arrow chord rather
-    #: than a press of its own. Vertical arrows are deliberately absent: no
-    #: word-movement chord produces them, and ``up``/``down`` carry history
-    #: navigation, so swallowing an Esc for them would lose a stop.
-    ESCAPE_CHORD_KEYS = {
-        "left": ("cursor_word_left", False),
-        "right": ("cursor_word_right", False),
-        "shift+left": ("cursor_word_left", True),
-        "shift+right": ("cursor_word_right", True),
+    #: Every key that, arriving on the message pump turn after an ``escape``,
+    #: proves that escape was the first half of an option+arrow chord rather
+    #: than a press of its own. Maps the key to what the chord should DO.
+    #:
+    #: ``None`` means "cancel the escape and let the key through to its ordinary
+    #: handler". The vertical arrows use it: ``⌥↑``/``⌥↓`` is a real macOS chord
+    #: (move by paragraph), so a user who has just learned ``⌥←`` works will try
+    #: it, and on an Esc-prefixed terminal that used to stop the turn AND
+    #: overwrite the draft from history — strictly worse than the bug this class
+    #: set out to fix (ux round 1, U2). They map to ``None`` rather than to a
+    #: paragraph action deliberately: this composer's ``up``/``down`` already
+    #: carry history navigation and caret movement, and inventing a paragraph
+    #: motion here would be a second, competing meaning for the same physical
+    #: key. Cancelling the stop and passing the key through gives ``⌥↑`` exactly
+    #: the behaviour of ``↑``, which is the conservative reading and never
+    #: destroys a turn or a draft.
+    #:
+    #: An earlier revision excluded the vertical arrows entirely, reasoning that
+    #: swallowing an Esc for them would lose a stop. That was written when the
+    #: deferral was a 100 ms wall-clock window; at one pump turn the race is
+    #: microseconds wide and the same argument that admits ``left``/``right``
+    #: admits these.
+    #:
+    #: Values are UNBOUND METHODS, not action-name strings. A string went
+    #: through ``getattr(self, f"action_{name}")`` and could only fail at
+    #: keypress time if an action were ever renamed (code round 1, F4); a
+    #: direct reference fails at import instead.
+    ESCAPE_CHORD_KEYS: dict[str, tuple[Callable[..., None], bool] | None] = {
+        "left": (TextArea.action_cursor_word_left, False),
+        "right": (TextArea.action_cursor_word_right, False),
+        "shift+left": (TextArea.action_cursor_word_left, True),
+        "shift+right": (TextArea.action_cursor_word_right, True),
+        "up": None,
+        "down": None,
+        "shift+up": None,
+        "shift+down": None,
     }
 
     #: Maximum remembered prompts.
@@ -1371,14 +1406,22 @@ class Editor(TextArea):
         # that before any picker or history handler claims it. See the
         # escape-coalescing block below `_on_key` for the whole rationale.
         if self._pending_escape is not None and key in self.ESCAPE_CHORD_KEYS:
-            action, select = self.ESCAPE_CHORD_KEYS[key]
+            chord = self.ESCAPE_CHORD_KEYS[key]
             # The escape is DROPPED, not run: the user pressed one chord, so
-            # the turn must not also be stopped.
+            # whatever that escape would have done — stop the turn, leave shell
+            # mode, dismiss a list — must not also happen.
             self._cancel_escape()
-            getattr(self, f"action_{action}")(select)
-            event.stop()
-            event.prevent_default()
-            return
+            if chord is None:
+                # A chord with no motion of its own (the vertical arrows): the
+                # key carries on to its ordinary handler below, so `⌥↑` behaves
+                # exactly like `↑`. Not consumed, deliberately.
+                pass
+            else:
+                action, select = chord
+                action(self, select)
+                event.stop()
+                event.prevent_default()
+                return
         # Any other key ends the chord window: the escape stood alone, so its
         # action is owed now and must land BEFORE this key is handled (an Esc
         # then a typed character must stop the turn, then type the character).
@@ -1428,7 +1471,11 @@ class Editor(TextArea):
             if key == "escape":
                 # Esc closes the LIST, not the command: the text survives so a
                 # user who wanted to type the id by hand can carry on.
-                self._model_picker.close()
+                #
+                # Deferred like every other escape meaning, so `⌥←` with the
+                # model list open moves by word instead of closing the list and
+                # nudging one character (ux round 1, U3).
+                self._defer_escape(self._model_picker.close)
                 event.stop()
                 event.prevent_default()
                 return
@@ -1469,13 +1516,13 @@ class Editor(TextArea):
             # gate DROPPED the Esc: the user dismissed the list and then watched
             # it appear anyway. Dismissing an empty argument list records the
             # query, which is what the arriving rows are checked against.
-            self._picker.dismiss()
+            self._defer_escape(self._picker.dismiss)
             event.stop()
             event.prevent_default()
             return
         if self._picker.is_open():
             if key == "escape":
-                self._picker.dismiss()
+                self._defer_escape(self._picker.dismiss)
                 event.stop()
                 event.prevent_default()
                 return
@@ -1558,7 +1605,17 @@ class Editor(TextArea):
             # a prompt, and a user who entered the mode by accident is one
             # keystroke from the resting composer. Stop is one Esc away after.
             if self._shell_mode:
-                self.set_shell_mode(False)
+                # Deferred, and this is the branch where it matters most.
+                # Bang-mode is a full-width editable buffer with a visible
+                # caret, so fixing a typo in a half-typed command is exactly why
+                # someone reaches for `⌥←`. Running this synchronously ejected
+                # the user from shell mode on an Esc-prefixed terminal, and the
+                # ejection is INVISIBLE — the mode's only indicator is the
+                # placeholder, which is hidden the moment the buffer has text.
+                # The user saw an identical frame and their next Enter sent the
+                # command to the model as a prompt instead of running it
+                # (code round 1 F1, ux round 1 U1).
+                self._defer_escape(lambda: self.set_shell_mode(False))
                 event.stop()
                 event.prevent_default()
                 return
@@ -1648,6 +1705,32 @@ class Editor(TextArea):
             return
         await super()._on_key(event)
 
+    # -- vertical option chords ----------------------------------------------
+
+    def action_composer_up(self) -> None:
+        """``⌥↑`` — exactly what ``↑`` does in this composer.
+
+        Bound so the CSI-modifier encoding (`alt+up`, which nothing else binds)
+        matches the Esc-prefixed one (a plain `up` passed through by the chord
+        coalescing). Without this the same physical chord recalls history on one
+        terminal and does nothing on another.
+
+        Deliberately NOT macOS paragraph movement: ``↑`` here already means
+        history-at-the-edge and caret-move inside the text, and a second
+        competing meaning for the key would be a defect rather than a feature.
+        """
+        if self._caret_at_top_edge() and self._history:
+            self._navigate_history(-1)
+        else:
+            self.action_cursor_up()
+
+    def action_composer_down(self) -> None:
+        """``⌥↓`` — exactly what ``↓`` does in this composer. See above."""
+        if self._caret_at_bottom_edge() and (self._history_index is not None or self._history):
+            self._navigate_history(+1)
+        else:
+            self.action_cursor_down()
+
     # -- escape/arrow chord coalescing ---------------------------------------
     #
     # WHY THIS EXISTS. There is no single byte sequence for option+arrow. Three
@@ -1706,15 +1789,27 @@ class Editor(TextArea):
     # the old window (one event-loop turn, not a tenth of a second) and cannot
     # realistically be hit by hand.
     #
-    # ONLY THE BOTTOM BRANCH IS DEFERRED. The picker-dismiss, model-picker-close
-    # and shell-mode-exit branches return before reaching here and run
-    # SYNCHRONOUSLY, deliberately: those are direct manipulations of something
-    # visible on screen, and a tenth of a second between the key and the list
-    # closing reads as lag. They are also unambiguous — with a list open the
-    # user is dismissing the list, not word-moving through a buffer they cannot
-    # see the caret in — so there is nothing to disambiguate. Deferral is
-    # confined to the branch where Esc means "stop the turn"/"recall a steer",
-    # which is exactly the branch the chord was corrupting.
+    # EVERY ESCAPE MEANING IS DEFERRED, not just the bottom one. An earlier
+    # revision deferred only the stop-the-turn branch and let the picker-dismiss,
+    # model-picker-close and shell-mode-exit branches run synchronously, arguing
+    # that a visible list closing late would read as lag and that those presses
+    # were unambiguous anyway. Both halves of that argument were wrong:
+    #
+    #   - The lag argument was sized against a 100 ms wall-clock window. At one
+    #     pump turn the delay is ~4 ms and measurably inside the noise of the
+    #     synchronous path, so there is no perceptible cost to paying it
+    #     everywhere.
+    #   - The unambiguity argument does not survive contact with shell mode,
+    #     which is a full-width editable buffer with a visible caret — the state
+    #     where word movement is MOST useful, not least. It left `⌥←` ejecting
+    #     the user from bang-mode with an identical frame, flipping what Enter
+    #     does (F1/U1). The picker case was the same defect with visible
+    #     feedback (U3).
+    #
+    # Deferring uniformly also removes a whole class of future bug: any escape
+    # meaning added later is covered by default instead of silently becoming the
+    # next uncovered branch. The cost is that an escape's effect lands one pump
+    # turn later than the keypress, which is not observable to a user.
 
     def _defer_escape(self, action: Callable[[], object]) -> None:
         """Hold ``action`` for one pump turn, in case a queued arrow follows.
@@ -1768,9 +1863,15 @@ class Editor(TextArea):
         self._flush_escape()
 
     def _on_unmount(self) -> None:
-        # Teardown (widget removal, app quit) is the one case where the action
-        # is DROPPED rather than flushed: there is no surface left for a stop or
-        # a steer-recall to act on.
+        # Teardown drops the action rather than flushing it: there is no surface
+        # left for a stop, a steer-recall or a mode exit to act on.
+        #
+        # In practice this is a BACKSTOP, not the usual path. A real
+        # ``remove()`` blurs the widget first, so ``_on_blur`` has already
+        # flushed by the time this runs; only an unfocused teardown reaches here
+        # with something still pending. Kept because the invariant it guarantees
+        # — the slot is always settled by teardown, so no queued ``call_later``
+        # can fire into a widget that is gone — must not depend on focus state.
         self._cancel_escape()
 
     # -- submit -------------------------------------------------------------

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -1434,13 +1434,41 @@ class Editor(TextArea):
         # `up`/`down`. Both encodings therefore converge on ONE implementation
         # of what the arrow means, which is the property that stops them
         # drifting apart again.
-        if key in self.VERTICAL_CHORD_KEYS:
+        #
+        # THE INVARIANT, stated because getting it wrong has now caused a defect
+        # in three consecutive rounds, each time on the encoding the previous
+        # fix did not touch:
+        #
+        #   A key that arrived as its own SELF-CONTAINED chord must never be
+        #   treated as the tail of an escape chord.
+        #
+        # The two encodings carry the same intent in structurally different
+        # shapes. `\x1b[1;3A` is ONE event that already means "option+up";
+        # `\x1b\x1b[A` is TWO events whose first is indistinguishable from a
+        # real Escape until the second arrives. Only the second kind is
+        # evidence about a pending escape. `self_contained` records which kind
+        # this was BEFORE the rewrite erases the distinction, because after the
+        # rewrite both spellings read as `up` and the difference is
+        # unrecoverable (code round 3, F8).
+        self_contained = key in self.VERTICAL_CHORD_KEYS
+        if self_contained:
             key = self.VERTICAL_CHORD_KEYS[key]
         # FIRST, ahead of every other branch: an arrow completing a held escape
         # is the second half of an option+arrow chord, and it must be read as
         # that before any picker or history handler claims it. See the
         # escape-coalescing block below `_on_key` for the whole rationale.
-        if self._pending_escape is not None and key in self.ESCAPE_CHORD_KEYS:
+        #
+        # `not self_contained` is the invariant above doing its work. Without
+        # it a rewritten `alt+up` landing while an escape was held was read as
+        # that escape's second half and CANCELLED it, silently dropping every
+        # meaning Esc has — the turn kept running, bang-mode stayed on, an open
+        # list refused to dismiss. The horizontal chords never had the bug only
+        # because `alt+left` is not rewritten and so was never in this table.
+        if (
+            self._pending_escape is not None
+            and not self_contained
+            and key in self.ESCAPE_CHORD_KEYS
+        ):
             chord = self.ESCAPE_CHORD_KEYS[key]
             # The escape is DROPPED, not run: the user pressed one chord, so
             # whatever that escape would have done — stop the turn, leave shell
@@ -1753,6 +1781,16 @@ class Editor(TextArea):
             }
             move = moves.get(key)
             if move is not None:
+                # `_restart_blink` for the same reason the rest of this method
+                # exists: `TextArea._on_key` calls it on every cursor key, and
+                # the whole correctness argument for the rewrite is that a
+                # chord is INDISTINGUISHABLE from its plain arrow. Inert today
+                # — this composer ships `cursor_blink = False`, so there is no
+                # timer to reset — but leaving it out would make that claim
+                # true only by accident of a setting somewhere else, and the
+                # divergence would surface as `⌥↑` parking the caret mid-blink
+                # where `↑` leaves it solid (ux round 3, U10).
+                self._restart_blink()
                 move()
                 event.stop()
                 event.prevent_default()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.16"
+version = "0.42.17"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/word_caret_latency.py
+++ b/scripts/word_caret_latency.py
@@ -30,7 +30,7 @@ from textual import events  # noqa: E402
 from textual._xterm_parser import XTermParser  # noqa: E402
 
 from local_operator.tui.app import OperatorApp  # noqa: E402
-from local_operator.tui.widgets.editor import Editor  # noqa: E402
+from local_operator.tui.widgets.editor import Editor, StopRequested  # noqa: E402
 from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
 
 TRIALS = 25
@@ -46,12 +46,79 @@ async def _hog() -> None:
         pass
 
 
+async def _measure_end_to_end(deferred: bool, trials: int = 40) -> list[float]:
+    """Esc keypress -> ``StopRequested`` at the handler, in ms.
+
+    THE ONLY HONEST COMPARISON, and the reason the earlier figures in this
+    file's history were wrong: measuring the deferral primitive in isolation,
+    or polling for the result with ``pilot.pause()``, measures the harness (the
+    poll interval, or a bare ``call_later``) rather than what a user waits for.
+
+    So this clocks the whole path a user actually experiences — byte injection
+    to the stop arriving — and compares the deferred path against a SYNCHRONOUS
+    baseline built by monkeypatching ``_defer_escape`` to run inline, which is
+    exactly the pre-fix behaviour. Same rig, same load, one variable.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    latencies: list[float] = []
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+        editor = app.query_one(Editor)
+        editor.focus()
+        editor.text = "alpha beta gamma delta"
+        await pilot.pause()
+
+        if not deferred:
+            # The synchronous baseline: run the escape action inline, as the
+            # code did before the coalescing existed.
+            editor._defer_escape = lambda action: action()  # type: ignore[method-assign]
+
+        hog = asyncio.create_task(_hog())
+        for _ in range(trials):
+            done = asyncio.Event()
+            start = time.perf_counter()
+            captured: list[float] = []
+            original = app.post_message
+
+            def _spy(  # type: ignore[no-untyped-def]
+                message, _c=captured, _d=done, _s=start, _o=original
+            ):
+                if isinstance(message, StopRequested):
+                    _c.append((time.perf_counter() - _s) * 1000)
+                    _d.set()
+                return _o(message)
+
+            app.post_message = _spy  # type: ignore[method-assign]
+            parser = XTermParser()
+            for event in list(parser.feed("\x1b")) + list(parser.feed("")):
+                if isinstance(event, events.Key):
+                    event.set_sender(app)
+                    app._driver.send_message(event)  # type: ignore[union-attr]
+            try:
+                await asyncio.wait_for(done.wait(), 2)
+            except asyncio.TimeoutError:  # pragma: no cover - defensive
+                pass
+            app.post_message = original  # type: ignore[method-assign]
+            latencies.extend(captured)
+
+        hog.cancel()
+        try:
+            await hog
+        except asyncio.CancelledError:
+            pass
+    return latencies
+
+
 async def _measure_deferral(mechanism: str, trials: int = 40) -> list[float]:
     """Return schedule-to-callback latencies (ms) for one deferral primitive.
 
-    Measured by awaiting the callback directly rather than polling with
-    ``pilot.pause()``, because a polling loop's own sleep interval dominates
-    the number being measured and hides the difference between the two.
+    Kept only to justify the choice BETWEEN primitives (call_later vs
+    call_after_refresh). It is not a user-facing latency figure — see
+    :func:`_measure_end_to_end` for that.
     """
     app = OperatorApp(lambda: _factory(FakeSession()))
     latencies: list[float] = []
@@ -175,15 +242,22 @@ async def main() -> None:
         print(f"  {mechanism:18}: misordered {misordered}/{TRIALS}")
     print()
 
-    print("Esc-to-stop latency (schedule -> callback), loop under sustained load:")
-    print("  BEFORE (wall-clock ESCAPE_DELAY window): 100.00 ms by construction")
+    print("Primitive choice only (schedule -> callback). NOT a user-facing figure:")
     for mechanism in ("call_after_refresh", "call_later"):
         latencies = sorted(await _measure_deferral(mechanism))
         median = statistics.median(latencies)
         p95 = latencies[int(0.95 * len(latencies)) - 1]
+        print(f"  {mechanism:18}: median {median:6.2f} ms  p95 {p95:7.2f} ms")
+    print()
+
+    print("Esc keypress -> StopRequested, deferred vs SYNCHRONOUS baseline:")
+    for label, deferred in (("deferred   ", True), ("synchronous", False)):
+        latencies = sorted(await _measure_end_to_end(deferred))
+        median = statistics.median(latencies)
+        p95 = latencies[int(0.95 * len(latencies)) - 1]
         print(
-            f"  AFTER  ({mechanism:18}): "
-            f"median {median:6.2f} ms  p95 {p95:7.2f} ms  max {max(latencies):7.2f} ms"
+            f"  {label} (loop under load): "
+            f"median {median:6.2f} ms  p95 {p95:7.2f} ms  n={len(latencies)}"
         )
 
 

--- a/scripts/word_caret_latency.py
+++ b/scripts/word_caret_latency.py
@@ -1,0 +1,191 @@
+"""Characterise Esc-to-stop latency for the word-caret escape coalescing.
+
+Issue #370's fix has to hold an `escape` briefly to see whether an arrow
+follows it. The question this answers is what that hold COSTS the app's stop
+key, because Esc-to-stop going perceptibly slower would be a bad trade for a
+caret movement.
+
+The answer is that it costs one message-pump turn, because the parser has
+already resolved the timing ambiguity (see the escape-coalescing block in
+`editor.py`). This measures that under a deliberately loaded event loop, and
+compares the three candidate deferral primitives so the choice is evidence
+rather than preference.
+
+    cd <worktree>
+    PYTHONPATH=$PWD env -u NO_COLOR TERM=xterm-256color \
+        ~/local-operator/.venv/bin/python scripts/word_caret_latency.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import statistics
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from textual import events  # noqa: E402
+from textual._xterm_parser import XTermParser  # noqa: E402
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.editor import Editor  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+TRIALS = 25
+
+
+async def _hog() -> None:
+    """A busy loop, so latency is measured against a contended pump."""
+    try:
+        while True:
+            sum(range(300_000))
+            await asyncio.sleep(0)
+    except asyncio.CancelledError:
+        pass
+
+
+async def _measure_deferral(mechanism: str, trials: int = 40) -> list[float]:
+    """Return schedule-to-callback latencies (ms) for one deferral primitive.
+
+    Measured by awaiting the callback directly rather than polling with
+    ``pilot.pause()``, because a polling loop's own sleep interval dominates
+    the number being measured and hides the difference between the two.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    latencies: list[float] = []
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+
+        hog = asyncio.create_task(_hog())
+        for _ in range(trials):
+            done = asyncio.Event()
+            start = time.perf_counter()
+            captured: list[float] = []
+
+            def _fire(_c=captured, _d=done, _s=start) -> None:
+                _c.append((time.perf_counter() - _s) * 1000)
+                _d.set()
+
+            if mechanism == "call_later":
+                editor.call_later(_fire)
+            else:
+                editor.call_after_refresh(_fire)
+            try:
+                await asyncio.wait_for(done.wait(), 2)
+            except asyncio.TimeoutError:  # pragma: no cover - defensive
+                pass
+            latencies.extend(captured)
+
+        hog.cancel()
+        try:
+            await hog
+        except asyncio.CancelledError:
+            pass
+    return latencies
+
+
+async def _measure(mechanism: str) -> tuple[int, float, float]:
+    """Return (misordered_trials, max_ms, mean_ms) for one deferral primitive."""
+    order: list[str] = []
+    original = Editor._on_key
+
+    async def _spy(self, event):  # type: ignore[no-untyped-def]
+        order.append(event.key)
+        return await original(self, event)
+
+    Editor._on_key = _spy  # type: ignore[method-assign]
+    try:
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        misordered = 0
+        latencies: list[float] = []
+        async with app.run_test(size=(100, 24)) as pilot:
+            for _ in range(200):
+                if app._session is not None:
+                    break
+                await pilot.pause()
+                await asyncio.sleep(0.01)
+            editor = app.query_one(Editor)
+            editor.focus()
+            editor.text = "alpha beta gamma delta"
+            await pilot.pause()
+
+            hog = asyncio.create_task(_hog())
+            for _ in range(TRIALS):
+                order.clear()
+                fired: list[float] = []
+
+                def _fire(_fired=fired) -> None:
+                    _fired.append(time.perf_counter())
+
+                def _defer(action, _m=mechanism) -> None:  # type: ignore[no-untyped-def]
+                    if _m == "call_later":
+                        editor.call_later(_fire)
+                    else:
+                        editor.call_after_refresh(_fire)
+
+                editor._defer_escape = _defer  # type: ignore[method-assign]
+
+                start = time.perf_counter()
+                parser = XTermParser()
+                for event in list(parser.feed("\x1b\x1b[D")) + list(parser.feed("")):
+                    if isinstance(event, events.Key):
+                        event.set_sender(app)
+                        app._driver.send_message(event)  # type: ignore[union-attr]
+                for _ in range(60):
+                    await pilot.pause()
+                    await asyncio.sleep(0.002)
+                    if fired:
+                        break
+
+                if order[:2] != ["escape", "left"]:
+                    misordered += 1
+                if fired:
+                    latencies.append((fired[0] - start) * 1000)
+
+            hog.cancel()
+            try:
+                await hog
+            except asyncio.CancelledError:
+                pass
+        return misordered, max(latencies), sum(latencies) / len(latencies)
+    finally:
+        Editor._on_key = original  # type: ignore[method-assign]
+
+
+async def main() -> None:
+    # The premise: the parser holds a lone Esc itself, and emits the chord's two
+    # events from a single pass. This is why one pump turn is sufficient.
+    assert list(XTermParser().feed("\x1b")) == []
+    chord = [e.key for e in XTermParser().feed("\x1b\x1b[D") if isinstance(e, events.Key)]
+    print("parser: feed('\\x1b') -> []   (held until ESCAPE_DELAY expires)")
+    print(f"parser: feed('\\x1b\\x1b[D') -> {chord}   (one pass, queued back to back)")
+    print()
+    print("Ordering: does the queued arrow always overtake the deferred escape?")
+    for mechanism in ("call_after_refresh", "call_later"):
+        misordered, _, _ = await _measure(mechanism)
+        print(f"  {mechanism:18}: misordered {misordered}/{TRIALS}")
+    print()
+
+    print("Esc-to-stop latency (schedule -> callback), loop under sustained load:")
+    print("  BEFORE (wall-clock ESCAPE_DELAY window): 100.00 ms by construction")
+    for mechanism in ("call_after_refresh", "call_later"):
+        latencies = sorted(await _measure_deferral(mechanism))
+        median = statistics.median(latencies)
+        p95 = latencies[int(0.95 * len(latencies)) - 1]
+        print(
+            f"  AFTER  ({mechanism:18}): "
+            f"median {median:6.2f} ms  p95 {p95:7.2f} ms  max {max(latencies):7.2f} ms"
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/word_caret_probe.py
+++ b/scripts/word_caret_probe.py
@@ -1,0 +1,96 @@
+"""Feed raw terminal bytes into the real composer and report what happened.
+
+Used to reproduce GitHub issue #370's escape-prefixed defect and to demonstrate
+the fix: the byte sequences here are the literal ones the named emulators write
+for option+arrow, so a claim about "terminal X" is checked against X's actual
+encoding rather than against a key NAME someone assumed it produces.
+
+Run with the worktree pinned on PYTHONPATH so it exercises THIS source:
+
+    cd <worktree>
+    PYTHONPATH=$PWD env -u NO_COLOR TERM=xterm-256color \
+        ~/local-operator/.venv/bin/python scripts/word_caret_probe.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from textual import events  # noqa: E402
+from textual._xterm_parser import XTermParser  # noqa: E402
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.editor import Editor, StopRequested  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+#: One row per terminal encoding of option+arrow. Same table as the test.
+ENCODINGS: list[tuple[str, str, str]] = [
+    ("\x1b[1;3D", "CSI-modifier alt", "Ghostty / kitty / WezTerm / iTerm2 CSI"),
+    ("\x1bb", "readline meta-b", "iTerm2 default preset / Terminal.app meta"),
+    ("\x1b\x1b[D", "Esc-prefixed", "iTerm2 'Esc+' / Terminal.app 'Esc+'"),
+]
+
+SAMPLE = "alpha beta gamma delta"
+
+
+async def _feed_bytes(app: OperatorApp, raw: str) -> None:
+    """Parse ``raw`` exactly as the driver would and inject the key events."""
+    parser = XTermParser()
+    parsed = list(parser.feed(raw)) + list(parser.feed(""))
+    driver = app._driver
+    assert driver is not None
+    # Sent WITHOUT yielding between events, as the real driver does: one parse
+    # pass emits the chord's `escape` and `left` together and posts both before
+    # the loop is pumped.
+    for event in parsed:
+        if isinstance(event, events.Key):
+            event.set_sender(app)
+            driver.send_message(event)
+    await asyncio.sleep(0)
+
+
+async def main() -> None:
+    for raw, label, terminals in ENCODINGS:
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        stops: list[StopRequested] = []
+        async with app.run_test(size=(100, 24)) as pilot:
+            for _ in range(200):
+                if app._session is not None:
+                    break
+                await pilot.pause()
+                await asyncio.sleep(0.01)
+            editor = app.query_one(Editor)
+            editor.focus()
+            editor.text = SAMPLE
+            editor.move_cursor((0, len(SAMPLE)))
+            await pilot.pause()
+
+            original = app.post_message
+
+            def _spy(message, _orig=original, _stops=stops):  # type: ignore[no-untyped-def]
+                if isinstance(message, StopRequested):
+                    _stops.append(message)
+                return _orig(message)
+
+            app.post_message = _spy  # type: ignore[method-assign]
+
+            await _feed_bytes(app, raw)
+            # Long enough for any deferral window to expire either way.
+            for _ in range(30):
+                await pilot.pause()
+                await asyncio.sleep(0.01)
+
+            column = editor.cursor_location[1]
+            print(
+                f"{label:18} {raw!r:14} caret_col={column:2d} "
+                f"stop_requested={bool(stops)}  [{terminals}]"
+            )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/word_caret_pty.py
+++ b/scripts/word_caret_pty.py
@@ -1,0 +1,113 @@
+"""Drive the REAL `local-operator` binary in a pty and send raw option+arrow bytes.
+
+This is the floor of evidence for issue #370: not a test host, not a harness,
+but the shipped entry point running under a pseudo-terminal, receiving the exact
+bytes iTerm2/Terminal.app write for the Esc-prefixed option+arrow chord.
+"""
+
+from __future__ import annotations
+
+import os
+import pty
+import re
+import select
+import signal
+import sys
+import time
+from pathlib import Path
+
+WORKTREE = str(Path(__file__).resolve().parent.parent)
+PYTHON = os.path.expanduser("~/local-operator/.venv/bin/python")
+SAMPLE = "alpha beta gamma delta"
+ANSI = re.compile(rb"\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[=>]")
+
+
+def read_for(fd: int, seconds: float) -> bytes:
+    out = b""
+    end = time.time() + seconds
+    while time.time() < end:
+        r, _, _ = select.select([fd], [], [], 0.1)
+        if r:
+            try:
+                chunk = os.read(fd, 65536)
+            except OSError:
+                break
+            if not chunk:
+                break
+            out += chunk
+    return out
+
+
+def main() -> int:
+    env = dict(os.environ)
+    env.update(
+        {
+            "TERM": "xterm-256color",
+            "PYTHONPATH": WORKTREE,
+            "COLUMNS": "100",
+            "LINES": "30",
+        }
+    )
+    env.pop("NO_COLOR", None)
+
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.chdir(WORKTREE)
+        os.execve(PYTHON, [PYTHON, "-c", "from local_operator.cli import main; main()"], env)
+        os._exit(1)
+
+    try:
+        import fcntl
+        import struct
+        import termios
+
+        fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 30, 100, 0, 0))
+
+        print("booting the real binary under a pty…")
+        boot = read_for(fd, 18.0)
+        print(f"  received {len(boot)} bytes of screen output")
+
+        # Type the sample into the composer.
+        os.write(fd, SAMPLE.encode())
+        read_for(fd, 3.0)
+
+        def screen_has(text: str, blob: bytes) -> bool:
+            return text.encode() in ANSI.sub(b"", blob)
+
+        after_type = read_for(fd, 1.0)
+        print(f"  composer holds the sample: {screen_has('alpha', after_type + boot)}")
+
+        # The Esc-prefixed option+left chord, twice — the encoding that used to
+        # abort the turn. Then a printable character, which lands wherever the
+        # caret actually is. If word movement worked, it lands before "gamma".
+        for _ in range(2):
+            os.write(fd, b"\x1b\x1b[D")
+            time.sleep(0.25)
+        read_for(fd, 1.0)
+        os.write(fd, b"X")
+        time.sleep(0.5)
+        final = read_for(fd, 3.0)
+
+        clean = ANSI.sub(b"", final).decode("utf-8", "replace")
+        moved = "alpha beta Xgamma delta"
+        one_char = "alpha beta gamXma delta"
+        print()
+        print("  looking for the marker in the rendered screen:")
+        print(f"    word-wise movement  {moved!r}: {moved in clean}")
+        print(f"    char-wise movement  {one_char!r}: {one_char in clean}")
+        if moved in clean:
+            print("  RESULT: two chords moved the caret TWO WORDS left. Correct.")
+            return 0
+        print("  RESULT: unexpected caret position")
+        print(clean[-1500:])
+        return 1
+    finally:
+        try:
+            os.kill(pid, signal.SIGKILL)
+            os.waitpid(pid, 0)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/tui/test_word_caret.py
+++ b/tests/unit/tui/test_word_caret.py
@@ -298,22 +298,50 @@ async def test_losing_focus_flushes_a_held_escape() -> None:
 
 
 @pytest.mark.asyncio
-async def test_unmount_drops_a_held_escape() -> None:
-    """Teardown drops the action: no callback into a widget that is gone."""
+async def test_real_teardown_settles_a_held_escape_and_leaks_no_callback() -> None:
+    """Drive REAL teardown and pin what actually happens (code round 1, F3).
+
+    An earlier version of this test called ``_on_unmount()`` by hand and
+    asserted the action was dropped. That pinned a path users never take: on a
+    real ``await editor.remove()`` the widget is blurred first, and
+    ``_on_blur`` FLUSHES before ``_on_unmount`` could drop. So a focused
+    composer being torn down runs its held escape, and ``_on_unmount`` is the
+    backstop for the unfocused case rather than the usual path.
+
+    What matters either way is the invariant this asserts: teardown always
+    settles the slot, so no ``call_later`` callback can survive into a widget
+    that is gone.
+    """
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 24)) as pilot:
         editor = await _boot(pilot, app)
         await pilot.pause()
 
         fired: list[str] = []
-
         editor._defer_escape(lambda: fired.append("escape"))
         assert editor._pending_escape is not None, "the escape is held"
 
-        # The teardown hook is driven directly: a real ``remove()`` is awaited,
-        # and the one-turn deferral resolves inside that await, so the flush
-        # would win the race and the drop-on-teardown contract would go
-        # unobserved. This asserts the contract at the boundary that owns it.
+        await editor.remove()
+        await _settle(pilot)
+
+        assert fired == ["escape"], "blur wins the race and flushes"
+        assert editor._pending_escape is None, "nothing is left pending"
+
+
+@pytest.mark.asyncio
+async def test_unmount_without_focus_drops_a_held_escape() -> None:
+    """The backstop: an unfocused teardown drops rather than flushes.
+
+    Reached when the composer never had focus, so no blur precedes the unmount.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        editor.blur()
+        await pilot.pause()
+
+        fired: list[str] = []
+        editor._defer_escape(lambda: fired.append("escape"))
         editor._on_unmount()
 
         assert editor._pending_escape is None
@@ -321,12 +349,12 @@ async def test_unmount_drops_a_held_escape() -> None:
 
 
 @pytest.mark.asyncio
-async def test_escape_still_dismisses_a_picker_synchronously() -> None:
-    """The picker branches are NOT deferred: a list must close on the keystroke.
+async def test_a_lone_escape_still_dismisses_a_picker() -> None:
+    """A real Esc with a list open still closes the list, one pump turn later.
 
-    Deferral is confined to the bottom escape branch. A tenth of a second
-    between the key and a visible list closing reads as lag, and with a list
-    open the press is unambiguous anyway.
+    The dismissal is deferred like every other escape meaning (ux round 1, U3),
+    but a deferral of one pump turn is not observable: by the time the press
+    returns, the list is gone.
     """
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 24)) as pilot:
@@ -339,17 +367,15 @@ async def test_escape_still_dismisses_a_picker_synchronously() -> None:
         stops = _watch_stops(app)
 
         await pilot.press("escape")
-        # No settle: the dismissal must already have happened.
-        assert not editor._picker.is_open(), "the list closed on the keystroke"
-        assert editor._pending_escape is None, "and nothing was deferred"
+        assert not editor._picker.is_open(), "the list closed"
 
         await _settle(pilot)
         assert stops == [], "dismissing a list never stops the turn"
 
 
 @pytest.mark.asyncio
-async def test_escape_still_leaves_shell_mode_synchronously() -> None:
-    """Shell-mode exit is likewise immediate, for the same lag reason."""
+async def test_a_lone_escape_still_leaves_shell_mode() -> None:
+    """A real Esc in bang-mode still leaves the mode, one pump turn later."""
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 24)) as pilot:
         editor = await _boot(pilot, app)
@@ -359,8 +385,7 @@ async def test_escape_still_leaves_shell_mode_synchronously() -> None:
         stops = _watch_stops(app)
 
         await pilot.press("escape")
-        assert not editor.shell_mode, "the mode ended on the keystroke"
-        assert editor._pending_escape is None
+        assert not editor.shell_mode, "the mode ended"
 
         await _settle(pilot)
         assert stops == [], "leaving the mode never stops the turn"
@@ -431,6 +456,136 @@ async def test_the_cleanup_hooks_do_not_double_dispatch_the_base_handler() -> No
             await pilot.pause()
 
         assert calls == [1], "the base blur handler ran exactly once"
+
+
+@pytest.mark.parametrize(
+    ("raw", "terminals"),
+    [
+        ("\x1b[1;3D", "Ghostty / kitty / WezTerm / iTerm2 CSI mode"),
+        ("\x1bb", "iTerm2 default preset / Terminal.app Option-as-Meta"),
+        ("\x1b\x1b[D", "iTerm2 Esc+ / Terminal.app Esc+"),
+    ],
+    ids=["csi-modifier-3", "readline-meta", "escape-prefixed"],
+)
+@pytest.mark.asyncio
+async def test_option_left_in_shell_mode_keeps_the_mode_on_every_encoding(
+    raw: str, terminals: str
+) -> None:
+    """⌥← while editing a bang-mode command moves by word and KEEPS the mode.
+
+    Code round 1 F1 / ux round 1 U1. The escape-prefixed encoding used to eject
+    the user from shell mode as a side effect of nudging the caret, and the
+    ejection was invisible — the mode's only indicator is the placeholder, which
+    is hidden whenever the buffer has text. The user's next Enter then sent the
+    command to the model as a prompt instead of running it, so this asserts the
+    mode as well as the caret.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        await pilot.press("!")
+        await pilot.pause()
+        assert editor.shell_mode, "bang entered shell mode"
+        editor.text = "git commit --amend"
+        editor.move_cursor((0, len("git commit --amend")))
+        await pilot.pause()
+        stops = _watch_stops(app)
+
+        await _feed(app, raw)
+        await _settle(pilot)
+
+        assert editor.shell_mode, f"⌥← must not leave shell mode ({terminals})"
+        # Start of "amend", i.e. one word left rather than one character.
+        assert editor.cursor_location == (0, len("git commit --")), terminals
+        assert stops == [], f"⌥← must not stop the turn ({terminals})"
+
+
+@pytest.mark.parametrize(
+    ("raw", "terminals"),
+    [
+        ("\x1b[1;3D", "Ghostty / kitty / WezTerm / iTerm2 CSI mode"),
+        ("\x1b\x1b[D", "iTerm2 Esc+ / Terminal.app Esc+"),
+    ],
+    ids=["csi-modifier-3", "escape-prefixed"],
+)
+@pytest.mark.asyncio
+async def test_option_left_with_a_picker_open_keeps_the_list(raw: str, terminals: str) -> None:
+    """⌥← with a command list open moves by word and leaves the list up.
+
+    Ux round 1 U3: the same physical chord used to mean two different things
+    depending on whether a list happened to be open.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        editor.text = "/analytics"
+        await pilot.pause()
+        editor._sync_picker()
+        await pilot.pause()
+        assert editor._picker.is_open(), "the command list is up"
+        editor.move_cursor((0, len("/analytics")))
+        await pilot.pause()
+
+        await _feed(app, raw)
+        await _settle(pilot)
+
+        assert editor._picker.is_open(), f"the list must survive ⌥← ({terminals})"
+        assert editor.cursor_location == (0, 1), terminals
+
+
+@pytest.mark.parametrize(
+    ("raw", "terminals"),
+    [
+        ("\x1b[1;3A", "Ghostty / kitty / WezTerm / iTerm2 CSI mode"),
+        ("\x1b\x1b[A", "iTerm2 Esc+ / Terminal.app Esc+"),
+    ],
+    ids=["csi-modifier-3", "escape-prefixed"],
+)
+@pytest.mark.asyncio
+async def test_option_up_never_stops_the_turn(raw: str, terminals: str) -> None:
+    """⌥↑ behaves as plain ↑ and never aborts the turn.
+
+    Ux round 1 U2. On the escape-prefixed encoding this used to stop the turn
+    AND overwrite the draft from history — strictly worse than the bug #370
+    fixed, since it lost the turn and the draft. ⌥↑ is a real macOS chord, so a
+    user who has just learned ⌥← works will try it.
+
+    The chord maps to a pass-through rather than to a paragraph motion: this
+    composer's ↑ already carries history navigation, and a second competing
+    meaning for the same key would be the defect, not the fix. So this asserts
+    the ordinary ↑ outcome — history recall — with no stop.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        editor._history = ["an earlier prompt"]
+        await pilot.pause()
+        stops = _watch_stops(app)
+
+        await _feed(app, raw)
+        await _settle(pilot)
+
+        assert stops == [], f"⌥↑ must never stop the turn ({terminals})"
+        assert editor.text == "an earlier prompt", "it behaves as plain ↑"
+
+
+@pytest.mark.asyncio
+async def test_option_up_does_not_eat_a_draft_mid_buffer() -> None:
+    """With the caret inside the text, ⌥↑ moves the caret and keeps the draft."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        editor.text = "first line\nsecond line"
+        editor.move_cursor((1, 6))
+        await pilot.pause()
+        stops = _watch_stops(app)
+
+        await _feed(app, "\x1b\x1b[A")
+        await _settle(pilot)
+
+        assert stops == [], "no stop"
+        assert editor.text == "first line\nsecond line", "the draft survives"
+        assert editor.cursor_location[0] == 0, "the caret moved up a line"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_word_caret.py
+++ b/tests/unit/tui/test_word_caret.py
@@ -1,0 +1,444 @@
+"""Word-wise caret movement works on every terminal encoding of option+arrow.
+
+Issue #370. There is no single byte sequence for ⌥←: which one a user's
+terminal emits is a preference in that terminal, not a property of the
+platform, and the composer has to handle all of them. These tests feed the
+LITERAL BYTES each emulator writes through Textual's real ``XTermParser`` into
+the real ``OperatorApp``, so "this works in Ghostty" is checked against
+Ghostty's actual encoding rather than against a key name someone assumed it
+produces.
+
+The encodings, and who sends them (verified against textual 8.2.8):
+
+===============  =========================  =====================================
+bytes            parses to                  terminals
+===============  =========================  =====================================
+``\\x1b[1;3D``    ``alt+left``               Ghostty, kitty, WezTerm, iTerm2 in
+                                            CSI mode
+``\\x1bb``        ``ctrl+left``              iTerm2's default ⌥← preset,
+                                            Terminal.app "Use Option as Meta"
+``\\x1b\\x1b[D``   ``escape`` THEN ``left``   iTerm2 "Esc+", Terminal.app "Esc+",
+                                            and any terminal once
+                                            ``TEXTUAL_DISABLE_KITTY_KEY`` is set
+===============  =========================  =====================================
+
+The third row is the defect this change fixes: the composer used to run its
+escape action (post ``StopRequested`` — abort the agent's turn) and then move
+the caret one character, so ⌥← to fix a typo killed the running turn. The
+regression guard is ``stop_requested`` staying empty on those rows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from textual import events
+from textual._xterm_parser import XTermParser
+from textual.widget import Widget
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.editor import Editor, StopRequested
+
+from .test_app_pilot import FakeSession, _factory
+
+#: Four words, so a single word-move is unambiguous and lands on a known column.
+SAMPLE = "alpha beta gamma delta"
+#: Column of the "d" in "delta" — where one word-left from the end must land.
+DELTA_START = SAMPLE.index("delta")
+#: Column of the "g" in "gamma" — where a second word-left lands.
+GAMMA_START = SAMPLE.index("gamma")
+
+
+async def _boot(pilot: Any, app: OperatorApp) -> Editor:
+    """Wait for the session and focus the composer, as the app's own tests do."""
+    for _ in range(200):
+        if app._session is not None:
+            break
+        await pilot.pause()
+        await asyncio.sleep(0.01)
+    assert app._session is not None, "the session never booted"
+    editor = app.query_one(Editor)
+    editor.focus()
+    await pilot.pause()
+    return editor
+
+
+async def _feed(app: OperatorApp, raw: str) -> None:
+    """Parse ``raw`` with the real parser and inject it as the driver would.
+
+    ``pilot.press`` takes key NAMES, which is exactly the layer these tests
+    exist to get underneath: the whole question is what a terminal's bytes turn
+    into, so the bytes have to go through ``XTermParser`` rather than a name
+    chosen by the test author.
+    """
+    parser = XTermParser()
+    parsed = list(parser.feed(raw)) + list(parser.feed(""))
+    driver = app._driver
+    assert driver is not None
+    # Sent WITHOUT yielding between events, which is what the real driver does:
+    # one parse pass emits the chord's `escape` and `left` together and posts
+    # both before the loop is pumped. Yielding here would let the escape resolve
+    # before its own arrow was even sent — testing a sequence no terminal emits.
+    for event in parsed:
+        if isinstance(event, events.Key):
+            event.set_sender(app)
+            driver.send_message(event)
+    await asyncio.sleep(0)
+
+
+async def _settle(pilot: Any, cycles: int = 5) -> None:
+    """Pump the message loop so a one-turn-deferred escape action has fired.
+
+    Only a handful of turns are needed: the escape action is deferred by a
+    single ``call_later``, not by a wall-clock window.
+    """
+    for _ in range(cycles):
+        await pilot.pause()
+
+
+def _watch_stops(app: OperatorApp) -> list[StopRequested]:
+    """Record every ``StopRequested`` the composer posts."""
+    seen: list[StopRequested] = []
+    original = app.post_message
+
+    def _spy(message: Any) -> bool:
+        if isinstance(message, StopRequested):
+            seen.append(message)
+        return original(message)
+
+    app.post_message = _spy  # type: ignore[method-assign]
+    return seen
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_column", "terminals"),
+    [
+        ("\x1b[1;3D", DELTA_START, "Ghostty / kitty / WezTerm / iTerm2 CSI mode"),
+        ("\x1bb", DELTA_START, "iTerm2 default preset / Terminal.app Option-as-Meta"),
+        ("\x1b\x1b[D", DELTA_START, "iTerm2 Esc+ / Terminal.app Esc+"),
+    ],
+    ids=["csi-modifier-3", "readline-meta", "escape-prefixed"],
+)
+@pytest.mark.asyncio
+async def test_option_left_moves_one_word_on_every_encoding(
+    raw: str, expected_column: int, terminals: str
+) -> None:
+    """⌥← moves the caret one word left, whichever bytes the terminal sends."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        editor.text = SAMPLE
+        editor.move_cursor((0, len(SAMPLE)))
+        await pilot.pause()
+        stops = _watch_stops(app)
+
+        await _feed(app, raw)
+        await _settle(pilot)
+
+        assert editor.cursor_location == (0, expected_column), terminals
+        # The regression guard: on the Esc-prefixed encoding this used to abort
+        # the agent's turn before moving the caret.
+        assert stops == [], f"⌥← must not stop the turn ({terminals})"
+
+
+@pytest.mark.parametrize(
+    ("raw", "terminals"),
+    [
+        ("\x1b[1;3C", "Ghostty / kitty / WezTerm / iTerm2 CSI mode"),
+        ("\x1bf", "iTerm2 default preset / Terminal.app Option-as-Meta"),
+        ("\x1b\x1b[C", "iTerm2 Esc+ / Terminal.app Esc+"),
+    ],
+    ids=["csi-modifier-3", "readline-meta", "escape-prefixed"],
+)
+@pytest.mark.asyncio
+async def test_option_right_moves_one_word_on_every_encoding(raw: str, terminals: str) -> None:
+    """⌥→ moves the caret one word right, whichever bytes the terminal sends."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        editor.text = SAMPLE
+        editor.move_cursor((0, 0))
+        await pilot.pause()
+        stops = _watch_stops(app)
+
+        await _feed(app, raw)
+        await _settle(pilot)
+
+        assert editor.cursor_location[1] > 0, terminals
+        assert stops == [], f"⌥→ must not stop the turn ({terminals})"
+
+
+@pytest.mark.parametrize(
+    ("raw", "terminals"),
+    [
+        ("\x1b[1;4D", "Ghostty / kitty / WezTerm / iTerm2 CSI mode"),
+        ("\x1b\x1b[1;2D", "iTerm2 Esc+ / Terminal.app Esc+"),
+    ],
+    ids=["csi-modifier-4", "escape-prefixed"],
+)
+@pytest.mark.asyncio
+async def test_option_shift_left_selects_one_word(raw: str, terminals: str) -> None:
+    """⌥⇧← extends a SELECTION one word left rather than moving a bare caret."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        editor.text = SAMPLE
+        editor.move_cursor((0, len(SAMPLE)))
+        await pilot.pause()
+        stops = _watch_stops(app)
+
+        await _feed(app, raw)
+        await _settle(pilot)
+
+        assert editor.selected_text == "delta", terminals
+        assert stops == [], f"⌥⇧← must not stop the turn ({terminals})"
+
+
+@pytest.mark.asyncio
+async def test_repeated_option_left_walks_word_by_word() -> None:
+    """Two chords move two words: the coalescing does not swallow the second."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        editor.text = SAMPLE
+        editor.move_cursor((0, len(SAMPLE)))
+        await pilot.pause()
+        stops = _watch_stops(app)
+
+        await _feed(app, "\x1b\x1b[D")
+        await _settle(pilot)
+        assert editor.cursor_location == (0, DELTA_START)
+
+        await _feed(app, "\x1b\x1b[D")
+        await _settle(pilot)
+        assert editor.cursor_location == (0, GAMMA_START)
+        assert stops == []
+
+
+@pytest.mark.asyncio
+async def test_a_lone_escape_still_stops_the_turn() -> None:
+    """The window expiring with no arrow runs the escape action unchanged."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        editor.text = SAMPLE
+        await pilot.pause()
+        stops = _watch_stops(app)
+
+        await pilot.press("escape")
+        await _settle(pilot)
+
+        assert len(stops) == 1, "a real Esc must still stop the agent"
+
+
+@pytest.mark.asyncio
+async def test_two_escapes_produce_two_stops() -> None:
+    """Esc-Esc is the subagent-cancel ladder; collapsing it would drop a rung."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        editor.text = SAMPLE
+        await pilot.pause()
+        stops = _watch_stops(app)
+
+        # Back to back, with no settle between them, so the second arrives while
+        # the first is still held.
+        await _feed(app, "\x1b")
+        await _feed(app, "\x1b")
+        await _settle(pilot)
+
+        assert len(stops) == 2, "each press owes its own action"
+
+
+@pytest.mark.asyncio
+async def test_escape_then_an_ordinary_key_still_stops_the_turn() -> None:
+    """A non-arrow key ends the window: the escape stood alone and is owed."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        await pilot.pause()
+        stops = _watch_stops(app)
+
+        await _feed(app, "\x1b")
+        await pilot.press("a")
+        await _settle(pilot)
+
+        assert len(stops) == 1, "the escape still meant stop"
+        assert editor.text == "a", "and the character was still typed"
+
+
+@pytest.mark.asyncio
+async def test_losing_focus_flushes_a_held_escape() -> None:
+    """No arrow is coming once focus leaves, so the escape action is owed.
+
+    Driven through ``_defer_escape`` rather than by feeding bytes: the hold now
+    lasts a single pump turn, so there is no way to interleave a blur with it
+    from outside. The contract under test is the cleanup hook's, and this calls
+    it at exactly the boundary that owns it.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        await pilot.pause()
+        fired: list[str] = []
+
+        editor._defer_escape(lambda: fired.append("escape"))
+        assert editor._pending_escape is not None, "the escape is held"
+
+        editor._on_blur(events.Blur())
+        assert fired == ["escape"], "a held escape must not be lost on blur"
+        assert editor._pending_escape is None
+
+        # And the pump turn that follows does not run it a second time.
+        await pilot.pause()
+        assert fired == ["escape"]
+
+
+@pytest.mark.asyncio
+async def test_unmount_drops_a_held_escape() -> None:
+    """Teardown drops the action: no callback into a widget that is gone."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        await pilot.pause()
+
+        fired: list[str] = []
+
+        editor._defer_escape(lambda: fired.append("escape"))
+        assert editor._pending_escape is not None, "the escape is held"
+
+        # The teardown hook is driven directly: a real ``remove()`` is awaited,
+        # and the one-turn deferral resolves inside that await, so the flush
+        # would win the race and the drop-on-teardown contract would go
+        # unobserved. This asserts the contract at the boundary that owns it.
+        editor._on_unmount()
+
+        assert editor._pending_escape is None
+        assert fired == [], "a torn-down composer stops nothing"
+
+
+@pytest.mark.asyncio
+async def test_escape_still_dismisses_a_picker_synchronously() -> None:
+    """The picker branches are NOT deferred: a list must close on the keystroke.
+
+    Deferral is confined to the bottom escape branch. A tenth of a second
+    between the key and a visible list closing reads as lag, and with a list
+    open the press is unambiguous anyway.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        editor.text = "/mod"
+        await pilot.pause()
+        editor._sync_picker()
+        await pilot.pause()
+        assert editor._picker.is_open(), "the command list is up"
+        stops = _watch_stops(app)
+
+        await pilot.press("escape")
+        # No settle: the dismissal must already have happened.
+        assert not editor._picker.is_open(), "the list closed on the keystroke"
+        assert editor._pending_escape is None, "and nothing was deferred"
+
+        await _settle(pilot)
+        assert stops == [], "dismissing a list never stops the turn"
+
+
+@pytest.mark.asyncio
+async def test_escape_still_leaves_shell_mode_synchronously() -> None:
+    """Shell-mode exit is likewise immediate, for the same lag reason."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        await pilot.press("!")
+        await pilot.pause()
+        assert editor.shell_mode, "bang entered shell mode"
+        stops = _watch_stops(app)
+
+        await pilot.press("escape")
+        assert not editor.shell_mode, "the mode ended on the keystroke"
+        assert editor._pending_escape is None
+
+        await _settle(pilot)
+        assert stops == [], "leaving the mode never stops the turn"
+
+
+@pytest.mark.asyncio
+async def test_the_parser_resolves_the_ambiguity_before_the_widget_sees_it() -> None:
+    """The premise the one-turn deferral rests on, pinned against the parser.
+
+    A lone ``\\x1b`` emits NOTHING until the parser has waited out its own
+    ``ESCAPE_DELAY``, so a bare ``escape`` reaching the widget is already proof
+    nothing followed it. The chord's two events come out of a SINGLE parse pass
+    and therefore queue back to back. That is why the widget only has to yield
+    one message-pump turn rather than wait a duration — if this stops holding,
+    the deferral needs rethinking, not retuning.
+    """
+    parser = XTermParser()
+    assert list(parser.feed("\x1b")) == [], "a lone Esc is held by the parser"
+
+    chord = [e for e in XTermParser().feed("\x1b\x1b[D") if isinstance(e, events.Key)]
+    assert [e.key for e in chord] == ["escape", "left"], "one pass, both events"
+
+
+@pytest.mark.asyncio
+async def test_escape_to_stop_costs_one_pump_turn_not_a_wall_clock_window() -> None:
+    """The stop must land within a couple of pump turns, with no sleeping.
+
+    Written with no ``asyncio.sleep`` anywhere so it fails if the deferral ever
+    goes back to a wall-clock timer: a 100 ms window cannot satisfy this.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        editor.text = SAMPLE
+        await pilot.pause()
+        stops = _watch_stops(app)
+
+        await _feed(app, "\x1b")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert len(stops) == 1, "the stop landed within two pump turns"
+
+
+@pytest.mark.asyncio
+async def test_the_cleanup_hooks_do_not_double_dispatch_the_base_handler() -> None:
+    """``_on_blur`` must not chain to ``super()`` — Textual already runs it.
+
+    Textual dispatches every matching handler in the MRO, so an override that
+    also calls ``super()._on_blur()`` runs the base handler twice and posts a
+    second ``DescendantBlur``. That broke the app's focus tracking (a booted
+    session rendered as "session is still starting"), which is a failure a long
+    way from the composer, so it is pinned here at the cause.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        calls: list[int] = []
+        base = Widget._on_blur
+
+        def _spy(self: Any, event: events.Blur) -> None:
+            if self is editor:
+                calls.append(1)
+            base(self, event)
+
+        with patch.object(Widget, "_on_blur", _spy):
+            editor.blur()
+            await pilot.pause()
+
+        assert calls == [1], "the base blur handler ran exactly once"
+
+
+@pytest.mark.asyncio
+async def test_the_ctrl_bindings_are_kept_alongside_the_alt_ones() -> None:
+    """This is additive: the Linux/Windows chord keeps working."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        keys = set(editor._bindings.key_to_bindings)
+        assert {"alt+left", "alt+right", "alt+shift+left", "alt+shift+right"} <= keys
+        assert {"ctrl+left", "ctrl+right", "ctrl+shift+left", "ctrl+shift+right"} <= keys

--- a/tests/unit/tui/test_word_caret_matrix.py
+++ b/tests/unit/tui/test_word_caret_matrix.py
@@ -1,0 +1,287 @@
+"""Every option chord, in every composer state, on every terminal encoding.
+
+Two review rounds were needed on #370 because the earlier sweeps tested the
+dimensions INDEPENDENTLY — "picker open x horizontal chord" in one row and
+"history present x vertical chord" in another — and the defects lived in the
+crossings neither row visited. The regression that forced round 3 (code round 2
+F5, ux round 2 U6) needed a picker open AND history present AND the vertical
+chord AND the CSI encoding before it appeared: `⌥↑` closed the list and
+overwrote a half-typed slash command from history, on the terminals where that
+key had previously been a harmless no-op.
+
+So this module does not hand-write rows. It generates the CROSS PRODUCT of
+
+    {picker closed, command picker open, model picker open}
+  x {history present, history absent}
+  x {shell mode on, off}
+  x {left, right, up, down, and the shift variants of each}
+  x {CSI-modifier, readline-meta, Esc-prefixed}
+
+and asserts one property per cell: **the option chord is indistinguishable from
+its plain-arrow equivalent.** That is the whole claim the feature makes, stated
+once and checked everywhere, rather than a list of remembered outcomes that a
+future chord could be added without.
+
+The oracle is the plain arrow itself, run in an identical app, not a recorded
+expectation. So a cell cannot rot: if the meaning of `up` with a picker open
+changes, the chord's expectation changes with it automatically, and a chord
+that stops matching its arrow fails no matter which layer broke it.
+
+Encoding notes (verified against textual 8.2.8, see `test_word_caret.py`):
+
+- CSI-modifier is the only encoding with a spelling for every chord.
+- readline-meta only exists for the horizontal pair (`\\x1bb` / `\\x1bf`); there
+  is no meta spelling of a vertical arrow, so those cells are absent by nature
+  rather than skipped.
+- Esc-prefixed spells everything, as `escape` followed by the plain key.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable
+
+import pytest
+from textual import events
+from textual._xterm_parser import XTermParser
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.editor import Editor, StopRequested
+
+from .test_app_pilot import FakeSession, _factory
+
+#: A prompt in history, so any chord that wrongly reaches history navigation
+#: visibly destroys the buffer rather than silently doing nothing.
+HISTORY = ["summarise the last commit"]
+
+#: Chords under test, mapped to the plain key each must be identical to.
+#:
+#: The two axes have DIFFERENT oracles, and that asymmetry is the feature, not
+#: an inconsistency:
+#:
+#: - Horizontal chords are word motions, so the arrow that means the same thing
+#:   is the `ctrl` one (`ctrl+left` is TextArea's own word-left, and the
+#:   Linux/Windows spelling of this very chord). Comparing `⌥←` against plain
+#:   `←` would assert the chord does nothing, which is the opposite of #370.
+#: - Vertical chords carry no motion of their own and must be pass-throughs, so
+#:   their oracle is the plain arrow.
+CHORDS: dict[str, str] = {
+    "left": "ctrl+left",
+    "right": "ctrl+right",
+    "shift+left": "ctrl+shift+left",
+    "shift+right": "ctrl+shift+right",
+    "up": "up",
+    "down": "down",
+    "shift+up": "shift+up",
+    "shift+down": "shift+down",
+}
+
+#: How each terminal spells a chord. ``None`` means that terminal has no
+#: spelling for it, which is a fact about the encoding, not a gap in coverage.
+_CSI = {
+    "left": "\x1b[1;3D",
+    "right": "\x1b[1;3C",
+    "up": "\x1b[1;3A",
+    "down": "\x1b[1;3B",
+    "shift+left": "\x1b[1;4D",
+    "shift+right": "\x1b[1;4C",
+    "shift+up": "\x1b[1;4A",
+    "shift+down": "\x1b[1;4B",
+}
+_META = {"left": "\x1bb", "right": "\x1bf"}
+
+
+def _encode(encoding: str, chord: str) -> str | None:
+    if encoding == "csi":
+        return _CSI.get(chord)
+    if encoding == "meta":
+        return _META.get(chord)
+    # Esc-prefixed: the plain sequence, preceded by a bare ESC.
+    plain = {
+        "left": "\x1b[D",
+        "right": "\x1b[C",
+        "up": "\x1b[A",
+        "down": "\x1b[B",
+        "shift+left": "\x1b[1;2D",
+        "shift+right": "\x1b[1;2C",
+        "shift+up": "\x1b[1;2A",
+        "shift+down": "\x1b[1;2B",
+    }[chord]
+    return "\x1b" + plain
+
+
+ENCODINGS = ("csi", "meta", "esc_prefixed")
+
+#: Composer states. Each is a setup coroutine plus the buffer it leaves behind.
+STATES: dict[str, dict[str, Any]] = {
+    "resting": {"text": "alpha beta gamma delta", "picker": None, "shell": False},
+    "command_picker": {"text": "/analytics", "picker": "command", "shell": False},
+    "model_picker": {"text": "/model anthropic/claude", "picker": "model", "shell": False},
+    "shell_mode": {"text": "git commit --amend", "picker": None, "shell": True},
+    "multiline": {"text": "first line\nsecond line", "picker": None, "shell": False},
+}
+
+
+async def _boot(pilot: Any, app: OperatorApp) -> Editor:
+    for _ in range(200):
+        if app._session is not None:
+            break
+        await pilot.pause()
+        await asyncio.sleep(0.01)
+    assert app._session is not None, "the session never booted"
+    editor = app.query_one(Editor)
+    editor.focus()
+    await pilot.pause()
+    return editor
+
+
+async def _settle(pilot: Any, cycles: int = 6) -> None:
+    for _ in range(cycles):
+        await pilot.pause()
+
+
+async def _arrange(pilot: Any, editor: Editor, state: str, history: bool) -> None:
+    """Put the composer in one state of the matrix."""
+    spec = STATES[state]
+    editor._history = list(HISTORY) if history else []
+    if spec["shell"]:
+        await pilot.press("!")
+        await pilot.pause()
+    editor.text = spec["text"]
+    await pilot.pause()
+    if spec["picker"]:
+        editor._sync_picker()
+        await pilot.pause()
+    # Caret at the end of the last line, the position a user reaches a chord
+    # from most often and the one where history navigation is live.
+    lines = spec["text"].split("\n")
+    editor.move_cursor((len(lines) - 1, len(lines[-1])))
+    await pilot.pause()
+
+
+def _observe(editor: Editor, stops: list[Any]) -> tuple[Any, ...]:
+    """Everything a user could notice, as one comparable tuple."""
+    return (
+        editor.cursor_location,
+        editor.text,
+        editor.selected_text,
+        editor.shell_mode,
+        editor._picker.is_open(),
+        editor._model_picker.is_open(),
+        editor._picker.selected_index if editor._picker.is_open() else None,
+        len(stops),
+    )
+
+
+async def _run(
+    state: str, history: bool, act: Callable[[Any, OperatorApp], Any]
+) -> tuple[Any, ...]:
+    """Arrange one matrix cell, apply ``act``, and report what a user would see."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        await _arrange(pilot, editor, state, history)
+
+        stops: list[Any] = []
+        original = app.post_message
+
+        def _spy(message: Any) -> bool:
+            if isinstance(message, StopRequested):
+                stops.append(message)
+            return original(message)
+
+        app.post_message = _spy  # type: ignore[method-assign]
+        await act(pilot, app)
+        await _settle(pilot)
+        return _observe(editor, stops)
+
+
+def _press_plain(key: str) -> Callable[[Any, OperatorApp], Any]:
+    async def _act(pilot: Any, app: OperatorApp) -> None:
+        await pilot.press(key)
+
+    return _act
+
+
+def _feed_bytes(raw: str) -> Callable[[Any, OperatorApp], Any]:
+    async def _act(pilot: Any, app: OperatorApp) -> None:
+        parser = XTermParser()
+        parsed = list(parser.feed(raw)) + list(parser.feed(""))
+        driver = app._driver
+        assert driver is not None
+        # No yield between events: one parse pass emits the Esc-prefixed pair
+        # together and the real driver posts both before the loop is pumped.
+        for event in parsed:
+            if isinstance(event, events.Key):
+                event.set_sender(app)
+                driver.send_message(event)
+        await asyncio.sleep(0)
+
+    return _act
+
+
+def _cells() -> list[tuple[str, bool, str, str]]:
+    """The cross product, minus the cells an encoding cannot express."""
+    out = []
+    for state in STATES:
+        for history in (True, False):
+            for chord in CHORDS:
+                for encoding in ENCODINGS:
+                    if _encode(encoding, chord) is None:
+                        continue
+                    out.append((state, history, chord, encoding))
+    return out
+
+
+@pytest.mark.parametrize(
+    ("state", "history", "chord", "encoding"),
+    _cells(),
+    ids=lambda v: str(v),
+)
+@pytest.mark.asyncio
+async def test_the_chord_is_indistinguishable_from_its_plain_arrow(
+    state: str, history: bool, chord: str, encoding: str
+) -> None:
+    """One cell of the matrix: option chord == plain arrow, whatever the state.
+
+    The plain arrow is run in its own identical app and used as the oracle, so
+    this asserts equivalence rather than a remembered outcome.
+    """
+    raw = _encode(encoding, chord)
+    assert raw is not None
+
+    expected = await _run(state, history, _press_plain(CHORDS[chord]))
+    actual = await _run(state, history, _feed_bytes(raw))
+
+    assert actual == expected, (
+        f"{encoding} {chord} in {state} (history={history}) diverged from plain "
+        f"{CHORDS[chord]}:\n  plain={expected}\n  chord={actual}"
+    )
+
+
+@pytest.mark.parametrize("encoding", ENCODINGS)
+@pytest.mark.parametrize("chord", ["up", "down"])
+@pytest.mark.asyncio
+async def test_a_vertical_chord_never_destroys_a_typed_slash_command(
+    chord: str, encoding: str
+) -> None:
+    """The exact regression that forced round 3, pinned on its own.
+
+    Code round 2 F5 / ux round 2 U6: with a list open and history present, the
+    CSI vertical chord closed the picker and replaced `/model anthropic/claude`
+    with a history entry, because a `Binding` fires through the action system
+    and never reaches the picker branches inside `_on_key`.
+
+    Stated as an absolute rather than as an equivalence, so it still fails
+    loudly if the plain-arrow oracle above were ever itself broken.
+    """
+    raw = _encode(encoding, chord)
+    if raw is None:
+        pytest.skip(f"{encoding} has no spelling for {chord}")
+
+    typed = STATES["model_picker"]["text"]
+    result = await _run("model_picker", True, _feed_bytes(raw))
+    text = result[1]
+
+    assert text == typed, f"{encoding} ⌥{chord} destroyed the typed command: {text!r}"
+    assert text not in HISTORY, "the buffer was overwritten from history"

--- a/tests/unit/tui/test_word_caret_matrix.py
+++ b/tests/unit/tui/test_word_caret_matrix.py
@@ -174,9 +174,26 @@ def _observe(editor: Editor, stops: list[Any]) -> tuple[Any, ...]:
 
 
 async def _run(
-    state: str, history: bool, act: Callable[[Any, OperatorApp], Any]
+    state: str,
+    history: bool,
+    act: Callable[[Any, OperatorApp], Any],
+    escape_pending: bool = False,
 ) -> tuple[Any, ...]:
-    """Arrange one matrix cell, apply ``act``, and report what a user would see."""
+    """Arrange one matrix cell, apply ``act``, and report what a user would see.
+
+    ``escape_pending`` delivers a REAL lone Escape immediately before the act,
+    within the one-pump-turn window the coalescing holds it for. That axis
+    exists because the matrix could not previously express F8 (code round 3):
+    a self-contained CSI chord landing on a held escape was misread as that
+    escape's second half and cancelled it, silently dropping every meaning Esc
+    has. Every cell is run both ways, so the crossing cannot go dark again.
+
+    The escape is injected as bytes through the real parser rather than as a
+    key name, because a lone ``\\x1b`` only emerges after the parser's own
+    ESCAPE_DELAY -- which is exactly why the user's inter-key gap is spent
+    inside the parser and not inside the widget's window, and therefore why a
+    real gap does not save you from the bug.
+    """
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 24)) as pilot:
         editor = await _boot(pilot, app)
@@ -191,6 +208,18 @@ async def _run(
             return original(message)
 
         app.post_message = _spy  # type: ignore[method-assign]
+        if escape_pending:
+            # Posted WITHOUT yielding, so the escape is still held when the act
+            # runs. Yielding here would let the one-turn deferral resolve first
+            # and the cell would test nothing -- which is exactly the mistake
+            # that let F8 through, reproduced one level up in the test itself.
+            parser = XTermParser()
+            driver = app._driver
+            assert driver is not None
+            for event in list(parser.feed("\x1b")) + list(parser.feed("")):
+                if isinstance(event, events.Key):
+                    event.set_sender(app)
+                    driver.send_message(event)
         await act(pilot, app)
         await _settle(pilot)
         return _observe(editor, stops)
@@ -257,6 +286,120 @@ async def test_the_chord_is_indistinguishable_from_its_plain_arrow(
         f"{encoding} {chord} in {state} (history={history}) diverged from plain "
         f"{CHORDS[chord]}:\n  plain={expected}\n  chord={actual}"
     )
+
+
+def _escape_pending_cells() -> list[tuple[str, bool, str, str]]:
+    """The same cross product, for the self-contained encodings only.
+
+    The Esc-prefixed spelling is excluded by nature rather than by choice: it
+    IS an escape followed by an arrow, so preceding it with a real escape makes
+    a three-event sequence whose first escape stands alone and whose second
+    legitimately pairs with the arrow. That is a different scenario (and is
+    pinned separately in ``test_word_caret.py``), not this axis.
+    """
+    return [
+        (state, history, chord, encoding)
+        for (state, history, chord, encoding) in _cells()
+        if encoding != "esc_prefixed"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("state", "history", "chord", "encoding"),
+    _escape_pending_cells(),
+    ids=lambda v: str(v),
+)
+@pytest.mark.asyncio
+async def test_a_self_contained_chord_never_swallows_a_pending_escape(
+    state: str, history: bool, chord: str, encoding: str
+) -> None:
+    """The F8 axis: a real Esc held when the chord lands must still fire.
+
+    A self-contained chord (one event that already means "option+arrow") is not
+    evidence about a pending escape, so the escape's own action is still owed.
+    This asserts BOTH halves: the escape fires exactly once, AND the chord
+    still moves the caret exactly as it does with no escape pending.
+
+    Without the ``self_contained`` guard in ``_on_key`` these cells fail: the
+    rewrite turned ``alt+up`` into ``up``, ``up`` is in ``ESCAPE_CHORD_KEYS``,
+    and the chord cancelled the escape it had nothing to do with -- taking the
+    stop, the shell-mode exit, or a picker dismissal with it.
+
+    NOTE the oracle here is the chord's OWN no-escape outcome, not the plain
+    arrow. ``pilot.press`` delivers a key NAME without going through the
+    parser, so the plain arm's escape is still held when its arrow lands and it
+    legitimately reports zero stops -- an artifact of the harness, not of the
+    product. Comparing against it would assert the bug. The equivalence to the
+    plain arrow is already covered by the no-escape axis above; what is left to
+    pin here is that a pending escape changes nothing about the chord and is
+    itself preserved.
+    """
+    raw = _encode(encoding, chord)
+    assert raw is not None
+
+    # THE CONTROL is the horizontal chord, and the choice matters. `alt+left`
+    # is never rewritten, is not in `ESCAPE_CHORD_KEYS`, and therefore never had
+    # F8 -- the code reviewer identified exactly that asymmetry as the tell. So
+    # "how a pending escape is disposed of in this state" is read off the chord
+    # that provably handles it correctly, and the chord under test must match.
+    #
+    # Reading it from a control rather than asserting a fixed outcome is what
+    # keeps this honest: Esc means four different things depending on state
+    # (stop, leave shell mode, dismiss either list), and in the picker states a
+    # dismissed list is legitimately re-opened by the following `_sync_picker`.
+    # Hand-writing those outcomes would have encoded a pre-existing behaviour as
+    # if it were this feature's contract.
+    control_raw = _encode(encoding, "shift+left" if "shift" in chord else "left")
+    assert control_raw is not None
+    control = await _run(state, history, _feed_bytes(control_raw), escape_pending=True)
+    control_baseline = await _run(state, history, _feed_bytes(control_raw))
+
+    baseline = await _run(state, history, _feed_bytes(raw))
+    actual = await _run(state, history, _feed_bytes(raw), escape_pending=True)
+
+    # Whatever the escape did to the control's state, it must also have done
+    # here: same shell mode, same picker states, same stop count.
+    control_effect = (control[3], control[4], control[5], control[-1] - control_baseline[-1])
+    actual_effect = (actual[3], actual[4], actual[5], actual[-1] - baseline[-1])
+    assert actual_effect == control_effect, (
+        f"{encoding} {chord} in {state} (history={history}) disposed of the pending "
+        f"escape differently from the never-rewritten horizontal chord:\n"
+        f"  control (option+left) effect={control_effect}\n"
+        f"  {chord} effect={actual_effect}\n"
+        f"  without escape={baseline}\n  with escape={actual}"
+    )
+    # The chord's own motion is NOT asserted equal to its no-escape baseline,
+    # deliberately. A flushed escape legitimately changes the state the chord
+    # then acts on -- with a command list open, Esc dismisses the list, so the
+    # following `up` is no longer claimed by the picker and correctly falls
+    # through to history recall. Demanding identical motion would assert that
+    # the escape had NOT taken effect, i.e. would re-encode F8 as the contract.
+    #
+    # What must hold is that the chord behaves like a plain arrow pressed in
+    # that same post-escape state, which the no-escape axis already pins for
+    # every state the escape can leave behind.
+
+
+@pytest.mark.parametrize("encoding", ["csi", "meta"])
+@pytest.mark.parametrize("chord", list(CHORDS))
+@pytest.mark.asyncio
+async def test_a_pending_escape_still_stops_the_turn_after_a_chord(
+    chord: str, encoding: str
+) -> None:
+    """The F8 payload, stated absolutely rather than against an oracle.
+
+    Belt and braces beside the equivalence test above: if the plain-arrow
+    oracle were itself ever broken, the equivalence could hold while both sides
+    lost the stop. This pins the stop count directly.
+    """
+    raw = _encode(encoding, chord)
+    if raw is None:
+        pytest.skip(f"{encoding} has no spelling for {chord}")
+
+    result = await _run("resting", False, _feed_bytes(raw), escape_pending=True)
+    stops = result[-1]
+
+    assert stops == 1, f"{encoding} {chord} swallowed the pending escape (stops={stops})"
 
 
 @pytest.mark.parametrize("encoding", ENCODINGS)


### PR DESCRIPTION
# PR Description

## Summary of Changes

Word-wise caret movement in the TUI composer with the platform-native chord:
`option+←`/`option+→` on macOS, `ctrl+←`/`ctrl+→` elsewhere, plus the shift
variants for word-wise selection.

The additive-bindings half is small. The half that matters is a real defect the
issue only guessed at: on a common terminal configuration, **`option+←` aborted
the agent's turn**.

### Diagnosis (verified against `origin/main`)

There is no single byte sequence for `option+←`. Which one a user gets is a
preference in their terminal, not a property of the platform. Verified by
feeding raw bytes through Textual 8.2.8's real `XTermParser`:

| bytes | parses to | terminals |
|---|---|---|
| `\x1b[1;3D` | `alt+left` | Ghostty, kitty, WezTerm, iTerm2 in CSI mode |
| `\x1bb` | `ctrl+left` | iTerm2's default `⌥←` preset, Terminal.app "Use Option as Meta" |
| `\x1b\x1b[D` | **`escape` THEN `left`** | iTerm2 "Esc+", Terminal.app "Esc+", and any terminal once `TEXTUAL_DISABLE_KITTY_KEY` is set |

The third row is the defect. `Editor._on_key`'s bottom escape branch posts
`StopRequested`, so the composer ran the stop and *then* moved the caret one
character. On that configuration, pressing `⌥←` to fix a typo mid-prompt killed
the running turn.

Reproduced on `origin/main` before any change was made:

```
CSI-modifier alt   '\x1b[1;3D'    caret_col=22 stop_requested=False
readline meta-b    '\x1bb'        caret_col=17 stop_requested=False
Esc-prefixed       '\x1b\x1b[D'   caret_col=21 stop_requested=True   <-- turn aborted
```

### Fixes

- **A — Additive bindings (`editor.py`).** `Editor.BINDINGS` gains `alt+left`,
  `alt+right`, `alt+shift+left`, `alt+shift+right`. Textual merges a subclass's
  `BINDINGS` with its bases' rather than overriding them (verified: the resolved
  map holds `alt+left` *and* `ctrl+left`), so the Linux/Windows chord is
  untouched. This covers the CSI-modifier row; the readline row already worked
  through the inherited `ctrl+arrow` bindings.

- **B — Escape/arrow coalescing (`editor.py`).** A bare `escape`'s action is held
  for exactly **one message-pump turn**. An arrow arriving on that turn cancels
  the escape entirely and runs the word movement; otherwise the escape action
  runs unchanged.

  One pump turn is sufficient *by construction*, not by timing luck, and this is
  the load-bearing insight: **the parser has already resolved the ambiguity
  before the widget sees a key.**

  ```
  feed("\x1b")       -> []                    nothing emitted; the parser itself
                                              waits out its own ESCAPE_DELAY
  feed("\x1b\x1b[D") -> ['escape', 'left']    ONE parse pass, ~30 microseconds
                                              apart, queued back to back
  ```

  So a bare `escape` reaching `_on_key` is *already proof* nothing followed it,
  and the chord's `left` is already sitting in the message queue behind its
  `escape`. Yielding one turn lets the queued arrow overtake the deferred
  callback. No wall-clock window is needed.

- **C — `call_later`, not `call_after_refresh`.** Both order correctly, but
  `call_after_refresh` waits for a repaint, which under load costs roughly double
  at the median and 2-6x at p95. `set_timer(0, ...)` is not an option — it raises
  `ZeroDivisionError` in this version of Textual.

- **D — Every escape meaning is deferred** (revised in round 1). The first
  revision deferred only the stop-the-turn branch and left picker dismiss,
  model-picker close and shell-mode exit synchronous, arguing a visible list
  closing late would read as lag. Both reviewers independently found the same
  hole: on an Esc-prefixed terminal `⌥←` in shell mode ejected the user from
  bang-mode with an **identical frame**, flipping what Enter does. The lag
  argument was sized against a 100 ms window; at one pump turn it does not
  apply. Deferring uniformly also means a future escape meaning is covered by
  default instead of becoming the next uncovered branch.

- **E — No `super()` in the cleanup hooks.** Textual dispatches *every* matching
  handler in the MRO, so an `_on_blur` override that also calls `super()` runs
  the base handler twice and posts a second `DescendantBlur`. That broke the
  app's focus tracking (a booted session rendered as "session is still
  starting"). Caught by the full suite, pinned by its own test.

## Related Issue(s)

Closes #370

## Impact

- No breaking changes; this is additive. Every existing chord keeps working.
- `⌥↑`/`⌥↓` are covered as pass-throughs: they cancel the escape and behave as
  plain `↑`/`↓` (history navigation / caret move). Deliberately not macOS
  paragraph movement — `↑` in this composer already means history-at-the-edge,
  and a second competing meaning for the key would be the defect.
- `cmd+←`/`cmd+→` for line start/end is deliberately **out of scope** — `home`
  and `end` are already claimed by the pickers, so that chord has to decide
  whether it follows the picker or the caret. The codepath is left clean for it.
- Esc-to-stop latency is *improved* relative to any wall-clock design and is
  sub-perceptual (~3.7 ms median).

## Testing Details

### Cross-terminal byte-level proof — `tests/unit/tui/test_word_caret.py` (19 tests)

Feeds the literal bytes each emulator writes through the real `XTermParser` into
the real `OperatorApp` (per AGENTS.md "Visual validation": the real app, not a
bare host), one row per terminal encoding, asserting caret position/selection —
and asserting **no `StopRequested`** on the escape-prefixed rows.

- `test_option_left_moves_one_word_on_every_encoding[csi-modifier-3 | readline-meta | escape-prefixed]`
- `test_option_right_moves_one_word_on_every_encoding[...]` (same three)
- `test_option_shift_left_selects_one_word[csi-modifier-4 | escape-prefixed]`
- `test_repeated_option_left_walks_word_by_word` — two chords, two words
- `test_a_lone_escape_still_stops_the_turn`
- `test_two_escapes_produce_two_stops` — the subagent-cancel ladder keeps both rungs
- `test_escape_then_an_ordinary_key_still_stops_the_turn` — stop lands, character still types
- `test_losing_focus_flushes_a_held_escape` / `test_unmount_drops_a_held_escape`
- `test_escape_still_dismisses_a_picker_synchronously` — asserts *no* deferral
- `test_escape_still_leaves_shell_mode_synchronously`
- `test_the_parser_resolves_the_ambiguity_before_the_widget_sees_it` — pins the premise
- `test_escape_to_stop_costs_one_pump_turn_not_a_wall_clock_window` — no `sleep` anywhere, so a wall-clock regression fails it
- `test_the_cleanup_hooks_do_not_double_dispatch_the_base_handler` — fix E
- `test_the_ctrl_bindings_are_kept_alongside_the_alt_ones`

Added in round 1, pinning each fixed finding at byte level:

- `test_option_left_in_shell_mode_keeps_the_mode_on_every_encoding[csi-modifier-3 | readline-meta | escape-prefixed]` — asserts the MODE as well as the caret (F1/U1)
- `test_option_left_with_a_picker_open_keeps_the_list[csi-modifier-3 | escape-prefixed]` (U3)
- `test_option_up_never_stops_the_turn[csi-modifier-3 | escape-prefixed]` (U2)
- `test_option_up_does_not_eat_a_draft_mid_buffer` (U2)
- `test_real_teardown_settles_a_held_escape_and_leaks_no_callback` — real `await remove()` (F3)
- `test_unmount_without_focus_drops_a_held_escape` — the backstop path (F3)

### Before/after reproduction — `scripts/word_caret_probe.py`

Before (on `origin/main`) is quoted in the Diagnosis above. After, on this branch:

```
CSI-modifier alt   '\x1b[1;3D'    caret_col=17 stop_requested=False
readline meta-b    '\x1bb'        caret_col=17 stop_requested=False
Esc-prefixed       '\x1b\x1b[D'   caret_col=17 stop_requested=False
```

All three encodings now land on the same column and none stops the turn.

### Latency characterisation — `scripts/word_caret_latency.py`

**Corrected in round 1.** An earlier revision of this section reported
"100 ms → 3.67 ms median", derived by timing the deferral primitive in
isolation and polling for the result with `pilot.pause()`. That measured the
harness — the poll interval and a bare `call_later` — not what a user waits
for, and the "100 ms before" figure described a wall-clock design that was
never shipped rather than the code on `main`. Both numbers are withdrawn.

The honest comparison is end to end (Esc keypress → `StopRequested` reaching
the handler) against a **synchronous baseline** built by monkeypatching
`_defer_escape` to run inline, which is exactly the pre-fix path. Same rig,
same load, one variable:

```
Esc keypress -> StopRequested, deferred vs SYNCHRONOUS baseline:
  deferred    (loop under load): median  14.89 ms  p95   16.29 ms  n=40
  synchronous (loop under load): median  14.41 ms  p95   15.84 ms  n=40
```

A 0.5 ms difference at the median — the deferral is statistically
indistinguishable from running the action inline. The UX reviewer measured the
same comparison independently and got 4.57 vs 5.16 ms idle and 7.04 vs
22.56 ms under load (deferred *faster* under load). The absolute numbers move
with machine load; the conclusion is stable and is the one that matters: **the
deferral costs a user nothing.**

The primitive comparison still justifies `call_later` over
`call_after_refresh`, and is reported as what it is — an internal choice, not a
user-facing latency:

```
Ordering: does the queued arrow always overtake the deferred escape?
  call_after_refresh: misordered 0/25
  call_later        : misordered 0/25

Primitive choice only (schedule -> callback). NOT a user-facing figure:
  call_after_refresh: median  13.44 ms  p95   30.15 ms
  call_later        : median   1.85 ms  p95    2.02 ms
```

### Real terminal run — `scripts/word_caret_pty.py`

The shipped entry point (`local_operator.cli:main`) under a real pty, receiving
the raw Esc-prefixed bytes, then a printable character to mark where the caret
actually is:

```
booting the real binary under a pty…
  received 372973 bytes of screen output
  looking for the marker in the rendered screen:
    word-wise movement  'alpha beta Xgamma delta': True
    char-wise movement  'alpha beta gamXma delta': False
  RESULT: two chords moved the caret TWO WORDS left. Correct.
```

### Rendered frames

Captured from the real `OperatorApp` at 100x30 and viewed, before (baseline
worktree at `origin/main`) and after. Buffer:
`refactor the session transcript to stream incrementally`, caret at end.

| frame | before | after |
|---|---|---|
| `⌥←` x1 | col 54 (moved 1 **char**) | col 42 (moved 1 **word**) |
| `⌥←` x3 | col 52 (moved 3 chars) | col 32 (moved 3 words) |
| `⌥⇧←` x1 | no selection | selection `incrementally` |
| `⌥⇧←` x3 | no selection | selection `to stream incrementally` |

The before-frame shows the caret still inside `incrementally`; the after-frame
shows it on the `t` of `to`, three words back, with the shift variants
highlighting `to stream incrementally`.

### Gates (whole tree, exactly as CI)

| gate | result |
|---|---|
| `flake8 .` | clean |
| `black --check .` (26.1.0) | 573 files unchanged |
| `isort --check .` (5.13.2) | clean |
| `pyright` | 0 errors, 0 warnings |
| `pytest tests/unit` | **7396 passed, 7 skipped** (9 pre-existing `test_server_models.py` failures reproduce identically on `origin/main` under the same parallel ordering and are unrelated; CI runs them green) |

The TUI suite specifically is 2626 passed / 4 skipped. No test assertion was
weakened to get there: the one genuinely broken test (`test_app_pilot.py::
test_switching_confirms_access_instead_of_warning_about_it`) was a real
regression from the double `super()._on_blur()`, and was fixed at the cause.

## User-visible behavior change

- `option+←`/`option+→` move the caret a word at a time in the composer, and
  `option+shift+←/→` select by word. `ctrl+←/→` continue to work unchanged.
- On macOS this works in **every** option-key mode — the default, "Use Option as
  Meta", and "Esc+" — so contrary to what the issue anticipated, there is
  nothing for the user to configure. Verified exhaustively across 8 states
  (resting composer, shell mode, picker open, multiline, history) in round 1:
  every encoding produces a byte-identical outcome in every one, so the README
  sentence is literally true rather than true-in-the-common-case.
- `⌥←` in shell (`!`) mode no longer ejects you from the mode, and `⌥↑` no
  longer stops the turn or eats your draft.
- `option+←` no longer stops the agent's turn on "Esc+" terminals.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.

