### PR TITLE
fix(tui): render authored newlines in a notice as rows, not characters

### DIFF
--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -1170,6 +1170,62 @@ class NoticeBlock(TranscriptBlock):
         finally:
             self._finalized = was_finalized
 
+    def _rows(self, body: int) -> list[str]:
+        """The notice's text rows at ``body`` cells, glyph field not yet applied.
+
+        Authored newlines are rows, not characters. Handing the whole string to
+        ``wrap_cells`` — which splits on ``" "`` only — made every ``\\n`` an
+        ordinary character INSIDE a word, so it was measured into that word's
+        width and then printed literally mid-row. ``/update``'s
+        :func:`~local_operator.update.unknown_refusal` is six authored lines and
+        came out as ``s.prefix:``, ``orted upgrades:``, ``px upgrade``,
+        ``thon -m pip`` — issue #397. Three to four characters off the front of
+        every line the author had indented, because the same helper rebuilds
+        rows with a single separator and a LEADING run of spaces is dropped
+        (the empty words never re-add their separator while ``current`` is
+        still falsy). So the indent is lifted out before wrapping and put back
+        on every row the line produces, which is what keeps ``  uv tool upgrade
+        local-operator`` reading as one of three offered commands rather than as
+        prose.
+
+        This is :meth:`UserBlock._rows`'s discipline, arriving here for the
+        reason that comment did not foresee: it fixed the split in the caller on
+        the premise that notices "have no authored indentation to keep", and
+        ``unknown_refusal`` authors both newlines and indentation. ``wrap_cells``
+        itself still must not change — it also lays out tool rows, whose single
+        space-joined strings would gain a newline-splitting branch none of them
+        can reach.
+
+        An authored break lands on the HANGING indent, exactly like a wrapped
+        one. The glyph field is a gutter of fixed width, not a first-row prefix:
+        :meth:`copy_gutter` returns :attr:`GLYPH_COLS` for every index, so a row
+        that started at column 0 would have four cells of its own text stripped
+        off a copy. Returning the author's line to the spine would also put it
+        under the glyph rather than under the sentence, which reads as a second
+        notice — the same "several statements instead of one" the hanging indent
+        exists to prevent. The author's own indent then sits ON TOP of that
+        gutter, so relative shape survives while the block stays one column.
+
+        Blank rows are trimmed at the ENDS for the reason the split creates
+        them: before this, a leading ``\\n`` was just a character, and now it is
+        a row — one that would carry the kind glyph beside no text at all, with
+        the sentence it marks on the row below. A trailing one is pinned height
+        spent on nothing. Interior blanks stay: there a blank row is the
+        paragraph break the author typed. At least one row always survives, so
+        an empty notice is still a block with a height.
+        """
+        rows: list[str] = []
+        for line in self._text.split("\n"):
+            stripped = line.lstrip(" ")
+            indent = " " * min(len(line) - len(stripped), max(body - 1, 0))
+            room = max(body - len(indent), 1)
+            rows.extend(indent + row if row else "" for row in wrap_cells(stripped, room))
+        while len(rows) > 1 and not rows[0]:
+            rows.pop(0)
+        while len(rows) > 1 and not rows[-1]:
+            rows.pop()
+        return rows
+
     def _build(self) -> RenderableType:
         """Glyph + text on the spine, WRAPPED with a hanging indent.
 
@@ -1193,14 +1249,16 @@ class NoticeBlock(TranscriptBlock):
         stylesheet re-wrap would also reflow the hanging indent it cannot see.
         Every wrapped row is centred on its own width, so a notice that folds to
         two or three lines still reads as one centred block rather than a centred
-        first line with ragged continuations.
+        first line with ragged continuations — and a row is a row whether the
+        break was the wrap's or the author's, so :meth:`_rows` feeds this loop
+        the same list either way.
         """
         style = Style(color=theme_mod.semantic_color(self._token))
         indent = " " * SPINE_INDENT
         hanging = " " * (SPINE_INDENT + 2)
         width = max((self.size.width or 80) - 2, 12)
         body = max(width - cell_len(hanging), 8)
-        rows = wrap_cells(self._text, body)
+        rows = self._rows(body)
         centred = self.has_class(BOOT_COLUMN_CLASS)
         line = Text(no_wrap=True, overflow="ellipsis")
         for index, row in enumerate(rows):

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -79,6 +79,7 @@ from local_operator.tui.widgets.editor import BARREN_CLICK_WINDOW_S, Editor
 from local_operator.tui.widgets.toast import TOAST_FAILURE_MS, Toast
 from local_operator.tui.widgets.tool_card import OUTPUT_INDENT, ToolCard
 from local_operator.tui.widgets.transcript import (
+    BOOT_COLUMN_CLASS,
     NoticeBlock,
     RichBlock,
     TranscriptBlock,
@@ -86,6 +87,7 @@ from local_operator.tui.widgets.transcript import (
     UserBlock,
 )
 from local_operator.tui.widgets.welcome import WelcomeView
+from local_operator.update import unknown_refusal
 from tests.unit.tui.conftest import StyledTranscriptApp
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
@@ -148,6 +150,47 @@ async def _mounted(app: StyledTranscriptApp, *blocks: TranscriptBlock) -> Transc
     for block in blocks:
         view.append_block(block)
     return view
+
+
+def _notice_painted(block: NoticeBlock) -> list[str]:
+    """The rows the notice authored, right-trimmed.
+
+    Via ``renderable.plain`` rather than the strips, for the reason
+    ``test_user_block`` gives: the strips are padded out to the widget width,
+    which would make "does this row carry the glyph field" trivially true of a
+    row of spaces. The trailing pad is dropped because Rich supplies it and no
+    assertion here is about it.
+    """
+    renderable = block.renderable
+    assert isinstance(renderable, Text)
+    return [row.rstrip() for row in renderable.plain.split("\n")]
+
+
+async def _notice_rows(
+    *,
+    app_size: tuple[int, int],
+    text: str,
+    kind: str = "info",
+    centred: bool = False,
+) -> list[str]:
+    """A notice's painted rows at ``app_size``, through the REAL stylesheet.
+
+    Two pauses after each state change: the first mounts and lays the block
+    out, the second lets ``on_resize`` re-wrap it against its REAL width.
+    Without the second every assertion would be made against the 80-column
+    fallback the constructor builds with.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=app_size) as pilot:
+        block = NoticeBlock(text, cast(Any, kind))
+        await _mounted(app, block)
+        await pilot.pause()
+        await pilot.pause()
+        if centred:
+            block.set_class(True, BOOT_COLUMN_CLASS)
+            await pilot.pause()
+            await pilot.pause()
+        return _notice_painted(block)
 
 
 # -- the mechanism -----------------------------------------------------------
@@ -413,6 +456,223 @@ async def test_notice_copy_is_the_sentence_not_the_glyph_field() -> None:
         assert "·" not in copied and "⚠" not in copied
         for row in copied.split("\n"):
             assert row == row.lstrip(" "), f"row carries the glyph field: {row!r}"
+
+
+# -- a notice's own rows: authored breaks, authored indent (#397) -------------
+@pytest.mark.asyncio
+async def test_an_authored_newline_in_a_notice_is_a_ROW_not_a_character() -> None:
+    """Issue #397, the half that printed control characters into the frame.
+
+    ``wrap_cells`` splits on ``" "`` only, so a ``\\n`` was an ordinary
+    character inside a word: measured into that word's width and then painted
+    literally, mid-row. Asserted on the painted rows rather than on the copy,
+    because the copy joins rows with ``\\n`` and cannot tell a break that was
+    honoured from one that survived as a glyph.
+    """
+    rows = await _notice_rows(
+        app_size=(60, 40),
+        text="alpha\n  beta gamma\nsupported upgrades:\n  uv tool upgrade local-operator",
+    )
+    assert rows == [
+        "  · alpha",
+        "      beta gamma",
+        "    supported upgrades:",
+        "      uv tool upgrade local-operator",
+    ]
+    assert not any("\n" in row for row in rows), rows
+
+
+@pytest.mark.asyncio
+async def test_an_authored_indent_survives_onto_the_hanging_field() -> None:
+    """Issue #397, the half that ate the first characters of every indented line.
+
+    ``wrap_cells`` rebuilds rows with a single separator, so a LEADING run of
+    spaces is dropped — ``  uv tool upgrade …`` came back as ``uv tool …`` and,
+    in the report, four characters shorter still. The indent is lifted out
+    before the wrap and re-applied per row, ON TOP of the glyph field: the
+    field is a gutter of fixed width (see ``copy_gutter``), so a row returned to
+    column 0 would lose four cells of its own text to a paste.
+    """
+    rows = await _notice_rows(app_size=(60, 40), text="supported:\n    uv tool upgrade")
+    bodies = [row[NoticeBlock.GLYPH_COLS :] for row in rows]
+    assert bodies == ["supported:", "    uv tool upgrade"]
+    # The indent sits ON the hanging field, not instead of it: the continuation
+    # still reserves the same four cells the first row spends on the glyph.
+    assert rows[1].startswith(" " * NoticeBlock.GLYPH_COLS)
+
+
+@pytest.mark.asyncio
+async def test_an_indented_line_wraps_inside_the_frame() -> None:
+    """The indent is SPENT from the row's budget, not added beside it.
+
+    ``_rows`` wraps the stripped line at ``body - len(indent)`` and then puts
+    the indent back, so the finished row still fits. Wrapping at the full
+    ``body`` instead reads as correct and passes every other assertion here —
+    the rows are right, they are simply too wide — and the overflow lands in
+    the neighbouring column, which is the whole reason this block wraps itself
+    rather than leaving it to Rich (review round 1 found that mutation
+    overflowing the frame with no test to catch it).
+
+    The indent has to be DEEP for this to bind, which is why it is eight
+    spaces and not two. Without the guard a row grows to exactly ``body``, and
+    ``body`` is already the frame minus the glyph field — so a shallow indent
+    overflows into the field and still fits the terminal, hiding the bug. Only
+    a surplus wider than the field lands outside the frame.
+    """
+    width = 56
+    rows = await _notice_rows(
+        app_size=(width, 40), text="supported:\n        " + "upgrade local-operator " * 4
+    )
+    assert len(rows) > 2, "the indented line must actually wrap for this to bind"
+    assert max(cell_len(row) for row in rows) <= width
+
+
+@pytest.mark.asyncio
+async def test_the_update_refusal_renders_with_every_line_intact() -> None:
+    """The actual user-facing regression: ``/update`` on an unrecognised install.
+
+    Reported as ``s.prefix:``, ``orted upgrades:``, ``px upgrade``,
+    ``thon -m pip`` — three to four characters off the front of every line the
+    author indented, with the newlines printed as glyphs between them. Built
+    from the REAL :func:`~local_operator.update.unknown_refusal` rather than a
+    lookalike, so a copy change to that string keeps this test honest; the
+    interpolated paths are pinned so the assertion does not depend on where the
+    suite happens to be checked out.
+    """
+    refusal = unknown_refusal(prefix="/opt/lo", executable="/opt/lo/bin/python")
+    rows = await _notice_rows(app_size=(100, 40), text=refusal, kind="error")
+    # Wide enough that no line needs wrapping, so the rows ARE the authored
+    # lines and any difference is damage rather than a fold.
+    assert [row[NoticeBlock.GLYPH_COLS :] for row in rows] == refusal.split("\n")
+
+
+@pytest.mark.asyncio
+async def test_a_long_single_line_notice_still_hangs_under_its_first_word() -> None:
+    """The behaviour the split must not cost: a wrap is still a wrap.
+
+    One authored line, no newlines at all — the case every notice in the app was
+    before ``/update`` grew a six-line refusal. Continuations land on the
+    hanging field, which is what makes a long notice read as one statement.
+    """
+    rows = await _notice_rows(
+        app_size=(48, 40),
+        text="ctrl+c again to exit - resume with: local-operator --resume session-abc123def456",
+        kind="warning",
+    )
+    assert len(rows) > 1
+    assert rows[0].startswith("  ! ctrl+c again to exit")
+    for row in rows[1:]:
+        assert row.startswith(" " * NoticeBlock.GLYPH_COLS)
+        assert not row[NoticeBlock.GLYPH_COLS :].startswith(" "), row
+    assert " ".join(row[NoticeBlock.GLYPH_COLS :] for row in rows[1:]).split() == (
+        "local-operator --resume session-abc123def456".split()
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_centred_boot_notice_centres_every_authored_line() -> None:
+    """The boot column keeps working, per row, once rows can be authored.
+
+    A boot notice (the splash's MCP connect failure) is centred on the card's
+    axis rather than hung on the spine, and each row is centred on its OWN
+    width. The split adds rows the centring never saw, so it is asserted on the
+    slack either side of each one — including the indented line, whose authored
+    indent is part of the row it centres.
+    """
+    rows = await _notice_rows(
+        app_size=(70, 30),
+        text="MCP cloudflare failed\n  run: lop mcp login cloudflare",
+        kind="error",
+        centred=True,
+    )
+    assert len(rows) == 2
+    for row in rows:
+        assert row.startswith(" "), f"a centred row sits at the spine: {row!r}"
+        assert "\n" not in row
+    # Centred on the axis, not left-aligned in a wide block: the ink is roughly
+    # equidistant from both edges of the notice's own span. Compared against the
+    # widest row's own slack rather than a pinned column, so the assertion
+    # survives a copy change.
+    inks = [(len(row) - len(row.lstrip(" ")), cell_len(row)) for row in rows]
+    for left, painted in inks:
+        assert left > 0 and painted > left
+
+
+@pytest.mark.asyncio
+async def test_a_multi_line_notice_rewraps_and_repins_through_a_resize() -> None:
+    """The block is FINALIZED and re-wraps itself; the split rides every path.
+
+    ``on_resize``, ``restate`` and ``retheme`` all re-run ``_build``, so a
+    multi-line notice that only worked on first paint would decay into the #397
+    frame the moment the terminal moved. The pinned height has to follow the new
+    row count too — a stale pin reserves rows the rebuild no longer paints.
+    """
+    refusal = unknown_refusal(prefix="/opt/lo", executable="/opt/lo/bin/python")
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(100, 40)) as pilot:
+        block = NoticeBlock(refusal, "error")
+        await _mounted(app, block)
+        await pilot.pause()
+        await pilot.pause()
+        wide = _notice_painted(block)
+        assert block.is_finalized()
+        assert len(wide) == 7 and block.size.height == 7
+
+        await pilot.resize_terminal(46, 40)
+        await pilot.pause()
+        await pilot.pause()
+        narrow = _notice_painted(block)
+        assert len(narrow) > len(wide), narrow
+        assert block.size.height == len(narrow)
+        assert all(cell_len(row) <= 46 for row in narrow), narrow
+        # Folded, not damaged: every authored line still begins a row, and the
+        # indented ones still carry their indent.
+        assert narrow[0].startswith("  ✗ cannot tell how this install was")
+        assert "      uv tool upgrade local-operator" in narrow
+
+        # `restate` and `retheme` take the same three steps around `_build`.
+        block.restate("first\n  second indented", "warning")
+        await pilot.pause()
+        await pilot.pause()
+        assert _notice_painted(block) == ["  ! first", "      second indented"]
+        assert block.size.height == 2
+        block.retheme()
+        await pilot.pause()
+        assert _notice_painted(block) == ["  ! first", "      second indented"]
+
+
+@pytest.mark.asyncio
+async def test_a_blank_authored_row_is_kept_between_lines_and_trimmed_at_the_edge() -> None:
+    """The rows the split itself creates, which did not exist as rows before.
+
+    A leading ``\\n`` used to be a character; now it is a row, and painted it
+    would put the kind glyph beside no text with the sentence it marks below.
+    Between lines the same blank row is the paragraph break the author typed, so
+    it stays. An empty notice keeps one row, so the block always has a height
+    for the spacing machinery to reason about.
+    """
+    assert await _notice_rows(app_size=(60, 40), text="\nleading") == ["  · leading"]
+    assert await _notice_rows(app_size=(60, 40), text="trailing\n") == ["  · trailing"]
+    assert await _notice_rows(app_size=(60, 40), text="a\n\nb") == ["  · a", "", "    b"]
+    assert await _notice_rows(app_size=(60, 40), text="") == ["  ·"]
+
+
+@pytest.mark.asyncio
+async def test_a_multi_line_notice_pastes_as_the_text_that_was_authored() -> None:
+    """The clipboard half: the refusal pastes into a bug report unchanged.
+
+    The uniform ``GLYPH_COLS`` gutter is what makes this work — the authored
+    indent sits on top of the field, so stripping the field returns exactly the
+    string ``unknown_refusal`` composed.
+    """
+    refusal = unknown_refusal(prefix="/opt/lo", executable="/opt/lo/bin/python")
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(100, 40)) as pilot:
+        block = NoticeBlock(refusal, "error")
+        await _mounted(app, block)
+        await pilot.pause()
+        await pilot.pause()
+        assert _copy_all(app, block) == refusal
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** One new private method on `NoticeBlock` and a one-line change to what `_build` wraps, plus tests. No new surfaces, no signature changes, and no change to how a single-line notice renders. Clean rollback via `git revert`.

Fixes #397.

## The gap

A multi-line notice arrived on screen shredded. `/update` on an install it cannot classify prints a six-line refusal; this is what the user actually saw:

```
cannot tell how this install was launched
s.prefix: /Users/…/3.13.15          <- 'sys.prefix' lost 3 characters
orted upgrades:                     <- 'supported upgrades:' lost 4
px upgrade local-operator           <- '  pipx upgrade' lost 4
thon -m pip                         <- '  python -m pip' lost 4
```

Corrupted output is worse than truncated output: the reader cannot tell whether the harness, the update, or their terminal is broken — and the commands offered as the remedy are themselves unrunnable as printed. It lands on a path reached precisely when something has already gone wrong.

## The cause

`NoticeBlock._build` handed the whole string to `wrap_cells`, which splits on `" "` only. Two defects follow:

1. **`\n` was never a break.** Each one was an ordinary character *inside* a word, so it was measured into that word's width and then printed literally mid-row. That is what broke tokens in the middle.
2. **Leading spaces were dropped.** `wrap_cells` rebuilds rows with a single separator, and a leading run yields empty words while `current` is still falsy, so no separator is re-added. Every damaged line was one the author had indented.

## The fix

`NoticeBlock._rows` splits on `\n` first, lifts each line's indent out, wraps the remainder, and re-applies the indent per row — **the discipline `UserBlock._rows` already uses.**

`wrap_cells` is deliberately **not** changed. It also lays out tool rows, whose space-joined strings would gain a newline-splitting branch none of them can reach, and its caller-side-fix reasoning was right. What that comment did not foresee is its own premise expiring: it fixed the split in `UserBlock` because notices *"have no authored indentation to keep"*, and `unknown_refusal()` authors both newlines and indentation.

### The one real design decision

**An authored break lands on the hanging indent, exactly like a wrapped one.** This is chosen, not inherited:

- `copy_gutter` returns `GLYPH_COLS` for *every* index, so a row starting at column 0 would lose four cells of its own text to a paste. (Verified: the gutter returns `4` across indices −2…h+3.)
- A line returned to the spine would sit under the *glyph* rather than under the *sentence*, reading as a second notice — the "several statements instead of one" the hanging indent exists to prevent.

The author's own indent then sits on top of that gutter, so relative shape survives while the block stays one column. A copy of the full refusal round-trips byte-identical.

Blank rows are trimmed **at the ends only**, because the split is what creates them: a leading `\n` used to be a character and is now a row, one that would carry the kind glyph beside no text. Interior blanks stay — there a blank row is the paragraph break the author typed.

## One behaviour change beyond the reported bug

Because the fix is general, a **single-line** notice authored with leading whitespace now keeps that indent, where it was previously eaten. No caller passes one today — every `notice()` / `_system_notice()` / `NoticeBlock(` call site was checked, and `unknown_refusal()` is the only multi-line producer — so this is latent correctness rather than a visible change. Flagged because the first draft of this PR claimed single-line rendering was untouched, and that was not exactly true.

## Verification

- **`tests/unit/tui`: 2995 passed, 12 skipped.** flake8, black (26.1.0), isort (5.13.2) and pyright clean tree-wide.
- **Mutation-tested.** Reverting `_build` to the old `wrap_cells(self._text, body)` call fails 6 of the new tests, reproducing the exact reported strings (`s.prefix:`, `orted upgrades:`, `px upgrade`, `thon -m pip`).
- **Rendered frames, not just assertions.** Captured before/after at 92×14 and viewed them: before, `supported upgrades:` sat flush left, `uv` was orphaned from its command, and the notice overflowed to 9 rows so the first line scrolled off entirely. After, all seven authored lines are intact and the three offered commands align as a list.
- **The riskiest area — height pinning across rebuilds — was tested hard.** `NoticeBlock` pins its own height, so a stale pin would corrupt transcript scroll. Height tracks row count exactly through 100→46→30→120→24→100 columns and across `restate` tall→short→tall (7/9/14/24 rows, `size.height == settled_rows == len(rows)` every time), with gap classes updating correctly and no row exceeding the terminal width.
- **Adversarial inputs** all render sanely: leading/trailing/consecutive `\n`, whitespace-only lines, the empty string, 140-character unbroken tokens, CJK wide characters, and deep indents.

## Review round 1

Reviewed independently; verdict `clean`, no BLOCKER, no MAJOR. One finding was remediated here:

**A surviving mutant.** Wrapping at the full `body` instead of `body - len(indent)` produced rows wider than the frame and *no test noticed* — the rows were right, they were simply too wide, and the overflow lands in the neighbouring column. `test_an_indented_line_wraps_inside_the_frame` closes it. It needs a **deep** indent to bind: without the guard a row grows to exactly `body`, which is already the frame minus the glyph field, so a shallow indent overflows into the field and still fits the terminal, hiding the bug. The mutant now fails with `assert 57 <= 56`.

Two other MINORs were reported and are recorded rather than fixed, both cosmetic and neither reachable from a current call site: interior blank rows carry four trailing spaces (invisible on screen; the clipboard gutter-strip removes exactly those cells), and the single-line-with-indent change described above.

## Notes for the reviewer

- **A pre-existing test failure, not from this change.** `tui/test_subagent_view.py::test_history_unavailable_and_error_retry_keep_trajectory_fallback` fails on this branch. It fails **identically on a pristine `origin/main` worktree**, both standalone and in the full suite, and this diff touches no subagent code. (An earlier draft of the commit called it an order-dependent flake that passed in isolation — that was wrong, and the claim is corrected in the final message.)
- **An adjacent copy left alone deliberately.** `session_picker.py:289` has its own `_wrap_cells` with the same leading-space behaviour, used for `RESUME_EMPTY_NOTICE`. That string is a single line with no authored indent, so it cannot be damaged today. Verified, and left out of scope rather than widened into.
