### PR TITLE
chore(release): bump version to 0.43.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.43.18"
+version = "0.43.19"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Version bump for the 0.43.19 release: the steer-receipt session guard (#452) and the test-determinism work (#461).

Both PRs are merged on `main` with completed agent review rounds; this is the release bump only, no functional change.

## Testing evidence

Gates on this branch, verified by exit code (not stdout — isort's stdout is byte-identical on pass and fail, and black's banner goes to stderr):

```console
$ .venv/bin/python -m flake8 .;                         echo "flake8 rc=$?"
flake8 rc=0
$ uvx --from black==26.1.0 black --check .;             echo "black rc=$?"
black rc=0
$ uvx isort==5.13.2 --check .;                          echo "isort rc=$?"
isort rc=0
```

The only change is `version = "0.43.18"` -> `"0.43.19"` in `pyproject.toml`.