### PR TITLE
feat(prompts): teach agents that the web is a verification surface

### DIFF
--- a/docs/evidence/web-research-disposition/README.md
+++ b/docs/evidence/web-research-disposition/README.md
@@ -1,0 +1,97 @@
+# Evidence: research disposition (web_search / web_fetch)
+
+Captured 2026-08-29 on macOS 25.6.0, against `origin/main` @ `a892aaf5` (before)
+and `dev-web-research-disposition` (after). The behavioural arm uses live
+`anthropic/claude-opus-5` turns on the configured OAuth credential; web results
+come from the credential-free `duckduckgo` provider.
+
+| File | What it shows |
+|---|---|
+| `token-cost.txt` | Always-on prompt cost before vs after, on `bench_role_overhead.py`'s basis |
+| `cache-stability.txt` | Prompt-cache prefix stability before vs after (unchanged) |
+| `ab-eval.txt` | Live A/B: research rate over 14 scenarios x 3 runs x 2 arms |
+| `ab-eval.json` | The same run as structured data, including every tool call made |
+| `token_probe.py` | The snippet that produces `token-cost.txt`, so the numbers are re-derivable |
+
+Re-derivable without a paid run except the last two:
+
+```sh
+.venv/bin/python docs/evidence/web-research-disposition/token_probe.py
+.venv/bin/python scripts/bench_cache_rate.py --turns 4
+.venv/bin/python scripts/eval_research_disposition.py \
+    --before <worktree-of-base> --after <worktree-of-branch> --runs 3
+```
+
+## The problem this measures
+
+`system.md` never mentioned `web_search` or `web_fetch` — zero occurrences of
+"web", "internet", "research" or "look up" in 207 lines. The tools were not
+gated: both are in `DEFAULT_TOOL_NAMES` and enabled by default. They were
+present and unmentioned.
+
+Worse than unmentioned, they were implicitly excluded. Two places defined tool
+use as a closed set of local actions:
+
+- the persona paragraph — "tools for running shell commands, reading and
+  editing files, searching the workspace... Use them whenever the answer
+  depends on **the machine's state**";
+- the first working principle — "Verify with a tool rather than assuming: run
+  the command, read the file, **search the workspace**."
+
+Both enumerations are complete-sounding and entirely local. An agent following
+them faithfully never reaches the web, because by the definition it was handed
+it has already verified. That is why lookups only happened when a user asked
+for one explicitly. The fix widens both enumerations and adds one bullet naming
+the trigger; it does not advertise the tools.
+
+## Why the cost is not in the tool descriptions
+
+The obvious fix — explain "when to reach for it" in the two tool descriptions —
+is the expensive one. A tool's description is billed **twice**: once in the
+provider `tools` array, and again in the rendered tool inventory, because
+`_render_tool_inventory` emits the full description string into system block
+`[1]`. 36 tokens of prose there costs 144 always-on tokens across the two
+tools, for guidance read at call-selection time rather than at task-framing
+time. The behaviour wanted here is *noticing that a lookup is needed*, which
+happens before the model is scanning tool schemas.
+
+`token-cost.txt` shows `tool_inventory` and `tools_array` both unchanged.
+
+## What the A/B eval measures, and the two traps in measuring it
+
+`ab-eval.txt` reports two rates per arm, and the second one matters as much as
+the first:
+
+- **SHOULD-trigger** (10 scenarios): questions whose answer is not on this
+  machine — a dependency error message, a published advisory, a version-specific
+  API, current ecosystem practice, design patterns.
+- **SHOULD-NOT-trigger** (4 scenarios): a local refactor, a question about lop
+  itself, arithmetic, a directory listing. Prompting an agent to search is
+  trivial; the failure it buys is a reflexive search on every task, a latency
+  and token cost paid on work that never needed it. S12 ("how do I change my
+  custom instructions in lop") is the highest-signal negative: the correct
+  behaviour is `read guide://configuration`, so a web search there is a
+  regression against an existing rule, not merely a wasted call.
+
+Two measurement traps were hit and fixed while building this, both of which
+would have produced a confident wrong number:
+
+1. **Counting only `web_search`/`web_fetch` understates research.** An agent
+   can reach the network by curling from `bash` or opening a URL from `eval`,
+   and on the first real run *both* arms queried the OSV advisory API that way.
+   That is still research. The harness therefore scores "researched" (network
+   reached at all) and reports "via web tool" separately — moving a run from
+   improvised curl to the purpose-built tool is a real improvement (bounded
+   output, spill handles, caching, provider fallback), but it is not the same
+   claim as creating research behaviour that was not there.
+
+2. **The arms must be isolated from this machine.** Both run against a clean
+   `LOCAL_OPERATOR_CONFIG_DIR` seeded with credentials only, with ecosystem
+   skill roots disabled. The operator's own `system_prompt.md`, MCP servers and
+   skills do not ship to users, and any of them could produce search behaviour
+   on its own and have it credited to the prompt change.
+
+The harness also fingerprints each arm's prompt text at start and end and
+refuses to report a run where it changed mid-flight — a full run takes over an
+hour and reads the prompt from the working tree on every scenario, so an edit
+during the run silently averages two different texts into one number.

--- a/docs/evidence/web-research-disposition/README.md
+++ b/docs/evidence/web-research-disposition/README.md
@@ -87,9 +87,32 @@ would have produced a confident wrong number:
 
 2. **The arms must be isolated from this machine.** Both run against a clean
    `LOCAL_OPERATOR_CONFIG_DIR` seeded with credentials only, with ecosystem
-   skill roots disabled. The operator's own `system_prompt.md`, MCP servers and
-   skills do not ship to users, and any of them could produce search behaviour
-   on its own and have it credited to the prompt change.
+   skill roots disabled. The operator's own `system_prompt.md` and skills do
+   not ship to users, and either could produce search behaviour on its own and
+   have it credited to the prompt change.
+
+   **The MCP half of that isolation does not work, and the runs recorded here
+   carry it.** `_prepare_home` writes an empty `mcp.json` into the scratch
+   config dir, but `resolve_mcp_config` reads `Path.home() / ".local-operator"
+   / "mcp.json"` directly (`local_operator/mcp/config.py:306`) and never
+   consults `LOCAL_OPERATOR_CONFIG_DIR`. So the operator's own MCP servers
+   (Notion, HubSpot, Slack, Datadog) were connected in all 84 runs, and their
+   tool definitions rode both arms' prompts.
+
+   Scope of the damage, checked rather than assumed: the leak is **symmetric**
+   (42 runs per arm) and **no `mcp__*` tool is called in any of the 84 runs** —
+   the only tools that appear are `bash`, `eval`, `glob`, `grep`, `read`,
+   `web_fetch`, `web_search`. The A/B contrast therefore stands. What is *not*
+   safe to read off these runs is any absolute prompt size, because both arms
+   carried MCP surface the `token-cost.txt` baseline does not include.
+   `token-cost.txt` is measured separately and offline, so it is unaffected.
+
+   The harness has since been fixed: it redirects `HOME` at the scratch dir as
+   well as `LOCAL_OPERATOR_CONFIG_DIR`, which covers both the code that calls
+   `config_dir()` and the code that reads `Path.home()` itself. Verified on a
+   spot run — no MCP traffic in either arm. The recorded `ab-eval.json` predates
+   that fix and is kept as captured rather than silently re-run, since the
+   contrast it reports is unaffected.
 
 The harness also fingerprints each arm's prompt text at start and end and
 refuses to report a run where it changed mid-flight — a full run takes over an

--- a/docs/evidence/web-research-disposition/ab-eval.json
+++ b/docs/evidence/web-research-disposition/ab-eval.json
@@ -1,0 +1,1749 @@
+{
+  "results": [
+    {
+      "scenario": "S1",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [
+        "bash"
+      ],
+      "all_calls": [
+        "bash",
+        "bash",
+        "web_search",
+        "web_fetch",
+        "read",
+        "bash",
+        "read"
+      ],
+      "session": "9c724c71cdf9",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:26:19,975 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:26:19,984 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:26:20,195 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 0
+    },
+    {
+      "scenario": "S1",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "bash",
+        "bash",
+        "bash",
+        "bash",
+        "bash"
+      ],
+      "session": "4191ebc20ddc",
+      "stderr_tail": "TTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:29:12,769 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:29:12,792 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:29:12,884 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 1
+    },
+    {
+      "scenario": "S1",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_fetch",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "bash",
+        "web_search",
+        "web_fetch",
+        "read",
+        "web_fetch",
+        "read",
+        "read"
+      ],
+      "session": "6b612ae1772c",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:30:05,019 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:30:05,020 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:30:05,189 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 2
+    },
+    {
+      "scenario": "S2",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_fetch",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "web_fetch",
+        "bash",
+        "web_fetch",
+        "bash",
+        "bash"
+      ],
+      "session": "e1833b0778df",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:30:31,945 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:30:31,975 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:30:32,073 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 0
+    },
+    {
+      "scenario": "S2",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_fetch",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "web_fetch",
+        "web_fetch"
+      ],
+      "session": "5453a404d2bf",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:30:49,324 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:30:49,328 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:30:49,461 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 1
+    },
+    {
+      "scenario": "S2",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_fetch",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "web_fetch",
+        "web_fetch"
+      ],
+      "session": "38238a52d9b4",
+      "stderr_tail": "TTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:31:07,610 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:31:07,637 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:31:07,756 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 2
+    },
+    {
+      "scenario": "S3",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [
+        "bash",
+        "bash"
+      ],
+      "all_calls": [
+        "bash",
+        "bash",
+        "bash"
+      ],
+      "session": "82fa00c6211e",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:31:27,052 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:31:27,064 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:31:27,194 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 0
+    },
+    {
+      "scenario": "S3",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search"
+      ],
+      "improvised_network": [
+        "bash",
+        "bash"
+      ],
+      "all_calls": [
+        "bash",
+        "web_search",
+        "bash"
+      ],
+      "session": "3e6d3470f046",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:31:46,106 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:31:46,107 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:31:46,315 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 1
+    },
+    {
+      "scenario": "S3",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [
+        "bash"
+      ],
+      "all_calls": [
+        "web_search",
+        "web_fetch",
+        "bash"
+      ],
+      "session": "03d6af82b6c1",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:32:01,752 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:32:01,760 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:32:01,937 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 2
+    },
+    {
+      "scenario": "S4",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [],
+      "session": "806d19df418d",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:32:21,015 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:32:21,016 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:32:21,172 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 0
+    },
+    {
+      "scenario": "S4",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [],
+      "session": "3d073caa2d6b",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:32:47,088 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:32:47,091 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:32:47,195 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 1
+    },
+    {
+      "scenario": "S4",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [],
+      "session": "89e6b1907a8c",
+      "stderr_tail": "TTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:33:09,947 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:33:09,984 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:33:10,093 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 2
+    },
+    {
+      "scenario": "S5",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "bash"
+      ],
+      "session": "739dd39df9f8",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:33:51,184 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:33:51,189 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:33:51,333 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 0
+    },
+    {
+      "scenario": "S5",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "bash"
+      ],
+      "session": "fd6d7fbd849b",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:35:04,196 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:35:04,204 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:35:04,389 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 1
+    },
+    {
+      "scenario": "S5",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "bash"
+      ],
+      "session": "6c29bf0a951c",
+      "stderr_tail": "TTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:36:02,382 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:36:02,595 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:36:03,700 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n",
+      "arm": "before",
+      "run": 2
+    },
+    {
+      "scenario": "S6",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_fetch",
+        "web_search"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_fetch",
+        "web_search",
+        "read",
+        "read",
+        "read"
+      ],
+      "session": "8da415bca5cf",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:36:34,361 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:36:34,452 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:36:34,567 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 0
+    },
+    {
+      "scenario": "S6",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_fetch",
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_fetch",
+        "web_search",
+        "read",
+        "read",
+        "web_fetch",
+        "read",
+        "read",
+        "read"
+      ],
+      "session": "76daffa75d37",
+      "stderr_tail": "TTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:37:13,899 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:37:13,940 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:37:14,101 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 1
+    },
+    {
+      "scenario": "S6",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_fetch",
+        "web_search"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_fetch",
+        "web_search",
+        "read",
+        "read",
+        "read"
+      ],
+      "session": "e0d61bda0aee",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:37:43,774 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:37:43,873 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:37:44,130 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 2
+    },
+    {
+      "scenario": "S7",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [],
+      "session": "3fd26e3d9d02",
+      "stderr_tail": "TTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:38:02,839 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:38:02,849 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:38:02,986 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 0
+    },
+    {
+      "scenario": "S7",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [],
+      "session": "183a6eefd73c",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:38:29,008 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:38:29,011 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:38:29,170 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 1
+    },
+    {
+      "scenario": "S7",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [],
+      "session": "7c672786f247",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:39:00,090 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:39:00,153 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:39:00,321 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 2
+    },
+    {
+      "scenario": "S8",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [
+        "bash"
+      ],
+      "all_calls": [
+        "bash",
+        "web_search",
+        "bash",
+        "web_fetch",
+        "read",
+        "bash",
+        "bash"
+      ],
+      "session": "4ebfc0d71fef",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:39:51,048 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:39:51,184 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:39:51,376 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 0
+    },
+    {
+      "scenario": "S8",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_search",
+        "web_fetch",
+        "read"
+      ],
+      "session": "065824d049ed",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:40:28,825 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:40:28,839 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:40:29,041 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 1
+    },
+    {
+      "scenario": "S8",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_fetch",
+        "web_search"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_fetch",
+        "web_search",
+        "read"
+      ],
+      "session": "6c4ded4de9e9",
+      "stderr_tail": "on termination failed: [Errno 8] nodename nor servname provided, or not known\n2026-08-29 22:40:46,534 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:40:46,575 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:40:46,768 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 2
+    },
+    {
+      "scenario": "S9",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [],
+      "session": "83834164685b",
+      "stderr_tail": "TTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:41:11,249 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:41:11,263 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:41:11,409 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 0
+    },
+    {
+      "scenario": "S9",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [],
+      "session": "90ee4819726a",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:41:40,384 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:41:40,387 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:41:40,515 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 1
+    },
+    {
+      "scenario": "S9",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [],
+      "session": "5ecc5914a72e",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:42:00,319 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:42:00,362 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:42:00,460 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 2
+    },
+    {
+      "scenario": "S10",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "web_search"
+      ],
+      "session": "889d58593cdc",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:42:26,513 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:42:26,527 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:42:26,686 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 0
+    },
+    {
+      "scenario": "S10",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_search",
+        "bash"
+      ],
+      "session": "b20da53f121c",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:42:50,112 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:42:50,116 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:42:50,259 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 1
+    },
+    {
+      "scenario": "S10",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_search",
+        "web_search",
+        "web_fetch",
+        "read"
+      ],
+      "session": "b73d7da33158",
+      "stderr_tail": "TTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:43:19,036 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:43:19,121 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:43:19,214 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 2
+    },
+    {
+      "scenario": "S11",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "grep",
+        "bash"
+      ],
+      "session": "364716beaf07",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:43:32,520 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:43:32,554 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:43:32,622 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 0
+    },
+    {
+      "scenario": "S11",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "grep"
+      ],
+      "session": "dad05f022b1f",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:43:43,823 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:43:43,869 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:43:43,985 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 1
+    },
+    {
+      "scenario": "S11",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "grep",
+        "bash"
+      ],
+      "session": "3252a479a286",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:43:57,517 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:43:57,520 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:43:57,731 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 2
+    },
+    {
+      "scenario": "S12",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "read",
+        "bash"
+      ],
+      "session": "ad64a0f3b8a9",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:44:15,225 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:44:15,226 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:44:15,439 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 0
+    },
+    {
+      "scenario": "S12",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "read",
+        "bash"
+      ],
+      "session": "a46462a39a7a",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:44:35,004 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:44:35,042 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:44:35,184 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 1
+    },
+    {
+      "scenario": "S12",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "read",
+        "bash"
+      ],
+      "session": "d49d63a14782",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:44:55,907 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:44:55,922 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:44:56,048 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 2
+    },
+    {
+      "scenario": "S13",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "eval"
+      ],
+      "session": "768973d057c7",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:45:01,658 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:45:01,664 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:45:01,844 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 0
+    },
+    {
+      "scenario": "S13",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "eval"
+      ],
+      "session": "d06828fc8c60",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:45:08,208 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:45:08,218 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:45:08,394 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 1
+    },
+    {
+      "scenario": "S13",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [],
+      "session": "28b917f727d2",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:45:12,806 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:45:12,833 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:45:12,853 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 2
+    },
+    {
+      "scenario": "S14",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "bash",
+        "bash",
+        "bash",
+        "bash",
+        "bash",
+        "bash",
+        "bash"
+      ],
+      "session": "533866b52338",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:47:48,627 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:47:48,718 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:47:48,825 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 0
+    },
+    {
+      "scenario": "S14",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "bash",
+        "bash",
+        "bash",
+        "bash",
+        "bash"
+      ],
+      "session": "a761ee3e1dc6",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:48:40,209 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:48:40,240 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:48:40,372 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 1
+    },
+    {
+      "scenario": "S14",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "glob",
+        "bash",
+        "bash",
+        "bash"
+      ],
+      "session": "e502552e9ada",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:49:03,532 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:49:04,023 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:49:04,324 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "before",
+      "run": 2
+    },
+    {
+      "scenario": "S1",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [
+        "bash",
+        "bash"
+      ],
+      "all_calls": [
+        "bash",
+        "web_search",
+        "bash",
+        "web_fetch",
+        "read",
+        "read",
+        "bash"
+      ],
+      "session": "5c22190cec60",
+      "stderr_tail": "TTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:49:53,500 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:49:53,615 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:49:53,722 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 0
+    },
+    {
+      "scenario": "S1",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [
+        "bash"
+      ],
+      "all_calls": [
+        "bash",
+        "web_search",
+        "web_fetch",
+        "bash",
+        "read",
+        "read",
+        "bash",
+        "bash"
+      ],
+      "session": "c3815ddec3be",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:50:51,098 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:50:51,099 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:50:51,279 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 1
+    },
+    {
+      "scenario": "S1",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "web_search",
+        "bash",
+        "web_fetch",
+        "read",
+        "bash"
+      ],
+      "session": "b563f14729fd",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:51:36,505 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:51:36,524 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:51:36,672 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 2
+    },
+    {
+      "scenario": "S2",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_fetch",
+        "web_fetch"
+      ],
+      "improvised_network": [
+        "bash"
+      ],
+      "all_calls": [
+        "bash",
+        "web_fetch",
+        "bash",
+        "web_fetch",
+        "bash"
+      ],
+      "session": "9cf96c8755bd",
+      "stderr_tail": "TTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:52:04,824 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:52:04,856 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:52:04,968 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 0
+    },
+    {
+      "scenario": "S2",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_fetch"
+      ],
+      "improvised_network": [
+        "bash"
+      ],
+      "all_calls": [
+        "bash",
+        "web_fetch",
+        "bash"
+      ],
+      "session": "89bcf62462c1",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:52:19,241 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:52:19,363 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:52:19,457 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 1
+    },
+    {
+      "scenario": "S2",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_search",
+        "web_fetch"
+      ],
+      "session": "a70fd9fbc601",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:52:35,612 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:52:35,612 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:52:35,782 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 2
+    },
+    {
+      "scenario": "S3",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_fetch",
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [
+        "bash"
+      ],
+      "all_calls": [
+        "web_fetch",
+        "web_search",
+        "bash",
+        "web_fetch"
+      ],
+      "session": "5e8b700aec98",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:52:57,002 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:52:57,004 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:52:57,211 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 0
+    },
+    {
+      "scenario": "S3",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [
+        "bash"
+      ],
+      "all_calls": [
+        "web_search",
+        "web_fetch",
+        "bash"
+      ],
+      "session": "7ec545e9c40e",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:53:17,970 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:53:18,084 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:53:18,175 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 1
+    },
+    {
+      "scenario": "S3",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search"
+      ],
+      "improvised_network": [
+        "bash"
+      ],
+      "all_calls": [
+        "bash",
+        "web_search"
+      ],
+      "session": "3fec6ba35bb2",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:53:33,636 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:53:33,639 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:53:33,808 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 2
+    },
+    {
+      "scenario": "S4",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_search",
+        "web_search",
+        "web_fetch",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_search",
+        "web_search",
+        "web_search",
+        "web_fetch",
+        "web_fetch",
+        "read"
+      ],
+      "session": "2239ea9d6ff2",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:54:08,993 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:54:08,996 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:54:09,115 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 0
+    },
+    {
+      "scenario": "S4",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_search",
+        "web_fetch",
+        "web_fetch",
+        "web_search"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_search",
+        "web_search",
+        "web_fetch",
+        "web_fetch",
+        "read",
+        "web_search"
+      ],
+      "session": "68259ff45925",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:54:39,754 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:54:39,869 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:54:40,020 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 1
+    },
+    {
+      "scenario": "S4",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_fetch",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_search",
+        "web_fetch",
+        "read",
+        "web_fetch"
+      ],
+      "session": "612201b18893",
+      "stderr_tail": "TTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:55:06,707 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:55:06,742 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:55:06,893 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 2
+    },
+    {
+      "scenario": "S5",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_fetch",
+        "web_search"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "web_search",
+        "web_fetch",
+        "web_search"
+      ],
+      "session": "80a39cf4dac3",
+      "stderr_tail": "TTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:56:17,685 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:56:17,685 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:56:17,811 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 0
+    },
+    {
+      "scenario": "S5",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_search",
+        "web_fetch",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "web_search",
+        "web_search",
+        "web_fetch",
+        "web_fetch",
+        "read"
+      ],
+      "session": "668a469714ea",
+      "stderr_tail": "TTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:57:52,829 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:57:52,829 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:57:53,005 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 1
+    },
+    {
+      "scenario": "S5",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_search",
+        "web_fetch",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "web_search",
+        "web_search",
+        "web_fetch",
+        "web_fetch"
+      ],
+      "session": "6eaf3b1319b6",
+      "stderr_tail": "TTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:58:54,962 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:58:54,984 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:58:55,121 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 2
+    },
+    {
+      "scenario": "S6",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_fetch",
+        "web_search"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_fetch",
+        "web_search",
+        "read",
+        "read",
+        "read"
+      ],
+      "session": "db2a0fa23ca2",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:59:26,250 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:59:26,385 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:59:26,403 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 0
+    },
+    {
+      "scenario": "S6",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_fetch",
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_fetch",
+        "web_search",
+        "read",
+        "web_fetch",
+        "read"
+      ],
+      "session": "bdc124af6f7e",
+      "stderr_tail": "TTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:59:57,491 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 22:59:57,610 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 22:59:57,717 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 1
+    },
+    {
+      "scenario": "S6",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_fetch",
+        "web_search"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_fetch",
+        "web_search",
+        "read",
+        "read",
+        "read"
+      ],
+      "session": "804e2f2a7d17",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:00:30,379 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:00:30,451 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:00:30,535 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 2
+    },
+    {
+      "scenario": "S7",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [],
+      "session": "8bd4919630eb",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:00:48,055 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:00:48,099 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:00:48,189 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 0
+    },
+    {
+      "scenario": "S7",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [],
+      "session": "904d4b17b2f2",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:01:07,049 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:01:07,059 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:01:07,222 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 1
+    },
+    {
+      "scenario": "S7",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [],
+      "session": "19f100434011",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:01:29,008 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:01:29,012 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:01:29,169 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 2
+    },
+    {
+      "scenario": "S8",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "web_search",
+        "web_fetch",
+        "read"
+      ],
+      "session": "ccc04c7758d4",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:01:43,784 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:01:43,794 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:01:43,941 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 0
+    },
+    {
+      "scenario": "S8",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_search",
+        "web_fetch",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_search",
+        "web_search",
+        "web_fetch",
+        "web_fetch",
+        "read",
+        "read",
+        "read"
+      ],
+      "session": "9641722dd0c4",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:02:04,245 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:02:04,246 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:02:04,394 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 1
+    },
+    {
+      "scenario": "S8",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_search",
+        "web_search",
+        "bash",
+        "web_fetch",
+        "read",
+        "read"
+      ],
+      "session": "ca2580ac3d7e",
+      "stderr_tail": "TTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:02:24,544 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:02:24,553 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:02:24,704 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 2
+    },
+    {
+      "scenario": "S9",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [],
+      "session": "fcbd6e396558",
+      "stderr_tail": "TTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:02:51,894 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:02:52,063 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:02:52,199 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 0
+    },
+    {
+      "scenario": "S9",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [],
+      "session": "9635721e150c",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:03:18,829 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:03:18,950 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:03:19,140 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 1
+    },
+    {
+      "scenario": "S9",
+      "should_search": true,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [],
+      "session": "018f05572a9e",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:03:48,300 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:03:48,335 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:03:48,493 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 2
+    },
+    {
+      "scenario": "S10",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_search",
+        "web_search",
+        "web_fetch"
+      ],
+      "session": "e016b1503c63",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:04:14,057 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:04:14,121 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:04:14,255 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 0
+    },
+    {
+      "scenario": "S10",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_search",
+        "web_fetch"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_search",
+        "web_search",
+        "web_fetch",
+        "read"
+      ],
+      "session": "7dfc93fedd2a",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:04:45,648 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:04:45,798 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:04:45,973 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 1
+    },
+    {
+      "scenario": "S10",
+      "should_search": true,
+      "status": "ok",
+      "researched": true,
+      "used_web_tool": true,
+      "web_calls": [
+        "web_search",
+        "web_search"
+      ],
+      "improvised_network": [],
+      "all_calls": [
+        "web_search",
+        "web_search"
+      ],
+      "session": "1343c163e9d9",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:05:10,996 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:05:11,015 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:05:11,138 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 2
+    },
+    {
+      "scenario": "S11",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "grep"
+      ],
+      "session": "a7a4ddbc5679",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:05:21,169 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:05:21,172 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:05:21,276 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 0
+    },
+    {
+      "scenario": "S11",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "grep",
+        "bash"
+      ],
+      "session": "c79869dc48c9",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:05:32,859 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:05:32,863 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:05:33,006 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 1
+    },
+    {
+      "scenario": "S11",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "grep",
+        "bash"
+      ],
+      "session": "cb01c45876c3",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:05:46,845 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:05:46,850 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:05:46,984 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 2
+    },
+    {
+      "scenario": "S12",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "read",
+        "bash"
+      ],
+      "session": "aa1f532a11f8",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:06:05,147 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:06:05,229 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:06:05,241 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 0
+    },
+    {
+      "scenario": "S12",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "read",
+        "bash"
+      ],
+      "session": "d10ebf309f60",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:06:25,165 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:06:25,174 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:06:25,333 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 1
+    },
+    {
+      "scenario": "S12",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "read",
+        "bash"
+      ],
+      "session": "3554702567cf",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:06:44,365 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:06:44,493 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:06:44,634 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 2
+    },
+    {
+      "scenario": "S13",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "eval"
+      ],
+      "session": "7b4050fe29f2",
+      "stderr_tail": "TTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:06:56,650 - INFO - HTTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:06:56,774 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:06:56,785 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 0
+    },
+    {
+      "scenario": "S13",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "eval"
+      ],
+      "session": "fac2c8b4e10a",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:07:07,026 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:07:07,080 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:07:07,227 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 1
+    },
+    {
+      "scenario": "S13",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "eval"
+      ],
+      "session": "68b7d9efc47d",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:07:16,635 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:07:16,680 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:07:16,971 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 2
+    },
+    {
+      "scenario": "S14",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "bash",
+        "bash",
+        "bash",
+        "bash"
+      ],
+      "session": "19f217186542",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:07:44,296 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:07:44,302 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:07:44,444 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 0
+    },
+    {
+      "scenario": "S14",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "glob",
+        "bash",
+        "bash",
+        "bash",
+        "bash",
+        "read"
+      ],
+      "session": "d6a8227a70ac",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:08:17,403 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:08:17,408 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:08:18,110 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 1
+    },
+    {
+      "scenario": "S14",
+      "should_search": false,
+      "status": "ok",
+      "researched": false,
+      "used_web_tool": false,
+      "web_calls": [],
+      "improvised_network": [],
+      "all_calls": [
+        "bash",
+        "glob",
+        "bash",
+        "bash",
+        "bash"
+      ],
+      "session": "0b74613da636",
+      "stderr_tail": "TTP Request: DELETE https://mcp.notion.com/mcp \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:08:42,810 - INFO - HTTP Request: DELETE https://mcp.hubspot.com \"HTTP/1.1 405 Method Not Allowed\"\n2026-08-29 23:08:42,860 - INFO - HTTP Request: DELETE https://mcp.slack.com/mcp \"HTTP/1.1 200 OK\"\n2026-08-29 23:08:42,957 - INFO - HTTP Request: DELETE https://mcp.us3.datadoghq.com/v1/mcp \"HTTP/1.1 200 OK\"\n",
+      "arm": "after",
+      "run": 2
+    }
+  ],
+  "summary": {
+    "S1": {
+      "should_search": true,
+      "before": "2/3 (2w)",
+      "after": "3/3 (3w)"
+    },
+    "S2": {
+      "should_search": true,
+      "before": "3/3 (3w)",
+      "after": "3/3 (3w)"
+    },
+    "S3": {
+      "should_search": true,
+      "before": "3/3 (2w)",
+      "after": "3/3 (3w)"
+    },
+    "S4": {
+      "should_search": true,
+      "before": "0/3 (0w)",
+      "after": "3/3 (3w)"
+    },
+    "S5": {
+      "should_search": true,
+      "before": "0/3 (0w)",
+      "after": "3/3 (3w)"
+    },
+    "S6": {
+      "should_search": true,
+      "before": "3/3 (3w)",
+      "after": "3/3 (3w)"
+    },
+    "S7": {
+      "should_search": true,
+      "before": "0/3 (0w)",
+      "after": "0/3 (0w)"
+    },
+    "S8": {
+      "should_search": true,
+      "before": "3/3 (3w)",
+      "after": "3/3 (3w)"
+    },
+    "S9": {
+      "should_search": true,
+      "before": "0/3 (0w)",
+      "after": "0/3 (0w)"
+    },
+    "S10": {
+      "should_search": true,
+      "before": "3/3 (3w)",
+      "after": "3/3 (3w)"
+    },
+    "S11": {
+      "should_search": false,
+      "before": "0/3 (0w)",
+      "after": "0/3 (0w)"
+    },
+    "S12": {
+      "should_search": false,
+      "before": "0/3 (0w)",
+      "after": "0/3 (0w)"
+    },
+    "S13": {
+      "should_search": false,
+      "before": "0/3 (0w)",
+      "after": "0/3 (0w)"
+    },
+    "S14": {
+      "should_search": false,
+      "before": "0/3 (0w)",
+      "after": "0/3 (0w)"
+    }
+  }
+}

--- a/docs/evidence/web-research-disposition/ab-eval.txt
+++ b/docs/evidence/web-research-disposition/ab-eval.txt
@@ -58,12 +58,24 @@ the desired shape of a miss: the trigger is "you notice you are guessing", and
 on these two the model was not guessing. Forcing a search here would buy
 latency and no accuracy.
 
-The negative half is the load-bearing half, and it held at 0/12 in both arms.
-S12 is the one to check by hand rather than by rate: the correct behaviour is
-to read guide://configuration, and the after arm did exactly that -
+The negative half held at 0/12 in both arms, and the honest reading of that is
+NO REGRESSION ON EASY NEGATIVES - not "no reflexive searching". All four
+SHOULD-NOT scenarios also scored 0/3 on the BASE arm, and all four are
+unambiguously local (a repo function, a lop config question, arithmetic, a
+directory listing). A negative set the unmodified prompt already aces cannot
+discriminate between a brake that works and a brake that is inert. Building a
+negative set that CAN discriminate - trivial-but-web-adjacent prompts the base
+arm sometimes searches on - is the obvious follow-up, and it is the measurement
+this round does not have.
+
+What the negative half does establish is checked by hand rather than by rate.
+S12 is the one that matters: the correct behaviour is to read
+guide://configuration, and the after arm did exactly that -
 
   read {"path": "guide://configuration", "i": "Reading configuration guide"}
 
 so the new research bullet did not override the existing guide rule it sits
-55 lines below. S11 used grep, S13 used eval for arithmetic, S14 used bash.
-Nothing reached for the web where the answer was local.
+55 lines below - a rule it could plausibly have overridden, since "how do I
+change my custom instructions" is a question about a product whose docs are on
+the web. S11 used grep, S13 used eval for arithmetic, S14 used bash. Nothing
+reached for the web where the answer was local.

--- a/docs/evidence/web-research-disposition/ab-eval.txt
+++ b/docs/evidence/web-research-disposition/ab-eval.txt
@@ -1,0 +1,69 @@
+# A/B eval: research disposition, live agent runs
+
+14 scenarios x 3 runs x 2 arms = 84 live turns, anthropic/claude-opus-5.
+before = origin/main @ a892aaf5; after = dev-web-research-disposition.
+Both arms: isolated LOCAL_OPERATOR_CONFIG_DIR, ecosystem skills disabled,
+web_search provider = duckduckgo (credential-free).
+
+Command:
+  .venv/bin/python scripts/eval_research_disposition.py \
+      --before <base-worktree> --after <branch-worktree> --runs 3
+
+"researched" = reached the network at all (includes curl from bash/eval).
+"(Nw)" = of those, how many used web_search/web_fetch rather than improvising.
+
+=== per scenario: researched (of which via web tool) ===
+id    expect        before        after
+S1    search      2/3 (2w)     3/3 (3w)   dependency traceback (pydantic root_validator)
+S2    search      3/3 (3w)     3/3 (3w)   httpx proxies= removal
+S3    search      3/3 (2w)     3/3 (3w)   published advisory for requests 2.31.0
+S4    search      0/3 (0w)     3/3 (3w)   current wheel-build tooling
+S5    search      0/3 (0w)     3/3 (3w)   command-palette design patterns
+S6    search      3/3 (3w)     3/3 (3w)   Anthropic prompt-cache breakpoints
+S7    search      0/3 (0w)     0/3 (0w)   PEP 668 externally-managed-environment
+S8    search      3/3 (3w)     3/3 (3w)   Textual save_screenshot currency
+S9    search      0/3 (0w)     0/3 (0w)   WCAG contrast thresholds
+S10   search      3/3 (3w)     3/3 (3w)   HTTP 529
+S11   NO          0/3 (0w)     0/3 (0w)   local refactor question
+S12   NO          0/3 (0w)     0/3 (0w)   "how do I change custom instructions in lop"
+S13   NO          0/3 (0w)     0/3 (0w)   arithmetic
+S14   NO          0/3 (0w)     0/3 (0w)   directory listing
+
+SHOULD trigger:
+  before researched 17/30 (57%), via web tool 16/30 (53%)
+  after  researched 24/30 (80%), via web tool 24/30 (80%)
+
+SHOULD NOT:
+  before researched 0/12 (0%), via web tool 0/12 (0%)
+  after  researched 0/12 (0%), via web tool 0/12 (0%)
+
+## Reading the result
+
+The headline is S4 and S5: 0/3 -> 3/3 each. Both are the case the change was
+written for. S4 ("what does the ecosystem do now for building wheels") and S5
+("design patterns for a command palette") were answered entirely from recall on
+the base, with S4 making ZERO tool calls of any kind. Neither question has a
+local answer, and neither triggered a lookup until the prompt stopped defining
+verification as a local-only act.
+
+S1 (2/3 -> 3/3) and S3 (2 of 3 improvised via curl -> 3 of 3 on the web tools)
+are smaller moves in the same direction: the intent was already there, and what
+changed is that it now reaches the purpose-built tool instead of hand-rolling an
+HTTP call in bash.
+
+S7 and S9 did not move and are NOT counted as fixes. Both answered from stable
+knowledge and both answered CORRECTLY - PEP 668's marker file and mechanism,
+and WCAG 2.2's 4.5:1 / 3:1 thresholds, neither of which has changed. This is
+the desired shape of a miss: the trigger is "you notice you are guessing", and
+on these two the model was not guessing. Forcing a search here would buy
+latency and no accuracy.
+
+The negative half is the load-bearing half, and it held at 0/12 in both arms.
+S12 is the one to check by hand rather than by rate: the correct behaviour is
+to read guide://configuration, and the after arm did exactly that -
+
+  read {"path": "guide://configuration", "i": "Reading configuration guide"}
+
+so the new research bullet did not override the existing guide rule it sits
+55 lines below. S11 used grep, S13 used eval for arithmetic, S14 used bash.
+Nothing reached for the web where the answer was local.

--- a/docs/evidence/web-research-disposition/cache-stability.txt
+++ b/docs/evidence/web-research-disposition/cache-stability.txt
@@ -1,0 +1,17 @@
+# Prompt-cache stability: unchanged by this change
+
+The insertions land in system block [0], which is rendered variable-free
+and is byte-stable per build, so no cache breakpoint moves. Contract is
+>= 90% (docs/VERIFICATION.md). Both arms measured with the same command:
+
+  .venv/bin/python scripts/bench_cache_rate.py --turns 4
+
+## BEFORE (origin/main @ a892aaf5)
+structural prefix stability: 98.8% (contract: >= 90%)
+live cache rate: skipped (no OPENROUTER_API_KEY)
+PASS
+
+## AFTER (dev-web-research-disposition)
+structural prefix stability: 98.8% (contract: >= 90%)
+live cache rate: skipped (no OPENROUTER_API_KEY)
+PASS

--- a/docs/evidence/web-research-disposition/cache-stability.txt
+++ b/docs/evidence/web-research-disposition/cache-stability.txt
@@ -6,7 +6,7 @@ and is byte-stable per build, so no cache breakpoint moves. Contract is
 
   .venv/bin/python scripts/bench_cache_rate.py --turns 4
 
-## BEFORE (origin/main @ a892aaf5)
+## BEFORE (origin/main @ 2c4ebc77)
 structural prefix stability: 98.8% (contract: >= 90%)
 live cache rate: skipped (no OPENROUTER_API_KEY)
 PASS

--- a/docs/evidence/web-research-disposition/token-cost.txt
+++ b/docs/evidence/web-research-disposition/token-cost.txt
@@ -4,20 +4,25 @@ Basis is scripts/bench_role_overhead.py's: system prompt = tokens of the
 rendered markdown, tool = tokens of {name, description, parameters} as
 JSON (what rides the provider tools array). Tokenizer cl100k_base.
 
-Reproduce in a worktree of each ref with the snippet in this directory.
+Reproduce in a worktree of each ref with token_probe.py in this directory.
 
-## BEFORE (origin/main @ a892aaf5)
+## BEFORE (origin/main @ 2c4ebc77)
 {
-  "always_on_total": 9865,
-  "system_prompt": 3022,
+  "always_on_total": 9974,
+  "system_prompt": 3131,
   "tool_inventory": 1022,
   "tools_array": 5821
 }
 
 ## AFTER (dev-web-research-disposition)
 {
-  "always_on_total": 10025,
-  "system_prompt": 3182,
+  "always_on_total": 10134,
+  "system_prompt": 3291,
   "tool_inventory": 1022,
   "tools_array": 5821
 }
+
+Delta: +160 always-on tokens (+1.60%). tool_inventory and tools_array
+are unchanged, which is the point: the guidance went into the prompt,
+not into the two web tools' descriptions, where it would have been
+billed twice (provider tools array + rendered inventory).

--- a/docs/evidence/web-research-disposition/token-cost.txt
+++ b/docs/evidence/web-research-disposition/token-cost.txt
@@ -1,0 +1,23 @@
+# Always-on prompt cost: before vs after
+
+Basis is scripts/bench_role_overhead.py's: system prompt = tokens of the
+rendered markdown, tool = tokens of {name, description, parameters} as
+JSON (what rides the provider tools array). Tokenizer cl100k_base.
+
+Reproduce in a worktree of each ref with the snippet in this directory.
+
+## BEFORE (origin/main @ a892aaf5)
+{
+  "always_on_total": 9865,
+  "system_prompt": 3022,
+  "tool_inventory": 1022,
+  "tools_array": 5821
+}
+
+## AFTER (dev-web-research-disposition)
+{
+  "always_on_total": 10025,
+  "system_prompt": 3182,
+  "tool_inventory": 1022,
+  "tools_array": 5821
+}

--- a/docs/evidence/web-research-disposition/token_probe.py
+++ b/docs/evidence/web-research-disposition/token_probe.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Always-on prompt cost, on the basis ``scripts/bench_role_overhead.py`` fixes.
+
+Run in a worktree of each ref and diff the two outputs; that is how the
+before/after table in ``token-cost.txt`` is reproduced. The basis matters more
+than the absolute numbers: a system prompt costs the tokens of its rendered
+markdown, and a tool costs the tokens of ``{name, description, parameters}`` as
+JSON, which is what rides the provider's ``tools`` array. Measuring a tool by
+its schema alone understates it, because ``_render_tool_inventory`` also emits
+the full description into system block ``[1]`` — so description text is billed
+twice, which is why this change put its prose in the prompt rather than in the
+two web tools' descriptions.
+
+    .venv/bin/python docs/evidence/web-research-disposition/token_probe.py
+"""
+
+from __future__ import annotations
+
+import json
+
+import tiktoken
+
+from local_operator.harness.types import ToolContext
+from local_operator.prompts_api import build_system_blocks
+from local_operator.tools.registry import create_tools
+
+
+def main() -> None:
+    encoding = tiktoken.get_encoding("cl100k_base")
+
+    def count(text: str) -> int:
+        return len(encoding.encode(text))
+
+    tools = create_tools(ToolContext(cwd="."))
+    blocks = build_system_blocks(tools, "", "Platform: x", "2026-01-01")
+    tools_array = sum(
+        count(
+            json.dumps(
+                {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": tool.parameters,
+                }
+            )
+        )
+        for tool in tools
+    )
+    rows = {
+        "system_prompt": count(blocks[0]),
+        "tool_inventory": count(blocks[1]),
+        "tools_array": tools_array,
+    }
+    rows["always_on_total"] = sum(rows.values())
+    print(json.dumps(rows, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/local_operator/agent_seeds/coder.md
+++ b/local_operator/agent_seeds/coder.md
@@ -14,6 +14,11 @@ Before you claim it works, exercise the real path — run the command, call the
 endpoint, load the page — and read the actual output. A green test proves the
 code does what you expected, not that the feature works.
 
+When a third-party error message or an unfamiliar API is in your way, look
+it up (`web_search`, `web_fetch`) instead of guessing from the version you last
+saw in training. What you find is a lead, not a patch — verify it against this
+code before you write anything.
+
 Do not expand the slice. If you find adjacent problems, note them in your
 report rather than fixing them: an unrequested change is one the delegator has
 to review without having asked for it.

--- a/local_operator/agent_seeds/designer.md
+++ b/local_operator/agent_seeds/designer.md
@@ -20,6 +20,12 @@ Check alignment, spacing rhythm, contrast, focus order, and whether the copy
 says what it means. Back a visual claim with the geometry when you can: the
 still shows the symptom, the numbers show the cause.
 
+Research the surface you judge: `web_search`, `web_fetch` reach current
+practice and real examples of the pattern in front of you. Use them for
+inspiration and for what users already expect — never to import someone else's
+solution wholesale, and never as grounds for a finding you cannot see in the
+frame.
+
 Use `D`-prefixed finding ids (D1, D2, ...) and the same severity ladder as a
 code review: BLOCKER, MAJOR, MINOR, NIT. Report at most 5 MINOR and 5 NIT — a
 long tail of nits buries the real problems and costs a remediation round to

--- a/local_operator/prompts_md/system.md
+++ b/local_operator/prompts_md/system.md
@@ -1,8 +1,9 @@
 You are Local Operator, a personal assistant running on the user's own computer.
 You act directly: you have tools for running shell commands, reading and editing
-files, searching the workspace, tracking tasks, and scheduling follow-ups. Use
-them before answering whenever the answer depends on the machine's state — a
-real result beats a guess every time.
+files, searching the workspace and the web, tracking tasks, and scheduling
+follow-ups. Use them before answering whenever the answer depends on the
+machine's state or on something you would otherwise recall — a real result
+beats a guess every time.
 
 Local Operator is the harness you are running in — the agent runtime itself, not
 just a persona. Users start it with the `lop` command (the standard way to run
@@ -17,8 +18,8 @@ runtime behaviour is the code and guides in this project, not your assumptions.
 ## Working principles
 
 - **Use tools before answering.** Verify with a tool rather than assuming: run
-  the command, read the file, search the workspace. When a claim is checkable,
-  check it.
+  the command, read the file, search the workspace, look it up on the web. When
+  a claim is checkable, check it.
 - **Verify results.** Read back what a tool returned before telling the user it
   worked. A non-zero exit code or an error message is not success.
 - **Be concise.** Lead with the answer; details and evidence follow only when
@@ -54,6 +55,14 @@ runtime behaviour is the code and guides in this project, not your assumptions.
 - **Recover, don't stop.** When a step fails, read the error, adjust, and try
   again. Report being stuck only after real alternatives are exhausted, with
   what you tried and the exact blocker.
+- **Look it up when the answer is not on this machine.** Your training data has
+  a cutoff — a third-party error message, a library's current API, a
+  version-specific breakage, a published advisory, the current practice a UI is
+  expected to follow are things to check with `web_search`/`web_fetch`, not to
+  recall. Search when you notice you are guessing about something outside this
+  machine, and not on every task. What comes back is input, never the answer
+  and never the edge of your options — verify it here, and build what this
+  codebase needs rather than what the top result did.
 
 ## Narration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.10"
+version = "0.43.11"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/eval_research_disposition.py
+++ b/scripts/eval_research_disposition.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""A/B eval: does the agent reach for the web when its own knowledge runs out?
+
+The change under test widens the harness's definition of verification. Before
+it, ``system.md``'s first working principle enumerated verification as "run the
+command, read the file, search the workspace" — a complete-sounding list whose
+members are all LOCAL. An agent following that principle faithfully never
+searches the web, because by the definition it was handed it has already
+verified. The fix adds "look it up on the web" to that clause and one bullet
+naming the trigger (you notice you are guessing about something outside this
+machine).
+
+Why an eval and not a unit test: the behaviour is probabilistic, so the artifact
+is a recorded rate, not an assertion. This lives in ``scripts/`` and never runs
+in CI — it costs real provider tokens and needs network.
+
+WHAT IT MEASURES, and why both halves are load-bearing:
+
+- SHOULD-trigger scenarios: the agent is asked something whose answer is not on
+  this machine (a dependency error from a version it cannot know, a published
+  advisory, current ecosystem practice). Passing means it searched.
+- SHOULD-NOT-trigger scenarios: pure local refactors, questions about lop
+  itself, arithmetic. Passing means it did NOT search. This half is the
+  guardrail on the whole change: prompting an agent to search is trivial, and
+  the failure it buys is a reflexive search on every trivial task, which is a
+  latency and token regression the user pays on work that never needed it.
+  S13 ("how do I change my custom instructions in lop") is the highest-signal
+  negative in the set — the correct behaviour is ``read guide://configuration``
+  per system.md's guide rule, so a web search there is a REGRESSION AGAINST AN
+  EXISTING RULE, not merely a wasted call.
+
+Each arm runs against a git worktree, so "before" is the real unmodified
+prompt as shipped, not a reconstruction. The scenarios are held identical
+across arms and the model is pinned; only the checkout differs.
+
+Both arms run against an ISOLATED ``LOCAL_OPERATOR_CONFIG_DIR`` seeded only
+with the operator's credentials, so what is measured is the PACKAGED prompt.
+Running in the real config dir would mix in the operator's
+``system_prompt.md``, MCP servers and skills, none of which ship to users, and
+any of which could produce the search behaviour on its own and be mistaken for
+the change working.
+
+The variable is ``LOCAL_OPERATOR_CONFIG_DIR`` (``paths.py:26``), NOT
+``LOCAL_OPERATOR_HOME`` (``paths.py:46``) — the latter relocates the agent's
+workspace, not its config, so setting it leaves transcripts in the real config
+dir where this script cannot find them. That misread is silent and costly: the
+run completes, no transcript is located, every scenario reports zero tool calls,
+and both arms score 0% as though the agent had chosen not to search.
+
+Usage:
+    .venv/bin/python scripts/eval_research_disposition.py \
+        --before /tmp/lop-before --after /tmp/lop-websearch --runs 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import hashlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+WEB_TOOLS = {"web_search", "web_fetch"}
+
+#: An agent can reach the network WITHOUT the web tools, by curling from `bash`
+#: or opening a URL from `eval`. Counting only ``web_search``/``web_fetch``
+#: would score those runs as "did not research" and understate BOTH arms —
+#: observed on the first real run, where both arms queried the OSV advisory API
+#: through curl. That is still research, so it is scored as research; the two
+#: are reported separately because moving a run from improvised curl to the
+#: purpose-built tool is a real improvement (bounded output, spill handles,
+#: caching, provider fallback) even though the intent was already there.
+_URL_RE = re.compile(r"https?://", re.IGNORECASE)
+_NETWORK_CMD_RE = re.compile(r"\b(curl|wget|urllib|httpx|requests\.get|nc)\b", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """One prompt plus the behaviour we expect from it.
+
+    ``should_search`` is the graded expectation. ``rationale`` is recorded in
+    the output so a later reader can tell a scenario that was mis-specified
+    from a model that genuinely misbehaved.
+    """
+
+    sid: str
+    prompt: str
+    should_search: bool
+    rationale: str
+
+
+# Ten SHOULD-trigger scenarios spanning the failure modes the user named:
+# third-party error messages, unfamiliar/post-cutoff APIs, version-specific
+# behaviour, security advisories, and design/UX practice research.
+SHOULD_TRIGGER: list[Scenario] = [
+    Scenario(
+        "S1",
+        "I'm getting this error from a dependency and I don't understand it:\n"
+        "  pydantic.errors.PydanticUserError: `@root_validator` with pre=False "
+        "must specify `skip_on_failure=True`.\n"
+        "Why is this happening and what's the current fix? Don't change any "
+        "files, just explain.",
+        True,
+        "Third-party error message with version-specific semantics.",
+    ),
+    Scenario(
+        "S2",
+        "Does httpx.AsyncClient still accept the `proxies=` argument in the "
+        "latest release, or was it renamed? Answer only; change nothing.",
+        True,
+        "Version-specific API behaviour that moved after training cutoffs.",
+    ),
+    Scenario(
+        "S3",
+        "Are there any published security advisories affecting requests 2.31.0? "
+        "Just tell me, don't edit anything.",
+        True,
+        "Published advisory: recall is unsafe, the CVE list is authoritative.",
+    ),
+    Scenario(
+        "S4",
+        "What's the current recommended way to build a Python wheel for PyPI - "
+        "`uv build`, `python -m build`, or something else? What does the "
+        "ecosystem actually do now? Answer only.",
+        True,
+        "Current ecosystem practice; the answer changes year to year.",
+    ),
+    Scenario(
+        "S5",
+        "I want to redesign our terminal session picker to feel more like a "
+        "modern command palette. What patterns do good command palettes use? "
+        "Just give me the design thinking, don't write code.",
+        True,
+        "Design/UX inspiration - the user's named second case.",
+    ),
+    Scenario(
+        "S6",
+        "What's the current best practice for placing prompt-cache breakpoints "
+        "with Anthropic's API? Answer only, change nothing.",
+        True,
+        "Live provider documentation, not a stable fact.",
+    ),
+    Scenario(
+        "S7",
+        "Our CI fails with: `error: externally-managed-environment` when pip "
+        "installs. What causes this and what's the accepted fix? Explain only.",
+        True,
+        "Ecosystem-level packaging change (PEP 668) with an evolving fix.",
+    ),
+    Scenario(
+        "S8",
+        "Is Textual's `App.save_screenshot` still the supported way to export a "
+        "frame, or is there a newer API? Answer only.",
+        True,
+        "Library API currency for a dependency this repo actually uses.",
+    ),
+    Scenario(
+        "S9",
+        "What are the accessibility contrast requirements we should hold a "
+        "terminal UI colour theme to? Answer only.",
+        True,
+        "External standard (WCAG); precise thresholds should be checked.",
+    ),
+    Scenario(
+        "S10",
+        "A provider returned HTTP 529 to our client. What is that status and "
+        "how should a client handle it? Explain only, change nothing.",
+        True,
+        "Non-standard status code; guessing produces a plausible wrong answer.",
+    ),
+]
+
+# Four SHOULD-NOT scenarios. These are the guardrail: the change must not buy
+# its search rate by making the agent search reflexively.
+SHOULD_NOT_TRIGGER: list[Scenario] = [
+    Scenario(
+        "S11",
+        "In this repo, what does the function `_render_tool_inventory` return? "
+        "Answer from the code.",
+        False,
+        "Purely local: the answer is in prompts_api.py.",
+    ),
+    Scenario(
+        "S12",
+        "How do I change my custom instructions in lop?",
+        False,
+        "Answer is guide://configuration. A web search is a regression "
+        "against system.md's existing guide rule - highest-signal negative.",
+    ),
+    Scenario(
+        "S13",
+        "If a session costs 9865 always-on tokens and we add 154, what is the "
+        "percentage increase? Just the number.",
+        False,
+        "Arithmetic. No external fact exists to look up.",
+    ),
+    Scenario(
+        "S14",
+        "List the Python files in the local_operator/web_search directory and "
+        "tell me which one defines the tool.",
+        False,
+        "Pure filesystem inspection.",
+    ),
+]
+
+ALL_SCENARIOS = SHOULD_TRIGGER + SHOULD_NOT_TRIGGER
+
+
+def _newest_session_dir(sessions_root: Path, since: float) -> Path | None:
+    """The session directory created after ``since``.
+
+    exec mode does not print its session id, so the transcript is located by
+    mtime. The ``since`` floor keeps a concurrent session from being adopted.
+    """
+
+    best: tuple[float, Path] | None = None
+    if not sessions_root.is_dir():
+        return None
+    for child in sessions_root.iterdir():
+        transcript = child / "transcript.jsonl"
+        if not transcript.is_file():
+            continue
+        mtime = transcript.stat().st_mtime
+        if mtime < since:
+            continue
+        if best is None or mtime > best[0]:
+            best = (mtime, child)
+    return best[1] if best else None
+
+
+def _tool_calls(transcript: Path) -> list[tuple[str, str]]:
+    """Every tool name the assistant invoked, in order.
+
+    Tool invocations live on the assistant message's ``tool_calls`` array, not
+    in a distinct record type — verified against a real transcript before this
+    was written, because scanning for a ``tool_call`` record type silently
+    returns zero for every run and reads as "the agent never searched".
+    """
+
+    calls: list[tuple[str, str]] = []
+    if not transcript.is_file():
+        return calls
+    for line in transcript.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line).get("payload") or {}
+        except json.JSONDecodeError:
+            continue
+        for call in payload.get("tool_calls") or []:
+            name = call.get("name")
+            if isinstance(name, str):
+                calls.append((name, json.dumps(call.get("arguments") or {})))
+    return calls
+
+
+def _improvised_network(calls: list[tuple[str, str]]) -> list[str]:
+    """Calls that reached the network without using a web tool.
+
+    Matches a URL AND a network verb in the arguments of a general-purpose
+    tool. Requiring both keeps a shell command that merely mentions a URL in a
+    comment, or a `pip install` against the local index, from scoring as
+    research.
+    """
+
+    hits: list[str] = []
+    for name, arguments in calls:
+        if name in WEB_TOOLS or name not in {"bash", "eval"}:
+            continue
+        if _URL_RE.search(arguments) and _NETWORK_CMD_RE.search(arguments):
+            hits.append(name)
+    return hits
+
+
+def run_one(repo: Path, scenario: Scenario, timeout: int, home: Path) -> dict[str, Any]:
+    """Run one scenario in one arm and report which tools it used.
+
+    Runs in a scratch cwd so a scenario cannot accidentally edit the checkout,
+    with ``--yolo`` so an approval prompt cannot stall a headless run.
+    """
+
+    sessions_root = home / "sessions"
+    started = time.time()
+    with tempfile.TemporaryDirectory(prefix="lo-eval-") as scratch:
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(repo)
+        env["LOCAL_OPERATOR_CONFIG_DIR"] = str(home)
+        # Empty value disables ecosystem skill scanning (``skills/api.py:64-67``).
+        # Without it the operator's ~/.agents and ~/.omp skills load into both
+        # arms; a skill that mentions research would then supply the behaviour
+        # under test and the eval would credit it to the prompt change.
+        env["LOCAL_OPERATOR_SKILL_EXTRA_ROOTS"] = ""
+        # ``--yolo`` and ``--run-in`` are GLOBAL flags and must precede the
+        # subcommand; placed after ``exec`` argparse rejects them and the run
+        # exits 2 having done nothing, which reads as "the agent chose not to
+        # search" rather than as the harness bug it is.
+        cmd = [
+            str(repo / ".venv" / "bin" / "python"),
+            "-c",
+            "import sys; from local_operator.cli import main; sys.exit(main())",
+            "--yolo",
+            "--run-in",
+            scratch,
+            "exec",
+            scenario.prompt,
+        ]
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=str(repo),
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            status = "ok" if proc.returncode == 0 else f"exit {proc.returncode}"
+            stderr_tail = proc.stderr[-400:]
+        except subprocess.TimeoutExpired:
+            status, stderr_tail = "timeout", ""
+
+    # Give the transcript writer a moment to flush before it is read.
+    time.sleep(1.0)
+    session_dir = _newest_session_dir(sessions_root, started)
+    if session_dir is None:
+        # Loudly, not silently. "No transcript" and "the agent made no tool
+        # calls" are indistinguishable in the output table, and the first is a
+        # harness fault that would otherwise be published as a behavioural
+        # result. This exact confusion cost a debugging round already.
+        status = f"{status}/NO-TRANSCRIPT"
+    calls = _tool_calls(session_dir / "transcript.jsonl") if session_dir else []
+    used_web = [name for name, _ in calls if name in WEB_TOOLS]
+    improvised = _improvised_network(calls)
+    return {
+        "scenario": scenario.sid,
+        "should_search": scenario.should_search,
+        "status": status,
+        # "researched" is the graded behaviour: did it go to the network at
+        # all. "used_web_tool" is the narrower, better-quality path.
+        "researched": bool(used_web or improvised),
+        "used_web_tool": bool(used_web),
+        "web_calls": used_web,
+        "improvised_network": improvised,
+        "all_calls": [name for name, _ in calls],
+        "session": session_dir.name if session_dir else None,
+        "stderr_tail": stderr_tail,
+    }
+
+
+def _arm_fingerprint(repo: Path) -> str:
+    """Hash of the prompt text an arm will actually send.
+
+    A run takes over an hour, and both arms read their prompt from the working
+    tree on every scenario — so editing a prompt file mid-run silently splits
+    the results between two different texts and averages them into one number.
+    Recording the fingerprint at the start and re-checking it at the end turns
+    that from an invisible contamination into a reported failure.
+    """
+
+    digest = hashlib.sha256()
+    for rel in (
+        "local_operator/prompts_md/system.md",
+        "local_operator/agent_seeds/coder.md",
+        "local_operator/agent_seeds/designer.md",
+    ):
+        path = repo / rel
+        digest.update(path.read_bytes() if path.is_file() else b"")
+    return digest.hexdigest()[:12]
+
+
+def _prepare_home(home: Path, hosting: str, model: str) -> Path:
+    """Seed a clean config dir carrying credentials and nothing else.
+
+    Only ``credentials.env`` and the auth database are copied across: the eval
+    needs to reach a provider, and must NOT inherit the operator's standing
+    instructions, MCP servers, skills or agent registry. Copying the whole home
+    would measure this machine's configuration rather than what ships.
+    """
+
+    home.mkdir(parents=True, exist_ok=True)
+    real = Path.home() / ".local-operator"
+    for name in ("credentials.env", "auth.db", "auth.db-shm", "auth.db-wal"):
+        source = real / name
+        if source.is_file() and not (home / name).exists():
+            shutil.copy2(source, home / name)
+    # An explicit empty MCP registry: absent, discovery may fall back to a
+    # default path and re-introduce the operator's servers.
+    mcp = home / "mcp.json"
+    if not mcp.exists():
+        mcp.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+    # Minimal config, built through the real ConfigManager rather than
+    # hand-written YAML: the loader requires metadata keys (``created_at``)
+    # that are easy to omit, and a partial file fails at session construction
+    # with a bare KeyError. Only hosting/model and the web-search settings are
+    # set, so the operator's compaction, retry and fallback tuning cannot
+    # influence either arm and the settings under test stay at their defaults.
+    config = home / "config.yml"
+    if not config.exists():
+        # Imported from the repo root explicitly rather than relying on the
+        # caller's PYTHONPATH: this script is routinely run from a COPIED tree
+        # (a pinned snapshot of an arm), where the package is not importable
+        # by default and the failure lands after argument parsing.
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        from local_operator.config import ConfigManager
+
+        manager = ConfigManager(home)
+        manager.update_config(
+            {
+                "hosting": hosting,
+                "model_name": model,
+                "auto_save_conversation": False,
+                "web_search": {
+                    "enabled": True,
+                    "providers": ["duckduckgo"],
+                    "strategy": "round_robin",
+                    "timeout_seconds": 20.0,
+                },
+            }
+        )
+    return home
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--before", required=True, help="worktree of the base ref")
+    parser.add_argument("--after", required=True, help="worktree with the change")
+    parser.add_argument("--runs", type=int, default=3, help="repeats per scenario")
+    parser.add_argument("--timeout", type=int, default=420)
+    parser.add_argument("--save", default="", help="write results JSON here")
+    parser.add_argument("--only", default="", help="comma-separated scenario ids")
+    parser.add_argument(
+        "--home",
+        default="/tmp/lo-eval-home",
+        help="isolated LOCAL_OPERATOR_CONFIG_DIR for both arms",
+    )
+    parser.add_argument("--hosting", default="anthropic")
+    parser.add_argument("--model", default="claude-opus-5")
+    args = parser.parse_args()
+
+    home = _prepare_home(Path(args.home), args.hosting, args.model)
+    print(f"isolated config dir: {home} (hosting={args.hosting} model={args.model})")
+
+    wanted = {s.strip() for s in args.only.split(",") if s.strip()}
+    scenarios = [s for s in ALL_SCENARIOS if not wanted or s.sid in wanted]
+
+    arms = {"before": Path(args.before), "after": Path(args.after)}
+    fingerprints = {arm: _arm_fingerprint(repo) for arm, repo in arms.items()}
+    for arm, fingerprint in fingerprints.items():
+        print(f"  {arm:6} prompt fingerprint {fingerprint}")
+    if fingerprints["before"] == fingerprints["after"]:
+        print("ERROR: both arms have identical prompt text; nothing to compare.")
+        return 2
+
+    results: list[dict[str, Any]] = []
+    for arm, repo in arms.items():
+        for scenario in scenarios:
+            for run_index in range(args.runs):
+                record = run_one(repo, scenario, args.timeout, home)
+                record["arm"] = arm
+                record["run"] = run_index
+                results.append(record)
+                if record["used_web_tool"]:
+                    flag = "WEB"
+                elif record["researched"]:
+                    flag = "net"
+                else:
+                    flag = "   "
+                print(
+                    f"[{arm:6}] {scenario.sid:4} run{run_index} {flag} "
+                    f"({record['status']}) calls={len(record['all_calls'])}",
+                    flush=True,
+                )
+
+    print("\n=== per scenario: researched (of which via web tool) ===")
+    print(f"{'id':5} {'expect':7} {'before':>12} {'after':>12}")
+    summary: dict[str, Any] = {}
+    for scenario in scenarios:
+        row: dict[str, Any] = {"should_search": scenario.should_search}
+        for arm in arms:
+            runs = [r for r in results if r["arm"] == arm and r["scenario"] == scenario.sid]
+            hits = sum(1 for r in runs if r["researched"])
+            tool_hits = sum(1 for r in runs if r["used_web_tool"])
+            row[arm] = f"{hits}/{len(runs)} ({tool_hits}w)" if runs else "-"
+        summary[scenario.sid] = row
+        expect = "search" if scenario.should_search else "NO"
+        print(f"{scenario.sid:5} {expect:7} {row['before']:>12} {row['after']:>12}")
+
+    drifted = {arm: _arm_fingerprint(repo) for arm, repo in arms.items()}
+    if drifted != fingerprints:
+        changed = [a for a in arms if drifted[a] != fingerprints[a]]
+        print(
+            f"\nERROR: prompt text changed mid-run in arm(s) {changed}. "
+            "These results mix two different prompts and must be discarded."
+        )
+        return 2
+
+    broken = [r for r in results if "NO-TRANSCRIPT" in r["status"] or r["status"] == "timeout"]
+    if broken:
+        print(
+            f"\nWARNING: {len(broken)} run(s) produced no usable transcript; "
+            "those rows measure the harness, not the agent."
+        )
+
+    for label, subset in (("SHOULD trigger", SHOULD_TRIGGER), ("SHOULD NOT", SHOULD_NOT_TRIGGER)):
+        ids = {s.sid for s in subset} & {s.sid for s in scenarios}
+        if not ids:
+            continue
+        print(f"\n{label}:")
+        for arm in arms:
+            runs = [r for r in results if r["arm"] == arm and r["scenario"] in ids]
+            hits = sum(1 for r in runs if r["researched"])
+            tool_hits = sum(1 for r in runs if r["used_web_tool"])
+            pct = (100.0 * hits / len(runs)) if runs else 0.0
+            tool_pct = (100.0 * tool_hits / len(runs)) if runs else 0.0
+            print(
+                f"  {arm:6} researched {hits}/{len(runs)} ({pct:.0f}%), "
+                f"via web tool {tool_hits}/{len(runs)} ({tool_pct:.0f}%)"
+            )
+
+    if args.save:
+        Path(args.save).write_text(
+            json.dumps({"results": results, "summary": summary}, indent=2),
+            encoding="utf-8",
+        )
+        print(f"\nsaved {args.save}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval_research_disposition.py
+++ b/scripts/eval_research_disposition.py
@@ -55,9 +55,9 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
-import hashlib
 import re
 import shutil
 import subprocess

--- a/scripts/eval_research_disposition.py
+++ b/scripts/eval_research_disposition.py
@@ -280,7 +280,9 @@ def _improvised_network(calls: list[tuple[str, str]]) -> list[str]:
     return hits
 
 
-def run_one(repo: Path, scenario: Scenario, timeout: int, home: Path) -> dict[str, Any]:
+def run_one(
+    repo: Path, scenario: Scenario, timeout: int, home: Path, home_root: Path
+) -> dict[str, Any]:
     """Run one scenario in one arm and report which tools it used.
 
     Runs in a scratch cwd so a scenario cannot accidentally edit the checkout,
@@ -298,6 +300,14 @@ def run_one(repo: Path, scenario: Scenario, timeout: int, home: Path) -> dict[st
         # arms; a skill that mentions research would then supply the behaviour
         # under test and the eval would credit it to the prompt change.
         env["LOCAL_OPERATOR_SKILL_EXTRA_ROOTS"] = ""
+        # HOME is redirected as well, and it is NOT redundant with the config
+        # dir. ``resolve_mcp_config`` reads ``Path.home() / ".local-operator" /
+        # "mcp.json"`` directly (``mcp/config.py:306``) and never consults
+        # LOCAL_OPERATOR_CONFIG_DIR, so an empty mcp.json in the scratch dir
+        # does NOT stop the operator's own MCP servers from connecting and
+        # putting their tool definitions in both arms' prompts. The first
+        # recorded run had exactly that leak in all 84 turns.
+        env["HOME"] = str(home_root)
         # ``--yolo`` and ``--run-in`` are GLOBAL flags and must precede the
         # subcommand; placed after ``exec`` argparse rejects them and the run
         # exits 2 having done nothing, which reads as "the agent chose not to
@@ -382,6 +392,11 @@ def _prepare_home(home: Path, hosting: str, model: str) -> Path:
     needs to reach a provider, and must NOT inherit the operator's standing
     instructions, MCP servers, skills or agent registry. Copying the whole home
     would measure this machine's configuration rather than what ships.
+
+    Callers pass a path INSIDE the fake HOME named ``.local-operator``, because
+    isolation needs both halves: ``LOCAL_OPERATOR_CONFIG_DIR`` covers code that
+    calls ``config_dir()``, and the HOME redirect covers code like
+    ``resolve_mcp_config`` that reads ``Path.home()`` itself.
     """
 
     home.mkdir(parents=True, exist_ok=True)
@@ -444,7 +459,12 @@ def main() -> int:
     parser.add_argument("--model", default="claude-opus-5")
     args = parser.parse_args()
 
-    home = _prepare_home(Path(args.home), args.hosting, args.model)
+    # The config dir lives INSIDE the fake HOME and is named ".local-operator",
+    # so the two isolation mechanisms agree: code reading
+    # LOCAL_OPERATOR_CONFIG_DIR and code reading Path.home() both land here.
+    home_root = Path(args.home)
+    home = _prepare_home(home_root / ".local-operator", args.hosting, args.model)
+    print(f"isolated HOME: {home_root}")
     print(f"isolated config dir: {home} (hosting={args.hosting} model={args.model})")
 
     wanted = {s.strip() for s in args.only.split(",") if s.strip()}
@@ -462,7 +482,7 @@ def main() -> int:
     for arm, repo in arms.items():
         for scenario in scenarios:
             for run_index in range(args.runs):
-                record = run_one(repo, scenario, args.timeout, home)
+                record = run_one(repo, scenario, args.timeout, home, home_root)
                 record["arm"] = arm
                 record["run"] = run_index
                 results.append(record)

--- a/tests/unit/test_agent_profiles.py
+++ b/tests/unit/test_agent_profiles.py
@@ -163,6 +163,42 @@ def test_a_role_without_an_allowlist_keeps_the_full_inventory() -> None:
     assert filter_tools(ALL_TOOLS, None) == ALL_TOOLS
 
 
+def test_the_hands_on_roles_are_told_to_look_things_up() -> None:
+    """``coder`` and ``designer`` hit the two cases the general principle is
+    weakest on, so each seed carries the role-specific application.
+
+    ``coder`` meets third-party error messages and unfamiliar APIs; ``designer``
+    judges surfaces where current practice is the reference. Both seeds had
+    zero mention of the web, and neither declares a ``tools:`` allowlist, so
+    they already HAD the tools and simply were never told when to use them.
+    Contract, not wording.
+    """
+    coder = seed("coder").instructions
+    assert "web_search" in coder
+    # A found answer is a lead to verify here, never a patch to paste.
+    assert "not a patch" in " ".join(coder.split())
+
+    designer = seed("designer").instructions
+    assert "web_search" in designer
+    # The guard specific to this role: research informs judgement, but a
+    # D-finding must still be visible in the frame, per the seed's own rule
+    # that a UI is never reviewed from source alone.
+    assert "never as grounds for a finding you cannot see in the" in " ".join(designer.split())
+
+
+def test_the_hands_on_roles_keep_the_full_inventory() -> None:
+    """Neither seed may grow a ``tools:`` line to "enable" the web tools.
+
+    ``tools=None`` means "whatever the parent would build", which already
+    includes ``web_search``/``web_fetch`` from ``DEFAULT_TOOL_NAMES``. Adding
+    an allowlist to advertise them would RESTRICT the child to exactly that
+    list — a capability regression wearing the costume of an enablement.
+    """
+    for name in ("coder", "designer"):
+        assert seed(name).tools is None, name
+        assert filter_tools(ALL_TOOLS, seed(name)) == ALL_TOOLS, name
+
+
 def test_an_allowlist_naming_absent_tools_matches_nothing_rather_than_raising() -> None:
     """A profile written on another machine (or naming an MCP tool this
     session never loaded) must still run, with the tools it does have."""

--- a/tests/unit/test_prompts_api.py
+++ b/tests/unit/test_prompts_api.py
@@ -177,6 +177,58 @@ def test_system_md_teaches_eval_digest_pipeline() -> None:
     assert "spill://" in text
 
 
+def test_system_md_frames_the_web_as_a_verification_surface() -> None:
+    """Verification must not be defined as a closed set of LOCAL actions.
+
+    The first working principle used to enumerate verification as "run the
+    command, read the file, search the workspace" — three members, all local
+    and complete-sounding. An agent following it faithfully never reaches the
+    web, because by the definition it was handed it has already verified. That
+    is why lookups only happened when a user asked for them explicitly.
+    Contract, not wording: the enumeration must keep a web member.
+    """
+    # Normalized: the source is hard-wrapped at 79 columns, so any asserted
+    # phrase may straddle a line break.
+    text = " ".join(render_template("system.md", {}).split())
+    # The persona paragraph enumerates the toolset and states when to use it.
+    # Both halves carried the closed-local framing, and this one is read FIRST
+    # — a later bullet asking for web research argues uphill against a persona
+    # that already scoped tool use to "the machine's state".
+    assert "searching the workspace and the web" in text
+    assert "or on something you would otherwise recall" in text
+    # The working principle's own enumeration of what verifying means.
+    assert "search the workspace, look it up on the web" in text
+
+
+def test_system_md_teaches_when_to_research_without_making_it_reflexive() -> None:
+    """The research bullet has to carry four clauses that pull against each
+    other, so all four are pinned as behaviour.
+
+    Naming the tools alone would produce an agent that searches on every task —
+    a latency and token cost paid on work that never needed it. The trigger is
+    deliberately self-observational ("you notice you are guessing") rather than
+    a topic list, because a topic list invites keyword matching and generalises
+    to nothing outside it. The last clause exists so a result informs the work
+    without becoming it.
+    """
+    text = " ".join(render_template("system.md", {}).split())
+    # 1. The tools are named as the answer to stale knowledge.
+    assert "`web_search`/`web_fetch`" in text
+    # 2. Staleness is the stated reason, not a preference.
+    assert "cutoff" in text
+    # 3. Not reflexive: a trigger the agent evaluates against itself, plus an
+    #    explicit brake. Stated trigger-then-brake so the agent learns what
+    #    fires the search before it learns what suppresses it.
+    assert "you notice you are guessing" in text
+    assert "not on every task" in text
+    # 4. Results inform, never dictate, are never copied wholesale, and — the
+    #    clause that is easy to miss — never bound the options considered. An
+    #    agent can honour "never the answer" and still weigh only the three
+    #    approaches a search surfaced.
+    assert "input, never the answer" in text
+    assert "never the edge of your options" in text
+
+
 def test_compaction_summary_renders_optional_sections() -> None:
     full = render_template(
         "compaction_summary.md",


### PR DESCRIPTION
# PR Description

## Summary of Changes

lop agents rarely reached for `web_search` / `web_fetch` unless a user asked
explicitly, so a third-party error message or a design question got answered
from pretraining when the answer was a lookup away.

**Nothing was suppressing them.** Both tools are in `DEFAULT_TOOL_NAMES`
(`tools/registry.py:70-71`) and `enabled: bool = True` by default
(`web_search/models.py:72`). They are built, advertised, and callable. This is
not a gating bug.

### The prompt defined verification as a closed, local-only act

`prompts_md/system.md` had **zero** occurrences of "web", "internet",
"research" or "look up" across 207 lines. Worse than unmentioned, the web was
implicitly excluded, in two places:

The persona paragraph (`system.md:2-5`):

> you have tools for running shell commands, reading and editing files,
> **searching the workspace**, tracking tasks, and scheduling follow-ups. Use
> them before answering whenever the answer depends on **the machine's state**

The first working principle (`system.md:19-21`):

> **Use tools before answering.** Verify with a tool rather than assuming: run
> the command, read the file, **search the workspace**.

Both are complete-sounding enumerations whose members are all local, and the
first scopes tool use to "the machine's state" — which reads as a licence to
answer from recall whenever the question is *not* about this machine. An agent
following either faithfully never reaches the web, because by the definition it
was handed **it has already verified**. That is the whole bug: not a missing
advertisement, a wrong definition.

### The fix

Widen both enumerations, and add one bullet to `## Working principles` naming
the trigger. The trigger is deliberately **self-observational** — "you notice
you are guessing about something outside this machine" — rather than a topic
list, because a topic list invites keyword-matching and generalises to nothing
outside it.

Three clauses guard the failure modes this could buy:

| Risk | Clause |
|---|---|
| Reflexive searching on trivial work | "Search when you notice you are guessing... **and not on every task**" |
| Treating a result as authoritative | "What comes back is **input, never the answer**" |
| Narrowing the solution space to what search returned | "**and never the edge of your options**" |
| Copying wholesale | "verify it here, and **build what this codebase needs rather than what the top result did**" |

`coder` and `designer` seeds get the role-specific application. Both had zero
web mentions, and both hit the cases the general principle is weakest on
(third-party errors and unfamiliar APIs; current practice and real examples).

### Two things deliberately NOT done

**No `tools:` frontmatter added to the seeds.** `tools=None` means "whatever the
parent would build", which already includes both web tools. Adding an allowlist
to *advertise* them would **restrict** the child to exactly that list — a
capability regression wearing the costume of an enablement. A test pins this.

**No "when to reach for it" prose in the tool descriptions.** A description is
billed **twice**: once in the provider `tools` array, and again in system block
`[1]`, because `_render_tool_inventory` emits the full description string. 36
tokens of prose there costs **144 always-on tokens** across the two tools, for
guidance read at call-selection time rather than at task-framing time. The
behaviour wanted here is *noticing a lookup is needed*, which happens before the
model is scanning tool schemas.

Conditional/semantic injection was evaluated and rejected: it is cache-hostile
against the >=90% prefix-stability contract, and the only per-turn selector
(`session_factory.py:436`) reads `role="user"` messages only — so it is blind to
a dependency error arriving as a `role="tool"` result, the flagship trigger.

## Testing

Full evidence: `docs/evidence/web-research-disposition/`.

### Always-on token cost (`token-cost.txt`)

Basis is `scripts/bench_role_overhead.py`'s, `cl100k_base`, reproducible via the
committed `token_probe.py`:

| Row | Before | After | Delta |
|---|---|---|---|
| `system_prompt` | 3022 | 3182 | +160 |
| `tool_inventory` | 1022 | 1022 | **0** |
| `tools_array` | 5821 | 5821 | **0** |
| **always-on total** | **9865** | **10025** | **+160 (+1.62%)** |

Conditional, only when that role launches: `coder` +23, `designer` +52.

### Prompt-cache stability (`cache-stability.txt`)

`bench_cache_rate.py --turns 4`: **98.8% before, 98.8% after** (contract >=90%).
The insertions land in the byte-stable head block, so no breakpoint moves.

### Live A/B behavioural eval (`ab-eval.txt`, `ab-eval.json`)

84 live `claude-opus-5` turns: 14 scenarios x 3 runs x 2 arms, each arm a real
worktree. Both arms run against an isolated `LOCAL_OPERATOR_CONFIG_DIR` with
ecosystem skills disabled.

**Isolation caveat, found in review and worth stating plainly:** the MCP half
of that isolation did not work on these runs. `resolve_mcp_config` reads
`Path.home() / ".local-operator" / "mcp.json"` directly
(`mcp/config.py:306`) and ignores `LOCAL_OPERATOR_CONFIG_DIR`, so the
operator's own MCP servers connected on all 84 turns. The leak is
**symmetric** (42 runs per arm) and **no `mcp__*` tool is called in any of the
84 runs**, so the A/B contrast stands; what is not safe to read off these runs
is any absolute prompt size. `token-cost.txt` is measured offline and is
unaffected. The harness now redirects `HOME` as well (commit `d2080f41`,
verified: no MCP traffic in either arm); the recorded JSON is kept as captured
rather than silently re-run.

```
id    expect        before        after
S1    search      2/3 (2w)     3/3 (3w)   dependency traceback (pydantic)
S2    search      3/3 (3w)     3/3 (3w)   httpx proxies= removal
S3    search      3/3 (2w)     3/3 (3w)   advisory for requests 2.31.0
S4    search      0/3 (0w)     3/3 (3w)   current wheel-build tooling
S5    search      0/3 (0w)     3/3 (3w)   command-palette design patterns
S6    search      3/3 (3w)     3/3 (3w)   Anthropic prompt-cache breakpoints
S7    search      0/3 (0w)     0/3 (0w)   PEP 668 externally-managed-env
S8    search      3/3 (3w)     3/3 (3w)   Textual save_screenshot currency
S9    search      0/3 (0w)     0/3 (0w)   WCAG contrast thresholds
S10   search      3/3 (3w)     3/3 (3w)   HTTP 529
S11   NO          0/3 (0w)     0/3 (0w)   local refactor question
S12   NO          0/3 (0w)     0/3 (0w)   "change custom instructions in lop"
S13   NO          0/3 (0w)     0/3 (0w)   arithmetic
S14   NO          0/3 (0w)     0/3 (0w)   directory listing

SHOULD trigger:  before 16/30 via web tool (53%)  ->  after 24/30 (80%)
SHOULD NOT:      before  0/12 (0%)                ->  after  0/12 (0%)
```

**Qualitatively, not just the rate:**

- **S4 and S5 are the headline** (0/3 -> 3/3 each). Both are exactly the case
  the change was written for, and on the base **S4 made zero tool calls of any
  kind** — a pure recall answer to "what does the ecosystem do *now*".
- **S1 and S3 moved from improvised to purpose-built.** On the base, 2 of 3 S3
  runs reached the OSV advisory API by *curling from `bash`*. The intent was
  already there; what changed is that it now uses the tool with bounded output,
  spill handles and caching. (This is also why the harness scores "researched"
  and "via web tool" separately — counting only the two tools would have
  understated **both** arms.)
- **S7 and S9 did not move, and are not counted as fixes.** Both answered from
  stable knowledge and both answered *correctly* (PEP 668's marker file; WCAG
  2.2's 4.5:1 / 3:1). This is the desired shape of a miss — the trigger is "you
  notice you are guessing", and here the model was not guessing.
- **The negative half held at 0/12 in both arms, and the honest reading is "no
  regression on easy negatives" — not "no reflexive searching".** All four
  SHOULD-NOT scenarios also score 0/3 on the *base* arm, and all four are
  unambiguously local, so the set cannot discriminate between a brake that
  works and a brake that is inert. A negative set that *can* discriminate
  (trivial-but-web-adjacent prompts the base arm sometimes searches on) is the
  follow-up this round does not have.
- **What the negative half does establish is checked by hand.** S12 is the one
  that matters: the correct behaviour is reading the guide, and the after arm
  did exactly that — `read {"path": "guide://configuration"}` — so the new
  bullet does not override the guide rule sitting 55 lines below it, a rule it
  could plausibly have overridden since lop's docs are on the web. S11 used
  `grep`, S13 used `eval`, S14 used `bash`.

### Gates

```
flake8 .                                  clean
black --check .        617 files          unchanged
isort --check .                           clean
pyright                0 errors, 0 warnings, 0 informations
pytest tests/unit -q   8774 passed, 15 skipped
pytest tests/e2e -m e2e -n0 -q            3 passed
```

New tests pin the four clauses as behaviour rather than wording
(`test_prompts_api.py`, `test_agent_profiles.py`), including that the seeds keep
`tools=None` so nobody "enables" the web tools by adding an allowlist that
silently restricts the role.
