### PR TITLE
fix(tui,mobile): de-dupe user echoes by message id, not text

### DIFF
--- a/docs/evidence/echo-dedup-id/README.md
+++ b/docs/evidence/echo-dedup-id/README.md
@@ -1,0 +1,44 @@
+# Echo de-duplication by message id (#228, #231)
+
+Evidence for replacing text-based user-echo de-duplication with an id-based
+registry on both front ends.
+
+## Reproductions
+
+Both scripts probe for the new argument, so they run **unchanged** against
+`origin/main` and against the fix — the two arms differ only in the code under
+test. Run with the tree on `PYTHONPATH` (the repo `.venv` is editable and would
+otherwise resolve `local_operator` to the main checkout):
+
+```sh
+PYTHONPATH=<tree> .venv/bin/python repro_231.py
+env -u NO_COLOR TERM=xterm-256color PYTHONPATH=<tree> .venv/bin/python repro_228.py <tree>
+```
+
+- `repro_228.py.txt` — a TUI steer `continue`, then the phone's own `continue`
+  as a distinct message. Base paints 1 row (the phone's message is swallowed);
+  head paints 2.
+- `repro_231.py.txt` — a phone steer, four assistant rows to push its echo past
+  the 3-entry window, then the drain's announcement. Base paints 2 rows (the
+  steer is repainted); head paints 1.
+
+## The id contract, against the real engine
+
+`verify_live.py.txt` drives a real `Session` with a scripted stream and observes
+the emitted `MessageStartEvent`s, rather than reading the source. It asserts the
+property the registry depends on: the id handed to `prompt(message_id=)` and the
+id of the object queued by `steer_message` are the ids the announcements carry.
+
+## Frames
+
+Captured from the real `OperatorApp` at 100x30 per AGENTS.md "Visual
+validation", so `local_operator.tcss` is applied. `shot_228.py.txt` is the
+capture script; it takes an output path and the tree root.
+
+- `frames/before_collision.svg` — base: one `continue` row and its queued
+  notice. The phone's message never appears.
+- `frames/after_collision.svg` — head: two `continue` rows, each with its gutter
+  rule and the correct `gap-above` spacing.
+- `frames/after_true_duplicate.svg` — head, the other direction: the steer's own
+  delivery follows, the notice settles to `sent — the agent has it now`, and no
+  third row is added.

--- a/docs/evidence/echo-dedup-id/frames/after_collision.svg
+++ b/docs/evidence/echo-dedup-id/frames/after_collision.svg
@@ -1,0 +1,180 @@
+<svg class="rich-terminal" viewBox="0 0 1238 782.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-4099933039-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-4099933039-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-4099933039-r1 { fill: #c5c8c6 }
+.terminal-4099933039-r2 { fill: #837c6d }
+.terminal-4099933039-r3 { fill: #e9e5db }
+.terminal-4099933039-r4 { fill: #b5afa2 }
+.terminal-4099933039-r5 { fill: #1e1a14 }
+.terminal-4099933039-r6 { fill: #4a4539 }
+.terminal-4099933039-r7 { fill: #6ea8d8 }
+.terminal-4099933039-r8 { fill: #ef8078;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-4099933039-clip-terminal">
+      <rect x="0" y="0" width="1219.0" height="731.0" />
+    </clipPath>
+    <clipPath id="terminal-4099933039-line-0">
+    <rect x="0" y="1.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-1">
+    <rect x="0" y="25.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-2">
+    <rect x="0" y="50.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-3">
+    <rect x="0" y="74.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-4">
+    <rect x="0" y="99.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-5">
+    <rect x="0" y="123.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-6">
+    <rect x="0" y="147.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-7">
+    <rect x="0" y="172.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-8">
+    <rect x="0" y="196.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-9">
+    <rect x="0" y="221.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-10">
+    <rect x="0" y="245.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-11">
+    <rect x="0" y="269.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-12">
+    <rect x="0" y="294.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-13">
+    <rect x="0" y="318.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-14">
+    <rect x="0" y="343.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-15">
+    <rect x="0" y="367.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-16">
+    <rect x="0" y="391.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-17">
+    <rect x="0" y="416.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-18">
+    <rect x="0" y="440.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-19">
+    <rect x="0" y="465.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-20">
+    <rect x="0" y="489.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-21">
+    <rect x="0" y="513.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-22">
+    <rect x="0" y="538.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-23">
+    <rect x="0" y="562.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-24">
+    <rect x="0" y="587.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-25">
+    <rect x="0" y="611.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-26">
+    <rect x="0" y="635.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-27">
+    <rect x="0" y="660.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4099933039-line-28">
+    <rect x="0" y="684.7" width="1220" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="780" rx="8"/><text class="terminal-4099933039-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">Local&#160;Operator</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-4099933039-clip-terminal)">
+    <rect fill="#14110c" x="0" y="1.5" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="25.9" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="50.3" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="146.4" y="50.3" width="1049.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="74.7" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="73.2" y="99.1" width="463.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="536.8" y="99.1" width="658.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="123.5" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="147.9" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="146.4" y="147.9" width="1049.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="172.3" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="196.7" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="221.1" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="245.5" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="269.9" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="294.3" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="318.7" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="343.1" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="367.5" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="391.9" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="416.3" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="440.7" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="465.1" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="489.5" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="513.9" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="538.3" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="562.7" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="587.1" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="36.6" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#e9e5db" x="61" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="73.2" y="611.5" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="353.8" y="611.5" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1183.4" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1195.6" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="635.9" width="1171.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1195.6" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="660.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="170.8" y="660.3" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="207.4" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="231.8" y="660.3" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="597.8" y="660.3" width="573.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1171.2" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1183.4" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1195.6" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="684.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="684.7" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="684.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="709.1" width="1220" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-4099933039-matrix">
+    <text class="terminal-4099933039-r1" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-4099933039-line-0)">
+</text><text class="terminal-4099933039-r1" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-4099933039-line-1)">
+</text><text class="terminal-4099933039-r2" x="24.4" y="68.8" textLength="24.4" clip-path="url(#terminal-4099933039-line-2)">▌&#160;</text><text class="terminal-4099933039-r3" x="48.8" y="68.8" textLength="97.6" clip-path="url(#terminal-4099933039-line-2)">continue</text><text class="terminal-4099933039-r1" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-4099933039-line-2)">
+</text><text class="terminal-4099933039-r1" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-4099933039-line-3)">
+</text><text class="terminal-4099933039-r4" x="48.8" y="117.6" textLength="24.4" clip-path="url(#terminal-4099933039-line-4)">·&#160;</text><text class="terminal-4099933039-r4" x="73.2" y="117.6" textLength="463.6" clip-path="url(#terminal-4099933039-line-4)">queued&#160;—&#160;sends&#160;when&#160;this&#160;step&#160;finishes</text><text class="terminal-4099933039-r1" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-4099933039-line-4)">
+</text><text class="terminal-4099933039-r1" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-4099933039-line-5)">
+</text><text class="terminal-4099933039-r2" x="24.4" y="166.4" textLength="24.4" clip-path="url(#terminal-4099933039-line-6)">▌&#160;</text><text class="terminal-4099933039-r3" x="48.8" y="166.4" textLength="97.6" clip-path="url(#terminal-4099933039-line-6)">continue</text><text class="terminal-4099933039-r1" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-4099933039-line-6)">
+</text><text class="terminal-4099933039-r1" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-4099933039-line-7)">
+</text><text class="terminal-4099933039-r1" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-4099933039-line-8)">
+</text><text class="terminal-4099933039-r1" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-4099933039-line-9)">
+</text><text class="terminal-4099933039-r1" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-4099933039-line-10)">
+</text><text class="terminal-4099933039-r1" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-4099933039-line-11)">
+</text><text class="terminal-4099933039-r1" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-4099933039-line-12)">
+</text><text class="terminal-4099933039-r1" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-4099933039-line-13)">
+</text><text class="terminal-4099933039-r1" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-4099933039-line-14)">
+</text><text class="terminal-4099933039-r1" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-4099933039-line-15)">
+</text><text class="terminal-4099933039-r1" x="1220" y="410.4" textLength="12.2" clip-path="url(#terminal-4099933039-line-16)">
+</text><text class="terminal-4099933039-r1" x="1220" y="434.8" textLength="12.2" clip-path="url(#terminal-4099933039-line-17)">
+</text><text class="terminal-4099933039-r1" x="1220" y="459.2" textLength="12.2" clip-path="url(#terminal-4099933039-line-18)">
+</text><text class="terminal-4099933039-r1" x="1220" y="483.6" textLength="12.2" clip-path="url(#terminal-4099933039-line-19)">
+</text><text class="terminal-4099933039-r1" x="1220" y="508" textLength="12.2" clip-path="url(#terminal-4099933039-line-20)">
+</text><text class="terminal-4099933039-r1" x="1220" y="532.4" textLength="12.2" clip-path="url(#terminal-4099933039-line-21)">
+</text><text class="terminal-4099933039-r1" x="1220" y="556.8" textLength="12.2" clip-path="url(#terminal-4099933039-line-22)">
+</text><text class="terminal-4099933039-r1" x="1220" y="581.2" textLength="12.2" clip-path="url(#terminal-4099933039-line-23)">
+</text><text class="terminal-4099933039-r1" x="1220" y="605.6" textLength="12.2" clip-path="url(#terminal-4099933039-line-24)">
+</text><text class="terminal-4099933039-r3" x="24.4" y="630" textLength="12.2" clip-path="url(#terminal-4099933039-line-25)">❯</text><text class="terminal-4099933039-r2" x="73.2" y="630" textLength="280.6" clip-path="url(#terminal-4099933039-line-25)">Message&#160;Local&#160;Operator…</text><text class="terminal-4099933039-r1" x="1220" y="630" textLength="12.2" clip-path="url(#terminal-4099933039-line-25)">
+</text><text class="terminal-4099933039-r1" x="1220" y="654.4" textLength="12.2" clip-path="url(#terminal-4099933039-line-26)">
+</text><text class="terminal-4099933039-r2" x="24.4" y="678.8" textLength="24.4" clip-path="url(#terminal-4099933039-line-27)">◆&#160;</text><text class="terminal-4099933039-r3" x="48.8" y="678.8" textLength="122" clip-path="url(#terminal-4099933039-line-27)">test/model</text><text class="terminal-4099933039-r6" x="170.8" y="678.8" textLength="36.6" clip-path="url(#terminal-4099933039-line-27)">&#160;›&#160;</text><text class="terminal-4099933039-r2" x="207.4" y="678.8" textLength="24.4" clip-path="url(#terminal-4099933039-line-27)">⌂&#160;</text><text class="terminal-4099933039-r7" x="231.8" y="678.8" textLength="366" clip-path="url(#terminal-4099933039-line-27)">/private/tmp/lop-echo-dedup-id</text><text class="terminal-4099933039-r8" x="1171.2" y="678.8" textLength="12.2" clip-path="url(#terminal-4099933039-line-27)">!</text><text class="terminal-4099933039-r1" x="1220" y="678.8" textLength="12.2" clip-path="url(#terminal-4099933039-line-27)">
+</text><text class="terminal-4099933039-r1" x="1220" y="703.2" textLength="12.2" clip-path="url(#terminal-4099933039-line-28)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/evidence/echo-dedup-id/frames/after_true_duplicate.svg
+++ b/docs/evidence/echo-dedup-id/frames/after_true_duplicate.svg
@@ -1,0 +1,179 @@
+<svg class="rich-terminal" viewBox="0 0 1238 782.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-3954245859-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-3954245859-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-3954245859-r1 { fill: #c5c8c6 }
+.terminal-3954245859-r2 { fill: #837c6d }
+.terminal-3954245859-r3 { fill: #e9e5db }
+.terminal-3954245859-r4 { fill: #1e1a14 }
+.terminal-3954245859-r5 { fill: #4a4539 }
+.terminal-3954245859-r6 { fill: #6ea8d8 }
+.terminal-3954245859-r7 { fill: #ef8078;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-3954245859-clip-terminal">
+      <rect x="0" y="0" width="1219.0" height="731.0" />
+    </clipPath>
+    <clipPath id="terminal-3954245859-line-0">
+    <rect x="0" y="1.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-1">
+    <rect x="0" y="25.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-2">
+    <rect x="0" y="50.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-3">
+    <rect x="0" y="74.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-4">
+    <rect x="0" y="99.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-5">
+    <rect x="0" y="123.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-6">
+    <rect x="0" y="147.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-7">
+    <rect x="0" y="172.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-8">
+    <rect x="0" y="196.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-9">
+    <rect x="0" y="221.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-10">
+    <rect x="0" y="245.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-11">
+    <rect x="0" y="269.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-12">
+    <rect x="0" y="294.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-13">
+    <rect x="0" y="318.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-14">
+    <rect x="0" y="343.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-15">
+    <rect x="0" y="367.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-16">
+    <rect x="0" y="391.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-17">
+    <rect x="0" y="416.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-18">
+    <rect x="0" y="440.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-19">
+    <rect x="0" y="465.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-20">
+    <rect x="0" y="489.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-21">
+    <rect x="0" y="513.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-22">
+    <rect x="0" y="538.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-23">
+    <rect x="0" y="562.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-24">
+    <rect x="0" y="587.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-25">
+    <rect x="0" y="611.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-26">
+    <rect x="0" y="635.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-27">
+    <rect x="0" y="660.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3954245859-line-28">
+    <rect x="0" y="684.7" width="1220" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="780" rx="8"/><text class="terminal-3954245859-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">Local&#160;Operator</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3954245859-clip-terminal)">
+    <rect fill="#14110c" x="0" y="1.5" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="25.9" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="50.3" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="146.4" y="50.3" width="1049.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="74.7" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="73.2" y="99.1" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="402.6" y="99.1" width="793" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="123.5" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="147.9" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="146.4" y="147.9" width="1049.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="172.3" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="196.7" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="221.1" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="245.5" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="269.9" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="294.3" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="318.7" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="343.1" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="367.5" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="391.9" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="416.3" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="440.7" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="465.1" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="489.5" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="513.9" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="538.3" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="562.7" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="587.1" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="36.6" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#e9e5db" x="61" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="73.2" y="611.5" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="353.8" y="611.5" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1183.4" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1195.6" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="635.9" width="1171.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1195.6" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="660.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="170.8" y="660.3" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="207.4" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="231.8" y="660.3" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="597.8" y="660.3" width="573.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1171.2" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1183.4" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1195.6" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="684.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="684.7" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="684.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="709.1" width="1220" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-3954245859-matrix">
+    <text class="terminal-3954245859-r1" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-3954245859-line-0)">
+</text><text class="terminal-3954245859-r1" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-3954245859-line-1)">
+</text><text class="terminal-3954245859-r2" x="24.4" y="68.8" textLength="24.4" clip-path="url(#terminal-3954245859-line-2)">▌&#160;</text><text class="terminal-3954245859-r3" x="48.8" y="68.8" textLength="97.6" clip-path="url(#terminal-3954245859-line-2)">continue</text><text class="terminal-3954245859-r1" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-3954245859-line-2)">
+</text><text class="terminal-3954245859-r1" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-3954245859-line-3)">
+</text><text class="terminal-3954245859-r3" x="48.8" y="117.6" textLength="24.4" clip-path="url(#terminal-3954245859-line-4)">✓&#160;</text><text class="terminal-3954245859-r3" x="73.2" y="117.6" textLength="329.4" clip-path="url(#terminal-3954245859-line-4)">sent&#160;—&#160;the&#160;agent&#160;has&#160;it&#160;now</text><text class="terminal-3954245859-r1" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-3954245859-line-4)">
+</text><text class="terminal-3954245859-r1" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-3954245859-line-5)">
+</text><text class="terminal-3954245859-r2" x="24.4" y="166.4" textLength="24.4" clip-path="url(#terminal-3954245859-line-6)">▌&#160;</text><text class="terminal-3954245859-r3" x="48.8" y="166.4" textLength="97.6" clip-path="url(#terminal-3954245859-line-6)">continue</text><text class="terminal-3954245859-r1" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-3954245859-line-6)">
+</text><text class="terminal-3954245859-r1" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-3954245859-line-7)">
+</text><text class="terminal-3954245859-r1" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-3954245859-line-8)">
+</text><text class="terminal-3954245859-r1" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-3954245859-line-9)">
+</text><text class="terminal-3954245859-r1" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-3954245859-line-10)">
+</text><text class="terminal-3954245859-r1" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-3954245859-line-11)">
+</text><text class="terminal-3954245859-r1" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-3954245859-line-12)">
+</text><text class="terminal-3954245859-r1" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-3954245859-line-13)">
+</text><text class="terminal-3954245859-r1" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-3954245859-line-14)">
+</text><text class="terminal-3954245859-r1" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-3954245859-line-15)">
+</text><text class="terminal-3954245859-r1" x="1220" y="410.4" textLength="12.2" clip-path="url(#terminal-3954245859-line-16)">
+</text><text class="terminal-3954245859-r1" x="1220" y="434.8" textLength="12.2" clip-path="url(#terminal-3954245859-line-17)">
+</text><text class="terminal-3954245859-r1" x="1220" y="459.2" textLength="12.2" clip-path="url(#terminal-3954245859-line-18)">
+</text><text class="terminal-3954245859-r1" x="1220" y="483.6" textLength="12.2" clip-path="url(#terminal-3954245859-line-19)">
+</text><text class="terminal-3954245859-r1" x="1220" y="508" textLength="12.2" clip-path="url(#terminal-3954245859-line-20)">
+</text><text class="terminal-3954245859-r1" x="1220" y="532.4" textLength="12.2" clip-path="url(#terminal-3954245859-line-21)">
+</text><text class="terminal-3954245859-r1" x="1220" y="556.8" textLength="12.2" clip-path="url(#terminal-3954245859-line-22)">
+</text><text class="terminal-3954245859-r1" x="1220" y="581.2" textLength="12.2" clip-path="url(#terminal-3954245859-line-23)">
+</text><text class="terminal-3954245859-r1" x="1220" y="605.6" textLength="12.2" clip-path="url(#terminal-3954245859-line-24)">
+</text><text class="terminal-3954245859-r3" x="24.4" y="630" textLength="12.2" clip-path="url(#terminal-3954245859-line-25)">❯</text><text class="terminal-3954245859-r2" x="73.2" y="630" textLength="280.6" clip-path="url(#terminal-3954245859-line-25)">Message&#160;Local&#160;Operator…</text><text class="terminal-3954245859-r1" x="1220" y="630" textLength="12.2" clip-path="url(#terminal-3954245859-line-25)">
+</text><text class="terminal-3954245859-r1" x="1220" y="654.4" textLength="12.2" clip-path="url(#terminal-3954245859-line-26)">
+</text><text class="terminal-3954245859-r2" x="24.4" y="678.8" textLength="24.4" clip-path="url(#terminal-3954245859-line-27)">◆&#160;</text><text class="terminal-3954245859-r3" x="48.8" y="678.8" textLength="122" clip-path="url(#terminal-3954245859-line-27)">test/model</text><text class="terminal-3954245859-r5" x="170.8" y="678.8" textLength="36.6" clip-path="url(#terminal-3954245859-line-27)">&#160;›&#160;</text><text class="terminal-3954245859-r2" x="207.4" y="678.8" textLength="24.4" clip-path="url(#terminal-3954245859-line-27)">⌂&#160;</text><text class="terminal-3954245859-r6" x="231.8" y="678.8" textLength="366" clip-path="url(#terminal-3954245859-line-27)">/private/tmp/lop-echo-dedup-id</text><text class="terminal-3954245859-r7" x="1171.2" y="678.8" textLength="12.2" clip-path="url(#terminal-3954245859-line-27)">!</text><text class="terminal-3954245859-r1" x="1220" y="678.8" textLength="12.2" clip-path="url(#terminal-3954245859-line-27)">
+</text><text class="terminal-3954245859-r1" x="1220" y="703.2" textLength="12.2" clip-path="url(#terminal-3954245859-line-28)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/evidence/echo-dedup-id/frames/before_collision.svg
+++ b/docs/evidence/echo-dedup-id/frames/before_collision.svg
@@ -1,0 +1,180 @@
+<svg class="rich-terminal" viewBox="0 0 1238 782.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-1066222773-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-1066222773-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-1066222773-r1 { fill: #c5c8c6 }
+.terminal-1066222773-r2 { fill: #837c6d }
+.terminal-1066222773-r3 { fill: #e9e5db }
+.terminal-1066222773-r4 { fill: #b5afa2 }
+.terminal-1066222773-r5 { fill: #1e1a14 }
+.terminal-1066222773-r6 { fill: #4a4539 }
+.terminal-1066222773-r7 { fill: #6ea8d8 }
+.terminal-1066222773-r8 { fill: #ef8078;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-1066222773-clip-terminal">
+      <rect x="0" y="0" width="1219.0" height="731.0" />
+    </clipPath>
+    <clipPath id="terminal-1066222773-line-0">
+    <rect x="0" y="1.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-1">
+    <rect x="0" y="25.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-2">
+    <rect x="0" y="50.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-3">
+    <rect x="0" y="74.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-4">
+    <rect x="0" y="99.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-5">
+    <rect x="0" y="123.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-6">
+    <rect x="0" y="147.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-7">
+    <rect x="0" y="172.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-8">
+    <rect x="0" y="196.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-9">
+    <rect x="0" y="221.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-10">
+    <rect x="0" y="245.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-11">
+    <rect x="0" y="269.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-12">
+    <rect x="0" y="294.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-13">
+    <rect x="0" y="318.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-14">
+    <rect x="0" y="343.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-15">
+    <rect x="0" y="367.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-16">
+    <rect x="0" y="391.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-17">
+    <rect x="0" y="416.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-18">
+    <rect x="0" y="440.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-19">
+    <rect x="0" y="465.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-20">
+    <rect x="0" y="489.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-21">
+    <rect x="0" y="513.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-22">
+    <rect x="0" y="538.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-23">
+    <rect x="0" y="562.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-24">
+    <rect x="0" y="587.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-25">
+    <rect x="0" y="611.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-26">
+    <rect x="0" y="635.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-27">
+    <rect x="0" y="660.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1066222773-line-28">
+    <rect x="0" y="684.7" width="1220" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="780" rx="8"/><text class="terminal-1066222773-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">Local&#160;Operator</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1066222773-clip-terminal)">
+    <rect fill="#14110c" x="0" y="1.5" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="25.9" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="50.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="50.3" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="146.4" y="50.3" width="1049.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="74.7" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="48.8" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="73.2" y="99.1" width="463.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="536.8" y="99.1" width="658.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="123.5" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="147.9" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="172.3" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="196.7" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="221.1" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="245.5" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="269.9" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="294.3" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="318.7" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="343.1" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="367.5" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="391.9" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="416.3" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="440.7" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="465.1" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="489.5" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="513.9" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="538.3" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="562.7" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="587.1" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="36.6" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#e9e5db" x="61" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="73.2" y="611.5" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="353.8" y="611.5" width="829.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1183.4" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1195.6" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="635.9" width="1171.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1195.6" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="24.4" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="48.8" y="660.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="170.8" y="660.3" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="207.4" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="231.8" y="660.3" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="561.2" y="660.3" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1171.2" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1183.4" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1195.6" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="684.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="12.2" y="684.7" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="684.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="709.1" width="1220" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-1066222773-matrix">
+    <text class="terminal-1066222773-r1" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-1066222773-line-0)">
+</text><text class="terminal-1066222773-r1" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-1066222773-line-1)">
+</text><text class="terminal-1066222773-r2" x="24.4" y="68.8" textLength="24.4" clip-path="url(#terminal-1066222773-line-2)">▌&#160;</text><text class="terminal-1066222773-r3" x="48.8" y="68.8" textLength="97.6" clip-path="url(#terminal-1066222773-line-2)">continue</text><text class="terminal-1066222773-r1" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-1066222773-line-2)">
+</text><text class="terminal-1066222773-r1" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-1066222773-line-3)">
+</text><text class="terminal-1066222773-r4" x="48.8" y="117.6" textLength="24.4" clip-path="url(#terminal-1066222773-line-4)">·&#160;</text><text class="terminal-1066222773-r4" x="73.2" y="117.6" textLength="463.6" clip-path="url(#terminal-1066222773-line-4)">queued&#160;—&#160;sends&#160;when&#160;this&#160;step&#160;finishes</text><text class="terminal-1066222773-r1" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-1066222773-line-4)">
+</text><text class="terminal-1066222773-r1" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-1066222773-line-5)">
+</text><text class="terminal-1066222773-r1" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-1066222773-line-6)">
+</text><text class="terminal-1066222773-r1" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-1066222773-line-7)">
+</text><text class="terminal-1066222773-r1" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-1066222773-line-8)">
+</text><text class="terminal-1066222773-r1" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-1066222773-line-9)">
+</text><text class="terminal-1066222773-r1" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-1066222773-line-10)">
+</text><text class="terminal-1066222773-r1" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-1066222773-line-11)">
+</text><text class="terminal-1066222773-r1" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-1066222773-line-12)">
+</text><text class="terminal-1066222773-r1" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-1066222773-line-13)">
+</text><text class="terminal-1066222773-r1" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-1066222773-line-14)">
+</text><text class="terminal-1066222773-r1" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-1066222773-line-15)">
+</text><text class="terminal-1066222773-r1" x="1220" y="410.4" textLength="12.2" clip-path="url(#terminal-1066222773-line-16)">
+</text><text class="terminal-1066222773-r1" x="1220" y="434.8" textLength="12.2" clip-path="url(#terminal-1066222773-line-17)">
+</text><text class="terminal-1066222773-r1" x="1220" y="459.2" textLength="12.2" clip-path="url(#terminal-1066222773-line-18)">
+</text><text class="terminal-1066222773-r1" x="1220" y="483.6" textLength="12.2" clip-path="url(#terminal-1066222773-line-19)">
+</text><text class="terminal-1066222773-r1" x="1220" y="508" textLength="12.2" clip-path="url(#terminal-1066222773-line-20)">
+</text><text class="terminal-1066222773-r1" x="1220" y="532.4" textLength="12.2" clip-path="url(#terminal-1066222773-line-21)">
+</text><text class="terminal-1066222773-r1" x="1220" y="556.8" textLength="12.2" clip-path="url(#terminal-1066222773-line-22)">
+</text><text class="terminal-1066222773-r1" x="1220" y="581.2" textLength="12.2" clip-path="url(#terminal-1066222773-line-23)">
+</text><text class="terminal-1066222773-r1" x="1220" y="605.6" textLength="12.2" clip-path="url(#terminal-1066222773-line-24)">
+</text><text class="terminal-1066222773-r3" x="24.4" y="630" textLength="12.2" clip-path="url(#terminal-1066222773-line-25)">❯</text><text class="terminal-1066222773-r2" x="73.2" y="630" textLength="280.6" clip-path="url(#terminal-1066222773-line-25)">Message&#160;Local&#160;Operator…</text><text class="terminal-1066222773-r1" x="1220" y="630" textLength="12.2" clip-path="url(#terminal-1066222773-line-25)">
+</text><text class="terminal-1066222773-r1" x="1220" y="654.4" textLength="12.2" clip-path="url(#terminal-1066222773-line-26)">
+</text><text class="terminal-1066222773-r2" x="24.4" y="678.8" textLength="24.4" clip-path="url(#terminal-1066222773-line-27)">◆&#160;</text><text class="terminal-1066222773-r3" x="48.8" y="678.8" textLength="122" clip-path="url(#terminal-1066222773-line-27)">test/model</text><text class="terminal-1066222773-r6" x="170.8" y="678.8" textLength="36.6" clip-path="url(#terminal-1066222773-line-27)">&#160;›&#160;</text><text class="terminal-1066222773-r2" x="207.4" y="678.8" textLength="24.4" clip-path="url(#terminal-1066222773-line-27)">⌂&#160;</text><text class="terminal-1066222773-r7" x="231.8" y="678.8" textLength="329.4" clip-path="url(#terminal-1066222773-line-27)">/private/tmp/lop-base-check</text><text class="terminal-1066222773-r8" x="1171.2" y="678.8" textLength="12.2" clip-path="url(#terminal-1066222773-line-27)">!</text><text class="terminal-1066222773-r1" x="1220" y="678.8" textLength="12.2" clip-path="url(#terminal-1066222773-line-27)">
+</text><text class="terminal-1066222773-r1" x="1220" y="703.2" textLength="12.2" clip-path="url(#terminal-1066222773-line-28)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/evidence/echo-dedup-id/repro_228.py.txt
+++ b/docs/evidence/echo-dedup-id/repro_228.py.txt
@@ -1,0 +1,54 @@
+"""Issue #228 reproduction: a phone prompt whose words collide with a pending
+TUI echo must still paint. Runs unchanged on both trees.
+
+The TUI queues a steer "continue" (its echo is pending), then the PHONE sends
+its own "continue" — a DISTINCT message with its own id. Matching by text
+consumed the steer's entry and painted nothing.
+"""
+import asyncio, inspect, sys
+sys.path.insert(0, sys.argv[1])  # repo root, so `tests.` imports resolve
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.events import UserMessageStart
+from local_operator.tui.widgets.editor import Editor
+from local_operator.tui.widgets.transcript import TranscriptView, UserBlock
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+class Streaming(FakeSession):
+    """Mid-turn, so a submit is STEERED rather than prompted."""
+    @property
+    def is_streaming(self): return True
+
+
+def user_rows(app, text):
+    return [b for b in app.query_one(TranscriptView).blocks()
+            if isinstance(b, UserBlock) and b.text() == text]
+
+
+async def main() -> int:
+    session = Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(200):
+            if app._session is not None: break
+            await pilot.pause(); await asyncio.sleep(0.01)
+        ed = app.query_one(Editor); ed.focus(); await pilot.pause()
+        ed.text = "continue"; await pilot.pause()
+        await pilot.press("enter"); await pilot.pause()
+        print(f"TUI steer echo painted                : {len(user_rows(app,'continue'))} row")
+
+        # The phone's OWN "continue": same words, different message identity.
+        supports_id = "message_id" in inspect.signature(UserMessageStart.__init__).parameters
+        evt = (UserMessageStart("continue", 0, "phone-message-id") if supports_id
+               else UserMessageStart("continue", 0))
+        app.post_message(evt); await pilot.pause()
+
+        rows = len(user_rows(app, "continue"))
+        print(f"UserMessageStart carries message_id   : {supports_id}")
+        print(f"rows after the phone's message        : {rows}  (expected 2)")
+        print("RESULT: " + ("PASS - the phone's message painted" if rows == 2
+                            else "FAIL - the phone's message was swallowed"))
+        return 0 if rows == 2 else 1
+
+sys.exit(asyncio.run(main()))

--- a/docs/evidence/echo-dedup-id/repro_231.py.txt
+++ b/docs/evidence/echo-dedup-id/repro_231.py.txt
@@ -1,0 +1,37 @@
+"""Issue #231 reproduction, using ONLY the base API so it runs on both trees.
+
+A phone steer is echoed optimistically; the turn keeps running (assistant rows
+land); only then is the steer drained and announced. The 3-entry tail scan can
+no longer see the echo and repaints the message.
+"""
+import sys
+from local_operator.harness.types import Message, MessageStartEvent
+from local_operator.mobile.projection import ProjectionFold
+from local_operator.mobile.types import SessionProjection
+
+fold = ProjectionFold(SessionProjection(session_id="s1", pid=1))
+
+# The handle's optimistic echo for a phone steer. Base API: no id argument.
+# On the fixed tree the handle passes message_id; emulate BOTH by probing.
+import inspect
+supports_id = "message_id" in inspect.signature(fold.note_user_message).parameters
+CMD = "cmd-steer-1"
+if supports_id:
+    fold.note_user_message("use the other endpoint", steer=True, message_id=CMD)
+else:
+    fold.note_user_message("use the other endpoint", steer=True)
+
+# The turn continues: assistant rows push the echo out of the 3-entry window.
+for i in range(4):
+    fold.fold_event(MessageStartEvent(message=Message.assistant(f"still working {i}")))
+
+# The drain finally announces the steer, carrying the id the handle supplied.
+fold.absorb_user_event(Message.user("use the other endpoint", id=CMD))
+
+rows = [e for e in fold.projection.transcript if e.text == "use the other endpoint"]
+print(f"note_user_message supports message_id : {supports_id}")
+print(f"rows carrying the steer text          : {len(rows)}  (expected 1)")
+print(f"row kinds                             : {[r.kind for r in rows]}")
+print("RESULT: " + ("PASS - steer painted once" if len(rows) == 1
+                    else f"FAIL - steer repainted, {len(rows)} rows"))
+sys.exit(0 if len(rows) == 1 else 1)

--- a/docs/evidence/echo-dedup-id/shot_228.py.txt
+++ b/docs/evidence/echo-dedup-id/shot_228.py.txt
@@ -1,0 +1,40 @@
+"""Render the #228 collision case: a TUI steer "continue", then the phone's own
+"continue". Uses the REAL OperatorApp (so local_operator.tcss applies)."""
+import asyncio, inspect, sys
+sys.path.insert(0, sys.argv[2])
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.events import UserMessageStart
+from local_operator.tui.widgets.editor import Editor
+from local_operator.tui.widgets.transcript import TranscriptView, UserBlock
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+class Streaming(FakeSession):
+    @property
+    def is_streaming(self): return True
+
+
+async def main() -> None:
+    session = Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(200):
+            if app._session is not None: break
+            await pilot.pause(); await asyncio.sleep(0.01)
+        ed = app.query_one(Editor); ed.focus(); await pilot.pause()
+        ed.text = "continue"; await pilot.pause()
+        await pilot.press("enter"); await pilot.pause()
+
+        supports_id = "message_id" in inspect.signature(UserMessageStart.__init__).parameters
+        evt = (UserMessageStart("continue", 0, "phone-message-id") if supports_id
+               else UserMessageStart("continue", 0))
+        app.post_message(evt)
+        await pilot.pause(); await pilot.pause()
+
+        rows = [b for b in app.query_one(TranscriptView).blocks()
+                if isinstance(b, UserBlock) and b.text() == "continue"]
+        app.save_screenshot(sys.argv[1])
+        print(f"{sys.argv[1]}: {len(rows)} 'continue' user row(s)")
+
+asyncio.run(main())

--- a/docs/evidence/echo-dedup-id/verify_live.py.txt
+++ b/docs/evidence/echo-dedup-id/verify_live.py.txt
@@ -1,0 +1,59 @@
+"""Drive a REAL Session and OBSERVE the announced MessageStartEvent ids.
+
+The registry is only correct if the id the TUI hands prompt()/steer_message()
+is the id that comes back on the announcement. Asserted against the real
+engine, not a fake and not the source text.
+"""
+import asyncio, sys
+sys.path.insert(0, "/tmp/lop-echo-dedup-id")
+import pathlib, tempfile
+
+from local_operator.harness.types import Message, MessageStartEvent, StreamEndEvent
+from local_operator.session.session import Session
+from local_operator.session.transcript import Transcript
+from tests.unit.session.test_session import MODEL, ScriptedStream
+
+
+async def main() -> int:
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    announced: list[str] = []
+
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")]])
+    session = Session(
+        model=MODEL,
+        stream_fn=stream,
+        tools=[],
+        transcript=Transcript(tmp / "sess"),
+        system_blocks_provider=lambda: ["stable"],
+    )
+
+    def on_event(event):
+        if isinstance(event, MessageStartEvent):
+            msg = event.message
+            if isinstance(msg, Message) and msg.role == "user":
+                announced.append(str(msg.id))
+
+    session.subscribe(on_event)
+
+    # 1. The prompt path: the TUI mints the id and pushes it in.
+    await session.prompt("continue", message_id="tui-minted-id")
+    print(f"prompt(message_id='tui-minted-id') announced : {announced}")
+    ok_prompt = announced == ["tui-minted-id"]
+
+    # 2. The steer path: the queued object's own id is announced at the drain.
+    announced.clear()
+    steer = Message.user("continue")
+    session.steer_message(steer)
+    drained = await session._drain_steering()
+    print(f"steer_message(id={steer.id[:12]}...) announced  : "
+          f"{[a[:12] + '...' for a in announced]}")
+    ok_steer = announced == [steer.id] and len(drained) == 1
+
+    print()
+    print(f"prompt id round-trips : {ok_prompt}")
+    print(f"steer id round-trips  : {ok_steer}")
+    print("RESULT: " + ("PASS - the announced id is the id the TUI registered"
+                        if ok_prompt and ok_steer else "FAIL"))
+    return 0 if (ok_prompt and ok_steer) else 1
+
+sys.exit(asyncio.run(main()))

--- a/docs/evidence/echo-dedup-id/verify_live.py.txt
+++ b/docs/evidence/echo-dedup-id/verify_live.py.txt
@@ -5,8 +5,15 @@ is the id that comes back on the announcement. Asserted against the real
 engine, not a fake and not the source text.
 """
 import asyncio, sys
-sys.path.insert(0, "/tmp/lop-echo-dedup-id")
 import pathlib, tempfile
+
+# The repo root, derived from this file's own location rather than hardcoded:
+# committed evidence has to run from any checkout, not only the worktree it was
+# written in (round 1, F3). Falls back to argv[1] when the script is copied out
+# of docs/evidence/, which is how it is usually run.
+_here = pathlib.Path(__file__).resolve()
+_root = sys.argv[1] if len(sys.argv) > 1 else str(_here.parents[3])
+sys.path.insert(0, _root)
 
 from local_operator.harness.types import Message, MessageStartEvent, StreamEndEvent
 from local_operator.session.session import Session

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -618,7 +618,19 @@ class OwnedSessionHandle(SessionHandle):
             raise
         self._command_reservations.accept(command_id)
         self._projection.queued_count += 1
-        self._fold.note_user_message(text, steer=True)
+        # Register the echo under the id the session will actually announce, so
+        # the drain's MessageStartEvent upgrades THIS row rather than being
+        # matched against the transcript tail (issue #231) — a steer is
+        # delivered at a later tool boundary, by which point assistant and tool
+        # rows have pushed the echo out of any window. Only when `message_id`
+        # really reached the session: a session that mints its own id would
+        # announce something this key could never match, and the fold's tail
+        # fallback is the correct behaviour there.
+        self._fold.note_user_message(
+            text,
+            steer=True,
+            message_id=command_id if "message_id" in fields else None,
+        )
         self._notify()
         return "steering queued"
 

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -345,6 +345,21 @@ class ProjectionFold:
         # have several at once (a parallel tool batch); the phone renders the
         # front one and a "1 of N" badge. See push_pending/pop_pending.
         self._pending_queue: list[PendingRequest] = []
+        # Optimistic user rows this fold painted whose MessageStartEvent has
+        # not arrived yet, keyed by the message id the handle handed the
+        # session. `absorb_user_event` pops the entry instead of scanning the
+        # transcript tail: a phone steer is announced at a LATER tool boundary,
+        # so assistant and tool rows push its echo out of any fixed window and
+        # the tail scan repainted it (issue #231, the mobile twin of the TUI's
+        # #227). Holds the TranscriptEntry itself, because the event's job is
+        # to upgrade that row in place (id and image refs) rather than to
+        # suppress a second one.
+        #
+        # An entry is retired by its own event, and otherwise by the wholesale
+        # `fold_history` rebuild — the rows it described are gone and the
+        # rebuilt tail carries the persisted messages instead, so a surviving
+        # entry would point at a row no longer in the transcript.
+        self._pending_user_echoes: dict[str, TranscriptEntry] = {}
 
     # -- history -----------------------------------------------------------
 
@@ -423,8 +438,12 @@ class ProjectionFold:
                         message.text,
                         result_details if isinstance(result_details, dict) else None,
                     )
-        # A resumed fold starts clean: no streaming row, no half-run tools.
+        # A resumed fold starts clean: no streaming row, no half-run tools, and
+        # no pending echoes — the rows those entries pointed at have just been
+        # replaced wholesale, and the persisted history already carries any
+        # message that was really delivered.
         self._open_message_id = None
+        self._pending_user_echoes.clear()
         self.projection.transcript = self._cap_tail(entries)
         # Prune the correlation maps to the surviving tail: a long history
         # pairs every historical tool call, and keeping ids whose rows were
@@ -618,21 +637,35 @@ class ProjectionFold:
 
     # -- user turns --------------------------------------------------------------
 
-    def note_user_message(self, text: str, *, steer: bool = False) -> None:
+    def note_user_message(
+        self, text: str, *, steer: bool = False, message_id: str | None = None
+    ) -> None:
         """Append the user's own message to the transcript. Called by the
         handle's prompt/steer path, because the harness only emits
         MessageStartEvent for ASSISTANT messages — a live user prompt never
         reaches the fold as an event, so without this the phone showed the
         agent's reply with no sign of what the human asked (and, for a
-        phone-sent prompt, no echo of the tap at all)."""
-        self._append(
-            TranscriptEntry(
-                id=f"user-{time.time_ns()}",
-                kind="steer" if steer else "user",
-                text=text,
-                final=True,
-            )
+        phone-sent prompt, no echo of the tap at all).
+
+        ``message_id`` is the id the handle handed the session for this very
+        message (the ``ContinuationCommand`` id, which becomes the ``Message``
+        id). Recorded in the pending-echo registry so :meth:`absorb_user_event`
+        recognises the eventual event as THIS row rather than guessing from the
+        transcript tail — see that method for why the guess was wrong. Omitted
+        by callers with no id to offer, which keeps the legacy tail match.
+        """
+        entry = TranscriptEntry(
+            # Synthetic id when the handle has none: the row still needs a
+            # unique key for the web client's list reconciliation, and the
+            # registry below is what carries the correlation instead.
+            id=message_id or f"user-{time.time_ns()}",
+            kind="steer" if steer else "user",
+            text=text,
+            final=True,
         )
+        self._append(entry)
+        if message_id:
+            self._pending_user_echoes[message_id] = entry
         self._bump()
 
     def note_peer_message(self, text: str, *, sender: dict[str, Any] | None = None) -> None:
@@ -659,23 +692,52 @@ class ProjectionFold:
         TUI→phone direction that was missing. Returns True when it added the
         row; False when the row was already there (the handle's optimistic
         ``note_user_message`` echo for a phone-sent prompt), so the same
-        message never appears twice on the phone."""
+        message never appears twice on the phone.
+
+        De-duped against an explicit registry keyed by MESSAGE ID, not by a
+        scan of the transcript tail (issue #231). A phone STEER is announced
+        only when the drain takes it, at a later tool boundary, so assistant
+        and tool rows land between the echo and its event and push the echo out
+        of any fixed-size window — the three-entry scan this replaces repainted
+        the steer the moment that happened. The id is exact and order-free,
+        which also fixes the mirror-image failure the window had: a genuinely
+        distinct message whose words collide with a recent row was swallowed.
+
+        The in-place UPGRADE is preserved and load-bearing: a phone-sent prompt
+        is echoed WITHOUT image refs (the handle holds only the wire images),
+        so when the real event arrives carrying the attachments the echoed row
+        takes the message's id and refs rather than being skipped — otherwise
+        the thumbnails never appear for the sender.
+        """
         if not isinstance(message, Message) or message.role != "user":
             return False
         text = message.text
         refs = _image_refs(message)
-        # De-dupe the optimistic echo: same text already sitting at the tail.
-        # A phone-sent prompt was echoed by note_user_message WITHOUT image
-        # refs (the handle has only the wire images, not a persisted id), so
-        # when the real MessageStartEvent arrives carrying the attachments,
-        # upgrade the echoed row's id and image refs in place rather than
-        # skipping it — otherwise the thumbnails never appear for the sender.
-        for entry in reversed(self.projection.transcript[-3:]):
-            if entry.kind in ("user", "steer") and entry.text == text:
-                if refs and not entry.images:
-                    entry.id = message.id
-                    entry.images = refs
-                return False
+        entry = self._pending_user_echoes.pop(message.id, None)
+        if entry is None:
+            # No registered echo: either this message came from ANOTHER surface
+            # (the TUI→phone direction this method exists to paint), or the
+            # handle had no id to register. Fall back to the historical tail
+            # scan ONLY for rows the registry does not own, so a legacy handle
+            # keeps its de-dup while a row with an exact event still coming is
+            # never consumed by a colliding neighbour's words.
+            owned = {held.id for held in self._pending_user_echoes.values()}
+            for candidate in reversed(self.projection.transcript[-3:]):
+                if (
+                    candidate.kind in ("user", "steer")
+                    and candidate.text == text
+                    and candidate.id not in owned
+                ):
+                    entry = candidate
+                    break
+        if entry is not None:
+            # Adopt the persisted identity either way: the row was keyed by the
+            # command id (or a synthetic one), and the message id is what later
+            # history folds and the web client's list reconciliation agree on.
+            entry.id = message.id
+            if refs and not entry.images:
+                entry.images = refs
+            return False
         self._append(
             TranscriptEntry(id=message.id, kind="user", text=text, images=refs, final=True)
         )
@@ -1072,6 +1134,20 @@ class ProjectionFold:
     def _append(self, entry: TranscriptEntry) -> None:
         self.projection.transcript.append(entry)
         self.projection.transcript = self._cap_tail(self.projection.transcript)
+        if self._pending_user_echoes:
+            # Drop echo entries whose row the cap just trimmed. Two reasons,
+            # both bounding: an entry pointing at a row no longer in the
+            # projection can only upgrade something invisible, and a steer the
+            # phone RECALLS is never announced, so without this its entry would
+            # sit in the dict for the life of the session. A trimmed row's
+            # event now paints at the tail, which is the honest rendering — the
+            # row it would have upgraded is gone.
+            live = {row.id for row in self.projection.transcript}
+            self._pending_user_echoes = {
+                message_id: row
+                for message_id, row in self._pending_user_echoes.items()
+                if row.id in live
+            }
 
     @staticmethod
     def _cap_tail(entries: list[TranscriptEntry]) -> list[TranscriptEntry]:

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -341,7 +341,11 @@ class TuiSessionHandle(SessionHandle):
 
         if not await self._on_app(do_steer):
             return "already admitted"
-        self._fold.note_user_message(text, steer=True)
+        # Keyed by the id `do_steer` handed the session (always supplied on
+        # this path), so the drain's MessageStartEvent upgrades THIS row
+        # instead of being matched against the transcript tail — by delivery
+        # time a steer's echo is several assistant/tool rows back (issue #231).
+        self._fold.note_user_message(text, steer=True, message_id=command_id)
         if self._on_projection is not None:
             self._on_projection()
         return "steering queued"

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -1011,19 +1011,54 @@ class RemoteSession:
 
     # -- driving turns ------------------------------------------------------
 
-    async def prompt(self, text: str, images: Sequence[ImageContent] | None = None) -> None:
+    async def prompt(
+        self,
+        text: str,
+        images: Sequence[ImageContent] | None = None,
+        *,
+        message_id: str | None = None,
+    ) -> None:
+        """Send a prompt to the owner, optionally under a caller-supplied id.
+
+        ``message_id`` becomes the ``ContinuationCommand`` id, which the owner
+        adopts as the ``Message`` id and announces back on the user
+        ``MessageStartEvent``. A follower TUI needs that round trip for the same
+        reason the owner path does: it registers the id it painted a row for and
+        matches the announcement against it, so a DISTINCT message with
+        colliding words still paints (#228). Without the keyword the TUI's seam
+        probe found nothing to hand an id to, registered the entry id-less, and
+        an attached follower kept the swallow this class of fix removes.
+
+        The steering twin has always carried identity this way
+        (``_send_steer_when_ready`` sends ``command_id=message.id``); this is
+        the prompt path catching up with its own sibling. Minted here when the
+        caller supplies nothing, which is the historical behaviour.
+        """
         await self._owner_ready.wait()
         target = self._takeover_target
         if target is not None:
-            await target.prompt(text, images)
+            # A takeover means a real in-process Session now owns the
+            # conversation. Forward the id only when that target can take one:
+            # the seam is optional on SessionProtocol, and a target without it
+            # mints its own — the same probe the TUI makes, for the same reason.
+            if message_id and "message_id" in inspect.signature(target.prompt).parameters:
+                await target.prompt(text, images, message_id=message_id)
+            else:
+                await target.prompt(text, images)
             return
         client = self._client
         if client is None or not client.connected:
             raise ConnectionError("session owner is reconnecting")
-        command = ContinuationCommand.create(
-            self._session_id,
-            text,
-            [_image_to_wire(image) for image in (images or [])],
+        images_wire = [_image_to_wire(image) for image in (images or [])]
+        command = (
+            ContinuationCommand(
+                command_id=message_id,
+                session_id=self._session_id,
+                text=text,
+                images=images_wire,
+            )
+            if message_id
+            else ContinuationCommand.create(self._session_id, text, images_wire)
         )
         await client.send_command(command, streaming=self._streaming)
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1125,10 +1125,15 @@ class _PendingUserEcho(NamedTuple):
     different id and is therefore painted, where the previous text match
     swallowed it (issue #228).
 
-    Empty when this surface could not know the id in advance — a session whose
-    ``prompt`` predates the ``message_id`` seam mints the id internally. Such an
-    entry keeps the historical text match, so an older or third-party session
-    behaves exactly as it did rather than double-painting every row.
+    Empty when this surface could not hand the id over — ``message_id`` is
+    OPTIONAL on ``SessionProtocol``, and a session without it mints the id
+    internally, so registering one here would key the entry to an id no
+    announcement can carry and paint every row twice. Such an entry keeps the
+    historical text match, limit included. Both in-tree sessions accept the
+    keyword (``Session``, and ``RemoteSession`` — the class an attached
+    follower TUI drives, which kept the #228 swallow until it did); the
+    fallback covers implementations outside the protocol's guarantee, not a
+    shipping path.
     """
 
     message_id: str
@@ -1775,10 +1780,11 @@ class OperatorApp(App[None]):
         #: the old session's queue.
         #:
         #: The text is retained as the FALLBACK key for a session that cannot
-        #: take a caller-supplied id (`prompt()` without the `message_id`
-        #: seam — older or third-party implementations mint their own), and as
-        #: the key the two retire-on-failure sites already use. Those entries
-        #: keep the historical by-text behaviour, limit included.
+        #: take a caller-supplied id (`message_id` is optional on
+        #: `SessionProtocol`; an implementation without it mints its own), and
+        #: as the key the two retire-on-failure sites already use. Those
+        #: entries keep the historical by-text behaviour, limit included. Both
+        #: in-tree sessions take the keyword, so no shipping path relies on it.
         self._pending_user_echoes: list[_PendingUserEcho] = []
         #: Wake receipts painted LIVE this session, as ``(wake_id, occurrence)``
         #: keys. ``on_wake_delivered`` records each; the history replay skips a
@@ -8627,9 +8633,20 @@ class OperatorApp(App[None]):
             # The row is already on screen — registered here so that event is
             # recognised as our own echo rather than painted again.
             #
-            # No probe on this path: `steer_message` queues the very object
-            # built above, so the announced message IS `steer_message` and its
-            # id is authoritative for every session implementation.
+            # No probe on this path, because there is no keyword to probe for:
+            # `steer_message` takes the Message OBJECT, so the id is carried by
+            # the thing queued rather than offered alongside it. Both in-tree
+            # sessions preserve it — `Session` announces the queued object
+            # itself at the drain, and `RemoteSession` sends
+            # `command_id=message.id`, which the owner adopts as the Message id.
+            #
+            # That is the contract this registration relies on, and it is
+            # stronger than what `SessionProtocol` writes down: an
+            # implementation that RE-MINTED the id while queueing would announce
+            # something this entry could never match and paint the steer twice.
+            # No such implementation exists in tree, and unlike the prompt path
+            # there is no signature to probe — a re-minting host would have to
+            # be caught by its own tests (round 1, F2).
             self._register_user_echo(text, message_id=steer_message.id)
             # Held with the notice so Esc can lift the whole steer — the queued
             # row, the user row and its image blocks — back out of the
@@ -8705,9 +8722,11 @@ class OperatorApp(App[None]):
         # The id is minted HERE and pushed into the session rather than read
         # back from it: `prompt()` returns only when the whole turn is over,
         # long after the announcement, so the correlation key has to travel
-        # outward. A session without the `message_id` seam (older or
-        # third-party) mints its own id, so the entry registers without one and
-        # falls back to matching by text.
+        # outward. The keyword is optional on `SessionProtocol`, so a session
+        # without it mints its own id and the entry registers id-less, falling
+        # back to text. Both in-tree sessions accept it -- `RemoteSession`
+        # included, which is what an attached follower TUI drives and which
+        # swallowed cross-surface prompts until it did (round 1, F1).
         echo = self._register_user_echo(text, message_id=self._echo_message_id(session.prompt))
         # A turn STARTING ends any barren click gesture: from here Ctrl+C means
         # "stop this turn", and a claim raised before the turn existed cannot

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -23,11 +23,13 @@ error`` status and can be retried with ``/reload`` (TUI-012).
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import os
 import re
 import sys
 import time
+import uuid
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from functools import partial
@@ -1114,6 +1116,33 @@ class NoticeFn(Protocol):
     def __call__(self, body: str, kind: NoticeKind = "info") -> None: ...
 
 
+class _PendingUserEcho(NamedTuple):
+    """One user row this TUI painted whose ``MessageStartEvent`` is still coming.
+
+    ``message_id`` is the id of the very ``Message`` the session will announce,
+    which is what makes the match EXACT rather than a guess: a distinct message
+    carrying identical words (a phone "yes" against a pending TUI "yes") has a
+    different id and is therefore painted, where the previous text match
+    swallowed it (issue #228).
+
+    Empty when this surface could not know the id in advance — a session whose
+    ``prompt`` predates the ``message_id`` seam mints the id internally. Such an
+    entry keeps the historical text match, so an older or third-party session
+    behaves exactly as it did rather than double-painting every row.
+    """
+
+    message_id: str
+    text: str
+
+    def prompt_kwargs(self) -> dict[str, Any]:
+        """The ``prompt()`` keyword that pins the announced message to this entry.
+
+        Empty for a session without the ``message_id`` seam, where the entry
+        falls back to matching by text.
+        """
+        return {"message_id": self.message_id} if self.message_id else {}
+
+
 class _ProviderRows(NamedTuple):
     """The provider list's rows, plus what to say when it could not be built.
 
@@ -1714,30 +1743,43 @@ class OperatorApp(App[None]):
         #: The two together are the FIFO the engine drains: these rows were
         #: queued first, so they settle first (see `on_steering_delivered`).
         self._deferred_steer_notices: list[NoticeBlock] = []
-        #: User-message texts this TUI has ALREADY painted (or deliberately
-        #: declined to paint) whose ``MessageStartEvent`` from the session is
-        #: still coming. ``on_user_message_start`` consumes a matching entry
-        #: instead of painting a second row. An explicit registry, not a scan
-        #: of the transcript tail: the session announces a STEER only when the
-        #: drain takes it, which is a later tool boundary, and every tool card
+        #: User messages this TUI has ALREADY painted (or deliberately declined
+        #: to paint) whose ``MessageStartEvent`` from the session is still
+        #: coming. ``on_user_message_start`` consumes a matching entry instead
+        #: of painting a second row. An explicit registry, not a scan of the
+        #: transcript tail: the session announces a STEER only when the drain
+        #: takes it, which is a later tool boundary, and every tool card
         #: mounted in between pushed the echo out of any fixed-size window —
         #: the tail scan this replaces painted every steered message twice the
         #: moment two blocks landed between the echo and its delivery.
         #:
-        #: Texts, not block references: the entry's job is to say "this event
-        #: is our own echo", and it must keep saying so after a `/clear` has
-        #: removed the block it described (the engine's queue survives the
-        #: clear, so the event still arrives). Cleared on a session swap, where
-        #: the messages died with the old session's queue and a stale entry
-        #: would swallow the next conversation's first identical prompt.
+        #: Entries carry the MESSAGE ID, not just the text (issue #228). The
+        #: id is minted here and handed to the session (`message_id=` on
+        #: `prompt`, the `Message` object itself on `steer_message`), so the
+        #: event that comes back names the very message this row was painted
+        #: for. That is what tells our own echo apart from a DISTINCT message
+        #: whose words collide: repeated "yes" / "continue" sent from the phone
+        #: while a TUI echo of the same words is pending used to consume that
+        #: entry, leaving the foreign message unpainted here even though the
+        #: model received it. An unknown id is by definition not ours, so it
+        #: paints.
         #:
-        #: Known limit, inherent to matching by text: a prompt arriving from
-        #: ANOTHER front end with words identical to a still-pending steer
-        #: consumes that steer's entry — the foreign message stays unpainted
-        #: here and the steer's own event later paints the row. Rare (same
-        #: words, same window, two surfaces) and self-healing, but not
-        #: hazard-free, and the reader deserves to know.
-        self._pending_user_echoes: list[str] = []
+        #: Matching stays by VALUE, never by position: events do NOT arrive in
+        #: registration order (a steer an aborted turn left in the queue is
+        #: announced inside the NEXT turn, after that turn's own prompt echo),
+        #: so the id lookup is a scan of the whole list rather than a peek at
+        #: either end. Ids, not block references: the entry must keep saying
+        #: "this event is ours" after a `/clear` has removed the block it
+        #: described (the engine's queue survives the clear, so the event still
+        #: arrives). Cleared on a session swap, where the messages died with
+        #: the old session's queue.
+        #:
+        #: The text is retained as the FALLBACK key for a session that cannot
+        #: take a caller-supplied id (`prompt()` without the `message_id`
+        #: seam — older or third-party implementations mint their own), and as
+        #: the key the two retire-on-failure sites already use. Those entries
+        #: keep the historical by-text behaviour, limit included.
+        self._pending_user_echoes: list[_PendingUserEcho] = []
         #: Wake receipts painted LIVE this session, as ``(wake_id, occurrence)``
         #: keys. ``on_wake_delivered`` records each; the history replay skips a
         #: persisted ``wake_prompt`` whose key is already here — otherwise a
@@ -8584,7 +8626,11 @@ class OperatorApp(App[None]):
             # when the drain actually takes it (the mobile→TUI echo channel).
             # The row is already on screen — registered here so that event is
             # recognised as our own echo rather than painted again.
-            self._pending_user_echoes.append(text)
+            #
+            # No probe on this path: `steer_message` queues the very object
+            # built above, so the announced message IS `steer_message` and its
+            # id is authoritative for every session implementation.
+            self._register_user_echo(text, message_id=steer_message.id)
             # Held with the notice so Esc can lift the whole steer — the queued
             # row, the user row and its image blocks — back out of the
             # transcript and into the composer (:meth:`_recall_queued_steers`).
@@ -8655,7 +8701,14 @@ class OperatorApp(App[None]):
         # so register it for `on_user_message_start` to consume rather than
         # repaint. Here rather than in `_submit_prompt`, because this is the
         # single dispatch point every prompt passes through, held or not.
-        self._pending_user_echoes.append(text)
+        #
+        # The id is minted HERE and pushed into the session rather than read
+        # back from it: `prompt()` returns only when the whole turn is over,
+        # long after the announcement, so the correlation key has to travel
+        # outward. A session without the `message_id` seam (older or
+        # third-party) mints its own id, so the entry registers without one and
+        # falls back to matching by text.
+        echo = self._register_user_echo(text, message_id=self._echo_message_id(session.prompt))
         # A turn STARTING ends any barren click gesture: from here Ctrl+C means
         # "stop this turn", and a claim raised before the turn existed cannot
         # speak for a press aimed at it (agent review round 3, R3-3). Belt and
@@ -8675,15 +8728,15 @@ class OperatorApp(App[None]):
         async def run_prompt() -> None:
             try:
                 async with self._turn_provider_lock:
-                    await session.prompt(text, images)
+                    await session.prompt(text, images, **echo.prompt_kwargs())
             except Exception as error:  # surface, never crash the app
                 self._append_block(NoticeBlock(str(error), "error"))
                 # A prompt that failed never announced itself, so its echo
                 # entry has no event coming. Left standing it would swallow
-                # the next identical prompt's event; `_consume_user_echo` is
+                # the next identical prompt's event; `_discard_user_echo` is
                 # safe because a delivered announcement has already consumed
                 # the entry.
-                self._consume_user_echo(text)
+                self._discard_user_echo(echo)
             finally:
                 # agent_end usually flips this first; a redundant update is a
                 # no-op, and this covers sessions that end without agent_end.
@@ -12104,14 +12157,16 @@ class OperatorApp(App[None]):
                 # prompt. Register it so the event is consumed silently instead
                 # of painting the loudest mark in the transcript for words the
                 # user never typed.
-                self._pending_user_echoes.append(LOOP_PROMPT)
+                echo = self._register_user_echo(
+                    LOOP_PROMPT, message_id=self._echo_message_id(session.prompt)
+                )
                 try:
-                    await session.prompt(LOOP_PROMPT)
+                    await session.prompt(LOOP_PROMPT, **echo.prompt_kwargs())
                 except Exception as error:  # surface and stop; never spin
                     notice(f"loop stopped: {error}", "error")
                     # Same stale-entry hazard as `_start_turn`: a failed
                     # prompt never announces, so take the entry back out.
-                    self._consume_user_echo(LOOP_PROMPT)
+                    self._discard_user_echo(echo)
                     break
                 finally:
                     if self._status is not None:
@@ -12205,20 +12260,23 @@ class OperatorApp(App[None]):
                 if self._status is not None:
                     self._status.update(streaming=True)
                 # Format ONCE and reuse the exact string for both the echo
-                # registration and the prompt: the echo registry matches on the
-                # submitted string byte-for-byte, so a second `.format` here
-                # could drift and leave the user MessageStartEvent unconsumed.
+                # registration and the prompt: an id-less entry (a session
+                # without the `message_id` seam) still matches on the submitted
+                # string byte-for-byte, so a second `.format` here could drift
+                # and leave the user MessageStartEvent unconsumed.
                 prompt = LOOP_GOAL_PROMPT.format(goal=goal)
-                self._pending_user_echoes.append(prompt)
+                echo = self._register_user_echo(
+                    prompt, message_id=self._echo_message_id(session.prompt)
+                )
                 try:
-                    await session.prompt(prompt)
+                    await session.prompt(prompt, **echo.prompt_kwargs())
                 except Exception as error:  # surface and stop; never spin
                     if self._status is not None:
                         self._status.update(streaming=False)
                     notice(f"loop stopped: {error}", "error")
                     # A failed prompt never announces, so take the stale echo
                     # entry back out (same hazard as numeric mode / `_start_turn`).
-                    self._consume_user_echo(prompt)
+                    self._discard_user_echo(echo)
                     break
                 # NOTE: the status is deliberately NOT reset to idle here — it
                 # stays in a working state across the judge call below so the
@@ -16467,31 +16525,100 @@ class OperatorApp(App[None]):
         every steered message twice once two tool cards landed in between
         (issue: duplicated steering messages).
 
-        Matching is by text, not by position: events do NOT always arrive in
-        registration order (a steer an aborted turn left in the queue is
-        announced inside the NEXT turn, after that turn's own prompt echo),
-        and entries with identical text are indistinguishable — which is
-        fine, because either one consumed is the right row suppressed.
-        Correctness comes from "every event for a painted echo finds an
+        Matched on the MESSAGE ID, never on position: the app minted the id it
+        registered and handed it to the session, so the announcement names the
+        exact row. This is what makes a distinct message with colliding words
+        paint (issue #228) — an id this surface never registered is not our
+        echo, however familiar the words. It is also why order does not matter:
+        events do NOT always arrive in registration order (a steer an aborted
+        turn left in the queue is announced inside the NEXT turn, after that
+        turn's own prompt echo), and an id lookup is order-free where a
+        positional one is not.
+
+        Falls back to the historical text match for an entry with no id — a
+        session whose ``prompt`` predates the ``message_id`` seam mints the id
+        internally, so this surface cannot know it in advance. Correctness for
+        those entries still comes from "every event for a painted echo finds an
         entry", not from any ordering guarantee."""
-        if self._consume_user_echo(message.prompt):
+        if self._consume_user_echo(message.prompt, message_id=message.message_id):
             return  # our own echo — the row is already painted
         self._append_block(UserBlock(message.prompt, message.image_count))
         self._append_image_blocks(list(message.images))
 
-    def _consume_user_echo(self, text: str) -> bool:
-        """Take one pending echo entry for ``text``; True if there was one.
+    @staticmethod
+    def _echo_message_id(prompt: Callable[..., Any]) -> str:
+        """A fresh correlation id, or "" when ``prompt`` cannot accept one.
 
-        The one spelling for the three sites that retire an entry: the
-        delivery handler (consume = suppress the repaint) and the two failed
-        ``prompt()`` paths (consume = drop an entry whose event is never
-        coming). ``remove``-by-value swallows the already-consumed case for
-        free."""
+        The id only correlates if the session actually USES it: a ``prompt``
+        without the ``message_id`` keyword mints its own id internally, and
+        registering ours would produce an entry no announcement can ever match
+        — every prompt would then paint twice. Probed rather than assumed
+        because `SessionProtocol` does not require the keyword and the mobile
+        handles already probe the same seam the same way (`owned.py`,
+        `tui_handle.py`); a session that cannot be introspected is treated as
+        the older shape, which is the safe direction.
+        """
         try:
-            self._pending_user_echoes.remove(text)
-            return True
-        except ValueError:
-            return False
+            supported = "message_id" in inspect.signature(prompt).parameters
+        except (TypeError, ValueError):  # builtins and C callables have no signature
+            supported = False
+        return uuid.uuid4().hex if supported else ""
+
+    def _register_user_echo(self, text: str, *, message_id: str = "") -> _PendingUserEcho:
+        """Record a row this TUI painted whose announcement is still coming.
+
+        Returns the entry so the caller can retire it by identity if the
+        message turns out never to be announced (a ``prompt()`` that raised, a
+        recalled steer). Identity rather than a re-lookup, because two
+        registrations can legitimately carry the same words and the caller must
+        take back exactly its own.
+        """
+        entry = _PendingUserEcho(message_id, text)
+        self._pending_user_echoes.append(entry)
+        return entry
+
+    def _discard_user_echo(self, entry: _PendingUserEcho) -> None:
+        """Drop an entry whose ``MessageStartEvent`` is never coming.
+
+        The failure half of the registry: a prompt that raised never announced
+        itself, and a recalled steer left the queue, so leaving either entry
+        standing would swallow the announcement of the RESEND. Silent when the
+        entry is already gone — a delivery may have consumed it first, and that
+        race is benign.
+        """
+        for index, held in enumerate(self._pending_user_echoes):
+            if held is entry:
+                del self._pending_user_echoes[index]
+                return
+
+    def _consume_user_echo(self, text: str, *, message_id: str = "") -> bool:
+        """Take one pending echo entry; True if there was one.
+
+        The one spelling for the sites that retire an entry: the delivery
+        handler (consume = suppress the repaint), the two failed ``prompt()``
+        paths and the steer recall (consume = drop an entry whose event is
+        never coming). A miss is not an error — an entry already consumed, or
+        never registered, is the common case.
+
+        ``message_id`` is preferred and decides alone when it matches: the id
+        came back from the session naming the very message a row was painted
+        for. Only when no entry carries that id does the search fall back to
+        text, and then only over entries with NO id of their own — an entry
+        that has one has an exact answer coming, so consuming it on a word
+        collision is precisely the #228 defect. The retire-on-failure callers
+        pass no id and reach the text branch by construction.
+        """
+        entries = self._pending_user_echoes
+        if message_id:
+            for index, entry in enumerate(entries):
+                if entry.message_id == message_id:
+                    del entries[index]
+                    return True
+        for index, entry in enumerate(entries):
+            if not entry.message_id and entry.text == text:
+                del entries[index]
+                return True
+        return False
 
     def on_assistant_message_start(self, message: AssistantMessageStart) -> None:
         """A message opened — but nothing is MOUNTED until text actually arrives.
@@ -16895,12 +17022,14 @@ class OperatorApp(App[None]):
         if stop_notice is not None and stop_notice.text() == RECALL_DECLINE_NOTICE:
             transcript.remove_block(stop_notice)
             self._stop_notice = None
-        # The steer branch registered its text as a pending user echo so the
-        # delivery's MessageStartEvent would not repaint it; the recall has
-        # removed the painted row, so the entry must go with it — left in
-        # place it would swallow the RESEND's echo and the resent message
-        # would never paint.
-        self._consume_user_echo(text)
+        # The steer branch registered a pending echo so the delivery's
+        # MessageStartEvent would not repaint it; the recall has removed the
+        # painted row, so the entry must go with it — left in place it would
+        # swallow the RESEND's echo and the resent message would never paint.
+        # By the message's OWN id, which is the key the steer registered under:
+        # `message` is the object `steer_message` queued, so this takes exactly
+        # this steer's entry and never a sibling with the same words.
+        self._consume_user_echo(text, message_id=message.id)
         for held in self._queued_steer_notices:
             if held is notice:
                 self._queued_steer_notices.remove(held)

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -158,11 +158,22 @@ class UserMessageStart(Message):
     prompt (and image count) so the TUI can paint it — the mobile→TUI half of
     keeping the two surfaces in step. The TUI's own prompt path already paints
     its UserBlock optimistically, so the app de-dupes on arrival. The field is
-    ``prompt``, not ``text``: Textual's ``Message`` reserves ``text``."""
+    ``prompt``, not ``text``: Textual's ``Message`` reserves ``text``.
 
-    def __init__(self, prompt: str, images: list[ImageContent] | int) -> None:
+    ``message_id`` is the announced ``Message``'s own id — the correlation key
+    the app's pending-echo registry matches on, in the same role
+    :class:`PeerMessageDelivered` uses it for. It is what tells a prompt this
+    TUI painted apart from a DISTINCT message that happens to carry identical
+    words (repeated "yes" / "continue" from the phone, issue #228); matching
+    those by text swallowed the foreign row. Defaults to empty for reduced
+    event producers and synthetic tests, where the app falls back to its
+    historical text match.
+    """
+
+    def __init__(self, prompt: str, images: list[ImageContent] | int, message_id: str = "") -> None:
         super().__init__()
         self.prompt = prompt
+        self.message_id = message_id
         # Integer remains accepted for older synthetic tests and reduced event
         # producers. Production carries immutable blocks; only that path can
         # render thumbnails, while the compatibility path preserves its receipt.
@@ -576,7 +587,11 @@ class EventController:
         # is the AgentMessage union, so pyright needs the isinstance.
         if isinstance(message, HarnessMessage) and message.role == "user":
             images = [b for b in message.content if isinstance(b, ImageContent)]
-            self._post(UserMessageStart(message.text, images))
+            # The message id rides along as the echo-dedup correlation key: the
+            # app registered the same id when it painted the row optimistically,
+            # so an event whose id it does not recognise is a genuinely new
+            # message and must be painted even when the words repeat (#228).
+            self._post(UserMessageStart(message.text, images, message.id))
             return
         self._assistant_buffer = ""
         self._assistant_seen = ""

--- a/tests/unit/mobile/test_projection.py
+++ b/tests/unit/mobile/test_projection.py
@@ -886,3 +886,107 @@ def test_absorb_user_event_upgrades_echoed_row_with_image_refs() -> None:
     upgraded = fold.projection.transcript[-1]
     assert upgraded.id == message.id
     assert upgraded.images == [{"index": 0, "mime_type": "image/png"}]
+
+
+# --- issue #231: user echoes de-duped by id, not by a 3-entry tail window ----
+
+
+def test_a_phone_steer_is_not_repainted_once_assistant_rows_push_it_out() -> None:
+    """Issue #231, reproduced: the defect the tail window guaranteed.
+
+    A phone steer is echoed optimistically, then the turn keeps running — the
+    engine only drains the steering queue at a LATER tool boundary, so by the
+    time the message's own ``MessageStartEvent`` arrives the echo is several
+    assistant rows back. The three-entry scan could no longer see it and
+    painted the steer a second time. The registry keys on the message id, so
+    distance from the tail is irrelevant.
+    """
+    fold = make_fold()
+    command_id = "cmd-steer-1"
+    fold.note_user_message("use the other endpoint", steer=True, message_id=command_id)
+    assert len([e for e in fold.projection.transcript if e.kind == "steer"]) == 1
+
+    # The turn goes on: four assistant rows push the echo well past the window
+    # the old scan looked at.
+    for index in range(4):
+        fold.fold_event(
+            MessageStartEvent(message=Message.assistant(f"still working {index}")),
+        )
+    assert len(fold.projection.transcript) == 5
+
+    # Only NOW is the steer drained and announced, carrying the id the handle
+    # supplied as the message id.
+    fold.absorb_user_event(Message.user("use the other endpoint", id=command_id))
+
+    rows = [e for e in fold.projection.transcript if e.text == "use the other endpoint"]
+    assert len(rows) == 1, "the drain repainted a steer already on the phone"
+    assert rows[0].kind == "steer", "the echo's own row survives, not a fresh user row"
+
+
+def test_absorb_user_event_returns_false_for_a_registered_echo() -> None:
+    """The de-dupe contract the callers read: a registered echo is folded into
+    the existing row, so the fold reports it did NOT add one."""
+    fold = make_fold()
+    fold.note_user_message("already on screen", steer=True, message_id="cmd-2")
+    added = fold.absorb_user_event(Message.user("already on screen", id="cmd-2"))
+    assert added is False
+    assert len([e for e in fold.projection.transcript if e.text == "already on screen"]) == 1
+
+
+def test_a_distinct_message_with_colliding_words_still_paints() -> None:
+    """The mirror image of the same defect: a genuinely NEW message whose text
+    matched a recent row was swallowed by the window. Different id, different
+    message, so it must appear."""
+    fold = make_fold()
+    fold.note_user_message("continue", steer=True, message_id="cmd-3")
+    fold.absorb_user_event(Message.user("continue", id="a-different-message"))
+    rows = [e for e in fold.projection.transcript if e.text == "continue"]
+    assert len(rows) == 2, "a distinct message must not be eaten by a word collision"
+
+
+def test_a_registered_echo_row_is_not_consumed_by_a_colliding_neighbour() -> None:
+    """The tail fallback (for handles with no id) must not spend a row that has
+    an EXACT event coming: that row's own announcement would then find its
+    entry gone and paint the duplicate this issue exists to remove."""
+    fold = make_fold()
+    fold.note_user_message("same words", steer=True, message_id="cmd-4")
+
+    # An id-less announcement carrying the same words: not the registered
+    # steer's, so it paints rather than consuming that row.
+    fold.absorb_user_event(Message.user("same words", id="foreign"))
+    assert len([e for e in fold.projection.transcript if e.text == "same words"]) == 2
+
+    # The registered steer's own event still upgrades its row, adding nothing.
+    fold.absorb_user_event(Message.user("same words", id="cmd-4"))
+    assert len([e for e in fold.projection.transcript if e.text == "same words"]) == 2
+
+
+def test_the_echoed_row_adopts_the_persisted_message_id() -> None:
+    """The row is keyed by the command id until the real message arrives; from
+    then on it must carry the message id, which is what a later history fold
+    and the web client's list reconciliation agree on."""
+    fold = make_fold()
+    fold.note_user_message("key me", steer=True, message_id="cmd-5")
+    assert fold.projection.transcript[-1].id == "cmd-5"
+    fold.absorb_user_event(Message.user("key me", id="cmd-5"))
+    assert fold.projection.transcript[-1].id == "cmd-5"
+
+
+def test_a_legacy_handle_without_an_id_keeps_the_tail_dedup() -> None:
+    """A handle that supplies no id (older/third-party) still de-dupes its own
+    echo through the historical tail scan — the compatibility path."""
+    fold = make_fold()
+    fold.note_user_message("no id supplied", steer=True)
+    added = fold.absorb_user_event(Message.user("no id supplied"))
+    assert added is False
+    assert len([e for e in fold.projection.transcript if e.text == "no id supplied"]) == 1
+
+
+def test_a_history_fold_clears_pending_echoes() -> None:
+    """A wholesale rebuild replaces the rows the entries pointed at, so a
+    surviving entry would reference a row no longer in the transcript."""
+    fold = make_fold()
+    fold.note_user_message("pending across the fold", steer=True, message_id="cmd-6")
+    assert fold._pending_user_echoes
+    fold.fold_history([Message.user("something else entirely")])
+    assert fold._pending_user_echoes == {}

--- a/tests/unit/session/test_remote_round2.py
+++ b/tests/unit/session/test_remote_round2.py
@@ -817,3 +817,95 @@ async def test_compact_now_during_recovery_refuses_in_user_language(
     finally:
         if remote is not None:
             await remote.dispose()
+
+
+# --- round 1, F1: the follower's prompt path carries the caller's id ---------
+
+
+class _RecordingClient:
+    """A connected-shape client that records the command instead of sending it."""
+
+    connected = True
+
+    def __init__(self) -> None:
+        self.commands: list[Any] = []
+
+    async def send_command(self, command: Any, *, streaming: bool = False) -> str:
+        self.commands.append(command)
+        return "prompt admitted"
+
+
+@pytest.mark.asyncio
+async def test_follower_prompt_carries_a_caller_supplied_message_id() -> None:
+    """A follower TUI correlates its optimistic echo by id like the owner does.
+
+    The TUI probes ``prompt`` for a ``message_id`` keyword and registers the id
+    it supplies, matching the announcement against it. ``RemoteSession.prompt``
+    had no such keyword -- it minted its own via ``ContinuationCommand.create``
+    -- so on an attached follower the probe failed, the entry registered
+    id-less, and a DISTINCT message whose words collided was still swallowed
+    (#228). The id must reach the wire as the command id, which the owner then
+    adopts as the Message id and announces back.
+    """
+    remote = _bare_remote(Path("/tmp/r1-f1-prompt"))
+    remote._owner_ready.set()
+    client = _RecordingClient()
+    remote._client = client  # type: ignore[assignment]
+
+    await remote.prompt("continue", message_id="tui-minted-id")
+
+    assert len(client.commands) == 1
+    assert (
+        client.commands[0].command_id == "tui-minted-id"
+    ), "the caller's id must ride the wire as the command id"
+    assert client.commands[0].text == "continue"
+
+
+@pytest.mark.asyncio
+async def test_follower_prompt_still_mints_an_id_when_none_is_supplied() -> None:
+    """The historical behaviour is preserved for callers that supply nothing:
+    the command still gets a fresh, valid identity rather than an empty one."""
+    import uuid
+
+    remote = _bare_remote(Path("/tmp/r1-f1-mint"))
+    remote._owner_ready.set()
+    client = _RecordingClient()
+    remote._client = client  # type: ignore[assignment]
+
+    await remote.prompt("no id supplied")
+
+    assert len(client.commands) == 1
+    minted = client.commands[0].command_id
+    assert minted, "a command with no identity cannot be reconciled on reconnect"
+    uuid.UUID(minted)  # the wire validator requires a real UUID
+
+
+@pytest.mark.asyncio
+async def test_a_takeover_target_without_the_seam_is_not_handed_an_id() -> None:
+    """``message_id`` is optional on SessionProtocol, so a takeover target that
+    cannot accept one must be called the old way rather than with a keyword it
+    would reject -- the same probe the TUI makes, for the same reason."""
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    class _LegacyTarget:
+        async def prompt(self, text: str, images: Any = None) -> None:
+            calls.append((text, {}))
+
+    class _ModernTarget:
+        async def prompt(
+            self, text: str, images: Any = None, *, message_id: str | None = None
+        ) -> None:
+            calls.append((text, {"message_id": message_id}))
+
+    legacy = _bare_remote(Path("/tmp/r1-f1-legacy"))
+    legacy._owner_ready.set()
+    legacy._takeover_target = _LegacyTarget()  # type: ignore[assignment]
+    await legacy.prompt("hello", message_id="an-id")
+    assert calls == [("hello", {})], "a legacy target must not receive the keyword"
+
+    calls.clear()
+    modern = _bare_remote(Path("/tmp/r1-f1-modern"))
+    modern._owner_ready.set()
+    modern._takeover_target = _ModernTarget()  # type: ignore[assignment]
+    await modern.prompt("hello", message_id="an-id")
+    assert calls == [("hello", {"message_id": "an-id"})], "the id must reach a capable target"

--- a/tests/unit/tui/test_user_echo_dedup.py
+++ b/tests/unit/tui/test_user_echo_dedup.py
@@ -16,6 +16,16 @@ the TUI paints for a message the session will later announce is recorded in
 ``_pending_user_echoes``, and ``on_user_message_start`` consumes a matching
 entry instead of painting. No entry means the message came from another front
 end, which is the case the handler exists to paint.
+
+Issue #228 is the second half: the registry originally matched by TEXT, so a
+DISTINCT message whose words collided with a pending echo (repeated "yes" /
+"continue" sent from the phone while a TUI echo of the same words was still
+outstanding) consumed that entry and never painted — the message reached the
+model and the transcript stayed silent about it. Entries now carry the message
+id the app itself minted and handed to the session, so an id this surface never
+registered paints however familiar the words. An entry with no id (a session
+whose ``prompt`` predates the ``message_id`` seam) keeps the text match, which
+is what the ``FakeSession`` cases below exercise.
 """
 
 from __future__ import annotations
@@ -55,6 +65,54 @@ class _Streaming(FakeSession):
         # `steer` override did and let the base fake hold the object.
         self.steers.append(message.text)
         super().steer_message(message)
+
+
+class _IdAware(FakeSession):
+    """A fake with the production ``message_id`` seam on ``prompt``.
+
+    ``FakeSession`` deliberately predates it, which is how the legacy text
+    fallback stays covered; this one is the shape the real ``Session`` has, so
+    the app mints a correlation id and hands it over. ``prompt_ids`` records
+    what it received, which is the id the real session would then announce.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.prompt_ids: list[str | None] = []
+
+    async def prompt(  # type: ignore[override]
+        self,
+        text: str,
+        images: Sequence[ImageContent] | None = None,
+        *,
+        message_id: str | None = None,
+    ) -> None:
+        self.prompt_ids.append(message_id)
+        await super().prompt(text, images)
+
+
+def _echo_ids(app: OperatorApp) -> list[str]:
+    """The message ids of the pending echo entries, in registration order."""
+    return [entry.message_id for entry in app._pending_user_echoes]
+
+
+def _echo_texts(app: OperatorApp) -> list[str]:
+    """The texts of the pending echo entries, in registration order."""
+    return [entry.text for entry in app._pending_user_echoes]
+
+
+def _steer_id(session: FakeSession, text: str) -> str:
+    """The id of the queued steering Message carrying ``text``.
+
+    The session announces a drained steer with the very object the app queued,
+    so this is the id the real ``MessageStartEvent`` would carry — the tests
+    below post it rather than an empty id, which is what makes them exercise
+    the id path instead of the legacy fallback.
+    """
+    for message in session.queued_steering():
+        if getattr(message, "text", None) == text:
+            return str(message.id)
+    raise AssertionError(f"no queued steer carrying {text!r}")
 
 
 def _user_blocks(app: OperatorApp, text: str) -> list[UserBlock]:
@@ -120,7 +178,7 @@ async def test_a_steered_message_is_not_painted_again_by_its_own_delivery() -> N
         app._append_block(NoticeBlock("stand-in for a second tool card", "info"))
         await pilot.pause()
 
-        app.post_message(UserMessageStart(steer, 0))
+        app.post_message(UserMessageStart(steer, 0, _steer_id(session, steer)))
         await pilot.pause()
 
         assert len(_user_blocks(app, steer)) == 1, "the delivery echoed an already-painted row"
@@ -141,10 +199,12 @@ async def test_two_steers_drained_together_neither_repaints() -> None:
         await _submit(pilot, app, "second steer")
         assert session.steers == ["first steer", "second steer"]
 
+        first_id = _steer_id(session, "first steer")
+        second_id = _steer_id(session, "second steer")
         app.post_message(SteeringDelivered(2))
         await pilot.pause()
-        app.post_message(UserMessageStart("first steer", 0))
-        app.post_message(UserMessageStart("second steer", 0))
+        app.post_message(UserMessageStart("first steer", 0, first_id))
+        app.post_message(UserMessageStart("second steer", 0, second_id))
         await pilot.pause()
 
         assert len(_user_blocks(app, "first steer")) == 1
@@ -207,7 +267,7 @@ async def test_a_session_swap_drops_the_echoes_waiting_on_the_old_queue() -> Non
     async with app.run_test(size=(100, 24)) as pilot:
         await pilot.pause()
         await _submit(pilot, app, "same words, new session")
-        assert app._pending_user_echoes == ["same words, new session"]
+        assert _echo_texts(app) == ["same words, new session"]
 
         app._session_factory = lambda: _factory(FakeSession())  # type: ignore[assignment]
         await app._reload_session()
@@ -257,15 +317,16 @@ async def test_a_pending_echo_survives_clear_and_is_consumed_by_its_event() -> N
     async with app.run_test(size=(100, 24)) as pilot:
         await pilot.pause()
         await _submit(pilot, app, "survives the clear")
-        assert app._pending_user_echoes == ["survives the clear"]
+        assert _echo_texts(app) == ["survives the clear"]
+        steer_id = _steer_id(session, "survives the clear")
 
         app._clear_transcript()
         await pilot.pause()
-        assert app._pending_user_echoes == [
+        assert _echo_texts(app) == [
             "survives the clear"
         ], "the clear removed the row but not the event that is still coming"
 
-        app.post_message(UserMessageStart("survives the clear", 0))
+        app.post_message(UserMessageStart("survives the clear", 0, steer_id))
         await pilot.pause()
         assert app._pending_user_echoes == []
         assert _user_blocks(app, "survives the clear") == [], "consumed, not repainted"
@@ -284,19 +345,20 @@ async def test_a_deferred_steer_is_settled_not_repainted_by_the_next_turns_echo(
     async with app.run_test(size=(100, 24)) as pilot:
         await pilot.pause()
         await _submit(pilot, app, "deferred across the turn")
-        assert app._pending_user_echoes == ["deferred across the turn"]
+        assert _echo_texts(app) == ["deferred across the turn"]
+        steer_id = _steer_id(session, "deferred across the turn")
 
         app.post_message(TurnEnded(True, None))
         await pilot.pause()
         assert DEFERRED_STEER_NOTICE in _notice_texts(app)
-        assert app._pending_user_echoes == [
+        assert _echo_texts(app) == [
             "deferred across the turn"
         ], "the turn ended, but the message is still queued — the entry stays"
 
         # The next turn's drain: the receipt settles the deferred row, and the
         # announcement consumes the entry instead of repainting the message.
         app.post_message(SteeringDelivered(1))
-        app.post_message(UserMessageStart("deferred across the turn", 0))
+        app.post_message(UserMessageStart("deferred across the turn", 0, steer_id))
         await pilot.pause()
         texts = _notice_texts(app)
         assert SENT_STEER_NOTICE in texts and DEFERRED_STEER_NOTICE not in texts
@@ -321,3 +383,147 @@ async def test_the_loop_prompt_never_gets_a_user_row() -> None:
         app.post_message(UserMessageStart(LOOP_PROMPT, 0))
         await pilot.pause()
         assert _user_blocks(app, LOOP_PROMPT) == []
+
+
+# --- issue #228: a distinct message whose words collide must still paint ------
+
+
+@pytest.mark.asyncio
+async def test_a_foreign_prompt_with_the_words_of_a_pending_steer_still_paints() -> None:
+    """Issue #228, reproduced: the collision the text match swallowed.
+
+    A steer is queued from the TUI ("continue") and its echo is pending. The
+    PHONE then sends its own "continue", which the session announces with a
+    DIFFERENT message id. Matching by text consumed the steer's entry and
+    painted nothing, so the TUI showed one row where the conversation had two
+    messages — the model saw both and the transcript denied one of them. The id
+    is what tells them apart.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "continue")
+        assert len(_user_blocks(app, "continue")) == 1, "the TUI's own echo"
+        steer_id = _steer_id(session, "continue")
+
+        # The phone's message: same words, its own identity.
+        app.post_message(UserMessageStart("continue", 0, "phone-message-id"))
+        await pilot.pause()
+        assert (
+            len(_user_blocks(app, "continue")) == 2
+        ), "the phone's distinct message must paint; matching by text swallowed it"
+        assert _echo_ids(app) == [steer_id], "the steer's entry is still waiting on its own event"
+
+        # And the true duplicate is still suppressed EXACTLY once: the steer's
+        # own delivery finds its entry and repaints nothing.
+        app.post_message(SteeringDelivered(1))
+        app.post_message(UserMessageStart("continue", 0, steer_id))
+        await pilot.pause()
+        assert len(_user_blocks(app, "continue")) == 2, "the steer's own event must not repaint"
+        assert app._pending_user_echoes == []
+
+
+@pytest.mark.asyncio
+async def test_the_prompt_path_registers_the_id_it_handed_the_session() -> None:
+    """The prompt half of the same contract, end to end.
+
+    The app mints the correlation id and pushes it into ``prompt(message_id=)``
+    — it cannot read one back, because ``prompt`` returns only when the whole
+    turn is over, long after the announcement. The id the session received is
+    therefore the id its ``MessageStartEvent`` carries, and it must be the id
+    sitting in the registry.
+    """
+    session = _IdAware()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "a prompt with an id")
+        for _ in range(10):
+            await pilot.pause()
+
+        assert session.prompts == ["a prompt with an id"]
+        assert session.prompt_ids and session.prompt_ids[0], "the app must supply a message_id"
+        assert _echo_ids(app) == [session.prompt_ids[0]]
+
+        # A colliding message from elsewhere paints...
+        app.post_message(UserMessageStart("a prompt with an id", 0, "some-other-id"))
+        await pilot.pause()
+        assert len(_user_blocks(app, "a prompt with an id")) == 2
+
+        # ...and this prompt's own announcement still suppresses its repaint.
+        app.post_message(UserMessageStart("a prompt with an id", 0, session.prompt_ids[0] or ""))
+        await pilot.pause()
+        assert len(_user_blocks(app, "a prompt with an id")) == 2
+        assert app._pending_user_echoes == []
+
+
+@pytest.mark.asyncio
+async def test_a_session_without_the_message_id_seam_keeps_the_text_match() -> None:
+    """``FakeSession.prompt`` has no ``message_id`` keyword, so the app must
+    NOT mint an id it cannot hand over: an entry keyed by an id the session
+    will never announce could match nothing, and every prompt would paint
+    twice. Such an entry registers id-less and matches by text, exactly as
+    before — the compatibility path older and third-party sessions ride."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "no id seam here")
+        for _ in range(10):
+            await pilot.pause()
+        assert _echo_ids(app) == [""], "no id may be minted for a session that cannot take one"
+
+        # The session mints its own id, so the announcement carries one the app
+        # has never seen — and the text fallback is what suppresses the repaint.
+        app.post_message(UserMessageStart("no id seam here", 0, "session-minted-id"))
+        await pilot.pause()
+        assert len(_user_blocks(app, "no id seam here")) == 1
+        assert app._pending_user_echoes == []
+
+
+@pytest.mark.asyncio
+async def test_an_id_carrying_entry_is_never_consumed_by_a_text_collision() -> None:
+    """The fallback must not undo the fix. An entry that HAS an id has an exact
+    event coming, so an id-less announcement carrying the same words must paint
+    rather than spend it — otherwise the steer's own delivery would later find
+    its entry gone and paint the duplicate #227 removed."""
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "yes")
+        steer_id = _steer_id(session, "yes")
+
+        # An announcement with no id at all (a reduced event producer): it is
+        # not this steer's, so it paints and leaves the entry standing.
+        app.post_message(UserMessageStart("yes", 0))
+        await pilot.pause()
+        assert len(_user_blocks(app, "yes")) == 2
+        assert _echo_ids(app) == [steer_id]
+
+        app.post_message(UserMessageStart("yes", 0, steer_id))
+        await pilot.pause()
+        assert len(_user_blocks(app, "yes")) == 2, "the steer's own delivery must not repaint"
+
+
+@pytest.mark.asyncio
+async def test_a_recalled_steer_takes_only_its_own_entry() -> None:
+    """Esc unsends a queued steer, so its entry must go with the row it
+    described. By ID: with two steers carrying the same words, a by-text
+    removal could take the sibling's entry and leave the recalled one standing
+    — the survivor would then swallow the resend's echo."""
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "same words")
+        await _submit(pilot, app, "same words")
+        first_id = _steer_id(session, "same words")
+        ids = _echo_ids(app)
+        assert len(ids) == 2 and ids[0] == first_id
+
+        # Esc recalls the NEWEST steer; its entry, and only its entry, goes.
+        await pilot.press("escape")
+        await pilot.pause()
+        assert _echo_ids(app) == [first_id], "the recall took the wrong steer's entry"


### PR DESCRIPTION
# PR Description

## Summary of Changes

Both front ends matched an optimistic user echo against the session's eventual
`MessageStartEvent` by **text**. A genuinely distinct message whose words
collided with a pending echo was therefore mistaken for that echo, and the two
surfaces failed in opposite directions from the same root cause.

### The shared defect

A surface paints the user's row the instant they hit send, then the session
announces that same message back to every front end (the cross-surface echo
channel). To avoid painting twice, each surface has to recognise its own echo —
and both recognised it by comparing the words.

Words are not identity. Two different messages routinely carry the same text:
`yes`, `continue`, `go on` are the most common things anyone sends.

### #228, TUI: a cross-surface prompt was swallowed

`_pending_user_echoes` held bare strings, and `on_user_message_start` did
`self._pending_user_echoes.remove(text)`. A prompt sent from the **phone** whose
text equalled a pending TUI echo consumed that entry and painted nothing. The
message reached the model and the transcript stayed silent about it, so the
agent answered a question the TUI never showed being asked.

Entries now carry the message id:

```python
class _PendingUserEcho(NamedTuple):
    message_id: str
    text: str
```

The app **mints** the id and pushes it into `prompt(message_id=...)`, or reads it
off the `Message` that `steer_message` queues. It cannot read one back — `prompt`
returns when the whole turn is over, long after the announcement — so the
correlation key has to travel outward. `UserMessageStart` carries the id through
the events bridge, following the `PeerMessageDelivered.message_id` pattern
already in that file.

### #231, mobile: a phone steer was repainted

`absorb_user_event` scanned `self.projection.transcript[-3:]` for an entry with
equal text. A steer is delivered at a **later tool boundary** by definition, so
assistant and tool rows land between the echo and its event and push the echo out
of a three-entry window — after which the drain repainted the message. This is
the same defect #227 fixed in the TUI, one surface over, so it gets the same
registry, keyed by the id the handle handed the session.

The **in-place upgrade is preserved**, and it is load-bearing: a phone-sent
prompt is echoed without image refs (the handle holds only the wire images), so
when the real event arrives carrying the attachments the echoed row adopts the
message's id and refs rather than being skipped. Without it the sender's own
thumbnails never appear.

### Not regressing #227

The prior fix's docstring records why matching was by text and not by position,
and the bug it fixed (duplicated steering messages, the fixed three-block
window). Two properties it depends on are preserved deliberately:

- **A steer's echo can sit arbitrarily far from the tail.** An id lookup scans
  the whole registry, so distance is irrelevant — strictly weaker an assumption
  than the tail scan it replaces.
- **Events do not arrive in registration order.** A steer left queued by an
  aborted turn is announced inside the *next* turn, after that turn's own prompt
  echo. An id match is order-free where a positional one is not.

Two compatibility rules keep it safe:

- A session whose `prompt` predates the `message_id` seam mints its own id, so
  the app registers an **id-less** entry and keeps the historical text match.
  Registering an id such a session will never announce would match nothing and
  paint every prompt twice, so the seam is probed, never assumed.
- An entry that **has** an id is never consumed by a text collision. Spending it
  on a colliding neighbour would leave the real announcement to paint the
  duplicate #227 removed.

## Testing Evidence

### The defects, reproduced on base and fixed at head

Both scripts run **unchanged** against either tree (they probe for the new
argument), so the two arms differ only in the code under test.

`#228` — a TUI steer `continue`, then the phone's own `continue`:

```
$ PYTHONPATH=<tree> .venv/bin/python /tmp/repro_228.py <tree>

=== BASE (3c79116c) ===
TUI steer echo painted                : 1 row
UserMessageStart carries message_id   : False
rows after the phone's message        : 1  (expected 2)
RESULT: FAIL - the phone's message was swallowed

=== HEAD ===
TUI steer echo painted                : 1 row
UserMessageStart carries message_id   : True
rows after the phone's message        : 2  (expected 2)
RESULT: PASS - the phone's message painted
```

`#231` — a phone steer, then four assistant rows push it past the 3-entry
window, then the drain announces it:

```
$ PYTHONPATH=<tree> .venv/bin/python /tmp/repro_231.py

=== BASE (3c79116c) ===
note_user_message supports message_id : False
rows carrying the steer text          : 2  (expected 1)
row kinds                             : ['steer', 'user']
RESULT: FAIL - steer repainted, 2 rows

=== HEAD ===
note_user_message supports message_id : True
rows carrying the steer text          : 1  (expected 1)
row kinds                             : ['steer']
RESULT: PASS - steer painted once
```

### The id contract, against the REAL Session

The registry is only correct if the id handed to the engine is the id that comes
back on the announcement. Driven against a real `Session` with a scripted stream,
observing the emitted events rather than reading the source:

```
$ PYTHONPATH=. .venv/bin/python /tmp/verify_live.py
prompt(message_id='tui-minted-id') announced : ['tui-minted-id']
steer_message(id=150de97db82b...) announced  : ['150de97db82b...']

prompt id round-trips : True
steer id round-trips  : True
RESULT: PASS - the announced id is the id the TUI registered
```

### Both directions, visually

Rendered from the real `OperatorApp` (so `local_operator.tcss` applies) at
100x30, and inspected as images rather than trusted from row counts.

| frame | what it shows |
|---|---|
| `frames/before_collision.svg` | **Base**: one `continue` row and its queued notice. The phone's message is absent from the transcript entirely. |
| `frames/after_collision.svg` | **Head**: two `continue` rows, each with its own gutter rule and the correct `gap-above` spacing. |
| `frames/after_true_duplicate.svg` | **Head, the other direction**: the steer's *own* delivery then arrives, the notice settles to `sent — the agent has it now`, and no third row is added. The duplicate is suppressed exactly once. |

All frames, both reproduction scripts and the live-engine check are committed
under `docs/evidence/echo-dedup-id/`.

### Regression tests

Nine new tests pin both directions on both surfaces.

TUI (`tests/unit/tui/test_user_echo_dedup.py`), 15 passing:

- a foreign prompt with the words of a pending steer still paints, **and** that
  steer's own delivery then repaints nothing
- the prompt path registers the id it handed the session
- a session without the `message_id` seam keeps the text match
- an id-carrying entry is never consumed by a text collision
- a recalled steer takes only its own entry, with two same-text steers queued

Mobile (`tests/unit/mobile/test_projection.py`), 44 passing:

- a phone steer is not repainted once assistant rows push it out of the window
- a distinct message with colliding words still paints
- a registered echo row is not consumed by a colliding neighbour
- the echoed row adopts the persisted message id
- a legacy handle without an id keeps the tail de-dup
- a history fold clears pending echoes

The five existing tests that posted synthetic id-less events were updated to
carry the real ids (via a `_steer_id` helper reading the queued `Message`),
which is what makes them exercise the id path; the legacy-fallback cases keep
using `FakeSession`, which deliberately has no `message_id` seam.

### Gates

```
flake8 .                       clean
black --check .                625 files unchanged
isort --check .                clean
pyright .                      0 errors, 0 warnings, 0 informations
pytest tests/unit              8996 passed, 15 skipped, 1 failed
```

The one failure is `test_cancel_backgrounded_bash_kills_process_group`, a
timing-sensitive process-group test in the bash tool. It passes in isolation on
**both** this branch and `origin/main`, and this PR touches only the TUI app and
events bridge and the mobile projection. Several agent sessions were running the
suite concurrently on this machine; the same load also flaked
`test_launch_subagent` on base (1 of 3 runs, with its own message reporting a
CPU-calibrated bound).

## Risk

The de-dup key changes, so the failure mode to worry about is an echo that finds
no entry and paints twice. Three things bound it: the id is probed rather than
assumed (a session that cannot take one registers id-less and keeps the old
behaviour), the text match survives untouched for those entries, and the
id round-trip is verified against the real `Session` on both the prompt and
steer paths above. The registration sites are enumerable and all five were
converted: submit-steer, `_start_turn`, both `/loop` workers, and the recall.

The mobile registry is bounded by dropping entries whose row the transcript cap
trimmed, which also retires the entry of a steer the phone recalls and never
sends.

Closes #228
Closes #231
