### PR TITLE
feat(tui): expanded todo footer says how much is left

### DIFF
--- a/local_operator/tui/widgets/todo_panel.py
+++ b/local_operator/tui/widgets/todo_panel.py
@@ -490,6 +490,14 @@ class TodoPanel(Container):
         # a status surface with no other tick to ride (the 1 Hz poll returns
         # early on the guard). `init=False` because the first paint composes its
         # own footer.
+        #
+        # RESIZE is deliberately NOT watched (design round 1, D4). A resize
+        # changes the budget, which IS in the equality guard, so `sync` rebuilds
+        # the body and recomposes the footer on the same pass — verified by the
+        # reviewer at 100x30 -> 100x60 (footer correctly drops to bare) and back
+        # to 100x24 (correctly restates the remainder). Adding a resize watcher
+        # would be a second path to the same repaint, which is the drift this
+        # panel's single-authority rules exist to prevent.
         self.watch(self._scroll, "scroll_y", self._repaint_expanded_footer, init=False)
 
     # -- sync -----------------------------------------------------------------
@@ -1177,10 +1185,11 @@ class TodoPanel(Container):
         row.append("ctrl+t to collapse" if self._expanded else "ctrl+t to expand", style=muted)
         return row
 
-    def _expanded_viewport(self) -> tuple[int, int]:
-        """``(first_body_line, rows)`` the expanded scroll region is showing.
+    def _expanded_viewport(self) -> tuple[int, int, int]:
+        """``(first_body_line, rows, max_scroll)`` for the expanded scroll region.
 
-        The window the footer describes, in BODY-LINE coordinates.
+        The window the footer describes, in BODY-LINE coordinates, plus how far
+        the region can still travel.
 
         ``rows`` restates :meth:`sync`'s own ``max_height`` expression (the row
         budget minus the pinned affordance row) rather than reading the region's
@@ -1191,33 +1200,49 @@ class TodoPanel(Container):
         for a viewport that no longer exists — with no later event to correct it,
         since a scroll is the only thing that repaints the footer and the reader
         has not scrolled yet. Restating sync's expression makes the two agree by
-        construction. It is a CAP, so it equals the painted viewport whenever the
-        body overflows, which is the only case that paints a footer at all: a
-        body shorter than the cap is fully visible and returns no footer.
+        construction.
+
+        ``max_scroll`` is derived the same way (body lines minus the viewport)
+        rather than read off ``self._scroll.max_scroll_y``, for that same
+        staleness reason and so the build path and the scroll path answer "is
+        there more below?" from ONE expression. Once the region has settled the
+        two agree; before it has, only this one is right.
         """
         rows = max(1, self._body_rows() - 1)
         # ``scroll_y`` is a float reactive mid-animation; the fold is a row index.
         offset = max(0, int(self._scroll.scroll_y))
-        return offset, rows
+        max_scroll = max(0, self._expanded_body_lines - rows)
+        return min(offset, max_scroll), rows, max_scroll
 
     def _expanded_footer(self, affordance: Text) -> Text:
         """Prefix the expanded control row with position + overflow (#264, #265).
 
-        ONE footer, not two bolted together. ``↓ 12 of 18 · ctrl+t to collapse``
-        answers both deferred findings with a single set of numbers: the arrow is
-        U4's "content continues below" cue for a reader who never sees the
-        scrollbar thumb (keyboard-only, or a short window where the thumb is one
-        cell), and ``12 of 18`` is U5's orientation. Painting both suggestions
-        literally (``12 of 18 · ↓ 6 below``) would state one fact twice — the
-        remainder is just ``18 - 12`` — so the arrow rides the position instead of
-        repeating it. ``12`` is the LAST todo the viewport reaches, so scrolling
-        to the end lands on ``18 of 18`` and the arrow drops: the cue disappears
-        exactly when there is nothing below, which is the honesty U4 asks for.
+        ONE footer, not two bolted together. ``↓ 6 more · ctrl+t to collapse``
+        answers both deferred findings with a SINGLE number: the arrow is U4's
+        "content continues below" cue for a reader who never sees the scrollbar
+        thumb (keyboard-only, or a short window where the thumb is one cell), and
+        the remainder is U5's orientation. Painting both suggestions literally
+        (``12 of 18 · ↓ 6 below``) would state one fact twice, so only one number
+        is carried.
+
+        WHICH number is ``N more``, not ``N of M`` (UX round 1, U2). ``N of M``
+        looked like the richer choice, but every convention a terminal reader
+        brings to it — pagers, ``less``, search results — makes ``N`` the CURRENT
+        item, while the only ``N`` this panel can compute is the last todo the
+        viewport reaches. Items carry no ordinals, so no visible row can confirm
+        the number, and an unverifiable number invites the other reading ("N are
+        showing"), which is also false. A REMAINDER needs no ordinals to be
+        checked: scroll, and it goes down. It also mirrors the collapsed
+        ``+11 more`` the same reader saw one keypress earlier, so the vocabulary
+        is learned rather than novel, and it is the cheapest string of the
+        candidates — which is what keeps the cue alive at narrow widths (U1).
 
         Appears ONLY when the body actually overflows its viewport. An expanded
         list that fits entirely is not a place a reader can be lost in, and a
-        permanent ``5 of 5`` would be chrome that never changes — the collapsed
-        state does not confess a remainder it does not have either.
+        permanent ``0 more`` would be chrome that never changes — the collapsed
+        state does not confess a remainder it does not have either. At the END of
+        a scroll the remainder is zero and the prefix legitimately vanishes, so
+        its absence MEANS "nothing more" instead of being ambiguous.
 
         INK — ``dim``, the SAME tier as the collapsed ``+N more`` prefix, and
         deliberately not ``muted``. This is the expanded mirror of that prefix (a
@@ -1235,28 +1260,90 @@ class TodoPanel(Container):
         grew would spend the narrow width on the count and leave ``ctrl+t to
         colla…`` — shedding the affordance and keeping the summary, the exact
         inversion ``usage_panel._hint_row`` documents. The hotkey is the one
-        token that must always survive; position is polish.
+        token that must always survive; the remainder is polish.
+
+        The fit is tested against the prefix's WIDEST rendering for this list,
+        not the one being painted (U1). Testing the current string made the cue's
+        presence depend on how many digits the number happened to have, so at 34
+        columns it survived ``↓ 9 more`` and vanished at ``↓ 10 more`` — showing
+        the reader the exact pre-change "this is everything" row with eight todos
+        still hidden. Worse than never showing it, because absence had been
+        taught to mean something. Sizing on the widest value makes the cue a
+        property of the width and the list length alone: it can no longer appear
+        and disappear under a reader who is only scrolling.
+
+        The ARROW is never shed. When the widest prefix does not fit, the NUMBER
+        goes and a bare ``↓ ·`` stays, because the arrow is U4's actual cue while
+        the count is only U5's orientation — a footer that drops the arrow to
+        keep a number has shed the finding it exists to answer.
         """
         total = len(self._expanded_item_rows)
         if not total:
             return affordance
-        offset, rows = self._expanded_viewport()
-        if self._expanded_body_lines <= rows:
-            return affordance  # fits entirely: no position to state, no overflow
-        # ``seen`` counts TODOS at or above the fold, so the number tracks the
+        offset, rows, max_scroll = self._expanded_viewport()
+        if max_scroll <= 0:
+            return affordance  # fits entirely: nothing below, nothing to confess
+        # ``seen`` counts TODOS at or above the fold, so the remainder tracks the
         # list the user is reading rather than the rows the panel happens to
         # paint (phase headers and the root line are not todos).
         fold = offset + rows
         seen = sum(1 for index in self._expanded_item_rows if index < fold)
-        seen = max(1, min(total, seen))
-        prefix = Text(no_wrap=True, overflow="ellipsis")
-        arrow = "↓ " if seen < total else ""
-        prefix.append(
-            f"{arrow}{seen} of {total} · ", style=Style(color=theme_mod.semantic_color("dim"))
-        )
+        remaining = max(0, total - max(0, min(total, seen)))
+        # THE ARROW RIDES THE BODY, NOT THE TODO COUNT (design round 1, D2).
+        # ``remaining`` counts todos, but the thing that SCROLLS is the body, and
+        # the two disagree whenever the lines below the fold are chrome: a plan
+        # ending in an empty phase painted ``no arrow`` with its ``Gamma · 0/0``
+        # header still hidden, contradicting the scrollbar thumb in the same
+        # frame. "Is there more to see?" is a question about the viewport, so it
+        # is answered from the viewport.
+        more_below = offset < max_scroll
+        dim = Style(color=theme_mod.semantic_color("dim"))
         cells = self._row_cells()
-        if cells and prefix.cell_len + affordance.cell_len > cells:
-            return affordance  # too narrow for both: the hotkey wins outright
+        # Sized on the WIDEST remainder this list can show (U1): ``total`` at the
+        # top of the scroll. Whatever fits must fit at every position, or the cue
+        # is not offered at all.
+        widest = Text(f"↓ {total} more · ", no_wrap=True, overflow="ellipsis")
+        if cells and widest.cell_len + affordance.cell_len > cells:
+            if not more_below:
+                return affordance
+            # Too narrow for the number: keep the arrow alone rather than lose
+            # the cue. Still width-tested, so the hotkey outranks even this.
+            bare = Text(no_wrap=True, overflow="ellipsis")
+            bare.append("↓ · ", style=dim)
+            if cells and bare.cell_len + affordance.cell_len > cells:
+                return affordance  # too narrow for both: the hotkey wins outright
+            bare.append_text(affordance)
+            return bare
+        if not more_below:
+            # END OF THE SCROLL — no remainder, so no prefix. The row becomes
+            # byte-identical to the no-overflow footer, which is correct because
+            # both mean "nothing is hidden" (UX round 1, U4). Absence can carry
+            # that meaning only because the widest-fit rule above guarantees the
+            # prefix never disappears for any OTHER reason.
+            return affordance
+        prefix = Text(no_wrap=True, overflow="ellipsis")
+        if not remaining:
+            # More body below, but no more TODOS — the remainder is chrome, e.g.
+            # the header of a trailing phase with no items. ``↓ 0 more`` would be
+            # nonsense and ``↓ 1 more`` would be a lie, so the arrow says
+            # "keep going" without quantifying what is left. This is the seam
+            # D2's separation of concerns opens: the arrow answers the viewport,
+            # the number answers the todo list, and only here do they diverge.
+            prefix.append("↓ more · ", style=dim)
+            prefix.append_text(affordance)
+            return prefix
+        # The remainder is right-aligned in the widest number's field (design
+        # round 1, D1 — the column-stability finding, re-aimed at this wording).
+        # D1 measured the hotkey jumping two cells when the arrow dropped under
+        # ``N of M``; its literal remedy (two reserved spaces) does not transplant
+        # here, because ``N more`` sheds the WHOLE prefix at the end rather than
+        # just the arrow. The same defect class survives the rewording in a form
+        # that bites more often, though: ``↓ 10 more`` -> ``↓ 9 more`` is a
+        # one-cell shift at every power-of-ten boundary, mid-scroll, with the
+        # reader watching. Padding to ``len(str(total))`` pins the hotkey's column
+        # across every position the prefix is shown at, so the only time it moves
+        # is the single deliberate transition to the end state.
+        prefix.append(f"↓ {remaining:>{len(str(total))}} more · ", style=dim)
         prefix.append_text(affordance)
         return prefix
 

--- a/local_operator/tui/widgets/todo_panel.py
+++ b/local_operator/tui/widgets/todo_panel.py
@@ -371,11 +371,16 @@ class TodoPanel(Container):
         self._affordance = TodoAffordance()
         #: What is painted, as an equality guard the 1 Hz poll repaints only on
         #: change (same discipline as the assistant flush). The state tuple is
-        #: ``(fingerprint, budget, expanded, hidden_phase_names)`` (design §7.3):
+        #: ``(fingerprint, budget, cells, expanded, hidden_phase_names)``
+        #: (design §7.3):
         #: * fingerprint — ``(phase_name, text, status, reason)`` per item, so a
         #:   phase rename or an item moving phases repaints;
         #: * budget — the same list renders a different number of rows when its
         #:   space changes;
+        #: * cells — the width a row is clipped against (UX round 2, U7). The
+        #:   budget is a HEIGHT, so a width-only resize would otherwise no-op
+        #:   and leave the compositor cropping a 30-cell footer into a 16-cell
+        #:   region, cutting ``ctrl+t`` itself;
         #: * expanded — a ``ctrl+t`` toggle changes what is shown with no store
         #:   change, so it must be in the guard or the toggle would no-op;
         #: * hidden — a phase crossing the auto-hide threshold changes the view
@@ -385,6 +390,7 @@ class TodoPanel(Container):
                 str,
                 str | None,
                 tuple[tuple[str, str, str, str], ...],
+                int,
                 int,
                 bool,
                 frozenset[str],
@@ -491,13 +497,14 @@ class TodoPanel(Container):
         # early on the guard). `init=False` because the first paint composes its
         # own footer.
         #
-        # RESIZE is deliberately NOT watched (design round 1, D4). A resize
-        # changes the budget, which IS in the equality guard, so `sync` rebuilds
-        # the body and recomposes the footer on the same pass — verified by the
-        # reviewer at 100x30 -> 100x60 (footer correctly drops to bare) and back
-        # to 100x24 (correctly restates the remainder). Adding a resize watcher
-        # would be a second path to the same repaint, which is the drift this
-        # panel's single-authority rules exist to prevent.
+        # RESIZE is deliberately NOT watched here (design round 1, D4), because
+        # `sync`'s equality guard already covers it on BOTH axes: height through
+        # the budget, and width through `_row_cells()` (UX round 2, U7 — the
+        # width term was missing and an edge drag left the row composed for the
+        # old width). A resize therefore rebuilds the body and recomposes the
+        # footer on the same pass. Adding a resize watcher would be a second path
+        # to the same repaint, which is the drift this panel's single-authority
+        # rules exist to prevent.
         self.watch(self._scroll, "scroll_y", self._repaint_expanded_footer, init=False)
 
     # -- sync -----------------------------------------------------------------
@@ -589,11 +596,25 @@ class TodoPanel(Container):
             # Session identity belongs in the guard even when both lists are
             # empty or byte-identical: retargeting must never retain another
             # session's panel state or delayed phase-hide clocks.
+            # WIDTH rides the guard beside the budget (UX round 2, U7). The
+            # budget is ``_body_rows()``, which is a HEIGHT, so a width-only
+            # resize (an edge drag) changed nothing in this tuple and the guard
+            # returned early holding a row composed for a width that no longer
+            # existed. Rows are clipped against ``_row_cells()`` (see
+            # :meth:`_row_cells`), and the expanded footer's shed decision reads
+            # the same value, so a stale width leaves the compositor cropping a
+            # 30-cell row into a 16-cell region — cutting ``ctrl+t`` itself, the
+            # one token that must always survive. Main never showed this on the
+            # expanded row because its 18-cell row was too short to be cropped
+            # past the hotkey; this row is long enough to be harmed, so the
+            # pre-existing hole became user-visible here and is closed here.
+            cells = self._row_cells()
             state = (
                 selected_id,
                 transcript_directory,
                 fingerprint,
                 budget,
+                cells,
                 self._expanded,
                 hidden,
             )
@@ -1273,9 +1294,32 @@ class TodoPanel(Container):
         and disappear under a reader who is only scrolling.
 
         The ARROW is never shed. When the widest prefix does not fit, the NUMBER
-        goes and a bare ``↓ ·`` stays, because the arrow is U4's actual cue while
+        goes and a bare ``↓`` stays, because the arrow is U4's actual cue while
         the count is only U5's orientation — a footer that drops the arrow to
-        keep a number has shed the finding it exists to answer.
+        keep a number has shed the finding it exists to answer. The separator
+        goes WITH the number it was separating (UX round 2 U8 / design round 2
+        D7): ``↓ ·`` left a bullet with nothing on its left, which read as a
+        count that had failed to render rather than as a deliberate shed.
+
+        WHY THE NUMBER COUNTS TODOS AND NOT BODY ROWS, given that the arrow is
+        derived from body rows (D2) and that counting rows would delete the
+        numberless seam below outright: the COLLAPSED row's ``+N more`` counts
+        todos (``hidden_done + hidden_open``), and the pairing between the two
+        rows is the whole reason this wording was chosen — same noun, same
+        position, same tier, one glyph swapped, as UX round 2 confirmed a reader
+        experiences it. Counting body rows here would leave ``+11 more`` and
+        ``↓ 9 more`` saying "more" about two different things one keypress apart,
+        and a reader who scrolled and counted todos would find the number simply
+        wrong — a verifiable falsehood, which is worse than the unverifiable one
+        U2 rejected. The seam is paid for with alignment instead (see below).
+
+        A KNOWN COST of the widest-fit rule (UX round 2, U9): the prefix is a
+        function of width AND list length, and list length is something a live
+        agent session changes constantly. A list growing past a digit boundary at
+        a narrow width can therefore trade the count for the bare arrow with no
+        scroll and no resize. The arrow survives — the reader is never told "this
+        is everything" when it is not — so this is orientation lost, not a lie,
+        and it is the accepted price of the rule that closed U1.
         """
         total = len(self._expanded_item_rows)
         if not total:
@@ -1307,9 +1351,11 @@ class TodoPanel(Container):
             if not more_below:
                 return affordance
             # Too narrow for the number: keep the arrow alone rather than lose
-            # the cue. Still width-tested, so the hotkey outranks even this.
+            # the cue. Still width-tested, so the hotkey outranks even this. The
+            # separator goes with the number it separated (U8/D7) — ``↓ ·`` read
+            # as a bullet whose noun failed to render.
             bare = Text(no_wrap=True, overflow="ellipsis")
-            bare.append("↓ · ", style=dim)
+            bare.append("↓ ", style=dim)
             if cells and bare.cell_len + affordance.cell_len > cells:
                 return affordance  # too narrow for both: the hotkey wins outright
             bare.append_text(affordance)
@@ -1329,7 +1375,14 @@ class TodoPanel(Container):
             # "keep going" without quantifying what is left. This is the seam
             # D2's separation of concerns opens: the arrow answers the viewport,
             # the number answers the todo list, and only here do they diverge.
-            prefix.append("↓ more · ", style=dim)
+            #
+            # Padded into the SAME field as every numbered position (design
+            # round 2, D6). Left unpadded this row was 3 cells narrower than its
+            # siblings and moved the hotkey one notch BEFORE the deliberate
+            # end-state move, so a reader scrolling to the bottom saw the
+            # affordance shift twice where the design intends once — D1's exact
+            # defect class, re-opened by the row that fixed D2.
+            prefix.append(f"↓ {'':>{len(str(total))}} more · ", style=dim)
             prefix.append_text(affordance)
             return prefix
         # The remainder is right-aligned in the widest number's field (design

--- a/local_operator/tui/widgets/todo_panel.py
+++ b/local_operator/tui/widgets/todo_panel.py
@@ -254,6 +254,19 @@ def select_collapsed(items: list[dict[str, Any]], cap: int) -> tuple[list[dict[s
     return [*lead, *within], hidden
 
 
+def _item_line_indices(lines: list[Text]) -> list[int]:
+    """Body-line indices that carry a TODO, in paint order.
+
+    The expanded footer counts TODOS, not rows: a body line is a phase header,
+    the root ``stage`` line, or an item, and a position that counted chrome
+    would tell the reader ``14 of 21`` about an eighteen-item list. Item rows are
+    recognised by the tool's own ``- [`` mark, the same predicate
+    :meth:`TodoPanel._guarantee_expanded_item` already uses to find the first
+    item — one way of asking "is this a todo row?", not two.
+    """
+    return [i for i, line in enumerate(lines) if "- [" in line.plain]
+
+
 def _active_phase_index(phases: list[dict[str, Any]]) -> int:
     """Index of the EARLIEST phase still holding open work — the collapsed
     view's viewport anchor (omp ``formatSummary``'s ``currentIdx``, todo.ts:732).
@@ -395,6 +408,15 @@ class TodoPanel(Container):
         #: line count, and the two must agree or the band reflows on the first
         #: frame (see :meth:`predicted_rows`).
         self._painted_rows: int = 0
+        #: Body-line indices carrying a todo, and the body's total line count,
+        #: as of the last EXPANDED paint — the two numbers the position footer
+        #: (#264/#265) is computed from. Recorded at paint time because the
+        #: scroll-time repaint (:meth:`_repaint_expanded_footer`) has no phases
+        #: to rebuild from and must not re-read the store: a scroll changes the
+        #: viewport, never the list. Empty whenever the panel is collapsed or the
+        #: affordance was dropped, which is what makes "no footer" the default.
+        self._expanded_item_rows: list[int] = []
+        self._expanded_body_lines: int = 0
         self._restored_todos: dict[str, list[dict[str, Any]]] = {}
         self._todo_loads: dict[str, asyncio.Task[None]] = {}
         # Hidden until the first todo exists: an empty panel is not content.
@@ -458,6 +480,17 @@ class TodoPanel(Container):
         # guard still governs a single repaint.
         yield self._scroll
         yield self._affordance
+
+    def on_mount(self) -> None:
+        # The expanded footer's position is a function of the scroll offset, and
+        # a scroll repaints nothing on its own — `sync`'s equality guard covers
+        # the store, the budget, the expanded flag and the hidden set, none of
+        # which a wheel notch or a `ctrl+down` moves. Watching the reactive is
+        # the only signal that fires exactly when the count changes; the panel is
+        # a status surface with no other tick to ride (the 1 Hz poll returns
+        # early on the guard). `init=False` because the first paint composes its
+        # own footer.
+        self.watch(self._scroll, "scroll_y", self._repaint_expanded_footer, init=False)
 
     # -- sync -----------------------------------------------------------------
     async def _load_restored_todos(
@@ -646,7 +679,6 @@ class TodoPanel(Container):
         (defect 2). Both list-of-rows results and the affordance are clipped to
         width here, uniformly, so no row can push the band past the screen.
         """
-        dim = Style(color=theme_mod.semantic_color("dim"))
         # The headerless back-compat path is the IMPLICIT single phase only, so
         # the panel and the ``view`` receipt make the identical choice (design
         # §5.2 — one list spelled one way). ``builtin._todo_view_text`` gates its
@@ -673,26 +705,50 @@ class TodoPanel(Container):
         if self._expanded and affordance is not None:
             lines, affordance = self._guarantee_expanded_item(lines, affordance)
 
+        # EXPANDED POSITION/OVERFLOW FOOTER (#264 U4 + #265 U5). Composed HERE,
+        # not inside ``_affordance_row``, because it is a function of the FINAL
+        # line list: ``_guarantee_expanded_item`` above may have dropped chrome
+        # rows or the affordance itself, and a footer computed before that would
+        # describe a viewport the panel no longer paints.
+        if self._expanded and affordance is not None:
+            self._expanded_item_rows = _item_line_indices(lines)
+            self._expanded_body_lines = len(lines)
+            affordance = self._expanded_footer(affordance)
+        else:
+            self._expanded_item_rows = []
+            self._expanded_body_lines = 0
+
         # The clip happens HERE, against a width, because nothing in the layout
         # supplies one (see :meth:`_row_cells`). Applied uniformly to headers,
         # items and the affordance so no row can push the band past the screen.
-        cells = self._row_cells()
-        if cells:
-            for line in [*lines, *([affordance] if affordance is not None else [])]:
-                if line.cell_len <= cells:
-                    continue
-                # Rich's own ``overflow="ellipsis"`` leaves the cut as "word …"
-                # whenever it lands on a space, so the same row would truncate in
-                # two typographic styles one column apart. The project's one
-                # truncator rstrips first (``tool_card.truncate_cells``) and this
-                # does the same, span-aware: crop a cell short, drop the trailing
-                # space, then spend that cell on the marker — which is `dim`
-                # because a truncation mark is chrome, not part of the sentence.
-                line.truncate(cells - 1, overflow="crop")
-                while line.plain.endswith(" "):
-                    line.right_crop(1)
-                line.append("…", style=dim)
+        for line in [*lines, *([affordance] if affordance is not None else [])]:
+            self._clip_row(line)
         return Text("\n").join(lines), affordance
+
+    def _clip_row(self, line: Text) -> None:
+        """Truncate one composed row to the width it is drawn at, IN PLACE.
+
+        This panel's single truncator, shared by :meth:`_build`'s uniform pass
+        and the scroll-time footer repaint (:meth:`_repaint_expanded_footer`): a
+        footer that gains its ``N of M`` prefix mid-scroll must be cut the same
+        way as one that carried it from the last full paint, or the same row
+        truncates in two typographic styles depending on how it got there.
+
+        Rich's own ``overflow="ellipsis"`` leaves the cut as "word …" whenever it
+        lands on a space, so the same row would truncate in two typographic
+        styles one column apart. The project's one truncator rstrips first
+        (``tool_card.truncate_cells``) and this does the same, span-aware: crop a
+        cell short, drop the trailing space, then spend that cell on the marker —
+        which is ``dim`` because a truncation mark is chrome, not part of the
+        sentence.
+        """
+        cells = self._row_cells()
+        if not cells or line.cell_len <= cells:
+            return
+        line.truncate(cells - 1, overflow="crop")
+        while line.plain.endswith(" "):
+            line.right_crop(1)
+        line.append("…", style=Style(color=theme_mod.semantic_color("dim")))
 
     def _build_flat(self, items: list[dict[str, Any]]) -> tuple[list[Text], Text | None]:
         """The single-phase (implicit ``\"Todos\"``) render — HEADERLESS and
@@ -1094,7 +1150,13 @@ class TodoPanel(Container):
         with ``0, 0`` and never carries a hidden-count prefix. This corrects the
         original design's "expanded is bounded by ``_body_rows()`` too": expanded
         genuinely reveals every todo (defect 1), so there is no hidden remainder
-        left to confess.
+        left to confess. That invariant is why the expanded POSITION footer
+        (#264/#265) is composed in :meth:`_expanded_footer` on top of this row
+        rather than inside it: ``N of M`` states where the viewport sits in a
+        list that is entirely present, which is a different claim from
+        collapsed's ``+N more`` confession that items are missing. Keeping the
+        two apart is what stops the position count from being mistaken for a
+        hidden remainder returning.
 
         The hidden-count prefix stays ``dim`` (chrome — a running total), but the
         ``ctrl+t`` hotkey token steps up to ``muted`` (D3/U3): fully ``dim`` it is
@@ -1114,6 +1176,115 @@ class TodoPanel(Container):
                 row.append(f"+{hidden_done} done · ", style=dim)
         row.append("ctrl+t to collapse" if self._expanded else "ctrl+t to expand", style=muted)
         return row
+
+    def _expanded_viewport(self) -> tuple[int, int]:
+        """``(first_body_line, rows)`` the expanded scroll region is showing.
+
+        The window the footer describes, in BODY-LINE coordinates.
+
+        ``rows`` restates :meth:`sync`'s own ``max_height`` expression (the row
+        budget minus the pinned affordance row) rather than reading the region's
+        ``content_size``. That is not a shortcut, it is the only correct source
+        here: :meth:`_build` runs BEFORE ``sync`` applies the new cap, so on the
+        frame a ``ctrl+t`` expands the panel ``content_size`` still holds the
+        COLLAPSED height, and a footer computed from it would state a position
+        for a viewport that no longer exists — with no later event to correct it,
+        since a scroll is the only thing that repaints the footer and the reader
+        has not scrolled yet. Restating sync's expression makes the two agree by
+        construction. It is a CAP, so it equals the painted viewport whenever the
+        body overflows, which is the only case that paints a footer at all: a
+        body shorter than the cap is fully visible and returns no footer.
+        """
+        rows = max(1, self._body_rows() - 1)
+        # ``scroll_y`` is a float reactive mid-animation; the fold is a row index.
+        offset = max(0, int(self._scroll.scroll_y))
+        return offset, rows
+
+    def _expanded_footer(self, affordance: Text) -> Text:
+        """Prefix the expanded control row with position + overflow (#264, #265).
+
+        ONE footer, not two bolted together. ``↓ 12 of 18 · ctrl+t to collapse``
+        answers both deferred findings with a single set of numbers: the arrow is
+        U4's "content continues below" cue for a reader who never sees the
+        scrollbar thumb (keyboard-only, or a short window where the thumb is one
+        cell), and ``12 of 18`` is U5's orientation. Painting both suggestions
+        literally (``12 of 18 · ↓ 6 below``) would state one fact twice — the
+        remainder is just ``18 - 12`` — so the arrow rides the position instead of
+        repeating it. ``12`` is the LAST todo the viewport reaches, so scrolling
+        to the end lands on ``18 of 18`` and the arrow drops: the cue disappears
+        exactly when there is nothing below, which is the honesty U4 asks for.
+
+        Appears ONLY when the body actually overflows its viewport. An expanded
+        list that fits entirely is not a place a reader can be lost in, and a
+        permanent ``5 of 5`` would be chrome that never changes — the collapsed
+        state does not confess a remainder it does not have either.
+
+        INK — ``dim``, the SAME tier as the collapsed ``+N more`` prefix, and
+        deliberately not ``muted``. This is the expanded mirror of that prefix (a
+        running total, chrome), and the docstring above records why the split
+        exists: the ``ctrl+t`` token is ``muted`` at 7.93:1 because it is the ONLY
+        signal the toggle exists, and it has to stay the loudest thing on the row.
+        Painting a positional count at ``muted`` would put chrome level with the
+        one actionable token and invert that hierarchy — a reader would find the
+        numbers before the key. ``dim`` at 4.18:1 is what ``+N more`` is judged
+        legible enough to say, and this says no more than that.
+
+        WIDTH — the prefix is dropped WHOLE when it does not fit beside the
+        hotkey, never truncated into it. The row is ``no_wrap``/``ellipsis`` and
+        clipped against the screen (:meth:`_clip_row`), so a footer that simply
+        grew would spend the narrow width on the count and leave ``ctrl+t to
+        colla…`` — shedding the affordance and keeping the summary, the exact
+        inversion ``usage_panel._hint_row`` documents. The hotkey is the one
+        token that must always survive; position is polish.
+        """
+        total = len(self._expanded_item_rows)
+        if not total:
+            return affordance
+        offset, rows = self._expanded_viewport()
+        if self._expanded_body_lines <= rows:
+            return affordance  # fits entirely: no position to state, no overflow
+        # ``seen`` counts TODOS at or above the fold, so the number tracks the
+        # list the user is reading rather than the rows the panel happens to
+        # paint (phase headers and the root line are not todos).
+        fold = offset + rows
+        seen = sum(1 for index in self._expanded_item_rows if index < fold)
+        seen = max(1, min(total, seen))
+        prefix = Text(no_wrap=True, overflow="ellipsis")
+        arrow = "↓ " if seen < total else ""
+        prefix.append(
+            f"{arrow}{seen} of {total} · ", style=Style(color=theme_mod.semantic_color("dim"))
+        )
+        cells = self._row_cells()
+        if cells and prefix.cell_len + affordance.cell_len > cells:
+            return affordance  # too narrow for both: the hotkey wins outright
+        prefix.append_text(affordance)
+        return prefix
+
+    def _repaint_expanded_footer(self, *_args: Any) -> None:
+        """Restate the footer's position after a scroll, without a full repaint.
+
+        The numbers are a function of the scroll offset, and NOTHING else
+        repaints when a reader scrolls the expanded list: ``sync``'s equality
+        guard (design §7.3) covers the store, the budget, the expanded flag and
+        the hidden set, and a scroll moves none of them. Deliberately so — adding
+        the offset to that tuple would rebuild the whole body on every wheel
+        notch. Watching the reactive instead is the signal that fires exactly
+        when the answer changes, the same trade ``SubagentView`` makes for its
+        scroll arrows.
+
+        Recomposes from :meth:`_affordance_row`, the single authority for the
+        hotkey token, so the scroll path and the build path cannot spell the
+        control two ways. Writes only on a real change: ``update`` refreshes the
+        widget, and a watcher that wrote unconditionally would repaint once per
+        scroll event for the many notches that do not move the count.
+        """
+        if not self._expanded or not self._affordance.display:
+            return
+        footer = self._expanded_footer(self._affordance_row(0, 0))
+        self._clip_row(footer)
+        if str(self._affordance.content) == footer.plain:
+            return
+        self._affordance.update(footer)
 
     # -- budgets --------------------------------------------------------------
     def _row_cells(self) -> int:

--- a/tests/unit/tui/test_todo_panel_phases.py
+++ b/tests/unit/tui/test_todo_panel_phases.py
@@ -1402,10 +1402,19 @@ async def test_expanded_footer_keeps_the_hotkey_column_fixed_while_scrolling() -
                     shapes.add("bare")  # the end state deliberately sheds the prefix
                     continue
                 columns.add(footer.index("ctrl+t"))
-                # Total, not ``int(...)``: the seam row carries no digits, and an
-                # assertion that dies parsing before it checks is not a guard.
-                digits = footer.split(" more")[0].removeprefix("↓ ").strip()
-                shapes.add("numbered" if digits.isdigit() else "numberless")
+                # The taxonomy is TOTAL (design round 3, D9). The widget paints
+                # four shapes, and folding the arrow-only row (``↓ ctrl+t``, at
+                # shed widths) into ``numberless`` would let the guard conflate
+                # two genuinely different layouts if the sweep were ever widened
+                # to a narrow geometry. Also note this parse must not assume a
+                # digit: an assertion that dies parsing before it checks is not
+                # a guard, which is how the round-2 version of this test missed
+                # the seam row entirely.
+                if "more" not in footer:
+                    shapes.add("arrowonly")
+                else:
+                    digits = footer.split(" more")[0].removeprefix("↓ ").strip()
+                    shapes.add("numbered" if digits.isdigit() else "numberless")
             # The sweep must actually reach every shape, or it proves nothing.
             assert shapes == {"numbered", "numberless", "bare"}, f"{size}: {shapes}"
             assert len(columns) == 1, f"{size}: ctrl+t moved between {sorted(columns)}"
@@ -1461,10 +1470,19 @@ async def test_expanded_footer_recomposes_when_only_the_width_changes() -> None:
     the hotkey.
 
     Asserts against a FRESH BOOT at each width, which is what the reader should
-    have got, rather than against a hand-written expectation."""
+    have got, rather than against a hand-written expectation.
+
+    The sweep walks BOTH directions (UX round 3, U11). A monotone narrowing walk
+    passes against a panel that recomposes on narrowing and no-ops on widening —
+    and that panel is broken for a reader who drags a split back open, unmaximizes
+    or rotates a tiling layout: at 60 columns it would still paint the 10-cell row
+    composed for 14, so the arrow and the count are both gone with todos hidden.
+    That is U1's "told this is everything" shape arriving through the resize door,
+    and one direction of sampling cannot see it."""
     from local_operator.tools import builtin
 
-    widths = (34, 26, 22, 20, 16)
+    # Narrowing, then widening back out past where it started.
+    widths = (34, 26, 22, 20, 16, 20, 26, 34, 60)
     fixture: list[dict[str, object]] = [
         {"name": "Todos", "items": [_item(f"task {n}", "pending") for n in range(20)]}
     ]

--- a/tests/unit/tui/test_todo_panel_phases.py
+++ b/tests/unit/tui/test_todo_panel_phases.py
@@ -1148,15 +1148,16 @@ def _long_multi_phase() -> list[dict[str, object]]:
 
 
 @pytest.mark.asyncio
-async def test_expanded_overflow_footer_states_position_and_more_below() -> None:
+async def test_expanded_overflow_footer_states_the_remainder_below() -> None:
     """U4 + U5 as ONE footer: an expanded list that overflows reads
-    ``↓ N of M · ctrl+t to collapse``.
+    ``↓ N more · ctrl+t to collapse``.
 
     The scrollbar thumb was the only signal content continued — invisible to a
-    keyboard-only reader and easy to miss on a short window. ``M`` is the REAL
-    list length (asserted off the fixture, not restated) and ``N`` counts todos
-    at or above the fold, so the pair orients the reader as well as confessing
-    the remainder."""
+    keyboard-only reader and easy to miss on a short window. The number is a
+    REMAINDER, not a position (UX round 1, U2): ``N of M`` reads as "the item I
+    am looking at" by every terminal convention, and no visible row carries an
+    ordinal that could confirm it. A remainder is checkable by scrolling, and it
+    mirrors the collapsed ``+N more`` the reader saw one keypress earlier."""
     from local_operator.tools import builtin
 
     session = FakeSession()
@@ -1171,12 +1172,13 @@ async def test_expanded_overflow_footer_states_position_and_more_below() -> None
         assert panel._scroll.max_scroll_y > 0
         footer = _affordance_text(panel)
         assert footer.endswith("ctrl+t to collapse"), footer
-        assert f" of {total} · " in footer, footer
         assert footer.startswith("↓ "), footer
-        # The position is a count of TODOS, not painted rows: phase headers and
-        # the root line are chrome and must not inflate it.
-        seen = int(footer.split(" of ")[0].removeprefix("↓ "))
-        assert 0 < seen < total, footer
+        assert " more · " in footer, footer
+        # The remainder counts TODOS, not painted rows: phase headers and the
+        # root line are chrome and must not inflate it. At the top of the scroll
+        # some todos are visible, so the remainder is strictly between 0 and all.
+        remaining = int(footer.split(" more")[0].removeprefix("↓ ").strip())
+        assert 0 < remaining < total, footer
         builtin.TODO_STORE.clear()
 
 
@@ -1234,8 +1236,14 @@ async def test_expanded_footer_tracks_the_keyboard_scroll_and_drops_the_arrow() 
         for _ in range(12):
             await pilot.pause()
         assert panel._scroll.scroll_y == panel._scroll.max_scroll_y
+        # At the end there is no remainder, so the prefix is gone ENTIRELY and
+        # the row is byte-identical to the no-overflow footer — both mean
+        # "nothing is hidden" (UX round 1, U4). Absence can carry that meaning
+        # only because the widest-fit rule stops the prefix vanishing for any
+        # other reason.
         at_end = _affordance_text(panel)
-        assert at_end == f"{total} of {total} · ctrl+t to collapse", at_end
+        assert at_end == "ctrl+t to collapse", at_end
+        assert str(total) not in at_end, at_end
 
         await pilot.press("ctrl+up")
         for _ in range(12):
@@ -1268,10 +1276,15 @@ async def test_expanded_footer_sheds_whole_before_it_eats_the_hotkey() -> None:
             footer = _affordance_text(panel)
             # ``ctrl+t`` survives at every width — the one non-negotiable token.
             assert "ctrl+t" in footer, f"w={width}: {footer!r}"
-            if " of " in footer:
+            if " more · " in footer:
                 # Wide enough for both: the hotkey phrase stays WHOLE behind the
                 # prefix, never clipped to pay for the count.
                 assert footer.endswith("ctrl+t to collapse"), f"w={width}: {footer!r}"
+            elif footer.startswith("↓"):
+                # Too narrow for the number but not for the cue: the NUMBER is
+                # what goes, never the arrow. The arrow is U4's finding; the
+                # count is only U5's orientation.
+                assert footer == "↓ · ctrl+t to collapse", f"w={width}: {footer!r}"
             else:
                 # Shed WHOLE: the row is exactly what it was before this feature,
                 # with no count fragment and no orphaned separator.
@@ -1295,5 +1308,118 @@ async def test_collapsed_affordance_is_unchanged_by_the_expanded_footer() -> Non
         footer = _affordance_text(panel)
         assert footer.endswith("· ctrl+t to expand"), footer
         assert footer.startswith("+"), footer
-        assert "of" not in footer.split("·")[0], footer
+        assert "↓" not in footer, footer
+        builtin.TODO_STORE.clear()
+
+
+@pytest.mark.asyncio
+async def test_expanded_footer_arrow_follows_the_body_not_the_todo_count() -> None:
+    """Design round 1, D2: the arrow answers "is there more to SEE", so it is
+    derived from the viewport, never from the todo remainder.
+
+    A plan whose last phase has no items (a shape the tool schema accepts, and
+    the natural rendering of work not yet started) puts a phase HEADER below the
+    fold with no todo behind it. Deriving the arrow from the todo count painted
+    "nothing below" while that header was hidden — contradicting the scrollbar
+    thumb in the same frame, which is precisely the failure #264 exists to
+    prevent. The counts stay todo-based; only the arrow moved."""
+    from local_operator.tools import builtin
+
+    session = FakeSession()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _booted_panel(
+            app,
+            pilot,
+            [
+                {"name": "Alpha", "items": [_item(f"alpha {n}", "pending") for n in range(9)]},
+                {"name": "Beta", "items": [_item(f"beta {n}", "pending") for n in range(6)]},
+                # The whole point: a trailing phase contributing a header row and
+                # no item rows, so body lines outlast todo rows.
+                {"name": "Gamma", "items": []},
+            ],
+        )
+        panel = await _settled_expand(app, pilot)
+        max_scroll = panel._scroll.max_scroll_y
+        assert max_scroll > 0
+
+        for offset in range(max_scroll + 1):
+            panel._scroll.scroll_to(y=offset, animate=False)
+            for _ in range(8):
+                await pilot.pause()
+            footer = _affordance_text(panel)
+            more_below = offset < max_scroll
+            assert ("↓" in footer) is more_below, f"y={offset}: {footer!r}"
+        builtin.TODO_STORE.clear()
+
+
+@pytest.mark.asyncio
+async def test_expanded_footer_keeps_the_hotkey_column_fixed_while_scrolling() -> None:
+    """Design round 1, D1: the ``ctrl+t`` token must not move under a reader who
+    is only scrolling.
+
+    D1 measured a two-cell jump when the arrow dropped under the old ``N of M``
+    wording. ``N more`` sheds the whole prefix at the end instead, but the same
+    defect class survives the rewording as a one-cell shift at every
+    power-of-ten boundary (``↓ 10 more`` -> ``↓ 9 more``) — mid-scroll, with the
+    reader watching. The remainder is padded to the widest number's width so the
+    column is pinned across every position the prefix is shown at."""
+    from local_operator.tools import builtin
+
+    session = FakeSession()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _booted_panel(app, pilot, _long_multi_phase())
+        panel = await _settled_expand(app, pilot)
+        assert panel._scroll.max_scroll_y > 0
+
+        columns = set()
+        crossed_ten = False
+        for offset in range(panel._scroll.max_scroll_y + 1):
+            panel._scroll.scroll_to(y=offset, animate=False)
+            for _ in range(8):
+                await pilot.pause()
+            footer = _affordance_text(panel)
+            if "↓" not in footer:
+                continue  # the end state deliberately sheds the prefix
+            columns.add(footer.index("ctrl+t"))
+            remaining = int(footer.split(" more")[0].removeprefix("↓ ").strip())
+            crossed_ten |= remaining < 10
+        # The scroll must actually cross a digit boundary, or this proves nothing.
+        assert crossed_ten, "fixture never drops below ten remaining"
+        assert len(columns) == 1, f"ctrl+t moved between columns {sorted(columns)}"
+        builtin.TODO_STORE.clear()
+
+
+@pytest.mark.asyncio
+async def test_expanded_footer_cue_never_vanishes_mid_scroll_at_narrow_widths() -> None:
+    """UX round 1, U1: the cue's presence is a property of the width and the list
+    length, never of the number's current digit count.
+
+    Width-testing the prefix against its CURRENT text made the cue survive
+    ``↓ 9 more`` and vanish at ``↓ 10 more``, so a reader at 34 columns was shown
+    the exact pre-change "this is everything" row with todos still hidden. That
+    is worse than never showing a cue, because absence had been taught to mean
+    something. Sizing on the widest remainder makes the cue stable: shown at
+    every position, or at none."""
+    from local_operator.tools import builtin
+
+    session = FakeSession()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(34, 16)) as pilot:
+        await _booted_panel(app, pilot, _long_multi_phase())
+        panel = await _settled_expand(app, pilot)
+        max_scroll = panel._scroll.max_scroll_y
+        assert max_scroll > 0
+
+        # Every position before the end must carry the cue — no gaps.
+        blind = []
+        for offset in range(max_scroll):
+            panel._scroll.scroll_to(y=offset, animate=False)
+            for _ in range(8):
+                await pilot.pause()
+            footer = _affordance_text(panel)
+            if "↓" not in footer:
+                blind.append((offset, footer))
+        assert not blind, f"cue vanished mid-scroll at {blind}"
         builtin.TODO_STORE.clear()

--- a/tests/unit/tui/test_todo_panel_phases.py
+++ b/tests/unit/tui/test_todo_panel_phases.py
@@ -1067,3 +1067,233 @@ async def test_expanded_shows_an_item_at_the_floor_flat_and_phased() -> None:
             assert scroll.max_scroll_y > 0
             assert app.query_one("#input-shell").region.height > 0
             builtin.TODO_STORE.clear()
+
+
+# --------------------------------------------------------------------------- #
+# Expanded overflow/position footer (#264 U4, #265 U5)
+# --------------------------------------------------------------------------- #
+
+
+async def _booted_panel(  # type: ignore[no-untyped-def]
+    app: OperatorApp, pilot, phases: list[dict[str, object]]
+) -> TodoPanel:
+    """Seed the store once the SESSION exists, repaint, and hand back the panel.
+
+    Waits for ``app._session`` rather than a frame count. The app paints before
+    its session exists (the factory is awaited in a boot worker) and the panel
+    reads the store keyed by ``session_id``, so a repaint landing in that window
+    finds no todos and hides the panel — which reads as an assertion about
+    footers failing for a reason that has nothing to do with footers.
+    ``test_band_panels.py`` documents the same race and waits the same way.
+    """
+    for _ in range(200):
+        await pilot.pause()
+        if app._session is not None:
+            break
+    from local_operator.tools import builtin
+
+    builtin.TODO_STORE["sess"] = phases
+    app._refresh_band()
+    await pilot.pause()
+    return app.query_one(TodoPanel)
+
+
+async def _settled_expand(app: OperatorApp, pilot) -> TodoPanel:  # type: ignore[no-untyped-def]
+    """Press ``ctrl+t`` and wait for the scroll region's virtual size to settle.
+
+    The panel repaints in the tick the flag flips (``request_toggle`` ->
+    ``_refresh_band``), but ``max_scroll_y`` is a function of a virtual size the
+    compositor computes a frame later. A single ``pause`` therefore reads
+    ``max_scroll_y == 0`` on a list that does overflow, which is the shape of a
+    flake rather than a defect — the footer's own text is already correct at that
+    point. Settling here keeps the OVERFLOW PRECONDITION honest: a test asserting
+    an overflow footer must first prove the list actually overflows.
+    """
+    panel = app.query_one(TodoPanel)
+    await pilot.press("ctrl+t")
+    for _ in range(40):
+        await pilot.pause()
+        if panel._scroll.max_scroll_y > 0:
+            break
+    return panel
+
+
+def _long_multi_phase() -> list[dict[str, object]]:
+    """A 17-item plan that overflows the expanded budget on a 100x30 terminal.
+
+    Deliberately longer than ``_big_multi_phase``: that one FITS at a normal
+    height (it is the fixture proving expand reveals everything), so it can never
+    exercise the overflow footer. The counts here are asserted against
+    ``sum(len(phase items))`` rather than restated, so a fixture edit cannot make
+    a wrong position number look right.
+    """
+    return [
+        {"name": "Discovery", "items": [_item(f"discovery task {n}", "done") for n in range(4)]},
+        {
+            "name": "Implementation",
+            "items": [
+                _item("implementation task 0", "done"),
+                *[_item(f"implementation task {n}", "pending") for n in range(1, 6)],
+                _item("implementation task 6", "blocked", reason="waiting on review"),
+            ],
+        },
+        {
+            "name": "Validation",
+            "items": [
+                *[_item(f"validation task {n}", "pending") for n in range(5)],
+                _item("validation task 5", "dropped"),
+            ],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_expanded_overflow_footer_states_position_and_more_below() -> None:
+    """U4 + U5 as ONE footer: an expanded list that overflows reads
+    ``↓ N of M · ctrl+t to collapse``.
+
+    The scrollbar thumb was the only signal content continued — invisible to a
+    keyboard-only reader and easy to miss on a short window. ``M`` is the REAL
+    list length (asserted off the fixture, not restated) and ``N`` counts todos
+    at or above the fold, so the pair orients the reader as well as confessing
+    the remainder."""
+    from local_operator.tools import builtin
+
+    session = FakeSession()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        phases = _long_multi_phase()
+        total = sum(len(phase["items"]) for phase in phases)  # type: ignore[arg-type]
+        await _booted_panel(app, pilot, phases)
+        panel = await _settled_expand(app, pilot)
+
+        # Precondition: this list really does overflow, or the footer is vacuous.
+        assert panel._scroll.max_scroll_y > 0
+        footer = _affordance_text(panel)
+        assert footer.endswith("ctrl+t to collapse"), footer
+        assert f" of {total} · " in footer, footer
+        assert footer.startswith("↓ "), footer
+        # The position is a count of TODOS, not painted rows: phase headers and
+        # the root line are chrome and must not inflate it.
+        seen = int(footer.split(" of ")[0].removeprefix("↓ "))
+        assert 0 < seen < total, footer
+        builtin.TODO_STORE.clear()
+
+
+@pytest.mark.asyncio
+async def test_expanded_footer_absent_when_the_whole_list_is_visible() -> None:
+    """No overflow, no cue. An expanded list the reader can see in full is not a
+    place to be lost in, and a permanent ``5 of 5`` would be chrome that never
+    changes — collapsed does not confess a remainder it does not have either."""
+    from local_operator.tools import builtin
+
+    session = FakeSession()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        panel = await _booted_panel(
+            app,
+            pilot,
+            [
+                {"name": "Auth", "items": [_item("token exchange", "pending")]},
+                {"name": "Cleanup", "items": [_item("remove the shim", "pending")]},
+            ],
+        )
+        await pilot.press("ctrl+t")
+        await pilot.pause()
+
+        assert panel._scroll.max_scroll_y == 0  # precondition: nothing hidden
+        assert _affordance_text(panel) == "ctrl+t to collapse"
+        builtin.TODO_STORE.clear()
+
+
+@pytest.mark.asyncio
+async def test_expanded_footer_tracks_the_keyboard_scroll_and_drops_the_arrow() -> None:
+    """The position follows ``ctrl+down``/``ctrl+up`` (U2's real key path), and
+    reaching the end drops the ``↓`` while the count reads ``M of M``.
+
+    A scroll repaints nothing on its own — ``sync``'s equality guard covers the
+    store, the budget, the expanded flag and the hidden set, none of which a
+    scroll moves — so this is the regression guard for the ``scroll_y`` watcher.
+    A footer frozen at its first-paint numbers would be worse than none: it would
+    claim more content below after the reader had already reached the end."""
+    from local_operator.tools import builtin
+
+    session = FakeSession()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        phases = _long_multi_phase()
+        total = sum(len(phase["items"]) for phase in phases)  # type: ignore[arg-type]
+        await _booted_panel(app, pilot, phases)
+        panel = await _settled_expand(app, pilot)
+        assert panel._scroll.max_scroll_y > 0  # precondition: it really overflows
+        at_top = _affordance_text(panel)
+        assert at_top.startswith("↓ "), at_top
+
+        # The REAL binding, not the scroll API: this is the path a user takes.
+        await pilot.press("ctrl+down")
+        for _ in range(12):
+            await pilot.pause()
+        assert panel._scroll.scroll_y == panel._scroll.max_scroll_y
+        at_end = _affordance_text(panel)
+        assert at_end == f"{total} of {total} · ctrl+t to collapse", at_end
+
+        await pilot.press("ctrl+up")
+        for _ in range(12):
+            await pilot.pause()
+        assert _affordance_text(panel) == at_top
+        builtin.TODO_STORE.clear()
+
+
+@pytest.mark.asyncio
+async def test_expanded_footer_sheds_whole_before_it_eats_the_hotkey() -> None:
+    """Narrow width: the position prefix is dropped ENTIRE, never truncated into
+    the ``ctrl+t`` token.
+
+    The row is ``no_wrap``/``ellipsis`` and clipped against the screen, so a
+    footer that merely grew would spend a narrow width on the count and leave
+    ``ctrl+t to colla…`` — keeping the summary and shedding the affordance, the
+    exact inversion ``usage_panel._hint_row`` documents. The hotkey is the only
+    signal the toggle exists; position is polish."""
+    from local_operator.tools import builtin
+
+    session = FakeSession()
+    for width in (16, 20, 40):
+        session = FakeSession()
+        app = OperatorApp(_async_factory(session))
+        async with app.run_test(size=(width, 30)) as pilot:
+            panel = await _booted_panel(app, pilot, _long_multi_phase())
+            await pilot.press("ctrl+t")
+            await pilot.pause()
+
+            footer = _affordance_text(panel)
+            # ``ctrl+t`` survives at every width — the one non-negotiable token.
+            assert "ctrl+t" in footer, f"w={width}: {footer!r}"
+            if " of " in footer:
+                # Wide enough for both: the hotkey phrase stays WHOLE behind the
+                # prefix, never clipped to pay for the count.
+                assert footer.endswith("ctrl+t to collapse"), f"w={width}: {footer!r}"
+            else:
+                # Shed WHOLE: the row is exactly what it was before this feature,
+                # with no count fragment and no orphaned separator.
+                assert footer.startswith("ctrl+t to"), f"w={width}: {footer!r}"
+                assert "·" not in footer, f"w={width}: {footer!r}"
+            builtin.TODO_STORE.clear()
+
+
+@pytest.mark.asyncio
+async def test_collapsed_affordance_is_unchanged_by_the_expanded_footer() -> None:
+    """The collapsed row keeps its ``+N more · ctrl+t to expand`` exactly: the
+    new footer is an EXPANDED-only addition, and the collapsed goldens
+    (``test_band_panels.py``) must not move."""
+    from local_operator.tools import builtin
+
+    session = FakeSession()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        panel = await _booted_panel(app, pilot, _long_multi_phase())
+        assert panel._expanded is False
+        footer = _affordance_text(panel)
+        assert footer.endswith("· ctrl+t to expand"), footer
+        assert footer.startswith("+"), footer
+        assert "of" not in footer.split("·")[0], footer
+        builtin.TODO_STORE.clear()

--- a/tests/unit/tui/test_todo_panel_phases.py
+++ b/tests/unit/tui/test_todo_panel_phases.py
@@ -1118,6 +1118,24 @@ async def _settled_expand(app: OperatorApp, pilot) -> TodoPanel:  # type: ignore
     return panel
 
 
+def _trailing_chrome_phases() -> list[dict[str, object]]:
+    """A plan whose LAST body line is chrome, not a todo.
+
+    A trailing phase with no items (a shape the tool schema accepts, and the
+    natural rendering of work not yet started) contributes a header row and no
+    item rows, so body lines outlast todo rows. This is the only fixture that can
+    reach the footer's numberless seam — the position where the arrow is on
+    because the body has more to show while the todo remainder is zero — so any
+    guard over "every footer shape" has to run on THIS list, not on
+    ``_long_multi_phase``.
+    """
+    return [
+        {"name": "Alpha", "items": [_item(f"alpha {n}", "pending") for n in range(9)]},
+        {"name": "Beta", "items": [_item(f"beta {n}", "pending") for n in range(6)]},
+        {"name": "Gamma", "items": []},
+    ]
+
+
 def _long_multi_phase() -> list[dict[str, object]]:
     """A 17-item plan that overflows the expanded budget on a 100x30 terminal.
 
@@ -1328,17 +1346,7 @@ async def test_expanded_footer_arrow_follows_the_body_not_the_todo_count() -> No
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await _booted_panel(
-            app,
-            pilot,
-            [
-                {"name": "Alpha", "items": [_item(f"alpha {n}", "pending") for n in range(9)]},
-                {"name": "Beta", "items": [_item(f"beta {n}", "pending") for n in range(6)]},
-                # The whole point: a trailing phase contributing a header row and
-                # no item rows, so body lines outlast todo rows.
-                {"name": "Gamma", "items": []},
-            ],
-        )
+        await _booted_panel(app, pilot, _trailing_chrome_phases())
         panel = await _settled_expand(app, pilot)
         max_scroll = panel._scroll.max_scroll_y
         assert max_scroll > 0
@@ -1363,32 +1371,45 @@ async def test_expanded_footer_keeps_the_hotkey_column_fixed_while_scrolling() -
     defect class survives the rewording as a one-cell shift at every
     power-of-ten boundary (``↓ 10 more`` -> ``↓ 9 more``) — mid-scroll, with the
     reader watching. The remainder is padded to the widest number's width so the
-    column is pinned across every position the prefix is shown at."""
+    column is pinned across every position the prefix is shown at.
+
+    Runs on ``_trailing_chrome_phases`` and over several geometries, because the
+    round-1 version of this guard was structurally blind (design round 2, D6):
+    it used a fixture that can never reach a zero remainder, so it could not
+    render the NUMBERLESS seam row — which was the one shape that had not been
+    padded, and which moved the hotkey three cells one notch before the
+    deliberate end-state move. The parse below therefore must not assume a digit
+    either: the round-1 version would have raised ``ValueError`` on that row and
+    died before reaching its own assertion, which is not a guard."""
     from local_operator.tools import builtin
 
-    session = FakeSession()
-    app = OperatorApp(_async_factory(session))
-    async with app.run_test(size=(100, 24)) as pilot:
-        await _booted_panel(app, pilot, _long_multi_phase())
-        panel = await _settled_expand(app, pilot)
-        assert panel._scroll.max_scroll_y > 0
+    for size in ((100, 30), (100, 24), (60, 30), (45, 30)):
+        session = FakeSession()
+        app = OperatorApp(_async_factory(session))
+        async with app.run_test(size=size) as pilot:
+            await _booted_panel(app, pilot, _trailing_chrome_phases())
+            panel = await _settled_expand(app, pilot)
+            assert panel._scroll.max_scroll_y > 0, size
 
-        columns = set()
-        crossed_ten = False
-        for offset in range(panel._scroll.max_scroll_y + 1):
-            panel._scroll.scroll_to(y=offset, animate=False)
-            for _ in range(8):
-                await pilot.pause()
-            footer = _affordance_text(panel)
-            if "↓" not in footer:
-                continue  # the end state deliberately sheds the prefix
-            columns.add(footer.index("ctrl+t"))
-            remaining = int(footer.split(" more")[0].removeprefix("↓ ").strip())
-            crossed_ten |= remaining < 10
-        # The scroll must actually cross a digit boundary, or this proves nothing.
-        assert crossed_ten, "fixture never drops below ten remaining"
-        assert len(columns) == 1, f"ctrl+t moved between columns {sorted(columns)}"
-        builtin.TODO_STORE.clear()
+            columns: set[int] = set()
+            shapes: set[str] = set()
+            for offset in range(panel._scroll.max_scroll_y + 1):
+                panel._scroll.scroll_to(y=offset, animate=False)
+                for _ in range(8):
+                    await pilot.pause()
+                footer = _affordance_text(panel)
+                if "↓" not in footer:
+                    shapes.add("bare")  # the end state deliberately sheds the prefix
+                    continue
+                columns.add(footer.index("ctrl+t"))
+                # Total, not ``int(...)``: the seam row carries no digits, and an
+                # assertion that dies parsing before it checks is not a guard.
+                digits = footer.split(" more")[0].removeprefix("↓ ").strip()
+                shapes.add("numbered" if digits.isdigit() else "numberless")
+            # The sweep must actually reach every shape, or it proves nothing.
+            assert shapes == {"numbered", "numberless", "bare"}, f"{size}: {shapes}"
+            assert len(columns) == 1, f"{size}: ctrl+t moved between {sorted(columns)}"
+            builtin.TODO_STORE.clear()
 
 
 @pytest.mark.asyncio
@@ -1422,4 +1443,67 @@ async def test_expanded_footer_cue_never_vanishes_mid_scroll_at_narrow_widths() 
             if "↓" not in footer:
                 blind.append((offset, footer))
         assert not blind, f"cue vanished mid-scroll at {blind}"
+        builtin.TODO_STORE.clear()
+
+
+@pytest.mark.asyncio
+async def test_expanded_footer_recomposes_when_only_the_width_changes() -> None:
+    """UX round 2, U7: a width-only resize must not leave the row composed for
+    the width it no longer has.
+
+    ``sync``'s equality guard held the budget (a HEIGHT) but not
+    ``_row_cells()``, so an edge drag that changed only the width returned early
+    and kept a 30-cell footer. Rows are clipped against the width, and the
+    compositor then cropped that row into a much narrower region — cutting
+    ``ctrl+t`` itself, which is the one token that must always survive and the
+    exact invariant this panel sets for itself. ``main`` never showed this on the
+    expanded row only because its 18-cell row was too short to be cropped past
+    the hotkey.
+
+    Asserts against a FRESH BOOT at each width, which is what the reader should
+    have got, rather than against a hand-written expectation."""
+    from local_operator.tools import builtin
+
+    widths = (34, 26, 22, 20, 16)
+    fixture: list[dict[str, object]] = [
+        {"name": "Todos", "items": [_item(f"task {n}", "pending") for n in range(20)]}
+    ]
+
+    # What each width looks like when the panel is built for it from the start.
+    fresh: dict[int, str] = {}
+    for width in widths:
+        session = FakeSession()
+        app = OperatorApp(_async_factory(session))
+        async with app.run_test(size=(width, 24)) as pilot:
+            await _booted_panel(app, pilot, fixture)
+            panel = await _settled_expand(app, pilot)
+            panel._scroll.scroll_to(y=4, animate=False)
+            for _ in range(8):
+                await pilot.pause()
+            fresh[width] = _affordance_text(panel)
+            builtin.TODO_STORE.clear()
+
+    # The same widths reached by narrowing an already-expanded panel.
+    session = FakeSession()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(60, 24)) as pilot:
+        await _booted_panel(app, pilot, fixture)
+        panel = await _settled_expand(app, pilot)
+        panel._scroll.scroll_to(y=4, animate=False)
+        for _ in range(8):
+            await pilot.pause()
+
+        for width in widths:
+            await pilot.resize_terminal(width, 24)
+            for _ in range(12):
+                await pilot.pause()
+            resized = _affordance_text(panel)
+            assert (
+                resized == fresh[width]
+            ), f"w={width}: resize left {resized!r}, fresh boot paints {fresh[width]!r}"
+            # The invariant the crop was breaking: the hotkey stays readable in
+            # what the region can actually show, not merely in the composed Text.
+            cells = panel._row_cells()
+            painted = resized[:cells] if cells else resized
+            assert "ctrl+t" in painted, f"w={width}: ctrl+t cropped away from {painted!r}"
         builtin.TODO_STORE.clear()


### PR DESCRIPTION
# PR Description

Closes #264
Closes #265

## Summary of Changes

#264 is U4 and #265 is U5. Both were deferred from PR #260's round-1 UX review,
and #265 says it is "best done alongside U4", so this designs them as ONE
expanded-state footer rather than bolting two independent strings together.

### The defect

When an expanded todo list overflows its height budget, the only signal that
content continues is the scrollbar thumb. That is easy to miss on a short window
and it does not exist at all for a keyboard-only reader. Once you scroll, nothing
tells you how much is left.

Captured on `origin/main` at 100x30 with a 17-todo plan, expanded and scrolled to
three positions:

| scroll position | footer on `main` |
|---|---|
| top (6 todos below the fold) | `ctrl+t to collapse` |
| middle (3 below) | `ctrl+t to collapse` |
| bottom (0 below) | `ctrl+t to collapse` |

The same row in all three states, silent about all of it.

### The fix

```
↓ 6 more · ctrl+t to collapse       at the top
↓ 3 more · ctrl+t to collapse       mid-scroll
ctrl+t to collapse                  at the end, prefix gone entirely
```

One number answers both findings. The arrow is U4's "content continues" cue; the
remainder is U5's orientation. Painting both suggestions literally
(`12 of 18 · ↓ 6 below`) would state one fact twice, so only one number is carried.

**Why a remainder and not `N of M`.** The first revision of this PR carried
`↓ 11 of 17`. Review measured that unverifiable: every convention a terminal
reader brings to `N of M` — pagers, `less`, search results — makes `N` the
*current* item, but the only `N` this panel can compute is the last todo the
viewport reaches. Items carry no ordinals, so no visible row can confirm the
number, and it invites the other reading ("N are showing"), which is also false.
A remainder is checkable by scrolling, and it mirrors the collapsed `+11 more`
the same reader saw one keypress earlier.

### Constraints the issues and reviews called out, and how each is met

**The cue never vanishes while content continues.** The prefix is width-tested
against its *widest* rendering for the list, not the string being painted. Sizing
on the current text made the cue's survival depend on the number's digit count,
so at 34 columns it lived at `↓ 9 of 17` and died at `↓ 10 of 17` — showing the
exact pre-change "this is everything" row with 8 todos still hidden. That is
worse than never showing a cue, because absence had been taught to mean something.

**The arrow is derived from the viewport, not the todo count.** The counts are
todo-based, but the thing that *scrolls* is the body, and the two disagree when
the lines below the fold are chrome. A plan ending in an empty phase declared
"nothing below" with its `Gamma · 0/0` header still hidden, contradicting the
scrollbar thumb in the same frame. The arrow now rides `offset < max_scroll`.
Where the arrow is on but no todos remain, the prefix reads `↓ more ·`, since
`↓ 0 more` would be nonsense and `↓ 1 more` a lie.

**The number is shed before the arrow.** When even the widest remainder will not
fit, a bare `↓` is kept. The arrow is the finding #264 filed; the count is only
#265's orientation, so a footer that dropped the arrow to keep a number would
have shed the thing it exists to say. The separator goes with the number it was
separating: `↓ ·` left a bullet with nothing on its left, which read as a count
that had failed to render rather than a deliberate shed.

**Every footer shape occupies the same field.** Where the arrow is on but no
todos remain below (chrome below the fold, e.g. a trailing empty phase), the row
reads `↓    more ·` — padded to the widest number's width, so it does not shift
the hotkey one notch before the deliberate end-state move.

**The hotkey column is pinned.** The remainder is right-aligned in the widest
number's field, so `↓ 10 more` → `↓ 9 more` does not shift `ctrl+t` mid-scroll,
and the numberless row is padded into that same field. Measured single-valued at
column 12 across full notch-by-notch scrolls at 100x30, 100x24, 60x30 and 45x30.

**Why the number counts todos and not body rows.** Counting body rows would make
the number consistent with the arrow by construction and delete the numberless
row entirely, which is tempting. It is rejected because the collapsed row's
`+N more` counts *todos*, and the pairing between the two rows is the whole
reason this wording was chosen — same noun, one keypress apart. Counting rows
here would leave `+11 more` and `↓ 9 more` describing two different quantities,
and a reader who scrolled and counted todos would find the number simply wrong.
An unverifiable number was the U2 objection; a verifiable falsehood is worse.

**Ink respects the documented dim-vs-muted split.** The prefix is `dim` (measured
4.18:1 against the panel ground), the same tier as the collapsed `+N more`, and
deliberately not `muted`. The `ctrl+t` token is `muted` (7.93:1) because it is the
only signal the toggle exists; a count at `muted` would invert that hierarchy.

**Expanded still reveals everything.** The footer is composed *on top of*
`_affordance_row` in `_expanded_footer`, never inside it, so the M1/U1 invariant
that expanded is called with `0, 0` and hides nothing is untouched.

**No cue when there is no overflow.** An expanded list visible in full keeps the
bare `ctrl+t to collapse`. At the end of a scroll the row becomes byte-identical
to that same footer, which is correct: both mean "nothing is hidden".

**The count is todos, not rows.** Counting body lines would report `14 of 21`
about a 17-item list.

### How the footer stays live

A scroll repaints nothing on its own: `sync`'s equality guard (design §7.3)
covers the store, the budget, the expanded flag and the hidden set, and a scroll
moves none of them. Adding the offset to that tuple would rebuild the whole body
on every wheel notch, so the remainder rides a `scroll_y` watcher instead — the
same trade `SubagentView` makes for its scroll arrows. It recomposes from
`_affordance_row`, the single authority for the hotkey token, and writes only
when the text actually changes.

Resize is not watched, because the equality guard covers it on **both** axes:
height through the budget, and width through `_row_cells()`. The width term was
missing until round 2 — the budget is a height, so an edge drag that changed only
the width returned early and left the row composed for a width that no longer
existed. That was harmless on main's 18-cell expanded row and not on this one at
30 cells: the compositor's crop landed past `ctrl+t`. Both axes are in the guard
now, so a resize rebuilds the body and recomposes the footer on the same pass.

`_expanded_viewport` restates `sync`'s own `max_height` expression rather than
reading the region's `content_size`. That is not a shortcut: `_build` runs before
`sync` applies the new cap, so on the frame `ctrl+t` expands the panel
`content_size` still holds the collapsed height, and there is no later event to
correct a footer computed from it — a scroll is the only thing that repaints it,
and the reader has not scrolled yet.

Also factors `_build`'s inline truncation into `_clip_row`, so the scroll-time
repaint and the full paint cut a row the same way.

## Testing Evidence

Purely visual/UX, so a green suite is not the evidence. Frames captured with the
real `OperatorApp` under `run_test`, exported with `app.save_screenshot()`, then
rendered and viewed as images per AGENTS.md "Visual validation". All probes are
single-process `run_test` drives; no pytest pool was used to produce any of it.

**Every frame was re-captured after round 2.** Both wording changes invalidated
the previous set; the numbers quoted below come from the same probe runs.

### Scroll states at 100x30, 17 todos across 3 phases

| state | footer |
|---|---|
| collapsed (control) | `+11 more · ctrl+t to expand` |
| expanded, whole list fits (2 todos) | `ctrl+t to collapse` |
| expanded overflow, top | `↓  6 more · ctrl+t to collapse` |
| expanded overflow, middle | `↓  3 more · ctrl+t to collapse` |
| expanded overflow, end | `ctrl+t to collapse` |

The collapsed row and the fits-entirely row are unchanged from base.

### The hotkey column, across every footer shape

The round-1 guard ran on a fixture that cannot reach a zero remainder, so it
never rendered the numberless row — the one shape that had not been padded. The
sweep now runs on the trailing-chrome fixture and asserts it reaches all three
shapes (numbered, numberless, bare):

```
gamma (seam)  (100, 30)  cols=[12]  seam_row=yes  OK
gamma (seam)  (100, 24)  cols=[12]  seam_row=yes  OK
gamma (seam)  ( 80, 26)  cols=[12]  seam_row=yes  OK
gamma (seam)  ( 60, 30)  cols=[12]  seam_row=yes  OK
gamma (seam)  ( 45, 30)  cols=[12]  seam_row=yes  OK
gamma (seam)  ( 36, 30)  cols=[12]  seam_row=yes  OK
gamma n=40    (100, 30)  cols=[12]  seam_row=yes  OK
gamma n=120   (100, 30)  cols=[13]  seam_row=yes  OK
```

The guard was verified against the *unfixed* code before being trusted: it fails
with the reviewer's exact `ctrl+t moved between columns [9, 12]` and passes on
this head.

### The arrow follows the body, not the todo count

Trailing phase with no items, every reachable offset:

```
y=0 body_lines_below=4 arrow=True  expect=True  OK  '↓  3 more · ctrl+t to collapse'
y=1 body_lines_below=3 arrow=True  expect=True  OK  '↓  2 more · ctrl+t to collapse'
y=2 body_lines_below=2 arrow=True  expect=True  OK  '↓  1 more · ctrl+t to collapse'
y=3 body_lines_below=1 arrow=True  expect=True  OK  '↓    more · ctrl+t to collapse'
y=4 body_lines_below=0 arrow=False expect=False OK  'ctrl+t to collapse'
```

In the rendered frame at `y=3` the thumb has a visible gap beneath it and the
footer says there is more; at the end `Gamma · 0/0` is on screen, the thumb
reaches the bottom, and the footer is bare. The two cues agree in the pixels, and
`ctrl+t` sits on the same column in both.

### A width-only resize recomposes

Expanded, parked at `y=4`, narrowed from 60 columns with the height held. Asserted
against a **fresh boot** at each width rather than a hand-written expectation:

```
start w=60: '↓  8 more · ctrl+t to collapse'
  -> w=34  cells=30  ctrl+t OK  '↓  8 more · ctrl+t to collapse'
  -> w=30  cells=26  ctrl+t OK  '↓ ctrl+t to collapse'
  -> w=26  cells=22  ctrl+t OK  '↓ ctrl+t to collapse'
  -> w=22  cells=18  ctrl+t OK  'ctrl+t to collapse'
  -> w=20  cells=16  ctrl+t OK  'ctrl+t to colla…'
  -> w=18  cells=14  ctrl+t OK  'ctrl+t to col…'
  -> w=16  cells=12  ctrl+t OK  'ctrl+t to c…'
```

Before the fix the same gesture left `↓  8 more · ctrl+` at w=20 and `↓  8 more ·
c` at w=16, where main keeps `ctrl+t` readable. The regression test drives the
real `resize_terminal` and also asserts the hotkey survives in what the region can
actually paint, not merely in the composed `Text`.

The sweep walks **both directions** (`34, 26, 22, 20, 16, 20, 26, 34, 60`). A
narrowing-only walk passes against a panel that recomposes on narrowing and no-ops
on widening, which is broken for a reader who drags a split back open — verified
against exactly that mutant, which the one-directional guard passed and this one
fails at the first widening step.

### The cue is stable across every scroll position

```
w=34 (17 items):   positions before the end=17,  blind=0  -> STABLE
w=35 (120 items):  positions before the end=117, blind=0  -> STABLE
w=36 (120 items):  positions before the end=117, blind=0  -> STABLE
```

Round 1 measured 8 of 17 positions blind at w=34 and 110 of 117 at w=35.

### Width sweep, 14..45 columns

```
14..21  'ctrl+t to…' … 'ctrl+t to collap…'     prefix shed whole (identical to base)
22..23  'ctrl+t to collapse'                    prefix shed whole (identical to base)
24..33  '↓ ctrl+t to collapse'                  number shed, ARROW KEPT
34..45  '↓  6 more · ctrl+t to collapse'        full prefix
```

`ctrl+t` is present at every width. **The arrow reaches 24 columns**; under the
first revision it required 34, and it reached 26 before D7 dropped the orphaned
separator from the shed form.

Note that **24 and 25 are no longer byte-identical to pristine `main`** — they now
carry the arrow, which is D7's two-cell saving working as intended. Widths 14..23
remain byte-identical to base. An earlier revision of this description claimed
byte-identical behaviour at 24/25; that is no longer true and the boundary above
is the re-measured one.

### Collapse/expand round trip

```
expanded, overflowing: '↓  6 more · ctrl+t to collapse' max_scroll_y=6
   scrolled to end:    'ctrl+t to collapse'
   collapsed:          '+11 more · ctrl+t to expand'
   re-expanded:        '↓  6 more · ctrl+t to collapse' scroll_y=0
```

### Cross-version check

The one version-sensitive construct is the nested f-string format spec used for
the padding. Verified on a real 3.12 interpreter, not just the local 3.14 venv:

```
$ uv run --python 3.12 --no-project python -c ...
python 3.12.13
'↓  6 more · '
'↓ 15 more · '
'↓ 117 more · '
```

Identical to what 3.14 renders. The diff touches two files, adds no `except`
clause and no filesystem call, so the `resolve()`/ELOOP cross-version trap does
not apply.

### Gates

```
.venv/bin/python -m flake8 .                                  clean
uvx --from black==26.1.0 black --check .                      625 files unchanged
uvx isort==5.13.2 --check .                                   clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   0 errors, 0 warnings, 0 informations
pytest tests/unit/tui/test_todo_panel_phases.py -k footer -n0  9 passed
```

Ten tests cover this footer. Both round-2 guards were checked against the unfixed
code first — a guard that has not been seen to fail is not a guard, which is the
lesson of D6, where the round-1 column test could not have caught the row it was
meant to protect.

The full `tests/unit` suite is left to CI's 3.12 and 3.13 legs: the machine has
been running three to eleven other agents' pytest pools continuously, and the
standing RAM limit forbids adding another. The first revision's full local run
was green apart from known load-sensitive flakes.

## Risk

Low and contained to one widget's footer row. The panel is a status surface whose
`sync` is wrapped in a `try/except` that hides it rather than raising, so the
worst case is a hidden panel, not a downed app. The collapsed path is untouched,
the expanded-reveals-everything invariant is unchanged, and `ctrl+t` survives at
every width down to 14 columns.

The moving parts are the `scroll_y` watcher — guarded on `self._expanded` and
`self._affordance.display`, writing only on a real text change, reading recorded
paint state rather than the store — and `_expanded_viewport`, which derives the
viewport and `max_scroll` from `sync`'s own `max_height` expression rather than
the region's `content_size`, because `_build` runs before `sync` applies the new
cap and `content_size` is stale on the frame `ctrl+t` fires.

## Deliberately not done

- **Footer hidden entirely at h<=13** (UX U5). Verified identical on pristine
  `origin/main`, so pre-existing and out of scope.
- **No "content above" counterpart** (UX U6) and **`↓` shared with `editor.py`'s
  `RESIZED_MARK`** (design D5). Follow-ups, per their reviewers.
- **Hysteresis on the shed boundary** (design D3). Rejected with reason: it would
  make the row depend on which direction the terminal was resized, so the same
  width would render two different rows depending on history. Worse than a crisp
  boundary for a status surface, and untestable without storing resize history.
- **Counting body rows instead of todos** (would close D6/U10 structurally).
  Rejected with reason: the collapsed `+N more` counts todos, and breaking that
  pairing trades an unverifiable number for a verifiable falsehood. Padding the
  seam row closes the same defect without touching the vocabulary.
- **Two scroll notches that do not move the number** (UX U3). Structural, and the
  reviewer notes `↓ N more` has the identical property.
- **Count evaporating when a list grows past a digit boundary at narrow width**
  (UX U9). The accepted cost of the widest-fit rule that closed U1; the arrow
  survives, so it is orientation lost rather than a lie. Recorded in the
  docstring where the rule is explained.
- The pre-existing boot-race flake in `test_todo_panel_phases.py`, per above.
