### PR TITLE
chore(release): bump version to 0.43.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.4"
+version = "0.43.5"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## What

Bumps `pyproject.toml` to `0.43.5` so the subagent duplicate-notice fix reaches PyPI.

## Why

`v0.43.4` was tagged and published from #365 while #404 was still in review. #404 merged as `e55b79e8`, **after** that tag, so the fix is in `main` but in no published release — `pip install local-operator` still gets 0.43.4 without it. Verified:

```
$ git merge-base --is-ancestor e55b79e8 v0.43.4 && echo IN || echo NOT-IN
NOT-IN
$ curl -s https://pypi.org/pypi/local-operator/json | python3 -c "import sys,json;print(json.load(sys.stdin)['info']['version'])"
0.43.4
```

## Version choice

Patch, per AGENTS.md "Versioning": a bug fix with no new capability. Nothing here changes what the product can do.

## Contents

Version line only — no source change. The shipped fix is #404, which carried four agent review rounds (code + design) and is already merged.

## Testing

Version-only change; CI covers it. The fix itself was validated in #404: deterministic repro (1 error event rendering 12 rows before, 1 after), cross-fold regression tests, and reproducible before/after rendered TUI frames.