### PR TITLE
chore(release): bump version to 0.43.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.13"
+version = "0.43.14"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
# PR Description

## Summary of Changes

Bumps `version` in `pyproject.toml` from `0.43.13` to `0.43.14`. One line.

**This exists because `main` currently carries a version that is already
published to PyPI without the code that is on `main`.**

#439 (the Codex CLI MCP import) and #448 (`fix(harness): a silent tool-only turn
must not carry an empty text block`) both cut `0.43.13` while in review. #448
merged first and released it, so:

```
$ git merge-base --is-ancestor aaa5a5a3 v0.43.13
(non-zero) -> NO: v0.43.13 does not contain #439's merge commit

$ curl -s https://pypi.org/pypi/local-operator/json | ...
latest: 0.43.13
0.43.13 published: True
0.43.14 published: False
```

So `v0.43.13` on PyPI is real but has no Codex import in it, while `main`
(`aaa5a5a3`, which does) still says `0.43.13`. Cutting a GitHub Release at the
current `main` would build a wheel claiming a version PyPI already holds, and
the publish job would fail on the duplicate. `0.43.14` is the next free version.

Patch remains the correct bump: the change being released is a fifth MCP import
source, which is not a step-function capability and cannot be named as one in a
release title.

## Impact

- No behaviour change. `pyproject.toml` is the single source of the version —
  everything that reports it (`update.py`, `config.py`, `server/app.py`,
  `tui/widgets/welcome.py`) reads it through `importlib.metadata`, and there are
  no lockfiles, so nothing else needed updating. Verified:

  ```
  $ git grep -n "0\.43\.13"
  pyproject.toml:7:version = "0.43.13"
  ```

  A single tracked reference, which is the one this PR changes.

## Testing Details

### The release this unblocks actually works at this head

A version bump whose whole purpose is to make a release publishable should
demonstrate that the thing being released works. Against the real
`~/.codex/config.toml` at this branch's head (server names and provenance only,
no `env` values):

```
$ PYTHONPATH=/tmp/lop-version-bump .venv/bin/python -c "load_all_mcp_configs(cwd)"
codex-sourced servers at this head: ['gitlab', 'launchdarkly', 'minerva-qa',
                                     'node_repl', 'openaiDeveloperDocs']
total: 12
```

The five Codex servers from #439 are imported on `main` as merged.

### Gates

```
$ .venv/bin/python -m flake8 .
(clean)

$ uvx --from black==26.1.0 black --check .
All done! 625 files would be left unchanged.

$ uvx isort==5.13.2 --check .
(clean)

$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations

$ .venv/bin/python -m pytest tests/unit/mcp -q
284 passed in 18.53s
```

The full unit suite is left to CI, which runs it on 3.12 and 3.13 — a
single-line version change cannot affect it in a way the matrix would miss.

## Checklist

- [x] Collision verified against PyPI and the git tag, not inferred
- [x] Every tracked reference to the version checked, not just `pyproject.toml`
- [x] Gates run over the whole tree
- [x] Confirmed the released change works at this head

Refs #439
