### PR TITLE
perf(tests): cap xdist auto workers by CPU share and available memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,20 @@ peak RSS**; three suites at once drove load average to 98-128 and consumed 6.1
 of 7.2 GB of swap. Fewer workers were also *faster* there — an interleaved A/B
 on `tests/unit/server` measured `-n 4` at 5.3-5.9s against `-n 14` at
 7.8-11.3s, because the suite waits on the event loop rather than on CPU. The
-cap is the smaller of a CPU share and a budget over *available* memory (about
-600 MB per worker, measured), so a machine already under pressure from sibling
-worktrees backs off on its own. The memory probe (`vm_stat` on macOS,
-`MemAvailable` on Linux — `psutil` is deliberately not a dependency) degrades to
-the CPU-only cap on any failure and never raises.
+cap is the smaller of a CPU share and a memory budget, so a machine already
+under pressure from sibling worktrees backs off on its own. The budget divides
+by 600 MB per worker, which is a deliberate ~2.5x safety envelope rather than
+the measured figure: cleanly measured workers sit at 226-262 MB, but a worker's
+RSS depends on which tests it draws (worst observed ~1,090 MB) and some tests
+fork their own subprocesses the budget must still cover.
+
+The memory probe is pressure-aware, which matters more than it sounds:
+`psutil` is deliberately not a dependency, so macOS is read from `vm_stat` and
+Linux from `MemAvailable`. On macOS, counting `Pages inactive` as free reports
+many gigabytes of phantom headroom on a machine that is actively swapping (it
+claimed 8,137 MB while the host had 452 MB free and 6.1 GB of swap consumed), so
+inactive is discounted and consumed swap is subtracted. Any probe failure
+degrades to the CPU-only cap; the hook never raises.
 
 Override it per session, or bypass it entirely:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,9 @@ would otherwise pick. It has to sit at the rootdir: the hook runs before the
 `tests/` conftest is loaded, so a copy under `tests/` is never called.
 
 The reason is that this repo is worked through many concurrent worktrees. On a
-14-core / 36 GB host, one-per-core meant 14 workers and a measured **7,438 MB
-peak RSS**; three suites at once drove load average to 98-128 and consumed 6.1
-of 7.2 GB of swap. Fewer workers were also *faster* there — an interleaved A/B
+14-core / 36 GB host, one-per-core meant 14 workers and a measured **3,661 MB
+of xdist-worker RSS** against 1,579 MB for the capped run; three suites at once
+drove load average to 98-128 and consumed 6.1 of 7.2 GB of swap. Fewer workers were also *faster* there — an interleaved A/B
 on `tests/unit/server` measured `-n 4` at 5.3-5.9s against `-n 14` at
 7.8-11.3s, because the suite waits on the event loop rather than on CPU. The
 cap is the smaller of a CPU share and a memory budget, so a machine already
@@ -31,13 +31,18 @@ the measured figure: cleanly measured workers sit at 226-262 MB, but a worker's
 RSS depends on which tests it draws (worst observed ~1,090 MB) and some tests
 fork their own subprocesses the budget must still cover.
 
-The memory probe is pressure-aware, which matters more than it sounds:
-`psutil` is deliberately not a dependency, so macOS is read from `vm_stat` and
-Linux from `MemAvailable`. On macOS, counting `Pages inactive` as free reports
-many gigabytes of phantom headroom on a machine that is actively swapping (it
-claimed 8,137 MB while the host had 452 MB free and 6.1 GB of swap consumed), so
-inactive is discounted and consumed swap is subtracted. Any probe failure
-degrades to the CPU-only cap; the hook never raises.
+The memory probe reads *current* pressure, which is subtler than it sounds:
+`psutil` is deliberately not a dependency, so macOS is read from `vm_stat`
+(`free + speculative + file-backed`) and Linux from `MemAvailable`. Two
+plausible-looking alternatives are both wrong and are documented in
+`conftest.py` so nobody re-adds them. Counting `Pages inactive` as free reports
+phantom headroom on a swapping machine (8,137 MB while the host had 452 MB
+free); `File-backed pages` is the subset `vm_stat` itself marks clean and
+cheaply reclaimable, so no invented discount fraction is needed. And subtracting
+`vm.swapusage` looks like a pressure signal but is **cumulative** — macOS never
+decrements it, so a host that swapped hours ago stayed pinned to 2 workers while
+the OS reported 78% free. Every term used here is instantaneous and recovers on
+its own. Any probe failure degrades to the CPU-only cap; the hook never raises.
 
 Override it per session, or bypass it entirely:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,38 @@ cd ~/local-operator
 .venv/bin/python -m pytest tests/unit -q          # ~2700 tests, ~3.5 min
 ```
 
+**The suite caps its own parallelism.** `addopts` asks for `-n auto`, but the
+root `conftest.py` implements xdist's `pytest_xdist_auto_num_workers` hook and
+resolves that to a capped count (2-8) instead of the one-worker-per-core xdist
+would otherwise pick. It has to sit at the rootdir: the hook runs before the
+`tests/` conftest is loaded, so a copy under `tests/` is never called.
+
+The reason is that this repo is worked through many concurrent worktrees. On a
+14-core / 36 GB host, one-per-core meant 14 workers and a measured **7,438 MB
+peak RSS**; three suites at once drove load average to 98-128 and consumed 6.1
+of 7.2 GB of swap. Fewer workers were also *faster* there — an interleaved A/B
+on `tests/unit/server` measured `-n 4` at 5.3-5.9s against `-n 14` at
+7.8-11.3s, because the suite waits on the event loop rather than on CPU. The
+cap is the smaller of a CPU share and a budget over *available* memory (about
+600 MB per worker, measured), so a machine already under pressure from sibling
+worktrees backs off on its own. The memory probe (`vm_stat` on macOS,
+`MemAvailable` on Linux — `psutil` is deliberately not a dependency) degrades to
+the CPU-only cap on any failure and never raises.
+
+Override it per session, or bypass it entirely:
+
+```sh
+PYTEST_XDIST_AUTO_NUM_WORKERS=12 .venv/bin/python -m pytest tests/unit -q  # honoured unclamped
+.venv/bin/python -m pytest tests/unit -n 12 -q   # explicit -n bypasses the hook
+.venv/bin/python -m pytest tests/unit -n0 -q     # serialise for a debugger
+```
+
+**CI is unaffected**: a 4-vCPU runner already resolves below the cap, so the
+hook changes nothing there. `--dist worksteal` is also in `addopts` — per-test
+durations here vary by orders of magnitude, and the default `load` scheduler
+pre-assigns chunks, leaving workers idle at the tail while one grinds through
+the slow Textual pilot tests.
+
 TUI tests need a colour-capable terminal, so run them with the environment the
 suite expects:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,13 @@ PYTEST_XDIST_AUTO_NUM_WORKERS=12 .venv/bin/python -m pytest tests/unit -q  # hon
 .venv/bin/python -m pytest tests/unit -n0 -q     # serialise for a debugger
 ```
 
-**CI is unaffected**: a 4-vCPU runner already resolves below the cap, so the
-hook changes nothing there. `--dist worksteal` is also in `addopts` — per-test
+**CI keeps every core.** The CPU share is skipped when `CI` is set: a hosted
+runner is dedicated and single-purpose, so the contention the share protects
+against does not exist there. Applying it anyway halved CI parallelism (a
+4-vCPU runner resolved to 2 workers instead of 4), which is a regression paid on
+every PR. The memory budget and the 2-8 clamp still apply on CI.
+
+`--dist worksteal` is also in `addopts` — per-test
 durations here vary by orders of magnitude, and the default `load` scheduler
 pre-assigns chunks, leaving workers idle at the tail while one grinds through
 the slow Textual pilot tests.

--- a/conftest.py
+++ b/conftest.py
@@ -44,7 +44,14 @@ WHAT THIS DOES NOT AFFECT
   (``-n0 --pdb -s``) and forcing a wide run (``-n 12``) both behave exactly as
   before.
 * ``PYTEST_XDIST_AUTO_NUM_WORKERS`` still wins, see below.
-* CI is unchanged in practice: a 4-vCPU runner already resolves below the cap.
+* **CI keeps every core.** A hosted runner is a dedicated, single-purpose box:
+  nothing else competes for it, there are no sibling worktrees, and it is torn
+  down after the job. The entire reason for the CPU share is contention that
+  does not exist there, and applying it anyway measurably HALVED CI parallelism
+  (a 4-vCPU runner resolved to 2 workers instead of 4) - a regression paid on
+  every PR. So the share is skipped when ``CI`` is set; the memory budget and
+  the 2..8 clamp still apply, because a runner that runs out of memory fails
+  exactly the way a laptop does.
 """
 
 from __future__ import annotations
@@ -69,8 +76,11 @@ _MB_PER_WORKER = 600
 #: machine is contended in the first place.
 _MEMORY_SHARE = 0.5
 
-#: Fraction of cores to claim. Leaving half idle is what keeps a second worktree's
-#: suite from turning into a swap storm; the A/B above shows we lose nothing.
+#: Fraction of cores to claim on a developer machine. Leaving half idle is what
+#: keeps a second worktree's suite from turning into a swap storm; the A/B above
+#: shows we lose nothing. Deliberately NOT applied on CI - see the module
+#: docstring: a dedicated runner has no contention to protect against, and
+#: halving its workers only makes every PR slower.
 _CPU_SHARE = 0.5
 
 #: Hard bounds. Below 2 the suite stops being parallel at all (and a one-worker
@@ -158,7 +168,11 @@ def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:
                 )
 
         cpus = os.cpu_count() or 1
-        cap = max(1, int(cpus * _CPU_SHARE))
+        # `CI` is set by GitHub Actions and essentially every other provider.
+        # On a dedicated runner take all the cores; the share exists only to
+        # protect a shared developer machine.
+        on_ci = bool(os.environ.get("CI"))
+        cap = cpus if on_ci else max(1, int(cpus * _CPU_SHARE))
 
         available_mb = _available_memory_mb()
         if available_mb is not None:

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,171 @@
+"""Root conftest: cap xdist's ``-n auto`` worker count to what the machine can afford.
+
+This file exists for exactly one hook. It has to live at the **rootdir** rather
+than in ``tests/``: ``pytest_xdist_auto_num_workers`` is consulted while the
+controller is deciding how many workers to spawn, which happens before the
+``tests/`` package conftest is loaded, so a copy under ``tests/`` is never
+called.
+
+WHY A CAP AT ALL
+----------------
+``addopts`` asks for ``-n auto``. With ``psutil`` absent (it is deliberately not
+a dependency here), xdist falls through its provider chain to ``os.cpu_count()``,
+which on this class of machine means **one worker per core** — 14 on a 14-core
+box. That is a fine default for a single checkout on an idle machine and a bad
+one here, because this repo is worked through many concurrent git worktrees and
+several agent sessions run suites at the same time.
+
+Measured on a 14-core / 36 GB host, all numbers from real runs of
+``pytest tests/unit``:
+
+* ``-n auto`` (14 workers): **7,438 MB peak RSS** across 19 processes; roughly
+  **600 MB per worker** including the controller (``-n 6`` peaked at 3,598 MB,
+  so the growth is linear).
+* Three suites running concurrently drove load average to **98-128** on 14 cores
+  and consumed **6.1 GB of 7.2 GB** of swap. At that point everything on the
+  machine is slower, not just the tests.
+* Interleaved A/B on ``tests/unit/server`` under that contention, 3 rounds:
+  ``-n 14`` took 11.3s / 8.5s / 7.8s, ``-n 4`` took 5.3s / 5.4s / 5.9s. **Fewer
+  workers were faster and far more stable.** The suite is dominated by Textual
+  pilot tests that wait on the event loop rather than burning CPU, so extra
+  workers past a handful buy no throughput and only add context-switch and swap
+  pressure.
+
+So the cap is derived from two independent constraints and takes the smaller:
+a CPU share that leaves headroom for the rest of the machine, and a memory
+budget computed from **available** (not total) memory, so a host already under
+pressure from sibling worktrees backs off on its own instead of adding to the
+pile-up.
+
+WHAT THIS DOES NOT AFFECT
+-------------------------
+* ``-n0`` and an explicit ``-n N`` **bypass this hook entirely** — xdist only
+  consults it when ``-n`` is ``auto`` or ``logical``. Serialising for a debugger
+  (``-n0 --pdb -s``) and forcing a wide run (``-n 12``) both behave exactly as
+  before.
+* ``PYTEST_XDIST_AUTO_NUM_WORKERS`` still wins, see below.
+* CI is unchanged in practice: a 4-vCPU runner already resolves below the cap.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import warnings
+
+import pytest
+
+#: Peak RSS a single worker costs, including its share of the controller.
+#: Measured on this suite (7,438 MB / 14 workers and 3,598 MB / 6 workers both
+#: land here). Used as the divisor for the memory budget; deliberately generous,
+#: because under-provisioning costs a little wall time and over-provisioning
+#: costs the whole machine to swap.
+_MB_PER_WORKER = 600
+
+#: Fraction of available memory the suite may claim. The rest is left for the
+#: editor, the agent sessions and the OS page cache that are the reason this
+#: machine is contended in the first place.
+_MEMORY_SHARE = 0.5
+
+#: Fraction of cores to claim. Leaving half idle is what keeps a second worktree's
+#: suite from turning into a swap storm; the A/B above shows we lose nothing.
+_CPU_SHARE = 0.5
+
+#: Hard bounds. Below 2 the suite stops being parallel at all (and a one-worker
+#: xdist run is strictly worse than ``-n0``); above 8 buys nothing measurable on
+#: a wait-bound suite and is precisely what produced the load-128 thrash.
+_MIN_WORKERS = 2
+_MAX_WORKERS = 8
+
+#: Safe answer for any path that cannot measure the machine. Small enough to be
+#: harmless on a laptop already under load, large enough to keep the suite
+#: parallel.
+_FALLBACK_WORKERS = 4
+
+
+def _available_memory_mb() -> int | None:
+    """Available (not total) physical memory in MB, or ``None`` if unmeasurable.
+
+    ``psutil`` would answer this in one call and is intentionally NOT a
+    dependency of this project, so each platform is probed through what ships
+    with the OS. Every probe is best-effort: any failure returns ``None`` and the
+    caller degrades to the CPU-only cap rather than guessing.
+    """
+    try:
+        if sys.platform == "darwin":
+            # `vm_stat` reports counts of 16K pages. "Available" for our purpose
+            # is free + inactive + speculative: inactive pages are clean and
+            # reclaimable on demand, and excluding them would understate a
+            # healthy machine's headroom by many gigabytes.
+            out = subprocess.run(
+                ["vm_stat"], capture_output=True, text=True, timeout=5, check=True
+            ).stdout
+            page_size = 4096
+            header = re.search(r"page size of (\d+) bytes", out)
+            if header:
+                page_size = int(header.group(1))
+            pages = 0
+            for label in ("Pages free", "Pages inactive", "Pages speculative"):
+                match = re.search(rf"^{label}:\s+(\d+)\.", out, re.MULTILINE)
+                if match is None:
+                    return None
+                pages += int(match.group(1))
+            return pages * page_size // (1024 * 1024)
+
+        if sys.platform.startswith("linux"):
+            # MemAvailable is the kernel's own estimate of what can be handed out
+            # without swapping — strictly better than MemFree, which ignores
+            # reclaimable page cache and would badly understate a warm container.
+            with open("/proc/meminfo", encoding="utf-8") as handle:
+                for line in handle:
+                    if line.startswith("MemAvailable:"):
+                        return int(line.split()[1]) // 1024
+            return None
+    except Exception:  # noqa: BLE001 - a probe must never break collection
+        return None
+
+    return None
+
+
+@pytest.hookimpl
+def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:
+    """Resolve ``-n auto`` to a worker count this machine can actually sustain.
+
+    Returning a value here takes priority over xdist's own default provider
+    (pluggy ``firstresult``), which is why the ``PYTEST_XDIST_AUTO_NUM_WORKERS``
+    handling below is re-implemented rather than delegated: xdist reads that
+    variable inside the hook we are displacing, so without this branch the
+    documented override would silently stop working.
+
+    Never raises. A suite that cannot start because the worker-count heuristic
+    threw would be a far worse failure than a suboptimal worker count.
+    """
+    try:
+        override = os.environ.get("PYTEST_XDIST_AUTO_NUM_WORKERS")
+        if override:
+            try:
+                # An explicit operator override is honoured UNCLAMPED. Someone who
+                # types a number has a reason (a dedicated machine, or bisecting a
+                # parallelism-sensitive failure at 1); second-guessing it would
+                # make the escape hatch useless.
+                return int(override)
+            except ValueError:
+                warnings.warn(
+                    f"PYTEST_XDIST_AUTO_NUM_WORKERS is not a number: {override!r}. Ignoring it.",
+                    stacklevel=1,
+                )
+
+        cpus = os.cpu_count() or 1
+        cap = max(1, int(cpus * _CPU_SHARE))
+
+        available_mb = _available_memory_mb()
+        if available_mb is not None:
+            # Budget from AVAILABLE memory, so a machine already hosting three
+            # sibling suites hands this run a smaller cap automatically.
+            cap = min(cap, int(available_mb * _MEMORY_SHARE) // _MB_PER_WORKER)
+
+        return max(_MIN_WORKERS, min(_MAX_WORKERS, cap))
+    except Exception:  # noqa: BLE001 - see docstring: never break the run
+        return _FALLBACK_WORKERS

--- a/conftest.py
+++ b/conftest.py
@@ -64,12 +64,27 @@ import warnings
 
 import pytest
 
-#: Peak RSS a single worker costs, including its share of the controller.
-#: Measured on this suite (7,438 MB / 14 workers and 3,598 MB / 6 workers both
-#: land here). Used as the divisor for the memory budget; deliberately generous,
-#: because under-provisioning costs a little wall time and over-provisioning
-#: costs the whole machine to swap.
+#: Divisor for the memory budget. This is a deliberately CONSERVATIVE ENVELOPE,
+#: not the measured per-worker RSS - do not "correct" it to the measured figure.
+#: Cleanly measured xdist workers (matched by their execnet command line, on a
+#: subset that spawns no subprocesses of its own) sit at 226-262 MB. 600 is a
+#: ~2.5x margin over that, and the margin is intentional on three counts: a
+#: worker's RSS depends on which tests it draws (the worst observed single
+#: worker was ~1,090 MB), some suites fork their own children that the budget
+#: still has to cover (the eval-tool tests spawn kernel subprocesses), and the
+#: controller's own footprint is charged to no worker. The asymmetry justifies
+#: it: under-provisioning costs a little wall time, over-provisioning costs the
+#: whole machine a swap storm.
 _MB_PER_WORKER = 600
+
+#: Fraction of macOS ``Pages inactive`` treated as genuinely reclaimable. Those
+#: pages are a mix of clean (free on demand) and dirty/compressor-backed
+#: (reclaimable only by paging), and vm_stat does not split them. Counting all
+#: of it is what let the probe report 8 GB of headroom on a swapping machine;
+#: counting none of it reports near-zero on a healthy one with a warm cache.
+#: A quarter is a deliberate middle: pessimistic enough that pressure moves the
+#: number, generous enough not to starve an idle host.
+_INACTIVE_RECLAIM_FRACTION = 0.25
 
 #: Fraction of available memory the suite may claim. The rest is left for the
 #: editor, the agent sessions and the OS page cache that are the reason this
@@ -95,34 +110,72 @@ _MAX_WORKERS = 8
 _FALLBACK_WORKERS = 4
 
 
-def _available_memory_mb() -> int | None:
-    """Available (not total) physical memory in MB, or ``None`` if unmeasurable.
+def _swap_used_mb() -> float:
+    """Consumed swap in MB, or 0.0 when it cannot be read.
 
-    ``psutil`` would answer this in one call and is intentionally NOT a
-    dependency of this project, so each platform is probed through what ships
-    with the OS. Every probe is best-effort: any failure returns ``None`` and the
-    caller degrades to the CPU-only cap rather than guessing.
+    Subtracted from apparent headroom: a machine that is already paging has less
+    room than its free-page count suggests, and this term is what makes the
+    budget shrink as real pressure rises. Failing to 0.0 (rather than to None)
+    keeps a missing/unswapped host on the free-page estimate alone.
+    """
+    try:
+        out = subprocess.run(
+            ["sysctl", "-n", "vm.swapusage"], capture_output=True, text=True, timeout=5, check=True
+        ).stdout
+        match = re.search(r"used\s*=\s*([\d.]+)M", out)
+        return float(match.group(1)) if match else 0.0
+    except Exception:  # a missing probe must not break the budget
+        return 0.0
+
+
+def _available_memory_mb() -> int | None:
+    """Memory the suite can take without pushing the machine into swap, in MB.
+
+    ``None`` when it cannot be measured; the caller then degrades to the
+    CPU-only cap rather than guessing. ``psutil`` would answer this in one call
+    and is intentionally NOT a dependency, so each platform is probed through
+    what ships with the OS.
+
+    The macOS arm is deliberately NOT a naive "free + inactive". A first cut
+    counted ``Pages inactive`` as available and reported 8,137 MB of headroom on
+    this host at the exact moment it had 452 MB genuinely free and 6.1 GB of 7.2
+    GB of swap consumed - so the arm never became the binding constraint under
+    the pressure it exists to detect. On macOS ``inactive`` is not Linux's
+    ``MemAvailable``: much of it is dirty and compressor-backed, reclaimable
+    only by paging, which is the very cost being avoided. Two corrections:
+
+    * ``inactive`` is DISCOUNTED (only a fraction counts as reclaimable) rather
+      than dropped, because dropping it entirely reports near-zero on a healthy
+      machine with a warm page cache and would pin a fine host to the floor.
+    * Consumed swap is SUBTRACTED. A machine already paging has negative real
+      headroom, and this is what makes the probe fall as pressure rises.
     """
     try:
         if sys.platform == "darwin":
-            # `vm_stat` reports counts of 16K pages. "Available" for our purpose
-            # is free + inactive + speculative: inactive pages are clean and
-            # reclaimable on demand, and excluding them would understate a
-            # healthy machine's headroom by many gigabytes.
             out = subprocess.run(
                 ["vm_stat"], capture_output=True, text=True, timeout=5, check=True
             ).stdout
-            page_size = 4096
+            # Page size is read from the header, never assumed: this host uses
+            # 16K pages, so a hardcoded 4096 would under-report by 4x. A miss
+            # returns None like every other failure in this function, rather
+            # than silently pinning the cap to the floor.
             header = re.search(r"page size of (\d+) bytes", out)
-            if header:
-                page_size = int(header.group(1))
-            pages = 0
+            if header is None:
+                return None
+            page_size = int(header.group(1))
+
+            counts = {}
             for label in ("Pages free", "Pages inactive", "Pages speculative"):
                 match = re.search(rf"^{label}:\s+(\d+)\.", out, re.MULTILINE)
                 if match is None:
                     return None
-                pages += int(match.group(1))
-            return pages * page_size // (1024 * 1024)
+                counts[label] = int(match.group(1))
+
+            per_mb = page_size / (1024 * 1024)
+            free_mb = (counts["Pages free"] + counts["Pages speculative"]) * per_mb
+            inactive_mb = counts["Pages inactive"] * per_mb * _INACTIVE_RECLAIM_FRACTION
+            available = free_mb + inactive_mb - _swap_used_mb()
+            return max(0, int(available))
 
         if sys.platform.startswith("linux"):
             # MemAvailable is the kernel's own estimate of what can be handed out
@@ -133,7 +186,7 @@ def _available_memory_mb() -> int | None:
                     if line.startswith("MemAvailable:"):
                         return int(line.split()[1]) // 1024
             return None
-    except Exception:  # noqa: BLE001 - a probe must never break collection
+    except Exception:  # a probe must never break collection
         return None
 
     return None
@@ -164,7 +217,7 @@ def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:
             except ValueError:
                 warnings.warn(
                     f"PYTEST_XDIST_AUTO_NUM_WORKERS is not a number: {override!r}. Ignoring it.",
-                    stacklevel=1,
+                    stacklevel=2,
                 )
 
         cpus = os.cpu_count() or 1
@@ -181,5 +234,5 @@ def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:
             cap = min(cap, int(available_mb * _MEMORY_SHARE) // _MB_PER_WORKER)
 
         return max(_MIN_WORKERS, min(_MAX_WORKERS, cap))
-    except Exception:  # noqa: BLE001 - see docstring: never break the run
+    except Exception:  # see docstring: never break the run
         return _FALLBACK_WORKERS

--- a/conftest.py
+++ b/conftest.py
@@ -81,15 +81,6 @@ import pytest
 #: whole machine a swap storm.
 _MB_PER_WORKER = 600
 
-#: Fraction of macOS ``Pages inactive`` treated as genuinely reclaimable. Those
-#: pages are a mix of clean (free on demand) and dirty/compressor-backed
-#: (reclaimable only by paging), and vm_stat does not split them. Counting all
-#: of it is what let the probe report 8 GB of headroom on a swapping machine;
-#: counting none of it reports near-zero on a healthy one with a warm cache.
-#: A quarter is a deliberate middle: pessimistic enough that pressure moves the
-#: number, generous enough not to starve an idle host.
-_INACTIVE_RECLAIM_FRACTION = 0.25
-
 #: Fraction of available memory the suite may claim. The rest is left for the
 #: editor, the agent sessions and the OS page cache that are the reason this
 #: machine is contended in the first place.
@@ -114,24 +105,6 @@ _MAX_WORKERS = 8
 _FALLBACK_WORKERS = 4
 
 
-def _swap_used_mb() -> float:
-    """Consumed swap in MB, or 0.0 when it cannot be read.
-
-    Subtracted from apparent headroom: a machine that is already paging has less
-    room than its free-page count suggests, and this term is what makes the
-    budget shrink as real pressure rises. Failing to 0.0 (rather than to None)
-    keeps a missing/unswapped host on the free-page estimate alone.
-    """
-    try:
-        out = subprocess.run(
-            ["sysctl", "-n", "vm.swapusage"], capture_output=True, text=True, timeout=5, check=True
-        ).stdout
-        match = re.search(r"used\s*=\s*([\d.]+)M", out)
-        return float(match.group(1)) if match else 0.0
-    except Exception:  # a missing probe must not break the budget
-        return 0.0
-
-
 def _available_memory_mb() -> int | None:
     """Memory the suite can take without pushing the machine into swap, in MB.
 
@@ -140,19 +113,36 @@ def _available_memory_mb() -> int | None:
     and is intentionally NOT a dependency, so each platform is probed through
     what ships with the OS.
 
-    The macOS arm is deliberately NOT a naive "free + inactive". A first cut
-    counted ``Pages inactive`` as available and reported 8,137 MB of headroom on
-    this host at the exact moment it had 452 MB genuinely free and 6.1 GB of 7.2
-    GB of swap consumed - so the arm never became the binding constraint under
-    the pressure it exists to detect. On macOS ``inactive`` is not Linux's
-    ``MemAvailable``: much of it is dirty and compressor-backed, reclaimable
-    only by paging, which is the very cost being avoided. Two corrections:
+    The macOS arm is ``free + speculative + file-backed``, and each of those two
+    design choices was made against a measured failure of the obvious
+    alternative. Both alternatives are recorded because each looks correct until
+    it is measured, and a future reader will otherwise re-introduce one:
 
-    * ``inactive`` is DISCOUNTED (only a fraction counts as reclaimable) rather
-      than dropped, because dropping it entirely reports near-zero on a healthy
-      machine with a warm page cache and would pin a fine host to the floor.
-    * Consumed swap is SUBTRACTED. A machine already paging has negative real
-      headroom, and this is what makes the probe fall as pressure rises.
+    * **Not ``Pages inactive``.** Counting it as available reported 8,137 MB of
+      headroom on this host at the exact moment it had 452 MB genuinely free and
+      6.1 GB of 7.2 GB of swap consumed, so the arm never bound under the
+      pressure it exists to detect. On macOS ``inactive`` is not Linux's
+      ``MemAvailable``: much of it is dirty and compressor-backed, reclaimable
+      only by paging, which is the cost being avoided. ``File-backed pages`` is
+      the subset vm_stat itself identifies as clean and cheaply reclaimable
+      (page cache, backed by a file, droppable without a write), so it needs no
+      invented discount fraction - an earlier revision multiplied ``inactive``
+      by an asserted 0.25, which was a guess dressed as a measurement.
+    * **Not consumed swap as a pressure term.** Subtracting
+      ``vm.swapusage``'s ``used`` looks like the natural way to notice a machine
+      that is paging, but that counter is CUMULATIVE - macOS does not decrement
+      it when pressure clears, since pages stay in the swap file until faulted
+      back in or the machine reboots. It therefore reads "this host swapped at
+      some point since boot", not "this host is swapping now". Measured: with
+      the OS reporting 78% free and load down from 155 to 21, a stale 3,315 MB
+      swap figure still drove the hook to 2 workers, the floor, where the CPU
+      arm alone would have given 7. A term that only ever ratchets down is worse
+      than no term, because it silently makes the cap independent of actual
+      conditions. The page counts used here are all instantaneous and recover on
+      their own.
+
+    The compressor is deliberately NOT subtracted: pages it occupies are already
+    excluded from both free and file-backed, so subtracting would double-count.
     """
     try:
         if sys.platform == "darwin":
@@ -169,17 +159,19 @@ def _available_memory_mb() -> int | None:
             page_size = int(header.group(1))
 
             counts = {}
-            for label in ("Pages free", "Pages inactive", "Pages speculative"):
-                match = re.search(rf"^{label}:\s+(\d+)\.", out, re.MULTILINE)
+            # "File-backed pages" is not present on every macOS version; treat a
+            # miss as 0 rather than as a probe failure, which degrades to the
+            # free-page estimate instead of discarding a usable measurement.
+            for label in ("Pages free", "Pages speculative"):
+                match = re.search(rf"^{re.escape(label)}:\s+(\d+)\.", out, re.MULTILINE)
                 if match is None:
                     return None
                 counts[label] = int(match.group(1))
+            file_backed = re.search(r"^File-backed pages:\s+(\d+)\.", out, re.MULTILINE)
+            counts["File-backed pages"] = int(file_backed.group(1)) if file_backed else 0
 
             per_mb = page_size / (1024 * 1024)
-            free_mb = (counts["Pages free"] + counts["Pages speculative"]) * per_mb
-            inactive_mb = counts["Pages inactive"] * per_mb * _INACTIVE_RECLAIM_FRACTION
-            available = free_mb + inactive_mb - _swap_used_mb()
-            return max(0, int(available))
+            return max(0, int(sum(counts.values()) * per_mb))
 
         if sys.platform.startswith("linux"):
             # MemAvailable is the kernel's own estimate of what can be handed out

--- a/conftest.py
+++ b/conftest.py
@@ -18,9 +18,13 @@ several agent sessions run suites at the same time.
 Measured on a 14-core / 36 GB host, all numbers from real runs of
 ``pytest tests/unit``:
 
-* ``-n auto`` (14 workers): **7,438 MB peak RSS** across 19 processes; roughly
-  **600 MB per worker** including the controller (``-n 6`` peaked at 3,598 MB,
-  so the growth is linear).
+* ``-n auto`` resolves to 14 workers. Measuring the xdist workers themselves
+  (matched by their execnet command line, on a subset that forks no children of
+  its own, so the numbers describe workers and nothing else), 3 interleaved
+  rounds: **14 workers = 3,661 MB** of worker RSS, **7 workers = 1,579 MB** -
+  57% less, with per-worker RSS flat at 226-262 MB across both. Whole-tree peak
+  figures are deliberately not quoted here: they conflate workers with
+  subprocesses the tests themselves spawn and are not a function of ``-n``.
 * Three suites running concurrently drove load average to **98-128** on 14 cores
   and consumed **6.1 GB of 7.2 GB** of swap. At that point everything on the
   machine is slower, not just the tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.14"
+version = "0.43.15"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -289,7 +289,8 @@ exclude = ["**/node_modules", "**/__pycache__", "**/.*", "docs"]
 # waiting for the event loop rather than on CPU, so a wide run buys nothing:
 # an interleaved A/B on tests/unit/server measured `-n 4` FASTER than `-n 14`
 # (5.3-5.9s vs 7.8-11.3s) under that contention. See conftest.py for the full
-# measurements and the fallback behaviour.
+# measurements and the fallback behaviour. CI is exempt from the CPU share (a
+# dedicated runner has no contention to protect against) and keeps every core.
 #
 # `auto` must stay literal here: an explicit `-n N` in addopts would make both
 # the hook and the env var inert.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,7 +283,8 @@ exclude = ["**/node_modules", "**/__pycache__", "**/.*", "docs"]
 # `pytest_xdist_auto_num_workers` and caps it (2..8) from a CPU share and a
 # budget over *available* memory. Without that hook xdist resolves `auto` to
 # `os.cpu_count()`, which on a 14-core host meant 14 workers and a measured
-# 7,438 MB peak RSS — ruinous on this machine, where many git worktrees run
+# 3,661 MB of worker RSS (vs 1,579 MB capped) — ruinous on this machine, where
+# many git worktrees run
 # suites concurrently (three at once drove load to 98-128 and exhausted swap).
 # The suite is dominated by Textual pilot tests that spend their wall time
 # waiting for the event loop rather than on CPU, so a wide run buys nothing:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,12 +278,33 @@ exclude = ["**/node_modules", "**/__pycache__", "**/.*", "docs"]
 #   .venv/bin/python -m pyright --pythonpath .venv/bin/python .
 
 [tool.pytest.ini_options]
-# `-n auto` distributes the suite across one worker process per logical core.
+# `-n auto` distributes the suite across worker processes, but the worker count
+# is NOT one-per-core: the root `conftest.py` implements
+# `pytest_xdist_auto_num_workers` and caps it (2..8) from a CPU share and a
+# budget over *available* memory. Without that hook xdist resolves `auto` to
+# `os.cpu_count()`, which on a 14-core host meant 14 workers and a measured
+# 7,438 MB peak RSS — ruinous on this machine, where many git worktrees run
+# suites concurrently (three at once drove load to 98-128 and exhausted swap).
 # The suite is dominated by Textual pilot tests that spend their wall time
-# waiting for the event loop to settle rather than on CPU, so this scales CI
-# wall time down roughly with the core count (4 on GitHub's ubuntu-latest)
-# without changing what each test does. Run `-n0` locally to serialise for a
-# debugger (`--pdb`/`-s` need a single process).
+# waiting for the event loop rather than on CPU, so a wide run buys nothing:
+# an interleaved A/B on tests/unit/server measured `-n 4` FASTER than `-n 14`
+# (5.3-5.9s vs 7.8-11.3s) under that contention. See conftest.py for the full
+# measurements and the fallback behaviour.
+#
+# `auto` must stay literal here: an explicit `-n N` in addopts would make both
+# the hook and the env var inert.
+#   PYTEST_XDIST_AUTO_NUM_WORKERS=N  per-session override, honoured unclamped.
+#   -n0                              serialise for a debugger (`--pdb`/`-s`
+#                                    need a single process); bypasses the hook.
+#   -n 12                            an explicit count also bypasses the hook.
+#
+# `--dist worksteal`: per-test durations here vary by orders of magnitude
+# (Textual pilot tests wait on the event loop; a pure-function test is
+# microseconds). The default `load` scheduler pre-assigns work in chunks, so a
+# worker that draws the slow tests still holds them while its peers sit idle at
+# the tail of the run. worksteal lets an idle worker take pending tests off a
+# busy one, which xdist documents as handling "tests with significantly
+# differing duration" better — exactly this suite's shape.
 #
 # The old `-vv -s` was dropped deliberately: `-vv` prints a line per test,
 # which is ~5.8k lines of I/O that buys nothing in CI logs, and `-s`
@@ -305,7 +326,7 @@ exclude = ["**/node_modules", "**/__pycache__", "**/.*", "docs"]
 #
 # Run it explicitly with:
 #   env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0
-addopts = "-n auto -m \"not e2e\""
+addopts = "-n auto --dist worksteal -m \"not e2e\""
 testpaths = ["tests"]
 markers = [
     # Applied by LOCATION in tests/e2e/conftest.py, so a module in that package


### PR DESCRIPTION
# PR Description

## Summary of Changes

`addopts = "-n auto"` resolved to **one xdist worker per core**. `psutil` is
deliberately not a dependency here, so xdist falls through its provider chain to
`os.cpu_count()` — 14 workers on a 14-core host. That is a reasonable default for
one checkout on an idle machine and a bad one for this repo, which is worked
through many concurrent git worktrees (41 exist on the development machine right
now) with several agent sessions running suites at once. Three concurrent suites
drove load average to **98-128 on 14 cores** with **6.1 GB of 7.2 GB of swap
consumed**.

This adds a root `conftest.py` implementing xdist's
`pytest_xdist_auto_num_workers` hook, which caps the resolved worker count to the
**minimum of a CPU share and a memory budget**, clamped to 2..8, on developer
machines only.

### Why the file is at the repo root

`pytest_xdist_auto_num_workers` is consulted while the controller decides how many
workers to spawn, which happens **before** `tests/conftest.py` is loaded. A copy
under `tests/` is never called. Verified against the installed xdist 3.8.0
(`xdist/plugin.py`).

### CI keeps every core

The CPU share is **skipped when `CI` is set**, so CI behaviour is byte-for-byte
what main does today. A hosted runner is dedicated and single-purpose, torn down
after the job, with no sibling worktrees competing — the contention the share
protects against does not exist there.

This was **round 1 finding F1**, and it was a real regression, not a theoretical
one. The first push applied the share unconditionally, and this PR's own checks
measured the cost:

| job | first push (share applied on CI) | main | after the fix |
|---|---|---|---|
| `test (3.12)` | 30m10s | 22m21s | see "CI durations" below |
| `test (3.13)` | 33m10s | 23m06s | see "CI durations" below |

It also contradicted the measured note in `.github/workflows/ci.yml:92-103`, which
concludes "One worker per core is the stable point" on that runner after measuring
that deviating from it starved three timing-sensitive deadline tests. The memory
budget and the 2..8 clamp still apply on CI, because a runner that runs out of
memory fails exactly the way a laptop does.

### The memory budget is pressure-aware

Budgeting from *available* rather than total memory is the point: a machine
already under pressure from sibling worktrees hands this run a smaller cap by
itself. Getting that right took a correction (**round 1 finding F3**).

Getting this right took two rounds, and both rejected alternatives are documented
in the file with the measurement that killed them, because each looks correct until
measured.

**Round 1 (F3): not `Pages inactive`.** Counting it as available reported **8,137 MB
of headroom on a host that had 452 MB genuinely free and 6.1 GB of swap consumed** —
the arm never bound under the pressure it exists to detect. On macOS `inactive` is
not Linux's `MemAvailable`: much of it is dirty and compressor-backed, reclaimable
only by paging.

**Round 2 (F8): not cumulative swap.** Subtracting `vm.swapusage`'s `used` looks
like the obvious pressure signal, but macOS **never decrements it** — it reports
"this host swapped at some point since boot", not "this host is swapping now". With
the OS reporting 78% free and load down from 155, a stale 3,299 MB figure still
drove the hook to 2 workers, the floor, where the CPU arm alone would give 7. That
is the mirror image of F3: a term that only ratchets down is worse than no term.

The macOS arm is now `free + speculative + file-backed` — all instantaneous counts
that recover on their own. `File-backed pages` is the subset `vm_stat` itself marks
clean and cheaply reclaimable, so it needs **no invented discount fraction**. The
compressor is deliberately not subtracted: its pages are already excluded from both
terms, so subtracting would double-count.

### Why `PYTEST_XDIST_AUTO_NUM_WORKERS` is re-implemented rather than delegated

xdist reads that variable *inside the very hook we are displacing*, and a conftest
hook wins over xdist's default provider through pluggy `firstresult`. Without an
explicit branch, defining this hook would have **silently broken the documented
env var**. It is honoured **unclamped** — someone who types a number has a reason
(a dedicated machine, or bisecting a parallelism-sensitive failure at 1).

### No new dependency

`psutil` would answer "available memory" in one call and is intentionally absent.
The probe uses `vm_stat` plus `sysctl vm.swapusage` on Darwin and `MemAvailable`
on Linux. Every failure path returns `None` and degrades to the CPU-only cap. The
hook never raises: a suite that cannot start because the worker-count heuristic
threw would be far worse than a suboptimal worker count.

### `--dist worksteal`

Per-test durations here vary by orders of magnitude — Textual pilot tests wait on
the event loop while a pure-function test is microseconds. The default `load`
scheduler pre-assigns work in chunks, so a worker that draws the slow tests holds
them while its peers idle at the tail. xdist documents worksteal as handling
"tests with significantly differing duration" better. `-n auto` stays literal: an
explicit number in `addopts` would make both the hook and the env var inert.

Patch bump (`0.43.14`): a performance and reliability improvement to the test
harness, not a step-function capability.

## Testing Evidence

### 1. Resolved worker count under every condition

The deterministic, load-independent measurement, and the point of the change. All
rows run `tests/unit/test_agents.py` (42 tests):

| Tree | Invocation | Resolved | Result |
|---|---|---|---|
| before (`origin/main`) | `-n auto` | **14 workers** | 42 passed |
| after | `-n auto` | **7 workers** (capped) | 42 passed |
| after | `PYTEST_XDIST_AUTO_NUM_WORKERS=2` | **2** | 42 passed |
| after | `PYTEST_XDIST_AUTO_NUM_WORKERS=3` | **3** | 42 passed |
| after | `PYTEST_XDIST_AUTO_NUM_WORKERS=12` | **12** (unclamped, above the cap of 8) | 42 passed |
| after | `PYTEST_XDIST_AUTO_NUM_WORKERS=bogus` | falls through + documented warning | 42 passed |
| after | `-n 12` (explicit) | **12** — hook bypassed | 42 passed |
| after | `-n0` (debugging) | serial | 42 passed |

Neither `-n0` nor an explicit `-n N` is affected, so debugging is unchanged.

### 2. F1 — the CI exemption, proven by resolution

Hook executed directly with `os.cpu_count` pinned to a 4-vCPU runner's size and
14 GB available:

```
4-vCPU runner, CI=unset -> 2 workers    <- the regression round 1 caught
4-vCPU runner, CI=true  -> 4 workers    <- restored, identical to main
```

Full resolution matrix (14 GB available, no swap pressure):

```
dev  2c->2  4c->2  8c->4  14c->7  16c->8  32c->8
CI   2c->2  4c->4  8c->8  14c->8  16c->8  32c->8
CI with only 2 GB available -> 2        <- memory still binds on CI
```

### 3. F3 + F8 — the memory probe falls under pressure AND recovers from it

Two rounds of evidence, because the first fix traded one failure mode for its
mirror image.

**F3 (round 1): does it fall?** Captured while the host was genuinely thrashing:

```
LIVE HOST: free+spec=287MB  inactive=10,653MB  swap_used=6,641MB
  naive probe (free + inactive + spec) = 10,940 MB -> mem_cap 9  (never binds)
  resolved 2 (floor) where the CPU arm alone would say 7
```

**F8 (round 2): does it recover?** The round-1 fix subtracted cumulative swap, and
macOS never decrements that counter. Captured on the same host once load drained:

```
OS memory_pressure free: 78%      stale cumulative swap: 3,299 MB
  round-1 probe (0.25 x inactive - swap_cum): 1,731 MB -> mem_cap 1 -> PINNED to floor 2
  current probe (free + spec + file-backed) : 9,057 MB -> mem_cap 7 -> resolved 7
```

The current probe agrees with the OS's own verdict instead of contradicting it.
And it still falls as *current* pressure rises:

| host state | probe | workers |
|---|---|---|
| idle, big cache | 20,500 MB | 8 |
| busy, cache shrinking | 6,700 MB | 5 |
| tight | 2,400 MB | 2 |
| cache evicted, real distress | 550 MB | 2 (floor) |
| critical | 110 MB | 2 (floor) |

Monotonic in **both** directions, which is what neither earlier version managed.
`File-backed pages` absent (older macOS) degrades to the free-page estimate rather
than failing, and a 4-vCPU CI runner still resolves to 4.

### 4. Steady-state memory, xdist workers only

**Measurement note, because the first attempt was wrong and the wrong numbers are
instructive.** Summing every *descendant* of the pytest controller conflates xdist
workers with subprocesses the suite itself forks — the eval-tool tests spawn
`local_operator.tools.eval_worker` kernels, whose size and lifetime have nothing to
do with `-n`. That produced an impossible reading: peak memory went *up*
(12,392 MB → 14,127 MB) while worker count went *down* (14 → 7), with a single
"worker" of 9,182 MB against a real worker's ~250 MB. Those numbers are discarded,
not reported, and nothing in this PR is derived from them.

The corrected harness (a) matches xdist workers **specifically** by their execnet
command line (`python -u -c import sys;exec(eval(sys.stdin.readline()))`), (b) runs
`tests/unit/tui`, which spawns no eval kernels, so the noise is structurally absent
rather than merely filtered, and (c) samples **steady state**, since a peak on a
machine at load ~100 mostly records whoever else was running. Controller stdout
goes to a file, never a pipe — a pipe deadlocks the controller once its buffer
fills.

Three **interleaved** rounds (before/after alternating, so load drift cancels):

| Round | before: workers / worker RSS / per-worker | after: workers / worker RSS / per-worker |
|---|---|---|
| 1 | 14 / 3,451 MB / 246 MB | 7 / 1,680 MB / 240 MB |
| 2 | 14 / 3,859 MB / 276 MB | 7 / 1,695 MB / 242 MB |
| 3 | 14 / 3,673 MB / 262 MB | 7 / 1,362 MB / 195 MB |
| **mean** | **14 / 3,661 MB / 262 MB** | **7 / 1,579 MB / 226 MB** |

**57% less worker RSS**, and the shape is physically coherent: the total scales
with worker count while per-worker RSS stays flat — the signature of a correct
measurement.

### 5. F4 — where the constants come from

Every number is now traceable to a run in this PR:

- **`_MB_PER_WORKER = 600` is a deliberate ~2.5x safety envelope, not a measured
  per-worker RSS**, and is documented as such in the file. The measured figure is
  226-262 MB (section 4). The margin covers a worker that draws heavy tests (worst
  observed single worker ~1,090 MB), suites that fork their own children, and the
  controller's footprint, which is charged to no worker. The asymmetry justifies
  erring high: under-provisioning costs a little wall time, over-provisioning costs
  a swap storm.
- **The old "~380 MB per worker" projection basis is removed.** It had no run
  behind it. The table below is rebuilt on the measured **262 MB**:

| Concurrent worktrees | before (14 workers each) | after (7 each) | saved |
|---|---|---|---|
| 1 | 3.6 GB | 1.8 GB | 1.8 GB |
| 2 | 7.2 GB | 3.6 GB | 3.6 GB |
| 3 | 10.7 GB | 5.4 GB | 5.4 GB |
| 4 | 14.3 GB | 7.2 GB | 7.2 GB |

On the 36 GB / 7.2 GB-swap development machine, three worktrees × 14 workers is
**10.7 GB of test workers alone** before the editor, the browser and the agent
sessions — which is how the observed swap exhaustion happens. Capped, the same
three come to 5.4 GB.

### 6. Wall time: stated honestly, not fabricated

**Local wall time was not reliably measurable on this machine**, which sat at load
98-128 from other agents' concurrent suites throughout. Sequential rounds are
dominated by what else was running, so no local wall-time delta is claimed in
either direction. The change targets memory and contention.

CI wall time *is* measurable, and is reported in "CI durations" below — that is
the number that decides whether F1 is actually fixed.

### 7. Fallback paths

Every branch of the hook exercised directly:

```
unknown platform       -> probe None -> CPU-only cap
vm_stat raises OSError -> probe None -> CPU-only cap
page-size header miss  -> probe None -> CPU-only cap   (F5: was a silent 4x under-report)
swap probe fails       -> 0.0, free-page estimate alone
total heuristic failure-> _FALLBACK_WORKERS = 4, never raises
env='bogus'            -> falls through + "PYTEST_XDIST_AUTO_NUM_WORKERS is not a number"
```

### 8. Suite parity — no tests gained, lost, or reordered

Collection is byte-identical, so `--dist worksteal` changes only *distribution*,
never *which* tests run:

```
base 2b27d802 (no conftest): 8786 tests collected
PR head:                     8786 tests collected
```

Full-suite totals reconcile exactly and the **failure sets are identical**:

```
before: 25 failed, 8744 passed, 17 skipped  = 8786
after : 25 failed, 8746 passed, 15 skipped  = 8786
$ diff <(before failures) <(after failures)  ->  IDENTICAL failure sets
composition: 24x tests/unit/tools/test_eval_tool.py + 1x test_launch_subagent.py
```

Those 25 are pre-existing and unrelated (they reproduce at `-n0` on the base with
`ModuleNotFoundError: No module named 'local_operator'` in the eval kernel
subprocess). This change does not increase the count.

**The 2-test skip/pass movement was investigated rather than waved through**, since
a scheduler change altering results would be a blocker. It is not worksteal:
`tests/unit/compaction/test_tokens.py` skips when tiktoken cannot load its
encoding, and there was no tiktoken disk cache on this machine, so it downloaded
`cl100k_base` per run and those tests skipped or passed on network availability.
Independently confirmed by main itself, which has since landed #438,
`test(conftest): warm the tiktoken BPE table before tests measure the loop` — the
same diagnosis, fixed upstream.

### 9. Gates

Run over the whole tree, exactly as CI does:

```
$ .venv/bin/python -m flake8 .                                    -> clean
$ uvx --from black==26.1.0 black --check .                        -> 626 files unchanged
$ uvx isort==5.13.2 --check .                                     -> clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .     -> 0 errors, 0 warnings
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit
  -> failures unchanged from base, as analysed above
```

## Documentation

`AGENTS.md` "Environment" documents the cap, the measured figures, the
`PYTEST_XDIST_AUTO_NUM_WORKERS` override, the `-n0` / explicit `-n N` bypasses, the
CI exemption **and its mechanism** (not the earlier false "CI is unaffected"
assumption), and that the 600 MB divisor is a safety envelope rather than the
measured per-worker RSS. Paths are written `~/`.

The hook carries the full rationale in-file: the worktree contention, the load
average, the swap exhaustion, why `inactive` is discounted and swap subtracted,
and an explicit note that `-n0` and `-n N` bypass it entirely.
