### PR TITLE
fix(session): recover from an unknown hosting provider instead of dying

### DIFF
--- a/local_operator/bootstrap.py
+++ b/local_operator/bootstrap.py
@@ -94,9 +94,12 @@ def resolve_hosting_model(
             # second literal here drifts from it the first time either is
             # reworded. Imported lazily to keep this off the session_factory
             # stack until the rare no-default path is actually hit.
-            from local_operator.session_factory import _no_model_message
+            from local_operator.session_factory import (
+                ModelNotConfiguredError,
+                _no_model_message,
+            )
 
-            raise ValueError(_no_model_message(hosting))
+            raise ModelNotConfiguredError(_no_model_message(hosting), hosting)
     return hosting, model_name
 
 

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -2125,11 +2125,33 @@ def _preflight_hosting_model(
     """
     from local_operator.session_factory import (
         HostingNotConfiguredError,
+        HostingUnknownError,
         resolve_hosting_model,
     )
 
     try:
         hosting, _model_name = resolve_hosting_model(current_agent, args, config_manager)
+    except HostingUnknownError as exc:
+        # Hosting names a provider the registry does not own (a typo, a
+        # hand-edited config, an id dropped by an upgrade). Recoverable in
+        # EXACTLY the way "nothing configured" is -- the user fixes it with
+        # `/login` or `/provider` from inside the app -- so the interactive TUI
+        # path opens in the same setup state rather than dying at preflight.
+        # Ordered before the HostingNotConfiguredError branch because it is a
+        # subclass of it and would otherwise be swallowed by that handler, which
+        # would print the first-run quickstart and never name the bad value.
+        if allow_setup_state:
+            return None
+        # Non-interactive paths (headless REPL, exec, non-tty) keep fail-fast:
+        # a scripted run must not limp along with no usable model. The message
+        # names the offending value AND the remedy, following
+        # `_print_first_run_quickstart`'s "name everything at once" principle --
+        # the quickstart itself is wrong here, because it says "nothing is
+        # configured" when something IS configured, just not to a real provider.
+        from local_operator.cli_style import ERROR, paint
+
+        print(paint(f"Error: {exc}", ERROR, stream=sys.stderr), file=sys.stderr)
+        return 1
     except HostingNotConfiguredError:
         # No hosting resolved. On the interactive TUI path this is not an error:
         # the app opens in a setup state so the user can `/login` from inside it.

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -2126,11 +2126,32 @@ def _preflight_hosting_model(
     from local_operator.session_factory import (
         HostingNotConfiguredError,
         HostingUnknownError,
+        ModelNotConfiguredError,
         resolve_hosting_model,
     )
 
     try:
         hosting, _model_name = resolve_hosting_model(current_agent, args, config_manager)
+    except ModelNotConfiguredError as exc:
+        # Hosting is a real provider but has no resolvable model -- the state
+        # `/login <provider-with-no-default>` writes on purpose. Recoverable on
+        # the interactive path in EXACTLY the way an unknown hosting is: the
+        # setup state's `/model` picker writes the missing value, so the app
+        # opens rather than refusing to launch. Ordered before its base class
+        # for the same reason the HostingUnknownError branch is: it is a
+        # subclass and would otherwise be swallowed by that handler, which
+        # would print the first-run quickstart and never mention the model.
+        if allow_setup_state:
+            return None
+        # Non-interactive paths keep fail-fast with the informative message: a
+        # scripted or CI run has nobody to answer a picker, and limping along
+        # on a model nobody chose is how a cron job silently bills a different
+        # provider. Same shape as the ValueError branch below, which this
+        # branch now shadows for the resolver's own raise.
+        from local_operator.cli_style import ERROR, paint
+
+        print(paint(f"Error: {exc}", ERROR, stream=sys.stderr), file=sys.stderr)
+        return 1
     except HostingUnknownError as exc:
         # Hosting names a provider the registry does not own (a typo, a
         # hand-edited config, an id dropped by an upgrade). Recoverable in

--- a/local_operator/providers/auth_cli.py
+++ b/local_operator/providers/auth_cli.py
@@ -185,16 +185,16 @@ def _apply_login_defaults(provider_id: str) -> None:
 
     When hosting is ALREADY set we touch nothing and print nothing: a user
     logging into a second provider to switch models later has not asked to
-    change their default, and silently repointing it would be a surprise.
+    change their default, and silently repointing it would be a surprise. The
+    exception is a hosting that is set but names no provider the registry owns,
+    which is repaired rather than preserved.
 
-    The exception is a hosting that is set but names a provider the registry
-    does not own (a typo, a hand-edited config, an id dropped by an upgrade).
-    That config cannot boot, and the error it produces RECOMMENDS this command
-    as the remedy — so "already set, leave it alone" would send the user round
-    the same loop the paragraph above describes, just one level further in. The
-    stale ``model_name`` is replaced with it, because it belonged to the
-    provider being repaired and would point a real provider at a model id that
-    never existed.
+    The POLICY lives in :func:`providers.login_defaults.plan_login_defaults`,
+    shared with the TUI's ``/login``; this function only applies the plan and
+    prints the receipt. That split is deliberate: the two copies of this rule
+    had already drifted into writing different hosting ids and different models
+    for the same provider, which is the class of bug the shared planner exists
+    to make impossible.
 
     Imported lazily and guarded: this is a convenience on top of a login that
     already succeeded, so a config write failure (read-only dir) must not turn a
@@ -202,28 +202,25 @@ def _apply_login_defaults(provider_id: str) -> None:
     """
     try:
         from local_operator.config import ConfigManager
-        from local_operator.model.defaults import default_model_for
         from local_operator.paths import config_dir
+        from local_operator.providers.login_defaults import plan_login_defaults
 
         manager = ConfigManager(config_dir())
-        configured = manager.get_config_value("hosting")
-        # Asked of the registry, not of a hardcoded list, so this accepts
-        # exactly what the engine accepts (legacy aliases included) and cannot
-        # drift from the resolver's own validation.
-        repairing = bool(configured) and get_provider_definition(str(configured)) is None
-        if configured and not repairing:
-            return
-        manager.set_config_value("hosting", provider_id)
-        model = default_model_for(provider_id) or ""
-        message = (
-            f"Replaced unusable hosting '{configured}' with '{provider_id}'"
-            if repairing
-            else f"Set default hosting to '{provider_id}'"
+        plan = plan_login_defaults(
+            provider_id,
+            manager.get_config_value("hosting"),
+            manager.get_config_value("model_name"),
         )
-        if model and (repairing or not manager.get_config_value("model_name")):
-            manager.set_config_value("model_name", model)
-            message += f" and model to '{model}'"
-        print(f"{message}.")
+        if plan.hosting is None:
+            return
+        manager.set_config_value("hosting", plan.hosting)
+        # ``None`` means leave it alone; ``""`` means clear a model that
+        # belonged to the provider we just replaced. Compared against None
+        # explicitly so the clearing case is not swallowed by a falsy test.
+        if plan.model_name is not None:
+            manager.set_config_value("model_name", plan.model_name)
+        if plan.receipt:
+            print(f"{plan.receipt[:1].upper()}{plan.receipt[1:]}.")
     except Exception as exc:  # noqa: BLE001 — never fail a completed login
         print(f"Note: logged in, but could not set default hosting/model: {exc}")
 

--- a/local_operator/providers/auth_cli.py
+++ b/local_operator/providers/auth_cli.py
@@ -187,6 +187,15 @@ def _apply_login_defaults(provider_id: str) -> None:
     logging into a second provider to switch models later has not asked to
     change their default, and silently repointing it would be a surprise.
 
+    The exception is a hosting that is set but names a provider the registry
+    does not own (a typo, a hand-edited config, an id dropped by an upgrade).
+    That config cannot boot, and the error it produces RECOMMENDS this command
+    as the remedy — so "already set, leave it alone" would send the user round
+    the same loop the paragraph above describes, just one level further in. The
+    stale ``model_name`` is replaced with it, because it belonged to the
+    provider being repaired and would point a real provider at a model id that
+    never existed.
+
     Imported lazily and guarded: this is a convenience on top of a login that
     already succeeded, so a config write failure (read-only dir) must not turn a
     successful login into a failure.
@@ -197,12 +206,21 @@ def _apply_login_defaults(provider_id: str) -> None:
         from local_operator.paths import config_dir
 
         manager = ConfigManager(config_dir())
-        if manager.get_config_value("hosting"):
+        configured = manager.get_config_value("hosting")
+        # Asked of the registry, not of a hardcoded list, so this accepts
+        # exactly what the engine accepts (legacy aliases included) and cannot
+        # drift from the resolver's own validation.
+        repairing = bool(configured) and get_provider_definition(str(configured)) is None
+        if configured and not repairing:
             return
         manager.set_config_value("hosting", provider_id)
         model = default_model_for(provider_id) or ""
-        message = f"Set default hosting to '{provider_id}'"
-        if model and not manager.get_config_value("model_name"):
+        message = (
+            f"Replaced unusable hosting '{configured}' with '{provider_id}'"
+            if repairing
+            else f"Set default hosting to '{provider_id}'"
+        )
+        if model and (repairing or not manager.get_config_value("model_name")):
             manager.set_config_value("model_name", model)
             message += f" and model to '{model}'"
         print(f"{message}.")

--- a/local_operator/providers/login_defaults.py
+++ b/local_operator/providers/login_defaults.py
@@ -100,9 +100,23 @@ def plan_login_defaults(
       failure it cannot is strictly worse than the bug being repaired.
     - Clearing (rather than keeping) a model with no known default is what
       makes the repair safe for ``alibaba-token-plan``, which resolves to no
-      default at all. An empty ``model_name`` is a state the startup resolver
-      already handles and reports precisely; a model belonging to a provider
-      that never existed is not.
+      default at all. A model belonging to a provider that never existed is
+      strictly worse: it boots and then fails at stream time, where the app
+      cannot explain it.
+
+      An empty ``model_name`` is NOT a fully-configured state, and this module
+      must not pretend otherwise — an earlier version of this docstring claimed
+      the startup resolver "already handles" it, which was false and shipped a
+      dead end. What the resolver actually does is raise
+      ``ModelNotConfiguredError`` (``session_factory``), a RECOVERABLE member of
+      the ``HostingNotConfiguredError`` family: the TUI opens in the setup state
+      where ``/model`` supplies the missing value and boots the session, and the
+      non-interactive paths still fail fast with a message naming concrete model
+      ids. So the repair trades an unbootable config for one that needs one more
+      answer from the user, and the surface that asks for it is reachable —
+      which is the property that has to hold, and the reason the boot-level test
+      in ``tests/unit/tui/test_app_pilot.py`` asserts it end to end rather than
+      stopping at the config file.
     """
     if hosting and not is_unusable_hosting(hosting):
         return LoginDefaults(hosting=None, model_name=None, receipt=None, repairing=False)
@@ -112,6 +126,16 @@ def plan_login_defaults(
     # under the provider it authenticates, and that is what the app must point
     # at. This is also what gives the flavour a default model to inherit.
     resolved = credential_provider_id(provider_id)
+    # The module's entire purpose is "never write a hosting the registry does
+    # not own". `credential_provider_id` PASSES UNKNOWN ids through, so without
+    # this a careless caller (`plan_login_defaults("not-a-provider", ...)`)
+    # would write exactly the unusable hosting this planner exists to refuse.
+    # Both current front ends reach here only after a successful login against
+    # a registry-resolved definition, so this is a belt, not a currently-hit
+    # path -- and a no-op plan is the honest answer when there is nothing
+    # legitimate to write.
+    if get_provider_definition(resolved) is None:
+        return LoginDefaults(hosting=None, model_name=None, receipt=None, repairing=False)
     default_model = default_model_for(resolved) or ""
 
     if repairing:

--- a/local_operator/providers/login_defaults.py
+++ b/local_operator/providers/login_defaults.py
@@ -1,0 +1,141 @@
+"""The ONE rule for what a successful login writes to config.
+
+Why this module exists: this decision had two implementations — one in
+``providers/auth_cli`` for ``local-operator login``, one in ``tui/app`` for
+``/login`` — and they drifted on every axis that mattered. They wrote different
+hosting ids for the same provider (raw ``provider_id`` vs
+``credential_provider_id``), decided "is the current hosting broken?" by
+different tests (a registry lookup vs a TUI-only state flag), and therefore
+produced different config for identical input: logging into ``xai-oauth`` from a
+corrupted config yielded ``xai`` + ``grok-3`` on one path and ``xai-oauth`` +
+the dead model on the other.
+
+That divergence is not incidental to the bug this module was extracted for. The
+original defect — a config naming a provider the registry does not own leaving
+the session unbootable and unrepairable — survived precisely because the
+"recover from a bad provider" logic lived in more than one place and no single
+place was responsible for being right. Fixing it in two copies would have
+rebuilt the same trap. Both front ends now call :func:`plan_login_defaults`, so
+a change to the policy is a change to one function.
+
+Pure and side-effect-free by construction: it reads no config file, writes no
+config file, and prints nothing. Callers own their own ``ConfigManager`` and
+their own reporting surface (stdout for the CLI, a transcript notice for the
+TUI), which is the only thing that legitimately differs between them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from local_operator.model.defaults import default_model_for
+from local_operator.providers.registry import (
+    credential_provider_id,
+    get_provider_definition,
+)
+
+
+@dataclass(frozen=True)
+class LoginDefaults:
+    """What a login should write, and how to describe it.
+
+    ``model_name`` is ``None`` when the caller must leave the stored value
+    alone, and ``""`` when it must CLEAR it — a distinction that carries real
+    weight (see :func:`plan_login_defaults`), so it cannot be collapsed into a
+    single falsy check.
+    """
+
+    #: The hosting id to write, or ``None`` to leave hosting untouched.
+    hosting: str | None
+    #: ``None`` = leave as-is, ``""`` = clear it, otherwise the id to write.
+    model_name: str | None
+    #: One-line receipt for the user, or ``None`` when nothing was written.
+    receipt: str | None
+    #: True when this replaces a hosting the registry does not own, as opposed
+    #: to filling in an empty one. Callers use it only for wording.
+    repairing: bool
+
+
+def is_unusable_hosting(hosting: str | None) -> bool:
+    """True when ``hosting`` is set but names no provider the engine accepts.
+
+    Asked of the registry rather than a hardcoded id list, for the same reason
+    the startup resolver does it that way: ``get_provider_definition`` resolves
+    legacy aliases (``noop`` -> ``test``), so a membership test against ids
+    would classify a WORKING alias config as corrupt and silently repoint a
+    user's default. Empty hosting is not "unusable" — it is the separate
+    nothing-configured case, which has its own first-run handling.
+    """
+    return bool(hosting) and get_provider_definition(str(hosting)) is None
+
+
+def plan_login_defaults(
+    provider_id: str, hosting: str | None, model_name: str | None
+) -> LoginDefaults:
+    """Decide what a just-completed login for ``provider_id`` should write.
+
+    Three cases, in order:
+
+    1. **Hosting already set and usable** — write nothing. A user logging into
+       a second provider to switch models later has not asked to change their
+       default, and silently repointing it would be a surprise.
+    2. **Hosting empty** — adopt this provider and its default model. Without
+       this, ``login`` stored a credential but left hosting empty, so the very
+       command the "not configured" error recommends looped straight back to
+       the same error.
+    3. **Hosting set but unusable** — REPLACE it. That config cannot boot, and
+       the error it produces recommends this command as the remedy, so
+       "already set, leave it alone" would loop one level deeper.
+
+    The model is resolved through ``credential_provider_id`` and, when
+    repairing, is always overwritten — cleared if the provider has no known
+    default. Both halves of that are load-bearing:
+
+    - A login FLAVOUR (``xai-oauth``, ``openai-device``, ``zai-oauth``) is an
+      authentication route, not a hosting id, and it has no default model of
+      its own. Writing the raw flavour id as hosting left the stale model in
+      place beside it, producing a config that BOOTS — ``configure_model``
+      accepts the pair — and then fails at stream time on a model the provider
+      never heard of. Trading a boot failure the app explains for a runtime
+      failure it cannot is strictly worse than the bug being repaired.
+    - Clearing (rather than keeping) a model with no known default is what
+      makes the repair safe for ``alibaba-token-plan``, which resolves to no
+      default at all. An empty ``model_name`` is a state the startup resolver
+      already handles and reports precisely; a model belonging to a provider
+      that never existed is not.
+    """
+    if hosting and not is_unusable_hosting(hosting):
+        return LoginDefaults(hosting=None, model_name=None, receipt=None, repairing=False)
+
+    repairing = is_unusable_hosting(hosting)
+    # The credential's storage id is the real hosting: an OAuth flavour stores
+    # under the provider it authenticates, and that is what the app must point
+    # at. This is also what gives the flavour a default model to inherit.
+    resolved = credential_provider_id(provider_id)
+    default_model = default_model_for(resolved) or ""
+
+    if repairing:
+        # Always overwrite: the stored model belonged to the provider being
+        # replaced. "" clears it rather than leaving a dead id behind.
+        model_to_write: str | None = default_model
+        receipt = f"replaced unusable hosting '{hosting}' with '{resolved}'"
+        if default_model:
+            receipt += f", model to '{default_model}'"
+        else:
+            # Named explicitly: a cleared model changes what the next launch
+            # does, so it must not be a silent side effect of logging in.
+            receipt += ", cleared the model it left behind (no default known)"
+    else:
+        # First-run: only fill an EMPTY model, so a user who deliberately chose
+        # one keeps it.
+        model_to_write = default_model if (default_model and not model_name) else None
+        receipt = f"set default hosting to '{resolved}'"
+        if model_to_write:
+            receipt += f", model to '{model_to_write}'"
+
+    return LoginDefaults(
+        hosting=resolved,
+        model_name=model_to_write,
+        receipt=receipt,
+        repairing=repairing,
+    )

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -244,6 +244,71 @@ class HostingNotConfiguredError(ValueError):
     """
 
 
+class HostingUnknownError(HostingNotConfiguredError):
+    """Raised when hosting names a provider the registry does not own.
+
+    A SUBCLASS of :class:`HostingNotConfiguredError`, and that is the whole
+    point of the fix it belongs to. The two conditions had been treated
+    asymmetrically: "nothing configured" was a guided first-run state, while
+    "configured to garbage" (a typo, a hand-edited config, a provider id
+    removed by an upgrade) was a fatal crash. The user's remedy is IDENTICAL in
+    both cases -- ``/login`` / ``/provider`` / ``/model`` from inside the app --
+    so the recoverable classification has to cover both, or a one-character typo
+    in ``config.yml`` locks the user out of the only surface that can repair it.
+    Reported as ``Unsupported hosting platform: anthropicxyq`` from deep inside
+    ``configure_model``, it left every session dead AND every provider-switch
+    command answering "session is still starting...", because ``_session``
+    stayed ``None``.
+
+    Subclassing rather than adding a sibling means the existing
+    recoverable-setup handling (the CLI preflight's
+    ``except HostingNotConfiguredError``, the TUI's ``isinstance`` check in
+    ``_on_boot_failed``) picks this up with no change, and cannot be updated for
+    one condition while forgetting the other. The two stay DISTINGUISHABLE by
+    type, which is what lets each surface say "nothing configured" or
+    "configured to an unknown provider 'X'" rather than one vague message
+    covering both.
+
+    Do NOT "simplify" this back into a bare ``ValueError`` at the resolver, and
+    do not relax ``configure_model``'s own guard: that guard is a correct
+    programming-error backstop for callers that bypass this resolver, and the
+    bug was that bad CONFIG could reach it, not that it existed.
+
+    The offending value is carried as :attr:`hosting` rather than left to be
+    re-parsed out of the message text: the TUI needs to name it in phrasing of
+    its own (action-first, because its splash truncates from the right), and
+    scraping it back out of a sentence is how the two surfaces drift apart the
+    first time either is reworded.
+    """
+
+    def __init__(self, message: str, hosting: str = "") -> None:
+        super().__init__(message)
+        self.hosting = hosting
+
+
+def _unknown_hosting_message(hosting: str) -> str:
+    """Error text for a hosting id the provider registry does not know.
+
+    Names the offending value AND the remedy, because the message this replaces
+    ("Unsupported hosting platform: anthropicxyq") named only the value and left
+    the user to guess what a supported one looks like. Concrete provider ids are
+    inlined rather than generated from the registry, matching
+    :func:`_no_model_message` directly below -- a short, stable example list
+    reads better than a dump of every id, and spelling the examples out is
+    already this module's convention.
+
+    Used by the non-interactive fail-fast paths (headless REPL, ``exec``,
+    non-tty). The TUI writes its own action-first phrasing for the same
+    condition, because its splash line truncates from the right.
+    """
+    return (
+        f"Hosting '{hosting}' in your configuration is not a known provider. "
+        "Set a supported one with `local-operator config edit hosting <provider>` "
+        "or `local-operator login <provider>` (e.g. openai, anthropic, google); "
+        "`local-operator provider` lists them all."
+    )
+
+
 def _no_model_message(hosting: str) -> str:
     """Error text for a provider with no known default model.
 
@@ -278,6 +343,27 @@ def resolve_hosting_model(
     )
     if not hosting:
         raise HostingNotConfiguredError("Hosting platform is not configured.")
+    # Validate the RESOLVED hosting here, in the same preflight that already
+    # catches the not-configured case, rather than letting a garbage value sail
+    # through and detonate in `configure_model` deep inside boot. WHERE this is
+    # detected is what makes it recoverable: this is the one point both the CLI
+    # preflight and the TUI boot handler classify, so the same condition raised
+    # here reaches the guided setup state while raised later it reaches the red
+    # "session failed to start" this fix exists to remove.
+    #
+    # Checked through `get_provider_definition`, NOT a membership test against
+    # provider ids: that function resolves legacy aliases (`noop` -> `test`), so
+    # an id test would newly reject an alias the engine still accepts and turn a
+    # working config into a setup prompt. It is also the exact lookup
+    # `configure_model` performs, so this accepts precisely what the engine
+    # accepts -- a preflight stricter than the engine is its own outage.
+    from local_operator.providers.registry import get_provider_definition
+
+    if get_provider_definition(hosting) is None:
+        # Before the default-model lookup below: an unknown provider has no
+        # default model either, so checking the model first reported the missing
+        # model (a symptom) and buried the unknown provider (the cause).
+        raise HostingUnknownError(_unknown_hosting_message(hosting), hosting)
     if not model_name:
         # A hosting with no model is not a dead end: every mainstream provider
         # has a reasonable default, so resolve to it rather than raising. Only

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -281,12 +281,42 @@ class HostingUnknownError(HostingNotConfiguredError):
     first time either is reworded.
     """
 
-    def __init__(self, message: str, hosting: str = "") -> None:
+    def __init__(self, message: str, hosting: str = "", source: str = "config") -> None:
         super().__init__(message)
         self.hosting = hosting
+        #: WHERE the bad value came from: ``"config"``, ``"flag"`` (``--hosting``)
+        #: or ``"agent"`` (an agent record). Carried because the in-app repair
+        #: writes the CONFIG FILE, so it can only fix the config case: precedence
+        #: is agent > flag > config, and a login that rewrites config while the
+        #: bad value comes from argv or an agent record changes nothing the next
+        #: boot will read. The UI uses this to avoid promising a repair it cannot
+        #: perform — telling the user to run `/login` against a `--hosting` typo
+        #: is a loop, and a wrong instruction is worse than none.
+        self.source = source
 
 
-def _unknown_hosting_message(hosting: str) -> str:
+#: How the user changes a bad hosting value, per source. Keyed by
+#: :attr:`HostingUnknownError.source`, because the remedy genuinely differs: only
+#: the config case is fixed by `login`/`config edit`, and naming the wrong one
+#: sends the user round a loop that cannot terminate.
+_HOSTING_SOURCE_REMEDY = {
+    "config": (
+        "Set a supported one with `local-operator config edit hosting <provider>` "
+        "or `local-operator login <provider>` (e.g. openai, anthropic, google); "
+        "`local-operator provider` lists them all."
+    ),
+    "flag": (
+        "It came from the --hosting flag, so correct that flag (e.g. "
+        "--hosting openai); `local-operator provider` lists the supported ids."
+    ),
+    "agent": (
+        "It came from the agent's own record, which overrides config, so update "
+        "the agent's hosting; `local-operator provider` lists the supported ids."
+    ),
+}
+
+
+def _unknown_hosting_message(hosting: str, source: str = "config") -> str:
     """Error text for a hosting id the provider registry does not know.
 
     Names the offending value AND the remedy, because the message this replaces
@@ -301,12 +331,13 @@ def _unknown_hosting_message(hosting: str) -> str:
     non-tty). The TUI writes its own action-first phrasing for the same
     condition, because its splash line truncates from the right.
     """
-    return (
-        f"Hosting '{hosting}' in your configuration is not a known provider. "
-        "Set a supported one with `local-operator config edit hosting <provider>` "
-        "or `local-operator login <provider>` (e.g. openai, anthropic, google); "
-        "`local-operator provider` lists them all."
-    )
+    where = {
+        "config": "in your configuration",
+        "flag": "passed with --hosting",
+        "agent": "on the agent record",
+    }.get(source, "in your configuration")
+    remedy = _HOSTING_SOURCE_REMEDY.get(source, _HOSTING_SOURCE_REMEDY["config"])
+    return f"Hosting '{hosting}' {where} is not a known provider. {remedy}"
 
 
 def _no_model_message(hosting: str) -> str:
@@ -333,10 +364,13 @@ def resolve_hosting_model(
     Raises ``ValueError`` with the legacy message shapes when either value is
     missing, so the CLI's red-banner handler reports it exactly like before.
     """
-    hosting: str | None = getattr(agent, "hosting", None) if agent is not None else None
-    hosting = (
-        hosting or getattr(args, "hosting", None) or config_manager.get_config_value("hosting")
-    )
+    # The SOURCE is tracked alongside the value, not just the value: the repair
+    # offered when this turns out to be unusable writes the config file, which
+    # is only the last of these three. See HostingUnknownError.source.
+    agent_hosting: str | None = getattr(agent, "hosting", None) if agent is not None else None
+    flag_hosting: str | None = getattr(args, "hosting", None)
+    hosting = agent_hosting or flag_hosting or config_manager.get_config_value("hosting")
+    hosting_source = "agent" if agent_hosting else "flag" if flag_hosting else "config"
     model_name: str | None = getattr(agent, "model", None) if agent is not None else None
     model_name = (
         model_name or getattr(args, "model", None) or config_manager.get_config_value("model_name")
@@ -363,7 +397,9 @@ def resolve_hosting_model(
         # Before the default-model lookup below: an unknown provider has no
         # default model either, so checking the model first reported the missing
         # model (a symptom) and buried the unknown provider (the cause).
-        raise HostingUnknownError(_unknown_hosting_message(hosting), hosting)
+        raise HostingUnknownError(
+            _unknown_hosting_message(hosting, hosting_source), hosting, hosting_source
+        )
     if not model_name:
         # A hosting with no model is not a dead end: every mainstream provider
         # has a reasonable default, so resolve to it rather than raising. Only

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -295,6 +295,47 @@ class HostingUnknownError(HostingNotConfiguredError):
         self.source = source
 
 
+class ModelNotConfiguredError(HostingNotConfiguredError):
+    """Raised when hosting is a real provider but no model can be resolved for it.
+
+    A SIBLING of :class:`HostingUnknownError` under the recoverable base, for the
+    same reason that class exists: the user's remedy is reachable only from
+    inside the app, so the condition has to reach the surface that offers it.
+    Raised as a bare ``ValueError`` it missed the ``isinstance`` gate in the
+    TUI's ``_on_boot_failed``, landed in the red "session failed to start" branch
+    with ``_session`` None and ``_setup_state`` False, and left every provider
+    command answering "session is still starting..." -- the exact terminal state
+    this error family was introduced to remove.
+
+    That is reachable through the app's OWN repair: logging in to a provider with
+    no known default model (``alibaba-token-plan``) writes a registry-VALID
+    hosting with an empty model, so the next boot arrives here. Before this
+    class the user was stuck HARDER after the repair than before it -- ``/login``
+    wrote nothing because hosting was now valid, and ``/model`` had no session to
+    talk to.
+
+    DISTINCT from ``HostingUnknownError`` rather than reusing it, because the
+    diagnosis differs and the surfaces say so: hosting is fine here, the MODEL is
+    missing, and telling a user whose provider is correct that it "is not a known
+    provider" sends them to fix the one thing that is not broken. The hosting is
+    carried for the same reason its sibling carries it -- so the UI can name it
+    without re-parsing a sentence.
+
+    Recoverable does NOT mean permissive: the non-interactive paths (headless
+    REPL, ``exec``, non-tty) still fail fast on this in ``_preflight_hosting_model``,
+    because a scripted run has no one to answer the prompt and must not limp
+    along picking a model nobody chose.
+    """
+
+    def __init__(self, message: str, hosting: str = "") -> None:
+        super().__init__(message)
+        #: The provider that resolved fine but has no model. Unlike its sibling
+        #: this needs no ``source``: hosting came from somewhere valid, and the
+        #: remedy (`/model`, which writes config) is the same wherever the empty
+        #: model came from.
+        self.hosting = hosting
+
+
 #: How the user changes a bad hosting value, per source. Keyed by
 #: :attr:`HostingUnknownError.source`, because the remedy genuinely differs: only
 #: the config case is fixed by `login`/`config edit`, and naming the wrong one
@@ -409,7 +450,16 @@ def resolve_hosting_model(
 
         model_name = default_model_for(hosting)
         if not model_name:
-            raise ValueError(_no_model_message(hosting))
+            # RECOVERABLE, not fatal: a provider with no known default is a
+            # config the user can still fix from inside the app (`/model`), and
+            # this is a config the app itself writes -- `/login` into a provider
+            # with no default clears the model deliberately. Raised as a plain
+            # ValueError it bypassed the TUI's recoverable-error gate and became
+            # the dead "session failed to start" state, which is what made the
+            # sanctioned repair leave the user worse off than the corruption it
+            # repaired. The message is unchanged -- it names concrete model ids,
+            # and the fail-fast paths still print exactly it.
+            raise ModelNotConfiguredError(_no_model_message(hosting), hosting)
     return hosting, model_name
 
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1499,6 +1499,12 @@ class OperatorApp(App[None]):
         #: `/login` that resolves it. While set, a successful login reloads the
         #: session (there is none yet) rather than only re-polling the splash.
         self._setup_state = False
+        #: The unknown provider id that put us in the setup state, when that is
+        #: why we are here (``None`` for the nothing-configured case). Read by
+        #: `_apply_login_defaults`, which must OVERWRITE a hosting that is set
+        #: but invalid — its "only adopt when empty" rule is right for a user
+        #: adding a second provider and wrong for a config that cannot boot.
+        self._invalid_hosting: str | None = None
         #: Invoked before a post-login session rebuild so the launch-time config
         #: manager (captured by the session factory closure) re-reads the
         #: hosting/model that `/login` just wrote to disk. ``None`` outside the
@@ -3264,10 +3270,24 @@ class OperatorApp(App[None]):
         # `/login` affordance and the `/model` / `/provider` surfaces are the
         # setup UI — no separate wizard. Imported lazily beside every other
         # session_factory reference in this module.
-        from local_operator.session_factory import HostingNotConfiguredError
+        from local_operator.session_factory import (
+            HostingNotConfiguredError,
+            HostingUnknownError,
+        )
 
         if isinstance(error, HostingNotConfiguredError):
-            self._enter_setup_state()
+            # HostingUnknownError is a SUBCLASS, so a config naming a provider
+            # the registry does not own lands here too, and deliberately: its
+            # remedy is the same `/login` / `/provider` the unconfigured case
+            # uses, and treating it as a crash instead left the user unable to
+            # switch away from the bad value from inside the app (`_session`
+            # stayed None, so every provider command answered "session is still
+            # starting..."). The bad value is carried into the setup state so
+            # the guidance can name what is actually wrong.
+            bad_hosting = getattr(error, "hosting", None)
+            self._enter_setup_state(
+                unknown_hosting=bad_hosting if isinstance(error, HostingUnknownError) else None
+            )
             return
         self._system_notice(f"session failed to start: {error}", "error")
         assert self._status is not None
@@ -3278,19 +3298,33 @@ class OperatorApp(App[None]):
         # accepted and painted where the app meant to say "session error".
         self._status.update(model_label="session error", model_name="", streaming=False)
 
-    def _enter_setup_state(self) -> None:
+    def _enter_setup_state(self, *, unknown_hosting: str | None = None) -> None:
         """First-run setup: guide the user to `/login` with no session yet.
 
         Reached when the session could not be built because NOTHING is
-        configured (see :meth:`_on_boot_failed`). No parallel wizard: the splash
-        already owns the empty-state real estate and carries a notice row, so the
-        guidance lives there, the status band says "setup" instead of a model
-        name, and the existing `/login` / `/model` / `/provider` commands do the
-        work. A successful `/login` sets hosting + a default model and reloads
-        the session (see :meth:`_login_flow`), which lands the user in a normal
-        working app.
+        configured, or because what IS configured names a provider the registry
+        does not own (see :meth:`_on_boot_failed`). No parallel wizard: the
+        splash already owns the empty-state real estate and carries a notice row,
+        so the guidance lives there, the status band says "setup" instead of a
+        model name, and the existing `/login` / `/model` / `/provider` commands
+        do the work. A successful `/login` sets hosting + a default model and
+        reloads the session (see :meth:`_login_flow`), which lands the user in a
+        normal working app.
+
+        ``unknown_hosting`` names the bad value for the second case. The two
+        conditions share this ONE state on purpose (identical remedy), but not
+        one message: telling a user whose config says `anthropicxyq` that "no
+        provider is configured" contradicts the file they are looking at and
+        sends them looking for the wrong problem.
         """
         self._setup_state = True
+        # The bad value is remembered so the post-login rebuild can OVERWRITE it.
+        # Without this the recovery is a loop: `_apply_login_defaults` only
+        # adopts a provider when hosting is empty, and here it is not empty --
+        # it is wrong -- so a successful `/login` would write nothing, the
+        # rebuild would resolve the same bad hosting, and the app would drop
+        # straight back into this state having told the user it was starting.
+        self._invalid_hosting = unknown_hosting
         # A notice, not a red error: the splash paints this in the warning voice
         # beside its `/login` hint, which is exactly the affordance the user
         # needs. Toast headline included so it is noticed on a busy first frame.
@@ -3299,11 +3333,25 @@ class OperatorApp(App[None]):
         # BEFORE the diagnosis or it is what drops (D2). The band and toast
         # already carry "no provider configured", so leading with the remedy
         # spends the scarce columns on the one thing they do not.
-        self._announce_on_splash(
-            "Run /login <provider> to get started (e.g. /login openai) "
-            "— no provider configured yet, or /provider to see the list.",
-            "warning",
-        )
+        # Action-first in BOTH variants, for the reason above: the command
+        # survives truncation, the diagnosis is what may be cut. The bad-value
+        # variant still names the offending id early, because "which word in my
+        # config is wrong" is the one thing the user cannot work out from the
+        # remedy alone, and names real providers so the fix is a copy rather
+        # than a guess.
+        if unknown_hosting:
+            self._announce_on_splash(
+                f"Run /login <provider> to fix this (e.g. /login openai) "
+                f"— '{unknown_hosting}' in your config is not a known provider, "
+                "or /provider to see the list.",
+                "warning",
+            )
+        else:
+            self._announce_on_splash(
+                "Run /login <provider> to get started (e.g. /login openai) "
+                "— no provider configured yet, or /provider to see the list.",
+                "warning",
+            )
         if self._status is not None:
             # "setup" rather than a model name: there is no model until the user
             # picks a provider, and leaving MODEL_PENDING up would read as a
@@ -14304,13 +14352,31 @@ class OperatorApp(App[None]):
             from local_operator.providers.registry import credential_provider_id
 
             manager = ConfigManager(config_dir())
-            if manager.get_config_value("hosting"):
+            configured = manager.get_config_value("hosting")
+            # "Already configured" only counts when it is configured to
+            # something REAL. A hosting the registry does not own is what put
+            # the app in the setup state, and leaving it in place made the
+            # login a no-op: the rebuild resolved the same bad value and fell
+            # back into setup, so the user logged in successfully and still had
+            # no session -- the same dead end this whole path exists to end.
+            # Compared against the value the boot failure actually reported
+            # rather than re-validating here, so this stays a config writer and
+            # the registry lookup keeps living in the resolver.
+            if configured and configured != self._invalid_hosting:
                 return None
             hosting = credential_provider_id(provider)
             manager.set_config_value("hosting", hosting)
             model = default_model_for(hosting) or ""
             receipt = f"set default hosting to '{hosting}'"
-            if model and not manager.get_config_value("model_name"):
+            # The stored model belonged to the provider we are replacing, so
+            # when we are REPAIRING a bad hosting it has to be replaced too:
+            # keeping it would point a real provider at a model id from a
+            # provider that never existed, turning a boot failure the app
+            # explains into a stream failure it cannot. A normal first-run
+            # login still only fills an EMPTY model, so a user who deliberately
+            # chose a model keeps it.
+            repairing = bool(configured) and configured == self._invalid_hosting
+            if model and (repairing or not manager.get_config_value("model_name")):
                 manager.set_config_value("model_name", model)
                 receipt += f", model to '{model}'"
             return receipt
@@ -14367,6 +14433,10 @@ class OperatorApp(App[None]):
             # is hidden right now because the notice above is a transcript block.
             if self._setup_state:
                 self._setup_state = False
+                # Cleared with the state that owns it: the repair is written,
+                # and a LATER `/login` (the user adding a second provider) must
+                # not be read as another repair and overwrite their hosting.
+                self._invalid_hosting = None
                 # Reconcile the launch-time config manager with what
                 # `_apply_login_defaults` just wrote, or the rebuild resolves the
                 # same empty config and drops back into setup.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3284,9 +3284,10 @@ class OperatorApp(App[None]):
             # stayed None, so every provider command answered "session is still
             # starting..."). The bad value is carried into the setup state so
             # the guidance can name what is actually wrong.
-            bad_hosting = getattr(error, "hosting", None)
+            unknown = isinstance(error, HostingUnknownError)
             self._enter_setup_state(
-                unknown_hosting=bad_hosting if isinstance(error, HostingUnknownError) else None
+                unknown_hosting=getattr(error, "hosting", None) if unknown else None,
+                hosting_source=getattr(error, "source", "config") if unknown else "config",
             )
             return
         self._system_notice(f"session failed to start: {error}", "error")
@@ -3298,7 +3299,9 @@ class OperatorApp(App[None]):
         # accepted and painted where the app meant to say "session error".
         self._status.update(model_label="session error", model_name="", streaming=False)
 
-    def _enter_setup_state(self, *, unknown_hosting: str | None = None) -> None:
+    def _enter_setup_state(
+        self, *, unknown_hosting: str | None = None, hosting_source: str = "config"
+    ) -> None:
         """First-run setup: guide the user to `/login` with no session yet.
 
         Reached when the session could not be built because NOTHING is
@@ -3316,6 +3319,13 @@ class OperatorApp(App[None]):
         one message: telling a user whose config says `anthropicxyq` that "no
         provider is configured" contradicts the file they are looking at and
         sends them looking for the wrong problem.
+
+        ``hosting_source`` keeps that honesty one step further. `/login` writes
+        the CONFIG FILE, but precedence is agent > flag > config, so when the
+        bad value came from `--hosting` or an agent record a login cannot fix
+        it — the next boot resolves the same value and returns here. Promising
+        a remedy that cannot work is a loop the user cannot see the shape of,
+        so those cases name the real source instead.
         """
         self._setup_state = True
         # The bad value is remembered so the post-login rebuild can OVERWRITE it.
@@ -3334,23 +3344,49 @@ class OperatorApp(App[None]):
         # already carry "no provider configured", so leading with the remedy
         # spends the scarce columns on the one thing they do not.
         # Action-first in BOTH variants, for the reason above: the command
-        # survives truncation, the diagnosis is what may be cut. The bad-value
-        # variant still names the offending id early, because "which word in my
-        # config is wrong" is the one thing the user cannot work out from the
-        # remedy alone, and names real providers so the fix is a copy rather
-        # than a guess.
-        if unknown_hosting:
+        # survives truncation, the diagnosis is what may be cut.
+        #
+        # LENGTH is the other half of that constraint, and word order alone did
+        # not satisfy it. The first version of the unknown-provider line ran to
+        # 141 characters, so at 80 and 100 columns — the widths people actually
+        # use — it was cut mid-clause on "is not", and at 60 the offending value
+        # never appeared at all: the user was told to fix "this" without ever
+        # being told what "this" was, which is precisely what naming the value
+        # exists to prevent. Both lines are now short enough to survive 80
+        # columns whole.
+        #
+        # A runnable example (`/login openai`) replaces the `<provider>`
+        # placeholder plus a parenthetical example: the placeholder form spent
+        # ~30 of the scarcest columns saying the same thing twice, and the
+        # concrete command teaches the shape by itself. `/provider` is kept
+        # because it is the discovery affordance for "which providers exist".
+        if unknown_hosting and hosting_source != "config":
+            # `/login` writes config, and config is NOT what produced this
+            # value, so recommending it here would be a lie that loops. Name
+            # the real source and keep the line inside 80 columns.
+            origin = "--hosting" if hosting_source == "flag" else "the agent"
             self._announce_on_splash(
-                f"Run /login <provider> to fix this (e.g. /login openai) "
-                f"— '{unknown_hosting}' in your config is not a known provider, "
-                "or /provider to see the list.",
+                f"'{unknown_hosting}' from {origin} is not a known provider "
+                "(/provider lists them).",
                 "warning",
+                headline=f"Unknown provider '{unknown_hosting}'",
+            )
+        elif unknown_hosting:
+            self._announce_on_splash(
+                f"/login openai — '{unknown_hosting}' is not a known "
+                "provider (/provider lists all).",
+                "warning",
+                # The headline is passed rather than sniffed out of the text:
+                # the toast is the ONE element that is never truncated, so it
+                # is where the bad value is guaranteed to reach the user even
+                # on a narrow terminal.
+                headline=f"Unknown provider '{unknown_hosting}'",
             )
         else:
             self._announce_on_splash(
-                "Run /login <provider> to get started (e.g. /login openai) "
-                "— no provider configured yet, or /provider to see the list.",
+                "/login openai to get started — no provider configured " "(/provider lists all).",
                 "warning",
+                headline="No provider configured",
             )
         if self._status is not None:
             # "setup" rather than a model name: there is no model until the user
@@ -14347,39 +14383,34 @@ class OperatorApp(App[None]):
         """
         try:
             from local_operator.config import ConfigManager
-            from local_operator.model.defaults import default_model_for
             from local_operator.paths import config_dir
-            from local_operator.providers.registry import credential_provider_id
+            from local_operator.providers.login_defaults import plan_login_defaults
 
             manager = ConfigManager(config_dir())
-            configured = manager.get_config_value("hosting")
-            # "Already configured" only counts when it is configured to
-            # something REAL. A hosting the registry does not own is what put
-            # the app in the setup state, and leaving it in place made the
-            # login a no-op: the rebuild resolved the same bad value and fell
-            # back into setup, so the user logged in successfully and still had
-            # no session -- the same dead end this whole path exists to end.
-            # Compared against the value the boot failure actually reported
-            # rather than re-validating here, so this stays a config writer and
-            # the registry lookup keeps living in the resolver.
-            if configured and configured != self._invalid_hosting:
+            # The POLICY is shared with `local-operator login` (see
+            # providers/login_defaults): what to write for a given provider and
+            # current config is one function, because this rule previously
+            # existed twice and the copies drifted into writing different
+            # hosting ids and different models for identical input. The
+            # "is the current hosting broken?" test is the planner's REGISTRY
+            # lookup rather than this app's `_invalid_hosting` flag: the flag is
+            # strictly narrower (it only knows about a value THIS boot
+            # reported), so a config corrupted by another route was repaired by
+            # the CLI and ignored here.
+            plan = plan_login_defaults(
+                provider,
+                manager.get_config_value("hosting"),
+                manager.get_config_value("model_name"),
+            )
+            if plan.hosting is None:
                 return None
-            hosting = credential_provider_id(provider)
-            manager.set_config_value("hosting", hosting)
-            model = default_model_for(hosting) or ""
-            receipt = f"set default hosting to '{hosting}'"
-            # The stored model belonged to the provider we are replacing, so
-            # when we are REPAIRING a bad hosting it has to be replaced too:
-            # keeping it would point a real provider at a model id from a
-            # provider that never existed, turning a boot failure the app
-            # explains into a stream failure it cannot. A normal first-run
-            # login still only fills an EMPTY model, so a user who deliberately
-            # chose a model keeps it.
-            repairing = bool(configured) and configured == self._invalid_hosting
-            if model and (repairing or not manager.get_config_value("model_name")):
-                manager.set_config_value("model_name", model)
-                receipt += f", model to '{model}'"
-            return receipt
+            manager.set_config_value("hosting", plan.hosting)
+            # ``None`` = leave it; ``""`` = clear a model belonging to the
+            # provider just replaced. The explicit None test is what keeps the
+            # clearing case from being swallowed by a falsy check.
+            if plan.model_name is not None:
+                manager.set_config_value("model_name", plan.model_name)
+            return plan.receipt
         except Exception as error:  # noqa: BLE001 — never fail a completed login
             return f"logged in, but could not save default hosting/model: {error}"
 
@@ -16828,7 +16859,9 @@ class OperatorApp(App[None]):
             self._live_peer_receipts.add(message.message_id)
         self._append_block(PeerMessageBlock(message.body, message.sender))
 
-    def _announce_on_splash(self, text: str, kind: NoticeKind) -> None:
+    def _announce_on_splash(
+        self, text: str, kind: NoticeKind, *, headline: str | None = None
+    ) -> None:
         """Hold ``text`` on the splash and raise a toast for it.
 
         The splash is content-sized and rests on the input card, so a
@@ -16851,7 +16884,7 @@ class OperatorApp(App[None]):
         except NoMatches:
             return
         duration = TOAST_FAILURE_MS if kind in ("warning", "error") else TOAST_DEFAULT_MS
-        toast.show(_splash_toast_headline(text), duration_ms=duration)
+        toast.show(_splash_toast_headline(text, headline), duration_ms=duration)
 
     def _recall_queued_steers(self) -> None:
         """Esc: lift the newest still-queued steer back into the composer.
@@ -17498,8 +17531,12 @@ def _first_line(text: str) -> str:
     return ""
 
 
-def _splash_toast_headline(text: str) -> str:
+def _splash_toast_headline(text: str, headline: str | None = None) -> str:
     """The toast half of a splash announcement: a glance, not the reason.
+
+    ``headline`` is the caller's own glance for states it can name. Prefer it
+    over the text-sniffing fallbacks below: it cannot silently stop matching
+    when the message is reworded.
 
     The splash row already carries the full sentence. Repeating it in the
     toast made a two-row card that sat on the mark (design round 1, D1)
@@ -17508,6 +17545,8 @@ def _splash_toast_headline(text: str) -> str:
     zai/glm-5.3`` — because that is the model the next prompt will hit.
     Anything else stays one short clause, never the whole line.
     """
+    if headline:
+        return headline
     body = " ".join(text.split())
     if not body:
         return "Notice"
@@ -17522,6 +17561,15 @@ def _splash_toast_headline(text: str) -> str:
     # sentence lands mid-word ("…configured ye…") and repeats the greeting the
     # splash already owns (D5), so the setup notice gets its own clean headline
     # naming the condition rather than a truncated slice of the action line.
+    #
+    # Callers that KNOW the state pass ``headline`` explicitly instead of
+    # relying on the substring probe below. Deriving a headline by re-parsing
+    # prose is fragile in a way that already bit us: this branch matched the
+    # literal "no provider configured", so when the unknown-provider message
+    # was added — a sibling state one row away in the same function — it fell
+    # through to the blind cut and reintroduced the exact dangling-fragment
+    # defect D5 was raised against. A new message must not silently regress a
+    # fixed finding by failing to contain a magic phrase.
     if "no provider configured" in body.lower():
         return "No provider configured"
     # One clause, no wrap: the toast sits over the lockup, and a second

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1500,11 +1500,22 @@ class OperatorApp(App[None]):
         #: session (there is none yet) rather than only re-polling the splash.
         self._setup_state = False
         #: The unknown provider id that put us in the setup state, when that is
-        #: why we are here (``None`` for the nothing-configured case). Read by
-        #: `_apply_login_defaults`, which must OVERWRITE a hosting that is set
-        #: but invalid — its "only adopt when empty" rule is right for a user
-        #: adding a second provider and wrong for a config that cannot boot.
+        #: why we are here (``None`` for the nothing-configured case).
+        #:
+        #: Kept as a RECORD of why this boot entered setup, not as policy input.
+        #: It used to drive the repair in `_apply_login_defaults`; that decision
+        #: now belongs to `providers/login_defaults`, which asks the registry
+        #: instead. The registry test is strictly wider — it also repairs a
+        #: config corrupted by another route, which this flag cannot see — and
+        #: the flag is deliberately not consulted anywhere, so the two can never
+        #: disagree about whether a config is broken.
         self._invalid_hosting: str | None = None
+        #: The provider that resolved fine but has no model, when THAT is why we
+        #: are in the setup state (``None`` otherwise). Unlike `_invalid_hosting`
+        #: this one IS read: `/model` and the picker's `d` key consult it to
+        #: decide that a saved default should also boot the session that does
+        #: not exist yet, which is what makes this setup state escapable.
+        self._model_missing_for: str | None = None
         #: Invoked before a post-login session rebuild so the launch-time config
         #: manager (captured by the session factory closure) re-reads the
         #: hosting/model that `/login` just wrote to disk. ``None`` outside the
@@ -3273,6 +3284,7 @@ class OperatorApp(App[None]):
         from local_operator.session_factory import (
             HostingNotConfiguredError,
             HostingUnknownError,
+            ModelNotConfiguredError,
         )
 
         if isinstance(error, HostingNotConfiguredError):
@@ -3284,10 +3296,19 @@ class OperatorApp(App[None]):
             # stayed None, so every provider command answered "session is still
             # starting..."). The bad value is carried into the setup state so
             # the guidance can name what is actually wrong.
+            #
+            # ModelNotConfiguredError is the THIRD member of the family and is
+            # routed here for the same reason, but it is passed separately: the
+            # provider is correct and the MODEL is missing, so reusing the
+            # unknown-provider wording would send the user to fix the one part
+            # of their config that is right. It has no `source` -- `/model`
+            # writes config whatever the empty model came from.
             unknown = isinstance(error, HostingUnknownError)
+            no_model = isinstance(error, ModelNotConfiguredError)
             self._enter_setup_state(
                 unknown_hosting=getattr(error, "hosting", None) if unknown else None,
                 hosting_source=getattr(error, "source", "config") if unknown else "config",
+                model_missing_for=getattr(error, "hosting", None) if no_model else None,
             )
             return
         self._system_notice(f"session failed to start: {error}", "error")
@@ -3300,7 +3321,11 @@ class OperatorApp(App[None]):
         self._status.update(model_label="session error", model_name="", streaming=False)
 
     def _enter_setup_state(
-        self, *, unknown_hosting: str | None = None, hosting_source: str = "config"
+        self,
+        *,
+        unknown_hosting: str | None = None,
+        hosting_source: str = "config",
+        model_missing_for: str | None = None,
     ) -> None:
         """First-run setup: guide the user to `/login` with no session yet.
 
@@ -3320,6 +3345,16 @@ class OperatorApp(App[None]):
         provider is configured" contradicts the file they are looking at and
         sends them looking for the wrong problem.
 
+        ``model_missing_for`` names the THIRD way in: hosting resolves to a real
+        provider that has no known default model, so there is nothing to boot
+        with. The remedy is `/model` rather than `/login` -- a login would write
+        nothing, because hosting is already valid -- and the splash says so. This
+        state is reached by the app's own repair (`/login` into a provider with
+        no default clears the model deliberately), which is why it must be
+        escapable rather than merely non-red: see :meth:`_cmd_model` and
+        :meth:`_persist_default_from_picker`, which rebuild the session from
+        setup instead of refusing with "session is still starting...".
+
         ``hosting_source`` keeps that honesty one step further. `/login` writes
         the CONFIG FILE, but precedence is agent > flag > config, so when the
         bad value came from `--hosting` or an agent record a login cannot fix
@@ -3328,6 +3363,12 @@ class OperatorApp(App[None]):
         so those cases name the real source instead.
         """
         self._setup_state = True
+        # Remembered for the SAME reason `_invalid_hosting` is: the escape from
+        # this variant is `/model`, which writes config and must then rebuild
+        # the session that does not exist yet. Without it a user who picked a
+        # model would have their choice saved and still be looking at a setup
+        # splash, which is the "repaired but still stuck" shape of B1 again.
+        self._model_missing_for = model_missing_for
         # The bad value is remembered so the post-login rebuild can OVERWRITE it.
         # Without this the recovery is a loop: `_apply_login_defaults` only
         # adopts a provider when hosting is empty, and here it is not empty --
@@ -3360,7 +3401,22 @@ class OperatorApp(App[None]):
         # ~30 of the scarcest columns saying the same thing twice, and the
         # concrete command teaches the shape by itself. `/provider` is kept
         # because it is the discovery affordance for "which providers exist".
-        if unknown_hosting and hosting_source != "config":
+        if model_missing_for:
+            # `/model` and NOT `/login`: hosting is already a provider the
+            # registry owns, so a login writes nothing (the planner's
+            # "already set and usable" branch) and the user would loop. The
+            # provider is named because it is correct -- the user needs to know
+            # which provider they are choosing a model for, not to doubt it.
+            #
+            # Budget: the splash paints this row at `terminal width - 6` cells
+            # (measured, see the test guard), so this stays inside 74 to render
+            # whole on an 80-column terminal.
+            self._announce_on_splash(
+                f"/model to pick one — '{model_missing_for}' has no default model.",
+                "warning",
+                headline=f"No model set for '{model_missing_for}'",
+            )
+        elif unknown_hosting and hosting_source != "config":
             # `/login` writes config, and config is NOT what produced this
             # value, so recommending it here would be a lie that loops. Name
             # the real source and keep the line inside 80 columns.
@@ -10870,6 +10926,21 @@ class OperatorApp(App[None]):
                 "warning",
             )
             return
+        if session is None and self._setup_state and self._model_missing_for and target:
+            # THE ESCAPE from the no-default-model setup state. Without this the
+            # state is a trap: hosting is already registry-valid, so `/login`
+            # writes nothing, and this method's "session is still starting..."
+            # refusal below is exactly the message the user is stuck behind.
+            # Landing in a non-red setup state would then be a cosmetic fix --
+            # the same dead end wearing a different colour.
+            #
+            # A switch is meaningless with no session to switch, so this is
+            # unconditionally the PERSIST-and-boot path: write the pair to
+            # config, then rebuild. `persist_default` is not required, because a
+            # user who names a model at a prompt that has no session is asking
+            # to start one.
+            self._recover_from_missing_model(target, notice)
+            return
         if session is None or not hasattr(session, "set_model"):
             # A rejected command changed nothing, so the conversation has not
             # started: `_system_notice` keeps the boot composition intact where
@@ -11124,12 +11195,99 @@ class OperatorApp(App[None]):
         except Exception as error:  # noqa: BLE001 — a read-only config dir
             self._system_notice(f"could not save default: {error}", "warning")
             return
+        if self._setup_state and self._model_missing_for:
+            # In the no-model setup state this key is a RECOVERY, not just a
+            # preference: the value it just wrote is the one thing the session
+            # was missing, so "used from the next launch" would be false advice
+            # — there is no current launch to prefer, and telling the user to
+            # restart is the dead end this state exists to avoid.
+            self._system_notice(
+                f"boot default saved to {saved_to}: hosting {row.provider}, "
+                f"model_name {row.model_id}"
+            )
+            self._leave_setup_state_and_boot(self._notice)
+            return
         # Names both halves, the file and the keys, exactly as the command's
         # own receipt does — one vocabulary for one outcome reached two ways.
         self._system_notice(
             f"boot default saved to {saved_to}: hosting {row.provider}, "
             f"model_name {row.model_id} (used from the next launch)"
         )
+
+    def _recover_from_missing_model(self, target: str, notice: NoticeFn) -> None:
+        """Write a model into config from the setup state, then BOOT the session.
+
+        The way out of the "hosting is valid but has no default model" setup
+        state. That state is reachable through the app's own repair — logging in
+        to a provider with no known default (`alibaba-token-plan`) deliberately
+        clears the model — and every other recovery command is a no-op in it:
+        `/login` writes nothing because hosting is already a provider the
+        registry owns, and `/provider` only lists. So this is the ONE path out,
+        and it has to do both halves. Writing config without rebuilding would
+        save the user's choice and leave them looking at the same setup splash
+        until they restarted the app, which is the "repaired but still stuck"
+        defect this exists to close, one step further along.
+
+        The provider is taken from the selector rather than from
+        ``_model_missing_for``: a user who cannot run the configured provider
+        should be able to leave for one they can, and refusing a different
+        provider here would be a second dead end for the sake of tidiness.
+        """
+        provider, sep, model_id = target.partition("/")
+        if not sep or not model_id:
+            self._system_notice(
+                "usage: /model <provider>/<model-id> (e.g. openai/gpt-4o)", "warning"
+            )
+            return
+        provider = provider.lower()
+        # Validated BEFORE the write, for the reason the ordinary switch path
+        # gives: `resolve_model` does not raise on an unknown provider, so a typo
+        # would be persisted and the next boot would return here — the same loop
+        # with an extra step in it.
+        if self._providers is not None and self._providers.provider(provider) is None:
+            self._system_notice(f"unknown provider: {provider} — see /provider", "warning")
+            return
+        try:
+            from local_operator.config import ConfigManager
+            from local_operator.paths import config_dir
+
+            manager = ConfigManager(config_dir())
+            manager.set_config_value("hosting", provider)
+            manager.set_config_value("model_name", model_id)
+            saved_to = _home_relative(str(manager.config_file))
+        except Exception as error:  # noqa: BLE001 — a read-only config dir
+            # Fatal HERE, unlike the ordinary `/model default` path where the
+            # live switch already succeeded: with no session, an unwritten
+            # config means the rebuild below would resolve the same empty model
+            # and drop straight back into this state.
+            self._system_notice(f"could not save the model: {error}", "error")
+            return
+        notice(f"saved hosting {provider}, model_name {model_id} to {saved_to}", "info")
+        self._leave_setup_state_and_boot(notice)
+
+    def _leave_setup_state_and_boot(self, notice: NoticeFn) -> None:
+        """Clear the setup state and build the session its config now allows.
+
+        Shared by the two commands that can supply the missing model — `/model
+        <p>/<id>` and the picker's `d` key — so the escape is one sequence
+        rather than two copies that drift; that class of divergence is what
+        `providers/login_defaults` was extracted to end. `/login` keeps its own
+        tail because it is already inside a worker and awaits the rebuild
+        directly, while these two are synchronous command handlers and must hand
+        the rebuild to one.
+
+        The ordering is load-bearing rather than incidental: ``_on_config_changed``
+        must run before the rebuild, or the launch-time config manager captured
+        by the session factory replays the very values that failed and the app
+        drops straight back into setup having said it was starting.
+        """
+        self._setup_state = False
+        self._model_missing_for = None
+        self._invalid_hosting = None
+        if self._on_config_changed is not None:
+            self._on_config_changed()
+        notice("starting session…", "info")
+        self._run_session_transition(self._reload_session())
 
     def _persist_hint_notice(self) -> str:
         """The line a bare ``/model`` prints above the list.
@@ -14468,6 +14626,14 @@ class OperatorApp(App[None]):
                 # and a LATER `/login` (the user adding a second provider) must
                 # not be read as another repair and overwrite their hosting.
                 self._invalid_hosting = None
+                # Same lifetime, same reason. A login cannot itself supply a
+                # missing model (it writes nothing when hosting is already
+                # valid), so if that is why we were in setup the rebuild below
+                # re-enters it — which is recoverable, not fatal, and the splash
+                # still points at `/model`. What must not survive is a stale
+                # flag telling a LATER `/model` to rebuild a session that is by
+                # then running normally.
+                self._model_missing_for = None
                 # Reconcile the launch-time config manager with what
                 # `_apply_login_defaults` just wrote, or the rebuild resolves the
                 # same empty config and drops back into setup.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.14"
+version = "0.43.15"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.15"
+version = "0.43.16"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/bad_hosting_shot.py
+++ b/scripts/bad_hosting_shot.py
@@ -1,0 +1,98 @@
+"""Capture the TUI frame a user gets when config names an unknown provider.
+
+Drives the REAL ``OperatorApp`` (so ``local_operator.tcss`` is applied — the
+lightweight test hosts declare no ``CSS_PATH`` and would show none of the
+styling) with a session factory that fails exactly the way a corrupted
+``hosting:`` value fails in production: by calling the real
+``resolve_hosting_model`` against a config carrying the bad value, and letting
+whatever it raises escape into the app's boot-failure handler.
+
+Resolving for real rather than raising a hand-written error is the point. A
+synthetic ``ValueError`` would prove only that the handler paints what it is
+given; routing through the resolver is what makes the before/after pair
+evidence about the DEFECT (which error class the boot path produces for a bad
+hosting) instead of evidence about the painter.
+
+The model name is deliberately a REAL one: the operator's corrupted config
+paired ``hosting: anthropicxyq`` with a valid ``model_name``, so leaving it
+empty would trip the unrelated "no default model for this hosting" branch and
+capture the wrong failure.
+
+Usage:
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/bad_hosting_shot.py out.svg [hosting] [WIDTHxHEIGHT]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+
+if TYPE_CHECKING:
+    from local_operator.config import ConfigManager
+from tests.unit.tui.test_app_pilot import FakeProviderController  # noqa: E402
+
+
+class _Config:
+    """Minimal ConfigManager stand-in holding the corrupted hosting value."""
+
+    def __init__(self, hosting: str) -> None:
+        self._values = {"hosting": hosting, "model_name": "claude-sonnet-4-5"}
+
+    def get_config_value(self, key: str, default=None):
+        return self._values.get(key, default)
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    hosting = sys.argv[2] if len(sys.argv) > 2 else "anthropicxyq"
+    size = sys.argv[3] if len(sys.argv) > 3 else "100x30"
+    width, height = (int(part) for part in size.split("x"))
+
+    async def _factory():
+        from local_operator.model.configure import configure_model
+        from local_operator.session_factory import resolve_hosting_model
+
+        # The production boot chain, in order: the preflight resolver, then the
+        # model configuration that `create_session` reaches next. Before the
+        # fix the resolver passes the garbage through and `configure_model`
+        # raises the bare "Unsupported hosting platform" ValueError; after it,
+        # the resolver classifies it first. Keeping BOTH calls here is what
+        # lets one script capture both frames, and what makes the pair show
+        # WHICH layer answered rather than just which text was painted.
+        # Cast: the resolver only ever calls `get_config_value` on this, and a
+        # real ConfigManager would write a config file the capture does not want.
+        resolved, model = resolve_hosting_model(
+            None,
+            argparse.Namespace(hosting=None, model=None),
+            cast("ConfigManager", _Config(hosting)),
+        )
+        configure_model(hosting=resolved, model_name=model, credential_manager=None)
+        raise AssertionError("boot chain accepted a bad hosting value")
+
+    app = OperatorApp(_factory, provider_controller=FakeProviderController())
+    async with app.run_test(size=(width, height)) as pilot:
+        # Poll until the boot task has actually settled: the band starts at
+        # "connecting…" and a fixed sleep captures that transient rather than
+        # the failure state under test.
+        for _ in range(60):
+            await pilot.pause()
+            await asyncio.sleep(0.05)
+            label = app._status._model_label if app._status is not None else ""
+            if label != "connecting…" or app._setup_state:
+                break
+        await pilot.pause()
+        app.save_screenshot(out)
+        label = app._status._model_label if app._status is not None else "?"
+        print(f"saved={out} setup_state={app._setup_state} band={label!r}")
+        print(f"splash_notice={app._splash_notice!r}")
+
+
+asyncio.run(main())

--- a/tests/unit/providers/test_login_defaults.py
+++ b/tests/unit/providers/test_login_defaults.py
@@ -66,6 +66,95 @@ def test_apply_login_defaults_leaves_existing_hosting_untouched(
     assert reloaded.get_config_value("model_name") == "gpt-4o"
 
 
+@pytest.mark.parametrize(
+    ("provider", "expected_hosting", "expected_model"),
+    [
+        # Login FLAVOURS: authentication routes, not hosting ids. Each has no
+        # default model of its own, which is what made the first version of the
+        # repair leave the dead model in place beside the new hosting.
+        ("xai-oauth", "xai", "grok-3"),
+        ("openai-device", "openai", "gpt-4o"),
+        ("zai-oauth", "zai", "glm-5.3"),
+        # No default model even after alias resolution: the stale model must be
+        # CLEARED, not kept. An empty model_name is a state the resolver handles
+        # and explains; a model from a provider that never existed is not.
+        ("alibaba-token-plan", "alibaba-token-plan", ""),
+        # Ordinary provider with a default: the baseline case.
+        ("deepseek", "deepseek", "deepseek-chat"),
+    ],
+)
+def test_repair_never_leaves_a_model_from_the_replaced_provider(
+    provider: str, expected_hosting: str, expected_model: str
+) -> None:
+    """A repair must not produce a config that boots and then fails at stream time.
+
+    The regression this pins: writing the raw login-flavour id as hosting left
+    `model_name` untouched when that flavour had no default model, yielding e.g.
+    `hosting='xai-oauth' model_name='claude-sonnet-4-5'`. `configure_model`
+    ACCEPTS that pair, so boot succeeded and the failure moved to stream time as
+    a provider-side unknown-model error -- trading a boot failure the app
+    explains for a runtime failure it cannot.
+    """
+    from local_operator.providers.login_defaults import plan_login_defaults
+
+    plan = plan_login_defaults(provider, "anthropicxyq", "claude-sonnet-4-5")
+
+    assert plan.repairing is True
+    assert plan.hosting == expected_hosting
+    # Never None while repairing: the stale model is always overwritten, and ""
+    # (clear it) is a deliberate value rather than "leave it alone".
+    assert plan.model_name == expected_model
+    assert plan.model_name != "claude-sonnet-4-5"
+
+
+def test_plan_is_the_single_source_of_truth_for_both_login_front_ends() -> None:
+    """Both `/login` and `local-operator login` must plan identically.
+
+    The two copies of this rule had drifted on every axis that mattered (which
+    hosting id, which brokenness test, which model), which is the class of bug
+    the shared planner exists to make impossible. Asserting the front ends call
+    the planner rather than re-deriving the policy is what keeps them together.
+    """
+    import inspect
+
+    from local_operator.providers import auth_cli
+    from local_operator.tui import app as tui_app
+
+    for source in (
+        inspect.getsource(auth_cli._apply_login_defaults),
+        inspect.getsource(tui_app.OperatorApp._apply_login_defaults),
+    ):
+        assert "plan_login_defaults" in source
+        # The policy must not be re-implemented beside the call.
+        assert "default_model_for" not in source
+        assert "credential_provider_id" not in source
+
+
+def test_plan_leaves_a_usable_hosting_alone() -> None:
+    """Logging into a second provider must not repoint an existing default."""
+    from local_operator.providers.login_defaults import plan_login_defaults
+
+    plan = plan_login_defaults("deepseek", "openai", "gpt-4o")
+    assert plan.hosting is None
+    assert plan.model_name is None
+    assert plan.receipt is None
+
+
+def test_plan_treats_a_legacy_alias_as_usable() -> None:
+    """`noop` is not a registry id -- it maps to `test`, and must not be
+    mistaken for a corrupted value and silently replaced."""
+    from local_operator.providers.login_defaults import (
+        is_unusable_hosting,
+        plan_login_defaults,
+    )
+
+    assert is_unusable_hosting("noop") is False
+    assert is_unusable_hosting("anthropicxyq") is True
+    # Empty hosting is the separate nothing-configured case, not "unusable".
+    assert is_unusable_hosting("") is False
+    assert plan_login_defaults("deepseek", "noop", "m").hosting is None
+
+
 def test_apply_login_defaults_repairs_an_unknown_hosting(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/providers/test_login_defaults.py
+++ b/tests/unit/providers/test_login_defaults.py
@@ -66,6 +66,53 @@ def test_apply_login_defaults_leaves_existing_hosting_untouched(
     assert reloaded.get_config_value("model_name") == "gpt-4o"
 
 
+def test_apply_login_defaults_repairs_an_unknown_hosting(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`login` REPLACES a hosting the registry does not own.
+
+    The unknown-hosting error recommends this exact command, so the "already
+    set, leave it alone" rule had to gain an exception: without it the login
+    stored a credential, wrote nothing, and the next run failed to boot on the
+    same corrupted value — the remedy looping back to the problem it fixes.
+    The stale model goes with it: it belonged to the provider being replaced.
+    """
+    from local_operator.paths import CONFIG_DIR_ENV
+    from local_operator.providers import auth_cli
+
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path))
+    manager = ConfigManager(tmp_path)
+    manager.set_config_value("hosting", "anthropicxyq")
+    manager.set_config_value("model_name", "claude-sonnet-4-5")
+
+    auth_cli._apply_login_defaults("deepseek")
+
+    reloaded = ConfigManager(tmp_path)
+    assert reloaded.get_config_value("hosting") == "deepseek"
+    assert reloaded.get_config_value("model_name") == "deepseek-chat"
+
+
+def test_apply_login_defaults_leaves_a_legacy_alias_hosting_untouched(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A legacy ALIAS is a valid hosting and must not be treated as corrupt.
+
+    `noop` is not a registry id — it maps to `test`. The repair check asks the
+    registry (which resolves aliases) rather than testing membership against
+    ids, so a working alias config is not silently repointed by a later login.
+    """
+    from local_operator.paths import CONFIG_DIR_ENV
+    from local_operator.providers import auth_cli
+
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path))
+    manager = ConfigManager(tmp_path)
+    manager.set_config_value("hosting", "noop")
+
+    auth_cli._apply_login_defaults("deepseek")
+
+    assert ConfigManager(tmp_path).get_config_value("hosting") == "noop"
+
+
 def test_resolve_hosting_model_falls_back_to_default_model(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/providers/test_login_defaults.py
+++ b/tests/unit/providers/test_login_defaults.py
@@ -76,8 +76,9 @@ def test_apply_login_defaults_leaves_existing_hosting_untouched(
         ("openai-device", "openai", "gpt-4o"),
         ("zai-oauth", "zai", "glm-5.3"),
         # No default model even after alias resolution: the stale model must be
-        # CLEARED, not kept. An empty model_name is a state the resolver handles
-        # and explains; a model from a provider that never existed is not.
+        # CLEARED, not kept. An empty model_name is a recoverable setup state
+        # (ModelNotConfiguredError), not a fully-configured boot; a model from
+        # a provider that never existed is worse (boots, then fails at stream).
         ("alibaba-token-plan", "alibaba-token-plan", ""),
         # Ordinary provider with a default: the baseline case.
         ("deepseek", "deepseek", "deepseek-chat"),
@@ -128,6 +129,23 @@ def test_plan_is_the_single_source_of_truth_for_both_login_front_ends() -> None:
         # The policy must not be re-implemented beside the call.
         assert "default_model_for" not in source
         assert "credential_provider_id" not in source
+
+
+def test_plan_refuses_to_write_an_unknown_provider_id() -> None:
+    """A bogus provider_id must not become a hosting the registry does not own.
+
+    `credential_provider_id` passes unknown ids through, so without a registry
+    check this planner -- whose purpose is "never write a hosting the engine
+    cannot boot" -- would write exactly that. Both current callers reach here
+    only after a successful login, so this is not reachable today; the no-op
+    is the honest answer when there is nothing legitimate to write (M1).
+    """
+    from local_operator.providers.login_defaults import plan_login_defaults
+
+    plan = plan_login_defaults("not-a-provider", "anthropicxyq", "stale")
+    assert plan.hosting is None
+    assert plan.model_name is None
+    assert plan.receipt is None
 
 
 def test_plan_leaves_a_usable_hosting_alone() -> None:

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -1008,6 +1008,94 @@ def test_main_preflight_missing_hosting_tty_enters_setup(
     assert seen.get("on_config_changed") is not None
 
 
+def _bad_hosting_config_manager(*args, **kwargs) -> MagicMock:
+    """ConfigManager stand-in whose hosting names no real provider.
+
+    Mirrors the corrupted `config.yml` that motivated the fix: a typo'd hosting
+    beside a perfectly valid model name, which is why the failure surfaced as
+    "Unsupported hosting platform" rather than as a missing-model error.
+    """
+    values = {"hosting": "anthropicxyq", "model_name": "claude-sonnet-4-5"}
+    return MagicMock(get_config_value=lambda key, *a: values.get(key, False))
+
+
+def test_main_preflight_unknown_hosting_tty_enters_setup(
+    tmp_home: Path, quiet_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """tty + a hosting the registry does not own -> the app OPENS (setup state).
+
+    The hotfix: this configuration used to fail preflight/boot outright, so the
+    user got a red "session failed to start" and, with no session, could not
+    use `/login` or `/model` to escape it either. It is now classified exactly
+    like the nothing-configured case, which is the state the in-app remedies
+    work from.
+    """
+    seen: dict[str, Any] = {}
+
+    async def fake_create_session(*args, **kwargs):
+        seen["factory_called"] = True
+        return object()
+
+    monkeypatch.setattr("local_operator.cli.create_session", fake_create_session)
+
+    fake_tui = types.ModuleType("local_operator.tui")
+
+    async def fake_run_tui(
+        session_factory,
+        theme_name: str = "dark",
+        provider_controller=None,
+        resume_factory=None,
+        on_config_changed=None,
+    ) -> int:
+        seen["launched"] = True
+        return 0
+
+    setattr(fake_tui, "run_tui", fake_run_tui)
+    monkeypatch.setitem(sys.modules, "local_operator.tui", fake_tui)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    monkeypatch.setattr("local_operator.cli.ConfigManager", _bad_hosting_config_manager)
+    monkeypatch.setattr("local_operator.cli.CredentialManager", MagicMock())
+    monkeypatch.setattr("local_operator.agents.AgentRegistry", MagicMock())
+
+    with patch("sys.argv", ["program"]):
+        assert main() == 0
+    assert seen.get("launched") is True
+
+
+def test_main_preflight_unknown_hosting_non_tty_fails_fast_naming_the_value(
+    tmp_home: Path, quiet_env: None, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """Non-tty keeps fail-fast, with a message naming the value AND the remedy.
+
+    A scripted/CI run must not limp along with no usable model. It must also
+    not be told "nothing is configured" (the first-run quickstart), because
+    something IS configured -- just not to a real provider, and the user needs
+    to know WHICH word in their config is wrong.
+    """
+    called: dict[str, bool] = {"factory": False}
+
+    async def fake_create_session(*args, **kwargs):
+        called["factory"] = True
+        return MagicMock()
+
+    monkeypatch.setattr("local_operator.cli.create_session", fake_create_session)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
+    monkeypatch.setattr("local_operator.cli.ConfigManager", _bad_hosting_config_manager)
+    monkeypatch.setattr("local_operator.cli.CredentialManager", MagicMock())
+    monkeypatch.setattr("local_operator.agents.AgentRegistry", MagicMock())
+
+    with patch("sys.argv", ["program"]):
+        assert main() == 1
+    err = capsys.readouterr().err
+    assert "anthropicxyq" in err
+    assert "not a known provider" in err
+    # The remedy, not just the diagnosis.
+    assert "config edit hosting" in err or "login <provider>" in err
+    # NOT the first-run quickstart: it would contradict the user's own file.
+    assert "not configured yet" not in err
+    assert called["factory"] is False
+
+
 def test_main_interactive_missing_api_key_warns_and_starts(
     tmp_home: Path,
     quiet_env: None,

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -253,6 +253,54 @@ def test_resolve_unknown_hosting_is_distinguishable_from_unconfigured() -> None:
 
 
 @pytest.mark.parametrize(
+    ("source", "agent_hosting", "flag_hosting", "config_hosting", "expected_remedy"),
+    [
+        ("config", None, None, "anthropicxyq", "config edit hosting"),
+        ("flag", None, "anthropicxyq", "anthropic", "--hosting openai"),
+        ("agent", "anthropicxyq", None, "anthropic", "agent's hosting"),
+    ],
+)
+def test_unknown_hosting_names_the_source_it_actually_came_from(
+    source: str,
+    agent_hosting: str | None,
+    flag_hosting: str | None,
+    config_hosting: str,
+    expected_remedy: str,
+) -> None:
+    """The remedy must match where the value came from.
+
+    Precedence is agent > flag > config, but the in-app repair (`/login`) only
+    writes the CONFIG FILE. Telling a user whose bad value came from `--hosting`
+    or an agent record to run `/login` sends them round a loop that cannot
+    terminate: the login writes config, the next boot resolves the agent/flag
+    value again, and the app returns to setup having claimed it was fixed.
+    """
+    from local_operator.session_factory import HostingUnknownError
+
+    # Cast: the resolver only reads `.hosting`/`.model` off the agent, and a
+    # real AgentData needs a registry to construct.
+    agent = (
+        cast("AgentData", SimpleNamespace(hosting=agent_hosting, model="m"))
+        if agent_hosting
+        else None
+    )
+    config = cast(
+        "ConfigManager",
+        FakeConfigManager({"hosting": config_hosting, "model_name": "m"}),
+    )
+    with pytest.raises(HostingUnknownError) as caught:
+        resolve_hosting_model(agent, _args(hosting=flag_hosting), config)
+
+    error = caught.value
+    assert error.source == source
+    assert error.hosting == "anthropicxyq"
+    assert expected_remedy in str(error)
+    if source != "config":
+        # Must NOT recommend the config-only remedy for a value config cannot fix.
+        assert "local-operator login" not in str(error)
+
+
+@pytest.mark.parametrize(
     ("hosting", "model"),
     [
         ("anthropic", "claude-sonnet-4-5"),

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -189,10 +189,21 @@ def test_resolve_known_hosting_no_default_still_raises_for_model() -> None:
     ``DEFAULT_MODEL_NAMES``. The case previously used a fictional hosting id,
     which now trips the unknown-provider guard first and would assert the wrong
     error; the provider must be real for this to still be about the MODEL.
+
+    The type is ``ModelNotConfiguredError``, not a bare ``ValueError``: the TUI
+    and CLI preflight classify by ``isinstance`` against the recoverable family,
+    so a plain ValueError here is the dead "session failed to start" state (B1).
     """
+    from local_operator.session_factory import (
+        HostingNotConfiguredError,
+        ModelNotConfiguredError,
+    )
+
     config = cast("ConfigManager", FakeConfigManager({}))
-    with pytest.raises(ValueError, match="no default is known"):
+    with pytest.raises(ModelNotConfiguredError, match="no default is known") as caught:
         resolve_hosting_model(None, _args(hosting="ollama"), config)
+    assert isinstance(caught.value, HostingNotConfiguredError)
+    assert caught.value.hosting == "ollama"
 
 
 def test_resolve_unknown_hosting_is_recoverable_setup_not_a_crash() -> None:

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -181,12 +181,92 @@ def test_resolve_missing_values_raise_legacy_messages() -> None:
     assert resolve_hosting_model(None, _args(hosting="openai"), config) == ("openai", "gpt-4o")
 
 
-def test_resolve_unknown_hosting_no_default_still_raises_for_model() -> None:
+def test_resolve_known_hosting_no_default_still_raises_for_model() -> None:
     """A provider with NO known default still errors on a missing model, now
-    naming current models to choose from (item 3)."""
+    naming current models to choose from (item 3).
+
+    Uses ``ollama`` — a REGISTRY-KNOWN provider that has no entry in
+    ``DEFAULT_MODEL_NAMES``. The case previously used a fictional hosting id,
+    which now trips the unknown-provider guard first and would assert the wrong
+    error; the provider must be real for this to still be about the MODEL.
+    """
     config = cast("ConfigManager", FakeConfigManager({}))
     with pytest.raises(ValueError, match="no default is known"):
-        resolve_hosting_model(None, _args(hosting="some-custom-host"), config)
+        resolve_hosting_model(None, _args(hosting="ollama"), config)
+
+
+def test_resolve_unknown_hosting_is_recoverable_setup_not_a_crash() -> None:
+    """A hosting the registry does not own raises the RECOVERABLE error type.
+
+    This is the regression guard for the hotfix: a corrupted/typo'd
+    ``hosting:`` value used to sail through this resolver and detonate later in
+    ``configure_model`` as a bare ValueError, which the TUI painted as a dead
+    "session failed to start" with no session — so the user could not switch
+    provider from inside the app either. Catching it HERE, as a subclass of the
+    error the setup-state gate already classifies, is what makes it survivable.
+    """
+    from local_operator.session_factory import (
+        HostingNotConfiguredError,
+        HostingUnknownError,
+    )
+
+    config = cast(
+        "ConfigManager",
+        FakeConfigManager({"hosting": "anthropicxyq", "model_name": "claude-sonnet-4-5"}),
+    )
+    with pytest.raises(HostingUnknownError) as caught:
+        resolve_hosting_model(None, _args(), config)
+
+    error = caught.value
+    # Recoverable-setup by TYPE: this is what the CLI preflight and the TUI
+    # boot handler branch on, so the subclassing is load-bearing, not cosmetic.
+    assert isinstance(error, HostingNotConfiguredError)
+    # ValueError ancestry preserved for legacy ``except ValueError`` callers.
+    assert isinstance(error, ValueError)
+    # The offending value is carried structurally so a UI can phrase its own
+    # message without scraping it back out of the sentence.
+    assert error.hosting == "anthropicxyq"
+    # The message names the problem AND the remedy — the old one named neither
+    # a remedy nor a valid provider.
+    text = str(error)
+    assert "anthropicxyq" in text
+    assert "not a known provider" in text
+    assert "login" in text
+
+
+def test_resolve_unknown_hosting_is_distinguishable_from_unconfigured() -> None:
+    """The two setup conditions stay separable, so the messages can differ.
+
+    Telling a user whose config says ``anthropicxyq`` that "nothing is
+    configured" contradicts the file in front of them; the shared base class
+    must not collapse that distinction.
+    """
+    from local_operator.session_factory import (
+        HostingNotConfiguredError,
+        HostingUnknownError,
+    )
+
+    empty = cast("ConfigManager", FakeConfigManager({}))
+    with pytest.raises(HostingNotConfiguredError) as caught:
+        resolve_hosting_model(None, _args(), empty)
+    assert not isinstance(caught.value, HostingUnknownError)
+
+
+@pytest.mark.parametrize(
+    ("hosting", "model"),
+    [
+        ("anthropic", "claude-sonnet-4-5"),
+        ("openai", "gpt-4o"),
+        # Legacy alias: `noop` is not a registry id, it MAPS to `test`. The
+        # validation goes through get_provider_definition precisely so an alias
+        # the engine still accepts is not newly rejected as a bad provider.
+        ("noop", "mock-model"),
+    ],
+)
+def test_resolve_valid_hosting_and_aliases_unaffected(hosting: str, model: str) -> None:
+    """The new guard must not narrow what the engine already accepts."""
+    config = cast("ConfigManager", FakeConfigManager({"hosting": hosting, "model_name": model}))
+    assert resolve_hosting_model(None, _args(), config) == (hosting, model)
 
 
 # --- Compaction coercion (CL-01) --------------------------------------------------

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -692,6 +692,26 @@ async def test_boot_typing_sends_prompt() -> None:
         assert len(transcript.blocks()) == 1
 
 
+async def _await_setup_state(app: Any, pilot: Any) -> None:
+    """Pause until the boot task has actually reached the setup state.
+
+    A fixed number of pauses plus a sleep is not enough: boot runs as a worker
+    task, and under a loaded runner (xdist, or simply a filtered selection that
+    packs these cases together) it routinely needs longer than the budget. That
+    made the assertion a race that passed when the test ran alone and failed
+    when it ran beside others -- observed on origin/main before this change,
+    not introduced by it. Polling for the state the test is about removes the
+    timing from the assertion while still failing (on timeout) if the state is
+    never reached.
+    """
+    for _ in range(100):
+        await pilot.pause()
+        if app._setup_state:
+            return
+        await asyncio.sleep(0.05)
+    await pilot.pause()
+
+
 @pytest.mark.asyncio
 async def test_first_run_setup_state_when_hosting_unconfigured() -> None:
     """A boot that fails with HostingNotConfiguredError enters the guided setup
@@ -703,11 +723,7 @@ async def test_first_run_setup_state_when_hosting_unconfigured() -> None:
 
     app = OperatorApp(_no_hosting_factory, provider_controller=FakeProviderController())
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
-        for _ in range(6):
-            await pilot.pause()
-        await asyncio.sleep(0.2)
-        await pilot.pause()
+        await _await_setup_state(app, pilot)
         # The setup flag is set and the band says "setup", not a model or error.
         assert app._setup_state is True
         assert app._status is not None
@@ -718,6 +734,120 @@ async def test_first_run_setup_state_when_hosting_unconfigured() -> None:
         assert "no provider configured" in app._splash_notice
         # The splash was NOT retired: it is still the empty-state block.
         assert app._welcome_visible is True
+
+
+@pytest.mark.asyncio
+async def test_setup_state_when_hosting_names_an_unknown_provider() -> None:
+    """A corrupted `hosting:` value lands in the SAME recoverable setup state.
+
+    The hotfix regression guard. A typo'd provider used to reach the TUI as a
+    bare ValueError out of `configure_model`, which painted a red "session
+    failed to start: Unsupported hosting platform: anthropicxyq" and left
+    `_session` None -- so `/model`, `/provider` and the rest all answered
+    "session is still starting..." and the user could not switch away from the
+    bad value without hand-editing YAML outside the app.
+    """
+    from local_operator.session_factory import HostingUnknownError
+
+    async def _bad_hosting_factory():
+        raise HostingUnknownError(
+            "Hosting 'anthropicxyq' ... not a known provider.", "anthropicxyq"
+        )
+
+    app = OperatorApp(_bad_hosting_factory, provider_controller=FakeProviderController())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _await_setup_state(app, pilot)
+        # Setup state, not a dead session: the band must not say "session error".
+        assert app._setup_state is True
+        assert app._status is not None
+        assert app._status._model_label == "setup"
+        # The bad value is remembered so the post-login rebuild can overwrite it.
+        assert app._invalid_hosting == "anthropicxyq"
+        assert app._splash_notice is not None
+        notice = app._splash_notice
+        # Action-first: the splash truncates from the right on a narrow
+        # terminal, so the remedy must precede the diagnosis or it is what
+        # drops. Asserted by POSITION, not just presence.
+        assert notice.index("/login") < notice.index("anthropicxyq")
+        # It names the offending value and does not read as a crash.
+        assert "anthropicxyq" in notice
+        assert "not a known provider" in notice
+        assert "failed" not in notice.lower()
+        # It must NOT claim nothing is configured -- something is, just wrongly.
+        assert "no provider configured" not in notice
+        assert app._welcome_visible is True
+
+
+@pytest.mark.asyncio
+async def test_login_from_bad_provider_setup_state_repairs_the_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The RECOVERY half: `/login` from the bad-provider setup state must write.
+
+    Landing in setup state is only half a fix. `_apply_login_defaults` adopts a
+    provider ONLY when hosting is empty, and in this state it is not empty --
+    it is wrong -- so without the repair branch the login wrote nothing, the
+    rebuild resolved the same bad value, and the user was told "starting
+    session..." before dropping straight back into setup.
+    """
+    from local_operator.config import ConfigManager
+    from local_operator.paths import CONFIG_DIR_ENV
+    from local_operator.session_factory import HostingUnknownError
+
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path))
+    seed = ConfigManager(tmp_path)
+    seed.set_config_value("hosting", "anthropicxyq")
+    seed.set_config_value("model_name", "claude-sonnet-4-5")
+
+    async def _bad_hosting_factory():
+        raise HostingUnknownError(
+            "Hosting 'anthropicxyq' ... not a known provider.", "anthropicxyq"
+        )
+
+    app = OperatorApp(_bad_hosting_factory, provider_controller=FakeProviderController())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _await_setup_state(app, pilot)
+        assert app._setup_state is True
+
+        # The write half of the `/login` flow, run against the real config.
+        receipt = app._apply_login_defaults("deepseek")
+
+    assert receipt is not None
+    assert "deepseek" in receipt
+    repaired = ConfigManager(tmp_path)
+    assert repaired.get_config_value("hosting") == "deepseek"
+    # The model belonged to the provider that was replaced, so it is replaced
+    # too -- otherwise a real provider is pointed at a model that never existed.
+    assert repaired.get_config_value("model_name") == "deepseek-chat"
+
+
+@pytest.mark.asyncio
+async def test_login_outside_setup_state_still_leaves_hosting_alone(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The repair must not leak into the ordinary add-a-second-provider login.
+
+    `_invalid_hosting` is None outside the bad-provider setup state, so a user
+    logging into another provider keeps the default they chose.
+    """
+    from local_operator.config import ConfigManager
+    from local_operator.paths import CONFIG_DIR_ENV
+
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path))
+    seed = ConfigManager(tmp_path)
+    seed.set_config_value("hosting", "openai")
+    seed.set_config_value("model_name", "gpt-4o")
+
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session), provider_controller=FakeProviderController())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        assert app._invalid_hosting is None
+        assert app._apply_login_defaults("deepseek") is None
+
+    unchanged = ConfigManager(tmp_path)
+    assert unchanged.get_config_value("hosting") == "openai"
+    assert unchanged.get_config_value("model_name") == "gpt-4o"
 
 
 def test_splash_toast_headline_names_the_fallback_target() -> None:

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -769,6 +769,15 @@ async def test_setup_state_when_hosting_names_an_unknown_provider() -> None:
         # terminal, so the remedy must precede the diagnosis or it is what
         # drops. Asserted by POSITION, not just presence.
         assert notice.index("/login") < notice.index("anthropicxyq")
+        # LENGTH, not just order. The first version of this line ran to 141
+        # characters, so at 80 and 100 columns it was cut mid-clause and at 60
+        # the bad value never rendered at all -- the user was told to fix
+        # "this" without being told what "this" was. The splash paints a "! "
+        # prefix, so the budget is the terminal width minus that.
+        assert len(notice) <= 78, f"notice must survive an 80-col terminal: {len(notice)}"
+        # The value must be inside the part that survives the narrowest
+        # terminal we capture (60 cols), which is the whole point of naming it.
+        assert notice.index("anthropicxyq") + len("anthropicxyq") <= 58
         # It names the offending value and does not read as a crash.
         assert "anthropicxyq" in notice
         assert "not a known provider" in notice
@@ -776,6 +785,33 @@ async def test_setup_state_when_hosting_names_an_unknown_provider() -> None:
         # It must NOT claim nothing is configured -- something is, just wrongly.
         assert "no provider configured" not in notice
         assert app._welcome_visible is True
+
+
+@pytest.mark.asyncio
+async def test_setup_state_does_not_promise_a_login_it_cannot_honour() -> None:
+    """A bad value from --hosting or an agent record must not recommend /login.
+
+    Precedence is agent > flag > config, but `/login` writes the CONFIG FILE.
+    Recommending it for a value that came from argv or an agent record is a
+    loop the user cannot see the shape of: the login succeeds, writes config,
+    the next boot resolves the same flag/agent value, and the app returns to
+    setup having claimed it was fixed.
+    """
+    from local_operator.session_factory import HostingUnknownError
+
+    async def _flag_hosting_factory():
+        raise HostingUnknownError("…not a known provider.", "anthropicxyq", "flag")
+
+    app = OperatorApp(_flag_hosting_factory, provider_controller=FakeProviderController())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _await_setup_state(app, pilot)
+        notice = app._splash_notice
+        assert notice is not None
+        # Names the real source, and does NOT tell the user to run /login.
+        assert "--hosting" in notice
+        assert "anthropicxyq" in notice
+        assert "/login" not in notice
+        assert len(notice) <= 78
 
 
 @pytest.mark.asyncio
@@ -864,6 +900,34 @@ def test_splash_toast_headline_names_the_fallback_target() -> None:
     )
     assert _splash_toast_headline("session failed to start") == "session failed to start"
     assert _splash_toast_headline("") == "Notice"
+
+
+def test_splash_toast_headline_prefers_an_explicit_headline() -> None:
+    """A caller that knows the state names it; no prose sniffing required.
+
+    This is the durable form of the D5 fix. That finding was addressed by
+    matching the literal substring "no provider configured", which silently
+    stopped applying when the sibling unknown-provider message was added: it
+    contains no such phrase, so it fell through to the blind 35-cell cut and
+    reproduced the dangling-fragment defect D5 existed to remove. An explicit
+    headline cannot regress by being reworded.
+    """
+    long_line = "Run /login openai — 'anthropicxyq' is not a known provider (/provider lists them)."
+    # Without a headline the long line is blind-cut mid-parenthetical.
+    assert _splash_toast_headline(long_line).endswith("…")
+    # With one, the toast is a clean glance carrying the bad value — and the
+    # toast is the one element that is never truncated by terminal width.
+    assert (
+        _splash_toast_headline(long_line, "Unknown provider 'anthropicxyq'")
+        == "Unknown provider 'anthropicxyq'"
+    )
+    # The explicit headline wins over the legacy substring probe too, so the
+    # two setup states are headlined by the same mechanism rather than one
+    # each.
+    assert (
+        _splash_toast_headline("… no provider configured …", "No provider configured")
+        == "No provider configured"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -7,6 +7,7 @@ paints first, then awaits the session in a worker.
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import json
 import os
@@ -772,9 +773,22 @@ async def test_setup_state_when_hosting_names_an_unknown_provider() -> None:
         # LENGTH, not just order. The first version of this line ran to 141
         # characters, so at 80 and 100 columns it was cut mid-clause and at 60
         # the bad value never rendered at all -- the user was told to fix
-        # "this" without being told what "this" was. The splash paints a "! "
-        # prefix, so the budget is the terminal width minus that.
-        assert len(notice) <= 78, f"notice must survive an 80-col terminal: {len(notice)}"
+        # "this" without being told what "this" was.
+        #
+        # What this number actually buys (D6): the notice row paints into
+        # `terminal width - 6` cells, not `width - 2`. MEASURED against the real
+        # widget across widths 74..95, not derived from the "! " prefix: a
+        # 77-char notice first renders whole at 83 columns and a 78-char one
+        # needs 84. So 78 is a REGROWTH CEILING (it fails the 141-char
+        # regression it was written for), NOT a promise of 80-column survival --
+        # the budget for that is 74, and the line asserted here is 77, so it is
+        # cut by three cells on an 80-column terminal today. Stated plainly
+        # because the previous comment claimed the opposite, which is how a
+        # future notice written to "the limit" would be silently truncated while
+        # this suite stayed green. New notices should target 74; see
+        # `test_repaired_config_boots_into_an_escapable_state`, which holds its
+        # own line to that.
+        assert len(notice) <= 78, f"notice must not regrow past the 84-col ceiling: {len(notice)}"
         # The value must be inside the part that survives the narrowest
         # terminal we capture (60 cols), which is the whole point of naming it.
         assert notice.index("anthropicxyq") + len("anthropicxyq") <= 58
@@ -811,6 +825,9 @@ async def test_setup_state_does_not_promise_a_login_it_cannot_honour() -> None:
         assert "--hosting" in notice
         assert "anthropicxyq" in notice
         assert "/login" not in notice
+        # Regrowth ceiling, not an 80-column guarantee -- see the measured note
+        # on the sibling assertion above for what this number does and does not
+        # buy (D6).
         assert len(notice) <= 78
 
 
@@ -855,6 +872,222 @@ async def test_login_from_bad_provider_setup_state_repairs_the_config(
     # The model belonged to the provider that was replaced, so it is replaced
     # too -- otherwise a real provider is pointed at a model that never existed.
     assert repaired.get_config_value("model_name") == "deepseek-chat"
+
+
+@pytest.mark.parametrize(
+    "provider, expect_setup",
+    [
+        # The two loginable providers with no default model: `/login` here
+        # writes a registry-VALID hosting with a CLEARED model, which is the
+        # config the repair produces on purpose.
+        ("alibaba-token-plan", True),
+        ("alibaba-token-plan-oauth", True),
+        # Control: an ordinary provider brings its own default, so the repaired
+        # config boots straight through and must NOT land in setup. Without it
+        # this test would pass on a build that sent every login to setup.
+        ("deepseek", False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_repaired_config_boots_into_an_escapable_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    provider: str,
+    expect_setup: bool,
+) -> None:
+    """A repaired config must BOOT, and its setup state must be escapable (B1).
+
+    The coverage gap this closes: every other assertion about the repair stops
+    at the plan or at the config file, and none asserted that the config the
+    repair writes can actually start a session. `alibaba-token-plan` has no
+    default model, so the repair clears the model deliberately — and the
+    resolver used to answer that with a plain `ValueError`, which misses the
+    recoverable-error gate in `_on_boot_failed` and painted the red "session
+    failed to start" with `_session=None` AND `_setup_state=False`. That is the
+    exact terminal state this PR exists to remove, reached by following the
+    PR's own remedy, so the user was stuck HARDER after the repair than before.
+
+    Asserted end to end (repair -> config -> boot -> recovery command) because
+    that is the only sequence in which the defect is visible: each step in
+    isolation looked correct, which is precisely how it shipped.
+
+    The DEFECT is what is pinned, not the mechanism: the assertions are "not the
+    dead state" and "the user can get out", so a different recoverable shape
+    still passes and a regression to a dead end cannot.
+    """
+    from local_operator.config import ConfigManager
+    from local_operator.paths import CONFIG_DIR_ENV
+    from local_operator.providers.login_defaults import plan_login_defaults
+    from local_operator.session_factory import resolve_hosting_model
+
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path))
+    seed = ConfigManager(tmp_path)
+    seed.set_config_value("hosting", "anthropicxyq")
+    seed.set_config_value("model_name", "claude-sonnet-4-5")
+
+    # The repair the app performs on a successful `/login`, through the real
+    # planner rather than a hand-written config: the point is that this exact
+    # pair is what the product writes.
+    plan = plan_login_defaults(
+        provider, seed.get_config_value("hosting"), seed.get_config_value("model_name")
+    )
+    assert plan.hosting is not None
+    seed.set_config_value("hosting", plan.hosting)
+    if plan.model_name is not None:
+        seed.set_config_value("model_name", plan.model_name)
+
+    # The REAL startup resolver decides what the next boot does, so the boot
+    # error under test is the one the resolver actually raises.
+    boot_error: Exception | None = None
+    try:
+        resolve_hosting_model(
+            None, argparse.Namespace(hosting=None, model=None), ConfigManager(tmp_path)
+        )
+    except Exception as exc:  # noqa: BLE001 — the condition under test
+        boot_error = exc
+
+    if not expect_setup:
+        assert boot_error is None, f"control provider must boot: {boot_error}"
+        return
+
+    assert boot_error is not None
+    session = FakeSession()
+
+    async def _factory():
+        # Re-reads config every call, so the rebuild after the recovery sees
+        # what the recovery wrote rather than a value captured at construction.
+        if not ConfigManager(tmp_path).get_config_value("model_name"):
+            raise boot_error
+        return session
+
+    app = OperatorApp(_factory, provider_controller=FakeProviderController())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _await_setup_state(app, pilot)
+
+        # NOT the dead state. Both halves are asserted: `_setup_state` False
+        # with `_session` None is the red branch, and it is the conjunction
+        # that made every recovery command answer "session is still starting…".
+        assert app._setup_state is True
+        assert app._status is not None
+        assert app._status._model_label == "setup"
+        assert app._status._model_label != "session error"
+
+        notice = app._splash_notice
+        assert notice is not None
+        # It names the provider and points at the command that can actually
+        # fix this. `/login` must NOT be promised: hosting is already
+        # registry-valid, so a login writes nothing and the user loops.
+        assert provider.startswith("alibaba")
+        assert "alibaba-token-plan" in notice
+        assert "/model" in notice
+        assert "failed" not in notice.lower()
+        # Budget check, same rule as the sibling splash assertions. The notice
+        # row paints into `terminal width - 6` cells (the splash's gutter and
+        # the "! " glyph), MEASURED against the real widget, so a line of 74
+        # renders whole at 80 columns and one of 78 needs 84. The guard is 74
+        # rather than 78 so a notice written to the old number is caught here
+        # instead of being silently cut on the terminal width most people use.
+        assert len(notice) <= 74, f"notice must survive an 80-col terminal: {len(notice)}"
+
+        # THE SUBSTANCE: the state must be escapable. A setup state you cannot
+        # leave is the same bug wearing a different colour.
+        app._cmd_model("deepseek/deepseek-chat", lambda body, kind="info": None)
+        for _ in range(200):
+            await pilot.pause()
+            if app._session is not None:
+                break
+            await asyncio.sleep(0.02)
+
+        assert app._session is session, "the recovery command must BUILD the session"
+        assert app._setup_state is False
+
+    # The escape persisted the pair, so the next launch does not return here.
+    recovered = ConfigManager(tmp_path)
+    assert recovered.get_config_value("hosting") == "deepseek"
+    assert recovered.get_config_value("model_name") == "deepseek-chat"
+
+
+@pytest.mark.asyncio
+async def test_missing_model_is_recoverable_not_fatal_on_every_surface() -> None:
+    """The no-model error must carry the recoverable ancestry, not bare ValueError.
+
+    The type is the fix: `_on_boot_failed` and the CLI preflight both classify by
+    `isinstance`, so a plain `ValueError` here bypassed the guided setup state no
+    matter how good its message was. Asserted at the type level as well as
+    through the app because that ancestry is load-bearing for two callers, and a
+    later "simplification" back to `ValueError` would silently restore the dead
+    end.
+    """
+    from local_operator.session_factory import (
+        HostingNotConfiguredError,
+        HostingUnknownError,
+        ModelNotConfiguredError,
+        resolve_hosting_model,
+    )
+
+    class _Cfg:
+        def get_config_value(self, key, default=None):
+            return {"hosting": "alibaba-token-plan", "model_name": ""}.get(key, default)
+
+    with pytest.raises(ModelNotConfiguredError) as caught:
+        resolve_hosting_model(
+            None,
+            argparse.Namespace(hosting=None, model=None),
+            cast(Any, _Cfg()),
+        )
+
+    error = caught.value
+    # Recoverable family, so the setup-state gate picks it up …
+    assert isinstance(error, HostingNotConfiguredError)
+    # … but DISTINCT from the unknown-provider case, whose wording would tell
+    # the user to fix the one part of their config that is correct.
+    assert not isinstance(error, HostingUnknownError)
+    # Legacy `except ValueError` callers keep working.
+    assert isinstance(error, ValueError)
+    # The informative text survives: it names concrete model ids, which is what
+    # the non-interactive paths print.
+    assert "alibaba-token-plan" in str(error)
+    assert "gpt-4o" in str(error)
+    assert error.hosting == "alibaba-token-plan"
+
+
+def test_non_interactive_preflight_still_fails_fast_without_a_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Recoverable in the TUI must NOT mean permissive in a script.
+
+    A scripted or CI run has nobody to answer a model picker, so limping along
+    on a model nobody chose is how a cron job silently bills a different
+    provider. `allow_setup_state` is the ONLY thing that separates the two, so
+    both directions are asserted here rather than trusting the flag's name.
+    """
+    from local_operator.cli import _preflight_hosting_model
+    from local_operator.config import ConfigManager
+
+    config = ConfigManager(tmp_path)
+    config.set_config_value("hosting", "alibaba-token-plan")
+    config.set_config_value("model_name", "")
+    args = argparse.Namespace(hosting=None, model=None)
+
+    # Non-interactive: fatal, with the message that names concrete model ids.
+    result = _preflight_hosting_model(
+        config, cast(Any, None), cast(Any, None), None, cast(Any, args)
+    )
+    assert result == 1
+    assert "no default is known" in capsys.readouterr().err
+
+    # Interactive TUI: opens, so the user can reach `/model`.
+    assert (
+        _preflight_hosting_model(
+            config,
+            cast(Any, None),
+            cast(Any, None),
+            None,
+            cast(Any, args),
+            allow_setup_state=True,
+        )
+        is None
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# PR Description

## Summary of Changes

A corrupted or typo'd `hosting:` in `config.yml` killed every new session
permanently, and left the user with no way out from inside the app:

```
× session failed to start: Unsupported hosting platform: anthropicxyq
```

The status band read `session error`, and trying to switch to a working
provider from inside the app answered:

```
! session is still starting…
```

So the session was unusable AND the provider could not be changed — the only
exit was hand-editing YAML outside the app. Hit in the wild from a
`hosting: anthropicxyq` value beside a perfectly valid `model_name`.

### Cause

Two layers, and the second is what turned a bad value into a lockout.

`session_factory.resolve_hosting_model` validated only that hosting was
**non-empty**:

```python
if not hosting:
    raise HostingNotConfiguredError("Hosting platform is not configured.")
```

It never checked that a non-empty hosting is a provider the registry actually
owns, so garbage passed preflight and detonated deeper in boot as a bare
`ValueError` from `configure_model` (`Unsupported hosting platform: …`).

The TUI's `_on_boot_failed` special-cases **only** `HostingNotConfiguredError`
→ `_enter_setup_state()`. A bare `ValueError` therefore took the red
"session failed to start" branch and `_session` stayed `None` — which is why
roughly twenty guarded commands, `/model` and `/provider` among them, replied
"session is still starting…".

**The asymmetry was the bug.** "Nothing configured" was treated as a guided
first-run state; "configured to an unknown provider" was treated as a fatal
crash — even though the user's remedy is identical in both cases (`/login`,
`/provider`, `/model` from inside the app).

### Fix

- **`HostingUnknownError`, a SUBCLASS of `HostingNotConfiguredError`.** The
  existing recoverable-setup handling picks it up with no change and cannot be
  updated for one condition while forgetting the other, while the two stay
  distinguishable by type so the messages can differ. `ValueError` ancestry is
  preserved for legacy `except ValueError` callers.
- **Validate at preflight**, in `resolve_hosting_model` where the
  not-configured case is already caught, through `get_provider_definition` —
  not a membership test against ids — so legacy aliases (`noop` → `test`) keep
  working and the preflight accepts exactly what the engine accepts.
- **TUI** routes it to the existing `_enter_setup_state()` (no parallel
  wizard), with an action-first message naming the bad value and the remedy.
- **The recovery loop is closed.** `_apply_login_defaults` (both the TUI and
  `auth_cli`) adopted a provider only when hosting was *empty* — here it is not
  empty, it is *wrong* — so a `/login` from this state wrote nothing and fell
  straight back into setup. It now replaces a hosting the registry does not
  own, and the stale `model_name` that belonged to it.
- **Non-interactive paths keep fail-fast**, with a message naming the offending
  value and the remedy instead of a raw traceback.

`configure_model`'s own `ValueError` is deliberately untouched: it is a correct
programming-error guard (asserted by `tests/unit/model/test_configure.py`), and
the fix is to stop bad config *reaching* it.

## Testing

**The real reproduction, before and after.** A genuinely corrupted config
written through `ConfigManager` (`hosting: anthropicxyq`,
`model_name: claude-sonnet-4-5`), run against the actual CLI.

Before, on clean `origin/main` — worse than reported, a raw traceback:

```
  File "/private/tmp/lop-baseline/local_operator/model/configure.py", line 1517, in configure_model
    raise ValueError(f"Unsupported hosting platform: {hosting}")
ValueError: Unsupported hosting platform: anthropicxyq
Please review and correct the error to continue.
exit=1
```

After, on this branch — one actionable line, still exit 1 on the non-tty path:

```
Error: Hosting 'anthropicxyq' in your configuration is not a known provider. Set a
supported one with `local-operator config edit hosting <provider>` or
`local-operator login <provider>` (e.g. openai, anthropic, google);
`local-operator provider` lists them all.
exit=1
```

**The recovery actually recovers** (this is the half that was missing — landing
in setup state is worthless if the login writes nothing):

```
before: hosting='anthropicxyq' model='claude-sonnet-4-5'
Replaced unusable hosting 'anthropicxyq' with 'deepseek' and model to 'deepseek-chat'.
after : hosting='deepseek' model='deepseek-chat'
```

and the repaired config then boots to the REPL:

```
Local Operator (headless REPL — Ctrl-C interrupts a turn, Ctrl-D exits)
```

**No regression for valid configs.** A valid provider (`anthropic`) and a
legacy alias (`noop`, which is not a registry id — it maps to `test`) both
still reach the REPL with no hosting error. The alias case is why validation
goes through `get_provider_definition` rather than an id membership test.

### Visual evidence (user-visible TUI text)

Captured from the **real `OperatorApp`** via `run_test` + `save_screenshot`
(the stylesheet-loading host, per AGENTS.md "Visual validation"), driven
through the real boot chain — `resolve_hosting_model` then `configure_model` —
so the frames show which layer answered, not just which text was painted.
Script: `scripts/bad_hosting_shot.py`. Both frames rendered and inspected.

| | |
|---|---|
| **Before** | `~/workspace/lop-provider-recover-shots/before-bad-provider.svg` — red `✗ session failed to start: Unsupported hosting platform: anthropicxyq`, band reads `session error`, no session |
| **After** | `~/workspace/lop-provider-recover-shots/after-bad-provider.svg` — warning-voice splash naming the bad value and the remedy, band reads `setup`, a `/login  set up a provider` row appears |
| **After (60x24)** | `~/workspace/lop-provider-recover-shots/after-bad-provider-narrow.svg` — narrow-terminal truncation check |

The narrow capture is the reason for the word order: at 60 columns the line
truncates to `! Run /login <provider> to fix this (e.g. /login openai…` — the
**remedy survives and only the diagnosis is cut**, which is the action-first
constraint documented at `_enter_setup_state`. Asserted by position in the
test, not merely by substring presence.

### Regression coverage

- `test_resolve_unknown_hosting_is_recoverable_setup_not_a_crash` — the
  recoverable type, the `ValueError` ancestry, the structurally-carried bad
  value, and a message naming problem + remedy.
- `test_resolve_unknown_hosting_is_distinguishable_from_unconfigured` — the
  shared base class must not collapse the two conditions.
- `test_resolve_valid_hosting_and_aliases_unaffected` — parametrised over
  `anthropic`, `openai` and the `noop` alias.
- `test_setup_state_when_hosting_names_an_unknown_provider` — setup state, not
  a dead session; splash names the value; asserts `/login` precedes the
  diagnosis; asserts it does *not* claim nothing is configured.
- `test_login_from_bad_provider_setup_state_repairs_the_config` /
  `test_login_outside_setup_state_still_leaves_hosting_alone` — the repair
  works and does not leak into the ordinary add-a-second-provider login.
- `test_main_preflight_unknown_hosting_tty_enters_setup` /
  `…_non_tty_fails_fast_naming_the_value` — both CLI paths.
- `test_apply_login_defaults_repairs_an_unknown_hosting` /
  `…_leaves_a_legacy_alias_hosting_untouched`.

`test_resolve_unknown_hosting_no_default_still_raises_for_model` was renamed to
`…_known_hosting_…` and switched from a fictional hosting id to `ollama` (a
registry-known provider with no default model): the old fixture now trips the
new guard first, so it would have asserted the wrong error.

### Gates

flake8 clean · black 626 files unchanged · isort clean · pyright **0 errors, 0
warnings, 0 informations**.

Targeted suites (`test_session_factory.py`, `providers/`, `test_cli_new.py`):
**856 passed**. Full TUI suite: **3838 passed, 12 skipped**, 2 failures in
`tests/unit/tui/test_subagent_view.py` — shown below to be pre-existing and
load-dependent, not caused by this change.

> **Suites were run with reduced parallelism (`-n 4` instead of the default
> `-n auto` = 14 workers)** because the machine was under memory pressure from
> several concurrent sessions.

**Deferrals**

- `deferred — pre-existing cross-test ordering flake in tests/unit/tui
  (test_subagent_view.py), not caused by this change and not mine to fix here.`

  Established rather than assumed. The module passes 104/104 in isolation on
  this branch and on clean `origin/main`. Running
  `test_app_pilot.py test_subagent_view.py` together at `-n 4` reproduces
  `test_history_unavailable_and_error_retry_keep_trajectory_fallback`
  (`assert 'history unavailable' in 'read-only'`) **identically on clean
  origin/main** (`1 failed, 348 passed`) and on this branch
  (`1 failed, 351 passed`) — same test, same assertion, base included. It is
  worker-sharding dependent, which is why a full baseline run at `-n 4`
  happened to pass 3837 while the same tree fails under a different split. The
  failing assertions live in files this PR does not touch.
- `deferred — the setup-state pilot tests used a fixed pause budget and raced
  under load; test_first_run_setup_state_when_hosting_unconfigured failed on
  clean origin/main under a filtered selection. Fixed here rather than
  deferred (a shared _await_setup_state poll helper), since the new tests share
  the pattern and would inherit the flake.`
