### PR TITLE
chore(release): bump version to 0.42.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.42.18"
+version = "0.42.19"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Version bump for the release carrying #384 (read-only roles get network and inherited MCP reach).

`v0.42.18` was tagged by #389 before #384 merged, so the subagent network fix is not in any published release. This bumps to 0.42.19 so it can ship.

Version-only change; no code. Gates and full CI ran green on #384 at its rebased head 8f293c71 (14/14).