### PR TITLE
test: warm the tiktoken table once, not on the loop under test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,47 @@ def restore_root_logger() -> Iterator[None]:
         root.setLevel(saved_level)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def warm_token_encoding() -> None:
+    """Load tiktoken's BPE table ONCE, before any test can be timed against it.
+
+    ``tiktoken.get_encoding`` populates a cache under ``tempfile.gettempdir()``
+    on first use, and on a cache miss it DOWNLOADS the table. Measured on this
+    tree: 2339 ms cold against 62 ms warm. That download is a synchronous
+    network call, and the estimator deliberately runs inline on the event loop
+    for histories under ``OFFLOAD_MIN_CHARS`` — so on a machine with a cold
+    cache the first estimate blocks the loop for seconds.
+
+    That is what made ``test_the_loop_stays_responsive_while_several_subagents_run``
+    flaky, and only on CI: a developer's box has run the tokenizer before, a
+    fresh runner has not. Reproduced directly — a cold ``_get_encoding()`` on
+    the loop thread measures 1213 ms of stall against that test's 1000 ms
+    bound, which matches the 1029-1425 ms CI failures exactly. It failed 9 of
+    main's last 10 runs and blocked three approved PRs.
+
+    Warming here rather than raising the bound keeps the assertion measuring
+    what it was written to measure. The bound is calibrated evidence — 1353 ms
+    before the compaction fix, 139 ms after — so loosening it to swallow a
+    2.3 s download would blind it to a real regression. This is the same
+    principle as ``isolate_environment`` one screen up: a test must not depend
+    on ambient machine state, and "has this machine downloaded the BPE table
+    before?" is exactly that.
+
+    Session-scoped, and per xdist WORKER (each worker is its own process with
+    its own module state), which is the right granularity: the cost is paid
+    once per worker instead of by whichever test happens to touch the
+    tokenizer first. Never raises - a machine that genuinely cannot load
+    tiktoken falls through to the chars/4 estimate, and the suite must still
+    run there.
+    """
+    try:
+        from local_operator.compaction.tokens import _get_encoding
+
+        _get_encoding()
+    except Exception:  # noqa: BLE001 - warming is best-effort, never fatal
+        pass
+
+
 @pytest.fixture
 def terminal_output(tmp_path) -> Iterator[Path]:
     """Everything written to file descriptor 2 during the test, as a file.


### PR DESCRIPTION
# PR Description

> **Draft** — opened for discussion before merge. It changes the meaning of every timing assertion in the suite, so it deserves a look from someone who knows the compaction path before it lands.

Fixes #433.

## Change classification

**C2 — standard.** One session-scoped autouse fixture in `tests/conftest.py`. No production code, no test assertions changed, no bounds moved. 41 added lines, 0 removed.

## The problem

CI on `main` is failing **9 of its last 10 runs** on a single assertion, blocking three approved PRs:

```
tests/unit/session/test_launch_subagent.py:2191
AssertionError: the event loop stalled for 1029..1425 ms while subagents ran
```

## Root cause

`tiktoken.get_encoding` caches under `tempfile.gettempdir()` and **downloads the BPE table on a miss** — **2339 ms cold vs 62 ms warm** on this tree. `estimate_tokens` deliberately runs inline on the event loop for histories under `OFFLOAD_MIN_CHARS`, so a cold cache means the first estimate blocks the loop for seconds.

That is why it fails only on CI: a developer's box has run the tokenizer before, a fresh runner has not.

## Evidence

Reproduced directly, not inferred:

| condition | result |
| --- | --- |
| cold `_get_encoding()` on the loop thread | **1213 ms** stall (bound: 1000 ms) |
| the real test, `TIKTOKEN_CACHE_DIR` empty, **without** this fixture | **FAILS at 1065 ms** |
| the real test, `TIKTOKEN_CACHE_DIR` empty, **with** this fixture | **passes** |

That middle row is the control: the fixture is doing the work, not luck.

## What it is not

"Flaky timing test on a loaded runner" is the obvious guess and it is wrong. Each of these was measured before settling on the cause:

- **Not CPU contention.** A bare watchdog under 56-way oversubscription on 14 cores reaches **7 ms** — three orders of magnitude under the bound. The stall is real in-process blocking.
- **Not xdist.** Reproduces at `-n0`.
- **Not `--cov`.** Reproduces without it.
- **Not `isolate_environment` repointing `HOME`.** tiktoken never consults `HOME`.

## Why warm instead of raising the bound

The 1 s bound is calibrated evidence — the test's own docstring records 1353 ms before the compaction fix and 139 ms after. Raising it to swallow a 2.3 s download would blind the assertion to exactly the regression it exists to catch, and the failure mode would be silent.

Warming also matches the principle `isolate_environment` already applies two fixtures up in the same file: a test must not depend on ambient machine state, and *"has this machine downloaded the BPE table before?"* is precisely that.

Session-scoped means once per xdist worker process, so the cost is paid at setup rather than by whichever test touches the tokenizer first. It never raises — a machine that cannot load tiktoken falls through to the chars/4 estimate and the suite still runs.

## Verification

- `tests/unit/session`: **573 passed**
- flake8, black (26.1.0), isort (5.13.2): clean
- The cold-cache control above, run both ways

## What a reviewer should push on

**This does not help real users.** The same cold-load stall is reachable in production: a first-run user with an empty tiktoken cache pays a multi-second event-loop block on their first turn that crosses an estimator path. This fixture fixes the *test*, not that. Worth deciding whether `_get_encoding` should be warmed on a worker thread at session start, or whether a cold load should be forced through the `to_thread` hop regardless of history size — recorded in #433 rather than widened into here.

**It masks a real signal by design.** After this, a genuine cold-start stall in the estimator path will no longer show up in that test. That is the intended trade — the test is about *compaction not blocking the loop*, not about tokenizer warm-up — but it is a deliberate narrowing and worth agreeing on.
