### PR TITLE
feat(mcp): import MCP servers from the Codex CLI config

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ lop mcp list
 
 Server configs are discovered from the project (`.local-operator/mcp.json`,
 `.mcp.json`), your home directory, and best-effort imports of Claude Code,
-Cursor, and VS Code configs — so servers you already configured
+Cursor, VS Code, and Codex CLI configs — so servers you already configured
 elsewhere just show up. See [docs/mcp.md](./docs/mcp.md) for the trust model
 before enabling project-supplied servers.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -5,8 +5,9 @@ are discovered from project files (`<cwd>/.local-operator/mcp.json`,
 `<cwd>/.mcp.json`), the user file (`~/.local-operator/mcp.json`), and
 best-effort imports of other tools' configs (`~/.claude.json` — top-level
 `mcpServers` plus project-scoped `projects.<cwd>.mcpServers`,
-`<cwd>/.claude/.mcp.json`, `~/.cursor/mcp.json`, `<cwd>/.vscode/mcp.json`).
-Project configs win over user configs, which win over imports;
+`<cwd>/.claude/.mcp.json`, `~/.cursor/mcp.json`, `<cwd>/.vscode/mcp.json`,
+`~/.codex/config.toml` — TOML, `[mcp_servers.<name>]` tables, user scope
+only). Project configs win over user configs, which win over imports;
 `disabledServers` beats `enabledServers`, which beats a server's own
 `enabled: false`.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -7,7 +7,8 @@ best-effort imports of other tools' configs (`~/.claude.json` — top-level
 `mcpServers` plus project-scoped `projects.<cwd>.mcpServers`,
 `<cwd>/.claude/.mcp.json`, `~/.cursor/mcp.json`, `<cwd>/.vscode/mcp.json`,
 `~/.codex/config.toml` — TOML, `[mcp_servers.<name>]` tables, user scope
-only). Project configs win over user configs, which win over imports;
+only, meaning literally that path: Codex's `CODEX_HOME` override is not
+consulted). Project configs win over user configs, which win over imports;
 `disabledServers` beats `enabledServers`, which beats a server's own
 `enabled: false`.
 

--- a/local_operator/guides/mcp/GUIDE.md
+++ b/local_operator/guides/mcp/GUIDE.md
@@ -77,7 +77,9 @@ Highest precedence first:
 1. `<cwd>/.local-operator/mcp.json`
 2. `<cwd>/.mcp.json`
 3. `~/.local-operator/mcp.json`
-4. Compatible imports from Claude, Cursor, and VS Code MCP files
+4. Compatible imports from Claude, Cursor, VS Code, and Codex CLI MCP files
+   (Codex is `~/.codex/config.toml`, TOML with `[mcp_servers.<name>]` tables,
+   and is read last, so it never overrides another tool's definition)
 
 Project values beat user values and imported values. `disabledServers` beats `enabledServers`, which beats a server's own `enabled: false` value.
 

--- a/local_operator/mcp/config.py
+++ b/local_operator/mcp/config.py
@@ -7,7 +7,8 @@ onto local-operator paths:
 - User config: ``~/.local-operator/mcp.json``.
 - Best-effort imports of foreign tool configs: ``~/.claude.json``
   (``mcpServers`` key), ``<cwd>/.claude/.mcp.json``, ``~/.cursor/mcp.json``,
-  ``<cwd>/.vscode/mcp.json`` (``mcp.servers`` key).
+  ``<cwd>/.vscode/mcp.json`` (``mcp.servers`` key), ``~/.codex/config.toml``
+  (TOML, ``[mcp_servers.<name>]`` tables; issue #367).
 
 Priority: project > user > imports; later sources NEVER override an earlier
 one (first-seen wins at the name level). ``disabledServers`` lists collected
@@ -20,6 +21,8 @@ from __future__ import annotations
 import json
 import os
 import re
+import tomllib
+from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path
 from typing import Any, Literal
@@ -182,6 +185,12 @@ def _coerce_server_config(raw: JsonValue) -> MCPServerConfig | None:
         return None
 
 
+#: A candidate-file reader: path -> parsed document, or ``None`` when the file
+#: is missing or unparsable. Every reader is best-effort by contract, so a
+#: foreign config we do not own can never break discovery of the ones we do.
+_ConfigReader = Callable[[Path], "dict[str, Any] | None"]
+
+
 def _read_json(path: Path) -> dict[str, Any] | None:
     """Best-effort JSON read: missing file or bad JSON yields ``None``."""
     try:
@@ -190,6 +199,32 @@ def _read_json(path: Path) -> dict[str, Any] | None:
         loaded = json.loads(path.read_text(encoding="utf-8"))
         return loaded if isinstance(loaded, dict) else None
     except (OSError, ValueError, UnicodeDecodeError):
+        return None
+
+
+def _read_toml(path: Path) -> dict[str, Any] | None:
+    """Best-effort TOML read: missing file or bad TOML yields ``None``.
+
+    Codex CLI (``~/.codex/config.toml``) is the one import source that is not
+    JSON, so it needs its own reader rather than another ``_read_json`` entry
+    (issue #367). The contract is deliberately identical to ``_read_json``'s:
+    a config we do not own must never be able to break discovery of the ones
+    we do, so every failure mode degrades to "this file contributes nothing".
+
+    This import is READ-ONLY, permanently and by construction: ``tomllib`` is
+    stdlib on the 3.12 floor but exposes ``load``/``loads`` only — it cannot
+    emit TOML — and ``tomli_w`` is not a dependency. Writing the file back
+    would also lose the comments and formatting of a file another tool owns.
+    ``/mcp remove`` therefore refuses a Codex-imported server by name instead
+    of pretending it can delete it (see ``_mcp_remove_result`` in the TUI).
+    """
+    try:
+        if not path.is_file():
+            return None
+        with path.open("rb") as handle:  # tomllib requires binary + UTF-8
+            loaded = tomllib.load(handle)
+        return loaded if isinstance(loaded, dict) else None
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
         return None
 
 
@@ -230,8 +265,10 @@ def _claude_json_servers(doc: dict[str, Any], root: Path) -> dict[str, Any]:
 def _imported_servers(doc: dict[str, Any], key_path: tuple[str, ...] | None) -> dict[str, Any]:
     """Server entries from a foreign tool config.
 
-    ``key_path`` walks nested dicts (``("mcp", "servers")`` for VS Code);
-    ``None`` means the ``mcpServers`` key at the top level.
+    ``key_path`` walks nested dicts (``("mcp", "servers")`` for VS Code,
+    ``("mcp_servers",)`` for Codex's ``[mcp_servers.<name>]`` tables, which
+    ``tomllib`` parses into exactly that nested-dict shape); ``None`` means
+    the ``mcpServers`` key at the top level.
     """
     if key_path is None:
         return _local_operator_servers(doc)
@@ -292,6 +329,8 @@ def load_all_mcp_configs(
     5. ``<cwd>/.claude/.mcp.json``
     6. ``~/.cursor/mcp.json``
     7. ``<cwd>/.vscode/mcp.json`` (``mcp.servers`` key)
+    8. ``~/.codex/config.toml`` (TOML, ``[mcp_servers.<name>]`` tables;
+       user scope only — Codex project-scoped config is not imported)
 
     Enable/disable resolution uses lists from the local-operator files
     (project first, then user): ``disabledServers`` wins over
@@ -309,15 +348,25 @@ def load_all_mcp_configs(
     disabled: set[str] = set()
     enabled: set[str] = set()
 
-    # (path, key_path into doc for the servers dict) in priority order.
-    candidates: list[tuple[Path, tuple[str, ...] | None]] = [
-        (project_path, None),
-        (project_dot_path, None),
-        (user_path, None),
-        (home / ".claude.json", None),
-        (root / ".claude" / ".mcp.json", None),
-        (home / ".cursor" / "mcp.json", None),
-        (root / ".vscode" / "mcp.json", ("mcp", "servers")),
+    # (path, reader, key_path into doc for the servers dict) in priority
+    # order. The reader travels WITH the candidate so a non-JSON source is
+    # just another row here: the enable/disable lists, the two-pass
+    # suppression resolution and the ``sources`` provenance map below all stay
+    # format-agnostic instead of growing a parallel loop per file format.
+    candidates: list[tuple[Path, _ConfigReader, tuple[str, ...] | None]] = [
+        (project_path, _read_json, None),
+        (project_dot_path, _read_json, None),
+        (user_path, _read_json, None),
+        (home / ".claude.json", _read_json, None),
+        (root / ".claude" / ".mcp.json", _read_json, None),
+        (home / ".cursor" / "mcp.json", _read_json, None),
+        (root / ".vscode" / "mcp.json", _read_json, ("mcp", "servers")),
+        # Codex CLI is APPENDED LAST on purpose (issue #367): first-seen-wins
+        # makes position observable whenever two tools define the same server
+        # name, and last is the only position that guarantees Codex can never
+        # override local-operator's own files OR any of the other imports.
+        # User scope only; Codex project-scoped config is out of scope here.
+        (home / ".codex" / "config.toml", _read_toml, ("mcp_servers",)),
     ]
 
     claude_path = home / ".claude.json"
@@ -328,8 +377,8 @@ def load_all_mcp_configs(
     # name slot, block the user-level entry of the same name, and then get
     # deleted — leaving the server absent instead of falling back.
     per_name: dict[str, list[tuple[MCPServerConfig, str]]] = {}
-    for path, key_path in candidates:
-        doc = _read_json(path)
+    for path, reader, key_path in candidates:
+        doc = reader(path)
         if doc is None:
             continue
         # Local-operator files contribute enable/disable lists.
@@ -458,7 +507,7 @@ def owned_scope_for_source(
 ) -> str | None:
     """The write scope whose file is ``source``, or ``None`` when unowned.
 
-    ``load_all_mcp_configs`` merges seven sources but :func:`_scope_path` only
+    ``load_all_mcp_configs`` merges eight sources but :func:`_scope_path` only
     ever writes two of them, so "where did this server come from" and "can we
     edit it here" are different questions. Callers that MUTATE a server (the
     TUI's ``/mcp remove``) must ask this one: removing an entry defined by

--- a/local_operator/mcp/config.py
+++ b/local_operator/mcp/config.py
@@ -211,6 +211,12 @@ def _read_toml(path: Path) -> dict[str, Any] | None:
     a config we do not own must never be able to break discovery of the ones
     we do, so every failure mode degrades to "this file contributes nothing".
 
+    User scope means literally ``~/.codex/config.toml``. Codex's own
+    ``CODEX_HOME`` override is deliberately NOT consulted: no other candidate
+    honours a foreign tool's env var either, and doing it here would make this
+    the first such precedent. A user who has relocated their Codex home gets
+    no import rather than a wrong one.
+
     This import is READ-ONLY, permanently and by construction: ``tomllib`` is
     stdlib on the 3.12 floor but exposes ``load``/``loads`` only — it cannot
     emit TOML — and ``tomli_w`` is not a dependency. Writing the file back
@@ -224,7 +230,13 @@ def _read_toml(path: Path) -> dict[str, Any] | None:
         with path.open("rb") as handle:  # tomllib requires binary + UTF-8
             loaded = tomllib.load(handle)
         return loaded if isinstance(loaded, dict) else None
-    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError, RecursionError):
+        # ``RecursionError`` has no counterpart in ``_read_json``: ``tomllib``
+        # is a recursive-descent parser written in Python, so deeply nested
+        # inline tables blow the stack (measured: raises at depth 2000, where
+        # the C-implemented ``json.loads`` still parses). Catching it is what
+        # keeps this reader's "every failure mode contributes nothing" promise
+        # literally true rather than true-in-practice.
         return None
 
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15410,7 +15410,7 @@ class OperatorApp(App[None]):
         """Do one ``/mcp remove`` and return its receipt as ``(text, kind)``.
 
         The refusal is the point of this command. ``load_all_mcp_configs``
-        merges SEVEN sources but local-operator only writes two of them, so a
+        merges EIGHT sources but local-operator only writes two of them, so a
         server can be perfectly visible in ``/mcp`` and still be none of our
         business to delete. Removing an entry defined by ``~/.claude.json``
         would either fail or, worse, write a local-operator file that shadows a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.12"
+version = "0.43.13"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/mcp/test_config.py
+++ b/tests/unit/mcp/test_config.py
@@ -363,6 +363,47 @@ class TestCodexImport:
         configs, _ = load_all_mcp_configs(cwd)
         assert set(configs) == {"ours"}
 
+    def test_non_dict_mcp_servers_shapes_degrade(self, tmp_path: Path, home: Path) -> None:
+        """The shapes a HAND-EDITED TOML actually produces: a scalar where the
+        table should be, and a scalar entry inside it. Both degrade to
+        contributing nothing while our own file still loads."""
+        cwd = tmp_path / "proj"
+        _write(
+            home / ".local-operator" / "mcp.json",
+            {"mcpServers": {"ours": _stdio("ours-cmd")}},
+        )
+        _write_toml(home / ".codex" / "config.toml", 'mcp_servers = "nope"\n')
+        configs, _ = load_all_mcp_configs(cwd)
+        assert set(configs) == {"ours"}
+
+        _write_toml(home / ".codex" / "config.toml", "[mcp_servers]\nbroken = 1\n")
+        configs, _ = load_all_mcp_configs(cwd)
+        assert set(configs) == {"ours"}
+
+    def test_deeply_nested_toml_degrades_instead_of_raising(
+        self, tmp_path: Path, home: Path
+    ) -> None:
+        """``tomllib`` is a recursive-descent parser in Python, so deep inline
+        nesting raises ``RecursionError`` where ``json.loads`` (C) does not.
+        The reader promises every failure degrades to nothing, so this must not
+        escape ``load_all_mcp_configs`` (review round 1, F2)."""
+        cwd = tmp_path / "proj"
+        _write(
+            home / ".local-operator" / "mcp.json",
+            {"mcpServers": {"ours": _stdio("ours-cmd")}},
+        )
+        depth = 2000
+        _write_toml(
+            home / ".codex" / "config.toml",
+            '[mcp_servers.x]\ncommand = "c"\nnested = '
+            + "{ a = " * depth
+            + "1"
+            + " }" * depth
+            + "\n",
+        )
+        configs, _ = load_all_mcp_configs(cwd)
+        assert set(configs) == {"ours"}
+
     def test_missing_codex_file_is_a_no_op(self, tmp_path: Path, home: Path) -> None:
         cwd = tmp_path / "proj"
         assert not (home / ".codex").exists()

--- a/tests/unit/mcp/test_config.py
+++ b/tests/unit/mcp/test_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import textwrap
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -37,6 +38,12 @@ def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 def _write(path: Path, doc: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(doc), encoding="utf-8")
+
+
+def _write_toml(path: Path, body: str) -> None:
+    """Write a Codex-shaped TOML config, dedented so tests can stay indented."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
 
 
 def _stdio(command: str = "npx", **extra: Any) -> dict[str, Any]:
@@ -257,6 +264,187 @@ class TestShapesAndImports:
         configs, sources = load_all_mcp_configs(tmp_path)
         assert configs == {}
         assert sources == {}
+
+
+class TestCodexImport:
+    """``~/.codex/config.toml`` (issue #367): the one non-JSON import source."""
+
+    def test_stdio_and_remote_servers_imported_with_provenance(
+        self, tmp_path: Path, home: Path
+    ) -> None:
+        """Codex ``[mcp_servers.<name>]`` tables map onto both transports.
+
+        ``command``/``args``/``env`` and ``url`` are exactly what
+        ``_coerce_server_config`` already infers from, so no Codex-specific
+        transport handling should be needed.
+        """
+        cwd = tmp_path / "proj"
+        cwd.mkdir(parents=True)
+        _write_toml(
+            home / ".codex" / "config.toml",
+            """
+            [mcp_servers.node_repl]
+            command = "node_repl"
+            args = ["--stdio"]
+            env = { NODE_PATH = "/opt/node" }
+
+            [mcp_servers.docs]
+            url = "https://developers.example.com/mcp"
+            """,
+        )
+        configs, sources = load_all_mcp_configs(cwd)
+        stdio = configs["node_repl"]
+        assert isinstance(stdio, MCPStdioServerConfig)
+        assert stdio.command == "node_repl"
+        assert stdio.args == ["--stdio"]
+        assert stdio.env == {"NODE_PATH": "/opt/node"}
+        remote = configs["docs"]
+        assert isinstance(remote, MCPHttpServerConfig)
+        assert remote.url == "https://developers.example.com/mcp"
+        assert sources["node_repl"].endswith(".codex/config.toml")
+        assert sources["docs"].endswith(".codex/config.toml")
+
+    def test_codex_never_overrides_any_earlier_source(self, tmp_path: Path, home: Path) -> None:
+        """Codex is APPENDED LAST, so first-seen-wins makes it lose every tie.
+
+        The position is the whole point of the ordering decision on #367: it
+        can override neither local-operator's own files nor the other imports.
+        """
+        cwd = tmp_path / "proj"
+        _write(
+            home / ".local-operator" / "mcp.json",
+            {"mcpServers": {"lop_srv": _stdio("lop-cmd")}},
+        )
+        _write(home / ".claude.json", {"mcpServers": {"claude_srv": _stdio("claude-cmd")}})
+        _write(home / ".cursor" / "mcp.json", {"mcpServers": {"cursor_srv": _stdio("cursor-cmd")}})
+        _write(
+            cwd / ".vscode" / "mcp.json",
+            {"mcp": {"servers": {"vscode_srv": _stdio("vscode-cmd")}}},
+        )
+        _write_toml(
+            home / ".codex" / "config.toml",
+            """
+            [mcp_servers.lop_srv]
+            command = "codex-cmd"
+
+            [mcp_servers.claude_srv]
+            command = "codex-cmd"
+
+            [mcp_servers.cursor_srv]
+            command = "codex-cmd"
+
+            [mcp_servers.vscode_srv]
+            command = "codex-cmd"
+
+            [mcp_servers.codex_only]
+            command = "codex-cmd"
+            """,
+        )
+        configs, sources = load_all_mcp_configs(cwd)
+        assert _command(configs, "lop_srv") == "lop-cmd"
+        assert _command(configs, "claude_srv") == "claude-cmd"
+        assert _command(configs, "cursor_srv") == "cursor-cmd"
+        assert _command(configs, "vscode_srv") == "vscode-cmd"
+        # Only the name no other tool claimed comes from Codex.
+        assert _command(configs, "codex_only") == "codex-cmd"
+        assert sources["codex_only"].endswith(".codex/config.toml")
+
+    def test_malformed_toml_degrades_to_no_servers(self, tmp_path: Path, home: Path) -> None:
+        """Best-effort, exactly like ``_read_json``: a broken foreign config
+        must never break discovery of the files we DO own."""
+        cwd = tmp_path / "proj"
+        _write(
+            home / ".local-operator" / "mcp.json",
+            {"mcpServers": {"ours": _stdio("ours-cmd")}},
+        )
+        path = home / ".codex" / "config.toml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("[mcp_servers.broken\ncommand = ", encoding="utf-8")
+        configs, _ = load_all_mcp_configs(cwd)
+        assert set(configs) == {"ours"}
+
+    def test_missing_codex_file_is_a_no_op(self, tmp_path: Path, home: Path) -> None:
+        cwd = tmp_path / "proj"
+        assert not (home / ".codex").exists()
+        configs, sources = load_all_mcp_configs(cwd)
+        assert configs == {}
+        assert sources == {}
+
+    def test_unmodelled_codex_keys_still_load(self, tmp_path: Path, home: Path) -> None:
+        """Codex carries keys we do not model (``startup_timeout_sec``,
+        ``cwd``). ``extra="allow"`` must keep the entry loadable rather than
+        rejecting the server for a field that is simply not ours."""
+        cwd = tmp_path / "proj"
+        _write_toml(
+            home / ".codex" / "config.toml",
+            """
+            [mcp_servers.slow]
+            command = "slow-server"
+            startup_timeout_sec = 120
+            cwd = "/tmp/work"
+            """,
+        )
+        configs, _ = load_all_mcp_configs(cwd)
+        cfg = configs["slow"]
+        assert isinstance(cfg, MCPStdioServerConfig)
+        assert cfg.command == "slow-server"
+        assert cfg.cwd == "/tmp/work"
+        # The unmodelled key survives round-tripping rather than being dropped.
+        assert cfg.model_dump()["startup_timeout_sec"] == 120
+
+    def test_codex_enabled_false_suppresses(self, tmp_path: Path, home: Path) -> None:
+        """``enabled`` IS modelled, so a server the user disabled in Codex
+        stays disabled here — importing a config means importing its opinion
+        about what should run."""
+        cwd = tmp_path / "proj"
+        _write_toml(
+            home / ".codex" / "config.toml",
+            """
+            [mcp_servers.on]
+            command = "on-cmd"
+
+            [mcp_servers.off]
+            command = "off-cmd"
+            enabled = false
+            """,
+        )
+        configs, _ = load_all_mcp_configs(cwd)
+        assert set(configs) == {"on"}
+
+    def test_local_operator_disabled_list_suppresses_a_codex_server(
+        self, tmp_path: Path, home: Path
+    ) -> None:
+        """The enable/disable lists are format-agnostic: they come from the
+        local-operator files and apply to every source, Codex included."""
+        cwd = tmp_path / "proj"
+        _write(home / ".local-operator" / "mcp.json", {"disabledServers": ["noisy"]})
+        _write_toml(
+            home / ".codex" / "config.toml",
+            """
+            [mcp_servers.noisy]
+            command = "noisy-cmd"
+
+            [mcp_servers.quiet]
+            command = "quiet-cmd"
+            """,
+        )
+        configs, _ = load_all_mcp_configs(cwd)
+        assert set(configs) == {"quiet"}
+
+    def test_codex_source_is_not_an_owned_write_scope(self, tmp_path: Path, home: Path) -> None:
+        """``tomllib`` cannot write, so a Codex source can never resolve to a
+        scope ``remove_server`` would edit. This is what makes the TUI's
+        ``/mcp remove`` refusal correct rather than merely conservative."""
+        cwd = tmp_path / "proj"
+        _write_toml(
+            home / ".codex" / "config.toml",
+            """
+            [mcp_servers.codexy]
+            command = "codex-cmd"
+            """,
+        )
+        _configs, sources = load_all_mcp_configs(cwd)
+        assert owned_scope_for_source(sources["codexy"], cwd) is None
 
 
 class TestValidation:

--- a/tests/unit/mcp/test_config.py
+++ b/tests/unit/mcp/test_config.py
@@ -573,7 +573,7 @@ class TestCliHelpers:
         self, tmp_path: Path, home: Path
     ) -> None:
         """The gate behind ``/mcp remove``'s refusal. ``load_all_mcp_configs``
-        merges seven sources but ``_scope_path`` writes exactly two, so every
+        merges eight sources but ``_scope_path`` writes exactly two, so every
         other source must come back unowned — deleting from one would either
         fail or shadow a config the user still maintains in another tool."""
         cwd = tmp_path / "owned-proj"

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -5718,6 +5718,43 @@ async def test_mcp_remove_refuses_a_server_defined_by_a_foreign_config(
 
 
 @pytest.mark.asyncio
+async def test_mcp_remove_refuses_a_codex_imported_server(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The Codex refusal is PERMANENT, not a policy choice: `tomllib` parses
+    TOML and cannot emit it (`tomli_w` is not a dependency), so a server
+    defined by `~/.codex/config.toml` can be listed but never removed in
+    place. The refusal has to name that file and Codex CLI, because "remove it
+    there" is the only action left to the user (issues #367/#368)."""
+    home = _mcp_home(tmp_path, monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    (home / ".codex").mkdir(parents=True)
+    codex_config = home / ".codex" / "config.toml"
+    codex_config.write_text(
+        '[mcp_servers.codexy]\nurl = "https://codexy.example/mcp"\n', encoding="utf-8"
+    )
+    codex_before = codex_config.read_text()
+    manager = FakeMcpManager(["filesystem", "grafana", "notion", "codexy"], [])
+    app = OperatorApp(lambda: _factory(McpSession(manager=manager, startup=McpStartupOutcome())))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        app.query_one(Toast).dismiss_toast()
+        await _type_command(pilot, app, "mcp remove codexy")
+        for _ in range(6):
+            await pilot.pause()
+        text = _transcript_text(app)
+        assert "~/.codex/config.toml" in text
+        # The origin phrase soft-wraps at the transcript width, so collapse
+        # whitespace before matching rather than asserting on a line break.
+        assert "imported from Codex CLI" in " ".join(text.split())
+        assert "Remove it there" in text
+        # A `not found` here would be the confusing failure #368 replaced.
+        assert "is not configured" not in text
+    assert codex_config.read_text() == codex_before
+
+
+@pytest.mark.asyncio
 async def test_mcp_add_writes_both_transports_and_names_the_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
# PR Description

## Summary of Changes

Servers configured in Codex CLI's `~/.codex/config.toml` were invisible to Local
Operator. `load_all_mcp_configs` imported Claude Code, Cursor and VS Code but not
Codex, so `lop mcp list` showed none of them and a session could not use them.

### Codex needs its own reader, not another `_read_json` row

Every existing import source is JSON. Codex's config is **TOML**, with servers
under `[mcp_servers.<name>]` tables rather than an `mcpServers` object, so this
adds a small stdlib `tomllib` reader (`_read_toml`). Its contract is deliberately
identical to `_read_json`'s — a config we do not own must never break discovery
of the ones we do — so `OSError`, `UnicodeDecodeError` and
`tomllib.TOMLDecodeError` all degrade to "this file contributes nothing".

`tomllib` is stdlib on the repo's `>=3.12` floor, so this adds **no dependency**.

### The candidate list carries its reader now

Rather than bolt a parallel loop beside `candidates`, the tuple went from
`(path, key_path)` to `(path, reader, key_path)`:

```python
candidates: list[tuple[Path, _ConfigReader, tuple[str, ...] | None]] = [
    (project_path, _read_json, None),
    ...
    (root / ".vscode" / "mcp.json", _read_json, ("mcp", "servers")),
    (home / ".codex" / "config.toml", _read_toml, ("mcp_servers",)),
]
```

That keeps the enable/disable list collection, the **two-pass suppression
resolution** (the one that stops a disabled project entry from claiming a name
slot and shadowing a lower-priority entry of the same name) and the `sources`
provenance map entirely unchanged and format-agnostic. `_imported_servers`
already walks a `key_path` into nested dicts, and `tomllib` parses
`[mcp_servers.<name>]` into exactly that nested-dict shape, so `("mcp_servers",)`
needed no new traversal code.

### Why Codex is appended LAST

The issue body only required "after the local-operator files", which any position
4-8 satisfies; the relative order against the other imports was left open. Per
the collaborator's analysis on #367, **appending last** is taken: first-seen-wins
makes position observable whenever two tools define the same server name, and
last is the only position that guarantees Codex can override neither
local-operator's own files nor Claude/Cursor/VS Code. User scope only — Codex
project-scoped config is deliberately out of scope, matching the issue's "user
scope alone would cover the common case".

### The import is read-only permanently, by construction

`tomllib` exposes `load`/`loads` and cannot emit TOML, and `tomli_w` is not a
dependency. Writing the file back would also destroy the comments and formatting
of a file another tool owns. So a Codex-imported server can be listed but never
removed in place.

The refusal machinery for that already landed on `main` (`_FOREIGN_MCP_CONFIGS`
registers `(".codex", "config.toml")`, and `_mcp_remove_result`'s docstring
explains the permanent case), but until this PR nothing could ever reach it —
the loader never produced a Codex source. **That path is now verified end to
end** rather than assumed, by a real run and a pilot test. The only code change
on that side is the docstring's "merges SEVEN sources" -> "EIGHT".

### Prose that would now be wrong

`config.py`'s module docstring, `load_all_mcp_configs`' numbered priority list
(now 1-8), `owned_scope_for_source`'s "merges seven sources",
`_mcp_remove_result`'s "SEVEN sources", `docs/mcp.md` and `README.md` all
enumerate the import sources and are updated. `docs/REWRITE.md` was deliberately
left alone: it is the historical rewrite contract describing what that branch
shipped, not live documentation of current behaviour.

## Impact

- No breaking changes, no new dependency, no new public API.
- Version bumped to `0.43.13` — **patch**. A self-contained fifth import source
  is not a step-function capability; nothing users could not previously do
  becomes possible, a config they already maintain simply stops being ignored.
  (Originally cut as `0.43.11`; rebased onto `origin/main` after 0.43.11 and
  0.43.12 were released from other work while this PR was in review.)

## Testing Details

> The real `~/.codex/config.toml` used for the live evidence contains secrets in
> `env`. **Only server NAMES and provenance paths are reproduced below** — no
> file contents, no env values. The config was never opened with a file reader,
> only parsed by a script that prints names.

### Live reproduction: the real config, before and after

The operator's real `~/.codex/config.toml` defines 8 servers, two of which
(`computer-use`, `linear`) carry `enabled = false` in Codex.

**BEFORE** (pristine `origin/main` worktree, same machine, same real config):

```
$ PYTHONPATH=/tmp/lop-main-baseline .venv/bin/python -c "from local_operator.cli import main; ..." mcp list

╭─ MCP Servers ─────────────────────────────────
│ cloudflare: https://mcp.cloudflare.com/mcp
│ datadog: https://mcp.us3.datadoghq.com/v1/mcp
│ google-workspace: uvx
│ hubspot: https://mcp.hubspot.com
│ linear: https://mcp.linear.app/mcp
│ notion: https://mcp.notion.com/mcp
│ slack: https://mcp.slack.com/mcp
╰──────────────────────────────────────────────
```

Seven servers, all from `~/.local-operator/mcp.json`. **Zero Codex servers** —
this is the reported bug.

**AFTER** (this branch, identical invocation):

```
╭─ MCP Servers ─────────────────────────────────
│ cloudflare: https://mcp.cloudflare.com/mcp
│ datadog: https://mcp.us3.datadoghq.com/v1/mcp
│ gitlab: https://gitlab.com/api/v4/mcp                       <- Codex
│ google-workspace: uvx
│ hubspot: https://mcp.hubspot.com
│ launchdarkly: https://mcp.launchdarkly.com/mcp/launchdarkly  <- Codex
│ linear: https://mcp.linear.app/mcp
│ minerva-qa: https://mcp.qa.gominerva.com/mcp                 <- Codex
│ node_repl: /Applications/ChatGPT.app/.../node_repl           <- Codex
│ notion: https://mcp.notion.com/mcp
│ openaiDeveloperDocs: https://developers.openai.com/mcp       <- Codex
╰──────────────────────────────────────────────
```

### Provenance, and the ordering decision holding on real data

```
$ ... -c "load_all_mcp_configs(cwd) -> name, type, source"

  cloudflare             http   ~/.local-operator/mcp.json
  datadog                http   ~/.local-operator/mcp.json     <- also in Codex; ours wins
  gitlab                 http   ~/.codex/config.toml
  google-workspace       stdio  ~/.local-operator/mcp.json
  hubspot                http   ~/.local-operator/mcp.json
  launchdarkly           http   ~/.codex/config.toml
  linear                 http   ~/.local-operator/mcp.json     <- also in Codex; ours wins
  minerva-qa             http   ~/.codex/config.toml
  node_repl              stdio  ~/.codex/config.toml
  notion                 http   ~/.local-operator/mcp.json
  openaiDeveloperDocs    http   ~/.codex/config.toml
  slack                  http   ~/.local-operator/mcp.json
total: 12    codex-sourced: 5
```

Three properties confirmed on real data rather than fixtures:

1. **Codex never overrides.** `datadog` and `linear` exist in both files; both
   resolve to `~/.local-operator/mcp.json`.
2. **Both transports map cleanly.** `node_repl` (stdio, `command`/`args`/`env`)
   and four remote `url` servers all land on the right model with no
   Codex-specific transport code — `_coerce_server_config`'s existing inference
   handles them.
3. **Codex `enabled = false` is honoured.** `computer-use` carries it in Codex
   and is correctly absent from the 12. A server the user disabled in Codex
   stays disabled here.

### Unmodelled Codex keys survive

`node_repl` carries `startup_timeout_sec`, which Local Operator does not model:

```
node_repl type: stdio command set: True
startup_timeout_sec preserved: True -> 120
```

`extra="allow"` keeps it loadable and round-trips the key rather than dropping
the server for a field that is not ours. (`env` keys were listed by name only
during verification; values were never printed.)

### The `/mcp remove` refusal, reached for real

Against the real config, through the actual TUI helpers (`load_all_mcp_configs`
-> `owned_scope_for_source` -> `_foreign_config_origin`), asserting the scope is
genuinely unowned:

```
/mcp remove gitlab    ->  'gitlab' is defined in ~/.codex/config.toml
                          (imported from Codex CLI), not by local-operator.
                          Remove it there.
/mcp remove node_repl ->  'node_repl' is defined in ~/.codex/config.toml
                          (imported from Codex CLI), not by local-operator.
                          Remove it there.
```

Not the `not found` that #368 set out to replace. The full path is also driven
through the real app in a pilot test
(`test_mcp_remove_refuses_a_codex_imported_server`), which asserts the transcript
names the file and the tool, and that the TOML file is byte-identical afterwards.

### The tests genuinely catch the bug

The eight new `TestCodexImport` cases were copied onto a clean `origin/main`
worktree:

```
$ .venv/bin/python -m pytest tests/unit/mcp/test_config.py -q -k Codex   # on origin/main
6 failed, 2 passed in 4.14s
```

Six fail with `KeyError: 'codexy'` / empty config sets. The two that pass are the
degrade cases (malformed TOML, missing file), which are vacuously true without
the feature and are there to pin the best-effort contract, not to detect it.

### Gates — full tree, exactly as CI runs them

```
$ .venv/bin/python -m flake8 .
(clean)

$ uvx --from black==26.1.0 black --check .
All done! 618 files would be left unchanged.

$ uvx isort==5.13.2 --check .
(clean)

$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
8804 passed, 15 skipped, 453 warnings in 369.17s (0:06:09)
```

Zero failures across the whole unit suite.

## Checklist

- [x] Tests added, verified to fail against `origin/main`
- [x] Real execution evidence captured before and after against the real config
- [x] Secrets redacted — names and provenance only
- [x] All CI gates run over the whole tree

Closes #367

