### PR TITLE
test(harness,tui,providers): wait on conditions instead of the clock

### DIFF
--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -51,13 +51,119 @@ from local_operator.tools.registry import create_tools
 MODEL = ModelSpec(provider="test", model_id="m", context_window=100_000)
 
 
-async def wait_for(predicate, timeout: float = 10.0) -> None:
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + timeout
-    while not predicate():
-        if loop.time() > deadline:
-            raise AssertionError("timed out waiting for condition")
+#: Ceiling for the signal-free pump below, counted in LOOP TURNS rather than
+#: in seconds. That unit is the whole point (#122): machine contention
+#: stretches how long a turn takes but not how many turns the awaited work
+#: needs, so a loaded box cannot exhaust this budget the way it exhausted the
+#: 10 s wall-clock deadline this replaced. It is a deadlock guard — reached
+#: only when the awaited thing is never going to happen — not a timing
+#: assumption, and raising it is never the fix for a failure here.
+MAX_PUMP_TURNS = 3000
+
+#: Same role for the signal-driven wait: a wedged test must fail rather than
+#: hang a CI job forever (this suite has no pytest-timeout). Generous because
+#: it can never be the discriminator — the success path blocks on an
+#: ``asyncio.Event`` set by the code under test and never compares elapsed
+#: time — so the only run that reaches it is one where the signal will not
+#: arrive at all.
+DEADLOCK_GUARD_S = 120.0
+
+
+class ChangeSignal:
+    """An edge fed by the code under test's OWN notifications.
+
+    The deterministic synchronisation point #122 asks for. A child's progress
+    is published twice over — ``SubagentComms.notify_detail_persisted`` fires
+    after each durable transcript append, and the parent's event stream
+    carries ``SubagentStartEvent``/``SubagentProgressEvent`` — so a test that
+    needs "the child got somewhere" can block on those publications instead of
+    re-reading the filesystem on a timer and betting the answer arrives before
+    a deadline.
+
+    Both sources are watched because neither alone covers every predicate:
+    the detail registry sees nested children the parent stream never routes,
+    and the parent stream carries the attach moment (``SubagentStartEvent`` is
+    emitted immediately after ``comms.attach``) that makes ``session_dir_of``
+    non-None before any transcript append has happened.
+
+    Level-triggered on purpose: :meth:`settle` clears the flag BEFORE the
+    caller re-tests its predicate, so a notification racing in between the
+    test and the wait is kept rather than lost.
+    """
+
+    def __init__(self) -> None:
+        self._event = asyncio.Event()
+        self._unsubscribes: list[Callable[[], None]] = []
+
+    def _fire(self, *_: Any) -> None:
+        self._event.set()
+
+    def watch_comms(self, comms) -> "ChangeSignal":
+        """Wake on every durable child-transcript append."""
+        self._unsubscribes.append(comms.subscribe_detail_changes(self._fire))
+        return self
+
+    def watch_session(self, session: Session) -> "ChangeSignal":
+        """Wake on every event the parent's stream carries."""
+        self._unsubscribes.append(session.subscribe(self._fire))
+        return self
+
+    def arm(self) -> None:
+        """Drop any pending edge so the next wait blocks on a NEW one."""
+        self._event.clear()
+
+    async def settle(self) -> None:
+        """Block until something publishes."""
+        await self._event.wait()
+        self._event.clear()
+
+    def close(self) -> None:
+        for unsubscribe in self._unsubscribes:
+            unsubscribe()
+        self._unsubscribes.clear()
+
+
+async def _await_signalled(predicate, signal: "ChangeSignal") -> None:
+    """Re-test ``predicate`` once per publication, forever. Bounded by caller."""
+    while True:
+        # Armed BEFORE the test, never after: a publication landing between
+        # the test and the wait is then still on the flag, so the edge that
+        # would satisfy the predicate can never be missed.
+        signal.arm()
+        if predicate():
+            return
+        await signal.settle()
+
+
+async def wait_for(predicate, *, signal: "ChangeSignal | None" = None) -> None:
+    """Block until ``predicate`` holds, on an event rather than on a clock.
+
+    With a ``signal``, each re-test follows a publication from the code under
+    test, so this waits exactly as long as the work takes and no longer: there
+    is no elapsed-time comparison anywhere on the success path. That is the
+    property #122 asks for, and it is why the integration cases below pass one.
+
+    Without one — the in-process cases over ``FakeChild``, where the awaited
+    step is a coroutine this test itself scheduled and there is nothing to
+    subscribe to — it pumps the loop and bounds itself by TURN COUNT. See
+    :data:`MAX_PUMP_TURNS` for why that unit survives contention where seconds
+    did not.
+    """
+    if signal is not None:
+        try:
+            await asyncio.wait_for(_await_signalled(predicate, signal), DEADLOCK_GUARD_S)
+        except asyncio.TimeoutError:
+            raise AssertionError(
+                "the code under test published no change satisfying the condition in "
+                f"{DEADLOCK_GUARD_S:.0f}s — it is wedged, not merely slow"
+            ) from None
+        return
+
+    for _ in range(MAX_PUMP_TURNS):
+        if predicate():
+            return
         await asyncio.sleep(0.01)
+    raise AssertionError(f"condition never held across {MAX_PUMP_TURNS} loop turns")
 
 
 def has_complete_tool_round(session_dir) -> bool:
@@ -1586,39 +1692,50 @@ async def test_a_resumed_child_replays_the_stopped_ones_transcript(tmp_path, mon
     await parent.async_init()
     job_id = parent._launch_subagent(label="docs", prompt="Update the docs.")
     comms = parent.subagent_comms
-    await wait_for(lambda: comms.session_dir_of(job_id) is not None)
-    # Let it finish real work before stopping it, and wait on THAT rather than
-    # on a duration: the child persists each tool round at its loop boundary
-    # (``Session._persist_progress``) roughly 0.29s after launch, so the fixed
-    # 0.3s sleep this replaced was inside one standard deviation of the thing
-    # it was betting against and lost the coin flip about a third of the time.
-    # Resume is only meaningful over a child that got somewhere, so the
-    # condition to wait for is a completed round, with seconds of headroom so
-    # this fails only if the child genuinely never runs a tool.
-    await wait_for(lambda: has_complete_tool_round(comms.session_dir_of(job_id)), timeout=30.0)
-    await comms.cancel(job_id)
-    await wait_for(lambda: status_of(parent, job_id) == "cancelled")
-    await wait_for(lambda: len(Transcript(comms.session_dir_of(job_id)).build_llm_history()) >= 2)
-    before = Transcript(comms.session_dir_of(job_id)).build_llm_history()
-    original = parent.jobs.get(job_id)
-    assert original is not None and original.launch_message_id == before[0].id
+    # Every wait below rides the child's own publications rather than a
+    # deadline (#122): both sources are watched because the parent stream
+    # carries attach and settle while the detail registry carries each durable
+    # transcript append, and this test waits on all three kinds of fact.
+    signal = ChangeSignal().watch_comms(comms).watch_session(parent)
+    try:
+        await wait_for(lambda: comms.session_dir_of(job_id) is not None, signal=signal)
+        # Let it finish real work before stopping it, and wait on THAT rather
+        # than on a duration: the child persists each tool round at its loop
+        # boundary (``Session._persist_progress``) roughly 0.29s after launch,
+        # so the fixed 0.3s sleep this originally replaced was inside one
+        # standard deviation of the thing it was betting against. Resume is
+        # only meaningful over a child that got somewhere, so the condition is
+        # a completed round — and it is now awaited on the append that creates
+        # it, so a loaded machine makes this slower, never red.
+        await wait_for(lambda: has_complete_tool_round(comms.session_dir_of(job_id)), signal=signal)
+        await comms.cancel(job_id)
+        await wait_for(lambda: status_of(parent, job_id) == "cancelled", signal=signal)
+        await wait_for(
+            lambda: len(Transcript(comms.session_dir_of(job_id)).build_llm_history()) >= 2,
+            signal=signal,
+        )
+        before = Transcript(comms.session_dir_of(job_id)).build_llm_history()
+        original = parent.jobs.get(job_id)
+        assert original is not None and original.launch_message_id == before[0].id
 
-    new_id, error = comms.resume(job_id, "You were interrupted. Wrap up.")
+        new_id, error = comms.resume(job_id, "You were interrupted. Wrap up.")
 
-    assert error is None and new_id is not None
-    continuation = parent.jobs.get(new_id)
-    assert continuation is not None and continuation.launch_message_id
-    assert continuation.launch_message_id != original.launch_message_id
-    await wait_for(lambda: status_of(parent, new_id) != "running")
-    assert comms.session_dir_of(new_id) == comms.session_dir_of(job_id)
-    after = Transcript(comms.session_dir_of(new_id)).build_llm_history()
-    assert len(after) > len(before)
-    assert any(message.id == continuation.launch_message_id for message in after)
-    resumed_node = comms.node(new_id)
-    assert resumed_node is not None
-    assert resumed_node.launch_message_id == continuation.launch_message_id
-    assert first_text(after) == first_text(before) == "Update the docs."
-    assert status_of(parent, new_id) == "completed"
+        assert error is None and new_id is not None
+        continuation = parent.jobs.get(new_id)
+        assert continuation is not None and continuation.launch_message_id
+        assert continuation.launch_message_id != original.launch_message_id
+        await wait_for(lambda: status_of(parent, new_id) != "running", signal=signal)
+        assert comms.session_dir_of(new_id) == comms.session_dir_of(job_id)
+        after = Transcript(comms.session_dir_of(new_id)).build_llm_history()
+        assert len(after) > len(before)
+        assert any(message.id == continuation.launch_message_id for message in after)
+        resumed_node = comms.node(new_id)
+        assert resumed_node is not None
+        assert resumed_node.launch_message_id == continuation.launch_message_id
+        assert first_text(after) == first_text(before) == "Update the docs."
+        assert status_of(parent, new_id) == "completed"
+    finally:
+        signal.close()
     await parent.dispose()
 
 
@@ -1633,15 +1750,23 @@ async def test_a_cancelled_child_keeps_the_work_it_had_already_done(tmp_path, mo
     await parent.async_init()
     job_id = parent._launch_subagent(label="docs", prompt="Update the docs.")
     comms = parent.subagent_comms
-    await wait_for(lambda: comms.session_dir_of(job_id) is not None)
-    # Wait for the round itself, not for how long a round usually takes. The
-    # assertions below are entirely about work the child had ALREADY completed
-    # before the cancel, so cancelling early does not fail loudly — it silently
-    # asserts over a transcript holding only the launch prompt.
-    await wait_for(lambda: has_complete_tool_round(comms.session_dir_of(job_id)), timeout=30.0)
+    signal = ChangeSignal().watch_comms(comms).watch_session(parent)
+    try:
+        await wait_for(lambda: comms.session_dir_of(job_id) is not None, signal=signal)
+        # Wait for the round itself, not for how long a round usually takes.
+        # The assertions below are entirely about work the child had ALREADY
+        # completed before the cancel, so cancelling early does not fail
+        # loudly — it silently asserts over a transcript holding only the
+        # launch prompt.
+        await wait_for(lambda: has_complete_tool_round(comms.session_dir_of(job_id)), signal=signal)
 
-    await comms.cancel(job_id)
-    await wait_for(lambda: len(Transcript(comms.session_dir_of(job_id)).build_llm_history()) > 1)
+        await comms.cancel(job_id)
+        await wait_for(
+            lambda: len(Transcript(comms.session_dir_of(job_id)).build_llm_history()) > 1,
+            signal=signal,
+        )
+    finally:
+        signal.close()
 
     history = Transcript(comms.session_dir_of(job_id)).build_llm_history()
     assert any(
@@ -2348,7 +2473,7 @@ async def test_a_question_buffered_past_the_grace_is_answered_once_it_attaches()
     # ``wait_for``'s default. (A 20 s budget would spend 10 s in the grace and
     # time the WAIT out, not the ask.)
     asking = asyncio.create_task(comms.ask("job-1", "stuck?", 4_000))
-    await wait_for(lambda: bool(comms._records["job-1"].pending), timeout=5.0)
+    await wait_for(lambda: bool(comms._records["job-1"].pending))
 
     comms.attach("job-1", child, tmp_dir())  # the window finally closes
     await wait_for(lambda: bool(child.asides))
@@ -2388,7 +2513,7 @@ async def test_a_stale_buffered_question_cannot_answer_the_next_asker():
 
     # 4 s budget -> 2 s attach grace, comfortably inside ``wait_for``.
     asking = asyncio.create_task(comms.ask("job-1", "NEW: are you blocked?", 4_000))
-    await wait_for(lambda: bool(comms._records["job-1"].pending), timeout=5.0)
+    await wait_for(lambda: bool(comms._records["job-1"].pending))
 
     comms.attach("job-1", child, tmp_dir())
     await wait_for(lambda: bool(child.asides))
@@ -2425,7 +2550,7 @@ async def test_a_second_question_is_refused_on_the_buffered_path_too():
 
     first = asyncio.create_task(comms.ask("job-1", "Q-A", 4_000))
     # Past the attach grace (half the budget, so 2 s here), where Q-A buffers.
-    await wait_for(lambda: bool(comms._records["job-1"].pending), timeout=5.0)
+    await wait_for(lambda: bool(comms._records["job-1"].pending))
     held = comms._records["job-1"].ask
 
     second = await comms.ask("job-1", "Q-B", 4_000)

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -61,12 +61,19 @@ MODEL = ModelSpec(provider="test", model_id="m", context_window=100_000)
 MAX_PUMP_TURNS = 3000
 
 #: Same role for the signal-driven wait: a wedged test must fail rather than
-#: hang a CI job forever (this suite has no pytest-timeout). Generous because
-#: it can never be the discriminator — the success path blocks on an
+#: hang a CI job forever (this suite has no pytest-timeout). It can never be
+#: the discriminator for TIMING — the success path blocks on an
 #: ``asyncio.Event`` set by the code under test and never compares elapsed
-#: time — so the only run that reaches it is one where the signal will not
-#: arrive at all.
-DEADLOCK_GUARD_S = 120.0
+#: time — so the only run that reaches it is one where the signal is not
+#: coming at all.
+#:
+#: It is still a COST, though, which is why it is 30 s and not the 120 s this
+#: started at (review round 1, F2): a wedge is paid per affected test, and four
+#: waits here share the bound, so an over-generous guard turns one real
+#: regression in child persistence into minutes of CI. These tests complete in
+#: about a second, so 30 s is still ~30x the observed work — far too wide to
+#: fire on slowness, narrow enough to keep the feedback loop short.
+DEADLOCK_GUARD_S = 30.0
 
 
 class ChangeSignal:

--- a/tests/unit/mobile/test_tui_ask.py
+++ b/tests/unit/mobile/test_tui_ask.py
@@ -134,14 +134,36 @@ class _Control:
 
 
 async def _control_for(app: OperatorApp, pilot) -> _Control:
-    for _ in range(50):
-        if app._mobile_registrant is not None:
+    """Connect to the app's control socket once its record is really published.
+
+    Waits on the DISCOVERY RECORD, not on the registrant object, and the
+    distinction is the whole bug this replaced. ``Registrant.start`` spawns a
+    daemon thread and returns; the record is written by ``_serve`` on that
+    thread. So ``app._mobile_registrant is not None`` means "registration was
+    requested", not "the record is on disk" — and the old helper waited for the
+    first and then immediately asserted the second, which is only true when
+    the thread happens to win the race.
+
+    On an idle machine it always does, which is why this reads as solid: 5/5
+    passes unloaded and 206/206 for the module at ``-n4``. CI runs ``-n auto``
+    (14 workers), and there it fails as ``no discovery record published`` —
+    observed on two unrelated PRs whose diffs touch no mobile code, and once
+    passing and failing on the SAME head. Polling the condition the assertion
+    actually depends on removes the gap entirely.
+
+    The bound is a deadlock guard rather than a timing assumption: it is
+    reached only when nothing ever publishes.
+    """
+    from local_operator.mobile import registry
+    from local_operator.mobile.registry import SessionRecord
+
+    records: list[tuple[SessionRecord, str]] = []
+    for _ in range(200):
+        records = registry.scan()
+        if records:
             break
         await pilot.pause(0.05)
     assert app._mobile_registrant is not None, "mobile registrant never started"
-    from local_operator.mobile import registry
-
-    records = registry.scan()
     assert records, "no discovery record published"
     record, _state = records[0]
     return await _Control.connect(record.control_port, record.control_key)

--- a/tests/unit/mobile/test_tui_ask.py
+++ b/tests/unit/mobile/test_tui_ask.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 
 import pytest
 
@@ -155,17 +156,36 @@ async def _control_for(app: OperatorApp, pilot) -> _Control:
     reached only when nothing ever publishes.
     """
     from local_operator.mobile import registry
-    from local_operator.mobile.registry import SessionRecord
 
-    records: list[tuple[SessionRecord, str]] = []
+    records = []
     for _ in range(200):
         records = registry.scan()
         if records:
             break
         await pilot.pause(0.05)
-    assert app._mobile_registrant is not None, "mobile registrant never started"
-    assert records, "no discovery record published"
-    record, _state = records[0]
+    # Reported against the registrant when there is one, because "started but
+    # never published" and "never started" are different failures and the
+    # second is the more likely one to introduce. Checked only on the failure
+    # path: once a record exists the registrant necessarily started, so
+    # asserting it first would have read as though it were still part of the
+    # wait — the exact misreading that produced the original bug (round 1, F4).
+    if not records:
+        assert app._mobile_registrant is not None, "mobile registrant never started"
+        raise AssertionError("registrant started but published no discovery record")
+    # This process's own record, not merely the first one scanned: ``scan`` is a
+    # global discovery read, so indexing it assumes nothing else has published.
+    # That holds under the suite's per-test config dir today, but matching on
+    # our own pid states the requirement rather than depending on it, and turns
+    # a stray record into a legible failure instead of a connection to someone
+    # else's socket (round 1, F6). Pid rather than control port because the port
+    # is stamped on the registrant's thread when the listener binds, so reading
+    # it here would reintroduce exactly the cross-thread race this helper fixes.
+    mine = os.getpid()
+    record = next((r for r, _state in records if r.pid == mine), None)
+    assert record is not None, (
+        f"no discovery record for this process (pid {mine}); "
+        f"scan saw pids {[r.pid for r, _ in records]}"
+    )
     return await _Control.connect(record.control_port, record.control_key)
 
 

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -1811,20 +1811,30 @@ class TestTransientFailuresAreRetriedOnEveryCallPath:
             return OpenAICompatClient("https://api.test.example/v1", http_client=http)
 
         seen: list[Any] = []
-        with pytest.raises(ProviderError) as excinfo:
-            async for event in stream_with_failover(
-                _request(), FakeAuth({"openai": ["k"]}), {"retry": {"baseDelayMs": 1}}, client_for
-            ):
-                seen.append(event)
-        error = excinfo.value
-        assert error.status == 429
-        assert error.kind == "quota"
-        assert "Rate limit exceeded" in str(error)
-        # The visible delta was forwarded exactly once; nothing was replayed.
-        assert [e for e in seen if isinstance(e, StreamTextDelta)] == [
-            StreamTextDelta(delta="Gate")
-        ]
-        await http.aclose()
+        # Closed in ``finally`` — the shape every other client-owning test in
+        # this file already uses. With the close after the assertions, a
+        # failing assertion left the client open and the reader chasing an
+        # "unclosed client" warning attached to whichever later test happened
+        # to trip the collector, instead of the assertion that actually failed.
+        try:
+            with pytest.raises(ProviderError) as excinfo:
+                async for event in stream_with_failover(
+                    _request(),
+                    FakeAuth({"openai": ["k"]}),
+                    {"retry": {"baseDelayMs": 1}},
+                    client_for,
+                ):
+                    seen.append(event)
+            error = excinfo.value
+            assert error.status == 429
+            assert error.kind == "quota"
+            assert "Rate limit exceeded" in str(error)
+            # The visible delta was forwarded exactly once; nothing was replayed.
+            assert [e for e in seen if isinstance(e, StreamTextDelta)] == [
+                StreamTextDelta(delta="Gate")
+            ]
+        finally:
+            await http.aclose()
 
     async def test_the_one_shot_call_the_session_makes_is_marked_replayable(self) -> None:
         """Wiring, not policy: ``_one_shot_complete`` is the compaction summary

--- a/tests/unit/tui/test_subagent_stats.py
+++ b/tests/unit/tui/test_subagent_stats.py
@@ -87,8 +87,24 @@ async def _booted(app: OperatorApp) -> None:
     no elapsed-time comparison left on this path — a slower machine makes this
     slower, never red. It also cannot hang past the run: ``run_test`` cancels
     outstanding workers on exit.
+
+    The empty selection is checked rather than passed, because Textual's
+    ``wait_for_complete`` is ``gather(*[w.wait() for w in (workers or self)])``
+    and an empty list is FALSY — it would fall through to every worker in the
+    manager, which is a wait that passes by waiting on the wrong thing. That
+    case is live here: a worker is dropped from the manager once it finishes
+    (``_remove_worker``), so a caller that already booted finds nothing to
+    select. It is legitimate, but only when the session is already adopted, so
+    that is asserted instead of assumed (review round 1, F1).
     """
-    await app.workers.wait_for_complete([w for w in app.workers if w.group == "session"])
+    workers = [w for w in app.workers if w.group == "session"]
+    if workers:
+        await app.workers.wait_for_complete(workers)
+        return
+    assert app._session is not None, (
+        "no session worker is pending and no session was adopted — the boot "
+        "worker never ran, so waiting here would have waited on nothing"
+    )
 
 
 async def _priced(app: OperatorApp, pilot: Any, panel: SubagentPanel, job_id: str) -> None:
@@ -101,10 +117,15 @@ async def _priced(app: OperatorApp, pilot: Any, panel: SubagentPanel, job_id: st
     Waiting on that worker is deterministic; the reading it produces is then
     handed back through ``call_from_thread``, so one pause after it lands is
     what lets that callback run on the UI thread and populate the cache.
+
+    Guarded against the empty selection for the reason given in :func:`_booted`:
+    an empty list makes ``wait_for_complete`` wait on EVERY worker instead of
+    none. Here the legitimate empty case is a reading already in the cache, so
+    the wait is simply skipped and the assertion below does the checking.
     """
-    await app.workers.wait_for_complete(
-        [w for w in app.workers if w.group == f"subagent-stats-{job_id}"]
-    )
+    workers = [w for w in app.workers if w.group == f"subagent-stats-{job_id}"]
+    if workers:
+        await app.workers.wait_for_complete(workers)
     await pilot.pause()
     assert panel.stats_for(job_id).cost is not None, (
         "the stats worker finished without pricing the child — the band under test "
@@ -1452,9 +1473,14 @@ async def test_a_swept_child_is_dropped_from_the_stats_cache() -> None:
         # workers and then let those callbacks run, rather than betting 20
         # frames covers them — same substitution as ``_booted``, and the same
         # reason: the frame budget is the part that load moves.
-        await app.workers.wait_for_complete(
-            [w for w in app.workers if w.group.startswith("subagent-stats-")]
-        )
+        #
+        # Only when the selection is non-empty: an empty list is falsy and
+        # would make ``wait_for_complete`` wait on every worker in the manager
+        # rather than none (see ``_booted``). The assertion below is what
+        # decides the outcome either way.
+        stats_workers = [w for w in app.workers if w.group.startswith("subagent-stats-")]
+        if stats_workers:
+            await app.workers.wait_for_complete(stats_workers)
         await pilot.pause()
         assert len(panel._stats) == 5
         session.jobs = _fake_jobs(jobs[0])  # retention sweeps the rest

--- a/tests/unit/tui/test_subagent_stats.py
+++ b/tests/unit/tui/test_subagent_stats.py
@@ -70,6 +70,48 @@ def _model_shown(label: str, *, short: bool = False) -> str:
     return format_model_label(label, short=short)
 
 
+async def _booted(app: OperatorApp) -> None:
+    """Block until the boot worker has adopted a session.
+
+    Waits on the WORKER, not on a frame budget (#142). The app paints before
+    its session exists — ``on_mount`` hands ``_boot_session`` to
+    ``run_worker(group="session")`` precisely so first paint does not wait on
+    the factory — and every band assertion here reads the ledger THROUGH that
+    session, so an unbooted app reports no jobs at all. The bounded
+    ``for _ in range(50): await pilot.pause()`` this replaces was a bet that
+    50 frames outlast the factory, and under contention it lost: measured 5
+    failures in 10 runs at 10-way concurrency, every one of them
+    ``assert app._session is not None``.
+
+    ``wait_for_complete`` returns when the worker's task finishes, so there is
+    no elapsed-time comparison left on this path — a slower machine makes this
+    slower, never red. It also cannot hang past the run: ``run_test`` cancels
+    outstanding workers on exit.
+    """
+    await app.workers.wait_for_complete([w for w in app.workers if w.group == "session"])
+
+
+async def _priced(app: OperatorApp, pilot: Any, panel: SubagentPanel, job_id: str) -> None:
+    """Block until the panel's off-thread reader has priced ``job_id``.
+
+    Same substitution as :func:`_booted`, one layer down and with one extra
+    step. ``SubagentPanel._read_stats`` runs ``job_stats`` on a THREAD worker
+    (group ``subagent-stats-<id>``) because pricing a child resolves its model,
+    which for an unlisted model is a provider listing plus a catalogue fetch.
+    Waiting on that worker is deterministic; the reading it produces is then
+    handed back through ``call_from_thread``, so one pause after it lands is
+    what lets that callback run on the UI thread and populate the cache.
+    """
+    await app.workers.wait_for_complete(
+        [w for w in app.workers if w.group == f"subagent-stats-{job_id}"]
+    )
+    await pilot.pause()
+    assert panel.stats_for(job_id).cost is not None, (
+        "the stats worker finished without pricing the child — the band under test "
+        "reads this cache, so the assertions below would pass on an empty reading"
+    )
+
+
 class Job:
     """An ``AsyncJob`` as the panel reads one — duck-typed, like the widget."""
 
@@ -965,10 +1007,7 @@ async def test_opening_and_leaving_a_page_repoints_and_restores_the_live_band(
         # The session boots in a worker, and the band re-points off the LIVE
         # session's ledger — asserting before it lands reads an app that has
         # no jobs to point at yet.
-        for _ in range(50):
-            await pilot.pause()
-            if app._session is not None:
-                break
+        await _booted(app)
         assert app._session is not None
         assert app._status is not None
         app._status.update(model_label="test/model", cost="$1.20")
@@ -977,15 +1016,12 @@ async def test_opening_and_leaving_a_page_repoints_and_restores_the_live_band(
 
         app._open_subagent_view(job.id)
         # The band reads the panel's reading rather than deriving one, and that
-        # reading is taken off-thread — a repaint may not price a child. Pump
-        # until it lands, which is what a user experiences as the numbers
+        # reading is taken off-thread — a repaint may not price a child. Wait
+        # on the reader itself, which is what a user experiences as the numbers
         # appearing a frame or two after the page does.
         panel = app.query_one(SubagentPanel)
         panel.sync(session)
-        for _ in range(60):
-            await pilot.pause()
-            if panel.stats_for(job.id).cost is not None:
-                break
+        await _priced(app, pilot, panel, job.id)
         app._refresh_subagent_view()
         child = app._status.render_text(120).plain
         assert _model_shown(CHILD_MODEL) in child, child
@@ -1166,10 +1202,7 @@ async def test_an_open_page_does_not_reinstate_the_per_event_repaint() -> None:
     session.jobs = _fake_jobs(*jobs)
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(120, 40)) as pilot:
-        for _ in range(50):
-            await pilot.pause()
-            if app._session is not None:
-                break
+        await _booted(app)
         panel = app.query_one(SubagentPanel)
         panel.sync(session)
         panel._tick()
@@ -1414,10 +1447,15 @@ async def test_a_swept_child_is_dropped_from_the_stats_cache() -> None:
         panel = app.query_one(SubagentPanel)
         panel.sync(session)
         panel._tick()
-        for _ in range(20):
-            await pilot.pause()
-            if len(panel._stats) == 5:
-                break
+        # Five children, five thread workers (``subagent-stats-<id>``), each
+        # landing its reading through ``call_from_thread``. Wait on the
+        # workers and then let those callbacks run, rather than betting 20
+        # frames covers them — same substitution as ``_booted``, and the same
+        # reason: the frame budget is the part that load moves.
+        await app.workers.wait_for_complete(
+            [w for w in app.workers if w.group.startswith("subagent-stats-")]
+        )
+        await pilot.pause()
         assert len(panel._stats) == 5
         session.jobs = _fake_jobs(jobs[0])  # retention sweeps the rest
         panel.sync(session)

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -136,10 +136,32 @@ TRAJECTORY = [
 
 
 def _job_with(trajectory: list[dict[str, Any]], status: str = "completed") -> Any:
+    """A job carrying its OWN copy of ``trajectory``.
+
+    The copy is the fix for a cross-test leak, not tidiness. Callers pass the
+    module-level :data:`TRAJECTORY`, and three tests mutate what they get back
+    to drive a live update: ``job.trajectory.append(...)`` at the "mounted
+    once" and "coalesced frame" cases, and ``del job.trajectory[:3]`` at the
+    eviction case. Assigning by reference made those edits land on the SHARED
+    list, so every test that ran afterwards folded a trajectory with an extra
+    tool call in it, or with its first message missing.
+
+    That is why this file failed only in company and passed alone, and why the
+    failure moved around: which test sees the corruption depends on execution
+    order, so xdist changes the symptom (2 failures at ``-n4``, 1 at ``-n0``)
+    without changing the cause. Observed as
+    ``assert [...'ToolCard'] == [...'AssistantBlock']`` and
+    ``assert 'history unavailable' in 'read-only'``.
+
+    A shallow copy is sufficient and deliberate: the leak is list membership
+    (append/delete), and no test mutates an event dict in place. Copying the
+    list here rather than asking each test to remember means a new test cannot
+    reintroduce this by writing the obvious thing.
+    """
     job = _Job("sub-1", "audit the ingest path", status=status)
     if status != "running":
         job.settled_at = job.start_time + 42
-    job.trajectory = trajectory
+    job.trajectory = list(trajectory)
     return job
 
 
@@ -848,14 +870,27 @@ async def test_escape_from_child_restores_composer_when_roster_row_was_hidden() 
 
 
 async def _wait_history(pilot: Any, view: SubagentView) -> None:
-    started = view._history_loading
-    for _ in range(100):
-        await asyncio.sleep(0.005)
-        await pilot.pause()
-        started = started or view._history_loading or bool(view._history_entries)
-        if started and not view._history_loading:
-            return
-    raise AssertionError("history worker did not settle")
+    """Block until the history page worker has settled.
+
+    The page is read off the loop (``asyncio.to_thread`` inside a
+    ``subagent-history`` worker), and the flags the callers assert on
+    (``_history_unavailable``, ``_history_error``, ``_history_entries``) are
+    written in that worker's completion path. Waiting on the WORKER is waiting
+    on those writes; the previous 100-cycle poll was spending a frame budget
+    and calling it settled when the budget ran out, which is why
+    ``test_history_unavailable_and_error_retry_keep_trajectory_fallback``
+    failed under xdist as ``assert 'history unavailable' in 'read-only'`` —
+    the state it asserted had simply not been written yet.
+
+    The selection is checked rather than passed because Textual's
+    ``wait_for_complete`` treats an empty list as falsy and falls back to
+    waiting on EVERY worker. Empty here legitimately means the read already
+    finished, so the pause below is enough to let its callback land.
+    """
+    workers = [w for w in view.workers if w.group == "subagent-history"]
+    if workers:
+        await view.workers.wait_for_complete(workers)
+    await pilot.pause()
 
 
 async def _wait_geometry_settled(
@@ -1340,6 +1375,11 @@ async def test_history_unavailable_and_error_retry_keep_trajectory_fallback(
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(90, 28)) as pilot:
         view = await _open(pilot, app, job)
+        # Opening the page kicks off the first history read, and the missing
+        # directory is discovered on that worker — so the note is not painted
+        # until it settles. Asserting straight after _open read whatever state
+        # happened to be current one frame in.
+        await _wait_history(pilot, view)
         assert HISTORY_UNAVAILABLE_NOTE in view._history_state_text()
         assert "Reading the ingest path." in " ".join(view.rendered_rows())
 


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Test-only. No file under `local_operator/`
is touched, so no runtime path changes and the rollback is `git revert`.

## Summary of Changes

Three issues, one defect shape: **a test that waits for asynchronous work by
spending a fixed budget, then asserts as though the budget were a guarantee.**
On an idle machine the budget is 20-50x more than the work needs, so the tests
look solid; under contention the work stretches, the budget does not, and the
suite goes red for reasons that have nothing to do with the code under test.

The fix in every case is to wait on the *event the test actually cares about*,
published by the code under test itself.

### 1. `#122` — `test_comms.wait_for` had a 10 s wall-clock deadline

`tests/unit/harness/test_comms.py` polled a predicate and raised
`AssertionError("timed out waiting for condition")` once 10 s of wall clock had
passed. Two integration tests
(`test_a_resumed_child_replays_the_stopped_ones_transcript`,
`test_a_cancelled_child_keeps_the_work_it_had_already_done`) wait through a real
child session doing real tool rounds, so they are the ones that lose that race.

Replaced with `ChangeSignal`, an `asyncio.Event` fed by the two publications the
production code already makes:

| source | fires when |
| --- | --- |
| `SubagentComms.subscribe_detail_changes` | after each durable transcript append (`notify_detail_persisted`) |
| `Session.subscribe` | every parent-stream event, which carries attach (`SubagentStartEvent`) and settle |

Both are watched because neither alone covers every predicate used here: the
detail registry sees nested children the parent stream never routes, and the
parent stream carries the attach moment that makes `session_dir_of` non-`None`
before any append has happened. The signal is level-triggered — `arm()` clears
the flag *before* the predicate is tested — so a publication landing between the
test and the wait is kept rather than lost.

The two tests now have **no elapsed-time comparison anywhere on their success
path**. A `DEADLOCK_GUARD_S = 120.0` remains, but it can never be the
discriminator: the success path blocks on an event, so the only run that reaches
the guard is one where the signal is never coming (this suite has no
`pytest-timeout`, so a wedged test would otherwise hang CI forever).

Call sites that drive `FakeChild` in-process keep a pump, but bounded by **loop
turns** (`MAX_PUMP_TURNS`) rather than seconds. That unit is the point:
contention stretches how long a turn takes, not how many turns the awaited work
needs.

### 2. `#224` — a client closed after its assertions

`test_an_openrouter_error_chunk_after_partial_output_arrives_named` called
`await http.aclose()` *after* its assertions, so a failing assertion skipped the
close. Moved into `finally`, which is the shape the other 22 client-owning tests
in that file already use. Audited the file: it was the only `aclose()` in
`test_failover.py` outside a `finally`.

### 3. `#142` — frame budgets standing in for worker completion

Two cases in `tests/unit/tui/test_subagent_stats.py` waited on
`for _ in range(50): await pilot.pause()` for work owned by **Textual workers**:

- `OperatorApp.on_mount` hands `_boot_session` to `run_worker(group="session")`
  precisely so first paint does not wait on the factory. Every band assertion
  reads the ledger *through* that session, so an unbooted app reports no jobs at
  all — the observed failure is `assert app._session is not None`.
- `SubagentPanel._read_stats` prices each child on a thread worker
  (`subagent-stats-<id>`) because resolving an unlisted model is a 10 s provider
  listing plus a 3 s catalogue fetch.

Both now wait on the worker itself via `WorkerManager.wait_for_complete`, plus
one `pause()` after the thread worker so its `call_from_thread` callback lands.
`run_test` cancels outstanding workers on exit, so this cannot hang past the run.

The `_priced` helper also asserts the reading is actually populated, so a worker
that finishes without pricing fails loudly instead of letting the band
assertions pass against an empty reading.

### 4. The mobile ask helper — same class, added during review

`tests/unit/mobile/test_tui_ask.py::_control_for` is the shared helper for that
module. It polled until `app._mobile_registrant is not None`, then *immediately*
called `registry.scan()` and asserted the result non-empty.

Those are not the same event. `Registrant.start` spawns a daemon thread and
returns; the record is written by `_serve` **on that thread**. So the registrant
existing means registration was *requested*, not that the record is on disk —
wait-on-a-proxy-then-assert-on-the-real-thing, the same shape as the rest of
this diff. It now polls `registry.scan()` itself. The registrant assertion is
kept, moved after the wait, so "nothing ever started" still reports as itself
rather than as a missing record.

This was blocking two unrelated PRs (#450 on 3.12, #453 on 3.13) with
`no discovery record published` — different tests, same helper, and neither
diff touches mobile code. The clearest evidence it is environmental: on #450 it
failed on run `33326634006` and passed on run `33326636132` against an
**identical head**.

**The two `test_loop_liveness.py` cases in #142 need no change, and this is
evidence rather than an opinion.** #142 was filed against `42e5268`, where the
probe compared *wall-clock gaps between heartbeats* (`MAX_GAP_S = 0.12`) — a
statistic that widens whenever the loop thread is not *scheduled*, which is
exactly what load does. #136 replaced it with `time.thread_time` on the loop
thread, which only grows when the loop thread genuinely runs without yielding.
Measured below: they now pass under the same load that used to break them.

## Related Issue(s)

Closes #122
Closes #224
Closes #142

## Testing Evidence

Host: 14 cores. This box runs a dozen agent sessions, so load moves minute to
minute; every comparison below is therefore either **paired** (both arms
back-to-back under one load) or reports the load it ran at.

### The failure, reproduced on base

`test_opening_and_leaving_a_page_repoints_and_restores_the_live_band`, 10 pytest
processes racing each other, on a clean `origin/main` worktree:

```
== lop-td-base tests/unit/tui/test_subagent_stats.py
== 5 passed / 5 failed of 10 (spinners=24, load=258.33 228.89 184.52)

E  AssertionError: assert None is not None
E   +  where None = OperatorApp(...)._session
FAILED tests/unit/tui/test_subagent_stats.py::test_opening_and_leaving_a_page_repoints_and_restores_the_live_band
```

Every failure is the same assertion: the app had not adopted a session inside 50
frames.

### The head, same procedure, 30 runs

```
== lop-test-determinism tests/unit/tui/test_subagent_stats.py
after round 1: 10 passed / 0 failed
after round 2: 20 passed / 0 failed
after round 3: 30 passed / 0 failed
== 30 passed / 0 failed of 30 (procs=10 rounds=3 spinners=16, load=212.57 250.51 267.04)
```

Whole module, 30 concurrent runs at load ~250, zero failures.

### Why a pass/fail sample understates it: the margin, measured

A sample only says whether the budget was crossed on the runs observed. The
quantity that decides it is **how many frames boot actually costs against the 50
the test allowed**. Measured with an uncapped probe (`.prwork` scratch, 8
concurrent processes, 4 apps each):

| condition | frames to session adoption |
| --- | --- |
| idle, any app | `[1, 1, 1, 1, 1]` |
| loaded, **first** app in each process | `15, 17, 18, 22, 24, 24, 24, 27, 27, 29, 30, 32, 34, 34` |
| loaded, subsequent apps in same process | `1` |

The first `run_test` in a worker pays the session-graph import; that is the run
the 50-frame budget had to cover. Idle it costs 1 frame — a 50x margin, which is
why this reads as solid on a quiet machine. Under load it costs **15-34 frames,
a margin of 1.5-3.3x**, and the observed failures are the tail of that
distribution crossing 50. `wait_for_complete` removes the budget entirely, so
the distribution no longer has a failing tail to reach.

Child pricing measured `0-1` frames against its 60-frame budget in every
condition, so that one was not close to failing — it is converted for the same
reason regardless: it is the same bet, and it costs nothing to stop making it.

### `#122`, before and after

The comms pair is slow (a real child, real tool rounds), so the paired A/B is at
lower width. Both arms back-to-back under one load:

```
== targets: test_a_resumed_child_replays_the_stopped_ones_transcript
             test_a_cancelled_child_keeps_the_work_it_had_already_done
== BASE(origin/main)          : 24 passed /  0 failed of 24
== HEAD(dev-test-determinism) : 24 passed /  0 failed of 24
```

Honest reading: **I did not reproduce a #122 failure on this box.** The issue
records it from a run with six concurrent pytest sessions plus a second agent's
suites; my harness reached load ~250 without crossing its 10 s deadline. The
change still stands on the mechanism rather than on a reproduction — the old
code compares `loop.time()` against a deadline and the new code does not compare
time at all — and the module is green: `106 passed`.

### The whole module set, after

```
$ .venv/bin/python -m pytest -n4 -q \
    tests/unit/harness/test_comms.py tests/unit/tui/test_subagent_stats.py \
    tests/unit/providers/test_failover.py tests/unit/tools/test_loop_liveness.py \
    tests/unit/tui/test_app_pilot.py
585 passed, 87 warnings in 65.36s
```

### Full unit suite

```
$ .venv/bin/python -m pytest tests/unit -n4 -q; echo "pytest rc=$?"
9143 passed, 15 skipped, 403 warnings in 565.55s (0:09:25)
pytest rc=0
```

Clean at the current head. The run before the round-1 fixes had one failure,
`test_subagent_view.py::test_history_unavailable_and_error_retry_keep_trajectory_fallback`
— which turned out to be a real defect in that file rather than ambient noise,
and is now fixed here (see "A third mechanism" below).

An earlier revision of this body also recorded
`test_app_pilot.py::test_esc_aborts_a_running_shell_command` failing once; it
passes 3/3 on clean `origin/main` and in every run since, and this diff does not
touch that file.

### `test_loop_liveness.py` is already fixed, measured

The two cases #142 names, on **clean `origin/main`**, under the load that the
issue reports breaking them:

```
== 10 passed / 0 failed of 10 (spinners=24, load=170.45 153.28 140.50)
== 10 passed / 0 failed of 10 (spinners=48, load=262.30 216.77 172.77)   [whole file]
```

At `42e5268` (the SHA #142 cites) the probe was `MAX_GAP_S = 0.12` on wall-clock
gaps; #136 replaced it with loop-thread CPU. Touching these now would be
changing a guard that is already load-immune.

### The mobile helper

```
$ .venv/bin/python -m pytest -n4 -q tests/unit/mobile
206 passed, 2 warnings in 6.63s
```

Honest reading, same as #122: **I did not reproduce this one locally either.**
It needs CI's 14-worker profile; four runs of `tests/unit/mobile tests/unit/tui`
at `-n auto` came back clean on **both** arms:

```
BASE  run1 rc=0   run2 rc=0   run3 rc=1 (test_subagent_view)   run4 rc=0
HEAD  run1 rc=0   run2 rc=0   run3 rc=0   run4 rc=1 (test_subagent_view)
```

The change rests on the mechanism, which is not in doubt: the old code waits for
a thread to be *spawned* and asserts the thread's *output* is already written.
CI is the measurement that matters here and it runs on this PR.

(Those `test_subagent_view` failures on both arms were the shared-fixture leak,
diagnosed and fixed in this PR — see "A third mechanism". At the time they were
recorded as ambient noise, which was wrong.)

### Gates

Verified by exit code, whole tree, CI's exact commands:

```
.venv/bin/python -m flake8 .                                flake8 rc=0
uvx --from black==26.1.0 black --check .                    black rc=0
uvx isort==5.13.2 --check .                                 isort rc=0
.venv/bin/python -m pyright --pythonpath .venv/bin/python . pyright rc=0
.venv/bin/python -m pytest tests/unit -n4 -q                pytest rc=0
```

Exit codes rather than stdout, deliberately: while adding the round-1 fixes an
import landed in the wrong order and `isort --check .` printed its usual
`Skipped 1 files` to stdout while returning **rc=1**, with the real error on
stderr. A tail of stdout would have read as green. Black's success banner
likewise goes to stderr.

Rebased onto `7916e5ae` (current `origin/main`), cleanly and with no conflicts,
so the round is fresh against what ships.

## Disposition: the wider flake population

#142's four are part of a larger set, and the manager supplied CI data showing 3
of the last 8 `main` runs red. Recording what I found and deliberately left, so
the next reader does not rediscover it. **No new issues were filed for these.**

**Fixed here:** `#122`'s two comms tests, `#224`'s client close, `#142`'s two
`test_subagent_stats.py` cases, `test_tui_ask.py::_control_for`, and both
`test_subagent_view.py` defects (the last three added during review because
they were actively blocking other PRs' CI).

### CORRECTION — the `test_a_live_selection_never_swallows_the_interrupt` claim

**An earlier revision of this body claimed that test fails 8/8 unloaded and is a
deterministic binding defect. That claim was wrong and is withdrawn.** Round 1
could not reproduce it in 13 runs, so I re-measured across four trees, by exit
code:

```
current head (rebased):        6 runs, 0 failures
65ca130a (my later base):      3 runs, 0 failures
75f867bf (the tree I
  originally measured):        4 runs, 0 failures
cc8319d2^ (before #446):       3 runs, 0 failures
```

16 unloaded runs, zero failures, **including on the exact tree my original
measurement ran against**. So this was not a stale measurement corrected by
cc8319d2 — cc8319d2 is not the fix, and the test body is byte-identical before
and after it. My original run was simply wrong, and I have not been able to
reconstruct the mistake.

Under CPU load (24 spinners, load average 24 to 77) it does fail:

```
6 runs at -n0 under load: 3 failed, 3 passed
all 3 failures: interrupt[False], assert [] == ['interrupted']
```

**So it is a load flake after all — the original guidance given to this board
was correct, and my finding briefly and wrongly reversed it.** It belongs to
#142's class, not to a separate binding-defect class. Not fixed here (it is in
a file this PR does not otherwise touch, and the fix is not the one-line kind),
but nobody should chase a deterministic defect in the binding chain, because
there is not one.

**Left untouched, same class but out of scope:**
`test_a_multi_click_on_a_blank_line_leaves_a_live_range`,
`test_the_inset_is_never_what_tips_a_long_subagent_list_over` (`NoMatches: No
nodes match '#band'`), `test_redundant_roster_events_skip_the_sidecar_write`,
and `test_app_pilot.py::test_esc_aborts_a_running_shell_command`.

### A third mechanism: shared mutable fixture state

Round 1 was told `test_subagent_view.py` fails deterministically at `-n4` and
passes at `-n0`, and asked whether that was a third mechanism. It is, and it is
two distinct defects in one file. Neither is a clock budget and neither is a
wait on a proxy:

**1. A module-level list handed out by reference.** `_job_with(TRAJECTORY)`
assigned the shared list straight onto the job. Three tests mutate what they
get back to drive a live update (`job.trajectory.append(...)` twice,
`del job.trajectory[:3]` once), so those edits landed on the module-level list
and every later test folded a corrupted trajectory. That is the
`assert [...'ToolCard'] == [...'AssistantBlock']` failure: an extra tool call
left behind by an earlier test. Fixed by copying the list in `_job_with`, so a
new test cannot reintroduce it by writing the obvious thing.

This is why the symptom moved around and why xdist changed the count without
changing the cause: which test sees the corruption depends on execution order.

**2. An assertion one frame after opening the page.**
`test_history_unavailable_and_error_retry_keep_trajectory_fallback` asserted
`HISTORY_UNAVAILABLE_NOTE` immediately after `_open`, but the missing directory
is discovered inside a `subagent-history` worker (`asyncio.to_thread`), and
`_history_unavailable` is written in its completion path. This one IS this PR's
main class. `_wait_history` was itself a 100-cycle budget poll; it now waits on
the worker, and the test waits before asserting.

Measured by exit code, `tests/unit/tui/test_subagent_view.py` at `-n auto`
(14 workers, CI's profile):

```
BASE (origin/main b56cf73f):  8 passed, 2 failed  of 10 runs
HEAD:                        10 passed, 0 failed  of 10 runs
```

Base also fails at `-n0` (1 of 1) once the ordering is unlucky, so the
"deterministic at -n4, invisible at -n0" framing was a sampling artefact of the
corruption's position rather than a property of xdist.

### The shared mechanism, named

The manager asked whether these want one mechanism rather than seven point
fixes. They do, and it is narrower than "wait on a condition":

> **A Textual test must wait on the app's own completion signal for work the app
> put on a worker — never on a count of `pilot.pause()` calls.**

`pilot.pause()` advances one message-pump cycle. It does not advance a
`run_worker` task, a thread worker, or a layout pass; it only yields long enough
that *something else may* progress. So `for _ in range(N): await pilot.pause()`
is not a wait — it is a bet that N pump cycles is longer than an unrelated piece
of asynchronous work, priced on an idle machine.

Both visible patterns are that one bet:
- *asserting on elapsed time* — the budget is spent, the work is not done;
- *querying a widget before layout settled* (`NoMatches: '#band'`) — the same
  bet, where the awaited work is compose/layout rather than a worker.

The general remedy is the one applied here: find who owns the work
(`app.workers` for a worker, an `asyncio.Event` the code already publishes for a
session boundary) and block on that. `WorkerManager.wait_for_complete` covers
every `run_worker`/`run_worker(thread=True)` case, which is most of the TUI
suite's exposure, and it is mechanical to apply. I did not sweep the whole suite
for it here because that is a large diff whose risk is unrelated to these three
issues, but the two helpers added in `test_subagent_stats.py` (`_booted`,
`_priced`) are the pattern in a form another file can copy.

Not colliding with #434/#438: both touch only `tests/conftest.py`, which this
diff does not.

## Impact

- **Breaking changes:** none. Test-only.
- **Risk:** the changed waits could in principle mask a real hang. Mitigated by
  keeping a bound on every path (`DEADLOCK_GUARD_S`, `MAX_PUMP_TURNS`,
  `run_test`'s own worker cancellation) and by `_priced` asserting the reading it
  waited for is actually there, so a worker that completes without doing its job
  fails rather than passing quietly.
- **Rollback:** `git revert`.

