### PR TITLE
perf(compaction): supersede repeated observations of one url or surface

### DIFF
--- a/local_operator/compaction/pruning.py
+++ b/local_operator/compaction/pruning.py
@@ -187,10 +187,17 @@ def _supersede_key(message: Message) -> str | None:
         # navigated elsewhere is a different resource, and a selector-scoped
         # read is not the whole page. Without this a read of the footer would
         # blank an earlier read of the article body on the same tab.
-        scope = url if isinstance(url, str) and url else ""
+        # The parts are LENGTH-PREFIXED rather than joined by a separator.
+        # A bare separator collides on real input: url "https://a#body" with no
+        # selector and url "https://a" with selector "body" are different reads
+        # that would otherwise produce one key, so the newer would blank the
+        # older and lose content the model still needs. No delimiter can appear
+        # inside a length, so this is unambiguous for every input. Absent and
+        # None still share a key, which is correct -- they are the same absence.
+        scope_url = url if isinstance(url, str) else ""
         selector = details.get("selector")
-        if isinstance(selector, str) and selector:
-            scope = f"{scope}#{selector}"
+        scope_selector = selector if isinstance(selector, str) else ""
+        scope = f"{len(scope_url)}:{scope_url}{len(scope_selector)}:{scope_selector}"
         return f"{message.tool_name}:surface:{surface}:{scope}"
     if isinstance(url, str) and url:
         return f"{message.tool_name}:url:{url}:{details.get('range') or 'full'}"

--- a/local_operator/compaction/pruning.py
+++ b/local_operator/compaction/pruning.py
@@ -153,17 +153,20 @@ def _supersede_key(message: Message) -> str | None:
     range of the same file (they share not one line), while a full-file read
     supersedes every earlier range — handled in the pass below.
 
-    ``details['surface']`` is the same idea for tools that OBSERVE rather than
-    read: a screen, a page, a canvas. Each result describes the live state of
-    one surface, so a newer observation of the same surface supersedes every
-    older one completely -- the older text describes a screen that no longer
-    exists, exactly as a stale screenshot does.
+    ``details['supersede_key']`` lets a tool opt a result in explicitly, for
+    resources a path does not name: a URL, a page, a live surface. It is an
+    OPT-IN the emitting tool states, deliberately not inferred from ambient
+    fields like a url or a surface handle. Inference is unsafe here because a
+    single handle covers many DIFFERENT results: the browser tool stamps its
+    ``surface_id`` on every action, so keying on it made a 40-character
+    ``click`` blank the accessibility snapshot and console errors the agent had
+    just gathered to decide what to click. Only the tool knows which of its
+    results are re-reads of one thing and which are distinct observations of
+    it, so only the tool may say so.
 
-    Without this, a screen-driving agent accumulates every observation's text
-    forever. Measured on an OSWorld 2.0 episode: 374 tool results held ~71.5k
-    tokens of superseded observation text at cycle 371, most of it the task
-    instruction repeated verbatim in every single result, and the context had
-    grown to 133k with the compaction trigger still correctly far away.
+    The value must therefore identify the CONTENT, including any variant that
+    changes what comes back (a raw versus rendered fetch of one URL is two
+    different answers, not one superseding the other).
     """
     details = _details_of(message)
     if not message.tool_name:
@@ -171,36 +174,9 @@ def _supersede_key(message: Message) -> str | None:
     path = details.get("path")
     if isinstance(path, str) and path:
         return f"{message.tool_name}:{path}:{details.get('range') or 'full'}"
-    # A URL identifies a re-fetchable resource exactly as a path identifies a
-    # file: ``read <url>`` and ``web_fetch`` of the same address return the
-    # live state of one thing, so the newer answer supersedes the older.
-    url = details.get("url")
-    # A SURFACE is the same idea for tools that OBSERVE rather than fetch: a
-    # browser tab, a screen, a canvas. Each result describes the live state of
-    # that surface, so a newer view supersedes every older one -- the older
-    # text describes a page that no longer exists, exactly as a stale
-    # screenshot does. The browser tool names its handle ``surface_id``;
-    # ``surface`` is the generic spelling for other observers.
-    surface = details.get("surface") or details.get("surface_id")
-    if isinstance(surface, str) and surface:
-        # Scope to what is being observed THROUGH the surface: a tab that has
-        # navigated elsewhere is a different resource, and a selector-scoped
-        # read is not the whole page. Without this a read of the footer would
-        # blank an earlier read of the article body on the same tab.
-        # The parts are LENGTH-PREFIXED rather than joined by a separator.
-        # A bare separator collides on real input: url "https://a#body" with no
-        # selector and url "https://a" with selector "body" are different reads
-        # that would otherwise produce one key, so the newer would blank the
-        # older and lose content the model still needs. No delimiter can appear
-        # inside a length, so this is unambiguous for every input. Absent and
-        # None still share a key, which is correct -- they are the same absence.
-        scope_url = url if isinstance(url, str) else ""
-        selector = details.get("selector")
-        scope_selector = selector if isinstance(selector, str) else ""
-        scope = f"{len(scope_url)}:{scope_url}{len(scope_selector)}:{scope_selector}"
-        return f"{message.tool_name}:surface:{surface}:{scope}"
-    if isinstance(url, str) and url:
-        return f"{message.tool_name}:url:{url}:{details.get('range') or 'full'}"
+    declared = details.get("supersede_key")
+    if isinstance(declared, str) and declared:
+        return f"{message.tool_name}:declared:{declared}"
     return None
 
 

--- a/local_operator/compaction/pruning.py
+++ b/local_operator/compaction/pruning.py
@@ -7,10 +7,10 @@ details. The flags never reach provider wire formats.
 
 Two passes (``pruneSupersededToolResults``):
 
-(a) **Superseded reads** — a later tool result for the same path makes the
-    earlier output dead weight (the model re-read precisely because the old
-    copy was stale). The supersede key is ``details['path']``; results without
-    a path group by tool name.
+(a) **Superseded results** — a later tool result for the same path, or with
+    the same explicitly declared ``details['supersede_key']``, makes the
+    earlier output dead weight. Results with neither key are exempt: grouping
+    pathless results by tool name would collapse legitimately distinct output.
 (b) **Useless-flagged results** — tools self-flag contextually worthless
     output (zero-match search, timed-out wait); blanked once consumed.
 
@@ -55,7 +55,7 @@ __all__ = [
 MIN_PRUNE_TOKENS = 50
 
 #: Exact placeholder written over a superseded tool result.
-SUPERSEDED_NOTICE = "[Superseded by a newer read of this file]"
+SUPERSEDED_NOTICE = "[Superseded by a newer result for the same resource]"
 
 #: Exact placeholder written over an elided useless tool result.
 USELESS_NOTICE = "[Uneventful result elided]"
@@ -173,7 +173,9 @@ def _supersede_key(message: Message) -> str | None:
         return None
     path = details.get("path")
     if isinstance(path, str) and path:
-        return f"{message.tool_name}:{path}:{details.get('range') or 'full'}"
+        # The namespace marker prevents a path crafted like a declared key
+        # from colliding with a tool's explicit opt-in contract.
+        return f"{message.tool_name}:path:{path}:{details.get('range') or 'full'}"
     declared = details.get("supersede_key")
     if isinstance(declared, str) and declared:
         return f"{message.tool_name}:declared:{declared}"

--- a/local_operator/compaction/pruning.py
+++ b/local_operator/compaction/pruning.py
@@ -152,11 +152,48 @@ def _supersede_key(message: Message) -> str | None:
     The range rides in the key: a ranged read must NOT supersede a different
     range of the same file (they share not one line), while a full-file read
     supersedes every earlier range — handled in the pass below.
+
+    ``details['surface']`` is the same idea for tools that OBSERVE rather than
+    read: a screen, a page, a canvas. Each result describes the live state of
+    one surface, so a newer observation of the same surface supersedes every
+    older one completely -- the older text describes a screen that no longer
+    exists, exactly as a stale screenshot does.
+
+    Without this, a screen-driving agent accumulates every observation's text
+    forever. Measured on an OSWorld 2.0 episode: 374 tool results held ~71.5k
+    tokens of superseded observation text at cycle 371, most of it the task
+    instruction repeated verbatim in every single result, and the context had
+    grown to 133k with the compaction trigger still correctly far away.
     """
     details = _details_of(message)
+    if not message.tool_name:
+        return None
     path = details.get("path")
-    if isinstance(path, str) and path and message.tool_name:
+    if isinstance(path, str) and path:
         return f"{message.tool_name}:{path}:{details.get('range') or 'full'}"
+    # A URL identifies a re-fetchable resource exactly as a path identifies a
+    # file: ``read <url>`` and ``web_fetch`` of the same address return the
+    # live state of one thing, so the newer answer supersedes the older.
+    url = details.get("url")
+    # A SURFACE is the same idea for tools that OBSERVE rather than fetch: a
+    # browser tab, a screen, a canvas. Each result describes the live state of
+    # that surface, so a newer view supersedes every older one -- the older
+    # text describes a page that no longer exists, exactly as a stale
+    # screenshot does. The browser tool names its handle ``surface_id``;
+    # ``surface`` is the generic spelling for other observers.
+    surface = details.get("surface") or details.get("surface_id")
+    if isinstance(surface, str) and surface:
+        # Scope to what is being observed THROUGH the surface: a tab that has
+        # navigated elsewhere is a different resource, and a selector-scoped
+        # read is not the whole page. Without this a read of the footer would
+        # blank an earlier read of the article body on the same tab.
+        scope = url if isinstance(url, str) and url else ""
+        selector = details.get("selector")
+        if isinstance(selector, str) and selector:
+            scope = f"{scope}#{selector}"
+        return f"{message.tool_name}:surface:{surface}:{scope}"
+    if isinstance(url, str) and url:
+        return f"{message.tool_name}:url:{url}:{details.get('range') or 'full'}"
     return None
 
 

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -2300,7 +2300,16 @@ async def execute_read(
                 "read",
                 f"Cannot resolve '{target}': the resolver does not handle this URL.",
             )
-        return _text(tool_call_id, "read", content, details={"url": target})
+        # A URL read is a re-read of one resource: a later read of the same
+        # URL describes its newer state, so the older text is dead weight.
+        # Declared explicitly (never inferred) because only this call site
+        # knows the result is the whole resource rather than one view of it.
+        return _text(
+            tool_call_id,
+            "read",
+            content,
+            details={"url": target, "supersede_key": target},
+        )
 
     cwd = _safe_cwd(context)
     path, inside, resolvable = _resolve_workspace_path(target, cwd)

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -2300,16 +2300,13 @@ async def execute_read(
                 "read",
                 f"Cannot resolve '{target}': the resolver does not handle this URL.",
             )
-        # A URL read is a re-read of one resource: a later read of the same
-        # URL describes its newer state, so the older text is dead weight.
-        # Declared explicitly (never inferred) because only this call site
-        # knows the result is the whole resource rather than one view of it.
-        return _text(
-            tool_call_id,
-            "read",
-            content,
-            details={"url": target, "supersede_key": target},
-        )
+        # Deliberately NO supersede_key here. This path serves internal URLs
+        # (skill://, guide://, mcp://), and skill reads are exempt from pruning
+        # anyway -- ``_is_prunable`` protects them because a pruned skill just
+        # gets re-read in a loop. Declaring a key would be inert for those and
+        # would add avoidable risk for the rest, since a resolver result is not
+        # always the same content under the same URL.
+        return _text(tool_call_id, "read", content, details={"url": target})
 
     cwd = _safe_cwd(context)
     path, inside, resolvable = _resolve_workspace_path(target, cwd)

--- a/local_operator/web_fetch/tool.py
+++ b/local_operator/web_fetch/tool.py
@@ -238,6 +238,7 @@ def _cache_hit_result(
     ttl_seconds: int,
     tool_name: str,
     context: ToolContext | None,
+    variant: str | None = None,
 ) -> tuple[str, dict[str, Any]] | None:
     """Rebuild a result from a cache entry, or ``None`` when the hit is unusable.
 
@@ -278,7 +279,12 @@ def _cache_hit_result(
         "ok": http_ok,
         "http_error": not http_ok,
     }
-    preview, details, _handle = _shape_from_content(result_like, content, tool_name, context)
+    # Same declared supersede key as a fresh fetch: a cached re-read describes
+    # the same resource, so it must group with the fresh ones rather than
+    # escaping the supersede pass for having been served from cache.
+    preview, details, _handle = _shape_from_content(
+        result_like, content, tool_name, context, variant=variant
+    )
     return preview, details
 
 
@@ -347,7 +353,9 @@ async def run_fetch(
     if not refresh and settings.cache_ttl_seconds > 0:
         entry = read_cache_entry(normalized, variant)
         if entry is not None:
-            hit = _cache_hit_result(entry, settings.cache_ttl_seconds, tool_name, context)
+            hit = _cache_hit_result(
+                entry, settings.cache_ttl_seconds, tool_name, context, variant=variant
+            )
             if hit is not None:
                 preview, details = hit
                 return preview, details, False

--- a/local_operator/web_fetch/tool.py
+++ b/local_operator/web_fetch/tool.py
@@ -186,6 +186,7 @@ def _shape_from_content(
     content: str,
     tool_name: str,
     context: ToolContext | None,
+    variant: str | None = None,
 ) -> tuple[str, dict[str, Any], str | None]:
     """Build ``(preview_text, details, spill_handle)`` from full ``content``.
 
@@ -209,6 +210,14 @@ def _shape_from_content(
     body, spill_details = spill_truncate(content, tool_name, context)
     preview = f"{header}\n\n{body}" if body else header
     details = dict(result_like)
+    # A re-fetch of the same URL in the same rendition supersedes this result:
+    # both describe the live state of one resource. Scoped by ``cache_variant``
+    # for the same reason the cache is -- a raw fetch and a rendered fetch of
+    # one URL are different answers, and a byte-capped one is not the full
+    # body, so neither may blank the other.
+    url_for_key = result_like.get("final_url") or result_like.get("url")
+    if isinstance(url_for_key, str) and url_for_key and variant:
+        details["supersede_key"] = f"{url_for_key}\x00{variant}"
     details["lines"] = content.count("\n") + 1 if content else 0
     details["preview_chars"] = len(preview)
     if spill_details is not None:
@@ -382,7 +391,9 @@ async def run_fetch(
         "ok": http_ok,
         "http_error": not http_ok,
     }
-    preview, details, handle = _shape_from_content(result_like, result.content, tool_name, context)
+    preview, details, handle = _shape_from_content(
+        result_like, result.content, tool_name, context, variant=variant
+    )
 
     # Record the cache entry pointing at the spill handle (metadata only). Only
     # 2xx responses are cached (M4): a 4xx/5xx cached for the full TTL would

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.7"
+version = "0.44.8"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/compaction/test_pruning.py
+++ b/tests/unit/compaction/test_pruning.py
@@ -6,6 +6,7 @@ from local_operator.compaction.pruning import (
     MIN_PRUNE_TOKENS,
     SUPERSEDED_NOTICE,
     USELESS_NOTICE,
+    _supersede_key,
     compute_suffix_tokens,
     prune_tool_outputs,
 )
@@ -346,3 +347,30 @@ def test_distinct_observations_are_never_superseded() -> None:
         pruned, _changed = prune_tool_outputs(full, now_ms=0, last_activity_ms=0)
         after = _text_len(pruned)
         assert after == before, f"{label}: blanked {before - after} chars of distinct content"
+
+
+def test_the_surface_key_cannot_confuse_a_fragment_with_a_selector() -> None:
+    """Distinct reads must never share a key, or blanking loses real content.
+
+    Joining url and selector with a bare separator collides: a read of
+    ``https://a#body`` with no selector and a read of ``https://a`` scoped to
+    selector ``body`` are different results that would produce one key, and the
+    newer would blank the older. Length-prefixing the parts removes the
+    ambiguity for every input, including empty and missing.
+    """
+    fragment = _observer("c1", "browser", {"surface_id": "s:1", "url": "https://a#body"})
+    scoped = _observer(
+        "c2", "browser", {"surface_id": "s:1", "url": "https://a", "selector": "body"}
+    )
+    assert _supersede_key(fragment) != _supersede_key(scoped)
+
+    # And the pass itself must leave both alive.
+    messages = [Message.user("go"), fragment, scoped]
+    before = _text_len(messages)
+    pruned, _changed = prune_tool_outputs(messages, now_ms=0, last_activity_ms=0)
+    assert _text_len(pruned) == before
+
+    # Absent and None are the same absence, so they SHOULD share a key.
+    assert _supersede_key(
+        _observer("c3", "browser", {"surface_id": "s:1", "url": None, "selector": "body"})
+    ) == _supersede_key(_observer("c4", "browser", {"surface_id": "s:1", "selector": "body"}))

--- a/tests/unit/compaction/test_pruning.py
+++ b/tests/unit/compaction/test_pruning.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 """Cache-aware pruning: superseded reads, useless blanking, and every guard."""
 
 from local_operator.compaction.pruning import (
@@ -8,7 +10,7 @@ from local_operator.compaction.pruning import (
     prune_tool_outputs,
 )
 from local_operator.compaction.tokens import estimate_tokens
-from local_operator.harness.types import Message
+from local_operator.harness.types import Message, TextContent
 
 NOW = 10_000_000
 ACTIVE = NOW  # not idle
@@ -257,3 +259,90 @@ def test_identical_ranged_read_is_superseded_like_identical_full():
     out, changed = prune_tool_outputs(messages, NOW, ACTIVE)
     assert changed is True
     assert first.text == SUPERSEDED_NOTICE
+
+
+def _observer(call_id: str, name: str, details: dict[str, Any], body: str = "x" * 1200) -> Message:
+    return Message(
+        role="tool",
+        tool_call_id=call_id,
+        tool_name=name,
+        content=[TextContent(text=f"{call_id} {body}")],
+        provider_payload={"details": details},
+    )
+
+
+def _text_len(messages: list[Message]) -> int:
+    """Total characters of TEXT content, ignoring non-text blocks."""
+    return sum(
+        len(block.text)
+        for message in messages
+        for block in (message.content if isinstance(message.content, list) else [])
+        if isinstance(block, TextContent)
+    )
+
+
+def _first_text(message: Message) -> str:
+    blocks = message.content if isinstance(message.content, list) else []
+    return next((b.text for b in blocks if isinstance(b, TextContent)), "")
+
+
+def test_re_observing_one_resource_supersedes_the_earlier_view() -> None:
+    """A URL or a browser surface identifies a live resource, like a path.
+
+    Only path-carrying reads superseded before this, so an agent that polled
+    one page -- watching a CI build, re-fetching a status endpoint, re-reading
+    a tab after acting on it -- carried every stale copy for the rest of the
+    session. Each of those results describes a page that no longer exists.
+    """
+    page = {"surface_id": "s:1", "url": "https://ci/build/9", "selector": "body"}
+    messages = [Message.user("watch it")] + [_observer(f"c{i}", "browser", page) for i in range(8)]
+    before = _text_len(messages)
+
+    pruned, changed = prune_tool_outputs(messages, now_ms=0, last_activity_ms=0)
+
+    assert changed
+    after = _text_len(pruned)
+    assert after < before * 0.3, f"only saved {100 * (1 - after / before):.0f}%"
+    # The newest view must survive intact: it is the only one describing reality.
+    assert "x" * 1200 in _first_text(pruned[-1])
+
+    fetches = [Message.user("poll")] + [
+        _observer(f"f{i}", "web_fetch", {"url": "https://api/status"}) for i in range(6)
+    ]
+    pruned_fetches, changed_fetches = prune_tool_outputs(fetches, now_ms=0, last_activity_ms=0)
+    assert changed_fetches
+    assert _text_len(pruned_fetches) < _text_len(fetches[:1]) + 1200 * 2
+
+
+def test_distinct_observations_are_never_superseded() -> None:
+    """The saving must come from redundancy only, never from real content.
+
+    Different pages, a tab that has navigated elsewhere, a differently-scoped
+    read of the same tab, and bare commands are all genuinely distinct results.
+    Blanking any of them would be data loss dressed up as an optimization.
+    """
+    cases = {
+        "different pages": [
+            _observer(f"p{i}", "browser", {"surface_id": "s:1", "url": f"https://s/{i}"})
+            for i in range(8)
+        ],
+        "same tab, navigated": [
+            _observer("n1", "browser", {"surface_id": "s:1", "url": "https://a"}),
+            _observer("n2", "browser", {"surface_id": "s:1", "url": "https://b"}),
+        ],
+        "same page, different selector": [
+            _observer(
+                "s1", "browser", {"surface_id": "s:1", "url": "https://a", "selector": "article"}
+            ),
+            _observer(
+                "s2", "browser", {"surface_id": "s:1", "url": "https://a", "selector": "footer"}
+            ),
+        ],
+        "bare commands": [_observer(f"b{i}", "bash", {}) for i in range(8)],
+    }
+    for label, messages in cases.items():
+        full = [Message.user("go")] + messages
+        before = _text_len(full)
+        pruned, _changed = prune_tool_outputs(full, now_ms=0, last_activity_ms=0)
+        after = _text_len(pruned)
+        assert after == before, f"{label}: blanked {before - after} chars of distinct content"

--- a/tests/unit/compaction/test_pruning.py
+++ b/tests/unit/compaction/test_pruning.py
@@ -1,6 +1,6 @@
-from typing import Any
-
 """Cache-aware pruning: superseded reads, useless blanking, and every guard."""
+
+from typing import Any
 
 from local_operator.compaction.pruning import (
     MIN_PRUNE_TOKENS,
@@ -36,6 +36,7 @@ def test_superseded_read_blanked_with_pairing_intact():
     out, changed = prune_tool_outputs(messages, NOW, ACTIVE)
     assert changed is True
     assert len(out) == 4  # never deleted
+    assert old_read.text == "[Superseded by a newer result for the same resource]"
     assert old_read.text == SUPERSEDED_NOTICE
     assert old_read.provider_payload is not None
     assert old_read.provider_payload["pruned"] is True
@@ -306,6 +307,18 @@ def test_a_declared_key_supersedes_re_reads_of_one_resource() -> None:
     assert _text_len(pruned) < before * 0.35
     # The newest result must survive intact: it alone describes reality.
     assert "x" * 1200 in _first_text(pruned[-1])
+
+
+def test_path_and_declared_key_namespaces_cannot_collide() -> None:
+    """A path that resembles a declaration must remain a different resource."""
+    path = _observer("path", "read", {"path": "declared:/etc/passwd"})
+    declared = _observer("declared", "read", {"supersede_key": "/etc/passwd:full"})
+
+    before = _text_len([path, declared])
+    pruned, changed = prune_tool_outputs([path, declared], now_ms=0, last_activity_ms=0)
+
+    assert changed is False
+    assert _text_len(pruned) == before
 
 
 def test_a_declared_key_never_blanks_a_different_result() -> None:

--- a/tests/unit/compaction/test_pruning.py
+++ b/tests/unit/compaction/test_pruning.py
@@ -6,7 +6,6 @@ from local_operator.compaction.pruning import (
     MIN_PRUNE_TOKENS,
     SUPERSEDED_NOTICE,
     USELESS_NOTICE,
-    _supersede_key,
     compute_suffix_tokens,
     prune_tool_outputs,
 )
@@ -287,90 +286,66 @@ def _first_text(message: Message) -> str:
     return next((b.text for b in blocks if isinstance(b, TextContent)), "")
 
 
-def test_re_observing_one_resource_supersedes_the_earlier_view() -> None:
-    """A URL or a browser surface identifies a live resource, like a path.
+def test_a_declared_key_supersedes_re_reads_of_one_resource() -> None:
+    """A tool may declare that its result is a re-read of one thing.
 
-    Only path-carrying reads superseded before this, so an agent that polled
-    one page -- watching a CI build, re-fetching a status endpoint, re-reading
-    a tab after acting on it -- carried every stale copy for the rest of the
-    session. Each of those results describes a page that no longer exists.
+    ``details['supersede_key']`` names the CONTENT, so a later result carrying
+    the same key describes the same resource in a newer state and the older one
+    is dead weight. Polling one endpoint is the common case.
     """
-    page = {"surface_id": "s:1", "url": "https://ci/build/9", "selector": "body"}
-    messages = [Message.user("watch it")] + [_observer(f"c{i}", "browser", page) for i in range(8)]
+    key = "https://api/status\x00rendered"
+    messages = [Message.user("poll")] + [
+        _observer(f"c{i}", "web_fetch", {"url": "https://api/status", "supersede_key": key})
+        for i in range(6)
+    ]
     before = _text_len(messages)
 
     pruned, changed = prune_tool_outputs(messages, now_ms=0, last_activity_ms=0)
 
     assert changed
-    after = _text_len(pruned)
-    assert after < before * 0.3, f"only saved {100 * (1 - after / before):.0f}%"
-    # The newest view must survive intact: it is the only one describing reality.
+    assert _text_len(pruned) < before * 0.35
+    # The newest result must survive intact: it alone describes reality.
     assert "x" * 1200 in _first_text(pruned[-1])
 
-    fetches = [Message.user("poll")] + [
-        _observer(f"f{i}", "web_fetch", {"url": "https://api/status"}) for i in range(6)
-    ]
-    pruned_fetches, changed_fetches = prune_tool_outputs(fetches, now_ms=0, last_activity_ms=0)
-    assert changed_fetches
-    assert _text_len(pruned_fetches) < _text_len(fetches[:1]) + 1200 * 2
 
-
-def test_distinct_observations_are_never_superseded() -> None:
+def test_a_declared_key_never_blanks_a_different_result() -> None:
     """The saving must come from redundancy only, never from real content.
 
-    Different pages, a tab that has navigated elsewhere, a differently-scoped
-    read of the same tab, and bare commands are all genuinely distinct results.
-    Blanking any of them would be data loss dressed up as an optimization.
+    This is the axis that makes inference unsafe and the opt-in necessary. A
+    browser stamps ONE surface handle on every action it performs, so a key
+    inferred from that handle collapses an accessibility snapshot, the console
+    log, a scroll and a click into a single group -- and a 40-character click
+    result then blanks the snapshot and the errors the agent gathered to decide
+    what to click. Only results the tool DECLARES to be the same content may be
+    grouped, and a differing declaration must keep them apart.
     """
-    cases = {
-        "different pages": [
-            _observer(f"p{i}", "browser", {"surface_id": "s:1", "url": f"https://s/{i}"})
-            for i in range(8)
-        ],
-        "same tab, navigated": [
-            _observer("n1", "browser", {"surface_id": "s:1", "url": "https://a"}),
-            _observer("n2", "browser", {"surface_id": "s:1", "url": "https://b"}),
-        ],
-        "same page, different selector": [
-            _observer(
-                "s1", "browser", {"surface_id": "s:1", "url": "https://a", "selector": "article"}
-            ),
-            _observer(
-                "s2", "browser", {"surface_id": "s:1", "url": "https://a", "selector": "footer"}
-            ),
-        ],
-        "bare commands": [_observer(f"b{i}", "bash", {}) for i in range(8)],
-    }
-    for label, messages in cases.items():
-        full = [Message.user("go")] + messages
-        before = _text_len(full)
-        pruned, _changed = prune_tool_outputs(full, now_ms=0, last_activity_ms=0)
-        after = _text_len(pruned)
-        assert after == before, f"{label}: blanked {before - after} chars of distinct content"
-
-
-def test_the_surface_key_cannot_confuse_a_fragment_with_a_selector() -> None:
-    """Distinct reads must never share a key, or blanking loses real content.
-
-    Joining url and selector with a bare separator collides: a read of
-    ``https://a#body`` with no selector and a read of ``https://a`` scoped to
-    selector ``body`` are different results that would produce one key, and the
-    newer would blank the older. Length-prefixing the parts removes the
-    ambiguity for every input, including empty and missing.
-    """
-    fragment = _observer("c1", "browser", {"surface_id": "s:1", "url": "https://a#body"})
-    scoped = _observer(
-        "c2", "browser", {"surface_id": "s:1", "url": "https://a", "selector": "body"}
+    surface = {"surface_id": "s:1", "url": "https://app/form", "title": "Form"}
+    flow = [
+        Message.user("fill the form"),
+        _observer("snapshot", "browser", dict(surface)),
+        _observer("console", "browser", dict(surface)),
+        _observer("scrolled", "browser", dict(surface)),
+        _observer("clicked", "browser", dict(surface), body="y" * 40),
+    ]
+    before = _text_len(flow)
+    pruned, _changed = prune_tool_outputs(flow, now_ms=0, last_activity_ms=0)
+    assert _text_len(pruned) == before, (
+        "a browser surface handle is stamped on every action, so it must not "
+        "group them; blanking here loses the snapshot the click depended on"
     )
-    assert _supersede_key(fragment) != _supersede_key(scoped)
 
-    # And the pass itself must leave both alive.
-    messages = [Message.user("go"), fragment, scoped]
-    before = _text_len(messages)
-    pruned, _changed = prune_tool_outputs(messages, now_ms=0, last_activity_ms=0)
-    assert _text_len(pruned) == before
+    # Renditions of one URL are different answers and must not blank each other.
+    raw = _observer("raw", "web_fetch", {"url": "https://a", "supersede_key": "https://a\x00raw"})
+    rendered = _observer(
+        "rendered", "web_fetch", {"url": "https://a", "supersede_key": "https://a\x00rendered"}
+    )
+    mixed = [Message.user("go"), raw, rendered]
+    before_mixed = _text_len(mixed)
+    pruned_mixed, _ = prune_tool_outputs(mixed, now_ms=0, last_activity_ms=0)
+    assert _text_len(pruned_mixed) == before_mixed
 
-    # Absent and None are the same absence, so they SHOULD share a key.
-    assert _supersede_key(
-        _observer("c3", "browser", {"surface_id": "s:1", "url": None, "selector": "body"})
-    ) == _supersede_key(_observer("c4", "browser", {"surface_id": "s:1", "selector": "body"}))
+    # And results with no declaration at all stay exempt, as before.
+    bare = [Message.user("go")] + [_observer(f"b{i}", "bash", {}) for i in range(8)]
+    before_bare = _text_len(bare)
+    pruned_bare, _ = prune_tool_outputs(bare, now_ms=0, last_activity_ms=0)
+    assert _text_len(pruned_bare) == before_bare

--- a/tests/unit/web_fetch/test_tool.py
+++ b/tests/unit/web_fetch/test_tool.py
@@ -98,6 +98,8 @@ async def test_cache_hit_makes_no_network_call(context: ToolContext) -> None:
         "https://example.com/x", tool_name="web_fetch", context=context, transport=transport
     )
     assert d1["cache"] == "miss"
+    fresh_key = "https://example.com/x\x00raw=0|max_bytes=default"
+    assert d1["supersede_key"] == fresh_key
     first_calls = transport.calls
     assert first_calls >= 1
 
@@ -105,6 +107,10 @@ async def test_cache_hit_makes_no_network_call(context: ToolContext) -> None:
         "https://example.com/x", tool_name="web_fetch", context=context, transport=transport
     )
     assert d2["cache"] == "hit"
+    # A hit is still a re-read of the same rendition. Pinning equality here
+    # catches either call site dropping the variant as the result is shaped.
+    assert d2["supersede_key"] == fresh_key
+    assert d2["supersede_key"] == d1["supersede_key"]
     # Zero additional HTTP calls on the cache hit.
     assert transport.calls == first_calls
 
@@ -173,6 +179,7 @@ async def test_raw_and_rendered_do_not_share_cache_entry(context: ToolContext) -
     )
     assert "<html>" in p_raw  # verbatim source
     assert d_raw["render_method"] == "text"
+    assert d_raw["supersede_key"] == "https://example.com/p\x00raw=1|max_bytes=default"
 
     # raw=False for the same URL must NOT hit the raw entry: it renders markdown.
     p_rendered, d_rendered, _e = await run_fetch(
@@ -183,6 +190,8 @@ async def test_raw_and_rendered_do_not_share_cache_entry(context: ToolContext) -
     )
     assert d_rendered["cache"] == "miss"  # different variant → no collision
     assert d_rendered["render_method"] == "markdownify"
+    assert d_rendered["supersede_key"] == "https://example.com/p\x00raw=0|max_bytes=default"
+    assert d_rendered["supersede_key"] != d_raw["supersede_key"]
     assert "# Heading" in p_rendered
     assert "<html>" not in p_rendered
 
@@ -194,6 +203,34 @@ async def test_raw_and_rendered_do_not_share_cache_entry(context: ToolContext) -
         transport=transport,
     )
     assert d3["cache"] == "hit"
+
+
+@pytest.mark.asyncio
+async def test_max_bytes_variants_emit_distinct_supersede_keys(context: ToolContext) -> None:
+    """Byte caps change the returned content, so they name distinct resources."""
+    page = _html_page(100)
+    transport = _CountingTransport(
+        lambda req: httpx.Response(200, text=page, headers={"content-type": "text/html"})
+    )
+
+    _small_preview, small, _small_error = await run_fetch(
+        "https://example.com/capped",
+        tool_name="web_fetch",
+        context=context,
+        transport=transport,
+        max_bytes=2048,
+    )
+    _large_preview, large, _large_error = await run_fetch(
+        "https://example.com/capped",
+        tool_name="web_fetch",
+        context=context,
+        transport=transport,
+        max_bytes=4096,
+    )
+
+    assert small["supersede_key"] == "https://example.com/capped\x00raw=0|max_bytes=2048"
+    assert large["supersede_key"] == "https://example.com/capped\x00raw=0|max_bytes=4096"
+    assert small["supersede_key"] != large["supersede_key"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Add an explicit, tool-declared supersede key for results that are genuine re-reads of one resource, and opt `web_fetch` into it for both fresh and cached responses.

Before this change, compaction could supersede only path-based file reads. Polling one endpoint repeatedly therefore carried every stale copy for the rest of the session.

The key is deliberately **not inferred** from ambient fields such as browser `surface_id`, URL, or selector. The browser stamps one surface handle on snapshots, logs, scrolls, clicks, and other distinct actions; inferring from it caused silent data loss during review and was replaced by the safe opt-in design.

## General harness benefit

This runs in the existing shared `prune_tool_outputs` path used by normal sessions; it is not OSWorld-specific. `web_fetch` is the only current opt-in, and scopes its key by the existing `cache_variant(raw, max_bytes)` discriminator.

Measured through the session's real prune path:

```text
10 polls of one endpoint: 5,013 -> 597 tokens (88% saved)
newest result intact: True
```

Mixed fresh and cached responses:

```text
1,960 -> 378 tokens (81% saved)
```

Raw/rendered and different `max_bytes` variants emit different keys and never blank each other.

## Safety evidence

Round 1 reproduced the unsafe inference defect before fixing it:

```text
SNAPSHOT-TREE   -> blanked
CONSOLE-ERRORS  -> blanked
SCROLLED        -> blanked
CLICKED-SUBMIT  -> retained
```

The final design requires `details["supersede_key"]` from the emitting tool. Browser actions carry no declared key, so all four distinct results survive.

Mutation checks prove both sides of the contract:

```text
benefit test vs no declared key : FAILS (good)
safety test vs surface_id guess : FAILS (good)
```

Actual `run_fetch` call-site tests prove:
- fresh fetch emits a key;
- cache hit emits the same key;
- raw/rendered variants differ;
- differing `max_bytes` variants differ.

Path and declared namespaces are separated, and the model-visible notice is resource-generic.

## Verification

Current reviewed head before the release bump:
- focused compaction + web_fetch: 88 passed locally; reviewer focused suite: 38 passed
- non-TUI unit suite: 5,176 passed, 3 skipped locally
- independent reviewer full suite: 9,013 passed, 15 skipped, 1 load-related background-process cancellation flake that passed in isolation
- flake8: clean
- Black 26.1.0: clean
- isort 5.13.2: clean
- pyright: 0 errors

## Review rounds

- Round 1 found one blocker and three majors; all remediated.
- Round 2 confirmed the blocker resolved and found one remaining major in the cache-hit path; fixed and pinned by real call-site tests.
- Round 3 is clean and terminal on the code head: no blocker or major findings remain.

The final version-only head receives a fresh review before merge.
