### PR TITLE
fix(tui): guard the steer receipt by session, and stop the settle reflowing the transcript

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1845,9 +1845,16 @@ class OperatorApp(App[None]):
         #:
         #: A set of controllers rather than a flag: several rotations can be in
         #: flight, and identity is the same discriminator the guard itself uses.
+        #: Membership here goes through ``__hash__``/``__eq__`` rather than the
+        #: ``is not`` the guard uses on the live controller, so it is identity
+        #: only because :class:`EventController` inherits both from ``object``
+        #: — the same property the two `NoticeBlock` sets rely on. A controller
+        #: that ever defines either must revisit this lookup, or a superseded
+        #: controller could be spoofed into the allowance.
+        #:
         #: Cleared wherever the rows are, since an entry outliving the rows it
         #: was protecting would re-open the very race the guard closes.
-        self._superseded_steer_controllers: set[Any] = set()
+        self._superseded_steer_controllers: set[EventController] = set()
         #: User messages this TUI has ALREADY painted (or deliberately declined
         #: to paint) whose ``MessageStartEvent`` from the session is still
         #: coming. ``on_user_message_start`` consumes a matching entry instead

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -366,9 +366,23 @@ DEFERRED_STEER_NOTICE = "still queued — sends with your next message"
 #: future edit to this line has to re-run the sweep — a word added or dropped
 #: here silently reintroduces the reflow.
 #:
-#: Past tense, and the message named as the one already sent: by the time this
-#: is painted the user's next message is the message they just sent.
-DEFERRED_SENT_STEER_NOTICE = "sent — it rode along with your next message"
+#: `that next message`, not `your next message` (design round 1, D1). The turn
+#: that drains this row need not be one the user started: an idle wake
+#: (`Session._fire_wake` spawns its own turn for a wake that lands while the
+#: session is idle), a peer `lop send` and a background job result each open a
+#: turn that drains the steering queue. A row asserting the user sent something
+#: is then simply FALSE — the same class of defect as the dropped fact this
+#: string exists to fix, one state over. `that` names the message the steer
+#: travelled with without claiming who wrote it, and stays true on the common
+#: path where the user did write it.
+#:
+#: The alternative `the message below` was measured and rejected: it reflows at
+#: 22 and 24 columns. The binding constraint is WORD SHAPE, not length — every
+#: candidate here is 43 characters, but the row count follows the wrap points,
+#: and only a tail breaking like `with · your/that · next · message` tracks
+#: `DEFERRED_STEER_NOTICE` at every width. That is precisely why the sweep, and
+#: not the character count, is the instrument.
+DEFERRED_SENT_STEER_NOTICE = "sent — it rode along with that next message"
 #: The one row a recall decline prints (design round 1, D1): a silent Esc over
 #: a half-typed draft reads as a dropped keystroke, so the decline names the
 #: obstacle and the recovery. Named because the SUCCESSFUL recall retires its
@@ -1805,6 +1819,19 @@ class OperatorApp(App[None]):
         #: The two together are the FIFO the engine drains: these rows were
         #: queued first, so they settle first (see `on_steering_delivered`).
         self._deferred_steer_notices: list[NoticeBlock] = []
+        #: Controllers that were replaced by a swap which KEPT the transcript,
+        #: so a steer receipt still in flight from one of them is about a row
+        #: this app is still holding and must still settle it (review round 1,
+        #: F3). Only `_adopt_takeover_session` adds to this: a takeover is a
+        #: transport rotation, not a conversation change. `/reload` and `/new`
+        #: deliberately do NOT, because they clear the rows and the messages
+        #: those receipts describe left with the old session.
+        #:
+        #: A set of controllers rather than a flag: several rotations can be in
+        #: flight, and identity is the same discriminator the guard itself uses.
+        #: Cleared wherever the rows are, since an entry outliving the rows it
+        #: was protecting would re-open the very race the guard closes.
+        self._superseded_steer_controllers: set[Any] = set()
         #: User messages this TUI has ALREADY painted (or deliberately declined
         #: to paint) whose ``MessageStartEvent`` from the session is still
         #: coming. ``on_user_message_start`` consumes a matching entry instead
@@ -2597,6 +2624,17 @@ class OperatorApp(App[None]):
         """
         remote = self._session
         if self._controller is not None:
+            # A takeover KEEPS the conversation, so it also keeps the receipt's
+            # right to settle (review round 1, F3). The steer-delivery guard
+            # drops events from a superseded controller because a `/reload`
+            # cleared the rows they would have settled — but here the rows are
+            # deliberately still on screen and their messages are still the
+            # same session's, so a drain already in flight across the swap is
+            # about a row this app is still holding. Recording the outgoing
+            # controller as still-honoured is what keeps that receipt landing
+            # instead of leaving the row stuck on `queued` after the message
+            # actually went.
+            self._superseded_steer_controllers.add(self._controller)
             self._controller.dispose()
             self._controller = None
         if remote is not None:
@@ -3844,6 +3882,11 @@ class OperatorApp(App[None]):
         # watch the other front end paint it while this one stays silent.
         self._pending_user_echoes.clear()
         self._held_steer_blocks.clear()
+        # And the takeover allowance, which only ever protects rows: with the
+        # rows gone there is nothing left for a superseded controller's receipt
+        # to settle, and an entry outliving them would re-open the very race
+        # the guard closes (review round 1, F3).
+        self._superseded_steer_controllers.clear()
         # The per-call accrual belongs to a turn on the session being replaced.
         # Left standing, the NEXT session's first `agent_end` would subtract the
         # dead conversation's already-billed calls from its own turn total and
@@ -8010,6 +8053,9 @@ class OperatorApp(App[None]):
         self._queued_steer_notices.clear()
         self._deferred_steer_notices.clear()
         self._held_steer_blocks.clear()
+        # Same reason as the swap path: the allowance exists only to let a
+        # takeover's in-flight receipt reach a row that is still on screen.
+        self._superseded_steer_controllers.clear()
         # ``ends_empty_state=False``: the receipt reports on the CLEAR, so the
         # session has not started talking and the splash the clear just restored
         # must survive it. Going through ``_append_block`` rather than straight to
@@ -17622,12 +17668,24 @@ class OperatorApp(App[None]):
         drain. The emptiness check below is not sufficient for exactly that
         window: the lists are non-empty again, holding a row about a message
         this event says nothing about.
+
+        The premise is "the swap cleared the rows", NOT "the controller
+        changed", and those come apart on the takeover path (review round 1,
+        F3): `_adopt_takeover_session` rotates the transport while deliberately
+        keeping the transcript and the held rows, so a drain in flight across
+        that swap is still about a row this app holds and must still settle it.
+        Those controllers are recorded as still-honoured rather than the guard
+        being loosened for everyone, which would give the `/reload` race back.
         """
         origin = getattr(message, "origin", None)
-        if origin is not None and origin is not self._controller:
-            # A receipt from a session that is no longer on screen. Its rows
-            # went with the swap that cleared them, so there is nothing here it
-            # could honestly settle.
+        if (
+            origin is not None
+            and origin is not self._controller
+            and origin not in self._superseded_steer_controllers
+        ):
+            # A receipt from a conversation that is no longer on screen. Its
+            # rows went with the swap that cleared them, so there is nothing
+            # here it could honestly settle.
             return
         if not self._deferred_steer_notices and not self._queued_steer_notices:
             return  # a delivery for rows this app is no longer holding

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -329,6 +329,46 @@ MODEL_SWITCH_MID_TURN_NOTICE = "applies from the next step — this one finishes
 #: Dropping it also stops the row being WRONG on the error path, where the turn
 #: was not stopped by anyone: it failed, and its own error notice says so.
 DEFERRED_STEER_NOTICE = "still queued — sends with your next message"
+#: The settle for a row that was DEFERRED, where `SENT_STEER_NOTICE` is the
+#: settle for one delivered inside the turn it was queued against. Two strings
+#: for one transition, which #132 spent two rounds arguing against, so the case
+#: for the fourth is made here rather than assumed.
+#:
+#: It says something the shared string cannot (design round 1, D5). A deferred
+#: row promised `sends with your next message`; the user then typed that
+#: message and watched an older row flip to `sent — the agent has it now`, with
+#: no way to tell whether their steered text rode along with what they just
+#: sent or arrived separately — and the receipt sits ABOVE the message it
+#: travelled with, so the only cue is spatial and reads backwards. `it rode
+#: along` names the association the layout cannot.
+#:
+#: The shared string could not simply be re-worded to say this, which is what
+#: forces a fourth: `SENT_STEER_NOTICE` also settles the SAME-TURN case, the
+#: common path, where the message went at a tool boundary during the turn the
+#: user was watching. Any mention of a `next message` there is plainly wrong —
+#: there is no next message. The two settles are genuinely two facts.
+#:
+#: Its LENGTH is load-bearing, and this is the second reason it exists (design
+#: round 1, D1/D2). A notice's height is a step function of its wrap points, so
+#: a settle that shortens the text can shorten the ROW, pulling everything
+#: below it up at a moment the user did nothing — and with the transcript
+#: scrolled up the offset stays put while the extent drops, so the viewport
+#: appears to scroll itself. Measured on the real block
+#: (`scripts/steer_receipt_transitions.py`), the shared 27-character string
+#: shrank the deferred row at every width from 28 to 52 columns. At 43
+#: characters this renders to the SAME height as `DEFERRED_STEER_NOTICE` at
+#: every width from 28 to 80 (`scripts/steer_receipt_candidates.py`), so the
+#: cross-turn settle now rewrites the row in place without moving a thing.
+#:
+#: Chosen by MEASUREMENT, not by character count: the round-1 candidate `sent
+#: with your next message` was picked as "27 → 28 characters" and is in fact 27,
+#: identical to the string it replaced, and moved no wrap point at all. Any
+#: future edit to this line has to re-run the sweep — a word added or dropped
+#: here silently reintroduces the reflow.
+#:
+#: Past tense, and the message named as the one already sent: by the time this
+#: is painted the user's next message is the message they just sent.
+DEFERRED_SENT_STEER_NOTICE = "sent — it rode along with your next message"
 #: The one row a recall decline prints (design round 1, D1): a silent Esc over
 #: a half-typed draft reads as a dropped keystroke, so the decline names the
 #: obstacle and the recovery. Named because the SUCCESSFUL recall retires its
@@ -17572,7 +17612,23 @@ class OperatorApp(App[None]):
         rows" and "the messages that went" are the same set — across BOTH held
         lists, which is why they concatenate here; see
         `_deferred_steer_notices` for why deferred rows lead.
+
+        Gated on the delivery coming from the controller this app is CURRENTLY
+        listening to (issue #160, F3). `/reload` disposes the old controller,
+        but a `steering_delivered` it had already dispatched is a queued Textual
+        message that unsubscribing cannot recall, and it is handled after the
+        swap cleared these lists — so a user quick enough to steer into the
+        replacement session had that new row settled by the dead session's
+        drain. The emptiness check below is not sufficient for exactly that
+        window: the lists are non-empty again, holding a row about a message
+        this event says nothing about.
         """
+        origin = getattr(message, "origin", None)
+        if origin is not None and origin is not self._controller:
+            # A receipt from a session that is no longer on screen. Its rows
+            # went with the swap that cleared them, so there is nothing here it
+            # could honestly settle.
+            return
         if not self._deferred_steer_notices and not self._queued_steer_notices:
             return  # a delivery for rows this app is no longer holding
         # Defensive bounds: a producer that omits `count` (or sends a nonsense
@@ -17599,6 +17655,13 @@ class OperatorApp(App[None]):
         held = self._deferred_steer_notices + self._queued_steer_notices
         taken = max(1, min(count, len(held)))
         settled, remaining = held[:taken], held[taken:]
+        # WHICH settle each row gets, captured before the lists are rewritten
+        # below. A row from the deferred list travelled with the user's next
+        # message and says so (`DEFERRED_SENT_STEER_NOTICE`); a row from the
+        # queued list went inside the turn it was queued against and takes the
+        # plain `SENT_STEER_NOTICE`. Identity again, for the reason the
+        # membership split below states.
+        was_deferred = set(self._deferred_steer_notices)
         # Split back apart by MEMBERSHIP rather than by arithmetic on `taken`:
         # the lists were concatenated for ordering only, and each survivor goes
         # back to whichever list it came from, because the two mean different
@@ -17622,7 +17685,10 @@ class OperatorApp(App[None]):
         ]
         for block in settled:
             try:
-                block.restate(SENT_STEER_NOTICE, "success")
+                block.restate(
+                    (DEFERRED_SENT_STEER_NOTICE if block in was_deferred else SENT_STEER_NOTICE),
+                    "success",
+                )
             except Exception:  # a receipt must never take the app down
                 logger.debug("queued-steer notice could not be settled", exc_info=True)
         # Delivered entries can never be recalled: drop their held blocks so

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -316,7 +316,23 @@ MODEL_SWITCH_MID_TURN_NOTICE = "applies from the next step — this one finishes
 #: The turn ended without ever reaching a boundary to drain at — interrupted,
 #: failed, or simply answered with no further tool calls. ONE string for all
 #: three, because they are one fact from the user's side: the message is waiting
-#: and goes with their next message, and what they do about it is identical.
+#: and goes with whatever prompt opens the next turn, and what they do about it
+#: is identical.
+#:
+#: `that next message`, not `your next message` (design round 2, D6). The turn
+#: that drains this row need not be one the user started: an idle wake, a peer
+#: `lop send` and a background job result each open their own turn and drain the
+#: steering queue, so the promise named a message that need not exist. The
+#: settle one state over (`DEFERRED_SENT_STEER_NOTICE`) was corrected for
+#: exactly this in round 1, and leaving the promise saying `your` above a settle
+#: saying `that` reads as a considered distinction rather than the oversight it
+#: was. Promise and settle now share the deictic, so the row visibly restates
+#: itself instead of switching pronouns mid-story.
+#:
+#: Geometry-neutral, measured rather than assumed — this is the REFERENCE height
+#: every other receipt string is matched against, so a change here moves the
+#: whole set. `scripts/steer_receipt_transitions.py` over 20-90 columns reports
+#: the same pre-existing `q->d` band and `d->ds` still clean at every width.
 #:
 #: An earlier version named the interrupt in the row ("the turn was stopped"),
 #: which cost 22 cells to restate the `! interrupted` notice sitting one row
@@ -328,7 +344,7 @@ MODEL_SWITCH_MID_TURN_NOTICE = "applies from the next step — this one finishes
 #:
 #: Dropping it also stops the row being WRONG on the error path, where the turn
 #: was not stopped by anyone: it failed, and its own error notice says so.
-DEFERRED_STEER_NOTICE = "still queued — sends with your next message"
+DEFERRED_STEER_NOTICE = "still queued — sends with that next message"
 #: The settle for a row that was DEFERRED, where `SENT_STEER_NOTICE` is the
 #: settle for one delivered inside the turn it was queued against. Two strings
 #: for one transition, which #132 spent two rounds arguing against, so the case

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -364,11 +364,22 @@ class SteeringDelivered(Message):
     the app settles that row against this instead of leaving a promise about the
     future standing after the future arrived. ``count`` is how many messages
     went in at the one boundary.
+
+    ``origin`` is the controller that posted it, and it is what makes the
+    receipt safe across a session swap (issue #160, F3). A generation number
+    cannot answer this hazard: generations are per-controller, and the stale
+    event comes from a DIFFERENT controller with its own counter, so the two
+    numbers are not comparable. Identity is, and the app drops a delivery whose
+    origin is no longer the controller it is listening to — see
+    ``OperatorApp.on_steering_delivered``. ``None`` means "unstamped, treat as
+    current": a hand-posted message in a test is simulating the live session,
+    and only a stamped origin can be PROVEN stale.
     """
 
-    def __init__(self, count: int) -> None:
+    def __init__(self, count: int, origin: Any | None = None) -> None:
         super().__init__()
         self.count = count
+        self.origin = origin
 
 
 class SubagentStarted(Message):
@@ -677,11 +688,25 @@ class EventController:
         self._post(PeerMessageDelivered(event.body, dict(event.sender), event.message_id))
 
     def _handle_steering_delivered(self, event: SteeringDeliveredEvent) -> None:
-        # No generation guard, deliberately: the drain belongs to whichever turn
-        # is running, and the app settles a row it is holding a direct reference
-        # to rather than looking one up by turn. A late event finds nothing held
-        # and does nothing.
-        self._post(SteeringDelivered(getattr(event, "count", 1)))
+        # No TURN guard, deliberately: the drain belongs to whichever turn is
+        # running, and the app settles a row it is holding a direct reference to
+        # rather than looking one up by turn. Within one session a late event
+        # finds nothing held and does nothing.
+        #
+        # A SESSION guard, though, because that reasoning stops holding at a
+        # swap (issue #160, F3). `/reload` disposes this controller, but a
+        # `steering_delivered` already dispatched is a Textual message sitting
+        # in the app's queue, and unsubscribing cannot recall it. It is handled
+        # after the swap cleared the held lists — by which time the user may
+        # have steered into the REPLACEMENT session, whose row is then held and
+        # would be falsely settled by the dying session's drain.
+        #
+        # Stamped with `self`, not with a generation: generations are
+        # per-controller counters, so the outgoing controller's number is not
+        # comparable with the incoming one's and could collide with it outright.
+        # The app compares against the controller it currently listens to, which
+        # is the question actually being asked.
+        self._post(SteeringDelivered(getattr(event, "count", 1), origin=self))
 
     def _handle_compaction_start(self, event: CompactionStartEvent) -> None:
         self._post(CompactionStarted(event.reason))

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -376,7 +376,7 @@ class SteeringDelivered(Message):
     and only a stamped origin can be PROVEN stale.
     """
 
-    def __init__(self, count: int, origin: Any | None = None) -> None:
+    def __init__(self, count: int, origin: "EventController | None" = None) -> None:
         super().__init__()
         self.count = count
         self.origin = origin

--- a/scripts/steer_receipt_candidates.py
+++ b/scripts/steer_receipt_candidates.py
@@ -1,0 +1,70 @@
+"""Find a cross-turn settled string that does not reflow the row (#160 D1/D2/D5).
+
+The round-1 candidate was chosen by CHARACTER COUNT and was wrong: 27 characters
+is identical to the current string and moves no wrap point. Rendered height is
+the only thing that matters, and it is a step function of the wrap points, so
+candidates are measured in a mounted block at every width instead of counted.
+
+A candidate PASSES when its rendered height equals ``DEFERRED_STEER_NOTICE``'s
+at every width in the range: that is exactly the condition under which the
+cross-turn settle rewrites the row without moving anything below it.
+
+Usage:
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/steer_receipt_candidates.py [lo] [hi]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from local_operator.tui.app import DEFERRED_STEER_NOTICE, OperatorApp  # noqa: E402
+from local_operator.tui.widgets.transcript import NoticeBlock  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+CANDIDATES = [
+    "sent with your message — the agent has it now",
+    "sent — the agent has it with your message",
+    "sent — it went with the message you just sent",
+    "sent — it rode along with your next message",
+    "sent with your message — the agent has it",
+    "sent — the agent has it, with your message",
+    "sent with your last message — the agent has it",
+    "sent — the agent has it now",  # the current shared string, as control
+]
+
+
+async def _heights(cols: int, texts: list[str]) -> list[int]:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(cols, 24)) as pilot:
+        await pilot.pause()
+        blocks = [NoticeBlock(text, "note") for text in texts]
+        for block in blocks:
+            app._append_block(block)
+        await pilot.pause()
+        await pilot.pause()
+        return [block.virtual_region.height for block in blocks]
+
+
+async def main() -> None:
+    lo = int(sys.argv[1]) if len(sys.argv) > 1 else 28
+    hi = int(sys.argv[2]) if len(sys.argv) > 2 else 80
+    texts = [DEFERRED_STEER_NOTICE, *CANDIDATES]
+    mismatches: dict[str, list[int]] = {c: [] for c in CANDIDATES}
+    for cols in range(lo, hi + 1):
+        heights = await _heights(cols, texts)
+        deferred, rest = heights[0], heights[1:]
+        for candidate, height in zip(CANDIDATES, rest):
+            if height != deferred:
+                mismatches[candidate].append(cols)
+    for candidate in CANDIDATES:
+        bad = mismatches[candidate]
+        verdict = "MATCHES deferred at every width" if not bad else f"differs at {bad}"
+        print(f"len={len(candidate):3} {candidate!r}\n      {verdict}\n")
+
+
+asyncio.run(main())

--- a/scripts/steer_receipt_candidates.py
+++ b/scripts/steer_receipt_candidates.py
@@ -9,6 +9,11 @@ A candidate PASSES when its rendered height equals ``DEFERRED_STEER_NOTICE``'s
 at every width in the range: that is exactly the condition under which the
 cross-turn settle rewrites the row without moving anything below it.
 
+Coupled to ``tests.unit.tui.test_app_pilot`` for its ``FakeSession``/``_factory``
+(review round 1, F5): nothing runs these in CI, so a rename there breaks them
+silently -- which is exactly when someone editing the receipt copy needs them.
+If the import fails, that pair is what moved.
+
 Usage:
     env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
         scripts/steer_receipt_candidates.py [lo] [hi]
@@ -27,13 +32,23 @@ from local_operator.tui.widgets.transcript import NoticeBlock  # noqa: E402
 from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
 
 CANDIDATES = [
-    "sent with your message — the agent has it now",
-    "sent — the agent has it with your message",
-    "sent — it went with the message you just sent",
+    # The shipped string, and the alternatives design review round 1 (D1/D2)
+    # measured against it. `your next message` is FALSE on every turn the user
+    # did not start -- an idle wake, a peer `lop send`, or a background job
+    # result each open their own turn and drain the queue -- so the row named a
+    # message that need not exist. `that next message` drops the
+    # authorship claim without asserting a position the reader must verify.
+    "sent — it rode along with that next message",  # shipped
+    # Rejected by measurement, and the reason is instructive: the binding
+    # constraint is WORD SHAPE, not length. These are 43 characters like the
+    # shipped string, but their tails break differently and so reflow in the
+    # narrow band. `the message below` was design round 1's suggestion.
+    "sent — it rode along with the message below",
+    "sent — it went along with the message below",
     "sent — it rode along with your next message",
-    "sent with your message — the agent has it",
-    "sent — the agent has it, with your message",
-    "sent with your last message — the agent has it",
+    "sent — it rode along with your last message",
+    "sent — it rode along with the next message",
+    "sent — it went out with the message below it",
     "sent — the agent has it now",  # the current shared string, as control
 ]
 

--- a/scripts/steer_receipt_probe.py
+++ b/scripts/steer_receipt_probe.py
@@ -1,0 +1,147 @@
+"""Measure the settle reflow of a DEFERRED steer receipt (issue #160, D1/D2).
+
+Drives the real ``OperatorApp`` (so the stylesheet and the transcript's real
+gap/anchor accounting apply), puts one steer row into the DEFERRED state, and
+reports the geometry either side of the delivery that settles it:
+
+  * the receipt block's row count,
+  * the transcript's ``virtual_size`` and ``scroll_offset``,
+  * how many viewport rows change between the two frames.
+
+Both scroll states are measured because they fail differently: pinned to the
+bottom the offset auto-corrects (only the tail moves), while scrolled up the
+offset stays put and the same offset shows different text.
+
+Usage:
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/steer_receipt_probe.py [cols ...]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.events import SteeringDelivered, TurnEnded  # noqa: E402
+from local_operator.tui.widgets.editor import Editor  # noqa: E402
+from local_operator.tui.widgets.transcript import (  # noqa: E402
+    NoticeBlock,
+    TranscriptView,
+)
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+
+class _Streaming(FakeSession):
+    """Mid-turn, so a submit is STEERED rather than prompted."""
+
+    @property
+    def is_streaming(self) -> bool:
+        return True
+
+
+async def _submit(pilot: Any, app: OperatorApp, text: str) -> None:
+    for _ in range(200):
+        if app._session is not None:
+            break
+        await pilot.pause()
+        await asyncio.sleep(0.01)
+    editor = app.query_one(Editor)
+    editor.focus()
+    await pilot.pause()
+    editor.text = text
+    await pilot.pause()
+    await pilot.press("enter")
+    await pilot.pause()
+
+
+def _rows(app: OperatorApp) -> list[str]:
+    return [strip.text.rstrip() for strip in app.screen._compositor.render_strips()]
+
+
+def _receipt(app: OperatorApp) -> NoticeBlock:
+    held = app._deferred_steer_notices or app._queued_steer_notices
+    return held[0]
+
+
+def _geometry(app: OperatorApp, block: NoticeBlock) -> dict[str, Any]:
+    view = app.query_one(TranscriptView)
+    return {
+        "text": block._text,
+        "h": block.virtual_region.height,
+        "virtual_size": view.virtual_size.height,
+        "scroll_offset": view.scroll_offset.y,
+        "max_scroll_y": view.max_scroll_y,
+    }
+
+
+async def _measure(cols: int, *, scrolled_up: bool, shot: str | None = None) -> None:
+    app = OperatorApp(lambda: _factory(_Streaming()))
+    async with app.run_test(size=(cols, 24)) as pilot:
+        await pilot.pause()
+        # Enough history that scrolling up has somewhere to go. Plain rows,
+        # not steers: only ONE receipt may be in flight or the settle would
+        # move several rows at once and overstate the magnitude.
+        for index in range(30):
+            app._append_block(NoticeBlock(f"history row {index}", "info"))
+        await pilot.pause()
+        await _submit(pilot, app, "and use the staging credentials")
+        for index in range(30, 44):
+            app._append_block(NoticeBlock(f"history row {index}", "info"))
+        await pilot.pause()
+        app.post_message(TurnEnded(True, None))
+        await pilot.pause()
+        await pilot.pause()
+
+        view = app.query_one(TranscriptView)
+        if scrolled_up:
+            view.scroll_to(y=25, animate=False, immediate=True)
+            await pilot.pause()
+            await pilot.pause()
+
+        block = _receipt(app)
+        before = _geometry(app, block)
+        before_rows = _rows(app)
+        if shot:
+            app.save_screenshot(f"{shot}-before.svg")
+
+        app.post_message(SteeringDelivered(1))
+        await pilot.pause()
+        await pilot.pause()
+
+        after = _geometry(app, block)
+        after_rows = _rows(app)
+        if shot:
+            app.save_screenshot(f"{shot}-after.svg")
+
+        changed = sum(1 for a, b in zip(before_rows, after_rows) if a != b)
+        state = "scrolled up" if scrolled_up else "pinned to bottom"
+        print(f"--- {cols} cols, {state}")
+        for label, snap in (("before", before), ("after", after)):
+            print(
+                f"  {label:6} h={snap['h']} "
+                f"virtual_size={snap['virtual_size']} "
+                f"scroll_offset={snap['scroll_offset']} "
+                f"max_scroll_y={snap['max_scroll_y']} "
+                f"{snap['text']!r}"
+            )
+        print(f"  viewport rows changed: {changed}/{len(before_rows)}")
+
+
+async def main() -> None:
+    widths = [int(arg) for arg in sys.argv[1:] if arg.isdigit()] or [52, 53]
+    shot_base = next((arg for arg in sys.argv[1:] if not arg.isdigit()), None)
+    for cols in widths:
+        for scrolled_up in (False, True):
+            shot = None
+            if shot_base:
+                suffix = "scrolled" if scrolled_up else "pinned"
+                shot = f"{shot_base}-{cols}-{suffix}"
+            await _measure(cols, scrolled_up=scrolled_up, shot=shot)
+
+
+asyncio.run(main())

--- a/scripts/steer_receipt_probe.py
+++ b/scripts/steer_receipt_probe.py
@@ -12,6 +12,11 @@ Both scroll states are measured because they fail differently: pinned to the
 bottom the offset auto-corrects (only the tail moves), while scrolled up the
 offset stays put and the same offset shows different text.
 
+Coupled to ``tests.unit.tui.test_app_pilot`` for its ``FakeSession``/``_factory``
+(review round 1, F5): nothing runs these in CI, so a rename there breaks them
+silently -- which is exactly when someone editing the receipt copy needs them.
+If the import fails, that pair is what moved.
+
 Usage:
     env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
         scripts/steer_receipt_probe.py [cols ...]

--- a/scripts/steer_receipt_transitions.py
+++ b/scripts/steer_receipt_transitions.py
@@ -1,0 +1,72 @@
+"""Every height change a steer receipt makes over its life, per width.
+
+A receipt row is restated at most twice: ``queued`` -> ``deferred`` when the
+turn ends without draining, and either of those -> ``sent`` when the engine
+takes the message. Each restate that changes the row count reflows everything
+below it. This tabulates all three transitions so the fix can be judged against
+the whole set rather than the one transition issue #160 names.
+
+Usage:
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/steer_receipt_transitions.py [lo] [hi]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from local_operator.tui.app import (  # noqa: E402
+    DEFERRED_SENT_STEER_NOTICE,
+    DEFERRED_STEER_NOTICE,
+    QUEUED_STEER_NOTICE,
+    SENT_STEER_NOTICE,
+    OperatorApp,
+)
+from local_operator.tui.widgets.transcript import NoticeBlock  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+
+async def _heights(cols: int) -> dict[str, int]:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(cols, 24)) as pilot:
+        await pilot.pause()
+        blocks = {
+            "queued": NoticeBlock(QUEUED_STEER_NOTICE, "note"),
+            "sent": NoticeBlock(SENT_STEER_NOTICE, "success"),
+            "deferred": NoticeBlock(DEFERRED_STEER_NOTICE, "note"),
+            "deferred_sent": NoticeBlock(DEFERRED_SENT_STEER_NOTICE, "success"),
+        }
+        for block in blocks.values():
+            app._append_block(block)
+        await pilot.pause()
+        await pilot.pause()
+        return {name: block.virtual_region.height for name, block in blocks.items()}
+
+
+async def main() -> None:
+    lo = int(sys.argv[1]) if len(sys.argv) > 1 else 30
+    hi = int(sys.argv[2]) if len(sys.argv) > 2 else 60
+    print("cols  q  s  d ds   q->s (same turn)  q->d (turn end)  d->ds (cross turn)")
+    bands: dict[str, list[int]] = {"q->s": [], "q->d": [], "d->ds": []}
+    for cols in range(lo, hi + 1):
+        h = await _heights(cols)
+        q, s, d, ds = h["queued"], h["sent"], h["deferred"], h["deferred_sent"]
+        cells = []
+        for key, a, b in (("q->s", q, s), ("q->d", q, d), ("d->ds", d, ds)):
+            if a == b:
+                cells.append(" " * 16)
+                continue
+            bands[key].append(cols)
+            verb = "shrink" if b < a else "GROW  "
+            cells.append(f"{verb} {a}->{b}      "[:16])
+        print(f"{cols:4}  {q}  {s}  {d}  {ds}   {cells[0]} {cells[1]} {cells[2]}")
+    print()
+    for key, cols_list in bands.items():
+        print(f"{key}: reflows at {cols_list or 'no width'}")
+
+
+asyncio.run(main())

--- a/scripts/steer_receipt_transitions.py
+++ b/scripts/steer_receipt_transitions.py
@@ -6,6 +6,11 @@ takes the message. Each restate that changes the row count reflows everything
 below it. This tabulates all three transitions so the fix can be judged against
 the whole set rather than the one transition issue #160 names.
 
+Coupled to ``tests.unit.tui.test_app_pilot`` for its ``FakeSession``/``_factory``
+(review round 1, F5): nothing runs these in CI, so a rename there breaks them
+silently -- which is exactly when someone editing the receipt copy needs them.
+If the import fails, that pair is what moved.
+
 Usage:
     env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
         scripts/steer_receipt_transitions.py [lo] [hi]

--- a/tests/unit/tui/test_queued_steer_receipt.py
+++ b/tests/unit/tui/test_queued_steer_receipt.py
@@ -280,6 +280,14 @@ async def test_an_interrupted_turn_retires_the_promise_it_can_no_longer_keep() -
         # it was lost — the user would retype and the agent would get it twice.
         assert "not sent" not in DEFERRED_STEER_NOTICE
         assert "still queued" in DEFERRED_STEER_NOTICE
+        # And it must not claim the user will send that message (design round 2,
+        # D6). A wake that lands while idle, a peer `lop send` and a background
+        # job result each open their own turn and drain the queue, so the turn
+        # this row is waiting on need not be one the user started. The promise
+        # and the settle share the deictic for that reason; `your` in either is
+        # the same false authorship claim one state apart.
+        assert "your" not in DEFERRED_STEER_NOTICE
+        assert "your" not in DEFERRED_SENT_STEER_NOTICE
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_queued_steer_receipt.py
+++ b/tests/unit/tui/test_queued_steer_receipt.py
@@ -30,6 +30,7 @@ from local_operator.harness.types import ModelSpec, SteeringDeliveredEvent
 from local_operator.session.session import Session
 from local_operator.session.transcript import Transcript
 from local_operator.tui.app import (
+    DEFERRED_SENT_STEER_NOTICE,
     DEFERRED_STEER_NOTICE,
     QUEUED_STEER_NOTICE,
     SENT_STEER_NOTICE,
@@ -303,7 +304,11 @@ async def test_a_deferred_row_is_settled_by_the_delivery_it_was_waiting_for() ->
         await pilot.pause()
 
         texts = _notice_texts(app)
-        assert texts.count(SENT_STEER_NOTICE) == 1
+        # The DEFERRED settle, not the shared one: this row promised to go with
+        # the user's next message and it did, which is the one fact the
+        # same-turn string cannot carry (issue #160, D5).
+        assert texts.count(DEFERRED_SENT_STEER_NOTICE) == 1
+        assert SENT_STEER_NOTICE not in texts
         assert DEFERRED_STEER_NOTICE not in texts, "the kept promise still reads as waiting"
         assert QUEUED_STEER_NOTICE not in texts
         assert app._deferred_steer_notices == []
@@ -336,7 +341,7 @@ async def test_a_deferred_row_settles_before_one_queued_against_the_new_turn() -
         app.post_message(SteeringDelivered(1))
         await pilot.pause()
 
-        assert older._text == SENT_STEER_NOTICE, "the older message was the one that went"
+        assert older._text == DEFERRED_SENT_STEER_NOTICE, "the older message was the one that went"
         assert newer._text == QUEUED_STEER_NOTICE, "the newer row must keep promising"
         assert app._deferred_steer_notices == []
         assert app._queued_steer_notices == [newer]
@@ -378,7 +383,7 @@ async def test_a_surviving_deferred_row_stays_deferred_and_is_not_restated_again
         app.post_message(garbled)
         await pilot.pause()
 
-        assert older._text == SENT_STEER_NOTICE
+        assert older._text == DEFERRED_SENT_STEER_NOTICE
         assert younger._text == DEFERRED_STEER_NOTICE
         # The survivor is still DEFERRED. Landing in the queued list instead
         # would be invisible here and wrong on the next turn end, below.
@@ -660,3 +665,184 @@ async def test_an_interrupt_spends_the_loud_ink_once() -> None:
         assert "interrupted" in alarms[0]
         # And the settled row is present, quiet, and says the message survives.
         assert any(DEFERRED_STEER_NOTICE in row for row in rows), rows
+
+
+@pytest.mark.asyncio
+async def test_a_dead_sessions_delivery_cannot_settle_the_new_sessions_row() -> None:
+    """Issue #160, F3: the receipt is guarded by SESSION, not only by turn.
+
+    `/reload` disposes the outgoing controller, but an event it had ALREADY
+    dispatched is a Textual message sitting in the app's queue, and
+    unsubscribing cannot recall one. It is handled after the swap cleared the
+    held lists — and a user quick enough to steer into the replacement session
+    has a row held again by then, so the dying session's drain settled a row
+    about a message it knows nothing about.
+
+    Driven by racing dispose deliberately, because nothing else reaches it: the
+    outgoing controller's handler is invoked while it is still subscribed (the
+    engine emitting on its way down) and the resulting message is left to be
+    handled after the swap, which is exactly the real ordering.
+    """
+    outgoing = _Streaming()
+    app = OperatorApp(lambda: _factory(outgoing))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        # The controller is installed by the boot WORKER, so waiting on the
+        # condition rather than on a frame count is what keeps this
+        # deterministic on a loaded machine — the same race `_submit` documents.
+        for _ in range(200):
+            if app._controller is not None:
+                break
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+        assert app._controller is not None, "the session never booted"
+        dying_controller = app._controller
+
+        # The swap.
+        replacement = _Streaming()
+        app._session_factory = lambda: _factory(replacement)  # type: ignore[assignment]
+        await app._reload_session()
+        for _ in range(4):
+            await pilot.pause()
+        assert app._controller is not dying_controller, "the swap must install a new controller"
+
+        # The user steers into the REPLACEMENT session, so a row is held again.
+        await _submit(pilot, app, "an instruction for the new session")
+        assert QUEUED_STEER_NOTICE in _notice_texts(app)
+        (new_row,) = app._queued_steer_notices
+
+        # NOW the dying session's drain is handled. This is the ordering the
+        # race produces and the reason the emptiness check cannot catch it: the
+        # outgoing controller emitted on its way down, its message sat in the
+        # app's queue behind the swap, and by the time it is handled the lists
+        # are non-empty again — holding a row about a DIFFERENT conversation's
+        # message. Dispatched through the dead controller's own handler so the
+        # message carries exactly the stamp the production path gives it.
+        dying_controller._handle_steering_delivered(SteeringDeliveredEvent(count=1))
+        await pilot.pause()
+        await pilot.pause()
+
+        # The dead session's receipt must not settle it: that message went into
+        # a conversation the user cannot see, and this row is still promising a
+        # delivery that has not happened.
+        assert new_row._text == QUEUED_STEER_NOTICE
+        assert SENT_STEER_NOTICE not in _notice_texts(app)
+        assert DEFERRED_SENT_STEER_NOTICE not in _notice_texts(app)
+        assert app._queued_steer_notices == [new_row]
+
+        # And the LIVE session's own delivery still settles it, so the guard
+        # refuses the stale event rather than the event type.
+        assert app._controller is not None
+        app._controller._handle_steering_delivered(SteeringDeliveredEvent(count=1))
+        await pilot.pause()
+        assert new_row._text == SENT_STEER_NOTICE
+
+
+@pytest.mark.asyncio
+async def test_the_cross_turn_settle_does_not_change_the_rows_height() -> None:
+    """Issue #160, D1/D2: settling a deferred row must not reflow the transcript.
+
+    A notice's height is a step function of its wrap points, so a settle that
+    shortens the text can shorten the ROW — pulling everything below it up at a
+    moment the user did not act, and, with the transcript scrolled up, leaving
+    `scroll_offset` on a viewport that now shows different text. Measured on
+    base, the shared 27-character settle shrank the deferred row at every width
+    from 28 to 52 columns (`scripts/steer_receipt_transitions.py`).
+
+    `DEFERRED_SENT_STEER_NOTICE` is sized to match, which is the whole reason it
+    is 43 characters. This pins that: a word added or dropped from either string
+    moves a wrap point at some width and silently brings the jump back, and the
+    character counts alone cannot tell you — the round-1 candidate was chosen by
+    counting and turned out to be the same length as the string it replaced.
+
+    Every width from 28 up, because the crossovers are not where arithmetic on
+    the string lengths puts them: the transcript's own padding and scrollbar are
+    in the block's usable width and not in the raw character count.
+    """
+    for cols in range(28, 61):
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(cols, 24)) as pilot:
+            await pilot.pause()
+            # The SAME block restated, which is what the settle actually does.
+            # Two blocks compared side by side measure something else: adaptive
+            # spacing gives the second one a gap row when the first is
+            # multi-row, so `virtual_region` differs by one for reasons that
+            # have nothing to do with the copy.
+            row = NoticeBlock(DEFERRED_STEER_NOTICE, "note")
+            app._append_block(row)
+            await pilot.pause()
+            await pilot.pause()
+            before = row.virtual_region.height
+
+            row.restate(DEFERRED_SENT_STEER_NOTICE, "success")
+            await pilot.pause()
+            await pilot.pause()
+
+            assert row.virtual_region.height == before, (
+                f"at {cols} columns the cross-turn settle changes the row from "
+                f"{before} to {row.virtual_region.height} rows"
+            )
+
+
+@pytest.mark.asyncio
+async def test_a_settling_deferred_row_leaves_a_scrolled_up_reader_alone() -> None:
+    """The symptom D2 describes, driven end to end rather than measured statically.
+
+    With the transcript scrolled up mid-history, a shrinking row drops
+    `virtual_size` while `scroll_offset` stays put, so the same offset shows
+    different text and the viewport appears to scroll itself. 52 columns is the
+    width at which base was worst (measured: virtual_size 51 -> 49, 8 of 24
+    viewport rows changed with nothing the user did).
+
+    The assertion is on the FRAME, not on the string: what the user is promised
+    is that nothing below the receipt moves, and a future copy change that
+    reintroduces the reflow has to fail here even if it keeps every word this
+    test could otherwise look for.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(52, 24)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "and use the staging credentials")
+        # History below the receipt, so there is something for a reflow to move
+        # and somewhere for the reader to scroll away from the tail.
+        for index in range(20):
+            app._append_block(NoticeBlock(f"history row {index}", "info"))
+        app.post_message(TurnEnded(True, None))
+        await pilot.pause()
+        await pilot.pause()
+
+        view = app.query_one(TranscriptView)
+        view.scroll_to(y=8, animate=False, immediate=True)
+        await pilot.pause()
+        await pilot.pause()
+
+        before_extent = view.virtual_size.height
+        before_offset = view.scroll_offset.y
+        before_rows = [strip.text.rstrip() for strip in app.screen._compositor.render_strips()]
+
+        app.post_message(SteeringDelivered(1))
+        await pilot.pause()
+        await pilot.pause()
+
+        assert view.virtual_size.height == before_extent, "the settle moved the scrollable extent"
+        assert view.scroll_offset.y == before_offset
+        changed = [
+            (index, before, after)
+            for index, (before, after) in enumerate(
+                zip(
+                    before_rows,
+                    [strip.text.rstrip() for strip in app.screen._compositor.render_strips()],
+                )
+            )
+            if before != after
+        ]
+        # EXACTLY the receipt's own rows change. Anything else is content the
+        # user did not touch moving under them, which is the report.
+        assert all(
+            DEFERRED_STEER_NOTICE.split(" — ")[0] in before
+            or DEFERRED_SENT_STEER_NOTICE.split(" — ")[0] in after
+            or "message" in before
+            or "message" in after
+            for _, before, after in changed
+        ), changed

--- a/tests/unit/tui/test_queued_steer_receipt.py
+++ b/tests/unit/tui/test_queued_steer_receipt.py
@@ -38,7 +38,7 @@ from local_operator.tui.app import (
 )
 from local_operator.tui.events import SteeringDelivered, TurnEnded
 from local_operator.tui.widgets.editor import Editor
-from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
+from local_operator.tui.widgets.transcript import NoticeBlock, NoticeKind, TranscriptView
 
 from .test_app_pilot import FakeSession, _factory
 
@@ -78,6 +78,50 @@ def _notice_blocks(app: OperatorApp) -> list[NoticeBlock]:
 def _notice_texts(app: OperatorApp) -> list[str]:
     """Every notice row's text, in transcript order."""
     return [block._text for block in _notice_blocks(app)]
+
+
+async def _settled_notice_height(cols: int, text: str, kind: NoticeKind) -> int:
+    """The row count ``text`` renders to at ``cols`` columns, read once, settled.
+
+    One block in a FRESH app, rather than one block measured before and after a
+    restate. Two things make that the reliable protocol:
+
+    * The pre-restate reading of a restated block is racy — the region is not
+      always settled after a fixed number of pauses, so it comes back one row
+      short intermittently (review round 1, F2, measured at 1 in 12 at 52
+      columns). Here there is no baseline reading to slip: each string is
+      rendered independently and compared as a number.
+    * A second notice mounted beside the first is given a gap row by adaptive
+      spacing when its neighbour is multi-row, so two blocks in one app differ
+      in ``virtual_region`` for reasons that have nothing to do with the copy.
+
+    The height is taken from the block's OWN wrap of its own text at its own
+    measured width, not from ``virtual_region``. That is what makes it
+    deterministic: ``virtual_region`` is assigned by the compositor, so reading
+    it races the layout pass no matter how many frames are waited — polling it
+    for stability merely trades a fixed pause count for an unsettled plateau,
+    which is the same flake one step removed (observed at a width that moved
+    between runs). ``_rows`` is a pure function of the text and the body width,
+    it is the very computation that decides the row count, and it is what
+    ``_build`` itself calls, so it answers the question the test is actually
+    asking: how many rows does this string occupy here.
+
+    The width is still read from the mounted block, so the transcript's real
+    padding and scrollbar are in the number rather than assumed.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(cols, 24)) as pilot:
+        await pilot.pause()
+        block = NoticeBlock(text, kind)
+        app._append_block(block)
+        await pilot.pause()
+        await pilot.pause()
+        # Mirrors `NoticeBlock._build`: the block reserves a fixed glyph field
+        # and wraps the remainder, so the body is the block's width less that
+        # gutter. Read from the live block rather than recomputed from `cols`.
+        width = max((block.size.width or 80) - 2, 12)
+        body = max(width - block.GLYPH_COLS, 8)
+        return len(block._rows(body))
 
 
 async def _submit(pilot: Any, app: OperatorApp, text: str) -> None:
@@ -755,33 +799,35 @@ async def test_the_cross_turn_settle_does_not_change_the_rows_height() -> None:
     character counts alone cannot tell you — the round-1 candidate was chosen by
     counting and turned out to be the same length as the string it replaced.
 
-    Every width from 28 up, because the crossovers are not where arithmetic on
+    Every width from 20 up, because the crossovers are not where arithmetic on
     the string lengths puts them: the transcript's own padding and scrollbar are
-    in the block's usable width and not in the raw character count.
+    in the block's usable width and not in the raw character count. The binding
+    constraint is WORD SHAPE rather than length — all three receipt strings in
+    play are 43 characters, and `sent — it rode along with the message below`
+    still reflows at 22 and 24 because its tail breaks differently.
+
+    Each string is measured in its OWN app, read once through
+    `_settled_notice_height`, rather than by reading one block before and after
+    a restate. That protocol was racy (review round 1, F2): the pre-restate
+    reading is taken while the block's region may not have settled, so it came
+    back one row short about once in twelve at 52 columns — and over 33 widths
+    that made a red run likely, reporting a copy regression that did not exist.
+    The post-restate reading was never wrong; only the baseline slipped.
     """
-    for cols in range(28, 61):
-        app = OperatorApp(lambda: _factory(FakeSession()))
-        async with app.run_test(size=(cols, 24)) as pilot:
-            await pilot.pause()
-            # The SAME block restated, which is what the settle actually does.
-            # Two blocks compared side by side measure something else: adaptive
-            # spacing gives the second one a gap row when the first is
-            # multi-row, so `virtual_region` differs by one for reasons that
-            # have nothing to do with the copy.
-            row = NoticeBlock(DEFERRED_STEER_NOTICE, "note")
-            app._append_block(row)
-            await pilot.pause()
-            await pilot.pause()
-            before = row.virtual_region.height
-
-            row.restate(DEFERRED_SENT_STEER_NOTICE, "success")
-            await pilot.pause()
-            await pilot.pause()
-
-            assert row.virtual_region.height == before, (
-                f"at {cols} columns the cross-turn settle changes the row from "
-                f"{before} to {row.virtual_region.height} rows"
-            )
+    for cols in range(20, 91):
+        deferred = await _settled_notice_height(cols, DEFERRED_STEER_NOTICE, "note")
+        settled = await _settled_notice_height(cols, DEFERRED_SENT_STEER_NOTICE, "success")
+        # Naming both strings, because the failure a future reader will hit is
+        # "somebody edited the copy", and the message has to point at that
+        # rather than at the transcript.
+        assert deferred == settled, (
+            f"at {cols} columns the receipt strings render to different heights "
+            f"({deferred} vs {settled} rows), so the cross-turn settle reflows "
+            f"the transcript. The copy was edited and its wrap point moved:\n"
+            f"  deferred={DEFERRED_STEER_NOTICE!r}\n"
+            f"  settled ={DEFERRED_SENT_STEER_NOTICE!r}\n"
+            f"Re-run scripts/steer_receipt_candidates.py to pick a replacement."
+        )
 
 
 @pytest.mark.asyncio
@@ -846,3 +892,50 @@ async def test_a_settling_deferred_row_leaves_a_scrolled_up_reader_alone() -> No
             or "message" in after
             for _, before, after in changed
         ), changed
+
+
+@pytest.mark.asyncio
+async def test_a_takeover_still_settles_the_rows_it_deliberately_kept() -> None:
+    """Review round 1, F3: the guard's premise is "the rows went", not "the
+    controller changed", and the two come apart on takeover.
+
+    `_adopt_takeover_session` rotates the transport when the remote facade wins
+    the transcript lease. Unlike `/reload` it is NOT a conversation change: the
+    transcript, the held steer rows and the engine's queue all survive, and its
+    docstring says so. So a drain already in flight across that swap is about a
+    row this app is still holding, and dropping it leaves the receipt stuck on
+    `queued` after the message really went — the exact stale promise #151 and
+    #157 exist to prevent, reintroduced by a guard that over-generalised.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        for _ in range(200):
+            if app._controller is not None:
+                break
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+        assert app._controller is not None, "the session never booted"
+        outgoing_controller = app._controller
+
+        await _submit(pilot, app, "steered just before the lease changed hands")
+        assert QUEUED_STEER_NOTICE in _notice_texts(app)
+        (row,) = app._queued_steer_notices
+
+        # The takeover: a new session object, same conversation, transcript and
+        # held rows deliberately kept.
+        await app._adopt_takeover_session(_Streaming())
+        await pilot.pause()
+        assert app._controller is not outgoing_controller
+        assert app._queued_steer_notices == [row], "takeover must keep the held rows"
+
+        # The drain that was already in flight when the lease changed hands.
+        outgoing_controller._handle_steering_delivered(SteeringDeliveredEvent(count=1))
+        await pilot.pause()
+        await pilot.pause()
+
+        assert row._text == SENT_STEER_NOTICE, (
+            "a takeover keeps the conversation, so the receipt for a message "
+            "that really went must still settle its row"
+        )

--- a/tests/unit/tui/test_queued_steer_receipt.py
+++ b/tests/unit/tui/test_queued_steer_receipt.py
@@ -38,7 +38,11 @@ from local_operator.tui.app import (
 )
 from local_operator.tui.events import SteeringDelivered, TurnEnded
 from local_operator.tui.widgets.editor import Editor
-from local_operator.tui.widgets.transcript import NoticeBlock, NoticeKind, TranscriptView
+from local_operator.tui.widgets.transcript import (
+    NoticeBlock,
+    NoticeKind,
+    TranscriptView,
+)
 
 from .test_app_pilot import FakeSession, _factory
 

--- a/tests/unit/tui/test_user_echo_dedup.py
+++ b/tests/unit/tui/test_user_echo_dedup.py
@@ -37,6 +37,7 @@ import pytest
 
 from local_operator.harness.types import ImageContent
 from local_operator.tui.app import (
+    DEFERRED_SENT_STEER_NOTICE,
     DEFERRED_STEER_NOTICE,
     LOOP_PROMPT,
     SENT_STEER_NOTICE,
@@ -361,7 +362,10 @@ async def test_a_deferred_steer_is_settled_not_repainted_by_the_next_turns_echo(
         app.post_message(UserMessageStart("deferred across the turn", 0, steer_id))
         await pilot.pause()
         texts = _notice_texts(app)
-        assert SENT_STEER_NOTICE in texts and DEFERRED_STEER_NOTICE not in texts
+        # A row deferred ACROSS the turn takes the cross-turn settle: it went
+        # with the message this echo is about (issue #160, D5).
+        assert DEFERRED_SENT_STEER_NOTICE in texts and DEFERRED_STEER_NOTICE not in texts
+        assert SENT_STEER_NOTICE not in texts
         assert len(_user_blocks(app, "deferred across the turn")) == 1
 
 


### PR DESCRIPTION
# PR Description

## Summary of Changes

Three defects on the queued-steer receipt, deferred from #157 into #160: a
pre-existing race that settles the wrong session's row (F3), a settled string
that drops the deferred case's one distinguishing fact (D5), and the same
settle shrinking the row and moving the transcript under the reader (D1/D2).

### F3 — the receipt had no session guard

`_handle_steering_delivered` carried no guard at all, on the reasoning that a
late event finds nothing held and does nothing. That holds **within** a session
and stops holding at a swap. `/reload` disposes the outgoing controller, but an
event it has already dispatched is a Textual message sitting in the app's queue,
and unsubscribing cannot recall one. It is handled after the swap cleared the
held lists, and by then the user may have steered into the **replacement**
session, whose row is held again — so the dying conversation's drain settles a
row about a message it knows nothing about. The emptiness check cannot catch it
precisely because the lists are non-empty again.

The event now carries the controller that posted it, and the app drops a
delivery whose origin is not the controller it currently listens to.

**Identity, not a generation number.** The other `_handle_*` methods guard with
generations, but a generation cannot answer this hazard: generations are
per-controller counters, so the outgoing controller's number is not comparable
with the incoming one's and can collide with it outright. "Which session is this
from?" is the question actually being asked, and object identity answers it.

### D5 — a fourth string, and the argument for it

A row deferred across a turn promises `sends with your next message`. The user
types that message, and the older row flips to `sent — the agent has it now` —
true, but it drops the association, and the receipt sits *above* the message it
travelled with, so the only remaining cue is spatial and reads backwards.

`SENT_STEER_NOTICE` could not simply be re-worded, which is what forces a fourth
string after #132 spent two rounds arguing the set down to three: it also settles
the **same-turn** case, the common path, where the message went at a tool
boundary during the turn the user was watching. A "next message" the user has
already sent is plainly wrong there. The two settles are genuinely two facts, so
the settle now picks per row from the list membership the handler already tracks.

| constant | string |
|---|---|
| `QUEUED_STEER_NOTICE` | `queued — sends when this step finishes` |
| `SENT_STEER_NOTICE` (same turn) | `sent — the agent has it now` |
| `DEFERRED_STEER_NOTICE` | `still queued — sends with your next message` |
| `DEFERRED_SENT_STEER_NOTICE` (new, cross turn) | `sent — it rode along with your next message` |

### D1/D2 — measured, and the framing in the issue turns out to be incomplete

The issue describes one crossover at 53 columns. Measured on the real mounted
block (`scripts/steer_receipt_transitions.py`), the receipt reflows at **three**
transitions across **28 to 52 columns**, not one at 53 — and one of them predates
#157 entirely:

```
cols  q  s  d    q->s (same turn)  q->d (turn end)  d->s (cross turn)
  28  3  2  3    shrink 3->2                        shrink 3->2
  37  2  1  2    shrink 2->1                        shrink 2->1
  ...
  48  1  1  2                      GROW   1->2      shrink 2->1
  52  1  1  2                      GROW   1->2      shrink 2->1
  53  1  1  1

q->s: reflows at [28, 37..47]        <- same-turn settle, PRE-EXISTING
q->d: reflows at [29, 30, 31, 48..52] <- turn-end restate, PRE-EXISTING
d->s: reflows at [28..31, 37..52]     <- the cross-turn settle this PR fixes
```

That is decisive for the copy-versus-layout question the issue poses. No single
settled string can close all three: `queued → sent` and `deferred → sent` need
the settled string to match two *different* lengths at once. So this PR closes
the transition #160 is about, by copy, and leaves the two pre-existing ones
alone rather than half-solving them (see *Deliberately not done*).

`DEFERRED_SENT_STEER_NOTICE` is 43 characters and renders to the **same height
as `DEFERRED_STEER_NOTICE` at every width from 28 to 80**, so the cross-turn
settle rewrites the row in place and moves nothing below it.

**Chosen by measurement, not by counting.** The issue records the round-1
candidate `sent with your next message` being offered as "27 → 28 characters"
when it is in fact 27, identical to the string it replaced. Candidates were
therefore rendered in a mounted block at every width
(`scripts/steer_receipt_candidates.py`) rather than measured with `len()`; the
raw character count is not the wrap point, because the transcript's padding and
scrollbar are in the block's usable width and not in the string:

```
len= 45 'sent with your message — the agent has it now'   differs at [53, 54]
len= 41 'sent — the agent has it with your message'       differs at [30, 31, 51, 52]
len= 45 'sent — it went with the message you just sent'   differs at [32, 53, 54]
len= 43 'sent — it rode along with your next message'     MATCHES deferred at every width
len= 27 'sent — the agent has it now'  (current)          differs at [28..31, 37..52]
```

The three probe scripts ship because the copy's **length is load-bearing**: a
word added or dropped from either string silently reintroduces the reflow, and
the regression test below is what makes that fail loudly instead.

## Testing Evidence

### F3 — the race constructed, failing on base and passing at head

The reviewer on #157 could not construct this without deliberately racing
dispose, so the test drives that ordering directly: the outgoing controller's
handler is invoked, the swap runs, the user steers into the new session, and
only then is the dead controller's message handled.

Against **`origin/main`** (the new test, with the new constant aliased to the
shared string so it compiles):

```
$ .venv/bin/python -m pytest ... -k dead_sessions
>           assert new_row._text == QUEUED_STEER_NOTICE
E           AssertionError: assert 'sent — the agent has it now' == 'queued — sen...step finishes'
E             - queued — sends when this step finishes
E             + sent — the agent has it now
1 failed
```

The new session's row is falsely settled by the dead session's drain. At **head**:

```
$ .venv/bin/python -m pytest tests/unit/tui/test_queued_steer_receipt.py -q
19 passed
```

The test also asserts the **live** controller's delivery still settles the row,
so the guard refuses the stale event rather than the event type.

### D1/D2 — geometry, before and after

`scripts/steer_receipt_probe.py` drives the real app, puts one row into the
deferred state, and reports the frame either side of the delivery. Both scroll
states, since the issue notes only the scrolled-up one shows the jump.

**Base (`origin/main`), 52 columns:**

```
--- 52 cols, pinned to bottom
  before h=2 virtual_size=51 scroll_offset=36 max_scroll_y=36 'still queued — sends with your next message'
  after  h=1 virtual_size=49 scroll_offset=34 max_scroll_y=34 'sent — the agent has it now'
  viewport rows changed: 1/24
--- 52 cols, scrolled up
  before h=2 virtual_size=51 scroll_offset=25 max_scroll_y=36 'still queued — sends with your next message'
  after  h=1 virtual_size=49 scroll_offset=25 max_scroll_y=34 'sent — the agent has it now'
  viewport rows changed: 8/24
```

Row 2 → 1, extent 51 → 49, offset pinned at 25, and **8 of 24 viewport rows
change with nothing the user did**.

**Head, same widths:**

```
--- 52 cols, pinned to bottom
  before h=2 virtual_size=51 scroll_offset=36 max_scroll_y=36 'still queued — sends with your next message'
  after  h=2 virtual_size=51 scroll_offset=36 max_scroll_y=36 'sent — it rode along with your next message'
  viewport rows changed: 0/24
--- 52 cols, scrolled up
  before h=2 virtual_size=51 scroll_offset=25 max_scroll_y=36 'still queued — sends with your next message'
  after  h=2 virtual_size=51 scroll_offset=25 max_scroll_y=34 'sent — it rode along with your next message'
  viewport rows changed: 1/24
```

Height held at 2, extent held at 51, and the only row that changes is the
receipt's own. Pinned-to-bottom goes from 1 changed row to 0. At 53 columns
(where base was already clean) nothing regresses.

After the fix, the transition sweep reports:

```
d->ds: reflows at no width
```

### Rendered frames, 52 columns, scrolled up

Captured with `app.save_screenshot` per AGENTS.md "Visual validation" and viewed
as rendered images. The same frames as painted text, so the movement is legible
in the diff — `->` marks a viewport row whose content changed, with the reader
having touched nothing.

**Base (`origin/main`)** — the receipt collapses to one row and drags eight rows
of history up behind it; `history row 34` and `35` are pulled into view:

```
BEFORE                                          | AFTER
                                               | 
                                               | 
    · history row 25                           |     · history row 25
    · history row 26                           |     · history row 26
    · history row 27                           |     · history row 27
    · history row 28                           |     · history row 28
    · history row 29                           |     · history row 29
                                               | 
  ▌ and use the staging credentials            |   ▌ and use the staging credentials
                                             ->|                                             
    · still queued — sends with your next    ->|     ✓ sent — the agent has it now
      message                                ->|     · history row 30
                                             ->|     · history row 31
    · history row 30                         ->|     · history row 32
    · history row 31                         ->|     · history row 33                        
    · history row 32                         ->|     · history row 34
    · history row 33                         ->|     · history row 35
                                               | 
                                               | 
  ❯   Message Local Operator…                  |   ❯   Message Local Operator…
                                               | 
  ◆ test/model › ⌂ lop-steer-base              |   ◆ test/model › ⌂ lop-steer-base           
                                               | 
                                               |
```

**Head** — the receipt keeps its two rows, `history row 30` through `33` stay
exactly where they were, and the text now names the association the layout
could not:

```
BEFORE                                          | AFTER
                                               | 
                                               | 
    · history row 25                           |     · history row 25
    · history row 26                           |     · history row 26
    · history row 27                           |     · history row 27
    · history row 28                           |     · history row 28
    · history row 29                           |     · history row 29
                                               | 
  ▌ and use the staging credentials            |   ▌ and use the staging credentials
                                               |                                             
    · still queued — sends with your next    ->|     ✓ sent — it rode along with your next
      message                                  |       message
                                               | 
    · history row 30                           |     · history row 30                        
    · history row 31                           |     · history row 31
    · history row 32                           |     · history row 32
    · history row 33                           |     · history row 33
                                               | 
                                               | 
  ❯   Message Local Operator…  ctrl+v pastes   |   ❯   Message Local Operator…  ctrl+v pastes
                                               | 
  ◆ test/model › ⌂ lop-steer-receipt           |   ◆ test/model › ⌂ lop-steer-receipt        
                                               | 
                                               |
```

### Regression tests, all three failing on base

```
$ cd <worktree on origin/main>; pytest -k "height or scrolled_up_reader or dead_sessions"
FAILED test_a_dead_sessions_delivery_cannot_settle_the_new_sessions_row
        - assert 'sent — the agent has it now' == 'queued — sends when this step finishes'
FAILED test_the_cross_turn_settle_does_not_change_the_rows_height
        - at 28 columns the cross-turn settle changes the row from 3 to 2 rows
FAILED test_a_settling_deferred_row_leaves_a_scrolled_up_reader_alone
        - the settle moved the scrollable extent
3 failed
```

The height test restates **the same block** rather than comparing two, because
adaptive spacing gives a second adjacent notice a gap row and that difference
has nothing to do with the copy. The scrolled-up test asserts on the **frame**
(extent, offset, which rows changed) rather than on any string, so a future copy
change that reintroduces the reflow fails even if it keeps the words.

### Gates

Measured at the current head `3005e3a4`, by EXIT CODE, whole tree, repo config
— no narrowing to a path, no `--profile black`, no `| tail`, no `2>/dev/null`.
That form is not pedantry: this PR's round 1 claimed "isort clean" from a
path-narrowed run and round 2 (F7) found it red, and isort's stdout is
byte-identical on pass and fail (`Skipped 1 files` either way), so only the rc
distinguishes them. black's banner goes to stderr for the same reason.

```
.venv/bin/python -m flake8 .                          rc=0
uvx --from black==26.1.0 black --check .              rc=0
uvx isort==5.13.2 --check .                           rc=0
pyright --pythonpath .venv/bin/python .               rc=0
pytest test_queued_steer_receipt + test_user_echo_dedup
       + test_esc_recall + test_events (-n0)          rc=0
```

The full unit suite was run once at the original head (8789 passed, 15 skipped);
the failures at that time were load-sensitive timing tests unrelated to this
change, verified pre-existing on unmodified `origin/main`. It has not been re-run
on every subsequent head because the standing RAM constraint on this machine
forbids a second pytest pool while other sessions hold one.

The full-suite failures are all load-sensitive timing tests unrelated to this
change — this machine was running several agent sessions concurrently. Verified
as pre-existing rather than assumed:
`tests/unit/mobile/test_child_reaper.py::test_viewers_do_not_change_idle_timing`
fails **5 runs out of 5 on unmodified `origin/main`**, and every other failure
(`test_tui_responsiveness`, `test_launch_subagent`, `test_resume_subagents_todos`,
`test_paste_clipboard`, `test_transcript_selection`, and
`test_app_pilot::test_esc_aborts_a_running_shell_command`) passes when re-run in
isolation on this branch. None touch the steer receipt.

## Deliberately not done

- **The two pre-existing reflows the measurement uncovered** — the same-turn
  settle (`queued → sent`, 28 and 37–47 columns) and the turn-end restate
  (`queued → deferred`, 29–31 and 48–52 columns). Both predate #157, neither is
  in #160's scope, and closing them means either a fifth string or a real layout
  answer (reserving row height across a restate) that would touch `NoticeBlock`
  for every caller. Reported rather than half-solved.
- **A general layout fix.** Pinning the row's height across a restate would close
  all three bands at once and is the more complete answer, but it changes a
  shared widget's contract for every notice in the app, which is a much larger
  and riskier change than the issue asks for. Noted as the follow-up if the two
  bands above are judged worth closing.

Closes #160

