### PR TITLE
chore(release): bump version to 0.43.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.15"
+version = "0.43.16"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Version-only bump so #449 (the failover-cascade data-loss fix) can ship.

#449 merged carrying `0.43.15`, but `v0.43.15` had already been tagged and released minutes earlier by #445. Main therefore sits at a version whose tag exists, so `gh release create` would fail and the data-loss fix would not reach PyPI.

No code changes — `pyproject.toml` only.