### PR TITLE
chore(release): bump version to 0.43.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.5"
+version = "0.43.6"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## What

Bumps `pyproject.toml` to `0.43.6` so the `/resume` picker reach fix reaches PyPI.

## Why

`v0.43.5` was tagged and published from #417. #374 merged as `9b6a4279`, **after** that tag, so the fix is in `main` but in no published release — `pip install local-operator` still gets 0.43.5 without it. Verified:

```
$ git merge-base --is-ancestor 9b6a4279 v0.43.5 && echo IN || echo NOT-IN
NOT-IN
$ curl -s https://pypi.org/pypi/local-operator/json | python3 -c "import sys,json;print(json.load(sys.stdin)['info']['version'])"
0.43.5
```

## Version choice

Patch, per AGENTS.md "Versioning": a bug fix plus the performance work that makes the uncapped listing affordable. Nothing here changes what the product can fundamentally do — `/resume` already existed, it just could not reach every session.

## Contents

Version line only — no source change. The shipped fix is #374, which carried its full agent review rounds and is already merged.

## Testing

Version-only change. Gates run over the whole tree from a fresh worktree off `origin/main`, exactly as CI runs them:

```
$ .venv/bin/python -m flake8 .                        # clean
$ uvx --from black==26.1.0 black --check .            # 613 files would be left unchanged
$ uvx isort==5.13.2 --check .                         # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations
```

The fix itself was validated in #374: a regression test drives the real `/resume` command over a 250-session store (fails on `074902ae` with "picker holds 10 of 250 sessions"), 13 new tests, and before/after rendered TUI frames captured through the real `OperatorApp`.

## Known pre-existing CI failure

`test (3.12)` and `test (3.13)` are expected to fail here on `tests/unit/session/test_launch_subagent.py::test_the_loop_stays_responsive_while_several_subagents_run`. This is a **load-sensitive event-loop timing assertion that already fails on `main` itself**, not a regression from this PR — which changes one version string and no code.

Evidence: [run 33272052779](https://github.com/damianvtran/local-operator/actions/runs/33272052779), on main's own `chore(release): bump version to 0.43.5 (#417)` commit, fails the same two jobs on the same test:

```
AssertionError: the event loop stalled for 1087 ms while subagents ran;
a synchronous stretch is starving concurrent children
```

The same two jobs also fail on main for `test(ci): add a headless TUI end-to-end stage` (`fe7d2ada`), `fix(tui): stop a subagent notice re-printing` (`e55b79e8`), and `feat(compaction)` (`b44575d2`), and it reproduces across reruns — the measured stall lands in the 1024–1454 ms range against a 1000 ms threshold, so it trips whenever the runner is loaded.

One job additionally tripped a **second** wall-clock timing test, `tests/unit/tui/test_transcript_selection.py::test_a_deliberately_slow_double_click_is_still_a_double_click`, which is the same class of defect: it sleeps 0.7 s against this app's 0.9 s `CLICK_CHAIN_TIME_THRESHOLD`, leaving only 200 ms of slack for a loaded runner to eat. Both tests pass locally on an unloaded tree:

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
    tests/unit/tui/test_transcript_selection.py::test_a_deliberately_slow_double_click_is_still_a_double_click \
    tests/unit/session/test_launch_subagent.py::test_the_loop_stays_responsive_while_several_subagents_run -p no:randomly -n0 -q
2 passed in 4.92s
```

Clearest evidence that this is runner load and not the diff: **`test (3.12)` passed on one run of this PR and failed on the other, for the identical commit** — see [run 33273775177](https://github.com/damianvtran/local-operator/actions/runs/33273775177) (3.12 pass) against [run 33273792598](https://github.com/damianvtran/local-operator/actions/runs/33273792598) (3.12 fail). A one-line version-string change cannot be conditionally responsible.

`lint`, `type-check` and `pip-audit` are the jobs that meaningfully gate this PR, and all three are green on both runs. Fixing the two timing assertions is out of scope for a release bump and should be scoped separately.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended. (Version-only change; the fix's tests landed in #374.)
- [x] All new and existing tests pass, except the two pre-existing load-sensitive timing tests documented above, which also fail on `main` and pass locally.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.
