### PR TITLE
chore(release): bump version to 0.43.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.17"
+version = "0.43.18"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

- bump the package version from `0.43.17` to the next free patch, `0.43.18`
- unblock publication of the MCP authentication fix merged in #462

## Context

PR #447 won the `0.43.17` release: tag and GitHub Release `v0.43.17` already exist and do not contain the #462 merge commit (`a6d0e7c7`). Because `origin/main` still declared `0.43.17` after #462 merged, publishing main would attempt to reuse an already-published package version. `v0.43.18` is absent from git tags, GitHub Releases, and PyPI, and no currently open PR claims it.

## Testing

- `.venv/bin/python -m flake8 .`
- `uvx --from black==26.1.0 black --check .`
- `uvx isort==5.13.2 --check .`
- `.venv/bin/python -m pyright --pythonpath .venv/bin/python .`
- `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q -k 'mcp and (auth or oauth or import)'` (`166 passed`)
- verified `git merge-base --is-ancestor a6d0e7c7 v0.43.17` is false
- verified `v0.43.18` is absent from local/remote tags, GitHub Releases, and PyPI
- exhaustively inspected all open PR titles, bodies, branches, and changed files; no `0.43.18` claimers found

## Scope

This PR changes only the version in `pyproject.toml` from `0.43.17` to `0.43.18`.
