### PR TITLE
test(ci): add a headless TUI end-to-end stage that catches event-loop freezes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,24 +234,47 @@ jobs:
           echo "error-path stdout is clean"
 
   tui-e2e:
-    runs-on: ubuntu-latest
+    # BOTH platforms, and macOS is the one that makes this job worth having.
+    #
     # This job exists because a FULLY GREEN unit suite did not catch a total
     # event-loop freeze. PR #401 fixed a deadlock in the MCP OAuth refresh
     # lock: an unbounded blocking `fcntl.flock` on a worker thread, then
-    # `os.close(fd)` on the event-loop thread during cancellation — and on
-    # macOS/BSD `close()` blocks while a sibling thread is parked in `flock()`
-    # on that descriptor. `/resume` cancels in-flight MCP connects, so typing
-    # it froze the whole TUI: banner and composer slid to the bottom and the
-    # app answered nothing, permanently. 8000+ unit tests passed throughout,
-    # because every piece was individually correct and NOTHING drove the
-    # assembled application. This stage drives it.
+    # `os.close(fd)` on the event-loop thread during cancellation. 8000+ unit
+    # tests passed throughout, because every piece was individually correct and
+    # NOTHING drove the assembled application. This stage drives it.
     #
+    # The deadlock is a macOS/BSD property: `close()` blocks there while a
+    # sibling thread is parked in `flock()` on that descriptor, and on Linux it
+    # simply returns. That is measured, not assumed — the same probe reports
+    # `close_blocked=True` on darwin and `close_blocked=False` (7.4 us) on
+    # linux. Running the resume test against the PRE-FIX tree (80df237b^) in
+    # `python:3.12-slim` gives `1 passed`, RC=0: the regression test passes
+    # against the regression. Sampling `sys._current_frames()` through that run
+    # catches the worker parked in `_lock_exclusive`, so the lock IS contended
+    # on Linux and the cancellation does happen — the loop just never wedges.
+    #
+    # So an ubuntu-only wiring would have shipped this stage green against the
+    # very commit it was built to catch. macOS is therefore not a nice-to-have
+    # leg: it is the only platform where the freeze guard can go red at all.
+    # Linux stays because the rest of the stage is genuinely platform-neutral
+    # (boot, the write-turn artifacts, the transcript replay and the
+    # interactivity assertion) and it is the faster, always-available runner.
+    #
+    # `fail-fast: false` so a macOS queue delay or a Linux-only regression each
+    # report on their own rather than cancelling the other leg's evidence.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     # NO fork gate, deliberately, unlike cli-sanity/server-sanity below. Those
     # need a real OpenRouter key, so they are skipped on fork PRs that cannot
     # have one. This job is scripted end to end — no key, no network, no model
-    # — precisely so the resume-liveness assertion runs on EVERY pull request
-    # including forks. A contributor reintroducing that deadlock has to see it
-    # go red on their own PR, which a secrets-gated job could never do.
+    # — so it runs on EVERY pull request including forks, and because the
+    # matrix includes macOS, a fork contributor reintroducing the deadlock sees
+    # it go red on their own PR on the macOS leg. Both halves are load-bearing:
+    # a secrets-gated job could not reach forks at all, and a Linux-only job
+    # would reach them and report green.
     #
     # Fully headless: Textual's own `run_test()` pilot paints into an in-memory
     # compositor, so there is no window, no display server and no TTY beyond
@@ -262,23 +285,25 @@ jobs:
       - type-check
       - test
       - pip-audit
-    # Generous relative to the ~11 s the suite takes when healthy: the failure
-    # mode under test is a hang, and each test carries its own tighter
-    # `faulthandler` bound (see tests/e2e/watchdog.py) that fires first with a
-    # full thread dump. This ceiling is only the backstop for a hang that
-    # somehow escapes those, so it should never be what reports a freeze.
-    timeout-minutes: 15
+    # Generous relative to the ~11 s the stage takes when healthy (~14 s on a
+    # macOS runner, which is slower and queues longer). The failure mode under
+    # test is a hang, and each test carries its own tighter `faulthandler`
+    # bound (see tests/e2e/watchdog.py) that fires first with a full thread
+    # dump — a pre-fix red lands in ~63 s. This ceiling is only the backstop
+    # for a hang that escapes those, so it should never be what reports a
+    # freeze; it is sized to absorb macOS install and queue time instead.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Set Up Python 3.12
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      # The `mcp` extra is load-bearing here, not incidental: the resume test
-      # drives the REAL OAuth refresh lock through the REAL McpManager, and
-      # without the SDK the manager short-circuits every server with
-      # MCP_SDK_MISSING_ERROR — so the connect never reaches the lock and the
-      # test passes while exercising nothing at all.
+      # `mcp` is a BASE dependency, so `.[dev]` is sufficient and this job does
+      # not name it. If it ever becomes an extra, this install must name it
+      # explicitly: without the SDK the manager short-circuits every server
+      # with MCP_SDK_MISSING_ERROR, the connect never reaches the OAuth lock,
+      # and the resume test would pass while exercising nothing at all.
       - name: Install Package
         run: |
           python -m pip install --upgrade pip
@@ -296,8 +321,14 @@ jobs:
             python -m pytest tests/e2e -m e2e -n0 -q
       - name: Report a hang's thread dump
         # A tripped watchdog kills the process, so pytest never gets to print
-        # anything: the stacks of the parked threads live only in this file,
+        # anything: the stacks of the parked threads live only in a dump file,
         # and without this step a freeze reports as a bare non-zero exit.
+        #
+        # Safe to run after ANY failure. A dump file survives only when a bound
+        # actually fired (every ordinary exit path removes its own), and only
+        # files carrying faulthandler's `Timeout (` marker are printed — so an
+        # ordinary assertion failure gets an explicit "not a hang" line rather
+        # than a fabricated timeout claim for a test that failed in seconds.
         if: failure()
         run: python -m tests.e2e.watchdog
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,74 @@ jobs:
           test -s err_err.txt || { echo "expected a diagnostic on stderr"; exit 1; }
           echo "error-path stdout is clean"
 
+  tui-e2e:
+    runs-on: ubuntu-latest
+    # This job exists because a FULLY GREEN unit suite did not catch a total
+    # event-loop freeze. PR #401 fixed a deadlock in the MCP OAuth refresh
+    # lock: an unbounded blocking `fcntl.flock` on a worker thread, then
+    # `os.close(fd)` on the event-loop thread during cancellation — and on
+    # macOS/BSD `close()` blocks while a sibling thread is parked in `flock()`
+    # on that descriptor. `/resume` cancels in-flight MCP connects, so typing
+    # it froze the whole TUI: banner and composer slid to the bottom and the
+    # app answered nothing, permanently. 8000+ unit tests passed throughout,
+    # because every piece was individually correct and NOTHING drove the
+    # assembled application. This stage drives it.
+    #
+    # NO fork gate, deliberately, unlike cli-sanity/server-sanity below. Those
+    # need a real OpenRouter key, so they are skipped on fork PRs that cannot
+    # have one. This job is scripted end to end — no key, no network, no model
+    # — precisely so the resume-liveness assertion runs on EVERY pull request
+    # including forks. A contributor reintroducing that deadlock has to see it
+    # go red on their own PR, which a secrets-gated job could never do.
+    #
+    # Fully headless: Textual's own `run_test()` pilot paints into an in-memory
+    # compositor, so there is no window, no display server and no TTY beyond
+    # what the harness makes itself. It needs no `xvfb` and must never grow a
+    # real browser or terminal dependency.
+    needs:
+      - lint
+      - type-check
+      - test
+      - pip-audit
+    # Generous relative to the ~11 s the suite takes when healthy: the failure
+    # mode under test is a hang, and each test carries its own tighter
+    # `faulthandler` bound (see tests/e2e/watchdog.py) that fires first with a
+    # full thread dump. This ceiling is only the backstop for a hang that
+    # somehow escapes those, so it should never be what reports a freeze.
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set Up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # The `mcp` extra is load-bearing here, not incidental: the resume test
+      # drives the REAL OAuth refresh lock through the REAL McpManager, and
+      # without the SDK the manager short-circuits every server with
+      # MCP_SDK_MISSING_ERROR — so the connect never reaches the lock and the
+      # test passes while exercising nothing at all.
+      - name: Install Package
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run headless TUI end-to-end tests
+        # `-m e2e` overrides the `-m "not e2e"` in pyproject's addopts, which
+        # keeps this stage out of the unit run (a fired watchdog exits the
+        # process, which under xdist would kill a worker carrying unrelated
+        # tests). `-n0`: these contend real flock lock files and drive whole
+        # app lifecycles, so they run serially rather than under xdist.
+        # `env -u NO_COLOR TERM=xterm-256color` is what the TUI suite needs to
+        # compose a real frame, same as the documented local invocation.
+        run: |
+          env -u NO_COLOR TERM=xterm-256color \
+            python -m pytest tests/e2e -m e2e -n0 -q
+      - name: Report a hang's thread dump
+        # A tripped watchdog kills the process, so pytest never gets to print
+        # anything: the stacks of the parked threads live only in this file,
+        # and without this step a freeze reports as a bare non-zero exit.
+        if: failure()
+        run: python -m tests.e2e.watchdog
+
   server-sanity:
     runs-on: ubuntu-latest
     # Live-LLM job — same fork-secret gate as cli-sanity.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,16 @@ TTY) and uses no API key, so its CI job carries **no fork gate** — unlike
 deliberate: the resume-liveness assertion is the regression guard, so it has to
 run on every PR including forks.
 
+**It runs on a `[ubuntu-latest, macos-latest]` matrix, and the macOS leg is the
+one that makes it a regression guard.** The deadlock is a macOS/BSD property —
+`close()` blocks there behind a sibling `flock()`, and on Linux it returns in
+microseconds. Measured, not assumed: the same probe reports `close_blocked=True`
+on darwin and `False` on linux, and the resume test run against the pre-fix tree
+(`80df237b^`) in `python:3.12-slim` reports `1 passed`. Linux still runs the
+stage because boot, the write-turn artifacts and the transcript replay are
+platform-neutral, but **do not drop the macOS leg** — without it this stage goes
+green against the exact commit it exists to catch.
+
 Gates, all of which must be clean before a PR. **Run them over the whole tree,
 exactly as CI does** — these are the commands from `.github/workflows/ci.yml`:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,36 @@ suite expects:
 env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui -q
 ```
 
+`tests/e2e` is a separate stage that drives the **assembled** application —
+boot, a real turn through a real tool, and `/resume` — and it is **deselected
+from the default run** (`-m "not e2e"` in `addopts`). Run it explicitly:
+
+```sh
+env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
+```
+
+It exists because the whole unit suite was green while the TUI was completely
+frozen (#401: a blocking `flock` in the MCP OAuth refresh lock deadlocked the
+event loop on `/resume`). Two things about it are load-bearing rather than
+stylistic, and both are documented at length in `tests/e2e/watchdog.py`:
+
+- **Its failure mode is a hang, not an assertion.** The deadlock parks two
+  threads inside syscalls, so `asyncio.wait_for`, thread watchdogs and
+  signal-based timeouts all fail to fire — verified, not assumed. Only
+  `faulthandler.dump_traceback_later(exit=True)` survives it, because it runs
+  in a C thread and needs no GIL. A tripped watchdog kills the process and
+  writes every thread's stack to a file; `python -m tests.e2e.watchdog` prints
+  it back.
+- **It is why the stage is deselected and runs `-n0`.** Under xdist a fired
+  watchdog would kill a worker carrying unrelated tests and report them as an
+  infrastructure error rather than as the freeze they are.
+
+It is fully headless (Textual's `run_test()` pilot, no window, no display, no
+TTY) and uses no API key, so its CI job carries **no fork gate** — unlike
+`cli-sanity`/`server-sanity`, whose live-LLM secrets force one. That is
+deliberate: the resume-liveness assertion is the regression guard, so it has to
+run on every PR including forks.
+
 Gates, all of which must be clean before a PR. **Run them over the whole tree,
 exactly as CI does** — these are the commands from `.github/workflows/ci.yml`:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,8 +290,28 @@ exclude = ["**/node_modules", "**/__pycache__", "**/.*", "docs"]
 # (capture disabled) both adds that noise and is incompatible with xdist,
 # which needs to capture worker output. Tests assert on return values and
 # rendered frames, never on uncaptured stdout, so neither flag was load-bearing.
-addopts = "-n auto"
+# `-m "not e2e"`: the headless TUI end-to-end stage (tests/e2e) is deselected
+# from the default run and gets its own CI job. Two reasons, both about the
+# fact that its failure mode is a HANG rather than an assertion:
+#
+#   1. It is bounded by `faulthandler.dump_traceback_later(exit=True)`, which
+#      is the only watchdog that survives the kernel-level deadlock it exists
+#      to catch (see tests/e2e/watchdog.py). When it fires it takes the whole
+#      process down — acceptable in a dedicated job, but in the unit run under
+#      xdist that would kill a worker carrying unrelated tests and report them
+#      as an infrastructure error rather than as the freeze they actually are.
+#   2. It contends real `flock` lock files and drives whole app lifecycles, so
+#      it is wall-clock bound work that does not belong in the fast inner loop.
+#
+# Run it explicitly with:
+#   env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0
+addopts = "-n auto -m \"not e2e\""
 testpaths = ["tests"]
+markers = [
+    # Applied by LOCATION in tests/e2e/conftest.py, so a module in that package
+    # cannot forget it and silently rejoin the unit run.
+    "e2e: headless end-to-end tests that drive the assembled TUI application",
+]
 
 # Coverage is measured through pytest-cov (`--cov`), which understands xdist
 # and merges each worker's data automatically — the plain `coverage run -m

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,11 @@
+"""Headless end-to-end tests that drive the real TUI application.
+
+Separate from ``tests/unit`` because these are a different KIND of test with a
+different failure mode. A unit test that breaks prints an assertion; a test in
+here breaks by HANGING, because the defects it exists to catch are event-loop
+freezes. That difference is why this package carries its own watchdog
+(:mod:`tests.e2e.watchdog`) and its own ``e2e`` marker, and why the default
+``pytest`` run deselects it (see ``addopts`` in ``pyproject.toml``): the
+bounding machinery is load-bearing rather than incidental, and it should not
+be paid for on every unit run.
+"""

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,91 @@
+"""Headless, isolated fixtures for the end-to-end TUI stage.
+
+Two properties every test here depends on, both enforced once rather than
+remembered per test:
+
+**Headless.** ``App.run_test()`` uses Textual's ``HeadlessDriver``, which
+allocates no terminal, opens no window and never touches a display server —
+the app paints into an in-memory compositor that the pilot reads back. The
+knobs pinned below close the remaining side channels a composed frame still
+has to the developer's machine: the terminal title escape, desktop
+notifications and the shimmer timer. These matter beyond tidiness because the
+target machine routinely runs dozens of concurrent agent sessions, and a test
+suite that repainted a real terminal title or raised a notification would be
+stealing attention from every one of them.
+
+**Isolated.** Everything session-shaped writes under a per-test config dir.
+``LOCAL_OPERATOR_CONFIG_DIR`` is what ``local_operator.paths.config_dir()``
+reads on every call, and it is also where the MCP OAuth refresh LOCK FILES
+live — so without this, a test that contends that lock would contend the one
+the developer's real sessions are using. The root ``tests/conftest.py`` already
+repoints HOME; this narrows it to the specific directory the code under test
+resolves.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+#: Applied to every test in this package by ``pytest_collection_modifyitems``
+#: below, so an individual module cannot forget it and quietly rejoin the unit
+#: run (where its watchdog would kill the whole worker on a hang).
+E2E_MARKER = "e2e"
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Mark everything collected from this package ``e2e``.
+
+    Marking by LOCATION rather than by a ``pytestmark`` each module repeats:
+    the marker is what keeps these out of the default run, and a module that
+    forgot it would be silently promoted into the unit suite.
+    """
+    here = Path(__file__).parent
+    for item in items:
+        path = getattr(item, "path", None)
+        if path is not None and here in Path(path).parents or path == here:
+            item.add_marker(E2E_MARKER)
+
+
+@pytest.fixture(autouse=True)
+def headless_tui_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """A scratch config dir plus the environment a composed frame needs.
+
+    ``TERM``/``NO_COLOR`` mirror ``tests/unit/tui/conftest.py``: the app reads
+    colour support from the environment, and a developer whose shell exports
+    ``NO_COLOR`` would otherwise drive a differently-composed app than CI does.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    # A repainting shimmer makes "did the loop keep painting" a question about
+    # an animation timer rather than about the loop; pinned off for the same
+    # reason the unit TUI suite pins it.
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_SHIMMER", "1")
+    # The two escape hatches that reach OUTSIDE the headless surface. Textual's
+    # headless driver already suppresses both (the app gates them on
+    # ``is_headless``), so these are defence in depth: if a future change ever
+    # emitted them from a non-driver path, they must not reach the developer's
+    # real terminal or notification centre while fifty other sessions are open.
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_TERMINAL_TITLE", "1")
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", "1")
+    # The splash fires a one-shot PyPI probe on mount. Same reasoning as the
+    # unit TUI conftest: an e2e test must not pay a network timeout, and must
+    # not depend on pypi.org being reachable from a CI runner.
+    monkeypatch.setattr(
+        "local_operator.tui.app.OperatorApp._check_for_update",
+        lambda self: None,
+    )
+    yield config_dir
+
+
+@pytest.fixture
+def workspace(headless_tui_env: Path) -> Path:
+    """The directory a driven turn is allowed to write into."""
+    path = headless_tui_env / "workspace"
+    path.mkdir(parents=True, exist_ok=True)
+    return path

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -45,7 +45,9 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     here = Path(__file__).parent
     for item in items:
         path = getattr(item, "path", None)
-        if path is not None and here in Path(path).parents or path == here:
+        # A collected item's ``path`` is always the test FILE, so testing
+        # against this package's directory in its parents is the whole check.
+        if path is not None and here in Path(path).parents:
             item.add_marker(E2E_MARKER)
 
 

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -1,0 +1,259 @@
+"""Building blocks shared by the end-to-end tests: real app, real session.
+
+The rule this module exists to hold is that as little as possible is faked.
+The tests here are the answer to "the whole unit suite was green while the app
+was completely frozen", so anything replaced by a double is a place the stage
+cannot see. What IS replaced, and why:
+
+* **The provider stream.** A scripted ``stream_fn`` replaces the network, not
+  the harness: the real :class:`~local_operator.session.session.Session` still
+  runs its real agent loop over the scripted events, executes real tools and
+  writes a real transcript. This is what makes the stage deterministic enough
+  to run on every PR including forks, which is where the regression under test
+  has to be caught. See ``tests/e2e/test_tui_e2e.py``'s module docstring for
+  the full split.
+
+* **OAuth endpoint discovery.** Two HTTP round trips to a server that does not
+  exist. Replaced by the SDK's own documented fallback shape so the refresh
+  path proceeds to the lock — which is the part under test — without a network.
+
+Everything else is production code: ``OperatorApp``, ``Session``,
+``Transcript``, ``McpManager``, the real tool implementations, and the real
+cross-process OAuth refresh lock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections.abc import AsyncIterator, Iterable, Sequence
+from pathlib import Path
+from typing import Any
+
+from local_operator.harness.types import (
+    AbortSignal,
+    ChatRequest,
+    Message,
+    ModelSpec,
+    StreamEndEvent,
+    StreamEvent,
+    StreamTextDelta,
+    StreamToolCallDelta,
+    TextContent,
+)
+from local_operator.session.session import Session
+from local_operator.session.transcript import Transcript
+
+#: A model spec no provider is ever asked about. ``provider="test"`` keeps the
+#: pricing and discovery paths on their unknown-model branches instead of
+#: reaching the model registry over the network.
+TEST_MODEL = ModelSpec(provider="test", model_id="e2e-model", context_window=100_000)
+
+#: How long the pilot may wait for the app to adopt its session before the
+#: test calls it a failure. Generous relative to the real cost (adoption is a
+#: handful of loop turns) because a slow CI runner must not flake; short enough
+#: that a genuinely stuck boot is reported by the assertion rather than by the
+#: watchdog, which gives a clearer message.
+ADOPT_TIMEOUT_S = 20.0
+
+
+class ScriptedStream:
+    """Replays one canned event list per model call; records the requests.
+
+    Mirrors ``tests/unit/session/test_session.py``'s stream double deliberately
+    — the session's contract with a provider is one place, and a second shape
+    for it here would be a second thing to keep in step.
+    """
+
+    def __init__(self, turns: Sequence[Sequence[StreamEvent]]) -> None:
+        self.turns = [list(turn) for turn in turns]
+        self.requests: list[ChatRequest] = []
+
+    def __call__(
+        self, request: ChatRequest, signal: AbortSignal | None = None
+    ) -> AsyncIterator[StreamEvent]:
+        self.requests.append(request)
+        # A call past the end of the script is a test bug (the loop re-entered
+        # when the author expected it to stop), and an IndexError names it
+        # exactly. Answering with a bare stop would hide the extra turn.
+        turn = self.turns[len(self.requests) - 1]
+
+        async def gen() -> AsyncIterator[StreamEvent]:
+            for event in turn:
+                yield event
+
+        return gen()
+
+
+def tool_call_turn(
+    *,
+    text: str,
+    tool_name: str,
+    tool_call_id: str,
+    arguments: dict[str, Any],
+) -> list[StreamEvent]:
+    """One model turn that says something and then asks for one tool call."""
+    return [
+        StreamTextDelta(delta=text),
+        StreamToolCallDelta(
+            index=0,
+            id=tool_call_id,
+            name=tool_name,
+            argument_delta=json.dumps(arguments),
+        ),
+        StreamEndEvent(stop_reason="toolUse"),
+    ]
+
+
+def text_turn(text: str) -> list[StreamEvent]:
+    """One model turn that just answers and stops."""
+    return [StreamTextDelta(delta=text), StreamEndEvent(stop_reason="stop")]
+
+
+def build_session(
+    directory: Path,
+    stream: Any,
+    *,
+    tools: Iterable[Any] = (),
+    cwd: Path | None = None,
+) -> Session:
+    """A REAL session over a real transcript directory.
+
+    ``yolo=True`` because these tests drive turns, not the approval prompt:
+    with the gate armed every tool call would park waiting for a keypress the
+    test is not sending, and the approval surface has its own dedicated unit
+    coverage (``tests/unit/tui/test_approvals_ux.py``).
+    """
+    return Session(
+        model=TEST_MODEL,
+        stream_fn=stream,
+        tools=list(tools),
+        transcript=Transcript(directory),
+        system_blocks_provider=lambda *_args: [],
+        yolo=True,
+        cwd=str(cwd) if cwd is not None else None,
+    )
+
+
+async def seed_transcript(directory: Path, messages: Sequence[Message]) -> Transcript:
+    """Write ``messages`` to a session directory as a prior conversation.
+
+    This is what makes ``/resume`` a real resume rather than a screen swap:
+    the resumed session is built over a directory that already holds a
+    transcript on disk, exactly as a session closed yesterday would.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    transcript = Transcript(directory)
+    for message in messages:
+        await transcript.append_message(message)
+    transcript.flush()
+    return transcript
+
+
+def user_message(text: str) -> Message:
+    return Message(role="user", content=[TextContent(text=text)])
+
+
+def assistant_message(text: str) -> Message:
+    return Message(role="assistant", content=[TextContent(text=text)], stop_reason="stop")
+
+
+async def wait_for_adoption(app: Any, pilot: Any, timeout_s: float = ADOPT_TIMEOUT_S) -> None:
+    """Pump the pilot until the app has adopted a session, or fail saying so.
+
+    Polling rather than awaiting an event because adoption happens inside a
+    Textual worker the test does not own a handle to; this is the same shape
+    ``tests/unit/tui/test_resumed_conversation_name.py`` uses.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if app._session is not None:
+            return
+        await pilot.pause()
+    raise AssertionError(
+        f"the app never adopted a session within {timeout_s:g}s; "
+        f"transcript on screen: {transcript_text(app)!r}"
+    )
+
+
+def transcript_text(app: Any) -> str:
+    """Every transcript block flattened to the plain text a user would read.
+
+    Reads what was actually COMPOSED rather than what the session holds, which
+    is the distinction the resume test needs: a session can carry history that
+    never reached the screen, and that is precisely the bug shape here.
+    """
+    from local_operator.tui.widgets.transcript import TranscriptView
+    from tests.unit.tui.test_app_pilot import _renderable_plain
+
+    try:
+        view = app.query_one(TranscriptView)
+    except Exception:  # noqa: BLE001 — a screen with no transcript reads as empty
+        return ""
+    return "\n".join(_renderable_plain(getattr(block, "renderable", "")) for block in view.blocks())
+
+
+async def drain(pilot: Any, cycles: int = 30) -> None:
+    """Let the app settle: mount, layout, paint, and any queued workers."""
+    for _ in range(cycles):
+        await pilot.pause()
+
+
+class LoopLiveness:
+    """Counts how many times the event loop came back to us, and how late.
+
+    The distinction this class exists to draw: a test that merely waits for a
+    frame to appear passes on a loop that painted once and then died. What has
+    to be asserted after ``/resume`` is that the loop is STILL SCHEDULING —
+    that it keeps handing control back at roughly the cadence asked for. So
+    this records both the number of resumptions and the worst gap between them.
+
+    Note that on a fully deadlocked process this object never gets to report
+    anything at all: the freeze under test parks the loop thread inside a
+    syscall, so no counter advances and nothing raises. That is not a gap in
+    this class — it is exactly why :mod:`tests.e2e.watchdog` exists and why the
+    liveness assertion must run INSIDE a ``bounded`` block.
+    """
+
+    def __init__(self) -> None:
+        self.resumptions = 0
+        self.worst_gap_s = 0.0
+
+    async def observe(self, pilot: Any, seconds: float, interval_s: float = 0.02) -> None:
+        """Pump the pilot for ``seconds``, recording cadence as it goes."""
+        deadline = time.monotonic() + seconds
+        last = time.monotonic()
+        while time.monotonic() < deadline:
+            await pilot.pause(interval_s)
+            now = time.monotonic()
+            self.worst_gap_s = max(self.worst_gap_s, now - last)
+            last = now
+            self.resumptions += 1
+
+    def assert_alive(self, *, minimum: int, ceiling_s: float, context: str) -> None:
+        """The loop kept scheduling, and never went quiet for ``ceiling_s``."""
+        assert self.resumptions >= minimum, (
+            f"the event loop scheduled only {self.resumptions} times after {context} "
+            f"(expected at least {minimum}): the loop stopped servicing work"
+        )
+        assert self.worst_gap_s < ceiling_s, (
+            f"the event loop went quiet for {self.worst_gap_s:.2f}s after {context} "
+            f"(ceiling {ceiling_s:g}s): the app froze rather than kept painting"
+        )
+
+
+async def dispose_quietly(*sessions: Any) -> None:
+    """Tear sessions down without letting teardown noise mask a real failure.
+
+    Bounded, because a session whose MCP manager is wedged is exactly what
+    these tests construct on purpose, and an unbounded dispose in a teardown
+    path would convert an informative assertion failure into a hang.
+    """
+    for session in sessions:
+        if session is None:
+            continue
+        try:
+            await asyncio.wait_for(session.dispose(), timeout=10.0)
+        except BaseException:  # noqa: BLE001 — teardown must never mask the real error
+            pass

--- a/tests/e2e/mcp_lock.py
+++ b/tests/e2e/mcp_lock.py
@@ -1,0 +1,170 @@
+"""Rig that puts a real MCP connect inside the real OAuth refresh lock.
+
+This is the load-bearing half of the ``/resume`` liveness test. To reproduce
+#401 the app has to reach the genuine article — ``_oauth_refresh_lock`` in
+``local_operator/mcp/auth.py``, taking a genuine ``flock`` on a genuine file —
+because the deadlock is a property of the syscalls, not of the control flow. A
+mocked lock cannot deadlock, so a test built on one would pass against the
+broken code.
+
+Getting there requires three conditions, all set up here:
+
+1. **The lock must be contended**, or the acquire succeeds instantly and the
+   cancellation window never opens. A foreign holder takes it first.
+2. **The stored grant must be expired**, or ``ensure_mcp_oauth_fresh`` returns
+   before it ever reaches the lock (a still-valid token is not refreshed).
+3. **Endpoint discovery must not touch the network**, or the refresh fails on
+   a DNS lookup well before the lock.
+
+The holder is a SEPARATE open file description on the same path, not a second
+``flock`` on the same fd. ``flock`` locks are held per open-file-description,
+so re-locking the same descriptor would silently succeed and the rig would
+quietly test nothing.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import os
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from tests.unit.mcp.test_auth import FakeAuthStore
+
+#: A URL that resolves nowhere. Nothing here may make a network call, and a
+#: reserved-by-RFC ``.test`` TLD makes an accidental one fail fast and loudly
+#: rather than reaching a real host.
+SERVER_URL = "https://mcp.invalid.test/mcp"
+
+
+class ManagedFakeAuthStore(FakeAuthStore):
+    """The unit suite's in-memory store, plus the ``close`` the manager needs.
+
+    ``McpManager``'s injected-store parameter is typed ``ManagedAuthStore`` —
+    ``StructuralAuthStore`` plus a ``close`` it calls in ``disconnect_all``
+    when it owns the store. The unit fake predates that surface and has no
+    database handle to release. Subclassing to add the one missing method keeps
+    the store's behaviour identical to the one the auth tests exercise, while
+    satisfying the protocol honestly rather than widening a production type or
+    silencing the type checker at the call site.
+    """
+
+    def close(self) -> None:
+        """Nothing to release: this store is a list in memory."""
+
+
+def candidate_lock_paths(config_dir: Path) -> list[Path]:
+    """Every lock filename the code under test might use, across versions.
+
+    #401 changed the lock from one global file to one file per server keyed by
+    a URL digest. This test has to hold BOTH: the whole point of the stage is
+    that it is run against the pre-fix code to prove it goes red, and a rig
+    that only knew the post-fix filename would leave the pre-fix lock
+    uncontended and pass against the very defect it exists to catch.
+
+    Keep this list append-only for the same reason.
+    """
+    digest = hashlib.sha256(SERVER_URL.encode("utf-8")).hexdigest()[:16]
+    return [
+        config_dir / "mcp_oauth_refresh.lock",  # before #401: one global lock
+        config_dir / f"mcp_oauth_refresh_{digest}.lock",  # after #401: per server
+    ]
+
+
+@contextmanager
+def foreign_lock_holder(config_dir: Path) -> Iterator[list[Path]]:
+    """Hold every candidate lock file for the duration of the block.
+
+    Simulates the peer this lock exists to coordinate with: another
+    local-operator process mid-refresh, or one that died holding the lock.
+    Both are ordinary on a machine running several sessions, and both are what
+    parks a connect long enough for a ``/resume`` to cancel it.
+    """
+    config_dir.mkdir(parents=True, exist_ok=True)
+    paths = candidate_lock_paths(config_dir)
+    fds: list[int] = []
+    try:
+        for path in paths:
+            fd = os.open(str(path), os.O_CREAT | os.O_RDWR, 0o600)
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            fds.append(fd)
+        yield paths
+    finally:
+        for fd in fds:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+
+
+def stub_endpoint_discovery(monkeypatch: Any) -> None:
+    """Answer OAuth metadata discovery locally instead of over HTTP.
+
+    Uses the module's OWN ``_fallback_endpoints_for`` — the shape the SDK
+    synthesizes when discovery finds nothing — so the refresh path proceeds
+    with a structurally real endpoint set rather than a hand-built stand-in
+    that could drift from what the code expects.
+    """
+    from local_operator.mcp import auth as auth_mod
+
+    async def _local_discovery(server_url: str) -> Any:
+        return auth_mod._fallback_endpoints_for(server_url)
+
+    monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", _local_discovery)
+
+
+async def seed_expired_grant(store: Any) -> None:
+    """Store a grant old enough that the proactive refresh actually runs.
+
+    ``ensure_mcp_oauth_fresh`` returns early for a token still inside its
+    lifetime, so without an EXPIRED one the connect never reaches the lock and
+    the test silently exercises nothing. ``tokens_obtained_at`` is backdated
+    because expiry is computed from it, mirroring
+    ``tests/unit/mcp/test_auth.py``'s day-old-grant setup.
+    """
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+    from local_operator.mcp.auth import McpTokenStorage
+
+    storage = McpTokenStorage(SERVER_URL, store)
+    await storage.set_client_info(
+        OAuthClientInformationFull(client_id="e2e-client", client_secret="e2e-secret")
+    )
+    # A refresh_token must be present: with none, the refresh is skipped.
+    await storage.set_tokens(
+        OAuthToken(access_token="expired-access", refresh_token="refresh", expires_in=1)
+    )
+    store.rows[0].data["tokens_obtained_at"] = time.time() - 86_400
+
+
+def oauth_server_config() -> Any:
+    """The server config that sends ``_connect_server`` down the OAuth path."""
+    from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+    return MCPHttpServerConfig(url=SERVER_URL, auth=MCPAuthConfig(type="oauth"))
+
+
+async def parked_mcp_manager(config_dir: Path, cwd: Path, monkeypatch: Any) -> Any:
+    """A real ``McpManager`` with a real connect parked inside the real lock.
+
+    Returns the manager with one server deferred past the startup gate and its
+    connect task sitting in ``_oauth_refresh_lock``'s acquire — the precise
+    state a TUI is in when a user types ``/resume`` while MCP servers are
+    still coming up, which is the state #401 deadlocked from.
+    """
+    from local_operator.mcp.manager import McpManager
+
+    stub_endpoint_discovery(monkeypatch)
+    store = ManagedFakeAuthStore()
+    await seed_expired_grant(store)
+
+    manager = McpManager(str(cwd), auth_store=store)
+    # The real discovery round: the 250 ms gate passes, the OAuth server misses
+    # it (it is parked in the lock), and the manager files a live continuation
+    # task for it. That deferred task is what a dispose then cancels.
+    await manager._connect_round({"e2e-oauth": oauth_server_config()}, {"e2e-oauth": "test"})
+    return manager

--- a/tests/e2e/test_tui_e2e.py
+++ b/tests/e2e/test_tui_e2e.py
@@ -44,6 +44,25 @@ OpenRouter turn through the real agent against a real file write on every
 non-fork PR. This stage adds the assembled-application coverage that job
 cannot give, and the two are complementary rather than redundant.
 
+Where the freeze is observable
+------------------------------
+
+Being ungated is necessary for that fork-PR reach but not sufficient, and the
+missing half is the PLATFORM. The deadlock is a macOS/BSD property: ``close()``
+blocks there while a sibling thread is parked in ``flock()`` on the descriptor,
+and Linux simply lets it return (measured at 7.4 us). The lock is genuinely
+contended on Linux and the cancellation genuinely happens — the loop just never
+wedges — so this file's resume test reports ``1 passed`` against the pre-fix
+tree there.
+
+That is why the CI job runs a ``[ubuntu-latest, macos-latest]`` matrix. Linux
+carries the platform-neutral coverage (startup, the write-turn artifacts, the
+transcript replay and the interactivity assertion); **macOS is the only leg on
+which the freeze guard can go red at all.** A Linux-only wiring would reach
+every fork PR and tell all of them green, which is a worse failure than not
+having the stage: it is a guard that reports success against the very commit it
+was built to catch.
+
 Bounding
 --------
 
@@ -95,7 +114,12 @@ SCREEN = (100, 30)
 #:
 #: Verified against the pre-fix code: the deadlock trips RESUME_BOUND_S and the
 #: watchdog dumps both parked threads, so the red arrives in about a minute
-#: rather than at the job's own timeout with no diagnostic.
+#: (measured 62.6 s) rather than at the job's own timeout with no diagnostic.
+#: That latency is RESUME_BOUND_S itself, not a property of the deadlock — the
+#: freeze is permanent, so the bound is the only thing deciding how long CI
+#: waits before reporting it. Tuning this number down buys a faster red and
+#: spends headroom against a loaded runner; there is no other signal that trades
+#: off, so make that trade deliberately.
 BOOT_BOUND_S = 45.0
 TURN_BOUND_S = 45.0
 RESUME_BOUND_S = 60.0

--- a/tests/e2e/test_tui_e2e.py
+++ b/tests/e2e/test_tui_e2e.py
@@ -1,0 +1,409 @@
+"""End-to-end: does the real TUI actually work, start to finish?
+
+Why this stage exists
+---------------------
+
+PR #401 fixed a total event-loop freeze. ``_oauth_refresh_lock`` took an
+unbounded blocking ``fcntl.flock`` on a worker thread and then, during
+cancellation, called ``os.close(fd)`` from the event-loop thread — and on
+macOS/BSD ``close()`` blocks while a sibling thread is parked in ``flock()`` on
+that descriptor. Typing ``/resume`` disposes the MCP manager, which cancels
+in-flight connects, which is exactly that sequence. The banner and composer
+slid to the bottom of the screen and the app stopped responding to anything,
+forever.
+
+**The whole unit suite — 8000+ tests — was green through all of it.** Every
+piece was individually correct; nothing drove the assembled application, so
+nothing noticed that it had stopped moving. That gap is what this file closes,
+and it is the reason the assertions here are about LIVENESS rather than about
+values: a frozen app has perfectly correct state, it just never paints again.
+
+What is real and what is scripted
+---------------------------------
+
+The provider is scripted; everything else is production code. ``OperatorApp``,
+``Session``, the agent loop, the real ``write`` tool, ``Transcript`` on real
+files, ``McpManager``, and — critically — the real ``flock``-based OAuth
+refresh lock. The model is the one thing replaced, for a deliberate reason:
+
+* **The regression is not model-shaped.** A frozen event loop and a missing
+  file are caught identically by a scripted turn and a live one, and the
+  scripted version catches them in three seconds with no API key.
+* **It has to run on fork PRs.** ``cli-sanity`` and ``server-sanity`` are gated
+  behind ``head.repo.full_name == github.repository`` because fork PRs get no
+  secrets. A live-model e2e stage would inherit that gate, and the ``/resume``
+  liveness assertion is precisely the check that must never be skipped — a
+  contributor's PR reintroducing the deadlock has to go red on their own PR.
+* **A hang test cannot be flaky.** This stage's failure signal is "something
+  did not finish in time". Putting a live network call inside that bound would
+  make provider latency indistinguishable from the deadlock it exists to
+  catch, and a hang test that cries wolf is one people start ignoring.
+
+The live-model path is not lost: ``cli-sanity`` already drives a real
+OpenRouter turn through the real agent against a real file write on every
+non-fork PR. This stage adds the assembled-application coverage that job
+cannot give, and the two are complementary rather than redundant.
+
+Bounding
+--------
+
+Every step that can hang runs inside :func:`tests.e2e.watchdog.bounded`. Read
+that module before changing a timeout: the failure mode here defeats
+``asyncio.wait_for``, thread watchdogs and signal-based timeouts alike, and the
+C-level ``faulthandler`` timer is the only bound that survives it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.session.session import Session
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.tool_card import ToolCard
+from tests.e2e import mcp_lock
+from tests.e2e.harness import (
+    LoopLiveness,
+    ScriptedStream,
+    assistant_message,
+    build_session,
+    dispose_quietly,
+    drain,
+    seed_transcript,
+    text_turn,
+    tool_call_turn,
+    transcript_text,
+    user_message,
+    wait_for_adoption,
+)
+from tests.e2e.watchdog import bounded
+
+#: Terminal geometry for every test here. Wide enough that the assertions are
+#: about content rather than about truncation, and identical across tests so a
+#: failure is never a layout difference between them.
+SCREEN = (100, 30)
+
+#: Bounds, in wall-clock seconds. Measured healthy costs on a dev machine are
+#: 1.7 s (boot), 2.5 s (turn) and 6.6 s (resume, of which 4 s is the deliberate
+#: liveness watch below), so these carry roughly an order of magnitude of
+#: headroom. That ratio is the point: these exist to catch a HANG — an infinite
+#: wait — not to police performance on a loaded shared runner. A tight bound
+#: here would produce flaky reds, and a flaky hang-detector is one people learn
+#: to rerun, which is exactly how a real freeze gets waved through.
+#:
+#: Verified against the pre-fix code: the deadlock trips RESUME_BOUND_S and the
+#: watchdog dumps both parked threads, so the red arrives in about a minute
+#: rather than at the job's own timeout with no diagnostic.
+BOOT_BOUND_S = 45.0
+TURN_BOUND_S = 45.0
+RESUME_BOUND_S = 60.0
+
+#: How long the loop is watched after ``/resume``, and what counts as alive.
+#: The pre-fix code scores ZERO resumptions here (the process is deadlocked in
+#: a syscall and the watchdog fires instead), so the floor only has to exclude
+#: "the loop came back a handful of times and stopped". At 20 ms per pump, 4 s
+#: of a healthy loop yields ~180 resumptions; 40 is a floor a loaded runner
+#: cannot dip below while still being unmistakably alive.
+LIVENESS_WATCH_S = 4.0
+LIVENESS_MIN_RESUMPTIONS = 40
+LIVENESS_MAX_GAP_S = 1.5
+
+
+@pytest.mark.asyncio
+async def test_the_app_boots_paints_a_frame_and_becomes_interactive(
+    headless_tui_env: Path,
+) -> None:
+    """Startup: the app reaches an interactive state and has painted something.
+
+    The floor the rest of the file stands on. "Interactive" is asserted as the
+    composer holding focus and accepting typed text that lands in its buffer —
+    a mounted widget tree alone proves only that ``compose`` ran, and the boot
+    failure this guards against (a session factory that never returns) leaves a
+    perfectly composed screen that answers no keys.
+    """
+    from local_operator.tui.widgets.editor import Editor
+
+    session = build_session(
+        headless_tui_env / "sessions" / "boot",
+        ScriptedStream([]),
+        cwd=headless_tui_env,
+    )
+
+    async def factory() -> Session:
+        return session
+
+    app = OperatorApp(factory)
+    try:
+        with bounded(BOOT_BOUND_S, "TUI boot to an interactive frame"):
+            async with app.run_test(size=SCREEN) as pilot:
+                await wait_for_adoption(app, pilot)
+                await drain(pilot)
+
+                # It painted: the compositor has real rows, not an empty buffer.
+                strips = app.screen._compositor.render_strips()
+                assert strips, "the app mounted but painted no frame at all"
+                painted = "\n".join(strip.text for strip in strips)
+                assert painted.strip(), "the app painted a frame with nothing on it"
+
+                # It is interactive: keystrokes reach the focused composer.
+                editor = app.query_one(Editor)
+                assert editor.has_focus, "the composer never took focus, so nothing can be typed"
+                await pilot.press(*"hello")
+                await drain(pilot, cycles=5)
+                assert "hello" in editor.text, (
+                    "typed keys never reached the composer buffer: the app painted "
+                    "a frame but is not servicing input"
+                )
+    finally:
+        await dispose_quietly(session)
+
+
+@pytest.mark.asyncio
+async def test_a_turn_writes_a_real_file_and_leaves_its_trace_on_screen(
+    headless_tui_env: Path,
+    workspace: Path,
+) -> None:
+    """A driven turn: real tool, real file on disk, real card, real transcript.
+
+    Four artifacts, deliberately, because each one can fail while the others
+    look fine: the file proves the tool RAN, the card proves the UI was told,
+    the transcript records prove it was PERSISTED (so a resume can replay it),
+    and the assistant prose proves the streamed text reached the screen. A test
+    asserting only the first would pass on an app that executed the turn
+    invisibly.
+    """
+    from local_operator.tools.builtin import build_write_tool
+
+    target = workspace / "e2e-artifact.txt"
+    content = "written by the tui e2e stage"
+
+    stream = ScriptedStream(
+        [
+            tool_call_turn(
+                text="Writing that file now.",
+                tool_name="write",
+                tool_call_id="e2e-write-1",
+                arguments={"path": str(target), "content": content},
+            ),
+            text_turn("Done: the file is on disk."),
+        ]
+    )
+    session_dir = headless_tui_env / "sessions" / "turn"
+    session = build_session(session_dir, stream, tools=[build_write_tool()], cwd=workspace)
+
+    async def factory() -> Session:
+        return session
+
+    app = OperatorApp(factory)
+    try:
+        with bounded(TURN_BOUND_S, "a full turn through the write tool"):
+            async with app.run_test(size=SCREEN) as pilot:
+                await wait_for_adoption(app, pilot)
+                await drain(pilot)
+
+                await session.prompt(f"write {content!r} to {target}")
+                await drain(pilot, cycles=40)
+
+                # 1. The durable artifact: the tool actually wrote the file.
+                assert target.is_file(), (
+                    f"the write tool left no file at {target}: "
+                    f"workspace holds {sorted(p.name for p in workspace.iterdir())}"
+                )
+                assert target.read_text(encoding="utf-8") == content
+
+                # 2. The trace on screen: a settled card for THAT call.
+                cards = list(app.query(ToolCard))
+                assert cards, (
+                    "the turn executed a tool but no tool card reached the transcript; "
+                    f"transcript reads: {transcript_text(app)!r}"
+                )
+                assert any(card.tool_name == "write" for card in cards), (
+                    "a tool card was mounted but none of them is the write call: "
+                    f"{[card.tool_name for card in cards]}"
+                )
+
+                # 3. The streamed prose reached the screen too, not just the card.
+                on_screen = transcript_text(app)
+                assert (
+                    "Writing that file now." in on_screen
+                ), f"the assistant's streamed text never painted; transcript: {on_screen!r}"
+
+                # 4. Persistence: the call AND its result are on disk, which is
+                # what a later resume replays. A turn that renders but does not
+                # persist looks identical until you resume it.
+                records = _transcript_records(session_dir)
+                assert _has_tool_call(records, "write"), (
+                    "the write call was never journalled to the transcript, so a "
+                    "resume of this session would replay a turn with no tool in it"
+                )
+                assert _has_tool_result(records, "write"), (
+                    "the write call was journalled without its result, which is the "
+                    "shape a session killed mid-turn leaves behind"
+                )
+    finally:
+        await dispose_quietly(session)
+
+
+@pytest.mark.asyncio
+async def test_resume_replays_the_transcript_and_the_loop_keeps_painting(
+    headless_tui_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE regression test for #401: ``/resume`` must not freeze the app.
+
+    The setup reproduces the reported conditions rather than approximating
+    them. The live session owns a real ``McpManager`` with a real OAuth connect
+    parked inside the real ``flock``-based refresh lock, held by a foreign
+    process — the ordinary state of a TUI whose MCP servers are still coming up
+    on a machine running several sessions. ``/resume`` then disposes that
+    manager, cancelling the parked connect, which is the exact sequence that
+    deadlocked: worker thread inside ``flock()``, event-loop thread inside
+    ``os.close()`` on the same descriptor.
+
+    Two assertions, and the ORDER of importance is the reverse of the obvious
+    one:
+
+    1. The prior transcript is replayed onto the screen — the resume did its
+       job.
+    2. **The loop keeps scheduling afterward.** This is the assertion that
+       catches #401. A frozen app can satisfy (1) perfectly: the replay is
+       synchronous and happens before the freeze, so the last frame painted
+       shows the whole restored conversation. Asserting "the transcript
+       appeared" alone passes against the broken code. What distinguishes a
+       working app from a wedged one is only visible over TIME.
+
+    On the pre-fix code this test does not fail by assertion — the process is
+    deadlocked in a syscall, so no Python runs to raise. It fails by watchdog,
+    which dumps every thread's stack and exits. See :mod:`tests.e2e.watchdog`.
+    """
+    from local_operator.session_factory import attach_mcp_dispose
+
+    prior_user = "PRIOR-TURN-QUESTION"
+    prior_reply = "PRIOR-TURN-ANSWER"
+
+    resume_dir = headless_tui_env / "sessions" / "resume-target"
+    await seed_transcript(
+        resume_dir,
+        [user_message(prior_user), assistant_message(prior_reply)],
+    )
+
+    live_dir = headless_tui_env / "sessions" / "live"
+    live_session = build_session(live_dir, ScriptedStream([]), cwd=headless_tui_env)
+    resumed_session = build_session(resume_dir, ScriptedStream([]), cwd=headless_tui_env)
+
+    # The real manager, with a real connect parked in the real lock. Attached
+    # through the production helper so the dispose path under test is the one
+    # the factory actually wires, not a hand-rolled equivalent.
+    with mcp_lock.foreign_lock_holder(headless_tui_env):
+        manager = await mcp_lock.parked_mcp_manager(headless_tui_env, headless_tui_env, monkeypatch)
+        attach_mcp_dispose(live_session, manager)
+
+        async def factory() -> Session:
+            return live_session
+
+        async def resume_factory(_resume_id: str | None) -> Session:
+            return resumed_session
+
+        app = OperatorApp(factory, resume_factory=resume_factory)
+        try:
+            async with app.run_test(size=SCREEN) as pilot:
+                with bounded(BOOT_BOUND_S, "boot before /resume"):
+                    await wait_for_adoption(app, pilot)
+                    await drain(pilot)
+
+                # The connect really is parked in the lock: the manager deferred
+                # it past the startup gate and holds a live continuation for it.
+                # Without this the test could pass while exercising nothing.
+                assert manager._pending_continuations, (
+                    "no MCP connect is pending, so /resume has nothing to cancel "
+                    "and this test would not exercise the deadlock at all"
+                )
+
+                with bounded(RESUME_BOUND_S, "/resume and the liveness watch after it"):
+                    # The real command path, the same one the picker calls.
+                    app._resume_session("resume-target", lambda *_a, **_k: None)
+                    await drain(pilot, cycles=40)
+
+                    # (1) The resume did its job: the prior conversation is on
+                    # the screen, not merely in the session's memory.
+                    on_screen = transcript_text(app)
+                    assert prior_user in on_screen and prior_reply in on_screen, (
+                        "/resume did not replay the prior transcript onto the screen; "
+                        f"transcript reads: {on_screen!r}"
+                    )
+
+                    # (2) The assertion that catches #401. Everything above is
+                    # also true of a frozen app.
+                    liveness = LoopLiveness()
+                    await liveness.observe(pilot, LIVENESS_WATCH_S)
+                    liveness.assert_alive(
+                        minimum=LIVENESS_MIN_RESUMPTIONS,
+                        ceiling_s=LIVENESS_MAX_GAP_S,
+                        context="/resume disposed an MCP manager with a connect in the OAuth lock",
+                    )
+
+                    # Still interactive, not merely still ticking: a loop can
+                    # schedule timers while input handling is wedged behind a
+                    # blocked worker.
+                    from local_operator.tui.widgets.editor import Editor
+
+                    editor = app.query_one(Editor)
+                    editor.focus()
+                    await pilot.press(*"post")
+                    await drain(pilot, cycles=5)
+                    assert "post" in editor.text, (
+                        "the loop kept ticking but keystrokes no longer reach the "
+                        "composer: the app is live but not usable"
+                    )
+        finally:
+            await dispose_quietly(live_session, resumed_session)
+
+
+# --- transcript inspection ---------------------------------------------------
+#
+# Read back from the JSONL on disk rather than from the session's in-memory
+# history: "would a resume of this session see the turn" is a question about
+# the FILE, and an in-memory assertion answers a different one.
+
+
+def _transcript_records(directory: Path) -> list[dict[str, Any]]:
+    import json
+
+    path = directory / "transcript.jsonl"
+    if not path.is_file():
+        return []
+    records: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            records.append(json.loads(line))
+        except ValueError:  # a partially-flushed final line is not a record
+            continue
+    return records
+
+
+def _payloads(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [rec.get("payload") or {} for rec in records]
+
+
+def _has_tool_call(records: list[dict[str, Any]], tool_name: str) -> bool:
+    """True when an assistant message journalled a call to ``tool_name``."""
+    for payload in _payloads(records):
+        for call in payload.get("tool_calls") or []:
+            if isinstance(call, dict) and call.get("name") == tool_name:
+                return True
+    return False
+
+
+def _has_tool_result(records: list[dict[str, Any]], tool_name: str) -> bool:
+    """True when a result for ``tool_name`` was journalled beside its call."""
+    for payload in _payloads(records):
+        for result in payload.get("tool_results") or []:
+            if isinstance(result, dict) and result.get("tool_name") == tool_name:
+                return True
+        if payload.get("tool_name") == tool_name and payload.get("role") == "tool":
+            return True
+    return False

--- a/tests/e2e/watchdog.py
+++ b/tests/e2e/watchdog.py
@@ -1,0 +1,103 @@
+"""The wall-clock bound for tests whose failure mode is a hang.
+
+Why this is not ``asyncio.wait_for``
+------------------------------------
+
+Every other bound in this suite is a Python-level one, and none of them can
+work here. The regression this package exists to catch (#401) deadlocks the
+process at the *kernel* level: a worker thread parked in ``fcntl.flock()`` on a
+descriptor that the event-loop thread then calls ``os.close()`` on, which on
+macOS/BSD blocks until that ``flock()`` returns. Both threads are inside a
+syscall holding no bytecode, so:
+
+* ``asyncio.wait_for`` never fires, because the loop is the thing that stopped;
+* a ``threading.Thread`` watchdog never fires either, because it needs the GIL
+  released by a thread that will never return to release it deliberately, and
+  even when it does wake, the interpreter-level ``faulthandler.dump_traceback``
+  raises ``RuntimeError: file.fileno() is not a valid file descriptor`` under
+  Textual (which has taken over the terminal), and ``os._exit`` never runs;
+* ``pytest-timeout``'s default ``signal`` method never fires, because a Python
+  signal handler only runs between bytecodes.
+
+Measured, not assumed: driving the pre-fix code through ``/resume`` produced a
+process that ignored a 20 s thread watchdog and had to be ``kill -9``'d.
+
+``faulthandler.dump_traceback_later`` is the one bound that survives it. It
+arms a timer in a dedicated **C** thread that writes the stacks of every thread
+with ``write(2)`` directly to a file descriptor and then calls ``_exit(1)`` —
+no GIL, no Python frames, no interpreter state required. That makes a
+deadlocked run fail in seconds with the exact stacks of the parked threads,
+which is precisely the diagnostic a reader needs.
+
+The GRANULARITY is deliberate: the timer is armed around the specific step
+under test rather than around the whole test, so the dump names the operation
+that hung instead of "the test was slow".
+
+``exit=True`` kills the whole process, so a fired watchdog takes down the
+pytest worker with it. That is the intended behaviour and not a rough edge: a
+deadlocked interpreter cannot report a test failure through any gentler
+channel, and a hard exit carrying the stacks is strictly better than a job that
+sits until the CI wall clock reaps it with no diagnostic at all.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import faulthandler
+import os
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+#: Where the C-level dump is written. A real file rather than ``sys.stderr``:
+#: under a Textual pilot the app owns the terminal and pytest has replaced the
+#: stderr OBJECT, so ``faulthandler``'s fileno() lookup fails outright on it —
+#: the dump has to land somewhere with a genuine descriptor behind it. Kept in
+#: the OS temp dir rather than a tmp_path fixture so the path is stable and
+#: printable in the failure message a surviving process can still emit.
+DUMP_PATH = Path(os.environ.get("TMPDIR", "/tmp")) / "lo-tui-e2e-hang.log"
+
+
+@contextlib.contextmanager
+def bounded(seconds: float, what: str) -> Iterator[None]:
+    """Fail loudly, with every thread's stack, if ``what`` takes too long.
+
+    Wrap the smallest step that can hang, not the whole test: the dump's value
+    is that it names the parked operation, and a bound around ten steps only
+    tells you one of them stopped.
+    """
+    handle = DUMP_PATH.open("w", encoding="utf-8")
+    try:
+        handle.write(f"[e2e watchdog] {what!r} exceeded {seconds:g}s; every thread follows.\n")
+        handle.flush()
+        # cancel_dump_traceback_later() in the finally is what makes this
+        # re-entrant-safe across sequential steps in one test: each `bounded`
+        # block owns the single process-wide timer for its own duration.
+        faulthandler.dump_traceback_later(seconds, file=handle, exit=True)
+        try:
+            yield
+        finally:
+            faulthandler.cancel_dump_traceback_later()
+    finally:
+        handle.close()
+
+
+def report_previous_hang() -> str:
+    """The last watchdog dump, for a runner reconstructing why a worker died.
+
+    The dump is written by a process that then exits immediately, so nothing in
+    that process can attach it to a test report. This reads it back so the
+    surviving pytest session (or a human reading CI logs) can print the stacks.
+    """
+    if not DUMP_PATH.is_file():
+        return "(no watchdog dump was written)"
+    return DUMP_PATH.read_text(encoding="utf-8", errors="replace")
+
+
+def print_previous_hang_and_exit() -> None:  # pragma: no cover - operator aid
+    """``python -m tests.e2e.watchdog`` — show the last hang's stacks."""
+    sys.stdout.write(report_previous_hang())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print_previous_hang_and_exit()

--- a/tests/e2e/watchdog.py
+++ b/tests/e2e/watchdog.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import contextlib
 import faulthandler
+import itertools
 import os
 import sys
 from collections.abc import Iterator
@@ -55,7 +56,20 @@ from pathlib import Path
 #: the dump has to land somewhere with a genuine descriptor behind it. Kept in
 #: the OS temp dir rather than a tmp_path fixture so the path is stable and
 #: printable in the failure message a surviving process can still emit.
-DUMP_PATH = Path(os.environ.get("TMPDIR", "/tmp")) / "lo-tui-e2e-hang.log"
+DUMP_DIR = Path(os.environ.get("TMPDIR", "/tmp"))
+
+#: Filename prefix for one bounded block's dump. Each block gets its OWN file
+#: rather than a single shared path. A shared path is truncated by whichever
+#: block runs next, so a real hang's stacks could be destroyed by a later
+#: block's header — and the dump only survived at all because the hanging test
+#: happened to be the last one in the file.
+DUMP_PREFIX = "lo-tui-e2e-hang"
+
+#: The marker ``faulthandler`` itself writes when the timer actually fires
+#: (``Timeout (0:01:00)!``). Presence of this string is what distinguishes a
+#: genuine dump from a file whose header was written at arm time, so a reader
+#: is never handed a timeout claim for a test that failed on an assertion.
+FIRED_MARKER = "Timeout ("
 
 
 @contextlib.contextmanager
@@ -65,8 +79,22 @@ def bounded(seconds: float, what: str) -> Iterator[None]:
     Wrap the smallest step that can hang, not the whole test: the dump's value
     is that it names the parked operation, and a bound around ten steps only
     tells you one of them stopped.
+
+    The dump file's EXISTENCE is the signal, and keeping that honest drives the
+    shape here. ``faulthandler`` writes with a raw file descriptor from a C
+    thread, so the handle and its header must exist BEFORE the timer is armed —
+    the header cannot be deferred to the moment it fires. What can be deferred
+    is the file's survival: every ordinary exit path (success, assertion
+    failure, error) removes it, and only a fired watchdog leaves it behind,
+    because that path exits the process immediately and never reaches the
+    cleanup. So a file that is still there means the bound really tripped,
+    which is exactly what the CI reporting step claims when it prints one.
     """
-    handle = DUMP_PATH.open("w", encoding="utf-8")
+    # Unique per block and per process: pytest may run several bounded blocks,
+    # and under a fired watchdog the surviving file must be attributable to the
+    # block that actually hung rather than to whichever ran last.
+    path = DUMP_DIR / f"{DUMP_PREFIX}-{os.getpid()}-{next(_COUNTER)}.log"
+    handle = path.open("w", encoding="utf-8")
     try:
         handle.write(f"[e2e watchdog] {what!r} exceeded {seconds:g}s; every thread follows.\n")
         handle.flush()
@@ -80,18 +108,49 @@ def bounded(seconds: float, what: str) -> Iterator[None]:
             faulthandler.cancel_dump_traceback_later()
     finally:
         handle.close()
+        # Reached on success AND on an ordinary failure, never on a fired
+        # watchdog (which _exit()s from the C thread). This is what stops a
+        # green run or a plain assertion failure from leaving behind a file
+        # that reads as a hang report.
+        with contextlib.suppress(OSError):
+            path.unlink()
+
+
+#: Distinguishes concurrent bounded blocks within one process.
+_COUNTER = itertools.count()
 
 
 def report_previous_hang() -> str:
-    """The last watchdog dump, for a runner reconstructing why a worker died.
+    """The stacks of a bound that actually fired, or an explicit statement that
+    none did.
 
-    The dump is written by a process that then exits immediately, so nothing in
-    that process can attach it to a test report. This reads it back so the
-    surviving pytest session (or a human reading CI logs) can print the stacks.
+    Reads back what the dying process wrote: a fired watchdog ``_exit``s
+    immediately, so nothing in that process can attach the dump to a test
+    report. Only files carrying :data:`FIRED_MARKER` are reported, so this can
+    never present a header-only file as a timeout — the failure mode that made
+    an ordinary 3-second assertion failure look like a 45-second hang.
     """
-    if not DUMP_PATH.is_file():
-        return "(no watchdog dump was written)"
-    return DUMP_PATH.read_text(encoding="utf-8", errors="replace")
+    dumps = sorted(
+        (path for path in DUMP_DIR.glob(f"{DUMP_PREFIX}-*.log") if _is_real_dump(path)),
+        key=lambda path: path.stat().st_mtime,
+    )
+    if not dumps:
+        return (
+            "(no watchdog dump: nothing exceeded its bound in this run, so any "
+            "failure above is an ordinary assertion failure, not a hang)\n"
+        )
+    # Newest last so the most recent hang is what a reader sees at the bottom;
+    # every surviving dump is printed because a matrix leg can hang more than
+    # once and discarding the earlier one hides evidence.
+    return "\n".join(path.read_text(encoding="utf-8", errors="replace") for path in dumps)
+
+
+def _is_real_dump(path: Path) -> bool:
+    """True only for a file ``faulthandler`` actually wrote stacks into."""
+    try:
+        return FIRED_MARKER in path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
 
 
 def print_previous_hang_and_exit() -> None:  # pragma: no cover - operator aid


### PR DESCRIPTION
# PR Description

## Summary of Changes

PR #401 fixed a total event-loop freeze. `_oauth_refresh_lock` took an unbounded
blocking `fcntl.flock` on a worker thread and then, during cancellation, called
`os.close(fd)` from the event-loop thread — and on macOS/BSD `close()` blocks
while a sibling thread is parked in `flock()` on that descriptor. `/resume`
disposes the MCP manager, which cancels in-flight connects, which is exactly
that sequence. The banner and composer slid to the bottom of the screen and the
app answered nothing, permanently.

**The whole unit suite — 8000+ tests — was green throughout.** Every piece was
individually correct; nothing drove the assembled application, so nothing
noticed that it had stopped moving. This PR adds the stage that does.

`tests/e2e` drives the real `OperatorApp` through Textual's own `run_test()`
pilot, over a real `Session`, a real `Transcript` on real files, the real
`write` tool, and a real `McpManager` reaching the real flock-based OAuth
refresh lock. Three tests:

1. **Startup** — the app boots, paints a non-empty frame, and is genuinely
   interactive (the composer holds focus and typed keys land in its buffer). A
   mounted widget tree alone only proves `compose` ran.
2. **A real turn** — a scripted model turn calls the real `write` tool. Asserts
   four independent artifacts, because each can fail while the others look
   fine: the **file on disk**, the **tool card** in the transcript, the
   **streamed prose**, and the **journalled call and result** in
   `transcript.jsonl` (what a later resume replays).
3. **`/resume`** — the regression test for #401. Asserts both that the prior
   transcript is replayed onto the screen **and that the loop keeps scheduling
   afterward**.

The ordering in (3) matters more than it looks. A frozen app satisfies the
replay assertion perfectly: the replay is synchronous and completes before the
freeze, so the last frame painted shows the whole restored conversation.
Asserting "the transcript appeared" passes against the broken code. What
separates a working app from a wedged one is only visible over time, so
`LoopLiveness` measures resumption count and worst scheduling gap over a 4 s
window after the resume, then checks the composer still accepts keys — a loop
can service timers while input handling is wedged behind a blocked worker.

### Reaching the real deadlock

The rig had to reach the genuine `flock`, because the defect is a property of
the syscalls rather than of the control flow — a mocked lock cannot deadlock,
so a test built on one passes against the broken code. `tests/e2e/mcp_lock.py`
sets up the three conditions that are all required:

- a **foreign** lock holder (a separate open file description; `flock` is held
  per-OFD, so re-locking the same fd would silently succeed and test nothing);
- an **expired** stored grant, since `ensure_mcp_oauth_fresh` returns before
  reaching the lock for a token still inside its lifetime;
- endpoint discovery answered locally via the module's own
  `_fallback_endpoints_for`, so nothing touches the network.

It holds **both** candidate lock filenames — the pre-#401 global
`mcp_oauth_refresh.lock` and the post-fix per-server digest — because the stage
is meant to be run against the pre-fix code to prove it goes red, and a rig that
only knew the new name would leave the old lock uncontended.

### Bounding is load-bearing, not incidental

The failure mode here is a hang, and the usual bounds do not work on it. This
was measured, not assumed. The deadlock parks two threads inside syscalls, so:

- `asyncio.wait_for` never fires — the loop is the thing that stopped;
- a `threading.Thread` watchdog never fires — and when it does wake,
  `faulthandler.dump_traceback()` raises `RuntimeError: file.fileno() is not a
  valid file descriptor` under Textual, and `os._exit` never runs;
- `pytest-timeout`'s default `signal` method never fires — a Python signal
  handler only runs between bytecodes.

A prototype driving the pre-fix code through `/resume` ignored a 20 s thread
watchdog entirely and had to be `kill -9`'d.

`faulthandler.dump_traceback_later(exit=True)` is the one bound that survives:
it arms a timer in a dedicated **C** thread that writes every thread's stack
with `write(2)` and calls `_exit(1)` — no GIL, no Python frames. It is armed
around the specific step under test rather than the whole test, so the dump
names the operation that hung. The CI job prints it on failure
(`python -m tests.e2e.watchdog`), since the dumping process exits before pytest
can report anything.

Because a fired watchdog kills the process, the stage is **deselected from the
default run** (`-m "not e2e"` in `addopts`) and runs `-n0`: under xdist it would
otherwise kill a worker carrying unrelated tests and report them as an
infrastructure error rather than as the freeze they are.

### Deterministic, so it runs on forks

Only the provider is scripted; everything else is production code. That is a
deliberate trade, and the reason is the fork gate:

- **The regression is not model-shaped.** A frozen loop and a missing file are
  caught identically by a scripted turn and a live one — in ~12 s, with no key.
- **It has to run on fork PRs.** `cli-sanity`/`server-sanity` are gated behind
  `head.repo.full_name == github.repository` because fork PRs get no secrets. A
  live-model stage would inherit that gate, and the resume-liveness assertion is
  precisely the one that must never be skipped: a contributor reintroducing the
  deadlock has to see it go red on their own PR. **Being ungated is necessary
  for that reach but not sufficient — the platform decides whether the defect is
  observable at all. See "Platform" below; this is what review round 1 caught.**
- **A hang test cannot be flaky.** Putting a live network call inside the bound
  would make provider latency indistinguishable from the deadlock, and a hang
  detector that cries wolf is one people learn to rerun.

The live-model path is not lost: `cli-sanity` already drives a real OpenRouter
turn against a real file write on every non-fork PR. The two are complementary.

### Platform: where the freeze is actually observable

**Round 1 caught this, and it invalidated the argument above as originally
written.** The stage was wired `runs-on: ubuntu-latest`. The deadlock is a
macOS/BSD property — `close()` blocks there behind a sibling `flock()` — and
Linux does not have it. Measured on both:

```
macOS  (this box):  platform=darwin  close_blocked=True
Linux  (container): platform=linux   close_blocked=False  close_s=0.0000074
```

Run end to end against the **pre-fix** tree (`80df237b^`) in `python:3.12-slim`:

```
$ env -u NO_COLOR TERM=xterm-256color python -m pytest tests/e2e -m e2e -n0 -q
...                                     [100%]
3 passed in 11.66s
```

The regression test passed against the regression, on the runner CI used. This
was not the rig failing to reach the lock — the flock is genuinely contended on
Linux and the cancellation genuinely happens; the loop just never wedges.

The job now runs a `[ubuntu-latest, macos-latest]` matrix, `fail-fast: false`.
Linux keeps the platform-neutral coverage (startup, write-turn artifacts,
transcript replay, interactivity); **macOS is the only leg on which the freeze
guard can go red at all.** `timeout-minutes` raised 15 -> 20 for the slower,
longer-queuing macOS runner; `RESUME_BOUND_S` stays 60 s, which still yields the
measured 62.6 s red. The fork story now holds in full: ungated so it reaches
fork PRs, and on a platform where the defect is visible when it does.

## Related Issue(s)

- Follow-up to #401 (the freeze this stage exists to catch). No ticket.

## Impact

- **Test/CI infrastructure only.** No runtime code changed, no dependency
  added, no public API touched — so **no version bump** (stays `0.43.3`).
- The default `pytest` run is unchanged in content: the new stage is deselected
  from it and runs as its own parallel CI job beside `cli-sanity`/`server-sanity`.
- Fully headless by construction: no window, no display server, no browser, no
  TTY beyond what the pilot makes in memory.

## Testing Details

### 1. The stage catches the bug it was written for

The whole point. Reverted the fix by running the identical stage against
`80df237b^` (the commit before #401) in a throwaway worktree.

**RED — pre-fix code.** The third test never reports; the watchdog fires and
kills the process:

```
$ cd /tmp/lop-tui-e2e-prefix && git log --oneline -1
0ed1051e fix(tui): make double-click and triple-click select in the composer (#388)
$ grep -n "fcntl.flock(fd, fcntl.LOCK_EX)$" local_operator/mcp/auth.py
1358:        fcntl.flock(fd, fcntl.LOCK_EX)

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
..
PYTEST EXIT=1
```

The two dots are startup and the write turn passing; the run then dies. The
watchdog dump names the deadlock exactly — worker thread in `flock`, event-loop
thread in `os.close`, reached through the real MCP connect path:

```
$ python -m tests.e2e.watchdog
[e2e watchdog] '/resume and the liveness watch after it' exceeded 60s; every thread follows.
Timeout (0:01:00)!

Thread 0x000000016cd13000 [asyncio_0] (most recent call first):
  File ".../local_operator/mcp/auth.py", line 1358 in _lock_exclusive
  File ".../concurrent/futures/thread.py", line 73 in run
  ...

Thread 0x00000001f5846180 (most recent call first):
  File ".../local_operator/mcp/auth.py", line 1400 in _oauth_refresh_lock
  File ".../contextlib.py", line 214 in __aenter__
  File ".../local_operator/mcp/auth.py", line 1642 in ensure_mcp_oauth_fresh
  File ".../local_operator/mcp/manager.py", line 1583 in _ensure_oauth_fresh
  File ".../local_operator/mcp/manager.py", line 1341 in _connect_server
```

Those two source lines on the pre-fix tree:

```
$ sed -n '1358p;1400p' local_operator/mcp/auth.py
        fcntl.flock(fd, fcntl.LOCK_EX)     # worker thread, unbounded
        os.close(fd)                       # event-loop thread -> deadlock
```

**GREEN — this branch, on current `main` (0.43.3):**

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -v
tests/e2e/test_tui_e2e.py::test_the_app_boots_paints_a_frame_and_becomes_interactive PASSED [ 33%]
tests/e2e/test_tui_e2e.py::test_a_turn_writes_a_real_file_and_leaves_its_trace_on_screen PASSED [ 66%]
tests/e2e/test_tui_e2e.py::test_resume_replays_the_transcript_and_the_loop_keeps_painting PASSED [100%]
============================== 3 passed in 14.93s ==============================
PYTEST EXIT=0
```

**Per-platform matrix, re-run after round 1** — this is now the core evidence,
because it is what proves the guard is live on the runner that executes it:

| leg | code | result |
|---|---|---|
| macOS | pre-fix (`80df237b^`) | **RC=1**, watchdog names `auth.py:1358 _lock_exclusive` (flock) + `auth.py:1400 _oauth_refresh_lock` (os.close) |
| macOS | fixed (head) | `3 passed in 12.74s` |
| Linux | pre-fix (`80df237b^`) | `3 passed` — documented, and exactly why the macOS leg is mandatory |
| Linux | fixed (head) | `3 passed in 12.20s` |

The macOS row is the regression guard; the Linux rows show the platform-neutral
coverage works and that Linux alone would have been a false green.

### 2. The macOS close-vs-flock premise, verified directly

The whole design rests on `close()` blocking while a sibling thread is in
`flock()`. Confirmed on this machine rather than taken from the #401 write-up:

```
$ python3 probe_close.py
os.close() BLOCKED for >3s: True
```

And that `faulthandler.dump_traceback_later` still fires through exactly that
deadlock, where a thread watchdog does not:

```
$ python3 fh_probe.py; echo "exit=$?"
exit=1
$ head -2 fh_probe.log
Timeout (0:00:03)!
Thread 0x0000000171a6f000 [Thread-1 (park)] (most recent call first):
```

### 2b. The dump file now means what the CI step claims (F2)

`bounded()` used to write its header on entry to one shared path, so CI's
`if: failure()` step printed a timeout claim after *any* failure. The header
cannot be deferred — `faulthandler` needs the fd armed before the hang — so the
file's **survival** carries the signal instead: each block writes its own file
and removes it on every ordinary exit path, while a fired watchdog `_exit`s
before cleanup. The reporter prints only files carrying faulthandler's own
`Timeout (` marker. Checked in all three states:

```
# green run
3 passed in 10.23s
$ python -m tests.e2e.watchdog
(no watchdog dump: nothing exceeded its bound in this run, so any failure
 above is an ordinary assertion failure, not a hang)

# ordinary assertion failure (write-turn), fails in ~3s
1 failed, 2 passed in 13.98s
$ python -m tests.e2e.watchdog          # what `if: failure()` runs
(no watchdog dump: nothing exceeded its bound in this run, so any failure
 above is an ordinary assertion failure, not a hang)

# real hang (pre-fix macOS)
RC=1
$ python -m tests.e2e.watchdog
[e2e watchdog] '/resume and the liveness watch after it' exceeded 60s; ...
Timeout (0:01:00)!
  File ".../local_operator/mcp/auth.py", line 1358 in _lock_exclusive
  File ".../local_operator/mcp/auth.py", line 1400 in _oauth_refresh_lock
```

Previously the middle case printed `'a full turn through the write tool'
exceeded 45s` for a test that failed on an assertion in three seconds.

### 3. Headless: no window, no focus change

Measured against the real window server, not asserted. Frontmost application and
visible-window count sampled before and after a full run:

```
$ .venv/bin/python headless_check.py
BEFORE  frontmost='Terminal'  visible-window-count=29
pytest exit: 0
3 passed in 10.47s
AFTER   frontmost='Terminal'  visible-window-count=29
FOCUS UNCHANGED: True
NO NEW WINDOWS : True
```

And it runs with no TTY, no `DISPLAY`, and a scrubbed environment — the shape a
CI runner has:

```
$ env -i PATH=/usr/bin:/bin HOME=$HOME TMPDIR=$TMPDIR TERM=xterm-256color \
    .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q < /dev/null > notty.log 2>&1
$ echo "exit=$?"; tail -1 notty.log
exit=0
3 passed in 10.20s

$ env -i PATH=/usr/bin:/bin HOME=$HOME .venv/bin/python \
    -c "import sys;print('stdin tty:',sys.stdin.isatty(),'stdout tty:',sys.stdout.isatty())" < /dev/null | cat
stdin tty: False stdout tty: False
```

### 4. The stage really exercises the lock

A test that sets up a deadlock rig and then fails to reach it would pass while
proving nothing, so the resume test asserts the precondition explicitly before
the act:

```python
assert manager._pending_continuations, (
    "no MCP connect is pending, so /resume has nothing to cancel "
    "and this test would not exercise the deadlock at all"
)
```

Confirmed live during development — the manager defers the OAuth server past the
250 ms startup gate and holds a continuation for it:

```
adopted: True
pending continuations: ['srv']
```

### 5. Marker wiring, both directions

The stage must stay out of the default run and must still be runnable:

```
$ .venv/bin/python -m pytest tests/e2e -q          # default addopts
no tests ran in 1.53s                              # deselected, as intended

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
3 passed in 10.08s
```

The marker is applied by **location** in `tests/e2e/conftest.py`, so a new module
in that package cannot forget it and silently rejoin the unit suite.

### 6. Timeout headroom is deliberate

Measured healthy durations against the configured bounds — roughly an order of
magnitude of headroom, so a loaded shared runner cannot produce a flaky red:

```
$ ... -m pytest tests/e2e -m e2e -n0 -q --durations=10
6.57s call  test_resume_replays_the_transcript_and_the_loop_keeps_painting   (bound 60s)
2.53s call  test_a_turn_writes_a_real_file_and_leaves_its_trace_on_screen    (bound 45s)
1.68s call  test_the_app_boots_paints_a_frame_and_becomes_interactive        (bound 45s)
```

The pre-fix red still arrives in ~60 s with a full diagnostic, rather than at the
job's own 15-minute timeout with none.

### 7. Gates

All clean on the whole tree, exactly as CI runs them:

```
$ .venv/bin/python -m flake8 .
$ uvx --from black==26.1.0 black --check .
599 files would be left unchanged.
$ uvx isort==5.13.2 --check .
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations
```

Pyright caught two real defects in the first draft (session factories typed
`object` rather than `Session`, and a test double missing the `close` the
manager's `ManagedAuthStore` requires); both were fixed properly — the store by
subclassing the unit suite's fake to add the one missing method — rather than
silenced.

**Full unit suite** (`tests/unit`, this branch): `24 failed, 8486 passed, 15
skipped, 1 xfailed`. All 24 failures are the known pre-existing
`tests/unit/tools/test_eval_tool.py` module-resolution artifacts in the local
venv. Verified against pristine `origin/main` rather than assumed — the failure
sets are byte-identical:

```
$ diff branch_fails.txt base_fails.txt && echo "IDENTICAL FAILURE SETS"
IDENTICAL FAILURE SETS — all pre-existing, none introduced by this branch
```

(`tests/unit/mobile/test_tui_bridge.py` passed on both.)

## Notes for reviewers

- **Adjacent issue, not fixed here** (out of scope, flagged for the record):
  `tools/group_reaper.py::_ledger_lock` uses a blocking `flock`. It is not the
  same defect class — synchronous, single-threaded, no event loop — and #401's
  own audit reached the same conclusion, but it is the one remaining blocking
  acquire in the tree.
- `tests/e2e/mcp_lock.py::candidate_lock_paths` should stay **append-only**. It
  is what lets this stage be run against older revisions to prove it still
  catches the regression; dropping the legacy name would quietly weaken it.

