### PR TITLE
chore(release): bump version to 0.43.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.5"
+version = "0.43.6"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release bump for v0.43.6, covering the two fixes merged after the v0.43.5 tag:

- #411 fix(tui): keep the ghost caret at the insertion point
- #374 fix(resume): reach every session in the picker, not the newest 200

Version-only change: `pyproject.toml` 0.43.5 -> 0.43.6. No code, no tests, no docs.

## Why a new bump

`v0.43.5` was tagged at 302f3e3e (#417). Both fixes above merged to main *after* that tag, so neither is in any published version. 0.43.6 is the patch that ships them.

## Testing evidence

Version-only diff; the shipped code is exactly what was reviewed and merged under #411 and #374, each of which carried its own agent review rounds and CI.

```
$ git diff origin/main..HEAD --stat
 pyproject.toml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
