### PR TITLE
fix(skills,providers): work the deferred listing-parity and quota-cascade follow-ups

### DIFF
--- a/local_operator/guides/discovery.py
+++ b/local_operator/guides/discovery.py
@@ -69,6 +69,14 @@ def make_guide_resolver(guides: Mapping[str, Skill]):
 
     Resolver errors are returned as content so the model sees the available
     names and can self-correct in one tool round, matching ``skill://``.
+
+    ``OSError`` is caught for the same reason ``make_skill_resolver`` catches
+    it, and the two must stay in step: both adapters share
+    :func:`resolve_resource_url`, so any filesystem failure reachable through
+    one is reachable through the other (a GUIDE.md deleted or chmod-000'd
+    between discovery and the read). Catching only ``ValueError`` here let a
+    ``PermissionError`` escape a resolver whose contract is "never raises",
+    on the one surface that is packaged with the harness (review F7).
     """
 
     def resolver(url: str) -> str | None:
@@ -76,7 +84,7 @@ def make_guide_resolver(guides: Mapping[str, Skill]):
             return None
         try:
             return resolve_resource_url(url, guides, scheme="guide", label="guide")
-        except ValueError as exc:
+        except (ValueError, OSError) as exc:
             return str(exc)
 
     return resolver

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -2132,6 +2132,7 @@ class SessionStreamFn:
         *,
         different_provider: bool = False,
         reserve_percent: float = 10.0,
+        quota_cache: dict[str, str] | None = None,
     ) -> Any | None:
         """The first configured fallback with working auth, bench- and quota-aware.
 
@@ -2157,12 +2158,26 @@ class SessionStreamFn:
         configured fallback" to a user who has several, and the stream
         walk's own retry machinery is the right place to discover which
         bench has expired.
+
+        ``quota_cache`` is the memo of provider+model availability verdicts.
+        It belongs to the CALLER's boundary walk, not to one invocation: a
+        preflight that rotates through several accounts calls this once per
+        rotation step, and a per-call cache re-probed every fallback
+        provider's usage endpoint on each of them — a three-account
+        Anthropic pool re-asked Kimi three times for one message boundary
+        (review F7). The verdicts cannot disagree within a walk anyway: they
+        are derived from usage reports fetched over a few hundred
+        milliseconds, and ``_provider_quota_availability`` enumerates blocked
+        rows too, so the recovery walk lifting a block mid-boundary does not
+        change what a re-probe would answer. ``None`` keeps the standalone
+        contract for a caller with no walk of its own.
         """
         from local_operator.providers.failover import parse_selector
 
         first_benched: Any | None = None
         first_depleted: Any | None = None
-        quota_cache: dict[str, str] = {}
+        if quota_cache is None:
+            quota_cache = {}
         for target in self._fallback_targets(model):
             provider, target_model = parse_selector(target.selector)
             if different_provider and provider == model.provider:
@@ -2344,6 +2359,13 @@ class SessionStreamFn:
             return
 
         attempted_ids: set[int] = set()
+        # One memo for the WHOLE boundary walk. Rotating through this
+        # provider's accounts re-enters the loop, and each pass may consult
+        # the fallback chain; scoping the memo per call re-probed every
+        # fallback provider's usage endpoint once per rotation step (review
+        # F7). See ``_first_available_fallback`` for why a verdict is stable
+        # across one walk.
+        quota_cache: dict[str, str] = {}
         while True:
             try:
                 access = await self._auth_store.get_oauth_access(
@@ -2378,6 +2400,7 @@ class SessionStreamFn:
                             tier_binding,
                             retry,
                             attempted_ids,
+                            quota_cache,
                         ):
                             continue
                         return
@@ -2385,6 +2408,7 @@ class SessionStreamFn:
                         model,
                         different_provider=True,
                         reserve_percent=retry.usage_reserve_percent,
+                        quota_cache=quota_cache,
                     )
                     if fallback is not None:
                         await self._route_state.activate(
@@ -2525,6 +2549,7 @@ class SessionStreamFn:
                             recovered[2],
                             retry,
                             attempted_ids,
+                            quota_cache,
                         ):
                             continue
                         return
@@ -2569,6 +2594,7 @@ class SessionStreamFn:
                 fallback = await self._first_available_fallback(
                     model,
                     reserve_percent=retry.usage_reserve_percent,
+                    quota_cache=quota_cache,
                 )
                 if fallback is None:
                     # Deduped per condition: the quota is spent and nothing can
@@ -2599,6 +2625,7 @@ class SessionStreamFn:
                 tier_binding,
                 retry,
                 attempted_ids,
+                quota_cache,
             ):
                 continue
             return
@@ -2613,11 +2640,16 @@ class SessionStreamFn:
         tier_binding: bool,
         retry: Any,
         attempted_ids: set[int],
+        quota_cache: dict[str, str] | None = None,
     ) -> bool:
         """Act on a low/depleted account-scope verdict.
 
         Returns True when the caller should re-resolve credentials (a sibling
         account took over), False when the routing decision is final.
+
+        ``quota_cache`` is the caller's boundary-walk memo of fallback
+        availability, threaded through so the chain is probed once per
+        boundary rather than once per account rotation (review F7).
 
         The binding windows that produced ``health`` can be scoped to a model
         tier while the shared windows still hold quota (Anthropic's
@@ -2666,6 +2698,7 @@ class SessionStreamFn:
             # but it can preserve reserve quota by reducing token spend.
             different_provider=health.state == "depleted",
             reserve_percent=retry.usage_reserve_percent,
+            quota_cache=quota_cache,
         )
         if not siblings and health.state == "reserve":
             # Last account on this provider, still holding spendable quota.
@@ -2757,6 +2790,7 @@ class SessionStreamFn:
                     recovered[2],
                     retry,
                     attempted_ids,
+                    quota_cache,
                 )
 
         if not siblings and fallback is None:

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -377,17 +377,27 @@ def usage_health(
         # denominator. Recognize only that boundary; positive amounts remain
         # unknown/fail-open rather than inventing a quota percentage (review
         # F3).
-        balances = [limit for limit in relevant if limit.amount.remaining is not None]
+        # Paired with the narrowed amount rather than filtered to bare limits:
+        # the filter already establishes ``remaining is not None``, but that
+        # narrowing does not survive the comprehension, so a later
+        # ``limit.amount.remaining > 0`` needs its own redundant None guard to
+        # type-check. Carrying the value the filter proved is what lets the
+        # positive-balance test below read as the single condition it is
+        # (review F9).
+        balances = [
+            (limit, limit.amount.remaining)
+            for limit in relevant
+            if limit.amount.remaining is not None
+        ]
         # DeepSeek returns one row per currency. One empty wallet does not
         # exhaust an account that still has funds in another, so exact-zero is
         # definitive only when EVERY denominator-less balance row is non-
         # positive. A mixed zero/positive report remains unknown rather than
         # being skipped (review F6).
-        if not balances or any(
-            limit.amount.remaining is not None and limit.amount.remaining > 0 for limit in balances
-        ):
+        if not balances or any(remaining > 0 for _limit, remaining in balances):
             return QuotaHealth("unknown")
-        zero_balance = balances
+        # Past this guard every entry in ``balances`` is a zeroed window, so
+        # the list IS the binding set the verdict below is built from.
         # This branch is unconditionally a depleted verdict (every balance is
         # zeroed), and a depleted account is usable again the moment ANY spent
         # window reopens -- a request needs only one window with headroom -- so
@@ -399,13 +409,13 @@ def usage_health(
         reset_after = min(
             (
                 value
-                for value in (limit.resets_in_ms(now_ms) for limit in zero_balance)
+                for value in (limit.resets_in_ms(now_ms) for limit, _ in balances)
                 if value is not None
             ),
             default=None,
         )
         scope: Literal["account", "model", "unknown"]
-        if all(limit.tier and not limit.shared for limit in zero_balance):
+        if all(limit.tier and not limit.shared for limit, _ in balances):
             scope = "model"
         else:
             scope = "account"
@@ -414,9 +424,9 @@ def usage_health(
             remaining_fraction=0.0,
             reset_after_ms=reset_after,
             scope=scope,
-            binding_labels=tuple(limit.label for limit in zero_balance),
+            binding_labels=tuple(limit.label for limit, _ in balances),
             binding_families=tuple(
-                dict.fromkeys(limit.tier for limit in zero_balance if limit.tier)
+                dict.fromkeys(limit.tier for limit, _ in balances if limit.tier)
             ),
         )
 

--- a/local_operator/skills/protocol.py
+++ b/local_operator/skills/protocol.py
@@ -53,29 +53,60 @@ def _read_text_capped(path: Path) -> str:
     return raw.decode("utf-8", errors="replace")
 
 
-def _list_directory(directory: Path) -> str:
+def _contained(child: Path, base_resolved: Path) -> bool:
+    """True when ``child``'s RESOLVED target stays inside ``base_resolved``.
+
+    This is the containment predicate ``_resolve_child`` enforces on read,
+    factored out so every listing surface can answer the same question the
+    resolver will. A listing that disagrees with it produces the
+    advertise-then-reject failure mode: a name the model is invited to read
+    and then refused.
+    """
+    try:
+        return child.resolve().is_relative_to(base_resolved)
+    except OSError:
+        return False
+
+
+def _list_directory(directory: Path, base_resolved: Path) -> str:
     """Render a directory listing: ``name/ (dir)`` for dirs, plain names for
     files, deterministic alphabetical order. Dotfiles are skipped (they are
     unlisted and unreadable by design) and the listing is capped at
     ``_MAX_LISTING_ENTRIES`` with an overflow marker. Names are
     percent-encoded the same way as the bare-read reference listing, so a
     name copied from here into a ``skill://<name>/<path>`` URL survives
-    ``urlsplit``/``unquote`` even when it contains ``%``, ``#`` or ``?``."""
+    ``urlsplit``/``unquote`` even when it contains ``%``, ``#`` or ``?``.
+
+    ``base_resolved`` is the resource root, already resolved by the caller.
+    A symlink whose target escapes it is omitted, because ``_resolve_child``
+    rejects a read of it: this is the child-path listing the bare-read
+    overflow marker routes to, so without the check the overflow path hands
+    back names that cannot be read (R3-2). Only symlinks are checked, the
+    same gate ``_reference_listing`` uses — ``_resolve_child`` resolves the
+    whole child path before calling here, so a non-symlink entry of an
+    already-contained directory cannot escape and does not need the stat.
+    Escaped entries are excluded from the overflow count too: the marker
+    promises "more entries" the caller can reach by listing a directory, and
+    an unreadable name is not one of them."""
     lines: list[str] = []
     try:
         entries = sorted(directory.iterdir(), key=lambda p: (p.name.lower(), p.name))
     except OSError:
         return "(unreadable directory)"
+    listable = [
+        entry
+        for entry in entries
+        if not entry.name.startswith(".")
+        and (not entry.is_symlink() or _contained(entry, base_resolved))
+    ]
     shown = 0
-    for entry in entries:
-        if entry.name.startswith("."):
-            continue
+    for entry in listable:
         if shown >= _MAX_LISTING_ENTRIES:
             break
         encoded = quote(entry.name, safe="")
         lines.append(f"{encoded}/ (dir)" if entry.is_dir() else encoded)
         shown += 1
-    hidden = sum(1 for entry in entries if not entry.name.startswith(".")) - shown
+    hidden = len(listable) - shown
     if hidden > 0:
         lines.append(f"[... {hidden} more entries not shown ...]")
     return "\n".join(lines) if lines else "(empty directory)"
@@ -109,7 +140,7 @@ def _resolve_child(
     if not target.exists():
         raise ValueError(f"{label.title()} path not found: {scheme}://{resource.name}/{relative}")
     if target.is_dir():
-        return _list_directory(target)
+        return _list_directory(target, base)
     return _read_text_capped(target)
 
 
@@ -128,8 +159,12 @@ def _reference_listing(resource: Skill, *, scheme: str) -> str:
     next move.
 
     Constraints, matching the resolver's own rules (``_resolve_child``) so
-    the listing never advertises a path a follow-up read would then reject,
-    and never hides one it would accept:
+    the listing never advertises a path a follow-up read would then reject.
+    The converse does not hold in one narrow case: deduplication can list
+    ONE route to a file the resolver would accept by several names (see the
+    symlink bullet), so a readable alias may be absent from the listing. No
+    reachable CONTENT is hidden — every listed route reads, and every
+    omitted route is a duplicate of a listed one:
 
     - dotfiles and dot-directories are skipped (unlisted and unreadable by
       design);
@@ -140,7 +175,16 @@ def _reference_listing(resource: Skill, *, scheme: str) -> str:
       resolver applies on read — and resolved directories are visited at
       most once so a link cycle cannot grow the walk. Deduplication means
       one ROUTE per directory is listed when an alias and its target both
-      appear; every route stays readable through the resolver either way;
+      appear; every route stays readable through the resolver either way.
+      HARDLINKS are the deliberate exception: a hardlink of the body file,
+      or of another reference, is listed as its own entry because resolved-
+      path equality cannot see one — telling them apart needs a per-entry
+      ``st_dev``/``st_ino`` stat on every walked file. That cost is paid on
+      every bare skill read to suppress a duplicate that (a) is readable
+      and correct if followed, and (b) essentially never occurs in an
+      authored skill tree, where references are ordinary files and symlinks.
+      Redundancy is the cheaper failure, so this is not worth fixing (R3-3);
+      revisit only if hardlinked skill trees become real;
     - names are percent-encoded exactly as ``_resolve_child``'s ``unquote``
       expects, so a filename containing ``%``, ``#`` or ``?`` survives the
       URL round-trip instead of being listed in a form ``urlsplit`` mangles;
@@ -171,15 +215,6 @@ def _reference_listing(resource: Skill, *, scheme: str) -> str:
     overflow = False
     visited: set[str] = set()
 
-    def _contained(child: Path) -> bool:
-        """True when the child's resolved target stays inside base_dir — the
-        same check ``_resolve_child`` applies, so listing and read agree on
-        every symlink."""
-        try:
-            return child.resolve().is_relative_to(base_resolved)
-        except OSError:
-            return False
-
     def _walk(directory: Path, depth: int) -> None:
         nonlocal overflow
         if depth > _MAX_REFERENCE_DEPTH or overflow:
@@ -201,14 +236,14 @@ def _reference_listing(resource: Skill, *, scheme: str) -> str:
             if child.name.startswith("."):
                 continue
             if child.is_dir():
-                if child.is_symlink() and not _contained(child):
+                if child.is_symlink() and not _contained(child, base_resolved):
                     continue
                 _walk(child, depth + 1)
             elif child.is_file():
                 if child == body_file:
                     continue
                 if child.is_symlink():
-                    if not _contained(child):
+                    if not _contained(child, base_resolved):
                         continue
                     try:
                         if child.resolve() == body_resolved:

--- a/local_operator/skills/protocol.py
+++ b/local_operator/skills/protocol.py
@@ -61,10 +61,19 @@ def _contained(child: Path, base_resolved: Path) -> bool:
     resolver will. A listing that disagrees with it produces the
     advertise-then-reject failure mode: a name the model is invited to read
     and then refused.
+
+    ``RuntimeError`` is caught beside ``OSError`` because ``resolve()`` does
+    not report a symlink loop the same way across supported interpreters: on
+    3.12/3.13 ``pathlib`` translates ELOOP into ``RuntimeError("Symlink loop
+    from ...")``, while on 3.14 it delegates to ``os.path.realpath`` and
+    returns the unresolved path instead. An uncaught loop would propagate out
+    of a LISTING, turning a link an author can create into a crash rather than
+    an omitted line. Measured on both, not assumed — and the divergence is why
+    the loop cases are covered by tests rather than by inspection.
     """
     try:
         return child.resolve().is_relative_to(base_resolved)
-    except OSError:
+    except (OSError, RuntimeError):
         return False
 
 
@@ -78,12 +87,17 @@ def _resolver_would_accept(child: Path, base_resolved: Path) -> bool:
     link and a self-referential loop both resolve to a path inside the base
     and satisfy containment, so only the ``exists()`` call (which follows the
     link, and is therefore False for both) rejects them.
+
+    ``exists()`` swallows its own ELOOP/ENOENT, so it needs no loop handling
+    of its own; :func:`_contained` carries that, and this call is reached only
+    after it. ``RuntimeError`` is caught here anyway so the pair degrades
+    identically under any interpreter that grows the same translation.
     """
     if not _contained(child, base_resolved):
         return False
     try:
         return child.exists()
-    except OSError:
+    except (OSError, RuntimeError):
         return False
 
 
@@ -162,7 +176,18 @@ def _resolve_child(
         )
 
     base = resource.base_dir.resolve()
-    target = (resource.base_dir / relative).resolve()
+    try:
+        target = (resource.base_dir / relative).resolve()
+    except (OSError, RuntimeError):
+        # A looping symlink is a bad PATH, not a broken resolver: on 3.12/3.13
+        # ``resolve()`` raises RuntimeError("Symlink loop from ...") for ELOOP
+        # while 3.14 returns the unresolved path and fails the ``exists()``
+        # below. Without this the same URL crashed the read on one interpreter
+        # and reported "path not found" on another. Degrade to the not-found
+        # error either way, matching what the listings now do by omitting it.
+        raise ValueError(
+            f"{label.title()} path not found: {scheme}://{resource.name}/{relative}"
+        ) from None
     if not target.is_relative_to(base):
         raise ValueError(f"Invalid {label} path '{raw_path}': escapes the {label} directory")
     if not target.exists():

--- a/local_operator/skills/protocol.py
+++ b/local_operator/skills/protocol.py
@@ -188,8 +188,12 @@ def _resolve_child(
             f"Invalid {label} path '{raw_path}': dotfiles are not listed and cannot be read"
         )
 
-    base = resource.base_dir.resolve()
     try:
+        # The BASE is resolved inside the guard too (review F6): a resource
+        # whose own base_dir is reached through a looping symlink raises here
+        # exactly as the child path does, and an escape from this line is the
+        # same uncaught RuntimeError on 3.12, just one statement earlier.
+        base = resource.base_dir.resolve()
         target = (resource.base_dir / relative).resolve()
     except (OSError, RuntimeError):
         # A looping symlink is a bad PATH, not a broken resolver: on 3.12/3.13
@@ -283,14 +287,18 @@ def _reference_listing(resource: Skill, *, scheme: str) -> str:
     base = resource.base_dir
     try:
         base_resolved = base.resolve()
-    except OSError:
+    except (OSError, RuntimeError):
+        # RuntimeError beside OSError for the same reason as ``_contained``
+        # (review F6): on 3.12/3.13 a looping base_dir raises RuntimeError
+        # here, and this listing rides a BARE READ whose body has already been
+        # returned — an escape would turn a successful read into a traceback.
         return ""
     body_file = resource.file_path
     try:
         # Resolved once so a symlink ALIAS of the body file is excluded too:
         # the caller just returned that content, whatever name it wears.
         body_resolved = body_file.resolve()
-    except OSError:
+    except (OSError, RuntimeError):
         body_resolved = body_file
     entries: list[str] = []
     overflow = False
@@ -302,7 +310,10 @@ def _reference_listing(resource: Skill, *, scheme: str) -> str:
             return
         try:
             key = str(directory.resolve())
-        except OSError:
+        except (OSError, RuntimeError):
+            # Same version-dependent ELOOP handling as everywhere else in this
+            # module (review F6): an unresolvable directory is skipped, never
+            # raised out of a listing.
             return
         if key in visited:
             return
@@ -329,7 +340,7 @@ def _reference_listing(resource: Skill, *, scheme: str) -> str:
                     try:
                         if child.resolve() == body_resolved:
                             continue
-                    except OSError:
+                    except (OSError, RuntimeError):
                         continue
                 if len(entries) >= _MAX_REFERENCE_ENTRIES:
                     overflow = True

--- a/local_operator/skills/protocol.py
+++ b/local_operator/skills/protocol.py
@@ -114,13 +114,18 @@ def _list_directory(directory: Path, base_resolved: Path) -> str:
     A SYMLINK is listed only when the resolver would also accept it, on the
     two grounds ``_resolve_child`` can refuse: its resolved target must stay
     inside ``base_resolved`` (R3-2), and it must actually exist (review F1).
-    The second is not implied by the first — ``resolve()`` is non-strict, so
-    a dangling link and a self-referential loop both resolve to a path INSIDE
-    the base and pass containment, then fail the resolver's ``exists()``.
-    ``Path.exists()`` follows the link, so it is False for exactly those two
-    shapes and True for a live one. The bare-read listing already drops both
-    (its walk tests ``is_file()``/``is_dir()``, which a broken link fails),
-    so this brings the two surfaces to parity rather than inventing a rule.
+    The second is not implied by the first, and WHICH check rejects a broken
+    link is version-dependent (review F4). On 3.13+ ``resolve()`` is
+    non-strict, so a dangling link and a self-referential loop both resolve to
+    a path INSIDE the base, pass containment, and are caught by ``exists()``
+    — which follows the link and is therefore False for both. On 3.12 a LOOP
+    never reaches ``exists()`` at all: ``pathlib`` converts ELOOP into
+    ``RuntimeError``, which :func:`_contained` catches, so containment is what
+    rejects it there. Both orderings end at the same listing, which is the
+    point; do not simplify either guard on the strength of one interpreter.
+    The bare-read listing already drops both shapes (its walk tests
+    ``is_file()``/``is_dir()``, which a broken link fails), so this brings the
+    two surfaces to parity rather than inventing a rule.
 
     Only symlinks are checked, the same gate ``_reference_listing`` uses.
     ``_resolve_child`` has already resolved AND existence-checked the whole
@@ -129,7 +134,15 @@ def _list_directory(directory: Path, base_resolved: Path) -> str:
     on the overwhelmingly common all-plain-files listing. Omitted entries are
     excluded from the overflow count too: the marker promises "more entries"
     the caller can reach by listing a directory, and an unreadable name is
-    not one of them."""
+    not one of them.
+
+    The parity is over REACHABILITY, not over every read failure. A file that
+    exists but denies permission (``chmod 000``, whether named directly or
+    through a link) is still listed and still fails the read with
+    ``PermissionError`` — pre-existing on both surfaces, and deliberately left
+    (review F5): the check would be a per-entry ``access()`` on every plain
+    file, the answer can change between listing and read anyway, and the
+    adapter degrades it to a message rather than a crash."""
     lines: list[str] = []
     try:
         entries = sorted(directory.iterdir(), key=lambda p: (p.name.lower(), p.name))

--- a/local_operator/skills/protocol.py
+++ b/local_operator/skills/protocol.py
@@ -68,6 +68,25 @@ def _contained(child: Path, base_resolved: Path) -> bool:
         return False
 
 
+def _resolver_would_accept(child: Path, base_resolved: Path) -> bool:
+    """True when ``_resolve_child`` would serve ``child`` rather than raise.
+
+    The resolver refuses a child path on two grounds a listing can check
+    cheaply, and both must hold or the listing advertises a name that errors
+    on read: containment (:func:`_contained`) and existence. Existence is a
+    SEPARATE question because ``Path.resolve()`` is non-strict — a dangling
+    link and a self-referential loop both resolve to a path inside the base
+    and satisfy containment, so only the ``exists()`` call (which follows the
+    link, and is therefore False for both) rejects them.
+    """
+    if not _contained(child, base_resolved):
+        return False
+    try:
+        return child.exists()
+    except OSError:
+        return False
+
+
 def _list_directory(directory: Path, base_resolved: Path) -> str:
     """Render a directory listing: ``name/ (dir)`` for dirs, plain names for
     files, deterministic alphabetical order. Dotfiles are skipped (they are
@@ -78,16 +97,25 @@ def _list_directory(directory: Path, base_resolved: Path) -> str:
     ``urlsplit``/``unquote`` even when it contains ``%``, ``#`` or ``?``.
 
     ``base_resolved`` is the resource root, already resolved by the caller.
-    A symlink whose target escapes it is omitted, because ``_resolve_child``
-    rejects a read of it: this is the child-path listing the bare-read
-    overflow marker routes to, so without the check the overflow path hands
-    back names that cannot be read (R3-2). Only symlinks are checked, the
-    same gate ``_reference_listing`` uses — ``_resolve_child`` resolves the
-    whole child path before calling here, so a non-symlink entry of an
-    already-contained directory cannot escape and does not need the stat.
-    Escaped entries are excluded from the overflow count too: the marker
-    promises "more entries" the caller can reach by listing a directory, and
-    an unreadable name is not one of them."""
+    A SYMLINK is listed only when the resolver would also accept it, on the
+    two grounds ``_resolve_child`` can refuse: its resolved target must stay
+    inside ``base_resolved`` (R3-2), and it must actually exist (review F1).
+    The second is not implied by the first — ``resolve()`` is non-strict, so
+    a dangling link and a self-referential loop both resolve to a path INSIDE
+    the base and pass containment, then fail the resolver's ``exists()``.
+    ``Path.exists()`` follows the link, so it is False for exactly those two
+    shapes and True for a live one. The bare-read listing already drops both
+    (its walk tests ``is_file()``/``is_dir()``, which a broken link fails),
+    so this brings the two surfaces to parity rather than inventing a rule.
+
+    Only symlinks are checked, the same gate ``_reference_listing`` uses.
+    ``_resolve_child`` has already resolved AND existence-checked the whole
+    child path before calling here, so a plain entry of an already-contained
+    directory can neither escape nor dangle: the extra stat would buy nothing
+    on the overwhelmingly common all-plain-files listing. Omitted entries are
+    excluded from the overflow count too: the marker promises "more entries"
+    the caller can reach by listing a directory, and an unreadable name is
+    not one of them."""
     lines: list[str] = []
     try:
         entries = sorted(directory.iterdir(), key=lambda p: (p.name.lower(), p.name))
@@ -97,7 +125,7 @@ def _list_directory(directory: Path, base_resolved: Path) -> str:
         entry
         for entry in entries
         if not entry.name.startswith(".")
-        and (not entry.is_symlink() or _contained(entry, base_resolved))
+        and (not entry.is_symlink() or _resolver_would_accept(entry, base_resolved))
     ]
     shown = 0
     for entry in listable:
@@ -178,13 +206,28 @@ def _reference_listing(resource: Skill, *, scheme: str) -> str:
       appear; every route stays readable through the resolver either way.
       HARDLINKS are the deliberate exception: a hardlink of the body file,
       or of another reference, is listed as its own entry because resolved-
-      path equality cannot see one — telling them apart needs a per-entry
-      ``st_dev``/``st_ino`` stat on every walked file. That cost is paid on
-      every bare skill read to suppress a duplicate that (a) is readable
-      and correct if followed, and (b) essentially never occurs in an
-      authored skill tree, where references are ordinary files and symlinks.
-      Redundancy is the cheaper failure, so this is not worth fixing (R3-3);
-      revisit only if hardlinked skill trees become real;
+      path equality cannot see one. Redundancy is the cheaper failure here,
+      so this is not worth fixing (R3-3); revisit only if hardlinked skill
+      trees become real.
+
+      That verdict is about WHAT THE STAT BUYS, not about stats being
+      expensive, since the containment/existence checks above are stats too
+      (review F2 read the two as inconsistent). Three things separate them.
+      They are paid by different entries: the checks above run only on
+      symlinks, so a listing of ordinary files skips them, while telling a
+      hardlink apart needs ``st_dev``/``st_ino`` on EVERY walked file.  They
+      buy different things: the checks above remove a name that ERRORS on
+      read, a correctness defect the model sees as a broken invitation,
+      whereas the hardlink check removes a name that reads correctly and is
+      merely redundant.  And they are wrong in different directions: an
+      unchecked escape or dangle is a promise the resolver breaks, while an
+      unchecked hardlink is one extra true line. Measured on this machine
+      over a 2000-entry directory, listing all plain files costs 7.4 ms
+      before this change and 18.1 ms after; an (unrealistic) all-symlink
+      directory costs 8.8 ms and 439 ms. The pathological arm is expensive,
+      but it is bounded by how many symlinks an author writes into one
+      references directory, and correctness is worth it there in a way
+      tidiness is not;
     - names are percent-encoded exactly as ``_resolve_child``'s ``unquote``
       expects, so a filename containing ``%``, ``#`` or ``?`` survives the
       URL round-trip instead of being listed in a form ``urlsplit`` mangles;

--- a/tests/unit/guides/test_guides.py
+++ b/tests/unit/guides/test_guides.py
@@ -15,6 +15,7 @@ from local_operator.session_factory import (
     _registered_agent_hints,
     _select_knowledge_block,
 )
+from local_operator.skills.discovery import Skill
 from local_operator.skills.embeddings import LocalEmbedder
 from local_operator.skills.index import SkillIndex, render_block
 
@@ -222,3 +223,66 @@ def test_system_prompt_demands_a_guide_read_before_acting() -> None:
 
     assert "guide://<name>" in text
     assert "MUST" in text
+
+
+def test_the_guide_resolver_never_raises_on_an_unreadable_body(tmp_path: Path) -> None:
+    """The adapter's contract is "never raises", on both resource surfaces.
+
+    ``guide://`` and ``skill://`` share ``resolve_resource_url``, so every
+    filesystem failure reachable through one is reachable through the other.
+    This adapter caught only ``ValueError``, so a GUIDE.md that exists but
+    denies permission (deleted or chmod-000'd between discovery and the read)
+    escaped as a ``PermissionError`` out of a resolver the read tool trusts not
+    to raise — while the identical skill URL returned the message as content
+    (review F7). The two must stay in step.
+    """
+    base = tmp_path / "packaged"
+    base.mkdir()
+    body = base / "GUIDE.md"
+    body.write_text("# body\n", encoding="utf-8")
+    body.chmod(0o000)
+    guide = Skill(
+        name="demo",
+        description="d" * 60,
+        file_path=body,
+        base_dir=base,
+        source=str(tmp_path),
+        resource_type="guide",
+    )
+
+    resolver = make_guide_resolver({"demo": guide})
+    try:
+        result = resolver("guide://demo")
+    finally:
+        body.chmod(0o600)  # let tmp_path cleanup remove it
+
+    # Returned AS CONTENT, not raised: the model sees why and can self-correct.
+    assert result is not None
+    assert "Permission denied" in result
+
+
+def test_a_looping_guide_base_dir_does_not_escape_the_resolver(tmp_path: Path) -> None:
+    """A looping ``base_dir`` is a bad resource, not a crash (review F6).
+
+    ``Path.resolve()`` reports ELOOP as ``RuntimeError`` on 3.12/3.13 and as a
+    non-strict success on 3.14, so the guards around it must catch both or the
+    behaviour forks by interpreter. Driven through the guide adapter because
+    that is where the "never raises" contract lives.
+    """
+    loop = tmp_path / "loopbase"
+    loop.symlink_to(tmp_path / "loopbase", target_is_directory=True)
+    guide = Skill(
+        name="demo",
+        description="d" * 60,
+        file_path=loop / "GUIDE.md",
+        base_dir=loop,
+        source=str(tmp_path),
+        resource_type="guide",
+    )
+
+    resolver = make_guide_resolver({"demo": guide})
+
+    # Neither the child listing nor the bare read may raise; both report.
+    child = resolver("guide://demo/references")
+    assert child is not None and "not found" in child
+    assert resolver("guide://demo") is not None

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -372,6 +372,30 @@ def _anthropic_tier_capped_usage(five_hour_used: float, fable_used: float) -> Us
     )
 
 
+def _anthropic_tier_only_usage(fable_used: float) -> UsageReport:
+    """A scoped tier cap with NO shared window reported beside it.
+
+    The F8 shape: the only observation about the account is that its Fable
+    weekly is spent. ``usage_health`` for a fable model therefore returns a
+    ``scope="model"`` verdict binding the ``fable`` family alone, and nothing
+    in the report speaks to what the account can still do for other models.
+    """
+    return UsageReport(
+        provider="anthropic",
+        limits=[
+            UsageLimit(
+                id="anthropic:7d:fable",
+                label="7 day (Fable)",
+                amount=UsageAmount(used=fable_used, limit=100.0, unit="percent"),
+                window="7d",
+                shared=False,
+                tier="fable",
+                resets_at_ms=10**15,
+            ),
+        ],
+    )
+
+
 def _anthropic_tier_spent_shared_remains(extra_used: float, shared_used: float) -> UsageReport:
     """A spent per-tier cap that leaves the account under an ACCOUNT-scope
     verdict while shared quota still remains.
@@ -1409,6 +1433,114 @@ async def test_preflight_skips_a_fully_spent_fallback_to_the_next_usable(tmp_pat
             await stream.preflight_usage(model)
 
         assert stream._route_state.active == FallbackTarget("xai/grok-4.6")
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_one_boundary_walk_probes_each_fallback_provider_once(tmp_path) -> None:
+    """Review F7: the fallback quota memo belongs to the WALK, not the call.
+
+    Three exhausted Anthropic accounts make preflight rotate three times, and
+    each rotation consults the fallback chain. With the memo scoped per call,
+    every rotation re-hit Kimi's and Z.AI's usage endpoints — six network
+    probes to answer a question whose answer cannot change inside one
+    boundary, against endpoints that rate-limit per source IP. One probe per
+    provider+model now serves the whole walk, and the route it picks is
+    unchanged.
+    """
+    store = AuthStore(tmp_path / "auth.db")
+    for suffix in ("a", "b", "c"):
+        store.upsert_credential("anthropic", _oauth(f"oauth-{suffix}", f"account-{suffix}"))
+    store.upsert_credential("kimi", {"key": "sk-kimi", "source": "login"})
+    store.upsert_credential("zai", {"key": "sk-zai", "source": "login"})
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {"default": ["kimi/k3", "zai/glm-5.3"]},
+            }
+        },
+        session_id=_session_hashing_to_first_row(3),
+    )
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+    probed: list[str] = []
+
+    async def usage_for_access(_client, provider, **_kwargs):
+        probed.append(provider)
+        if provider == "anthropic":
+            return _anthropic_usage(100.0)  # every account spent: rotate
+        if provider == "kimi":
+            return _kimi_usage(100.0)  # depleted: the walk continues past it
+        return _kimi_usage(20.0)  # zai has headroom and takes the route
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(model)
+
+        assert probed.count("kimi") == 1
+        assert probed.count("zai") == 1
+        # The saving must not have changed where the session lands.
+        assert stream._route_state.active == FallbackTarget("zai/glm-5.3")
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_a_tier_depletion_leaves_other_models_on_the_account(tmp_path) -> None:
+    """Review F8: a spent model-tier window must not strand other models.
+
+    Three accounts whose ONLY reported window is a ``7 day (Fable)`` cap at
+    100%. Routing ``claude-fable-5`` is therefore a pure model-tier
+    depletion: nothing observed says these accounts cannot serve
+    ``claude-opus-5``. The verdict is recorded as a ``model:fable``-scoped
+    block (see ``_write_quota_block``), so Fable stops and opus keeps every
+    account. An account-wide block here is the regression this pins — it
+    would take the pool out of service for every model until the Fable
+    weekly reset, days away.
+    """
+    store = AuthStore(tmp_path / "auth.db")
+    rows = [
+        store.upsert_credential("anthropic", _oauth(f"oauth-{s}", f"account-{s}"))
+        for s in ("a", "b", "c")
+    ]
+    store.upsert_credential("kimi", {"key": "sk-kimi", "source": "login"})
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {"default": ["kimi/k3"]},
+            }
+        },
+        session_id=_session_hashing_to_first_row(3),
+    )
+
+    async def usage_for_access(_client, provider, **_kwargs):
+        if provider == "anthropic":
+            return _anthropic_tier_only_usage(100.0)
+        return _kimi_usage(20.0)
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(ModelSpec(provider="anthropic", model_id="claude-fable-5"))
+
+        for row in rows:
+            # Never account-wide: that is what strands the other models.
+            assert not store.is_blocked(row.id, "anthropic")
+            assert not store.is_blocked_for_model(row.id, "anthropic", "claude-opus-5")
+        # Opus still resolves on this provider rather than falling to Kimi.
+        opus = await store.get_oauth_access("anthropic", "session-opus", model_id="claude-opus-5")
+        assert opus is not None
+        # The Fable cap itself is still honoured on the rotated accounts.
+        assert any(
+            store.is_blocked_for_model(row.id, "anthropic", "claude-fable-5") for row in rows
+        )
     finally:
         await stream.close()
         store.close()

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -176,6 +176,70 @@ def test_usage_health_exact_zero_balance_is_depleted_without_a_total() -> None:
     assert usage_health(mixed, "deepseek-chat").state == "unknown"
 
 
+def test_balance_only_branch_verdicts_survive_the_f9_cleanup() -> None:
+    """The exact-zero-vs-unknown boundary is deliberate; pin every side of it.
+
+    Review F9/F10 dropped a redundant ``remaining is not None`` guard and a
+    bare alias from this branch. The semantics around them are NOT redundant:
+    F3 says a positive balance stays unknown (no denominator to divide by) and
+    F6 says one empty wallet beside a funded one stays unknown too. This
+    enumerates the branch's inputs so a future readability pass cannot quietly
+    move the boundary — negative balances count as non-positive (a debt is not
+    headroom), a row with no ``remaining`` at all is not a balance row, and the
+    depleted verdict's derived fields come from the zeroed rows.
+    """
+
+    def _balance(remaining: float | None, *, shared: bool = True, tier: str = "") -> UsageLimit:
+        return UsageLimit(
+            id=f"p:balance:{remaining}:{tier}",
+            label=f"Balance {remaining}",
+            amount=UsageAmount(remaining=remaining, unit="usd"),
+            window="lifetime",
+            shared=shared,
+            tier=tier,
+            resets_at_ms=20_000,
+        )
+
+    def _health(*limits: UsageLimit, model: str = "deepseek-chat"):
+        return usage_health(
+            UsageReport(provider="deepseek", limits=list(limits)),
+            model,
+            reserve_percent=10,
+            now_ms=10_000,
+        )
+
+    # No balance row at all (nothing measurable, nothing to zero out).
+    assert _health().state == "unknown"
+    assert _health(_balance(None)).state == "unknown"
+    # Every balance zeroed: definitive exhaustion despite the missing total.
+    assert _health(_balance(0.0)).state == "depleted"
+    assert _health(_balance(0.0), _balance(0.0)).state == "depleted"
+    # A negative balance is not headroom, so it does not rescue the account.
+    assert _health(_balance(-5.0)).state == "depleted"
+    assert _health(_balance(0.0), _balance(-5.0)).state == "depleted"
+    # Any positive balance anywhere keeps the whole report unknown (F3/F6).
+    assert _health(_balance(10.0)).state == "unknown"
+    assert _health(_balance(0.0), _balance(10.0)).state == "unknown"
+    assert _health(_balance(-5.0), _balance(10.0)).state == "unknown"
+    # A row with no ``remaining`` is not a balance row: it neither zeroes the
+    # account nor rescues it, so the zeroed rows beside it still decide.
+    assert _health(_balance(0.0), _balance(None)).state == "depleted"
+    assert _health(_balance(10.0), _balance(None)).state == "unknown"
+
+    # The depleted verdict's derived fields are built from the zeroed rows.
+    depleted = _health(_balance(0.0), _balance(0.0))
+    assert depleted.remaining_fraction == 0.0
+    assert depleted.scope == "account"
+    assert depleted.reset_after_ms == 10_000
+    assert depleted.binding_labels == ("Balance 0.0", "Balance 0.0")
+
+    # Tier-only zeroed rows bind ONE model family, not the account.
+    tier_only = _health(_balance(0.0, shared=False, tier="fable"), model="claude-fable-5")
+    assert tier_only.state == "depleted"
+    assert tier_only.scope == "model"
+    assert tier_only.binding_families == ("fable",)
+
+
 def test_usage_health_depleted_reset_ignores_windows_merely_in_reserve() -> None:
     """The depleted horizon counts only fully-spent windows.
 

--- a/tests/unit/skills/test_protocol.py
+++ b/tests/unit/skills/test_protocol.py
@@ -530,6 +530,95 @@ class TestDirectoryListingContainment:
         assert listing.splitlines() == ["alias.md", "real.md"]
         assert resolve_skill_url("skill://epsilon/references/alias.md", skills) == "real"
 
+    def test_dangling_symlink_not_listed(self, tmp_path: Path) -> None:
+        # Review F1: the same advertise-then-reject class as R3-2, reached
+        # through EXISTENCE rather than containment. `resolve()` is
+        # non-strict, so a link to a missing sibling resolves INSIDE base_dir
+        # and passes the containment check, then fails the resolver's
+        # `exists()`.
+        skill = _make_skill(tmp_path, "eta")
+        refs = skill.base_dir / "references"
+        refs.mkdir()
+        (refs / "real.md").write_text("real", encoding="utf-8")
+        (refs / "dangling.md").symlink_to(refs / "never-created.md")
+        skills = {"eta": skill}
+
+        listing = resolve_skill_url("skill://eta/references", skills)
+        assert listing is not None
+        assert listing.splitlines() == ["real.md"]
+        with pytest.raises(ValueError, match="not found"):
+            resolve_skill_url("skill://eta/references/dangling.md", skills)
+
+    def test_looping_symlinks_not_listed(self, tmp_path: Path) -> None:
+        # A self-loop and a mutual loop both resolve to themselves — inside
+        # base_dir, so containment passes — and are ELOOP on read.
+        skill = _make_skill(tmp_path, "theta")
+        refs = skill.base_dir / "references"
+        refs.mkdir()
+        (refs / "real.md").write_text("real", encoding="utf-8")
+        (refs / "selfloop.md").symlink_to(refs / "selfloop.md")
+        (refs / "loop-a.md").symlink_to(refs / "loop-b.md")
+        (refs / "loop-b.md").symlink_to(refs / "loop-a.md")
+        skills = {"theta": skill}
+
+        listing = resolve_skill_url("skill://theta/references", skills)
+        assert listing is not None
+        assert listing.splitlines() == ["real.md"]
+        for name in ("selfloop.md", "loop-a.md", "loop-b.md"):
+            with pytest.raises(ValueError):
+                resolve_skill_url(f"skill://theta/references/{name}", skills)
+
+    def test_live_symlinks_survive_the_existence_check(self, tmp_path: Path) -> None:
+        # The existence check must not cost a working link. A file alias and
+        # a directory alias both resolve, exist, and stay readable.
+        skill = _make_skill(tmp_path, "iota")
+        refs = skill.base_dir / "references"
+        refs.mkdir()
+        (refs / "real.md").write_text("real", encoding="utf-8")
+        (refs / "alias.md").symlink_to(refs / "real.md")
+        (refs / "sub").mkdir()
+        (refs / "sub" / "deep.md").write_text("deep", encoding="utf-8")
+        (refs / "dirlink").symlink_to(refs / "sub", target_is_directory=True)
+        skills = {"iota": skill}
+
+        listing = resolve_skill_url("skill://iota/references", skills)
+        assert listing is not None
+        assert listing.splitlines() == [
+            "alias.md",
+            "dirlink/ (dir)",
+            "real.md",
+            "sub/ (dir)",
+        ]
+        assert resolve_skill_url("skill://iota/references/alias.md", skills) == "real"
+        assert resolve_skill_url("skill://iota/references/dirlink", skills) == "deep.md"
+
+    def test_every_listed_name_reads(self, tmp_path: Path) -> None:
+        # The invariant behind R3-2 and F1 stated directly, over every shape
+        # the resolver can refuse: whatever the listing prints, a read of it
+        # succeeds. Guards against a future third refusal ground being added
+        # to `_resolve_child` without the listing learning about it.
+        skill = _make_skill(tmp_path, "kappa")
+        refs = skill.base_dir / "references"
+        refs.mkdir()
+        outside = tmp_path / "outside.md"
+        outside.write_text("SECRET", encoding="utf-8")
+        outside_dir = tmp_path / "outside-dir"
+        outside_dir.mkdir()
+        (refs / "real.md").write_text("real", encoding="utf-8")
+        (refs / "alias.md").symlink_to(refs / "real.md")
+        (refs / "escape.md").symlink_to(outside)
+        (refs / "escape-dir").symlink_to(outside_dir, target_is_directory=True)
+        (refs / "dangling.md").symlink_to(refs / "gone.md")
+        (refs / "selfloop.md").symlink_to(refs / "selfloop.md")
+        skills = {"kappa": skill}
+
+        listing = resolve_skill_url("skill://kappa/references", skills)
+        assert listing is not None
+        names = [line.removesuffix("/ (dir)") for line in listing.splitlines()]
+        assert names == ["alias.md", "real.md"]
+        for name in names:
+            assert resolve_skill_url(f"skill://kappa/references/{name}", skills) is not None
+
     def test_escaped_entries_do_not_inflate_the_overflow_count(self, tmp_path: Path) -> None:
         # The marker promises entries the caller can still reach. Counting an
         # unlistable symlink in "N more entries not shown" would promise a

--- a/tests/unit/skills/test_protocol.py
+++ b/tests/unit/skills/test_protocol.py
@@ -568,6 +568,48 @@ class TestDirectoryListingContainment:
             with pytest.raises(ValueError):
                 resolve_skill_url(f"skill://theta/references/{name}", skills)
 
+    def test_a_looping_symlink_never_escapes_as_a_runtimeerror(self, tmp_path: Path) -> None:
+        """Reading a looping link is a ValueError on every supported version.
+
+        Caught by CI, not by inspection: ``Path.resolve()`` reports ELOOP
+        differently across the interpreters this project supports. On 3.12 and
+        3.13 pathlib translates it into ``RuntimeError("Symlink loop from
+        ...")``; on 3.14 it delegates to ``os.path.realpath``, returns the
+        unresolved path, and the failure surfaces at ``exists()`` instead. The
+        listing and the resolver both catch it, so the same URL behaves the
+        same way on all of them instead of crashing on one and reporting a
+        clean error on another.
+        """
+        skill = _make_skill(tmp_path, "lambda_")
+        (skill.base_dir / "selfloop.md").symlink_to(skill.base_dir / "selfloop.md")
+        (skill.base_dir / "a.md").symlink_to(skill.base_dir / "b.md")
+        (skill.base_dir / "b.md").symlink_to(skill.base_dir / "a.md")
+        skills = {"lambda_": skill}
+
+        for name in ("selfloop.md", "a.md", "b.md"):
+            with pytest.raises(ValueError, match="not found"):
+                resolve_skill_url(f"skill://lambda_/{name}", skills)
+
+        # And a loop anywhere in the tree never breaks the listings that walk
+        # past it -- the bare read still returns its body, not a traceback.
+        body = resolve_skill_url("skill://lambda_", skills)
+        assert body is not None and "# Test skill body" in body
+
+    def test_looping_directory_symlink_does_not_break_a_listing(self, tmp_path: Path) -> None:
+        # The directory arm of the same problem: `_list_directory` stats every
+        # entry, so a self-referential DIRECTORY link is on the walk's path.
+        skill = _make_skill(tmp_path, "mu")
+        refs = skill.base_dir / "references"
+        refs.mkdir()
+        (refs / "real.md").write_text("real", encoding="utf-8")
+        (refs / "dirloop").symlink_to(refs / "dirloop", target_is_directory=True)
+        skills = {"mu": skill}
+
+        assert resolve_skill_url("skill://mu/references", skills) == "real.md"
+        body = resolve_skill_url("skill://mu", skills)
+        assert body is not None
+        assert "references/real.md" in body
+
     def test_live_symlinks_survive_the_existence_check(self, tmp_path: Path) -> None:
         # The existence check must not cost a working link. A file alias and
         # a directory alias both resolve, exist, and stay readable.

--- a/tests/unit/skills/test_protocol.py
+++ b/tests/unit/skills/test_protocol.py
@@ -471,5 +471,87 @@ class TestReferenceListing:
         assert resolve_skill_url("skill://alpha/references", skills) == "one.md"
 
 
+class TestDirectoryListingContainment:
+    """R3-2: the child-path listing must agree with the resolver on symlinks.
+
+    ``_list_directory`` is where the bare-read overflow marker sends the
+    model, so a name it prints is an invitation to read. Printing one whose
+    resolved target escapes ``base_dir`` is the advertise-then-reject failure
+    mode R1-1 fixed on the bare-read listing, reproduced on this second
+    surface.
+    """
+
+    def test_escaping_symlinked_file_not_listed(self, tmp_path: Path) -> None:
+        skill = _make_skill(tmp_path, "gamma")
+        refs = skill.base_dir / "references"
+        refs.mkdir()
+        (refs / "real.md").write_text("real", encoding="utf-8")
+        outside = tmp_path / "outside.md"
+        outside.write_text("SECRET", encoding="utf-8")
+        (refs / "escape.md").symlink_to(outside)
+        skills = {"gamma": skill}
+
+        listing = resolve_skill_url("skill://gamma/references", skills)
+        assert listing is not None
+        assert listing.splitlines() == ["real.md"]
+        # And the resolver still refuses the path, so nothing became readable.
+        with pytest.raises(ValueError, match="escapes"):
+            resolve_skill_url("skill://gamma/references/escape.md", skills)
+
+    def test_escaping_symlinked_directory_not_listed(self, tmp_path: Path) -> None:
+        skill = _make_skill(tmp_path, "delta")
+        refs = skill.base_dir / "references"
+        refs.mkdir()
+        (refs / "real.md").write_text("real", encoding="utf-8")
+        outside = tmp_path / "outside-dir"
+        outside.mkdir()
+        (outside / "leak.md").write_text("SECRET", encoding="utf-8")
+        (refs / "escape").symlink_to(outside, target_is_directory=True)
+        skills = {"delta": skill}
+
+        listing = resolve_skill_url("skill://delta/references", skills)
+        assert listing is not None
+        assert listing.splitlines() == ["real.md"]
+        with pytest.raises(ValueError, match="escapes"):
+            resolve_skill_url("skill://delta/references/escape", skills)
+
+    def test_internal_symlink_still_listed(self, tmp_path: Path) -> None:
+        # The containment check must not cost the readable case: a symlink
+        # resolving INSIDE base_dir stays listed and stays readable.
+        skill = _make_skill(tmp_path, "epsilon")
+        refs = skill.base_dir / "references"
+        refs.mkdir()
+        (refs / "real.md").write_text("real", encoding="utf-8")
+        (refs / "alias.md").symlink_to(refs / "real.md")
+        skills = {"epsilon": skill}
+
+        listing = resolve_skill_url("skill://epsilon/references", skills)
+        assert listing is not None
+        assert listing.splitlines() == ["alias.md", "real.md"]
+        assert resolve_skill_url("skill://epsilon/references/alias.md", skills) == "real"
+
+    def test_escaped_entries_do_not_inflate_the_overflow_count(self, tmp_path: Path) -> None:
+        # The marker promises entries the caller can still reach. Counting an
+        # unlistable symlink in "N more entries not shown" would promise a
+        # name that does not exist for any follow-up read.
+        skill = _make_skill(tmp_path, "zeta")
+        refs = skill.base_dir / "references"
+        refs.mkdir()
+        outside = tmp_path / "outside.md"
+        outside.write_text("SECRET", encoding="utf-8")
+        for i in range(protocol._MAX_LISTING_ENTRIES + 5):
+            (refs / f"ref-{i:04d}.md").write_text("r", encoding="utf-8")
+        (refs / "zzz-escape.md").symlink_to(outside)
+        skills = {"zeta": skill}
+
+        listing = resolve_skill_url("skill://zeta/references", skills)
+        assert listing is not None
+        lines = listing.splitlines()
+        assert "zzz-escape.md" not in lines
+        # 5 overflowed real files, not 6: the escaping symlink is not one the
+        # caller could reach by listing this directory again.
+        assert lines[-1] == "[... 5 more entries not shown ...]"
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
# PR Description

## Summary of Changes

Two sets of deferred agent-review follow-ups: **#175** (skills listing parity,
R3-1..R3-3) and **#220** (provider quota cascade, F7..F10). Both were filed as
minor/nit deferrals from earlier rounds, so this is cleanup plus one real
defect — with one finding closed as **already fixed**, with evidence, rather
than with an invented change.

Closes #175
Closes #220

---

### #175 R3-2 — the child-path listing advertised paths the resolver rejects

The only substantive skills finding. `_list_directory` is the listing the
**bare-read overflow marker routes the model to** (`[... more files not shown;
list a directory with skill://<name>/<dir> ...]`), so a name it prints is an
invitation to read. It listed symlinks whose resolved target escapes
`base_dir`, and `_resolve_child` then rejects a read of exactly those names.
That is R1-1's advertise-then-reject failure mode reproduced on the secondary
listing surface.

`_contained()` moves out of `_reference_listing`'s closure to module scope and
is applied on both listing surfaces, so the two listings and the resolver
answer one containment question rather than three. Only **symlinks** are
checked, matching what `_reference_listing` already does: `_resolve_child`
resolves the whole child path before calling here, so a non-symlink entry of an
already-contained directory cannot escape and does not need the stat.

Escaped entries are excluded from the **overflow count** too. The marker
promises "N more entries" a caller can reach by listing the directory again,
and a name that cannot be read is not one of them.

`_list_directory` took only `directory`, so the base dir is threaded in. There
is one call site (`_resolve_child`), which already had `base` resolved.

### #175 R3-1 — the docstring made a claim the code does not keep

`_reference_listing`'s intro still said the listing "never hides one it would
accept" while only the symlink bullet had been softened in `8138bf2`.
Deduplication genuinely can omit a readable **alias**. The intro now says what
is actually true: no reachable *content* is hidden, because every listed route
reads and every omitted route is a duplicate of a listed one.

### #175 R3-3 — hardlinks: decided against, and the reasoning is now in the code

A hardlink of the body file is listed, because resolved-path equality cannot
see hardlinks. **Not fixed**, deliberately. Telling a hardlink apart needs a
per-entry `st_dev`/`st_ino` stat on every walked file, paid on every bare skill
read, to suppress a duplicate that (a) is readable and correct if followed and
(b) does not occur in authored skill trees, where references are ordinary files
and symlinks. Redundancy is the cheaper failure. The reasoning is written into
the docstring so the next reader does not re-litigate it.

---

### #220 F7 — the fallback quota memo was scoped one level too tight

Real, and measured. `quota_cache` lived inside `_first_available_fallback`, so
it memoized one call. But preflight **rotates once per account** and consults
the fallback chain on each pass, so the cache was thrown away between rotation
steps: a three-account Anthropic pool re-probed every fallback provider's usage
endpoint three times to answer one message boundary — against endpoints that
rate-limit per source IP, which is the same class of problem the shared
preflight cache (#277) exists to stop.

The memo now belongs to the boundary walk in `preflight_usage` and is threaded
through `_apply_account_health` to every `_first_available_fallback` call site.
The parameter is optional, so a caller with no walk of its own keeps the
standalone contract.

The verdicts cannot disagree inside one walk: they derive from usage reports
fetched over a few hundred milliseconds, and `_provider_quota_availability`
enumerates blocked rows anyway, so the recovery walk lifting a block
mid-boundary does not change what a re-probe would answer.

### #220 F8 — already fixed by PR #238; no change invented

F8 asked for a **demotion instead of a provider-wide block** when a model-tier
window (`7 day (Fable)`) depletes, so the account's other-model capacity is not
stranded until the tier reset.

**That stranding no longer exists.** PR #238 (`f5dadc69`, "scope quota blocks
to the model family that spent them") reached the same goal by a different
mechanism: a verdict whose only binding windows are model-family caps is
written as `block_scope='model:<family>'`, so the row still resolves for every
other model. A demotion on top would be a second mechanism beside an
established one, which is the thing to avoid, and it would be *weaker* — a
demotion is in-process and 2-minute TTL'd, while the tier really is spent until
its reset and should stay recorded.

Replayed against the tree F8 was filed on and against `main` (evidence below).
A regression test pins the behaviour; no speculative change was made.

### #220 F9/F10 — zero-balance branch readability, zero behaviour change

The `remaining is not None` guard and the `zero_balance = balances` alias are
gone. One correction to the finding: the guard was **not purely redundant** —
the filter's narrowing does not survive the comprehension, so pyright rejects a
bare `limit.amount.remaining > 0` (`reportOptionalOperand`). So rather than
deleting a load-bearing guard, `balances` now carries the value the filter
already proved as a pair, and the positive-balance test reads as the single
condition it is.

The F3 and F6 semantics around it are deliberate and untouched: a positive
balance stays `unknown` (no denominator), and a mixed zero/positive DeepSeek
report stays `unknown` rather than being called depleted.

---

## Testing Evidence

### #175 R3-2: the escaping symlink, before and after

A skill dir containing `references/real.md`, a symlink `escape.md` to a file
outside `base_dir`, and a symlink `escape-dir` to a directory outside it.

```
$ python /tmp/repro_175.py     # on base (origin/main)
--- _list_directory output for skill://demo/references ---
escape-dir/ (dir)
escape.md
real.md
--- resolver verdict on the advertised entries ---
escape.md: REJECTED -> Invalid skill path '/references/escape.md': escapes the skill directory
escape-dir: REJECTED -> Invalid skill path '/references/escape-dir': escapes the skill directory

ADVERTISE-THEN-REJECT PRESENT: True
```

```
$ python /tmp/repro_175.py     # at head
--- _list_directory output for skill://demo/references ---
real.md
--- resolver verdict on the advertised entries ---
escape.md: REJECTED -> Invalid skill path '/references/escape.md': escapes the skill directory
escape-dir: REJECTED -> Invalid skill path '/references/escape-dir': escapes the skill directory

ADVERTISE-THEN-REJECT PRESENT: False
```

The listing stops advertising them; the resolver still rejects a read of them,
so nothing became reachable that was not before.

The four new tests fail on base and pass at head:

```
$ git stash -- local_operator/ && pytest tests/unit/skills/test_protocol.py -k DirectoryListingContainment
FAILED ...::test_escaping_symlinked_directory_not_listed  - assert ['escape/ (dir)', 'real.md'] == ['real.md']
FAILED ...::test_escaping_symlinked_file_not_listed       - assert ['escape.md', 'real.md'] == ['real.md']
FAILED ...::test_escaped_entries_do_not_inflate_the_overflow_count
                                  - assert '[... 6 more ...]' == '[... 5 more ...]'
3 failed, 1 passed

$ git stash pop && pytest tests/unit/skills/test_protocol.py
48 passed in 7.70s
```

The one that passes on base is `test_internal_symlink_still_listed` — the guard
that the containment check does not cost the readable case.

### #220 F7: fallback probes per boundary walk

Three exhausted Anthropic accounts (so preflight rotates three times), chain
`kimi/k3` then `zai/glm-5.3`, kimi depleted so the walk continues past it.

```
=== BASE (origin/main) ===
[base] fallback usage probes in ONE boundary walk:
  kimi = 3   zai = 3
  order = ['anthropic', 'kimi', 'zai', 'anthropic', 'kimi', 'zai', 'anthropic', 'kimi', 'zai']
  pinned = FallbackTarget(selector='zai/glm-5.3', effort=None)

=== HEAD ===
[head] fallback usage probes in ONE boundary walk:
  kimi = 1   zai = 1
  order = ['anthropic', 'kimi', 'zai', 'anthropic', 'anthropic']
  pinned = FallbackTarget(selector='zai/glm-5.3', effort=None)
```

Six fallback usage probes become two, and **the route the session lands on is
unchanged** — which is the property that matters, since this is a cost fix, not
a routing change. The regression test asserts both:

```
$ git stash -- local_operator/ && pytest -k one_boundary_walk
>       assert probed.count("kimi") == 1
E       AssertionError: assert 3 == 1
1 failed

$ git stash pop && pytest -k "one_boundary_walk or tier_depletion_leaves"
2 passed
```

### #220 F8: the stranding is already gone

Three Anthropic accounts whose **only** reported window is `7 day (Fable)` at
100%. Routing `claude-fable-5` is therefore a pure model-tier depletion —
nothing observed says these accounts cannot serve `claude-opus-5`.

```
=== #216 tree (b8652c63 — the tree F8 was filed against) ===
[pr216] 3 accounts, ONLY a `7 day (Fable)` window, all 100% spent
  cred 1: account_wide=True  fable=True  opus=True
  cred 2: account_wide=True  fable=True  opus=True
  cred 3: account_wide=False fable=False opus=False

=== current main / this branch ===
[head] 3 accounts, ONLY a `7 day (Fable)` window, all 100% spent
  cred 1: account_wide=False fable=True  opus=False
  cred 2: account_wide=False fable=True  opus=False
  cred 3: account_wide=False fable=False opus=False
  OPUS-usable rows  = [1, 2, 3]
```

On the #216 tree the tier verdict wrote **account-wide** blocks (`opus=True` —
the stranding). On main it writes family-scoped ones, so opus keeps every
account while Fable is correctly stopped. The block rows themselves:

```
$ python probe_f8_scope.py
auth_credential_blocks rows (credential_id, provider_key, block_scope):
   (1, 'anthropic:oauth', 'model:fable')
   (2, 'anthropic:oauth', 'model:fable')
```

`model:fable`, not account-wide. `test_a_tier_depletion_leaves_other_models_on_the_account`
pins this so it cannot regress back.

### #220 F9/F10: proving zero behaviour change

A readability edit to a branch with deliberate semantics needs proof, not a
green suite. Every combination of up to three denominator-less balance rows —
`remaining` in `{None, 0.0, 10.0, -5.0}` x `{shared, tier-scoped, neither}` x
three reset times — crossed with two model ids, comparing the **full**
`QuotaHealth` (state, remaining_fraction, reset_after_ms, scope,
binding_labels, binding_families):

```
[base] cases=95978
[base] sha256=aa841533c258c8910440efa4a3a611da7d1edbebddd351f086c23495387bda23
[head] cases=95978
[head] sha256=aa841533c258c8910440efa4a3a611da7d1edbebddd351f086c23495387bda23

$ diff f9-base.jsonl f9-head.jsonl
IDENTICAL: zero behaviour change across all cases
```

Byte-identical verdicts. What matters is which BOUNDARIES that
crosses, not the case count: exact zero vs positive (F3), one zeroed row beside
a funded one (F6), negative balances, `None` rows mixed with real ones, and
tier-scoped vs shared rows. The count is wide but shallow — most cases are
interior points restating the same few behaviours — and agent review round 1
made this point, running a smaller enumeration aimed squarely at those
boundaries and reaching the same verdict.

The shipped test `test_balance_only_branch_verdicts_survive_the_f9_cleanup`
enumerates the boundary explicitly (negative balances count as non-positive; a
row with no `remaining` is not a balance row; any positive balance anywhere
keeps the report unknown) so a future readability pass cannot move it quietly.
It passes on base too — that is the point of a pin.

### Round-1 review remediation (F1, F2)

Agent review round 1 was clean/terminal (0 blockers, 0 majors). Both minors are
fixed in `683997a0`, and the branch is rebased onto current `main` (v0.43.12).

**F1** — `_list_directory` still listed symlinks that resolve to nothing.
`resolve()` is non-strict, so a dangling link and a self-loop resolve to a path
*inside* `base_dir`, pass the R3-2 containment check, and then fail the
resolver's `exists()`. Same advertise-then-reject class, reached through
existence rather than containment:

```
--- before ---                          --- after ---
dangling.md  REJECTED (not found)       real.md   READ OK
loop-a.md    REJECTED (not found)
loop-b.md    REJECTED (not found)       ADVERTISED-THEN-REJECTED: []
real.md      READ OK
selfloop.md  REJECTED (not found)

ADVERTISED-THEN-REJECTED: ['dangling.md', 'loop-a.md', 'loop-b.md', 'selfloop.md']
```

The symlink gate now asks the resolver's whole question via a named
`_resolver_would_accept()` (contained AND existing). The bare-read listing was
already clean here — its walk tests `is_file()`/`is_dir()`, which a broken link
fails — so this is the two surfaces reaching parity. Four tests added; three
fail on the pre-F1 tree, and the fourth
(`test_every_listed_name_reads`) states the invariant behind both R3-2 and F1
directly: whatever the listing prints, a read of it succeeds.

**F2** — the R3-3 note rejected a per-entry stat as too costly while R3-2 added
per-entry `resolve()` calls. The note now explains why the two costs differ
rather than pretending they are the same: the containment/existence checks run
only on symlinks (an ordinary-file listing skips them) while hardlink detection
needs `st_dev`/`st_ino` on every walked file; the checks remove a name that
ERRORS on read while the hardlink check removes a name that reads correctly;
and they are wrong in opposite directions. Measured over a 2000-entry directory,
interleaved arms, warmed, best-of-15:

```
files         pre-PR base:   7.4 ms   |   this PR:  18.1 ms
symlinks      pre-PR base:   8.8 ms   |   this PR: 439.2 ms
mostly-files  pre-PR base:   7.3 ms   |   this PR:  82.1 ms
```

The realistic case stays in the tens of milliseconds; the all-symlink case is
bounded by how many symlinks an author writes into one `references/` directory.
The check is not moved after the 500-entry cap, which would be cheaper: the cap
slices the filtered list, so filtering afterwards would let unreadable entries
consume cap slots and push readable files out.

### Gates

```
flake8 .                            clean
black --check .  (26.1.0)           618 files would be left unchanged
isort --check .  (5.13.2)           clean
pyright .                           0 errors, 0 warnings, 0 informations
pytest tests/unit/skills tests/unit/providers tests/unit/model
                                    1218 passed in 18.48s
pytest tests/unit                   8791 passed, 15 skipped, 11 failed
```

The 11 full-suite failures are **pre-existing wall-clock flakes** on a loaded
machine, all in subsystems this PR does not touch (TUI timing, mobile reaper
idle timing, MCP teardown timing, bash steering, loop-responsiveness ceilings).
All 11 pass in isolation on this branch:

```
$ pytest <the 11 failed node ids> -p no:randomly
5 passed in 12.73s
6 passed in 36.30s
```

Confirmed pre-existing rather than introduced, by running one of them against
unmodified base under the same CPU load:

```
=== BASE under CPU load x5 ===
1 passed / 1 passed / 1 passed / 1 passed / 1 failed
```

`test_a_deliberately_slow_double_click_is_still_a_double_click` sleeps 0.7 s
against a 0.9 s `CLICK_CHAIN_TIME_THRESHOLD`, so a 200 ms scheduling delay
fails it on base and head alike.

## Risk

Low, and the two halves are independent.

The skills change makes a listing strictly smaller, and only by names the
resolver already refused — no path becomes readable, and the internal-symlink
test guards the readable case. The F7 change is a memo lifetime, with the route
outcome asserted unchanged. F9/F10 is proven behaviour-preserving across the
F3/F6 boundary cases, independently re-enumerated in review. F8 is no code change at all.

