### PR TITLE
fix(tui): stream the subagent view in place instead of remounting it

### DIFF
--- a/local_operator/tui/widgets/assistant.py
+++ b/local_operator/tui/widgets/assistant.py
@@ -362,8 +362,21 @@ class AssistantBlock(TranscriptBlock):
         self._apply_rows(self._flat_rows(self._flat_width()))
 
     def _flat_width(self) -> int:
-        """The width the rows are built at — the block's own once laid out."""
-        return self.size.width or FALLBACK_WIDTH
+        """The width the rows are built at — the block's own once laid out.
+
+        Before layout it is the width this block is ABOUT to be given, which
+        :meth:`TranscriptBlock.fold_width` derives from the container it was
+        appended into. Going straight to :data:`FALLBACK_WIDTH` here is what
+        made every mount-then-stream path fold at 80 columns, pin that fold as
+        the block's height, and re-fold one frame later when ``on_resize``
+        landed: at 140 columns the block measurably built at 80 and settled at
+        134, which a reader sees as the message flashing narrow. The pin is
+        untouched — ``_apply_rows`` still pins the count of whatever rows it is
+        handed — so the invariant that a self-authoring block is never MEASURED
+        holds exactly as before; only the width those rows are folded at is
+        better informed.
+        """
+        return self.fold_width(FALLBACK_WIDTH)
 
     def _flat_console(self) -> Console | None:
         """The app's console, or ``None`` when this block is detached.

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -1730,15 +1730,34 @@ class SubagentView(Vertical):
                 new_blocks = [entry_block(entry, fold_width=fold) for entry in new_entries]
                 # TWO LISTS, ONE INDEX. `prefix` counts entries, which exclude
                 # the truncation note; `insert_blocks` indexes the BODY's list,
-                # which holds it at 0 because it is appended before any row
-                # (`_sync_body` mounts it outside the diffed sequence and keeps
-                # it out of `self._blocks`). Measured on a truncated
-                # trajectory: `view._blocks` 168 against a body of 169. Without
-                # the offset a history page prepended to a truncated child
-                # lands one row too high — above the note that is supposed to
-                # head the page. Both conditions are needed at once, which is
-                # why it survived unnoticed (review round 1, N1).
-                head_offset = 1 if self._head_block is not None else 0
+                # which also holds the note (`_sync_body` mounts it outside the
+                # diffed sequence and keeps it out of `self._blocks`). Measured
+                # on a truncated trajectory: `view._blocks` 168 against a body
+                # of 169. Without the offset a history page prepended to a
+                # truncated child lands one row too high — above the note that
+                # is supposed to head the page. Both conditions are needed at
+                # once, which is why it survived unnoticed (review round 1, N1).
+                #
+                # Keyed on the note's POSITION, not its existence. It is
+                # created lazily and appended at whatever length the body has
+                # reached, so it heads the list only when the child was already
+                # truncated at open. A child that crosses the cap while the
+                # page is open mounts it mid-list (measured: index 5 of 257),
+                # and correcting for a note that is not above the rows pushes
+                # the prepended page one row too low instead — which is how
+                # this arrived as a misordering the previous fix introduced
+                # (`durable 40` above `durable 0`) in a case `origin/main` had
+                # right (review round 2, M3).
+                mounted_blocks = self._body.blocks()
+                head_offset = (
+                    1
+                    if (
+                        self._head_block is not None
+                        and mounted_blocks
+                        and mounted_blocks[0] is self._head_block
+                    )
+                    else 0
+                )
                 self._body.insert_blocks(prefix + head_offset, new_blocks, anchor_offset=anchor)
                 self._blocks[prefix:prefix] = new_blocks
                 self._entries[prefix:prefix] = new_entries

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -98,6 +98,23 @@ from local_operator.tui.widgets.transcript import (
 #: pinned by a test, so the two halves of the contract cannot drift silently.
 TRAJECTORY_MAX_EVENTS = 500
 
+#: Refreshes the first reconcile may wait for the body to be LAID OUT before it
+#: gives up and folds at the fallback width anyway.
+#:
+#: `on_mount` runs before Textual has assigned the body a region, so the width
+#: every block would fold at reads 0 and `TranscriptBlock.fold_width` falls to
+#: its 80-column fallback: the page builds its first rows at 80, PINS that
+#: height, and re-folds a frame later, which a reader sees as the message
+#: flashing narrow on opening a page mid-stream. Measured at 140x34: 2 of 20
+#: opens painted the 80-column build.
+#:
+#: Two, because the ordering that needs the most is mount-then-fill-in-one-beat
+#: (`_open_subagent_view`'s deferred fill winning its race with layout), which
+#: measured exactly two refreshes before the body reported 135. It is a bound
+#: rather than a loop so a body that never gains a width paints its rows at the
+#: fallback instead of never painting them at all.
+SYNC_LAYOUT_WAITS = 2
+
 #: Rows of a delegated brief the page shows before folding the rest away. Three
 #: carries the opening sentence or two — enough to say what was asked — while
 #: leaving the child's own work the majority of a 60-column body. Measured
@@ -246,6 +263,21 @@ class SubagentEntry:
     #: diffed sequence, so its arrival at the cap appends a row instead of
     #: renumbering every entry and rebuilding the page under the reader.
     head: bool = False
+    #: Is this row DONE GROWING? A text row that has had its ``message_end``,
+    #: or a durable history row, which is complete by definition.
+    #:
+    #: Distinct from the job being settled, and that distinction is the point:
+    #: a running child's transcript is mostly FINISHED messages — the prose it
+    #: writes between tool calls — and deriving completeness from the job
+    #: status alone left every one of them unfinalized for the whole run. They
+    #: then rendered with the streaming splice's concatenated fold, which
+    #: cannot produce the blank row between two paragraphs, and because a
+    #: block PINS its height to the rows it authored they were pinned short
+    #: and grew by one row each when the job finally settled (measured 5 -> 6
+    #: and 2 -> 3 on a two-message child) — a reflow of exactly the kind this
+    #: page's in-place reconciliation exists to remove. The stream carries the
+    #: fact; it was only being discarded at the fold.
+    complete: bool = False
 
 
 def _notice(key: str, text: str, kind: NoticeKind = "info", *, head: bool = False) -> SubagentEntry:
@@ -265,6 +297,16 @@ def _supersedes(new: SubagentEntry, old: SubagentEntry) -> bool:
     if new.kind != old.kind:
         return True  # the row changed shape; the newer reading is the one to trust
     if new.kind == "text":
+        if old.complete and not new.complete:
+            # COMPLETENESS IS AS LOSABLE AS TEXT. `message_end` is an event
+            # like any other, so the rolling window evicts it too: a later
+            # fold of the same message then reports it as still streaming.
+            # Accepting that would un-finalize a committed block, and
+            # `update_entry_block` answers a finalized block's text change
+            # with a REMOUNT — so a row that had settled correctly would be
+            # torn down and rebuilt mid-read. Same rule as the text length
+            # below, applied to the other thing a fold can lose.
+            return False
         return len(new.text) >= len(old.text)
     if new.kind == "tool":
         # A settled outcome supersedes a live one; the reverse never does.
@@ -342,8 +384,16 @@ def fold_transcript_entries(
                 )
             else:
                 label = "Subagent · replied" if details.get("reply_to") else "Subagent"
+                # Renders as an AssistantBlock, and a recorded communication is
+                # whole the moment it exists — it never streams — so it settles
+                # on arrival rather than waiting for the job.
                 folded.append(
-                    SubagentEntry(f"comm:{entry.id}", "subagent_message", text=f"{label}\n\n{body}")
+                    SubagentEntry(
+                        f"comm:{entry.id}",
+                        "subagent_message",
+                        text=f"{label}\n\n{body}",
+                        complete=True,
+                    )
                 )
             continue
         if entry.type != ENTRY_MESSAGE:
@@ -365,7 +415,11 @@ def fold_transcript_entries(
             continue
         if role == "assistant":
             if text:
-                folded.append(SubagentEntry(entry.id, "text", text=text))
+                # A durable row is a message the engine already committed to
+                # the transcript, so it is complete whatever the job is doing
+                # now. Saying so here is what stops a paged-in history message
+                # rendering with the streaming fold on a live page.
+                folded.append(SubagentEntry(entry.id, "text", text=text, complete=True))
             for raw_call in payload.get("tool_calls") or ():
                 if not isinstance(raw_call, Mapping):
                     continue
@@ -419,6 +473,10 @@ def fold_trajectory(events: Sequence[Any], *, settled: bool = False) -> list[Sub
     # represented separately; the set keeps the same first-seen contract in O(1).
     remembered: set[tuple[str, str]] = set()
     streams: dict[str, str] = {}
+    #: Message ids whose ``message_end`` arrived in THIS window. The child is
+    #: done writing them even while it goes on working, which is what lets the
+    #: page finalize them per row instead of waiting for the job to settle.
+    finished: set[str] = set()
     tools: dict[str, SubagentEntry] = {}
     notices: dict[str, SubagentEntry] = {}
 
@@ -464,6 +522,7 @@ def fold_trajectory(events: Sequence[Any], *, settled: bool = False) -> list[Sub
                 if message_id not in streams and not text:
                     continue
                 streams[message_id] = text
+                finished.add(message_id)
                 remember("text", message_id)
         elif etype == "tool_execution_start":
             # One normalisation for the whole pair. The lookup below used to
@@ -548,7 +607,18 @@ def fold_trajectory(events: Sequence[Any], *, settled: bool = False) -> list[Sub
         if kind == "text":
             text = strip_control_sequences(streams.get(key, "")).strip()
             if text:  # a tool-use message carries no prose — spend no row
-                rows.append(SubagentEntry(key=key, kind="text", text=text))
+                # `settled` finishes the LAST message too: a child killed
+                # mid-turn never sends its `message_end`, and that row is done
+                # growing for the only reason that matters — nothing is left
+                # to send it deltas.
+                rows.append(
+                    SubagentEntry(
+                        key=key,
+                        kind="text",
+                        text=text,
+                        complete=key in finished or settled,
+                    )
+                )
         elif kind == "tool":
             entry = tools[key]
             if settled and entry.outcome is None:
@@ -717,11 +787,17 @@ def entry_block(
     re-folds one frame later, which a reader sees as the row flashing narrow.
     Zero means "not supplied" and keeps the old fallback behaviour.
 
-    ``settled`` says whether this text row is done growing. A row that may
-    still receive deltas must NOT be finalized: a finalized ``AssistantBlock``
-    ignores ``update_text``, so finalizing on construction is what forced the
-    page to rebuild a streaming message instead of updating it — and a rebuild
-    discards the incremental markdown cache and re-lexes the whole message.
+    ``settled`` says whether the JOB has stopped. A text row is committed when
+    it is done growing, which is ``entry.complete or settled`` — the row's own
+    ``message_end`` if it had one, else the job stopping (the last message of a
+    child killed mid-turn never gets one). A row that may still receive deltas
+    must NOT be finalized: a finalized ``AssistantBlock`` ignores
+    ``update_text``, so finalizing on construction is what forced the page to
+    rebuild a streaming message instead of updating it — and a rebuild discards
+    the incremental markdown cache and re-lexes the whole message. Finalizing
+    per ROW rather than per PASS is what keeps a message that finished ten
+    tool calls ago from rendering with the streaming splice's fold, missing
+    its paragraph breaks, until the child eventually exits.
     """
     if entry.kind == "prompt":
         return InstructionBlock(entry.text)
@@ -732,7 +808,7 @@ def entry_block(
         if fold_width:
             block.set_fold_hint(fold_width)
         block.update_text(entry.text)
-        if settled:
+        if entry.complete or settled:
             block.finalize_text()
         return block
     if entry.kind == "notice":
@@ -832,15 +908,17 @@ def update_entry_block(
             return False
         if entry.text != previous.text:
             block.update_text(entry.text)
-        if settled:
-            # The child STOPPED, which is a change to this row even when its
-            # text did not move: a live block carries the streaming splice's
-            # concatenated fold, and committing re-renders the whole message
-            # once — which is what restores the blank row between paragraphs
-            # that the splice cannot produce mid-stream. Checked on every pass
-            # rather than only on a text change, because the refresh that
-            # observes a job settle usually carries no new text at all;
-            # `finalize_text` is itself idempotent, so this runs once.
+        if entry.complete or settled:
+            # This ROW stopped growing — its own `message_end` arrived, or the
+            # job stopped and nothing is left to send it deltas. Either is a
+            # change to the row even when its text did not move: a live block
+            # carries the streaming splice's concatenated fold, and committing
+            # re-renders the whole message once — which is what restores the
+            # blank row between paragraphs that the splice cannot produce
+            # mid-stream. Checked on every pass rather than only on a text
+            # change, because the refresh that observes a message end or a job
+            # settle usually carries no new text at all; `finalize_text` is
+            # itself idempotent, so this runs once.
             block.finalize_text()
         return True
     if entry == previous:
@@ -1145,6 +1223,16 @@ class SubagentView(Vertical):
         #: the container to mount.
         self._pending: list[SubagentEntry] = []
         self._pending_head: SubagentEntry | None = None
+        #: Refreshes the first reconcile may still wait for a laid-out body.
+        #: `on_mount` fires before the body has a region, so every width the
+        #: page could fold at reads 0 there and `fold_width` falls to its
+        #: 80-column fallback; `_sync_body` postpones instead and replays once
+        #: the body has a real width. It is a BUDGET rather than a flag
+        #: because one refresh is not always enough — the mount-then-fill
+        #: ordering needs two — and it is bounded rather than open so a body
+        #: that never gains a width degrades to the old fallback fold instead
+        #: of postponing the page's only content forever.
+        self._sync_layout_waits = SYNC_LAYOUT_WAITS
         #: Last painted title inputs. The spinner ticks eight times a second
         #: and everything else on the row moves once a second at most.
         self._chrome_state: tuple[Any, ...] | None = None
@@ -1640,7 +1728,18 @@ class SubagentView(Vertical):
                 # same body width every other block on this page does.
                 fold = self._body.scrollable_content_region.width
                 new_blocks = [entry_block(entry, fold_width=fold) for entry in new_entries]
-                self._body.insert_blocks(prefix, new_blocks, anchor_offset=anchor)
+                # TWO LISTS, ONE INDEX. `prefix` counts entries, which exclude
+                # the truncation note; `insert_blocks` indexes the BODY's list,
+                # which holds it at 0 because it is appended before any row
+                # (`_sync_body` mounts it outside the diffed sequence and keeps
+                # it out of `self._blocks`). Measured on a truncated
+                # trajectory: `view._blocks` 168 against a body of 169. Without
+                # the offset a history page prepended to a truncated child
+                # lands one row too high — above the note that is supposed to
+                # head the page. Both conditions are needed at once, which is
+                # why it survived unnoticed (review round 1, N1).
+                head_offset = 1 if self._head_block is not None else 0
+                self._body.insert_blocks(prefix + head_offset, new_blocks, anchor_offset=anchor)
                 self._blocks[prefix:prefix] = new_blocks
                 self._entries[prefix:prefix] = new_entries
                 self._pending = entries
@@ -1706,6 +1805,17 @@ class SubagentView(Vertical):
         rows.insert(1, getattr(self._breadcrumb, "renderable", ""))
         return [_plain(row) for row in rows]
 
+    def _replay_pending_sync(self) -> None:
+        """Reconcile the fold that was postponed for want of a laid-out width.
+
+        Runs one refresh after the deferral, by which point Textual has given
+        the body its region. It reads ``_pending`` rather than closing over the
+        entries it was scheduled with, so a refresh that lands in the gap wins:
+        the page paints what is CURRENT at the moment it can paint correctly,
+        never a snapshot that is already one tick stale.
+        """
+        self._sync_body(self._pending, self._pending_head)
+
     def _sync_body(self, entries: list[SubagentEntry], head: SubagentEntry | None) -> None:
         """Bring the mounted blocks into agreement with ``entries``.
 
@@ -1734,6 +1844,10 @@ class SubagentView(Vertical):
         scrolled up is not moved, because an in-place update mounts nothing;
         and no row is ever dropped, because the fold that produced ``entries``
         has already been through :func:`_supersedes`.
+
+        The FIRST pass is deferred by a frame when the body has not been laid
+        out yet — see the guard below. Reconciling into a zero-width body is
+        not cheaper than waiting, it is just wrong a frame earlier.
         """
         if not self._body.is_mounted:
             return  # `on_mount` replays the pending fold once the body exists
@@ -1743,9 +1857,40 @@ class SubagentView(Vertical):
         # DETACHED and would otherwise fold at 80 columns and re-fold a frame
         # later, visibly.
         fold = self._body.scrollable_content_region.width
+        if not fold and entries and self._sync_layout_waits > 0:
+            # MOUNTED IS NOT LAID OUT. `on_mount` runs before Textual has
+            # assigned this body a region, so every width the page could ask
+            # for — the body's size, its container, the view's own — reads 0,
+            # and a fold of 0 sends `fold_width` to its 80-column fallback.
+            # Measured over 20 opens at 140x34: 2 of them built the page's
+            # first blocks at 80 and re-folded them to 135 a frame later, and
+            # the compositor painted the 80-column build, which is the width
+            # flash on opening a page mid-stream.
+            #
+            # The screen's width is the one non-zero source here (138) and it
+            # is deliberately NOT used: it is the whole terminal, 3 cells wider
+            # than the body's 135, so a hint from it folds too wide and clips.
+            # Waiting one frame is the only way to build at a width that is
+            # RIGHT rather than merely non-zero. It costs a frame of empty
+            # body, not a reflow — the rows appear once, already correct,
+            # instead of appearing narrow and re-folding under the reader.
+            #
+            # A BUDGET, not a one-shot: the mount-then-fill ordering needs two
+            # refreshes before the body has a region, and a single deferral
+            # replayed into a still-zero width and folded at 80 anyway. Bounded
+            # so a body that never gains a width (a page closed under the
+            # deferral, a zero-height layout) falls through to the old fallback
+            # behaviour and paints SOMETHING rather than postponing forever.
+            self._sync_layout_waits -= 1
+            self.call_after_refresh(self._replay_pending_sync)
+            return
         # A row may still receive deltas while the child is working, so a text
-        # block is only committed once the job stops. Finalizing earlier is
-        # what made a streaming message unupdatable and therefore rebuilt.
+        # block is committed once the row itself is done — `entry.complete`,
+        # i.e. its `message_end` arrived — or once the job stops, which
+        # finishes the last message of a child that was killed mid-turn.
+        # Finalizing earlier is what made a streaming message unupdatable and
+        # therefore rebuilt; finalizing per PASS instead of per ROW is what
+        # left finished messages folded as if they were still streaming.
         settled = not self._running and not self._queued
         if head is not None and self._head_block is None:
             self._head_block = NoticeBlock(head.text, head.notice_kind)

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -698,7 +698,9 @@ class InstructionBlock(UserBlock):
             parent.refresh_gap_around(self)
 
 
-def entry_block(entry: SubagentEntry) -> TranscriptBlock:
+def entry_block(
+    entry: SubagentEntry, *, fold_width: int = 0, settled: bool = True
+) -> TranscriptBlock:
     """One folded entry as the block the main conversation would have used.
 
     Tool rows settle through :meth:`ToolCard.restore` rather than
@@ -707,6 +709,19 @@ def entry_block(entry: SubagentEntry) -> TranscriptBlock:
     the tool took. Both trajectory end events and durable tool messages carry
     the executor's measured duration, so replay restores that authoritative
     value and leaves the column blank only for legacy rows that predate it.
+
+    ``fold_width`` is the width of the body this block is about to be mounted
+    into. Every block here bakes its width into the rows it authors AND pins
+    its height to the count of them, and each one is built DETACHED — no
+    parent to borrow a width from — so without this it folds at 80 columns and
+    re-folds one frame later, which a reader sees as the row flashing narrow.
+    Zero means "not supplied" and keeps the old fallback behaviour.
+
+    ``settled`` says whether this text row is done growing. A row that may
+    still receive deltas must NOT be finalized: a finalized ``AssistantBlock``
+    ignores ``update_text``, so finalizing on construction is what forced the
+    page to rebuild a streaming message instead of updating it — and a rebuild
+    discards the incremental markdown cache and re-lexes the whole message.
     """
     if entry.kind == "prompt":
         return InstructionBlock(entry.text)
@@ -714,8 +729,11 @@ def entry_block(entry: SubagentEntry) -> TranscriptBlock:
         return UserBlock(entry.text)
     if entry.kind in ("text", "subagent_message"):
         block = AssistantBlock()
+        if fold_width:
+            block.set_fold_hint(fold_width)
         block.update_text(entry.text)
-        block.finalize_text()
+        if settled:
+            block.finalize_text()
         return block
     if entry.kind == "notice":
         if entry.key == "__working__":
@@ -723,6 +741,8 @@ def entry_block(entry: SubagentEntry) -> TranscriptBlock:
             return WorkingBlock(activity, activity)
         return NoticeBlock(entry.text, entry.notice_kind)
     card = ToolCard("", entry.tool_name, entry.tool_args, entry.intent)
+    if fold_width:
+        card.set_fold_hint(fold_width)
     if entry.outcome == "error":
         card.restore(
             state="error",
@@ -751,6 +771,140 @@ def entry_block(entry: SubagentEntry) -> TranscriptBlock:
         # settled arms exist to avoid.
         card.restore(state="running")
     return card
+
+
+#: Keys of the rows :meth:`SubagentView._tail_entry` produces. They share one
+#: slot at the foot of the page — "is anything still coming?" — and the page
+#: holds that slot apart from the diffed sequence because it is positioned by
+#: ROLE, not by index: it is always last, so every row the child adds moves it.
+TAIL_KEYS = frozenset({"__working__", "__gone__", "__empty__"})
+
+
+def _split_tail(
+    entries: Sequence[SubagentEntry],
+) -> tuple[list[SubagentEntry], SubagentEntry | None]:
+    """Separate the terminating row, if the list ends with one."""
+    if entries and entries[-1].key in TAIL_KEYS:
+        return list(entries[:-1]), entries[-1]
+    return list(entries), None
+
+
+def update_entry_block(
+    block: TranscriptBlock,
+    entry: SubagentEntry,
+    previous: SubagentEntry,
+    *,
+    settled: bool = True,
+) -> bool:
+    """Bring an already-mounted ``block`` up to ``entry``, or refuse.
+
+    The counterpart to :func:`entry_block`, and the reason the page can stream
+    at all. Rebuilding a row is not a cheap way to update it: a remounted
+    :class:`AssistantBlock` throws away the incremental markdown cache the
+    whole streaming design exists to keep, so the settling final response —
+    the longest message on the page — got re-lexed in full on every tick
+    (measured 7.91 ms vs 0.62 ms at 8700 characters, 12.7x), and a remounted
+    :class:`WorkingBlock` restarts its shimmer sweep and its clock.
+
+    Returns True when the block now agrees with ``entry``. False means this
+    change cannot be applied in place and the caller must remount the row —
+    the honest answer for the cases the widgets deliberately refuse (a settled
+    tool card going back to running, a notice changing kind of block, an
+    instruction's collapsed text being rewritten under the reader's toggle).
+    ``previous`` is what the row was showing, which is what makes "did this
+    actually change" answerable without asking the DOM.
+    """
+    if entry.kind != previous.kind:
+        return False  # a row that changed shape is a different row
+    if entry.kind in ("text", "subagent_message"):
+        if not isinstance(block, AssistantBlock):
+            return False
+        if block.is_finalized():
+            # Committed and immutable: agreeing is the whole answer, and a row
+            # that has somehow gained text after settling has to be rebuilt
+            # because `update_text` is a no-op on a finalized block.
+            return entry.text == previous.text
+        # Only ever GROWS. A shorter text at the same key is the rolling window
+        # having evicted the opening deltas, which `_supersedes` already
+        # refuses; reaching here with one would mean silently truncating a
+        # message on screen, so the row is rebuilt rather than shrunk.
+        if not entry.text.startswith(previous.text):
+            return False
+        if entry.text != previous.text:
+            block.update_text(entry.text)
+        if settled:
+            # The child STOPPED, which is a change to this row even when its
+            # text did not move: a live block carries the streaming splice's
+            # concatenated fold, and committing re-renders the whole message
+            # once — which is what restores the blank row between paragraphs
+            # that the splice cannot produce mid-stream. Checked on every pass
+            # rather than only on a text change, because the refresh that
+            # observes a job settle usually carries no new text at all;
+            # `finalize_text` is itself idempotent, so this runs once.
+            block.finalize_text()
+        return True
+    if entry == previous:
+        return True  # identical row: the common refresh, and it repaints nothing
+    if entry.kind == "tool":
+        if not isinstance(block, ToolCard):
+            return False
+        # Identity, name and arguments are fixed at the call; only the OUTCOME
+        # moves, and only ever from live to settled. `restore` is the settling
+        # seam for a card the page did not run itself, and it stays the seam
+        # here for exactly the reason `entry_block` documents: `mark_done`
+        # would compute a duration from when this page painted the row, not
+        # from how long the child's tool took. The card's `_started` is already
+        # None (every card this page builds is `restore`d at construction), so
+        # settling it in place cannot resurrect the fabricated-duration bug —
+        # the value below is the executor's own, or blank.
+        if (entry.tool_name, entry.tool_args, entry.intent) != (
+            previous.tool_name,
+            previous.tool_args,
+            previous.intent,
+        ):
+            return False
+        if previous.outcome is not None or entry.outcome is None:
+            # Already settled, or still running with nothing new to say. A
+            # settled card is finalized and must not be reopened.
+            return False
+        if entry.outcome == "error":
+            block.restore(
+                state="error",
+                result_text=entry.result_text,
+                details=entry.details,
+                error=_first_line(entry.result_text),
+                duration_s=entry.duration_s,
+            )
+        elif entry.outcome == "interrupted":
+            block.restore(state="interrupted")
+        else:
+            block.restore(
+                state="success",
+                result_text=entry.result_text,
+                details=entry.details,
+                duration_s=entry.duration_s,
+            )
+        return True
+    if entry.kind == "notice":
+        if entry.key == "__working__":
+            if not isinstance(block, WorkingBlock):
+                return False
+            # The tail line is the one row that MUST survive a refresh: it
+            # owns an animation and a clock, and both restart when the widget
+            # does. `set_activity` is the widget's own seam for exactly this
+            # and keeps the phase clock running when only the label moved.
+            activity = entry.text or "thinking"
+            block.set_activity(activity, activity)
+            return True
+        if not isinstance(block, NoticeBlock):
+            return False
+        block.restate(entry.text, entry.notice_kind)
+        return True
+    # Prompt and user rows are written once and never revised — `_supersedes`
+    # says so — so a changed one is a genuinely different row. `InstructionBlock`
+    # in particular holds reader state (its expand toggle) that a rewrite would
+    # silently discard.
+    return False
 
 
 class SubagentViewDismissed(Message):
@@ -1460,26 +1614,41 @@ class SubagentView(Vertical):
             # the synthetic delegation. Find the unchanged prefix and suffix so
             # the insertion uses TranscriptView's post-layout height anchor
             # instead of rebuilding from the prompt and letting Textual shift it.
+            #
+            # Compared over the BODY rows only. The terminating row is pinned
+            # to the foot of the transcript rather than held at an index, so
+            # letting it into this comparison would make an unchanged tail
+            # count toward the suffix while its block sits outside the range
+            # these indices address — an off-by-one that inserts a history
+            # page into the middle of the page it was meant to precede.
+            old_body, old_tail = _split_tail(self._entries)
+            new_body, _ = _split_tail(entries)
             prefix = 0
-            for previous, current in zip(self._entries, entries):
+            for previous, current in zip(old_body, new_body):
                 if previous != current:
                     break
                 prefix += 1
             suffix = 0
-            for previous, current in zip(
-                reversed(self._entries[prefix:]), reversed(entries[prefix:])
-            ):
+            for previous, current in zip(reversed(old_body[prefix:]), reversed(new_body[prefix:])):
                 if previous != current:
                     break
                 suffix += 1
-            count = len(entries) - prefix - suffix
-            if count > 0 and len(self._entries) - prefix == suffix:
-                new_entries = entries[prefix : prefix + count]
-                new_blocks = [entry_block(entry) for entry in new_entries]
+            count = len(new_body) - prefix - suffix
+            if count > 0 and len(old_body) - prefix == suffix:
+                new_entries = new_body[prefix : prefix + count]
+                # History rows are settled by definition, and they fold at the
+                # same body width every other block on this page does.
+                fold = self._body.scrollable_content_region.width
+                new_blocks = [entry_block(entry, fold_width=fold) for entry in new_entries]
                 self._body.insert_blocks(prefix, new_blocks, anchor_offset=anchor)
                 self._blocks[prefix:prefix] = new_blocks
                 self._entries[prefix:prefix] = new_entries
                 self._pending = entries
+                # The tail entry itself may still have moved (a page load can
+                # flip `__empty__` to nothing at all), so it is reconciled
+                # through the ordinary path rather than assumed unchanged.
+                if _split_tail(entries)[1] != old_tail:
+                    self._sync_body(entries, self._pending_head)
                 return
         self._pending = entries
         self._sync_body(entries, self._pending_head)
@@ -1540,35 +1709,111 @@ class SubagentView(Vertical):
     def _sync_body(self, entries: list[SubagentEntry], head: SubagentEntry | None) -> None:
         """Bring the mounted blocks into agreement with ``entries``.
 
-        Diffed, never rebuilt. Because the page accumulates, the sequence is
-        append-mostly by construction — the tail message grows, the tail tool
-        settles — so the common refresh mounts one block and touches nothing
-        else. A mid-list tool settling out of order (one batch, several calls)
-        remounts from there down, which is bounded and correct.
+        Reconciled IN PLACE, keyed on identity. The predecessor diffed by
+        VALUE: it found the longest prefix of rows that compared equal and
+        rebuilt everything after it. A growing message never compares equal to
+        itself, so the row being streamed was destroyed and rebuilt on every
+        tick, and the tail working line under it went with it — 240 mounts and
+        239 removes over 120 streaming ticks, where one mount and no removes
+        is the correct answer. What the user saw was the message flashing at
+        the fallback fold width for a frame (a rebuilt block is built
+        unmounted) and the working line's shimmer and clock restarting under
+        it. A mid-list row settling was worse than linear: rebuilding the
+        suffix beneath it made a settling batch of 16 parallel calls cost 272
+        mounts.
+
+        So the sequence is matched by KEY — the identity ``SubagentEntry``
+        already promises — and a row whose content moved is UPDATED through
+        :func:`update_entry_block`. Remount is reserved for what genuinely
+        needs it: a new row, a row whose kind changed, a reordering, and the
+        changes the widgets refuse in place.
+
+        Everything the value diff guaranteed is preserved. The ``__prompt__``
+        head keeps its position because it keeps its key; the truncation row
+        is still mounted once, outside this sequence; a reader who has
+        scrolled up is not moved, because an in-place update mounts nothing;
+        and no row is ever dropped, because the fold that produced ``entries``
+        has already been through :func:`_supersedes`.
         """
         if not self._body.is_mounted:
             return  # `on_mount` replays the pending fold once the body exists
+        # The width every block built below is about to be mounted at. Read
+        # once per pass from the body's scrollable content region — the blocks
+        # are `width: 1fr` children of it — because each is constructed
+        # DETACHED and would otherwise fold at 80 columns and re-fold a frame
+        # later, visibly.
+        fold = self._body.scrollable_content_region.width
+        # A row may still receive deltas while the child is working, so a text
+        # block is only committed once the job stops. Finalizing earlier is
+        # what made a streaming message unupdatable and therefore rebuilt.
+        settled = not self._running and not self._queued
         if head is not None and self._head_block is None:
             self._head_block = NoticeBlock(head.text, head.notice_kind)
             self._body.append_block(self._head_block)
+
+        # The terminating row is held OUT of the diffed sequence, for the same
+        # reason the truncation row is: it is positioned by role rather than by
+        # index. It is always last, so every row the child adds shifts it, and
+        # a positional walk would see that shift as the tail row having changed
+        # and rebuild it — destroying the one widget on the page that owns an
+        # animation and a clock. Pinning it (`TranscriptView.pin_tail`, which
+        # the main conversation already uses for its own working line) makes
+        # later rows mount ABOVE it instead, so the widget is never disturbed.
+        old_body, old_tail_entry = _split_tail(self._entries)
+        new_body, new_tail_entry = _split_tail(entries)
+        blocks = self._blocks
+        old_tail_block = blocks[len(old_body)] if old_tail_entry is not None else None
+        body_blocks = blocks[: len(old_body)]
+
+        # Positional and keyed, not by value. Order is content here — two rows
+        # swapping places is a different page — so the walk stops at the first
+        # position whose identity differs or whose change the widget refuses,
+        # and only from there down is anything remounted.
         common = 0
-        for previous, current in zip(self._entries, entries):
-            if previous != current:
+        limit = min(len(old_body), len(new_body))
+        while common < limit:
+            was, now = old_body[common], new_body[common]
+            if was.key != now.key:
+                break
+            if not update_entry_block(body_blocks[common], now, was, settled=settled):
                 break
             common += 1
-        if common == len(self._entries) == len(entries):
-            return
-        for block in reversed(self._blocks[common:]):
+
+        for block in reversed(body_blocks[common:]):
             self._body.remove_block(block)
-        del self._blocks[common:]
-        # Opening a retained 500-event child can add hundreds of rows at once.
-        # Mount them as one Textual batch so stylesheet/layout settlement happens
-        # once; live refreshes still append their ordinary one-row suffix.
-        with self._body.batch_append():
-            for entry in entries[common:]:
-                block = entry_block(entry)
-                self._body.append_block(block)
-                self._blocks.append(block)
+        del body_blocks[common:]
+        if body_blocks[common:] or new_body[common:]:
+            # Opening a retained 500-event child can add hundreds of rows at
+            # once. Mount them as one Textual batch so stylesheet/layout
+            # settlement happens once; live refreshes still append their
+            # ordinary one-row suffix. (A pinned tail suspends the batching —
+            # see `batch_append` — which is why the tail is reconciled after
+            # this, so the first fill of a page still batches.)
+            with self._body.batch_append():
+                for entry in new_body[common:]:
+                    block = entry_block(entry, fold_width=fold, settled=settled)
+                    self._body.append_block(block)
+                    body_blocks.append(block)
+
+        tail_block = old_tail_block
+        if old_tail_entry is not None and new_tail_entry is not None:
+            if old_tail_entry.key != new_tail_entry.key or not update_entry_block(
+                old_tail_block, new_tail_entry, old_tail_entry  # type: ignore[arg-type]
+            ):
+                # A change of terminating STATE (running → gone, say) is a
+                # different row, so it is rebuilt; a change of activity inside
+                # one state was already applied in place above.
+                self._body.remove_block(old_tail_block)  # type: ignore[arg-type]
+                tail_block = entry_block(new_tail_entry, fold_width=fold)
+                self._body.pin_tail(tail_block)
+        elif new_tail_entry is not None:
+            tail_block = entry_block(new_tail_entry, fold_width=fold)
+            self._body.pin_tail(tail_block)
+        elif old_tail_block is not None:
+            self._body.remove_block(old_tail_block)
+            tail_block = None
+
+        self._blocks = [*body_blocks, *([tail_block] if tail_block is not None else [])]
         self._entries = list(entries)
 
     def _empty_state(self) -> str:

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -1558,8 +1558,16 @@ class ToolCard(ExpandableActionBlock):
         pointer crossing a card's edge, each reflowed the entire screen to
         repaint one row.
         """
-        container = getattr(self, "container_size", None)
-        width = self.size.width or (container.width if container else 0)
+        # `fold_width(0)` walks size → container → the parent transcript's
+        # scrollable content region, and returns 0 only when none of the three
+        # can answer. That third rung is new and is what stops a card built
+        # before its first layout pass from fitting itself to the whole
+        # terminal (the console rung below) or to 80 columns: both are the
+        # wrong column for a block inside the transcript, and the row visibly
+        # re-fitted a frame later. The console rung is kept as the last resort
+        # BEFORE the fallback because reaching it is also how this method
+        # detects that there is no app to paint into at all.
+        width = self.fold_width(0)
         detached = False
         if width <= 0:
             try:

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -263,6 +263,12 @@ class TranscriptBlock(Static):
     _settled_rows_cache: int | None = None
     #: Memoized "taller than one row?" answer for the spacing decision.
     _multirow_cache: bool | None = None
+    #: Width to fold at while this block has no width of its own and no parent
+    #: to borrow one from — set by a builder that KNOWS where the block is
+    #: about to be mounted. Zero means "not supplied", which is the state of
+    #: every block the app builds through the ordinary mount-then-fill path.
+    #: See :meth:`fold_width` for why the ladder cannot answer this case itself.
+    _fold_hint: int = 0
 
     def set_content(self, renderable: RenderableType, *, layout: bool = True) -> None:
         """Apply ``renderable`` as the block content (no-op once finalized).
@@ -307,6 +313,79 @@ class TranscriptBlock(Static):
             Content.from_rich_text(renderable) if isinstance(renderable, Text) else renderable,
             layout=layout,
         )
+
+    def set_fold_hint(self, width: int) -> None:
+        """Tell a not-yet-parented block the width it is being built for.
+
+        The escape hatch for the one case :meth:`fold_width`'s ladder cannot
+        serve: a block CONSTRUCTED detached and given its content before it is
+        appended anywhere. The ladder walks the block, its container and its
+        parent, and such a block has none of the three — so it folds at the
+        caller's fallback and re-folds a frame later, which is the width flash
+        this whole mechanism exists to remove.
+
+        Only a caller that can prove the destination may use it, and it is a
+        HINT rather than an override: everything above it in the ladder wins,
+        so a stale hint cannot outlive the block's first real layout.
+        """
+        self._fold_hint = max(0, width)
+
+    def fold_width(self, fallback: int) -> int:
+        """The width this block should fold its rows at, right now.
+
+        Every block here bakes its width into the rows it authors, so the one
+        that matters is the width it will END UP at — not the one Textual has
+        got round to assigning. A block is routinely given its content while
+        it is still unmounted or mounted-but-not-yet-laid-out (the app builds
+        a block, fills it, and appends it; the subagent page reconciles into a
+        body that lays out one frame later), and in that window ``self.size``
+        is 0. Falling straight to a hardcoded 80 there is what made a message
+        fold narrow, pin that fold as its height, and then re-fold a frame
+        later when the resize landed — a visible width flash on every mount
+        into a terminal that is not 80 columns wide.
+
+        The ladder walks from the most authoritative source down:
+
+        1. the block's own laid-out width, once it has one;
+        2. its container's, which Textual assigns before the child;
+        3. the PARENT's scrollable content region, which is the width this
+           block is about to be given — the transcript is a vertical container
+           of ``width: 1fr`` blocks, so its scrollable content width (its own
+           content box less any scrollbar gutter) is exactly the child's
+           eventual width. Measured on the subagent page at 140x34: 134, which
+           is the settled ``_built_width`` to the cell, at 100x30: 94, and at
+           60x24 with a scrollbar up: 54;
+        4. a :meth:`set_fold_hint` supplied by a builder that knows where this
+           block is going, for a block built entirely detached — it has no
+           parent to ask, so nothing above this rung can answer;
+        5. ``fallback`` — reached only when nothing knows anything, i.e. a
+           detached block in a unit test.
+
+        It deliberately does NOT consult ``app.console.width``: that is the
+        whole TERMINAL (175 in the harness above), never this block's column,
+        so a block that trusted it would fold far too wide and clip.
+
+        ``fallback`` is passed rather than read from a module constant because
+        the three callers own different ones; they agree on 80 today, and this
+        method is about ordering the sources, not about unifying the last step.
+        """
+        width = self.size.width
+        if width:
+            return width
+        container = getattr(self, "container_size", None)
+        width = container.width if container is not None else 0
+        if width:
+            return width
+        parent = self.parent
+        if isinstance(parent, Widget):
+            # `scrollable_content_region` is the content box minus the gutter
+            # a shown scrollbar occupies, which is the difference between a
+            # fold that is right and one that is two cells too wide on a
+            # scrolled page.
+            region = parent.scrollable_content_region
+            if region.width:
+                return region.width
+        return self._fold_hint or fallback
 
     def invalidate_row_measurements(self) -> None:
         """Drop the memoized row counts (content or WIDTH changed).
@@ -1217,8 +1296,10 @@ class WakeBlock(ExpandableActionBlock):
         """
         from local_operator.tui.widgets.tool_card import FALLBACK_WIDTH
 
-        container = getattr(self, "container_size", None)
-        width = self.size.width or (container.width if container else 0)
+        # Same ladder as `ToolCard._refresh_row`, for the same reason: a row
+        # built before its first layout pass must fold at the width it is
+        # about to be given, not at the terminal's or at 80.
+        width = self.fold_width(0)
         detached = False
         if width <= 0:
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.16"
+version = "0.42.17"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -2202,3 +2202,226 @@ async def test_the_scroll_caption_keeps_the_space_every_other_hint_has() -> None
         view = await _open(pilot, app, _job_with(TRAJECTORY))
         assert "↑↓ scroll" in view.rendered_rows()[-1]
         assert "↑↓scroll" not in view.rendered_rows()[-1]
+
+
+# -- streaming reconciliation -----------------------------------------------
+#
+# The page used to re-derive its whole transcript and REMOUNT the tail on every
+# refresh tick, where the main conversation mutates one long-lived block in
+# place. A growing message never compares equal to itself, so its block was
+# destroyed and rebuilt per tick: measured on the predecessor at 240 mounts and
+# 239 removes over 120 ticks, with a new WorkingBlock (and therefore a restarted
+# shimmer sweep and clock) every time. The tests below fail on that code.
+
+
+def _stream(mid: str, body: str) -> list[dict[str, Any]]:
+    """An assistant message still being streamed — start, then one delta."""
+    return [
+        {"type": "message_start", "message": {"role": "assistant", "id": mid}},
+        {"type": "message_update", "message": {"role": "assistant", "id": mid}, "delta": body},
+    ]
+
+
+class _MountCounter:
+    """Counts what a refresh actually costs the container."""
+
+    def __init__(self, view: SubagentView) -> None:
+        self.mounts = 0
+        self.removes = 0
+        body = view._body
+        append, remove = body.append_block, body.remove_block
+
+        def append_block(block: Any) -> Any:
+            self.mounts += 1
+            return append(block)
+
+        def remove_block(block: Any) -> Any:
+            self.removes += 1
+            return remove(block)
+
+        body.append_block = append_block  # type: ignore[method-assign]
+        body.remove_block = remove_block  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
+async def test_a_streaming_message_keeps_one_block_across_refreshes() -> None:
+    """The row being streamed is UPDATED, not rebuilt.
+
+    Block identity is the assertion because it is what the user feels: a
+    rebuilt AssistantBlock is constructed unmounted (so it folds at the
+    fallback width for a frame, which reads as the message flashing narrow)
+    and it discards the incremental markdown cache, so the settling final
+    response is re-lexed in full on every tick.
+    """
+    job = _job_with(_stream("m1", ""), status="running")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        view = await _open(pilot, app, job)
+        await pilot.pause()
+        counter = _MountCounter(view)
+        identities: set[int] = set()
+        text = ""
+        for index in range(12):
+            text += f"token{index} "
+            job.trajectory = _stream("m1", text)
+            app._refresh_subagent_view()
+            await pilot.pause()
+            block = next(b for b in view._body.blocks() if isinstance(b, AssistantBlock))
+            identities.add(id(block))
+        assert len(identities) == 1, "the streaming block was rebuilt"
+        assert counter.removes == 0, f"{counter.removes} rows torn down while streaming"
+        # The message on screen is the whole accumulated text, not a fragment.
+        assert "token0 " in block.text() and block.text().endswith("token11")
+
+
+@pytest.mark.asyncio
+async def test_the_working_tail_survives_every_refresh() -> None:
+    """The tail line owns an animation and a clock, and both restart when the
+    widget does. It is pinned (`TranscriptView.pin_tail`, the same lever the
+    main conversation uses) so rows mount ABOVE it instead of replacing it."""
+    job = _job_with(_stream("m1", "opening"), status="running")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        view = await _open(pilot, app, job)
+        await pilot.pause()
+        identities: set[int] = set()
+        events = list(job.trajectory)
+        for index in range(6):
+            # Rows keep arriving UNDER the tail: each pass adds a settled tool,
+            # which is exactly the case that used to drag the tail down with it.
+            events.append(_call(f"c{index}", "read", path=f"f{index}.py"))
+            events.append(_result(f"c{index}", "read", "ok"))
+            job.trajectory = list(events)
+            app._refresh_subagent_view()
+            await pilot.pause()
+            tail = [b for b in view._body.blocks() if isinstance(b, WorkingBlock)]
+            assert len(tail) == 1, "the page grew a second working line"
+            identities.add(id(tail[0]))
+        assert len(identities) == 1, "the working line was rebuilt under the reader"
+        # It is still LAST: the whole point of pinning it.
+        assert isinstance(view._body.blocks()[-1], WorkingBlock)
+
+
+@pytest.mark.asyncio
+async def test_a_settling_mid_list_tool_does_not_rebuild_the_rows_beneath_it() -> None:
+    """One parallel batch settling oldest-first used to rebuild the whole
+    suffix under each result — 272 mounts for 16 pairs, quadratic in the rows
+    below the one that changed. Settling a card is now an update to that card."""
+    events: list[dict[str, Any]] = []
+    for index in range(4):
+        events.extend(_text(f"m{index}", f"step {index}"))
+        events.append(_call(f"c{index}", "bash", command=f"step {index}"))
+    job = _job_with(list(events), status="running")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        view = await _open(pilot, app, job)
+        await pilot.pause()
+        cards = {id(block) for block in view._body.blocks() if isinstance(block, ToolCard)}
+        assert len(cards) == 4
+        counter = _MountCounter(view)
+        for index in range(4):
+            events.append(_result(f"c{index}", "bash", "ok"))
+            job.trajectory = list(events)
+            app._refresh_subagent_view()
+            await pilot.pause()
+        assert counter.mounts == 0, f"{counter.mounts} rows remounted by settling tools"
+        assert counter.removes == 0, f"{counter.removes} rows torn down by settling tools"
+        # Same widgets, now carrying their outcome and the executor's duration.
+        settled = [block for block in view._body.blocks() if isinstance(block, ToolCard)]
+        assert {id(card) for card in settled} == cards
+        assert all(card.is_finalized() for card in settled)
+
+
+@pytest.mark.asyncio
+async def test_a_row_folds_at_the_body_width_it_is_mounted_into() -> None:
+    """No block is built at the 80-column fallback and re-folded a frame later.
+
+    That flash was visible on ANY mount path, not only the streaming one: a
+    block authors its own rows and PINS its height to the count of them, so a
+    fallback-width build pinned a fallback-width height until the resize
+    landed. On a 140-column terminal the block measurably built at 80 and
+    settled at 134.
+    """
+    prose = "a paragraph of the child's prose that folds differently at 80 columns. "
+    job = _job_with(_stream("m1", prose * 3), status="running")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(140, 34)) as pilot:
+        view = await _open(pilot, app, job)
+        for _ in range(4):
+            await pilot.pause()
+        body_width = view._body.scrollable_content_region.width
+        assert body_width > 80, "the fixture needs a body wider than the fallback"
+
+        # Every fold performed from here on, whichever path builds it. The
+        # predecessor rebuilt the row on each streaming tick, and a rebuilt
+        # block is constructed with no parent to ask for a width, so it folded
+        # at 80 and re-folded once `on_resize` landed — a frame of narrow text
+        # per tick.
+        folds: list[int] = []
+        original = AssistantBlock._apply_rows
+
+        def record(self: AssistantBlock, text: Any) -> Any:
+            folds.append(self._flat_width())
+            return original(self, text)
+
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(AssistantBlock, "_apply_rows", record)
+        try:
+            job.trajectory = _stream("m1", prose * 4)
+            app._refresh_subagent_view()
+            for _ in range(4):
+                await pilot.pause()
+        finally:
+            monkeypatch.undo()
+
+        assert folds, "no fold was performed"
+        assert all(width == body_width for width in folds), folds
+        block = next(b for b in view._body.blocks() if isinstance(b, AssistantBlock))
+        assert block._built_width == body_width
+
+
+@pytest.mark.asyncio
+async def test_a_settled_message_is_committed_in_the_block_it_streamed_into() -> None:
+    """Settling COMMITS the row rather than rebuilding it.
+
+    The streaming splice concatenates a frozen prefix with the volatile tail,
+    which cannot produce the blank row between two paragraphs until the whole
+    message is re-rendered once (`AssistantBlock.finalize_text`). The main
+    conversation does that at `message_end`; this page has no such event, so it
+    commits on the refresh that observes the job settle. Without it a finished
+    child kept its mid-stream fold forever — a paragraph break the same text
+    shows in the main transcript, missing here.
+    """
+    body = "First paragraph here.\n\nSecond paragraph here."
+    job = _job_with(_stream("m1", body), status="running")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(140, 34)) as pilot:
+        view = await _open(pilot, app, job)
+        await pilot.pause()
+        block = next(b for b in view._body.blocks() if isinstance(b, AssistantBlock))
+        streaming = str(block.renderable)
+        assert not block.is_finalized()
+
+        # The child stops. Note the trajectory does NOT change: the settle is
+        # the job's status moving, which is the case a text-only diff misses.
+        job.status = "completed"
+        job.settled_at = job.start_time + 5
+        app._refresh_subagent_view()
+        await pilot.pause()
+
+        settled = next(b for b in view._body.blocks() if isinstance(b, AssistantBlock))
+        assert id(settled) == id(block), "the message was rebuilt to settle it"
+        assert settled.is_finalized()
+        rows = str(settled.renderable).split("\n")
+        assert any(not row.strip() for row in rows), rows
+        assert len(rows) == len(streaming.split("\n")) + 1

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -2618,3 +2618,60 @@ async def test_a_history_page_lands_below_the_truncation_note(tmp_path) -> None:
 
         # The note still heads the page, and nothing was inserted above it.
         assert view._body.blocks()[0] is view._head_block, "a history page landed above the note"
+
+
+@pytest.mark.asyncio
+async def test_a_history_page_lands_in_order_when_the_cap_is_crossed_mid_read(tmp_path) -> None:
+    """The prepend offset keys on the note's POSITION, not its existence.
+
+    `_head_block` is created lazily and appended at whatever length the body
+    has reached, so it heads the list only when the child was ALREADY
+    truncated when the page opened. A child that is under the cap at open and
+    crosses it while the reader watches mounts the note mid-list (measured:
+    index 5 of 257) — and correcting for a note that is not above the rows
+    pushes the prepended page one row too LOW, which reorders the durable
+    window (`durable 40` above `durable 0`).
+
+    That is the mirror image of round 1's N1 and it is the case `origin/main`
+    happened to get right, so it needs its own guard: the two scenarios are
+    disjoint and a fix conditioned on existence alone passes the other test
+    while breaking this one (review round 2, M3).
+    """
+    transcript = Transcript(tmp_path / "child")
+    for index in range(140):
+        await transcript.append_message(Message.assistant(f"durable {index}"))
+    # UNDER the cap at open: no truncation note exists yet.
+    job = _job_with(_text("m0", "live 0"), status="running")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, job)
+        await _wait_history(pilot, view)
+        assert view._head_block is None, "the fixture must start under the cap"
+
+        # Now cross the cap under the reader, which appends the note mid-list.
+        events: list[dict[str, Any]] = []
+        while len(events) < TRAJECTORY_MAX_EVENTS + 10:
+            events.extend(_text(f"m{len(events)}", f"live {len(events)}"))
+        job.trajectory = events
+        app._refresh_subagent_view()
+        for _ in range(4):
+            await pilot.pause()
+        assert view._head_block is not None, "the fixture needs to cross the cap"
+        assert (
+            view._body.blocks()[0] is not view._head_block
+        ), "this test only means anything while the note is NOT at index 0"
+
+        view.action_home()
+        await _wait_history(pilot, view)
+        await _wait_geometry_settled(pilot, view._body)
+
+        # The durable window stays in order: the page that was paged in must
+        # not be split around the row it belongs above.
+        durable = [row for row in view.rendered_rows() if row.strip().startswith("durable ")]
+        ordering = [int(row.strip().split()[1]) for row in durable]
+        assert ordering == sorted(ordering), f"the prepended page landed out of order: {ordering}"

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -2263,6 +2263,10 @@ async def test_a_streaming_message_keeps_one_block_across_refreshes() -> None:
         counter = _MountCounter(view)
         identities: set[int] = set()
         text = ""
+        # Bound before the loop so the assertions below are reachable even if
+        # the body never runs: an empty loop would otherwise leave `block`
+        # unbound and turn a real failure into a NameError at the assert.
+        block: AssistantBlock | None = None
         for index in range(12):
             text += f"token{index} "
             job.trajectory = _stream("m1", text)
@@ -2273,6 +2277,7 @@ async def test_a_streaming_message_keeps_one_block_across_refreshes() -> None:
         assert len(identities) == 1, "the streaming block was rebuilt"
         assert counter.removes == 0, f"{counter.removes} rows torn down while streaming"
         # The message on screen is the whole accumulated text, not a fragment.
+        assert block is not None
         assert "token0 " in block.text() and block.text().endswith("token11")
 
 

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -41,7 +41,7 @@ from local_operator.session.transcript import (
     TranscriptPage,
 )
 from local_operator.tui.app import SUBAGENT_LAYOUT_CLASS, OperatorApp
-from local_operator.tui.widgets.assistant import AssistantBlock
+from local_operator.tui.widgets.assistant import FALLBACK_WIDTH, AssistantBlock
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.subagent_panel import (
     GLYPH_DONE,
@@ -2253,7 +2253,13 @@ async def test_a_streaming_message_keeps_one_block_across_refreshes() -> None:
     and it discards the incremental markdown cache, so the settling final
     response is re-lexed in full on every tick.
     """
-    job = _job_with(_stream("m1", ""), status="running")
+    # Seeded with its first token rather than empty so the row already EXISTS
+    # when the counter is installed. From an empty message the block's first
+    # appearance would land inside the loop and count as a mount, which is a
+    # legitimate one — and an assertion that has to tolerate it cannot tell a
+    # first mount from a duplicate row appended beside the streaming one.
+    text = "opening "
+    job = _job_with(_stream("m1", text), status="running")
     session = FakeSession()
     session.jobs = _fake_jobs(job)
     app = OperatorApp(_async_factory(session))
@@ -2262,7 +2268,6 @@ async def test_a_streaming_message_keeps_one_block_across_refreshes() -> None:
         await pilot.pause()
         counter = _MountCounter(view)
         identities: set[int] = set()
-        text = ""
         # Bound before the loop so the assertions below are reachable even if
         # the body never runs: an empty loop would otherwise leave `block`
         # unbound and turn a real failure into a NameError at the assert.
@@ -2276,8 +2281,13 @@ async def test_a_streaming_message_keeps_one_block_across_refreshes() -> None:
             identities.add(id(block))
         assert len(identities) == 1, "the streaming block was rebuilt"
         assert counter.removes == 0, f"{counter.removes} rows torn down while streaming"
+        # Identity alone would not catch a DUPLICATE row appended beside the
+        # streaming one — the set stays size 1 while the page grows a second
+        # copy of the message. The sibling settling test asserts this too.
+        assert counter.mounts == 0, f"{counter.mounts} rows remounted while streaming"
         # The message on screen is the whole accumulated text, not a fragment.
         assert block is not None
+        assert block.text().startswith("opening")
         assert "token0 " in block.text() and block.text().endswith("token11")
 
 
@@ -2352,45 +2362,82 @@ async def test_a_row_folds_at_the_body_width_it_is_mounted_into() -> None:
     fallback-width build pinned a fallback-width height until the resize
     landed. On a 140-column terminal the block measurably built at 80 and
     settled at 134.
+
+    The probe is installed BEFORE the page opens, which is the whole point.
+    Round 1 of review caught the predecessor of this test arming it after
+    `_open`, so every fold performed during the initial mount was invisible to
+    the assertion: the test passed while the page still built its first blocks
+    at 80 and re-folded them a frame later, painted (measured on 2 of 20 opens
+    at 140x34 — `on_mount` runs before the body has a region, so the width
+    every source could report is 0). The mount path is the one a reader
+    actually sees flash, so it is the one that has to be covered.
+
+    The page is opened and FILLED in one synchronous beat, which is the
+    ordering `_open_subagent_view` produces whenever its deferred fill wins the
+    race with layout. Left to the scheduler the race resolves the harmless way
+    on most runs (2 of 20 opens showed the flash), so driving the ordering is
+    what makes this a regression test rather than a coin toss.
     """
     prose = "a paragraph of the child's prose that folds differently at 80 columns. "
-    job = _job_with(_stream("m1", prose * 3), status="running")
+    job = _job_with(_stream("m1", prose * 3) + _stream("m2", prose * 2), status="running")
     session = FakeSession()
     session.jobs = _fake_jobs(job)
     app = OperatorApp(_async_factory(session))
-    async with app.run_test(size=(140, 34)) as pilot:
-        view = await _open(pilot, app, job)
-        for _ in range(4):
+
+    # Every fold performed by ANY path, armed before the page exists. The
+    # predecessor of this test installed its probe AFTER the page was open, so
+    # the mount folds it names were invisible to it; it passed while the flash
+    # still happened. The streaming path is covered too: a rebuilt block is
+    # constructed with no parent to ask for a width, so it folded at 80 and
+    # re-folded once `on_resize` landed — a frame of narrow text per tick.
+    folds: list[int] = []
+    original = AssistantBlock._apply_rows
+
+    def record(self: AssistantBlock, text: Any) -> Any:
+        folds.append(self._flat_width())
+        return original(self, text)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(AssistantBlock, "_apply_rows", record)
+    try:
+        async with app.run_test(size=(140, 34)) as pilot:
+            for _ in range(80):
+                await pilot.pause()
+                if app._session is not None:
+                    break
+            app._append_block(UserBlock("audit the ingest path"))
+            app._refresh_band()
             await pilot.pause()
-        body_width = view._body.scrollable_content_region.width
-        assert body_width > 80, "the fixture needs a body wider than the fallback"
 
-        # Every fold performed from here on, whichever path builds it. The
-        # predecessor rebuilt the row on each streaming tick, and a rebuilt
-        # block is constructed with no parent to ask for a width, so it folded
-        # at 80 and re-folded once `on_resize` landed — a frame of narrow text
-        # per tick.
-        folds: list[int] = []
-        original = AssistantBlock._apply_rows
+            app._open_subagent_view(str(job.id))
+            view = app.query_one(SubagentView)
+            # The condition under test: mounted, not yet laid out, so every
+            # width the page could read is 0 and a naive fold falls to 80.
+            assert view._body.scrollable_content_region.width == 0
+            app._refresh_subagent_view(str(job.id))
+            for _ in range(4):
+                await pilot.pause()
 
-        def record(self: AssistantBlock, text: Any) -> Any:
-            folds.append(self._flat_width())
-            return original(self, text)
+            body_width = view._body.scrollable_content_region.width
+            assert body_width > 80, "the fixture needs a body wider than the fallback"
+            mount_folds = list(folds)
 
-        monkeypatch = pytest.MonkeyPatch()
-        monkeypatch.setattr(AssistantBlock, "_apply_rows", record)
-        try:
-            job.trajectory = _stream("m1", prose * 4)
+            job.trajectory = _stream("m1", prose * 4) + _stream("m2", prose * 2)
             app._refresh_subagent_view()
             for _ in range(4):
                 await pilot.pause()
-        finally:
-            monkeypatch.undo()
 
-        assert folds, "no fold was performed"
-        assert all(width == body_width for width in folds), folds
-        block = next(b for b in view._body.blocks() if isinstance(b, AssistantBlock))
-        assert block._built_width == body_width
+            assert mount_folds, "the mount path performed no fold to check"
+            assert folds != mount_folds, "the streaming path performed no fold to check"
+            # Stated as the FALLBACK rather than as "== body_width" so the
+            # failure names the defect: a fold at 80 is the flash, whatever
+            # else the ladder may legitimately report mid-layout.
+            assert FALLBACK_WIDTH not in folds, folds
+            assert all(width == body_width for width in folds), folds
+            block = next(b for b in view._body.blocks() if isinstance(b, AssistantBlock))
+            assert block._built_width == body_width
+    finally:
+        monkeypatch.undo()
 
 
 @pytest.mark.asyncio
@@ -2430,3 +2477,144 @@ async def test_a_settled_message_is_committed_in_the_block_it_streamed_into() ->
         rows = str(settled.renderable).split("\n")
         assert any(not row.strip() for row in rows), rows
         assert len(rows) == len(streaming.split("\n")) + 1
+
+
+@pytest.mark.asyncio
+async def test_a_finished_message_is_committed_while_the_child_is_still_working() -> None:
+    """Completeness is a property of the ROW, not of the job (review round 1, M1).
+
+    A running child's transcript is mostly finished messages — the prose it
+    writes between tool calls, each of which already had its `message_end`.
+    Deriving "may this be committed?" from the job status alone left every one
+    of them rendering with the streaming splice's concatenated fold, which
+    cannot produce the blank row between two paragraphs. Worse, `_apply_rows`
+    pins height to the row count, so those rows were pinned SHORT and grew
+    when the job eventually settled: measured 5 -> 6 and 2 -> 3 rows on this
+    exact fixture, a one-row content shift per message at settle, which is the
+    reflow class this page's in-place reconciliation exists to remove.
+
+    So the assertion is the pair: the paragraph break is present WHILE the
+    child works, and the row count does not move when it stops.
+    """
+    events = _text("m1", "Plan:\n\n- step one\n- step two\n\nNow running it.")
+    events += _text("m2", "That worked.\n\nMoving on to the next file.")
+    # A call the child is still running, so the job is unambiguously live
+    # while both messages above are complete.
+    events.append(_call("c0", "bash", command="pytest -q"))
+    job = _job_with(events, status="running")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(140, 34)) as pilot:
+        view = await _open(pilot, app, job)
+        for _ in range(4):
+            await pilot.pause()
+
+        live = [b for b in view._body.blocks() if isinstance(b, AssistantBlock)]
+        assert len(live) == 2, live
+        for block in live:
+            assert block.is_finalized(), "a finished message was left uncommitted"
+            rows = str(block.renderable).split("\n")
+            assert any(not row.strip() for row in rows), rows
+        live_rows = [len(str(block.renderable).split("\n")) for block in live]
+
+        # The child stops. The trajectory does not change — only the status —
+        # which is exactly the refresh that used to grow every one of these
+        # rows by one.
+        job.status = "completed"
+        job.settled_at = job.start_time + 5
+        app._refresh_subagent_view()
+        for _ in range(4):
+            await pilot.pause()
+
+        settled = [b for b in view._body.blocks() if isinstance(b, AssistantBlock)]
+        assert [id(b) for b in settled] == [id(b) for b in live], "rows were rebuilt at settle"
+        settled_rows = [len(str(block.renderable).split("\n")) for block in settled]
+        assert (
+            settled_rows == live_rows
+        ), f"content reflowed at settle: {live_rows} -> {settled_rows}"
+
+
+@pytest.mark.asyncio
+async def test_an_evicted_message_end_does_not_uncommit_a_settled_row() -> None:
+    """A fold that LOST the `message_end` must not un-finalize the row.
+
+    The trajectory is a rolling window, so `message_end` is as evictable as
+    any other event: a later fold of the same message can report it as still
+    streaming. Accepting that would un-finalize a committed block, and
+    `update_entry_block` answers a finalized block whose text moved with a
+    REMOUNT — so a row that had settled correctly would be torn down and
+    rebuilt under the reader. `_supersedes` refuses the downgrade for the same
+    reason it refuses a shorter text.
+    """
+    body = "First paragraph.\n\nSecond paragraph."
+    job = _job_with(_text("m1", body) + [_call("c0", "bash", command="go")], status="running")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(140, 34)) as pilot:
+        view = await _open(pilot, app, job)
+        for _ in range(4):
+            await pilot.pause()
+        block = next(b for b in view._body.blocks() if isinstance(b, AssistantBlock))
+        assert block.is_finalized()
+        rows = len(str(block.renderable).split("\n"))
+
+        # The window rolls: the same message is now reported WITHOUT its end.
+        job.trajectory = _stream("m1", body) + [_call("c0", "bash", command="go")]
+        app._refresh_subagent_view()
+        for _ in range(4):
+            await pilot.pause()
+
+        after = next(b for b in view._body.blocks() if isinstance(b, AssistantBlock))
+        assert id(after) == id(block), "the settled row was rebuilt by a worse fold"
+        assert after.is_finalized(), "an evicted message_end un-committed the row"
+        assert len(str(after.renderable).split("\n")) == rows
+        # The page's own record, which is where the refusal happens: the block
+        # above stays finalized either way (a finalized block answers an
+        # unchanged text with agreement), so asserting only on the widget
+        # would pass with the guard removed.
+        assert view._known["m1"].complete, "the page forgot the row was complete"
+
+
+@pytest.mark.asyncio
+async def test_a_history_page_lands_below_the_truncation_note(tmp_path) -> None:
+    """The prepend index accounts for the head block (review round 1, N1).
+
+    `prefix` is counted over ENTRIES, which exclude the truncation note, but
+    `TranscriptView.insert_blocks` indexes the BODY's list, which holds that
+    note at 0 — `_sync_body` mounts it outside the diffed sequence and keeps it
+    out of `self._blocks` (measured: `view._blocks` 168 against a body of 169).
+    Both a truncated trajectory and a durable history page are needed at once
+    for the skew to show, which is why it went unnoticed; without the offset
+    the history page is inserted ABOVE the note that is supposed to head the
+    page.
+    """
+    transcript = Transcript(tmp_path / "child")
+    for index in range(140):
+        await transcript.append_message(Message.assistant(f"durable {index}"))
+    # Over the cap, so the page carries its truncation note as a head block.
+    events: list[dict[str, Any]] = []
+    while len(events) < TRAJECTORY_MAX_EVENTS + 10:
+        events.extend(_text(f"m{len(events)}", f"live {len(events)}"))
+    job = _job_with(events, status="completed")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, job)
+        await _wait_history(pilot, view)
+        assert view._head_block is not None, "the fixture needs a truncated trajectory"
+        assert view._body.blocks()[0] is view._head_block
+
+        before = len(view._body.blocks())
+        view.action_home()
+        await _wait_history(pilot, view)
+        await _wait_geometry_settled(pilot, view._body)
+        assert len(view._body.blocks()) > before, "no history page was prepended"
+
+        # The note still heads the page, and nothing was inserted above it.
+        assert view._body.blocks()[0] is view._head_block, "a history page landed above the note"


### PR DESCRIPTION
## Problem

The subagent page flickers while a child streams: the transcript alternates between a narrow fold and full width, the working line blinks to black, and the page never settles into the steady stream the main conversation shows. It is worst around a child's final response and on long trajectories.

The cause is structural, not cosmetic. `SubagentView` never streams — it re-derives the whole transcript on every refresh tick and **remounts the blocks**, where the main conversation mutates one long-lived block in place (`OperatorApp._ensure_streaming_block`, which holds `_streaming_block` and calls `update_text` per delta).

`_sync_body` diffed by **value** over frozen `SubagentEntry` dataclasses: it kept the common prefix and tore down the entire suffix. A growing message never compares equal to its previous fold, so its block was destroyed and rebuilt on every tick. Three consequences, each matching one reported symptom:

- **Narrow-then-wide snap.** `entry_block` built the `AssistantBlock` *unmounted*, so `_flat_width()` fell to `FALLBACK_WIDTH = 80` and `_apply_rows` pinned the height to an 80-column fold. `on_resize` re-folded to the real width a frame later. Every tick painted one frame at 80 columns and the next at the true width.
- **Blink to black.** The tail `WorkingBlock` sits below the changed text row, so the suffix teardown took it too. It was a new widget every tick, restarting its shimmer sweep and its clock, and the row was absent entirely for the frame between `remove()` and the next paint.
- **Worst on the final response and long runs.** Each remount discarded the incremental markdown cache (`_frozen_text`/`_frozen_flat`), so `finalize_text()` re-lexed the whole message every tick instead of appending to a frozen prefix. Separately, a row settling mid-list rebuilt the whole suffix beneath it, which is O(n²) on parallel tool batches.

PR #359 reduced refresh *frequency*; it left the remount-per-refresh architecture intact, which is why the flicker survived it.

## Change

**`subagent_view.py` — stream in place.** `_sync_body` now reconciles by **identity** (`SubagentEntry.key`) rather than by value, updating rows through a new `update_entry_block`: text grows via `AssistantBlock.update_text` (preserving the frozen-prefix cache), tools settle through the existing `ToolCard.restore` seam with the executor's authoritative `duration_s`, notices restate. Remount is reserved for genuine reordering or a row changing kind. The tail row is split out of the diffed sequence and **pinned** via `TranscriptView.pin_tail` — the same lever the main conversation uses — so rows mount above it instead of replacing it.

Settling is keyed on **job status, not text**: this page has no `message_end`, and the refresh that observes a child stopping usually carries no new text, so a text-keyed rule left a finished child wearing the splice's fold and missing the paragraph break the main transcript shows.

**`transcript.py` — fold at the width you will actually get.** New `TranscriptBlock.fold_width(fallback)` resolves the width a block is *about to* be laid out at, walking from most authoritative down: own size → container size → the parent's `scrollable_content_region` (exactly what a `width: 1fr` child of the transcript receives) → an optional `set_fold_hint` for blocks built fully detached → the caller's fallback. `app.console.width` is deliberately **not** a rung: that is the whole terminal (175 in the harness), never the block's column, so a block trusting it would fold too wide and clip.

**`assistant.py`, `tool_card.py`** route their fold width through that ladder instead of `self.size.width or FALLBACK_WIDTH`; `WakeBlock._refresh_row` too.

The height-pin invariant in `_apply_rows` is unchanged — it still pins `styles.height` to the row count it is handed and lays out only when that count moves. Only the width those rows are folded at is better informed, so no frame exists where a block has no height.

## Change classification

**C2, standard/pre-authorized.** A bounded rendering and performance correction in one observability surface plus the width ladder it shares with the transcript family. No schema migration, no security boundary, no irreversible rollout.

## Testing evidence

Probes drive the **real `OperatorApp`** through `run_test`, opening the page with `_open_subagent_view` and ticking it with `_refresh_subagent_view`, instrumenting `TranscriptView.append_block`/`remove_block`. Before figures come from a worktree at `origin/main` (fa62d097), after figures from this branch.

| Probe (100x30 unless noted) | Before | After |
| --- | ---: | ---: |
| 120 streaming ticks: mounts / removes | 240 / 239 | **1 / 0** |
| `AssistantBlock` identities over those ticks | 96 | **1** |
| `WorkingBlock` identities | 95 | **1** |
| `_built_width` at mount → settled (140 cols) | 80 → 134 | **134 → 134** |
| Painted frames showing a fallback-width fold | 2 | **0** |
| Parallel batch, mounts at 2 / 4 / 8 / 16 pairs | 6 / 20 / 72 / 272 | **0 / 0 / 0 / 0** |
| …mounts per settling row | 3.0 / 5.0 / 9.0 / 17.0 | **0.0** |

The re-lex cost that made long final responses worst is addressed by the identity result above: block identity is now 1, so `_frozen_text`/`_frozen_flat` survive every tick instead of being discarded. Measured remount-vs-reuse per tick on `origin/main` was 1.11 ms vs 0.31 ms at 290 chars (3.6×) rising to 7.91 ms vs 0.62 ms at 8,700 chars (12.7×) — that gap is what the growing final response was paying.

Reader-facing invariants were checked directly, not assumed: scroll position holds across a refresh for a reader scrolled up (`scroll_before == scroll_after == 8`, both trees).

### Visual validation

Consecutive mid-stream frames at 140x34, captured per `AGENTS.md` "Visual validation" and viewed rendered, before and after: `/tmp/subagent-frames/{before,after}-f{1,2,3}.svg`. Consecutive settled frames (f2→f3) differ in **only** the two spinner glyphs in both trees — no reflow between paint and settle. The after frames show the shimmer live on the `thinking` tail and the settled paragraph break present.

### Regression tests

Five tests added to `tests/unit/tui/test_subagent_view.py`: a streaming message keeps one block identity; the working tail survives every refresh and stays last; settling mid-list tools cause zero mounts/removes; every row folds at the body width it is mounted into; a settled message is committed in the block it streamed into.

All five **fail on `origin/main`** and pass here. Verified independently by copying the new test file onto a clean baseline worktree:

```
FAILED test_a_streaming_message_keeps_one_block_across_refreshes - the streaming block was rebuilt
FAILED test_the_working_tail_survives_every_refresh - the working line was rebuilt under the reader (assert 6 == 1)
FAILED test_a_settling_mid_list_tool_does_not_rebuild_the_rows_beneath_it - 20 rows remounted (assert 20 == 0)
FAILED test_a_row_folds_at_the_body_width_it_is_mounted_into - assert [80, 80, 135]
```

`[80, 80, 135]` is the width flash itself, captured as an assertion.

### Gates

`flake8` ✅ · `black --check` ✅ (569 files) · `isort --check` ✅ · `pyright` ✅ on the changed files (a full-tree run was abandoned after three concurrent pyright processes on this machine pushed it past 50 minutes; CI runs the full tree) · `tests/unit/tui` ✅ · touched-area suites (`subagent_view`, `stream_anchor`, `tool_card`, `transcript_selection`, `snapshot`) ✅ 334 passed.

Two **pre-existing** flakes, both reproduced on a clean baseline worktree with this change absent, and left alone as out of scope:

- `test_app_pilot.py::test_switching_confirms_access_instead_of_warning_about_it` — 2/3 baseline runs
- `test_subagent_view.py::test_history_unavailable_and_error_retry_keep_trajectory_fallback` — 1/12 baseline runs

Under heavy machine load (load average >40, several agents building concurrently) `test_app_pilot.py` sheds a handful of boot-timing tests on baseline as well — 5 failures on an untouched `origin/main` checkout in the same window.

## Non-goals

- Transcript virtualization or a compositor redesign.
- Redesigning the child page's layout or information architecture.
- The bare `size.width or 80` in `approval.py`, `image_block.py`, `key_prompt.py` and the `settled_rows`/`_multirow_cache` measurement helpers: out of slice, and none is on this flicker path.
- The two pre-existing flakes above.
