### PR TITLE
chore(release): bump version to 0.43.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.2"
+version = "0.43.3"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
The OAuth refresh lock deadlock fix (#401) landed with a 0.43.2 bump, but v0.43.2 had already been tagged and published to PyPI while that PR was in review. Bumping to 0.43.3 so the fix ships under a version that can actually be released.

No functional change: version string only.

## Testing evidence

```
$ curl -s https://pypi.org/pypi/local-operator/json | python3 -c "import sys,json;print(json.load(sys.stdin)['info']['version'])"
0.43.2

$ gh release view v0.43.2 --json tag --jq .tag
v0.43.2
```

Both confirm 0.43.2 is taken, so main's version was unreleasable as-is.