### PR TITLE
feat(tui): inline ghost text for slash completions

### DIFF
--- a/local_operator/tui/widgets/command_picker.py
+++ b/local_operator/tui/widgets/command_picker.py
@@ -507,7 +507,58 @@ def completion_for(
     # and Tab would appear to fill the field and abandon it in one keystroke.
     suffix = " " if mode is CompletionMode.NAME_ARGUMENT else ""
     filled = f"{text[: argument.start]}{row_name}{suffix}{text[argument.end :]}"
-    return filled, argument.start + len(row_name) + len(suffix)
+    caret_after = argument.start + len(row_name) + len(suffix)
+    if mode is CompletionMode.NAME_ARGUMENT:
+        # INLINE ENGAGE. When a draft survives outside the command token,
+        # ``Editor._complete_name_argument`` does NOT stop at the span
+        # replacement above: it hands off to ``_reassemble_prompt_command``,
+        # which moves the whole ``/<cmd> <name>`` construct to the FRONT of the
+        # buffer with the surviving draft as its message. That second edit has
+        # to be modelled HERE, in the one function both Tab and the ghost read,
+        # or the ghost describes an edit that never happens — it previewed a
+        # dimmed append while Tab reordered the entire buffer (review round 1,
+        # B1). Modelling it rather than special-casing the renderer is what
+        # keeps "one function, one answer" true; a renderer-side exception
+        # would reintroduce exactly the two-implementations drift this shared
+        # helper exists to prevent.
+        #
+        # The result is deliberately NOT an append, so ``ghost_for``'s
+        # ``startswith`` rule withholds the ghost of its own accord. That is
+        # the honest outcome: no string appended at the caret can describe a
+        # whole-buffer reordering, the same reason a fuzzy match shows nothing.
+        outside = (text[: argument.token_start] + text[argument.end :]).strip()
+        if outside:
+            return _reassembled_completion(filled, caret_after, known)
+    return filled, caret_after
+
+
+def _reassembled_completion(
+    filled: str, caret: int, known: frozenset[str]
+) -> tuple[str, int] | None:
+    """Apply the inline reassembly to an already-filled NAME_ARGUMENT buffer.
+
+    Mirrors ``Editor._reassemble_prompt_command`` on the FILLED text, which is
+    the state that method actually runs against (the name is in place before
+    the token span is recomputed). Kept beside :func:`completion_for` so the
+    prediction and the edit are read together and cannot drift apart.
+    """
+    span = slash_token_span(filled, caret, known)
+    if span is None:
+        return None
+    token_start, token_end = span
+    command = filled[token_start:token_end].strip()
+    # One adjoining separator goes with the token, matching the splice rule so
+    # ``msg /goal`` and ``/goal\nmsg`` both collapse to just ``msg``. The
+    # PRECEDING separator is preferred; the following one is taken only when
+    # the token opened the buffer.
+    start, end = token_start, token_end
+    if start > 0 and filled[start - 1] in " \t\n":
+        start -= 1
+    elif end < len(filled) and filled[end] in " \t\n":
+        end += 1
+    rest = (filled[:start] + filled[end:]).strip()
+    assembled = f"{command} {rest}" if rest else f"{command} "
+    return assembled, len(assembled)
 
 
 def ghost_for(completion: tuple[str, int] | None, text: str) -> str:

--- a/local_operator/tui/widgets/command_picker.py
+++ b/local_operator/tui/widgets/command_picker.py
@@ -441,6 +441,98 @@ def slash_argument(
     return None if context is None else context.value
 
 
+class CompletionMode(Enum):
+    """Which slot :func:`completion_for` is completing.
+
+    The three completion sites in ``Editor`` differ only in which span they
+    rewrite and whether a trailing space follows the inserted name, and that
+    difference is exactly what this enum names.
+    """
+
+    #: The command WORD — ``/mc`` → ``/mcp `` (``Editor._apply_command``).
+    COMMAND = "command"
+    #: An enum-tail ARGUMENT — ``/mcp lo`` → ``/mcp login``, no trailing space
+    #: so the matcher keeps matching (``Editor._complete_argument``).
+    ARGUMENT = "argument"
+    #: A NAME+message argument — ``/team fro`` → ``/team frontend-guild ``, the
+    #: space opening the message tail (``Editor._complete_name_argument``).
+    NAME_ARGUMENT = "name_argument"
+
+
+def completion_for(
+    text: str,
+    caret: int,
+    mode: CompletionMode,
+    row_name: str,
+    commands: tuple[str, ...],
+    known: frozenset[str] = frozenset(),
+) -> tuple[str, int] | None:
+    """The buffer and caret that accepting ``row_name`` produces — pure.
+
+    THE single source of truth for "what does choosing this row put in the
+    buffer". The three ``Editor`` completion methods delegate their string
+    arithmetic here and keep only their side effects (running the command, the
+    inline reassembly), and the composer's inline GHOST TEXT is derived from
+    the very same call. That shared derivation is what makes the ghost's
+    invariant true by construction rather than by two implementations agreeing:
+    the dimmed cells the user sees are computed from the same ``new_text`` that
+    Tab commits, so ``buffer + ghost == buffer_after_tab`` cannot drift the way
+    two parallel string builders would.
+
+    Every mode replaces a SPAN — ``[start, end)`` — rather than splicing to the
+    end of the buffer, because inline detection means a message may follow the
+    command token (``fix this /te|``) and that suffix is the user's prose. Note
+    the consequence for the ghost: a span replacement is only an APPEND when
+    the row extends what was typed, which is why the ghost rule tests
+    ``new_text.startswith(text)`` instead of assuming it.
+
+    Returns ``None`` when the caret is not in the slot ``mode`` names — the
+    parse the caller would otherwise have had to repeat.
+    """
+    if mode is CompletionMode.COMMAND:
+        context = slash_context(text, caret, known)
+        if context is None:
+            return None
+        # The trailing space is load-bearing, not cosmetic: it terminates the
+        # word (closing the command list) and, for a list-taking command, opens
+        # the argument list. It is part of what Tab commits, so it is part of
+        # the ghost too.
+        completed = f"{text[: context.start]}/{row_name} {text[context.end :]}"
+        return completed, context.start + len(row_name) + 2
+    argument = slash_argument_context(text, commands, caret, known)
+    if argument is None:
+        return None
+    # NAME+message commands take the terminating space (it opens the message
+    # tail); enum-tail arguments must NOT, or the matcher would stop matching
+    # and Tab would appear to fill the field and abandon it in one keystroke.
+    suffix = " " if mode is CompletionMode.NAME_ARGUMENT else ""
+    filled = f"{text[: argument.start]}{row_name}{suffix}{text[argument.end :]}"
+    return filled, argument.start + len(row_name) + len(suffix)
+
+
+def ghost_for(completion: tuple[str, int] | None, text: str) -> str:
+    """The dimmed remainder to preview, or ``""`` when none can be honest.
+
+    The ghost is shown IF AND ONLY IF the completion is a pure APPEND to what
+    the user typed. Completion rewrites a SPAN (see :func:`completion_for`), so
+    for a prefix match that happens to look like an append but for a FUZZY one
+    it rewrites characters already on screen: ``/lg`` + Tab yields ``/login ``,
+    which is not ``/lg`` plus anything. No string appended at the caret can
+    describe that edit, so any ghost there would display characters Tab does
+    not produce — a lie about the next keystroke. The picker row already
+    carries the meaning in that case, so showing nothing costs nothing.
+
+    ``startswith`` is deliberately CASE-SENSITIVE. ``/MCP lo`` + Tab inserts
+    the registry's own casing (``login``), so a case-insensitive check would
+    pass and then paint a ghost whose visible characters differ from the ones
+    Tab commits. Same rule, same reason: only an exact append is honest.
+    """
+    if completion is None:
+        return ""
+    new_text, _caret = completion
+    return new_text[len(text) :] if new_text.startswith(text) else ""
+
+
 #: Below this many typed characters the fuzzy tail is suppressed. A one- or
 #: two-letter query matches an arbitrary-looking set by subsequence — `/u`
 #: offered `usage, quit, accounts, logout` and `/g` offered
@@ -687,6 +779,24 @@ class CommandPicker(Static):
         if not self._matches:
             return None
         return self._matches[self._selected][0]
+
+    def highlighted_choice(self) -> ArgumentChoice | None:
+        """The highlighted ARGUMENT row itself, or ``None``.
+
+        The row OBJECT, not just its name, so a caller can read the flags the
+        app set on it. The safety gate needs ``alert`` — whether choosing this
+        row destroys something — and that is a per-ROW fact the command word
+        cannot answer: ``/mcp remove <server>`` deletes a config while
+        ``/mcp login <server>`` does not, and both live under the same word
+        (see ``Editor._argument_is_destructive``).
+
+        Returns ``None`` in COMMAND mode, where the match is a
+        :class:`SlashCommand` and the question does not apply.
+        """
+        if not self._matches or self._mode is not PickerMode.ARGUMENT:
+            return None
+        choice = self._matches[self._selected][1]
+        return choice if isinstance(choice, ArgumentChoice) else None
 
     @property
     def selected_index(self) -> int:

--- a/local_operator/tui/widgets/command_picker.py
+++ b/local_operator/tui/widgets/command_picker.py
@@ -954,6 +954,19 @@ class CommandPicker(Static):
                 self._reset_rows()
                 self.display = True
                 self._repaint()
+                # The rows are gone even though the surface stays up, so the
+                # observers have to hear it: this is the ONE exit from `_apply`
+                # that used to return without reporting, and the composer's
+                # inline ghost outlived the row it described because of it. The
+                # list would sit showing "credential store unreadable" while the
+                # composer still promised `/mcp login`, and Tab — the key the
+                # dim text exists to describe — inserted a literal tab (UX
+                # review round 2, U9). `_reset_rows` has already emptied
+                # `_matches`, so the report is what turns that into a cleared
+                # preview. Every other path out of `_apply` reports; this one
+                # must too, or "a notice replaced the rows" becomes invisible to
+                # anything watching the accept target.
+                self._report_highlight()
                 return
             self._close()
             return

--- a/local_operator/tui/widgets/command_picker.py
+++ b/local_operator/tui/widgets/command_picker.py
@@ -677,9 +677,25 @@ class CommandPicker(Static):
         self,
         on_choose: Callable[[str], None],
         on_highlight: Callable[[str | None], None] | None = None,
+        on_preview: Callable[[str | None], None] | None = None,
     ) -> None:
         super().__init__()
         self._on_choose = on_choose
+        #: Observer for the row an ACCEPT KEY would take — a SEPARATE question
+        #: from ``on_highlight``, and the reason this is its own channel rather
+        #: than another caller of that one. ``on_highlight`` answers "what is
+        #: the eye on", so it prefers the HOVER and only reports ARGUMENT rows;
+        #: both are right for a row preview and wrong for the composer's inline
+        #: ghost, which is a prediction about what Tab will insert. Reusing the
+        #: highlight channel left the ghost a row behind on every arrow press in
+        #: COMMAND mode (nothing reported there at all) and repainted it to the
+        #: hovered row while Tab still acted on the keyboard selection (review
+        #: round 1, U1/U2). Fired from the same state-change sites, so any way
+        #: the accept target moves reaches it.
+        self._on_preview = on_preview
+        #: Last name reported to ``_on_preview``, de-duplicated for the same
+        #: reason as ``_reported_highlight``.
+        self._reported_preview: str | None = None
         #: Observer for the row the user is CONSIDERING — the hover target when
         #: the mouse is over a row, else the keyboard highlight — called with
         #: ``None`` when an argument list stops showing rows. It exists for
@@ -1463,6 +1479,7 @@ class CommandPicker(Static):
         De-duplicated on the name: a mouse crossing five cells of one row and
         a repaint that reproduced the same set both say nothing new.
         """
+        self._report_preview()
         if self._on_highlight is None or self._suppress_report:
             return
         name: str | None = None
@@ -1473,6 +1490,31 @@ class CommandPicker(Static):
         if name != self._reported_highlight:
             self._reported_highlight = name
             self._on_highlight(name)
+
+    def _report_preview(self) -> None:
+        """Tell the observer which row an ACCEPT KEY would take right now.
+
+        Deliberately different from :meth:`_report_highlight` on both axes:
+
+        * **Both modes.** A command-word list has nothing to *preview* in the
+          ``/theme`` sense, but it certainly has an accept target — the ghost
+          in COMMAND mode is the feature's most common state.
+        * **Keyboard selection only, never the hover.** Tab acts on
+          ``_selected``, so a ghost following the pointer would promise a row
+          the key will not insert. Resting the pointer over the list while
+          reaching for Tab was enough to trigger it (U2).
+
+        Reports ``None`` when the list is not showing rows, which is what
+        retires the ghost on dismissal and on close (U3).
+        """
+        if self._on_preview is None or self._suppress_report:
+            return
+        name: str | None = None
+        if self._matches and self.display and 0 <= self._selected < len(self._matches):
+            name = self._matches[self._selected][0]
+        if name != self._reported_preview:
+            self._reported_preview = name
+            self._on_preview(name)
 
     def _reset_rows(self) -> None:
         """Drop every row and the state that pointed into them, but not the

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -97,7 +97,10 @@ from local_operator.media import ImageInfo, sniff_image, sniff_image_file
 from local_operator.tui.autocomplete import ArgumentMode, SlashCommand
 from local_operator.tui.widgets.command_picker import (
     CommandPicker,
+    CompletionMode,
     PickerMode,
+    completion_for,
+    ghost_for,
     slash_argument,
     slash_argument_context,
     slash_context,
@@ -2806,6 +2809,18 @@ class Editor(TextArea):
         ):
             self._copy_gesture = False
             self._copied_selection = None
+        # A caret move invalidates the ghost: it is rendered AT the caret, so a
+        # ghost set while the caret sat at the end of `/mcp login` and then left
+        # standing renders mid-word once the caret moves back into it
+        # (`/mcp loGHOSTgin notion`, reproduced). Clearing here rather than
+        # re-deriving keeps this watcher cheap and cannot itself paint: the next
+        # `_sync_picker` re-derives on the following keystroke.
+        #
+        # `getattr` for the same reason as above — a reactive watcher can fire
+        # during base-class construction, before this subclass's attributes
+        # exist.
+        if getattr(self, "suggestion", ""):
+            self.suggestion = ""
 
     # -- paste ----------------------------------------------------------------
     async def _on_paste(self, event: events.Paste) -> None:
@@ -3534,6 +3549,11 @@ class Editor(TextArea):
             # always sets the notice to "", so the hint owns the channel cleanly.
             if self._is_name_argument_command(self._argument_command):
                 self._picker.set_notice(self._name_switch_hint(list_argument) or "")
+        # The ghost is re-derived from the freshly synced picker, on the one
+        # path every keystroke already takes. Placed after both list branches so
+        # it reads the picker state this sync just settled, never the previous
+        # keystroke's.
+        self._sync_ghost()
         argument = slash_argument(self.text, self.MODEL_COMMANDS, cursor, self._command_names)
         if argument is None:
             if self._model_picker.is_open():
@@ -3556,6 +3576,12 @@ class Editor(TextArea):
         list) is reported as a close — the preview must not outlive its list.
         """
         command = self._argument_command
+        # Arrowing the list moves the preview with it: the ghost describes the
+        # HIGHLIGHTED row, so a highlight change is one of the two ways its
+        # answer can change (the other is a keystroke, handled by
+        # :meth:`_sync_picker`). The name is passed in because the picker
+        # reports it before ``highlighted_name()`` would.
+        self._sync_ghost(name)
         self.post_message(ArgumentHighlightChanged(command or "", name if command else None))
 
     def _command_word(self) -> str | None:
@@ -3684,14 +3710,44 @@ class Editor(TextArea):
     def _argument_is_destructive(self) -> bool:
         """Whether the OPEN argument list removes something when a row is chosen.
 
-        Read off the buffer's command word rather than the rows: what a keystroke
-        destroys is a property of the command, and a per-row flag would make the
-        gate depend on data the app happened to fill in.
+        TWO conditions, OR-ed — the command WORD, or the highlighted ROW's own
+        ``alert`` flag. Both, because they protect different things and neither
+        subsumes the other:
+
+        * ``DESTRUCTIVE_COMMANDS`` is the FLOOR. It is a property of the command
+          and holds however the app filled the rows in, so a list that arrives
+          empty, late, or without flags is still gated. It must not be replaced
+          by the row check: that would make credential safety depend on data the
+          app happened to set, and any `/logout` row that ever shipped without
+          ``alert=True`` would silently lose the protection it has today.
+
+        * The ROW flag is the PRECISION. A command word is the wrong
+          granularity for a two-level command: under `/mcp`, `remove` and
+          `logout` destroy while `login` and `reauth` do not, so adding `mcp`
+          to the tuple would tax the harmless sibling — `/mcp login lin` +
+          Enter would fill instead of running. ``ArgumentChoice.alert`` is
+          already set on exactly the destructive rows, so this is per-slot
+          precision from machinery that already exists rather than a second
+          confirmation mechanism.
+
+        Without the row condition, `/mcp remove fsy` — three characters that
+        spell nothing, narrowed by the fuzzy matcher to one survivor — deleted a
+        server config from disk on a single Enter, because the command word is
+        `mcp` and not `logout`. That is the `/logout oer` → openrouter hazard
+        this gate was written for, reached through a word the tuple could not
+        see. The same hole existed for `/mcp logout`.
+
+        Note ``alert`` is also set on rows that are merely CONSEQUENTIAL rather
+        than deleting (`/approvals default auto`, whose effect outlives the
+        window). Gating those the same way is the safe direction: the only cost
+        is that Enter fills and a second Enter runs.
         """
-        return (
-            self._picker.mode is PickerMode.ARGUMENT
-            and self._argument_command in self.DESTRUCTIVE_COMMANDS
-        )
+        if self._picker.mode is not PickerMode.ARGUMENT:
+            return False
+        if self._argument_command in self.DESTRUCTIVE_COMMANDS:
+            return True
+        choice = self._picker.highlighted_choice()
+        return choice is not None and choice.alert
 
     def _picker_query(self) -> str | None:
         """The text the open list is matching against, or ``None`` when closed.
@@ -3706,6 +3762,135 @@ class Editor(TextArea):
             return slash_argument(self.text, self._argument_commands, cursor, self._command_names)
         context = slash_context(self.text, cursor, self._command_names)
         return None if context is None else context.query
+
+    def _completion_for(self, mode: CompletionMode, name: str) -> tuple[str, int] | None:
+        """``(new_text, new_caret)`` for accepting ``name``, or ``None``.
+
+        The widget-side adapter over the pure :func:`completion_for`: it supplies
+        this editor's vocabulary and live caret so both the completion sites and
+        the ghost ask the question the same way. Everything else about a
+        completion (running the command, the inline reassembly, the
+        trailing-space policy) stays where it was.
+        """
+        return completion_for(
+            self.text,
+            self._caret_offset(),
+            mode,
+            name,
+            self._argument_commands,
+            self._command_names,
+        )
+
+    def _completion_mode(self) -> CompletionMode | None:
+        """Which slot the OPEN picker would complete into, or ``None``.
+
+        Reads the picker's own mode rather than re-parsing, so the ghost can
+        never describe a different slot from the one Tab would act on.
+        """
+        if not self._picker.is_open():
+            return None
+        if self._picker.mode is not PickerMode.ARGUMENT:
+            return CompletionMode.COMMAND
+        if self._is_name_argument_command(self._argument_command):
+            return CompletionMode.NAME_ARGUMENT
+        return CompletionMode.ARGUMENT
+
+    def _ghost_completion(self, name: str | None = None) -> str:
+        """The dimmed inline preview of what Tab would insert, or ``""``.
+
+        Ghost text is rendered by Textual's own ``suggestion`` reactive (the
+        ``text-area--suggestion`` component, inserted at the caret in
+        ``TextArea._render_line``). Nothing here paints: a bespoke render pass
+        would duplicate the framework AND could not be ordered correctly against
+        :meth:`_paint_markers`/:meth:`_paint_slash`, which post-process a
+        finished ``Strip``.
+
+        Using the native path means living with two of its properties, and the
+        THREE GATES below are what put both out of reach. They are not caution;
+        removing any one of them reintroduces a specific, reproduced defect:
+
+        1. **Caret at the END of the command's line, with no selection.** The
+           ghost adds cells the DOCUMENT does not have, while
+           :meth:`_slash_cells` and :meth:`_marker_cells` compute their x-ranges
+           from document columns. Any highlighted run at or after the caret
+           therefore slides against the rendered strip — observed as the ghost
+           painted in the command colour with the real text's highlight stripped
+           off. With the caret at the line end there is no such run left to
+           misalign. **Relaxing this gate silently reintroduces that mispaint**:
+           driving the widget with the gate bypassed renders ``/mc`` + ghost
+           ``p `` as ``/p mc``, and no test of the ghost's TEXT would catch it.
+        2. **The ghost fits the remaining width.** Textual injects the
+           suggestion AFTER the wrap sections are divided, so a long ghost
+           neither wraps nor crops and simply overruns the composer.
+        3. **Single-line buffer.** Same wrap machinery, and a multi-line draft is
+           not a state the command lists are live in anyway.
+
+        Beyond the gates, the ghost is shown only when accepting the row is a
+        pure APPEND to the buffer (see :func:`ghost_for`) — a fuzzy match
+        rewrites typed characters, so no ghost can honestly describe it.
+        """
+        mode = self._completion_mode()
+        if mode is None:
+            return ""
+        row = name if name is not None else self._picker.highlighted_name()
+        if row is None:
+            return ""
+        text = self.text
+        # Gate 3, and gate 1's selection half. A selection means Tab's edit is
+        # not an insertion at a caret at all.
+        if "\n" in text or self.selection.start != self.selection.end:
+            return ""
+        caret = self._caret_offset()
+        if caret != len(text):
+            return ""
+        ghost = ghost_for(self._completion_for(mode, row), text)
+        if not ghost:
+            return ""
+        # Gate 2. The row's text cells are ``content_size.width`` less the
+        # gutter, and the caret sits at ``column`` within them (single-line by
+        # gate 3, so the document column IS the screen column). A ghost that
+        # would not fit is dropped ENTIRELY rather than rendered overrunning:
+        # cropping it would show fewer characters than Tab inserts, which breaks
+        # the same invariant from the other direction.
+        width = self.content_size.width - self.gutter_width
+        column = self.selection.end[1]
+        if width <= 0 or column + len(ghost) > width:
+            return ""
+        return ghost
+
+    def _sync_ghost(self, name: str | None = None) -> None:
+        """Push the current ghost into Textual's ``suggestion`` reactive.
+
+        The whole write. Called from :meth:`_sync_picker` (which already
+        re-derives every list from the buffer on each keystroke) and from
+        :meth:`_on_picker_highlight` (so arrowing the list moves the preview
+        with it), which between them cover every way the answer can change.
+        """
+        self.suggestion = self._ghost_completion(name)
+
+    def action_cursor_right(self, select: bool = False) -> None:
+        """Move the caret one cell right. NEVER accept the ghost.
+
+        ``TextArea.action_cursor_right`` inserts ``suggestion`` when one is set,
+        which is the fish/zsh-autosuggest convention. This widget deliberately
+        does not take it: Tab is the single accept key the ghost's invariant
+        (``buffer + ghost == buffer after Tab``) is stated over, and issue #370
+        wants ``alt+←/→`` and ``cmd+←/→`` as caret motion in this same composer.
+        A ``→`` that sometimes types five characters and sometimes moves one cell
+        would make that family of chords mean two different things depending on
+        whether a list happens to be open.
+
+        Clearing the suggestion around the super() call is what skips the insert
+        without reimplementing the caret arithmetic, which is non-trivial
+        (selection collapse, soft-wrap, end-of-document). The ghost is then
+        re-derived rather than restored: the caret has moved, so whether it is
+        still honest is exactly the question :meth:`_ghost_completion` answers.
+        """
+        self.suggestion = ""
+        try:
+            super().action_cursor_right(select)
+        finally:
+            self._sync_ghost()
 
     def _apply_command(self, name: str) -> None:
         """What CHOOSING a row does — the picker's ``on_choose`` callback.
@@ -3742,19 +3927,16 @@ class Editor(TextArea):
                 return
             self._run_argument(name)
             return
-        context = slash_context(self.text, self._caret_offset(), self._command_names)
-        if context is None:
+        # The string arithmetic lives in ``completion_for`` so the inline ghost
+        # is derived from the SAME function this commits: the dimmed cells the
+        # user sees are exactly the characters Tab writes, by construction
+        # rather than by two builders agreeing (see :meth:`_ghost_completion`).
+        # It replaces ONLY the command token ``[start, end)``, because inline
+        # detection means a message may follow it and that prose must survive.
+        completed = self._completion_for(CompletionMode.COMMAND, name)
+        if completed is None:
             return
-        # Replace ONLY the command token ``[start, end)`` with ``/name ``. The
-        # word used to run to the end of the buffer, so a completion could splice
-        # to the end; inline detection means a message may follow the token
-        # (``fix this /te|`` or ``/te| ship it``), and that suffix is the user's
-        # prose — it must survive verbatim. The trailing space is load-bearing:
-        # it terminates the word (closing the command list) and, for a
-        # list-taking command, opens the argument list.
-        text = self.text
-        completed = f"{text[: context.start]}/{name} {text[context.end :]}"
-        self._set_text_and_caret(completed, context.start + len(name) + 2)
+        self._set_text_and_caret(*completed)
 
     def _resolve_argument(self, name: str, key: str, unambiguous: bool) -> None:
         """Tab/Enter on an argument row: complete it, or run it.
@@ -3785,20 +3967,15 @@ class Editor(TextArea):
         space terminates the argument, so the matcher would stop matching and Tab
         would appear to fill the field and abandon it in one keystroke.
         """
-        context = slash_argument_context(
-            self.text, self._argument_commands, self._caret_offset(), self._command_names
-        )
-        if context is None:
+        # Shared with the ghost through ``completion_for`` (see
+        # :meth:`_apply_command`). It replaces the argument SPAN ``[start,
+        # end)`` rather than the buffer tail: inline detection means the command
+        # may not be the last thing in the draft, so trimming the argument's
+        # length off the end would corrupt a trailing message.
+        completed = self._completion_for(CompletionMode.ARGUMENT, name)
+        if completed is None:
             return
-        # Replace the argument SPAN ``[start, end)`` rather than the buffer tail:
-        # inline detection means the command may not be the last thing in the
-        # draft, so trimming the argument's length off the end would corrupt a
-        # trailing message. ``end`` is the end of the command's line, which is
-        # the whole argument by construction.
-        text = self.text
-        self._set_text_and_caret(
-            f"{text[: context.start]}{name}{text[context.end :]}", context.start + len(name)
-        )
+        self._set_text_and_caret(*completed)
 
     def _run_argument(self, name: str) -> None:
         """Complete ``name`` and run, so the command's own handler runs it.
@@ -3950,12 +4127,15 @@ class Editor(TextArea):
         )
         if context is None:
             return
-        # Fill the name+space into the argument SPAN (not the buffer tail), so a
-        # trailing inline message would survive. ``context.end`` is the end of the
-        # command's line, the whole argument by construction.
+        # Fill the name+space through the shared helper (see
+        # :meth:`_apply_command`), which replaces the argument SPAN rather than
+        # the buffer tail so a trailing inline message survives. The context is
+        # still read here because the INLINE branch below needs its token span.
         text = self.text
-        filled = f"{text[: context.start]}{name} {text[context.end :]}"
-        caret = context.start + len(name) + 1
+        completed = self._completion_for(CompletionMode.NAME_ARGUMENT, name)
+        if completed is None:
+            return
+        filled, caret = completed
         # If a draft survives outside the command token, this is an INLINE engage:
         # reassemble to the front rather than leaving the command mid-draft. The
         # name is already filled, so the token now reads ``/team <name>``; the

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -3992,7 +3992,7 @@ class Editor(TextArea):
         """
         self.suggestion = self._ghost_completion(name)
 
-    def _on_resize(self, event: events.Resize) -> None:
+    def _on_resize(self) -> None:
         """Re-check the width gate when the composer's width changes.
 
         Gate 2's answer is a function of the terminal width, and nothing else
@@ -4003,9 +4003,11 @@ class Editor(TextArea):
         correctly withheld at 18 columns did not come back on widening until
         the user typed another character (review round 1, U4).
 
-        Cheap and idempotent, so it needs no guard. The event is deliberately
-        not stopped — the base class re-wraps on it.
+        Cheap and idempotent, so it needs no guard. ``super()`` first because
+        the base class re-wraps here, and the gate measures against the wrapped
+        geometry.
         """
+        super()._on_resize()
         self._sync_ghost()
 
     def action_cursor_right(self, select: bool = False) -> None:

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -3565,7 +3565,20 @@ class Editor(TextArea):
                     # so the tracking key is the verb token and any change posts
                     # a refresh (verbs while it is bare, servers once a verb is
                     # chosen — the builder reads the space itself).
-                    subcommand = first_tok.lower() if list_argument else ""
+                    #
+                    # The SEPARATOR is part of the key, not just the token. The
+                    # builder flips from the verb rows to that verb's server
+                    # rows precisely on the terminating space, so a token-only
+                    # key made `login` and `login ` the same state and posted no
+                    # refresh across the one transition that changes the answer:
+                    # the server rows were unreachable by typing, and the picker
+                    # sat empty and closed. This is the identical trap the
+                    # `/team` branch below documents for `chart` → `chart `,
+                    # which is why that branch tracks a boundary rather than a
+                    # token (#377 review round 2). Keyed on the whole
+                    # `verb + sep` so both edges cross: entering the server slot
+                    # and backspacing out of it.
+                    subcommand = f"{first_tok.lower()}{sep}" if list_argument else ""
                     if subcommand != self._argument_subcommand:
                         self._argument_subcommand = subcommand
                         self.post_message(RefreshArgumentChoices(command))

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -2881,18 +2881,24 @@ class Editor(TextArea):
         ):
             self._copy_gesture = False
             self._copied_selection = None
-        # A caret move invalidates the ghost: it is rendered AT the caret, so a
-        # ghost set while the caret sat at the end of `/mcp login` and then left
-        # standing renders mid-word once the caret moves back into it
-        # (`/mcp loGHOSTgin notion`, reproduced). Clearing here rather than
-        # re-deriving keeps this watcher cheap and cannot itself paint: the next
-        # `_sync_picker` re-derives on the following keystroke.
+        # A caret move changes the ghost's answer: it renders AT the caret, so
+        # one set while the caret sat at the end of `/mcp login` renders
+        # mid-word once the caret moves back into it (`/mcp loGHOSTgin notion`,
+        # reproduced) — gate 1 is what refuses that, and this is where the
+        # question gets re-asked.
+        #
+        # RE-DERIVED, not merely cleared. Clearing was cheaper but made two
+        # routes to the same caret position disagree: `left` then `right`
+        # restored the preview (``action_cursor_right`` re-derives in its
+        # `finally`) while `left` then `end` left it blank, with the same caret
+        # and the same open list (review round 1, U5). Asking the gates is the
+        # only answer that cannot depend on which key got you here.
         #
         # `getattr` for the same reason as above — a reactive watcher can fire
         # during base-class construction, before this subclass's attributes
-        # exist.
-        if getattr(self, "suggestion", ""):
-            self.suggestion = ""
+        # exist, and `_ghost_completion` reads several of them.
+        if hasattr(self, "_picker"):
+            self._sync_ghost()
 
     # -- paste ----------------------------------------------------------------
     async def _on_paste(self, event: events.Paste) -> None:
@@ -3922,6 +3928,26 @@ class Editor(TextArea):
             return ""
         row = name if name is not None else self._picker.highlighted_name()
         if row is None:
+            return ""
+        # Nothing typed to complete FROM, and no row deliberately chosen. A
+        # bare `/` offers the whole registry in registration order, so ghosting
+        # its first row is not extending a query, it is naming the top of an
+        # unfiltered list — the feature's first frame spent on a coin flip
+        # (review round 1, U7). The picker already models "too little typed to
+        # guess" for its fuzzy tail (`FUZZY_MIN_QUERY_CHARS`); this is the same
+        # judgement one keystroke earlier.
+        #
+        # `chosen_by_hand` is the exemption, and it is the same signal the
+        # ambiguity gate trusts to let Enter send: once the user has ARROWED to
+        # a row they have named it themselves, so previewing it is reporting
+        # their choice rather than guessing at one. An ARGUMENT slot is exempt
+        # outright — its empty-query list enumerates that command's own values
+        # (`/mcp ` → the verbs), which IS the answer to what was typed.
+        if (
+            mode is CompletionMode.COMMAND
+            and not self._picker_query()
+            and not self._picker.chosen_by_hand
+        ):
             return ""
         text = self.text
         # Gate 3, and gate 1's selection half. A selection means Tab's edit is

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -3817,12 +3817,14 @@ class Editor(TextArea):
 
         * The ROW flag is the PRECISION. A command word is the wrong
           granularity for a two-level command: under `/mcp`, `remove` and
-          `logout` destroy while `login` and `reauth` do not, so adding `mcp`
-          to the tuple would tax the harmless sibling — `/mcp login lin` +
-          Enter would fill instead of running. ``ArgumentChoice.alert`` is
-          already set on exactly the destructive rows, so this is per-slot
-          precision from machinery that already exists rather than a second
-          confirmation mechanism.
+          `logout` destroy outright and `reauth` forgets the stored credential
+          before re-authorizing (`_cmd_mcp` runs `_mcp_logout` first), while
+          `login` only ever adds a grant. Adding `mcp` to the tuple would tax
+          that one harmless sibling — `/mcp login lin` + Enter would fill
+          instead of running. ``ArgumentChoice.alert`` is set per row, so the
+          gate follows what a row actually does rather than what its command
+          word is called, using machinery that already exists rather than a
+          second confirmation mechanism.
 
         Without the row condition, `/mcp remove fsy` — three characters that
         spell nothing, narrowed by the fuzzy matcher to one survivor — deleted a

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -1053,7 +1053,77 @@ class Editor(TextArea):
         # the same cells: a marker opens with `[` and lives in the message tail,
         # the command word and name open with `/` on line 0 — so order is
         # immaterial for correctness (see :meth:`_paint_slash`).
-        return self._paint_slash(self._paint_markers(super().render_line(y), y), y)
+        return self._paint_ghost_caret(
+            self._paint_slash(self._paint_markers(super().render_line(y), y), y), y
+        )
+
+    def _paint_ghost_caret(self, strip: Strip, y: int) -> Strip:
+        """Move the caret block OFF the ghost, onto the last typed cell.
+
+        Textual inserts the suggestion AT ``cursor_column`` and then paints the
+        caret over that same cell, so the composer's opaque block
+        (``text-area--cursor``, an inverted ground) landed on the ghost's FIRST
+        character. Two consequences, one cause (design review round 1, D1/D2):
+
+        * every command's completion ends in a trailing space, so a fully typed
+          command (`/mcp`) has the one-character ghost `' '` — entirely under
+          the block, drawing ZERO dim pixels. The feature was invisible in the
+          state every user passes through on the way to Enter;
+        * a longer ghost split into a bright inverted cell and a dim tail
+          (`/mcp login n` painting `o` inverted then `tion` grey), which reads
+          as one errored character rather than as a caret.
+
+        The block itself is deliberate and load-bearing elsewhere — the boot
+        composer, the read-only composer and the attachment chip all assert an
+        inverted caret cell — so it is kept exactly as it is and MOVED instead:
+        one cell left, onto the last character the user actually typed. That is
+        the boundary between committed and previewed text, which is where the
+        eye needs the mark anyway, and it leaves the whole ghost painting in
+        ``$lo-dim``.
+
+        A post-pass rather than a change to the base class's ``_render_line``,
+        matching the idiom :meth:`_paint_markers` and :meth:`_paint_slash`
+        already establish: adjust cells the base class has finished painting.
+        Runs only while a ghost is showing, so ordinary editing is untouched and
+        pays one boolean.
+        """
+        if not self.suggestion or not self._draw_cursor:
+            return strip
+        row, column = self.selection.end
+        # Nothing to move the caret onto at column 0 (a ghost on an empty line),
+        # so the base class's painting stands.
+        if column <= 0:
+            return strip
+        # The ghost's gates guarantee a single line with the caret at its end,
+        # but the wrap still decides WHICH screen row carries that column, and
+        # only that row may be repainted.
+        wrapped = self.wrapped_document
+        absolute_y = self.scroll_offset.y + y
+        if absolute_y >= wrapped.height:
+            return strip
+        row_line, _section_start = wrapped.offset_to_location(Offset(0, absolute_y))
+        if row_line != row:
+            return strip
+        caret_x = wrapped.location_to_offset((row, column)).x + self.gutter_width
+        typed_x = wrapped.location_to_offset((row, column - 1)).x + self.gutter_width
+        if caret_x >= strip.cell_length or typed_x >= caret_x:
+            return strip
+        cursor_style = self.get_component_rich_style("text-area--cursor")
+        ghost_style = self.get_component_rich_style("text-area--suggestion")
+        # Rebuild three runs: text before the last typed cell, that cell now
+        # carrying the caret, and the ghost cell restored to the dim ink the
+        # base class overpainted.
+        left, rest = strip.divide([typed_x, strip.cell_length])
+        typed_cell, tail = rest.divide([caret_x - typed_x, rest.cell_length])
+        ghost_cell, right = tail.divide([1, tail.cell_length])
+        return Strip.join(
+            [
+                left,
+                Strip(Segment.apply_style(typed_cell, post_style=cursor_style)),
+                Strip(Segment.apply_style(ghost_cell, post_style=ghost_style)),
+                right,
+            ]
+        )
 
     # -- public API ---------------------------------------------------------
     @property

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -834,7 +834,9 @@ class Editor(TextArea):
         # Built BEFORE super().__init__: TextArea's constructor loads its
         # initial document, which funnels through load_text() and therefore
         # through _sync_picker().
-        self._picker = CommandPicker(self._apply_command, self._on_picker_highlight)
+        self._picker = CommandPicker(
+            self._apply_command, self._on_picker_highlight, self._on_picker_preview
+        )
         self._model_picker = ModelPicker(self._apply_model)
         # Which list-taking command the argument list is currently open for, or
         # None when the buffer is not in one. This is the transition edge the
@@ -3576,13 +3578,29 @@ class Editor(TextArea):
         list) is reported as a close — the preview must not outlive its list.
         """
         command = self._argument_command
-        # Arrowing the list moves the preview with it: the ghost describes the
-        # HIGHLIGHTED row, so a highlight change is one of the two ways its
-        # answer can change (the other is a keystroke, handled by
-        # :meth:`_sync_picker`). The name is passed in because the picker
-        # reports it before ``highlighted_name()`` would.
-        self._sync_ghost(name)
         self.post_message(ArgumentHighlightChanged(command or "", name if command else None))
+
+    def _on_picker_preview(self, name: str | None) -> None:
+        """Re-derive the ghost whenever the ACCEPT TARGET moves.
+
+        THE one place the ghost answers to the picker, and the reason it is a
+        separate channel from :meth:`_on_picker_highlight`: the ghost is a
+        prediction about Tab, not a report of what the eye is on. The picker
+        fires this from every site that can move the selection or take the rows
+        away — arrows, wheel, page/home/end, a refilled list, dismissal, close
+        — so "the ghost is re-derived only on keystrokes" stops being true.
+        Four separate defects (a stale row after an arrow, a hover-driven
+        preview, a ghost outliving Esc, and a preview that never came back)
+        were all that one gap (review round 1, U1-U3).
+
+        ``name`` is passed through because the picker reports it before
+        ``highlighted_name()`` would return it, and ``None`` means the list is
+        no longer offering anything — which clears the ghost.
+        """
+        if name is None:
+            self.suggestion = ""
+            return
+        self._sync_ghost(name)
 
     def _command_word(self) -> str | None:
         """The lower-cased command word of the slash token AT THE CARET.
@@ -3854,19 +3872,45 @@ class Editor(TextArea):
         # the same invariant from the other direction.
         width = self.content_size.width - self.gutter_width
         column = self.selection.end[1]
-        if width <= 0 or column + len(ghost) > width:
+        # ``>=``, not ``>``. Textual reserves the cell AT the caret for the
+        # caret itself, so a ghost ending exactly at the content edge still
+        # pushes the rendered strip one cell past the box — measured at w=19
+        # (`/analytic` + `s `) and w=13 (`/mc` + `p `), where the strip came
+        # back one wider than the same row with no ghost. The boundary case is
+        # the only one that matters here, and it was the one the original
+        # comparison admitted (review round 1, B2).
+        if width <= 0 or column + len(ghost) >= width:
             return ""
         return ghost
 
     def _sync_ghost(self, name: str | None = None) -> None:
         """Push the current ghost into Textual's ``suggestion`` reactive.
 
-        The whole write. Called from :meth:`_sync_picker` (which already
-        re-derives every list from the buffer on each keystroke) and from
-        :meth:`_on_picker_highlight` (so arrowing the list moves the preview
-        with it), which between them cover every way the answer can change.
+        The whole write, and the ONE place it happens. Its inputs are the
+        buffer, the picker's accept target, and the available width, so it is
+        driven from exactly the three things that can change those:
+        :meth:`_sync_picker` (a keystroke), :meth:`_on_picker_preview` (the
+        selection moved or the rows went away), and :meth:`_on_resize` (the
+        width gate's answer changed). Anything re-deriving the ghost from a
+        fourth place is a path waiting to go stale.
         """
         self.suggestion = self._ghost_completion(name)
+
+    def _on_resize(self, event: events.Resize) -> None:
+        """Re-check the width gate when the composer's width changes.
+
+        Gate 2's answer is a function of the terminal width, and nothing else
+        re-asked it: a ghost admitted at 100 columns stayed painted when the
+        terminal was narrowed to 13, where it overran and cropped the user's
+        own text (``/usage`` rendering as ``/usag``) — the exact failure the
+        gate exists to prevent. The inverse was equally wrong: a ghost
+        correctly withheld at 18 columns did not come back on widening until
+        the user typed another character (review round 1, U4).
+
+        Cheap and idempotent, so it needs no guard. The event is deliberately
+        not stopped — the base class re-wraps on it.
+        """
+        self._sync_ghost()
 
     def action_cursor_right(self, select: bool = False) -> None:
         """Move the caret one cell right. NEVER accept the ghost.

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -4128,29 +4128,24 @@ class Editor(TextArea):
         if context is None:
             return
         # Fill the name+space through the shared helper (see
-        # :meth:`_apply_command`), which replaces the argument SPAN rather than
-        # the buffer tail so a trailing inline message survives. The context is
-        # still read here because the INLINE branch below needs its token span.
-        text = self.text
+        # :meth:`_apply_command`). ``completion_for`` models BOTH edits this
+        # completion can make — the span replacement, and the inline
+        # reassembly that moves the whole construct to the front when a draft
+        # survives outside the token — so the buffer this writes is the exact
+        # buffer the ghost predicted (review round 1, B1). Reading the answer
+        # from there rather than recomputing the reassembly here is what makes
+        # that guarantee structural instead of a coincidence of two edits
+        # happening to agree.
+        # An INLINE engage (a draft outside the token) therefore arrives here
+        # already reassembled, and is STAGED rather than submitted — the user
+        # reads the assembled line and presses Enter themselves.
+        # ``_set_text_and_caret`` re-derives the pickers either way, so the
+        # command word paints as recognised and a list-taking command opens its
+        # argument list.
         completed = self._completion_for(CompletionMode.NAME_ARGUMENT, name)
         if completed is None:
             return
-        filled, caret = completed
-        # If a draft survives outside the command token, this is an INLINE engage:
-        # reassemble to the front rather than leaving the command mid-draft. The
-        # name is already filled, so the token now reads ``/team <name>``; the
-        # reassembly moves it to the front with the rest of the draft appended.
-        outside = (text[: context.token_start] + text[context.end :]).strip()
-        if outside:
-            # Recompute the token span on the FILLED text (the name changed its
-            # length) and reassemble from there.
-            self.text = filled
-            self.move_cursor(self._location_at_offset(caret))
-            span = slash_token_span(self.text, caret, self._command_names)
-            if span is not None:
-                self._reassemble_prompt_command(*span)
-            return
-        self._set_text_and_caret(filled, caret)
+        self._set_text_and_caret(*completed)
 
     def _extend_to_common_prefix(self) -> None:
         """Grow the typed word to the matches' longest common prefix, no further.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.19"
+version = "0.42.20"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/server/test_server_models.py
+++ b/tests/unit/server/test_server_models.py
@@ -14,13 +14,49 @@ from local_operator.clients.openrouter import (
     OpenRouterModelData,
     OpenRouterModelPricing,
 )
+from local_operator.env import get_env_config
 from local_operator.server.app import app
 
 
 @pytest.fixture
 def client():
-    """Create a test client for the FastAPI app."""
-    return TestClient(app)
+    """Create a test client for the FastAPI app, with the state it depends on.
+
+    A bare ``TestClient(app)`` does NOT run the lifespan handler — that only
+    happens when the client is used as a context manager — so
+    ``app.state.env_config`` is never set here. The ``/v1/models`` routes
+    resolve it through ``Depends(get_env_config)``, which reads
+    ``request.app.state.env_config`` directly, so these tests only passed when
+    some EARLIER test in the same worker process had already populated that
+    shared state (the async fixtures in ``conftest.py`` do, and ``app`` is a
+    module-level singleton shared by every test in the process).
+
+    That made the file order-dependent rather than broken: it passes in a run
+    where a neighbour seeded the state first and fails with
+    ``AttributeError: 'State' object has no attribute 'env_config'`` in one
+    where it lands first on an xdist worker. Which happens is decided by how
+    many tests the suite collects, so adding tests ANYWHERE could flip it —
+    which is how it surfaced, on a branch whose only change here was 56 new TUI
+    tests shifting the distribution.
+
+    Setting the attribute the fixture's own tests need makes the file
+    self-contained, which is the property it should have had: a test that
+    depends on a sibling having run is not a test of anything it names.
+    """
+    # Restored afterwards so a lifespan-backed value from another test in the
+    # same process is not clobbered — this fixture owns the value only for the
+    # duration of its own test.
+    had_env_config = hasattr(app.state, "env_config")
+    previous = getattr(app.state, "env_config", None)
+    if not had_env_config or previous is None:
+        app.state.env_config = get_env_config()
+    try:
+        yield TestClient(app)
+    finally:
+        if had_env_config:
+            app.state.env_config = previous
+        elif hasattr(app.state, "env_config"):
+            delattr(app.state, "env_config")
 
 
 def test_list_providers_with_ollama_active(client):

--- a/tests/unit/tui/test_destructive_argument_gate.py
+++ b/tests/unit/tui/test_destructive_argument_gate.py
@@ -1,0 +1,220 @@
+"""The destructive-argument gate: which Enter may FIRE and which must FILL.
+
+The gate exists because the registry's blast radius is uneven and the matcher
+is a fuzzy SUBSEQUENCE matcher, so a query that spells nothing can still leave
+a single survivor — ``/logout oer`` reached openrouter. On a destructive list
+that makes one mis-keystroke unrecoverable, so those lists demand the name in
+full or an explicit arrow before Enter acts.
+
+``Editor.DESTRUCTIVE_COMMANDS`` matches the COMMAND WORD, which is the wrong
+granularity for a two-level command. Under ``/mcp`` the word is ``mcp`` for
+every verb, so ``/mcp remove fsy`` — three characters that spell nothing —
+narrowed to one survivor and DELETED A SERVER CONFIG FROM DISK on a single
+Enter. Reproduced on the live key path; the same hole existed for
+``/mcp logout``. The fix reads the highlighted ROW's ``alert`` flag, which the
+app already sets on exactly the destructive rows, and keeps the command-word
+tuple as a floor.
+
+Every case drives REAL keys through ``run_test``. The defect was invisible to
+reasoning about the source and only appeared under an actual Enter, so a test
+that called the gate directly would have agreed with the bug.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.autocomplete import ArgumentChoice
+from local_operator.tui.widgets.editor import Editor
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+#: ``/mcp remove`` rows, shaped exactly as the app builds them: compound names
+#: (the matcher compares against the WHOLE argument) carrying ``alert=True``
+#: because choosing one deletes a server from the config file.
+#:
+#: Constructed HERE rather than driven through the app's own
+#: ``_mcp_argument_choices`` because the ``/mcp remove`` verb ships in a
+#: concurrent PR. The gate under test reads the flag off the row, so rows with
+#: the right shape exercise it faithfully and this file does not depend on that
+#: branch landing first.
+REMOVE_ROWS = [
+    ArgumentChoice("remove filesystem", "Remove the filesystem server", alert=True),
+    ArgumentChoice("remove grafana", "Remove the grafana server", alert=True),
+]
+
+#: ``/mcp logout`` — destructive for the same reason (an OAuth credential costs
+#: another browser round trip to get back). The app already sets ``alert`` here.
+LOGOUT_ROWS = [
+    ArgumentChoice("logout filesystem", "Forget the stored credential", alert=True),
+    ArgumentChoice("logout grafana", "Forget the stored credential", alert=True),
+]
+
+#: ``/mcp login`` — the NON-destructive sibling under the same command word.
+#: This is why the fix is not ``DESTRUCTIVE_COMMANDS = ("logout", "mcp")``:
+#: that would tax this flow to protect the ones above.
+LOGIN_ROWS = [
+    ArgumentChoice("login filesystem", "Authorize the filesystem server"),
+    ArgumentChoice("login grafana", "Authorize the grafana server"),
+]
+
+
+async def _settle(pilot: Any, times: int = 8) -> None:
+    for _ in range(times):
+        await pilot.pause()
+
+
+async def _fuzzy_enter(rows: list[ArgumentChoice], typed: str, key: str = "enter") -> Any:
+    """Type ``typed`` into ``/mcp `` against ``rows``, then press ``key``.
+
+    Returns ``(buffer_before, buffer_after, destructive, matched_rows)``. An
+    empty buffer afterwards means the command FIRED (the submit path clears
+    it); a filled one means the gate held and completed instead.
+
+    The rows are re-pushed after typing because the app answers the argument
+    query one message-loop tick behind the keystroke, and this harness has no
+    app-side handler to refill them.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        editor.text = "/mcp "
+        editor.move_cursor(editor._end_of_buffer())
+        editor._sync_picker()
+        await _settle(pilot, 8)
+        editor.picker.set_choices(list(rows))
+        await _settle(pilot, 6)
+        for char in typed:
+            await pilot.press("space" if char == " " else char)
+            await _settle(pilot, 5)
+        editor.picker.set_choices(list(rows))
+        await _settle(pilot, 6)
+
+        matched = [name for name, _ in editor.picker.suggestions()]
+        destructive = editor._argument_is_destructive()
+        before = editor.text
+        await pilot.press(key)
+        await _settle(pilot, 10)
+        return before, editor.text, destructive, matched
+
+
+@pytest.mark.asyncio
+async def test_a_fuzzy_mcp_remove_fills_instead_of_deleting() -> None:
+    """THE data-loss case: ``/mcp remove fsy`` + Enter must not delete anything.
+
+    ``fsy`` is a subsequence of ``filesystem`` that spells nothing — the user
+    never named the server. Before the fix the matcher narrowed to one survivor,
+    the gate answered False because the command word is ``mcp``, and Enter fired:
+    buffer cleared, config gone from disk.
+
+    The gate now fills the exact name instead, so the buffer holds what the user
+    would have had to type — one match, so a SECOND Enter runs it deliberately.
+    """
+    before, after, destructive, matched = await _fuzzy_enter(REMOVE_ROWS, "remove fsy")
+
+    assert matched == ["remove filesystem"], matched
+    assert destructive is True, "an alert row must make the slot destructive"
+    assert before == "/mcp remove fsy"
+    assert after == "/mcp remove filesystem", f"Enter fired on a fuzzy delete: {after!r}"
+
+
+@pytest.mark.asyncio
+async def test_a_fuzzy_mcp_logout_fills_the_preexisting_hole() -> None:
+    """``/mcp logout <fuzzy>`` + Enter fills — the hole that predates the fix.
+
+    Same shape as ``/mcp remove`` and destructive for the same reason. It was
+    already reachable before either PR: ``/mcp logout`` has always been gated
+    only by the command word ``mcp``, which is not in the tuple.
+    """
+    _before, after, destructive, matched = await _fuzzy_enter(LOGOUT_ROWS, "logout fsy")
+
+    assert matched == ["logout filesystem"], matched
+    assert destructive is True
+    assert after == "/mcp logout filesystem", f"Enter fired on a fuzzy logout: {after!r}"
+
+
+@pytest.mark.asyncio
+async def test_a_fuzzy_mcp_login_still_runs() -> None:
+    """The non-destructive sibling is NOT taxed by its destructive relatives.
+
+    This is the whole reason the fix reads the row rather than adding ``mcp`` to
+    ``DESTRUCTIVE_COMMANDS``. ``/mcp login`` opens a browser and re-uses an
+    existing grant if there is one; the worst case of a wrong pick is an
+    authorization the user cancels, not a deletion. It keeps the single-match
+    Enter that every harmless list has.
+    """
+    _before, after, destructive, matched = await _fuzzy_enter(LOGIN_ROWS, "login fsy")
+
+    assert matched == ["login filesystem"], matched
+    assert destructive is False, "a login row must not be gated as destructive"
+    assert after == "", f"the harmless sibling stopped running on Enter: {after!r}"
+
+
+@pytest.mark.asyncio
+async def test_a_gated_enter_fills_the_same_text_as_tab() -> None:
+    """A fill-instead-of-fire Enter is byte-identical to Tab on the same row.
+
+    Both keys reach ``_complete_argument``, which derives its text from the
+    shared ``completion_for``. Pinned because the gate turns Enter into a
+    completion key for these rows, and a completion that differed from Tab's
+    would mean the row named two different commands depending on the key — the
+    exact property the picker's Tab/Enter design exists to prevent.
+    """
+    _b1, tab_text, _d1, _m1 = await _fuzzy_enter(REMOVE_ROWS, "remove fsy", key="tab")
+    _b2, enter_text, _d2, _m2 = await _fuzzy_enter(REMOVE_ROWS, "remove fsy", key="enter")
+
+    assert tab_text == enter_text == "/mcp remove filesystem", (tab_text, enter_text)
+
+
+@pytest.mark.asyncio
+async def test_the_command_word_floor_survives_a_row_without_flags() -> None:
+    """``DESTRUCTIVE_COMMANDS`` still gates on its own, with no flag in sight.
+
+    The regression guard for the constraint that the row check ADDS to the
+    command-word check rather than replacing it. Every ``/logout`` row the app
+    builds carries ``alert=True`` today, so a replacement would pass the suite
+    while making credential safety depend on data the app happened to set — and
+    any future row that shipped without the flag would silently lose the
+    protection. Rows here deliberately carry ``alert=False`` to prove the floor
+    holds without them.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        editor.text = "/logout "
+        editor.move_cursor(editor._end_of_buffer())
+        editor._sync_picker()
+        await _settle(pilot, 8)
+        unflagged = [
+            ArgumentChoice("openrouter", "Forget the key"),
+            ArgumentChoice("deepseek", ""),
+        ]
+        editor.picker.set_choices(unflagged)
+        await _settle(pilot, 6)
+
+        assert (
+            editor._argument_is_destructive() is True
+        ), "the command-word floor must gate /logout even when no row carries alert"
+
+
+@pytest.mark.asyncio
+async def test_logout_rows_all_carry_the_alert_flag() -> None:
+    """The premise the OR relies on, asserted rather than assumed.
+
+    Not a test of the gate but of the data it now reads: if a ``/logout`` row
+    ever ships without ``alert``, the row condition contributes nothing there
+    and the floor is doing all the work — which is fine, and is exactly why the
+    floor was kept. This states that expectation where a future change to the
+    row builder will see it.
+    """
+    from tests.unit.tui.test_command_picker import _logout_choices
+
+    rows = _logout_choices()
+    assert rows, "the fixture must offer rows for this to mean anything"
+    assert all(choice.alert for choice in rows), [c.name for c in rows if not c.alert]

--- a/tests/unit/tui/test_destructive_argument_gate.py
+++ b/tests/unit/tui/test_destructive_argument_gate.py
@@ -239,9 +239,18 @@ async def test_the_gate_is_armed_on_the_typed_path(verb: str, alert: bool, expec
     key missed the verb→space transition). The alert flags and this gate were
     both inert on the one path a user actually takes.
 
-    Every other test of this gate seeds the buffer through ``_set_editor_line``,
-    which calls ``_sync_picker()`` directly and therefore cannot observe a
-    missing message. This one types, which is why it would have caught it.
+    This test does NOT bind the refresh-key fix, despite typing. It calls
+    ``set_choices`` itself, so the rows are present whether or not the widget
+    posted ``RefreshArgumentChoices`` — reverting that fix leaves this file
+    10/10 green (UX review round 3, U11). What it binds is the GATE: that a
+    row's ``alert`` flag arms ``_argument_is_destructive`` on a buffer built by
+    real key presses, which is the half that was silently answering False.
+
+    The refresh fix is bound by
+    ``test_ghost_text.py::test_typing_into_the_mcp_server_slot_opens_its_rows``,
+    which asserts the rows arrive without staging them and fails 3/3 on revert.
+    Look there, not here, when deciding whether a change to the refresh key is
+    safe.
 
     The rows are constructed here because ``/mcp remove`` and the ``reauth``
     alert flag ship in the concurrent PR; the gate reads the flag off the row,

--- a/tests/unit/tui/test_destructive_argument_gate.py
+++ b/tests/unit/tui/test_destructive_argument_gate.py
@@ -218,3 +218,50 @@ async def test_logout_rows_all_carry_the_alert_flag() -> None:
     rows = _logout_choices()
     assert rows, "the fixture must offer rows for this to mean anything"
     assert all(choice.alert for choice in rows), [c.name for c in rows if not c.alert]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "verb,alert,expected",
+    [
+        ("remove", True, True),
+        ("logout", True, True),
+        ("reauth", True, True),
+        ("login", False, False),
+    ],
+)
+async def test_the_gate_is_armed_on_the_typed_path(verb: str, alert: bool, expected: bool) -> None:
+    """The gate must arm through REAL keystrokes, not just a seeded buffer.
+
+    ``_argument_is_destructive`` reads the highlighted row's flag, and a CLOSED
+    list has no highlighted row — so the gate silently answered False for every
+    ``/mcp`` row while the server slot was unreachable by typing (the refresh
+    key missed the verb→space transition). The alert flags and this gate were
+    both inert on the one path a user actually takes.
+
+    Every other test of this gate seeds the buffer through ``_set_editor_line``,
+    which calls ``_sync_picker()`` directly and therefore cannot observe a
+    missing message. This one types, which is why it would have caught it.
+
+    The rows are constructed here because ``/mcp remove`` and the ``reauth``
+    alert flag ship in the concurrent PR; the gate reads the flag off the row,
+    so rows of the right shape exercise it faithfully.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in f"/mcp {verb} ":
+            await pilot.press("space" if char == " " else char)
+            await _settle(pilot, 6)
+        editor.picker.set_choices(
+            [
+                ArgumentChoice(f"{verb} linear", "", alert=alert),
+                ArgumentChoice(f"{verb} notion", "", alert=alert),
+            ]
+        )
+        await _settle(pilot, 8)
+
+        assert editor.picker.is_open(), f"/mcp {verb} left the picker closed by typing"
+        assert editor._argument_is_destructive() is expected

--- a/tests/unit/tui/test_ghost_text.py
+++ b/tests/unit/tui/test_ghost_text.py
@@ -27,6 +27,8 @@ from unittest.mock import patch
 import pytest
 
 from local_operator.tui.app import OperatorApp
+from textual.widgets.text_area import Selection
+
 from local_operator.tui.widgets.editor import Editor
 from tests.unit.tui.test_app_pilot import (
     FakeMcpManager,
@@ -158,6 +160,93 @@ async def test_tab_commits_exactly_the_ghost(seed: str, typed: str, expected: st
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "typed",
+    ["review this /team ", "fix the bug /agent cod"],
+)
+async def test_an_inline_name_command_shows_no_ghost(typed: str) -> None:
+    """The reassembly path previews nothing, because it is not an append.
+
+    ``/team`` and ``/agent`` are NAME+message commands, and when a draft
+    survives outside the command token, accepting a row does not just fill the
+    span — ``_complete_name_argument`` moves the whole ``/<cmd> <name>``
+    construct to the FRONT of the buffer with the draft as its message. The
+    ghost previewed only the span replacement, so ``review this /team `` showed
+    a dimmed ``chart `` and Tab produced ``/team chart review this`` (review
+    round 1, B1).
+
+    ``completion_for`` now models both edits, so the predicted buffer is a
+    reordering rather than an append and ``ghost_for``'s ``startswith`` rule
+    withholds the preview on its own. Asserted through real keys, and the
+    invariant is re-checked here rather than assumed: whatever the ghost says,
+    it must still describe Tab.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type(pilot, typed)
+        await _settle(pilot, 10)
+        before = editor.text
+        ghost = editor.suggestion
+        await pilot.press("tab")
+        await _settle(pilot, 10)
+        after = editor.text
+
+    assert ghost == "", f"the reassembly path previewed {ghost!r}, which Tab does not append"
+    # Tab still reassembles — the fix is to the prediction, not to the edit.
+    assert after != before and after.startswith(("/team ", "/agent ")), after
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "typed,width,expected",
+    [
+        # `/analytic` (9 cells) + ghost `s ` (2) needs 11 free cells.
+        ("/analytic", 20, "s "),  # 12 available: room to spare
+        ("/analytic", 19, ""),  # 11 available: EXACTLY the boundary
+        ("/mc", 14, "p "),  # 6 available
+        ("/mc", 13, ""),  # 5 available: EXACTLY the boundary
+    ],
+)
+async def test_the_width_gate_rejects_the_exact_boundary(
+    typed: str, width: int, expected: str
+) -> None:
+    """At ``col + len(ghost) == width`` the ghost must be refused, not admitted.
+
+    Textual reserves the cell AT the caret for the caret itself, so a ghost
+    ending exactly at the content edge still pushed the rendered strip one cell
+    past the box — measured as a strip one wider than the same row with no
+    ghost, at w=19 and w=13 (review round 1, B2). The original ``>`` admitted
+    precisely that case, and the existing width test sampled widths comfortably
+    either side of it.
+
+    Both a fitting and a boundary width per ghost, so the test discriminates
+    rather than just asserting emptiness at narrow widths.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(width, 20)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type(pilot, typed)
+        await _settle(pilot, 8)
+        ghost = editor.suggestion
+        with_ghost = editor.render_line(0).cell_length
+        editor.suggestion = ""
+        await _settle(pilot, 3)
+        without_ghost = editor.render_line(0).cell_length
+
+    assert ghost == expected, f"w={width}: ghost {ghost!r} != {expected!r}"
+    # The point of the gate, asserted directly: a ghost never widens the row.
+    assert with_ghost == without_ghost, (
+        f"w={width}: the ghost pushed the strip from {without_ghost} to "
+        f"{with_ghost} cells — it overran the content box"
+    )
+
+
+@pytest.mark.asyncio
 async def test_the_ghost_is_dropped_when_it_would_not_fit() -> None:
     """Gate 2: a ghost wider than the row is withheld, not cropped.
 
@@ -236,6 +325,46 @@ async def test_moving_the_caret_clears_the_ghost() -> None:
 
 
 @pytest.mark.asyncio
+async def test_gate_one_alone_withholds_a_mid_caret_ghost() -> None:
+    """Gate 1's OWN contribution, isolated from ``watch_selection``.
+
+    ``test_moving_the_caret_clears_the_ghost`` presses ``left``, which fires
+    ``watch_selection`` — and that clears the ghost independently, so the
+    assertion passes whether or not gate 1 exists. Deleting the gate left the
+    whole suite green (review round 1, M1), which is the worst kind of gap:
+    the docstring warns a future editor not to relax the gate, and nothing
+    held them to it.
+
+    This asks :meth:`_ghost_completion` directly with the caret parked
+    mid-buffer, which is the one question the gate answers by itself. The state
+    is reachable rather than synthetic: brute-forcing the pure functions finds
+    34 caret-mid combinations that yield a real ghost, of which ``/mcp `` with
+    the caret inside the word is one.
+
+    Verified to FAIL with the gate removed (it returns ``' '``, painting a
+    one-space ghost mid-word) and pass with it present.
+    """
+    app = _mcp_app()
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type(pilot, "/mcp")
+        await _settle(pilot, 8)
+        # The list is open on `mcp`, so a ghost is genuinely on offer here.
+        assert editor.picker.highlighted_name() == "mcp"
+        assert editor._ghost_completion() == " ", "precondition: caret at end still ghosts"
+
+        # Park the caret INSIDE the word without going through a key press, so
+        # `watch_selection`'s own clearing cannot be what produces the result.
+        editor.selection = Selection((0, 2), (0, 2))
+        assert editor._ghost_completion() == "", (
+            "gate 1 admitted a ghost with the caret mid-word — it would render "
+            "between the typed characters (`/p mc`)"
+        )
+
+
+@pytest.mark.asyncio
 async def test_enter_completes_to_the_same_text_as_tab() -> None:
     """Enter's COMPLETING path is byte-identical to Tab's.
 
@@ -291,3 +420,129 @@ async def test_a_multiline_draft_shows_no_ghost() -> None:
         editor._sync_picker()
         await _settle(pilot, 8)
         assert editor.suggestion == "", editor.suggestion
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("typed,downs", [("/", 1), ("/", 2), ("/lo", 1), ("/lo", 2)])
+async def test_arrowing_the_command_list_moves_the_ghost_with_it(typed: str, downs: int) -> None:
+    """The ghost follows the ACCEPT TARGET, including in COMMAND mode.
+
+    The ghost used to ride ``on_highlight``, which reports only ARGUMENT rows —
+    so in COMMAND mode nothing reported during an arrow press and the only sync
+    was the one at the top of ``_on_key``, which runs BEFORE ``picker.move()``.
+    The preview sat one row behind: `/` then `down` showed `help ` and Tab
+    inserted `/exit ` (review round 1, U1).
+
+    Parametrised over both lists and two depths because the defect persisted for
+    every subsequent arrow, so a single-press test could have passed on an
+    off-by-one that merely shifted.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type(pilot, typed)
+        for _ in range(downs):
+            await pilot.press("down")
+            await _settle(pilot, 6)
+        highlighted = editor.picker.highlighted_name()
+        before = editor.text
+        ghost = editor.suggestion
+        await pilot.press("tab")
+        await _settle(pilot, 10)
+        after = editor.text
+
+    assert ghost, "arrowing a list left no preview at all"
+    assert before + ghost == after, (
+        f"after {downs} down press(es) the ghost promised {(before + ghost)!r} "
+        f"but Tab inserted {after!r} (highlighted row was {highlighted!r})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_hovering_the_list_does_not_repaint_the_ghost() -> None:
+    """The ghost follows the KEYBOARD selection, never the pointer.
+
+    ``_report_highlight`` deliberately prefers the hover — correct for the row
+    grounds, wrong for a prediction about a key. Resting the pointer over the
+    third row previewed `/mcp reauth` while Tab still inserted `/mcp login`,
+    and no keystroke existed to correct it (review round 1, U2).
+    """
+    app = _mcp_app()
+    configs = _oauth_configs()
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        with patch("local_operator.mcp.config.load_all_mcp_configs", return_value=(configs, {})):
+            await _type(pilot, "/mcp ")
+            await _settle(pilot, 10)
+            keyboard_ghost = editor.suggestion
+            for row in range(3):
+                await pilot.hover(editor.picker, offset=(2, row))
+                await _settle(pilot, 6)
+                assert editor.suggestion == keyboard_ghost, (
+                    f"hovering row {row} repainted the ghost to {editor.suggestion!r}; "
+                    "Tab acts on the keyboard selection, so the preview must too"
+                )
+            before = editor.text
+            ghost = editor.suggestion
+            await pilot.press("tab")
+            await _settle(pilot, 10)
+            after = editor.text
+
+    assert before + ghost == after, f"{(before + ghost)!r} != {after!r}"
+
+
+@pytest.mark.asyncio
+async def test_escape_clears_the_ghost_with_the_list() -> None:
+    """Dismissing the list retires the preview it was explaining.
+
+    Escape hid the rows but left the dimmed cells painted, and Tab with no open
+    picker is a literal tab: the screen promised `/mcp ` and the buffer became
+    `/mc ` (review round 1, U3). The ghost must not outlive its own legend.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type(pilot, "/mc")
+        await _settle(pilot, 8)
+        assert editor.suggestion == "p ", "precondition: a ghost is showing"
+
+        await pilot.press("escape")
+        await _settle(pilot, 8)
+
+        assert editor.picker.is_open() is False
+        assert editor.suggestion == "", "the ghost outlived the list Escape dismissed"
+
+
+@pytest.mark.asyncio
+async def test_resizing_re_checks_the_width_gate() -> None:
+    """Gate 2's answer depends on the width, so a resize has to re-ask it.
+
+    Nothing re-derived the ghost on resize: one admitted at 100 columns stayed
+    painted when the terminal was narrowed to 13, where it overran and cropped
+    the user's own text — the exact failure the gate exists to prevent. The
+    inverse was equally wrong: a ghost correctly withheld at a narrow width did
+    not return on widening until another character was typed (review round 1,
+    U4).
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type(pilot, "/us")
+        await _settle(pilot, 8)
+        assert editor.suggestion == "age ", editor.suggestion
+
+        await pilot.resize_terminal(13, 20)
+        await _settle(pilot, 10)
+        assert editor.suggestion == "", "a ghost survived a narrowing that made it overrun"
+
+        await pilot.resize_terminal(100, 24)
+        await _settle(pilot, 10)
+        assert editor.suggestion == "age ", "the ghost did not come back when the room did"

--- a/tests/unit/tui/test_ghost_text.py
+++ b/tests/unit/tui/test_ghost_text.py
@@ -546,3 +546,29 @@ async def test_resizing_re_checks_the_width_gate() -> None:
         await pilot.resize_terminal(100, 24)
         await _settle(pilot, 10)
         assert editor.suggestion == "age ", "the ghost did not come back when the room did"
+
+
+@pytest.mark.asyncio
+async def test_a_bare_slash_predicts_nothing_until_a_row_is_chosen() -> None:
+    """`/` alone has no query to extend, so it previews nothing.
+
+    A bare slash offers the whole registry in registration order; ghosting row
+    one names the top of an unfiltered list rather than completing anything the
+    user typed, so the feature's first frame was a coin flip (review round 1,
+    U7). One typed character makes the prediction real, and an explicit arrow
+    is a deliberate choice the preview should report — the same
+    ``chosen_by_hand`` signal the ambiguity gate trusts to let Enter send.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type(pilot, "/")
+        await _settle(pilot, 8)
+        assert editor.picker.suggestions(), "precondition: the list is showing rows"
+        assert editor.suggestion == "", "a bare / guessed at the top row"
+
+        await _type(pilot, "h")
+        await _settle(pilot, 8)
+        assert editor.suggestion == "elp ", "a typed character must resume predicting"

--- a/tests/unit/tui/test_ghost_text.py
+++ b/tests/unit/tui/test_ghost_text.py
@@ -615,9 +615,9 @@ async def test_a_notice_replacing_the_rows_retires_the_ghost() -> None:
             await _settle(pilot, 8)
 
             assert editor.picker.display is expect_display, notice
-            assert editor.suggestion == "", (
-                f"notice={notice!r}: the ghost outlived the rows it described"
-            )
+            assert (
+                editor.suggestion == ""
+            ), f"notice={notice!r}: the ghost outlived the rows it described"
             assert "login" not in editor.render_line(0).text
 
 
@@ -649,9 +649,7 @@ async def test_typing_into_the_mcp_server_slot_opens_its_rows(verb: str) -> None
         editor = app.query_one(Editor)
         editor.focus()
         with (
-            patch(
-                "local_operator.mcp.config.load_all_mcp_configs", return_value=(configs, {})
-            ),
+            patch("local_operator.mcp.config.load_all_mcp_configs", return_value=(configs, {})),
             # `/mcp logout` offers only servers that actually hold a credential
             # (the `/logout` rule), so both have to be staged for the three
             # verbs to be comparable.

--- a/tests/unit/tui/test_ghost_text.py
+++ b/tests/unit/tui/test_ghost_text.py
@@ -1,0 +1,293 @@
+"""Inline ghost text in the composer — the Tab invariant and its gates.
+
+The whole feature rests on ONE promise: **the dimmed cells the user sees are
+exactly the characters Tab commits**, i.e. ``buffer + ghost == buffer after
+Tab``. Everything here exists to hold that promise against the shape of the
+completion code, which does not naturally have it — every completion site
+replaces a SPAN (``text[:start] + name + text[end:]``), and a span replacement
+only looks like an append when the row happens to extend what was typed. For a
+FUZZY match it rewrites characters already on screen (``/lg`` + Tab yields
+``/login ``), so no ghost can honestly describe it and the correct ghost is
+none at all.
+
+The cases are driven through ``run_test`` with REAL key presses rather than by
+calling the completion methods, because that is the only way the span
+arithmetic is exercised end to end: a unit-level assertion about
+``completion_for`` would agree with itself while the widget did something else
+with the caret. The pilot runs the real ``OperatorApp``, so the picker rows
+come from the shipped ``SLASH_COMMANDS`` registry rather than a fixture that
+could drift from it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.editor import Editor
+from tests.unit.tui.test_app_pilot import (
+    FakeMcpManager,
+    FakeSession,
+    McpSession,
+    _factory,
+)
+
+
+def _oauth_configs() -> dict[str, Any]:
+    """Two OAuth servers, which is what makes the ``/mcp`` compound rows exist.
+
+    ``_mcp_argument_choices`` offers server rows as compound ``login notion``
+    names because the matcher compares against the WHOLE argument. That shape
+    is the hardest completion in the app to predict from the list alone, and is
+    the case the feature was asked for.
+    """
+    from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+    return {
+        "linear": MCPHttpServerConfig(
+            url="https://mcp.linear.app/mcp", auth=MCPAuthConfig(type="oauth")
+        ),
+        "notion": MCPHttpServerConfig(
+            url="https://mcp.notion.com/mcp", auth=MCPAuthConfig(type="oauth")
+        ),
+    }
+
+
+def _mcp_app() -> OperatorApp:
+    from local_operator.session.mcp_status import McpStartupOutcome
+
+    configs = _oauth_configs()
+    manager = FakeMcpManager(["linear", "notion"], ["linear"])
+    manager._configs = configs
+    session = McpSession(manager=manager, startup=McpStartupOutcome())
+    return OperatorApp(lambda: _factory(session))
+
+
+async def _settle(pilot: Any, times: int = 8) -> None:
+    for _ in range(times):
+        await pilot.pause()
+
+
+async def _type(pilot: Any, keys: str) -> None:
+    """Type ``keys`` one press at a time, settling between each.
+
+    Per-key settling matters: the argument rows are filled by the app answering
+    a posted message, so a burst of presses can outrun the list the ghost is
+    derived from.
+    """
+    for char in keys:
+        await pilot.press("space" if char == " " else char)
+        await _settle(pilot, 5)
+
+
+#: ``(seed, typed, expected_ghost)``. ``seed`` is set on the buffer first (the
+#: faithful shortcut for "the user already got here"), then ``typed`` goes in
+#: as real presses. An expected ghost of ``""`` is the honest-refusal case, not
+#: an absent assertion — it is what makes a fuzzy or case-mismatched row show
+#: nothing rather than a lie.
+GHOST_CASES = [
+    # Command WORD, prefix match: the ghost carries the trailing space, because
+    # `/mc` + Tab yields `/mcp ` WITH it. Invisible on screen and deliberately
+    # asserted, since dropping it would break the invariant silently.
+    ("", "/mc", "p "),
+    ("", "/te", "am "),
+    # Enum-tail ARGUMENT: no trailing space, matching `_complete_argument`'s
+    # rule that the space would terminate the argument and close the list.
+    ("/mcp ", "lo", "gin"),
+    ("/mcp ", "l", "ogin"),
+    # The COMPOUND `/mcp` row the issue is about. Reached through `/mcp login `
+    # because that is the route on which the app fills the server rows.
+    ("/mcp login ", "n", "otion"),
+    ("/mcp login ", "l", "inear"),
+    # FUZZY: `/lg` + Tab produces `/login `, which is not `/lg` plus anything.
+    # A span rewrite cannot be described by characters appended at the caret,
+    # so the only honest ghost is none.
+    ("", "/lg", ""),
+    ("/mcp ", "lgn", ""),
+    # CASE: `/MCP lo` + Tab inserts the registry's own casing, so a
+    # case-INSENSITIVE startswith would pass here and then paint characters Tab
+    # does not produce. Pinned so the check is never "helpfully" relaxed.
+    ("", "/MC", ""),
+    ("/mcp ", "LO", ""),
+    ("", "/Te", ""),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("seed,typed,expected", GHOST_CASES)
+async def test_tab_commits_exactly_the_ghost(seed: str, typed: str, expected: str) -> None:
+    """THE invariant: ``buffer + ghost == buffer after Tab``, or no ghost.
+
+    Asserted in both directions on purpose. The expected-ghost check pins WHICH
+    characters are dimmed (so a case-insensitive or fuzzy ghost fails here),
+    and the concatenation check pins that those exact characters are what Tab
+    writes (so a completion that rewrote the span differently fails there).
+    Either alone would pass a version of the bug.
+    """
+    app = _mcp_app()
+    configs = _oauth_configs()
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        with patch("local_operator.mcp.config.load_all_mcp_configs", return_value=(configs, {})):
+            if seed:
+                editor.text = seed
+                editor.move_cursor(editor._end_of_buffer())
+                editor._sync_picker()
+                await _settle(pilot, 10)
+            await _type(pilot, typed)
+            await _settle(pilot, 10)
+
+            before = editor.text
+            ghost = editor.suggestion
+            assert ghost == expected, f"{before!r}: ghost {ghost!r} != {expected!r}"
+
+            await pilot.press("tab")
+            await _settle(pilot, 10)
+            after = editor.text
+
+    if ghost:
+        assert before + ghost == after, (
+            f"invariant broken: {before!r} + {ghost!r} != {after!r} — the dimmed "
+            "cells are not the characters Tab committed"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_ghost_is_dropped_when_it_would_not_fit() -> None:
+    """Gate 2: a ghost wider than the row is withheld, not cropped.
+
+    Textual injects the suggestion AFTER the wrap sections are divided, so a
+    long ghost neither wraps nor crops — it simply overruns the composer. The
+    gate withholds it ENTIRELY rather than truncating, because a cropped ghost
+    would show fewer characters than Tab inserts and break the invariant from
+    the other direction. Same buffer at two widths, so the width is provably
+    the only variable.
+    """
+    ghosts = {}
+    for width in (100, 18):
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(width, 24)) as pilot:
+            await _settle(pilot, 6)
+            editor = app.query_one(Editor)
+            editor.focus()
+            await _type(pilot, "/analytic")
+            await _settle(pilot, 8)
+            ghosts[width] = (editor.text, editor.suggestion)
+
+    assert ghosts[100] == ("/analytic", "s "), ghosts[100]
+    # 18 columns leaves 10 text cells, so `/analytic` (9) plus `s ` cannot fit.
+    assert ghosts[18] == ("/analytic", ""), ghosts[18]
+
+
+@pytest.mark.asyncio
+async def test_right_arrow_does_not_accept_the_ghost() -> None:
+    """``→`` stays a pure caret key.
+
+    ``TextArea.action_cursor_right`` inserts ``suggestion`` natively (the
+    fish/zsh-autosuggest convention). This widget overrides that: Tab is the
+    single accept key the invariant is stated over, and issue #370 wants
+    ``alt+←/→``/``cmd+←/→`` as caret motion in this same composer — a ``→``
+    that sometimes types five characters would make that family of chords mean
+    two different things depending on whether a list is open.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type(pilot, "/mc")
+        await _settle(pilot, 8)
+        assert editor.suggestion == "p ", editor.suggestion
+
+        await pilot.press("right")
+        await _settle(pilot, 8)
+        assert editor.text == "/mc", f"→ accepted the ghost: {editor.text!r}"
+
+
+@pytest.mark.asyncio
+async def test_moving_the_caret_clears_the_ghost() -> None:
+    """Gate 1: a ghost is only ever rendered with the caret at the line end.
+
+    The ghost adds cells the DOCUMENT does not have, while ``_slash_cells`` and
+    ``_marker_cells`` compute their x-ranges from document columns — so a ghost
+    left standing after the caret moves back into the word renders mid-word.
+    Verified by rendering the actual strip, not just reading the reactive:
+    driving the widget with the gate bypassed paints row 0 as ``/p mc``.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type(pilot, "/mc")
+        await _settle(pilot, 8)
+        assert editor.suggestion == "p "
+        assert editor.render_line(0).text.startswith("/mcp"), editor.render_line(0).text
+
+        await pilot.press("left")
+        await _settle(pilot, 8)
+        assert editor.suggestion == "", "a ghost survived a caret move"
+        assert editor.render_line(0).text.startswith("/mc "), editor.render_line(0).text
+
+
+@pytest.mark.asyncio
+async def test_enter_completes_to_the_same_text_as_tab() -> None:
+    """Enter's COMPLETING path is byte-identical to Tab's.
+
+    Both keys deliberately insert the same completion so a row can never mean
+    two different commands depending on the key, and the ghost is stated over
+    Tab — so if Enter's completion diverged, the ghost would be a lie for
+    whichever key the user actually pressed. Only the completing cases are
+    compared: an UNAMBIGUOUS Enter runs the command instead, and an ambiguous
+    Enter on the command WORD takes the common-prefix path
+    (``_extend_to_common_prefix``), which is not a row completion and is
+    deliberately never ghosted.
+    """
+    configs = _oauth_configs()
+    results = {}
+    for key in ("tab", "enter"):
+        app = _mcp_app()
+        async with app.run_test(size=(100, 24)) as pilot:
+            await _settle(pilot, 6)
+            editor = app.query_one(Editor)
+            editor.focus()
+            with patch(
+                "local_operator.mcp.config.load_all_mcp_configs", return_value=(configs, {})
+            ):
+                editor.text = "/mcp login "
+                editor.move_cursor(editor._end_of_buffer())
+                editor._sync_picker()
+                await _settle(pilot, 10)
+                await _type(pilot, "n")
+                await _settle(pilot, 10)
+                ghost = editor.suggestion
+                await pilot.press(key)
+                await _settle(pilot, 10)
+                results[key] = (ghost, editor.text)
+
+    assert results["tab"] == results["enter"] == ("otion", "/mcp login notion"), results
+
+
+@pytest.mark.asyncio
+async def test_a_multiline_draft_shows_no_ghost() -> None:
+    """Gate 3: single-line buffers only.
+
+    The wrap machinery the suggestion is injected around is per-line, and a
+    multi-line draft is not a state the command lists are live in anyway — so
+    the gate costs nothing and removes a whole class of misplacement.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        editor.text = "draft line\n/mc"
+        editor.move_cursor(editor._end_of_buffer())
+        editor._sync_picker()
+        await _settle(pilot, 8)
+        assert editor.suggestion == "", editor.suggestion

--- a/tests/unit/tui/test_ghost_text.py
+++ b/tests/unit/tui/test_ghost_text.py
@@ -28,6 +28,7 @@ import pytest
 from textual.widgets.text_area import Selection
 
 from local_operator.tui.app import OperatorApp
+from local_operator.tui.autocomplete import ArgumentChoice
 from local_operator.tui.widgets.editor import Editor
 from tests.unit.tui.test_app_pilot import (
     FakeMcpManager,
@@ -571,3 +572,100 @@ async def test_a_bare_slash_predicts_nothing_until_a_row_is_chosen() -> None:
         await _type(pilot, "h")
         await _settle(pilot, 8)
         assert editor.suggestion == "elp ", "a typed character must resume predicting"
+
+
+@pytest.mark.asyncio
+async def test_a_notice_replacing_the_rows_retires_the_ghost() -> None:
+    """A list that swaps its rows for a notice must not leave a ghost behind.
+
+    ``CommandPicker._apply`` keeps the surface up when an argument list comes
+    back empty but carries a notice ("credential store unreadable…"), and that
+    branch was the one exit that returned without reporting — so the rows
+    vanished while the composer went on promising a row that no longer existed,
+    and Tab inserted a literal tab against it (UX review round 2, U9).
+
+    The control below is what makes this a test of the NOTICE path rather than
+    of emptiness: the same empty fill without a notice already retired the
+    ghost, because it falls through to ``_close()``, which reports.
+    """
+    for notice, expect_display in (("credential store unreadable", True), ("", False)):
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(100, 24)) as pilot:
+            await _settle(pilot, 6)
+            editor = app.query_one(Editor)
+            editor.focus()
+            editor.text = "/mcp "
+            editor.move_cursor(editor._end_of_buffer())
+            editor._sync_picker()
+            await _settle(pilot, 8)
+            editor.picker.set_choices(
+                [
+                    ArgumentChoice("login", ""),
+                    ArgumentChoice("logout", "", alert=True),
+                    ArgumentChoice("reauth", ""),
+                ]
+            )
+            await _settle(pilot, 6)
+            assert editor.suggestion == "login", "precondition: a ghost is showing"
+
+            # The app re-answers the OPEN list with nothing to offer.
+            if notice:
+                editor.picker.set_notice(notice)
+            editor.picker.set_choices([])
+            await _settle(pilot, 8)
+
+            assert editor.picker.display is expect_display, notice
+            assert editor.suggestion == "", (
+                f"notice={notice!r}: the ghost outlived the rows it described"
+            )
+            assert "login" not in editor.render_line(0).text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("verb", ["login", "logout", "reauth"])
+async def test_typing_into_the_mcp_server_slot_opens_its_rows(verb: str) -> None:
+    """The verb→server transition must post a refresh, so typing reaches the rows.
+
+    ``_sync_picker`` keyed the ``/mcp`` refresh on the first TOKEN only, so
+    ``login`` and ``login `` were the same state — and the terminating space is
+    exactly where ``_mcp_argument_choices`` flips from the verb rows to that
+    verb's server rows. No refresh was posted across the one transition that
+    changes the answer, leaving the server rows unreachable by typing: an empty,
+    unopened picker on every entry path (#377 review round 2).
+
+    Driven with REAL key presses. Every existing test of this surface uses
+    ``_set_editor_line``, which calls ``_sync_picker()`` directly and so cannot
+    observe a missing message — which is why the defect survived a suite that
+    covers these rows.
+    """
+    from local_operator.session.mcp_status import McpStartupOutcome
+
+    configs = _oauth_configs()
+    manager = FakeMcpManager(["linear", "notion"], ["linear"])
+    manager._configs = configs
+    app = OperatorApp(lambda: _factory(McpSession(manager=manager, startup=McpStartupOutcome())))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        with (
+            patch(
+                "local_operator.mcp.config.load_all_mcp_configs", return_value=(configs, {})
+            ),
+            # `/mcp logout` offers only servers that actually hold a credential
+            # (the `/logout` rule), so both have to be staged for the three
+            # verbs to be comparable.
+            patch(
+                "local_operator.mcp.auth.mcp_logged_out_servers",
+                return_value={
+                    "https://mcp.linear.app/mcp",
+                    "https://mcp.notion.com/mcp",
+                },
+            ),
+        ):
+            await _type(pilot, f"/mcp {verb} ")
+            await _settle(pilot, 12)
+            rows = [name for name, _ in editor.picker.suggestions()]
+
+    assert editor.picker.is_open(), f"/mcp {verb} left the picker closed"
+    assert rows == [f"{verb} linear", f"{verb} notion"], rows

--- a/tests/unit/tui/test_ghost_text.py
+++ b/tests/unit/tui/test_ghost_text.py
@@ -667,3 +667,104 @@ async def test_typing_into_the_mcp_server_slot_opens_its_rows(verb: str) -> None
 
     assert editor.picker.is_open(), f"/mcp {verb} left the picker closed"
     assert rows == [f"{verb} linear", f"{verb} notion"], rows
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "typed,ghost,caret_char,ghost_head",
+    [
+        # The D1 case: a fully typed command whose whole completion is the
+        # trailing space. With the caret block on the ghost this drew ZERO dim
+        # pixels and the frame was byte-identical to the pre-feature baseline.
+        ("/mcp", " ", "p", " "),
+        # A multi-character ghost: D2's "bright inverted cell then a dim tail".
+        ("/mc", "p ", "c", "p"),
+        ("/analytic", "s ", "c", "s"),
+    ],
+)
+async def test_the_caret_block_sits_on_typed_text_not_on_the_ghost(
+    typed: str, ghost: str, caret_char: str, ghost_head: str
+) -> None:
+    """The caret must not consume the ghost's first cell.
+
+    Textual inserts the suggestion AT ``cursor_column`` and then paints the
+    caret over that same cell, so the composer's inverted block landed on the
+    ghost's first character — invisible for a one-character ghost, and an
+    errored-looking bright cell for a longer one (design review round 1,
+    D1/D2). ``_paint_ghost_caret`` moves the block one cell left onto the last
+    typed character.
+
+    Asserted on the RENDERED SEGMENTS rather than on a screenshot, because the
+    defect is a colour assignment: the cell carrying the caret must be the
+    typed one, and the ghost's first cell must carry the suggestion ink. The
+    post-pass had no test at all, so neutering it left the suite green while
+    the most important design finding regressed (agent review round 2, N1).
+    """
+    app = _mcp_app()
+    configs = _oauth_configs()
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        with patch("local_operator.mcp.config.load_all_mcp_configs", return_value=(configs, {})):
+            await _type(pilot, typed)
+            await _settle(pilot, 10)
+            assert editor.suggestion == ghost, editor.suggestion
+
+            cursor_style = editor.get_component_rich_style("text-area--cursor")
+            ghost_style = editor.get_component_rich_style("text-area--suggestion")
+            segments = [
+                (seg.text, seg.style) for seg in editor.render_line(0)._segments if seg.text
+            ]
+
+    # The caret cell: the LAST TYPED character, carrying the cursor ground.
+    caret_cells = [
+        text
+        for text, style in segments
+        if style is not None and style.bgcolor == cursor_style.bgcolor and text.strip()
+    ]
+    assert caret_cells == [caret_char], (
+        f"the caret block should sit on the typed {caret_char!r}, not on "
+        f"{caret_cells!r} — it is covering the ghost again"
+    )
+
+    # The ghost's first cell: dim ink, NOT the cursor ground.
+    ghost_cells = [
+        text for text, style in segments if style is not None and style.color == ghost_style.color
+    ]
+    assert ghost_cells, "no cell carried the suggestion colour — the ghost is invisible"
+    assert ghost_cells[0].startswith(ghost_head), ghost_cells
+
+
+@pytest.mark.asyncio
+async def test_a_live_selection_withholds_the_ghost() -> None:
+    """The SELECTION half of gate 1, isolated from ``watch_selection``.
+
+    A ghost is an insertion at a caret, and a live range means Tab's edit is
+    not that — so the preview would describe an edit the key will not make.
+    ``shift+left`` clears the ghost through ``watch_selection`` regardless, so
+    relaxing this clause left the suite green (agent review round 2, N2), the
+    same shape as round 1's M1 one clause over.
+
+    Reachable: with the anchor earlier and the selection END at the buffer end,
+    the caret-offset half of the gate passes and only this clause refuses.
+    """
+    app = _mcp_app()
+    configs = _oauth_configs()
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        with patch("local_operator.mcp.config.load_all_mcp_configs", return_value=(configs, {})):
+            await _type(pilot, "/mcp")
+            await _settle(pilot, 10)
+            assert editor._ghost_completion() == " ", "precondition: caret at end ghosts"
+
+            # Anchor earlier, END still at the buffer end: the caret half of
+            # gate 1 passes, so only the selection clause can refuse.
+            editor.selection = Selection((0, 1), (0, 4))
+            assert editor._caret_offset() == len(editor.text), "the caret half must still pass"
+            assert editor._ghost_completion() == "", (
+                "a live selection admitted a ghost — Tab would replace the range, "
+                "not append at a caret"
+            )

--- a/tests/unit/tui/test_ghost_text.py
+++ b/tests/unit/tui/test_ghost_text.py
@@ -99,7 +99,18 @@ GHOST_CASES = [
     # Enum-tail ARGUMENT: no trailing space, matching `_complete_argument`'s
     # rule that the space would terminate the argument and close the list.
     ("/mcp ", "lo", "gin"),
-    ("/mcp ", "l", "ogin"),
+    # `l` alone is deliberately NOT pinned to a literal. It is the one row in
+    # this table whose answer depends on which verbs `/mcp` offers rather than
+    # on the completion arithmetic: it was `ogin` when the verb set was
+    # login/logout/reauth, and becomes `ist` the moment a `list` verb is added
+    # (#377), which sorts ahead of it. Both branches were green in isolation, so
+    # neither CI run saw the crossing — a frozen literal here is a merge
+    # conflict waiting in a file nobody expects one in.
+    #
+    # `None` means "derive the expectation from the highlighted row", which is
+    # what this test is actually about: the ghost must equal the remainder of
+    # whatever row Tab would take. That keeps the case honest under any verb set.
+    ("/mcp ", "l", None),
     # The COMPOUND `/mcp` row the issue is about. Reached through `/mcp login `
     # because that is the route on which the app fills the server rows.
     ("/mcp login ", "n", "otion"),
@@ -120,7 +131,7 @@ GHOST_CASES = [
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("seed,typed,expected", GHOST_CASES)
-async def test_tab_commits_exactly_the_ghost(seed: str, typed: str, expected: str) -> None:
+async def test_tab_commits_exactly_the_ghost(seed: str, typed: str, expected: str | None) -> None:
     """THE invariant: ``buffer + ghost == buffer after Tab``, or no ghost.
 
     Asserted in both directions on purpose. The expected-ghost check pins WHICH
@@ -146,6 +157,13 @@ async def test_tab_commits_exactly_the_ghost(seed: str, typed: str, expected: st
 
             before = editor.text
             ghost = editor.suggestion
+            if expected is None:
+                # Registry-dependent row: the expectation IS the highlighted
+                # row's remainder, so the case survives a change to the verb set
+                # while still asserting the ghost describes the accept target.
+                row = editor.picker.highlighted_name()
+                assert row is not None, f"{before!r}: no row highlighted to predict from"
+                expected = row[len(before.rpartition(" ")[2]) :]
             assert ghost == expected, f"{before!r}: ghost {ghost!r} != {expected!r}"
 
             await pilot.press("tab")
@@ -768,3 +786,88 @@ async def test_a_live_selection_withholds_the_ghost() -> None:
                 "a live selection admitted a ghost — Tab would replace the range, "
                 "not append at a caret"
             )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chord,ends_at_buffer_end",
+    [
+        # Every encoding #375 supports, in both directions. `alt+*` is the macOS
+        # chord, `ctrl+*` the Linux/Windows one; both reach the same action.
+        ("alt+left", False),
+        ("alt+right", True),
+        ("ctrl+left", False),
+        ("ctrl+right", True),
+        # Shift variants select rather than move, so they leave a live range.
+        ("alt+shift+left", False),
+        ("alt+shift+right", True),
+    ],
+)
+async def test_word_wise_caret_chords_never_accept_the_ghost(
+    chord: str, ends_at_buffer_end: bool
+) -> None:
+    """Word-wise movement moves the caret and never inserts the preview.
+
+    A NEW interaction: #375 landed ``option+←/→`` word-wise caret movement (the
+    ``alt``/``ctrl`` encodings and their Shift variants) into the same composer
+    this PR paints a ghost in, and the ghost sits AT the caret. Neither PR could
+    have tested the crossing, so it is pinned here.
+
+    The contract is the one plain ``→`` already has (see
+    :func:`test_right_arrow_does_not_accept_the_ghost`): these are caret keys,
+    and Tab remains the single accept key the invariant is stated over. The
+    buffer must be untouched by every one of them.
+
+    The ghost's own gates then decide whether a preview survives the move: it is
+    withheld once the caret leaves the end of the buffer (gate 1) or a Shift
+    variant opens a selection (gate 1's selection clause), and re-derived when a
+    move lands back at the end — which is why the expectation is a function of
+    where the chord finishes rather than a constant.
+    """
+    typed = "fix the parser /mc"
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type(pilot, typed)
+        await _settle(pilot, 8)
+        assert editor.suggestion == "p ", "precondition: a ghost is showing"
+
+        await pilot.press(chord)
+        await _settle(pilot, 8)
+
+        assert editor.text == typed, f"{chord} mutated the buffer: {editor.text!r}"
+        selection_open = editor.selection.start != editor.selection.end
+        if ends_at_buffer_end and not selection_open:
+            assert editor.suggestion == "p ", f"{chord} lost a ghost that is still true"
+        else:
+            assert editor.suggestion == "", f"{chord} left a ghost away from the caret"
+
+
+@pytest.mark.asyncio
+async def test_the_escape_prefixed_word_chord_does_not_accept_the_ghost() -> None:
+    """The Esc-prefixed encoding of the same chord, which parses as TWO events.
+
+    Terminals in "Esc+" mode send ``option+→`` as ``\\x1b`` then ``\\x1b[C``, so
+    the widget sees ``escape`` followed by ``right``. #375 coalesces those into
+    word movement; this asserts the composer's ghost survives that path the same
+    way — the buffer is untouched, and the preview is retired because the escape
+    dismissed the list it described (the U3 rule).
+    """
+    typed = "fix the parser /mc"
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle(pilot, 6)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type(pilot, typed)
+        await _settle(pilot, 8)
+        assert editor.suggestion == "p "
+
+        await pilot.press("escape")
+        await pilot.press("right")
+        await _settle(pilot, 10)
+
+        assert editor.text == typed, f"the chord mutated the buffer: {editor.text!r}"
+        assert editor.suggestion == "", "a ghost outlived the list escape dismissed"

--- a/tests/unit/tui/test_ghost_text.py
+++ b/tests/unit/tui/test_ghost_text.py
@@ -25,10 +25,9 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
-
-from local_operator.tui.app import OperatorApp
 from textual.widgets.text_area import Selection
 
+from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.editor import Editor
 from tests.unit.tui.test_app_pilot import (
     FakeMcpManager,


### PR DESCRIPTION
# PR Description

## Summary of Changes

Inline ghost text in the composer (issue #368, part 1 of 2): the remainder of
the highlighted picker row is rendered dimmed ahead of the caret, so the user
can see exactly what Tab will produce without mapping a highlighted row back
onto their own buffer. This is the case the issue asks for:

```
/mcp login n␣otion          ← "otion" dimmed, inline
```

It also carries a **data-loss fix** on the destructive-argument gate, found by
driving the real key path (credit to the PR 2 / `/mcp` verbs investigation).

### The invariant

The whole feature rests on one promise: **the dimmed cells are exactly the
characters Tab commits** — `buffer_before + ghost == buffer_after_tab`, always.

That is not free. All three completion sites replace a **span**
(`text[:start] + name + text[end:]`), which only *looks* like an append when
the row extends what was typed. For a fuzzy match it rewrites characters
already on screen: `/lg` + Tab yields `/login `, which is not `/lg` plus
anything.

So the ghost and Tab now derive from **one shared pure function**,
`completion_for()` in `command_picker.py`, which the three `Editor` completion
methods delegate their string arithmetic to (side effects stay where they
were). The invariant is true by construction rather than by two builders
agreeing. `ghost_for()` then shows a ghost **only when the completion is a pure
append**; a fuzzy match previews nothing, because no string appended at the
caret could honestly describe that edit. The check is deliberately
case-sensitive: `/MCP lo` + Tab inserts the registry's own casing, so a
case-insensitive check would paint characters Tab does not produce.

### Native mechanism, not a bespoke render pass

Textual 8.2.8 already has ghost text: the `suggestion` reactive, the
`text-area--suggestion` component (already styled `$lo-dim` in
`local_operator.tcss`), and insertion at the caret in `_render_line`. This PR
uses it. A hand-rolled paint would duplicate the framework and could not be
ordered correctly against `_paint_markers`/`_paint_slash`, which post-process a
finished `Strip`.

### Three gates

The native path has two real defects for this widget, both neutralised by
gates rather than new render code:

1. **Caret at the end of the line, no selection.** The ghost adds cells the
   *document* lacks, while `_slash_cells`/`_marker_cells` compute x-ranges from
   *document* columns — so any highlighted run at or after the caret slides
   against the rendered strip. Proven: with the gate bypassed, `/mc` + ghost
   `p ` renders as **`/p mc`**. Relaxing this gate silently reintroduces that
   mispaint, and no test of the ghost's *text* would catch it.
2. **The ghost fits the remaining width.** Textual injects the suggestion after
   wrap sections are divided, so a long ghost neither wraps nor crops and
   overruns the composer. It is withheld entirely rather than cropped —
   a cropped ghost would show fewer characters than Tab inserts.
3. **Single-line buffer.** Same wrap machinery.

`watch_selection` also clears the ghost on any caret move, since a ghost left
standing renders mid-word (`/mcp loGHOSTgin notion`).

### `→` stays a pure caret key

`TextArea.action_cursor_right` inserts the suggestion natively. That is
overridden here: Tab is the single accept key the invariant is stated over, and
**#370** wants `alt+←/→` and `cmd+←/→` as caret motion in this same composer. A
`→` that sometimes types five characters would make that family of chords mean
two different things depending on whether a list is open.

### Data-loss fix: destructive rows under a two-level command

`_argument_is_destructive` matched only the **command word** against
`DESTRUCTIVE_COMMANDS = ("logout",)`. Under `/mcp` the word is `mcp` for every
verb, so:

```
buffer "/mcp remove fsy"     (fuzzy subsequence; the user never spelled the name)
rows   ["remove filesystem"] (matcher narrowed to one survivor)
Enter  -> buffer cleared, and ON DISK the server is gone
```

A config deleted by three characters that spell nothing — exactly the
`/logout oer` → openrouter hazard the gate was written for, reached through a
word the tuple could not see. **The same hole already existed for
`/mcp logout`** and is closed by the same fix.

The fix reads the highlighted row's existing `ArgumentChoice.alert` flag, which
the app already sets on precisely the destructive rows — per-slot precision
from machinery already in the codebase, no second confirmation mechanism. It is
**OR-ed with the command-word tuple, not a replacement**: the tuple stays as a
floor so a list that arrives empty, late, or without flags is still gated, and
credential safety never becomes dependent on data the app happened to set.
`DESTRUCTIVE_COMMANDS = ("logout", "mcp")` was rejected as the wrong
granularity — it would tax the harmless `/mcp login lin` sibling.

## Testing

### The invariant, driven with real key presses

Span-replacement bugs are invisible to unit-level reasoning, so every case goes
through `run_test` with actual presses. `buffer + ghost` vs `buffer after Tab`:

```
  '/mc'          ghost='p '     tab->'/mcp '               OK
  '/te'          ghost='am '    tab->'/team '              OK
  '/mcp lo'      ghost='gin'    tab->'/mcp login'          OK
  '/mcp l'       ghost='ogin'   tab->'/mcp login'          OK
  '/mcp login n' ghost='otion'  tab->'/mcp login notion'   OK   ← the issue's case
  '/mcp login l' ghost='inear'  tab->'/mcp login linear'   OK
  '/lg'          ghost=''       tab->'/login '             OK   ← fuzzy: no ghost
  '/mcp lgn'     ghost=''       tab->'/mcp login'          OK   ← fuzzy: no ghost
  '/MC'          ghost=''       tab->'/mcp '               OK   ← case: no ghost
  '/mcp LO'      ghost=''       tab->'/mcp login'          OK   ← case: no ghost
  '/Te'          ghost=''       tab->'/team '              OK   ← case: no ghost
ALL OK
```

The issue's `/mcp login n` example was re-derived against a real config rather
than trusted from the text; it reproduces exactly.

### Gate 1 mispaint, proven by rendering the strip

```
  caret at end : ghost='p ' rendered='/mcp          '
  caret moved  : ghost=''   rendered='/mc           '
  GATE BYPASSED: ghost='p ' rendered='/p mc         '  <-- the mispaint the gate prevents
```

### Gate 2 overflow, and `→`

```
  width=100 content= 69 col=9 ghost='s '
  width= 18 content= 10 col=9 ghost=''        ← withheld, not cropped

  ghost='p ' before='/mc' after-right='/mc'   ← OK (pure caret key)
```

### The data-loss fix, before and after

Reproduced on **untouched `origin/main`** (rows constructed directly, so this
does not depend on PR 2's branch), then re-run on this branch:

```
=== origin/main (BEFORE) ===
  /mcp remove fuzzy  destructive=False before='/mcp remove fsy' after=''  FIRED (deletes!)
  /mcp logout fuzzy  destructive=False before='/mcp logout fsy' after=''  FIRED (deletes!)
  remove via ENTER   destructive=False after=''                           FIRED
  gated Enter == Tab: DIVERGES

=== this branch (AFTER) ===
  /mcp remove fuzzy  destructive=True  after='/mcp remove filesystem'     FILLED (safe)
  /mcp logout fuzzy  destructive=True  after='/mcp logout filesystem'     FILLED (safe)
  /mcp login fuzzy   destructive=False after=''                           FIRED (correct: harmless sibling)
  gated Enter == Tab: BYTE-IDENTICAL
```

### `/logout` regression guard — proven unchanged, not assumed

Driven on both trees, since replacing the tuple (rather than OR-ing) would have
silently regressed credential protection:

```
=== BASELINE origin/main ===              === BRANCH dev-ghost-text ===
every /logout row carries alert=True: True (2 rows)   [identical]
'/logout '          destructive=True  after='/logout anthropic'   [identical]
'/logout oer'       destructive=True  after='' submitted=[...]    [identical]
'/logout anthropic' destructive=True  after='' submitted=[...]    [identical]
'/login oer'        destructive=False after='' submitted=[...]    [identical]
unflagged /logout rows -> destructive=True (floor holds)          [identical]
```

Byte-identical on both trees, and the floor still gates rows carrying no flag.

### Suites and gates

- New tests: `test_ghost_text.py` (39) + `test_destructive_argument_gate.py`
  (10) — **49 pass here**, and each one is verified BOUND by reverting the fix
  it guards and confirming it fails, rather than merely agreeing with whatever
  the code does.
- `tests/unit/tui`: **2668 passed, 0 failed**.
- `tests/unit` whole: the residual failures are `eval_tool`/subprocess tests
  that reproduce identically on a clean `origin/main` worktree — an artifact of
  running from a worktree, where the editable venv resolves `local_operator` to
  the main checkout.
- **Correction (agent review round 1, M2).** An earlier revision of this
  section attributed the red CI job to `test_app_pilot.py`. That was wrong. The
  actual failures were `test_launch_subagent.py::test_the_loop_stays_responsive_while_several_subagents_run`
  and `test_resume_subagents_todos.py::test_redundant_roster_events_skip_the_sidecar_write`,
  both in `tests/unit/session/`, which this PR does not touch. Both were
  confirmed pre-existing on a clean base-SHA worktree by the reviewer and
  reproduced here (1 failure in 3 runs of `tests/unit/session` at CI
  parallelism; 6/6 passing serially). The conclusion held; the evidence named
  the wrong file.
- `flake8 .` clean; `black --check .` clean (571 files); `isort --check .`
  clean; `pyright` **0 errors, 15s** over the whole tree (568 files) — runnable
  locally since `f32802e3` restored the default excludes, so this gate is
  verified rather than deferred to CI.
- Per-keystroke cost measured: the slash path goes 1.68 → 1.92 ms/sync, prose
  path unchanged.

### Visual validation

Frames captured with the real `OperatorApp` (the lightweight test hosts declare
no `CSS_PATH`, so they would not show the stylesheet at all), before-frames
taken from a clean `origin/main` worktree rather than by stashing. Rendered and
inspected:

| case | before | after |
|---|---|---|
| `/mc` | no ghost | `p` dimmed inline |
| `/mcp lo` | no ghost | `gin` dimmed inline |
| `/mcp login n` | no ghost | `otion` dimmed inline |
| `/lg` (fuzzy) | no ghost | no ghost (correct) |
| `/analytic` @ 40 cols | no ghost | `s ` shown |
| `/analytic` @ 18 cols | no ghost | withheld, no overrun |

## Notes

- **Adjacent issue, deliberately not fixed:** typing `/mcp login n` straight
  through leaves the compound row list empty, while the same buffer reached via
  `/mcp login ` populates it. Reproduced on untouched `origin/main`, so it
  predates this PR and is out of scope here.
- `_extend_to_common_prefix` (the ambiguous-Enter path) is deliberately never
  ghosted: it is not a row completion.
- Part 2 of #368 (`/mcp list|add|remove`) is a separate PR; this one does not
  touch `app.py`.

Closes part 1 of #368.


