### PR TITLE
fix(tui): copy only the highlighted glyphs for a sub-line selection

### DIFF
--- a/local_operator/tui/widgets/_copy_markdown.py
+++ b/local_operator/tui/widgets/_copy_markdown.py
@@ -297,6 +297,82 @@ def _is_rule_like(text: str) -> bool:
     return bool(body) and set(body) <= {"-", "─", ":", " ", "=", "_"}
 
 
+#: The quote bar as Rich paints it, repeated once per nesting level. A quote's
+#: CONTINUATION rows carry it too, which is what makes it furniture on every row
+#: of the construct rather than a marker that identifies the first one.
+_RENDERED_QUOTE_PREFIX_RE = re.compile(r"^(?:▌ ?)+")
+
+#: A rendered list marker and the space after it, with its leading indent. Only
+#: the row that OPENS the item carries this; a continuation is indented to the
+#: same column with spaces, which ``str.lstrip`` handles instead.
+_RENDERED_LIST_PREFIX_RE = re.compile(r"^\s*(?:[•◦▪]|\d{1,9})\s+")
+
+
+def furniture_width(row: str, source_line: str | None, *, opens_line: bool, fenced: bool) -> int:
+    """Leading cells of ``row`` that Rich PAINTED rather than the model wrote.
+
+    The row-level answer to the question :meth:`TranscriptBlock.copy_gutter`
+    asks per block, and it has to live here because it is only answerable with
+    the alignment: the same ``▌`` is furniture on a quote row and content on a
+    row of a fenced diagram, and nothing about the glyph itself says which.
+    ``source_line`` is the line :func:`align` mapped the row to, so the decision
+    is made from what the model actually wrote.
+
+    Why not a glyph regex over the row alone — the approach
+    ``test_a_quote_dragged_from_column_zero_keeps_the_bar`` rejects: inside a
+    fence it turns ``  1 / 0`` into ``/ 0``, because a code line that starts
+    with a digit is indistinguishable from a rendered ordered marker by glyph
+    alone. Keying on the source line makes ``fenced`` an explicit refusal
+    instead of a coincidence, so code copies byte for byte.
+
+    ``opens_line`` separates an item's first rendered row from its wrapped
+    continuations. Rich paints `` • `` once and indents the rest to the same
+    column, so a continuation's furniture is pure indent — stripping a marker
+    pattern there would eat content that merely looks like one (a continuation
+    beginning ``2026 was the year`` is the reported shape of that bug).
+    """
+    if source_line is None or fenced:
+        # Unplaceable rows and code are returned verbatim: with no source line
+        # to attribute a prefix to, every glyph is content until proven
+        # otherwise, and that is the conservative direction for a clipboard.
+        return 0
+    if _QUOTE_RE.match(source_line):
+        match = _RENDERED_QUOTE_PREFIX_RE.match(row)
+        return match.end() if match else 0
+    if _LIST_RE.match(source_line):
+        if opens_line:
+            match = _RENDERED_LIST_PREFIX_RE.match(row)
+            return match.end() if match else 0
+        return len(row) - len(row.lstrip(" "))
+    return 0
+
+
+def wrap_separator(before: str, after: str, source_line: str | None) -> str:
+    """What the terminal CONSUMED at the fold between two rows of one source line.
+
+    A soft wrap is not always a space. Rich breaks at a space when it can and
+    consumes it, so rejoining needs one put back; but a token wider than the
+    render segment is broken MID-TOKEN and nothing is consumed, so putting a
+    space back would invent a character the user never had. Measured, both are
+    reachable in ordinary prose at ordinary widths: a bare URL or a long
+    identifier folds mid-token at 40 columns while the sentence around it folds
+    at spaces.
+
+    The discriminator is the source line itself, which is the only place that
+    records what was really between them: if the last token of ``before``
+    concatenated to the first token of ``after`` occurs in it, the fold split
+    one token and the rejoin takes nothing. Asking the source rather than
+    inferring from the row's fill level is what makes this exact rather than a
+    heuristic about padding.
+    """
+    if source_line is None:
+        return " "
+    tokens_before, tokens_after = before.split(), after.split()
+    if not tokens_before or not tokens_after:
+        return " "
+    return "" if (tokens_before[-1] + tokens_after[0]) in source_line else " "
+
+
 def slice_markdown(source: str, mapping: list[int | None], first_row: int, last_row: int) -> str:
     """The markdown for rendered rows ``first_row..last_row`` inclusive.
 

--- a/local_operator/tui/widgets/_copy_markdown.py
+++ b/local_operator/tui/widgets/_copy_markdown.py
@@ -28,9 +28,28 @@ renderer trims them.
 from __future__ import annotations
 
 import re
+import unicodedata
 
 #: A line that opens or closes a fenced code block.
-_FENCE_RE = re.compile(r"^\s{0,3}(`{3,}|~{3,})")
+#:
+#: The indent is deliberately UNBOUNDED rather than CommonMark's three spaces.
+#: Three is the limit relative to the block's CONTAINER, and these lines arrive
+#: flat with no container context, so a fence indented under a list item — four
+#: spaces under ``- `` , five under ``1. `` , more when nested — read as ordinary
+#: text under a bounded pattern. That made ``classify`` return an EMPTY covered
+#: set for one of the most common shapes this app paints (numbered steps with a
+#: fenced command under each), which in turn let ``furniture_width`` take its
+#: list branch over CODE and strip a leading digit: ``3 rows expected`` copied as
+#: ``rows expected`` (design round 2, D2-1).
+#:
+#: The trade-off, taken knowingly: a literal `````` ``` ```` inside a FOUR-SPACE
+#: INDENTED code block is now read as a fence. That construct is vanishingly rare
+#: in assistant output (Rich's markdown renders indented code as code either
+#: way), while list-nested fences are routine, and the failure directions are not
+#: symmetric — over-recognising a fence makes the copy verbatim, which is the
+#: conservative answer for a clipboard, while under-recognising one deletes
+#: characters from the user's code.
+_FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
 #: A list item (bullet or ordered).
 _LIST_RE = re.compile(r"^\s{0,3}(?:[-+*]|\d{1,9}[.)])\s")
 #: A blockquote line (one or more ``>`` levels).
@@ -229,15 +248,48 @@ def align(source: str, rendered_rows: list[str]) -> list[int | None]:
                 if look in covered or not line.strip():
                     continue
                 if _LIST_RE.match(line) or _QUOTE_RE.match(line) or _HEADING_RE.match(line):
+                    # A bare ``>`` separating two quote lines paints no word of
+                    # its own, so it cannot answer whether this row starts a new
+                    # structural line. Stopping the scan there hid the quoted
+                    # LIST behind it: every row of the list was attributed to the
+                    # quote's opening line, so ``furniture_width`` was handed a
+                    # source line that is a quote but not a list item and kept
+                    # the ``•`` (design round 2, D2-4).
+                    if _QUOTE_RE.match(line) and not _strip_markup(line):
+                        continue
                     anchor = _first_word(_strip_markup(line)) or _first_word(line)
                     if word and anchor and word == anchor:
                         starts_structural = True
+                    break
+
+        # A FENCE BODY line likewise always opens its own rendered row, and it
+        # has to be checked separately because the structural scan above skips
+        # covered lines. Without this a fence indented under a list item was
+        # absorbed as a WRAP of the item that opens it: the item's wrap budget
+        # was still live, the code row matched no structural anchor, so the code
+        # was attributed to ``- Run the check:``. That mis-attribution is what
+        # made ``fenced`` False over code even once ``classify`` saw the fence,
+        # so ``furniture_width`` read the code's leading ``1`` as an ordered
+        # marker and deleted it (design round 2, D2-1, second cause).
+        #
+        # Matched on EXACT stripped text, the same key the anchor scan below
+        # uses for a covered line: a code line has no markup to normalise, and
+        # an exact match cannot steal a row from the prose it wraps.
+        starts_fence_body = False
+        if not starts_structural:
+            for look in range(src, min(src + _LOOKAHEAD, n)):
+                if look in markers or look not in covered:
+                    continue
+                line = src_lines[look]
+                if line.strip() and row.strip() == line.strip():
+                    starts_fence_body = True
                     break
         if (
             current is not None
             and budget > 0
             and not no_wrap_now
             and not starts_structural
+            and not starts_fence_body
             and not _RENDERED_MARKER_RE.match(row)
         ):
             placed = current
@@ -336,41 +388,191 @@ def furniture_width(row: str, source_line: str | None, *, opens_line: bool, fenc
         # to attribute a prefix to, every glyph is content until proven
         # otherwise, and that is the conservative direction for a clipboard.
         return 0
-    if _QUOTE_RE.match(source_line):
+    # Constructs COMPOSE, so the branches are applied in painted order rather
+    # than as an either/or. A list nested in a blockquote paints ``▌  • text``:
+    # testing the quote first and returning stripped the bar but kept the ``•``,
+    # leaking a glyph that is nowhere in the user's document and flipping the
+    # paste format on a one-cell change of drag start (design round 2, D2-4).
+    width = 0
+    remainder = source_line
+    if _QUOTE_RE.match(remainder):
         match = _RENDERED_QUOTE_PREFIX_RE.match(row)
-        return match.end() if match else 0
-    if _LIST_RE.match(source_line):
+        if match:
+            width = match.end()
+        # Peel the quote marker so the line can be re-tested for what it CONTAINS
+        # — the same source line is both a quote line and a list item.
+        remainder = _QUOTE_RE.sub("", remainder, count=1)
+
+    if _LIST_RE.match(remainder):
         if opens_line:
-            match = _RENDERED_LIST_PREFIX_RE.match(row)
-            return match.end() if match else 0
-        return len(row) - len(row.lstrip(" "))
-    return 0
+            match = _RENDERED_LIST_PREFIX_RE.match(row[width:])
+            return width + (match.end() if match else 0)
+        # A continuation is indented to the marker's column with plain spaces.
+        tail = row[width:]
+        return width + (len(tail) - len(tail.lstrip(" ")))
+    return width
 
 
-def wrap_separator(before: str, after: str, source_line: str | None) -> str:
-    """What the terminal CONSUMED at the fold between two rows of one source line.
+#: Inline markers Rich DROPS when it paints, so a rendered row is not a literal
+#: substring of its source line. Stepping over these is what lets the positional
+#: walk below place a row of ``**bold text** and `code```.
+_INLINE_MARKUP = "*_`~"
+
+
+def _skip_inline_markup(source: str, i: int) -> int:
+    """Advance past inline markers at ``i`` that render as nothing.
+
+    Handles emphasis/code runs and a link's ``](target)`` tail, whose label is
+    painted while the target is not.
+    """
+    while i < len(source):
+        char = source[i]
+        if char in _INLINE_MARKUP or char == "[":
+            i += 1
+            continue
+        if char == "]" and source.startswith("](", i):
+            close = source.find(")", i + 2)
+            if close < 0:
+                return i
+            i = close + 1
+            continue
+        break
+    return i
+
+
+def _match_visible(source: str, start: int, text: str) -> int | None:
+    """End offset of ``text`` rendered from ``source`` at ``start``, or ``None``.
+
+    Compares the LITERAL character first and only treats a mismatch as markup.
+    The order matters: intraword ``_`` is literal in CommonMark, so a walk that
+    skipped markers unconditionally could not place
+    ``some_verylongtoken_here`` and fell back to guessing on exactly the
+    mid-token folds the separator has to get right.
+    """
+    i, j = start, 0
+    while j < len(text):
+        if i < len(source) and source[i] == text[j]:
+            i += 1
+            j += 1
+            continue
+        nxt = _skip_inline_markup(source, i)
+        if nxt == i:
+            return None
+        i = nxt
+    return i
+
+
+def _separator_for_scripts(left: str, right: str) -> str:
+    """Fallback separator judged from the characters either side of a fold.
+
+    Only reached when the positional walk could not place the rows. A terminal
+    breaks CJK between any two characters because those scripts do not write
+    spaces, so a space there is never something the user had; Latin text breaks
+    at a space it then consumes, so one has to go back. Asking the adjacent
+    characters is a HEURISTIC, but a far narrower one than assuming a space
+    everywhere: it is what stops a Chinese or Japanese paragraph gaining an
+    invented space at every fold (review round 2, R2-2; design round 2, D2-3),
+    while leaving Latin prose — emoji and double-width cells included, which are
+    placed by the walk and never reach here — rejoining with the space it lost.
+    """
+    for char in (left, right):
+        if not char or unicodedata.east_asian_width(char) not in ("W", "F"):
+            continue
+        # Width alone is the WRONG test: an emoji is double-width too, and emoji
+        # sit in space-delimited Latin prose that genuinely lost a space at the
+        # fold. Review round 2 verified emoji already copied correctly, so the
+        # rule is narrowed to wide characters that are TEXT (letters and the
+        # CJK punctuation that ends a clause) rather than symbols (category
+        # ``So``, which is where emoji live).
+        if unicodedata.category(char)[0] in ("L", "P"):
+            return ""
+    return " "
+
+
+def wrap_separators(row_texts: list[str], source_line: str | None) -> list[str]:
+    """What the terminal CONSUMED at each fold between rows of ONE source line.
+
+    Returns one separator per fold, so ``len(row_texts) - 1`` entries.
 
     A soft wrap is not always a space. Rich breaks at a space when it can and
     consumes it, so rejoining needs one put back; but a token wider than the
     render segment is broken MID-TOKEN and nothing is consumed, so putting a
-    space back would invent a character the user never had. Measured, both are
-    reachable in ordinary prose at ordinary widths: a bare URL or a long
-    identifier folds mid-token at 40 columns while the sentence around it folds
-    at spaces.
+    space back would invent a character the user never had. Both are reachable
+    in ordinary prose at ordinary widths: a bare URL folds mid-token at 40
+    columns while the sentence around it folds at spaces.
 
-    The discriminator is the source line itself, which is the only place that
-    records what was really between them: if the last token of ``before``
-    concatenated to the first token of ``after`` occurs in it, the fold split
-    one token and the rejoin takes nothing. Asking the source rather than
-    inferring from the row's fill level is what makes this exact rather than a
-    heuristic about padding.
+    **The decision is POSITIONAL.** The rows are walked against the source line
+    with a cursor, and the separator for a fold is the whitespace actually
+    sitting at that point in the line. The previous test — does
+    ``last_token_of_A + first_token_of_B`` occur ANYWHERE in the line — ignored
+    position, so a line using both ``file system`` and ``filesystem`` judged a
+    real space-fold to be mid-token and welded two words shut: ``filesystem
+    layer``, silently wrong and unrepairable by the reader (review round 2,
+    R2-1; design round 2, D2-2, 30 reproductions across five prose lines).
+
+    The walk is **end-anchored**: the rows must consume the line's whole visible
+    content, which is what forces a single correct alignment instead of letting
+    an early partial match stand. ``row_texts`` must therefore be the FULL rows
+    of the source line, not a selection's clipped ends.
+
+    When the walk cannot place the rows the answer falls to
+    :func:`_separator_for_scripts`, and that fallback IS a heuristic — stated
+    plainly here because an earlier version of this docstring claimed the
+    source-asking approach was exact when it was not (design round 2, D2-2).
     """
-    if source_line is None:
-        return " "
-    tokens_before, tokens_after = before.split(), after.split()
-    if not tokens_before or not tokens_after:
-        return " "
-    return "" if (tokens_before[-1] + tokens_after[0]) in source_line else " "
+    folds = max(len(row_texts) - 1, 0)
+    if not folds:
+        return []
+
+    stripped = [text.strip() for text in row_texts]
+    if source_line is not None:
+        walked = _walk_folds(stripped, source_line)
+        if walked is not None:
+            return walked
+
+    # No placement, so decide each fold from the scripts meeting at it. This is
+    # also the branch an unplaceable row takes (``align`` returned ``None``),
+    # where returning ``" "`` unconditionally is what put a space into CJK.
+    return [_separator_for_scripts(stripped[i][-1:], stripped[i + 1][:1]) for i in range(folds)]
+
+
+def _walk_folds(row_texts: list[str], source_line: str) -> list[str] | None:
+    """Separators from a positional walk of ``row_texts`` over ``source_line``.
+
+    ``None`` when no start offset lets the rows consume the line exactly, which
+    leaves the caller its documented fallback rather than a wrong answer.
+    """
+    for start in range(len(source_line) + 1):
+        cursor = _match_visible(source_line, start, row_texts[0])
+        if cursor is None:
+            continue
+        separators: list[str] = []
+        for text in row_texts[1:]:
+            # Step over whatever sits between the rows: the whitespace the fold
+            # consumed, plus any inline marker that paints nothing. Whether that
+            # run held WHITESPACE is the whole question — that is the character
+            # the rejoin has to put back.
+            gap = cursor
+            saw_space = False
+            while gap < len(source_line):
+                if source_line[gap].isspace():
+                    saw_space = True
+                    gap += 1
+                    continue
+                nxt = _skip_inline_markup(source_line, gap)
+                if nxt == gap:
+                    break
+                gap = nxt
+            end = _match_visible(source_line, gap, text)
+            if end is None:
+                separators = []
+                break
+            separators.append(" " if saw_space else "")
+            cursor = end
+        else:
+            if source_line[cursor:].strip() == "":
+                return separators
+    return None
 
 
 def slice_markdown(source: str, mapping: list[int | None], first_row: int, last_row: int) -> str:

--- a/local_operator/tui/widgets/_copy_markdown.py
+++ b/local_operator/tui/widgets/_copy_markdown.py
@@ -463,12 +463,20 @@ def _skip_inline_markup(source: str, i: int) -> int:
     return i
 
 
-def _skip_painted_nothing(source: str, i: int) -> tuple[int, bool]:
+def _skip_painted_nothing(source: str, i: int) -> tuple[int, str]:
     """Advance past everything at ``i`` that paints NO glyph.
 
-    Returns the new offset and whether any WHITESPACE was among what was
-    skipped -- at a fold that is the whole question, since the consumed space
-    is the character a rejoin has to put back.
+    Returns the new offset and the WHITESPACE that was among what was skipped --
+    at a fold that is the whole question, since the consumed whitespace is what
+    a rejoin has to put back.
+
+    The whitespace is returned VERBATIM rather than as a flag. Answering "was
+    there a space?" made the rejoin put back exactly one, so a fold landing on a
+    run of two or more spaces silently collapsed it: aligned columns in prose
+    lost their alignment and a double-spaced sentence lost a space the document
+    had (review round 4, R4-2). The walk knows what the run was, so reporting a
+    plausible single space instead of the real one is the same
+    guess-rather-than-know shape one level down from the refusals above.
 
     One definition of "paints as nothing" serves both places the walk needs it:
     the gap between two rows, and the tail after the last one. They were
@@ -478,17 +486,17 @@ def _skip_painted_nothing(source: str, i: int) -> tuple[int, bool]:
     mid-token fold on such a line gained a space that split a URL or a
     filesystem path (review round 3, R3-1; design round 3, D3-1).
     """
-    saw_space = False
+    skipped: list[str] = []
     while i < len(source):
         if source[i].isspace():
-            saw_space = True
+            skipped.append(source[i])
             i += 1
             continue
         nxt = _skip_inline_markup(source, i)
         if nxt == i:
             break
         i = nxt
-    return i, saw_space
+    return i, "".join(skipped)
 
 
 def _match_visible(source: str, start: int, text: str) -> int | None:
@@ -661,12 +669,16 @@ def _walk_folds(row_texts: list[str], source_line: str) -> list[str] | None:
                 separators.append("")
                 cursor = end
                 continue
-            gap, saw_space = _skip_painted_nothing(source_line, cursor)
+            gap, consumed = _skip_painted_nothing(source_line, cursor)
             end = _match_visible(source_line, gap, text)
             if end is None:
                 separators = []
                 break
-            separators.append(" " if saw_space else "")
+            # The consumed run VERBATIM, not a single space standing in for it
+            # (review round 4, R4-2). Newlines cannot appear here -- the walk
+            # runs within one source line -- so this only ever restores the
+            # spaces and tabs the fold ate.
+            separators.append(consumed)
             cursor = end
         else:
             # End-anchor on the VISIBLE residual. Markers that paint nothing are

--- a/local_operator/tui/widgets/_copy_markdown.py
+++ b/local_operator/tui/widgets/_copy_markdown.py
@@ -419,14 +419,37 @@ def furniture_width(row: str, source_line: str | None, *, opens_line: bool, fenc
 _INLINE_MARKUP = "*_`~"
 
 
+def _is_word_char(char: str) -> bool:
+    """A character CommonMark counts as word-interior for emphasis purposes."""
+    return bool(char) and (char.isalnum() or char == "_")
+
+
+def _is_intraword_underscore(source: str, i: int) -> bool:
+    """``_`` at ``i`` sits inside a word, so CommonMark paints it LITERALLY.
+
+    CommonMark deliberately exempts ``_`` from intraword emphasis so that
+    ``snake_case`` survives, which ``*`` does not need. Treating such an
+    underscore as a dropped marker made the walk unable to place a row that
+    BEGINS on one -- exactly what Rich produces when it folds a long
+    ``some_very_long_identifier_name`` mid-token -- so the line fell to the
+    guess and every fold on it gained a space (review round 3, R3-2).
+    """
+    before = source[i - 1] if i else ""
+    after = source[i + 1] if i + 1 < len(source) else ""
+    return _is_word_char(before) and _is_word_char(after)
+
+
 def _skip_inline_markup(source: str, i: int) -> int:
     """Advance past inline markers at ``i`` that render as nothing.
 
     Handles emphasis/code runs and a link's ``](target)`` tail, whose label is
-    painted while the target is not.
+    painted while the target is not. An intraword ``_`` is content, not a
+    marker, and is left for the literal comparison to consume.
     """
     while i < len(source):
         char = source[i]
+        if char == "_" and _is_intraword_underscore(source, i):
+            break
         if char in _INLINE_MARKUP or char == "[":
             i += 1
             continue
@@ -438,6 +461,34 @@ def _skip_inline_markup(source: str, i: int) -> int:
             continue
         break
     return i
+
+
+def _skip_painted_nothing(source: str, i: int) -> tuple[int, bool]:
+    """Advance past everything at ``i`` that paints NO glyph.
+
+    Returns the new offset and whether any WHITESPACE was among what was
+    skipped -- at a fold that is the whole question, since the consumed space
+    is the character a rejoin has to put back.
+
+    One definition of "paints as nothing" serves both places the walk needs it:
+    the gap between two rows, and the tail after the last one. They were
+    written separately, and the tail test compared the RAW residual, so a line
+    ending in `` ` ``, ``**`` or ``](url)`` left a marker standing after the
+    final row, failed to place, and fell to the guess -- which is how a
+    mid-token fold on such a line gained a space that split a URL or a
+    filesystem path (review round 3, R3-1; design round 3, D3-1).
+    """
+    saw_space = False
+    while i < len(source):
+        if source[i].isspace():
+            saw_space = True
+            i += 1
+            continue
+        nxt = _skip_inline_markup(source, i)
+        if nxt == i:
+            break
+        i = nxt
+    return i, saw_space
 
 
 def _match_visible(source: str, start: int, text: str) -> int | None:
@@ -462,19 +513,61 @@ def _match_visible(source: str, start: int, text: str) -> int | None:
     return i
 
 
-def _separator_for_scripts(left: str, right: str) -> str:
-    """Fallback separator judged from the characters either side of a fold.
+def locate_source_line(row_texts: list[str], source: str) -> str | None:
+    """The one source line these rows are the full wrapping of, or ``None``.
 
-    Only reached when the positional walk could not place the rows. A terminal
-    breaks CJK between any two characters because those scripts do not write
-    spaces, so a space there is never something the user had; Latin text breaks
-    at a space it then consumes, so one has to go back. Asking the adjacent
-    characters is a HEURISTIC, but a far narrower one than assuming a space
-    everywhere: it is what stops a Chinese or Japanese paragraph gaining an
-    invented space at every fold (review round 2, R2-2; design round 2, D2-3),
-    while leaving Latin prose — emoji and double-width cells included, which are
-    placed by the walk and never reach here — rejoining with the space it lost.
+    Used when :func:`align` placed none of the rows. That is absence of evidence
+    from the aligner, not proof the rows share a line, so instead of loosening
+    the rule the evidence is sought DIRECTLY: a line that the end-anchored walk
+    can place these rows against is a line they demonstrably came from.
+
+    ``None`` when no line places them or when several do -- an ambiguous answer
+    is still no answer, and the caller must fall back to something that does not
+    need to know. Without this, a selection over rows the aligner could not place
+    was judged a single-line take on no evidence at all, which welded three
+    separate lines of a fenced block into one (review round 3, R3-2).
     """
+    if len(row_texts) < 2:
+        return None
+    found: str | None = None
+    for line in source.split("\n"):
+        if not line.strip():
+            continue
+        if _walk_folds([text.rstrip() for text in row_texts], line) is None:
+            continue
+        if found is not None:
+            return None
+        found = line
+    return found
+
+
+def separators_without_source(row_texts: list[str]) -> list[str]:
+    """Last-resort separators when there is NO source line to walk at all.
+
+    Reachable only when ``align`` placed none of the selected rows, so the
+    markdown path has nothing to offer either and the rendered glyphs are the
+    only truthful answer available. The name states the precondition that
+    :func:`wrap_separators` refuses to guess past: this function is chosen
+    deliberately by a caller that has checked there is no evidence, never
+    reached by falling through.
+
+    A terminal breaks CJK between any two characters because those scripts do
+    not write spaces, so a space there is never something the user had; Latin
+    text breaks at a space it then consumes, so one has to go back. Asking the
+    adjacent characters IS a heuristic, and it is kept only for the case where
+    the alternative is refusing to copy anything: it is what stops a Chinese or
+    Japanese paragraph gaining an invented space at every fold (review round 2,
+    R2-2; design round 2, D2-3).
+    """
+    stripped = [text.strip() for text in row_texts]
+    return [
+        _separator_for_scripts(stripped[i][-1:], stripped[i + 1][:1])
+        for i in range(max(len(stripped) - 1, 0))
+    ]
+
+
+def _separator_for_scripts(left: str, right: str) -> str:
+    """One fold's separator judged from the characters meeting at it."""
     for char in (left, right):
         if not char or unicodedata.east_asian_width(char) not in ("W", "F"):
             continue
@@ -489,7 +582,7 @@ def _separator_for_scripts(left: str, right: str) -> str:
     return " "
 
 
-def wrap_separators(row_texts: list[str], source_line: str | None) -> list[str]:
+def wrap_separators(row_texts: list[str], source_line: str | None) -> list[str] | None:
     """What the terminal CONSUMED at each fold between rows of ONE source line.
 
     Returns one separator per fold, so ``len(row_texts) - 1`` entries.
@@ -515,25 +608,31 @@ def wrap_separators(row_texts: list[str], source_line: str | None) -> list[str]:
     an early partial match stand. ``row_texts`` must therefore be the FULL rows
     of the source line, not a selection's clipped ends.
 
-    When the walk cannot place the rows the answer falls to
-    :func:`_separator_for_scripts`, and that fallback IS a heuristic — stated
-    plainly here because an earlier version of this docstring claimed the
-    source-asking approach was exact when it was not (design round 2, D2-2).
+    **``None`` means "I cannot know", and is not a separator.** When the rows
+    cannot be placed against the line there is no evidence about what the fold
+    consumed, and every previous attempt to answer anyway shipped a defect:
+    guessing ``" "`` split a URL and a filesystem path, guessing from the
+    adjacent scripts welded a compound, and both were silent because a
+    plausible character looks like an answer. Three rounds of findings
+    (R2-1, R2-2, R3-1, R3-2) are one root cause — the precondition above was
+    documented but not enforced, so the caller's clipped or unplaced rows
+    reached a fallback that invented a character rather than refusing.
+    Refusing hands the decision back to the caller, which has a truthful
+    answer available (the markdown source) that this function does not.
     """
     folds = max(len(row_texts) - 1, 0)
     if not folds:
+        # No fold, nothing to rejoin: knowable without any evidence at all, so
+        # a single-row sub-line take never depends on the walk.
         return []
 
-    stripped = [text.strip() for text in row_texts]
-    if source_line is not None:
-        walked = _walk_folds(stripped, source_line)
-        if walked is not None:
-            return walked
-
-    # No placement, so decide each fold from the scripts meeting at it. This is
-    # also the branch an unplaceable row takes (``align`` returned ``None``),
-    # where returning ``" "`` unconditionally is what put a space into CJK.
-    return [_separator_for_scripts(stripped[i][-1:], stripped[i + 1][:1]) for i in range(folds)]
+    if source_line is None:
+        return None
+    # Rows keep their LEADING whitespace on purpose. When a fold's space does not
+    # fit at the end of a row Rich moves it to the start of the next one instead
+    # of consuming it, so that space is still on screen and still on the
+    # clipboard; adding a separator too would double it.
+    return _walk_folds([text.rstrip() for text in row_texts], source_line)
 
 
 def _walk_folds(row_texts: list[str], source_line: str) -> list[str] | None:
@@ -552,17 +651,17 @@ def _walk_folds(row_texts: list[str], source_line: str) -> list[str] | None:
             # consumed, plus any inline marker that paints nothing. Whether that
             # run held WHITESPACE is the whole question — that is the character
             # the rejoin has to put back.
-            gap = cursor
-            saw_space = False
-            while gap < len(source_line):
-                if source_line[gap].isspace():
-                    saw_space = True
-                    gap += 1
-                    continue
-                nxt = _skip_inline_markup(source_line, gap)
-                if nxt == gap:
-                    break
-                gap = nxt
+            # LITERAL FIRST, the same order :func:`_match_visible` uses and for
+            # the same reason: a row that already carries the fold's whitespace
+            # at its start consumed nothing, so the rejoin must add nothing.
+            # Only when the row cannot be matched where the cursor stands is the
+            # gap skipped and its whitespace put back.
+            end = _match_visible(source_line, cursor, text)
+            if end is not None:
+                separators.append("")
+                cursor = end
+                continue
+            gap, saw_space = _skip_painted_nothing(source_line, cursor)
             end = _match_visible(source_line, gap, text)
             if end is None:
                 separators = []
@@ -570,7 +669,12 @@ def _walk_folds(row_texts: list[str], source_line: str) -> list[str] | None:
             separators.append(" " if saw_space else "")
             cursor = end
         else:
-            if source_line[cursor:].strip() == "":
+            # End-anchor on the VISIBLE residual. Markers that paint nothing are
+            # not content the rows failed to cover, so a line closing on
+            # `` `code` ``, ``**bold**`` or ``[label](url)`` must still count as
+            # fully consumed (review round 3, R3-1).
+            tail, _ = _skip_painted_nothing(source_line, cursor)
+            if source_line[tail:].strip() == "":
                 return separators
     return None
 

--- a/local_operator/tui/widgets/assistant.py
+++ b/local_operator/tui/widgets/assistant.py
@@ -650,16 +650,51 @@ class AssistantBlock(TranscriptBlock):
         painted as several rows, the same defect, and measured at width 60 a
         row-count gate still copied all 128 characters of it.
 
+        **The glyph path strips painted furniture per row**, via
+        :func:`_copy_markdown.furniture_width` rather than :meth:`copy_gutter`.
+        The inherited gutter is 0 and has to be: an assistant message has no
+        fixed one, because whether a leading ``▌`` is decoration or content
+        depends on the construct the row belongs to, and only the alignment
+        knows. Clamping to 0 stripped nothing, so a sub-line drag across a
+        wrapped quote's fold pasted the ``▌`` and a column-0 drag pasted the
+        ``•`` — furniture the markdown path never emitted, found independently
+        by review round 1 (R1-1) and design round 1 (D1). It also meant one
+        cell of difference in where a drag STARTED silently switched the paste
+        between markdown and rendered glyphs, which is why the full-coverage
+        predicate above measures against the same painted width.
+
+        **Rows of one source line rejoin with what the terminal consumed**, not
+        with a newline: the gate guarantees they share a source line, so each
+        break between them is a soft wrap at the current width rather than a
+        character in the document (design round 1, D2). A space is not always
+        right — a token wider than the render segment is folded mid-token and
+        nothing is consumed — so the separator is decided against the source
+        line by :func:`_copy_markdown.wrap_separator`.
+
         **The accepted cost**, stated so it is chosen rather than rediscovered:
         a drag from the middle of one bullet to the middle of the next copies
         both bullets WHOLE. The reader gets more than they highlighted. That is
         deliberate — trimming those ends needs the column mapping that does not
-        exist, and degrading any multi-row take to glyphs would put the ``▌``
-        and ``•`` furniture back into the paste this method exists to keep it
-        out of (which ``test_blockquote_copies_as_markdown_not_the_bar``
-        guards). A sub-line take also loses inline markers: dragging one bold
-        word yields ``frontend``, not ``**frontend**``. That is the base rule —
-        the clipboard is what the highlight covered.
+        exist, and the markdown path is the only one that can state a multi-line
+        take as valid markdown at all. Reviewed and accepted as shippable in
+        design round 1 (D3). A sub-line take also loses inline markers: dragging
+        one bold word yields ``frontend``, not ``**frontend**``. That is the
+        base rule — the clipboard is what the highlight covered — and it was
+        accepted in design round 1 (D4) for the reason that the reader pointed
+        at a frame with no asterisks anywhere on it.
+
+        A sub-line take across a TABLE row is the same rule and the one place
+        it costs something real: the rendered row has no ``|``, so the paste is
+        ``alpha  0.91`` and no longer reads as a table row (design round 1, D5).
+        It is left as the rule rather than special-cased because the whole-row
+        gesture — the one a reader makes to take a row AS a row — still covers
+        the row and still copies ``| alpha | 0.91 |`` from the source.
+
+        **A drag that lies entirely in a row's trailing pad copies nothing**,
+        deliberately: it selects no glyph, and Rich's pad is not content the
+        reader can see. ``_put_on_clipboard`` drops the empty payload, so there
+        is no write and no receipt — the same answer a zero-width click gets
+        (review round 1, R1-2).
         """
         visual = self._render()
         if not isinstance(visual, Content):
@@ -706,21 +741,59 @@ class AssistantBlock(TranscriptBlock):
                 # wrong. ``end`` also arrives three ways: -1 for end-of-row, a
                 # column inside the pad when the drag overran the last glyph, or
                 # a column short of it. Only the glyph count settles all three.
-                starts_full = first_start <= self.copy_gutter(first_index)
+                # The gutter is the row's PAINTED furniture, not the block's
+                # ``copy_gutter`` of 0: a full-content take must read as full
+                # whether or not the reader's drag began on the ``▌`` cell, or
+                # the same gesture one cell left would fall to the glyph path
+                # and paste a different document (design round 1, D1).
+                starts_full = first_start <= self._furniture_width(
+                    rows, mapping, first_index, content
+                )
                 ends_full = last_end == -1 or last_end >= len(rows[last_index].rstrip())
                 sub_line = not (starts_full and ends_full)
 
         if sub_line:
-            # Sliced exactly as ``TranscriptBlock.get_selection`` slices it
-            # (gutter-clamped start, ``-1`` meaning end of row), but over the
-            # content rows only: a blank row caught at the edge of the drag
-            # would otherwise contribute a line break the reader never
-            # highlighted, turning the receipt into ``copied 2 lines``.
+            # Sliced as ``TranscriptBlock.get_selection`` slices it (``-1``
+            # meaning end of row), but over the content rows only — a blank row
+            # caught at the edge of the drag would contribute a line break the
+            # reader never highlighted — and clamped past each row's PAINTED
+            # furniture rather than past ``copy_gutter``.
+            #
+            # ``copy_gutter`` is 0 on this block and cannot be anything else:
+            # an assistant message has no fixed gutter, because what is
+            # furniture depends on the construct the row belongs to. Clamping
+            # to it stripped nothing, so a sub-line take across a wrapped
+            # quote's fold put the ``▌`` on the clipboard and a column-0 drag
+            # picked up the ``•`` — furniture the base commit never copied, and
+            # the exact leak this method's docstring claims to prevent (review
+            # round 1, R1-1; design round 1, D1).
             glyphs = [
-                rows[index][max(start, self.copy_gutter(index)) : None if end == -1 else end]
+                rows[index][
+                    max(start, self._furniture_width(rows, mapping, index, content)) : (
+                        None if end == -1 else end
+                    )
+                ]
                 for index, (start, end) in content
             ]
-            return "\n".join(row.rstrip() for row in glyphs), "\n"
+            trimmed = [row.rstrip() for row in glyphs]
+
+            # Rejoined with what the TERMINAL consumed at each fold, not with a
+            # newline. The gate above guarantees these rows share one source
+            # line, so every break between them is a SOFT WRAP — an artifact of
+            # the current width, not a character in the document. Pasting it
+            # sent a phrase to Slack as two lines and turned the receipt into
+            # ``copied 2 lines`` for part of one sentence, the mirror of the
+            # composer bug ``_put_on_clipboard`` already fixed (design round 1,
+            # D2). Once rejoined the receipt falls into the character branch by
+            # itself, so the unit needs no separate fix.
+            source_line = self._source_line(mapping, content[0][0])
+            joined = trimmed[0]
+            for position, text in enumerate(trimmed[1:], start=1):
+                if not text:
+                    continue
+                separator = _copy_markdown.wrap_separator(joined, text, source_line)
+                joined = f"{joined}{separator}{text}" if joined else text
+            return joined, "\n"
 
         # Widened to whole source lines on purpose — see the accepted cost
         # above. The bounds come from ``selected`` rather than ``content`` so
@@ -731,3 +804,51 @@ class AssistantBlock(TranscriptBlock):
         if not copied:
             return super().get_selection(selection)
         return copied, "\n"
+
+    def _source_line(self, mapping: list[int | None], row: int) -> str | None:
+        """The source line rendered row ``row`` came from, or ``None``.
+
+        ``None`` for a row :func:`_copy_markdown.align` could not place, which
+        every caller treats as "assume nothing": the alignment is the only
+        evidence about what a painted glyph means, so without it the row is
+        returned verbatim rather than guessed at.
+        """
+        if row >= len(mapping):
+            return None
+        source = mapping[row]
+        if source is None:
+            return None
+        lines = self._full_text.split("\n")
+        return lines[source] if source < len(lines) else None
+
+    def _furniture_width(
+        self,
+        rows: list[str],
+        mapping: list[int | None],
+        row: int,
+        content: list[tuple[int, tuple[int, int]]],
+    ) -> int:
+        """Painted-furniture columns on rendered row ``row``.
+
+        The per-row gutter this block cannot express as a constant. See
+        :func:`_copy_markdown.furniture_width` for why the answer needs the
+        source line: the same glyph is decoration on a quote row and content
+        inside a fence.
+
+        A row OPENS its source line when the previous content row came from a
+        different one — which is what distinguishes a list item's marker row
+        from its wrapped continuations, whose furniture is indent alone.
+        """
+        source = mapping[row] if row < len(mapping) else None
+        previous: int | None = None
+        for index, _ in content:
+            if index == row:
+                break
+            previous = mapping[index] if index < len(mapping) else None
+        covered, _ = _copy_markdown.classify(self._full_text.split("\n"))
+        return _copy_markdown.furniture_width(
+            rows[row],
+            self._source_line(mapping, row),
+            opens_line=source != previous,
+            fenced=source is not None and source in covered,
+        )

--- a/local_operator/tui/widgets/assistant.py
+++ b/local_operator/tui/widgets/assistant.py
@@ -633,8 +633,8 @@ class AssistantBlock(TranscriptBlock):
         Column-trimmed markdown source is not the missing third option — it is
         **impossible**, not merely unimplemented, and that is what decides the
         rule. A rendered column does not index a source column: measured on the
-        reported bullet, ``frontend`` sits at rendered column 56 and source
-        column 57, because ``- `` paints as `` • `` (+1) and the ``**`` around
+        reported bullet, ``frontend`` sits at rendered column 57 and source
+        column 58, because ``- `` paints as `` • `` (+1) and the ``**`` around
         the word vanishes (-2). The offset is content-dependent AND signed, and
         :func:`_copy_markdown.align` deliberately maps rows to source *lines*,
         never claiming a column correspondence. So for a partial row there are

--- a/local_operator/tui/widgets/assistant.py
+++ b/local_operator/tui/widgets/assistant.py
@@ -728,13 +728,29 @@ class AssistantBlock(TranscriptBlock):
         if content:
             # Source LINES, not rows: a paragraph that wraps is one line painted
             # as several, and a phrase dragged across that fold is as much a
-            # sub-line take as one inside a single row. A row ``align`` cannot
-            # place contributes nothing, which leaves the conservative answer
-            # (glyphs are always truthful) if alignment itself ever regresses.
-            sources = {
-                mapping[i] for i, _ in content if i < len(mapping) and mapping[i] is not None
-            }
-            if len(sources) <= 1:
+            # sub-line take as one inside a single row.
+            #
+            # An UNPLACED row (``align`` returned ``None``) is absence of
+            # evidence, not agreement. Dropping it from the set let a selection
+            # spanning an unplaced row and a placed one collapse to one element
+            # and read as a single-source-line take it never was: two lines of a
+            # fenced block were then rejoined into ONE RUNNABLE COMMAND (review
+            # round 3, R3-2; design round 3, D3-2). It now disqualifies the gate,
+            # sending the take down the markdown path, which states a multi-line
+            # selection as multiple lines.
+            #
+            # MIXED evidence is what disqualifies: when some rows are placed and
+            # others are not, nothing can say whether the unplaced ones belong to
+            # the placed one's line, so a single-element set is not agreement.
+            # When NO row is placed the situation is different in kind rather
+            # than in degree -- there is no line-boundary evidence at all, which
+            # is ordinary for a CJK paragraph where no anchor word survives, and
+            # the markdown path has nothing to offer either. That case keeps the
+            # glyph answer (review round 2, R2-2).
+            row_sources = [mapping[i] if i < len(mapping) else None for i, _ in content]
+            sources = {source for source in row_sources if source is not None}
+            mixed = bool(sources) and None in row_sources
+            if not mixed and len(sources) <= 1:
                 first_index, (first_start, _) = content[0]
                 last_index, (_, last_end) = content[-1]
                 # ``rstrip()`` is the only honest measure of the row's actual
@@ -790,36 +806,157 @@ class AssistantBlock(TranscriptBlock):
             # composer bug ``_put_on_clipboard`` already fixed (design round 1,
             # D2). Once rejoined the receipt falls into the character branch by
             # itself, so the unit needs no separate fix.
-            # The separators are decided from the FULL rows of the source line,
-            # not from the clipped ends the reader highlighted. The walk that
-            # replaced the old substring test is positional and end-anchored, so
-            # it needs the same text Rich painted: a trimmed first row cannot be
-            # located in the source line, and a partial take is exactly where a
-            # membership test used to guess wrong (review round 2, R2-1).
+            # The separators are decided from EVERY row of the source line, not
+            # from the rows the reader's drag happened to touch. The walk is
+            # end-anchored: it asks the rows to consume the line's whole visible
+            # content, so handing it a selection-shaped subset violates its
+            # precondition and it cannot place them. That is what a drag stopping
+            # one row short of a paragraph's end used to do, and the guess it
+            # fell to put a space through a URL and a filesystem path (review
+            # round 3, R3-1; design round 3, D3-1). Supplying the full row set
+            # makes the precondition hold BY CONSTRUCTION rather than by hope --
+            # the mapping already knows every row of the line.
+            # A single-row take has no fold inside it, so it needs no evidence
+            # about what a fold consumed. Asking anyway would make an unplaceable
+            # line degrade a take that was never at risk.
             source_line = self._source_line(mapping, content[0][0])
-            full_rows = [
-                rows[index][self._furniture_width(rows, mapping, index, content) :].rstrip()
-                for index, _ in content
-            ]
-            separators = _copy_markdown.wrap_separators(full_rows, source_line)
+            fold_rows, first_offset = self._source_line_rows(rows, mapping, content)
+            separators: list[str] | None = []
+            if len(trimmed) > 1:
+                separators = _copy_markdown.wrap_separators(fold_rows, source_line)
+
+            # ``None`` is a refusal, not a separator: the walk could not place
+            # these rows, so nothing here knows what the fold consumed. Inventing
+            # a plausible character is precisely the failure of the last three
+            # rounds, so the take falls back to the markdown source, which is
+            # truthful without needing to know the fold.
+            if separators is None:
+                # No placement, so this code does not know what the fold
+                # consumed. There are two ways to be in that position and they
+                # have DIFFERENT safe answers:
+                #
+                # * ``align`` placed the rows but the walk could not consume the
+                #   line (a clipped or unusual selection). The markdown source
+                #   is still available and is truthful, so use it.
+                # * ``align`` placed NOTHING, which is ordinary for a CJK
+                #   paragraph where no anchor word survives. There is no
+                #   markdown to fall back to, so the rendered glyphs are the
+                #   only truthful answer and the script heuristic decides the
+                #   fold -- chosen explicitly here rather than fallen into.
+                if source_line is None:
+                    # Look for the evidence directly before assuming there is
+                    # none: a line the walk CAN place these rows against is proof
+                    # they came from it. Only when no line places them, or
+                    # several do, is there genuinely nothing to know.
+                    source_line = _copy_markdown.locate_source_line(fold_rows, self._full_text)
+                    if source_line is not None:
+                        separators = _copy_markdown.wrap_separators(fold_rows, source_line)
+
+                if separators is None:
+                    if source_line is not None or self._may_hide_a_line_boundary():
+                        copied = self._markdown_for_rows(mapping, selected[0][0], selected[-1][0])
+                        if copied:
+                            return copied, "\n"
+                        return super().get_selection(selection)
+                    separators = _copy_markdown.separators_without_source(fold_rows)
 
             joined = trimmed[0]
             for offset, text in enumerate(trimmed[1:]):
                 if not text:
                     continue
-                separator = separators[offset] if offset < len(separators) else " "
+                # Indexed against the FULL row set, so the reader's first row is
+                # at ``first_offset``. No length guard with a ``" "`` default:
+                # that default is the same invented character in miniature, and a
+                # skew here is a bug to surface, not to paper over (review round
+                # 3, R3-3). The slice above guarantees the index is in range.
+                separator = separators[first_offset + offset]
                 joined = f"{joined}{separator}{text}" if joined else text
             return joined, "\n"
 
         # Widened to whole source lines on purpose — see the accepted cost
         # above. The bounds come from ``selected`` rather than ``content`` so
         # the markdown path spans exactly the rows it has always spanned.
-        first_row = selected[0][0]
-        last_row = selected[-1][0]
-        copied = _copy_markdown.slice_markdown(self._full_text, mapping, first_row, last_row)
+        copied = self._markdown_for_rows(mapping, selected[0][0], selected[-1][0])
         if not copied:
             return super().get_selection(selection)
         return copied, "\n"
+
+    def _markdown_for_rows(self, mapping: list[int | None], first_row: int, last_row: int) -> str:
+        """Markdown for ``first_row..last_row``, widened over UNPLACED edge rows.
+
+        :func:`_copy_markdown.slice_markdown` collects source lines through the
+        mapping, so a row ``align`` could not place contributes nothing. When
+        such a row is at the EDGE of the selection its source line is dropped
+        entirely and content the reader lit vanishes from the clipboard --
+        reachable on the continuation rows of an over-long line inside a fence,
+        which is where R3-2's welded shell command was found.
+
+        Widening each end out to the nearest placed row recovers those lines
+        through the existing gap fill. It errs toward copying MORE than was
+        highlighted, which is this path's already-accepted cost (design round 1,
+        D3) and the only safe direction: a paste with an extra line is one the
+        reader can see and trim, a silently missing or welded line is not.
+        """
+        first, last = first_row, last_row
+        while first > 0 and (first >= len(mapping) or mapping[first] is None):
+            first -= 1
+        while last < len(mapping) - 1 and mapping[last] is None:
+            last += 1
+        return _copy_markdown.slice_markdown(self._full_text, mapping, first, last)
+
+    def _may_hide_a_line_boundary(self) -> bool:
+        """Could an unplaced run of rows straddle TWO source lines?
+
+        The script heuristic in :func:`_copy_markdown.separators_without_source`
+        answers what a FOLD consumed, which is only a meaningful question if the
+        rows really are folds of one line. When the message has a single
+        non-blank source line that is certain by construction -- the ordinary CJK
+        paragraph, where no anchor word survives for ``align`` to place.
+
+        With several source lines it is not certain, and assuming it welded three
+        lines of a fenced block into one (review round 3, R3-2). Then the answer
+        must come from the markdown source, which needs no fold knowledge.
+        """
+        return len([line for line in self._full_text.split("\n") if line.strip()]) > 1
+
+    def _source_line_rows(
+        self,
+        rows: list[str],
+        mapping: list[int | None],
+        content: list[tuple[int, tuple[int, int]]],
+    ) -> tuple[list[str], int]:
+        """Every rendered row of the selected source line, and the drag's offset.
+
+        :func:`_copy_markdown.wrap_separators` is end-anchored, so it can only
+        place rows that are the WHOLE of the source line. The selection is not
+        that: a reader highlighting exactly a URL stops before the paragraph's
+        last row, and handing those clipped rows to the walk is what made it
+        give up and fall to a guess that split the URL (review round 3, R3-1).
+
+        The mapping already knows which rows belong to the line, so the full set
+        is recovered from it rather than inferred from the drag. The second
+        element is the index of the reader's FIRST row within that set, which is
+        what lets the caller read the separator for its own folds out of the
+        full-line answer.
+
+        The gate above guarantees a single source line and no unplaced content
+        rows, so ``content`` cannot straddle two lines here.
+        """
+        source = mapping[content[0][0]] if content[0][0] < len(mapping) else None
+        indices = [i for i, mapped in enumerate(mapping) if mapped == source and rows[i].strip()]
+        if not indices:
+            indices = [index for index, _ in content]
+        first_offset = indices.index(content[0][0]) if content[0][0] in indices else 0
+        # Furniture is measured against the FULL row set, not the selection:
+        # ``opens_line`` asks whether the previous content row came from another
+        # source line, and answering that from the drag's rows would call a
+        # continuation row a marker row whenever the reader started mid-line.
+        span = [(index, (0, -1)) for index in indices]
+        full_rows = [
+            rows[index][self._furniture_width(rows, mapping, index, span) :].rstrip()
+            for index in indices
+        ]
+        return full_rows, first_offset
 
     def _source_line(self, mapping: list[int | None], row: int) -> str | None:
         """The source line rendered row ``row`` came from, or ``None``.

--- a/local_operator/tui/widgets/assistant.py
+++ b/local_operator/tui/widgets/assistant.py
@@ -896,7 +896,30 @@ class AssistantBlock(TranscriptBlock):
         highlighted, which is this path's already-accepted cost (design round 1,
         D3) and the only safe direction: a paste with an extra line is one the
         reader can see and trim, a silently missing or welded line is not.
+
+        GATED ON EVIDENCE THAT THERE IS SOMETHING TO RESCUE. Widening only helps
+        where the selection already yields a line and an unplaced EDGE row would
+        drop a neighbour. Where NO selected row is placed there is no such line:
+        the un-widened slice is ``""``, the caller already falls back to the
+        frame copy -- exactly the lit glyphs -- and widening pre-empts that
+        correct answer. Worse, because ``slice_markdown`` collects through the
+        mapping, widening over unplaced rows adds no line of its own; it drags
+        the window onto whichever line IS placed, so the copy becomes a
+        DIFFERENT line than the one highlighted. A reader who lit one shell
+        command then pastes another and runs it (review round 4, R4-1; design
+        round 4, D4-1) -- the same harm class as R3-2's weld, and nothing on the
+        clipboard signals the substitution. Rescuing a lit line needs evidence
+        that a line was there to rescue; with no placed row there is none, which
+        is the same guess-rather-than-know shape this path exists to refuse.
         """
+        placed = any(
+            mapping[row] is not None
+            for row in range(first_row, min(last_row, len(mapping) - 1) + 1)
+            if row < len(mapping)
+        )
+        if not placed:
+            return ""
+
         first, last = first_row, last_row
         while first > 0 and (first >= len(mapping) or mapping[first] is None):
             first -= 1

--- a/local_operator/tui/widgets/assistant.py
+++ b/local_operator/tui/widgets/assistant.py
@@ -621,6 +621,45 @@ class AssistantBlock(TranscriptBlock):
         When the source cannot be aligned (an empty message, or a frame the
         walker cannot place), the method falls back to the base frame copy so a
         copy never comes back empty-handed.
+
+        **The one selection markdown cannot answer: a SUB-LINE take.** Reported
+        from the field — dragging the eight cells of one word out of a bullet
+        announced ``copied 115 characters`` and put the whole source line on the
+        clipboard. The cause was structural rather than an off-by-one: the row
+        walk kept only ``first_row``/``last_row`` and dropped the column pair
+        ``get_span`` returns, and ``slice_markdown`` is row-granular by
+        contract, so every partial row was widened to the source line under it.
+
+        Column-trimmed markdown source is not the missing third option — it is
+        **impossible**, not merely unimplemented, and that is what decides the
+        rule. A rendered column does not index a source column: measured on the
+        reported bullet, ``frontend`` sits at rendered column 56 and source
+        column 57, because ``- `` paints as `` • `` (+1) and the ``**`` around
+        the word vanishes (-2). The offset is content-dependent AND signed, and
+        :func:`_copy_markdown.align` deliberately maps rows to source *lines*,
+        never claiming a column correspondence. So for a partial row there are
+        exactly two truthful answers — the glyphs that were highlighted, or a
+        whole line the reader did not select — and the second is the bug.
+
+        Hence the boundary, drawn on SOURCE LINES rather than on rendered rows:
+        a selection that does not cover the full content of the rows it touches
+        **and** touches at most one source line copies the highlighted glyphs,
+        per :meth:`TranscriptBlock.copy_gutter`'s rule. Everything wider stays
+        markdown. Counting source lines rather than rows is also what covers a
+        phrase dragged across a wrapped paragraph's fold — one source line
+        painted as several rows, the same defect, and measured at width 60 a
+        row-count gate still copied all 128 characters of it.
+
+        **The accepted cost**, stated so it is chosen rather than rediscovered:
+        a drag from the middle of one bullet to the middle of the next copies
+        both bullets WHOLE. The reader gets more than they highlighted. That is
+        deliberate — trimming those ends needs the column mapping that does not
+        exist, and degrading any multi-row take to glyphs would put the ``▌``
+        and ``•`` furniture back into the paste this method exists to keep it
+        out of (which ``test_blockquote_copies_as_markdown_not_the_bar``
+        guards). A sub-line take also loses inline markers: dragging one bold
+        word yields ``frontend``, not ``**frontend**``. That is the base rule —
+        the clipboard is what the highlight covered.
         """
         visual = self._render()
         if not isinstance(visual, Content):
@@ -628,16 +667,66 @@ class AssistantBlock(TranscriptBlock):
         if not self._full_text.strip():
             return super().get_selection(selection)
         rows = visual.plain.split("\n")
-        first_row: int | None = None
-        last_row: int | None = None
-        for index in range(len(rows)):
-            if selection.get_span(index) is not None:
-                if first_row is None:
-                    first_row = index
-                last_row = index
-        if first_row is None or last_row is None:
-            return None
         mapping = _copy_markdown.align(self._full_text, rows)
+
+        # The same ``Selection.get_span`` the band paints with, chrome rows
+        # dropped, so the clipboard and the highlight cannot disagree.
+        selected: list[tuple[int, tuple[int, int]]] = []
+        for index in range(len(rows)):
+            span = selection.get_span(index)
+            if span is not None and not self.copy_row_is_chrome(index):
+                selected.append((index, span))
+        if not selected:
+            return None
+
+        # Blank rows carry no glyphs, so they neither prove nor disprove a
+        # sub-line take: a whole-message copy legitimately spans the blank
+        # separator rows between paragraphs, and letting one veto the markdown
+        # path would degrade every multi-paragraph copy to rendered text.
+        content = [(i, span) for i, span in selected if rows[i].strip()]
+
+        sub_line = False
+        if content:
+            # Source LINES, not rows: a paragraph that wraps is one line painted
+            # as several, and a phrase dragged across that fold is as much a
+            # sub-line take as one inside a single row. A row ``align`` cannot
+            # place contributes nothing, which leaves the conservative answer
+            # (glyphs are always truthful) if alignment itself ever regresses.
+            sources = {
+                mapping[i] for i, _ in content if i < len(mapping) and mapping[i] is not None
+            }
+            if len(sources) <= 1:
+                first_index, (first_start, _) = content[0]
+                last_index, (_, last_end) = content[-1]
+                # ``rstrip()`` is the only honest measure of the row's actual
+                # content here. Rich pads each row out to its RENDER SEGMENT's
+                # width, which is not the block's — measured, prose rows pad to
+                # 76 while table rows in the same message pad to 14 — so any
+                # predicate against the block width or raw ``len(row)`` is
+                # wrong. ``end`` also arrives three ways: -1 for end-of-row, a
+                # column inside the pad when the drag overran the last glyph, or
+                # a column short of it. Only the glyph count settles all three.
+                starts_full = first_start <= self.copy_gutter(first_index)
+                ends_full = last_end == -1 or last_end >= len(rows[last_index].rstrip())
+                sub_line = not (starts_full and ends_full)
+
+        if sub_line:
+            # Sliced exactly as ``TranscriptBlock.get_selection`` slices it
+            # (gutter-clamped start, ``-1`` meaning end of row), but over the
+            # content rows only: a blank row caught at the edge of the drag
+            # would otherwise contribute a line break the reader never
+            # highlighted, turning the receipt into ``copied 2 lines``.
+            glyphs = [
+                rows[index][max(start, self.copy_gutter(index)) : None if end == -1 else end]
+                for index, (start, end) in content
+            ]
+            return "\n".join(row.rstrip() for row in glyphs), "\n"
+
+        # Widened to whole source lines on purpose — see the accepted cost
+        # above. The bounds come from ``selected`` rather than ``content`` so
+        # the markdown path spans exactly the rows it has always spanned.
+        first_row = selected[0][0]
+        last_row = selected[-1][0]
         copied = _copy_markdown.slice_markdown(self._full_text, mapping, first_row, last_row)
         if not copied:
             return super().get_selection(selection)

--- a/local_operator/tui/widgets/assistant.py
+++ b/local_operator/tui/widgets/assistant.py
@@ -668,8 +668,12 @@ class AssistantBlock(TranscriptBlock):
         break between them is a soft wrap at the current width rather than a
         character in the document (design round 1, D2). A space is not always
         right — a token wider than the render segment is folded mid-token and
-        nothing is consumed — so the separator is decided against the source
-        line by :func:`_copy_markdown.wrap_separator`.
+        nothing is consumed — so each fold's separator is decided by walking
+        the row against its source line, :func:`_copy_markdown.wrap_separators`.
+        The decision is POSITIONAL: an earlier version asked only whether the
+        two rows' adjoining tokens appeared welded ANYWHERE in the line, which
+        destroyed a real word boundary on any line using both ``file system``
+        and ``filesystem`` (review round 2, R2-1; design round 2, D2-2).
 
         **The accepted cost**, stated so it is chosen rather than rediscovered:
         a drag from the middle of one bullet to the middle of the next copies
@@ -786,12 +790,24 @@ class AssistantBlock(TranscriptBlock):
             # composer bug ``_put_on_clipboard`` already fixed (design round 1,
             # D2). Once rejoined the receipt falls into the character branch by
             # itself, so the unit needs no separate fix.
+            # The separators are decided from the FULL rows of the source line,
+            # not from the clipped ends the reader highlighted. The walk that
+            # replaced the old substring test is positional and end-anchored, so
+            # it needs the same text Rich painted: a trimmed first row cannot be
+            # located in the source line, and a partial take is exactly where a
+            # membership test used to guess wrong (review round 2, R2-1).
             source_line = self._source_line(mapping, content[0][0])
+            full_rows = [
+                rows[index][self._furniture_width(rows, mapping, index, content) :].rstrip()
+                for index, _ in content
+            ]
+            separators = _copy_markdown.wrap_separators(full_rows, source_line)
+
             joined = trimmed[0]
-            for position, text in enumerate(trimmed[1:], start=1):
+            for offset, text in enumerate(trimmed[1:]):
                 if not text:
                     continue
-                separator = _copy_markdown.wrap_separator(joined, text, source_line)
+                separator = separators[offset] if offset < len(separators) else " "
                 joined = f"{joined}{separator}{text}" if joined else text
             return joined, "\n"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.0"
+version = "0.43.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -517,6 +517,23 @@ WRAPPED = (
     "wrap across several rendered rows at a narrow terminal width.\n"
 )
 
+#: A blockquote long enough to WRAP, which the module had no fixture for — and
+#: that gap is why a green suite missed the furniture leak of review round 1
+#: (R1-1) and design round 1 (D1). It is the one wrapped construct whose
+#: continuation rows carry furniture: Rich repeats ``▌`` on every row of a
+#: quote, so a sub-line take over its fold is the case where a gutter of 0
+#: strips nothing.
+WRAPPED_QUOTE = (
+    "Here is a reply you can paste:\n\n"
+    "> This is a fairly long quoted sentence that will certainly wrap across "
+    "more than one rendered row at this width.\n"
+)
+
+#: A single source line holding a token wider than a narrow render segment.
+#: Rich folds it MID-TOKEN and consumes nothing, unlike a fold at a space —
+#: so a take across this fold must rejoin with no separator at all.
+LONG_TOKEN = "See supercalifragilisticexpialidociousandthensome_verylongtoken_here now.\n"
+
 
 def _rendered_rows(block: AssistantBlock) -> list[str]:
     """The frame's rows, as ``get_selection`` and the highlight both see them."""
@@ -595,7 +612,12 @@ async def test_a_phrase_across_a_wrap_boundary_copies_only_the_phrase() -> None:
         copied = block.get_selection(selection)
 
         assert copied is not None
-        assert copied[0] == "important paragraph that will\ncertainly wrap across several"
+        # Rejoined with the space the terminal consumed at the fold, not with
+        # the fold itself: the rows share one source line, so the break is an
+        # artifact of this width (design round 1, D2).
+        assert copied[0] == "important paragraph that will certainly wrap across several"
+        assert "\n" not in copied[0]
+        assert copied[0] in WRAPPED
         assert "This is a single" not in copied[0]
 
 
@@ -770,18 +792,23 @@ async def test_a_word_inside_a_blockquote_copies_without_the_bar() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_quote_dragged_from_column_zero_keeps_the_bar() -> None:
-    """The accepted wrinkle: a column-0 quote drag DOES copy the ``▌``.
+async def test_a_quote_dragged_from_column_zero_drops_the_bar() -> None:
+    """A column-0 quote drag copies the QUOTED TEXT, never the ``▌``.
 
-    ``AssistantBlock`` does not override ``copy_gutter``, so it inherits 0 —
-    and a drag that starts at column 0 genuinely crossed the bar's cell, so
-    returning it is a faithful report of the highlight. Pinned as a decision
-    rather than left to be discovered: the obvious "fix" is a regex stripping
-    leading furniture, and that CORRUPTS CODE — inside a fence it turns
-    ``  1 / 0`` into ``/ 0``, because a code line starting with a digit is
-    indistinguishable from a rendered ordered-list marker by glyph alone. The
-    safe alternative is a mapping-aware gutter, warranted only if this is ever
-    actually reported.
+    This pinned the opposite until review round 1 (R1-1) and design round 1
+    (D1) independently rejected it: the bar is painted decoration, it exists
+    nowhere in the user's document, and a paste carrying it shows a glyph they
+    cannot account for. It also made the paste FORMAT depend on one invisible
+    cell of drag start — column 0 gave rendered glyphs with the bar, column 1
+    gave clean text — which is the surprise the whole method exists to remove.
+
+    The rejected fix was a regex over the row, and rejecting it was right: it
+    CORRUPTS CODE, turning a fenced ``  1 / 0`` into ``/ 0`` because a code
+    line starting with a digit is indistinguishable from an ordered marker by
+    glyph alone. The mapping-aware gutter it named as the safe alternative is
+    what now runs — ``_copy_markdown.furniture_width`` asks which SOURCE LINE
+    the row came from, so a fence is refused explicitly rather than by luck
+    (pinned by ``test_a_column_zero_drag_inside_a_fence_keeps_the_code``).
     """
     app = StyledTranscriptApp()
     async with app.run_test(size=(80, 40)) as pilot:
@@ -797,7 +824,207 @@ async def test_a_quote_dragged_from_column_zero_keeps_the_bar() -> None:
         copied = block.get_selection(selection)
 
         assert copied is not None
-        assert copied[0] == "▌ Thanks for the"
+        assert copied[0] == "Thanks for the"
+        assert "▌" not in copied[0]
+
+
+@pytest.mark.asyncio
+async def test_a_sub_line_take_across_a_wrapped_quote_never_copies_the_bar() -> None:
+    """The R1-1/D1 leak: a drag over a wrapped quote's fold must not paste ``▌``.
+
+    The regression both reviewers found independently, and the case the module
+    had no fixture for. A wrapped blockquote is ONE source line painted as
+    several rows, so it passes the source-line gate onto the glyph path — and
+    every one of those rows carries a ``▌``, because Rich repeats the bar on
+    continuations. With the block's inherited ``copy_gutter`` of 0 the clamp
+    stripped nothing and the bar reached the clipboard, which the markdown path
+    it replaced had never done.
+
+    Two assertions rather than one: no bar (the leak) and no newline (D2, since
+    this take also crosses a soft wrap), because the fold is where both defects
+    surface at once.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(60, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(WRAPPED_QUOTE)
+        block.finalize_text()
+        await pilot.pause()
+
+        rows = _rendered_rows(block)
+        bars = [i for i, row in enumerate(rows) if row.startswith("▌")]
+        assert len(bars) >= 2, f"the quote must actually wrap, or this proves nothing: {rows!r}"
+
+        selection = Selection.from_offsets(Offset(x=10, y=bars[0]), Offset(x=12, y=bars[1]))
+        copied = block.get_selection(selection)
+
+        assert copied is not None
+        assert "▌" not in copied[0]
+        assert "\n" not in copied[0]
+        assert copied[0] == "a fairly long quoted sentence that will certainly"
+
+
+@pytest.mark.asyncio
+async def test_a_column_zero_drag_inside_a_bullet_drops_the_marker() -> None:
+    """A column-0 bullet drag copies the item's text, never the ``•``.
+
+    The bullet half of D1, identical in mechanism to the quote bar and called
+    out in review round 1 (R1-3) as the case the documentation named nowhere.
+    Pinned separately because the two take different branches of
+    ``furniture_width``: a quote strips a repeated bar, a list strips a marker
+    on the row that opens the item.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(150, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(BULLETS)
+        block.finalize_text()
+        await pilot.pause()
+
+        rows = _rendered_rows(block)
+        row, _, _ = _find(rows, "Transient")
+        selection = Selection.from_offsets(Offset(x=0, y=row), Offset(x=36, y=row))
+        copied = block.get_selection(selection)
+
+        assert copied is not None
+        assert copied[0] == "Transient failures in the ingest"
+        assert "•" not in copied[0]
+
+
+@pytest.mark.asyncio
+async def test_a_column_zero_drag_inside_a_fence_keeps_the_code() -> None:
+    """Furniture stripping must never touch code — the reason it is mapping-aware.
+
+    The hazard the rejected regex fix would have caused, pinned so the cheap
+    implementation cannot come back: a fenced line beginning with a digit looks
+    exactly like a rendered ordered-list marker, and a glyph-level strip turns
+    ``1 / 0`` into ``/ 0``. ``furniture_width`` refuses on the SOURCE line's
+    fence membership, so the code copies byte for byte including its indent.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(60, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text("```python\nif x:\n    1 / 0  # boom\n```\n")
+        block.finalize_text()
+        await pilot.pause()
+
+        rows = _rendered_rows(block)
+        row = next(i for i, text in enumerate(rows) if "1 / 0" in text)
+        # Column 0 to just past the ``0``, stopping short of the comment: a
+        # column-0 start is what reaches the furniture clamp, and leaving the
+        # comment out is what keeps this on the sub-line path rather than
+        # widening to the whole fenced block.
+        end = rows[row].index("/ 0") + len("/ 0")
+        selection = Selection.from_offsets(Offset(x=0, y=row), Offset(x=end, y=row))
+        copied = block.get_selection(selection)
+
+        assert copied is not None
+        # The digit survives: a glyph-level strip would read `` 1 `` as an
+        # ordered-list marker and hand back ``/ 0``.
+        assert copied[0].strip() == "1 / 0"
+        assert "#" not in copied[0]
+
+
+@pytest.mark.asyncio
+async def test_a_take_across_a_mid_token_fold_rejoins_with_no_space() -> None:
+    """A fold inside a long token consumed nothing, so the rejoin adds nothing.
+
+    The counterpart to the wrap-fold rejoin, and the case a blanket
+    ``" ".join`` would corrupt: Rich breaks a token wider than the render
+    segment mid-token, so putting a space back would invent a character the
+    document never had and silently break a pasted URL or identifier. Measured
+    reachable in ordinary prose at ordinary widths, which is why
+    ``wrap_separator`` asks the source line instead of assuming a space.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(34, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(LONG_TOKEN)
+        block.finalize_text()
+        await pilot.pause()
+
+        rows = _rendered_rows(block)
+        content = [i for i, row in enumerate(rows) if row.strip()]
+        first = next(i for i in content if "supercal" in rows[i])
+        last = next(i for i in content if "here now." in rows[i])
+        assert first != last, "the token must actually fold, or this proves nothing"
+
+        selection = Selection.from_offsets(
+            Offset(x=rows[first].index("supercal"), y=first),
+            Offset(x=rows[last].index("here") + len("here"), y=last),
+        )
+        copied = block.get_selection(selection)
+
+        assert copied is not None
+        assert copied[0] == "supercalifragilisticexpialidociousandthensome_verylongtoken_here"
+        assert copied[0] in LONG_TOKEN
+        assert "\n" not in copied[0]
+
+
+@pytest.mark.asyncio
+async def test_a_whole_table_row_take_keeps_the_markdown_pipes() -> None:
+    """The escape hatch that makes D5 an accepted cost rather than a defect.
+
+    A sub-line take across a table row copies ``alpha  0.91`` without the
+    ``|``, which design round 1 (D5) flagged as the one construct where the
+    rendered form is less useful than the source. It stays the rule because the
+    WHOLE-row gesture still reaches the markdown path and still yields a
+    pasteable row. Pinned so a future widening of the sub-line gate cannot take
+    that fallback away silently.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(80, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(
+            "Results:\n\n| Name | Score |\n|------|-------|\n| alpha | 0.91 |\n| beta | 0.87 |\n"
+        )
+        block.finalize_text()
+        await pilot.pause()
+
+        rows = _rendered_rows(block)
+        row, _, _ = _find(rows, "alpha")
+        selection = Selection.from_offsets(Offset(x=0, y=row), Offset(x=len(rows[row]), y=row))
+        copied = block.get_selection(selection)
+
+        assert copied is not None
+        assert copied[0] == "| alpha | 0.91 |"
+
+
+@pytest.mark.asyncio
+async def test_a_drag_entirely_inside_the_trailing_pad_copies_nothing() -> None:
+    """A drag over Rich's pad selects no glyph, so nothing is written. Decided.
+
+    Review round 1 (R1-2) asked whether the silence is right. It is, and it is
+    pinned here rather than left implicit: the pad is not content the reader can
+    see, so there is nothing truthful to copy, and ``_put_on_clipboard`` drops
+    an empty payload without a receipt — the same answer a zero-width click
+    already gets. A toast here would announce a copy that did not happen.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(150, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(BULLETS)
+        block.finalize_text()
+        await pilot.pause()
+
+        rows = _rendered_rows(block)
+        row, _, _ = _find(rows, "Transient")
+        visible_end = len(rows[row].rstrip())
+        assert visible_end < len(rows[row]), "the row must carry a pad, or this proves nothing"
+
+        selection = Selection.from_offsets(
+            Offset(x=visible_end + 5, y=row), Offset(x=visible_end + 20, y=row)
+        )
+        copied = block.get_selection(selection)
+
+        assert copied is not None
+        assert copied[0] == ""
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -3384,6 +3384,20 @@ async def test_no_two_fenced_lines_are_ever_welded_into_one(name: str) -> None:
     Asserted against the source's own line boundaries rather than against a
     rendered row, because the harm is specifically that a line boundary the
     document has went missing.
+
+    The predicate is FRAGMENT-level, not whole-line. Requiring two COMPLETE
+    source body lines in one output line made the test narrower than the defect
+    it was written for: the user-visible harm is a command TAIL meeting the next
+    command's HEAD (``cd /srv/ingest psql -h``), and a fence whose lines are
+    longer than the pane -- the common case for shell and SQL -- never puts a
+    whole body line on one row. The whole-line form passed on all nine
+    ``fence_indent_*`` fixtures, the shape D3-2 actually lived in, and caught the
+    defect only by luck on ``fence_structural_body``, whose body lines are short
+    enough to appear whole (design round 4, D4-2). Anchoring on a chunk of each
+    line catches the weld wherever it lands.
+
+    Swept from width 28 and across start columns 0-2 for the same reason: the
+    control welds at widths and start columns the old range never visited.
     """
     text = ORACLE_FENCE_CORPUS[name]
     body = [
@@ -3391,8 +3405,26 @@ async def test_no_two_fenced_lines_are_ever_welded_into_one(name: str) -> None:
         for line in text.split("\n")
         if line.strip() and not line.strip().startswith("```")
     ]
+    # A weld joins the END of one body line to the START of another, so each
+    # line is probed by its own head and tail rather than by its whole text.
+    # Only DISCRIMINATING chunks count: two body lines may legitimately share a
+    # head or tail (``fence_structural_body``'s all end "must stay verbatim"),
+    # and a shared chunk cannot say which line a fragment came from, so counting
+    # it would report a weld on an honest single-line take.
+    chunk = 12
+    marks: list[tuple[str, list[str]]] = []
+    for line in body:
+        if len(line) < chunk:
+            continue
+        parts = sorted(
+            part
+            for part in {line[:chunk], line[-chunk:]}
+            if sum(part in other for other in body) == 1
+        )
+        if parts:
+            marks.append((line, parts))
 
-    for width in range(40, 76, 2):
+    for width in range(28, 76, 2):
         app = StyledTranscriptApp()
         async with app.run_test(size=(width, 120)) as pilot:
             block = AssistantBlock()
@@ -3414,22 +3446,266 @@ async def test_no_two_fenced_lines_are_ever_welded_into_one(name: str) -> None:
                     # the defect is live. That is precisely how three rounds of
                     # sampled tests stayed green.
                     ends = {len(rows[last].rstrip()), 20, 8}
-                    for end_column in sorted(e for e in ends if e > 0):
-                        selection = Selection.from_offsets(
-                            Offset(x=0, y=first), Offset(x=end_column, y=last)
-                        )
-                        copied = block.get_selection(selection)
-                        if copied is None:
-                            continue
-                        for line in copied[0].split("\n"):
-                            # Any output line containing two DISTINCT source body
-                            # lines is a weld: the boundary between them is gone.
-                            hits = [b for b in body if b and b in line and b != line.strip()]
-                            assert len(hits) < 2, (
-                                f"{name} at width {width}, rows {first}..{last}: welded "
-                                f"two source lines into one.\n  copied line: {line!r}\n"
-                                f"  welded    : {hits!r}"
+                    for start_column in (0, 1, 2):
+                        for end_column in sorted(e for e in ends if e > 0):
+                            selection = Selection.from_offsets(
+                                Offset(x=start_column, y=first),
+                                Offset(x=end_column, y=last),
                             )
+                            copied = block.get_selection(selection)
+                            if copied is None:
+                                continue
+                            for line in copied[0].split("\n"):
+                                # An output line carrying a fragment of two
+                                # DISTINCT source body lines is a weld: the
+                                # boundary between them is gone, and a shell
+                                # handed that line runs two commands.
+                                hits = [
+                                    src
+                                    for src, parts in marks
+                                    if src != line.strip() and any(part in line for part in parts)
+                                ]
+                                assert len(hits) < 2, (
+                                    f"{name} at width {width}, rows {first}..{last}, start "
+                                    f"column {start_column}: welded two source lines into "
+                                    f"one.\n  copied line: {line!r}\n  welded    : {hits!r}"
+                                )
+
+
+#: Constructs whose over-long lines leave continuation rows that ``align``
+#: cannot place. That is the shape where a copy can silently SUBSTITUTE one
+#: source line for another, so the substitution oracle sweeps them specifically.
+ORACLE_SUBSTITUTION_CORPUS: dict[str, str] = {
+    "fence_long_commands": (
+        "Run these in order:\n\n```sh\ncd /srv/ingest\n"
+        "psql -h db.internal -U ingest -c 'select count(*) from staging.rows where state = 1'\n"
+        "systemctl restart ingest-worker --now --no-block\n```\n\nThen check the dashboard.\n"
+    ),
+    "fence_sql_then_prose": (
+        "```sql\n"
+        "select a.id, a.name, b.value from alpha a join beta b on b.id = a.beta_id;\n"
+        "update alpha set flagged = true where created_at < now() - interval '30 days';\n"
+        "```\n\nTRAILING_ONE is a paragraph after the fence that was never highlighted.\n"
+    ),
+    "table_long_notes": (
+        "| name | score | notes |\n| --- | --- | --- |\n"
+        "| alpha | 0.91 | the first row with some longer note text here that wraps |\n"
+        "| beta | 0.72 | the second row, also with a reasonably long note here |"
+    ),
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param(
+            name,
+            marks=(
+                # PRE-EXISTING and unchanged by this PR -- identical at the merge
+                # base, at `6f72a29e` and here. ``align`` maps a wrapped table
+                # row's continuation rows to the NEXT table row, so a whole-row
+                # take copies the wrong row. That lives in ``align``'s table
+                # handling rather than in this copy path, so it is tracked as
+                # issue #399 rather than widened into this PR. Marked xfail
+                # rather than dropped from the corpus: the oracle keeps reporting
+                # it, and the marker fails loudly once #399 is fixed.
+                [
+                    pytest.mark.xfail(
+                        reason="pre-existing table mis-mapping, issue #399", strict=True
+                    )
+                ]
+                if name == "table_long_notes"
+                else []
+            ),
+        )
+        for name in sorted(ORACLE_SUBSTITUTION_CORPUS)
+    ],
+)
+async def test_a_fully_covered_row_is_never_replaced_by_a_different_line(name: str) -> None:
+    """A take must contain the rows the reader LIT, not merely real source text.
+
+    The companion invariant to the contiguity oracle, and the hole that admitted
+    R4-1. Contiguity is a MEMBERSHIP test: it catches text this code invented and
+    text it welded, but a copy that hands back a different, genuine source line
+    is still perfectly contiguous and sails through. That is exactly what the
+    unplaced-edge widening did -- dragging the ``psql`` command copied the
+    ``systemctl`` command, so a reader pasting into a terminal ran a command they
+    never highlighted (review round 4, R4-1; design round 4, D4-1).
+
+    So this asserts the other half: every rendered row the drag covered in FULL
+    must be represented in the copy. A fully covered row is unambiguous about the
+    reader's intent in a way a partial one is not, which is what makes the
+    assertion safe to state without predicting which construct will break it.
+    """
+    text = ORACLE_SUBSTITUTION_CORPUS[name]
+
+    for width in range(28, 102, 2):
+        app = StyledTranscriptApp()
+        async with app.run_test(size=(width, 120)) as pilot:
+            block = AssistantBlock()
+            await _mounted(app, block)
+            block.update_text(text)
+            block.finalize_text()
+            await pilot.pause()
+
+            rows = _rendered_rows(block)
+            for index, row in enumerate(rows):
+                lit = row.strip()
+                # Short rows carry too little to identify; a fence marker row is
+                # furniture whose own text is legitimately re-emitted elsewhere.
+                if len(lit) < 12 or lit.startswith("```"):
+                    continue
+                selection = Selection.from_offsets(
+                    Offset(x=0, y=index), Offset(x=len(row.rstrip()), y=index)
+                )
+                copied = block.get_selection(selection)
+                if copied is None:
+                    continue
+                # Compared with folds flattened: the markdown path may return the
+                # line unwrapped, which is a truthful answer to the same gesture.
+                haystack = " ".join(copied[0].split())
+                needle = " ".join(lit.split())[:12]
+                assert needle in haystack, (
+                    f"{name} at width {width}, row {index}: the fully highlighted row is "
+                    f"not in the copy -- a different line was substituted for it.\n"
+                    f"  highlighted: {lit!r}\n  copied     : {copied[0]!r}"
+                )
+
+
+@pytest.mark.asyncio
+async def test_widening_over_unplaced_rows_needs_a_placed_row_to_rescue() -> None:
+    """``_markdown_for_rows`` widens only where a lit line can be recovered.
+
+    Direct cover for the widening itself, which shipped in round 3 with no test
+    of its own -- and was therefore free to substitute one source line for
+    another. Both halves are asserted together because the finding is precisely
+    that the two cases have DIFFERENT right answers:
+
+    * with a placed row in the band, widening over an unplaced EDGE row rescues a
+      line ``slice_markdown`` would otherwise drop;
+    * with NO placed row there is nothing to rescue, the un-widened slice is
+      empty, and the caller's fallback to the frame copy is the correct minimal
+      answer. Widening there dragged the window onto whichever line happened to
+      be placed (review round 4, R4-1; design round 4, D4-1).
+    """
+    text = ORACLE_SUBSTITUTION_CORPUS["fence_sql_then_prose"]
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(76, 120)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(text)
+        block.finalize_text()
+        await pilot.pause()
+
+        rows = _rendered_rows(block)
+        mapping = _copy_markdown.align(block._full_text, rows)
+        target = next(i for i, row in enumerate(rows) if "a.beta_id;" in row)
+        assert mapping[target] is None, "fixture no longer reproduces an unplaced row"
+
+        # No placed row in the band: refuse rather than widen onto a neighbour.
+        assert block._markdown_for_rows(mapping, target, target) == ""
+
+        # The reader sees the minimal answer, not the construct plus the
+        # paragraph below the closing fence that the band never touched.
+        selection = Selection.from_offsets(
+            Offset(x=0, y=target), Offset(x=len(rows[target].rstrip()), y=target)
+        )
+        copied = block.get_selection(selection)
+        assert copied is not None
+        assert copied[0].strip() == "a.beta_id;", copied[0]
+        assert "TRAILING_ONE" not in copied[0], copied[0]
+
+    # ...and the rescue itself still works. A band whose FIRST row is unplaced
+    # but which reaches a placed row: without widening, ``slice_markdown`` picks
+    # only the placed line and the lit `psql` command is dropped from the copy.
+    text = ORACLE_SUBSTITUTION_CORPUS["fence_long_commands"]
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(76, 120)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(text)
+        block.finalize_text()
+        await pilot.pause()
+
+        rows = _rendered_rows(block)
+        mapping = _copy_markdown.align(block._full_text, rows)
+        first = next(i for i, row in enumerate(rows) if "psql" in row)
+        last = next(i for i in range(first + 1, len(mapping)) if mapping[i] is not None)
+        assert mapping[first] is None, "fixture no longer reproduces an unplaced edge row"
+
+        # The un-widened slice is what would ship without the rescue.
+        unwidened = _copy_markdown.slice_markdown(block._full_text, mapping, first, last)
+        assert "psql" not in unwidened, unwidened
+
+        widened = block._markdown_for_rows(mapping, first, last)
+        assert "psql -h db.internal" in widened, widened
+        # ...and the rescue does not weld the two commands onto one line.
+        assert not any(
+            "psql" in line and "systemctl" in line for line in widened.split("\n")
+        ), widened
+
+
+@pytest.mark.asyncio
+async def test_a_fold_at_a_double_space_puts_both_spaces_back() -> None:
+    """A rejoin restores the whitespace run VERBATIM, not one space (R4-2).
+
+    ``_skip_painted_nothing`` reported WHETHER it had skipped whitespace, so a
+    fold landing on a run of two or more spaces rejoined with exactly one and the
+    document lost a character it had. The walk placed these rows, so this is not
+    a refusal failure -- it is the same "a plausible character looks like an
+    answer" shape one level down, and the fix is to carry the count.
+    """
+    text = "A line ending in two spaces  and then continuing with more text to force a fold."
+
+    seen = 0
+    for width in range(24, 92, 2):
+        app = StyledTranscriptApp()
+        async with app.run_test(size=(width, 120)) as pilot:
+            block = AssistantBlock()
+            await _mounted(app, block)
+            block.update_text(text)
+            block.finalize_text()
+            await pilot.pause()
+
+            rows = _rendered_rows(block)
+            content = [i for i, row in enumerate(rows) if row.strip()]
+            if len(content) < 2:
+                continue
+            for last in content[1:]:
+                selection = Selection.from_offsets(
+                    Offset(x=1, y=content[0]), Offset(x=len(rows[last].rstrip()), y=last)
+                )
+                copied = block.get_selection(selection)
+                if copied is None or "\n" in copied[0]:
+                    continue
+                stripped = copied[0].strip()
+                if not stripped:
+                    continue
+                seen += 1
+                # The single truthful answer for a rejoined sub-line take: it is
+                # a verbatim span of the source, double space included.
+                assert stripped in text, (
+                    f"width {width}: the rejoin did not reproduce the source's spacing.\n"
+                    f"  copied: {copied[0]!r}"
+                )
+
+    assert seen, "the sweep never reached a rejoined take"
+
+
+def test_skip_painted_nothing_reports_the_whitespace_it_consumed() -> None:
+    """The unit behind R4-2: the consumed run comes back, not a boolean.
+
+    Pinned at the function level as well as end-to-end, because the bool return
+    was locally plausible -- ``" " if saw_space else ""`` reads as correct until
+    the run is longer than one character.
+    """
+    assert _copy_markdown._skip_painted_nothing("a  b", 1) == (3, "  ")
+    assert _copy_markdown._skip_painted_nothing("a b", 1) == (2, " ")
+    assert _copy_markdown._skip_painted_nothing("a\tb", 1) == (2, "\t")
+    assert _copy_markdown._skip_painted_nothing("ab", 1) == (1, "")
+    # Markers that paint nothing are skipped without contributing whitespace.
+    assert _copy_markdown._skip_painted_nothing("a**  b", 1) == (5, "  ")
 
 
 def test_a_fence_marker_in_indented_code_reads_as_a_fence_on_purpose() -> None:

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -482,6 +482,373 @@ async def test_a_drag_starting_inside_the_gutter_still_copies_from_the_prose() -
         assert block.get_selection(selection) == ("summarise", "\n")
 
 
+# -- a sub-line take copies what was highlighted -----------------------------
+#
+# Reported from the field: dragging the eight cells of one word inside a
+# rendered bullet announced ``copied 115 characters`` and put the WHOLE source
+# line on the clipboard. ``AssistantBlock.get_selection`` reduced the selection
+# to a first and last row and dropped the column pair ``get_span`` returns, and
+# ``slice_markdown`` is row-granular by contract, so every partial row was
+# widened to the source line beneath it.
+#
+# The rule that answers it, and the reason it is drawn where it is: there is no
+# third option between "the glyphs" and "the whole source line". Column-trimmed
+# markdown would need a rendered column to index a source column, and it does
+# not — ``frontend`` sits at rendered column 56 and source column 57 in the
+# fixture below, because ``- `` paints as `` • `` (+1) while the ``**`` vanishes
+# (-2), an offset that is content-dependent and signed. So a take that does not
+# cover the full content of its rows AND touches at most one source line copies
+# glyphs; everything wider stays markdown.
+#: The reported message: a bold word mid-bullet, plus a second bullet so a
+#: multi-line drag has somewhere to go. At width 150 the first bullet renders
+#: as one row, which is what makes the sub-row drag below the reported gesture.
+BULLETS = (
+    "Here is what I found:\n\n"
+    "- Transient failures in the ingest path never reach the **frontend** "
+    "without a retry, so the user sees a stale row.\n"
+    "- The second bullet exists so a multi-line drag has somewhere to go.\n"
+)
+
+#: One long source line, rendered at a width that folds it across rows. The
+#: wrap is the point: it is ONE source line painted as several, so a phrase
+#: dragged over the fold is the same defect as one inside a single row.
+WRAPPED = (
+    "This is a single but quite important paragraph that will certainly "
+    "wrap across several rendered rows at a narrow terminal width.\n"
+)
+
+
+def _rendered_rows(block: AssistantBlock) -> list[str]:
+    """The frame's rows, as ``get_selection`` and the highlight both see them."""
+    visual = block._render()
+    assert isinstance(visual, Content)
+    return visual.plain.split("\n")
+
+
+def _find(rows: list[str], word: str) -> tuple[int, int, int]:
+    """``(row, start, end)`` of ``word`` in the RENDERED frame.
+
+    Located rather than hard-coded because the whole point of these tests is
+    that rendered columns are not source columns: a literal column here would
+    encode the very assumption the fix exists to deny, and would drift with any
+    change to how the markdown theme paints a bullet.
+    """
+    for index, row in enumerate(rows):
+        if word in row:
+            start = row.index(word)
+            return index, start, start + len(word)
+    raise AssertionError(f"{word!r} is not on the frame: {rows!r}")
+
+
+@pytest.mark.asyncio
+async def test_a_word_dragged_out_of_a_bullet_copies_only_that_word() -> None:
+    """The reported bug: 8 cells highlighted must not copy 115 characters.
+
+    Pins that a sub-row take is no longer widened to its source line. The
+    negative assertion is the one that fails on the old code — the word alone
+    is a substring of the over-copy, so equality is what makes this a
+    regression test rather than a smoke test.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(150, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(BULLETS)
+        block.finalize_text()
+        await pilot.pause()
+
+        row, start, end = _find(_rendered_rows(block), "frontend")
+        selection = Selection.from_offsets(Offset(x=start, y=row), Offset(x=end, y=row))
+        copied = block.get_selection(selection)
+
+        assert copied == ("frontend", "\n")
+        # The rest of the source line, which the old code copied wholesale.
+        assert "Transient failures" not in copied[0]
+        # The receipt the user reads is a count of exactly this string.
+        assert len(copied[0]) == 8
+
+
+@pytest.mark.asyncio
+async def test_a_phrase_across_a_wrap_boundary_copies_only_the_phrase() -> None:
+    """A wrapped paragraph is ONE source line, so a drag over its fold is sub-line.
+
+    Pins that the gate counts SOURCE LINES and not rendered rows. A row-count
+    gate (``len(content) == 1``) fixes the reported case and leaves this one
+    live: measured at width 60 it still returned all 128 characters of the
+    paragraph for a two-row drag. Anyone narrowing the gate has to fail here.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(60, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(WRAPPED)
+        block.finalize_text()
+        await pilot.pause()
+
+        rows = _rendered_rows(block)
+        first_row, start, _ = _find(rows, "important")
+        last_row, _, end = _find(rows, "several")
+        assert first_row != last_row, "the fixture must actually wrap, or this proves nothing"
+
+        selection = Selection.from_offsets(Offset(x=start, y=first_row), Offset(x=end, y=last_row))
+        copied = block.get_selection(selection)
+
+        assert copied is not None
+        assert copied[0] == "important paragraph that will\ncertainly wrap across several"
+        assert "This is a single" not in copied[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("form", ["exact", "into-the-pad", "sentinel"])
+async def test_a_whole_row_still_copies_markdown_source(form: str) -> None:
+    """Full coverage keeps the markdown path, however the drag reported its end.
+
+    ``end`` arrives three ways — the exact glyph count, a column inside Rich's
+    trailing pad when the drag overran the last glyph, and ``-1`` for "to end of
+    row" — and all three mean the same thing to a reader. Pins the ``rstrip()``
+    predicate: Rich pads each row to its RENDER SEGMENT's width (measured 146
+    for this bullet against 112 glyphs), so a predicate against the block width
+    or raw ``len(row)`` would call the exact-end case partial and degrade a
+    whole-line copy to rendered text.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(150, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(BULLETS)
+        block.finalize_text()
+        await pilot.pause()
+
+        rows = _rendered_rows(block)
+        row, _, _ = _find(rows, "frontend")
+        ends = {"exact": len(rows[row].rstrip()), "into-the-pad": len(rows[row]), "sentinel": -1}
+        # Hand-built rather than via ``from_offsets``, which normalises a -1 x
+        # into the selection START and so cannot express the sentinel form.
+        selection = cast("Any", _SpanOnRow(row, (0, ends[form])))
+
+        copied = block.get_selection(selection)
+        assert copied is not None
+        assert copied[0] == (
+            "- Transient failures in the ingest path never reach the **frontend** "
+            "without a retry, so the user sees a stale row."
+        )
+
+
+class _SpanOnRow:
+    """A selection of one hand-set span on one row.
+
+    ``Selection.from_offsets`` normalises its offsets, which makes the ``-1``
+    end sentinel unreachable through the public constructor — it is a value
+    Textual's own ``get_span`` PRODUCES for the rows in the middle of a
+    multi-row drag, not one an offset pair can state. Only ``get_span`` is
+    called by ``get_selection``, so duck-typing it is enough and keeps the test
+    honest about which of the three end forms it is exercising.
+    """
+
+    def __init__(self, row: int, span: tuple[int, int]) -> None:
+        self._row = row
+        self._span = span
+
+    def get_span(self, y: int) -> tuple[int, int] | None:
+        return self._span if y == self._row else None
+
+
+@pytest.mark.asyncio
+async def test_a_sub_row_take_inside_a_fence_copies_the_code_not_the_fence() -> None:
+    """Part of a code line copies that code, unfenced.
+
+    Pins that the glyph path does not re-fence a partial take: ``slice_markdown``
+    would return a three-line fenced block for a four-cell drag, which is both
+    more than was highlighted and not the snippet the reader pointed at.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(64, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text("```python\ndef f(x):\n    return x + 1\n```")
+        block.finalize_text()
+        await pilot.pause()
+
+        row, start, end = _find(_rendered_rows(block), "f(x)")
+        selection = Selection.from_offsets(Offset(x=start, y=row), Offset(x=end, y=row))
+
+        assert block.get_selection(selection) == ("f(x)", "\n")
+
+
+@pytest.mark.asyncio
+async def test_a_partial_multi_line_selection_still_copies_markdown() -> None:
+    """Two bullets with partial ends copy BOTH bullets whole. Deliberately.
+
+    This is the accepted cost of the rule, pinned so it cannot be "fixed" into
+    a degrade-anywhere rule without confronting the choice. Trimming the ends
+    would need a rendered-to-source column mapping that does not exist, and
+    degrading the whole take to glyphs would put the ``•`` and ``▌`` furniture
+    back into the paste — which is exactly the report that
+    ``test_blockquote_copies_as_markdown_not_the_bar`` guards against.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(150, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(BULLETS)
+        block.finalize_text()
+        await pilot.pause()
+
+        first_row, _, _ = _find(_rendered_rows(block), "frontend")
+        # Mid-way through the first bullet to mid-way through the second.
+        selection = Selection.from_offsets(Offset(x=10, y=first_row), Offset(x=20, y=first_row + 1))
+        copied = block.get_selection(selection)
+
+        assert copied is not None
+        assert copied[0].splitlines() == [
+            "- Transient failures in the ingest path never reach the **frontend** "
+            "without a retry, so the user sees a stale row.",
+            "- The second bullet exists so a multi-line drag has somewhere to go.",
+        ]
+
+
+@pytest.mark.asyncio
+async def test_a_word_inside_a_blockquote_copies_without_the_bar() -> None:
+    """A sub-row quote take is the word, not the ``▌`` and not the ``>`` line.
+
+    The counterpart to ``test_blockquote_copies_as_markdown_not_the_bar``: a
+    drag that starts PAST the bar never crosses that cell, so the bar is not
+    part of what was highlighted and is not part of the copy.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(80, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(
+            "Here is a reply you can paste:\n\n"
+            "> Thanks for the report. I verified the **flagged** value in out/main/index.jsc:\n"
+            "> it's the public project API key (phc_...), publishable by design.\n"
+        )
+        block.finalize_text()
+        await pilot.pause()
+
+        row, start, end = _find(_rendered_rows(block), "flagged")
+        selection = Selection.from_offsets(Offset(x=start, y=row), Offset(x=end, y=row))
+        copied = block.get_selection(selection)
+
+        assert copied == ("flagged", "\n")
+        assert "▌" not in copied[0]
+        assert ">" not in copied[0]
+
+
+@pytest.mark.asyncio
+async def test_a_quote_dragged_from_column_zero_keeps_the_bar() -> None:
+    """The accepted wrinkle: a column-0 quote drag DOES copy the ``▌``.
+
+    ``AssistantBlock`` does not override ``copy_gutter``, so it inherits 0 —
+    and a drag that starts at column 0 genuinely crossed the bar's cell, so
+    returning it is a faithful report of the highlight. Pinned as a decision
+    rather than left to be discovered: the obvious "fix" is a regex stripping
+    leading furniture, and that CORRUPTS CODE — inside a fence it turns
+    ``  1 / 0`` into ``/ 0``, because a code line starting with a digit is
+    indistinguishable from a rendered ordered-list marker by glyph alone. The
+    safe alternative is a mapping-aware gutter, warranted only if this is ever
+    actually reported.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(80, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text("Intro:\n\n> Thanks for the report, it is fixed now.\n")
+        block.finalize_text()
+        await pilot.pause()
+
+        rows = _rendered_rows(block)
+        row = next(i for i, text in enumerate(rows) if text.startswith("▌"))
+        selection = Selection.from_offsets(Offset(x=0, y=row), Offset(x=16, y=row))
+        copied = block.get_selection(selection)
+
+        assert copied is not None
+        assert copied[0] == "▌ Thanks for the"
+
+
+@pytest.mark.asyncio
+async def test_a_table_cell_copies_the_cell() -> None:
+    """One cell of a rendered table copies that cell, not the pipe row.
+
+    Pins that a sub-row take does not reintroduce markdown furniture the reader
+    cannot see: the frame draws no pipes, so a copy carrying ``| alpha | 0.91 |``
+    would contain characters no highlighted cell held.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(80, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(
+            "Results:\n\n| Name | Score |\n|------|-------|\n| alpha | 0.91 |\n| beta | 0.87 |\n"
+        )
+        block.finalize_text()
+        await pilot.pause()
+
+        row, start, end = _find(_rendered_rows(block), "alpha")
+        selection = Selection.from_offsets(Offset(x=start, y=row), Offset(x=end, y=row))
+        copied = block.get_selection(selection)
+
+        assert copied == ("alpha", "\n")
+        assert "|" not in copied[0]
+
+
+@pytest.mark.asyncio
+async def test_a_zero_width_selection_copies_nothing() -> None:
+    """A click is not a drag: an empty span copies an empty string.
+
+    Pins the click case, which under the old row-only reduction returned the
+    whole source line — a plain click on an answer would have put 115
+    characters on the clipboard. ``_put_on_clipboard`` drops a falsy payload
+    before the OSC 52 write, so this is also what keeps a click from raising a
+    ``copied 0 characters`` receipt.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(150, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(BULLETS)
+        block.finalize_text()
+        await pilot.pause()
+
+        row, start, _ = _find(_rendered_rows(block), "frontend")
+        selection = Selection.from_offsets(Offset(x=start, y=row), Offset(x=start, y=row))
+
+        assert block.get_selection(selection) == ("", "\n")
+
+
+@pytest.mark.asyncio
+async def test_the_reported_drag_end_to_end_reports_a_small_count() -> None:
+    """The whole gesture through the real app: drag a word, read the receipt.
+
+    The unit assertions above pin ``get_selection``; this pins what the USER
+    sees, which is where the bug was reported from. It goes through the real
+    mouse events, the real ``TextSelected`` release, the real clipboard write
+    and the real toast, because the receipt is the only part of the copy the
+    reader can check — ``copied 115 characters`` for an 8-cell drag was the
+    report.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(150, 26)) as pilot:
+        await pilot.pause()
+        app._append_block(UserBlock("summarise the ingest path"))
+        block = AssistantBlock()
+        app._append_block(block)
+        await pilot.pause()
+        block.update_text(BULLETS)
+        block.finalize_text()
+        await pilot.pause()
+        await pilot.pause()
+        app._clipboard = ""
+
+        row, start, end = _find(_rendered_rows(block), "frontend")
+        y = block.region.y + row
+        await _drag(app, pilot, (block.region.x + start, y), (block.region.x + end, y))
+
+        assert app._clipboard == "frontend"
+        assert app.query_one(Toast).message == "copied 8 characters"
+
+
 # -- the flatten's own claims ------------------------------------------------
 @pytest.mark.parametrize("width", [40, 60, 80])
 @pytest.mark.parametrize(

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -3181,3 +3181,277 @@ async def test_a_bullet_inside_a_quote_leaks_neither_the_bar_nor_the_dot() -> No
         assert (
             len(set(answers.values())) == 1
         ), f"the paste format flips with the drag's start cell: {answers}"
+
+
+# -- the oracle sweep --------------------------------------------------------
+#: Ordinary assistant output, not a minimised repro. Three rounds of findings
+#: were each correct on the case the previous round named and wrong on a
+#: neighbouring one, so the corpus is deliberately BROAD rather than pointed:
+#: every construct this app actually emits, and the inline shapes (long tokens,
+#: trailing markup, intraword punctuation) whose interaction with a fold is what
+#: the walk has to get right.
+ORACLE_CORPUS: dict[str, str] = {
+    "prose_inline_markup": (
+        "The **frontend** cache lives at `/var/lib/local-operator/cache.sqlite3` "
+        "and is managed by the *supervisor* process, see [the docs](https://d.io/x)."
+    ),
+    "prose_trailing_code": (
+        "The cache lives at /var/lib/local-operator/sessions/cache-index.sqlite3 "
+        "managed by `lop`"
+    ),
+    "prose_trailing_bold": (
+        "Download https://github.com/damianvtran/local-operator/releases/latest/"
+        "download/bundle.tgz now **today**"
+    ),
+    "snake_and_kebab": (
+        "Set database_connection_pool_max_size_in_the_config and the "
+        "some-very-long-kebab-case-flag-name-here before the deploy runs."
+    ),
+    "compound_open_and_closed": (
+        "The run time of the runtime is fine, and the set up of the setup, the "
+        "log in of the login, and the back end of the backend all check out."
+    ),
+    "bullets": (
+        "- a plain bullet item that is long enough to wrap across several rows\n"
+        "- another bullet mentioning /Users/somebody/Library/Application Support/x\n"
+        "  - a nested bullet that also wraps because it is quite long indeed"
+    ),
+    "ordered": (
+        "1. the first step which is long enough that it wraps at narrow widths\n"
+        "2. the second step, running `systemctl restart ingest-worker` for real\n"
+        "   1. a nested ordered step that is also long enough to fold somewhere"
+    ),
+    "quote": (
+        "> a quoted paragraph that is long enough to wrap across several rows\n"
+        "> and continues here with https://example.com/a/long/path?x=1 inside it"
+    ),
+    "nested_quote": (
+        "> outer quote text that wraps because it is long enough to do so\n"
+        ">> an inner nested quote that also wraps at the widths swept here"
+    ),
+    "quote_in_list": (
+        "- a bullet holding a quote\n"
+        "  > the quoted line inside the bullet, long enough that it folds\n"
+    ),
+    "list_in_quote": (
+        "> - a bullet inside a quote that is long enough to wrap somewhere\n"
+        "> - a second such bullet with a_snake_case_identifier_in_it here"
+    ),
+    "table": (
+        "| name | score | notes |\n"
+        "| --- | --- | --- |\n"
+        "| alpha | 0.91 | the first row with some longer note text here |\n"
+        "| beta | 0.72 | the second row, also with a reasonably long note |"
+    ),
+    "cjk": "这是一个中文段落，用于验证在终端宽度下折行之后复制粘贴不会插入多余的空格字符。",
+    "cjk_ja": "これは日本語の段落です。この行は端末の幅で折り返されますので、コピーの境界を検証します。",
+    "cjk_mixed": ("この API は runtime を使います。The server は port 8080 で listen します。"),
+    "emoji": "The report 🚀 is ready 🎉 and the summary 📊 follows with more text to wrap here.",
+}
+
+#: Fences are swept separately: every indent 0-8, inside list items, and with
+#: bodies whose lines LOOK structural. D2-1 was a deleted first character here
+#: and R3-2 a weld between two body lines, so the shape earns its own corpus.
+ORACLE_FENCE_CORPUS: dict[str, str] = {
+    f"fence_indent_{indent}": (
+        "Run these in order:\n\n"
+        f"{' ' * indent}```sh\n"
+        f"{' ' * indent}cd /srv/ingest\n"
+        f"{' ' * indent}psql -h db.internal -U ingest -c 'select count(*) from staging.rows'\n"
+        f"{' ' * indent}systemctl restart ingest-worker\n"
+        f"{' ' * indent}```\n\nThen check the dashboard.\n"
+    )
+    for indent in range(0, 9)
+} | {
+    "fence_in_list": (
+        "1. Run the check:\n\n"
+        "    ```sh\n"
+        "    ./scripts/check --verbose --with-a-long-flag-name --and-another one\n"
+        "    ```\n"
+    ),
+    "fence_structural_body": (
+        "```text\n"
+        "- this line looks like a bullet but is code and must stay verbatim\n"
+        "> this line looks like a quote but is code and must stay verbatim\n"
+        "3. this line looks ordered but is code and must stay verbatim here\n"
+        "```\n"
+    ),
+}
+
+
+async def _oracle_truth(text: str) -> list[str]:
+    """The rendered rows at a width so wide that NOTHING folds.
+
+    The oracle is independent of the code under test: it is the same renderer,
+    asked a question with no wrapping in it. A take at a narrow width has to be
+    findable in this, because folding is the only thing that changed.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(400, 120)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(text)
+        block.finalize_text()
+        await pilot.pause()
+        return [row.rstrip() for row in _rendered_rows(block) if row.strip()]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name", sorted(ORACLE_CORPUS | ORACLE_FENCE_CORPUS))
+async def test_every_take_is_a_contiguous_substring_of_the_source(name: str) -> None:
+    """THE STRUCTURAL TEST: sweep widths, and assert no take invents or deletes.
+
+    Every previous round's tests pinned the SYMPTOM that round reported, and
+    every round the next defect landed in the neighbouring case nobody had named
+    while the whole suite stayed green. This test pins the PROPERTY instead: a
+    copy must be text the reader could find in their own document.
+
+    A single invariant catches all four failure modes seen so far without
+    predicting which one to look for -- an invented space (R3-1) breaks it, a
+    weld across two source lines (R2-1, R3-2) breaks it, a deleted leading
+    character (D2-1) breaks it, and a space put into CJK (R2-2) breaks it.
+
+    Swept broadly rather than sampled, because every defect so far was reachable
+    at ordinary widths and missed by sampling.
+    """
+    text = (ORACLE_CORPUS | ORACLE_FENCE_CORPUS)[name]
+    truth = await _oracle_truth(text)
+
+    for width in range(30, 90, 2):
+        app = StyledTranscriptApp()
+        async with app.run_test(size=(width, 120)) as pilot:
+            block = AssistantBlock()
+            await _mounted(app, block)
+            block.update_text(text)
+            block.finalize_text()
+            await pilot.pause()
+
+            rows = _rendered_rows(block)
+            content = [i for i, row in enumerate(rows) if row.strip()]
+            if len(content) < 2:
+                continue
+
+            # A drag from just inside the first content row, ending both AT the
+            # last row's end and SHORT of it. Stopping short is the natural
+            # gesture for highlighting exactly a URL, and it is the case that
+            # violates the walk's end-anchored precondition -- sweeping only
+            # full-coverage drags reports all clear while the defect is live.
+            last_row = content[-1]
+            end_columns = {len(rows[last_row].rstrip()), 20, 10}
+            for start_column in (1, 2):
+                for end_column in sorted(e for e in end_columns if e > 0):
+                    selection = Selection.from_offsets(
+                        Offset(x=start_column, y=content[0]),
+                        Offset(x=end_column, y=last_row),
+                    )
+                    copied = block.get_selection(selection)
+                    if copied is None:
+                        continue
+                    for line in copied[0].split("\n"):
+                        stripped = line.strip()
+                        if not stripped:
+                            continue
+                        # TWO truthful answers, and exactly two. The glyph path
+                        # claims to be what was PAINTED, so it must be findable in
+                        # the unfolded frame; the markdown path claims to be what
+                        # the model WROTE, so it must be findable in the source.
+                        # Anything in neither is a character this code invented.
+                        # Testing against both is what keeps the oracle honest
+                        # without a marker blacklist -- a blacklist would be the
+                        # same guess-rather-than-know shape the fix removes.
+                        if any(stripped in row for row in truth):
+                            continue
+                        if stripped in text:
+                            continue
+                        raise AssertionError(
+                            f"{name} at width {width}, start column {start_column}: "
+                            f"copied a line that is in neither the rendered frame nor "
+                            f"the source.\n  copied: {line!r}\n  truth : {truth!r}"
+                        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name", sorted(ORACLE_FENCE_CORPUS))
+async def test_no_two_fenced_lines_are_ever_welded_into_one(name: str) -> None:
+    """Two commands in a fence must never arrive as one runnable line (R3-2).
+
+    The sharpest payload found so far: ``align`` cannot place the continuation
+    rows of an over-long fence body line, the sub-line gate DROPPED those
+    ``None`` mapping entries rather than treating them as absence of evidence,
+    and a take spanning one collapsed to a single-source-line judgement it never
+    was. The clipboard then joined two shell commands with a space.
+
+    Asserted against the source's own line boundaries rather than against a
+    rendered row, because the harm is specifically that a line boundary the
+    document has went missing.
+    """
+    text = ORACLE_FENCE_CORPUS[name]
+    body = [
+        line.strip()
+        for line in text.split("\n")
+        if line.strip() and not line.strip().startswith("```")
+    ]
+
+    for width in range(40, 76, 2):
+        app = StyledTranscriptApp()
+        async with app.run_test(size=(width, 120)) as pilot:
+            block = AssistantBlock()
+            await _mounted(app, block)
+            block.update_text(text)
+            block.finalize_text()
+            await pilot.pause()
+
+            rows = _rendered_rows(block)
+            content = [i for i, row in enumerate(rows) if row.strip()]
+            for first in content:
+                for last in content:
+                    if last <= first:
+                        continue
+                    # Ends SHORT of the last row as well as covering it. The
+                    # weld is only reachable on a sub-line take, and a take that
+                    # covers every row fully goes down the markdown path -- so a
+                    # sweep of full-coverage drags alone reports all clear while
+                    # the defect is live. That is precisely how three rounds of
+                    # sampled tests stayed green.
+                    ends = {len(rows[last].rstrip()), 20, 8}
+                    for end_column in sorted(e for e in ends if e > 0):
+                        selection = Selection.from_offsets(
+                            Offset(x=0, y=first), Offset(x=end_column, y=last)
+                        )
+                        copied = block.get_selection(selection)
+                        if copied is None:
+                            continue
+                        for line in copied[0].split("\n"):
+                            # Any output line containing two DISTINCT source body
+                            # lines is a weld: the boundary between them is gone.
+                            hits = [b for b in body if b and b in line and b != line.strip()]
+                            assert len(hits) < 2, (
+                                f"{name} at width {width}, rows {first}..{last}: welded "
+                                f"two source lines into one.\n  copied line: {line!r}\n"
+                                f"  welded    : {hits!r}"
+                            )
+
+
+def test_a_fence_marker_in_indented_code_reads_as_a_fence_on_purpose() -> None:
+    """The knowingly-accepted `_FENCE_RE` trade-off, pinned (review round 3, R3-4).
+
+    Widening the pattern past three leading spaces is what lets ``classify`` see
+    the fence under a list item, which is routine in this app's output. The cost
+    is that a literal ```` ``` ```` inside a FOUR-SPACE indented code block now
+    reads as a fence marker too.
+
+    That cost is accepted because the failure directions are not symmetric:
+    over-recognising a fence makes the copy VERBATIM, which is the conservative
+    answer for a clipboard, while under-recognising one deletes characters from
+    the user's code (design round 2, D2-1). Pinned so the next person to narrow
+    the pattern learns the widening was deliberate rather than reading this as a
+    bug to fix, and so the conservative DIRECTION is checked rather than assumed.
+    """
+    lines = ["Text:", "", "    ```", "    still indented code", "    ```", ""]
+    covered, markers = _copy_markdown.classify(lines)
+
+    # The accepted consequence, stated as the assertion rather than in prose.
+    assert markers == {2, 4}, f"the indented backticks did not read as markers: {markers}"
+    # ...and the direction that makes it acceptable: content stays covered, so
+    # the copy is verbatim rather than losing a leading character.
+    assert 3 in covered, f"the indented code line lost its fence cover: {covered}"

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -494,7 +494,7 @@ async def test_a_drag_starting_inside_the_gutter_still_copies_from_the_prose() -
 # The rule that answers it, and the reason it is drawn where it is: there is no
 # third option between "the glyphs" and "the whole source line". Column-trimmed
 # markdown would need a rendered column to index a source column, and it does
-# not — ``frontend`` sits at rendered column 56 and source column 57 in the
+# not — ``frontend`` sits at rendered column 57 and source column 58 in the
 # fixture below, because ``- `` paints as `` • `` (+1) while the ``**`` vanishes
 # (-2), an offset that is content-dependent and signed. So a take that does not
 # cover the full content of its rows AND touches at most one source line copies
@@ -561,6 +561,7 @@ async def test_a_word_dragged_out_of_a_bullet_copies_only_that_word() -> None:
         selection = Selection.from_offsets(Offset(x=start, y=row), Offset(x=end, y=row))
         copied = block.get_selection(selection)
 
+        assert copied is not None
         assert copied == ("frontend", "\n")
         # The rest of the source line, which the old code copied wholesale.
         assert "Transient failures" not in copied[0]
@@ -708,6 +709,37 @@ async def test_a_partial_multi_line_selection_still_copies_markdown() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("text", [MARKDOWN, BULLETS], ids=["mixed-constructs", "bullets"])
+async def test_a_whole_message_copy_is_byte_identical_markdown(text: str) -> None:
+    """Select-all still returns the source verbatim, not a rendered flattening.
+
+    The regression this pins is the one a sub-line rule is most likely to cause
+    by accident: the glyph path is strictly better for a partial take and
+    strictly WORSE for a whole one, so a gate that is even slightly too eager
+    degrades every select-all to rendered text — bullets as ``•``, bold with
+    its ``**`` stripped, the fence unfenced. Asserted as byte equality rather
+    than by substring (which the older markdown tests use) because a leaked
+    glyph path passes every substring check while dropping the blank separator
+    rows and the trailing pad, and equality is the only predicate that sees it.
+
+    ``BULLETS`` is included alongside ``MARKDOWN`` because it is the fixture
+    the sub-line tests drag inside of: the same message must copy whole when
+    the whole of it is taken.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(150, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(text)
+        block.finalize_text()
+        await pilot.pause()
+
+        # ``update_text`` keeps the message's own trailing newline, which is not
+        # part of any rendered row and so is not part of the copy.
+        assert _copy_all(app, block) == text.rstrip("\n")
+
+
+@pytest.mark.asyncio
 async def test_a_word_inside_a_blockquote_copies_without_the_bar() -> None:
     """A sub-row quote take is the word, not the ``▌`` and not the ``>`` line.
 
@@ -731,6 +763,7 @@ async def test_a_word_inside_a_blockquote_copies_without_the_bar() -> None:
         selection = Selection.from_offsets(Offset(x=start, y=row), Offset(x=end, y=row))
         copied = block.get_selection(selection)
 
+        assert copied is not None
         assert copied == ("flagged", "\n")
         assert "▌" not in copied[0]
         assert ">" not in copied[0]
@@ -789,6 +822,7 @@ async def test_a_table_cell_copies_the_cell() -> None:
         selection = Selection.from_offsets(Offset(x=start, y=row), Offset(x=end, y=row))
         copied = block.get_selection(selection)
 
+        assert copied is not None
         assert copied == ("alpha", "\n")
         assert "|" not in copied[0]
 

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -71,6 +71,7 @@ from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.glyphs import tool_icon
 from local_operator.tui.markdown_theme import install_markdown_theme
+from local_operator.tui.widgets import _copy_markdown
 from local_operator.tui.widgets.assistant import AssistantBlock, flatten
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.toast import TOAST_FAILURE_MS, Toast
@@ -534,6 +535,82 @@ WRAPPED_QUOTE = (
 #: so a take across this fold must rejoin with no separator at all.
 LONG_TOKEN = "See supercalifragilisticexpialidociousandthensome_verylongtoken_here now.\n"
 
+#: A line using BOTH the open and closed form of a compound. The closed form is
+#: what made the round-2 rejoin weld the open one shut: the discriminator asked
+#: whether ``file`` + ``system`` occurs ANYWHERE in the line, and it does, so a
+#: real space-fold was judged mid-token (review round 2, R2-1; design round 2,
+#: D2-2). Position is the only thing that separates the two occurrences.
+COMPOUND_PAIR = (
+    "The filesystem and the file system layer are different things in this "
+    "codebase, remember that.\n"
+)
+
+#: Ordinary English compound pairs, swept rather than sampled: a
+#: membership-versus-position bug reproduces on whichever pair happens to fall
+#: either side of the fold at a given width, so one fixture proves very little.
+COMPOUND_PAIRS = (
+    ("filesystem", "file system"),
+    ("login", "log in"),
+    ("setup", "set up"),
+    ("checkout", "check out"),
+    ("timeout", "time out"),
+    ("backup", "back up"),
+    ("workflow", "work flow"),
+    ("runtime", "run time"),
+    ("database", "data base"),
+    ("frontend", "front end"),
+    ("username", "user name"),
+    ("hostname", "host name"),
+    ("keyword", "key word"),
+    ("website", "web site"),
+    ("dropdown", "drop down"),
+)
+
+#: CJK prose. ``align`` cannot place these rows (no anchor word survives), so
+#: the copy takes the ``source_line is None`` fallback — the branch that
+#: returned ``" "`` unconditionally and put a space into text whose script never
+#: writes one (review round 2, R2-2; design round 2, D2-3).
+CJK_PARAGRAPH = "这是一个很长的中文句子用来测试换行和复制的行为是否正确无误请仔细检查每一个字符是否都被正确地复制到剪贴板中。\n"
+
+JAPANESE_PARAGRAPH = "これは日本語の段落です。この行は端末の幅で折り返されますので、コピーの境界を確認するのに適しています。\n"
+
+#: Emoji in Latin prose: double-width like CJK, but space-delimited, so a fold
+#: here DID consume a space. The control that keeps the CJK fix from being
+#: written as "wide characters never rejoin with a space" (review round 2
+#: verified emoji already copied correctly and asked that it stay that way).
+EMOJI_PROSE = "The status 🎉🎉🎉 report 🚀🚀🚀 with many emoji 🔥 and more text here now.\n"
+
+#: A fenced block indented INSIDE a list item — numbered steps with a command
+#: under each, one of the most common shapes this app paints. The fence sits at
+#: four spaces, which a three-space-bounded ``_FENCE_RE`` did not recognise, so
+#: ``classify`` saw no fence, ``furniture_width`` took its LIST branch over code
+#: and read the leading ``1`` as a rendered ordered marker (design round 2,
+#: D2-1). The code lines deliberately open with digits.
+NESTED_FENCE = (
+    "1. Start the service:\n"
+    "\n"
+    "    ```sh\n"
+    "    1 / 0\n"
+    "    docker compose up -d\n"
+    "    ```\n"
+    "\n"
+    "2. Then check the row count:\n"
+    "\n"
+    "    ```sh\n"
+    "    3 rows expected\n"
+    "    psql -c 'select count(*) from ingest'\n"
+    "    ```\n"
+)
+
+#: A bulleted list nested inside a blockquote. Rich paints ``▌  • text`` — two
+#: constructs' furniture on one row — and a branch chain that returns on the
+#: first match strips the bar and leaves the bullet (design round 2, D2-4).
+QUOTED_LIST = (
+    "> Here is a quoted list:\n"
+    ">\n"
+    "> - a quoted bullet item that is long enough to wrap across two rows\n"
+)
+
 
 def _rendered_rows(block: AssistantBlock) -> list[str]:
     """The frame's rows, as ``get_selection`` and the highlight both see them."""
@@ -937,7 +1014,7 @@ async def test_a_take_across_a_mid_token_fold_rejoins_with_no_space() -> None:
     segment mid-token, so putting a space back would invent a character the
     document never had and silently break a pasted URL or identifier. Measured
     reachable in ordinary prose at ordinary widths, which is why
-    ``wrap_separator`` asks the source line instead of assuming a space.
+    ``wrap_separators`` walks the source line instead of assuming a space.
     """
     app = StyledTranscriptApp()
     async with app.run_test(size=(34, 40)) as pilot:
@@ -2800,3 +2877,307 @@ async def test_a_receipt_retires_even_when_the_caret_moved_before_the_edit() -> 
         assert not any(
             "copied" in row.lower() for row in rows
         ), f"a stale copy receipt is still painted: {[r for r in rows if 'copied' in r.lower()]}"
+
+
+# -- review round 2 / design round 2 -----------------------------------------
+@pytest.mark.asyncio
+async def test_a_fold_between_two_words_keeps_the_space_the_user_had() -> None:
+    """Pins that the wrap rejoin is POSITIONAL, not a substring membership test.
+
+    The regression this replaces: ``wrap_separator`` asked whether the last
+    token of one row concatenated to the first token of the next occurred
+    ANYWHERE in the source line. A line using both ``file system`` and
+    ``filesystem`` answers yes, so a fold at a real space was judged mid-token
+    and the two words were welded shut — ``filesystem layer`` where the user
+    highlighted ``file system layer`` (review round 2, R2-1; design round 2,
+    D2-2).
+
+    That is silent corruption: unlike the over-copy it replaced and unlike the
+    newline before it, the paste looks like well-formed prose and the reader
+    cannot tell a character is missing. Swept across widths because which pair
+    lands either side of the fold is width-dependent.
+    """
+    welded: list[tuple[int, str]] = []
+    for width in range(28, 40):
+        app = StyledTranscriptApp()
+        async with app.run_test(size=(width, 40)) as pilot:
+            block = AssistantBlock()
+            await _mounted(app, block)
+            block.update_text(COMPOUND_PAIR)
+            block.finalize_text()
+            await pilot.pause()
+
+            rows = _rendered_rows(block)
+            # Anchor on the OPEN form's first word where it is followed by the
+            # fold, i.e. the last row that ends in "file" — the closed compound
+            # "filesystem" appears earlier in the same line, which is the whole
+            # point of the fixture, so a plain index() would find the wrong one.
+            last_row, _, end = _find(rows, "layer")
+            first_row = next(
+                (i for i in range(last_row - 1, -1, -1) if rows[i].rstrip().endswith("file")),
+                None,
+            )
+            if first_row is None:
+                continue  # the fold does not fall between "file" and "system" here
+            start = rows[first_row].rstrip().rindex("file")
+
+            selection = Selection.from_offsets(
+                Offset(x=start, y=first_row), Offset(x=end, y=last_row)
+            )
+            copied = block.get_selection(selection)
+            assert copied is not None
+
+            # The clipboard must be text the source actually contains. A welded
+            # compound is not, which is what makes this a regression test.
+            if copied[0] not in COMPOUND_PAIR:
+                welded.append((width, copied[0]))
+
+    assert not welded, f"the rejoin destroyed a word boundary: {welded}"
+
+
+@pytest.mark.asyncio
+async def test_no_ordinary_compound_pair_is_welded_at_any_width() -> None:
+    """The sweep that a single fixture cannot stand in for.
+
+    A membership-versus-position bug fires only when the two words either side
+    of the fold also appear welded elsewhere in the line, so it hides from any
+    sampled test whose fixture happens to fold elsewhere. Review round 2 found
+    it by probing 15 ordinary compound pairs; design round 2 found 30
+    reproductions across five prose lines. This pins the whole class rather
+    than the one example that was reported.
+    """
+    failures: list[tuple[str, int, str]] = []
+    for joined, spaced in COMPOUND_PAIRS:
+        head = spaced.split()[0]
+        source = (
+            f"The {joined} and the {spaced} layer are different things in this "
+            f"codebase, remember that.\n"
+        )
+        for width in (29, 31, 33, 35):
+            app = StyledTranscriptApp()
+            async with app.run_test(size=(width, 40)) as pilot:
+                block = AssistantBlock()
+                await _mounted(app, block)
+                block.update_text(source)
+                block.finalize_text()
+                await pilot.pause()
+
+                rows = _rendered_rows(block)
+                try:
+                    last_row, _, end = _find(rows, "layer")
+                except AssertionError:
+                    continue
+                first_row = next(
+                    (i for i in range(last_row - 1, -1, -1) if rows[i].rstrip().endswith(head)),
+                    None,
+                )
+                if first_row is None:
+                    continue  # this width does not fold between the pair's words
+                start = rows[first_row].rstrip().rindex(head)
+
+                selection = Selection.from_offsets(
+                    Offset(x=start, y=first_row), Offset(x=end, y=last_row)
+                )
+                copied = block.get_selection(selection)
+                assert copied is not None
+                if copied[0] not in source:
+                    failures.append((spaced, width, copied[0]))
+
+    assert not failures, f"compound pairs welded shut: {failures}"
+
+
+@pytest.mark.asyncio
+async def test_a_cjk_fold_does_not_invent_a_space() -> None:
+    """Pins the ``align``-returned-``None`` fallback as conservative.
+
+    ``wrap_separator`` returned ``" "`` unconditionally when the row could not
+    be placed. CJK rows are exactly that case — no anchor word survives, so the
+    whole message maps to ``None`` — and CJK never breaks at a space, so every
+    fold gained a character the document does not contain anywhere (review
+    round 2, R2-2; design round 2, D2-3).
+
+    In Japanese an interpolated space is not cosmetic; it reads as a deliberate
+    break. Asserted as "the clipboard is a substring of the source", the same
+    invariant the compound test uses, because that is the property a paste has
+    to have.
+    """
+    for label, text in (("chinese", CJK_PARAGRAPH), ("japanese", JAPANESE_PARAGRAPH)):
+        for width in (30, 34, 40):
+            app = StyledTranscriptApp()
+            async with app.run_test(size=(width, 40)) as pilot:
+                block = AssistantBlock()
+                await _mounted(app, block)
+                block.update_text(text)
+                block.finalize_text()
+                await pilot.pause()
+
+                rows = _rendered_rows(block)
+                content = [i for i, row in enumerate(rows) if row.strip()]
+                if len(content) < 2:
+                    continue
+                first_row, last_row = content[0], content[1]
+
+                selection = Selection.from_offsets(
+                    Offset(x=2, y=first_row),
+                    Offset(x=max(1, len(rows[last_row].rstrip()) - 4), y=last_row),
+                )
+                copied = block.get_selection(selection)
+                assert copied is not None
+                assert " " not in copied[0], (
+                    f"{label} at width {width} gained a space the source never had: "
+                    f"{copied[0]!r}"
+                )
+                assert copied[0] in text, (
+                    f"{label} at width {width} copied text absent from the source: "
+                    f"{copied[0]!r}"
+                )
+
+
+@pytest.mark.asyncio
+async def test_an_emoji_fold_still_rejoins_with_its_space() -> None:
+    """The control that keeps the CJK fix from over-reaching.
+
+    Emoji are double-width like CJK, but they sit in space-delimited Latin
+    prose, so a fold beside one DID consume a space and the rejoin must put it
+    back. Review round 2 verified emoji already copied correctly and explicitly
+    asked that width handling not be re-engineered, so this pins the boundary:
+    the rule is about scripts that do not write spaces, not about cell width.
+    """
+    for width in (30, 34, 40):
+        app = StyledTranscriptApp()
+        async with app.run_test(size=(width, 40)) as pilot:
+            block = AssistantBlock()
+            await _mounted(app, block)
+            block.update_text(EMOJI_PROSE)
+            block.finalize_text()
+            await pilot.pause()
+
+            rows = _rendered_rows(block)
+            first_row, start, _ = _find(rows, "status")
+            last_row, _, end = _find(rows, "emoji")
+            if first_row == last_row:
+                continue
+
+            selection = Selection.from_offsets(
+                Offset(x=start, y=first_row), Offset(x=end, y=last_row)
+            )
+            copied = block.get_selection(selection)
+            assert copied is not None
+            assert (
+                copied[0] in EMOJI_PROSE
+            ), f"emoji prose at width {width} did not rejoin as written: {copied[0]!r}"
+
+
+@pytest.mark.asyncio
+async def test_a_fence_indented_inside_a_list_item_keeps_its_first_character() -> None:
+    """The blocker: code nested under a list item lost its leading character.
+
+    ``test_a_column_zero_drag_inside_a_fence_keeps_the_code`` uses a TOP-LEVEL
+    fence, where both ``classify`` and ``align`` already worked, so it never
+    discriminated this case — it passes on the prior head too.
+
+    Two independent causes, either sufficient (design round 2, D2-1). The fence
+    pattern allowed at most three leading spaces while a fence under a list item
+    is conventionally indented four, so ``classify`` returned an empty covered
+    set; and ``align`` attributed the code rows to the LIST's source line rather
+    than to the fence body. With ``fenced`` false and a source line matching the
+    list pattern, ``furniture_width`` read the code's own leading ``1`` or ``3``
+    as a rendered ordered marker and stripped it, so ``3 rows expected`` pasted
+    as ``rows expected``. Silent corruption of a command the user highlighted.
+    """
+    for width in (40, 60):
+        app = StyledTranscriptApp()
+        async with app.run_test(size=(width, 40)) as pilot:
+            block = AssistantBlock()
+            await _mounted(app, block)
+            block.update_text(NESTED_FENCE)
+            block.finalize_text()
+            await pilot.pause()
+
+            rows = _rendered_rows(block)
+            code_row, _, _ = _find(rows, "3 rows expected")
+
+            # Column 0 through the row's end: the gesture that takes a line of
+            # code as a line of code.
+            selection = Selection.from_offsets(
+                Offset(x=0, y=code_row), Offset(x=len(rows[code_row]), y=code_row)
+            )
+            copied = block.get_selection(selection)
+            assert copied is not None
+            assert (
+                "3 rows expected" in copied[0]
+            ), f"the code's leading character was deleted at width {width}: {copied[0]!r}"
+
+            # And across the fold into the next code line, the shape design
+            # round 2 reported as 'rows expected psql -c'.
+            next_row, _, _ = _find(rows, "psql -c")
+            across = Selection.from_offsets(
+                Offset(x=0, y=code_row), Offset(x=len(rows[next_row].rstrip()), y=next_row)
+            )
+            copied_across = block.get_selection(across)
+            assert copied_across is not None
+            assert "3 rows expected" in copied_across[0], (
+                f"a take across the fold dropped the leading 3 at width {width}: "
+                f"{copied_across[0]!r}"
+            )
+
+
+def test_a_fence_is_recognised_at_a_list_item_indent() -> None:
+    """The first of D2-1's two causes, pinned at the unit it lives in.
+
+    A fence under ``- `` is indented four spaces and under ``1. `` five, so a
+    three-space bound made ``classify`` blind to the most common nested shape.
+    Pinned separately from the widget test because the widget test would still
+    pass if only the second cause were fixed, and this is the cheaper signal
+    about which one regressed.
+    """
+    for indent in range(0, 9):
+        source = f"{' ' * indent}```python\n{' ' * indent}1 / 0\n{' ' * indent}```\n"
+        lines: list[str] = list(source.split("\n"))
+        covered, markers = _copy_markdown.classify(lines)
+        assert markers == {0, 2}, f"indent {indent} hid the fence markers: {markers}"
+        assert 1 in covered, f"indent {indent} left the code line uncovered: {covered}"
+
+
+@pytest.mark.asyncio
+async def test_a_bullet_inside_a_quote_leaks_neither_the_bar_nor_the_dot() -> None:
+    """Constructs COMPOSE: quote furniture and list furniture on the same row.
+
+    ``furniture_width`` tested the quote pattern first and returned, so a list
+    inside a blockquote stripped the ``▌`` and kept the ``•`` — a glyph nowhere
+    in the user's document — and the paste format still flipped on a one-cell
+    change of drag start (design round 2, D2-4).
+
+    Asserted over a range of start columns because the format flip is precisely
+    a disagreement between adjacent columns: the whole-row gesture must give the
+    same answer wherever inside the painted furniture it began.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(44, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(QUOTED_LIST)
+        block.finalize_text()
+        await pilot.pause()
+
+        rows = _rendered_rows(block)
+        bullet_row, _, _ = _find(rows, "quoted bullet")
+
+        answers: dict[int, str] = {}
+        for column in range(0, 5):
+            selection = Selection.from_offsets(
+                Offset(x=column, y=bullet_row), Offset(x=len(rows[bullet_row]), y=bullet_row)
+            )
+            copied = block.get_selection(selection)
+            assert copied is not None
+            answers[column] = copied[0]
+            assert (
+                "•" not in copied[0]
+            ), f"start column {column} leaked a painted bullet: {copied[0]!r}"
+            assert (
+                "▌" not in copied[0]
+            ), f"start column {column} leaked a painted quote bar: {copied[0]!r}"
+
+        assert (
+            len(set(answers.values())) == 1
+        ), f"the paste format flips with the drag's start cell: {answers}"


### PR DESCRIPTION
# PR Description

## Summary of Changes

Dragging part of a rendered assistant message put the **whole source line** on
the clipboard. Reported from the field: highlighting the eight cells of one word
inside a rendered bullet announced `copied 115 characters` and pasted the entire
bullet.

`AssistantBlock.get_selection` reduced the selection to a `first_row`/`last_row`
pair and discarded the column span `Selection.get_span` returns. `slice_markdown`
is row-granular by contract, so every partially covered row was widened to the
source line beneath it.

### Why the obvious fix is not available

Column-trimmed markdown source is not a missing third option, it is impossible.
A rendered column does not index a source column. Measured on the reported
bullet, `frontend` sits at **rendered column 57** and **source column 58**,
because `- ` paints as ` • ` (+1) while the `**` around the word vanishes (-2).
The offset is content-dependent *and* signed, and `_copy_markdown.align`
deliberately maps rows to source **lines**, never claiming a column
correspondence.

So for a partially covered row there are exactly two truthful answers: the
glyphs that were highlighted, or a whole line the reader did not select. The
second one is the bug.

### The rule

A selection that does not cover the full content of the rows it touches **and**
touches at most one **source line** now returns the highlighted rendered glyphs,
delegating to the base `TranscriptBlock` slicing (which honours columns and the
`-1` end sentinel). Everything wider keeps the markdown-source copy unchanged.

Gating on **source lines** rather than rendered rows is what also fixes a phrase
dragged across a wrapped paragraph's fold: one source line painted as several
rows is the same defect. A row-count gate fixes the reported case and leaves that
one live (measured at width 60, it still returned all 128 characters).

Three predicates carry the rule, each commented where it lives:

- **Blank rows are excluded from the sub-line judgement.** A whole-message copy
  legitimately spans the blank separator rows between paragraphs; letting one
  veto the markdown path would degrade every multi-paragraph copy.
- **`rstrip()` is the only honest measure of a row's content.** Rich pads each
  row out to its *render segment's* width, not the block's — measured, prose rows
  pad to 76 while table rows in the same message pad to 14 — so any predicate
  against block width or raw `len(row)` is wrong.
- **`end` arrives three ways**: `-1` for end-of-row, a column inside the pad when
  the drag overran the last glyph, or a column short of it. Only the glyph count
  settles all three (parametrised in the tests).

### The accepted cost, stated so it is chosen rather than rediscovered

A drag from the middle of one bullet to the middle of the next copies **both
bullets whole**. Trimming those ends needs the column mapping that does not
exist, and degrading any multi-row take to glyphs would put the `▌` and `•`
furniture back into the paste this method exists to keep out of (which
`test_blockquote_copies_as_markdown_not_the_bar` guards). A sub-line take also
loses inline markers: dragging one bold word yields `frontend`, not
`**frontend**` — that is the base rule, the clipboard is what the highlight
covered. Both are pinned by tests so neither can be "fixed" without confronting
the choice.

## Related Issue(s)

- User-reported sub-line copy (no ticket).

## Impact

- No breaking changes, no dependency updates, no new public API.
- Whole-message and multi-source-line copies are **byte-for-byte unchanged**
  (verified by diffing the clipboard against `origin/main`, below).
- Version bumped to `0.42.16` (patch: a user-visible bug fix; `0.42.14` and
  `0.42.15` are already on PyPI).

## Testing Details

### Reproduction on `origin/main`, then the same reproduction fixed

A script drives the **real `OperatorApp`** through real mouse down/move/up
events, so it exercises the actual `TextSelected` release, clipboard write and
toast — not a hand-set `selections` dict. Run unchanged against a clean
`origin/main` worktree (f32802e3) and against this branch:

**BEFORE — `origin/main` (f32802e3):**

```
rendered row 2: ' • Transient failures in the ingest path never reach the frontend without a retry, so the user sees a stale row.'
drag covered rendered columns 57..65 (8 cells) = 'frontend'
------------------------------------------------------------------------
CLIPBOARD (115 chars): '- Transient failures in the ingest path never reach the **frontend** without a retry, so the user sees a stale row.'
TOAST RECEIPT: 'copied 115 characters'
------------------------------------------------------------------------
RESULT: BUG REPRODUCED - the whole source line reached the clipboard
```

**AFTER — this branch:**

```
rendered row 2: ' • Transient failures in the ingest path never reach the frontend without a retry, so the user sees a stale row.'
drag covered rendered columns 57..65 (8 cells) = 'frontend'
------------------------------------------------------------------------
CLIPBOARD (8 chars): 'frontend'
TOAST RECEIPT: 'copied 8 characters'
------------------------------------------------------------------------
RESULT: FIXED - only the highlighted glyphs were copied
```

### The second defect class: a phrase across a wrapped paragraph's fold

Same script shape, one 128-character source line painted as three rows at width
60, dragging `important … several` across the fold:

| | clipboard | receipt |
|---|---|---|
| `origin/main` | 128 chars — the **whole paragraph** | `copied 128 characters` |
| this branch | 59 chars — `'important paragraph that will\ncertainly wrap across several'` | `copied 2 lines` |

### The accepted cost, exercised (not just asserted)

```
drag: mid-bullet-1 (col 10) -> mid-bullet-2 (col 20), two source lines
TOAST: 'copied 2 lines'
CLIPBOARD:
  '- Transient failures in the ingest path never reach the **frontend** without a retry, so the user sees a stale row.'
  '- The second bullet exists so a multi-line drag has somewhere to go.'
```

Both bullets whole, as documented. This is the trade-off, working as intended.

### Whole-message copy is unchanged — diffed against `origin/main`

The regression a sub-line rule is most likely to cause by accident. The exact
clipboard for a select-all was captured on both trees and diffed:

```
=== MARKDOWN full copy (155 chars) ===  byte-identical to source: True
=== BULLETS  full copy (207 chars) ===  byte-identical to source: True
=== DIFF control vs branch ===
IDENTICAL - full-message copy unchanged by the fix
```

### The new tests fail on `origin/main` and pass here

The new test module was copied onto a clean `origin/main` worktree and run there.
**8 failed, 87 passed** — each failure is the old whole-line copy:

```
FAILED test_a_word_dragged_out_of_a_bullet_copies_only_that_word    - assert ('- Transient...e row.',) == ('frontend',)
FAILED test_a_phrase_across_a_wrap_boundary_copies_only_the_phrase  - assert 'This is a si...rminal width.' == 'important pa...cross several'
FAILED test_a_sub_row_take_inside_a_fence_copies_the_code_not_the_fence - assert ('```python\n...:\n```',) == ('f(x)',)
FAILED test_a_word_inside_a_blockquote_copies_without_the_bar       - assert ('> Thanks fo...esign.',) == ('flagged',)
FAILED test_a_quote_dragged_from_column_zero_keeps_the_bar          - assert '> Thanks for...is fixed now.' == '▌ Thanks for the'
FAILED test_a_table_cell_copies_the_cell                            - assert ('| alpha | 0.91 |',) == ('alpha',)
FAILED test_a_zero_width_selection_copies_nothing                   - assert ('- Transient...e row.',) == ('',)
FAILED test_the_reported_drag_end_to_end_reports_a_small_count      - assert '- Transient ... a stale row.' == 'frontend'
```

On this branch all 95 tests in the module pass.

### Test coverage added

Each test's docstring states the regression it pins:

- `test_a_word_dragged_out_of_a_bullet_copies_only_that_word` — the reported
  case, asserting the count is 8 and not 115.
- `test_a_phrase_across_a_wrap_boundary_copies_only_the_phrase` — the fold case;
  fails if anyone narrows the gate from source lines back to rendered rows.
- `test_a_whole_row_still_copies_markdown_source[exact|into-the-pad|sentinel]` —
  all three forms `end` arrives in; pins the `rstrip()` predicate.
- `test_a_whole_message_copy_is_byte_identical_markdown[mixed-constructs|bullets]`
  — select-all is the source verbatim, asserted as **byte equality** because a
  leaked glyph path passes every substring check.
- `test_a_partial_multi_line_selection_still_copies_markdown` — the accepted cost.
- `test_a_sub_row_take_inside_a_fence_copies_the_code_not_the_fence`,
  `test_a_word_inside_a_blockquote_copies_without_the_bar`,
  `test_a_quote_dragged_from_column_zero_keeps_the_bar`,
  `test_a_table_cell_copies_the_cell` — fence body, blockquote, and table row.
- `test_a_zero_width_selection_copies_nothing` — a click is not a drag; this one
  previously put 115 characters on the clipboard.
- `test_the_reported_drag_end_to_end_reports_a_small_count` — the whole gesture
  through the real app, asserting the toast the user reads.

### Visual validation (per AGENTS.md "Visual validation")

Frames captured from the **real `OperatorApp`** via `app.save_screenshot()`,
rendered and inspected — not eyeballed as markup. In every pair the highlight
band covers exactly the same cells; only the receipt changes.

| case | before | after |
|---|---|---|
| word in a bullet | `copied 115 characters` | `copied 8 characters` |
| phrase across a wrap fold | `copied 128 characters` | `copied 2 lines` |

The before-frames make the bug visible in the frame itself: the band lights only
`frontend` while the toast claims 115 characters.

### Full suite and gates

```
tests/unit — 7406 passed, 7 skipped in 232s
```

Gates run over the **whole tree**, exactly as CI runs them:

```
.venv/bin/python -m flake8 .                                   clean
uvx --from black==26.1.0 black --check .                       569 files unchanged
uvx isort==5.13.2 --check .                                    clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .    0 errors, 0 warnings
```

The pyright run caught five real `reportOptionalSubscript` errors in the new
tests (`copied[0]` after an equality assert, which does not narrow `Optional`);
fixed in 043d1929 rather than silenced.

### Correction: the xdist flake claim did not reproduce (review round 1, R1-4)

An earlier revision of this description claimed two tests in
`tests/unit/tui/test_transcript_selection.py` fail under `pytest-xdist` and
pass with `-n0`. **That claim is withdrawn — it does not reproduce.** Re-checked
on a clean control worktree of the merge base `f32802e3` and on this branch:

```
base f32802e3   pytest tests/unit/tui/test_transcript_selection.py      81 passed (xdist)
this branch     pytest tests/unit/tui/test_transcript_selection.py     101 passed (xdist)
base f32802e3   pytest tests/unit/tui/test_composer_seam.py -n0         69 passed
```

The reviewer independently measured the same 69 passed for
`test_composer_seam.py`. Nothing in this module is flaky under xdist, and the
characterisation is not carried forward.

## User-visible behavior change

- Dragging part of a rendered assistant message now copies **what was
  highlighted**, and the receipt counts those characters. Previously it copied
  the whole source line and reported its length.
- A phrase dragged across a wrapped paragraph's fold copies the phrase, not the
  whole paragraph, and arrives as ONE line: the fold is a soft wrap at the
  current width, so the rows rejoin with what the terminal consumed instead of
  carrying a hard `\n` into the paste. The receipt reads
  `copied 59 characters` rather than `copied 2 lines` (design round 1, D2).
- A sub-line drag never pastes rendering furniture. The `▌` of a quote and the
  `•` of a bullet are stripped per row against the source line the row came
  from, so a column-0 drag and a column-1 drag now produce the same document
  (review round 1 R1-1, design round 1 D1). Code inside a fence is exempt and
  copies byte for byte, indent included.
- A plain click (zero-width selection) no longer puts a whole line on the
  clipboard.
- Whole-message and multi-line copies still arrive as markdown source, unchanged:
  bold keeps `**`, fences keep their backticks, blockquotes keep `>`.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.

