### PR TITLE
chore(release): bump version to 0.42.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.17"
+version = "0.42.18"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Problem

`v0.42.17` was tagged on `2dc18571` (word-wise caret movement) while #379 was in review. #379 merged afterwards as `56e66c51` still declaring `0.42.17`, so the subagent-view streaming fix is on `main` under a version that is already tagged and live on PyPI. It has no publishable release of its own.

## Change

Bump `pyproject.toml` to `0.42.18`. Patch: #379 is a rendering and performance correction to one surface, not a step-function capability.

## Testing evidence

Version-only change; no source touched.

```
$ git diff origin/main..HEAD --stat
 pyproject.toml | 2 +-
```

Gates on this branch: flake8, black --check, isort --check, and full-tree pyright all clean.

## Change classification

**C1, standard/pre-authorized.** Release mechanics for an already-reviewed and already-merged change. The substantive work was reviewed over three agent code rounds and two design rounds on #379.