### PR TITLE
fix(providers): make tool schemas Gemini-compatible

### DIFF
--- a/local_operator/tools/agent_tool.py
+++ b/local_operator/tools/agent_tool.py
@@ -55,7 +55,7 @@ import logging
 from pathlib import Path
 from typing import Any, Callable, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from local_operator.agent_profiles import (
     MAX_INSTRUCTIONS_CHARS,
@@ -136,10 +136,24 @@ class AgentParams(BaseModel):
         default=None,
         description="create/update: restrict the profile to these tools. Omit for all.",
     )
-    effort: Literal["lo", "med", "hi", ""] | None = Field(
+    effort: Literal["lo", "med", "hi", "inherit"] | None = Field(
         default=None,
-        description="create/update: default model tier. '' clears it.",
+        description="create/update: default model tier. 'inherit' clears it.",
     )
+
+    @field_validator("effort", mode="before")
+    @classmethod
+    def _legacy_empty_effort(cls, value: Any) -> Any:
+        """Keep pre-sentinel callers working without advertising invalid schema.
+
+        Empty enum strings are rejected by Gemini function declarations. Older
+        callers may still send ``""`` to clear a pin, so normalize that legacy
+        wire value before the closed Literal validates while exposing the
+        explicit ``inherit`` spelling to models and providers.
+        """
+
+        return "inherit" if value == "" else value
+
     delegate: bool | None = Field(
         default=None,
         description=(
@@ -1013,9 +1027,14 @@ async def _op_write(
     else:
         tools = current.tools if current is not None else None
 
-    if params.effort is not None:
-        effort = params.effort.strip() or None
+    if params.effort == "inherit":
+        effort = None
+    elif params.effort is not None:
+        effort = params.effort
     else:
+        # Omission and JSON null both mean "leave unchanged"; only the explicit
+        # sentinel may remove a stored pin, so a model cannot clear configuration
+        # merely by filling an optional nullable field with its default.
         effort = current.effort if current is not None else None
 
     if params.delegate is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.0"
+version = "0.44.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -21,10 +21,12 @@ from local_operator.harness.types import (
     StreamUsageEvent,
     TextContent,
     ToolCall,
+    ToolContext,
     ToolResult,
 )
 from local_operator.providers.clients import (
     AnthropicClient,
+    GoogleClient,
     MockClient,
     OpenAICompatClient,
     _anthropic_stream_error,
@@ -33,6 +35,7 @@ from local_operator.providers.clients import (
     raise_for_status,
 )
 from local_operator.providers.failover import ProviderError
+from local_operator.tools.registry import create_tools
 
 pytestmark = pytest.mark.asyncio
 
@@ -743,7 +746,6 @@ async def test_mock_client_tool_branch() -> None:
 
 
 from local_operator.providers.auth_store import OAuthAccess  # noqa: E402
-from local_operator.providers.clients import GoogleClient  # noqa: E402
 
 
 async def test_anthropic_oauth_sends_bearer_and_beta_header() -> None:
@@ -949,6 +951,108 @@ async def test_openai_api_key_gpt5_uses_public_responses_end_to_end() -> None:
     # output_tokens_details.reasoning_tokens is the thinking slice of output.
     assert usage.reasoning_tokens == 4
     assert events[-1].stop_reason == "toolUse"
+
+
+def _enum_members(node: Any) -> list[Any]:
+    """Collect enum members from exactly the provider-bound JSON payload.
+
+    Walking the serialized body, rather than Pydantic models one by one, keeps
+    this guard on the path gateways inspect after the complete tool inventory
+    and the shared intent field have both been assembled.
+    """
+
+    members: list[Any] = []
+    if isinstance(node, dict):
+        enum = node.get("enum")
+        if isinstance(enum, list):
+            members.extend(enum)
+        for value in node.values():
+            members.extend(_enum_members(value))
+    elif isinstance(node, list):
+        for value in node:
+            members.extend(_enum_members(value))
+    return members
+
+
+def _default_tools_with_agent() -> list[AgentTool]:
+    """Build the real default inventory with the capability exposing ``agent``."""
+
+    return create_tools(ToolContext(cwd=".", agent_registry=object()))
+
+
+async def test_openrouter_gemini_full_tool_bundle_has_no_empty_enum_member() -> None:
+    """Exercise the real OpenRouter client and complete registry-built bundle."""
+
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            content=_sse([{"choices": [{"delta": {}, "finish_reason": "stop"}]}]),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    tools = _default_tools_with_agent()
+    assert "agent" in {tool.name for tool in tools}
+    spec = _spec(provider="openrouter", model_id="google/gemini-3.7-flash")
+    http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client = client_for_spec(spec, http_client=http)
+
+    await _collect(
+        client.stream(
+            ChatRequest(
+                model=spec,
+                messages=[Message.user("Use the tools if useful")],
+                tools=tools,
+            ),
+            "test-key",
+        )
+    )
+    await http.aclose()
+
+    assert "" not in _enum_members(captured["body"]["tools"])
+    agent = next(tool for tool in captured["body"]["tools"] if tool["function"]["name"] == "agent")
+    effort = agent["function"]["parameters"]["properties"]["effort"]
+    assert effort["anyOf"][0]["enum"] == ["lo", "med", "hi", "inherit"]
+
+
+def test_direct_google_full_tool_bundle_has_no_empty_enum_member() -> None:
+    tools = _default_tools_with_agent()
+    body = GoogleClient()._build_body(
+        ChatRequest(
+            model=_spec(provider="google", model_id="gemini-3.7-flash"),
+            messages=[Message.user("Use the tools if useful")],
+            tools=tools,
+        )
+    )
+
+    declarations = body["tools"][0]["function_declarations"]
+    assert "" not in _enum_members(declarations)
+    agent = next(declaration for declaration in declarations if declaration["name"] == "agent")
+    effort = agent["parameters"]["properties"]["effort"]
+    assert effort["anyOf"][0]["enum"] == ["lo", "med", "hi", "inherit"]
+
+
+@pytest.mark.parametrize(
+    ("provider", "model_id"),
+    [("openai", "gpt-5.4"), ("openrouter", "qwen/qwen3-coder")],
+)
+def test_openai_compatible_models_keep_agent_effort_semantics(provider: str, model_id: str) -> None:
+    """Ordinary OpenAI/Qwen routes receive every tier plus the clear sentinel."""
+
+    tools = _default_tools_with_agent()
+    request = ChatRequest(
+        model=_spec(provider=provider, model_id=model_id),
+        messages=[Message.user("clear it")],
+        tools=tools,
+    )
+    body = OpenAICompatClient("https://compat.example/v1")._build_body(request)
+    agent = next(tool for tool in body["tools"] if tool["function"]["name"] == "agent")
+    effort = agent["function"]["parameters"]["properties"]["effort"]
+
+    assert effort["anyOf"][0]["enum"] == ["lo", "med", "hi", "inherit"]
+    assert {branch["type"] for branch in effort["anyOf"]} == {"string", "null"}
 
 
 @pytest.mark.parametrize("provider", ["openrouter", "deepseek"])

--- a/tests/unit/tools/test_agent_tool.py
+++ b/tests/unit/tools/test_agent_tool.py
@@ -9,7 +9,7 @@ import pytest
 from local_operator.agent_profiles import load_seed, resolve_profile
 from local_operator.agents import AgentEditFields, AgentRegistry
 from local_operator.harness.types import ToolContext
-from local_operator.tools.agent_tool import build_agent_tool, execute_agent
+from local_operator.tools.agent_tool import AgentParams, build_agent_tool, execute_agent
 
 
 @pytest.fixture()
@@ -252,6 +252,52 @@ async def test_update_keeps_the_allowlist_it_was_not_asked_to_change(context, re
     assert after is not None
     assert after.tools == before.tools, "the allowlist is a capability boundary"
     assert "Read the diff first." in after.instructions
+
+
+def test_agent_schema_exposes_inherit_without_an_empty_enum_member() -> None:
+    effort = AgentParams.model_json_schema()["properties"]["effort"]
+    enum = effort["anyOf"][0]["enum"]
+
+    assert enum == ["lo", "med", "hi", "inherit"]
+    assert "" not in enum
+
+
+@pytest.mark.parametrize("effort", [None, "inherit"])
+@pytest.mark.asyncio
+async def test_update_effort_wire_semantics(context, registry, effort) -> None:
+    """Nullable omission preserves a pin; only the named sentinel clears it."""
+
+    await call(context, op="install", name="manager")
+    await call(context, op="update", name="manager", effort="lo")
+
+    args = {"effort": effort} if effort is not None else {}
+    await call(context, op="update", name="manager", description="new routing text", **args)
+
+    profile = resolve_profile("manager", registry=registry)
+    assert profile is not None
+    assert profile.effort == (None if effort == "inherit" else "lo")
+
+
+@pytest.mark.asyncio
+async def test_update_null_effort_preserves_existing_pin(context, registry) -> None:
+    await call(context, op="install", name="manager")
+    await call(context, op="update", name="manager", effort="lo")
+
+    await call(context, op="update", name="manager", effort=None)
+
+    profile = resolve_profile("manager", registry=registry)
+    assert profile is not None and profile.effort == "lo"
+
+
+@pytest.mark.asyncio
+async def test_legacy_empty_effort_still_clears_existing_pin(context, registry) -> None:
+    await call(context, op="install", name="manager")
+    await call(context, op="update", name="manager", effort="lo")
+
+    await call(context, op="update", name="manager", effort="")
+
+    profile = resolve_profile("manager", registry=registry)
+    assert profile is not None and profile.effort is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tools/test_registry.py
+++ b/tests/unit/tools/test_registry.py
@@ -126,6 +126,49 @@ def test_default_set_drops_ask_without_a_ui_to_draw_it_on() -> None:
     assert without == [name for name in withui if name != "ask"]
 
 
+def _invalid_enum_nodes(node: Any) -> list[str]:
+    findings: list[str] = []
+
+    def visit(value: Any, path: str, inherited_type: str | None = None) -> None:
+        if isinstance(value, dict):
+            declared_type = value.get("type", inherited_type)
+            if "enum" in value:
+                enum = value["enum"]
+                if not isinstance(enum, list) or not enum:
+                    findings.append(f"{path}.enum is not a non-empty array")
+                else:
+                    for member in enum:
+                        if member == "":
+                            findings.append(f"{path}.enum contains an empty string")
+                        elif declared_type == "string" and not isinstance(member, str):
+                            findings.append(
+                                f"{path}.enum member {member!r} does not match string type"
+                            )
+                        elif isinstance(member, (dict, list)):
+                            findings.append(f"{path}.enum contains a compound value")
+            for key, child in value.items():
+                child_type = declared_type if key in {"anyOf", "oneOf", "allOf"} else None
+                visit(child, f"{path}.{key}", child_type)
+        elif isinstance(value, list):
+            for index, child in enumerate(value):
+                visit(child, f"{path}[{index}]", inherited_type)
+
+    visit(node, "parameters")
+    return findings
+
+
+def test_no_builtin_schema_emits_a_provider_invalid_enum() -> None:
+    """Audit the complete emitted inventory, not only the schema fixed today."""
+
+    findings = {
+        tool.name: paths
+        for tool in create_tools(_engine_context())
+        if (paths := _invalid_enum_nodes(tool.parameters))
+    }
+
+    assert findings == {}
+
+
 def test_every_tool_has_schema_and_metadata() -> None:
     for tool in create_tools(_engine_context()):
         # JSON Schema derived from the pydantic params model


### PR DESCRIPTION
# PR Description

## Summary

OpenRouter routes OpenAI-compatible tool declarations to upstream model providers. Gemini 3.1/3.5 Flash Lite and Gemini 3.7 Flash reject a function enum containing an empty string, while Qwen accepts the same JSON Schema.

The built-in `agent` tool exposed the empty string as a model-facing sentinel for clearing a saved subagent effort pin:

```text
GenerateContentRequest.tools[0].function_declarations[13].parameters.properties[effort].any_of[0].enum[3]: cannot be empty
```

This replaces the ambiguous empty model-facing value with the explicit `inherit` sentinel at the schema source. The compatibility boundary remains centralized because every provider serializes the same `AgentTool.parameters` schema generated from `AgentParams`.

## Change class

C2 standard/pre-authorized reliability fix. The PR is the system of record; no RFC or tracker is required.

## Behavior and compatibility

- `effort: "lo" | "med" | "hi"` pins that configured model tier.
- omitted `effort` preserves the stored pin.
- JSON `null` preserves the stored pin.
- `effort: "inherit"` clears the pin and returns the profile to inherited model selection.
- legacy callers sending `effort: ""` still clear the pin through a Pydantic before-validator, but the blank value is no longer advertised in provider schemas.
- invalid effort strings remain rejected; no acceptance was broadened.

The complete built-in inventory now has a regression audit for empty enum members, empty enum arrays, compound enum members, and enum members that do not match their declared string type. OpenRouter, direct Google, ordinary OpenAI, and OpenRouter/Qwen serialization paths are covered separately.

## Real-path evidence

### Baseline reproduction

The global runtime on the pre-fix schema reached OpenRouter and failed before generation:

```text
$ lop --hosting openrouter --model google/gemini-3.7-flash exec --json \
    "Return exactly the word SCHEMA_OK. Do not call any tools."
HTTP/1.1 400 Bad Request
invalid request (HTTP 400): Provider returned error: * GenerateContentRequest.tools[0].function_declarations[14].parameters.properties[effort].any_of[0].enum[3]: cannot be empty
```

The declaration index varies with capability-gated tools; both failures resolve to `agent.parameters.properties.effort`.

### Fixed OpenRouter Gemini 3.7

After rebasing onto current `origin/main` (`b8cd5336`), the live worktree-source probe was repeated against the unchanged schema and again reached OpenRouter successfully:

```text
POST https://openrouter.ai/api/v1/chat/completions "HTTP/1.1 200 OK"
SCHEMA_OK
EXIT=0
```


The worktree source was placed first on `PYTHONPATH` and verified before execution so the shared editable venv could not resolve the main checkout:

```text
$ PYTHONPATH="$PWD" .venv/bin/python - <<'PY'
import local_operator.tools.agent_tool as module
print(module.__file__)
print(module.AgentParams.model_json_schema()['properties']['effort'])
PY
/private/tmp/lop-provider-tool-schema-compat/local_operator/tools/agent_tool.py
{'anyOf': [{'enum': ['lo', 'med', 'hi', 'inherit'], 'type': 'string'}, {'type': 'null'}], ...}

$ PYTHONPATH="$PWD" .venv/bin/local-operator \
    --hosting openrouter --model google/gemini-3.7-flash exec --json \
    "Return exactly the word SCHEMA_OK. Do not call any tools."
HTTP/1.1 200 OK
SCHEMA_OK
EXIT=0
```

### Actual screenshot + `read` tool probes

Each model received the complete built-in tool bundle, was told to invoke `read` exactly once on the same real PNG screenshot, and then report visible fields. Captured JSONL confirms one unique `read` call, one tool result, `agent_end.error=null`, process exit `0`, OpenRouter HTTP 200, and no schema-validation error for every model.

| OpenRouter model | Result |
| --- | --- |
| `google/gemini-3.1-flash-lite` | `{"app":"Calendar","event_title":"fyp24010","location":"CB417","start":"Wednesday, April 22, 2026, 11:00","end":"Wednesday, April 22, 2026, 12:00","primary_button":"Done"}` |
| `google/gemini-3.5-flash-lite` | `{"app":"Calendar","event_title":"fyp24010","location":"CB417","start":"Wednesday, April 22, 2026, 11:00","end":"Wednesday, April 22, 2026, 12:00","primary_button":"Done"}` |
| `google/gemini-3.7-flash` | `{"app":"Calendar","event_title":"fyp24010","location":"CB417","start":"Wednesday, April 22, 2026, 11:00","end":"Wednesday, April 22, 2026, 12:00","primary_button":"Done"}` |

Probe artifacts were captured under `/private/tmp/gemini-fixed-probes/` and checked without exposing credentials. The source screenshot remains outside this branch; this PR changes provider schema compatibility, not image rendering.

## Automated verification

| Gate | Result |
| --- | --- |
| focused provider/tool regressions | **277 passed** |
| full unit suite | **9104 passed, 15 skipped, 416 warnings** in 430.41s |
| `.venv/bin/python -m flake8 .` | clean |
| `uvx --from black==26.1.0 black --check .` | 635 files unchanged |
| `uvx isort==5.13.2 --check .` | clean; 1 configured skip |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | 0 errors, 0 warnings |
| `uv build` | built `local_operator-0.44.1.tar.gz` and `local_operator-0.44.1-py3-none-any.whl` |
| `twine check` | both distributions passed |
| wheel metadata | `local-operator 0.44.1` |

## Release and rollback

Patch release: `0.44.0` → `0.44.1`.

Rollback is a normal package downgrade to `0.44.0`. Legacy blank callers remain compatible, so no configuration or data migration is needed.

## Non-goals

- No provider-specific OpenRouter or Gemini sanitizer.
- No OSWorld-specific behavior.
- No changes to model reasoning-effort request parameters.
- No merge, tag, GitHub Release, PyPI publication, or local runtime update as part of opening this PR.



