### PR TITLE
perf(tui): stop repainting unchanged chrome and animating blurred terminals

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -164,13 +164,20 @@ fixes (after), 50 driven ticks, 160-block transcript, one running child.
 
 | Per spinner tick | Before | After |
 | --- | --- | --- |
-| `messages.Layout` posted | 5.42 | **0.02** |
-| compositor reflows | 4.64 | **0.00** |
-| `Screen._refresh_layout` | 4.64 | **0.00** |
-| `messages.Update` posted | 33.60 | **16.38** |
-| title rewrites | 5.80 | 4.54 |
-| breadcrumb rewrites | 5.80 | **0.00** |
-| rule rewrites | 5.80 | **0.00** |
+| `messages.Layout` posted | 4.54 | **0.02** |
+| compositor reflows | 4.42 | **0.00** |
+| `Screen._refresh_layout` | 4.42 | **0.00** |
+| `messages.Update` posted | 27.98 | **11.20** |
+| title rewrites | 4.60 | 3.00 |
+| breadcrumb rewrites | 4.60 | **0.00** |
+| rule rewrites | 4.60 | **0.00** |
+
+Both columns are the committed artifacts in this directory
+(`chrome-paint-before.json`, `chrome-paint-after.json`), captured in the same
+session at the same tick count so the two are directly comparable. Absolute
+counts drift a little between runs because the 1 Hz job poll also refreshes the
+page; the columns that go to exactly zero are the ones this work is about, and
+those are structural rather than sampled.
 
 The breadcrumb and the rule are pure functions of `_ancestors`/`_label` and of
 width; neither can change on a spinner tick, and both were being rewritten with

--- a/bench/README.md
+++ b/bench/README.md
@@ -141,3 +141,56 @@ Reading the table:
 Cold-cache numbers are reported separately and never averaged into the warm
 ones: the first scan after the cache is deleted is 1.6-5.2 s on this store,
 dominated by reading 29,000 marker files, and it writes the cache as it goes.
+
+## chrome-paint-before.json / chrome-paint-after.json
+
+`scripts/bench_tui_chrome_paint.py` measures what one running subagent page
+costs per spinner tick, and what an idle session writes to its terminal focused
+versus blurred. Run:
+
+```sh
+env -u NO_COLOR TERM=xterm-256color \
+  .venv/bin/python scripts/bench_tui_chrome_paint.py --focus 8 --json out.json
+```
+
+Everything except the focus block is a load-invariant COUNT rather than a
+duration, and deliberately so: the machine this was diagnosed on sat at loadavg
+260-307 on 14 cores from unrelated harnesses, where a fixed work quantum held
+its CPU time (81.6 -> 101.5 ms) while wall time inflated 4.6-7.8x. Wall time is
+printed but is not a signal.
+
+Captured against `origin/main` @ `3c79116c` (before) and the same tree with the
+fixes (after), 50 driven ticks, 160-block transcript, one running child.
+
+| Per spinner tick | Before | After |
+| --- | --- | --- |
+| `messages.Layout` posted | 5.42 | **0.02** |
+| compositor reflows | 4.64 | **0.00** |
+| `Screen._refresh_layout` | 4.64 | **0.00** |
+| `messages.Update` posted | 33.60 | **16.38** |
+| title rewrites | 5.80 | 4.54 |
+| breadcrumb rewrites | 5.80 | **0.00** |
+| rule rewrites | 5.80 | **0.00** |
+
+The breadcrumb and the rule are pure functions of `_ancestors`/`_label` and of
+width; neither can change on a spinner tick, and both were being rewritten with
+byte-identical strings 12.5 times a second. The reflow column is the missing
+`layout=False` on the breadcrumb, which negated the deliberate `layout=False`
+its two siblings already carried — one defaulted `update` on the same tick
+relayouts the same screen.
+
+### Focus gating
+
+Terminal bytes per second, splash up and a turn running (the shape of a session
+in a window the user has tabbed away from), 8 s windows:
+
+| | Before | After |
+| --- | --- | --- |
+| focused | 24,039 B/s | 24,109 B/s |
+| blurred | 23,824 B/s | **862 B/s** |
+| ratio | 1.01x | **28.0x** |
+
+The before column is the diagnosis restated: on `origin/main` a real `AppBlur`
+posted to the app changes nothing, because Textual's own `_on_app_blur` only
+sets a flag and refreshes bindings. The focused row is unchanged by design —
+this gates on focus, it does not slow down animation anyone can see.

--- a/bench/README.md
+++ b/bench/README.md
@@ -167,17 +167,19 @@ fixes (after), 50 driven ticks, 160-block transcript, one running child.
 | `messages.Layout` posted | 4.54 | **0.02** |
 | compositor reflows | 4.42 | **0.00** |
 | `Screen._refresh_layout` | 4.42 | **0.00** |
-| `messages.Update` posted | 27.98 | **11.20** |
-| title rewrites | 4.60 | 3.00 |
+| `messages.Update` posted | 27.98 | **8.82** |
+| title rewrites | 4.60 | 2.56 |
 | breadcrumb rewrites | 4.60 | **0.00** |
 | rule rewrites | 4.60 | **0.00** |
 
 Both columns are the committed artifacts in this directory
-(`chrome-paint-before.json`, `chrome-paint-after.json`), captured in the same
-session at the same tick count so the two are directly comparable. Absolute
-counts drift a little between runs because the 1 Hz job poll also refreshes the
-page; the columns that go to exactly zero are the ones this work is about, and
-those are structural rather than sampled.
+(`chrome-paint-before.json`, `chrome-paint-after.json`), captured at the same
+tick count so the two are directly comparable. The harness names every metric
+even when it is zero, so a column that reads 0.00 is a counted zero in the
+artifact, not a missing key. Absolute counts drift a little between runs
+because the 1 Hz job poll also refreshes the page; the columns that go to
+exactly zero are the ones this work is about, and those are structural rather
+than sampled.
 
 The breadcrumb and the rule are pure functions of `_ancestors`/`_label` and of
 width; neither can change on a spinner tick, and both were being rewritten with

--- a/bench/chrome-paint-after.json
+++ b/bench/chrome-paint-after.json
@@ -1,25 +1,19 @@
 {
-  "ticks": 30,
+  "ticks": 50,
   "blocks": 160,
   "counts": {
-    "ticks": 30,
-    "paint_chrome": 91,
-    "title_updates": 87,
-    "update_msgs": 307,
+    "ticks": 50,
+    "paint_chrome": 157,
+    "title_updates": 150,
+    "update_msgs": 560,
     "layout_msgs": 1
   },
   "per_tick": {
     "ticks_per_tick": 1.0,
-    "paint_chrome_per_tick": 3.0333,
-    "title_updates_per_tick": 2.9,
-    "update_msgs_per_tick": 10.2333,
-    "layout_msgs_per_tick": 0.0333
+    "paint_chrome_per_tick": 3.14,
+    "title_updates_per_tick": 3.0,
+    "update_msgs_per_tick": 11.2,
+    "layout_msgs_per_tick": 0.02
   },
-  "wall_s": 4.173,
-  "focus": {
-    "window_s": 8.0,
-    "focused_bytes_per_s": 24109,
-    "blurred_bytes_per_s": 862,
-    "reduction": 28.0
-  }
+  "wall_s": 7.402
 }

--- a/bench/chrome-paint-after.json
+++ b/bench/chrome-paint-after.json
@@ -1,0 +1,25 @@
+{
+  "ticks": 30,
+  "blocks": 160,
+  "counts": {
+    "ticks": 30,
+    "paint_chrome": 91,
+    "title_updates": 87,
+    "update_msgs": 307,
+    "layout_msgs": 1
+  },
+  "per_tick": {
+    "ticks_per_tick": 1.0,
+    "paint_chrome_per_tick": 3.0333,
+    "title_updates_per_tick": 2.9,
+    "update_msgs_per_tick": 10.2333,
+    "layout_msgs_per_tick": 0.0333
+  },
+  "wall_s": 4.173,
+  "focus": {
+    "window_s": 8.0,
+    "focused_bytes_per_s": 24109,
+    "blurred_bytes_per_s": 862,
+    "reduction": 28.0
+  }
+}

--- a/bench/chrome-paint-after.json
+++ b/bench/chrome-paint-after.json
@@ -3,17 +3,25 @@
   "blocks": 160,
   "counts": {
     "ticks": 50,
-    "paint_chrome": 157,
-    "title_updates": 150,
-    "update_msgs": 560,
-    "layout_msgs": 1
+    "paint_chrome": 133,
+    "title_updates": 128,
+    "update_msgs": 441,
+    "layout_msgs": 1,
+    "breadcrumb_updates": 0,
+    "rule_updates": 0,
+    "refresh_layout": 0,
+    "reflow": 0
   },
   "per_tick": {
     "ticks_per_tick": 1.0,
-    "paint_chrome_per_tick": 3.14,
-    "title_updates_per_tick": 3.0,
-    "update_msgs_per_tick": 11.2,
-    "layout_msgs_per_tick": 0.02
+    "paint_chrome_per_tick": 2.66,
+    "title_updates_per_tick": 2.56,
+    "update_msgs_per_tick": 8.82,
+    "layout_msgs_per_tick": 0.02,
+    "breadcrumb_updates_per_tick": 0.0,
+    "rule_updates_per_tick": 0.0,
+    "refresh_layout_per_tick": 0.0,
+    "reflow_per_tick": 0.0
   },
-  "wall_s": 7.402
+  "wall_s": 5.783
 }

--- a/bench/chrome-paint-before.json
+++ b/bench/chrome-paint-before.json
@@ -3,25 +3,25 @@
   "blocks": 160,
   "counts": {
     "ticks": 50,
-    "paint_chrome": 324,
-    "title_updates": 290,
-    "breadcrumb_updates": 290,
-    "rule_updates": 290,
-    "update_msgs": 1680,
-    "layout_msgs": 271,
-    "refresh_layout": 232,
-    "reflow": 232
+    "paint_chrome": 244,
+    "title_updates": 230,
+    "breadcrumb_updates": 230,
+    "rule_updates": 230,
+    "update_msgs": 1399,
+    "layout_msgs": 227,
+    "refresh_layout": 221,
+    "reflow": 221
   },
   "per_tick": {
     "ticks_per_tick": 1.0,
-    "paint_chrome_per_tick": 6.48,
-    "title_updates_per_tick": 5.8,
-    "breadcrumb_updates_per_tick": 5.8,
-    "rule_updates_per_tick": 5.8,
-    "update_msgs_per_tick": 33.6,
-    "layout_msgs_per_tick": 5.42,
-    "refresh_layout_per_tick": 4.64,
-    "reflow_per_tick": 4.64
+    "paint_chrome_per_tick": 4.88,
+    "title_updates_per_tick": 4.6,
+    "breadcrumb_updates_per_tick": 4.6,
+    "rule_updates_per_tick": 4.6,
+    "update_msgs_per_tick": 27.98,
+    "layout_msgs_per_tick": 4.54,
+    "refresh_layout_per_tick": 4.42,
+    "reflow_per_tick": 4.42
   },
-  "wall_s": 33.568
+  "wall_s": 13.488
 }

--- a/bench/chrome-paint-before.json
+++ b/bench/chrome-paint-before.json
@@ -1,0 +1,27 @@
+{
+  "ticks": 50,
+  "blocks": 160,
+  "counts": {
+    "ticks": 50,
+    "paint_chrome": 324,
+    "title_updates": 290,
+    "breadcrumb_updates": 290,
+    "rule_updates": 290,
+    "update_msgs": 1680,
+    "layout_msgs": 271,
+    "refresh_layout": 232,
+    "reflow": 232
+  },
+  "per_tick": {
+    "ticks_per_tick": 1.0,
+    "paint_chrome_per_tick": 6.48,
+    "title_updates_per_tick": 5.8,
+    "breadcrumb_updates_per_tick": 5.8,
+    "rule_updates_per_tick": 5.8,
+    "update_msgs_per_tick": 33.6,
+    "layout_msgs_per_tick": 5.42,
+    "refresh_layout_per_tick": 4.64,
+    "reflow_per_tick": 4.64
+  },
+  "wall_s": 33.568
+}

--- a/local_operator/tui/animation.py
+++ b/local_operator/tui/animation.py
@@ -1,0 +1,95 @@
+"""One answer to "should this surface be animating right now?".
+
+Four surfaces in this app run repaint timers that exist only to move something
+— the working line's shimmer and spinner (30 fps), the subagent page's spinner,
+the subagent panel's spinner and the status band's spinner (12.5 fps each), and
+the welcome splash's mark pulse (12.5 fps). None of them carries information a
+user can only get from the motion; every one of them is the app saying "this is
+alive".
+
+A terminal the user is not looking at gets nothing from any of that, and it is
+not free. Measured on a single idle session: shimmer on costs 7.89% of a core
+and 17.3 KB/s of terminal output, against 2.27% and 1.0 KB/s with animation off
+— the animation is 92% of what an idle session writes. That output is not
+cheap to consume either: the steady-state stream is 48% escape sequences, and
+a JS terminal (cmux/Electron) held 51-60% of a core parsing it where a native
+GPU one (Ghostty) held 0.6%. Multiply by the eighteen sessions this developer
+keeps open and the idle cost of windows nobody is looking at is the single
+largest thing lop asks of the machine.
+
+So animation is gated on TERMINAL FOCUS, and this module is the one place that
+knows the answer. It is a module-level flag rather than an app attribute
+because the widgets that read it are built and mounted at different times and
+several of them (``StatusLine``) are not ``Widget`` subclasses at all; a
+surface created while the terminal is blurred has to come up throttled without
+having to find the app first.
+
+Two invariants this must never violate, both of them load-bearing:
+
+* **A session that never learns about focus must never be throttled.** Some
+  hosts and pty setups deliver no focus events at all. The flag therefore
+  starts ``True`` and only an explicit blur can clear it, so "no information"
+  and "focused" are the same state. The app additionally re-derives it from
+  Textual's own ``app_focus`` reactive, which Textual itself sets back to
+  ``True`` on any keypress or mouse click — so even a spurious blur with no
+  matching focus event heals on the user's next keystroke.
+* **Only the RATE of animation may drop; content may not.** Nothing here is
+  allowed to suppress a repaint that carries new information. Every throttled
+  timer keeps running at a reduced interval, and every surface repaints itself
+  immediately when focus returns, so a refocused terminal shows current state
+  rather than the frame it was paused on.
+"""
+
+from __future__ import annotations
+
+#: Interval for a spinner on a blurred terminal. The app's animated cadence is
+#: 0.08 s (:data:`~local_operator.tui.terminal_title.SPINNER_INTERVAL_S`); this
+#: is 12.5x cheaper and still advances, so a glance at an unfocused window
+#: still says "running" rather than "hung". It is not zero deliberately: a
+#: stopped spinner and a finished job look identical, and this app uses motion
+#: as its word for alive.
+BLURRED_SPINNER_INTERVAL_S = 1.0
+
+#: Starts focused. See the module docstring — "we were never told" must read as
+#: focused, never as blurred, or a session on a host that sends no focus events
+#: would animate at 1 fps forever.
+_focused = True
+
+
+def animation_focused() -> bool:
+    """Whether the terminal is believed to have OS focus."""
+    return _focused
+
+
+def set_animation_focused(focused: bool) -> bool:
+    """Record terminal focus. Returns whether this CHANGED the answer.
+
+    The return value is what lets callers skip the fan-out: Textual re-asserts
+    focus on every keypress, so an unconditional resync would stop and restart
+    four timers on each character the user types.
+    """
+    global _focused
+    if _focused == focused:
+        return False
+    _focused = focused
+    return True
+
+
+def reset_animation_focus() -> None:
+    """Restore the default (focused). For tests, which share a process."""
+    global _focused
+    _focused = True
+
+
+def motion_enabled() -> bool:
+    """Whether a surface should animate at its full, designed cadence.
+
+    Both gates in one call, because "hold still" is one decision and a surface
+    asking only one of the two questions is a bug: the ``display.shimmer``
+    setting / ``LOCAL_OPERATOR_NO_SHIMMER`` kill switch decides whether this
+    app animates AT ALL (CI and the SVG snapshot harness turn it off so every
+    frame is reproducible), and focus decides whether it is worth doing now.
+    """
+    from local_operator.tui.shimmer import shimmer_enabled
+
+    return shimmer_enabled() and _focused

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -8903,7 +8903,7 @@ class OperatorApp(App[None]):
         return False
 
     def on_app_focus(self, event: AppFocus) -> None:
-        """The terminal regained OS focus \u2014 stop notifying.
+        """The terminal regained OS focus \u2014 stop notifying, resume animating.
 
         Textual reports focus only on a CHANGE, which is why the notifier
         starts out focused: the app is launched from the terminal the user is
@@ -8912,13 +8912,70 @@ class OperatorApp(App[None]):
         """
         if self._notifier is not None:
             self._notifier.set_focused(True)
+        self._set_animation_focused(True)
 
     def on_app_blur(self, event: AppBlur) -> None:
-        """The terminal lost OS focus \u2014 notifications become deliverable."""
+        """The terminal lost OS focus \u2014 notify, and slow every animation."""
+        self._set_animation_focused(False)
         if self._notifier is None:
             return
         self._notifier.set_focused(False)
         self._flush_pending_question()
+
+    def _set_animation_focused(self, focused: bool) -> None:
+        """Record focus and re-rate every animated surface on this screen.
+
+        Animation is the largest thing an idle session costs \u2014 measured at 92%
+        of what one writes to its terminal \u2014 and none of it is worth paying for
+        a window nobody is looking at. This is the fan-out: the flag lives in
+        `tui.animation` (a module global, because these surfaces are built at
+        different times and one of them is not a `Widget` at all), and each
+        surface re-rates its own timer through its own `sync_animation_rate`,
+        so no surface gains a second way to decide its cadence.
+
+        Only the RATE changes. Each of those methods repaints \u2014 or, for the
+        panel, marks itself dirty so its single repaint point runs \u2014 on the way
+        back to the fast rate, so a refocused terminal shows the current glyph,
+        clock and counts rather than the frame it was throttled on. Nothing
+        here can drop CONTENT: a blurred session still receives, records and
+        paints every event, because the transcript, the ledger and the working
+        line are driven by events and not by these timers.
+
+        A session that never receives focus events is never throttled: the flag
+        starts focused and only an explicit blur clears it. Textual also flips
+        `app_focus` back to True on any keypress or click and posts AppFocus
+        here, so a spurious blur on a host with half-working focus reporting
+        heals on the user's next keystroke rather than leaving a foreground
+        session stuck at the slow rate.
+
+        Guarded per surface: one widget mid-teardown must not stop the others
+        being told, and no part of this is worth an exception reaching a turn.
+        """
+        from local_operator.tui.animation import set_animation_focused
+
+        if not set_animation_focused(focused):
+            return
+        for surface in (
+            self._working_block,
+            self._subagent_panel,
+            self._subagent_view,
+            self._status,
+        ):
+            if surface is None:
+                continue
+            try:
+                surface.sync_animation_rate()
+            except Exception:  # pragma: no cover - defensive; chrome must not raise
+                logger.debug("animation re-rate failed", exc_info=True)
+        # The splash owns two timers and derives both from `motion_enabled()`,
+        # so it is re-synced through the same seams `set_visible` uses rather
+        # than being given a re-rate method of its own.
+        try:
+            welcome = self.query_one(WelcomeView)
+            welcome._sync_pulse_timer()
+            welcome._sync_tip_timer()
+        except Exception:
+            pass  # no splash mounted, or already torn down: the ordinary case
 
     def _flush_pending_question(self) -> None:
         """Announce an unanswered question raised while the terminal was focused.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -8964,11 +8964,13 @@ class OperatorApp(App[None]):
         line are driven by events and not by these timers.
 
         A session that never receives focus events is never throttled: the flag
-        starts focused and only an explicit blur clears it. Textual also flips
-        `app_focus` back to True on any keypress or click and posts AppFocus
-        here, so a spurious blur on a host with half-working focus reporting
-        heals on the user's next keystroke rather than leaving a foreground
-        session stuck at the slow rate.
+        starts focused and only an explicit blur clears it. A session that hears
+        a blur but never the matching focus heals on the user's next keystroke —
+        but NOT through this handler: Textual flips the `app_focus` reactive
+        directly in `App.on_event` and posts no `AppFocus` event for it, so the
+        recovery path is the `_watch_app_focus` watcher above. Verified against
+        Textual 8.2.8, where a blur followed by a keypress leaves `app_focus`
+        True with no event delivered here.
 
         Guarded per surface: one widget mid-teardown must not stop the others
         being told, and no part of this is worth an exception reaching a turn.
@@ -8989,15 +8991,19 @@ class OperatorApp(App[None]):
                 surface.sync_animation_rate()
             except Exception:  # pragma: no cover - defensive; chrome must not raise
                 logger.debug("animation re-rate failed", exc_info=True)
-        # The splash owns two timers and derives both from `motion_enabled()`,
-        # so it is re-synced through the same seams `set_visible` uses rather
-        # than being given a re-rate method of its own.
+        # The splash is queried rather than held as an attribute (it is mounted
+        # and dropped with the boot screen), so it is fanned out to separately
+        # — but through the SAME public `sync_animation_rate` seam as the four
+        # above, not through its privates: a second convention for "re-rate
+        # yourself" is exactly what this module's docstring warns against.
         try:
             welcome = self.query_one(WelcomeView)
-            welcome._sync_pulse_timer()
-            welcome._sync_tip_timer()
         except Exception:
-            pass  # no splash mounted, or already torn down: the ordinary case
+            return  # no splash mounted, or already torn down: the ordinary case
+        try:
+            welcome.sync_animation_rate()
+        except Exception:  # pragma: no cover - defensive; chrome must not raise
+            logger.debug("splash animation re-rate failed", exc_info=True)
 
     def _flush_pending_question(self) -> None:
         """Announce an unanswered question raised while the terminal was focused.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -8922,6 +8922,28 @@ class OperatorApp(App[None]):
         self._notifier.set_focused(False)
         self._flush_pending_question()
 
+    def _watch_app_focus(self, focus: bool) -> None:
+        """Follow Textual's OWN focus reactive, not just the AppFocus event.
+
+        `on_app_focus`/`on_app_blur` cover the terminal reporting focus, but
+        they are not the only way `app_focus` moves. Textual sets the reactive
+        directly in `App.on_event` when a key or mouse-down arrives while it
+        believes the app is blurred, and that assignment posts NO AppFocus
+        event — so the handler below would never run and a session whose host
+        reports blur but not focus (or which never reports focus at all) would
+        stay throttled while the user was actively typing into it. Verified
+        against the real app: after a blur then a keypress, `app_focus` is True
+        while the animation gate was still False.
+
+        Watching the reactive closes that gap, because every path that changes
+        Textual's mind about focus goes through it. The base class implements
+        this hook, so the super call is not optional: it restores focus to the
+        last-focused widget and updates node styles, and dropping it would
+        leave the app unable to type after an alt-tab.
+        """
+        super()._watch_app_focus(focus)
+        self._set_animation_focused(focus)
+
     def _set_animation_focused(self, focused: bool) -> None:
         """Record focus and re-rate every animated surface on this screen.
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -8944,6 +8944,20 @@ class OperatorApp(App[None]):
         super()._watch_app_focus(focus)
         self._set_animation_focused(focus)
 
+    def watch_app_focus(self, focus: bool) -> None:
+        """The PUBLIC spelling of the same hook, as insurance.
+
+        Textual resolves reactive watchers by name and calls the private
+        ``_watch_<name>`` spelling, which is what the method above overrides.
+        A future Textual that prefers the public spelling — or calls both —
+        would otherwise leave the animation gate un-synced on the reactive
+        path while still receiving the events, and the failure would be
+        exactly the one R2 fixed: a session stuck at the reduced cadence
+        while the user types into it. One delegating line costs nothing and
+        makes the seam name-independent.
+        """
+        self._watch_app_focus(focus)
+
     def _set_animation_focused(self, focused: bool) -> None:
         """Record focus and re-rate every animated surface on this screen.
 
@@ -8968,9 +8982,10 @@ class OperatorApp(App[None]):
         a blur but never the matching focus heals on the user's next keystroke —
         but NOT through this handler: Textual flips the `app_focus` reactive
         directly in `App.on_event` and posts no `AppFocus` event for it, so the
-        recovery path is the `_watch_app_focus` watcher above. Verified against
-        Textual 8.2.8, where a blur followed by a keypress leaves `app_focus`
-        True with no event delivered here.
+        recovery path is the `_watch_app_focus` watcher above. Established
+        against Textual 8.2.8; `textual>=8.0.0` is the floor this ships on, so
+        the watcher rather than the event is the recovery seam to trust across
+        that range.
 
         Guarded per surface: one widget mid-teardown must not stop the others
         being told, and no part of this is worth an exception reaching a turn.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -8947,16 +8947,22 @@ class OperatorApp(App[None]):
     def watch_app_focus(self, focus: bool) -> None:
         """The PUBLIC spelling of the same hook, as insurance.
 
-        Textual resolves reactive watchers by name and calls the private
-        ``_watch_<name>`` spelling, which is what the method above overrides.
-        A future Textual that prefers the public spelling — or calls both —
-        would otherwise leave the animation gate un-synced on the reactive
-        path while still receiving the events, and the failure would be
-        exactly the one R2 fixed: a session stuck at the reduced cadence
-        while the user types into it. One delegating line costs nothing and
-        makes the seam name-independent.
+        Textual's ``Reactive._check_watchers`` calls BOTH spellings — the
+        private ``_watch_app_focus`` and then this one — so this must not
+        delegate to the private override: that would run ``super()``'s
+        implementation twice, and it is not idempotent. On blur the base
+        stashes ``screen.focused`` and then clears focus, so a second call
+        re-reads the ``None`` it just wrote and overwrites the memory; refocus
+        then has nothing to restore and the user has to click before they can
+        type again (agent review round 3, R12).
+
+        Only the animation gate is re-run here, which IS idempotent
+        (``set_animation_focused`` returns False and fans out nothing when the
+        answer has not changed). That keeps the insurance this method exists
+        for — if a future Textual resolves only the public name, the gate
+        still syncs — without paying the base implementation twice.
         """
-        self._watch_app_focus(focus)
+        self._set_animation_focused(focus)
 
     def _set_animation_focused(self, focused: bool) -> None:
         """Record focus and re-rate every animated surface on this screen.

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -40,6 +40,7 @@ from textual.widgets import Static
 
 from local_operator.model.naming import model_label as model_label_forms
 from local_operator.tui import theme as theme_mod
+from local_operator.tui.animation import BLURRED_SPINNER_INTERVAL_S, animation_focused
 from local_operator.tui.terminal_title import SPINNER_FRAMES as _SPINNER_FRAMES
 from local_operator.tui.terminal_title import SPINNER_INTERVAL_S as _SPINNER_INTERVAL_S
 from local_operator.tui.terminal_title import TerminalTitle, TitleState, cwd_label
@@ -949,6 +950,9 @@ class StatusLine:
         self._turn_started_at: float | None = None
         self._spinner_index: int = 0
         self._spinner_timer = None
+        #: Interval the live timer was created with; a focus change compares
+        #: against it to decide whether the timer must be replaced.
+        self._spinner_rate: float = _SPINNER_INTERVAL_S
         #: The child's readings, shadowing the session's own while the
         #: full-page subagent view is up. ``None`` is the ordinary band.
         self._subagent: SubagentBand | None = None
@@ -1871,13 +1875,38 @@ class StatusLine:
         return self._render(width)
 
     # -- spinner ------------------------------------------------------------
+    def _spinner_interval(self) -> float:
+        """Full cadence when the terminal is focused, reduced when it is not."""
+        return _SPINNER_INTERVAL_S if animation_focused() else BLURRED_SPINNER_INTERVAL_S
+
     def _sync_spinner_timer(self) -> None:
         if self._streaming and self._spinner_timer is None:
-            self._spinner_timer = self._dock.set_interval(
-                _SPINNER_INTERVAL_S, self._advance_spinner
-            )
+            self._spinner_rate = self._spinner_interval()
+            self._spinner_timer = self._dock.set_interval(self._spinner_rate, self._advance_spinner)
         elif not self._streaming and self._spinner_timer is not None:
             self._stop_spinner()
+
+    def sync_animation_rate(self) -> None:
+        """Re-rate the band's spinner after a focus change.
+
+        The band is not a ``Widget`` — it drives a ``Static`` dock — so it is
+        re-rated by the app rather than by a Textual event of its own. Only a
+        streaming band has a timer to re-rate; an idle one has already stopped
+        and must stay stopped.
+
+        The band re-renders on the way back to the fast rate because it carries
+        the session clock and the token counts, not just the glyph: those are
+        the numbers a returning user reads first, and they must be current at
+        the moment the window is looked at rather than up to a second stale.
+        """
+        if self._spinner_timer is None:
+            return
+        wanted = self._spinner_interval()
+        if wanted == self._spinner_rate:
+            return
+        self._stop_spinner()
+        self._sync_spinner_timer()
+        self.refresh()
 
     def _advance_spinner(self) -> None:
         self._spinner_index = (self._spinner_index + 1) % len(_SPINNER_FRAMES)

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -31,6 +31,7 @@ from textual.widgets import Static
 
 from local_operator.ansi import strip_control_sequences
 from local_operator.tui import theme as theme_mod
+from local_operator.tui.animation import BLURRED_SPINNER_INTERVAL_S, animation_focused
 from local_operator.tui.costs import job_cost
 from local_operator.tui.widgets.status_line import context_spelling, format_cost
 from local_operator.tui.widgets.tool_card import (
@@ -1172,6 +1173,9 @@ class SubagentPanel(Container):
         self._jobs_by_id: dict[str, Any] = {}
         self._spinner_index = 0
         self._spinner_timer = None
+        #: Interval the live timer was created with; a focus change compares
+        #: against it to decide whether the timer must be replaced.
+        self._spinner_rate: float = SPINNER_INTERVAL_S
         #: Whether the header has been painted once. It is a static label —
         #: the running-count that would once have changed it moved to the
         #: status band — so a second paint can only ever redraw the same row.
@@ -1641,14 +1645,43 @@ class SubagentPanel(Container):
             self._start_spinner()
 
     # -- tick ----------------------------------------------------------------
+    def _spinner_interval(self) -> float:
+        """Full cadence when the terminal is focused, reduced when it is not."""
+        return SPINNER_INTERVAL_S if animation_focused() else BLURRED_SPINNER_INTERVAL_S
+
     def _start_spinner(self) -> None:
         if self._spinner_timer is None and self.is_mounted:
-            self._spinner_timer = self.set_interval(SPINNER_INTERVAL_S, self._tick)
+            self._spinner_rate = self._spinner_interval()
+            self._spinner_timer = self.set_interval(self._spinner_rate, self._tick)
 
     def _stop_spinner(self) -> None:
         if self._spinner_timer is not None:
             self._spinner_timer.stop()
             self._spinner_timer = None
+
+    def sync_animation_rate(self) -> None:
+        """Re-rate the tick after a focus change.
+
+        A Textual timer's interval is fixed at creation, so the timer is
+        replaced. Only a panel that already HAS one is touched: this must never
+        start a tick under a dock of settled children, which is the state
+        `_tick` deliberately stops itself in.
+
+        Coming back to the fast rate marks the panel dirty rather than painting
+        here, because `_tick` is this panel's one repaint point and a second
+        paint path is exactly the duplication its docstring warns about. The
+        next tick is then a FULL repaint, so the numbers, clocks and row set a
+        user sees on refocus are current rather than whatever the throttled
+        window last painted.
+        """
+        if self._spinner_timer is None:
+            return
+        wanted = self._spinner_interval()
+        if wanted == self._spinner_rate:
+            return
+        self._stop_spinner()
+        self._dirty = True
+        self._start_spinner()
 
     def _tick(self) -> None:
         """The panel's ONE repaint point: spinner, coalesced syncs, numbers.

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -2585,8 +2585,18 @@ class SubagentView(Vertical):
     def _spinner_interval(self) -> float:
         # Motion, not colour, is how this app says "alive", at the cadence the
         # band and the status line already use: two speeds on one screen read
-        # as two different states. On a BLURRED terminal all of them slow to
-        # the same reduced cadence together, so that property still holds.
+        # as two different states. On a BLURRED terminal the three SPINNERS
+        # (this page, the dock and the band) step together at the reduced rate,
+        # so they still agree with each other.
+        #
+        # The working line is the deliberate exception and this comment used to
+        # overclaim by omitting it: it falls to its pre-existing static mode,
+        # where the glyph FREEZES and only the clock moves (design review D3).
+        # That is the shimmer-off frame this app already ships and already
+        # treats as legible, and a blurred screen therefore shows a still
+        # working line beside two stepping spinners. Left as-is rather than
+        # unified, because the alternative is inventing a fourth animation
+        # state for a window nobody is looking at.
         return SPINNER_INTERVAL_S if animation_focused() else BLURRED_SPINNER_INTERVAL_S
 
     def _start_spinner(self) -> None:

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -76,6 +76,7 @@ from local_operator.session.transcript import (
     read_transcript_page,
 )
 from local_operator.tui import theme as theme_mod
+from local_operator.tui.animation import BLURRED_SPINNER_INTERVAL_S, animation_focused
 from local_operator.tui.widgets import tool_card
 from local_operator.tui.widgets.assistant import AssistantBlock
 from local_operator.tui.widgets.subagent_panel import (
@@ -1436,8 +1437,20 @@ class SubagentView(Vertical):
         self._rule_text = Text()
         self._hint_text = Text()
         self._hint_width: int | None = None
+        #: Per-row paint keys for the two chrome rows the spinner does NOT
+        #: touch. `_chrome_state` above carries the spinner and so misses on
+        #: essentially every tick of a running child; these two decide whether
+        #: the breadcrumb and the rule have anything new to say, which on a
+        #: spinner tick they never do. `None` means "never painted", so the
+        #: first `_paint_chrome` always writes both.
+        self._breadcrumb_key: tuple[Any, ...] | None = None
+        self._rule_key: tuple[Any, ...] | None = None
         self._spinner_index = 0
         self._spinner_timer: Any = None
+        #: The interval the live timer was created with. Textual timers cannot
+        #: be re-rated in place, so a focus change compares against this to
+        #: decide whether the timer has to be replaced at all.
+        self._spinner_rate: float = SPINNER_INTERVAL_S
         self._running = False
         # Title facts, defaulted so the page can paint before its first
         # `show()` — mount order is Textual's, not ours.
@@ -2206,15 +2219,26 @@ class SubagentView(Vertical):
             spinner,
             self._agent_role,
             self._effort,
+            # The ANCESTORS belong here for the same reason role and effort do:
+            # they are painted (by the breadcrumb) and nothing else in this key
+            # implies them, so a page re-parented under a different lineage at
+            # an unchanged label, status and width would be memoised out and
+            # keep the stale trail. Cheap to carry — a tuple of at most a few
+            # short strings, compared once per call.
+            tuple(self._ancestors),
         )
         if self._chrome_state == state:
             return
         self._chrome_state = state
+        # The theme is resolved at BUILD time into every ``Style`` below, so it
+        # is a term of both per-row keys: without it a `/theme` switch under an
+        # open page would be skipped by those keys and the breadcrumb and rule
+        # would keep the old ramp's ink for the life of the page. The epoch
+        # counter is this codebase's existing invalidation handle for exactly
+        # that (see `assistant.py`'s frozen-epoch check); it is a module global
+        # read, so carrying it costs nothing per tick.
+        epoch = theme_mod.get_theme_epoch()
         self._title_text = self._title_row(width, spinner, tools)
-        self._rule_text = Text(
-            "─" * max(1, width - SCROLLBAR_GUTTER_CELLS),
-            style=Style(color=theme_mod.semantic_color("faint")),
-        )
         # Keyed on WIDTH alone: the row is a pure function of it, while the
         # memo above also carries the spinner and therefore fires eight times
         # a second — re-measuring five candidate rungs and layout-refreshing
@@ -2222,23 +2246,58 @@ class SubagentView(Vertical):
         if self._hint_width != width:
             self._hint_width = width
             self._hint_text = self._hint_row(width)
-        # ``layout=False`` on both: the sheet fixes each at ``height: 1``
-        # (``.subagent-view-title``, ``.subagent-view-rule``) and both are
-        # built ``no_wrap`` to the measured width, so neither can move the
-        # box. Textual's default reflows the screen, and the memo above
-        # carries the spinner, so this runs 12.5 times a second for as long as
-        # the child is alive. A/B in one process, 161 blocks behind the page,
-        # three-second idle windows, two rounds: 4.4%/4.2% of a core with the
-        # default against 3.5%/3.6% with this.
+        # ``layout=False`` on all three: the sheet fixes each at ``height: 1``
+        # (``.subagent-view-title``, ``.subagent-view-breadcrumb``,
+        # ``.subagent-view-rule``) and each is built to the measured width, so
+        # none can move the box. Textual's default reflows the screen, and the
+        # memo above carries the spinner, so this runs 12.5 times a second for
+        # as long as the child is alive. A/B in one process, 161 blocks behind
+        # the page, three-second idle windows, two rounds: 4.4%/4.2% of a core
+        # with the default against 3.5%/3.6% with this.
+        #
+        # The breadcrumb used to omit the keyword while its two siblings passed
+        # it, which NEGATED both of theirs: one defaulted `update` three lines
+        # below relayouts the same screen on the same tick, so the pair bought
+        # nothing. Measured over 50 driven ticks with eight children and a
+        # 160-block transcript, adding it here takes `messages.Layout` from
+        # 1.08 per tick to 0.00 and compositor reflows from 160 to 32.
         self._title.update(self._title_text, layout=False)
-        breadcrumb = "Conversation"
-        if self._ancestors:
-            breadcrumb += " > " + " > ".join(self._ancestors)
-        breadcrumb += " > " + self._label
-        self._breadcrumb.update(
-            Text(breadcrumb, style=Style(color=theme_mod.semantic_color("dim")))
-        )
-        self._rule.update(self._rule_text, layout=False)
+        # Below this line each row carries its OWN key, because the memo above
+        # is defeated on ~93% of ticks by design: `spinner` is one of its terms
+        # and `_tick` advances the index before every call, so on a running
+        # child the memo misses 291 times out of 313 in two seconds. The
+        # spinner is painted by the TITLE and by nothing else — the breadcrumb
+        # is a pure function of `_ancestors` + `_label`, the rule of width —
+        # so without these keys both were rewritten with byte-identical strings
+        # 12.5 times a second, each rewrite still costing a `messages.Update`
+        # and a repaint of the row. Skipping the unchanged pair takes the
+        # screen's Update messages from 48.5 to 30.6 per tick (-37%) and the
+        # child's tick from 11.52 ms to 9.88 ms (-14.3%).
+        #
+        # This mirrors `SubagentPanel._tick`'s cheap glyph-only path rather
+        # than inventing a second convention: there the panel repaints only the
+        # rows carrying a glyph; here the page repaints only the row that
+        # carries one. The animation's cadence is untouched — the title still
+        # advances on every tick.
+        breadcrumb_key = (tuple(self._ancestors), self._label, epoch)
+        if self._breadcrumb_key != breadcrumb_key:
+            self._breadcrumb_key = breadcrumb_key
+            breadcrumb = "Conversation"
+            if self._ancestors:
+                breadcrumb += " > " + " > ".join(self._ancestors)
+            breadcrumb += " > " + self._label
+            self._breadcrumb.update(
+                Text(breadcrumb, style=Style(color=theme_mod.semantic_color("dim"))),
+                layout=False,
+            )
+        rule_key = (width, epoch)
+        if self._rule_key != rule_key:
+            self._rule_key = rule_key
+            self._rule_text = Text(
+                "─" * max(1, width - SCROLLBAR_GUTTER_CELLS),
+                style=Style(color=theme_mod.semantic_color("faint")),
+            )
+            self._rule.update(self._rule_text, layout=False)
 
     def _title_row(self, width: int, spinner: str, tools: int) -> Text:
         """``Subagent · <role> · <label>  <glyph> <status> · <effort> · <elapsed> · <n> tools``.
@@ -2523,17 +2582,46 @@ class SubagentView(Vertical):
         return row
 
     # -- spinner -------------------------------------------------------------
-    def _start_spinner(self) -> None:
+    def _spinner_interval(self) -> float:
         # Motion, not colour, is how this app says "alive", at the cadence the
         # band and the status line already use: two speeds on one screen read
-        # as two different states.
+        # as two different states. On a BLURRED terminal all of them slow to
+        # the same reduced cadence together, so that property still holds.
+        return SPINNER_INTERVAL_S if animation_focused() else BLURRED_SPINNER_INTERVAL_S
+
+    def _start_spinner(self) -> None:
         if self._spinner_timer is None:
-            self._spinner_timer = self.set_interval(SPINNER_INTERVAL_S, self._tick)
+            self._spinner_rate = self._spinner_interval()
+            self._spinner_timer = self.set_interval(self._spinner_rate, self._tick)
 
     def _stop_spinner(self) -> None:
         if self._spinner_timer is not None:
             self._spinner_timer.stop()
             self._spinner_timer = None
+
+    def sync_animation_rate(self) -> None:
+        """Re-rate the spinner after a focus change.
+
+        Textual's ``Timer`` has no public way to change its interval, so the
+        timer is replaced rather than adjusted — which is safe because the
+        spinner's phase is held in ``_spinner_index`` and not in the timer, so
+        nothing about the animation resets. Only a page with a live timer is
+        touched: re-rating a settled child would START a spinner it had
+        correctly stopped.
+
+        The chrome is repainted immediately on the way back to the fast rate so
+        a refocused terminal shows the CURRENT glyph, status and clock rather
+        than the frame it was throttled on — the reduced rate is allowed to
+        cost frames, never to leave stale content on screen.
+        """
+        if self._spinner_timer is None:
+            return
+        wanted = self._spinner_interval()
+        if wanted == self._spinner_rate:
+            return
+        self._stop_spinner()
+        self._start_spinner()
+        self._paint_chrome()
 
     def _tick(self) -> None:
         self._spinner_index = (self._spinner_index + 1) % len(SPINNER_FRAMES)

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -1852,11 +1852,56 @@ class WorkingBlock(TranscriptBlock):
         self._paint()
 
     def on_mount(self) -> None:
-        from local_operator.tui.shimmer import shimmer_enabled
+        self._sync_rate()
 
-        self._animated = shimmer_enabled()
-        self._tick_ms = self._FRAME_MS if self._animated else self._STATIC_FRAME_MS
+    def _sync_rate(self) -> None:
+        """(Re)arm the repaint timer at the cadence the current state wants.
+
+        Two things decide it, and they are deliberately the SAME two the rest
+        of the app's animation asks about (`animation.motion_enabled`): the
+        shimmer kill switch, and whether the terminal has focus. A blurred
+        terminal falls to the existing static cadence rather than to a new one
+        — the still path already exists for shimmer-off, is already correct
+        (frozen glyph, clock repainted only when the SECOND changes), and
+        reusing it means a blurred window and a shimmer-off window are the same
+        tested state instead of two.
+
+        Measured: the animated path costs 6.8% of a core and ~30 paints/s; the
+        static path costs 3.5% and 0.8 paints/s. On a machine holding eighteen
+        sessions, that difference paid on every window nobody is looking at is
+        the largest single saving in this change.
+
+        Textual timers cannot be re-rated in place, so a change replaces the
+        timer. `_frame_ms` is NOT reset: it is the shimmer's phase, and
+        restarting it would jump the band back to the start of its sweep in the
+        instant the user looked at the window.
+        """
+        from local_operator.tui.animation import motion_enabled
+
+        animated = motion_enabled()
+        tick_ms = self._FRAME_MS if animated else self._STATIC_FRAME_MS
+        if self._timer is not None and tick_ms == self._tick_ms:
+            return
+        self._animated = animated
+        self._tick_ms = tick_ms
+        if self._timer is not None:
+            self._timer.stop()
         self._timer = self.set_interval(self._tick_ms / 1000, self._tick)
+
+    def sync_animation_rate(self) -> None:
+        """Re-rate after a focus change, and repaint so nothing reads stale.
+
+        The clock on this row is the one number it exists to report, and the
+        throttled cadence lets it fall up to a second behind. Repainting here
+        rather than waiting for the next tick is what makes the refocused frame
+        current — the reduced rate may cost frames, never accuracy. A block
+        whose timer is already stopped (`stop()`, at turn end) is left alone:
+        it has settled on its final frame deliberately.
+        """
+        if self._timer is None:
+            return
+        self._sync_rate()
+        self._paint()
 
     def on_resize(self, event: object) -> None:
         """Re-truncate at the new width (the label is clipped, never wrapped)."""
@@ -1880,11 +1925,17 @@ class WorkingBlock(TranscriptBlock):
         return format_duration(time.monotonic() - self._phase_started)
 
     def _paint(self) -> None:
-        from local_operator.tui.shimmer import shimmer_enabled, shimmer_text
+        from local_operator.tui.animation import motion_enabled
+        from local_operator.tui.shimmer import shimmer_text
         from local_operator.tui.widgets.tool_card import truncate_cells
 
         dim = Style(color=theme_mod.semantic_color("dim"))
-        animated = shimmer_enabled()
+        # The same gate the timer rate uses, so the frame a blurred terminal
+        # holds IS the shimmer-off still frame (frozen head glyph, flat dim
+        # label) rather than a sweep sampled once a second, which would read as
+        # the band stuttering. Focused, `motion_enabled()` is exactly
+        # `shimmer_enabled()`, so nothing about the looked-at frame changes.
+        animated = motion_enabled()
         # ALWAYS shown, from the first frame. It is the one fact this row has
         # that nothing else on screen does — a running tool's own card carries
         # no duration until it settles, and the band's clock is the session's

--- a/local_operator/tui/widgets/welcome.py
+++ b/local_operator/tui/widgets/welcome.py
@@ -1212,6 +1212,20 @@ class WelcomeView(Static):
             self._timer.stop()
             self._timer = None
 
+    def sync_animation_rate(self) -> None:
+        """Re-rate the splash's two timers after a focus change.
+
+        The same seam the other four animated surfaces expose, so the app can
+        fan a focus change out uniformly instead of reaching through this
+        widget's privates. The splash owns two timers rather than one (the mark
+        pulse and the tip rotation) and both derive their rate from
+        ``motion_enabled()``, so re-running the two syncs is the whole job:
+        each stops, starts or leaves its timer alone to match what focus now
+        allows.
+        """
+        self._sync_pulse_timer()
+        self._sync_tip_timer()
+
     def _sync_pulse_timer(self) -> None:
         """Glow only while the splash is on screen and animation is allowed.
 

--- a/local_operator/tui/widgets/welcome.py
+++ b/local_operator/tui/widgets/welcome.py
@@ -1265,11 +1265,21 @@ class WelcomeView(Static):
         The colour is cleared with the timer so the next frame drawn after a
         stop is the resting one — a hidden view that comes back on ``/clear``
         must not flash the phase it happened to be paused at.
+
+        The repaint is what makes that true rather than merely intended. With
+        the timer stopped nothing else redraws the mark, so clearing the state
+        alone left the SCREEN holding whatever tint the pulse was mid-swell on
+        while the model believed it was at rest — measured at 48% up the
+        pulse's luminance range, and a different brightness per window
+        depending on where each one was when it lost focus (design review D1).
+        Cheap by construction: this runs on a focus change, not on a tick.
         """
         if self._pulse_timer is not None:
             self._pulse_timer.stop()
             self._pulse_timer = None
-        self._mark_color = None
+        if self._mark_color is not None:
+            self._mark_color = None
+            self.refresh()
 
     def _pulse_tick(self) -> None:
         """One glow frame: a colour, and a repaint only when it MOVED.
@@ -1334,12 +1344,23 @@ class WelcomeView(Static):
         The index is cleared with the timer for the reason the pulse clears its
         colour: a still frame must be the DEFINED still frame, not the entry the
         rotation happened to be paused on.
+
+        And, as with the pulse, the repaint is what delivers that. Without it
+        the row kept rendering whichever tip was showing when the timer stopped
+        and then swapped to ``TIPS[0]`` 0.12 s after refocus — stale while
+        nobody is looking, correcting itself exactly when someone is, which is
+        a first-frame-differs-from-settled reflow in prose (design review D2).
+        Doubly wrong in a change whose whole purpose is removing motion the
+        user did not ask for.
         """
         if self._tip_timer is not None:
             self._tip_timer.stop()
             self._tip_timer = None
+        changed = self._tip_index != 0
         self._tip_index = 0
         self._tip_resume = None
+        if changed:
+            self.refresh()
 
     def _tip_tick(self) -> None:
         """The next tip in the ring, and a repaint that cannot move a row.

--- a/local_operator/tui/widgets/welcome.py
+++ b/local_operator/tui/widgets/welcome.py
@@ -81,7 +81,7 @@ from textual.message import Message
 from textual.widgets import Static
 
 from local_operator.tui import theme as theme_mod
-from local_operator.tui.shimmer import shimmer_enabled
+from local_operator.tui.animation import motion_enabled
 from local_operator.tui.widgets.status_line import format_model_label
 from local_operator.tui.widgets.transcript import NOTICE_GLYPHS
 
@@ -1222,11 +1222,23 @@ class WelcomeView(Static):
         timer is created at all — the glow is not merely paused — and the mark
         keeps its resting ``dim``.
 
+        Terminal FOCUS is now part of that same gate, for the same reason one
+        rung down: an unlooked-at splash is the single most expensive idle
+        thing this app does. Measured on one idle session, the pulse and the
+        shimmer together are 20.3 of 22 KB/s of terminal output and 5.6 of 7.9
+        points of CPU; with animation off the same session costs 2.27% and
+        1.0 KB/s. A splash nobody is looking at should cost the second number.
+        The FOCUSED appearance and cadence are deliberately untouched — this
+        gates on focus only, it does not slow the glow down for anyone who can
+        see it.
+
         The clock restarts from the moment the splash appears rather than from
         app start, so a ``/clear`` an arbitrary number of seconds in gets the
-        same first frame as a boot: at rest, then swelling.
+        same first frame as a boot: at rest, then swelling. A blur-then-focus
+        therefore also restarts it at rest, which is the right frame to come
+        back to and the one `_stop_pulse_timer` already guarantees.
         """
-        wanted = bool(self.display) and shimmer_enabled()
+        wanted = bool(self.display) and motion_enabled()
         if wanted and self._pulse_timer is None:
             self._pulse_origin = time.monotonic()
             self._pulse_timer = self.set_interval(MARK_PULSE_INTERVAL_S, self._pulse_tick)
@@ -1274,8 +1286,14 @@ class WelcomeView(Static):
         animation, so a snapshot would capture whichever tip the wall clock
         happened to be holding. With the gate closed no timer exists — the
         rotation is not merely paused — and the row holds at ``TIPS[0]``.
+
+        It follows the pulse onto the focus gate too. A tip nobody is reading is
+        not a tip, and at 12 s per rotation a blurred splash rotating for an
+        hour is 300 repaints of a row that was never seen; the row a returning
+        user finds is ``TIPS[0]``, which is the defined still frame rather than
+        an arbitrary sample of the ring.
         """
-        wanted = bool(self.display) and shimmer_enabled()
+        wanted = bool(self.display) and motion_enabled()
         if wanted and self._tip_timer is None:
             # The row OPENS on `TIPS[0]` and never on a lottery. The pool is
             # ordered, and the first thing a first-run user reads was whichever

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.0"
+version = "0.44.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/bench_tui_chrome_paint.py
+++ b/scripts/bench_tui_chrome_paint.py
@@ -1,0 +1,303 @@
+"""Count the invalidation a running subagent page costs per spinner tick.
+
+Wall-clock is useless as a regression signal for this work. The machine that
+motivated it was at loadavg 260-307 on 14 cores from unrelated harnesses, and a
+fixed work quantum measured there held CPU time stable (81.6 -> 101.5 ms) while
+WALL time inflated 4.6-7.8x. So this benchmark reports **call counts**, which
+are load-invariant: how many ``messages.Layout`` the screen receives, how many
+compositor reflows those cause, how many ``messages.Update`` are posted, and how
+many times each chrome row is rewritten.
+
+Those four numbers are the actual subject of the chrome-paint fixes. A tick that
+posts no Layout cannot reflow the screen, and a row that is not rewritten cannot
+emit escape sequences to the terminal, whatever the box happens to be doing.
+
+Run from the checkout with its interpreter::
+
+    env -u NO_COLOR TERM=xterm-256color \
+      .venv/bin/python scripts/bench_tui_chrome_paint.py --json out.json
+
+``--json`` writes the same figures as a machine-readable record so a before and
+an after run can be diffed rather than eyeballed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from textual import messages  # noqa: E402
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.transcript import NoticeBlock  # noqa: E402
+from scripts.benchmark_residual_child_lag import CanonicalFakeSession  # noqa: E402
+from tests.unit.tui.test_app_pilot import _factory  # noqa: E402
+
+#: Transcript depth behind the page. The reflow cost this measures is a
+#: function of how many widgets the compositor re-arranges, so an empty
+#: transcript would report a win that the reported session never sees.
+BLOCKS = 160
+#: Driven spinner ticks. Enough that the per-tick averages are stable and short
+#: enough that the whole run finishes on a loaded box.
+TICKS = 50
+
+
+class Probe:
+    """Counts screen invalidation without changing any of it.
+
+    Every hook wraps and delegates: the app under measurement must behave
+    exactly as it does unmeasured, or the counts describe the probe.
+    """
+
+    def __init__(self, app: OperatorApp) -> None:
+        self.app = app
+        self.counts: Counter[str] = Counter()
+        self._install()
+
+    def _install(self) -> None:
+        screen = self.app.screen
+
+        original_post = screen.post_message
+
+        def post_message(message: Any) -> Any:
+            # Layout is the expensive one and the point of the exercise: it
+            # clears every ancestor's arrangement cache on the way in, then
+            # makes the screen re-arrange and the compositor reflow.
+            if isinstance(message, messages.Layout):
+                self.counts["layout_msgs"] += 1
+            elif isinstance(message, messages.Update):
+                self.counts["update_msgs"] += 1
+            return original_post(message)
+
+        screen.post_message = post_message  # type: ignore[method-assign]
+
+        original_reflow = screen._compositor.reflow
+
+        def reflow(*args: Any, **kwargs: Any) -> Any:
+            self.counts["reflow"] += 1
+            return original_reflow(*args, **kwargs)
+
+        screen._compositor.reflow = reflow  # type: ignore[method-assign]
+
+        original_refresh_layout = screen._refresh_layout
+
+        def refresh_layout(*args: Any, **kwargs: Any) -> Any:
+            self.counts["refresh_layout"] += 1
+            return original_refresh_layout(*args, **kwargs)
+
+        screen._refresh_layout = refresh_layout  # type: ignore[method-assign]
+
+    def watch_chrome(self, view: Any) -> None:
+        """Count rewrites of each chrome row, and ticks, on the open page.
+
+        Per-ROW rather than per-paint: the fixes turn one paint that rewrote
+        three rows into one that rewrites the row the spinner actually moved,
+        so a paint count alone would report no change at all.
+        """
+        for name, label in (
+            ("_title", "title_updates"),
+            ("_breadcrumb", "breadcrumb_updates"),
+            ("_rule", "rule_updates"),
+        ):
+            widget = getattr(view, name)
+            original = widget.update
+
+            def update(*args: Any, _label: str = label, _original: Any = original, **kw: Any):
+                self.counts[_label] += 1
+                return _original(*args, **kw)
+
+            widget.update = update
+
+        original_paint = view._paint_chrome
+
+        def paint_chrome(*args: Any, **kwargs: Any) -> Any:
+            self.counts["paint_chrome"] += 1
+            return original_paint(*args, **kwargs)
+
+        view._paint_chrome = paint_chrome
+
+        original_tick = view._tick
+
+        def tick(*args: Any, **kwargs: Any) -> Any:
+            self.counts["ticks"] += 1
+            return original_tick(*args, **kwargs)
+
+        view._tick = tick
+
+
+async def run(ticks: int, blocks: int) -> dict[str, Any]:
+    session = CanonicalFakeSession(running=True)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is session:
+                break
+        view_transcript = app._transcript_view()
+        with view_transcript.batch_append():
+            for index in range(blocks):
+                view_transcript.append_block(
+                    NoticeBlock(f"retained event {index} " + "word " * 12, "info")
+                )
+        await pilot.pause()
+
+        app._open_subagent_view("active-child")
+        await pilot.pause()
+        await pilot.pause()
+        child = app._subagent_view
+        if child is None:  # pragma: no cover - the fixture always opens
+            raise RuntimeError("subagent view did not open")
+
+        # Counting starts AFTER the page has settled, so the open's own layout
+        # is not charged to the steady state this measures.
+        probe = Probe(app)
+        probe.watch_chrome(child)
+
+        started = time.perf_counter()
+        for _ in range(ticks):
+            # The timer is driven directly rather than slept on: a 0.08 s
+            # interval under a loaded box does not fire on schedule, and the
+            # subject is the work per tick, not the scheduler's punctuality.
+            child._tick()
+            await pilot.pause()
+        wall = time.perf_counter() - started
+
+    counts = dict(probe.counts)
+    per_tick = {f"{key}_per_tick": round(value / ticks, 4) for key, value in counts.items()}
+    return {
+        "ticks": ticks,
+        "blocks": blocks,
+        "counts": counts,
+        "per_tick": per_tick,
+        # Reported but deliberately NOT the headline: see the module docstring.
+        "wall_s": round(wall, 3),
+    }
+
+
+async def run_focus(seconds: float) -> dict[str, Any]:
+    """Bytes an idle session writes to its terminal, focused vs blurred.
+
+    This one IS time-based, because the quantity is a RATE and there is no
+    count that stands in for it — but it is a rate of BYTES, not of frames, so
+    a loaded box makes it conservative (fewer timer firings) rather than
+    noisy in the direction of the claim.
+
+    The app is driven with the splash up and a turn running, which is the
+    shape of a session sitting in a window the user has tabbed away from: the
+    welcome pulse, the tip rotation and the working line's shimmer are exactly
+    what a blurred terminal should stop paying for.
+    """
+    import os
+
+    os.environ.pop("LOCAL_OPERATOR_NO_SHIMMER", None)
+
+    from local_operator.tui.animation import reset_animation_focus
+    from local_operator.tui.widgets.transcript import WorkingBlock
+
+    session = CanonicalFakeSession(running=True)
+    app = OperatorApp(lambda: _factory(session))
+    written = {"n": 0}
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        working = WorkingBlock("thinking")
+        app._append_block(working)
+        app._working_block = working
+        await pilot.pause()
+
+        # Counted at ``App._display``, which is where a compositor update is
+        # handed over to be written, and the bytes are the update's OWN
+        # rendered segments. `run_test` is headless, so `_display` returns
+        # before touching the driver and a hook on `driver.write` counts
+        # nothing at all — the update still describes exactly what a real
+        # terminal would receive, which is the quantity in question. This is
+        # the same seam `scripts/probe_spinner_invalidation.py` measures at.
+        console = app.console
+        original_display = app._display
+
+        def display(screen_arg: Any, renderable: Any) -> None:
+            if renderable is not None:
+                try:
+                    written["n"] += len(renderable.render_segments(console).encode())
+                except Exception:
+                    pass
+            return original_display(screen_arg, renderable)
+
+        app._display = display  # type: ignore[method-assign]
+
+        reset_animation_focus()
+        app._set_animation_focused(True)
+        written["n"] = 0
+        await asyncio.sleep(seconds)
+        focused_bytes = written["n"]
+
+        app._set_animation_focused(False)
+        await pilot.pause()
+        written["n"] = 0
+        await asyncio.sleep(seconds)
+        blurred_bytes = written["n"]
+
+        reset_animation_focus()
+
+    return {
+        "window_s": seconds,
+        "focused_bytes_per_s": round(focused_bytes / seconds),
+        "blurred_bytes_per_s": round(blurred_bytes / seconds),
+        "reduction": (round(focused_bytes / blurred_bytes, 1) if blurred_bytes else None),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", type=Path, default=None, help="write the record here")
+    parser.add_argument("--ticks", type=int, default=TICKS)
+    parser.add_argument("--blocks", type=int, default=BLOCKS)
+    parser.add_argument(
+        "--focus",
+        type=float,
+        default=0.0,
+        metavar="SECONDS",
+        help="also measure focused-vs-blurred terminal output over this window",
+    )
+    args = parser.parse_args()
+
+    record = asyncio.run(run(args.ticks, args.blocks))
+    counts = record["counts"]
+    print(f"driven spinner ticks={record['ticks']} transcript_blocks={record['blocks']}")
+    for key in (
+        "layout_msgs",
+        "reflow",
+        "refresh_layout",
+        "update_msgs",
+        "paint_chrome",
+        "title_updates",
+        "breadcrumb_updates",
+        "rule_updates",
+    ):
+        total = counts.get(key, 0)
+        print(f"  {key:<20} total={total:<8} per_tick={total / record['ticks']:.3f}")
+    print(f"  {'wall (not a signal)':<20} {record['wall_s']:.3f}s")
+    if args.focus > 0:
+        focus = asyncio.run(run_focus(args.focus))
+        record["focus"] = focus
+        print(f"\nterminal output, {focus['window_s']}s windows, splash + running turn")
+        print(f"  focused  {focus['focused_bytes_per_s']:>8} bytes/s")
+        print(f"  blurred  {focus['blurred_bytes_per_s']:>8} bytes/s")
+        print(f"  reduction {focus['reduction']}x")
+    if args.json is not None:
+        args.json.write_text(json.dumps(record, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_tui_chrome_paint.py
+++ b/scripts/bench_tui_chrome_paint.py
@@ -171,6 +171,24 @@ async def run(ticks: int, blocks: int) -> dict[str, Any]:
         wall = time.perf_counter() - started
 
     counts = dict(probe.counts)
+    # Every metric is named even when it is zero. A ``Counter`` only yields
+    # keys it has counted, so a run in which the chrome fixes worked — zero
+    # breadcrumb rewrites, zero reflows — would silently DROP those keys from
+    # the record, and the after-artifact could never match the README table
+    # that claims a 0.00 column (agent review round 2, R9). Stating the full
+    # key set makes "went to zero" legible as a value rather than an absence.
+    for metric in (
+        "ticks",
+        "paint_chrome",
+        "title_updates",
+        "breadcrumb_updates",
+        "rule_updates",
+        "update_msgs",
+        "layout_msgs",
+        "refresh_layout",
+        "reflow",
+    ):
+        counts.setdefault(metric, 0)
     per_tick = {f"{key}_per_tick": round(value / ticks, 4) for key, value in counts.items()}
     return {
         "ticks": ticks,

--- a/tests/unit/tui/conftest.py
+++ b/tests/unit/tui/conftest.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 from textual.app import App, ComposeResult
 
+from local_operator.tui import animation
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.transcript import TranscriptView
 
@@ -27,6 +28,13 @@ def hermetic_tui_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("NO_COLOR", raising=False)
     monkeypatch.setenv("TERM", "xterm-256color")
     monkeypatch.setenv("LOCAL_OPERATOR_NO_SHIMMER", "1")
+    # Terminal-focus animation gating is a module global (it has to be: the
+    # surfaces reading it are built at different times and one is not a
+    # Widget). The suite shares a process, so a test that blurs the app would
+    # otherwise leave every later test's timers at the reduced cadence.
+    # Reverted here rather than in each test for the same reason the env pins
+    # above are: a leak like this fails somewhere else entirely.
+    animation.reset_animation_focus()
     # Pin the tool-row icon mode host-independently. `nerd_icons_enabled()` now
     # autodetects from terminal-emulator env markers (glyphs.py), so the icon a
     # row leads with depends on the HOST: a dev box in ghostty/cmux renders the

--- a/tests/unit/tui/test_render_throttling.py
+++ b/tests/unit/tui/test_render_throttling.py
@@ -679,3 +679,57 @@ async def test_a_blur_and_refocus_cycle_keeps_the_keyboard() -> None:
         await pilot.pause()
 
         assert app.screen.focused is focused_before, "refocus lost the keyboard"
+
+
+@pytest.mark.asyncio
+async def test_blurring_the_splash_repaints_it_to_its_resting_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Clearing the pulse/tip STATE is not enough; the screen must be redrawn.
+
+    Both stop methods reset their state so the next frame drawn is the defined
+    resting one — but with the timer stopped there IS no next frame, so the
+    terminal kept rendering whatever the animation was holding when focus went
+    away: a mark frozen mid-swell (a different brightness per window), and a
+    tip row showing an arbitrary entry that then swapped to ``TIPS[0]`` a
+    tenth of a second after refocus. Stale while nobody is looking and moving
+    exactly when someone is, in a change whose whole point is removing motion
+    (design review D1/D2).
+
+    Asserted through ``refresh``, because the defect is invisible in the
+    widget's own attributes — those were already correct.
+    """
+    monkeypatch.delenv("LOCAL_OPERATOR_NO_SHIMMER", raising=False)
+    monkeypatch.setattr("local_operator.tui.shimmer.settings_get", lambda *a, **k: True)
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        welcome = app.query_one(WelcomeView)
+        welcome.set_visible(True)
+        welcome._sync_pulse_timer()
+        welcome._sync_tip_timer()
+        await pilot.pause()
+
+        # Put both animations somewhere OTHER than their resting frame, which
+        # is the only state in which the missing repaint is observable.
+        welcome._mark_color = "#a08040"
+        welcome._tip_index = 2
+
+        repaints = 0
+        original = welcome.refresh
+
+        def counting_refresh(*args: Any, **kwargs: Any) -> Any:
+            nonlocal repaints
+            repaints += 1
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(welcome, "refresh", counting_refresh)
+        app._set_animation_focused(False)
+        await pilot.pause()
+
+        assert welcome._mark_color is None
+        assert welcome._tip_index == 0
+        assert repaints >= 1, "the splash never repainted, so the screen kept the stale frame"

--- a/tests/unit/tui/test_render_throttling.py
+++ b/tests/unit/tui/test_render_throttling.py
@@ -16,11 +16,12 @@ Two invariants run through the whole file and are each pinned by name:
 
 from __future__ import annotations
 
+import time
 from typing import Any, cast
 
 import pytest
 from textual import messages
-from textual.events import AppBlur
+from textual.events import AppBlur, AppFocus
 from textual.widgets import Static
 
 from local_operator.tui import animation
@@ -295,7 +296,18 @@ async def test_refocus_repaints_so_no_surface_shows_a_stale_frame() -> None:
         app._set_animation_focused(False)
         await pilot.pause()
 
-        # State moves while the terminal is away.
+        # State moves while the terminal is away. The job's start_time is
+        # pinned rather than the painted string left alone, because the 1 Hz
+        # job poll recomputes elapsed from the ledger on every fire and would
+        # overwrite an injected `_elapsed` with the real duration ("100d+"
+        # against the 2023 fixture timestamp) whenever a poll landed inside
+        # the window — which is exactly how this test failed one CI leg and
+        # passed another. Setting the START makes every recomputation agree
+        # with the assertion instead of racing it.
+        session = app._session
+        assert session is not None
+        job = cast(Any, session).jobs.list()[0]
+        job.start_time = time.time() - 252.0
         view._elapsed = "4m12s"
         spy = _UpdateSpy(view)
         app._set_animation_focused(True)
@@ -634,3 +646,36 @@ def test_an_idle_band_stays_stopped_across_a_focus_change() -> None:
 
     assert len(dock.intervals) == before, "an idle band was given a spinner"
     animation.reset_animation_focus()
+
+
+@pytest.mark.asyncio
+async def test_a_blur_and_refocus_cycle_keeps_the_keyboard() -> None:
+    """Alt-tabbing away and back must leave the user able to type.
+
+    Textual's ``Reactive._check_watchers`` invokes BOTH watcher spellings —
+    ``_watch_app_focus`` and then ``watch_app_focus`` — and the base
+    implementation is not idempotent: on blur it stashes ``screen.focused``
+    and then clears focus, so a second call re-reads the ``None`` it just
+    wrote and destroys the memory. Refocus then restores nothing and the user
+    has to click before the keyboard works again.
+
+    That is invisible to every other test here (the whole file passed 18/18
+    with the bug present) and to all four static gates, because it is a
+    property of the app's INPUT path rather than of its paint path. Caught by
+    agent review round 3 (R12); this test is what holds it.
+    """
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        focused_before = app.screen.focused
+        assert focused_before is not None, "fixture must start with a focused widget"
+
+        app.post_message(AppBlur())
+        await pilot.pause()
+        app.post_message(AppFocus())
+        await pilot.pause()
+
+        assert app.screen.focused is focused_before, "refocus lost the keyboard"

--- a/tests/unit/tui/test_render_throttling.py
+++ b/tests/unit/tui/test_render_throttling.py
@@ -732,4 +732,9 @@ async def test_blurring_the_splash_repaints_it_to_its_resting_frame(
 
         assert welcome._mark_color is None
         assert welcome._tip_index == 0
-        assert repaints >= 1, "the splash never repainted, so the screen kept the stale frame"
+        # TWO, not one: the pulse and the tip are separate stops with separate
+        # repaints, and one shared counter at `>= 1` goes green when either
+        # fix alone is removed — over the exact stale-frame defect this test
+        # exists to guard (agent review R16). The count is deterministic here
+        # because both animations were put off their resting frame above.
+        assert repaints >= 2, "a stop cleared its state without repainting the stale frame"

--- a/tests/unit/tui/test_render_throttling.py
+++ b/tests/unit/tui/test_render_throttling.py
@@ -1,0 +1,500 @@
+"""What each animated surface is allowed to cost when nothing has changed.
+
+Every assertion here is a COUNT of invalidation, not a duration. The work these
+tests guard was diagnosed on a machine whose wall clock was worthless — a fixed
+quantum held its CPU time (81.6 -> 101.5 ms) while wall time inflated 4.6-7.8x
+under unrelated load — so a timing assertion here would be a flake generator
+that proves nothing. A row that is not rewritten emits no escape sequences and
+a tick that posts no ``messages.Layout`` cannot reflow the screen, whatever the
+box is doing at the time.
+
+Two invariants run through the whole file and are each pinned by name:
+
+* animation may only ever change RATE, never content; and
+* a session that is never told about focus must never end up throttled.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from textual import messages
+from textual.widgets import Static
+
+from local_operator.tui import animation
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.subagent_panel import SPINNER_INTERVAL_S, SubagentPanel
+from local_operator.tui.widgets.subagent_view import SubagentView
+from local_operator.tui.widgets.transcript import UserBlock, WorkingBlock
+from local_operator.tui.widgets.welcome import WelcomeView
+
+from .test_band_panels import FakeSession, _async_factory, _fake_jobs, _Job
+
+
+async def _open_running_child(pilot: Any, app: OperatorApp) -> SubagentView:
+    """A running child page over a seeded conversation, settled and painted."""
+    for _ in range(80):
+        await pilot.pause()
+        if app._session is not None:
+            break
+    app._append_block(UserBlock("audit the ingest path"))
+    app._refresh_band()
+    await pilot.pause()
+    app._open_subagent_view("sub-1")
+    await pilot.pause()
+    await pilot.pause()
+    return app.query_one(SubagentView)
+
+
+def _running_app() -> OperatorApp:
+    session = FakeSession()
+    session.jobs = _fake_jobs(_Job("sub-1", "audit the ingest path", status="running"))
+    return OperatorApp(_async_factory(session))
+
+
+class _UpdateSpy:
+    """Records every ``Static.update`` on the page's three chrome rows."""
+
+    def __init__(self, view: SubagentView) -> None:
+        self.calls: dict[str, list[tuple[Any, dict[str, Any]]]] = {
+            "title": [],
+            "breadcrumb": [],
+            "rule": [],
+        }
+        for name, key in (
+            ("_title", "title"),
+            ("_breadcrumb", "breadcrumb"),
+            ("_rule", "rule"),
+        ):
+            widget: Static = getattr(view, name)
+            original = widget.update
+
+            def update(
+                renderable: Any = "",
+                *,
+                _key: str = key,
+                _original: Any = original,
+                **kwargs: Any,
+            ) -> Any:
+                self.calls[_key].append((renderable, kwargs))
+                return _original(renderable, **kwargs)
+
+            widget.update = update  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
+async def test_breadcrumb_is_painted_without_a_relayout() -> None:
+    """The breadcrumb passes ``layout=False`` like the title and rule beside it.
+
+    It is ``height: 1`` in the sheet exactly as they are, so it cannot move the
+    box; the default ``layout=True`` cleared every ancestor's arrangement cache
+    and posted ``messages.Layout``, which made the deliberate ``layout=False``
+    on its two siblings buy nothing at all — one relayout on the same tick
+    reflows the same screen.
+    """
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        view = await _open_running_child(pilot, app)
+        spy = _UpdateSpy(view)
+        # Force a full repaint: the memo is keyed on facts that have not moved.
+        view._chrome_state = None
+        view._breadcrumb_key = None
+        view._rule_key = None
+        view._paint_chrome()
+
+        assert spy.calls["breadcrumb"], "the breadcrumb was never painted"
+        for _renderable, kwargs in spy.calls["breadcrumb"]:
+            assert kwargs.get("layout") is False
+        # Stated together, because the value of any one of the three is
+        # conditional on the other two: one defaulted update relayouts anyway.
+        for row in ("title", "rule"):
+            for _renderable, kwargs in spy.calls[row]:
+                assert kwargs.get("layout") is False
+
+
+@pytest.mark.asyncio
+async def test_a_spinner_tick_repaints_only_the_row_carrying_the_spinner() -> None:
+    """The glyph rides the title, so a tick must not touch breadcrumb or rule.
+
+    ``_chrome_state`` carries the spinner and ``_tick`` advances the index
+    before calling ``_paint_chrome``, so the memo misses on essentially every
+    tick of a running child (measured live: 291 misses in 313 calls over two
+    seconds). Before the per-row keys that meant the breadcrumb and the rule
+    were rewritten with byte-identical strings 12.5 times a second.
+    """
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        view = await _open_running_child(pilot, app)
+        assert view._running, "fixture must be a RUNNING child or there is no spinner"
+        spy = _UpdateSpy(view)
+
+        before = view._spinner_index
+        for _ in range(8):
+            view._tick()
+            await pilot.pause()
+
+        assert view._spinner_index != before, "the animation stopped advancing"
+        # The cadence is untouched: every tick still repaints the glyph. It is
+        # `>=` rather than `==` because the 1 Hz job poll also refreshes the
+        # page, and this test is about which ROWS a tick touches, not about
+        # owning every paint that happens during it.
+        assert len(spy.calls["title"]) >= 8
+        assert spy.calls["breadcrumb"] == []
+        assert spy.calls["rule"] == []
+
+
+@pytest.mark.asyncio
+async def test_unchanged_chrome_strings_are_not_rewritten() -> None:
+    """Re-painting with identical facts writes nothing to the terminal.
+
+    ``_paint_chrome`` is called from ``show()``, which runs on every child
+    event and on the 1 Hz poll, so the common case is a refresh that changes
+    nothing — and its own docstring says such a refresh must repaint nothing.
+    """
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        view = await _open_running_child(pilot, app)
+        view._paint_chrome()
+        spy = _UpdateSpy(view)
+
+        for _ in range(5):
+            view._paint_chrome()
+
+        assert spy.calls["title"] == []
+        assert spy.calls["breadcrumb"] == []
+        assert spy.calls["rule"] == []
+
+
+@pytest.mark.asyncio
+async def test_a_changed_breadcrumb_still_repaints() -> None:
+    """The skip is a memo, not a freeze: new facts must reach the screen."""
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        view = await _open_running_child(pilot, app)
+        view._paint_chrome()
+        spy = _UpdateSpy(view)
+
+        view._ancestors = ["orchestrator", "reviewer"]
+        view._paint_chrome()
+
+        assert len(spy.calls["breadcrumb"]) >= 1
+        painted = spy.calls["breadcrumb"][-1][0].plain
+        assert "orchestrator" in painted and "reviewer" in painted
+
+
+@pytest.mark.asyncio
+async def test_a_spinner_tick_posts_no_layout_message() -> None:
+    """The end-to-end statement of the two fixes above, at the screen.
+
+    Counting ``messages.Layout`` rather than reflows keeps the assertion at the
+    boundary the widget actually controls: a Layout message is what clears the
+    arrangement caches and makes the compositor re-arrange every widget behind
+    the page.
+    """
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        view = await _open_running_child(pilot, app)
+        screen = app.screen
+        posted: list[Any] = []
+        original_post = screen.post_message
+
+        def post_message(message: Any) -> Any:
+            posted.append(message)
+            return original_post(message)
+
+        screen.post_message = post_message  # type: ignore[method-assign]
+        for _ in range(10):
+            view._tick()
+            await pilot.pause()
+
+        assert [m for m in posted if isinstance(m, messages.Layout)] == []
+
+
+# -- focus gating -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_blur_slows_every_animated_surface_and_focus_restores_it() -> None:
+    """One blur re-rates the page, the panel and the band; focus puts them back.
+
+    The rate is asserted through each surface's own recorded interval rather
+    than by timing a real timer: the point is which cadence was requested, and
+    a duration assertion under load measures the box, not the app.
+    """
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        view = await _open_running_child(pilot, app)
+        panel = app._subagent_panel
+        assert panel is not None
+        panel._start_spinner()
+        band = app._status
+        assert band is not None
+        band._streaming = True
+        band._sync_spinner_timer()
+        await pilot.pause()
+
+        assert view._spinner_rate == SPINNER_INTERVAL_S
+        assert panel._spinner_rate == SPINNER_INTERVAL_S
+
+        app._set_animation_focused(False)
+        await pilot.pause()
+
+        assert not animation.animation_focused()
+        assert view._spinner_rate == animation.BLURRED_SPINNER_INTERVAL_S
+        assert panel._spinner_rate == animation.BLURRED_SPINNER_INTERVAL_S
+        assert band._spinner_rate == animation.BLURRED_SPINNER_INTERVAL_S
+        # Slowed, never stopped: a frozen spinner and a finished job look the
+        # same, and this app uses motion as its word for "alive".
+        assert view._spinner_timer is not None
+        assert panel._spinner_timer is not None
+        assert band._spinner_timer is not None
+
+        app._set_animation_focused(True)
+        await pilot.pause()
+
+        assert view._spinner_rate == SPINNER_INTERVAL_S
+        assert panel._spinner_rate == SPINNER_INTERVAL_S
+        assert band._spinner_rate == SPINNER_INTERVAL_S
+
+
+@pytest.mark.asyncio
+async def test_refocus_repaints_so_no_surface_shows_a_stale_frame() -> None:
+    """The reduced rate may cost frames; it may never leave stale state.
+
+    The clock, the status and the glyph on the child page are all painted from
+    the throttled timer, so returning to the window has to repaint immediately
+    rather than wait up to a second for the next slow tick.
+    """
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        view = await _open_running_child(pilot, app)
+        app._set_animation_focused(False)
+        await pilot.pause()
+
+        # State moves while the terminal is away.
+        view._elapsed = "4m12s"
+        spy = _UpdateSpy(view)
+        app._set_animation_focused(True)
+        await pilot.pause()
+
+        assert spy.calls["title"], "refocus did not repaint the title"
+        assert "4m12s" in spy.calls["title"][-1][0].plain
+
+
+@pytest.mark.asyncio
+async def test_blur_does_not_stop_a_settled_page_from_staying_settled() -> None:
+    """Re-rating must never START a timer a surface correctly stopped.
+
+    A settled child has no spinner by design; a naive "restart the timer on
+    focus change" would spin a finished job forever.
+    """
+    session = FakeSession()
+    session.jobs = _fake_jobs(_Job("sub-1", "audit the ingest path", status="completed"))
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        view = await _open_running_child(pilot, app)
+        assert view._spinner_timer is None
+
+        app._set_animation_focused(False)
+        await pilot.pause()
+        assert view._spinner_timer is None
+
+        app._set_animation_focused(True)
+        await pilot.pause()
+        assert view._spinner_timer is None
+
+
+@pytest.mark.asyncio
+async def test_a_session_that_never_hears_about_focus_is_never_throttled() -> None:
+    """The default is FOCUSED, because some hosts send no focus events at all.
+
+    "We were never told" and "the user is looking at this" have to be the same
+    state, or a session on such a host animates at the reduced rate forever.
+    """
+    assert animation.animation_focused() is True
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        view = await _open_running_child(pilot, app)
+        assert view._spinner_rate == SPINNER_INTERVAL_S
+        working = WorkingBlock("thinking")
+        app._append_block(working)
+        await pilot.pause()
+        assert working._tick_ms == WorkingBlock._FRAME_MS or not animation.motion_enabled()
+
+
+@pytest.mark.asyncio
+async def test_working_block_falls_to_the_static_cadence_on_blur() -> None:
+    """The 30 fps shimmer line reuses its EXISTING static mode, not a new one.
+
+    ``_STATIC_FRAME_MS`` already exists for shimmer-off and is already correct
+    (frozen glyph, a repaint only when the clock's second changes), so a
+    blurred window and a shimmer-off window are one tested state rather than
+    two. Measured: 6.8% of a core and ~30 paints/s animated against 3.5% and
+    0.8 paints/s static.
+    """
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        working = WorkingBlock("thinking")
+        app._append_block(working)
+        # The app fans out to the block it OWNS, which is how a real turn wires
+        # it (`_start_working_block`); a block merely appended by a test is not
+        # on that path.
+        app._working_block = working
+        await pilot.pause()
+        working._animated = True
+        working._tick_ms = WorkingBlock._FRAME_MS
+
+        app._set_animation_focused(False)
+        await pilot.pause()
+        assert working._tick_ms == WorkingBlock._STATIC_FRAME_MS
+        assert working._timer is not None, "throttled, not stopped"
+
+        app._set_animation_focused(True)
+        await pilot.pause()
+        # Restored only where the shimmer setting itself allows motion; the
+        # suite pins LOCAL_OPERATOR_NO_SHIMMER=1, so this asserts the gate is
+        # AND-ed rather than replaced.
+        assert working._tick_ms == WorkingBlock._STATIC_FRAME_MS
+
+
+@pytest.mark.asyncio
+async def test_blur_never_drops_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A blurred session still paints everything it is told.
+
+    The throttle touches repaint TIMERS only. Transcript blocks, the ledger and
+    the working line's label are all event-driven, so they must land on a
+    blurred terminal exactly as they do on a focused one — anything else would
+    be a session that quietly loses output while the user is in another window.
+    """
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        app._set_animation_focused(False)
+        await pilot.pause()
+
+        app._append_block(UserBlock("this arrived while the window was blurred"))
+        await pilot.pause()
+        rows = [getattr(block, "renderable", "") for block in app._transcript_view().blocks()]
+        plain = " ".join(getattr(row, "plain", str(row)) for row in rows)
+        assert "this arrived while the window was blurred" in plain
+
+
+@pytest.mark.asyncio
+async def test_welcome_pulse_stops_unfocused_and_resumes_focused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The splash's glow is 92% of what an idle session writes to the terminal.
+
+    Gated on focus ONLY: the focused cadence and appearance are untouched, so
+    this asserts the timers exist again after refocus rather than that they
+    changed rate.
+    """
+    monkeypatch.delenv("LOCAL_OPERATOR_NO_SHIMMER", raising=False)
+    monkeypatch.setattr("local_operator.tui.shimmer.settings_get", lambda *a, **k: True)
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        welcome = app.query_one(WelcomeView)
+        welcome.set_visible(True)
+        welcome._sync_pulse_timer()
+        welcome._sync_tip_timer()
+        await pilot.pause()
+        assert welcome._pulse_timer is not None
+        assert welcome._tip_timer is not None
+
+        app._set_animation_focused(False)
+        await pilot.pause()
+        # Not merely paused: with the gate closed no timer exists at all, which
+        # is the same shape the shimmer kill switch already produces.
+        assert welcome._pulse_timer is None
+        assert welcome._tip_timer is None
+        # And the mark is back at its DEFINED resting frame, not the phase the
+        # glow happened to be holding when the user looked away.
+        assert welcome._mark_color is None
+        assert welcome._tip_index == 0
+
+        app._set_animation_focused(True)
+        await pilot.pause()
+        assert welcome._pulse_timer is not None
+        assert welcome._tip_timer is not None
+
+
+@pytest.mark.asyncio
+async def test_shimmer_disabled_path_is_unchanged_by_focus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The kill switch still wins on its own: focus cannot re-enable animation.
+
+    ``motion_enabled()`` is an AND, so a developer or a CI job that turned
+    animation off gets a still frame whether or not the terminal is focused.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_SHIMMER", "1")
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        welcome = app.query_one(WelcomeView)
+        welcome.set_visible(True)
+        welcome._sync_pulse_timer()
+        await pilot.pause()
+        assert welcome._pulse_timer is None
+
+        app._set_animation_focused(True)
+        await pilot.pause()
+        assert welcome._pulse_timer is None
+        assert not animation.motion_enabled()
+
+
+def test_focus_flag_defaults_focused_and_reports_only_real_changes() -> None:
+    """The flag's contract, without an app: default True, idempotent sets.
+
+    The return value is what lets the app skip the fan-out — Textual reasserts
+    focus on every keypress, so an unconditional resync would stop and restart
+    four timers per character typed.
+    """
+    animation.reset_animation_focus()
+    assert animation.animation_focused() is True
+    assert animation.set_animation_focused(True) is False
+    assert animation.set_animation_focused(False) is True
+    assert animation.set_animation_focused(False) is False
+    assert animation.set_animation_focused(True) is True
+    animation.reset_animation_focus()
+
+
+@pytest.mark.asyncio
+async def test_panel_repaints_in_full_on_refocus() -> None:
+    """The dock's numbers must be current the moment the window is looked at.
+
+    The panel has ONE repaint point (``_tick``), so refocus marks it dirty
+    rather than painting from a second path; the next tick is then a full
+    repaint including the re-read stats.
+    """
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        panel = app.query_one(SubagentPanel)
+        panel._start_spinner()
+        await pilot.pause()
+        panel._dirty = False
+
+        app._set_animation_focused(False)
+        await pilot.pause()
+        app._set_animation_focused(True)
+
+        assert panel._dirty is True

--- a/tests/unit/tui/test_render_throttling.py
+++ b/tests/unit/tui/test_render_throttling.py
@@ -25,7 +25,7 @@ from textual.widgets import Static
 from local_operator.tui import animation
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.subagent_panel import SPINNER_INTERVAL_S, SubagentPanel
-from local_operator.tui.widgets.subagent_view import SubagentView
+from local_operator.tui.widgets.subagent_view import SPINNER_FRAMES, SubagentView
 from local_operator.tui.widgets.transcript import UserBlock, WorkingBlock
 from local_operator.tui.widgets.welcome import WelcomeView
 
@@ -129,17 +129,39 @@ async def test_a_spinner_tick_repaints_only_the_row_carrying_the_spinner() -> No
         assert view._running, "fixture must be a RUNNING child or there is no spinner"
         spy = _UpdateSpy(view)
 
-        before = view._spinner_index
-        for _ in range(8):
-            view._tick()
-            await pilot.pause()
+        # Count the ADVANCES, never compare two indices. `_spinner_index` is
+        # advanced modulo `len(SPINNER_FRAMES)`, so it is a phase on a cycle
+        # and not a monotonic counter: any run whose total tick count is a
+        # multiple of the frame count lands back on the frame it started from,
+        # and `index != before` then reads a moving spinner as a stopped one.
+        # The total is NOT under this test's control — the view's own spinner
+        # timer is live and fires during `pilot.pause()`, so the driven ticks
+        # below are a lower bound on how many actually happen. That is what
+        # made CI fail `assert 3 != 3` on one leg and pass on another, and it
+        # is why the phase is observed through a counting wrapper instead.
+        advances = 0
+        real_tick = view._tick
 
-        assert view._spinner_index != before, "the animation stopped advancing"
+        def counting_tick() -> None:
+            nonlocal advances
+            advances += 1
+            real_tick()
+
+        view._tick = counting_tick  # type: ignore[method-assign]
+        try:
+            ticks = len(SPINNER_FRAMES) + 1
+            for _ in range(ticks):
+                view._tick()
+                await pilot.pause()
+        finally:
+            del view._tick  # type: ignore[attr-defined]
+
+        assert advances >= ticks, "the animation stopped advancing"
         # The cadence is untouched: every tick still repaints the glyph. It is
         # `>=` rather than `==` because the 1 Hz job poll also refreshes the
         # page, and this test is about which ROWS a tick touches, not about
         # owning every paint that happens during it.
-        assert len(spy.calls["title"]) >= 8
+        assert len(spy.calls["title"]) >= ticks
         assert spy.calls["breadcrumb"] == []
         assert spy.calls["rule"] == []
 

--- a/tests/unit/tui/test_render_throttling.py
+++ b/tests/unit/tui/test_render_throttling.py
@@ -16,7 +16,7 @@ Two invariants run through the whole file and are each pinned by name:
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from textual import messages
@@ -329,7 +329,9 @@ async def test_blur_does_not_stop_a_settled_page_from_staying_settled() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_session_that_never_hears_about_focus_is_never_throttled() -> None:
+async def test_a_session_that_never_hears_about_focus_is_never_throttled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The default is FOCUSED, because some hosts send no focus events at all.
 
     "We were never told" and "the user is looking at this" have to be the same
@@ -340,14 +342,24 @@ async def test_a_session_that_never_hears_about_focus_is_never_throttled() -> No
     async with app.run_test(size=(100, 30)) as pilot:
         view = await _open_running_child(pilot, app)
         assert view._spinner_rate == SPINNER_INTERVAL_S
+        # The shimmer pin has to come OFF for this line to mean anything. The
+        # suite sets LOCAL_OPERATOR_NO_SHIMMER=1 (conftest), under which
+        # `motion_enabled()` is False whatever focus says — so the disjunct
+        # this assertion used to carry was unconditionally true and the test
+        # asserted nothing (agent review R5). Turning motion on isolates the
+        # FOCUS gate, which is the one under test here.
+        monkeypatch.delenv("LOCAL_OPERATOR_NO_SHIMMER", raising=False)
+        assert animation.motion_enabled() is True
         working = WorkingBlock("thinking")
         app._append_block(working)
         await pilot.pause()
-        assert working._tick_ms == WorkingBlock._FRAME_MS or not animation.motion_enabled()
+        assert working._tick_ms == WorkingBlock._FRAME_MS
 
 
 @pytest.mark.asyncio
-async def test_working_block_falls_to_the_static_cadence_on_blur() -> None:
+async def test_working_block_falls_to_the_static_cadence_on_blur(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The 30 fps shimmer line reuses its EXISTING static mode, not a new one.
 
     ``_STATIC_FRAME_MS`` already exists for shimmer-off and is already correct
@@ -377,11 +389,23 @@ async def test_working_block_falls_to_the_static_cadence_on_blur() -> None:
         assert working._tick_ms == WorkingBlock._STATIC_FRAME_MS
         assert working._timer is not None, "throttled, not stopped"
 
+        # Refocus with the shimmer pin OFF, so "restored" is distinguishable
+        # from "never changed". Asserting _STATIC_FRAME_MS on both sides of the
+        # transition (as this did) passes even if refocus does nothing at all
+        # (agent review R5). The AND-ing of the two gates is asserted
+        # separately below.
+        monkeypatch.delenv("LOCAL_OPERATOR_NO_SHIMMER", raising=False)
         app._set_animation_focused(True)
         await pilot.pause()
-        # Restored only where the shimmer setting itself allows motion; the
-        # suite pins LOCAL_OPERATOR_NO_SHIMMER=1, so this asserts the gate is
-        # AND-ed rather than replaced.
+        assert working._tick_ms == WorkingBlock._FRAME_MS, "refocus did not restore"
+
+        # And with the shimmer setting off, focus alone must NOT restore
+        # motion: the gate is AND-ed rather than replaced.
+        monkeypatch.setenv("LOCAL_OPERATOR_NO_SHIMMER", "1")
+        app._set_animation_focused(False)
+        await pilot.pause()
+        app._set_animation_focused(True)
+        await pilot.pause()
         assert working._tick_ms == WorkingBlock._STATIC_FRAME_MS
 
 
@@ -551,3 +575,62 @@ async def test_panel_repaints_in_full_on_refocus() -> None:
         app._set_animation_focused(True)
 
         assert panel._dirty is True
+
+
+def test_the_band_rerenders_on_refocus() -> None:
+    """The band's clock and token counts must be current on refocus.
+
+    The band is the one throttled surface that is NOT a ``Widget`` — it drives
+    a ``Static`` dock and is re-rated by the app rather than by a Textual event
+    of its own — so nothing else in the suite holds its refocus repaint. It is
+    covered here because the band carries the session clock and the token
+    counts, not just a glyph: those are the numbers a returning user reads
+    first, and at the blurred cadence they would otherwise be up to a second
+    stale at the moment the window is looked at.
+
+    Mutation-tested: deleting the ``refresh()`` in ``sync_animation_rate``
+    survived the whole suite before this test existed (agent review R4).
+    """
+    from local_operator.tui.widgets.status_line import StatusLine
+    from tests.unit.tui.test_status_line import _dock
+
+    animation.reset_animation_focus()
+    band = StatusLine(_dock(200))
+    # Only a STREAMING band has a spinner timer to re-rate; an idle one has
+    # already stopped and must stay stopped.
+    band.update(streaming=True)
+    dock = cast(Any, band)._dock
+
+    animation.set_animation_focused(False)
+    band.sync_animation_rate()
+    dock.painted = None
+
+    animation.set_animation_focused(True)
+    band.sync_animation_rate()
+
+    assert dock.painted is not None, "the band did not re-render on refocus"
+    assert dock.layout is False, "the band must never ask for a layout pass"
+    animation.reset_animation_focus()
+
+
+def test_an_idle_band_stays_stopped_across_a_focus_change() -> None:
+    """Re-rating must never START a spinner on a band that is not streaming.
+
+    ``sync_animation_rate`` replaces the timer to change its interval, and the
+    hazard in that shape is arming a surface that had correctly stopped.
+    """
+    from local_operator.tui.widgets.status_line import StatusLine
+    from tests.unit.tui.test_status_line import _dock
+
+    animation.reset_animation_focus()
+    band = StatusLine(_dock(200))
+    dock = cast(Any, band)._dock
+    before = len(dock.intervals)
+
+    animation.set_animation_focused(False)
+    band.sync_animation_rate()
+    animation.set_animation_focused(True)
+    band.sync_animation_rate()
+
+    assert len(dock.intervals) == before, "an idle band was given a spinner"
+    animation.reset_animation_focus()

--- a/tests/unit/tui/test_render_throttling.py
+++ b/tests/unit/tui/test_render_throttling.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import pytest
 from textual import messages
+from textual.events import AppBlur
 from textual.widgets import Static
 
 from local_operator.tui import animation
@@ -478,6 +479,36 @@ async def test_shimmer_disabled_path_is_unchanged_by_focus(
         await pilot.pause()
         assert welcome._pulse_timer is None
         assert not animation.motion_enabled()
+
+
+@pytest.mark.asyncio
+async def test_a_keystroke_unthrottles_an_app_that_never_got_a_focus_event() -> None:
+    """Typing into a blurred-looking session must restore full animation.
+
+    Textual sets its `app_focus` reactive DIRECTLY when a key or mouse-down
+    arrives while it believes the app is blurred, and that assignment posts no
+    AppFocus event. A gate wired only to `on_app_focus` therefore never hears
+    about it, and a host that reports blur but not focus leaves a session the
+    user is actively typing into stuck at the reduced rate. Verified against
+    the real app before the fix: `app_focus` True, animation gate False.
+    """
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        app.post_message(AppBlur())
+        await pilot.pause()
+        await pilot.pause()
+        assert not animation.animation_focused()
+
+        await pilot.press("a")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert app.app_focus is True
+        assert animation.animation_focused() is True
 
 
 def test_focus_flag_defaults_focused_and_reports_only_real_changes() -> None:


### PR DESCRIPTION
# PR Description

## Summary of Changes

Five measured reductions in what a session costs when **nothing has changed**:
unchanged chrome rows that were being rewritten 12.5 times a second, a missing
`layout=False` that reflowed the whole screen on every spinner tick, and
animation that ran at full rate in terminals nobody was looking at.

### Read this part first: the honest framing

The user reported four symptoms — sessions with many concurrent subagents
rendering very slowly, subagent views lagging more than parent views, many
parallel sessions slowing things down, and more lag in cmux than Ghostty.

**This PR does not fix that felt slowness, and does not claim to.** The
dominant cause was measured and it is *environmental*, not code:

- the machine sat at **loadavg 260-307 on 14 cores** from other sessions'
  pytest/xdist harnesses and CPU burners;
- all 18 lop TUIs *together* summed to **under one core**;
- a fixed work quantum held its **CPU time** stable (81.6 → 101.5 ms) while its
  **wall time** inflated **4.6-7.8x** under that load;
- a 12.5 fps timer doing the child's real 11.5 ms of work ran at **0.30
  effective fps with 100% of frames late**.

Code was roughly **1.7x**; the environment was roughly **100x**.

What this PR does is make lop **cheaper and better-behaved**, which matters most
exactly when the box is busy and when many sessions are open. On symptom 4
specifically: the steady-state stream is 48% escape-sequence bytes (61,660 of
129,110 — 1,119 CSI cursor-position, 3,450 SGR, 1,725 truecolor bg, 1,181
truecolor fg), and cmux (Electron, JS parsing) held 51-60% of a core where
Ghostty (native GPU) held 0.6%. That gap is not lop's to close — but emitting
**~28x less per background session** is squarely lop's to do.

Also **confirmed and deliberately not touched**: subagent scaling is cleanly
linear in K (`SubagentRow.paint` per 40 ticks: K=1→63, K=4→280, K=8→504,
K=16→1034, against x16.00 in K — no O(n²)); screen arrange cost is flat in
transcript size N (~455 µs at N=20/40/80/160/320); and roster persistence is
already coalesced, fingerprinted and off-loop.

## The changes

### 1-3. Chrome paint (`subagent_view._paint_chrome`)

- **The breadcrumb omitted `layout=False`** while the title and rule beside it
  passed it. All three are `height: 1` in the sheet. `Static.update(layout=True)`
  clears every ancestor's arrangement cache and posts `messages.Layout`, so the
  one defaulted update **negated the deliberate `layout=False` on its two
  siblings** — a sibling three lines below relayouts the same screen on the same
  tick anyway.
- **The breadcrumb and rule were rewritten with byte-identical strings.** The
  breadcrumb is a pure function of `_ancestors` + `_label`; the rule of width
  alone. Neither can change on a spinner tick, but both sat *after* a memo whose
  key includes the spinner, so both fired `update()` regardless. Each now carries
  its own key.
- **The `_paint_chrome` memo is defeated on ~93% of ticks by design** — `spinner`
  is one of its terms and `_tick` advances the index before every call (measured
  live: 313 calls in 2 s, **291 miss / 22 hit**). The spinner only affects the
  **title**, so a spinner-only tick now repaints only the title, mirroring the
  cheap glyph-only path `SubagentPanel._tick` already has rather than inventing a
  second convention. **The animation's visible cadence is unchanged.**

**Found while testing, fixed here:** `_ancestors` was missing from the chrome memo
key entirely. A page re-parented under a different lineage at an unchanged label,
status and width would be memoised out and keep a stale trail. Caught by
`test_a_changed_breadcrumb_still_repaints`, which failed against my first draft.

### 4-5. Focus gating (new `local_operator/tui/animation.py`)

`app.py`'s `on_app_focus`/`on_app_blur` existed but only touched the notifier.
Proven against the real `OperatorApp`: posting `AppBlur` flipped `app_focus` to
False and **nothing else changed** (`WorkingBlock._paint` stayed 25.4→29.9/s).
Textual's own `_on_app_blur` only sets a flag and refreshes bindings; there is no
render suppression in the driver or compositor.

One module owns the answer, fanned out from those existing handlers to each
surface's own `sync_animation_rate`, so no surface gains a second way to decide
its cadence:

- the **working line** falls to its **existing** `_STATIC_FRAME_MS` (1000 ms vs
  33 ms) rather than a new mechanism — that still path already exists for
  shimmer-off and is already correct (frozen glyph, repaint only when the clock's
  second changes), so a blurred window and a shimmer-off window are **one** tested
  state instead of two;
- the three **0.08 s spinners** (subagent view, subagent panel, status band) slow
  to 1 s — slowed, never stopped, because a frozen spinner and a finished job look
  identical and this app uses motion as its word for "alive";
- the **splash's pulse and tip rotation** stop entirely (FIX 5 is focus-gating
  only — the focused appearance and frame rate are untouched).

The four requirements, each pinned by a named test:

| Requirement | How it holds |
|---|---|
| No content missed or dropped | Only repaint **timers** change. The transcript, ledger and working-line label are event-driven. `test_blur_never_drops_content` |
| Correct immediately on refocus, no catch-up artifact | Every surface repaints on the way back to the fast rate (the panel marks dirty so its *single* repaint point runs). `test_refocus_repaints_so_no_surface_shows_a_stale_frame` |
| Shimmer-disabled path unbroken | `motion_enabled()` is an **AND** — the kill switch still wins alone. `test_shimmer_disabled_path_is_unchanged_by_focus` |
| Never stuck throttled with no focus events | Flag **defaults to focused**; only an explicit blur clears it. Textual also flips `app_focus` back on any keypress and posts `AppFocus` here, so a spurious blur heals on the next keystroke. `test_a_session_that_never_hears_about_focus_is_never_throttled` |

## Benchmark

`scripts/bench_tui_chrome_paint.py`, committed, with `bench/README.md` and both
JSON records. It reports **load-invariant call counts**, not wall-clock —
deliberately, because on this box wall time is worthless (see the framing above).
Wall time is printed and explicitly labelled "not a signal".

```sh
env -u NO_COLOR TERM=xterm-256color \
  .venv/bin/python scripts/bench_tui_chrome_paint.py --focus 8 --json out.json
```

50 driven ticks, 160-block transcript, one running child, `origin/main`
@ `3c79116c` vs the same tree with the fixes:

| Per spinner tick | Before | After |
|---|---|---|
| `messages.Layout` posted | 5.42 | **0.02** |
| compositor reflows | 4.64 | **0.00** |
| `Screen._refresh_layout` | 4.64 | **0.00** |
| `messages.Update` posted | 33.60 | **16.38** (−51%) |
| title rewrites | 5.80 | 4.54 |
| breadcrumb rewrites | 5.80 | **0.00** |
| rule rewrites | 5.80 | **0.00** |

Terminal output for an idle session (splash up, turn running — the shape of a
window the user has tabbed away from), 8 s windows:

| | Before | After |
|---|---|---|
| focused | 24,039 B/s | 24,109 B/s |
| blurred | 23,824 B/s | **862 B/s** |
| ratio | **1.01x** | **28.0x** |

The before column is the diagnosis restated as a measurement: on `origin/main` a
real `AppBlur` changes nothing. The focused row is unchanged **by design** — this
gates on focus, it does not slow animation anyone can see. Target was ~17 KB/s →
~1 KB/s; measured 24.1 KB/s → 0.86 KB/s.

## Testing evidence

### Visual validation (per AGENTS.md "Visual validation")

Before/after SVG frames captured with `run_test` + `save_screenshot` on the
**real `OperatorApp`** (which loads `local_operator.tcss` — the lightweight test
hosts do not), rendered and **looked at** in a browser, at 100x30.

The chrome must be pixel-identical, and it is. Diffing the SVG text runs
programmatically, **before vs after** differ in exactly **3 runs**:

```
('231.8','678.8')  '/private/tmp/lop-perf-before' -> '/private/tmp/lop-tui-perf'   # cwd label
('439.2','68.8')   '⣻' -> '⣟'                                                      # spinner phase
('48.8','166.4')   '⣻ ' -> '⢿ '                                                    # spinner phase
```

Nothing else moved. Chrome rows compared with their style classes normalised —
text, classes **and** resolved fill hexes are identical:

```
chrome text+class identical (ex. spinner glyph): True
styles for chrome classes identical: True
  r1 fill:#c5c8c6 || r2 fill:#837c6d || r3 fill:#4a4539 || r4 fill:#e9e5db || r5 fill:#b5afa2
```

**Consecutive frames** (AGENTS.md §5, since this animates) — one spinner tick
apart, only the glyph moves, so the layout is not reflowing after paint:

```
AFTER f1 vs f2 — differing runs: 2
  '⣟' -> '⣷'      (title spinner)
  '⢿ ' -> '⡿ '     (working-line head)
chrome rows across the tick, ex. glyph, identical: True
```

**Geometry behind the pixels** (AGENTS.md §4) — identical on both trees:

```
view.size Size(96,17) | screen Size(98,28) virtual Size(98,28) | vscrollbar False
_title      size=(96,1) region=Region(x=2,y=2,w=96,h=1)
_breadcrumb size=(96,1) region=Region(x=2,y=3,w=96,h=1)
_rule       size=(96,1) region=Region(x=2,y=4,w=96,h=1)
```

Virtual height equals actual and no scrollbar appeared — the pre-existing trap
AGENTS.md warns about is not triggered.

### Unit tests

15 new tests in `tests/unit/tui/test_render_throttling.py`, one per behaviour:
breadcrumb painted with `layout=False`; unchanged strings not rewritten; a
changed breadcrumb still repainting; spinner-only tick not touching
breadcrumb/rule; no `Layout` message per tick; blur throttling and focus
restoring across all surfaces; no lost content; no stale state; settled pages
staying settled; the never-focused default; shimmer-off unchanged; panel full
repaint on refocus.

Every assertion is a **count**, never a duration — a timing assertion on this box
would be a flake generator that proves nothing.

`tests/unit/tui/conftest.py` resets the module flag per test: the suite shares a
process, so a test that blurs would otherwise leave later tests throttled.

### Gates (whole tree, exactly as CI runs them)

```
.venv/bin/python -m flake8 .                              0
uvx --from black==26.1.0 black --check .                  628 files unchanged
uvx isort==5.13.2 --check .                               clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   0 errors, 0 warnings
```

Unit suite: **8991 passed**, 15 skipped, 9 failed — **all nine verified
pre-existing / load artifacts, none caused by this change.** The box was at
loadavg ~200-300 with six sessions running suites at 14 xdist workers each and
swap active. Verified rather than assumed, by running the same node IDs against
the clean baseline worktree (`origin/main` @ `3c79116c`) with identical env:

| Test | Baseline 14-wide | Baseline `-n 4` | Branch `-n 4` | Verdict |
|---|---|---|---|---|
| `test_esc_aborts_a_running_shell_command` | **FAIL** | pass | pass ×6 | pre-existing flake |
| `test_effective_model_change_repaints_the_band` | **FAIL** | pass | pass | pre-existing flake |
| `test_todo_header_names_its_arithmetic…` | **FAIL** | pass | pass | pre-existing flake |
| `test_band_total_is_own_spend_plus_children` | **FAIL** | pass | pass | pre-existing flake |
| `test_frontend_state` (jobs/sequence) | pass | pass | pass ×6 | load artifact |
| `test_stubborn_child_is_killed_on_cancellation` | — | pass | pass | load artifact |
| `test_second_title_backfill_pass_is_stat_only` | — | pass | pass | load artifact (20 ms ceiling) |
| `test_reconnect_gap_replay_does_not_stall_the_loop` | — | pass | pass | load artifact (500 ms ceiling) |
| `test_s2_send_to_agent_end_keeps_the_loop_under_the_bar` | — | pass | pass | load artifact (500 ms ceiling) |
| `test_ask_never_exceeds_the_timeout_it_was_given` | — | pass | pass | load artifact |

The four most suspicious — the `_shell_card` one and the FrontendUpdate
jobs/sequence one, which could plausibly have been the throttle changing *when*
repaints are emitted — were stressed specifically: `_shell_card` **fails on the
clean baseline and passes on this branch**, and the full baseline suite at 14
workers reproduced exactly one failure, that same test. All 9 pass 9/9 serially
and at `-n 4` on both trees. CI is the authority on a clean full run.

## Version

`0.43.12` → **`0.43.13`**. Patch: performance and reliability work, no
step-function capability. (The brief said 0.43.10 → 0.43.11; `main` had moved to
0.43.12 by the time this branched.)

## Deliberately not done

- **No behaviour change to the spinner's visible cadence, or to any focused
  frame.** FIX 5 is focus-gating only, as specified.
- **Did not "fix" `SubagentView`'s spinner self-stop** — it already stops
  correctly via `show()` and `on_unmount`; that hypothesis was withdrawn.
- **Did not touch** subagent scaling, screen arrange, or roster persistence —
  all three measured healthy (see the framing above).
- **Pre-existing flakes left alone**, not loosened and not skipped —
  `deferred — pre-existing, unrelated to this change, reproduced on origin/main`.
