### PR TITLE
chore(release): bump version to 0.43.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.9"
+version = "0.43.10"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Version bump so the peer-messaging fix merged in #410 can ship.

#410 merged at `0.43.9`, but `v0.43.9` had already been tagged and published to PyPI from `2b27d802` (#426), which does not contain that merge. `git merge-base --is-ancestor 73a1ccab v0.43.9` confirms the fix is absent from the released artifact, so it needs its own version to reach users.

Patch: no behaviour change in this PR beyond the version string.

Ships:
- #410 — a peer message (`lop send`) now wakes a session blocked in a long `wait` instead of being invisible until the wait's deadline, `--now`/steer cancellation returns the job id instead of "skipped", and the agent prompt names `lop sessions`/`lop send` so a session stops shelling out to cmux to message a peer.