### PR TITLE
chore(release): bump version to 0.43.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.13"
+version = "0.43.14"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
`main` carries `version = 0.43.13` but that tag was already published for the silent-tool-turn fix (#448), which merged while the compaction ruler fix (#429) was in its review rounds. #429 therefore landed on a version that cannot be tagged.

This bumps to 0.43.14 so the compaction fix ships under its own tag.

Version-only change: no source, no tests, no behaviour.