### PR TITLE
fix(update): detect a pip install into a base interpreter (mise/pyenv/asdf)

### DIFF
--- a/local_operator/update.py
+++ b/local_operator/update.py
@@ -279,6 +279,23 @@ def _is_editable_direct_url() -> bool:
     return isinstance(dir_info, dict) and dir_info.get("editable") is True
 
 
+def _installer_metadata() -> str:
+    """Lower-cased dist-info ``INSTALLER``, or ``""`` when there is none.
+
+    pip, uv and pipx each write the file, so it states outright which tool
+    owns the install rather than inferring it from a path. Absent is no
+    evidence at all (a vendored tree, a distro package), never a negative.
+    """
+    try:
+        dist = distribution("local-operator")
+    except PackageNotFoundError:
+        return ""
+    text = dist.read_text("INSTALLER")
+    if not text:
+        return ""
+    return text.strip().lower()
+
+
 def _is_uv_tool(prefix: Path) -> bool:
     """uv tool is the documented end-user path (README + the ``lop`` launcher).
 
@@ -320,10 +337,26 @@ def _is_pipx(prefix: Path) -> bool:
 
 
 def _is_ordinary_pip(prefix: Path) -> bool:
-    """A venv or virtual-env prefix: the remaining README ``pip install`` path."""
+    """A venv prefix, or a dist-info that names pip: the README ``pip install`` path.
+
+    The two layout probes both miss a *base* interpreter (#396). A ``mise``,
+    ``pyenv`` or ``asdf`` toolchain reports ``sys.prefix == sys.base_prefix``
+    and writes no ``pyvenv.cfg``, so an ordinary ``pip install
+    local-operator`` there fell through to ``UNKNOWN`` and ``/update``
+    refused an upgrade that ``pip install -U`` performs fine — a reporter on
+    0.42.13 could not reach 0.42.19 at all.
+
+    ``INSTALLER`` is consulted last and only for the exact value ``pip``.
+    ``uv`` and ``pipx`` reach this line only once their own probes above have
+    declined, and answering "pip" for them would be the guess this module
+    exists to refuse: ``uv`` is also what ``uv pip install --system`` writes
+    into a base prefix, where ``uv tool upgrade`` is the wrong command.
+    """
     if (prefix / "pyvenv.cfg").is_file():
         return True
-    return sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+    if sys.prefix != getattr(sys, "base_prefix", sys.prefix):
+        return True
+    return _installer_metadata() == "pip"
 
 
 def install_kind(

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -156,6 +156,36 @@ def test_force_bypasses_ttl_and_rewrites(tmp_path: Path) -> None:
     assert written["payload"]["version"] == "0.28.0"
 
 
+class _MetadataDist:
+    """Distribution stand-in exposing only the ``read_text`` the module calls.
+
+    ``object()`` is enough for the layout probes, which answer before any
+    metadata is read. The ``INSTALLER`` path needs a real file body, and
+    ``None`` — what ``read_text`` returns for an absent file — is the case
+    that must stay ``UNKNOWN``.
+    """
+
+    def __init__(self, installer: str | None = None) -> None:
+        self._installer = installer
+
+    def read_text(self, name: str) -> str | None:
+        return self._installer if name == "INSTALLER" else None
+
+
+@contextmanager
+def _base_interpreter(prefix: Path):
+    """``sys.prefix == sys.base_prefix``: the mise/pyenv/asdf layout of #396.
+
+    Patched rather than constructed because ``_is_ordinary_pip`` reads the
+    live ``sys``; the seam keeps the running process untouched.
+    """
+    with (
+        patch.object(update_mod.sys, "prefix", str(prefix)),
+        patch.object(update_mod.sys, "base_prefix", str(prefix)),
+    ):
+        yield
+
+
 def test_install_kind_uv_receipt(tmp_path: Path) -> None:
     prefix = tmp_path / "uv" / "tools" / "local-operator"
     prefix.mkdir(parents=True)
@@ -214,14 +244,106 @@ def test_install_kind_no_distribution(tmp_path: Path) -> None:
 
 
 def test_install_kind_unknown(tmp_path: Path) -> None:
+    """Genuinely unidentifiable: base prefix, no ``pyvenv.cfg``, no ``INSTALLER``.
+
+    Before #396 this asserted the bug — the same layout with a pip-written
+    ``INSTALLER`` was called UNKNOWN too. Refusing still has to be possible,
+    so the case is kept and stripped of the one signal that identifies it.
+    """
     with (
         patch.object(update_mod, "distribution") as dist,
         patch.object(update_mod, "_is_editable_direct_url", return_value=False),
-        patch.object(update_mod.sys, "prefix", str(tmp_path)),
-        patch.object(update_mod.sys, "base_prefix", str(tmp_path)),
+        _base_interpreter(tmp_path),
     ):
-        dist.return_value = object()
+        dist.return_value = _MetadataDist(installer=None)
         assert install_kind(prefix=tmp_path) is InstallKind.UNKNOWN
+
+
+@pytest.mark.parametrize("installer", ["uv", "pipx", "pipenv", "conda"])
+def test_install_kind_unknown_for_unrecognised_installer(tmp_path: Path, installer: str) -> None:
+    """Refuse-don't-guess: a foreign installer is not silently upgraded with pip.
+
+    The values are chosen to be EXECUTABLE versions of the probe's own
+    argument, not merely foreign names. ``uv`` is the one the docstring
+    reasons about — ``uv pip install --system`` writes it into a base
+    prefix, where ``uv tool upgrade`` is the wrong command — so accepting it
+    here would be exactly the guess the module refuses. ``pipx`` and
+    ``pipenv`` are the substring traps: a probe written as ``"pip" in
+    installer`` rather than ``== "pip"`` passes a ``conda``-only test and
+    fails these.
+    """
+    with (
+        patch.object(update_mod, "distribution") as dist,
+        patch.object(update_mod, "_is_editable_direct_url", return_value=False),
+        _base_interpreter(tmp_path),
+    ):
+        dist.return_value = _MetadataDist(installer=installer)
+        assert install_kind(prefix=tmp_path) is InstallKind.UNKNOWN
+
+
+def test_install_kind_pip_on_base_interpreter(tmp_path: Path) -> None:
+    """#396: ``pip install`` under mise/pyenv/asdf is PIP, not UNKNOWN.
+
+    The reporter's prefix equalled ``base_prefix`` and carried no
+    ``pyvenv.cfg``, so both layout probes declined and ``/update`` refused an
+    upgrade ``pip install -U`` would have made. ``INSTALLER`` says ``pip``.
+    """
+    with (
+        patch.object(update_mod, "distribution") as dist,
+        patch.object(update_mod, "_is_editable_direct_url", return_value=False),
+        _base_interpreter(tmp_path),
+    ):
+        dist.return_value = _MetadataDist(installer="pip\n")
+        assert not (tmp_path / "pyvenv.cfg").exists()
+        assert install_kind(prefix=tmp_path) is InstallKind.PIP
+
+
+def test_install_kind_uv_tool_not_downgraded_to_pip(tmp_path: Path) -> None:
+    """A uv tool env whose ``INSTALLER`` reads ``uv`` still upgrades with uv."""
+    prefix = tmp_path / "uv" / "tools" / "local-operator"
+    prefix.mkdir(parents=True)
+    (prefix / "uv-receipt.toml").write_text("[tool]\n", encoding="utf-8")
+    with (
+        patch.object(update_mod, "distribution") as dist,
+        patch.object(update_mod, "_is_editable_direct_url", return_value=False),
+        _base_interpreter(prefix),
+    ):
+        dist.return_value = _MetadataDist(installer="uv")
+        assert install_kind(prefix=prefix) is InstallKind.UV_TOOL
+
+
+def test_install_kind_pipx_not_downgraded_to_pip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """pipx vendors pip inside its venv, so its ``INSTALLER`` can read ``pip``."""
+    home = tmp_path / "pipx-home"
+    prefix = home / "venvs" / "local-operator"
+    prefix.mkdir(parents=True)
+    monkeypatch.setenv("PIPX_HOME", str(home))
+    with (
+        patch.object(update_mod, "distribution") as dist,
+        patch.object(update_mod, "_is_editable_direct_url", return_value=False),
+        _base_interpreter(prefix),
+    ):
+        dist.return_value = _MetadataDist(installer="pip")
+        assert install_kind(prefix=prefix) is InstallKind.PIPX
+
+
+def test_install_kind_editable_outranks_pip_installer(tmp_path: Path) -> None:
+    """The editable guard runs first: ``INSTALLER`` names the tool, not the safety.
+
+    A contributor's checkout is installed with ``pip install -e``, so its
+    ``INSTALLER`` reads ``pip`` exactly like the #396 repro. Letting that
+    signal reach ``_is_ordinary_pip`` would point ``pip install -U`` at the
+    repo ``.venv`` and smash the editable link.
+    """
+    with (
+        patch.object(update_mod, "distribution") as dist,
+        patch.object(update_mod, "_is_editable_direct_url", return_value=True),
+        _base_interpreter(tmp_path),
+    ):
+        dist.return_value = _MetadataDist(installer="pip")
+        assert install_kind(prefix=tmp_path) is InstallKind.EDITABLE
 
 
 def test_perform_upgrade_runs_detected_argv() -> None:


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** One new private helper and one extra probe inside an existing predicate, plus tests. No new surfaces, no signature changes, no behaviour change for any install that was already detected. Clean rollback via `git revert`.

Fixes #396.

## The gap

`/update` refused to upgrade an ordinary `pip install` whenever the target interpreter was a **base interpreter rather than a venv** — the layout `mise`, `pyenv` and `asdf` produce. The reporter was stuck on 0.42.13 and could not reach 0.42.19 at all:

```
checking for updates…
updating to v0.42.19…
cannot tell how this install was launched
```

`install_kind()` fell through every probe to `UNKNOWN`:

| probe | why it missed |
| --- | --- |
| `_is_uv_tool` | no `uv-receipt.toml`, no `uv/tools/` path segment |
| `_is_pipx` | not under `~/.local/pipx` |
| `_is_ordinary_pip` | no `pyvenv.cfg`, and `sys.prefix == sys.base_prefix` **by definition** for a base interpreter |

The refusal was *correct behaviour on wrong information*. `pip install -U local-operator` upgrades that install perfectly well; the detector simply had no probe that could see it. Version managers are a common way to get Python, and `pip install` into the active interpreter is the path of least resistance for anyone not already on `uv tool` or `pipx` — so this is an update mechanism that never works for that whole population.

## The fix

The dist metadata already states what the layout probes were inferring. pip, uv and pipx each write an `INSTALLER` file, so `_installer_metadata()` reads it and `_is_ordinary_pip` consults it after its two existing layout probes.

Three properties this rests on, each pinned by a test rather than asserted:

**1. The editable guard still answers first.** This is the highest-stakes property in the change. A contributor's `pip install -e` checkout *also* has `INSTALLER == pip`, so if that signal could reach the pip branch it would point `pip install -U` at the repo `.venv` and smash the editable link. It cannot: `install_kind` returns `EDITABLE` before any installer probe runs. `INSTALLER` names the *tool*, never whether upgrading in place is *safe*.

**2. uv tool and pipx still win their own probes.** Worth stating explicitly because **pipx vendors pip** — a pipx install's `INSTALLER` can literally read `pip`. It reaches the pip line only after `_is_pipx` has already declined, so the ordering is load-bearing rather than incidental.

**3. Only the exact value `pip` is accepted.** `uv` deliberately does **not** map to `UV_TOOL` here: `uv pip install --system` also writes `uv` into a base prefix, where `uv tool upgrade` is the wrong command. Anything else stays `UNKNOWN`, preserving the module's deliberate refuse-don't-guess design.

## On the rewritten test

`test_install_kind_unknown` previously constructed `prefix == base_prefix` with no `pyvenv.cfg` and asserted `UNKNOWN` — **this exact bug, pinned as expected behaviour**. It is rewritten rather than deleted: the same layout with no `INSTALLER` at all, so refusing stays possible and stays tested.

## Verification

**On the real path, not only mocks.** The published 0.42.19 wheel was installed under the *actual* mise 3.13.15 base interpreter, reproducing the reported evidence exactly (`prefix == base_prefix`, no `pyvenv.cfg`, `INSTALLER == 'pip'`). Swapping only `update.py`:

| | `install_kind()` | result |
| --- | --- | --- |
| shipped v0.42.19 | `UNKNOWN` | `UpdateError: no installer for unknown` |
| this branch | `PIP` | `[…/bin/python3, -m, pip, install, -U, local-operator]` |

Reverting `update.py` while keeping the tests makes the regression test fail with `UNKNOWN is not PIP`, so it genuinely pins the bug.

- `tests/unit/test_update.py`: **49 passed**
- Full `tests/unit`: **7833 passed, 15 skipped**
- flake8, black (26.1.0) and isort (5.13.2): clean tree-wide

## Review round 1

Reviewed independently; verdict `clean`, no BLOCKER. The editable guard was attacked directly by mutation — deleting `_is_editable_direct_url()` from the guard fails two tests, and reordering the probes above uv/pipx fails four including the vendored-pip case. Two findings were remediated on this branch:

- **The "exact value `pip` only" claim was not actually test-pinned.** Both `in ("pip", "uv")` and `"pip" in …` survived the original `conda`-only negative test. The case is now parametrised over `uv`, `pipx`, `pipenv` and `conda` — `uv` makes the docstring's own argument executable, and `pipx`/`pipenv` are the substring traps. Both mutants now fail.
- **An over-claim in the commit message** about the repo `.venv` resolving `EDITABLE` was qualified — see below.

## Two things a reviewer should know

**A pre-existing hazard this change makes worth naming.** A stale untracked `local_operator.egg-info/` in a worktree shadows the real dist-info for `importlib.metadata`, carries no `direct_url.json`, and so makes a contributor's checkout look non-editable. Running `/update` from the repo root in that state resolves `PIP` rather than refusing. This is **not introduced here** — `origin/main` behaves identically — but it is a real way to reach `pip install -U` pointed at a repo `.venv`. Filed separately rather than fixed in this slice.

Relatedly: a legacy `setup.py develop` checkout with no `direct_url.json` but `INSTALLER == pip` now classifies `PIP` where it previously classified `UNKNOWN`. Narrow, but an honest widening of the editable blast radius.

**Two claims in the docstring are reasoned, not measured.** `uv` and `pipx` are not installed on the machine this was developed on, so "pipx vendors pip" and "`uv pip install --system` writes `uv` into a base prefix" are argued rather than observed. The code is safe either way — both paths are protected by probe ordering, not by those claims — but a reviewer with either tool installed could usefully confirm them.

**One pre-existing flake, not from this change.** `tui/test_subagent_view.py::test_history_unavailable_and_error_retry_keep_trajectory_fallback` fails in full-suite runs and passes in isolation. It reproduces on pristine `origin/main` and this diff touches no TUI code.
