### PR TITLE
fix(harness): a silent tool-only turn must not carry an empty text block

### DIFF
--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -980,7 +980,13 @@ class AgentLoop:
             # ``context.messages`` on this path, but the object is observable,
             # and losing the partial answer on cancel is a behaviour change this
             # optimization has no business making.
-            assistant.content = [TextContent(text="".join(text_parts))]
+            #
+            # Guarded for the same reason as the assembly at the end of this
+            # function: a cancel before any text delta must leave ``content``
+            # as the empty LIST it was constructed with, not a list holding an
+            # empty text block.
+            if text_parts:
+                assistant.content = [TextContent(text="".join(text_parts))]
             raise
         except Exception as exc:
             # `error` below is handed straight to the UI, which prints it as a
@@ -1027,7 +1033,19 @@ class AgentLoop:
         # reports the text that did arrive — the frozen row on an aborted turn
         # is what the user is left reading. The hard-cancel path re-raises
         # above and assembles there for the same reason.
-        assistant.content = [TextContent(text="".join(text_parts))]
+        #
+        # ONLY when there is text. A turn that emits tool calls and no prose is
+        # ordinary — it is what every "call the tool, say nothing" step looks
+        # like — and this assignment used to be unreachable for it, because it
+        # lived inside the delta loop and no delta ever arrived. Hoisting it out
+        # made it run unconditionally, so such a turn started carrying
+        # ``[TextContent(text="")]`` where it used to carry ``[]``. Anthropic
+        # rejects that on the NEXT request of the turn with
+        # ``HTTP 400: messages: text content blocks must be non-empty``, which
+        # kills the run outright. The empty list is what the Message was
+        # constructed with and what every provider already handles.
+        if text_parts:
+            assistant.content = [TextContent(text="".join(text_parts))]
         assistant.tool_calls = [
             self._assemble_tool_call(state) for _, state in sorted(tool_states.items())
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.12"
+version = "0.43.13"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -209,6 +209,64 @@ async def test_full_turn_text_tool_text():
 
 
 @pytest.mark.asyncio
+async def test_a_tool_only_turn_carries_no_empty_text_block() -> None:
+    """A turn that calls a tool and says nothing must keep ``content == []``.
+
+    Anthropic rejects a message carrying an empty text block outright:
+
+        HTTP 400: messages: text content blocks must be non-empty
+
+    and it is the NEXT request of the turn that fails, so the run dies after
+    the tool has already run. "Call the tool, say nothing" is an ordinary
+    model turn — it is what most tool steps look like — so this is not an
+    edge case.
+
+    The assembly used to live inside the delta loop, where it was simply
+    unreachable when no text delta arrived. Hoisting it out of the loop (to
+    stop the per-delta rebuild being quadratic in response length) made it run
+    unconditionally, which turned "no text" into an empty text block rather
+    than no content at all. The guard is what keeps the optimization from
+    changing what a silent turn sends.
+    """
+
+    executed: list[str] = []
+    stream = ScriptedStream(
+        [
+            # No StreamTextDelta at all: tool call only.
+            [
+                tool_call_delta(0, id="call_1", name="echo"),
+                tool_call_delta(0, args='{"text":"hi"}'),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamTextDelta(delta="done"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(system_blocks=["sys"], tools=[echo_tool(executed)])
+    loop = AgentLoop()
+
+    events = []
+    async for event in loop.run([Message.user("go")], context, make_config(stream), None):
+        events.append(event)
+
+    final = events[-1]
+    assert isinstance(final, AgentEndEvent)
+    assistant = final.messages[0]
+    assert isinstance(assistant, Message)
+    assert assistant.content == [], "a silent turn must not carry a text block"
+    assert len(assistant.tool_calls) == 1
+    assert executed == ["echo"]
+
+    # The regression is only observable on the SECOND request, which is the one
+    # that carries the first assistant message back to the provider.
+    replayed = stream.requests[1].messages
+    assert not any(
+        getattr(block, "text", None) == ""
+        for message in replayed
+        for block in (message.content or [])
+    ), "an empty text block reached the provider"
+
+
+@pytest.mark.asyncio
 async def test_a_tool_result_is_redacted_before_it_reaches_the_model() -> None:
     """The ``read`` path the reviewer reproduced: a credential written by one
     tool and read by another must not survive into the tool message."""


### PR DESCRIPTION
# PR Description

## Summary of Changes

A question that needs a tool and no prose kills the run with a provider 400:

```
● web_search Checking requests 2.31.0 advisories
● web_fetch Reading upstream advisory list
model stream failed: invalid request (HTTP 400): messages: text content blocks must be non-empty
```

The tools execute, then the **next** request of the turn is rejected and the
answer is lost. Reproduced from an ordinary question ("are there published
security advisories for requests 2.31.0?").

### Cause

#443 hoisted the assistant-text assembly out of the streaming delta loop. That
change is correct and worth keeping — rebuilding the whole accumulated string on
every delta is quadratic in response length and was the gigabyte-scale memory
regression that release fixed.

But the assignment it moved was **conditionally unreachable** where it used to
live:

```python
async for event in stream:
    if isinstance(event, StreamTextDelta):
        text_parts.append(event.delta)
        assistant.content = [TextContent(text="".join(text_parts))]   # only ran if a delta arrived
```

A turn with no text delta never executed it, so `content` kept the `[]` it was
constructed with. Hoisted to the end of the function it runs unconditionally, so
the same turn now produces `[TextContent(text="")]`.

```
Message(role="assistant").content        -> []
[TextContent(text="".join([]))]          -> [TextContent(type='text', text='')]
```

**A turn that calls a tool and says nothing is ordinary** — it is what most tool
steps look like — so this is not an edge case, and it gets more likely the more
readily agents reach for tools.

### Fix

Assign only when there is text, on the normal path and on the hard-cancel path
(same reasoning, same guard). A silent turn keeps `[]`, which is what every
provider already handles.

## Testing

**The live reproduction, before and after.** Same query, same machine.

Before (at `3627aa4b`, with the prompt change reverted to prove it is not the
trigger):

```
● web_search Checking requests 2.31.0 advisories
● web_fetch Querying OSV for requests advisories
✗ web_fetch failed
Error: invalid request (HTTP 400): messages: text content blocks must be non-empty
```

After, on this branch — the query completes and answers:

```
| CVE-2024-35195 | Session with verify=False keeps TLS verification off ... | 2.32.0 |
| CVE-2024-47081 | URL-parsing flaw leaks .netrc credentials              | 2.32.4 |
| CVE-2026-25645 | extract_zipped_paths() predictable temp filename       | 2.33.0 |
```

**Bisected rather than guessed.** The failure reproduces at `3627aa4b` with the
prompt corpus reverted to its parent, and does *not* reproduce at `2c4ebc77`
with the new prompts applied. That isolates it to this commit and clears the
prompt change shipped in 0.43.11.

**Regression test** (`test_a_tool_only_turn_carries_no_empty_text_block`):
asserts `content == []` after a tool-only turn, and separately that no empty
text block reaches the provider on the second request — the request where the
failure is actually observable. Confirmed it **fails without the guard**
(`+ TextContent(type='text', text='')`) and passes with it, so it pins the
regression rather than the implementation.

**Gates:** flake8 clean, black 625 files unchanged, isort clean, pyright 0
errors / 0 warnings / 0 informations. `tests/unit/harness`, `tests/unit/session`
and `tests/e2e`: 932 passed serially (one `test_comms` timeout assertion flaked
under load and passes in isolation on this branch and on the base).