### PR TITLE
chore(release): bump version to 0.43.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.16"
+version = "0.43.17"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Version-only bump so #456 (recover from an unknown hosting provider instead of dying) can ship.

#456 merged carrying `0.43.16`, but `v0.43.16` had already been tagged and released by #460 while #456 was in review. Main therefore sits at a version whose tag exists and which is already on PyPI, so `gh release create v0.43.16` would fail and the provider-recovery fix would not reach users.

No code changes — `pyproject.toml` only.
