### PR TITLE
chore(release): bump version to 0.43.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.11"
+version = "0.43.12"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Version bump for the release carrying #427 (cmd+v / cmd+c clipboard chords).

`v0.43.11` was tagged and published from `3627aa4b` while #427 was in its final review round, so the merge commit `f3ae0441` is not contained in that tag and needs its own version to reach PyPI.

Mechanical: `pyproject.toml` only.