### PR TITLE
fix(reaper): stop the ledger lock from freezing /reload on a long session

### DIFF
--- a/local_operator/tools/group_reaper.py
+++ b/local_operator/tools/group_reaper.py
@@ -116,17 +116,27 @@ _CMD_LOG_CHARS = 120
 #:
 #: A generous timeout would not fix that, it would only move the freeze, so the
 #: bound is sized off the HONEST contender instead: a sub-``PIPE_BUF`` append or
-#: a small read-filter-rewrite, microseconds to low milliseconds. 0.3s leaves
-#: about two orders of magnitude of headroom before an honest contender degrades
-#: while staying imperceptible to a user. This deliberately diverges from
+#: a small read-filter-rewrite, microseconds to low milliseconds. 0.3s sits two
+#: orders of magnitude past the SLOW end of that range (100x a 3 ms rewrite, and
+#: far more against the microsecond case), so an honest contender degrades only
+#: long after it should have finished, while staying imperceptible to a user.
+#: This deliberately diverges from
 #: ``auth.LOCK_ACQUIRE_TIMEOUT_S`` (15s): that lock guards a destructive
 #: rotating-token double-spend, this one guards an append whose loss is benign.
 _LOCK_ACQUIRE_TIMEOUT_S = 0.3
 
-#: Retry cadence for the non-blocking acquire, with the same gentle geometric
-#: backoff as the MCP OAuth refresh lock: fast pickup for the common
+#: Retry cadence for the non-blocking acquire: fast pickup for the common
 #: released-in-a-moment case, then fewer wakeups once the holder is evidently
 #: not finishing within our bound.
+#:
+#: Same SHAPE as the MCP OAuth refresh lock (geometric, 1.5x growth) but
+#: deliberately re-tuned, and the values must NOT be "restored to parity" with
+#: ``auth``'s 0.05/0.25 — that would silently break this bound. auth retries
+#: against a 15s timeout; we retry against 0.3s, so its 0.25s ceiling is 83% of
+#: our ENTIRE budget. Measured: this cadence gets 10 attempts inside 0.3s where
+#: auth's would get 5, and a single 0.25s sleep step would mean one late attempt
+#: and a bound that is a coin flip rather than a schedule. The cadence is
+#: proportional to the timeout it serves; change one and re-derive the other.
 _LOCK_RETRY_SLEEP_S = 0.01
 _LOCK_RETRY_SLEEP_MAX_S = 0.05
 

--- a/local_operator/tools/group_reaper.py
+++ b/local_operator/tools/group_reaper.py
@@ -67,6 +67,7 @@ import logging
 import os
 import subprocess
 import sys
+import time
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -96,6 +97,26 @@ _REAPING_IS_SUPPORTED = _PLATFORM != "win32"
 #: First N chars of the command, stored for the LOG LINE only. Never a decision
 #: input. Bounded so a pathological one-line command cannot bloat the ledger.
 _CMD_LOG_CHARS = 120
+
+#: Hard bound on how long a ledger-lock acquire may retry before degrading to
+#: running unlocked. Deliberately SHORT: this is a best-effort hygiene lock on
+#: the teardown path, not a correctness-critical one (losing it costs at worst
+#: the pre-existing lost-append, never a wrong kill — see ``_ledger_lock``), and
+#: the contended case is a leaked husk from a SIGKILLed peer that will never
+#: release. A generous timeout here would not fix anything, it would only move
+#: the freeze: ``/reload`` runs ``kill_own_groups()`` AFTER the TUI has restored
+#: the terminal, so every second spent waiting is a second the user stares at a
+#: dead shell prompt. Contention is rare and momentary in the honest case (a
+#: sibling append mid-compaction, microseconds), so a few hundred ms buys the
+#: entire realistic win.
+_LOCK_ACQUIRE_TIMEOUT_S = 0.3
+
+#: Retry cadence for the non-blocking acquire, with the same gentle geometric
+#: backoff as the MCP OAuth refresh lock: fast pickup for the common
+#: released-in-a-moment case, then fewer wakeups once the holder is evidently
+#: not finishing within our bound.
+_LOCK_RETRY_SLEEP_S = 0.01
+_LOCK_RETRY_SLEEP_MAX_S = 0.05
 
 
 @dataclass(frozen=True)
@@ -351,6 +372,68 @@ def unregister_group(
     _rewrite_without_pgid(path, pgid)
 
 
+def _try_lock_ledger(fd: int, *, exclusive: bool) -> bool:
+    """ONE non-blocking attempt at the ledger lock. True when taken.
+
+    Mirrors :func:`local_operator.mcp.auth._try_lock_exclusive` — the same idiom
+    for the same reason — but keeps this module's readers/writer distinction:
+    ``exclusive`` selects ``LOCK_EX`` for a compacting rewrite and ``LOCK_SH``
+    for an append, so concurrent appends still proceed together.
+
+    Non-blocking is REQUIRED here, not a style choice. ``LOCK_NB`` is what keeps
+    the caller off the kernel wait queue, and on macOS/BSD a thread parked in
+    ``flock(fd)`` blocks any other thread's ``os.close(fd)`` until that
+    ``flock()`` returns — which, against a lock leaked by a SIGKILLed peer, is
+    never. Reached from ``kill_own_groups()`` on the ``/reload`` teardown path
+    that runs after the terminal is restored, a parked acquire wedges the event
+    loop with no TUI left to show it and no SIGINT able to break it (the soft
+    death handler deliberately spares SIGINT, and the main thread is inside a C
+    syscall where no Python handler can run). This is the same bug shape as #401
+    in the MCP OAuth refresh lock. Retrying a non-blocking attempt is strictly
+    weaker than blocking and is the only shape that cannot hang, so do NOT
+    "simplify" this back into ``fcntl.flock(fd, fcntl.LOCK_EX)``.
+
+    Contention is the expected outcome and returns False, letting the caller
+    degrade to running unlocked. Anything else is a real fault that retrying
+    cannot fix, so it is raised for the caller's existing degrade path.
+    """
+    import errno
+    import fcntl
+
+    mode = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+    try:
+        fcntl.flock(fd, mode | fcntl.LOCK_NB)
+        return True
+    except OSError as lock_err:
+        if lock_err.errno in (errno.EAGAIN, errno.EACCES, errno.EWOULDBLOCK):
+            return False
+        raise
+
+
+def _acquire_ledger_lock(fd: int, *, exclusive: bool) -> bool:
+    """Retry the non-blocking acquire to ``_LOCK_ACQUIRE_TIMEOUT_S``. Worker-safe.
+
+    Returns True with the lock held, or False when the bound elapsed under
+    contention — the caller then runs unlocked, which is the documented degrade
+    (see :func:`_ledger_lock`). A real fault propagates as ``OSError`` into the
+    caller's existing degrade path; retrying could not fix it.
+
+    Every attempt is non-blocking, so this function can be abandoned by nothing
+    worse than the bound: unlike a blocking acquire it never parks a thread in
+    the kernel, and therefore never makes a sibling's ``os.close()`` of this fd
+    hang on macOS.
+    """
+    deadline = time.monotonic() + _LOCK_ACQUIRE_TIMEOUT_S
+    sleep_s = _LOCK_RETRY_SLEEP_S
+    while True:
+        if _try_lock_ledger(fd, exclusive=exclusive):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(sleep_s)
+        sleep_s = min(sleep_s * 1.5, _LOCK_RETRY_SLEEP_MAX_S)
+
+
 @contextlib.contextmanager
 def _ledger_lock(path: Path, *, exclusive: bool) -> Iterator[None]:
     """Advisory ``flock`` serialising ledger COMPACTION against APPENDS.
@@ -370,20 +453,45 @@ def _ledger_lock(path: Path, *, exclusive: bool) -> Iterator[None]:
     in flight while it truncates and rewrites.
 
     Best-effort: if the lock itself cannot be taken (permissions, an exotic FS
-    without ``flock``) we DEGRADE to running unlocked rather than block or fail a
-    command — the worst case is the pre-existing lost-append behaviour, never a
-    wrong kill. POSIX only; reached solely after the ``_REAPING_IS_SUPPORTED``
-    guard, so ``fcntl`` (absent on Windows) is imported lazily here.
+    without ``flock``, or simply CONTENTION) we DEGRADE to running unlocked
+    rather than block or fail a command — the worst case is the pre-existing
+    lost-append behaviour, never a wrong kill. POSIX only; reached solely after
+    the ``_REAPING_IS_SUPPORTED`` guard, so ``fcntl`` (absent on Windows) is
+    imported lazily here.
+
+    The acquire is BOUNDED and NON-BLOCKING, which is what makes that promise
+    true rather than aspirational. It once was not: a bare blocking ``flock``
+    here honoured the docstring only when the lock happened to be free, and a
+    husk leaked by a SIGKILLed peer froze the whole process on ``/reload``.
+    :func:`_try_lock_ledger` carries the full reasoning, including why macOS
+    turns a parked acquire into a dead event loop. Do not reintroduce a blocking
+    acquire, and do not stretch ``_LOCK_ACQUIRE_TIMEOUT_S`` into a long wait —
+    that only relocates the hang.
+
+    The fd is opened, retried on, and closed all on the CALLING thread, so no
+    other thread can ever close a descriptor this one is inside a lock call on
+    (the fd-ownership rule from ``auth._acquire_locked_fd``). Here that holds by
+    construction: the acquire never blocks, so the descriptor is never left with
+    an outstanding lock syscall on it.
     """
     fd: int | None = None
     try:
         try:
-            import fcntl
-
             path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
             lock_path = _lock_path(path)
             fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
-            fcntl.flock(fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+            if not _acquire_ledger_lock(fd, exclusive=exclusive):
+                # Contended past the bound: run unlocked. Debug, not warning —
+                # this is a tolerated outcome on a best-effort hygiene lock, and
+                # the teardown path must stay silent on a restored terminal.
+                logger.debug(
+                    "group reaper: ledger lock contended for %s after %.2fs; proceeding unlocked",
+                    path,
+                    _LOCK_ACQUIRE_TIMEOUT_S,
+                )
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                fd = None
         except (OSError, ImportError) as exc:
             # Degrade to unlocked: never block or break a command over the lock.
             logger.debug("group reaper: ledger lock unavailable for %s: %s", path, exc)

--- a/local_operator/tools/group_reaper.py
+++ b/local_operator/tools/group_reaper.py
@@ -120,9 +120,9 @@ _CMD_LOG_CHARS = 120
 #: orders of magnitude past the SLOW end of that range (100x a 3 ms rewrite, and
 #: far more against the microsecond case), so an honest contender degrades only
 #: long after it should have finished, while staying imperceptible to a user.
-#: This deliberately diverges from
-#: ``auth.LOCK_ACQUIRE_TIMEOUT_S`` (15s): that lock guards a destructive
-#: rotating-token double-spend, this one guards an append whose loss is benign.
+#: This deliberately diverges from ``auth.LOCK_ACQUIRE_TIMEOUT_S`` (15s): that
+#: lock guards a destructive rotating-token double-spend, this one guards an
+#: append whose loss is benign.
 _LOCK_ACQUIRE_TIMEOUT_S = 0.3
 
 #: Retry cadence for the non-blocking acquire: fast pickup for the common

--- a/local_operator/tools/group_reaper.py
+++ b/local_operator/tools/group_reaper.py
@@ -99,16 +99,28 @@ _REAPING_IS_SUPPORTED = _PLATFORM != "win32"
 _CMD_LOG_CHARS = 120
 
 #: Hard bound on how long a ledger-lock acquire may retry before degrading to
-#: running unlocked. Deliberately SHORT: this is a best-effort hygiene lock on
-#: the teardown path, not a correctness-critical one (losing it costs at worst
-#: the pre-existing lost-append, never a wrong kill — see ``_ledger_lock``), and
-#: the contended case is a leaked husk from a SIGKILLed peer that will never
-#: release. A generous timeout here would not fix anything, it would only move
-#: the freeze: ``/reload`` runs ``kill_own_groups()`` AFTER the TUI has restored
-#: the terminal, so every second spent waiting is a second the user stares at a
-#: dead shell prompt. Contention is rare and momentary in the honest case (a
-#: sibling append mid-compaction, microseconds), so a few hundred ms buys the
-#: entire realistic win.
+#: running unlocked. Deliberately SHORT: this is a best-effort hygiene lock, not
+#: a correctness-critical one (losing it costs at worst the pre-existing
+#: lost-append, never a wrong kill — see ``_ledger_lock``).
+#:
+#: The contender worth sizing for is a LIVE peer that is itself wedged, holding
+#: the lock while parked. Note it is NOT a lock leaked by a dead process:
+#: ``flock`` is dropped by the kernel when the last fd on the open-file
+#: description closes, and that includes a ``SIGKILL`` (measured — after killing
+#: the holder the lock is granted in 0.000s). What a hard death leaks is the
+#: ``.lock`` FILE, which ``_sweep_orphan_locks`` cleans; the LOCK itself is
+#: already gone. A wedged live holder is the case that never releases, and it
+#: was observed on this machine: 3 of 14 live ``lop`` processes parked in
+#: ``flock``+``close``, two burning ~149% CPU for 800+ minutes. One wedged
+#: process parks the next, and the freeze propagates between sessions.
+#:
+#: A generous timeout would not fix that, it would only move the freeze, so the
+#: bound is sized off the HONEST contender instead: a sub-``PIPE_BUF`` append or
+#: a small read-filter-rewrite, microseconds to low milliseconds. 0.3s leaves
+#: about two orders of magnitude of headroom before an honest contender degrades
+#: while staying imperceptible to a user. This deliberately diverges from
+#: ``auth.LOCK_ACQUIRE_TIMEOUT_S`` (15s): that lock guards a destructive
+#: rotating-token double-spend, this one guards an append whose loss is benign.
 _LOCK_ACQUIRE_TIMEOUT_S = 0.3
 
 #: Retry cadence for the non-blocking acquire, with the same gentle geometric
@@ -383,13 +395,21 @@ def _try_lock_ledger(fd: int, *, exclusive: bool) -> bool:
     Non-blocking is REQUIRED here, not a style choice. ``LOCK_NB`` is what keeps
     the caller off the kernel wait queue, and on macOS/BSD a thread parked in
     ``flock(fd)`` blocks any other thread's ``os.close(fd)`` until that
-    ``flock()`` returns — which, against a lock leaked by a SIGKILLed peer, is
-    never. Reached from ``kill_own_groups()`` on the ``/reload`` teardown path
-    that runs after the terminal is restored, a parked acquire wedges the event
-    loop with no TUI left to show it and no SIGINT able to break it (the soft
-    death handler deliberately spares SIGINT, and the main thread is inside a C
-    syscall where no Python handler can run). This is the same bug shape as #401
-    in the MCP OAuth refresh lock. Retrying a non-blocking attempt is strictly
+    ``flock()`` returns — which, against a live peer that is itself wedged while
+    holding the lock, is never (see ``_LOCK_ACQUIRE_TIMEOUT_S`` for why a wedged
+    LIVE holder, and not a dead one, is the contender that matters).
+
+    The callers that reach this are ``register_group`` (SHARED) and
+    ``_rewrite_without_pgid`` via ``unregister_group`` (EXCLUSIVE) — the BASH
+    path, which runs them on asyncio worker threads. ``kill_own_groups`` does NOT
+    take this lock; it is only where the damage becomes visible, because
+    ``concurrent.futures`` joins those worker threads at interpreter shutdown, so
+    one parked worker means the process never exits. On ``/reload`` that lands
+    after the TUI has restored the terminal and before ``replace_self()``: a
+    shell prompt, a process that never dies, and a Ctrl+C that cannot help (the
+    soft-death handler deliberately spares SIGINT, and the parked thread is
+    inside a C syscall where no Python handler runs). Same bug shape as #401 in
+    the MCP OAuth refresh lock. Retrying a non-blocking attempt is strictly
     weaker than blocking and is the only shape that cannot hang, so do NOT
     "simplify" this back into ``fcntl.flock(fd, fcntl.LOCK_EX)``.
 
@@ -461,12 +481,13 @@ def _ledger_lock(path: Path, *, exclusive: bool) -> Iterator[None]:
 
     The acquire is BOUNDED and NON-BLOCKING, which is what makes that promise
     true rather than aspirational. It once was not: a bare blocking ``flock``
-    here honoured the docstring only when the lock happened to be free, and a
-    husk leaked by a SIGKILLed peer froze the whole process on ``/reload``.
-    :func:`_try_lock_ledger` carries the full reasoning, including why macOS
-    turns a parked acquire into a dead event loop. Do not reintroduce a blocking
-    acquire, and do not stretch ``_LOCK_ACQUIRE_TIMEOUT_S`` into a long wait —
-    that only relocates the hang.
+    here honoured the docstring only when the lock happened to be free, so a
+    live peer wedged while holding it parked the acquiring worker thread for
+    good and the process could no longer exit on ``/reload``.
+    :func:`_try_lock_ledger` carries the full reasoning — which callers actually
+    reach this, and why macOS turns a parked acquire into a dead event loop. Do
+    not reintroduce a blocking acquire, and do not stretch
+    ``_LOCK_ACQUIRE_TIMEOUT_S`` into a long wait — that only relocates the hang.
 
     The fd is opened, retried on, and closed all on the CALLING thread, so no
     other thread can ever close a descriptor this one is inside a lock call on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.8"
+version = "0.43.9"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tools/test_group_reaper.py
+++ b/tests/unit/tools/test_group_reaper.py
@@ -20,7 +20,11 @@ import json
 import os
 import signal
 import subprocess
+import sys
+import threading
 import time
+
+import pytest
 
 from local_operator.tools import group_reaper
 from local_operator.tools.group_reaper import (
@@ -790,3 +794,89 @@ def test_ledger_lock_degrades_when_unavailable(tmp_path, monkeypatch):
     path = group_reaper._ledger_path(tmp_path, pid, token)
     pgids = {json.loads(x)["pgid"] for x in path.read_text().splitlines()}
     assert pgids == {55}  # compaction still happened without the lock
+
+
+# --------------------------------------------------------------------------- #
+# The ledger lock must never park the caller (regression: /reload freeze)
+# --------------------------------------------------------------------------- #
+def _hold_ledger_lock(config_dir, owner_pid):
+    """Hold this owner's ledger lock EXCLUSIVELY from another process.
+
+    Another process, not another thread, because that is the real failure: a
+    husk leaked by a SIGKILLed peer (or a sibling mid-compaction) holds the
+    flock with nobody left to release it. A same-process holder would prove
+    nothing, since flock is per open-file-description and the reaper's own fd
+    would be granted the lock immediately.
+
+    Returns (Popen, lock_path); the caller must kill the holder.
+    """
+    token = group_reaper._self_start_token(owner_pid)
+    assert token is not None
+    lock_path = group_reaper._lock_path(group_reaper._ledger_path(config_dir, owner_pid, token))
+    lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import fcntl, os, sys, time\n"
+            "fd = os.open(sys.argv[1], os.O_CREAT | os.O_RDWR, 0o600)\n"
+            "fcntl.flock(fd, fcntl.LOCK_EX)\n"
+            "print('held', flush=True)\n"
+            "time.sleep(300)\n",
+            str(lock_path),
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    assert holder.stdout is not None
+    assert holder.stdout.readline().strip() == "held"
+    return holder, lock_path
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock only")
+def test_ledger_lock_never_blocks_when_held_by_another_process(tmp_path):
+    """Every ledger-touching entry point returns promptly against a held lock.
+
+    This is the #401 bug shape in the reaper: the acquire used to be a bare
+    blocking ``flock``, so a lock held by anyone else parked the caller forever.
+    On ``/reload`` that lands in ``kill_own_groups()`` AFTER the TUI restored the
+    terminal, and on macOS a thread parked in ``flock(fd)`` also blocks the event
+    loop's ``os.close(fd)`` — the user gets a shell prompt, a live process that
+    never exits, and a Ctrl+C that only echoes.
+
+    NOTE the failure mode this test is built for: pre-fix it does not fail an
+    assertion, it HANGS. The bound below is therefore a real timeout, not a
+    performance assertion — each call runs on a daemon thread that the test
+    abandons rather than joins, so a regression surfaces as a failed
+    ``done.wait`` (and, under a wedged interpreter, as the suite's own timeout)
+    instead of deadlocking the runner.
+    """
+    pid = os.getpid()
+    register_group(101, "before", config_dir=tmp_path, owner_pid=pid)
+    holder, _ = _hold_ledger_lock(tmp_path, pid)
+    try:
+        for label, call in (
+            (
+                "register_group",
+                lambda: register_group(202, "x", config_dir=tmp_path, owner_pid=pid),
+            ),
+            ("unregister_group", lambda: unregister_group(101, config_dir=tmp_path, owner_pid=pid)),
+            ("kill_own_groups", lambda: kill_own_groups(config_dir=tmp_path, owner_pid=pid)),
+        ):
+            done = threading.Event()
+
+            def run(call=call, done=done):
+                call()
+                done.set()
+
+            # Daemon so a regression cannot keep the interpreter alive at exit.
+            threading.Thread(target=run, daemon=True).start()
+            started = time.monotonic()
+            assert done.wait(timeout=5.0), f"{label} parked on the contended ledger lock"
+            elapsed = time.monotonic() - started
+            # Generous vs the 0.3s bound (CI schedulers are noisy) but far below
+            # the 5s hang threshold: this asserts BOUNDED, not fast.
+            assert elapsed < 3.0, f"{label} took {elapsed:.1f}s against a held lock"
+    finally:
+        holder.kill()
+        holder.wait(timeout=5)

--- a/tests/unit/tools/test_group_reaper.py
+++ b/tests/unit/tools/test_group_reaper.py
@@ -802,11 +802,18 @@ def test_ledger_lock_degrades_when_unavailable(tmp_path, monkeypatch):
 def _hold_ledger_lock(config_dir, owner_pid):
     """Hold this owner's ledger lock EXCLUSIVELY from another process.
 
-    Another process, not another thread, because that is the real failure: a
-    husk leaked by a SIGKILLed peer (or a sibling mid-compaction) holds the
-    flock with nobody left to release it. A same-process holder would prove
-    nothing, since flock is per open-file-description and the reaper's own fd
-    would be granted the lock immediately.
+    A separate process, not another thread, because it models the real failure:
+    a live peer wedged while holding the lock, which is what was observed in the
+    wild (several live ``lop`` processes parked in ``flock``+``close`` for hours)
+    and what never releases. Note a SIGKILLed peer would NOT do — the kernel
+    drops a flock when the holder dies, so the lock is granted immediately; what
+    a hard death leaks is the ``.lock`` file, not the lock.
+
+    A same-process holder would in fact contend (``_ledger_lock`` opens a fresh
+    fd, hence a fresh open-file-description: measured errno 35 on darwin), so it
+    is not that it would prove nothing — the separate process is chosen because
+    it is the honest model of a cross-session contender and cannot be defeated
+    by fd reuse inside the test.
 
     Returns (Popen, lock_path); the caller must kill the holder.
     """
@@ -838,11 +845,17 @@ def test_ledger_lock_never_blocks_when_held_by_another_process(tmp_path):
     """Every ledger-touching entry point returns promptly against a held lock.
 
     This is the #401 bug shape in the reaper: the acquire used to be a bare
-    blocking ``flock``, so a lock held by anyone else parked the caller forever.
-    On ``/reload`` that lands in ``kill_own_groups()`` AFTER the TUI restored the
-    terminal, and on macOS a thread parked in ``flock(fd)`` also blocks the event
-    loop's ``os.close(fd)`` — the user gets a shell prompt, a live process that
-    never exits, and a Ctrl+C that only echoes.
+    blocking ``flock``, so a lock held by a wedged live peer parked the caller
+    forever. The callers that actually park are ``register_group`` and
+    ``unregister_group`` on the bash path — ``kill_own_groups`` never takes this
+    lock and returns in 0.00s even pre-fix — and they run on asyncio worker
+    threads that interpreter shutdown joins, so on ``/reload`` the process cannot
+    exit after the TUI has restored the terminal. On macOS a parked thread also
+    blocks the event loop's ``os.close(fd)``. The user gets a shell prompt, a
+    live process that never exits, and a Ctrl+C that only echoes.
+
+    ``kill_own_groups`` is asserted anyway: it must STAY prompt, since it is the
+    teardown call the user is waiting on when the freeze becomes visible.
 
     NOTE the failure mode this test is built for: pre-fix it does not fail an
     assertion, it HANGS. The bound below is therefore a real timeout, not a


### PR DESCRIPTION
# PR Description

## Summary of Changes

`/reload` on a long-running session hangs forever after the TUI has already torn
down and restored the terminal. The user sees the shell prompt back, the process
never exits, and Ctrl+C only echoes `^C`.

### The lock did not honour its own contract

`_ledger_lock` in `local_operator/tools/group_reaper.py` documents itself as
best-effort:

> Best-effort: if the lock itself cannot be taken (permissions, an exotic FS
> without `flock`) we DEGRADE to running unlocked rather than **block** or fail a
> command — the worst case is the pre-existing lost-append behaviour, never a
> wrong kill.

The acquire under that docstring was blocking, with no `LOCK_NB` and no timeout:

```python
fcntl.flock(fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
```

So the promise held only when the lock happened to be free. Held by anyone else,
the acquire parks forever — the one outcome the docstring rules out.

The contender that never releases is a **live peer that is itself wedged** while
holding the lock, which is what was seen on this machine: 3 of 14 live `lop`
processes parked with the identical `flock`+`close` stack, two burning ~149% CPU
for 800+ minutes. One wedged process parks the next, and the freeze propagates
between sessions. Note it is **not** a lock leaked by a dead process: the kernel
drops a `flock` when the holder dies, `SIGKILL` included (measured — granted in
`0.000s` after killing the holder). A hard death leaks the `.lock` **file**, which
`_sweep_orphan_locks` already cleans; the **lock** is gone with the process.

### Which path actually parks

The callers that take this lock are `register_group` (SHARED) and
`_rewrite_without_pgid` via `unregister_group` (EXCLUSIVE) — the **bash path**.
`kill_own_groups` never takes it (it goes `_read_ledger` -> `_reap_if_still_ours`
-> `path.unlink`), measured on the pre-fix tree against a real held lock:

```
PRE-FIX register_group     returned=False after 3.00s   <- parked
PRE-FIX unregister_group   returned=False after 3.00s   <- parked
PRE-FIX kill_own_groups    returned=True after 0.01s    <- never touched the lock
```

### Why a parked acquire takes down the whole process

The bash tool registers each command's process group from an asyncio worker
thread, and `concurrent.futures` joins those threads at interpreter shutdown. One
worker parked in `flock` therefore means **the process never exits**. On macOS it
is worse still: `os.close(fd)` blocks until a sibling thread parked in `flock(fd)`
returns, so the event-loop thread's close wedges and the loop stops dead.

`/reload` is where this becomes visible, because `cli.py` `main()`'s teardown
`finally` runs after `run_tui` returns and `/reload` exits with `REEXEC_CODE(75)`
to re-exec — so the hang lands **after** the terminal is restored and **before**
`replace_self()`. `kill_own_groups` is what the user is waiting on there, but the
thread that is stuck was parked earlier, by the bash path. Ctrl+C cannot break it:
`_install_group_reaper_soft_death` deliberately excludes SIGINT (correctly — a
SIGINT is a turn abort that must spare background jobs), and the main thread is
inside a C syscall where no Python signal handler can run. Long sessions are
worse because they accumulate more registered groups and more chances of a
contended or leaked lock.

### The fix

This is the same bug class as #401 (`fix(mcp): stop the OAuth refresh lock from
freezing the TUI on /resume`, 80df237b), which fixed exactly this shape in
`local_operator/mcp/auth.py` and left `group_reaper.py` untouched. Rather than
invent a second idiom, this reuses the vetted one — `_try_lock_ledger` mirrors
`auth._try_lock_exclusive`, and `_acquire_ledger_lock` mirrors the bounded retry
in `auth._acquire_locked_fd` — with one deliberate difference: auth's helper is
exclusive-only, while the reaper needs the readers/writer distinction (SHARED for
appends so they still proceed concurrently, EXCLUSIVE for compaction), so
`exclusive` selects the mode and the distinction is kept intact.

- Every attempt is `LOCK_NB`, retried with geometric backoff to a **300ms**
  bound. The bound is sized off the HONEST contender — a sub-`PIPE_BUF` append or
  a small read-filter-rewrite, microseconds to low milliseconds — leaving ~2
  orders of magnitude of headroom while staying imperceptible. A generous timeout
  would not help against the wedged-peer case, it would only move the freeze.
  This deliberately diverges from `auth.LOCK_ACQUIRE_TIMEOUT_S` (15s): that lock
  guards a destructive rotating-token double-spend, this one guards an append
  whose loss is benign.
- `EAGAIN`/`EACCES`/`EWOULDBLOCK` is contention: degrade to unlocked, log at
  debug. Any other `OSError` is a real fault and flows into the existing degrade
  path unchanged.
- The degraded path keeps the existing semantics exactly — worst case is the
  pre-existing lost-append, never a wrong kill. **No reap gate was touched.**
- Comments record why non-blocking is required rather than stylistic (the darwin
  close-behind-flock property, the SIGINT exclusion) and carry the same explicit
  "do not simplify this back into a blocking acquire" warning as `auth.py`.

### Package-wide audit

Per the brief, every other `flock` call site was checked.
`session_lease.py:108` already uses `LOCK_NB` and is fine. After this change:

```
$ grep -rn "fcntl[.]flock" local_operator --include=*.py | grep -v LOCK_NB
local_operator/session_lease.py:133:      fcntl.flock(fd, fcntl.LOCK_UN)
local_operator/tools/group_reaper.py:394: ``fcntl.flock(fd, fcntl.LOCK_EX)``.   <- docstring warning
local_operator/tools/group_reaper.py:508: fcntl.flock(fd, fcntl.LOCK_UN)
local_operator/mcp/auth.py:1376:          ``fcntl.flock(fd, fcntl.LOCK_EX)``.   <- docstring warning
local_operator/mcp/auth.py:1459:          fcntl.flock(fd, fcntl.LOCK_UN)
local_operator/mcp/auth.py:1520:          ``fcntl.flock(fd, LOCK_EX)`` waits forever, ...
```

Only unlocks and docstring references remain. No blocking acquire survives
anywhere in the package.

## Impact

- No breaking changes, no dependency updates, no new public API.
- Version bumped to `0.43.9` — **patch**: a bug fix, no new capability. (Note the
  repo `pyproject.toml` read `0.43.5` while `0.43.8` was the published version;
  this is based on the actual latest release, confirmed against both
  `gh release list` and PyPI, so it does not regress.)

## Testing Details

### End-to-end: the real `/reload` teardown shape

Models what actually happens — groups registered off-loop through
`asyncio.to_thread` exactly as `execute_bash` does, `kill_own_groups()` on the
loop thread as `cli.py`'s teardown `finally` does, with the lock held by a
separate live process standing in for a wedged peer. The tell is whether the
process ever reaches interpreter exit, since that is where the executor join
parks.

**BEFORE (`origin/main`, a892aaf5):**

```
phase 1: lock held by a live wedged-peer stand-in
!!! STILL RUNNING after 25s -- FREEZE REPRODUCED
```

It never reaches phase 2. This is the reported bug: terminal restored, process
alive forever, `replace_self()` never called.

**AFTER (this branch):**

```
phase 1: lock held by a live wedged-peer stand-in
phase 2: 3 groups registered off-loop in 0.36s
phase 3: kill_own_groups done; TUI torn down, terminal restored
phase 4: process exiting -> /reload would now replace_self()
process exited cleanly after 1s
```

All four phases, clean exit in 1s, with the lock still held throughout.

### The diagnosis probe

The standalone probe from the bug report: one thread calls `register_group`
against a lock held by another process, with an 8s observation window.

```
BEFORE:  probing tree: /tmp/lop-prefix/local_operator/tools
         returned=False after 8.0s          <- parked, never returned

AFTER:   probing tree: /tmp/lop-reaper-flock/local_operator/tools
         returned=True after 0.3s           <- bounded at the 300ms budget
```

### The regression test genuinely catches the bug

`test_ledger_lock_never_blocks_when_held_by_another_process` holds the lock from
a **real second process** and asserts a hard time bound on `register_group`,
`unregister_group` and `kill_own_groups`. The separate process is chosen because
it honestly models a cross-session contender and cannot be defeated by fd reuse
inside the test — not because a same-process holder would fail to contend (it
does contend: `_ledger_lock` opens a fresh fd, hence a fresh open-file
description, measured errno 35 on darwin).

Its pre-fix failure mode is a **hang, not an assertion**, so each call runs on a
daemon thread the test abandons rather than joins — a regression surfaces as a
failed `done.wait` instead of deadlocking the runner. Verified by copying the new
test file onto a clean `origin/main` worktree:

**Against the pre-fix tree:**

```
$ .venv/bin/python -m pytest tests/unit/tools/test_group_reaper.py -n0 -k never_blocks
>               assert done.wait(timeout=5.0), f"{label} parked on the contended ledger lock"
E               AssertionError: register_group parked on the contended ledger lock
1 failed, 30 deselected in 8.65s
```

**Against this branch:**

```
$ .venv/bin/python -m pytest tests/unit/tools/test_group_reaper.py tests/unit/test_session_lease.py -q
38 passed in 2.21s
```

### Gates — full tree, exactly as CI runs them

```
$ .venv/bin/python -m flake8 .
(clean)

$ uvx --from black==26.1.0 black --check .
All done! 615 files would be left unchanged.

$ uvx isort==5.13.2 --check .
(clean)

$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
25 failed, 8746 passed, 15 skipped in 180.16s
```

**On the unit-suite failures: zero are caused by this change.** They are entirely
`tests/unit/tools/test_eval_tool.py`, which spawns kernel subprocesses that
cannot import `local_operator` from a worktree. Confirmed by running the same
suite on an unmodified `origin/main` worktree and diffing the failure sets:

```
base=24 after=24
=== ONLY IN AFTER (regressions) ===
(none)
=== ONLY IN BASE ===
(none)
```

Identical sets, and the same 24 also fail on unmodified code in the primary
checkout (`24 failed, 23 passed`), so this is a pre-existing local environment
issue with the eval kernel, not a regression. Flagged, deliberately not fixed
here — it is outside this slice.

### The freeze-guard e2e stage (round-1 finding C4)

`tui-e2e` is the stage purpose-built to catch exactly this deadlock class, and it
reported `skipping` on both CI runs: it declares `needs: [lint, type-check, test,
pip-audit]`, and `test` is red from the pre-existing flake below. So the guard was
structurally disarmed on the very PR it exists to guard.

Closing that gap by changing the workflow's `needs` would alter CI topology for
every PR in the repo, so it is **deferred to #428** rather than widened into this
bug fix. The signal itself was not skipped — the stage was run locally on macOS
at head, the platform AGENTS.md calls "the only platform where the freeze guard
can go red at all":

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
3 passed in 10.11s
```

## Checklist

- [x] Tests added for the regression, verified to fail on the pre-fix tree
- [x] Real execution evidence captured before and after, not just a green suite
- [x] All CI gates run over the whole tree
- [x] Comments record the why and the constraint per repo convention
- [x] Version bumped by materiality (patch)
