### PR TITLE
fix(mcp): stop the OAuth refresh lock from freezing the TUI on /resume

### DIFF
--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -105,22 +105,36 @@ REFRESH_SKEW_S = 60.0
 #: the startup gate defers us, and the breaker bounds retries.
 REFRESH_HTTP_TIMEOUT_S = 10.0
 
-#: Bound on ACQUIRING the cross-process refresh lock, derived from the honest
-#: budget of the critical section it guards: one token POST (capped at
-#: ``REFRESH_HTTP_TIMEOUT_S``) plus a couple of SQLite reads. A peer that holds
-#: the lock legitimately therefore clears it well inside this bound, and
-#: overrunning it means the holder is not working — a leaked lock from a killed
-#: process, or a peer wedged on something that is not our problem. Waiting
-#: longer than the work can possibly take buys nothing and costs a hung connect,
-#: so we give up and let the SDK's own refresh path handle it (see
+#: Bound on ACQUIRING the cross-process refresh lock, derived from the budget of
+#: the critical section it guards: one token POST plus a couple of SQLite reads.
+#: That derivation is only sound because the POST is capped in TOTAL wall time
+#: (see the ``asyncio.timeout`` in :func:`_refresh_oauth_token_locked`) —
+#: ``httpx.Timeout(REFRESH_HTTP_TIMEOUT_S)`` alone does NOT bound a request:
+#: it is per operation, and its read timeout is per socket read, so a dribbling
+#: server measured 140.7s inside a nominal 10s timeout. Keep the two in step: if
+#: the POST's cap is ever raised or removed, this bound stops being honest and a
+#: slow-but-working peer starts getting timed out by its own siblings.
+#: Overrunning this bound therefore means the holder really is not working — a
+#: leaked lock from a killed process, or a peer wedged on something that is not
+#: our problem. Waiting longer than the work can possibly take buys nothing and
+#: costs a hung connect, so we give up and degrade (see
 #: :func:`_oauth_refresh_lock`, which yields False rather than raising).
 LOCK_ACQUIRE_TIMEOUT_S = 15.0
 
-#: Gap between non-blocking lock attempts. Short enough that a released lock is
-#: picked up promptly and that a cancelled acquire abandons the retry loop
-#: within one tick, long enough that waiting out the full bound costs a few
-#: hundred cheap syscalls rather than a hot spin.
+#: FIRST gap between non-blocking lock attempts, and the cancellation
+#: granularity: a cancelled acquire abandons the retry loop within one sleep,
+#: so this also bounds how long an abandoned worker lingers. Small, because the
+#: overwhelmingly common contended case is a peer finishing in a moment and
+#: pickup latency is what the user feels.
 _LOCK_RETRY_SLEEP_S = 0.05
+
+#: Ceiling for the backoff below. A fixed 50 ms gap would cost ~300 wakeups per
+#: contended acquire per server, and six OAuth servers connecting together would
+#: run six worker threads ticking for up to the full bound against a default
+#: executor of 18. Backing off to a quarter second cuts that by most while
+#: leaving the fast case untouched, since a lock still free after a few seconds
+#: is a leaked one we are going to abandon anyway.
+_LOCK_RETRY_SLEEP_MAX_S = 0.25
 
 
 class McpAuthRequiredError(RuntimeError):
@@ -1413,13 +1427,18 @@ def _acquire_locked_fd(path: str, cancelled: threading.Event) -> int | None:
     """
     deadline = time.monotonic() + LOCK_ACQUIRE_TIMEOUT_S
     fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    sleep_s = _LOCK_RETRY_SLEEP_S
     try:
         while True:
             if _try_lock_exclusive(fd):
                 return fd
             if cancelled.is_set() or time.monotonic() >= deadline:
                 break
-            time.sleep(_LOCK_RETRY_SLEEP_S)
+            time.sleep(sleep_s)
+            # Gentle geometric backoff: keeps pickup fast for the common
+            # released-in-a-moment case, then stops burning wakeups once the
+            # holder is evidently not finishing soon.
+            sleep_s = min(sleep_s * 1.5, _LOCK_RETRY_SLEEP_MAX_S)
     except BaseException:
         os.close(fd)
         raise
@@ -1484,7 +1503,9 @@ async def _oauth_refresh_lock(server_url: str):
     exchange, and RE-READING the stored token after acquiring it, guarantees
     exactly one process performs the refresh no matter how many sessions start
     at once. The lock file lives next to ``auth.db``, is per server (see
-    :func:`_oauth_refresh_lock_path`), and is only ever flocked, never written.
+    :func:`_oauth_refresh_lock_path`), and carries no state: it is only ever
+    flocked, never read or written for content (on Windows it holds a single
+    padding byte, which ``msvcrt.locking`` requires to have a range to lock).
 
     Yields True when the lock was taken and False when the bounded acquire gave
     up. A False body must still be SAFE to run: the guarantee degrades from
@@ -1553,6 +1574,13 @@ def _close_abandoned_lock_fd(task: asyncio.Task[int | None]) -> None:
     the loop. Without it a lock acquired just as its waiter was cancelled would
     leak the descriptor and, worse, keep the lock held for the process's life.
     """
+    # On both of these paths the WORKER has already closed the fd itself, so
+    # there is nothing here to clean up: a cancelled task never returns one,
+    # and an exception unwinds through :func:`_acquire_locked_fd`'s
+    # ``except BaseException``, which closes before re-raising. That coupling is
+    # what makes the early returns safe — an edit that moves the ``os.open``
+    # into the ``try``, or adds a ``return fd`` ahead of the loop, would leak
+    # both the descriptor AND the lock here with no diagnostic.
     if task.cancelled():
         return
     if task.exception() is not None:
@@ -1707,9 +1735,30 @@ async def _refresh_oauth_token_locked(
         headers["Authorization"] = f"Basic {encoded}"
 
     try:
-        async with httpx.AsyncClient(timeout=httpx.Timeout(REFRESH_HTTP_TIMEOUT_S)) as client:
-            response = await client.post(token_endpoint, data=data, headers=headers)
-    except httpx.HTTPError:
+        # TOTAL wall-clock cap, not just httpx's per-operation timeouts.
+        # ``httpx.Timeout(N)`` sets connect/read/write/pool to N EACH, and the
+        # read timeout applies per socket read rather than to the whole
+        # response — so a server that dribbles the body stays inside every
+        # individual read and takes arbitrarily long. Measured against a server
+        # sending one byte every 2s, this exact request returned HTTP 200 after
+        # 140.7s with the 10s timeout set and never tripping it.
+        #
+        # That matters because this call runs UNDER the cross-process refresh
+        # lock, and ``LOCK_ACQUIRE_TIMEOUT_S`` is derived from the claim that
+        # the section is bounded by ``REFRESH_HTTP_TIMEOUT_S``. Without an
+        # overall cap that claim is false, and a slow-but-honest provider would
+        # systematically push every peer past its acquire bound onto the
+        # unlocked degrade path — which for the in-flight coordinator means the
+        # SDK's own unlocked refresh, i.e. the rotating-token double-spend this
+        # subsystem exists to prevent, reached by timeout instead of by race.
+        # Bounding the POST is what makes the documented budget true.
+        async with asyncio.timeout(REFRESH_HTTP_TIMEOUT_S):
+            async with httpx.AsyncClient(timeout=httpx.Timeout(REFRESH_HTTP_TIMEOUT_S)) as client:
+                response = await client.post(token_endpoint, data=data, headers=headers)
+    except (httpx.HTTPError, TimeoutError):
+        # ``asyncio.timeout`` raises TimeoutError (which ``httpx.HTTPError``
+        # does not cover); a refresh that overran its budget is simply a failed
+        # refresh, handled exactly like a transport error.
         logger.debug("MCP token refresh request failed for %s", server_url, exc_info=True)
         return False
     if response.status_code != 200:
@@ -1991,10 +2040,13 @@ def _make_refresh_coordinating_provider(
     class _RefreshCoordinatingOAuthProvider(OAuthClientProvider):
         # Bound on the re-read/refresh interception: a stuck lock acquisition or
         # a hung endpoint must not park an authenticated request forever. The
-        # file lock is only ever held for one token POST (REFRESH_HTTP_TIMEOUT_S)
-        # plus the SQLite read, so a peer that legitimately holds it clears well
-        # inside this bound; overrunning it means a leaked lock, and degrading to
-        # the SDK's own refresh is strictly better than blocking the request.
+        # file lock is only ever held for one token POST plus the SQLite read,
+        # and that POST is bounded in TOTAL wall time by the ``asyncio.timeout``
+        # in ``_refresh_oauth_token_locked`` (httpx's own per-operation timeout
+        # does not bound a dribbling response), so a peer that legitimately
+        # holds it clears well inside this bound. Overrunning it means a leaked
+        # lock, and degrading to the SDK's own refresh is strictly better than
+        # blocking the request.
         _refresh_coord_server_url = server_url
         _refresh_coord_storage = storage
         _refresh_coord_endpoints = endpoints

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -45,9 +45,11 @@ import contextlib
 import logging
 import os
 import sys
+import threading
 import time
 import weakref
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from urllib.parse import parse_qs, urlparse
 
@@ -102,6 +104,23 @@ REFRESH_SKEW_S = 60.0
 #: the token POST). A slow authorization server must not park the connect —
 #: the startup gate defers us, and the breaker bounds retries.
 REFRESH_HTTP_TIMEOUT_S = 10.0
+
+#: Bound on ACQUIRING the cross-process refresh lock, derived from the honest
+#: budget of the critical section it guards: one token POST (capped at
+#: ``REFRESH_HTTP_TIMEOUT_S``) plus a couple of SQLite reads. A peer that holds
+#: the lock legitimately therefore clears it well inside this bound, and
+#: overrunning it means the holder is not working — a leaked lock from a killed
+#: process, or a peer wedged on something that is not our problem. Waiting
+#: longer than the work can possibly take buys nothing and costs a hung connect,
+#: so we give up and let the SDK's own refresh path handle it (see
+#: :func:`_oauth_refresh_lock`, which yields False rather than raising).
+LOCK_ACQUIRE_TIMEOUT_S = 15.0
+
+#: Gap between non-blocking lock attempts. Short enough that a released lock is
+#: picked up promptly and that a cancelled acquire abandons the retry loop
+#: within one tick, long enough that waiting out the full bound costs a few
+#: hundred cheap syscalls rather than a hot spin.
+_LOCK_RETRY_SLEEP_S = 0.05
 
 
 class McpAuthRequiredError(RuntimeError):
@@ -1328,34 +1347,84 @@ async def _discover_oauth_endpoints_uncached(
         return None
 
 
-def _lock_exclusive(fd: int) -> None:
+def _try_lock_exclusive(fd: int) -> bool:
+    """ONE non-blocking attempt at the exclusive lock. True when taken.
+
+    Deliberately non-blocking on BOTH platforms. A blocking acquire parks a
+    worker thread inside the kernel on a descriptor the calling coroutine may
+    be about to close, and on macOS/BSD ``os.close()`` of a descriptor with a
+    sibling thread parked in ``flock()`` blocks until that ``flock()`` returns —
+    which, with the lock held by another process, is never. Called from the
+    event-loop thread's ``finally`` that is exactly the whole TUI freezing:
+    no repaint, no input. See :func:`_oauth_refresh_lock` for the full story.
+    Retrying a non-blocking attempt is strictly weaker than blocking and is the
+    only shape that stays cancellable, so do not "simplify" this back into
+    ``fcntl.flock(fd, fcntl.LOCK_EX)``.
+
+    Contention is the expected outcome and returns False; anything else is a
+    real fault (EBADF, EINVAL, an unsupported filesystem) that retrying cannot
+    fix, so it is raised for the caller to degrade on.
+    """
     if os.name == "nt":  # pragma: no cover - platform specific
         import errno as _errno
         import msvcrt
-        import time as _time
 
-        # ``LK_LOCK`` blocks but gives up after ~10 s (it retries once per
-        # second, ten times, then raises OSError) — while a peer legitimately
-        # holds the lock for up to REFRESH_HTTP_TIMEOUT_S of network time.
-        # Retry in a loop to match the POSIX flock's indefinite-block
-        # semantics; the loop is bounded generously rather than forever so a
-        # leaked lock (killed process) cannot park a connect eternally.
-        # Contention surfaces as EDEADLOCK/EACCES; anything else (EBADF,
-        # EINVAL) is a real fault that retrying cannot fix — raising it
-        # immediately beats hot-spinning the worker thread for the bound.
-        deadline = _time.monotonic() + 60.0
-        while True:
-            try:
-                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
-                return
-            except OSError as lock_err:
-                contended = lock_err.errno in (_errno.EDEADLOCK, _errno.EACCES)
-                if not contended or _time.monotonic() >= deadline:
-                    raise
+        try:
+            # ``msvcrt.locking`` locks a byte RANGE, so the file needs at least
+            # one byte to lock — an empty lock file would fail with EINVAL
+            # forever. Mirrors ``session_lease``'s handling of the same API.
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError as lock_err:
+            if lock_err.errno in (_errno.EDEADLOCK, _errno.EACCES, _errno.EAGAIN):
+                return False
+            raise
     else:
+        import errno as _errno
         import fcntl
 
-        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except OSError as lock_err:
+            if lock_err.errno in (_errno.EAGAIN, _errno.EACCES, _errno.EWOULDBLOCK):
+                return False
+            raise
+
+
+def _acquire_locked_fd(path: str, cancelled: threading.Event) -> int | None:
+    """Open ``path`` and take the exclusive lock on it, or give up. Worker-side.
+
+    Runs entirely on a worker thread and OWNS the descriptor for its whole life:
+    it opens the fd, retries the non-blocking acquire until the deadline, and on
+    any outcome other than success closes the fd ITSELF, in this same thread,
+    after the last lock syscall has returned. That ownership rule is the fix for
+    the deadlock — the event loop never closes a descriptor another thread might
+    still be inside a lock call on, because by construction no such moment
+    exists. Returns the locked fd on success (ownership passes to the caller,
+    which must unlock and close it) or ``None`` on timeout/cancellation.
+
+    ``cancelled`` is set by the coroutine when its await is cancelled, so an
+    abandoned acquire abandons the retry loop within one ``_LOCK_RETRY_SLEEP_S``
+    tick instead of holding a thread for the full bound.
+    """
+    deadline = time.monotonic() + LOCK_ACQUIRE_TIMEOUT_S
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        while True:
+            if _try_lock_exclusive(fd):
+                return fd
+            if cancelled.is_set() or time.monotonic() >= deadline:
+                break
+            time.sleep(_LOCK_RETRY_SLEEP_S)
+    except BaseException:
+        os.close(fd)
+        raise
+    os.close(fd)
+    return None
 
 
 def _unlock(fd: int) -> None:
@@ -1371,6 +1440,40 @@ def _unlock(fd: int) -> None:
         fcntl.flock(fd, fcntl.LOCK_UN)
 
 
+def _oauth_refresh_lock_path(server_url: str) -> Path:
+    """The lock file for ONE server's refresh exchange, in ``config_dir()``.
+
+    Keyed per server, because the race this lock exists to prevent is per
+    server: two processes spending the SAME server's rotating refresh token.
+    A single global lock file also serialised servers that can never race each
+    other, so one slow or unreachable provider parked every other server's
+    connect behind it — with six OAuth servers and several concurrent sessions
+    that is a queue nothing drains, and the observable symptom was two servers
+    connecting and the rest sitting on "connecting" forever.
+
+    The name is a SHA-256 digest of the URL rather than the URL itself: server
+    URLs contain ``/``, ``:`` and query strings that are not filename-safe, and
+    a digest is stable across runs and machines without any escaping scheme to
+    keep in step. Truncated to 16 hex chars — this namespaces a handful of
+    configured servers, not an adversarial keyspace.
+
+    The pre-fix global ``mcp_oauth_refresh.lock`` is deliberately left in place
+    and never cleaned up: another local-operator process running an older build
+    may still be using it, and deleting a file that a live peer holds an flock
+    on would silently drop that peer's mutual exclusion (its lock survives on
+    the unlinked inode while a new process creates a fresh file and takes an
+    uncontended lock). It is a zero-byte file; leaving it costs nothing.
+    """
+    import hashlib
+
+    from local_operator.paths import config_dir
+
+    lock_dir = config_dir()
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256(server_url.encode("utf-8")).hexdigest()[:16]
+    return lock_dir / f"mcp_oauth_refresh_{digest}.lock"
+
+
 @contextlib.asynccontextmanager
 async def _oauth_refresh_lock(server_url: str):
     """Serialize the refresh exchange across processes for one server.
@@ -1380,23 +1483,86 @@ async def _oauth_refresh_lock(server_url: str):
     first process's brand-new token. Holding an exclusive file lock around the
     exchange, and RE-READING the stored token after acquiring it, guarantees
     exactly one process performs the refresh no matter how many sessions start
-    at once. The lock file lives next to ``auth.db`` and is only ever flocked,
-    never written.
-    """
-    from local_operator.paths import config_dir
+    at once. The lock file lives next to ``auth.db``, is per server (see
+    :func:`_oauth_refresh_lock_path`), and is only ever flocked, never written.
 
-    lock_dir = config_dir()
-    lock_dir.mkdir(parents=True, exist_ok=True)
-    lock_path = lock_dir / "mcp_oauth_refresh.lock"
-    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    Yields True when the lock was taken and False when the bounded acquire gave
+    up. A False body must still be SAFE to run: the guarantee degrades from
+    "exactly one process refreshes" to "we tried", which is the best-effort
+    contract :func:`ensure_mcp_oauth_fresh` already documents. Blocking the
+    connect instead would trade a rare double-spend for a guaranteed hang.
+
+    Two rules this function exists to enforce, both learned from a freeze that
+    took the whole TUI down:
+
+    1. **The acquire is bounded and non-blocking.** A bare
+       ``fcntl.flock(fd, LOCK_EX)`` waits forever, so a lock leaked by a killed
+       process parks a connect eternally.
+    2. **The event loop never closes a descriptor a thread may be parked on.**
+       The acquiring thread owns its fd end to end (:func:`_acquire_locked_fd`
+       closes it itself on every non-success path), and the fd only ever
+       reaches this coroutine once no lock syscall is outstanding on it. This
+       matters because cancellation is routine here — ``/resume`` disposes the
+       manager, which cancels in-flight connect tasks mid-acquire — and on
+       macOS/BSD ``os.close()`` of a descriptor with a sibling thread inside
+       ``flock()`` blocks until that ``flock()`` returns. Called from a
+       ``finally`` on the event-loop thread, that stops the loop dead: the
+       screen freezes and never repaints. Do not reintroduce a blocking acquire
+       or an event-loop-side close of a possibly-in-use fd.
+    """
+    lock_path = _oauth_refresh_lock_path(server_url)
+    # Signals the worker to abandon its retry loop when our await is cancelled,
+    # so a cancelled acquire never leaves a thread running to the full bound.
+    cancelled = threading.Event()
+    # Acquire off the event loop: a contended lock must not stall other
+    # servers' connects. The lock is on the fd, so it survives the await.
+    acquire = asyncio.create_task(asyncio.to_thread(_acquire_locked_fd, str(lock_path), cancelled))
     try:
-        # Acquire off the event loop: a contended lock must not stall other
-        # servers' connects. The lock is on the fd, so it survives the await.
-        await asyncio.to_thread(_lock_exclusive, fd)
-        yield
+        fd = await asyncio.shield(acquire)
+    except asyncio.CancelledError:
+        # Hand the fd's fate entirely to the worker: tell it to stop, and let
+        # the (shielded, so still-running) task close whatever it opened once
+        # its last lock syscall has returned. We return immediately — nothing
+        # here touches the descriptor, which is what keeps the loop alive.
+        cancelled.set()
+        acquire.add_done_callback(_close_abandoned_lock_fd)
+        raise
+    if fd is None:
+        logger.debug(
+            "MCP OAuth refresh lock not acquired within %.0fs for %s; proceeding unlocked",
+            LOCK_ACQUIRE_TIMEOUT_S,
+            server_url,
+        )
+        yield False
+        return
+    try:
+        yield True
     finally:
+        # Safe to close on this thread: the worker returned the fd only after
+        # its lock call completed, so no thread is parked on it.
         with contextlib.suppress(Exception):
             _unlock(fd)
+        os.close(fd)
+
+
+def _close_abandoned_lock_fd(task: asyncio.Task[int | None]) -> None:
+    """Close a lock fd whose waiter was cancelled before it could take it.
+
+    Runs on the event loop when the shielded acquire finally settles, which is
+    AFTER the worker thread's last lock syscall — so this close can never block
+    the loop. Without it a lock acquired just as its waiter was cancelled would
+    leak the descriptor and, worse, keep the lock held for the process's life.
+    """
+    if task.cancelled():
+        return
+    if task.exception() is not None:
+        return
+    fd = task.result()
+    if fd is None:
+        return
+    with contextlib.suppress(Exception):
+        _unlock(fd)
+    with contextlib.suppress(OSError):
         os.close(fd)
 
 
@@ -1639,7 +1805,15 @@ async def ensure_mcp_oauth_fresh(
     ):
         return endpoints
 
-    async with _oauth_refresh_lock(server_url):
+    async with _oauth_refresh_lock(server_url) as locked:
+        if not locked:
+            # The bounded acquire gave up, so we cannot claim exclusivity and
+            # must not spend the rotating refresh token on a guess. Skip the
+            # PROACTIVE refresh and connect anyway: the SDK's own in-flow
+            # refresh still runs on the first 401, and the coordinator wrapper
+            # re-reads the store before it does. A skipped optimisation costs a
+            # round trip; blocking the connect costs the whole session.
+            return endpoints
         # Re-read under the lock: another session may have refreshed while we
         # waited. Spending a rotated refresh token a second time is exactly the
         # race this lock exists to prevent.
@@ -1837,11 +2011,19 @@ def _make_refresh_coordinating_provider(
             if ctx.is_token_valid() or not ctx.can_refresh_token():
                 return
             try:
-                async with _oauth_refresh_lock(self._refresh_coord_server_url):
+                async with _oauth_refresh_lock(self._refresh_coord_server_url) as locked:
                     # Re-read under the lock: a sibling process may have rotated
                     # the token while we waited. Adopting its result is what
                     # turns a double-spend into a no-op.
                     await self._resync_from_store(ctx)
+                    if not locked:
+                        # No exclusivity, so we must not perform the exchange
+                        # ourselves. The re-read above still upholds the
+                        # invariant that matters most (the SDK never spends an
+                        # in-memory refresh token older than storage's), and the
+                        # SDK's own refresh then proceeds — the pre-coordination
+                        # behaviour, which is the correct degrade.
+                        return
                     if ctx.is_token_valid():
                         return  # a peer already refreshed; do not spend again
                     # The invariant this whole block exists to guarantee: the
@@ -1919,6 +2101,9 @@ def _make_refresh_coordinating_provider(
             """
             try:
                 async with _oauth_refresh_lock(self._refresh_coord_server_url):
+                    # Adopt regardless of whether the lock was taken: this is a
+                    # READ, and reading the freshest persisted token is strictly
+                    # better than keeping a staler in-memory one even unlocked.
                     await self._resync_from_store(ctx)
             except Exception:  # noqa: BLE001 — best-effort; never break the request
                 logger.debug(
@@ -2097,6 +2282,9 @@ def _make_refresh_coordinating_provider(
             """
             try:
                 async with _oauth_refresh_lock(self._refresh_coord_server_url):
+                    # Adoption only READS the store and rewrites our own header;
+                    # it never spends the refresh token, so an unlocked pass is
+                    # safe and still beats handing a 401 straight to the SDK.
                     stored = await self.context.storage.get_tokens()
                     if stored is None or not stored.access_token:
                         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.1"
+version = "0.43.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -10,6 +10,7 @@ through the real SQLite store.
 from __future__ import annotations
 
 import contextlib
+import os
 from pathlib import Path
 from typing import Any
 
@@ -2326,3 +2327,220 @@ class TestRefreshOAuthTokenLocked:
         assert ok is True
         assert seen["ua"]  # non-empty
         assert seen["ua"].startswith("local-operator")
+
+
+class TestOAuthRefreshLock:
+    """The cross-process refresh lock must never park or freeze the event loop.
+
+    The bug these guard: the acquire was a bare blocking ``fcntl.flock(LOCK_EX)``
+    on a worker thread, and the ``finally`` closed the fd from the EVENT LOOP.
+    On macOS/BSD ``os.close()`` of a descriptor with a sibling thread parked in
+    ``flock()`` blocks until that ``flock()`` returns, so cancelling a connect
+    mid-acquire (exactly what ``/resume`` does when it disposes the manager)
+    froze the whole TUI: no repaint, no input, forever.
+    """
+
+    URL_A = "https://mcp.example.com/a"
+    URL_B = "https://mcp.example.com/b"
+
+    #: Command for a FOREIGN process that takes the lock and holds it. It must be
+    #: another process: ``flock`` is per open-file-description, so a second
+    #: acquire from this same process would not contend and would prove nothing.
+    _HOLDER_SRC = (
+        "import fcntl,os,sys,time;"
+        "fd=os.open(sys.argv[1],os.O_CREAT|os.O_RDWR,0o600);"
+        "fcntl.flock(fd,fcntl.LOCK_EX);"
+        "print('held',flush=True);"
+        "time.sleep(120)"
+    )
+
+    @contextlib.contextmanager
+    def _foreign_holder(self, path: Path) -> Any:
+        import subprocess
+        import sys as _sys
+
+        proc = subprocess.Popen(
+            [_sys.executable, "-c", self._HOLDER_SRC, str(path)],
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            assert proc.stdout is not None
+            assert proc.stdout.readline().strip() == "held"
+            yield proc
+        finally:
+            proc.kill()
+            proc.wait(timeout=10)
+
+    @pytest.fixture
+    def _cfg_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """An isolated config dir, so a test never contends with the developer's
+        own running sessions (several ``lop`` processes share the real one)."""
+        from local_operator.paths import CONFIG_DIR_ENV
+
+        monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path))
+        return tmp_path
+
+    def test_each_server_gets_its_own_lock_file(self, _cfg_dir: Path) -> None:
+        """A global lock made every OAuth server queue behind the slowest one, so
+        one unreachable provider left the rest stuck on "connecting" forever."""
+        from local_operator.mcp import auth as auth_mod
+
+        path_a = auth_mod._oauth_refresh_lock_path(self.URL_A)
+        path_b = auth_mod._oauth_refresh_lock_path(self.URL_B)
+
+        assert path_a != path_b
+        assert path_a.parent == _cfg_dir
+        # Stable across calls, or two processes would pick different files for
+        # the same server and never actually exclude each other.
+        assert path_a == auth_mod._oauth_refresh_lock_path(self.URL_A)
+
+    #: The cancel-mid-acquire dance, run in a CHILD process on purpose. Against
+    #: the pre-fix code the event loop is genuinely dead (the ``os.close`` in the
+    #: ``finally`` blocks it), so an in-process version of this test would hang
+    #: the whole suite instead of failing — ``asyncio.wait_for`` cannot fire on a
+    #: loop that is not running. A child with a hard timeout turns that hang into
+    #: a deterministic assertion failure.
+    _CANCEL_PROBE_SRC = """
+import asyncio, os, sys
+sys.path.insert(0, os.environ["LO_REPO"])
+from local_operator.mcp import auth as auth_mod
+
+URL = sys.argv[1]
+
+async def main() -> None:
+    entered = asyncio.Event()
+
+    async def acquire() -> None:
+        entered.set()
+        async with auth_mod._oauth_refresh_lock(URL):
+            pass
+
+    ticks = 0
+
+    async def heartbeat() -> None:
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    hb = asyncio.create_task(heartbeat())
+    task = asyncio.create_task(acquire())
+    await entered.wait()
+    await asyncio.sleep(0.2)
+    before = ticks
+    task.cancel()
+    try:
+        await asyncio.wait_for(task, timeout=10.0)
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        pass
+    await asyncio.sleep(0.1)
+    hb.cancel()
+    # Printed ONLY if the loop was still scheduling throughout the unwind.
+    print("UNWOUND", ticks > before, flush=True)
+
+asyncio.run(main())
+"""
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX flock semantics")
+    @pytest.mark.asyncio
+    async def test_cancelling_mid_acquire_unwinds_without_blocking_the_loop(
+        self, _cfg_dir: Path
+    ) -> None:
+        """THE regression guard for the ``/resume`` freeze.
+
+        With a foreign process holding the lock, cancel a task inside the
+        acquire (what disposing the MCP manager does to in-flight connects) and
+        require the unwind to finish promptly with the event loop still
+        scheduling. Pre-fix, the child never prints and this fails on timeout.
+        """
+        import subprocess
+        import sys as _sys
+
+        from local_operator.mcp import auth as auth_mod
+
+        # Hold BOTH the per-server file and the legacy global one, so the probe
+        # is genuinely contended whichever naming the code under test uses.
+        held = {_cfg_dir / "mcp_oauth_refresh.lock"}
+        path_fn = getattr(auth_mod, "_oauth_refresh_lock_path", None)
+        if path_fn is not None:
+            held.add(path_fn(self.URL_A))
+
+        with contextlib.ExitStack() as stack:
+            for path in sorted(held):
+                stack.enter_context(self._foreign_holder(path))
+
+            env = dict(os.environ)
+            env["LO_REPO"] = str(Path(__file__).resolve().parents[3])
+            env["LOCAL_OPERATOR_CONFIG_DIR"] = str(_cfg_dir)
+            proc = subprocess.run(
+                [_sys.executable, "-c", self._CANCEL_PROBE_SRC, self.URL_A],
+                capture_output=True,
+                text=True,
+                timeout=90,
+                env=env,
+            )
+
+        assert "UNWOUND True" in proc.stdout, (
+            "cancellation did not unwind with the loop alive; "
+            f"stdout={proc.stdout!r} stderr={proc.stderr[-2000:]!r}"
+        )
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX flock semantics")
+    @pytest.mark.asyncio
+    async def test_a_held_lock_is_abandoned_at_the_deadline_not_waited_on_forever(
+        self, _cfg_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A leaked lock (killed process) must not park a connect eternally: the
+        acquire gives up at the bound and yields False so the caller degrades to
+        the SDK's own refresh instead of hanging."""
+        import asyncio
+        import time as _time
+
+        from local_operator.mcp import auth as auth_mod
+
+        # Shrink the bound so the test costs a moment, not the real budget.
+        monkeypatch.setattr(auth_mod, "LOCK_ACQUIRE_TIMEOUT_S", 0.5)
+        lock_path = auth_mod._oauth_refresh_lock_path(self.URL_A)
+
+        with self._foreign_holder(lock_path):
+            started = _time.monotonic()
+            async with asyncio.timeout(20):
+                async with auth_mod._oauth_refresh_lock(self.URL_A) as locked:
+                    elapsed = _time.monotonic() - started
+                    # Degraded, but the body RAN: the connect proceeds.
+                    assert locked is False
+            assert elapsed < 10.0
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX flock semantics")
+    @pytest.mark.asyncio
+    async def test_one_servers_held_lock_does_not_delay_another_server(
+        self, _cfg_dir: Path
+    ) -> None:
+        """The contention this bug manufactured: with a shared lock file, a stuck
+        server B blocked server A's connect even though they can never race."""
+        import asyncio
+        import time as _time
+
+        from local_operator.mcp import auth as auth_mod
+
+        held = auth_mod._oauth_refresh_lock_path(self.URL_B)
+
+        with self._foreign_holder(held):
+            started = _time.monotonic()
+            async with asyncio.timeout(20):
+                async with auth_mod._oauth_refresh_lock(self.URL_A) as locked:
+                    assert locked is True  # uncontended
+            assert _time.monotonic() - started < 5.0
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX flock semantics")
+    @pytest.mark.asyncio
+    async def test_the_lock_is_released_for_the_next_waiter(self, _cfg_dir: Path) -> None:
+        """Normal release still works: a second acquire after a clean exit gets
+        the lock rather than timing out against our own leaked descriptor."""
+        from local_operator.mcp import auth as auth_mod
+
+        async with auth_mod._oauth_refresh_lock(self.URL_A) as first:
+            assert first is True
+        async with auth_mod._oauth_refresh_lock(self.URL_A) as second:
+            assert second is True

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -2544,3 +2545,272 @@ asyncio.run(main())
             assert first is True
         async with auth_mod._oauth_refresh_lock(self.URL_A) as second:
             assert second is True
+
+
+class TestRefreshLockDegradePaths:
+    """What the CALLERS do when the bounded acquire gives up.
+
+    ``TestOAuthRefreshLock`` proves the context manager yields False at the
+    deadline; these pin the thing that makes yielding False safe. The rule is
+    the same at both call sites: never SPEND the rotating refresh token without
+    exclusivity, but still adopt whatever a sibling already persisted. Getting
+    that ordering wrong is how a degrade turns into the double-spend the lock
+    exists to prevent.
+    """
+
+    URL = "https://mcp.example.com/v1/mcp"
+
+    def _cfg(self) -> MCPHttpServerConfig:
+        return MCPHttpServerConfig(url=self.URL, auth=MCPAuthConfig(type="oauth"))
+
+    def _endpoints(self):
+        from mcp.shared.auth import OAuthMetadata
+
+        from local_operator.mcp.auth import DiscoveredOAuthEndpoints
+
+        return DiscoveredOAuthEndpoints(
+            oauth_metadata=OAuthMetadata.model_validate(
+                {
+                    "issuer": self.URL,
+                    "authorization_endpoint": "https://a/authorize",
+                    "token_endpoint": "https://a/token",
+                }
+            )
+        )
+
+    @staticmethod
+    def _unlocked_lock_stub():
+        """A ``_oauth_refresh_lock`` that always reports "not acquired"."""
+
+        @contextlib.asynccontextmanager
+        async def stub(server_url: str):
+            yield False
+
+        return stub
+
+    @pytest.mark.asyncio
+    async def test_ensure_fresh_skips_the_exchange_when_the_lock_is_not_taken(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The proactive refresh must be SKIPPED, not attempted unlocked: without
+        exclusivity a second process may be spending the same rotating token."""
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp import auth as auth_mod
+
+        auth_mod._DISCOVERED_ENDPOINTS_CACHE.clear()
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        # Expired, so the refresh path is genuinely reached.
+        await storage.set_tokens(
+            OAuthToken(access_token="a-old", refresh_token="r-old", expires_in=1)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+
+        endpoints = self._endpoints()
+
+        async def fake_discover(url: str):
+            return endpoints
+
+        refreshed = {"n": 0}
+
+        async def fake_refresh(*args: Any, **kwargs: Any) -> bool:
+            refreshed["n"] += 1
+            return True
+
+        monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", fake_discover)
+        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", fake_refresh)
+        monkeypatch.setattr(auth_mod, "_oauth_refresh_lock", self._unlocked_lock_stub())
+
+        result = await auth_mod.ensure_mcp_oauth_fresh(self.URL, self._cfg(), store=store)
+
+        assert refreshed["n"] == 0  # no token spent without the lock
+        # Still returns the endpoints, so the CONNECT proceeds rather than
+        # hanging -- degrade, never block.
+        assert result is endpoints
+
+    @pytest.mark.asyncio
+    async def test_ensure_fresh_does_spend_the_token_when_the_lock_is_taken(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The control for the test above: with the lock held the exchange runs,
+        so the skip is attributable to the degrade and not to some other gate."""
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp import auth as auth_mod
+
+        auth_mod._DISCOVERED_ENDPOINTS_CACHE.clear()
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        await storage.set_tokens(
+            OAuthToken(access_token="a-old", refresh_token="r-old", expires_in=1)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+
+        endpoints = self._endpoints()
+
+        async def fake_discover(url: str):
+            return endpoints
+
+        refreshed = {"n": 0}
+
+        async def fake_refresh(*args: Any, **kwargs: Any) -> bool:
+            refreshed["n"] += 1
+            return True
+
+        @contextlib.asynccontextmanager
+        async def locked_stub(server_url: str):
+            yield True
+
+        monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", fake_discover)
+        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", fake_refresh)
+        monkeypatch.setattr(auth_mod, "_oauth_refresh_lock", locked_stub)
+
+        await auth_mod.ensure_mcp_oauth_fresh(self.URL, self._cfg(), store=store)
+
+        assert refreshed["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_inflight_coordination_resyncs_before_it_degrades(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The ordering that makes the in-flight degrade safe.
+
+        When the lock is not taken the coordinator must STILL re-read the store
+        first, then return without exchanging. The re-read is what upholds the
+        invariant that the SDK's own unlocked refresh never runs with an
+        in-memory refresh token older than what a sibling persisted; dropping it
+        (or returning before it) reintroduces the family-revoking double-spend.
+        """
+        import time as _time
+
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        await storage.set_tokens(
+            OAuthToken(access_token="a-old", refresh_token="r-old", expires_in=60)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+        # Age the issue time past the lifetime so the loaded token reads as
+        # EXPIRED -- the coordinator only intercepts when the SDK itself would
+        # refresh, which is the gate this test needs open.
+        store.rows[0].data["tokens_obtained_at"] = _time.time() - 600
+
+        provider = build_oauth_provider(
+            self.URL, self._cfg(), store=store, endpoints=self._endpoints()
+        )
+
+        refreshed = {"n": 0}
+
+        async def fake_refresh(*args: Any, **kwargs: Any) -> bool:
+            refreshed["n"] += 1
+            return True
+
+        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", fake_refresh)
+        monkeypatch.setattr(auth_mod, "_oauth_refresh_lock", self._unlocked_lock_stub())
+
+        ctx = provider.context
+        async with ctx.lock:
+            if not provider._initialized:
+                await provider._initialize()
+
+        # A sibling process rotates the token while we hold only a stale copy.
+        await storage.set_tokens(
+            OAuthToken(access_token="a-peer", refresh_token="r-peer", expires_in=3600)
+        )
+
+        await provider._coordinate_inflight_refresh()
+
+        # No exchange without the lock ...
+        assert refreshed["n"] == 0
+        # ... but the peer's token WAS adopted, which is the whole point.
+        assert ctx.current_tokens is not None
+        assert ctx.current_tokens.access_token == "a-peer"
+
+
+class TestCloseAbandonedLockFd:
+    """The done-callback that releases a lock nobody is waiting for any more.
+
+    Reached when a cancellation loses the race with a worker that goes on to WIN
+    the lock. Its failure mode is silent and durable: the fd stays open and the
+    lock stays held for the life of the process, so every later refresh for that
+    server degrades. No test reached it before.
+    """
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX flock semantics")
+    @pytest.mark.asyncio
+    async def test_a_won_but_abandoned_lock_is_released(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import asyncio
+        import subprocess
+        import sys as _sys
+
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.paths import CONFIG_DIR_ENV
+
+        monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path))
+        url = "https://mcp.example.com/abandoned"
+        lock_path = auth_mod._oauth_refresh_lock_path(url)
+
+        # Acquire for real, then hand the fd to the callback exactly as the
+        # cancellation arm does.
+        fd = auth_mod._acquire_locked_fd(str(lock_path), threading.Event())
+        assert fd is not None
+
+        async def _already_done() -> int:
+            return fd
+
+        task = asyncio.create_task(_already_done())
+        await task
+        auth_mod._close_abandoned_lock_fd(task)
+
+        # A FOREIGN process is the only honest witness: flock is per
+        # open-file-description, so a same-process attempt would succeed even if
+        # the callback had leaked the lock.
+        probe = subprocess.run(
+            [
+                _sys.executable,
+                "-c",
+                "import fcntl,os,sys;"
+                "fd=os.open(sys.argv[1],os.O_CREAT|os.O_RDWR,0o600);"
+                "\ntry:\n fcntl.flock(fd,fcntl.LOCK_EX|fcntl.LOCK_NB);print('FREE')\n"
+                "except OSError:\n print('HELD')",
+                str(lock_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert probe.stdout.strip() == "FREE", f"lock leaked: {probe.stdout!r}"
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_or_failed_acquire_is_a_no_op(self) -> None:
+        """Both early returns: the worker has already closed the fd on these
+        paths, so the callback must not touch a descriptor it does not own."""
+        import asyncio
+
+        from local_operator.mcp import auth as auth_mod
+
+        async def _boom() -> int:
+            raise OSError("open failed")
+
+        failed = asyncio.create_task(_boom())
+        with contextlib.suppress(OSError):
+            await failed
+        auth_mod._close_abandoned_lock_fd(failed)  # must not raise
+
+        async def _forever() -> int:
+            await asyncio.sleep(3600)
+            return -1
+
+        cancelled_task = asyncio.create_task(_forever())
+        await asyncio.sleep(0)
+        cancelled_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await cancelled_task
+        auth_mod._close_abandoned_lock_fd(cancelled_task)  # must not raise


### PR DESCRIPTION
# PR Description

## Summary of Changes

`/resume` froze the entire TUI, and MCP servers sat on "connecting" forever. Both
symptoms are one bug in `local_operator/mcp/auth.py::_oauth_refresh_lock`, where
three defects compound.

`/resume` disposes the MCP manager (`_cmd_resume` → `_resume_session` →
`_reload_session`), which cancels in-flight connect tasks. Those tasks were
parked in the OAuth refresh lock, whose acquire was a bare blocking
`fcntl.flock(fd, LOCK_EX)` on a worker thread — while its `finally` closed the
descriptor **from the event-loop thread**. On macOS/BSD, `close()` of a
descriptor with a sibling thread parked in `flock()` blocks until that `flock()`
returns. With the lock held by another process, that is never. The loop stopped
dead: no repaint, no input.

The `sample(1)` stack of a live stuck `lop` shows exactly this — the main thread
in `task_step → _gen_throw ×3 → async_gen_asend_throw → os_close → close` (a
cancellation thrown into the nested async context managers, landing in that
`finally`) while four `asyncio_N` worker threads sit in `fcntl_flock_impl →
flock`.

### D1 — the POSIX acquire was unbounded

`_lock_exclusive` bounded only the Windows path, with a 60s deadline loop whose
own docstring says the bound exists so "a leaked lock (killed process) cannot
park a connect eternally". POSIX — the platform this actually ships on — got a
bare blocking `flock`. A lock leaked by a killed process parked a connect
forever.

Now a bounded non-blocking `LOCK_EX|LOCK_NB` retry loop. The bound,
`LOCK_ACQUIRE_TIMEOUT_S = 15.0`, is derived from the honest budget of the section
it guards: one token POST (capped at `REFRESH_HTTP_TIMEOUT_S = 10.0`) plus a
SQLite read. A peer holding it legitimately clears well inside that; overrunning
it means the holder is not working, and waiting longer than the work can possibly
take buys nothing and costs a hung connect.

### D2 — cancellation stranded the worker, then `os.close()` deadlocked the loop

Restructured so the acquiring thread **owns its descriptor end to end**:
`_acquire_locked_fd` opens the fd, retries to the deadline, and on every
non-success path closes it *itself, on that thread, after its last lock syscall
has returned*. The fd only ever reaches the coroutine when no lock call is
outstanding on it, so by construction there is no moment at which the event loop
could close a descriptor a thread is parked on.

On cancellation the coroutine sets a `threading.Event` (so the worker abandons
its retry loop within one 50 ms tick rather than running to the full bound) and
hands the fd's fate to a done-callback on the shielded task. It touches the
descriptor itself not at all, which is what keeps the loop alive.

### D3 — the lock was global, which manufactured the contention

`_oauth_refresh_lock(server_url)` took `server_url` and **never used it**: every
server shared `config_dir()/mcp_oauth_refresh.lock`. All OAuth connects, across
all servers and all processes, serialised on one file. With six OAuth servers and
nine concurrent `lop` processes that queue never drained — only the two non-OAuth
servers (`google-workspace` stdio, `slack` static header) ever reached
"connected", matching the reported symptom exactly.

Observed live on the reporting machine while five wedged processes held it:

```
$ lsof ~/.local-operator/mcp_oauth_refresh.lock | tail -n +2 | awk '{print $2}' | sort -u
67593 68401 69760 70899 71531 92212
$ lsof ~/.local-operator/mcp_oauth_refresh.lock | tail -n +2 | wc -l
      28      # 28 fds held on ONE lock file
```

The lock is now keyed per server by a SHA-256 digest of the URL (URLs contain
`/`, `:` and query strings that are not filename-safe; a digest is stable across
runs and machines with no escaping scheme to keep in step).

**On the legacy global file:** deliberately left in place and not cleaned up.
Unlinking it would silently drop mutual exclusion for any peer process still
running an older build — its flock survives on the unlinked inode while a new
process creates a fresh file and takes an uncontended lock. It is a zero-byte
file; leaving it costs nothing.

### Degrade, never hang

On timeout the context manager yields `False` and the caller proceeds instead of
blocking. `ensure_mcp_oauth_fresh` skips the **proactive** refresh and connects
anyway; the SDK's own in-flow refresh still runs, and the coordinator wrapper
re-reads the store before it does. A skipped optimisation costs a round trip;
blocking the connect costs the session.

The caller was verified rather than assumed: `McpManager._ensure_oauth_fresh`
wraps the call in `except Exception` and logs at debug, so it tolerates both the
new return value and any `OSError` the acquire can still raise.

The coordinator's three call sites are handled by what they actually do. The two
read-only paths (`_adopt_freshest_stored_token`, `_adopt_peer_token_once`) adopt
the freshest stored token **regardless** of whether the lock was taken — they
only read and rewrite our own header, never spend the refresh token, so an
unlocked pass is safe and still beats the alternative. The one path that *would*
spend the token returns early when unlocked, after the re-read. That preserves
the invariant the coordinator exists for: the SDK never runs with an in-memory
refresh token older than storage.

### Audit for the same pattern elsewhere

Every `flock`/`os.close` pairing in the tree was checked for the close-on-blocked-fd
hazard:

- `session_lease.py::_stale_recovery_right` — **safe, left alone.** Already
  `LOCK_EX|LOCK_NB`, so no thread ever parks; the close cannot block.
- `tools/group_reaper.py::_ledger_lock` — blocking `flock`, but **not the same
  defect class**: it is a synchronous `@contextlib.contextmanager` on one thread,
  so there is no second thread for the close to race and no event loop to freeze.
  Reported, not fixed here.
- No other site pairs a blocking lock with a cross-thread close.

## Related Issue(s)

- User-reported `/resume` freeze and MCP servers stuck on "connecting" (no ticket).

## Impact

- No breaking changes, no dependency updates, no public API change.
- Version bumped to `0.43.2` (patch: a bug fix, per AGENTS.md versioning — no new
  capability).
- Behaviour change is strictly a removal of hangs. The refresh's race-freedom is
  unchanged in the common case; it degrades to best-effort only when the lock
  cannot be taken within 15s, which previously meant hanging forever.

## Testing Details

### The deadlock, reproduced on `origin/main` and fixed here

A probe holds the lock from a **foreign process** (flock is per open-file-
description, so a same-process acquire would not contend), enters the context
manager in a task, cancels it mid-acquire, and runs a heartbeat coroutine
standing in for the TUI's repaint pump.

**BEFORE — `origin/main` (e641a888).** The process had to be killed; even the
15s `asyncio.wait_for` never fired, because the event loop itself is dead:

```
$ cd /tmp/lop-lock-base && .venv/bin/python /tmp/lock_probe.py
foreign holder(s) hold: [.../mcp_oauth_refresh.lock, .../mcp_oauth_refresh_1cbd18bf1818c780.lock]
cancelling mid-acquire (loop ticks so far: 20)
TIMEOUT after 90.0s (process killed)
```

**AFTER — this branch:**

```
$ cd /tmp/lop-oauth-lock && .venv/bin/python /tmp/lock_probe.py
foreign holder(s) hold: [...]
cancelling mid-acquire (loop ticks so far: 20)
unwind took 0.00s
RESULT: OK — cancellation unwound in 0.000s, loop never blocked
```

### The bounded acquire and the per-server split, on the real code

```
$ cd /tmp/lop-oauth-lock && .venv/bin/python /tmp/lock_bound_probe.py
lock(A) = mcp_oauth_refresh_1cbd18bf1818c780.lock
lock(B) = mcp_oauth_refresh_fb39103c7d2edac2.lock
per-server split: YES

foreign process holds server A's lock (mcp_oauth_refresh_1cbd18bf1818c780.lock)
server B acquire: locked=True in 0.002s
server A acquire: locked=False after 15.03s
  -> body still ran, so the connect proceeds instead of hanging

B uncontended by A's held lock: PASS
A bounded at ~15s and degraded: PASS
```

### End-to-end on the refresh path, against the user's six real OAuth server URLs

The plain-connect path cannot discriminate the fix (with fresh tokens
`ensure_mcp_oauth_fresh` returns before ever taking the lock), so this drives the
path that *does* take it, with a scratch config dir and fabricated tokens — it
never touches the real `auth.db` and never spends a real refresh token.

**BEFORE — `origin/main`:** killed at 400s having printed **no scenario result at
all**; it never got past scenario A.

```
$ cd /tmp/lop-lock-base3 && .venv/bin/python /tmp/e2e_refresh_path.py
lock naming: GLOBAL (pre-fix)
--- 100s elapsed; still running? ---
STILL RUNNING -> main is DEADLOCKED
TIMEOUT after 400.0s (process killed)
```

**AFTER — this branch**, completing in ~15s:

```
lock naming: per-server
foreign process holds: mcp_oauth_refresh_1cbd18bf1818c780.lock

A. cancelling a connect mid-acquire (the /resume path)
   unwound in 0.000s | loop scheduling after unwind: True
   -> PASS

B. other servers' refresh path while notion's lock is held
   linear       locked=True  in   0.00s
   notion       locked=False in  15.05s  contended (expected)
   datadog      locked=True  in   0.00s
   cloudflare   locked=True  in   0.00s
   hubspot      locked=True  in   0.00s
   -> others unblocked: PASS
   -> held lock bounded+degraded: PASS
```

### End-to-end on the real app with the real config (7 servers)

The real `McpManager` against `~/.local-operator` — all 6 OAuth servers plus the
2 non-OAuth ones — **while the reporter's wedged processes still hold the legacy
global lock**:

```
$ cd /tmp/lop-oauth-lock && .venv/bin/python /tmp/e2e_mcp_connect.py
enabled servers (7): ['linear', 'google-workspace', 'slack', 'notion', 'datadog', 'cloudflare', 'hubspot']

startup finished in 1.6s (event-loop ticks: 26)

server                 status         detail
----------------------------------------------------------------------
linear                 connected
google-workspace       connected
slack                  connected
notion                 connected
datadog                connected
cloudflare             connected
hubspot                connected

servers still 'connecting': NONE
RESULT: PASS - every server reached a terminal state
```

### `/resume` into two real sessions, driving the actual TUI in a pty

The real `lop` TUI, booted with the real config, sent `/resume <id>`. The status
bar climbing `⊙ 2 → 7 MCP` and settling on "MCP ready" is the connect machinery
running live through the resume that used to freeze it.

Session `1835c1163ff4` ("Harden Against Credential Leak Patterns"):

```
$ NO_HOLD=1 env -u NO_COLOR TERM=xterm-256color python3 /tmp/resume_pty.py \
      /tmp/lop-oauth-lock 1835c1163ff4 fixed-real
[fixed-real] booted, 235446 bytes painted
[fixed-real] after /resume: 26507 bytes over 32s
[fixed-real] intervals that repainted: 2/12
[fixed-real] RESULT: PASS - app kept painting

$ grep -o "⊙ [0-9] MCP\|MCP ready: .*" /tmp/resume-fixed-real.txt | uniq | tail -3
⊙ 6 MCP
MCP ready: 7 servers, 203 tools
⊙ 7 MCP
```

Session `2d2a05bf777b` (the pasting session):

```
[fixed-real2] RESULT: PASS - app kept painting
⊙ 0 MCP → ⊙ 1 → 2 → 3 → 4 → 5 → 6 → 7 MCP
MCP ready: 7 servers, 203 tools
```

### Visual validation (AGENTS.md "Visual validation")

Frames exported from the **real `OperatorApp`** (which loads
`local_operator.tcss`), driven through a contended-then-cancelled connect, and
rendered and viewed rather than eyeballed as markup. The before-frame was taken
from a throwaway `origin/main` worktree, never by stashing.

- **before** (`origin/main`): the still is literally the *last frame the user
  ever sees* — the capture had to be taken **before** the cancel, because after
  it no screenshot is possible: the loop is dead. Status bar reads `connecting…`,
  and the process was still wedged 70s later having never reached the unwind.
- **after** (this branch): the cancel unwinds in **0.024s**, the app keeps
  painting, and a further user message renders after it ("the screen is still
  live and accepting input after the cancel") — proof the loop still schedules
  and the composer still accepts input.

### Regression test

`TestOAuthRefreshLock` in `tests/unit/mcp/test_auth.py` — five tests covering the
per-server split, the bounded degrade, cross-server non-contention, normal
release, and the cancellation guard.

The cancellation guard runs its probe in a **child process with a hard timeout**
on purpose: against the pre-fix code the loop is genuinely dead, so an in-process
version would hang the whole suite rather than fail (`asyncio.wait_for` cannot
fire on a loop that is not running). The child turns that hang into a
deterministic failure.

Verified to fail on `origin/main` **for the right reason** — the child genuinely
deadlocked for its full 90s bound:

```
$ cd /tmp/lop-lock-base && .venv/bin/python -m pytest tests/unit/mcp/test_auth.py \
      -k TestOAuthRefreshLock -q -p no:randomly
FAILED ...::test_cancelling_mid_acquire_unwinds_without_blocking_the_loop
    - subprocess.TimeoutExpired: Command '[...]' timed out after 90 seconds
FAILED ...::test_each_server_gets_its_own_lock_file
FAILED ...::test_one_servers_held_lock_does_not_delay_another_server
FAILED ...::test_a_held_lock_is_abandoned_at_the_deadline_not_waited_on_forever
FAILED ...::test_the_lock_is_released_for_the_next_waiter
5 failed in 121.46s (0:02:01)
```

And to pass on this branch in under two seconds:

```
$ cd /tmp/lop-oauth-lock && .venv/bin/python -m pytest tests/unit/mcp/test_auth.py \
      -k TestOAuthRefreshLock -q -p no:randomly
5 passed in 1.87s
```

### Gates

All four CI gates clean over the whole tree:

```
$ .venv/bin/python -m flake8 .                                   # clean
$ uvx --from black==26.1.0 black --check .                       # 592 files unchanged
$ uvx isort==5.13.2 --check .                                    # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .    # 0 errors
```

Full MCP suite:

```
$ .venv/bin/python -m pytest tests/unit/mcp -q
269 passed in 6.88s
```

Full unit suite: `8405 passed`. The 25 failures are **pre-existing and unrelated**
— 24 are `tests/unit/tools/test_eval_tool.py` failing on
`ModuleNotFoundError: No module named 'local_operator'` in its subprocess worker
(an artifact of the symlinked-venv worktree; they reproduce identically on the
untouched `~/local-operator` checkout), and one is an order-dependent flake in
`test_resume_subagents_todos.py` that passes in isolation on both trees. Neither
touches MCP auth.

### Note on the reporter's wedged processes

Several of their `lop` processes are currently wedged in this deadlock. None were
killed. Every test that needed a clean lock state used its own temporary
`LOCAL_OPERATOR_CONFIG_DIR`, and the real-config runs were done deliberately
*alongside* the wedged processes — which is what makes the "all 7 connected"
result meaningful rather than a clean-room artifact.
