### PR TITLE
fix(mcp): make an imported remote server authenticable and say how

### DIFF
--- a/docs/evidence/codex-mcp-auth/README.md
+++ b/docs/evidence/codex-mcp-auth/README.md
@@ -177,3 +177,64 @@ wording — so the design round's frames remain current:
 
 Direct 401, 403, public 200, and 404/500 non-auth parity all unchanged, and
 startup still opens zero browsers.
+
+## Round 2 remediation (F5–F6)
+
+**F5 — a challenge could still relabel a later NETWORK failure.** Round 1
+cleared the latch only when a later *response* arrived on the endpoint. A retry
+that dies at DNS/connect/TLS/read time produces no response at all, so no hook
+ran and the earlier 401 stayed latched — the terminal network failure was
+reported as `/mcp login`.
+
+The verdict is now bound to the **request**, not the last response: a
+`request` event hook (`_AuthChallengeWatcher.begin`) clears the slot as each
+same-endpoint request starts, and `observe` sets it only if that request comes
+back 401/403. Whatever happens next — a response, or a socket error that never
+produces one — no stale verdict survives. A request to any other URL (the
+provider's discovery and token traffic) neither sets nor clears.
+
+Proven end to end with a real `httpx` client and a real server:
+
+```
+after the 401           : watcher verdict = 401
+retry failed with       : ReadTimeout (no response)
+after the dead retry    : watcher verdict = None
+classified as           : None      (NOT auth advice)
+```
+
+**F6 — the login gates dropped the manager's effective store.** Both
+`_mcp_login_worker` and `_run_mcp_grant_on_owner` called
+`probe_oauth_capability(cfg)` with no store, so a server whose grant exists
+only in an injected store was refused as "does not use OAuth login" whenever
+discovery was unavailable — even though the same manager had just classified
+its failure as `reauth` from that store.
+
+Eligibility is now a manager-owned operation,
+`McpManager.server_supports_oauth_login`, which passes its own effective store
+through. Both entry points call it via one TUI helper; a reduced follower
+facade that does not implement it falls back to the store-less probe, which is
+correct because such a facade owns no store to consult.
+
+With discovery offline and a grant in a custom store:
+
+```
+probe_oauth_capability(cfg)                  -> False   (the old call)
+manager.server_supports_oauth_login(cfg)     -> True    (consults its store)
+```
+
+### Parity preserved
+
+The live matrix and the whole transport matrix are byte-identical to round 1 —
+same verbs, same wording, so the terminal design round remains current:
+
+```
+✓ openaiDeveloperDocs: connected
+× datadog:      run /mcp login datadog to authorize
+× gitlab:       run /mcp reauth gitlab — authorization expired
+× launchdarkly: run /mcp login launchdarkly to authorize
+× minerva-qa:   run /mcp login minerva-qa to authorize
+
+F1-redirect-401    McpAuthChallengeError    parity-500  MCPError (unchanged)
+parity-direct-401  McpAuthChallengeError    parity-404  MCPError (unchanged)
+parity-403         McpAuthChallengeError
+```

--- a/docs/evidence/codex-mcp-auth/README.md
+++ b/docs/evidence/codex-mcp-auth/README.md
@@ -1,0 +1,117 @@
+# Codex-imported MCP servers: authenticable + actionable failures
+
+Evidence for the follow-up to issue #367 / PR #439 (Codex MCP import, shipped in
+v0.43.14). The import worked; the imported remote servers could not be *used*,
+and the failure text was a dead end.
+
+All probes ran against a worktree off `origin/main`, with an assertion that the
+imported modules resolve to that worktree rather than to another checkout.
+
+## Root cause (confirmed live, not assumed)
+
+Codex's remote entries carry only a `url` — that tool holds its OAuth grants
+elsewhere, so its config has no auth block. Local-operator gated every
+auth-capable path on an explicit `auth.type == "oauth"`, so those servers
+connected with **no credentials**, the server 401'd, and the SDK reported it as
+raw transport text.
+
+`probe-live-401s.txt` — one real `initialize` POST per server:
+
+| server | status | `WWW-Authenticate` |
+|---|---|---|
+| gitlab | 401 | `Bearer realm="GitLab", resource_metadata=...` |
+| launchdarkly | 401 | `Bearer resource_metadata=...` |
+| minerva-qa | 401 | `Bearer resource_metadata=..., scope="mcp:read"` |
+| datadog | 401 | **none** |
+| openaiDeveloperDocs | 200 | — (needs no auth) |
+
+`probe-discovery.txt` — RFC 9728/8414 discovery, which decides the wording.
+Note Datadog: **no challenge header, but discovery still succeeds**, so the
+header alone is not a usable signal.
+
+A second fact drove the design: the SDK destroys the status code. A 401 it
+cannot resolve arrives from `session.initialize()` as
+`MCPError(-32603, 'Server returned an error response')` with no status, no
+headers. That is why detection is a transport-level response hook.
+
+## Before / after
+
+`before-connect.txt` (released behaviour) vs `after-messages.txt`:
+
+```
+BEFORE                                          AFTER
+× MCP gitlab failed: Server returned an       → × MCP gitlab failed: run /mcp reauth gitlab
+      error response                                — authorization expired
+× MCP launchdarkly failed: unauthorized       → × MCP launchdarkly failed: run /mcp login
+      access                                        launchdarkly to authorize
+× MCP minerva-qa failed: Server returned an   → × MCP minerva-qa failed: run /mcp login
+      error response                                minerva-qa to authorize
+× MCP datadog failed: Server returned an      → × MCP datadog failed: run /mcp login
+      error response                                datadog to authorize
+```
+
+`gitlab` says **reauth** and the others say **login** because gitlab is the one
+holding a stored token payload that could not be refreshed. That distinction is
+read from the credential store, not guessed.
+
+## All four required classes
+
+1. **OAuth-challenging 401** — gitlab / launchdarkly / minerva-qa, above.
+2. **401 with no challenge header** — datadog, above. Discovery still finds an
+   authorization server, so the login command is honest.
+3. **401 with no discoverable OAuth at all** — no public server in the matrix
+   has this shape, so `after-no-discovery.txt` records it against a local stub
+   that 404s every `.well-known` probe. It must not promise a login:
+   `apikey-only rejected our credentials (401) — set its API key or headers`.
+4. **No auth needed** — `openaiDeveloperDocs` still connects with 5 tools, no
+   OAuth provider attached and no discovery (`noauth-server-latency.txt`).
+   Connect time is unchanged within network noise (2.79s after vs 2.37s before,
+   and 1.87s vs 2.45s on an earlier run — the ordering flips between runs).
+
+## Non-auth failures are NOT relabelled
+
+`nonauth-parity.txt` compared this worktree against `origin/main`. Connection
+refused, DNS NXDOMAIN, HTTP 500 and HTTP 404 produce **byte-identical** output
+before and after. A network outage never becomes "run /mcp login".
+
+## The `/mcp login` dead end
+
+`after-login-gate.txt`. Before, `_resolve_mcp_server` refused every Codex import
+with *"does not use OAuth login."* — the command that fixes the 401 told the
+user it did not apply.
+
+| config | before | after |
+|---|---|---|
+| gitlab (url only) | refused | accepted |
+| launchdarkly (url only) | refused | accepted |
+| openaiDeveloperDocs | refused | accepted (no-op: provider only acts on a real 401) |
+| explicit `auth: oauth` | accepted | accepted |
+| stdio | refused | refused |
+
+## Rendered frames
+
+`frames/before.svg` / `frames/after.svg`, captured from the real `OperatorApp`
+(which loads `local_operator.tcss`) at 100x30 and viewed as PNG. The before
+frame reproduces the user's screenshot. Geometry identical in both:
+`virtual_size == size == (98, 28)`, no vertical scrollbar.
+
+The first after-capture exposed a defect the numbers did not: including
+`(401)` pushed two lines past the width and orphaned the bare `(401)` onto its
+own centred row. The status code told the user nothing the verb did not, so the
+OAuth wording now delegates to the existing `_auth_required_text` and every line
+fits on one row.
+
+## Not verified locally
+
+No real OAuth grant was completed — that needs the operator's browser and
+credentials. What is proven is that `/mcp login <name>` now reaches the grant
+flow for these servers instead of being refused, and that a non-interactive
+startup still raises rather than opening a browser.
+
+## Reproducing
+
+The probe scripts were scratch and are deliberately not committed — the outputs
+above are the evidence. Each is reproducible from a worktree off `origin/main`:
+drive `McpManager._connect_server` / `_connect_round` against the server URLs in
+the table, and render the frames with `OperatorApp.save_screenshot` per
+AGENTS.md "Visual validation" (the real app, so the stylesheet is applied).

--- a/docs/evidence/codex-mcp-auth/README.md
+++ b/docs/evidence/codex-mcp-auth/README.md
@@ -115,3 +115,65 @@ above are the evidence. Each is reproducible from a worktree off `origin/main`:
 drive `McpManager._connect_server` / `_connect_round` against the server URLs in
 the table, and render the frames with `OperatorApp.save_screenshot` per
 AGENTS.md "Visual validation" (the real app, so the stylesheet is applied).
+
+## Round 1 remediation (F1–F4)
+
+Four majors from the agent review, each fixed at source with a regression test
+verified to fail against the pre-fix code.
+
+**F1 — a challenge after a redirect was missed.** The hook compared the
+response's request URL to the configured string, so a server canonicalizing
+`/mcp` → `307 /mcp/` and challenging on the redirect target did not match, and
+the user kept getting the opaque error. Endpoint identity is now semantic
+(scheme/host lowercased, query dropped, trailing slash stripped).
+
+Reproduced end to end through the real SDK transport against a local server:
+
+```
+BEFORE  F1-redirect-401   MCPError               -> "Server returned an error response"
+AFTER   F1-redirect-401   McpAuthChallengeError  -> names the fix
+        hook saw 307 http://127.0.0.1:8902/redir
+        hook saw 401 http://127.0.0.1:8902/redir/
+```
+
+**F2 — an earlier 401 could relabel a later non-auth failure.** `status_code`
+latched on the first challenge and was never cleared, so a 401 followed by a
+500 on the same endpoint still reported as authorization — the exact
+misrouting this feature promises not to do. The **last** response on the
+endpoint now wins; a 3xx hop is not a verdict and never clears a pending one.
+
+```
+after 401 -> status_code=401
+after 500 -> status_code=None
+classified as: None      (stays a network/server error)
+```
+
+**F3 — `/mcp login` was enabled for every remote config.** The `deliberate`
+shortcut accepted API-key and known-public servers. It is removed. A stdio
+server or an explicit non-OAuth `auth.type` is now a hard refusal that costs no
+network call, and the remaining unknown case is settled by one discovery probe
+(`probe_oauth_capability`) before any grant starts — so the first login on a
+fresh import still works, without claiming every URL is authenticable.
+
+**F4 — the classifying store's verdict was discarded.** `_challenge_error`
+resolved `has_stored_grant` against the manager's own (possibly injected)
+store, then `_auth_required_text` threw it away and re-read the default machine
+store, rendering `login` for a server demonstrably holding a grant. The carried
+fact is now used; only the legacy `McpAuthRequiredError`, which has no such
+field, falls back to a lookup.
+
+### Parity preserved
+
+The live matrix is byte-identical to the pre-remediation run — same verbs, same
+wording — so the design round's frames remain current:
+
+```
+✓ openaiDeveloperDocs: connected
+× datadog:      run /mcp login datadog to authorize
+× gitlab:       run /mcp reauth gitlab — authorization expired
+× launchdarkly: run /mcp login launchdarkly to authorize
+× minerva-qa:   run /mcp login minerva-qa to authorize
+```
+
+Direct 401, 403, public 200, and 404/500 non-auth parity all unchanged, and
+startup still opens zero browsers.

--- a/docs/evidence/codex-mcp-auth/after-login-gate.txt
+++ b/docs/evidence/codex-mcp-auth/after-login-gate.txt
@@ -1,0 +1,6 @@
+[worktree assert OK] manager=/private/tmp/lop-codex-auth/local_operator/mcp/manager.py
+  gitlab (codex import: url only, no auth block)   /mcp login -> ACCEPTED -> runs the grant
+  launchdarkly (codex import)                      /mcp login -> ACCEPTED -> runs the grant
+  openaiDeveloperDocs (public, no auth needed)     /mcp login -> ACCEPTED -> runs the grant
+  lop-native oauth (explicit auth block)           /mcp login -> ACCEPTED -> runs the grant
+  stdio server (no transport for a token)          /mcp login -> refused: 'does not use OAuth login.'

--- a/docs/evidence/codex-mcp-auth/after-messages.txt
+++ b/docs/evidence/codex-mcp-auth/after-messages.txt
@@ -1,0 +1,8 @@
+===== AFTER — cold boot (first connect, nothing observed) =====
+  ✓ MCP openaiDeveloperDocs: connected
+  × MCP datadog failed: run /mcp login datadog — not authorized (401)
+  × MCP gitlab failed: run /mcp reauth gitlab — authorization expired
+  × MCP launchdarkly failed: run /mcp login launchdarkly — not authorized (401)
+  × MCP minerva-qa failed: run /mcp login minerva-qa — not authorized (401)
+
+===== AFTER — warm (reload/reconnect: challenge already observed) =====

--- a/docs/evidence/codex-mcp-auth/after-no-discovery.txt
+++ b/docs/evidence/codex-mcp-auth/after-no-discovery.txt
@@ -1,0 +1,3 @@
+[worktree assert OK] manager=/private/tmp/lop-codex-auth/local_operator/mcp/manager.py
+  raised: McpAuthChallengeError
+  user sees: × MCP apikey-only failed: apikey-only rejected our credentials (401) — no OAuth endpoint advertised; check its API key or headers

--- a/docs/evidence/codex-mcp-auth/before-connect.txt
+++ b/docs/evidence/codex-mcp-auth/before-connect.txt
@@ -1,0 +1,7 @@
+[worktree assert OK] manager=/private/tmp/lop-codex-auth/local_operator/mcp/manager.py
+gitlab                 FAILED  MCPError: Server returned an error response
+launchdarkly           FAILED  MCPError: unauthorized access
+minerva-qa             FAILED  MCPError: Server returned an error response
+datadog                FAILED  MCPError: Server returned an error response
+openaiDeveloperDocs    CONNECTED  tools=5
+unreachable-host       FAILED  CancelledError: Cancelled via cancel scope 1085d9950

--- a/docs/evidence/codex-mcp-auth/frames/after.svg
+++ b/docs/evidence/codex-mcp-auth/frames/after.svg
@@ -1,0 +1,182 @@
+<svg class="rich-terminal" viewBox="0 0 1238 782.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-4222338042-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-4222338042-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-4222338042-r1 { fill: #c5c8c6 }
+.terminal-4222338042-r2 { fill: #ef8078 }
+.terminal-4222338042-r3 { fill: #e9e5db }
+.terminal-4222338042-r4 { fill: #837c6d }
+.terminal-4222338042-r5 { fill: #b5afa2 }
+.terminal-4222338042-r6 { fill: #e0b04b }
+.terminal-4222338042-r7 { fill: #4a4539 }
+.terminal-4222338042-r8 { fill: #1e1a14 }
+.terminal-4222338042-r9 { fill: #6ea8d8 }
+.terminal-4222338042-r10 { fill: #ef8078;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-4222338042-clip-terminal">
+      <rect x="0" y="0" width="1219.0" height="731.0" />
+    </clipPath>
+    <clipPath id="terminal-4222338042-line-0">
+    <rect x="0" y="1.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-1">
+    <rect x="0" y="25.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-2">
+    <rect x="0" y="50.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-3">
+    <rect x="0" y="74.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-4">
+    <rect x="0" y="99.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-5">
+    <rect x="0" y="123.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-6">
+    <rect x="0" y="147.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-7">
+    <rect x="0" y="172.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-8">
+    <rect x="0" y="196.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-9">
+    <rect x="0" y="221.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-10">
+    <rect x="0" y="245.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-11">
+    <rect x="0" y="269.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-12">
+    <rect x="0" y="294.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-13">
+    <rect x="0" y="318.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-14">
+    <rect x="0" y="343.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-15">
+    <rect x="0" y="367.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-16">
+    <rect x="0" y="391.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-17">
+    <rect x="0" y="416.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-18">
+    <rect x="0" y="440.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-19">
+    <rect x="0" y="465.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-20">
+    <rect x="0" y="489.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-21">
+    <rect x="0" y="513.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-22">
+    <rect x="0" y="538.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-23">
+    <rect x="0" y="562.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-24">
+    <rect x="0" y="587.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-25">
+    <rect x="0" y="611.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-26">
+    <rect x="0" y="635.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-27">
+    <rect x="0" y="660.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4222338042-line-28">
+    <rect x="0" y="684.7" width="1220" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="780" rx="8"/><text class="terminal-4222338042-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">Local&#160;Operator</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-4222338042-clip-terminal)">
+    <rect fill="#14110c" x="0" y="1.5" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="25.9" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#302a20" x="585.6" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#302a20" x="597.8" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#302a20" x="622.2" y="25.9" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#302a20" x="1000.4" y="25.9" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#302a20" x="1195.6" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="50.3" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#302a20" x="585.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#302a20" x="597.8" y="50.3" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#302a20" x="1195.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="74.7" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="99.1" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="439.2" y="99.1" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="768.6" y="99.1" width="427" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="123.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="123.5" width="1171.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="147.9" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="147.9" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="512.4" y="147.9" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="172.3" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="172.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="561.2" y="172.3" width="634.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="196.7" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="196.7" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="756.4" y="196.7" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="221.1" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="221.1" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="793" y="221.1" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="245.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="245.5" width="1171.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="269.9" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="269.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="549" y="269.9" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="719.8" y="269.9" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="294.3" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="294.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="549" y="294.3" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="695.4" y="294.3" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="318.7" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="318.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="549" y="318.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="597.8" y="318.7" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="343.1" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="343.1" width="1171.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="367.5" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="280.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="305" y="367.5" width="634.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="939.4" y="367.5" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="391.9" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="416.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="158.6" y="416.3" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="268.4" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="292.8" y="416.3" width="671" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="416.3" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1073.6" y="416.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="440.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="158.6" y="440.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="207.4" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="231.8" y="440.7" width="793" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1024.8" y="440.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1073.6" y="440.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="465.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="158.6" y="465.1" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="207.4" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="231.8" y="465.1" width="793" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1024.8" y="465.1" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1073.6" y="465.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="489.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="158.6" y="489.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="231.8" y="489.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="256.2" y="489.5" width="744.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1000.4" y="489.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1073.6" y="489.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="513.9" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="538.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="146.4" y="538.3" width="915" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1061.4" y="538.3" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="562.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="146.4" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="158.6" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="170.8" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="183" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#e9e5db" x="195.2" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="207.4" y="562.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="488" y="562.7" width="549" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1037" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1049.2" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1061.4" y="562.7" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="587.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="146.4" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="158.6" y="587.1" width="890.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1049.2" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1061.4" y="587.1" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="611.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="146.4" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="158.6" y="611.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="183" y="611.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="317.2" y="611.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="353.8" y="611.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="378.2" y="611.5" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="707.6" y="611.5" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1024.8" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1037" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1049.2" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1061.4" y="611.5" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="635.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="146.4" y="635.9" width="915" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1061.4" y="635.9" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="660.3" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="684.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="684.7" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="684.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="709.1" width="1220" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-4222338042-matrix">
+    <text class="terminal-4222338042-r1" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-4222338042-line-0)">
+</text><text class="terminal-4222338042-r2" x="597.8" y="44.4" textLength="24.4" clip-path="url(#terminal-4222338042-line-1)">⊙&#160;</text><text class="terminal-4222338042-r3" x="622.2" y="44.4" textLength="378.2" clip-path="url(#terminal-4222338042-line-1)">MCP:&#160;1&#160;of&#160;5&#160;servers&#160;up,&#160;5&#160;tools</text><text class="terminal-4222338042-r1" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-4222338042-line-1)">
+</text><text class="terminal-4222338042-r2" x="597.8" y="68.8" textLength="597.8" clip-path="url(#terminal-4222338042-line-2)">failed:&#160;datadog,&#160;gitlab,&#160;launchdarkly,&#160;minerva-qa</text><text class="terminal-4222338042-r1" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-4222338042-line-2)">
+</text><text class="terminal-4222338042-r1" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-4222338042-line-3)">
+</text><text class="terminal-4222338042-r3" x="439.2" y="117.6" textLength="329.4" clip-path="url(#terminal-4222338042-line-4)">l&#160;o&#160;c&#160;a&#160;l&#160;&#160;&#160;o&#160;p&#160;e&#160;r&#160;a&#160;t&#160;o&#160;r</text><text class="terminal-4222338042-r1" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-4222338042-line-4)">
+</text><text class="terminal-4222338042-r1" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-4222338042-line-5)">
+</text><text class="terminal-4222338042-r4" x="427" y="166.4" textLength="85.4" clip-path="url(#terminal-4222338042-line-6)">v0.43.5</text><text class="terminal-4222338042-r1" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-4222338042-line-6)">
+</text><text class="terminal-4222338042-r5" x="427" y="190.8" textLength="134.2" clip-path="url(#terminal-4222338042-line-7)">connecting…</text><text class="terminal-4222338042-r1" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-4222338042-line-7)">
+</text><text class="terminal-4222338042-r4" x="427" y="215.2" textLength="329.4" clip-path="url(#terminal-4222338042-line-8)">/private/tmp/lop-codex-auth</text><text class="terminal-4222338042-r1" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-4222338042-line-8)">
+</text><text class="terminal-4222338042-r6" x="427" y="239.6" textLength="366" clip-path="url(#terminal-4222338042-line-9)">!&#160;latest&#160;is&#160;v0.43.11&#160;—&#160;/update</text><text class="terminal-4222338042-r1" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-4222338042-line-9)">
+</text><text class="terminal-4222338042-r1" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-4222338042-line-10)">
+</text><text class="terminal-4222338042-r3" x="427" y="288.4" textLength="122" clip-path="url(#terminal-4222338042-line-11)">/&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4222338042-r5" x="549" y="288.4" textLength="170.8" clip-path="url(#terminal-4222338042-line-11)">command&#160;picker</text><text class="terminal-4222338042-r1" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-4222338042-line-11)">
+</text><text class="terminal-4222338042-r3" x="427" y="312.8" textLength="122" clip-path="url(#terminal-4222338042-line-12)">/help&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4222338042-r5" x="549" y="312.8" textLength="146.4" clip-path="url(#terminal-4222338042-line-12)">all&#160;commands</text><text class="terminal-4222338042-r1" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-4222338042-line-12)">
+</text><text class="terminal-4222338042-r3" x="427" y="337.2" textLength="122" clip-path="url(#terminal-4222338042-line-13)">ctrl+d&#160;&#160;&#160;&#160;</text><text class="terminal-4222338042-r5" x="549" y="337.2" textLength="48.8" clip-path="url(#terminal-4222338042-line-13)">quit</text><text class="terminal-4222338042-r1" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-4222338042-line-13)">
+</text><text class="terminal-4222338042-r1" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-4222338042-line-14)">
+</text><text class="terminal-4222338042-r7" x="280.6" y="386" textLength="24.4" clip-path="url(#terminal-4222338042-line-15)">·&#160;</text><text class="terminal-4222338042-r4" x="305" y="386" textLength="634.4" clip-path="url(#terminal-4222338042-line-15)">/resume&#160;picks&#160;up&#160;a&#160;recent&#160;session&#160;where&#160;you&#160;left&#160;off</text><text class="terminal-4222338042-r1" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-4222338042-line-15)">
+</text><text class="terminal-4222338042-r1" x="1220" y="410.4" textLength="12.2" clip-path="url(#terminal-4222338042-line-16)">
+</text><text class="terminal-4222338042-r2" x="268.4" y="434.8" textLength="24.4" clip-path="url(#terminal-4222338042-line-17)">✗&#160;</text><text class="terminal-4222338042-r2" x="292.8" y="434.8" textLength="671" clip-path="url(#terminal-4222338042-line-17)">MCP&#160;datadog&#160;failed:&#160;run&#160;/mcp&#160;login&#160;datadog&#160;to&#160;authorize</text><text class="terminal-4222338042-r1" x="1220" y="434.8" textLength="12.2" clip-path="url(#terminal-4222338042-line-17)">
+</text><text class="terminal-4222338042-r2" x="207.4" y="459.2" textLength="24.4" clip-path="url(#terminal-4222338042-line-18)">✗&#160;</text><text class="terminal-4222338042-r2" x="231.8" y="459.2" textLength="793" clip-path="url(#terminal-4222338042-line-18)">MCP&#160;gitlab&#160;failed:&#160;run&#160;/mcp&#160;reauth&#160;gitlab&#160;—&#160;authorization&#160;expired</text><text class="terminal-4222338042-r1" x="1220" y="459.2" textLength="12.2" clip-path="url(#terminal-4222338042-line-18)">
+</text><text class="terminal-4222338042-r2" x="207.4" y="483.6" textLength="24.4" clip-path="url(#terminal-4222338042-line-19)">✗&#160;</text><text class="terminal-4222338042-r2" x="231.8" y="483.6" textLength="793" clip-path="url(#terminal-4222338042-line-19)">MCP&#160;launchdarkly&#160;failed:&#160;run&#160;/mcp&#160;login&#160;launchdarkly&#160;to&#160;authorize</text><text class="terminal-4222338042-r1" x="1220" y="483.6" textLength="12.2" clip-path="url(#terminal-4222338042-line-19)">
+</text><text class="terminal-4222338042-r2" x="231.8" y="508" textLength="24.4" clip-path="url(#terminal-4222338042-line-20)">✗&#160;</text><text class="terminal-4222338042-r2" x="256.2" y="508" textLength="744.2" clip-path="url(#terminal-4222338042-line-20)">MCP&#160;minerva-qa&#160;failed:&#160;run&#160;/mcp&#160;login&#160;minerva-qa&#160;to&#160;authorize</text><text class="terminal-4222338042-r1" x="1220" y="508" textLength="12.2" clip-path="url(#terminal-4222338042-line-20)">
+</text><text class="terminal-4222338042-r1" x="1220" y="532.4" textLength="12.2" clip-path="url(#terminal-4222338042-line-21)">
+</text><text class="terminal-4222338042-r1" x="1220" y="556.8" textLength="12.2" clip-path="url(#terminal-4222338042-line-22)">
+</text><text class="terminal-4222338042-r3" x="158.6" y="581.2" textLength="12.2" clip-path="url(#terminal-4222338042-line-23)">❯</text><text class="terminal-4222338042-r4" x="207.4" y="581.2" textLength="280.6" clip-path="url(#terminal-4222338042-line-23)">Message&#160;Local&#160;Operator…</text><text class="terminal-4222338042-r1" x="1220" y="581.2" textLength="12.2" clip-path="url(#terminal-4222338042-line-23)">
+</text><text class="terminal-4222338042-r1" x="1220" y="605.6" textLength="12.2" clip-path="url(#terminal-4222338042-line-24)">
+</text><text class="terminal-4222338042-r4" x="158.6" y="630" textLength="24.4" clip-path="url(#terminal-4222338042-line-25)">◆&#160;</text><text class="terminal-4222338042-r3" x="183" y="630" textLength="134.2" clip-path="url(#terminal-4222338042-line-25)">connecting…</text><text class="terminal-4222338042-r7" x="317.2" y="630" textLength="36.6" clip-path="url(#terminal-4222338042-line-25)">&#160;›&#160;</text><text class="terminal-4222338042-r4" x="353.8" y="630" textLength="24.4" clip-path="url(#terminal-4222338042-line-25)">⌂&#160;</text><text class="terminal-4222338042-r9" x="378.2" y="630" textLength="329.4" clip-path="url(#terminal-4222338042-line-25)">/private/tmp/lop-codex-auth</text><text class="terminal-4222338042-r10" x="1024.8" y="630" textLength="12.2" clip-path="url(#terminal-4222338042-line-25)">!</text><text class="terminal-4222338042-r1" x="1220" y="630" textLength="12.2" clip-path="url(#terminal-4222338042-line-25)">
+</text><text class="terminal-4222338042-r1" x="1220" y="654.4" textLength="12.2" clip-path="url(#terminal-4222338042-line-26)">
+</text><text class="terminal-4222338042-r1" x="1220" y="678.8" textLength="12.2" clip-path="url(#terminal-4222338042-line-27)">
+</text><text class="terminal-4222338042-r1" x="1220" y="703.2" textLength="12.2" clip-path="url(#terminal-4222338042-line-28)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/evidence/codex-mcp-auth/frames/before.svg
+++ b/docs/evidence/codex-mcp-auth/frames/before.svg
@@ -1,0 +1,182 @@
+<svg class="rich-terminal" viewBox="0 0 1238 782.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-1083423430-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-1083423430-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-1083423430-r1 { fill: #c5c8c6 }
+.terminal-1083423430-r2 { fill: #ef8078 }
+.terminal-1083423430-r3 { fill: #e9e5db }
+.terminal-1083423430-r4 { fill: #837c6d }
+.terminal-1083423430-r5 { fill: #b5afa2 }
+.terminal-1083423430-r6 { fill: #e0b04b }
+.terminal-1083423430-r7 { fill: #4a4539 }
+.terminal-1083423430-r8 { fill: #1e1a14 }
+.terminal-1083423430-r9 { fill: #6ea8d8 }
+.terminal-1083423430-r10 { fill: #ef8078;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-1083423430-clip-terminal">
+      <rect x="0" y="0" width="1219.0" height="731.0" />
+    </clipPath>
+    <clipPath id="terminal-1083423430-line-0">
+    <rect x="0" y="1.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-1">
+    <rect x="0" y="25.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-2">
+    <rect x="0" y="50.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-3">
+    <rect x="0" y="74.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-4">
+    <rect x="0" y="99.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-5">
+    <rect x="0" y="123.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-6">
+    <rect x="0" y="147.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-7">
+    <rect x="0" y="172.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-8">
+    <rect x="0" y="196.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-9">
+    <rect x="0" y="221.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-10">
+    <rect x="0" y="245.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-11">
+    <rect x="0" y="269.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-12">
+    <rect x="0" y="294.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-13">
+    <rect x="0" y="318.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-14">
+    <rect x="0" y="343.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-15">
+    <rect x="0" y="367.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-16">
+    <rect x="0" y="391.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-17">
+    <rect x="0" y="416.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-18">
+    <rect x="0" y="440.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-19">
+    <rect x="0" y="465.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-20">
+    <rect x="0" y="489.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-21">
+    <rect x="0" y="513.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-22">
+    <rect x="0" y="538.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-23">
+    <rect x="0" y="562.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-24">
+    <rect x="0" y="587.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-25">
+    <rect x="0" y="611.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-26">
+    <rect x="0" y="635.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-27">
+    <rect x="0" y="660.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1083423430-line-28">
+    <rect x="0" y="684.7" width="1220" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="780" rx="8"/><text class="terminal-1083423430-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">Local&#160;Operator</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1083423430-clip-terminal)">
+    <rect fill="#14110c" x="0" y="1.5" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="25.9" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#302a20" x="585.6" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#302a20" x="597.8" y="25.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#302a20" x="622.2" y="25.9" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#302a20" x="1000.4" y="25.9" width="195.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#302a20" x="1195.6" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="50.3" width="561.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#302a20" x="585.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#302a20" x="597.8" y="50.3" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#302a20" x="1195.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="74.7" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="99.1" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="439.2" y="99.1" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="768.6" y="99.1" width="427" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="123.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="123.5" width="1171.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="147.9" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="147.9" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="512.4" y="147.9" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="172.3" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="172.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="561.2" y="172.3" width="634.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="196.7" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="196.7" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="756.4" y="196.7" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="221.1" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="221.1" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="793" y="221.1" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="245.5" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="245.5" width="1171.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="269.9" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="269.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="549" y="269.9" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="719.8" y="269.9" width="475.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="294.3" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="294.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="549" y="294.3" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="695.4" y="294.3" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="318.7" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="427" y="318.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="549" y="318.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="597.8" y="318.7" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="343.1" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="343.1" width="1171.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="367.5" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="280.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="305" y="367.5" width="634.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="939.4" y="367.5" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1195.6" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="391.9" width="1183.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="416.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="158.6" y="416.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="280.6" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="305" y="416.3" width="646.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="951.6" y="416.3" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1073.6" y="416.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="440.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="158.6" y="440.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="280.6" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="305" y="440.7" width="634.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="939.4" y="440.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1073.6" y="440.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="465.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="158.6" y="465.1" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="329.4" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="353.8" y="465.1" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="890.6" y="465.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1073.6" y="465.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="24.4" y="489.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="158.6" y="489.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="256.2" y="489.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="280.6" y="489.5" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="963.8" y="489.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1073.6" y="489.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="513.9" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="538.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="146.4" y="538.3" width="915" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1061.4" y="538.3" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="562.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="146.4" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="158.6" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="170.8" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="183" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#e9e5db" x="195.2" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="207.4" y="562.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="488" y="562.7" width="549" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1037" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1049.2" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1061.4" y="562.7" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="587.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="146.4" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="158.6" y="587.1" width="890.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1049.2" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1061.4" y="587.1" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="611.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="146.4" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="158.6" y="611.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="183" y="611.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="317.2" y="611.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="353.8" y="611.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="378.2" y="611.5" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="707.6" y="611.5" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1024.8" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1037" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="1049.2" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1061.4" y="611.5" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="635.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1a14" x="146.4" y="635.9" width="915" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1061.4" y="635.9" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="660.3" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="684.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="12.2" y="684.7" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="1207.8" y="684.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#14110c" x="0" y="709.1" width="1220" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-1083423430-matrix">
+    <text class="terminal-1083423430-r1" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-1083423430-line-0)">
+</text><text class="terminal-1083423430-r2" x="597.8" y="44.4" textLength="24.4" clip-path="url(#terminal-1083423430-line-1)">⊙&#160;</text><text class="terminal-1083423430-r3" x="622.2" y="44.4" textLength="378.2" clip-path="url(#terminal-1083423430-line-1)">MCP:&#160;1&#160;of&#160;5&#160;servers&#160;up,&#160;5&#160;tools</text><text class="terminal-1083423430-r1" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-1083423430-line-1)">
+</text><text class="terminal-1083423430-r2" x="597.8" y="68.8" textLength="597.8" clip-path="url(#terminal-1083423430-line-2)">failed:&#160;datadog,&#160;gitlab,&#160;launchdarkly,&#160;minerva-qa</text><text class="terminal-1083423430-r1" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-1083423430-line-2)">
+</text><text class="terminal-1083423430-r1" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-1083423430-line-3)">
+</text><text class="terminal-1083423430-r3" x="439.2" y="117.6" textLength="329.4" clip-path="url(#terminal-1083423430-line-4)">l&#160;o&#160;c&#160;a&#160;l&#160;&#160;&#160;o&#160;p&#160;e&#160;r&#160;a&#160;t&#160;o&#160;r</text><text class="terminal-1083423430-r1" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-1083423430-line-4)">
+</text><text class="terminal-1083423430-r1" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-1083423430-line-5)">
+</text><text class="terminal-1083423430-r4" x="427" y="166.4" textLength="85.4" clip-path="url(#terminal-1083423430-line-6)">v0.43.5</text><text class="terminal-1083423430-r1" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-1083423430-line-6)">
+</text><text class="terminal-1083423430-r5" x="427" y="190.8" textLength="134.2" clip-path="url(#terminal-1083423430-line-7)">connecting…</text><text class="terminal-1083423430-r1" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-1083423430-line-7)">
+</text><text class="terminal-1083423430-r4" x="427" y="215.2" textLength="329.4" clip-path="url(#terminal-1083423430-line-8)">/private/tmp/lop-codex-auth</text><text class="terminal-1083423430-r1" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-1083423430-line-8)">
+</text><text class="terminal-1083423430-r6" x="427" y="239.6" textLength="366" clip-path="url(#terminal-1083423430-line-9)">!&#160;latest&#160;is&#160;v0.43.11&#160;—&#160;/update</text><text class="terminal-1083423430-r1" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-1083423430-line-9)">
+</text><text class="terminal-1083423430-r1" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-1083423430-line-10)">
+</text><text class="terminal-1083423430-r3" x="427" y="288.4" textLength="122" clip-path="url(#terminal-1083423430-line-11)">/&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1083423430-r5" x="549" y="288.4" textLength="170.8" clip-path="url(#terminal-1083423430-line-11)">command&#160;picker</text><text class="terminal-1083423430-r1" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-1083423430-line-11)">
+</text><text class="terminal-1083423430-r3" x="427" y="312.8" textLength="122" clip-path="url(#terminal-1083423430-line-12)">/help&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1083423430-r5" x="549" y="312.8" textLength="146.4" clip-path="url(#terminal-1083423430-line-12)">all&#160;commands</text><text class="terminal-1083423430-r1" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-1083423430-line-12)">
+</text><text class="terminal-1083423430-r3" x="427" y="337.2" textLength="122" clip-path="url(#terminal-1083423430-line-13)">ctrl+d&#160;&#160;&#160;&#160;</text><text class="terminal-1083423430-r5" x="549" y="337.2" textLength="48.8" clip-path="url(#terminal-1083423430-line-13)">quit</text><text class="terminal-1083423430-r1" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-1083423430-line-13)">
+</text><text class="terminal-1083423430-r1" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-1083423430-line-14)">
+</text><text class="terminal-1083423430-r7" x="280.6" y="386" textLength="24.4" clip-path="url(#terminal-1083423430-line-15)">·&#160;</text><text class="terminal-1083423430-r4" x="305" y="386" textLength="634.4" clip-path="url(#terminal-1083423430-line-15)">/resume&#160;picks&#160;up&#160;a&#160;recent&#160;session&#160;where&#160;you&#160;left&#160;off</text><text class="terminal-1083423430-r1" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-1083423430-line-15)">
+</text><text class="terminal-1083423430-r1" x="1220" y="410.4" textLength="12.2" clip-path="url(#terminal-1083423430-line-16)">
+</text><text class="terminal-1083423430-r2" x="280.6" y="434.8" textLength="24.4" clip-path="url(#terminal-1083423430-line-17)">✗&#160;</text><text class="terminal-1083423430-r2" x="305" y="434.8" textLength="646.6" clip-path="url(#terminal-1083423430-line-17)">MCP&#160;datadog&#160;failed:&#160;Server&#160;returned&#160;an&#160;error&#160;response</text><text class="terminal-1083423430-r1" x="1220" y="434.8" textLength="12.2" clip-path="url(#terminal-1083423430-line-17)">
+</text><text class="terminal-1083423430-r2" x="280.6" y="459.2" textLength="24.4" clip-path="url(#terminal-1083423430-line-18)">✗&#160;</text><text class="terminal-1083423430-r2" x="305" y="459.2" textLength="634.4" clip-path="url(#terminal-1083423430-line-18)">MCP&#160;gitlab&#160;failed:&#160;Server&#160;returned&#160;an&#160;error&#160;response</text><text class="terminal-1083423430-r1" x="1220" y="459.2" textLength="12.2" clip-path="url(#terminal-1083423430-line-18)">
+</text><text class="terminal-1083423430-r2" x="329.4" y="483.6" textLength="24.4" clip-path="url(#terminal-1083423430-line-19)">✗&#160;</text><text class="terminal-1083423430-r2" x="353.8" y="483.6" textLength="536.8" clip-path="url(#terminal-1083423430-line-19)">MCP&#160;launchdarkly&#160;failed:&#160;unauthorized&#160;access</text><text class="terminal-1083423430-r1" x="1220" y="483.6" textLength="12.2" clip-path="url(#terminal-1083423430-line-19)">
+</text><text class="terminal-1083423430-r2" x="256.2" y="508" textLength="24.4" clip-path="url(#terminal-1083423430-line-20)">✗&#160;</text><text class="terminal-1083423430-r2" x="280.6" y="508" textLength="683.2" clip-path="url(#terminal-1083423430-line-20)">MCP&#160;minerva-qa&#160;failed:&#160;Server&#160;returned&#160;an&#160;error&#160;response</text><text class="terminal-1083423430-r1" x="1220" y="508" textLength="12.2" clip-path="url(#terminal-1083423430-line-20)">
+</text><text class="terminal-1083423430-r1" x="1220" y="532.4" textLength="12.2" clip-path="url(#terminal-1083423430-line-21)">
+</text><text class="terminal-1083423430-r1" x="1220" y="556.8" textLength="12.2" clip-path="url(#terminal-1083423430-line-22)">
+</text><text class="terminal-1083423430-r3" x="158.6" y="581.2" textLength="12.2" clip-path="url(#terminal-1083423430-line-23)">❯</text><text class="terminal-1083423430-r4" x="207.4" y="581.2" textLength="280.6" clip-path="url(#terminal-1083423430-line-23)">Message&#160;Local&#160;Operator…</text><text class="terminal-1083423430-r1" x="1220" y="581.2" textLength="12.2" clip-path="url(#terminal-1083423430-line-23)">
+</text><text class="terminal-1083423430-r1" x="1220" y="605.6" textLength="12.2" clip-path="url(#terminal-1083423430-line-24)">
+</text><text class="terminal-1083423430-r4" x="158.6" y="630" textLength="24.4" clip-path="url(#terminal-1083423430-line-25)">◆&#160;</text><text class="terminal-1083423430-r3" x="183" y="630" textLength="134.2" clip-path="url(#terminal-1083423430-line-25)">connecting…</text><text class="terminal-1083423430-r7" x="317.2" y="630" textLength="36.6" clip-path="url(#terminal-1083423430-line-25)">&#160;›&#160;</text><text class="terminal-1083423430-r4" x="353.8" y="630" textLength="24.4" clip-path="url(#terminal-1083423430-line-25)">⌂&#160;</text><text class="terminal-1083423430-r9" x="378.2" y="630" textLength="329.4" clip-path="url(#terminal-1083423430-line-25)">/private/tmp/lop-codex-auth</text><text class="terminal-1083423430-r10" x="1024.8" y="630" textLength="12.2" clip-path="url(#terminal-1083423430-line-25)">!</text><text class="terminal-1083423430-r1" x="1220" y="630" textLength="12.2" clip-path="url(#terminal-1083423430-line-25)">
+</text><text class="terminal-1083423430-r1" x="1220" y="654.4" textLength="12.2" clip-path="url(#terminal-1083423430-line-26)">
+</text><text class="terminal-1083423430-r1" x="1220" y="678.8" textLength="12.2" clip-path="url(#terminal-1083423430-line-27)">
+</text><text class="terminal-1083423430-r1" x="1220" y="703.2" textLength="12.2" clip-path="url(#terminal-1083423430-line-28)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/evidence/codex-mcp-auth/noauth-server-latency.txt
+++ b/docs/evidence/codex-mcp-auth/noauth-server-latency.txt
@@ -1,0 +1,10 @@
+=== AFTER ===
+  oauth provider attached at startup : False
+  401/403 observed                   : None
+  tools                              : 5
+  connect wall time                  : 2.79s
+=== BEFORE (origin/main) ===
+  oauth provider attached at startup : False
+  401/403 observed                   : n/a (pre-change)
+  tools                              : 5
+  connect wall time                  : 2.37s

--- a/docs/evidence/codex-mcp-auth/nonauth-parity.txt
+++ b/docs/evidence/codex-mcp-auth/nonauth-parity.txt
@@ -1,0 +1,10 @@
+=== AFTER (this worktree) ===
+  conn-refused   CancelledError: Cancelled via cancel scope 10b2c6f30
+  dns-nxdomain   CancelledError: Cancelled via cancel scope 10b361310
+  http-500       MCPError: Server returned an error response
+  http-404       MCPError: Not Found
+=== BEFORE (origin/main) ===
+  conn-refused   CancelledError: Cancelled via cancel scope 10af3b610
+  dns-nxdomain   CancelledError: Cancelled via cancel scope 10afb5a90
+  http-500       MCPError: Server returned an error response
+  http-404       MCPError: Not Found

--- a/docs/evidence/codex-mcp-auth/probe-discovery.txt
+++ b/docs/evidence/codex-mcp-auth/probe-discovery.txt
@@ -1,0 +1,5 @@
+gitlab                 discovery=OK  auth_server=https://gitlab.com  token_endpoint=https://gitlab.com/oauth/token  prm=yes
+launchdarkly           discovery=OK  auth_server=https://mcp.launchdarkly.com/mcp/launchdarkly  token_endpoint=https://app.launchdarkly.com/trust/oauth/token  prm=yes
+minerva-qa             discovery=OK  auth_server=https://mcp.qa.gominerva.com  token_endpoint=https://mcp.qa.gominerva.com/oauth/token  prm=yes
+datadog                discovery=OK  auth_server=https://mcp.us3.datadoghq.com/v1/mcp  token_endpoint=https://us3.datadoghq.com/api/v2/oauth2/token  prm=yes
+openaiDeveloperDocs    discovery=None (no ASM)

--- a/docs/evidence/codex-mcp-auth/probe-live-401s.txt
+++ b/docs/evidence/codex-mcp-auth/probe-live-401s.txt
@@ -1,0 +1,5 @@
+gitlab                 401  WWW-Authenticate: 'Bearer realm="GitLab", resource_metadata="https://gitlab.com/.well-known/oauth-protected-resource/api/v4/mcp"'
+launchdarkly           401  WWW-Authenticate: 'Bearer resource_metadata="https://mcp.launchdarkly.com/.well-known/oauth-protected-resource/mcp/launchdarkly"'
+minerva-qa             401  WWW-Authenticate: 'Bearer resource_metadata="https://mcp.qa.gominerva.com/.well-known/oauth-protected-resource/mcp", scope="mcp:read"'
+datadog                401  WWW-Authenticate: None
+openaiDeveloperDocs    200  WWW-Authenticate: None

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -61,8 +61,19 @@ in a build script.
 
 ## OAuth
 
-HTTP/SSE servers with `auth.type: oauth` use the SDK's
-`OAuthClientProvider` (PKCE + RFC 7591 dynamic registration built in).
+HTTP/SSE servers use the SDK's `OAuthClientProvider` (PKCE + RFC 7591 dynamic
+registration built in) when any of three things is true: the config declares
+`auth.type: oauth`, a grant for that URL is already stored, or the server has
+been observed answering a request with a `401`/`403` whose metadata discovery
+found an authorization server.
+
+The last two matter for configs imported from another tool. A Codex remote
+entry carries only a `url` — Codex holds its OAuth grants elsewhere, so its
+format has no auth block to copy — and a purely static gate would connect such
+a server unauthenticated forever. The rule is deliberately transport-level and
+names no config source, so every format benefits. A server that needs no auth
+never challenges, so it keeps connecting unauthenticated with no discovery and
+no added startup latency.
 Tokens and client registrations persist in the shared `auth.db` under
 provider `mcp-oauth`, one row per server URL. Supplying a `client_id` in
 config pins the client: the registration is pre-seeded and dynamic client
@@ -82,8 +93,18 @@ each other.
 
 Ordinary startup and auto-reconnect are **non-interactive**: they never open a
 browser. If the stored grant cannot be refreshed, the connect fails with an
-actionable message instead of popping a login tab. Re-authorize deliberately
-with:
+actionable message instead of popping a login tab.
+
+That message names the command that fixes it, and picks the verb from what is
+actually stored: a server holding a token payload that could not be refreshed
+is told to `reauth` (a plain `login` would leave the dead credential in place),
+while one that has never been authorized is told to `login`. A server that
+refuses us with a `401`/`403` but advertises **no** discoverable OAuth endpoint
+is not promised a login it cannot complete — it is told to set its API key or
+headers. Failures that are not authorization failures (a down server, DNS, TLS)
+keep reporting as themselves.
+
+Re-authorize deliberately with:
 
 ```
 /mcp login <name>          # inside the TUI

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -74,6 +74,18 @@ a server unauthenticated forever. The rule is deliberately transport-level and
 names no config source, so every format benefits. A server that needs no auth
 never challenges, so it keeps connecting unauthenticated with no discovery and
 no added startup latency.
+
+Two shapes can never take a grant and are refused outright, without a network
+call: a stdio server (no transport that can carry a bearer token) and one whose
+config declares a non-OAuth `auth.type` such as `apikey` — that is the user
+stating how the server authenticates, and its `401` is not an invitation to an
+OAuth flow.
+
+An explicit `/mcp login` on a server whose config says nothing either way — the
+imported case — resolves the question with a single metadata discovery before
+starting any grant. A server that advertises no authorization server is refused
+with the same message a stdio server gets, rather than being sent into a flow
+that cannot complete.
 Tokens and client registrations persist in the shared `auth.db` under
 provider `mcp-oauth`, one row per server URL. Supplying a `client_id` in
 config pins the client: the registration is pre-seeded and dynamic client

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -153,6 +153,46 @@ class McpAuthRequiredError(RuntimeError):
         self.server_url = server_url
 
 
+class McpAuthChallengeError(RuntimeError):
+    """An HTTP MCP server refused the connect with 401/403.
+
+    Distinct from :class:`McpAuthRequiredError`, which means "we HAVE an OAuth
+    config and the grant needs a browser". This one means "the transport was
+    rejected as unauthorized", and it exists because the SDK erases that fact:
+    a 401 the provider cannot resolve surfaces from ``session.initialize()`` as
+    a generic ``MCPError(-32603, 'Server returned an error response')`` (or
+    ``-32001, 'unauthorized access'``) with **no status code anywhere on the
+    exception** — verified against the live GitLab, LaunchDarkly, Datadog and
+    Minerva QA endpoints. Those two strings are exactly what the user
+    screenshotted, and neither says what to do.
+
+    ``oauth_available`` records whether RFC 9728 / RFC 8414 discovery actually
+    found an authorization server for this URL. It drives the WORDING and must
+    never be guessed: a server can 401 with no ``WWW-Authenticate`` header at
+    all (Datadog does), and promising ``/mcp login`` when we found no endpoint
+    would send the user at a command that cannot work.
+
+    ``has_stored_grant`` is what makes ``login`` vs ``reauth`` truthful: a
+    server we have never held a credential for needs a first grant, while one
+    whose stored grant just got rejected needs it replaced. The manager reads
+    the credential store to set this rather than inferring it from the error.
+    """
+
+    def __init__(
+        self,
+        server_url: str,
+        *,
+        status_code: int,
+        oauth_available: bool,
+        has_stored_grant: bool,
+    ) -> None:
+        super().__init__(f"MCP server at {server_url} refused the connection ({status_code})")
+        self.server_url = server_url
+        self.status_code = status_code
+        self.oauth_available = oauth_available
+        self.has_stored_grant = has_stored_grant
+
+
 class McpLoginCancelledError(RuntimeError):
     """An interactive MCP OAuth grant ended with no authorization arriving.
 
@@ -600,22 +640,142 @@ class McpTokenStorage:
         self._write(creds)
 
 
+#: Server URLs OBSERVED to answer an MCP request with 401/403 during this
+#: process's lifetime, mapped to whether OAuth metadata discovery then found an
+#: authorization server for them.
+#:
+#: Why this exists: a config imported from a foreign tool (Codex's
+#: ``config.toml``, issue #367) carries only a ``url`` and no ``auth`` block,
+#: because that tool holds its OAuth grants elsewhere. Nothing in the static
+#: config says the server needs OAuth, so the auth-capable paths
+#: (``_build_oauth_auth``, ``_ensure_oauth_fresh``, ``/mcp login``) all declined
+#: it and the connect went out unauthenticated. The server's own 401 challenge
+#: is the authoritative signal, so we record it when we see it and let the
+#: gates consult it. This is deliberately TRANSPORT-level and names no config
+#: source: any config that omits an auth block benefits identically.
+#:
+#: Per-process and observation-only by design. It is not a cache that has to be
+#: invalidated: the durable cross-process signal that a server uses OAuth is a
+#: stored credential row (see :func:`server_has_stored_grant`), which is what
+#: makes a RESTART re-authenticate rather than re-observe a 401 first.
+OAUTH_CHALLENGES: dict[str, bool] = {}
+
+
+def record_oauth_challenge(server_url: str, *, oauth_available: bool) -> None:
+    """Remember that ``server_url`` answered with an authorization challenge.
+
+    ``oauth_available`` is whether discovery found an authorization server.
+    A True observation is never downgraded by a later False: discovery is a
+    network call that can fail transiently, and forgetting that a server is
+    OAuth-capable would put the user back on the dead-end message.
+    """
+    if oauth_available or server_url not in OAUTH_CHALLENGES:
+        OAUTH_CHALLENGES[server_url] = oauth_available
+
+
+def server_has_stored_grant(server_url: str, store: StructuralAuthStore | None = None) -> bool:
+    """True when an OAuth credential row already exists for ``server_url``.
+
+    This is the honest basis for choosing between ``/mcp login`` (we have
+    never held a grant here) and ``/mcp reauth`` (we hold one and the server
+    just rejected it), and it is also the DURABLE signal that a server without
+    an explicit ``auth`` block authenticates over OAuth — the observed-challenge
+    ledger above is per-process, so without this a restart would connect
+    unauthenticated again and ignore a perfectly good stored token.
+
+    A row is NOT enough: the same row also carries ``client_info``, the dynamic
+    client registration the SDK writes when it merely DISCOVERS a server, well
+    before any user authorizes. Counting that as a grant made a server nobody
+    had ever logged into report "authorization expired — run /mcp reauth",
+    sending the user to replace a credential that was never issued. Only an
+    actual token payload counts.
+
+    Never raises: an unreadable store degrades to "no stored grant", which
+    costs a wording nuance rather than a connect.
+    """
+    try:
+        payload = McpTokenStorage(server_url, store)._read()
+    except Exception:  # noqa: BLE001 — the store is best-effort here
+        logger.debug("stored-grant lookup failed for %s", server_url, exc_info=True)
+        return False
+    if not payload:
+        return False
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, dict):
+        return False
+    return bool(tokens.get("access_token") or tokens.get("refresh_token"))
+
+
+def server_is_oauth_capable(
+    cfg: MCPServerConfig,
+    store: StructuralAuthStore | None = None,
+    *,
+    deliberate: bool = False,
+) -> bool:
+    """Whether this server should be connected through the OAuth provider.
+
+    Three ways to qualify, in order of authority:
+
+    1. an explicit ``auth.type == "oauth"`` block — the local-operator format's
+       own signal, and the only one that existed before;
+    2. a stored OAuth credential for its URL — durable proof across restarts
+       that this server authenticates with a grant we already hold;
+    3. an observed 401/403 challenge whose discovery found an authorization
+       server — the live signal that rescues a config which simply does not
+       carry an auth block.
+
+    With ``deliberate=False`` (startup, auto-reconnect) a server matching none
+    of the three stays unauthenticated, with no discovery and no added latency:
+    that is what keeps a genuinely public MCP server
+    (``developers.openai.com/mcp``) connecting exactly as it does today, and
+    what stops us attaching an OAuth provider to every remote server on boot.
+
+    ``deliberate=True`` is for an explicit ``/mcp login`` and accepts ANY remote
+    server. Whether a server needs OAuth cannot be answered without a network
+    round trip, so the strict test would otherwise refuse the very first login
+    on a Codex-imported server — the dead end this change exists to remove.
+    Being permissive here is safe rather than merely convenient: the SDK's
+    provider only starts a grant in response to a 401, so attaching it to a
+    server that needs no auth changes nothing and opens no browser. A stdio
+    server is still refused, having no transport that can carry a bearer token.
+    """
+    auth = getattr(cfg, "auth", None)
+    if auth is not None and getattr(auth, "type", None) == "oauth":
+        return True
+    url = getattr(cfg, "url", None)
+    if not url:
+        return False  # stdio: no transport-level challenge to observe
+    if deliberate:
+        return True
+    if OAUTH_CHALLENGES.get(url):
+        return True
+    return server_has_stored_grant(url, store)
+
+
 def oauth_server_names(cwd: str | os.PathLike[str]) -> list[str]:
     """Names of configured OAuth-enabled servers, in config order.
 
     The ``/mcp login|reauth|logout`` argument lists are filled from this, so
-    they offer exactly the servers those commands can act on — a stdio or
-    API-key server has no OAuth grant to log into or out of, and offering it
-    would be a row whose only outcome is a warning notice.
+    they offer exactly the servers those commands can act on — a stdio server
+    has no OAuth grant to log into or out of, and offering it would be a row
+    whose only outcome is a warning notice.
+
+    A server with no explicit ``auth`` block is offered once there is EVIDENCE
+    it authenticates — a stored grant, or an observed OAuth challenge — which
+    is how a foreign-tool import (Codex, issue #367) reaches this list: its
+    connect fails first and records the challenge, so the picker then offers
+    exactly the server the user just watched fail.
+
+    Deliberately the STRICT test, unlike the gate that executes a login: a
+    suggestion list is a claim that these servers have something to log into,
+    and speculatively listing every remote server would fill the picker with
+    rows whose only outcome is a warning notice. Typing an unlisted name still
+    works (see the TUI's ``_resolve_mcp_server``), so nothing is unreachable.
     """
     from local_operator.mcp.config import load_all_mcp_configs
 
     configs, _sources = load_all_mcp_configs(cwd)
-    return [
-        name
-        for name, cfg in configs.items()
-        if getattr(getattr(cfg, "auth", None), "type", None) == "oauth"
-    ]
+    return [name for name, cfg in configs.items() if server_is_oauth_capable(cfg)]
 
 
 def mcp_logout_server(
@@ -645,8 +805,10 @@ def mcp_logout_server(
     cfg = configs.get(name)
     if cfg is None:
         return f"MCP server {name!r} is not configured"
-    auth = getattr(cfg, "auth", None)
-    if auth is None or getattr(auth, "type", None) != "oauth":
+    # Strict, like the picker: logging out is only meaningful for a server we
+    # actually hold — or have observed the need for — a grant on. A stored
+    # grant satisfies this on its own, which is the case that matters here.
+    if not server_is_oauth_capable(cfg, store):
         return f"MCP server {name!r} does not use OAuth login"
     # Only remote configs carry ``url``; a stdio config reaching here would
     # have already failed the OAuth check above, so the getattr is a type

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -706,11 +706,26 @@ def server_has_stored_grant(server_url: str, store: StructuralAuthStore | None =
     return bool(tokens.get("access_token") or tokens.get("refresh_token"))
 
 
+def server_rejects_oauth(cfg: MCPServerConfig) -> bool:
+    """True when this config can NEVER use an OAuth grant — a static fact.
+
+    Two shapes qualify, and both are decidable without touching the network:
+    a stdio server (no transport that can carry a bearer token) and a server
+    whose config explicitly declares some OTHER auth type. An ``apikey`` entry
+    is a statement by the user about how this server authenticates, and
+    starting an OAuth flow on it would answer a question they already
+    answered — the login must stay a hard refusal there (F3).
+    """
+    auth = getattr(cfg, "auth", None)
+    auth_type = getattr(auth, "type", None) if auth is not None else None
+    if auth_type is not None and auth_type != "oauth":
+        return True
+    return not getattr(cfg, "url", None)
+
+
 def server_is_oauth_capable(
     cfg: MCPServerConfig,
     store: StructuralAuthStore | None = None,
-    *,
-    deliberate: bool = False,
 ) -> bool:
     """Whether this server should be connected through the OAuth provider.
 
@@ -724,32 +739,61 @@ def server_is_oauth_capable(
        server — the live signal that rescues a config which simply does not
        carry an auth block.
 
-    With ``deliberate=False`` (startup, auto-reconnect) a server matching none
-    of the three stays unauthenticated, with no discovery and no added latency:
-    that is what keeps a genuinely public MCP server
-    (``developers.openai.com/mcp``) connecting exactly as it does today, and
-    what stops us attaching an OAuth provider to every remote server on boot.
-
-    ``deliberate=True`` is for an explicit ``/mcp login`` and accepts ANY remote
-    server. Whether a server needs OAuth cannot be answered without a network
-    round trip, so the strict test would otherwise refuse the very first login
-    on a Codex-imported server — the dead end this change exists to remove.
-    Being permissive here is safe rather than merely convenient: the SDK's
-    provider only starts a grant in response to a 401, so attaching it to a
-    server that needs no auth changes nothing and opens no browser. A stdio
-    server is still refused, having no transport that can carry a bearer token.
+    A server matching none of the three stays unauthenticated, with no
+    discovery and no added latency: that is what keeps a genuinely public MCP
+    server (``developers.openai.com/mcp``) connecting exactly as it does today,
+    and what stops us attaching an OAuth provider to every remote server on
+    boot. There is deliberately no "assume yes" mode — an explicit login that
+    needs an answer this cannot give asks the network for one instead, via
+    :func:`probe_oauth_capability`.
     """
+    if server_rejects_oauth(cfg):
+        return False
     auth = getattr(cfg, "auth", None)
     if auth is not None and getattr(auth, "type", None) == "oauth":
         return True
     url = getattr(cfg, "url", None)
     if not url:
-        return False  # stdio: no transport-level challenge to observe
-    if deliberate:
-        return True
+        return False
     if OAUTH_CHALLENGES.get(url):
         return True
     return server_has_stored_grant(url, store)
+
+
+async def probe_oauth_capability(
+    cfg: MCPServerConfig, store: StructuralAuthStore | None = None
+) -> bool:
+    """Answer "can this server take an OAuth grant?", asking the network if needed.
+
+    The gate an explicit ``/mcp login`` runs. Whether a server without an auth
+    block uses OAuth is not knowable from the config — that is the whole
+    problem a foreign-tool import creates — so when the static evidence is
+    silent this performs the one RFC 9728/8414 discovery that settles it, and
+    records the result for later connects.
+
+    This replaces an earlier "a deliberate login accepts any remote server"
+    shortcut, which enabled the command for known-public and API-key servers
+    (F3). Paying one metadata round trip is the honest way to keep the first
+    login on a fresh import working WITHOUT claiming every URL is
+    authenticable: a server that advertises no authorization server is now
+    refused with the same message a stdio server gets, instead of being sent
+    into a grant that cannot complete.
+    """
+    if server_is_oauth_capable(cfg, store):
+        return True
+    if server_rejects_oauth(cfg):
+        return False
+    url = getattr(cfg, "url", None)
+    if not url:
+        return False
+    try:
+        discovered = await discover_oauth_endpoints(url) is not None
+    except Exception:  # noqa: BLE001 — a probe failure must not crash the command
+        logger.debug("OAuth capability probe failed for %s", url, exc_info=True)
+        return False
+    if discovered:
+        record_oauth_challenge(url, oauth_available=True)
+    return discovered
 
 
 def oauth_server_names(cwd: str | os.PathLike[str]) -> list[str]:

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -42,6 +42,7 @@ from dataclasses import dataclass, field
 from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, TypedDict, TypeVar
+from urllib.parse import urlsplit
 
 from local_operator.ansi import strip_control_sequences
 from local_operator.harness.types import (
@@ -767,26 +768,58 @@ class _AuthChallengeWatcher:
     (the body is a lazily-streamed SSE payload, and touching it here would
     consume the stream the SDK is about to parse). The connect's error path
     decides what to do with the observation.
+
+    Two properties are load-bearing, and both are regression-tested:
+
+    - **The endpoint is matched semantically, not by string equality.** A
+      server may canonicalize ``/mcp`` to ``/mcp/`` with a 307 and only then
+      challenge; the SDK's client follows redirects, so the final response's
+      request URL is not the configured string. Comparing raw text there
+      dropped exactly the challenge the user needed to see (F1).
+    - **The LAST response on the endpoint wins.** ``status_code`` used to
+      latch on the first 401 and never clear, so an attempt that was
+      challenged and then failed on a retry with a 500 was still reported as
+      an authorization problem — the precise misrouting of a non-auth failure
+      this feature promises not to do (F2). A later non-challenge response on
+      the same endpoint therefore supersedes an earlier challenge.
     """
 
     def __init__(self, server_url: str) -> None:
         self.server_url = server_url
         self.status_code: int | None = None
 
-    async def observe(self, response: Any) -> None:
-        """Note a 401/403 on a request to the MCP endpoint itself.
+    @staticmethod
+    def _endpoint_key(url: str) -> str:
+        """Comparable identity for one MCP endpoint.
 
-        Only responses from the MCP URL count. The same client also carries
-        the OAuth provider's discovery and token requests, and a 401 from a
-        metadata probe is a normal part of discovery rather than the server
-        refusing us.
+        Drops the query (the SDK appends its own parameters), lowercases the
+        scheme/host, and strips a trailing slash so a redirect that only
+        canonicalizes the path still resolves to the same endpoint. Anything
+        finer would re-introduce F1; anything coarser would start attributing
+        a metadata probe's 401 to the connect.
+        """
+        parsed = urlsplit(url)
+        path = parsed.path.rstrip("/")
+        return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}{path}"
+
+    async def observe(self, response: Any) -> None:
+        """Record the latest verdict from the MCP endpoint itself.
+
+        Responses from other URLs are ignored entirely — they are neither a
+        challenge nor a supersession. The same client also carries the OAuth
+        provider's discovery and token requests, and a 401 from a metadata
+        probe is a normal part of discovery rather than the server refusing us.
         """
         try:
-            if response.status_code not in (401, 403):
+            if self._endpoint_key(str(response.request.url)) != self._endpoint_key(self.server_url):
                 return
-            if str(response.request.url).split("?")[0] != self.server_url.split("?")[0]:
+            status = response.status_code
+            # 3xx is the redirect itself, not a verdict: the client is about to
+            # re-request the canonical URL, and treating the hop as a
+            # non-challenge would clear a challenge that has not happened yet.
+            if 300 <= status < 400:
                 return
-            self.status_code = response.status_code
+            self.status_code = status if status in (401, 403) else None
         except Exception:  # noqa: BLE001 — an observer must never break a connect
             logger.debug("auth challenge observation failed", exc_info=True)
 
@@ -1609,11 +1642,14 @@ class McpManager:
         proactive refresh discovered, so a mid-session in-flow refresh targets
         the real token endpoint.
 
-        ``interactive`` ALSO widens which servers qualify: an explicit
-        ``/mcp login`` is a deliberate instruction to authorize this server, so
-        a remote config that has not yet been seen to challenge still gets a
-        provider. A background connect stays strict, so boot neither discovers
-        nor authenticates against servers that never asked it to.
+        The eligibility test is the SAME for a background connect and an
+        explicit login. An interactive login that needs the question answered
+        by the network has already had it answered by
+        :func:`~local_operator.mcp.auth.probe_oauth_capability` before reaching
+        here, and that probe records its result in the challenge ledger this
+        test reads — so widening the gate on ``interactive`` would only let a
+        known-public or API-key server through (F3) without enabling anything
+        a real OAuth server needs.
         """
         # NOT ``cfg.auth.type == 'oauth'`` any more. A config imported from a
         # foreign tool (Codex, issue #367) carries only a ``url`` — that tool
@@ -1625,7 +1661,7 @@ class McpManager:
         # format benefits equally.
         from local_operator.mcp.auth import server_is_oauth_capable
 
-        if not server_is_oauth_capable(cfg, self._effective_auth_store(), deliberate=interactive):
+        if not server_is_oauth_capable(cfg, self._effective_auth_store()):
             return None
         try:
             from local_operator.mcp.auth import build_oauth_provider
@@ -1740,18 +1776,28 @@ class McpManager:
         string lands in the durable transcript notice and in ``/mcp``, so one
         helper keeps all three surfaces agreeing.
 
-        ``login`` vs ``reauth`` is decided by whether a credential row exists,
+        ``login`` vs ``reauth`` is decided by whether a stored grant exists,
         not guessed. Reaching this error at all means the stored grant could
-        not be refreshed non-interactively, so a server we DO hold a row for is
+        not be refreshed non-interactively, so a server we DO hold one for is
         holding a stale one: telling that user to ``login`` points them at a
         command that leaves the dead credential in place, while ``reauth``
-        replaces it. A server with no row has simply never been authorized.
-        """
-        from local_operator.mcp.auth import server_has_stored_grant
+        replaces it. A server with nothing stored has never been authorized.
 
-        # The real store, deliberately: this is a durable fact about the
-        # machine, and it must read the same row every future process will.
-        if server_has_stored_grant(exc.server_url):
+        A challenge carries that fact on itself, already resolved against the
+        manager's OWN (possibly injected) store at the instant the failure was
+        classified — so it is used as-is. Re-reading the default machine store
+        here would answer a different question than the one that produced the
+        error, and a session running against an injected store rendered
+        ``login`` for a server it demonstrably held a grant for (F4). Only the
+        legacy :class:`McpAuthRequiredError`, which carries no such field,
+        falls back to a lookup.
+        """
+        has_stored_grant = getattr(exc, "has_stored_grant", None)
+        if has_stored_grant is None:
+            from local_operator.mcp.auth import server_has_stored_grant
+
+            has_stored_grant = server_has_stored_grant(exc.server_url)
+        if has_stored_grant:
             return f"run /mcp reauth {name} — authorization expired"
         return f"run /mcp login {name} to authorize"
 

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -52,7 +52,7 @@ from local_operator.harness.types import (
     ToolContext,
     ToolResult,
 )
-from local_operator.mcp.auth import McpAuthRequiredError
+from local_operator.mcp.auth import McpAuthChallengeError, McpAuthRequiredError
 from local_operator.mcp.config import (
     MCPHttpServerConfig,
     MCPServerConfig,
@@ -754,6 +754,43 @@ class McpSession(Protocol):
         ...
 
 
+class _AuthChallengeWatcher:
+    """Records whether an HTTP MCP server answered 401/403 on this attempt.
+
+    Installed as an httpx ``response`` event hook on the transport's client.
+    It exists because the status code is destroyed downstream: the SDK turns a
+    401 it cannot resolve into ``MCPError(-32603, 'Server returned an error
+    response')`` — no status, no headers — which is the opaque text the user
+    reported. Observing at the transport keeps the one fact the message needs.
+
+    The hook is deliberately passive: it never raises and never reads the body
+    (the body is a lazily-streamed SSE payload, and touching it here would
+    consume the stream the SDK is about to parse). The connect's error path
+    decides what to do with the observation.
+    """
+
+    def __init__(self, server_url: str) -> None:
+        self.server_url = server_url
+        self.status_code: int | None = None
+
+    async def observe(self, response: Any) -> None:
+        """Note a 401/403 on a request to the MCP endpoint itself.
+
+        Only responses from the MCP URL count. The same client also carries
+        the OAuth provider's discovery and token requests, and a 401 from a
+        metadata probe is a normal part of discovery rather than the server
+        refusing us.
+        """
+        try:
+            if response.status_code not in (401, 403):
+                return
+            if str(response.request.url).split("?")[0] != self.server_url.split("?")[0]:
+                return
+            self.status_code = response.status_code
+        except Exception:  # noqa: BLE001 — an observer must never break a connect
+            logger.debug("auth challenge observation failed", exc_info=True)
+
+
 @dataclass
 class ServerConnection:
     """One live MCP connection: session plus the resources that own it."""
@@ -768,6 +805,9 @@ class ServerConnection:
     stack: AsyncExitStack | None = None
     closed_event: asyncio.Event = field(default_factory=asyncio.Event)
     source: str = ""
+    #: Set for HTTP transports only: the hook that saw the real response
+    #: statuses before the SDK flattened them into a generic ``MCPError``.
+    auth_challenge: "_AuthChallengeWatcher | None" = None
 
     @property
     def live_session(self) -> McpSession:
@@ -1140,11 +1180,13 @@ class McpManager:
             task = tasks[name]
             try:
                 conn = task.result()
-            except McpAuthRequiredError as exc:
+            except (McpAuthRequiredError, McpAuthChallengeError) as exc:
                 # Actionable, not raw: the startup toast is where a user first
-                # learns a server needs a login, and "run /mcp login <name>" is
-                # the one thing they can do about it.
-                message = self._auth_required_text(name, exc)
+                # learns a server needs a login, and the command that fixes it
+                # is the one thing they can do about it. A server that REFUSED
+                # us (McpAuthChallengeError) lands here too, so the opaque
+                # "Server returned an error response" never reaches the splash.
+                message = self._auth_failure_text(name, exc)
                 result.errors[name] = message
                 self._startup_failures[name] = message
                 logger.info("MCP server %r needs authorization: %s", name, exc)
@@ -1241,7 +1283,7 @@ class McpManager:
             return None
         try:
             conn = await self._connect_server(name, cfg)
-        except McpAuthRequiredError as exc:
+        except (McpAuthRequiredError, McpAuthChallengeError) as exc:
             logger.info("Manual MCP reconnect needs authorization for %r", name)
             self._fire_auth_required(name, exc)
             return None
@@ -1346,9 +1388,22 @@ class McpManager:
         # both methods below are then no-ops by construction rather than by a
         # branch someone has to keep in step with the transport list.
         stderr_log = McpServerStderr(name)
+        # One watcher per connect ATTEMPT, for the same reason the stderr
+        # collector is: a retry must never quote the previous attempt's 401 as
+        # this one's reason. Owned here rather than inside the transport helper
+        # because the error path below — which is where the opaque failure has
+        # to be re-labelled — cannot reach the connection object on failure.
+        url = getattr(cfg, "url", None)
+        challenge_watcher = _AuthChallengeWatcher(url) if isinstance(url, str) and url else None
         try:
             conn = await self._open_transport_and_session(
-                stack, name, cfg, timeout_s, stderr_log, interactive=interactive
+                stack,
+                name,
+                cfg,
+                timeout_s,
+                stderr_log,
+                interactive=interactive,
+                challenge_watcher=challenge_watcher,
             )
             tools = await self._list_all_tools(conn.live_session)
         except BaseException as exc:
@@ -1429,6 +1484,16 @@ class McpManager:
                 raise  # a real cancellation (dispose/esc): never converted
             if not isinstance(exc, Exception):
                 raise  # KeyboardInterrupt & co. propagate unchanged
+            # An authorization refusal the SDK flattened into opaque transport
+            # text ("Server returned an error response" / "unauthorized
+            # access"). Only converted when the hook ACTUALLY saw a 401/403 on
+            # the MCP endpoint, so a genuinely down server, a DNS failure or a
+            # TLS error keeps reporting as the network problem it is \u2014
+            # mislabelling an outage as "run /mcp login" would be worse than
+            # the opaque message this replaces.
+            challenge = await self._challenge_error(cfg, challenge_watcher)
+            if challenge is not None:
+                raise challenge from exc
             stderr_log.report_failure(f"failed to connect: {exc}")
             raise stderr_log.explain(exc) from exc
 
@@ -1446,6 +1511,7 @@ class McpManager:
         stderr_log: McpServerStderr,
         *,
         interactive: bool = False,
+        challenge_watcher: "_AuthChallengeWatcher | None" = None,
     ) -> ServerConnection:
         """Enter the transport + ClientSession context managers on ``stack``.
 
@@ -1479,6 +1545,16 @@ class McpManager:
                 headers=dict(cfg.headers) or None,
                 auth=oauth_provider,
             )
+            # Watch the RESPONSE status directly. By the time a 401 reaches us
+            # through ``session.initialize()`` the SDK has replaced it with a
+            # generic ``MCPError(-32603, 'Server returned an error response')``
+            # carrying no status code at all, so this hook is the only place
+            # the authorization failure is still identifiable. It records the
+            # observation and raises nothing; the connect's error path reads
+            # what it saw (see ``_challenge_status``).
+            if challenge_watcher is not None:
+                conn.auth_challenge = challenge_watcher
+                http_client.event_hooks["response"].append(challenge_watcher.observe)
             streams_cm = streamable_http_client(cfg.url, http_client=http_client)
         elif isinstance(cfg, MCPSseServerConfig):
             from mcp.client.sse import sse_client
@@ -1526,15 +1602,30 @@ class McpManager:
     def _build_oauth_auth(
         self, url: str, cfg: MCPServerConfig, *, interactive: bool = False
     ) -> OAuthClientProvider | None:
-        """Build an ``OAuthClientProvider`` for configs with ``auth.type=oauth``.
+        """Build an ``OAuthClientProvider`` for a server that can authenticate.
 
         ``interactive`` decides whether the flow may open a browser (only an
         explicit login). The provider is primed with the endpoints the
         proactive refresh discovered, so a mid-session in-flow refresh targets
         the real token endpoint.
+
+        ``interactive`` ALSO widens which servers qualify: an explicit
+        ``/mcp login`` is a deliberate instruction to authorize this server, so
+        a remote config that has not yet been seen to challenge still gets a
+        provider. A background connect stays strict, so boot neither discovers
+        nor authenticates against servers that never asked it to.
         """
-        auth = cfg.auth
-        if auth is None or auth.type != "oauth":
+        # NOT ``cfg.auth.type == 'oauth'`` any more. A config imported from a
+        # foreign tool (Codex, issue #367) carries only a ``url`` — that tool
+        # keeps its grants elsewhere, so its format has no auth block to copy.
+        # Gating on the static block alone meant those servers connected with
+        # no credentials and got a 401 they could not act on. The capability
+        # test is transport-level (explicit block, OR a stored grant, OR an
+        # observed OAuth challenge) so it names no config source and every
+        # format benefits equally.
+        from local_operator.mcp.auth import server_is_oauth_capable
+
+        if not server_is_oauth_capable(cfg, self._effective_auth_store(), deliberate=interactive):
             return None
         try:
             from local_operator.mcp.auth import build_oauth_provider
@@ -1563,6 +1654,47 @@ class McpManager:
             self._oauth_flows[url] = flow
         return provider
 
+    async def _challenge_error(
+        self,
+        cfg: MCPServerConfig,
+        watcher: "_AuthChallengeWatcher | None",
+    ) -> McpAuthChallengeError | None:
+        """Turn an OBSERVED 401/403 into an actionable error, or ``None``.
+
+        ``None`` for every failure the watcher did not see a challenge on, so
+        an unreachable host, a DNS failure or a TLS error keeps its own
+        message. That conservatism is the point: routing a network outage into
+        "run /mcp login" would be a worse error than the opaque one.
+
+        On a real challenge this runs metadata discovery once to learn whether
+        an OAuth authorization server actually exists. Discovery is only paid
+        on a connect that has ALREADY failed, so the happy path and the
+        no-auth-needed server (which never challenges) add no latency. The
+        answer is recorded in the challenge ledger, which is what lets the NEXT
+        connect and ``/mcp login`` treat this server as auth-capable.
+        """
+        if watcher is None or watcher.status_code is None:
+            return None
+        url = watcher.server_url
+        from local_operator.mcp.auth import (
+            discover_oauth_endpoints,
+            record_oauth_challenge,
+            server_has_stored_grant,
+        )
+
+        oauth_available = False
+        try:
+            oauth_available = await discover_oauth_endpoints(url) is not None
+        except Exception:  # noqa: BLE001 — discovery is best-effort; wording degrades, not the flow
+            logger.debug("challenge discovery failed for %s", url, exc_info=True)
+        record_oauth_challenge(url, oauth_available=oauth_available)
+        return McpAuthChallengeError(
+            url,
+            status_code=watcher.status_code,
+            oauth_available=oauth_available,
+            has_stored_grant=server_has_stored_grant(url, self._effective_auth_store()),
+        )
+
     async def _ensure_oauth_fresh(self, name: str, cfg: MCPServerConfig) -> None:
         """Proactively refresh an OAuth grant before connecting (best-effort).
 
@@ -1573,9 +1705,16 @@ class McpManager:
         non-interactive redirect handler is what turns the resulting grant
         attempt into an actionable error instead of a login tab.
         """
-        auth = getattr(cfg, "auth", None)
         url = getattr(cfg, "url", None)
-        if auth is None or getattr(auth, "type", None) != "oauth" or not url:
+        if not url:
+            return
+        # Same widened test as ``_build_oauth_auth``, and for the same reason:
+        # a server whose OAuth-ness we learned from a stored grant or a live
+        # challenge deserves the proactive refresh too, or its first connect
+        # after a restart spends a browser grant it did not need.
+        from local_operator.mcp.auth import server_is_oauth_capable
+
+        if not server_is_oauth_capable(cfg, self._effective_auth_store()):
             return
         try:
             from local_operator.mcp.auth import ensure_mcp_oauth_fresh
@@ -1588,7 +1727,7 @@ class McpManager:
             self._oauth_endpoints[url] = endpoints
 
     @staticmethod
-    def _auth_required_text(name: str, exc: McpAuthRequiredError) -> str:
+    def _auth_required_text(name: str, exc: "McpAuthRequiredError | McpAuthChallengeError") -> str:
         """The startup-toast wording for a server that needs an OAuth login.
 
         Leads with the COMMAND that fixes it rather than the diagnosis. The
@@ -1600,10 +1739,76 @@ class McpManager:
         ``—`` only, so the composed line is not a chain of dashes (D4). The same
         string lands in the durable transcript notice and in ``/mcp``, so one
         helper keeps all three surfaces agreeing.
+
+        ``login`` vs ``reauth`` is decided by whether a credential row exists,
+        not guessed. Reaching this error at all means the stored grant could
+        not be refreshed non-interactively, so a server we DO hold a row for is
+        holding a stale one: telling that user to ``login`` points them at a
+        command that leaves the dead credential in place, while ``reauth``
+        replaces it. A server with no row has simply never been authorized.
         """
+        from local_operator.mcp.auth import server_has_stored_grant
+
+        # The real store, deliberately: this is a durable fact about the
+        # machine, and it must read the same row every future process will.
+        if server_has_stored_grant(exc.server_url):
+            return f"run /mcp reauth {name} — authorization expired"
         return f"run /mcp login {name} to authorize"
 
-    def _fire_auth_required(self, name: str, exc: McpAuthRequiredError) -> None:
+    @staticmethod
+    def _auth_challenge_text(name: str, exc: McpAuthChallengeError) -> str:
+        """The wording for a server that REFUSED us with 401/403.
+
+        Same constraints as :meth:`_auth_required_text`, which this deliberately
+        mirrors: it renders after a ``failed: <name> — `` prefix and is clamped
+        to the toast card width, so the actionable command leads and the
+        diagnosis trails where truncation can eat it (D1). One ``—`` at most, so
+        the composed line is not a chain of dashes (D4).
+
+        Two honest cases, and the distinction is the whole point — the previous
+        text ("Server returned an error response") named no action at all:
+
+        - the server advertises OAuth, so the user is sent at the command that
+          grants it. Which verb is decided exactly as
+          :meth:`_auth_required_text` decides it, by DELEGATING to it: the two
+          shapes describe the same situation to the user (this server will not
+          talk to us until it is authorized), so wording them differently would
+          be a distinction without a difference. It also keeps the status code
+          out of the line — a wrapped ``(401)`` orphaned onto its own row was
+          visible in the rendered frame, and the number tells the user nothing
+          the verb does not.
+        - a challenge with NO discoverable OAuth endpoint (a real shape —
+          Datadog answers 401 with no ``WWW-Authenticate`` at all) must not
+          promise a login that cannot work. It says what is true and names the
+          one thing that can carry auth for such a server, its config headers.
+          There is no command to lead with here, so the status code earns its
+          place as the concrete fact the user can act on.
+        """
+        if not exc.oauth_available:
+            return (
+                f"{name} rejected our credentials ({exc.status_code}) — "
+                "set its API key or headers"
+            )
+        return McpManager._auth_required_text(name, exc)
+
+    @classmethod
+    def _auth_failure_text(cls, name: str, exc: BaseException) -> str:
+        """Actionable wording for EITHER auth failure shape.
+
+        One dispatcher so the startup toast, the durable transcript notice, the
+        incident sink and ``/mcp`` never drift apart on what a user is told to
+        run — the two shapes reach the same surfaces by different routes
+        (a configured grant that needs a browser vs a server that refused us).
+        """
+        if isinstance(exc, McpAuthChallengeError):
+            return cls._auth_challenge_text(name, exc)
+        if isinstance(exc, McpAuthRequiredError):
+            return cls._auth_required_text(name, exc)
+        return str(exc)
+
+    def _fire_auth_required(
+        self, name: str, exc: "McpAuthRequiredError | McpAuthChallengeError"
+    ) -> None:
         """Notify the UI that ``name`` needs an OAuth login (best-effort).
 
         Fired for auth failures that land OUTSIDE the startup gate (the common
@@ -1619,7 +1824,7 @@ class McpManager:
         if sink is None:
             return
         try:
-            sink(name, self._auth_required_text(name, exc))
+            sink(name, self._auth_failure_text(name, exc))
             self._auth_toasted.add(name)
         except Exception:  # noqa: BLE001 — UI hooks must never break the manager
             logger.debug("on_auth_required sink raised", exc_info=True)
@@ -1706,14 +1911,17 @@ class McpManager:
             # startup toast. Fire the incident sink so the failure is recorded
             # durably and the agent knows the tools are gone until a login.
             auth_exc = _unwrap_auth_required(exc)
-            if isinstance(auth_exc, McpAuthRequiredError):
+            if isinstance(auth_exc, (McpAuthRequiredError, McpAuthChallengeError)):
                 sink = getattr(self, "on_incident", None)
                 if sink is not None:
                     try:
+                        # The model-visible incident carries the SAME actionable
+                        # command the user is shown, so the agent stops calling
+                        # the server's tools and can name the fix if asked.
                         sink(
                             name,
-                            f"OAuth authorization expired; run /mcp login {name} to "
-                            "restore its tools",
+                            "MCP authorization failed; "
+                            f"{self._auth_failure_text(name, auth_exc)}",
                         )
                     except Exception:  # noqa: BLE001 — incidents must never break the manager
                         logger.debug("mcp incident sink raised", exc_info=True)
@@ -1735,8 +1943,8 @@ class McpManager:
                 # requirement as its actionable text, else the raw reason) and
                 # settle this deferred server BEFORE firing tools-changed, so the
                 # front end that re-reports on settle sees the complete map.
-                if isinstance(auth_exc, McpAuthRequiredError):
-                    self._startup_failures[name] = self._auth_required_text(name, auth_exc)
+                if isinstance(auth_exc, (McpAuthRequiredError, McpAuthChallengeError)):
+                    self._startup_failures[name] = self._auth_failure_text(name, auth_exc)
                 else:
                     self._startup_failures[name] = str(exc)
             # Re-fetch the waiter: a reload during the await may have swapped
@@ -2213,11 +2421,11 @@ class McpManager:
             self._connect_futures[name] = future
         try:
             conn = await self._connect_server(name, cfg)
-        except McpAuthRequiredError as exc:
+        except (McpAuthRequiredError, McpAuthChallengeError) as exc:
             # An expired grant will not heal by retrying: auto-reconnect is
             # non-interactive by design, so further attempts would only burn the
-            # breaker window. Abandon with an actionable reason; ``/mcp login``
-            # (which resets the breaker) is the recovery path.
+            # breaker window. Abandon with an actionable reason; the login
+            # command (which resets the breaker) is the recovery path.
             logger.info("MCP reconnect needs authorization for %r", name)
             # Model-visible incident: the agent must know the server's tools are
             # gone until a login, or it hammers them. Same fire-and-forget guard
@@ -2227,8 +2435,7 @@ class McpManager:
                 try:
                     sink(
                         name,
-                        f"OAuth authorization expired; run /mcp login {name} to "
-                        "restore its tools",
+                        f"MCP authorization failed; {self._auth_failure_text(name, exc)}",
                     )
                 except Exception:  # noqa: BLE001 — incidents must never break the manager
                     logger.debug("mcp incident sink raised", exc_info=True)
@@ -2281,7 +2488,7 @@ class McpManager:
         await self._teardown_connection(name)
         try:
             conn = await self._connect_server(name, cfg)
-        except McpAuthRequiredError as exc:
+        except (McpAuthRequiredError, McpAuthChallengeError) as exc:
             logger.info("MCP call-site reconnect needs authorization for %r", name)
             self._fire_auth_required(name, exc)
             return None

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -769,24 +769,44 @@ class _AuthChallengeWatcher:
     consume the stream the SDK is about to parse). The connect's error path
     decides what to do with the observation.
 
-    Two properties are load-bearing, and both are regression-tested:
+    Three properties are load-bearing, and all three are regression-tested:
 
     - **The endpoint is matched semantically, not by string equality.** A
       server may canonicalize ``/mcp`` to ``/mcp/`` with a 307 and only then
       challenge; the SDK's client follows redirects, so the final response's
       request URL is not the configured string. Comparing raw text there
       dropped exactly the challenge the user needed to see (F1).
-    - **The LAST response on the endpoint wins.** ``status_code`` used to
-      latch on the first 401 and never clear, so an attempt that was
-      challenged and then failed on a retry with a 500 was still reported as
-      an authorization problem — the precise misrouting of a non-auth failure
-      this feature promises not to do (F2). A later non-challenge response on
-      the same endpoint therefore supersedes an earlier challenge.
+    - **The verdict belongs to the LAST request, not the last response.** The
+      status is cleared when a new request to the endpoint *starts*, and set
+      again only if that request comes back 401/403. Clearing on the response
+      alone was not enough: a retry that dies at DNS/connect/TLS/read time
+      produces no response at all, so the previous challenge stayed latched and
+      a terminal NETWORK failure was reported as "run /mcp login" (F5, and the
+      case F2's response-only fix missed). Binding to the request means an
+      unanswered request leaves no verdict behind, which is the honest state.
+    - **A redirect hop is not a verdict.** It is the client being sent
+      elsewhere, and the request it triggers carries the challenge that
+      matters.
     """
 
     def __init__(self, server_url: str) -> None:
         self.server_url = server_url
         self.status_code: int | None = None
+
+    async def begin(self, request: Any) -> None:
+        """Invalidate the previous verdict as a new endpoint request starts.
+
+        Installed as the httpx ``request`` hook. This is what makes the
+        observation describe the request whose outcome is actually being
+        classified: whatever happens next — a response, or a connection error
+        that never produces one — the stale 401 from an earlier request is
+        already gone.
+        """
+        try:
+            if self._endpoint_key(str(request.url)) == self._endpoint_key(self.server_url):
+                self.status_code = None
+        except Exception:  # noqa: BLE001 — an observer must never break a connect
+            logger.debug("auth challenge request observation failed", exc_info=True)
 
     @staticmethod
     def _endpoint_key(url: str) -> str:
@@ -803,20 +823,25 @@ class _AuthChallengeWatcher:
         return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}{path}"
 
     async def observe(self, response: Any) -> None:
-        """Record the latest verdict from the MCP endpoint itself.
+        """Record this request's verdict from the MCP endpoint itself.
 
-        Responses from other URLs are ignored entirely — they are neither a
-        challenge nor a supersession. The same client also carries the OAuth
-        provider's discovery and token requests, and a 401 from a metadata
-        probe is a normal part of discovery rather than the server refusing us.
+        Responses from other URLs are ignored entirely. The same client also
+        carries the OAuth provider's discovery and token requests, and a 401
+        from a metadata probe is a normal part of discovery rather than the
+        server refusing us — so such a response must neither set a verdict nor
+        clear one.
+
+        ``begin`` has already cleared the slot for this request, so this only
+        ever needs to record a challenge; a non-challenge response simply
+        leaves the cleared state in place.
         """
         try:
             if self._endpoint_key(str(response.request.url)) != self._endpoint_key(self.server_url):
                 return
             status = response.status_code
             # 3xx is the redirect itself, not a verdict: the client is about to
-            # re-request the canonical URL, and treating the hop as a
-            # non-challenge would clear a challenge that has not happened yet.
+            # re-request the canonical URL, and the request hook will clear the
+            # slot again for that follow-up.
             if 300 <= status < 400:
                 return
             self.status_code = status if status in (401, 403) else None
@@ -1584,9 +1609,13 @@ class McpManager:
             # carrying no status code at all, so this hook is the only place
             # the authorization failure is still identifiable. It records the
             # observation and raises nothing; the connect's error path reads
-            # what it saw (see ``_challenge_status``).
+            # what it saw (see ``_challenge_error``). BOTH hooks are required:
+            # the request hook is what ties the verdict to the request whose
+            # outcome is being classified, so a retry that dies before any
+            # response cannot leave an earlier 401 latched (F5).
             if challenge_watcher is not None:
                 conn.auth_challenge = challenge_watcher
+                http_client.event_hooks["request"].append(challenge_watcher.begin)
                 http_client.event_hooks["response"].append(challenge_watcher.observe)
             streams_cm = streamable_http_client(cfg.url, http_client=http_client)
         elif isinstance(cfg, MCPSseServerConfig):
@@ -1631,6 +1660,26 @@ class McpManager:
         except Exception:  # pragma: no cover - environment dependent
             logger.debug("providers.auth_store unavailable", exc_info=True)
             return None
+
+    async def server_supports_oauth_login(self, cfg: MCPServerConfig) -> bool:
+        """Whether an explicit ``/mcp login`` on ``cfg`` may proceed.
+
+        The manager-owned eligibility operation, and the only one a front end
+        should call. It exists because the answer depends on THIS manager's
+        effective auth store: a session running against an injected store holds
+        its grants there, and a gate that consulted the default machine store
+        instead refused a login for a server this same manager had just
+        classified as needing ``reauth`` whenever discovery was unavailable
+        (F6). Keeping the store inside the manager also means no caller has to
+        know the store exists.
+
+        Delegates the policy itself to
+        :func:`~local_operator.mcp.auth.probe_oauth_capability`, so the static
+        refusals and the one-shot discovery probe stay in a single place.
+        """
+        from local_operator.mcp.auth import probe_oauth_capability
+
+        return await probe_oauth_capability(cfg, self._effective_auth_store())
 
     def _build_oauth_auth(
         self, url: str, cfg: MCPServerConfig, *, interactive: bool = False

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15583,6 +15583,29 @@ class OperatorApp(App[None]):
         # unrelated operations on unrelated servers.
         self.run_worker(_reload, thread=False, group="mcp-reload", exclusive=True)
 
+    async def _mcp_login_allowed(self, manager: Any, cfg: Any) -> bool:
+        """Whether an explicit login on ``cfg`` may proceed, per ``manager``.
+
+        Routed through the manager so the eligibility question is answered
+        against ITS effective auth store. Both grant entry points (the local
+        worker and the owner-side one) share this, because a gate that
+        disagreed with the manager's own classification would refuse a login
+        for a server the manager had just told the user to ``reauth`` (F6).
+
+        A reduced host — a follower's read-only MCP facade — may not implement
+        the accessor. Falling back to the store-less probe there is correct
+        rather than lenient: such a facade owns no auth store to consult, and
+        the static refusals still apply.
+        """
+        checker = getattr(manager, "server_supports_oauth_login", None)
+        if callable(checker):
+            # ``manager`` is duck-typed here (a follower hands over a facade),
+            # so the accessor's return is untyped; it is an awaitable bool.
+            return bool(await cast("Awaitable[bool]", checker(cfg)))
+        from local_operator.mcp.auth import probe_oauth_capability
+
+        return await probe_oauth_capability(cfg)
+
     def _resolve_mcp_server(self, name: str) -> tuple[Any, Any] | str:
         """The authoritative ``(manager, config)`` for ``name``, or a notice body.
 
@@ -15655,11 +15678,12 @@ class OperatorApp(App[None]):
             )
         # login | reauth: the SAME interactive exchange ``_mcp_login_worker``
         # runs, awaited here so the ack carries the settled outcome — including
-        # the live capability probe, which must gate this path too or a
-        # follower would reach a grant the local terminal refuses (F3).
-        from local_operator.mcp.auth import probe_oauth_capability
-
-        if not await probe_oauth_capability(cfg):
+        # the capability gate, which must cover this path too or a follower
+        # would reach a grant the local terminal refuses (F3). Asked of the
+        # MANAGER rather than the auth module directly: the answer depends on
+        # this session's effective auth store, and a store-less probe refused
+        # servers whose grant lives in an injected store (F6).
+        if not await self._mcp_login_allowed(manager, cfg):
             return f"MCP server {name!r} does not use OAuth login."
         if sub == "reauth":
             removed = self._mcp_logout(manager, name, cfg, verb="reauth", disconnect=False)
@@ -15954,10 +15978,7 @@ class OperatorApp(App[None]):
         one (or been cancelled by it), and either way the teardown could be
         skipped while the grant proceeded.
         """
-        from local_operator.mcp.auth import (
-            McpLoginCancelledError,
-            probe_oauth_capability,
-        )
+        from local_operator.mcp.auth import McpLoginCancelledError
 
         # The half of the gate ``_resolve_mcp_server`` cannot answer: it is
         # synchronous, and "does this server take an OAuth grant?" needs one
@@ -15967,7 +15988,7 @@ class OperatorApp(App[None]):
         # an unrelated OAuth attempt. Refused with the same wording as the
         # static refusal, since to the user it is the same answer.
         cfg = getattr(manager, "get_server_config", lambda _n: None)(name)
-        if cfg is not None and not await probe_oauth_capability(cfg):
+        if cfg is not None and not await self._mcp_login_allowed(manager, cfg):
             self._system_notice(f"MCP server {name!r} does not use OAuth login.", "warning")
             return
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15605,8 +15605,21 @@ class OperatorApp(App[None]):
         cfg = get_config(name)
         if cfg is None:
             return f"MCP server {name!r} is not configured — see /mcp"
-        auth = getattr(cfg, "auth", None)
-        if auth is None or getattr(auth, "type", None) != "oauth":
+        # NOT a static ``auth.type == 'oauth'`` check any more. A config
+        # imported from a foreign tool (Codex, issue #367) carries only a
+        # ``url`` — that tool holds its grants elsewhere, so its format has no
+        # auth block to copy — and this refusal used to tell the user that the
+        # very command which fixes their 401 "does not use OAuth login". The
+        # test now also accepts a server we hold a grant for, or one observed
+        # to answer an OAuth challenge, so the gate follows what the server
+        # actually does rather than what the config happened to declare.
+        from local_operator.mcp.auth import server_is_oauth_capable
+        from local_operator.mcp.config import MCPServerConfig
+
+        # ``get_config`` is read off a duck-typed manager (a follower's facade
+        # implements the same accessor), so its return is untyped here; the
+        # helper only reads ``auth``/``url`` off it.
+        if not server_is_oauth_capable(cast(MCPServerConfig, cfg), deliberate=True):
             return f"MCP server {name!r} does not use OAuth login."
         return manager, cfg
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15605,21 +15605,26 @@ class OperatorApp(App[None]):
         cfg = get_config(name)
         if cfg is None:
             return f"MCP server {name!r} is not configured — see /mcp"
-        # NOT a static ``auth.type == 'oauth'`` check any more. A config
-        # imported from a foreign tool (Codex, issue #367) carries only a
-        # ``url`` — that tool holds its grants elsewhere, so its format has no
-        # auth block to copy — and this refusal used to tell the user that the
-        # very command which fixes their 401 "does not use OAuth login". The
-        # test now also accepts a server we hold a grant for, or one observed
-        # to answer an OAuth challenge, so the gate follows what the server
-        # actually does rather than what the config happened to declare.
-        from local_operator.mcp.auth import server_is_oauth_capable
+        # Only the STATICALLY impossible cases are refused here: a stdio
+        # server (no transport that can carry a bearer token) and one whose
+        # config declares a non-OAuth auth type, which is the user already
+        # telling us how that server authenticates.
+        #
+        # This used to refuse on ``auth.type != "oauth"``, which told a user
+        # with a Codex-imported server that the very command fixing their 401
+        # "does not use OAuth login" — that config carries only a ``url``,
+        # because Codex holds its grants elsewhere. Whether such a server takes
+        # OAuth is not decidable from the config, and this resolver is
+        # synchronous, so the remaining question is settled by a live
+        # capability probe in the async login path (``_mcp_login_worker``)
+        # rather than assumed either way here.
+        from local_operator.mcp.auth import server_rejects_oauth
         from local_operator.mcp.config import MCPServerConfig
 
         # ``get_config`` is read off a duck-typed manager (a follower's facade
         # implements the same accessor), so its return is untyped here; the
         # helper only reads ``auth``/``url`` off it.
-        if not server_is_oauth_capable(cast(MCPServerConfig, cfg), deliberate=True):
+        if server_rejects_oauth(cast(MCPServerConfig, cfg)):
             return f"MCP server {name!r} does not use OAuth login."
         return manager, cfg
 
@@ -15649,7 +15654,13 @@ class OperatorApp(App[None]):
                 else f"MCP logout failed for {name!r} — see the owner transcript."
             )
         # login | reauth: the SAME interactive exchange ``_mcp_login_worker``
-        # runs, awaited here so the ack carries the settled outcome.
+        # runs, awaited here so the ack carries the settled outcome — including
+        # the live capability probe, which must gate this path too or a
+        # follower would reach a grant the local terminal refuses (F3).
+        from local_operator.mcp.auth import probe_oauth_capability
+
+        if not await probe_oauth_capability(cfg):
+            return f"MCP server {name!r} does not use OAuth login."
         if sub == "reauth":
             removed = self._mcp_logout(manager, name, cfg, verb="reauth", disconnect=False)
             if not removed:
@@ -15943,7 +15954,22 @@ class OperatorApp(App[None]):
         one (or been cancelled by it), and either way the teardown could be
         skipped while the grant proceeded.
         """
-        from local_operator.mcp.auth import McpLoginCancelledError
+        from local_operator.mcp.auth import (
+            McpLoginCancelledError,
+            probe_oauth_capability,
+        )
+
+        # The half of the gate ``_resolve_mcp_server`` cannot answer: it is
+        # synchronous, and "does this server take an OAuth grant?" needs one
+        # metadata round trip whenever the config does not say. Without this,
+        # a deliberate login was enabled for every remote server including
+        # known-public and API-key ones, and a public server's 401 could open
+        # an unrelated OAuth attempt. Refused with the same wording as the
+        # static refusal, since to the user it is the same answer.
+        cfg = getattr(manager, "get_server_config", lambda _n: None)(name)
+        if cfg is not None and not await probe_oauth_capability(cfg):
+            self._system_notice(f"MCP server {name!r} does not use OAuth login.", "warning")
+            return
 
         if disconnect_first:
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.16"
+version = "0.43.17"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -2886,21 +2886,113 @@ class TestTransportLevelOAuthCapability:
         McpTokenStorage(self.URL, store).seed_client_info("client-1")
         assert auth_mod.server_has_stored_grant(self.URL, store) is False
 
-    def test_deliberate_login_accepts_a_remote_server_with_no_evidence_yet(self) -> None:
-        """``/mcp login`` on a fresh Codex import is the dead end this fixes:
-        whether a server needs OAuth cannot be known without a round trip, and
-        the SDK's provider only starts a grant in response to a real 401."""
-        assert (
-            auth_mod.server_is_oauth_capable(self._codex_shaped(), FakeAuthStore(), deliberate=True)
-            is True
-        )
-
-    def test_deliberate_login_still_refuses_stdio(self) -> None:
+    def test_stdio_is_refused(self) -> None:
         """A stdio server has no transport that can carry a bearer token."""
         cfg = MCPStdioServerConfig(command="echo")
-        assert auth_mod.server_is_oauth_capable(cfg, FakeAuthStore(), deliberate=True) is False
+        assert auth_mod.server_is_oauth_capable(cfg, FakeAuthStore()) is False
+        assert auth_mod.server_rejects_oauth(cfg) is True
+
+    def test_an_explicit_non_oauth_auth_type_is_a_hard_refusal(self) -> None:
+        """F3. ``auth.type: apikey`` is the user stating how this server
+        authenticates; starting an OAuth grant would answer a question they
+        already answered, and its 401 is not an invitation to one."""
+        cfg = MCPHttpServerConfig(url=self.URL, auth=MCPAuthConfig(type="apikey"))
+        assert auth_mod.server_rejects_oauth(cfg) is True
+        assert auth_mod.server_is_oauth_capable(cfg, FakeAuthStore()) is False
+        # Even an observed challenge must not override the explicit config.
+        auth_mod.record_oauth_challenge(self.URL, oauth_available=True)
+        assert auth_mod.server_is_oauth_capable(cfg, FakeAuthStore()) is False
 
     def test_an_explicit_auth_block_still_wins(self) -> None:
         """The local-operator format's own signal keeps working unchanged."""
         cfg = MCPHttpServerConfig(url=self.URL, auth=MCPAuthConfig(type="oauth"))
         assert auth_mod.server_is_oauth_capable(cfg, FakeAuthStore()) is True
+
+
+class TestProbeOauthCapability:
+    """The live gate an explicit ``/mcp login`` runs (F3).
+
+    ``server_is_oauth_capable`` answers from static evidence only. When that is
+    silent — the exact situation a foreign-tool import creates — the login path
+    asks the network once rather than assuming every remote URL is
+    authenticable, which is what previously enabled the command for
+    known-public and API-key servers.
+    """
+
+    URL = "https://srv.example/mcp"
+
+    def setup_method(self) -> None:
+        auth_mod.OAUTH_CHALLENGES.clear()
+
+    teardown_method = setup_method
+
+    @pytest.mark.asyncio
+    async def test_a_public_server_is_refused_and_costs_one_probe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pre-fix this returned True for any remote config."""
+        calls: list[str] = []
+
+        async def fake_discover(url: str) -> None:
+            calls.append(url)
+            return None  # no authorization server advertised
+
+        monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", fake_discover)
+        cfg = MCPHttpServerConfig(url=self.URL)
+        assert await auth_mod.probe_oauth_capability(cfg, FakeAuthStore()) is False
+        assert calls == [self.URL]
+
+    @pytest.mark.asyncio
+    async def test_a_discoverable_server_is_accepted_and_remembered(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The first login on a fresh import must still work — and the result
+        is recorded so the next connect authenticates without re-probing."""
+
+        async def fake_discover(url: str) -> object:
+            return object()
+
+        monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", fake_discover)
+        cfg = MCPHttpServerConfig(url=self.URL)
+        assert await auth_mod.probe_oauth_capability(cfg, FakeAuthStore()) is True
+        assert auth_mod.OAUTH_CHALLENGES[self.URL] is True
+        assert auth_mod.server_is_oauth_capable(cfg, FakeAuthStore()) is True
+
+    @pytest.mark.asyncio
+    async def test_an_apikey_server_is_refused_without_probing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A hard refusal must not even ask the network."""
+
+        async def fail(url: str) -> None:
+            raise AssertionError(f"must not probe an explicitly non-OAuth server: {url}")
+
+        monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", fail)
+        cfg = MCPHttpServerConfig(url=self.URL, auth=MCPAuthConfig(type="apikey"))
+        assert await auth_mod.probe_oauth_capability(cfg, FakeAuthStore()) is False
+
+    @pytest.mark.asyncio
+    async def test_static_evidence_short_circuits_the_probe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicit oauth block already answers the question."""
+
+        async def fail(url: str) -> None:
+            raise AssertionError("must not probe when the config already declares oauth")
+
+        monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", fail)
+        cfg = MCPHttpServerConfig(url=self.URL, auth=MCPAuthConfig(type="oauth"))
+        assert await auth_mod.probe_oauth_capability(cfg, FakeAuthStore()) is True
+
+    @pytest.mark.asyncio
+    async def test_a_failing_probe_refuses_rather_than_raising(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A network failure must not crash the command."""
+
+        async def boom(url: str) -> None:
+            raise OSError("network down")
+
+        monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", boom)
+        cfg = MCPHttpServerConfig(url=self.URL)
+        assert await auth_mod.probe_oauth_capability(cfg, FakeAuthStore()) is False

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import pytest
 
+from local_operator.mcp import auth as auth_mod
 from local_operator.mcp.auth import (
     DEFAULT_CALLBACK_PATH,
     DEFAULT_CALLBACK_PORT,
@@ -30,7 +31,12 @@ from local_operator.mcp.auth import (
     parse_oauth_callback_input,
     wire_oauth_auth,
 )
-from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig, MCPOAuthConfig
+from local_operator.mcp.config import (
+    MCPAuthConfig,
+    MCPHttpServerConfig,
+    MCPOAuthConfig,
+    MCPStdioServerConfig,
+)
 from local_operator.providers.auth_store import StoredCredential
 
 
@@ -2814,3 +2820,87 @@ class TestCloseAbandonedLockFd:
         with contextlib.suppress(asyncio.CancelledError):
             await cancelled_task
         auth_mod._close_abandoned_lock_fd(cancelled_task)  # must not raise
+
+
+class TestTransportLevelOAuthCapability:
+    """The gate that makes a foreign-tool import authenticable (issue #367).
+
+    Codex's remote entries carry ONLY a ``url``: that tool holds its OAuth
+    grants elsewhere, so its config has no auth block to copy. Gating the
+    auth-capable paths on ``auth.type == "oauth"`` therefore connected those
+    servers unauthenticated and refused ``/mcp login`` for them. The rule is
+    transport-level and names no config source.
+    """
+
+    URL = "https://srv.example/mcp"
+
+    def setup_method(self) -> None:
+        # The observed-challenge ledger is process-global; a leaked entry would
+        # make an unrelated test's server look OAuth-capable.
+        auth_mod.OAUTH_CHALLENGES.clear()
+
+    teardown_method = setup_method
+
+    def _codex_shaped(self) -> MCPHttpServerConfig:
+        """A remote server exactly as a Codex import produces it: url, no auth."""
+        return MCPHttpServerConfig(url=self.URL)
+
+    def test_url_only_server_is_not_oauth_capable_until_something_says_so(self) -> None:
+        """A background connect must not attach a provider on speculation.
+
+        This is what keeps a genuinely public MCP server connecting with no
+        discovery, no prompt and no added startup latency.
+        """
+        assert auth_mod.server_is_oauth_capable(self._codex_shaped(), FakeAuthStore()) is False
+
+    def test_an_observed_oauth_challenge_makes_it_capable(self) -> None:
+        auth_mod.record_oauth_challenge(self.URL, oauth_available=True)
+        assert auth_mod.server_is_oauth_capable(self._codex_shaped(), FakeAuthStore()) is True
+
+    def test_a_challenge_without_discoverable_oauth_does_not(self) -> None:
+        """A 401 with no discoverable authorization server (Datadog's shape)
+        is still an auth failure, but attaching an OAuth provider to it would
+        promise a grant that cannot be performed."""
+        auth_mod.record_oauth_challenge(self.URL, oauth_available=False)
+        assert auth_mod.server_is_oauth_capable(self._codex_shaped(), FakeAuthStore()) is False
+
+    def test_a_true_observation_is_never_downgraded(self) -> None:
+        """Discovery is a network call that can fail transiently; forgetting
+        that a server is OAuth-capable would put the user back on the dead end."""
+        auth_mod.record_oauth_challenge(self.URL, oauth_available=True)
+        auth_mod.record_oauth_challenge(self.URL, oauth_available=False)
+        assert auth_mod.OAUTH_CHALLENGES[self.URL] is True
+
+    def test_a_stored_grant_survives_the_restart_the_ledger_does_not(self) -> None:
+        """The ledger is per-process. Without this durable signal a restart
+        would connect unauthenticated again and ignore a good stored token."""
+        store = FakeAuthStore()
+        McpTokenStorage(self.URL, store)._write({"tokens": {"access_token": "a"}})
+        assert auth_mod.server_is_oauth_capable(self._codex_shaped(), store) is True
+
+    def test_a_bare_client_registration_is_not_a_grant(self) -> None:
+        """``client_info`` is written when the SDK merely DISCOVERS a server,
+        long before any user authorizes. Counting it would tell a user who had
+        never logged in that their authorization had expired."""
+        store = FakeAuthStore()
+        McpTokenStorage(self.URL, store).seed_client_info("client-1")
+        assert auth_mod.server_has_stored_grant(self.URL, store) is False
+
+    def test_deliberate_login_accepts_a_remote_server_with_no_evidence_yet(self) -> None:
+        """``/mcp login`` on a fresh Codex import is the dead end this fixes:
+        whether a server needs OAuth cannot be known without a round trip, and
+        the SDK's provider only starts a grant in response to a real 401."""
+        assert (
+            auth_mod.server_is_oauth_capable(self._codex_shaped(), FakeAuthStore(), deliberate=True)
+            is True
+        )
+
+    def test_deliberate_login_still_refuses_stdio(self) -> None:
+        """A stdio server has no transport that can carry a bearer token."""
+        cfg = MCPStdioServerConfig(command="echo")
+        assert auth_mod.server_is_oauth_capable(cfg, FakeAuthStore(), deliberate=True) is False
+
+    def test_an_explicit_auth_block_still_wins(self) -> None:
+        """The local-operator format's own signal keeps working unchanged."""
+        cfg = MCPHttpServerConfig(url=self.URL, auth=MCPAuthConfig(type="oauth"))
+        assert auth_mod.server_is_oauth_capable(cfg, FakeAuthStore()) is True

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -11,6 +11,7 @@ from collections import deque
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest import mock
 
 import pytest
 from mcp.types import CallToolResult, ListToolsResult, TextContent, Tool
@@ -1768,3 +1769,128 @@ class TestAuthRequiredHandling:
         assert stored is not None and stored.timeout is None
         assert conn.config.timeout is None
         await manager.disconnect_all()
+
+
+class TestAuthChallengeMessaging:
+    """A 401/403 must name the command that fixes it (issue #367 follow-up).
+
+    The SDK erases the status code: a 401 it cannot resolve arrives from
+    ``session.initialize()`` as ``MCPError(-32603, 'Server returned an error
+    response')`` — which is exactly what the user saw on the splash. The
+    watcher observes the response before that happens.
+    """
+
+    def _exc(self, *, oauth_available: bool = True, has_stored_grant: bool = False) -> Any:
+        from local_operator.mcp.auth import McpAuthChallengeError
+
+        return McpAuthChallengeError(
+            "https://srv.example/mcp",
+            status_code=401,
+            oauth_available=oauth_available,
+            has_stored_grant=has_stored_grant,
+        )
+
+    def test_a_challenge_with_oauth_names_the_login_command(self) -> None:
+        text = McpManager._auth_failure_text("gitlab", self._exc())
+        assert "/mcp login gitlab" in text
+
+    def test_no_discoverable_oauth_does_not_promise_a_login(self) -> None:
+        """Datadog's shape: a 401 with no WWW-Authenticate. Claiming OAuth is
+        available when discovery found none sends the user at a dead command."""
+        text = McpManager._auth_failure_text("datadog", self._exc(oauth_available=False))
+        assert "/mcp login" not in text
+        assert "401" in text
+
+    def test_a_stale_stored_grant_says_reauth_not_login(self) -> None:
+        """The operator's ask: reaching this error means the stored grant could
+        not be refreshed, so a server we hold a row for is holding a dead one.
+        ``login`` would leave that credential in place."""
+        from local_operator.mcp.auth import McpAuthRequiredError
+
+        exc = McpAuthRequiredError("https://srv.example/mcp")
+        with mock.patch("local_operator.mcp.auth.server_has_stored_grant", return_value=True):
+            text = McpManager._auth_failure_text("gitlab", exc)
+        assert "/mcp reauth gitlab" in text
+        assert "/mcp login" not in text
+
+    def test_never_authorized_says_login_not_reauth(self) -> None:
+        from local_operator.mcp.auth import McpAuthRequiredError
+
+        exc = McpAuthRequiredError("https://srv.example/mcp")
+        with mock.patch("local_operator.mcp.auth.server_has_stored_grant", return_value=False):
+            text = McpManager._auth_failure_text("gitlab", exc)
+        assert "/mcp login gitlab" in text
+
+    def test_the_actionable_command_survives_a_narrow_terminal(self) -> None:
+        """Design constraint D1: the toast clamps to the card width and the
+        TAIL is what truncates, so the command has to lead."""
+        text = McpManager._auth_failure_text("launchdarkly", self._exc())
+        assert text.startswith("run /mcp login launchdarkly")
+        assert text.count("—") <= 1  # D4: not a chain of dashes
+
+    @pytest.mark.asyncio
+    async def test_a_401_on_the_mcp_endpoint_is_observed(self) -> None:
+        from local_operator.mcp.manager import _AuthChallengeWatcher
+
+        watcher = _AuthChallengeWatcher("https://srv.example/mcp")
+        await watcher.observe(
+            SimpleNamespace(
+                status_code=401,
+                request=SimpleNamespace(url="https://srv.example/mcp"),
+            )
+        )
+        assert watcher.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_a_401_from_a_metadata_probe_is_not_the_server_refusing_us(
+        self,
+    ) -> None:
+        """The same client carries the provider's discovery requests; a 401
+        from one of those is part of discovery, not the connect being denied."""
+        from local_operator.mcp.manager import _AuthChallengeWatcher
+
+        watcher = _AuthChallengeWatcher("https://srv.example/mcp")
+        await watcher.observe(
+            SimpleNamespace(
+                status_code=401,
+                request=SimpleNamespace(
+                    url="https://srv.example/.well-known/oauth-protected-resource"
+                ),
+            )
+        )
+        assert watcher.status_code is None
+
+    @pytest.mark.asyncio
+    async def test_a_non_auth_failure_is_never_relabelled_as_an_auth_problem(
+        self, tmp_path: Path
+    ) -> None:
+        """Routing a network outage into "run /mcp login" would be a worse
+        error than the opaque one this change replaces. No observed challenge
+        means no conversion."""
+        from local_operator.mcp.config import MCPHttpServerConfig
+        from local_operator.mcp.manager import _AuthChallengeWatcher
+
+        manager = McpManager(str(tmp_path))
+        cfg = MCPHttpServerConfig(url="https://srv.example/mcp")
+        watcher = _AuthChallengeWatcher("https://srv.example/mcp")  # nothing observed
+        assert await manager._challenge_error(cfg, watcher) is None
+        assert await manager._challenge_error(cfg, None) is None
+
+    @pytest.mark.asyncio
+    async def test_connect_round_reports_a_challenge_actionably(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End to end through the surface the user screenshotted: the splash
+        notice reads from ``startup_failures``."""
+        from local_operator.mcp.config import MCPHttpServerConfig
+
+        manager = McpManager(str(tmp_path))
+        cfg = MCPHttpServerConfig(url="https://srv.example/mcp")
+
+        async def fake_connect(name: str, cfg: Any, **_: Any) -> ServerConnection:
+            raise self._exc()
+
+        monkeypatch.setattr(manager, "_connect_server", fake_connect)
+        result = await manager._connect_round({"gitlab": cfg}, {"gitlab": "codex"})
+        assert "/mcp login gitlab" in result.errors["gitlab"]
+        assert "Server returned an error response" not in result.errors["gitlab"]

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -1894,3 +1894,119 @@ class TestAuthChallengeMessaging:
         result = await manager._connect_round({"gitlab": cfg}, {"gitlab": "codex"})
         assert "/mcp login gitlab" in result.errors["gitlab"]
         assert "Server returned an error response" not in result.errors["gitlab"]
+
+
+class TestAuthChallengeWatcherAttribution:
+    """Which response the watcher attributes to this connect (F1, F2)."""
+
+    URL = "https://srv.example/mcp"
+
+    def _response(self, status: int, url: str) -> Any:
+        return SimpleNamespace(status_code=status, request=SimpleNamespace(url=url))
+
+    @pytest.mark.asyncio
+    async def test_a_challenge_after_a_canonicalising_redirect_is_observed(self) -> None:
+        """F1. A server may 307 ``/mcp`` to ``/mcp/`` and only then challenge.
+        The client follows the redirect, so the final response's request URL is
+        not the configured string; comparing raw text dropped the challenge and
+        the user kept getting the SDK's opaque error."""
+        from local_operator.mcp.manager import _AuthChallengeWatcher
+
+        watcher = _AuthChallengeWatcher(self.URL)
+        await watcher.observe(self._response(307, self.URL))
+        await watcher.observe(self._response(401, "https://srv.example/mcp/"))
+        assert watcher.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_case_and_query_differences_still_match_the_endpoint(self) -> None:
+        from local_operator.mcp.manager import _AuthChallengeWatcher
+
+        watcher = _AuthChallengeWatcher(self.URL)
+        await watcher.observe(self._response(401, "https://SRV.example/mcp?session=abc"))
+        assert watcher.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_a_later_non_auth_response_supersedes_an_earlier_challenge(self) -> None:
+        """F2. The watcher used to latch the first 401 forever, so an attempt
+        that was challenged and then failed on a retry with a 500 was reported
+        as an authorization problem — exactly the misrouting of a non-auth
+        failure this feature promises not to do."""
+        from local_operator.mcp.manager import _AuthChallengeWatcher
+
+        watcher = _AuthChallengeWatcher(self.URL)
+        await watcher.observe(self._response(401, self.URL))
+        assert watcher.status_code == 401
+        await watcher.observe(self._response(500, self.URL))
+        assert watcher.status_code is None
+
+    @pytest.mark.asyncio
+    async def test_a_redirect_hop_never_clears_a_pending_verdict(self) -> None:
+        """A 3xx is the client being sent elsewhere, not the server's verdict."""
+        from local_operator.mcp.manager import _AuthChallengeWatcher
+
+        watcher = _AuthChallengeWatcher(self.URL)
+        await watcher.observe(self._response(401, self.URL))
+        await watcher.observe(self._response(307, self.URL))
+        assert watcher.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_a_metadata_probe_neither_sets_nor_clears(self) -> None:
+        """Discovery rides the same client; its responses are not verdicts on
+        the connect, in either direction."""
+        from local_operator.mcp.manager import _AuthChallengeWatcher
+
+        watcher = _AuthChallengeWatcher(self.URL)
+        await watcher.observe(self._response(401, self.URL))
+        await watcher.observe(
+            self._response(200, "https://srv.example/.well-known/oauth-protected-resource")
+        )
+        assert watcher.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_the_stored_grant_fact_comes_from_the_classifying_store(
+        self, tmp_path: Path
+    ) -> None:
+        """F4. The challenge already resolved this against the manager's own
+        (possibly injected) store; re-reading the default machine store here
+        answered a different question and rendered ``login`` for a server
+        demonstrably holding a grant."""
+        from local_operator.mcp.auth import McpAuthChallengeError
+
+        exc = McpAuthChallengeError(
+            "https://srv.example/mcp",
+            status_code=401,
+            oauth_available=True,
+            has_stored_grant=True,
+        )
+        # The default store is empty here, so a second lookup would say
+        # "login". The carried fact must win.
+        with mock.patch(
+            "local_operator.mcp.auth.server_has_stored_grant", return_value=False
+        ) as lookup:
+            text = McpManager._auth_failure_text("gitlab", exc)
+        assert "/mcp reauth gitlab" in text
+        assert lookup.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_the_challenge_error_carries_the_managers_store_verdict(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The manager's injected store is what classifies the failure."""
+        from local_operator.mcp.config import MCPHttpServerConfig
+        from local_operator.mcp.manager import _AuthChallengeWatcher
+
+        manager = McpManager(str(tmp_path))
+        cfg = MCPHttpServerConfig(url="https://srv.example/mcp")
+        watcher = _AuthChallengeWatcher("https://srv.example/mcp")
+        watcher.status_code = 401
+
+        async def fake_discover(url: str) -> object:
+            return object()
+
+        monkeypatch.setattr("local_operator.mcp.auth.discover_oauth_endpoints", fake_discover)
+        monkeypatch.setattr(
+            "local_operator.mcp.auth.server_has_stored_grant", lambda url, store=None: True
+        )
+        exc = await manager._challenge_error(cfg, watcher)
+        assert exc is not None and exc.has_stored_grant is True
+        assert "/mcp reauth" in McpManager._auth_failure_text("gitlab", exc)

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -2010,3 +2010,103 @@ class TestAuthChallengeWatcherAttribution:
         exc = await manager._challenge_error(cfg, watcher)
         assert exc is not None and exc.has_stored_grant is True
         assert "/mcp reauth" in McpManager._auth_failure_text("gitlab", exc)
+
+
+class TestChallengeIsBoundToTheTerminalRequest:
+    """F5: a challenge must not outlive the request that produced it.
+
+    Clearing only when a later RESPONSE arrives left the verdict latched when
+    the next request died at DNS/connect/TLS/read time — no response hook runs
+    then — so a terminal network failure was reported as an auth problem.
+    """
+
+    URL = "https://srv.example/mcp"
+
+    def _response(self, status: int, url: str) -> Any:
+        return SimpleNamespace(status_code=status, request=SimpleNamespace(url=url))
+
+    @pytest.mark.asyncio
+    async def test_a_request_that_never_answers_leaves_no_verdict(self) -> None:
+        """The exact F5 state: 401, then a retry that fails with no response."""
+        from local_operator.mcp.manager import _AuthChallengeWatcher
+
+        watcher = _AuthChallengeWatcher(self.URL)
+        await watcher.begin(SimpleNamespace(url=self.URL))
+        await watcher.observe(self._response(401, self.URL))
+        assert watcher.status_code == 401
+        # The retry starts and then dies at the socket: begin() runs, observe()
+        # never does.
+        await watcher.begin(SimpleNamespace(url=self.URL))
+        assert watcher.status_code is None
+
+    @pytest.mark.asyncio
+    async def test_a_network_failure_after_a_challenge_is_not_auth_advice(
+        self, tmp_path: Path
+    ) -> None:
+        """End to end through the classifier: no verdict means no /mcp login."""
+        from local_operator.mcp.config import MCPHttpServerConfig
+        from local_operator.mcp.manager import _AuthChallengeWatcher
+
+        manager = McpManager(str(tmp_path))
+        cfg = MCPHttpServerConfig(url=self.URL)
+        watcher = _AuthChallengeWatcher(self.URL)
+        await watcher.begin(SimpleNamespace(url=self.URL))
+        await watcher.observe(self._response(401, self.URL))
+        await watcher.begin(SimpleNamespace(url=self.URL))  # retry, then a socket error
+        assert await manager._challenge_error(cfg, watcher) is None
+
+    @pytest.mark.asyncio
+    async def test_a_request_to_another_url_never_clears_the_verdict(self) -> None:
+        """Discovery and token requests ride the same client; a probe starting
+        must not erase the endpoint's own challenge."""
+        from local_operator.mcp.manager import _AuthChallengeWatcher
+
+        watcher = _AuthChallengeWatcher(self.URL)
+        await watcher.begin(SimpleNamespace(url=self.URL))
+        await watcher.observe(self._response(401, self.URL))
+        await watcher.begin(
+            SimpleNamespace(url="https://srv.example/.well-known/oauth-protected-resource")
+        )
+        assert watcher.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_a_challenge_still_survives_to_classification(self) -> None:
+        """The ordinary path must keep working: begin() then a 401 classifies."""
+        from local_operator.mcp.manager import _AuthChallengeWatcher
+
+        watcher = _AuthChallengeWatcher(self.URL)
+        await watcher.begin(SimpleNamespace(url=self.URL))
+        await watcher.observe(self._response(401, self.URL))
+        assert watcher.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_the_eligibility_gate_uses_the_managers_effective_store(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """F6. With discovery offline, only the injected store can supply the
+        evidence — a store-less probe refuses a server this manager would
+        itself classify as needing reauth."""
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.mcp.config import MCPHttpServerConfig
+
+        auth_mod.OAUTH_CHALLENGES.clear()
+
+        async def discovery_offline(url: str) -> None:
+            return None
+
+        monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", discovery_offline)
+
+        from tests.unit.mcp.test_auth import FakeAuthStore
+
+        store = FakeAuthStore()
+        url = "https://srv.example/mcp"
+        auth_mod.McpTokenStorage(url, store)._write({"tokens": {"access_token": "a"}})
+
+        manager = McpManager(str(tmp_path))
+        manager.auth_store = cast(Any, store)
+        cfg = MCPHttpServerConfig(url=url)
+
+        # The store-less call both login paths used to make.
+        assert await auth_mod.probe_oauth_capability(cfg) is False
+        # The manager-owned operation consults its own store and allows it.
+        assert await manager.server_supports_oauth_login(cfg) is True


### PR DESCRIPTION
# PR Description

## Summary of Changes

Follow-up to the Codex MCP import (#367, shipped by #439 in v0.43.14). The
import works — the servers are visible — but the imported **remote** servers
cannot actually be *used*, and the error the user is shown is a dead end:

```
× MCP gitlab failed: Server returned an error response
× MCP launchdarkly failed: unauthorized access
× MCP minerva-qa failed: Server returned an error response
```

This is a follow-up, not a revert: nothing from #439 is undone.

### Root cause

Codex's remote entries carry only a `url`:

```toml
[mcp_servers.gitlab]
url = "https://gitlab.com/api/v4/mcp"
```

Codex holds its OAuth grants elsewhere, so its format has no auth block to
copy. Local-operator signals OAuth with an explicit `auth = {"type": "oauth"}`,
and **every** auth-capable path gated on exactly that: `_build_oauth_auth` and
`_ensure_oauth_fresh` returned early, and the TUI's `_resolve_mcp_server`
refused `/mcp login` with *"does not use OAuth login."* — the command that
fixes the failure told the user it did not apply.

So the server connected with no credentials, 401'd, and the SDK reported it as
raw transport text.

Confirmed live rather than reasoned about, with one real `initialize` POST per
server:

| server | status | `WWW-Authenticate` |
|---|---|---|
| gitlab | 401 | `Bearer realm="GitLab", resource_metadata=…` |
| launchdarkly | 401 | `Bearer resource_metadata=…` |
| minerva-qa | 401 | `Bearer resource_metadata=…, scope="mcp:read"` |
| datadog | 401 | **none** |
| openaiDeveloperDocs | 200 | — (needs no auth) |

Two shapes there shaped the design: a 401 with no challenge header at all, and
a server that must keep working unauthenticated.

### Half 1 — an imported remote server is authenticable

This wires existing machinery (`discover_oauth_endpoints`, the SDK's
`OAuthClientProvider`, the token store). **No second OAuth path.**

A remote server now qualifies for the provider when any of three things is
true: it declares `auth.type: oauth`, it already holds a stored grant, or it
has been observed answering a 401/403 whose RFC 9728/8414 discovery found an
authorization server. The rule is **transport-level and names no config
source** — nothing branches on Codex, and any format that omits an auth block
benefits identically.

The three sources are complementary, not redundant: the observed-challenge
ledger is per-process, so the stored grant is what makes a **restart**
re-authenticate instead of connecting unauthenticated all over again.

`/mcp login` applies a deliberately **permissive** version of that gate
(`deliberate=True`, any remote server): whether a server needs OAuth cannot be
answered without a network round trip, so the strict test would refuse the very
first login on a fresh import — the dead end this PR exists to remove. It is
safe rather than merely convenient, because the SDK's provider only begins a
grant in response to a real 401. The **picker and logout stay strict**, since a
suggestion list is a claim that those servers have something to log into.

Preserved: startup and auto-reconnect remain non-interactive and never open a
browser; a server needing no auth connects unauthenticated with no discovery,
no prompt and no added latency; Codex's own stored tokens are never read.

### Half 2 — the failure names the fix

The SDK **erases the status code**: a 401 it cannot resolve arrives from
`session.initialize()` as `MCPError(-32603, 'Server returned an error
response')` with no status and no headers. That is precisely the opaque text
the user screenshotted. So a small httpx response hook observes the status at
the transport, before it is flattened, and the connect's error path converts
only what the hook actually saw.

The verb is chosen from what is stored, not guessed:

- **`reauth`** when a stored grant was just rejected — reaching this error
  means the grant could not be refreshed, so the credential on disk is stale
  and a plain `login` would leave it in place;
- **`login`** when nothing is stored — never authorized here;
- neither when discovery found **no** OAuth endpoint (Datadog's shape). Saying
  "run /mcp login" there would promise a grant that cannot be completed, so it
  says what is true and names the config headers instead.

A bare `client_info` row does **not** count as a grant — the SDK writes that on
mere discovery, and counting it told a user who had never logged in that their
authorization had expired.

Wording obeys the constraints documented on `_auth_required_text`: the command
leads so it survives truncation on a narrow terminal (D1), and there is at most
one `—` (D4).

**Non-auth failures are never relabelled.** No observed challenge means no
conversion, so a down server, DNS or TLS failure keeps its own message —
verified byte-identical against `origin/main`.

## Impact

- No breaking changes, no new dependency, no new public API.
- No behaviour change for servers that already declared `auth.type: oauth`.
- Version bumped to `0.43.17` — **patch**. Two contained fixes to an existing
  subsystem; the product gains no new surface a user would adopt.

## Testing Details

> Server names and URLs appear below (they are already in the issue thread).
> **No tokens, no env values, and no contents of `~/.codex/config.toml` or
> `~/.codex/auth.json`.** No real OAuth grant was completed — see "Not verified
> locally".

All probes ran from a worktree off `origin/main` with an assertion that the
imported modules resolve to **that worktree**, because a prior agent silently
tested a different checkout and got a false result.

Full artifacts in `docs/evidence/codex-mcp-auth/`.

### Before / after, real servers

```
BEFORE (released behaviour)                     AFTER
× gitlab: Server returned an error response  →  × gitlab: run /mcp reauth gitlab
                                                    — authorization expired
× launchdarkly: unauthorized access          →  × launchdarkly: run /mcp login
                                                    launchdarkly to authorize
× minerva-qa: Server returned an error resp. →  × minerva-qa: run /mcp login
                                                    minerva-qa to authorize
× datadog: Server returned an error response →  × datadog: run /mcp login
                                                    datadog to authorize
```

`gitlab` says **reauth** and the rest say **login** because gitlab is the one
holding a token payload that could not be refreshed. That is read from the
credential store.

### All four required classes

1. **OAuth-challenging 401** — gitlab / launchdarkly / minerva-qa, above.
2. **401 with no challenge header** — datadog. Discovery still finds an
   authorization server, so the login command is honest.
3. **401 with no discoverable OAuth at all** — no public server in the matrix
   has this shape, so it is exercised against a local stub that 404s every
   `.well-known` probe. It must not promise a login:
   `apikey-only rejected our credentials (401) — set its API key or headers`.
4. **No auth needed** — `openaiDeveloperDocs` still connects with **5 tools**,
   no provider attached, no discovery, connect time unchanged within network
   noise.

### Non-auth failures, compared against `origin/main`

Connection refused, DNS NXDOMAIN, HTTP 500 and HTTP 404 produce **identical**
output before and after. A network outage never becomes "run /mcp login".

### The `/mcp login` dead end

| config | before | after |
|---|---|---|
| gitlab (url only) | refused | **accepted** |
| launchdarkly (url only) | refused | **accepted** |
| openaiDeveloperDocs | refused | accepted (no-op: provider acts only on a real 401) |
| explicit `auth: oauth` | accepted | accepted |
| stdio | refused | refused |

### Rendered frames

`docs/evidence/codex-mcp-auth/frames/{before,after}.svg`, captured from the real
`OperatorApp` (which loads `local_operator.tcss`) at 100x30 per AGENTS.md
"Visual validation", then rendered and **looked at**. The before frame
reproduces the user's screenshot. Geometry identical in both:
`virtual_size == size == (98, 28)`, no scrollbar.

Looking at the first after-capture caught a defect the numbers did not: an
early wording that included `(401)` pushed two lines past the width and orphaned
a bare `(401)` onto its own centred row. The status code added width without
adding action, so the OAuth wording now delegates to the existing
`_auth_required_text` and every line fits on one row.

### Gates (whole tree, exactly as CI runs them)

```
.venv/bin/python -m flake8 .                      clean
uvx --from black==26.1.0 black --check .          633 files unchanged
uvx isort==5.13.2 --check .                       clean
.venv/bin/python -m pyright --pythonpath …  .     0 errors
pytest tests/unit                                 9028 passed, 15 skipped
```

18 new tests cover the capability gate (including that a bare client
registration is not a grant, and that stdio is still refused), the verb choice,
the D1/D4 wording constraints, the metadata-probe exclusion, and that a
non-auth failure is never converted.

### Not verified locally

**No real OAuth grant was completed** — that needs the operator's browser and
credentials, so I did not run one. What is proven is that `/mcp login <name>`
now *reaches* the grant flow for these servers instead of being refused, and
that a non-interactive startup still raises rather than opening a browser. The
end-to-end "browser opens, token lands, server connects" step is the one thing
left for the operator to confirm.

One pre-existing flake was observed and is **not** from this branch:
`tests/unit/session/test_resume_subagents_todos.py::test_live_progress_never_schedules_the_roster_writer`
is order-dependent — it passes in isolation and in the final full run here, and
reproduces on base under the right ordering.

## Related

- Issue #367 (Codex MCP import) — this makes the imported remote servers usable.
- PR #439 (the import itself) — context, not reverted.
