### PR TITLE
ci: stop the queue eating itself on a 20-job concurrency cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,21 @@ name: Pre-release CI Testing
 on:
   push:
     branches:
+      # ONLY `main` here, deliberately.
+      #
+      # `dev-*` used to be in this list as well, which double-billed every
+      # feature branch: a `dev-*` branch with an open PR fired a `push` run AND
+      # a `pull_request` run for the SAME commit, two identical sets of jobs
+      # whose results nobody read twice. At one point 29 of the SHAs in the
+      # queue were running both. The `pull_request` trigger below already
+      # covers feature branches, so dropping `dev-*` here halves the per-commit
+      # cost without reducing what is actually tested.
+      #
+      # A `dev-*` branch with NO open PR now gets no CI until the PR is opened.
+      # That is the intended trade: CI exists to gate review and merge, and an
+      # un-PR'd branch is gating nothing. Use `workflow_dispatch` to run it by
+      # hand if you need a pre-PR signal.
       - main
-      - 'dev-*'
   # PULL REQUESTS TOO. Without this a feature branch received NO CI until it
   # was already merged, which let a broken `pip install .` and an import that
   # fails on the declared minimum Python both reach review looking green.
@@ -12,9 +25,67 @@ on:
   pull_request:
   workflow_dispatch:
 
+# One in-flight run per ref. A review cycle force-pushes repeatedly, and
+# without this every superseded push kept its full job set queued to completion
+# against a 20-job account-wide concurrency cap — 56% of the active queue was
+# once running against commits their own branch had already moved past, while
+# the newest commit (the only one anybody was waiting on) sat behind them.
+#
+# `github.workflow` is in the key so this workflow never cancels a sibling
+# workflow's run on the same ref (the release/publish line in particular).
+#
+# `github.ref` is the right granularity: for a `pull_request` event it is the
+# PR's merge ref, so successive pushes to one PR supersede each other while
+# two different PRs never collide.
+#
+# A push to `main` is never cancelled BY A LATER MERGE, and the SHA in the
+# group key is how that is achieved. A push to `main` is a merge whose result
+# is the release signal and the record for that commit, so every one of those
+# runs must complete.
+#
+# The precise guarantee: no `main` run is cancelled or evicted by a run on a
+# DIFFERENT commit. Two runs on the SAME `main` commit — a re-run, or a
+# `workflow_dispatch` at a commit already building — do share a group and the
+# later one supersedes the earlier. That is acceptable because the survivor is
+# on the identical SHA and, not being a `pull_request`, runs the same full
+# both-leg matrix: the CI record is replaced by an equivalent one rather than
+# lost, which is also what a GitHub re-run does by design.
+#
+# `cancel-in-progress: false` alone would NOT deliver that. A concurrency group
+# permits one run in progress and, by default, only ONE run pending: when a
+# third arrives the waiting one is cancelled. With `main` merging faster than
+# this workflow's ~23 min duration (four merges inside 27 minutes was observed
+# while writing this), run A executes, B waits, C arrives and evicts B — and B
+# is then a commit on `main` that no CI ever reported on.
+#
+# Adding `github.sha` for `main` gives every merge commit its OWN group, so
+# `main` runs never contend and none can be cancelled or evicted. Feature
+# branches keep a per-ref group, so successive pushes to one PR still supersede
+# each other, which is where the throughput saving comes from.
+#
+# Why not `queue: max` (the documented way to hold up to 100 pending runs):
+# GitHub rejects `queue: max` combined with a `cancel-in-progress` that can
+# evaluate true, and this workflow needs cancellation on feature branches.
+# Tried, and it failed the run at plan time with:
+#   "The combination of 'queue: max' and 'cancel-in-progress: true'
+#    is not allowed"
+# A unique group per `main` commit reaches the same guarantee with keys that
+# have been supported all along, and it does not queue `main` runs behind each
+# other — they simply run.
+#
+# This matters specifically because the `test` matrix below runs the 3.13 leg
+# ONLY on `main`. `main` is the safety net for the narrowed pull request
+# matrix, so a hole in that net would undo the justification for narrowing it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || 'shared' }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    # Generous against the ~30 s this takes; it exists so a wedged install step
+    # cannot hold a concurrency slot for the 360-minute GitHub default.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -39,6 +110,7 @@ jobs:
 
   type-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       PYRIGHT_PYTHON_FORCE_VERSION: latest
     steps:
@@ -64,14 +136,67 @@ jobs:
         
   test:
     runs-on: ubuntu-latest
+    # ~23 min is the honest ceiling for a healthy run of this stage, so 40 is a
+    # backstop for a hang and not a limit healthy work can reach. It is
+    # load-bearing: a `test (3.13)` job once hung and held one of the account's
+    # 20 concurrency slots for 3h38m, because with no `timeout-minutes` the
+    # GitHub default is SIX HOURS. The suite's own failure modes assert or
+    # error in seconds; only a deadlock gets here.
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
-        # BOTH ends of `requires-python`. Testing only the minimum let a
-        # 3.13-only typing feature ship; testing only the newest would let a
-        # 3.12 incompatibility ship. The declared range has to be the tested
-        # range or the classifier is a guess.
-        python-version: ["3.12", "3.13"]
+        # BOTH ends of `requires-python` on `main`, the minimum only on pull
+        # requests.
+        #
+        # The rule this preserves is unchanged: testing only the minimum lets a
+        # 3.13-only typing feature ship, and testing only the newest lets a
+        # 3.12 incompatibility ship, so the declared range has to be the tested
+        # range or the classifier is a guess. `main` therefore still tests the
+        # full declared range, and no commit reaches a release without both
+        # ends having run on it.
+        #
+        # What changes is WHEN the 3.13 leg runs on feature work. This stage is
+        # ~23 min and was the single largest consumer of a 20-job account-wide
+        # concurrency cap; at two legs per run it alone could exceed the whole
+        # account's parallelism during a busy review cycle, and the queueing
+        # delayed every other branch AND the release pipeline. Running one leg
+        # per PR commit halves that.
+        #
+        # The cost, stated plainly: a 3.13-ONLY break is now caught when the PR
+        # merges to `main` rather than on the PR itself. That is a real
+        # reduction in per-PR gate strength.
+        #
+        # It was accepted on MEASURED grounds, not on the intuition that such
+        # breaks are rare. Surveying recent CI runs where BOTH legs actually
+        # reported a pass/fail (excluding cancelled legs), 3.13-only reds are a
+        # MINORITY of 3.12-only reds — measured repeatedly at roughly 1:2 to
+        # 1:7 depending on the window, and never once inverted. So the 3.13 leg
+        # is not carrying a unique load; if anything the 3.12 leg catches more.
+        #
+        # Deliberately a RATIO and not a fixed count: this repo merges fast
+        # enough that any absolute number is stale within hours, and two
+        # independent surveys of overlapping windows disagreed on the count
+        # while agreeing on the direction. The direction is the load-bearing
+        # part and it has held at every window measured.
+        #
+        # What decided it is WHY those reds happen: each was `1 failed` out of
+        # ~9000, on a DIFFERENT timing-sensitive test (transcript selection,
+        # resume-subagents, tui responsiveness), never the same test twice, and
+        # none was a genuine 3.13 language or typing incompatibility. One was
+        # confirmed by reading the log to be a composer-height timing assertion
+        # (test_transcript_selection.py:2243). They are flakes on a slow,
+        # loaded runner — the class of defect #461 ("wait on conditions instead
+        # of the clock") addresses.
+        #
+        # So relegating this leg to `main` takes a source of flaky reds out of
+        # the review loop while keeping the real incompatibility gate — which
+        # has not fired in this window — on every merge. If a true 3.13-only
+        # incompatibility ever DOES reach `main`, put "3.13" back into the
+        # pull_request arm rather than reaching for more concurrency; the flakes
+        # are the thing to fix first, and they are a separate concern from this
+        # workflow (see dev-test-determinism).
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.12"]') || fromJSON('["3.12", "3.13"]') }}
     steps:
       - uses: actions/checkout@v4
 
@@ -79,6 +204,27 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          # Restores pip's HTTP cache. Measured saving is SMALL — install is
+          # ~15-20 s of a ~23 min job — so this is emphatically not what fixes
+          # the queue; it removes a PyPI round trip and one network flake mode
+          # per job.
+          #
+          # Known limitation, stated so nobody reads more into this than it
+          # delivers: the key is `pyproject.toml`, and this project pins none of
+          # its 19 runtime dependencies (`>=` throughout) and has no lockfile.
+          # The key therefore only changes when that FILE changes, while the
+          # resolved wheels drift underneath it as upstreams release. The cache
+          # decays into staleness rather than staying current.
+          #
+          # That is safe, not merely tolerable: this is pip's HTTP download
+          # cache, not a restored site-packages. pip still resolves against the
+          # index on every run and reuses a cached download only when the
+          # resolution asks for that exact artifact, so a stale entry cannot pin
+          # an old version into a build or otherwise poison a run. Adding a
+          # lockfile would make this caching genuinely effective, and is the
+          # right fix if install time ever becomes material here.
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |
@@ -116,6 +262,7 @@ jobs:
 
   pip-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Install package

--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -3,8 +3,12 @@ name: Browser extension
 on:
   push:
     branches:
+      # `main` only, matching ci.yml: a `dev-*` branch with an open PR fired this
+      # workflow twice for the same commit (a push run and a pull_request run)
+      # for one identical result. Paths-gating kept the volume low enough that
+      # it never dominated the queue, but the duplication was the same defect
+      # and is fixed the same way.
       - main
-      - 'dev-*'
     paths:
       - 'extension/**'
       - 'local_operator/browser_bridge/protocol.py'
@@ -16,9 +20,17 @@ on:
       - 'local_operator/browser_bridge/gen_ts.py'
   workflow_dispatch:
 
+# Matches ci.yml, including the per-SHA group for `main` so a merge commit's
+# run can never be evicted by the next merge. See the long note in ci.yml for
+# why the SHA is in the key rather than `queue: max`.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || 'shared' }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,10 @@ jobs:
   # ---------------------------------------------------------------------------
   extension-release:
     runs-on: ubuntu-latest
+    # Bounded so a wedged step cannot hold one of the account's 20 concurrency
+    # slots for GitHub's 360-minute default. This is the RELEASE path, so a
+    # squatting job here blocks publishing, not just a branch's CI.
+    timeout-minutes: 15
     permissions:
       contents: write  # upload the zip as a release asset
     steps:
@@ -118,6 +122,7 @@ jobs:
 
   release-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       skip_build: ${{ steps.tag-check.outputs.skip_build }}
 
@@ -179,6 +184,7 @@ jobs:
 
   pypi-publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs:
       - release-build
     if: ${{ needs.release-build.result == 'success' && needs.release-build.outputs.skip_build == 'false' }}


### PR DESCRIPTION
# PR Description

## Summary of Changes

The Actions queue reached **69 active runs against ~11 executing**, delaying every branch and stalling the `0.43.16` `pypi-publish` job behind unrelated feature-branch work.

The repo is **public**, so standard-runner minutes are free and unlimited — this was never a spend problem. The binding constraint is the account-wide **20 concurrent jobs** on the Free plan ([Actions limits](https://docs.github.com/en/actions/reference/limits)), and **most of what was consuming it was work whose result nobody would ever read**.

Four causes, each measured on the live queue rather than assumed:

| # | Cause | Measured impact |
|---|---|---|
| 1 | No `concurrency` group — superseded runs never cancelled | **40 of 71 active runs (56%)** on already-superseded commits |
| 2 | `push: [dev-*]` **and** `pull_request` both fire | **29 SHAs** running two identical job sets |
| 3 | No `timeout-minutes` on 4 jobs → 360 min default | one hung job held a slot **3h38m** |
| 4 | `test` is ~23 min and ran **twice** per commit | largest single slot consumer |

Touches three workflows: `ci.yml` (all four fixes), `extension.yml` (same double-trigger, concurrency group, timeout), `publish.yml` (timeouts only).

### 1. Concurrency group

```yaml
group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || 'shared' }}
cancel-in-progress: true
```

Feature branches share one group per ref, so successive pushes to a PR supersede each other — that is where the throughput saving comes from. **`main` gets the commit SHA in its key**, so every merge commit lands in its own group and no `main` run is cancelled or evicted by a later merge.

**Why the SHA rather than `cancel-in-progress: false`.** A concurrency group allows one run in progress and, by default, only **one pending**; when a third arrives the waiting one is cancelled. With `main` merging faster than this workflow's ~23 min duration (four merges in 27 minutes was observed while writing this), run A executes, B waits, C arrives and evicts B — leaving B a commit on `main` that no CI ever reported on. `cancel-in-progress: false` protects only the *executing* run and would not have prevented that.

**Why not `queue: max`,** which is the documented way to hold pending runs: GitHub rejects it alongside a `cancel-in-progress` that can evaluate true, and cancellation on feature branches is the entire point. Attempted, and the run failed at plan time in 1 s with zero jobs:

```
evaluate plan concurrency: Error when evaluating 'concurrency'.
.github/workflows/ci.yml (Line: 65, Col: 10):
The combination of 'queue: max' and 'cancel-in-progress: true' is not allowed
```

The per-SHA key reaches a stronger guarantee than `queue: max` would have — `main` runs don't queue behind each other, they simply run — using keys supported all along.

**Known, accepted edge:** two runs on the *same* `main` commit (a re-run, or a `workflow_dispatch` at a commit already building) do share a group, and the later supersedes the earlier. The survivor is on the identical SHA and runs the same full both-leg matrix, so the record is replaced by an equivalent one rather than lost — which is what a GitHub re-run does by design anyway.

### 2. Double-trigger removed

`dev-*` leaves the `push` list in both `ci.yml` and `extension.yml`; `pull_request` already covers feature branches. A `dev-*` branch with no open PR now gets no CI until the PR exists — intended, since CI gates review and merge, and `workflow_dispatch` remains for a pre-PR signal.

### 3. Timeouts

Every job in all three workflows is now bounded: `ci.yml` `lint` 10 / `type-check` 15 / `test` 40 / `pip-audit` 10; `extension.yml` `build` 15; `publish.yml` `extension-release` 15 / `release-build` 20 / `pypi-publish` 20. These are hang backstops well above honest durations, not limits healthy work can reach. `publish.yml` matters most — a squatter there blocks *publishing*, which is exactly what happened to `0.43.16`.

### 4. Matrix scoped on PRs

PRs run the **3.12 leg only**; `main` still runs **both ends** of `requires-python`, so no commit reaches a release without the full declared range having run on it.

**The trade, measured rather than asserted.** Across 41 recent runs where both legs actually reported: **3** were 3.13-only red, **7** were 3.12-only red, 1 both. The 3.13 leg is not carrying a unique load. What decided it is *why* those 3 went red — each was `1 failed` of ~9000 on a different timing-sensitive test, never the same one twice, none a genuine 3.13 incompatibility (one confirmed from the log as a composer-height timing assertion at `test_transcript_selection.py:2243`). They are flakes on a loaded runner. So this takes a source of flaky reds out of the review loop while keeping the real incompatibility gate on every merge. Fix the flakes separately; if a true 3.13-only break ever reaches `main`, put `"3.13"` back in the `pull_request` arm rather than buying concurrency.

Pip caching is also added and **honestly labelled as marginal**: install is ~15-20 s of a ~23 min job, so it is *not* what fixes the queue. With no lockfile and 0 of 19 dependencies pinned, the key only changes when `pyproject.toml` does, so the cache decays rather than staying current. It cannot poison a run — it is pip's HTTP download cache, and pip still resolves against the index.

### What this deliberately does NOT do

- **No upgrade to Pro.** The observed ceiling was ~11 concurrent jobs against a nominal cap of 20 — the account was not saturating its existing allowance, so doubling the nominal cap would not have doubled throughput. Demand-side fixes first; measure again before spending.
- **No change to `-n auto`.** The existing comment documents that oversubscription was measured and starves timing-sensitive tests.

### Trade-off worth naming

Because `main` runs no longer contend, a merge burst runs them fully in parallel, and a `main` run is 9 jobs — three overlapping runs is 27 against a 20-job cap. This is not a regression (the base had no concurrency group at all) and the throughput win is on the PR side where the volume is, but it is correctness bought at some parallelism, not pure upside.

---

## Testing Evidence

### Live verification on the PR's own runs

Each structural fix was confirmed against the real Actions API, not by reading YAML:

**Double-trigger gone** — the first push produced exactly one run, where the old config would have produced two:

```
33331583538	pull_request	in_progress	432c4686      # no push run
```

**`cancel-in-progress` works** — pushed a second commit, re-listed 35 s later:

```
33331610417	pull_request	in_progress	          4f7fb181   <- new head
33331583538	pull_request	completed    cancelled  432c4686   <- auto-cancelled
```

Reproduced repeatedly across later pushes (`bc16010f`, `4de85de8` both auto-cancelled).

**PR matrix scoped** — jobs on a `pull_request` run:

```
type-check   completed  success
pip-audit    completed  success
lint         completed  success
test (3.12)  in_progress
```

One `test` leg, not two; `test (3.13)` correctly absent.

**The rejected config actually failed** — the `queue: max` head ran 1 s and dispatched **zero** jobs (`conclusion=failure`, empty jobs list), which is how the plan-time error above was found. The replacement head dispatches jobs normally.

### `actionlint`

Clean on all three workflows. The only finding is a **pre-existing** SC2086 info, confirmed by running against the base commit — same finding, line number shifts only because this PR adds comment lines.

Note `actionlint` 1.7.12 also rejects `queue: max` (`unexpected key "queue"`) because its schema predates the May 2026 feature — the live run, not the linter, is authoritative there.

### Every job bounded

Parsed from the resulting YAML:

```
ci.yml         lint 10   type-check 15   test 40   pip-audit 10
               cli-sanity 10   tui-e2e 20   server-sanity 10
extension.yml  build 15
publish.yml    extension-release 15   release-build 20   pypi-publish 20
```

Previously `lint`, `type-check`, `test`, `pip-audit` and all of `publish.yml` showed `NONE`.

### Group-key collision analysis

Simulated across events, since a key that collided two PRs would make them cancel each other:

```
push main c1       -> CI-refs/heads/main-aaa111
push main c2       -> CI-refs/heads/main-bbb222     distinct: no eviction
PR 465             -> CI-refs/pull/465/merge-shared
PR 465 new push    -> CI-refs/pull/465/merge-shared same: supersedes (intended)
PR 470             -> CI-refs/pull/470/merge-shared distinct from 465
```

`'shared'` is a constant for all non-`main` refs and contributes no discrimination — it does not need to, because `github.ref` is already its own segment and differs per PR and per branch.

### Backlog actually cleared

The hung run plus 36 superseded runs were cancelled by hand to unblock the release. **`0.43.16` `pypi-publish` then completed successfully**, and the queue went from **69 active → 31**, later to 17 queued / 10 running. That is the manual version of what change (1) now does automatically.

### Branch hygiene

Rebased onto current `origin/main` and squashed to one commit. Verified the diff is workflow-only — `3 files changed`, no unrelated code — since an earlier stale base made unrelated merged TUI work appear as deletions.

## Review

Two agent review rounds; see the round-1 and round-2 comments and their remediations. Round 1 found the pending-run eviction defect (R1-1) that the `github.sha` key now fixes, and corrected an unevidenced claim about 3.13 failure rates. Round 2 verified the replacement mechanism, independently confirmed the group key cannot collide two refs, and corrected the failure survey from 5 to 3 (my filter had mis-bucketed two `cancelled` legs as failures).

## Related

Root-caused while clearing the backlog holding the `0.43.16` release. Reported independently by a concurrent session, which reached the same conclusion about the concurrency group.