### PR TITLE
feat(evaluation): add benchmark-neutral protocol

### DIFF
--- a/local_operator/evaluation/__init__.py
+++ b/local_operator/evaluation/__init__.py
@@ -1,0 +1,5 @@
+"""Benchmark-neutral evaluation protocol package.
+
+The package root intentionally stays inert: callers opt into protocol model
+construction by importing :mod:`local_operator.evaluation.protocol` directly.
+"""

--- a/local_operator/evaluation/protocol.py
+++ b/local_operator/evaluation/protocol.py
@@ -338,14 +338,16 @@ class Observation(ProtocolModel):
     @field_validator("metadata", mode="before")
     @classmethod
     def _validate_wire_metadata(cls, metadata: Any) -> Any:
-        # IEEE-754 implementations disagree with Python about formatting and
-        # exactness outside this subset. Restricting metadata to strings,
-        # booleans, null, and signed safe integers makes the existing sorted,
-        # compact UTF-8 encoding portable without an RFC 8785 dependency.
-        _validate_metadata(metadata)
-        # JsonValue accepts concrete dict/list values only. Normalize safe
-        # Mapping/tuple inputs for Pydantic, then freeze the validated result.
-        return _thaw_json(metadata)
+        # Snapshot and freeze arbitrary caller mappings before Pydantic sees
+        # them. The resulting owned value is the sole source for normalization,
+        # so a stateful mapping cannot change between validation and storage.
+        if not isinstance(metadata, (FrozenMapping, Mapping)):
+            raise ValueError("metadata must be a mapping")
+        frozen = metadata if isinstance(metadata, FrozenMapping) else FrozenMapping(metadata)
+        # The portable subset excludes floats because runtimes disagree about
+        # formatting and exactness. Pydantic then validates only this normalized
+        # copy, never the caller-owned mapping or any nested mapping again.
+        return _thaw_json(frozen)
 
     @field_validator("metadata")
     @classmethod

--- a/local_operator/evaluation/protocol.py
+++ b/local_operator/evaluation/protocol.py
@@ -84,7 +84,7 @@ PortableMetadataValue = TypeAliasType(
 )
 
 
-class FrozenMapping(Mapping[str, JsonValue]):
+class FrozenMapping:
     """A recursively immutable mapping that remains copy and pickle friendly.
 
     ``MappingProxyType`` protects writes but cannot be deep-copied or pickled,
@@ -156,6 +156,21 @@ class FrozenMapping(Mapping[str, JsonValue]):
     def __len__(self) -> int:
         return len(self._items)
 
+    def keys(self) -> tuple[str, ...]:
+        return tuple(key for key, _value in self._items)
+
+    def items(self) -> tuple[tuple[str, Any], ...]:
+        return self._items
+
+    def values(self) -> tuple[Any, ...]:
+        return tuple(value for _key, value in self._items)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
     def __repr__(self) -> str:
         return f"FrozenMapping({_thaw_json(self)!r})"
 
@@ -164,7 +179,7 @@ class FrozenMapping(Mapping[str, JsonValue]):
         # equality rules (notably True == 1). Interoperability is canonical JSON,
         # so Python equality is deliberately closed to this immutable value type.
         if not isinstance(other, FrozenMapping):
-            return NotImplemented
+            return False
         return _typed_json_key(self) == _typed_json_key(other)
 
     def __hash__(self) -> int:
@@ -342,7 +357,7 @@ class Observation(ProtocolModel):
         return frozen
 
     @field_serializer("metadata")
-    def _serialize_metadata(self, metadata: Mapping[str, JsonValue]) -> dict[str, JsonValue]:
+    def _serialize_metadata(self, metadata: FrozenMapping) -> dict[str, JsonValue]:
         # Pydantic knows JsonValue but not MappingProxyType. Thaw only for wire
         # output; the model continues to expose recursively immutable values.
         thawed = _thaw_json(metadata)
@@ -661,6 +676,9 @@ def _validate_metadata(value: Any, *, path: str = "metadata", depth: int = 0) ->
         for index, item in enumerate(value):
             _validate_metadata(item, path=f"{path}[{index}]", depth=depth + 1)
         return
+    if isinstance(value, FrozenMapping):
+        _validate_metadata_items(value.items(), path=path, depth=depth)
+        return
     if isinstance(value, Mapping):
         # Dynamic keys use an ASCII subset whose code-point and UTF-16 sort
         # orders are identical across Python and JavaScript adapters.
@@ -685,6 +703,8 @@ def _freeze_metadata_value(value: Any, *, path: str, depth: int) -> Any:
             _freeze_metadata_value(item, path=f"{path}[{index}]", depth=depth + 1)
             for index, item in enumerate(value)
         )
+    if isinstance(value, FrozenMapping):
+        return value
     if isinstance(value, Mapping):
         return FrozenMapping._from_mapping(value, path=path, depth=depth)
     raise ValueError(f"{path} contains unsupported value type {type(value).__name__}")
@@ -695,6 +715,8 @@ def _freeze_json(value: Any) -> Any:
 
 
 def _thaw_json(value: Any) -> JsonValue:
+    if isinstance(value, FrozenMapping):
+        return {key: _thaw_json(item) for key, item in value.items()}
     if isinstance(value, Mapping):
         return {key: _thaw_json(item) for key, item in value.items()}
     if isinstance(value, (list, tuple)):
@@ -712,6 +734,11 @@ def _typed_json_key(value: Any) -> tuple[Any, ...]:
         return ("integer", value)
     if isinstance(value, str):
         return ("string", value)
+    if isinstance(value, FrozenMapping):
+        return (
+            "object",
+            tuple((key, _typed_json_key(item)) for key, item in value.items()),
+        )
     if isinstance(value, Mapping):
         return (
             "object",

--- a/local_operator/evaluation/protocol.py
+++ b/local_operator/evaluation/protocol.py
@@ -61,23 +61,34 @@ class FrozenMapping(Mapping[str, JsonValue]):
 
     ``MappingProxyType`` protects writes but cannot be deep-copied or pickled,
     both of which Pydantic callers reasonably use. This value object owns its
-    backing dictionary, exposes no mutable view, and reconstructs itself through
-    the same recursive freezer when unpickled.
+    canonical tuple of key/value pairs, exposes no mutable backing container,
+    and reconstructs itself through the same recursive freezer when unpickled.
     """
 
-    __slots__ = ("_data",)
+    __slots__ = ("_items",)
 
-    def __init__(self, values: Mapping[str, JsonValue]) -> None:
-        self._data = {key: _freeze_json(value) for key, value in values.items()}
+    def __init__(self, values: Mapping[str, Any]) -> None:
+        _validate_metadata(values)
+        object.__setattr__(
+            self,
+            "_items",
+            tuple((key, _freeze_json(value)) for key, value in sorted(values.items())),
+        )
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError(f"{type(self).__name__} is immutable")
 
     def __getitem__(self, key: str) -> JsonValue:
-        return self._data[key]
+        for candidate, value in self._items:
+            if candidate == key:
+                return value
+        raise KeyError(key)
 
     def __iter__(self) -> Iterator[str]:
-        return iter(self._data)
+        return (key for key, _value in self._items)
 
     def __len__(self) -> int:
-        return len(self._data)
+        return len(self._items)
 
     def __repr__(self) -> str:
         return f"FrozenMapping({_thaw_json(self)!r})"
@@ -87,13 +98,16 @@ class FrozenMapping(Mapping[str, JsonValue]):
             return NotImplemented
         return _thaw_json(self) == _thaw_json(other)
 
+    def __hash__(self) -> int:
+        return hash(self._items)
+
     def __deepcopy__(self, memo: dict[int, Any]) -> "FrozenMapping":
         # Every reachable value is immutable, so identity is a valid deep copy.
         memo[id(self)] = self
         return self
 
-    def __reduce__(self) -> tuple[type["FrozenMapping"], tuple[dict[str, JsonValue]]]:
-        return type(self), (dict(self._data),)
+    def __reduce__(self) -> tuple[type["FrozenMapping"], tuple[dict[str, Any]]]:
+        return type(self), (dict(self._items),)
 
 
 class ProtocolModel(BaseModel):
@@ -135,10 +149,15 @@ class ProtocolModel(BaseModel):
         ``deep`` is accepted for API compatibility but immutability makes the
         reconstructed result safe either way.
         """
+        fields_set = self.model_fields_set | (set(update) if update else set())
         values = self.model_dump(mode="python", round_trip=True)
         if update:
             values.update(deepcopy(dict(update)) if deep else update)
-        return type(self).model_validate(values, strict=True)
+        copied = type(self).model_validate(values, strict=True)
+        # Validation applies defaults, so restore which fields the caller
+        # supplied to preserve exclude_unset and Pydantic's copy contract.
+        object.__setattr__(copied, "__pydantic_fields_set__", fields_set)
+        return copied
 
 
 class ArtifactRef(ProtocolModel):
@@ -200,16 +219,9 @@ class FrameGeometry(ProtocolModel):
         source: FrameSize,
         destination: FrameSize,
     ) -> PixelPoint:
-        for name, value in (("x", x), ("y", y)):
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
-                raise TypeError(f"{name} must be an integer or float")
-            if not math.isfinite(value):
-                raise ValueError(f"{name} must be finite")
-        converted_x = math.floor(x * destination.width / source.width)
-        converted_y = math.floor(y * destination.height / source.height)
         return PixelPoint(
-            x=min(destination.width - 1, max(0, converted_x)),
-            y=min(destination.height - 1, max(0, converted_y)),
+            x=_scale_clamped_axis(x, source.width, destination.width, name="x"),
+            y=_scale_clamped_axis(y, source.height, destination.height, name="y"),
         )
 
 
@@ -230,7 +242,18 @@ class Observation(ProtocolModel):
     observation_id: Identifier
     text: str | None = Field(default=None, min_length=1, max_length=MAX_TEXT_LENGTH, pattern=r"\S")
     frames: tuple[FrameRef, ...] = Field(default=(), max_length=32)
-    metadata: Mapping[str, JsonValue] = Field(default_factory=dict, validate_default=True)
+    metadata: Mapping[str, JsonValue] = Field(
+        default_factory=dict,
+        validate_default=True,
+        description=(
+            "Portable metadata: recursively strings, booleans, null, safe integers, arrays, "
+            f"and ASCII-keyed objects; maximum depth {MAX_METADATA_DEPTH} and canonical size "
+            f"{MAX_METADATA_BYTES} bytes."
+        ),
+        json_schema_extra={
+            "propertyNames": {"pattern": r"^[A-Za-z0-9_.:-]{1,256}$"},
+        },
+    )
 
     @field_validator("frames", mode="before")
     @classmethod
@@ -247,7 +270,9 @@ class Observation(ProtocolModel):
         # booleans, null, and signed safe integers makes the existing sorted,
         # compact UTF-8 encoding portable without an RFC 8785 dependency.
         _validate_metadata(metadata)
-        return metadata
+        # JsonValue accepts concrete dict/list values only. Normalize safe
+        # Mapping/tuple inputs for Pydantic, then freeze the validated result.
+        return _thaw_json(metadata)
 
     @field_validator("metadata")
     @classmethod
@@ -257,6 +282,16 @@ class Observation(ProtocolModel):
         if len(canonical) > MAX_METADATA_BYTES:
             raise ValueError(f"metadata exceeds {MAX_METADATA_BYTES} canonical bytes")
         return frozen
+
+    @classmethod
+    def model_json_schema(cls, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        schema = super().model_json_schema(*args, **kwargs)
+        portable = _portable_metadata_schema()
+        schema.setdefault("$defs", {})["PortableMetadataValue"] = portable
+        schema["properties"]["metadata"]["additionalProperties"] = {
+            "$ref": "#/$defs/PortableMetadataValue"
+        }
+        return schema
 
     @field_serializer("metadata")
     def _serialize_metadata(self, metadata: Mapping[str, JsonValue]) -> dict[str, JsonValue]:
@@ -528,6 +563,26 @@ def _decode_canonical_json(payload: bytes | str) -> tuple[bytes, Any]:
     return raw, decoded
 
 
+def _scale_clamped_axis(
+    value: int | float,
+    source_size: int,
+    destination_size: int,
+    *,
+    name: str,
+) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{name} must be an integer or float")
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    # Compare before multiplying. This prevents enormous ints and finite floats
+    # near 1e308 from overflowing while preserving exact integer comparisons.
+    if value <= 0:
+        return 0
+    if value >= source_size - 1:
+        return destination_size - 1
+    return math.floor(value * destination_size / source_size)
+
+
 def _validate_metadata(value: Any, *, path: str = "metadata", depth: int = 0) -> None:
     """Enforce the portable, resource-bounded JSON subset at the RPC boundary."""
     if depth > MAX_METADATA_DEPTH:
@@ -540,11 +595,11 @@ def _validate_metadata(value: Any, *, path: str = "metadata", depth: int = 0) ->
         return
     if isinstance(value, float):
         raise ValueError(f"{path} floats are not supported; use a string or integer")
-    if isinstance(value, list):
+    if isinstance(value, (list, tuple)):
         for index, item in enumerate(value):
             _validate_metadata(item, path=f"{path}[{index}]", depth=depth + 1)
         return
-    if isinstance(value, dict):
+    if isinstance(value, Mapping):
         for key, item in value.items():
             if not isinstance(key, str):
                 raise ValueError(f"{path} object keys must be strings")
@@ -573,6 +628,32 @@ def _thaw_json(value: Any) -> JsonValue:
     if isinstance(value, tuple):
         return [_thaw_json(item) for item in value]
     return value
+
+
+def _portable_metadata_schema() -> dict[str, Any]:
+    value_ref = {"$ref": "#/$defs/PortableMetadataValue"}
+    return {
+        "description": (
+            f"Recursive portable metadata value; runtime limits depth to {MAX_METADATA_DEPTH} "
+            f"and canonical metadata to {MAX_METADATA_BYTES} bytes."
+        ),
+        "anyOf": [
+            {"type": "string"},
+            {"type": "boolean"},
+            {"type": "null"},
+            {
+                "type": "integer",
+                "minimum": -MAX_SAFE_JSON_INTEGER,
+                "maximum": MAX_SAFE_JSON_INTEGER,
+            },
+            {"type": "array", "items": value_ref},
+            {
+                "type": "object",
+                "propertyNames": {"pattern": r"^[A-Za-z0-9_.:-]{1,256}$"},
+                "additionalProperties": value_ref,
+            },
+        ],
+    }
 
 
 def _canonical_json_value(value: JsonValue) -> bytes:

--- a/local_operator/evaluation/protocol.py
+++ b/local_operator/evaluation/protocol.py
@@ -113,17 +113,20 @@ class FrozenMapping:
         if depth > MAX_METADATA_DEPTH:
             raise ValueError(f"{path} exceeds maximum nesting depth {MAX_METADATA_DEPTH}")
         snapshot = tuple(values.items())
-        keys = [key for key, _value in snapshot]
-        if len(keys) != len(set(keys)):
-            raise ValueError("metadata mapping contains duplicate keys")
-        frozen_items: list[tuple[str, Any]] = []
-        for key, value in snapshot:
+        # Validate type and syntax before hashing keys for duplicate detection;
+        # a hostile mapping may yield an unhashable non-string such as a list.
+        for key, _value in snapshot:
             if not isinstance(key, str):
                 raise ValueError(f"{path} object keys must be strings")
             if _METADATA_KEY_RE.fullmatch(key) is None:
                 raise ValueError(
                     f"{path} keys must match [A-Za-z0-9_.:-]{{1,{MAX_IDENTIFIER_LENGTH}}}"
                 )
+        keys = [key for key, _value in snapshot]
+        if len(keys) != len(set(keys)):
+            raise ValueError("metadata mapping contains duplicate keys")
+        frozen_items: list[tuple[str, Any]] = []
+        for key, value in snapshot:
             frozen_items.append(
                 (
                     key,

--- a/local_operator/evaluation/protocol.py
+++ b/local_operator/evaluation/protocol.py
@@ -1,0 +1,396 @@
+"""Strict, benchmark-neutral observations and structured computer actions.
+
+The protocol carries references to frame bytes rather than embedding them. This
+keeps a future adapter RPC small and prevents transport details (filesystem
+paths, object-store URLs, or inline base64) from becoming model-controlled
+capabilities. Every coordinate is interpreted against geometry captured in the
+observation; callers must never substitute the dimensions of a current display.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import string
+from typing import Annotated, Any, ClassVar, Literal, Self, TypeAlias
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    JsonValue,
+    TypeAdapter,
+    field_validator,
+    model_validator,
+)
+
+PROTOCOL_VERSION = "1.0"
+MAX_IDENTIFIER_LENGTH = 256
+MAX_TEXT_LENGTH = 100_000
+MAX_METADATA_BYTES = 64_000
+MAX_BATCH_SIZE = 64
+MAX_DIMENSION = 1_000_000
+MAX_COORDINATE = 1_000_000
+MAX_SCROLL_DELTA = 100_000
+MAX_WAIT_MS = 60_000
+
+Identifier = Annotated[
+    str,
+    Field(min_length=1, max_length=MAX_IDENTIFIER_LENGTH, pattern=r"\S"),
+]
+Coordinate = Annotated[int, Field(ge=0, le=MAX_COORDINATE)]
+MouseButton = Literal["left", "middle", "right"]
+
+
+class ProtocolModel(BaseModel):
+    """Immutable, coercion-free wire model shared by every protocol shape."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    def to_canonical_json(self) -> bytes:
+        """Return the one stable UTF-8 representation used for adapter RPCs."""
+        return json.dumps(
+            self.model_dump(mode="json"),
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+    @classmethod
+    def from_canonical_json(cls, payload: bytes | str) -> Self:
+        """Parse only canonical bytes so signatures and digests cannot disagree."""
+        raw = payload.encode("utf-8") if isinstance(payload, str) else payload
+        parsed = cls.model_validate_json(raw, strict=True)
+        if parsed.to_canonical_json() != raw:
+            raise ValueError("payload is valid JSON but is not canonical protocol JSON")
+        return parsed
+
+
+class ArtifactRef(ProtocolModel):
+    """Content-addressed bytes whose retrieval remains an adapter concern."""
+
+    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    media_type: str = Field(
+        min_length=3,
+        max_length=127,
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*$",
+    )
+    byte_count: int = Field(ge=1, le=10_000_000_000)
+
+
+class FrameSize(ProtocolModel):
+    """A top-left-origin pixel space captured with a specific frame."""
+
+    width: int = Field(ge=1, le=MAX_DIMENSION)
+    height: int = Field(ge=1, le=MAX_DIMENSION)
+    origin: Literal["top_left"] = "top_left"
+    unit: Literal["pixel"] = "pixel"
+
+
+class PixelPoint(ProtocolModel):
+    """An integer pixel selected under the protocol's floor-and-clamp policy."""
+
+    x: Coordinate
+    y: Coordinate
+
+
+class FrameGeometry(ProtocolModel):
+    """Native capture geometry and the exact resized frame shown to the model.
+
+    Conversion scales each axis independently, rounds toward negative infinity,
+    then clamps to the destination's inclusive pixel bounds. Clamping makes an
+    adapter boundary safe, but action validation still rejects out-of-frame
+    model coordinates so malformed model output is never silently repaired.
+    """
+
+    native: FrameSize
+    model_visible: FrameSize
+
+    def model_to_native(self, x: int | float, y: int | float) -> PixelPoint:
+        return self._convert(x, y, source=self.model_visible, destination=self.native)
+
+    def native_to_model(self, x: int | float, y: int | float) -> PixelPoint:
+        return self._convert(x, y, source=self.native, destination=self.model_visible)
+
+    @staticmethod
+    def _convert(
+        x: int | float,
+        y: int | float,
+        *,
+        source: FrameSize,
+        destination: FrameSize,
+    ) -> PixelPoint:
+        for name, value in (("x", x), ("y", y)):
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be an integer or float")
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+        converted_x = math.floor(x * destination.width / source.width)
+        converted_y = math.floor(y * destination.height / source.height)
+        return PixelPoint(
+            x=min(destination.width - 1, max(0, converted_x)),
+            y=min(destination.height - 1, max(0, converted_y)),
+        )
+
+
+class FrameRef(ProtocolModel):
+    """An ordered observation frame and the geometry used to interpret it."""
+
+    frame_id: Identifier
+    artifact: ArtifactRef
+    geometry: FrameGeometry
+
+
+class Observation(ProtocolModel):
+    """One immutable environment state presented during a stable episode."""
+
+    task_id: Identifier
+    episode_id: Identifier
+    sequence: int = Field(ge=0, le=2**63 - 1)
+    observation_id: Identifier
+    text: str | None = Field(default=None, max_length=MAX_TEXT_LENGTH)
+    frames: tuple[FrameRef, ...] = Field(default=(), max_length=32)
+    metadata: dict[str, JsonValue] = Field(default_factory=dict)
+
+    @field_validator("frames", mode="before")
+    @classmethod
+    def _freeze_json_frames(cls, frames: Any) -> Any:
+        # JSON has arrays but no tuples. Freeze exactly that wire shape while
+        # strict mode continues to reject strings, iterators, and coercions.
+        return tuple(frames) if isinstance(frames, list) else frames
+
+    @field_validator("metadata")
+    @classmethod
+    def _bounded_finite_metadata(cls, metadata: dict[str, JsonValue]) -> dict[str, JsonValue]:
+        _validate_metadata(metadata)
+        encoded = json.dumps(metadata, allow_nan=False, ensure_ascii=False, separators=(",", ":"))
+        if len(encoded.encode("utf-8")) > MAX_METADATA_BYTES:
+            raise ValueError(f"metadata exceeds {MAX_METADATA_BYTES} encoded bytes")
+        return metadata
+
+    @model_validator(mode="after")
+    def _unique_frames(self) -> Self:
+        ids = [frame.frame_id for frame in self.frames]
+        if len(ids) != len(set(ids)):
+            raise ValueError("frame_id values must be unique within an observation")
+        return self
+
+
+class _Action(ProtocolModel):
+    """Every action names the state it was selected from to expose staleness."""
+
+    observation_id: Identifier
+
+
+class _FrameAction(_Action):
+    frame_id: Identifier
+
+
+class _PointerAction(_FrameAction):
+    x: Coordinate
+    y: Coordinate
+    button: MouseButton = "left"
+
+
+class ClickAction(_PointerAction):
+    kind: Literal["click"] = "click"
+
+
+class DoubleClickAction(_PointerAction):
+    """A distinct action retained because existing compilers emit double-click."""
+
+    kind: Literal["double_click"] = "double_click"
+
+
+class TypeAction(_Action):
+    kind: Literal["type"] = "type"
+    text: str = Field(min_length=1, max_length=MAX_TEXT_LENGTH)
+
+
+_NAMED_KEYS = frozenset(
+    {
+        "ALT",
+        "BACKSPACE",
+        "CAPSLOCK",
+        "CTRL",
+        "DELETE",
+        "DOWN",
+        "END",
+        "ENTER",
+        "ESC",
+        "HOME",
+        "INSERT",
+        "LEFT",
+        "META",
+        "PAGEDOWN",
+        "PAGEUP",
+        "RIGHT",
+        "SHIFT",
+        "SPACE",
+        "TAB",
+        "UP",
+        *(f"F{index}" for index in range(1, 25)),
+    }
+)
+_PRINTABLE_KEYS = frozenset(string.ascii_letters + string.digits + string.punctuation)
+
+
+class KeyAction(_Action):
+    kind: Literal["key"] = "key"
+    keys: tuple[str, ...] = Field(min_length=1, max_length=8)
+
+    @field_validator("keys", mode="before")
+    @classmethod
+    def _freeze_json_keys(cls, keys: Any) -> Any:
+        return tuple(keys) if isinstance(keys, list) else keys
+
+    @field_validator("keys")
+    @classmethod
+    def _known_unique_keys(cls, keys: tuple[str, ...]) -> tuple[str, ...]:
+        normalized: list[str] = []
+        for key in keys:
+            candidate = key.upper() if len(key) > 1 else key
+            if candidate not in _NAMED_KEYS and candidate not in _PRINTABLE_KEYS:
+                raise ValueError(f"unknown key: {key!r}")
+            normalized.append(candidate)
+        if len(normalized) != len(set(normalized)):
+            raise ValueError("a key chord cannot contain duplicate keys")
+        return tuple(normalized)
+
+
+class ScrollAction(_FrameAction):
+    kind: Literal["scroll"] = "scroll"
+    x: Coordinate
+    y: Coordinate
+    delta_x: int = Field(default=0, ge=-MAX_SCROLL_DELTA, le=MAX_SCROLL_DELTA)
+    delta_y: int = Field(default=0, ge=-MAX_SCROLL_DELTA, le=MAX_SCROLL_DELTA)
+
+    @model_validator(mode="after")
+    def _requires_motion(self) -> Self:
+        if self.delta_x == 0 and self.delta_y == 0:
+            raise ValueError("scroll requires a non-zero delta")
+        return self
+
+
+class WaitAction(_Action):
+    kind: Literal["wait"] = "wait"
+    duration_ms: int = Field(ge=1, le=MAX_WAIT_MS)
+
+
+class FinishAction(_Action):
+    """A terminal model claim; grading remains the benchmark adapter's job."""
+
+    kind: Literal["finish"] = "finish"
+    status: Literal["done", "failed", "infeasible"]
+    reason: str = Field(min_length=1, max_length=10_000)
+
+
+class AskUserAction(_Action):
+    """A terminal pause identified independently from retries or re-delivery."""
+
+    kind: Literal["ask_user"] = "ask_user"
+    request_id: Identifier
+    question: str = Field(min_length=1, max_length=10_000)
+
+
+ComputerAction: TypeAlias = Annotated[
+    ClickAction
+    | DoubleClickAction
+    | TypeAction
+    | KeyAction
+    | ScrollAction
+    | WaitAction
+    | FinishAction
+    | AskUserAction,
+    Field(discriminator="kind"),
+]
+
+
+class ObservationEnvelope(ProtocolModel):
+    """Versioned adapter message carrying one environment observation."""
+
+    protocol_version: Literal["1.0"] = PROTOCOL_VERSION
+    kind: Literal["observation"] = "observation"
+    observation: Observation
+
+
+class ActionBatch(ProtocolModel):
+    """Versioned ordered actions selected from exactly one observation."""
+
+    protocol_version: Literal["1.0"] = PROTOCOL_VERSION
+    kind: Literal["action_batch"] = "action_batch"
+    task_id: Identifier
+    episode_id: Identifier
+    observation_id: Identifier
+    actions: tuple[ComputerAction, ...] = Field(min_length=1, max_length=MAX_BATCH_SIZE)
+
+    _TERMINAL_TYPES: ClassVar[tuple[type[ProtocolModel], ...]] = (FinishAction, AskUserAction)
+
+    @field_validator("actions", mode="before")
+    @classmethod
+    def _freeze_json_actions(cls, actions: Any) -> Any:
+        return tuple(actions) if isinstance(actions, list) else actions
+
+    @model_validator(mode="after")
+    def _bind_and_isolate_actions(self) -> Self:
+        mismatches = [
+            index
+            for index, action in enumerate(self.actions)
+            if action.observation_id != self.observation_id
+        ]
+        if mismatches:
+            raise ValueError(f"actions at indexes {mismatches} bind to a different observation_id")
+        if (
+            any(isinstance(action, self._TERMINAL_TYPES) for action in self.actions)
+            and len(self.actions) != 1
+        ):
+            raise ValueError("finish and ask_user must be the only action in their batch")
+        return self
+
+    def validate_for(self, observation: Observation) -> None:
+        """Reject stale episodes and coordinates before an adapter executes."""
+        expected = (observation.task_id, observation.episode_id, observation.observation_id)
+        actual = (self.task_id, self.episode_id, self.observation_id)
+        if actual != expected:
+            raise ValueError(
+                "action batch does not bind to the current task, episode, and observation"
+            )
+        frames = {frame.frame_id: frame for frame in observation.frames}
+        for action in self.actions:
+            if isinstance(action, (ClickAction, DoubleClickAction, ScrollAction)):
+                frame = frames.get(action.frame_id)
+                if frame is None:
+                    raise ValueError(f"action references unknown frame_id {action.frame_id!r}")
+                visible = frame.geometry.model_visible
+                if action.x >= visible.width or action.y >= visible.height:
+                    raise ValueError(
+                        f"action coordinate {action.x},{action.y} is outside model-visible frame "
+                        f"{visible.width}x{visible.height}"
+                    )
+
+
+ProtocolEnvelope: TypeAlias = Annotated[
+    ObservationEnvelope | ActionBatch,
+    Field(discriminator="kind"),
+]
+_ENVELOPE_ADAPTER = TypeAdapter(ProtocolEnvelope, config=ConfigDict(strict=True))
+
+
+def parse_envelope(payload: bytes | str) -> ProtocolEnvelope:
+    """Strictly parse a versioned RPC envelope without accepting unknown kinds."""
+    return _ENVELOPE_ADAPTER.validate_json(payload, strict=True)
+
+
+def _validate_metadata(value: JsonValue, *, path: str = "metadata") -> None:
+    """Keep recursively nested JSON finite and its object keys bounded."""
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError(f"{path} contains a non-finite number")
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_metadata(item, path=f"{path}[{index}]")
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            if not key or len(key) > MAX_IDENTIFIER_LENGTH:
+                raise ValueError(f"{path} contains an empty or overlong key")
+            _validate_metadata(item, path=f"{path}.{key}")

--- a/local_operator/evaluation/protocol.py
+++ b/local_operator/evaluation/protocol.py
@@ -5,6 +5,10 @@ keeps a future adapter RPC small and prevents transport details (filesystem
 paths, object-store URLs, or inline base64) from becoming model-controlled
 capabilities. Every coordinate is interpreted against geometry captured in the
 observation; callers must never substitute the dimensions of a current display.
+Metadata intentionally uses a portable JSON subset: strings, booleans, null,
+and signed integers exactly representable by IEEE-754 (up to 2^53 - 1). Floats
+are excluded so Python and future non-Python adapters produce identical bytes
+without depending on an RFC 8785 implementation.
 """
 
 from __future__ import annotations

--- a/local_operator/evaluation/protocol.py
+++ b/local_operator/evaluation/protocol.py
@@ -96,12 +96,47 @@ class FrozenMapping(Mapping[str, JsonValue]):
     __slots__ = ("_items",)
 
     def __init__(self, values: Mapping[str, Any]) -> None:
-        _validate_metadata(values)
-        object.__setattr__(
-            self,
-            "_items",
-            tuple((key, _freeze_json(value)) for key, value in sorted(values.items())),
-        )
+        # A Mapping may be stateful or adversarial. Traverse each mapping exactly
+        # once while validating and freezing that owned snapshot, so
+        # time-of-check and time-of-use cannot observe different data.
+        frozen = self._from_mapping(values, path="metadata", depth=0)
+        object.__setattr__(self, "_items", frozen._items)
+
+    @classmethod
+    def _from_mapping(
+        cls,
+        values: Mapping[str, Any],
+        *,
+        path: str,
+        depth: int,
+    ) -> "FrozenMapping":
+        if depth > MAX_METADATA_DEPTH:
+            raise ValueError(f"{path} exceeds maximum nesting depth {MAX_METADATA_DEPTH}")
+        snapshot = tuple(values.items())
+        keys = [key for key, _value in snapshot]
+        if len(keys) != len(set(keys)):
+            raise ValueError("metadata mapping contains duplicate keys")
+        frozen_items: list[tuple[str, Any]] = []
+        for key, value in snapshot:
+            if not isinstance(key, str):
+                raise ValueError(f"{path} object keys must be strings")
+            if _METADATA_KEY_RE.fullmatch(key) is None:
+                raise ValueError(
+                    f"{path} keys must match [A-Za-z0-9_.:-]{{1,{MAX_IDENTIFIER_LENGTH}}}"
+                )
+            frozen_items.append(
+                (
+                    key,
+                    _freeze_metadata_value(
+                        value,
+                        path=f"{path}.{key}",
+                        depth=depth + 1,
+                    ),
+                )
+            )
+        instance = object.__new__(cls)
+        object.__setattr__(instance, "_items", tuple(sorted(frozen_items)))
+        return instance
 
     def __setattr__(self, name: str, value: object) -> None:
         raise AttributeError(f"{type(self).__name__} is immutable")
@@ -125,12 +160,12 @@ class FrozenMapping(Mapping[str, JsonValue]):
         return f"FrozenMapping({_thaw_json(self)!r})"
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Mapping):
+        # Ordinary Mapping implementations have their own, often untyped,
+        # equality rules (notably True == 1). Interoperability is canonical JSON,
+        # so Python equality is deliberately closed to this immutable value type.
+        if not isinstance(other, FrozenMapping):
             return NotImplemented
-        try:
-            return _typed_json_key(self) == _typed_json_key(other)
-        except (TypeError, ValueError):
-            return False
+        return _typed_json_key(self) == _typed_json_key(other)
 
     def __hash__(self) -> int:
         return hash(_typed_json_key(self))
@@ -596,6 +631,20 @@ def _scale_clamped_axis(
     return math.floor(value * destination_size / source_size)
 
 
+def _validate_metadata_items(
+    items: tuple[tuple[Any, Any], ...],
+    *,
+    path: str = "metadata",
+    depth: int = 0,
+) -> None:
+    for key, item in items:
+        if not isinstance(key, str):
+            raise ValueError(f"{path} object keys must be strings")
+        if _METADATA_KEY_RE.fullmatch(key) is None:
+            raise ValueError(f"{path} keys must match [A-Za-z0-9_.:-]{{1,{MAX_IDENTIFIER_LENGTH}}}")
+        _validate_metadata(item, path=f"{path}.{key}", depth=depth + 1)
+
+
 def _validate_metadata(value: Any, *, path: str = "metadata", depth: int = 0) -> None:
     """Enforce the portable, resource-bounded JSON subset at the RPC boundary."""
     if depth > MAX_METADATA_DEPTH:
@@ -613,26 +662,36 @@ def _validate_metadata(value: Any, *, path: str = "metadata", depth: int = 0) ->
             _validate_metadata(item, path=f"{path}[{index}]", depth=depth + 1)
         return
     if isinstance(value, Mapping):
-        for key, item in value.items():
-            if not isinstance(key, str):
-                raise ValueError(f"{path} object keys must be strings")
-            # Dynamic keys use an ASCII subset whose code-point and UTF-16 sort
-            # orders are identical across Python and JavaScript adapters.
-            if _METADATA_KEY_RE.fullmatch(key) is None:
-                raise ValueError(
-                    f"{path} keys must match [A-Za-z0-9_.:-]{{1,{MAX_IDENTIFIER_LENGTH}}}"
-                )
-            _validate_metadata(item, path=f"{path}.{key}", depth=depth + 1)
+        # Dynamic keys use an ASCII subset whose code-point and UTF-16 sort
+        # orders are identical across Python and JavaScript adapters.
+        _validate_metadata_items(tuple(value.items()), path=path, depth=depth)
         return
     raise ValueError(f"{path} contains unsupported value type {type(value).__name__}")
 
 
-def _freeze_json(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return FrozenMapping(value)
+def _freeze_metadata_value(value: Any, *, path: str, depth: int) -> Any:
+    if depth > MAX_METADATA_DEPTH:
+        raise ValueError(f"{path} exceeds maximum nesting depth {MAX_METADATA_DEPTH}")
+    if value is None or isinstance(value, (str, bool)):
+        return value
+    if isinstance(value, int):
+        if not -MAX_SAFE_JSON_INTEGER <= value <= MAX_SAFE_JSON_INTEGER:
+            raise ValueError(f"{path} integer exceeds the portable JSON-safe range")
+        return value
+    if isinstance(value, float):
+        raise ValueError(f"{path} floats are not supported; use a string or integer")
     if isinstance(value, (list, tuple)):
-        return tuple(_freeze_json(item) for item in value)
-    return value
+        return tuple(
+            _freeze_metadata_value(item, path=f"{path}[{index}]", depth=depth + 1)
+            for index, item in enumerate(value)
+        )
+    if isinstance(value, Mapping):
+        return FrozenMapping._from_mapping(value, path=path, depth=depth)
+    raise ValueError(f"{path} contains unsupported value type {type(value).__name__}")
+
+
+def _freeze_json(value: Any) -> Any:
+    return _freeze_metadata_value(value, path="metadata", depth=0)
 
 
 def _thaw_json(value: Any) -> JsonValue:

--- a/local_operator/evaluation/protocol.py
+++ b/local_operator/evaluation/protocol.py
@@ -8,16 +8,19 @@ observation; callers must never substitute the dimensions of a current display.
 Metadata intentionally uses a portable JSON subset: strings, booleans, null,
 and signed integers exactly representable by IEEE-754 (up to 2^53 - 1). Floats
 are excluded so Python and future non-Python adapters produce identical bytes
-without depending on an RFC 8785 implementation.
+without depending on an RFC 8785 implementation. Canonical JSON is UTF-8 with
+literal Unicode, sorted ASCII object keys, compact ``,:`` separators, standard
+JSON control/quote/backslash escaping, and unescaped slashes.
 """
 
 from __future__ import annotations
 
 import json
 import math
+import re
 import string
-from collections.abc import Mapping
-from types import MappingProxyType
+from collections.abc import Iterator, Mapping
+from copy import deepcopy
 from typing import Annotated, Any, ClassVar, Literal, Self, TypeAlias
 
 from pydantic import (
@@ -37,6 +40,7 @@ MAX_TEXT_LENGTH = 100_000
 MAX_METADATA_BYTES = 64_000
 MAX_METADATA_DEPTH = 16
 MAX_SAFE_JSON_INTEGER = 2**53 - 1
+MAX_ENVELOPE_BYTES = 16 * 1024 * 1024
 MAX_BATCH_SIZE = 64
 MAX_DIMENSION = 1_000_000
 MAX_COORDINATE = 1_000_000
@@ -49,15 +53,56 @@ Identifier = Annotated[
 ]
 Coordinate = Annotated[int, Field(ge=0, le=MAX_COORDINATE)]
 MouseButton = Literal["left", "middle", "right"]
+_METADATA_KEY_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,256}$")
+
+
+class FrozenMapping(Mapping[str, JsonValue]):
+    """A recursively immutable mapping that remains copy and pickle friendly.
+
+    ``MappingProxyType`` protects writes but cannot be deep-copied or pickled,
+    both of which Pydantic callers reasonably use. This value object owns its
+    backing dictionary, exposes no mutable view, and reconstructs itself through
+    the same recursive freezer when unpickled.
+    """
+
+    __slots__ = ("_data",)
+
+    def __init__(self, values: Mapping[str, JsonValue]) -> None:
+        self._data = {key: _freeze_json(value) for key, value in values.items()}
+
+    def __getitem__(self, key: str) -> JsonValue:
+        return self._data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __repr__(self) -> str:
+        return f"FrozenMapping({_thaw_json(self)!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Mapping):
+            return NotImplemented
+        return _thaw_json(self) == _thaw_json(other)
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> "FrozenMapping":
+        # Every reachable value is immutable, so identity is a valid deep copy.
+        memo[id(self)] = self
+        return self
+
+    def __reduce__(self) -> tuple[type["FrozenMapping"], tuple[dict[str, JsonValue]]]:
+        return type(self), (dict(self._data),)
 
 
 class ProtocolModel(BaseModel):
     """Immutable, coercion-free wire model shared by every protocol shape."""
 
-    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True, validate_default=True)
 
     def to_canonical_json(self) -> bytes:
-        """Return the one stable UTF-8 representation used for adapter RPCs."""
+        """Return compact sorted UTF-8 JSON with literal Unicode and slashes."""
         return json.dumps(
             self.model_dump(mode="json"),
             allow_nan=False,
@@ -74,6 +119,26 @@ class ProtocolModel(BaseModel):
         if parsed.to_canonical_json() != raw:
             raise ValueError("payload is valid JSON but is not canonical protocol JSON")
         return parsed
+
+    def model_copy(
+        self,
+        *,
+        update: Mapping[str, Any] | None = None,
+        deep: bool = False,
+    ) -> Self:
+        """Copy through validation so updates cannot bypass wire invariants.
+
+        Pydantic's default ``model_copy(update=...)`` deliberately skips
+        validation. That is unsafe for frozen protocol values because it can
+        inject mutable metadata or invalid bounds. A serialized reconstruction
+        also gives nested protocol models the same validation as RPC input;
+        ``deep`` is accepted for API compatibility but immutability makes the
+        reconstructed result safe either way.
+        """
+        values = self.model_dump(mode="python", round_trip=True)
+        if update:
+            values.update(deepcopy(dict(update)) if deep else update)
+        return type(self).model_validate(values, strict=True)
 
 
 class ArtifactRef(ProtocolModel):
@@ -161,11 +226,11 @@ class Observation(ProtocolModel):
 
     task_id: Identifier
     episode_id: Identifier
-    sequence: int = Field(ge=0, le=2**63 - 1)
+    sequence: int = Field(ge=0, le=MAX_SAFE_JSON_INTEGER)
     observation_id: Identifier
     text: str | None = Field(default=None, min_length=1, max_length=MAX_TEXT_LENGTH, pattern=r"\S")
     frames: tuple[FrameRef, ...] = Field(default=(), max_length=32)
-    metadata: Mapping[str, JsonValue] = Field(default_factory=dict)
+    metadata: Mapping[str, JsonValue] = Field(default_factory=dict, validate_default=True)
 
     @field_validator("frames", mode="before")
     @classmethod
@@ -186,8 +251,8 @@ class Observation(ProtocolModel):
 
     @field_validator("metadata")
     @classmethod
-    def _freeze_metadata(cls, metadata: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
-        frozen = _freeze_json(metadata)
+    def _freeze_metadata(cls, metadata: Mapping[str, JsonValue]) -> FrozenMapping:
+        frozen = FrozenMapping(metadata)
         canonical = _canonical_json_value(_thaw_json(frozen))
         if len(canonical) > MAX_METADATA_BYTES:
             raise ValueError(f"metadata exceeds {MAX_METADATA_BYTES} canonical bytes")
@@ -432,7 +497,18 @@ def parse_envelope(payload: bytes | str) -> ProtocolEnvelope:
 
 
 def _decode_canonical_json(payload: bytes | str) -> tuple[bytes, Any]:
-    raw = payload.encode("utf-8") if isinstance(payload, str) else payload
+    # The cap applies to transport bytes before any decoder allocation or
+    # recursive parsing. Strings are measured in their protocol UTF-8 encoding.
+    if isinstance(payload, str):
+        raw = payload.encode("utf-8")
+    else:
+        raw = payload
+    if len(raw) > MAX_ENVELOPE_BYTES:
+        raise ValueError(f"protocol envelope exceeds {MAX_ENVELOPE_BYTES} bytes")
+    try:
+        raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError("protocol envelope is not valid UTF-8") from exc
 
     def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
         result: dict[str, Any] = {}
@@ -472,17 +548,21 @@ def _validate_metadata(value: Any, *, path: str = "metadata", depth: int = 0) ->
         for key, item in value.items():
             if not isinstance(key, str):
                 raise ValueError(f"{path} object keys must be strings")
-            if not key or len(key) > MAX_IDENTIFIER_LENGTH:
-                raise ValueError(f"{path} contains an empty or overlong key")
+            # Dynamic keys use an ASCII subset whose code-point and UTF-16 sort
+            # orders are identical across Python and JavaScript adapters.
+            if _METADATA_KEY_RE.fullmatch(key) is None:
+                raise ValueError(
+                    f"{path} keys must match [A-Za-z0-9_.:-]{{1,{MAX_IDENTIFIER_LENGTH}}}"
+                )
             _validate_metadata(item, path=f"{path}.{key}", depth=depth + 1)
         return
     raise ValueError(f"{path} contains unsupported value type {type(value).__name__}")
 
 
 def _freeze_json(value: Any) -> Any:
-    if isinstance(value, dict):
-        return MappingProxyType({key: _freeze_json(item) for key, item in value.items()})
-    if isinstance(value, list):
+    if isinstance(value, Mapping):
+        return FrozenMapping(value)
+    if isinstance(value, (list, tuple)):
         return tuple(_freeze_json(item) for item in value)
     return value
 

--- a/local_operator/evaluation/protocol.py
+++ b/local_operator/evaluation/protocol.py
@@ -149,7 +149,7 @@ class Observation(ProtocolModel):
     episode_id: Identifier
     sequence: int = Field(ge=0, le=2**63 - 1)
     observation_id: Identifier
-    text: str | None = Field(default=None, max_length=MAX_TEXT_LENGTH)
+    text: str | None = Field(default=None, min_length=1, max_length=MAX_TEXT_LENGTH, pattern=r"\S")
     frames: tuple[FrameRef, ...] = Field(default=(), max_length=32)
     metadata: dict[str, JsonValue] = Field(default_factory=dict)
 
@@ -197,15 +197,20 @@ class ClickAction(_PointerAction):
     kind: Literal["click"] = "click"
 
 
-class DoubleClickAction(_PointerAction):
+class DoubleClickAction(_FrameAction):
     """A distinct action retained because existing compilers emit double-click."""
 
     kind: Literal["double_click"] = "double_click"
+    x: Coordinate
+    y: Coordinate
+    # Historical compilers only emit left-button double clicks; closing this
+    # now avoids inventing adapter semantics that no implementation has proved.
+    button: Literal["left"] = "left"
 
 
 class TypeAction(_Action):
     kind: Literal["type"] = "type"
-    text: str = Field(min_length=1, max_length=MAX_TEXT_LENGTH)
+    text: str = Field(min_length=1, max_length=MAX_TEXT_LENGTH, pattern=r"\S")
 
 
 _NAMED_KEYS = frozenset(
@@ -283,7 +288,7 @@ class FinishAction(_Action):
 
     kind: Literal["finish"] = "finish"
     status: Literal["done", "failed", "infeasible"]
-    reason: str = Field(min_length=1, max_length=10_000)
+    reason: str = Field(min_length=1, max_length=10_000, pattern=r"\S")
 
 
 class AskUserAction(_Action):
@@ -291,7 +296,7 @@ class AskUserAction(_Action):
 
     kind: Literal["ask_user"] = "ask_user"
     request_id: Identifier
-    question: str = Field(min_length=1, max_length=10_000)
+    question: str = Field(min_length=1, max_length=10_000, pattern=r"\S")
 
 
 ComputerAction: TypeAlias = Annotated[

--- a/local_operator/evaluation/protocol.py
+++ b/local_operator/evaluation/protocol.py
@@ -33,6 +33,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+from typing_extensions import TypeAliasType
 
 PROTOCOL_VERSION = "1.0"
 MAX_IDENTIFIER_LENGTH = 256
@@ -54,6 +55,33 @@ Identifier = Annotated[
 Coordinate = Annotated[int, Field(ge=0, le=MAX_COORDINATE)]
 MouseButton = Literal["left", "middle", "right"]
 _METADATA_KEY_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,256}$")
+_METADATA_DESCRIPTION = (
+    f"Portable metadata; runtime maximum depth {MAX_METADATA_DEPTH} and canonical size "
+    f"{MAX_METADATA_BYTES} bytes."
+)
+_SafeMetadataInteger = Annotated[
+    int,
+    Field(ge=-MAX_SAFE_JSON_INTEGER, le=MAX_SAFE_JSON_INTEGER),
+]
+PortableMetadataObject = TypeAliasType(
+    "PortableMetadataObject",
+    Annotated[
+        dict[str, "PortableMetadataValue"],
+        Field(
+            description=_METADATA_DESCRIPTION,
+            json_schema_extra={"propertyNames": {"pattern": r"^[A-Za-z0-9_.:-]{1,256}$"}},
+        ),
+    ],
+)
+PortableMetadataValue = TypeAliasType(
+    "PortableMetadataValue",
+    str
+    | bool
+    | None
+    | _SafeMetadataInteger
+    | list["PortableMetadataValue"]  # pyright: ignore[reportInvalidTypeForm]
+    | PortableMetadataObject,
+)
 
 
 class FrozenMapping(Mapping[str, JsonValue]):
@@ -78,6 +106,9 @@ class FrozenMapping(Mapping[str, JsonValue]):
     def __setattr__(self, name: str, value: object) -> None:
         raise AttributeError(f"{type(self).__name__} is immutable")
 
+    def __delattr__(self, name: str) -> None:
+        raise AttributeError(f"{type(self).__name__} is immutable")
+
     def __getitem__(self, key: str) -> JsonValue:
         for candidate, value in self._items:
             if candidate == key:
@@ -96,10 +127,13 @@ class FrozenMapping(Mapping[str, JsonValue]):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Mapping):
             return NotImplemented
-        return _thaw_json(self) == _thaw_json(other)
+        try:
+            return _typed_json_key(self) == _typed_json_key(other)
+        except (TypeError, ValueError):
+            return False
 
     def __hash__(self) -> int:
-        return hash(self._items)
+        return hash(_typed_json_key(self))
 
     def __deepcopy__(self, memo: dict[int, Any]) -> "FrozenMapping":
         # Every reachable value is immutable, so identity is a valid deep copy.
@@ -242,18 +276,7 @@ class Observation(ProtocolModel):
     observation_id: Identifier
     text: str | None = Field(default=None, min_length=1, max_length=MAX_TEXT_LENGTH, pattern=r"\S")
     frames: tuple[FrameRef, ...] = Field(default=(), max_length=32)
-    metadata: Mapping[str, JsonValue] = Field(
-        default_factory=dict,
-        validate_default=True,
-        description=(
-            "Portable metadata: recursively strings, booleans, null, safe integers, arrays, "
-            f"and ASCII-keyed objects; maximum depth {MAX_METADATA_DEPTH} and canonical size "
-            f"{MAX_METADATA_BYTES} bytes."
-        ),
-        json_schema_extra={
-            "propertyNames": {"pattern": r"^[A-Za-z0-9_.:-]{1,256}$"},
-        },
-    )
+    metadata: PortableMetadataObject = Field(default_factory=dict, validate_default=True)
 
     @field_validator("frames", mode="before")
     @classmethod
@@ -282,16 +305,6 @@ class Observation(ProtocolModel):
         if len(canonical) > MAX_METADATA_BYTES:
             raise ValueError(f"metadata exceeds {MAX_METADATA_BYTES} canonical bytes")
         return frozen
-
-    @classmethod
-    def model_json_schema(cls, *args: Any, **kwargs: Any) -> dict[str, Any]:
-        schema = super().model_json_schema(*args, **kwargs)
-        portable = _portable_metadata_schema()
-        schema.setdefault("$defs", {})["PortableMetadataValue"] = portable
-        schema["properties"]["metadata"]["additionalProperties"] = {
-            "$ref": "#/$defs/PortableMetadataValue"
-        }
-        return schema
 
     @field_serializer("metadata")
     def _serialize_metadata(self, metadata: Mapping[str, JsonValue]) -> dict[str, JsonValue]:
@@ -625,35 +638,29 @@ def _freeze_json(value: Any) -> Any:
 def _thaw_json(value: Any) -> JsonValue:
     if isinstance(value, Mapping):
         return {key: _thaw_json(item) for key, item in value.items()}
-    if isinstance(value, tuple):
+    if isinstance(value, (list, tuple)):
         return [_thaw_json(item) for item in value]
     return value
 
 
-def _portable_metadata_schema() -> dict[str, Any]:
-    value_ref = {"$ref": "#/$defs/PortableMetadataValue"}
-    return {
-        "description": (
-            f"Recursive portable metadata value; runtime limits depth to {MAX_METADATA_DEPTH} "
-            f"and canonical metadata to {MAX_METADATA_BYTES} bytes."
-        ),
-        "anyOf": [
-            {"type": "string"},
-            {"type": "boolean"},
-            {"type": "null"},
-            {
-                "type": "integer",
-                "minimum": -MAX_SAFE_JSON_INTEGER,
-                "maximum": MAX_SAFE_JSON_INTEGER,
-            },
-            {"type": "array", "items": value_ref},
-            {
-                "type": "object",
-                "propertyNames": {"pattern": r"^[A-Za-z0-9_.:-]{1,256}$"},
-                "additionalProperties": value_ref,
-            },
-        ],
-    }
+def _typed_json_key(value: Any) -> tuple[Any, ...]:
+    """Return a hash/equality key that preserves JSON scalar type identity."""
+    if value is None:
+        return ("null",)
+    if isinstance(value, bool):
+        return ("boolean", value)
+    if isinstance(value, int):
+        return ("integer", value)
+    if isinstance(value, str):
+        return ("string", value)
+    if isinstance(value, Mapping):
+        return (
+            "object",
+            tuple((key, _typed_json_key(item)) for key, item in sorted(value.items())),
+        )
+    if isinstance(value, (list, tuple)):
+        return ("array", tuple(_typed_json_key(item) for item in value))
+    raise TypeError(f"unsupported JSON value type: {type(value).__name__}")
 
 
 def _canonical_json_value(value: JsonValue) -> bytes:

--- a/local_operator/evaluation/protocol.py
+++ b/local_operator/evaluation/protocol.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import json
 import math
 import string
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Annotated, Any, ClassVar, Literal, Self, TypeAlias
 
 from pydantic import (
@@ -20,6 +22,7 @@ from pydantic import (
     Field,
     JsonValue,
     TypeAdapter,
+    field_serializer,
     field_validator,
     model_validator,
 )
@@ -28,6 +31,8 @@ PROTOCOL_VERSION = "1.0"
 MAX_IDENTIFIER_LENGTH = 256
 MAX_TEXT_LENGTH = 100_000
 MAX_METADATA_BYTES = 64_000
+MAX_METADATA_DEPTH = 16
+MAX_SAFE_JSON_INTEGER = 2**53 - 1
 MAX_BATCH_SIZE = 64
 MAX_DIMENSION = 1_000_000
 MAX_COORDINATE = 1_000_000
@@ -60,8 +65,8 @@ class ProtocolModel(BaseModel):
     @classmethod
     def from_canonical_json(cls, payload: bytes | str) -> Self:
         """Parse only canonical bytes so signatures and digests cannot disagree."""
-        raw = payload.encode("utf-8") if isinstance(payload, str) else payload
-        parsed = cls.model_validate_json(raw, strict=True)
+        raw, decoded = _decode_canonical_json(payload)
+        parsed = cls.model_validate(decoded, strict=True)
         if parsed.to_canonical_json() != raw:
             raise ValueError("payload is valid JSON but is not canonical protocol JSON")
         return parsed
@@ -98,19 +103,24 @@ class PixelPoint(ProtocolModel):
 class FrameGeometry(ProtocolModel):
     """Native capture geometry and the exact resized frame shown to the model.
 
-    Conversion scales each axis independently, rounds toward negative infinity,
-    then clamps to the destination's inclusive pixel bounds. Clamping makes an
-    adapter boundary safe, but action validation still rejects out-of-frame
-    model coordinates so malformed model output is never silently repaired.
+    Each directed conversion scales an input pixel coordinate by
+    ``destination_size / source_size``, rounds toward negative infinity, then
+    clamps to the destination's inclusive pixel bounds. The methods are not
+    mathematical inverses when dimensions differ: downscaling merges pixels and
+    floor rounding can move a round trip toward the top-left. Clamping makes a
+    conversion boundary safe, but action validation rejects out-of-frame model
+    coordinates rather than silently repairing model output.
     """
 
     native: FrameSize
     model_visible: FrameSize
 
     def model_to_native(self, x: int | float, y: int | float) -> PixelPoint:
+        """Map from this frame's model-visible pixels into its native pixels."""
         return self._convert(x, y, source=self.model_visible, destination=self.native)
 
     def native_to_model(self, x: int | float, y: int | float) -> PixelPoint:
+        """Map from this frame's native pixels into its model-visible pixels."""
         return self._convert(x, y, source=self.native, destination=self.model_visible)
 
     @staticmethod
@@ -151,7 +161,7 @@ class Observation(ProtocolModel):
     observation_id: Identifier
     text: str | None = Field(default=None, min_length=1, max_length=MAX_TEXT_LENGTH, pattern=r"\S")
     frames: tuple[FrameRef, ...] = Field(default=(), max_length=32)
-    metadata: dict[str, JsonValue] = Field(default_factory=dict)
+    metadata: Mapping[str, JsonValue] = Field(default_factory=dict)
 
     @field_validator("frames", mode="before")
     @classmethod
@@ -160,14 +170,32 @@ class Observation(ProtocolModel):
         # strict mode continues to reject strings, iterators, and coercions.
         return tuple(frames) if isinstance(frames, list) else frames
 
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def _validate_wire_metadata(cls, metadata: Any) -> Any:
+        # IEEE-754 implementations disagree with Python about formatting and
+        # exactness outside this subset. Restricting metadata to strings,
+        # booleans, null, and signed safe integers makes the existing sorted,
+        # compact UTF-8 encoding portable without an RFC 8785 dependency.
+        _validate_metadata(metadata)
+        return metadata
+
     @field_validator("metadata")
     @classmethod
-    def _bounded_finite_metadata(cls, metadata: dict[str, JsonValue]) -> dict[str, JsonValue]:
-        _validate_metadata(metadata)
-        encoded = json.dumps(metadata, allow_nan=False, ensure_ascii=False, separators=(",", ":"))
-        if len(encoded.encode("utf-8")) > MAX_METADATA_BYTES:
-            raise ValueError(f"metadata exceeds {MAX_METADATA_BYTES} encoded bytes")
-        return metadata
+    def _freeze_metadata(cls, metadata: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
+        frozen = _freeze_json(metadata)
+        canonical = _canonical_json_value(_thaw_json(frozen))
+        if len(canonical) > MAX_METADATA_BYTES:
+            raise ValueError(f"metadata exceeds {MAX_METADATA_BYTES} canonical bytes")
+        return frozen
+
+    @field_serializer("metadata")
+    def _serialize_metadata(self, metadata: Mapping[str, JsonValue]) -> dict[str, JsonValue]:
+        # Pydantic knows JsonValue but not MappingProxyType. Thaw only for wire
+        # output; the model continues to expose recursively immutable values.
+        thawed = _thaw_json(metadata)
+        assert isinstance(thawed, dict)
+        return thawed
 
     @model_validator(mode="after")
     def _unique_frames(self) -> Self:
@@ -315,7 +343,9 @@ ComputerAction: TypeAlias = Annotated[
 class ObservationEnvelope(ProtocolModel):
     """Versioned adapter message carrying one environment observation."""
 
-    protocol_version: Literal["1.0"] = PROTOCOL_VERSION
+    # RPC senders must declare their version; accepting an omitted default
+    # would make version negotiation ambiguous during rolling upgrades.
+    protocol_version: Literal["1.0"]
     kind: Literal["observation"] = "observation"
     observation: Observation
 
@@ -323,7 +353,7 @@ class ObservationEnvelope(ProtocolModel):
 class ActionBatch(ProtocolModel):
     """Versioned ordered actions selected from exactly one observation."""
 
-    protocol_version: Literal["1.0"] = PROTOCOL_VERSION
+    protocol_version: Literal["1.0"]
     kind: Literal["action_batch"] = "action_batch"
     task_id: Identifier
     episode_id: Identifier
@@ -383,19 +413,89 @@ _ENVELOPE_ADAPTER = TypeAdapter(ProtocolEnvelope, config=ConfigDict(strict=True)
 
 
 def parse_envelope(payload: bytes | str) -> ProtocolEnvelope:
-    """Strictly parse a versioned RPC envelope without accepting unknown kinds."""
-    return _ENVELOPE_ADAPTER.validate_json(payload, strict=True)
+    """Parse one exact, explicitly versioned canonical RPC envelope.
+
+    Decoding with an object-pairs hook rejects duplicate names at every nesting
+    level before model validation can normalize them away. Re-encoding catches
+    other noncanonical representations as well as action validators that
+    normalize a value (for example, a lowercase named key).
+    """
+    raw, decoded = _decode_canonical_json(payload)
+    parsed = _ENVELOPE_ADAPTER.validate_python(decoded, strict=True)
+    if parsed.to_canonical_json() != raw:
+        raise ValueError("payload is valid JSON but is not canonical protocol JSON")
+    return parsed
 
 
-def _validate_metadata(value: JsonValue, *, path: str = "metadata") -> None:
-    """Keep recursively nested JSON finite and its object keys bounded."""
-    if isinstance(value, float) and not math.isfinite(value):
-        raise ValueError(f"{path} contains a non-finite number")
+def _decode_canonical_json(payload: bytes | str) -> tuple[bytes, Any]:
+    raw = payload.encode("utf-8") if isinstance(payload, str) else payload
+
+    def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON object key: {key!r}")
+            result[key] = value
+        return result
+
+    decoded = json.loads(
+        raw,
+        object_pairs_hook=reject_duplicate_keys,
+        parse_constant=lambda value: (_ for _ in ()).throw(
+            ValueError(f"nonstandard JSON constant: {value}")
+        ),
+    )
+    return raw, decoded
+
+
+def _validate_metadata(value: Any, *, path: str = "metadata", depth: int = 0) -> None:
+    """Enforce the portable, resource-bounded JSON subset at the RPC boundary."""
+    if depth > MAX_METADATA_DEPTH:
+        raise ValueError(f"{path} exceeds maximum nesting depth {MAX_METADATA_DEPTH}")
+    if value is None or isinstance(value, (str, bool)):
+        return
+    if isinstance(value, int):
+        if not -MAX_SAFE_JSON_INTEGER <= value <= MAX_SAFE_JSON_INTEGER:
+            raise ValueError(f"{path} integer exceeds the portable JSON-safe range")
+        return
+    if isinstance(value, float):
+        raise ValueError(f"{path} floats are not supported; use a string or integer")
     if isinstance(value, list):
         for index, item in enumerate(value):
-            _validate_metadata(item, path=f"{path}[{index}]")
-    elif isinstance(value, dict):
+            _validate_metadata(item, path=f"{path}[{index}]", depth=depth + 1)
+        return
+    if isinstance(value, dict):
         for key, item in value.items():
+            if not isinstance(key, str):
+                raise ValueError(f"{path} object keys must be strings")
             if not key or len(key) > MAX_IDENTIFIER_LENGTH:
                 raise ValueError(f"{path} contains an empty or overlong key")
-            _validate_metadata(item, path=f"{path}.{key}")
+            _validate_metadata(item, path=f"{path}.{key}", depth=depth + 1)
+        return
+    raise ValueError(f"{path} contains unsupported value type {type(value).__name__}")
+
+
+def _freeze_json(value: Any) -> Any:
+    if isinstance(value, dict):
+        return MappingProxyType({key: _freeze_json(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze_json(item) for item in value)
+    return value
+
+
+def _thaw_json(value: Any) -> JsonValue:
+    if isinstance(value, Mapping):
+        return {key: _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+def _canonical_json_value(value: JsonValue) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.2"
+version = "0.44.3"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/evaluation/__init__.py
+++ b/tests/unit/evaluation/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the opt-in evaluation protocol package."""

--- a/tests/unit/evaluation/test_protocol.py
+++ b/tests/unit/evaluation/test_protocol.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from types import MappingProxyType
 
 import pytest
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 
 from local_operator.evaluation.protocol import (
     MAX_BATCH_SIZE,
@@ -32,6 +32,7 @@ from local_operator.evaluation.protocol import (
     Observation,
     ObservationEnvelope,
     PixelPoint,
+    ProtocolEnvelope,
     ScrollAction,
     TypeAction,
     WaitAction,
@@ -280,7 +281,42 @@ def test_frozen_mapping_has_only_immutable_backing_and_is_hashable() -> None:
     before = observation.to_canonical_json()
     with pytest.raises(TypeError):
         observation.metadata["nested"]["ready"] = False  # type: ignore[index]
+    with pytest.raises(AttributeError):
+        del left._items
+    with pytest.raises(AttributeError):
+        del observation.metadata._items  # type: ignore[attr-defined]
+    assert hash(observation)
     assert observation.to_canonical_json() == before
+
+
+def test_frozen_mapping_equality_preserves_recursive_json_scalar_types() -> None:
+    pairs = [
+        (FrozenMapping({"value": True}), FrozenMapping({"value": 1})),
+        (FrozenMapping({"value": False}), FrozenMapping({"value": 0})),
+        (FrozenMapping({"value": [True]}), FrozenMapping({"value": [1]})),
+        (
+            FrozenMapping({"value": {"nested": False}}),
+            FrozenMapping({"value": {"nested": 0}}),
+        ),
+    ]
+    for boolean_map, integer_map in pairs:
+        assert boolean_map != integer_map
+        assert boolean_map != dict(integer_map)
+        assert len({boolean_map, integer_map}) == 2
+        assert {boolean_map: "bool", integer_map: "int"}[boolean_map] == "bool"
+    left = FrozenMapping({"value": [True, {"count": 1}]})
+    right = FrozenMapping({"value": (True, FrozenMapping({"count": 1}))})
+    assert left == right
+    assert hash(left) == hash(right)
+
+
+def test_protocol_model_equality_tracks_type_distinct_canonical_metadata() -> None:
+    boolean = Observation.model_validate(
+        {**_observation().model_dump(), "metadata": {"value": True}}
+    )
+    integer = Observation.model_validate({**_observation().model_dump(), "metadata": {"value": 1}})
+    assert boolean.to_canonical_json() != integer.to_canonical_json()
+    assert boolean != integer
 
 
 def test_metadata_survives_copy_deepcopy_pickle_and_validated_model_updates() -> None:
@@ -315,10 +351,19 @@ def test_metadata_accepts_mapping_and_tuple_inputs_but_rejects_invalid_mapping_k
     observation = Observation.model_validate(
         {
             **_observation().model_dump(),
-            "metadata": MappingProxyType({"items": (1, FrozenMapping({"safe": True}))}),
+            "metadata": MappingProxyType(
+                {
+                    "items": [
+                        1,
+                        (MappingProxyType({"deep": [FrozenMapping({"safe": True})]}),),
+                    ]
+                }
+            ),
         }
     )
-    assert observation.model_dump(mode="json")["metadata"] == {"items": [1, {"safe": True}]}
+    assert observation.model_dump(mode="json")["metadata"] == {
+        "items": [1, [{"deep": [{"safe": True}]}]]
+    }
     for metadata in (
         MappingProxyType({1: "bad"}),
         MappingProxyType({"bad key": "bad"}),
@@ -576,23 +621,35 @@ def test_canonical_observation_fixture_is_stable_and_requires_exact_encoding() -
             parse_envelope(noncanonical)
 
 
-def test_metadata_schema_matches_portable_recursive_runtime_subset() -> None:
-    schema = Observation.model_json_schema()
-    metadata = schema["properties"]["metadata"]
-    assert metadata["propertyNames"]["pattern"] == r"^[A-Za-z0-9_.:-]{1,256}$"
-    assert "depth 16" in metadata["description"]
-    assert "64000 bytes" in metadata["description"]
-    value = schema["$defs"]["PortableMetadataValue"]
+@pytest.mark.parametrize(
+    "schema",
+    [
+        Observation.model_json_schema(),
+        ObservationEnvelope.model_json_schema(),
+        TypeAdapter(ProtocolEnvelope).json_schema(),
+    ],
+)
+def test_metadata_schema_matches_portable_recursive_runtime_subset(
+    schema: dict[str, object],
+) -> None:
+    defs = schema["$defs"]  # type: ignore[index]
+    metadata_object = defs["PortableMetadataObject"]  # type: ignore[index]
+    assert metadata_object["propertyNames"]["pattern"] == r"^[A-Za-z0-9_.:-]{1,256}$"
+    assert "maximum depth 16" in metadata_object["description"]
+    assert "64000 bytes" in metadata_object["description"]
+    value = defs["PortableMetadataValue"]  # type: ignore[index]
     branches = value["anyOf"]
     assert not any(branch.get("type") == "number" for branch in branches)
+    assert not any(branch.get("additionalProperties") is True for branch in branches)
     integer = next(branch for branch in branches if branch.get("type") == "integer")
     assert integer == {
         "type": "integer",
         "minimum": -MAX_SAFE_JSON_INTEGER,
         "maximum": MAX_SAFE_JSON_INTEGER,
     }
-    object_branch = next(branch for branch in branches if branch.get("type") == "object")
-    assert object_branch["propertyNames"] == {"pattern": r"^[A-Za-z0-9_.:-]{1,256}$"}
+    array = next(branch for branch in branches if branch.get("type") == "array")
+    assert array["items"] == {"$ref": "#/$defs/PortableMetadataValue"}
+    assert {"$ref": "#/$defs/PortableMetadataObject"} in branches
 
 
 def test_metadata_keys_are_portable_ascii_and_values_remain_unicode() -> None:

--- a/tests/unit/evaluation/test_protocol.py
+++ b/tests/unit/evaluation/test_protocol.py
@@ -263,8 +263,27 @@ def test_key_validation_and_historical_double_click_are_explicit() -> None:
         DoubleClickAction(observation_id="observation-7", frame_id="frame-1", x=10, y=20).kind
         == "double_click"
     )
+    with pytest.raises(ValidationError):
+        DoubleClickAction(
+            observation_id="observation-7",
+            frame_id="frame-1",
+            x=10,
+            y=20,
+            button="right",  # type: ignore[arg-type]
+        )
     with pytest.raises(ValidationError, match="unknown key"):
         KeyAction(observation_id="observation-7", keys=("NOT_A_KEY",))
+
+
+def test_user_facing_strings_and_identifiers_reject_whitespace_only_values() -> None:
+    with pytest.raises(ValidationError):
+        TypeAction(observation_id="observation-7", text="   ")
+    with pytest.raises(ValidationError):
+        AskUserAction(observation_id="observation-7", request_id="   ", question="Which one?")
+    with pytest.raises(ValidationError):
+        AskUserAction(observation_id="observation-7", request_id="request-1", question="\n")
+    with pytest.raises(ValidationError):
+        FinishAction(observation_id="observation-7", status="failed", reason="\t")
 
 
 def test_batch_preserves_action_order_across_canonical_round_trip() -> None:

--- a/tests/unit/evaluation/test_protocol.py
+++ b/tests/unit/evaluation/test_protocol.py
@@ -377,6 +377,58 @@ def test_frozen_mapping_snapshots_stateful_mapping_exactly_once() -> None:
     assert copy.deepcopy(frozen) is frozen
 
 
+def test_observation_snapshots_top_level_and_nested_mappings_once() -> None:
+    class ChangingMapping(Mapping[str, object]):
+        def __init__(self, first: dict[str, object], later: dict[str, object]) -> None:
+            self.first = first
+            self.later = later
+            self.iterations = 0
+
+        @property
+        def current(self) -> dict[str, object]:
+            return self.first if self.iterations == 1 else self.later
+
+        def __iter__(self):
+            self.iterations += 1
+            return iter(self.current)
+
+        def __len__(self) -> int:
+            return len(self.current)
+
+        def __getitem__(self, key: str) -> object:
+            return self.current[key]
+
+    nested = ChangingMapping({"safe": True}, {"changed": float("nan")})
+    top = ChangingMapping(
+        {"items": [nested, (MappingProxyType({"stable": 1}),)]},
+        {"changed": float("nan")},
+    )
+    observation = Observation.model_validate({**_observation().model_dump(), "metadata": top})
+    assert top.iterations == 1
+    assert nested.iterations == 1
+    assert observation.model_dump(mode="json")["metadata"] == {
+        "items": [{"safe": True}, [{"stable": 1}]]
+    }
+    before = observation.to_canonical_json()
+    assert observation.model_copy(update={"metadata": observation.metadata}) == observation
+    assert observation.to_canonical_json() == before
+
+
+def test_observation_rejects_duplicate_keys_from_hostile_mapping() -> None:
+    class DuplicateMapping(Mapping[str, int]):
+        def __iter__(self):
+            return iter(("same", "same"))
+
+        def __len__(self) -> int:
+            return 2
+
+        def __getitem__(self, key: str) -> int:
+            return 1
+
+    with pytest.raises(ValidationError, match="duplicate keys"):
+        Observation.model_validate({**_observation().model_dump(), "metadata": DuplicateMapping()})
+
+
 def test_frozen_mapping_rejects_duplicate_keys_from_hostile_mapping() -> None:
     class DuplicateMapping(Mapping[str, int]):
         def __iter__(self):

--- a/tests/unit/evaluation/test_protocol.py
+++ b/tests/unit/evaluation/test_protocol.py
@@ -12,6 +12,8 @@ from pydantic import ValidationError
 
 from local_operator.evaluation.protocol import (
     MAX_BATCH_SIZE,
+    MAX_METADATA_DEPTH,
+    MAX_SAFE_JSON_INTEGER,
     ActionBatch,
     ArtifactRef,
     AskUserAction,
@@ -65,6 +67,7 @@ def _observation() -> Observation:
 def _batch(*actions: object, observation_id: str = "observation-7") -> ActionBatch:
     return ActionBatch.model_validate(
         {
+            "protocol_version": "1.0",
             "task_id": "task-1",
             "episode_id": "episode-1",
             "observation_id": observation_id,
@@ -125,6 +128,23 @@ def test_geometry_conversion_has_explicit_floor_and_clamp_policy() -> None:
             geometry.model_to_native(invalid, 1)
 
 
+def test_geometry_conversion_edges_and_round_trip_are_directional() -> None:
+    single = FrameGeometry(
+        native=FrameSize(width=1, height=1),
+        model_visible=FrameSize(width=1, height=1),
+    )
+    assert single.model_to_native(99, -99) == PixelPoint(x=0, y=0)
+    asymmetric = FrameGeometry(
+        native=FrameSize(width=1_000_000, height=1),
+        model_visible=FrameSize(width=3, height=999),
+    )
+    assert asymmetric.model_to_native(1, 998) == PixelPoint(x=333333, y=0)
+    point = asymmetric.native_to_model(999999, 0)
+    assert point == PixelPoint(x=2, y=0)
+    # Scaling with floor is intentionally lossy, not an inverse transform.
+    assert asymmetric.model_to_native(point.x, point.y) == PixelPoint(x=666666, y=0)
+
+
 def test_observation_is_strict_ordered_and_forbids_extras() -> None:
     observation = _observation()
     assert [frame.frame_id for frame in observation.frames] == ["frame-1"]
@@ -138,12 +158,68 @@ def test_observation_is_strict_ordered_and_forbids_extras() -> None:
         )
 
 
-@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
-def test_observation_metadata_rejects_nonfinite_numbers_at_any_depth(value: float) -> None:
-    with pytest.raises(ValidationError, match="non-finite"):
+@pytest.mark.parametrize(
+    "value",
+    [
+        -0.0,
+        1e-6,
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        MAX_SAFE_JSON_INTEGER + 1,
+        -MAX_SAFE_JSON_INTEGER - 1,
+    ],
+)
+def test_observation_metadata_rejects_nonportable_numbers_at_any_depth(value: float | int) -> None:
+    with pytest.raises(ValidationError):
         Observation.model_validate(
             {**_observation().model_dump(), "metadata": {"nested": [1, {"bad": value}]}}
         )
+
+
+def test_metadata_accepts_bool_and_safe_integer_boundaries() -> None:
+    observation = Observation.model_validate(
+        {
+            **_observation().model_dump(),
+            "metadata": {
+                "yes": True,
+                "no": False,
+                "minimum": -MAX_SAFE_JSON_INTEGER,
+                "maximum": MAX_SAFE_JSON_INTEGER,
+            },
+        }
+    )
+    assert observation.model_dump(mode="json")["metadata"] == {
+        "yes": True,
+        "no": False,
+        "minimum": -MAX_SAFE_JSON_INTEGER,
+        "maximum": MAX_SAFE_JSON_INTEGER,
+    }
+
+
+def test_metadata_is_recursively_immutable_and_serializes_canonically() -> None:
+    observation = _observation()
+    before = observation.to_canonical_json()
+    with pytest.raises(TypeError):
+        observation.metadata["new"] = 1  # type: ignore[index]
+    nested = observation.metadata["nested"]
+    with pytest.raises(TypeError):
+        nested["ready"] = False  # type: ignore[index]
+    values = Observation.model_validate(
+        {**observation.model_dump(), "metadata": {"items": [1, {"ready": True}]}}
+    )
+    with pytest.raises(AttributeError):
+        values.metadata["items"].append(float("nan"))  # type: ignore[union-attr]
+    assert observation.to_canonical_json() == before
+    assert Observation.from_canonical_json(before) == observation
+
+
+def test_metadata_depth_is_bounded_before_recursive_model_validation() -> None:
+    metadata: dict[str, object] = {"leaf": 1}
+    for _ in range(MAX_METADATA_DEPTH + 1):
+        metadata = {"nested": metadata}
+    with pytest.raises(ValidationError, match="maximum nesting depth"):
+        Observation.model_validate({**_observation().model_dump(), "metadata": metadata})
 
 
 def test_action_union_is_closed_and_has_no_command_escape_hatches() -> None:
@@ -206,6 +282,34 @@ def test_batch_validate_for_rejects_stale_identity_and_bad_frame_coordinates() -
                 y=719,
             )
         ).validate_for(observation)
+
+
+def test_batch_validates_each_action_against_its_own_frame_geometry() -> None:
+    observation = Observation(
+        task_id="task-1",
+        episode_id="episode-1",
+        sequence=0,
+        observation_id="observation-7",
+        frames=(
+            _frame(frame_id="large"),
+            FrameRef(
+                frame_id="small",
+                artifact=_artifact(),
+                geometry=FrameGeometry(
+                    native=FrameSize(width=20, height=20),
+                    model_visible=FrameSize(width=10, height=10),
+                ),
+            ),
+        ),
+    )
+    valid = _batch(
+        ClickAction(observation_id="observation-7", frame_id="large", x=100, y=100),
+        ClickAction(observation_id="observation-7", frame_id="small", x=9, y=9),
+    )
+    valid.validate_for(observation)
+    invalid = _batch(ClickAction(observation_id="observation-7", frame_id="small", x=100, y=100))
+    with pytest.raises(ValueError, match="outside model-visible frame 10x10"):
+        invalid.validate_for(observation)
 
 
 def test_terminal_actions_are_isolated_and_empty_batches_are_invalid() -> None:
@@ -298,7 +402,7 @@ def test_batch_preserves_action_order_across_canonical_round_trip() -> None:
 
 
 def test_canonical_observation_fixture_is_stable_and_requires_exact_encoding() -> None:
-    envelope = ObservationEnvelope(observation=_observation())
+    envelope = ObservationEnvelope(protocol_version="1.0", observation=_observation())
     expected = (
         '{"kind":"observation","observation":{"episode_id":"episode-1","frames":'
         '[{"artifact":{"byte_count":1234,"media_type":"image/png","sha256":"'
@@ -316,6 +420,38 @@ def test_canonical_observation_fixture_is_stable_and_requires_exact_encoding() -
     noncanonical = json.dumps(json.loads(expected), ensure_ascii=False).encode()
     with pytest.raises(ValueError, match="not canonical"):
         ObservationEnvelope.from_canonical_json(noncanonical)
+    with pytest.raises(ValueError, match="not canonical"):
+        parse_envelope(noncanonical)
+
+
+def test_generic_parser_requires_explicit_version_and_rejects_normalized_actions() -> None:
+    batch = ActionBatch(
+        protocol_version="1.0",
+        task_id="task-1",
+        episode_id="episode-1",
+        observation_id="observation-7",
+        actions=(KeyAction(observation_id="observation-7", keys=("ENTER",)),),
+    )
+    canonical = batch.to_canonical_json()
+    without_version = json.loads(canonical)
+    del without_version["protocol_version"]
+    with pytest.raises(ValidationError):
+        parse_envelope(json.dumps(without_version, separators=(",", ":"), sort_keys=True).encode())
+    lowercase_key = canonical.replace(b'"ENTER"', b'"enter"')
+    with pytest.raises(ValueError, match="not canonical"):
+        parse_envelope(lowercase_key)
+
+
+def test_generic_parser_rejects_duplicate_keys_at_any_depth() -> None:
+    envelope = ObservationEnvelope(protocol_version="1.0", observation=_observation())
+    canonical = envelope.to_canonical_json()
+    duplicate_top = canonical.replace(
+        b'{"kind":"observation",', b'{"kind":"observation","kind":"observation",', 1
+    )
+    duplicate_nested = canonical.replace(b'{"attempt":1,', b'{"attempt":1,"attempt":1,', 1)
+    for payload in (duplicate_top, duplicate_nested):
+        with pytest.raises(ValueError, match="duplicate JSON object key"):
+            parse_envelope(payload)
 
 
 @pytest.mark.parametrize("module", ["local_operator.cli", "local_operator.session_factory"])

--- a/tests/unit/evaluation/test_protocol.py
+++ b/tests/unit/evaluation/test_protocol.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import copy
 import json
+import pickle
 import subprocess
 import sys
 from pathlib import Path
@@ -12,6 +14,7 @@ from pydantic import ValidationError
 
 from local_operator.evaluation.protocol import (
     MAX_BATCH_SIZE,
+    MAX_ENVELOPE_BYTES,
     MAX_METADATA_DEPTH,
     MAX_SAFE_JSON_INTEGER,
     ActionBatch,
@@ -177,6 +180,18 @@ def test_observation_metadata_rejects_nonportable_numbers_at_any_depth(value: fl
         )
 
 
+def test_omitted_metadata_is_immutable_and_canonical() -> None:
+    observation = Observation(
+        task_id="task-1",
+        episode_id="episode-1",
+        sequence=0,
+        observation_id="observation-0",
+    )
+    with pytest.raises(TypeError):
+        observation.metadata["injected"] = 1  # type: ignore[index]
+    assert observation.model_dump(mode="json")["metadata"] == {}
+
+
 def test_metadata_accepts_bool_and_safe_integer_boundaries() -> None:
     observation = Observation.model_validate(
         {
@@ -214,12 +229,47 @@ def test_metadata_is_recursively_immutable_and_serializes_canonically() -> None:
     assert Observation.from_canonical_json(before) == observation
 
 
+def test_metadata_survives_copy_deepcopy_pickle_and_validated_model_updates() -> None:
+    observation = _observation()
+    canonical = observation.to_canonical_json()
+    shallow = observation.model_copy()
+    deep = observation.model_copy(deep=True)
+    copied = copy.deepcopy(observation)
+    restored = pickle.loads(pickle.dumps(observation))
+    for candidate in (shallow, deep, copied, restored):
+        assert candidate == observation
+        assert candidate.to_canonical_json() == canonical
+        with pytest.raises(TypeError):
+            candidate.metadata["injected"] = 1  # type: ignore[index]
+
+    updated = observation.model_copy(update={"metadata": {"items": [1, {"safe": True}]}})
+    with pytest.raises(TypeError):
+        updated.metadata["items"][1]["safe"] = False  # type: ignore[index]
+    assert updated.model_dump(mode="json")["metadata"] == {"items": [1, {"safe": True}]}
+
+    with pytest.raises(ValidationError):
+        observation.model_copy(update={"metadata": {"bad": [float("nan")]}})
+    with pytest.raises(ValidationError):
+        observation.model_copy(update={"sequence": MAX_SAFE_JSON_INTEGER + 1})
+
+
 def test_metadata_depth_is_bounded_before_recursive_model_validation() -> None:
     metadata: dict[str, object] = {"leaf": 1}
     for _ in range(MAX_METADATA_DEPTH + 1):
         metadata = {"nested": metadata}
     with pytest.raises(ValidationError, match="maximum nesting depth"):
         Observation.model_validate({**_observation().model_dump(), "metadata": metadata})
+
+
+def test_observation_sequence_is_bounded_to_portable_safe_integers() -> None:
+    maximum = Observation.model_validate(
+        {**_observation().model_dump(), "sequence": MAX_SAFE_JSON_INTEGER}
+    )
+    assert maximum.sequence == MAX_SAFE_JSON_INTEGER
+    with pytest.raises(ValidationError):
+        Observation.model_validate(
+            {**_observation().model_dump(), "sequence": MAX_SAFE_JSON_INTEGER + 1}
+        )
 
 
 def test_action_union_is_closed_and_has_no_command_escape_hatches() -> None:
@@ -434,6 +484,23 @@ def test_canonical_observation_fixture_is_stable_and_requires_exact_encoding() -
             parse_envelope(noncanonical)
 
 
+def test_metadata_keys_are_portable_ascii_and_values_remain_unicode() -> None:
+    metadata = {
+        "z:key": "snowman ☃ / slash",
+        "A.key": 'line\nquote"backslash\\',
+        "0-key": "é",
+    }
+    observation = Observation.model_validate({**_observation().model_dump(), "metadata": metadata})
+    canonical = observation.to_canonical_json()
+    assert b'"0-key":"\xc3\xa9","A.key":"line\\nquote\\"backslash\\\\","z:key"' in canonical
+    assert b"snowman \xe2\x98\x83 / slash" in canonical
+    for bad_key in ("", "space key", "control\n", "é", "😀", "a" * 257):
+        with pytest.raises(ValidationError, match="keys must match"):
+            Observation.model_validate(
+                {**_observation().model_dump(), "metadata": {"outer": {bad_key: 1}}}
+            )
+
+
 def test_generic_parser_requires_explicit_version_and_rejects_normalized_actions() -> None:
     batch = ActionBatch(
         protocol_version="1.0",
@@ -450,6 +517,27 @@ def test_generic_parser_requires_explicit_version_and_rejects_normalized_actions
     lowercase_key = canonical.replace(b'"ENTER"', b'"enter"')
     with pytest.raises(ValueError, match="not canonical"):
         parse_envelope(lowercase_key)
+
+
+def test_generic_parser_rejects_oversized_and_invalid_utf8_before_json_decode() -> None:
+    valid = ObservationEnvelope(
+        protocol_version="1.0", observation=_observation()
+    ).to_canonical_json()
+    assert parse_envelope(valid) == ObservationEnvelope(
+        protocol_version="1.0", observation=_observation()
+    )
+    oversized_bytes = b" " * (MAX_ENVELOPE_BYTES + 1)
+    oversized_text = "é" * (MAX_ENVELOPE_BYTES // 2 + 1)
+    for payload in (oversized_bytes, oversized_text):
+        with pytest.raises(ValueError, match="exceeds"):
+            parse_envelope(payload)
+    with pytest.raises(ValueError, match="not valid UTF-8"):
+        parse_envelope(b'"\xff"')
+    # A payload exactly at the raw limit reaches JSON parsing rather than the
+    # size guard; padding makes it noncanonical but remains bounded allocation.
+    exact = valid + b" " * (MAX_ENVELOPE_BYTES - len(valid))
+    with pytest.raises(ValueError, match="not canonical"):
+        parse_envelope(exact)
 
 
 def test_generic_parser_rejects_duplicate_keys_at_any_depth() -> None:

--- a/tests/unit/evaluation/test_protocol.py
+++ b/tests/unit/evaluation/test_protocol.py
@@ -1,0 +1,329 @@
+"""Discriminating contract tests for the benchmark-neutral evaluation wire format."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from local_operator.evaluation.protocol import (
+    MAX_BATCH_SIZE,
+    ActionBatch,
+    ArtifactRef,
+    AskUserAction,
+    ClickAction,
+    DoubleClickAction,
+    FinishAction,
+    FrameGeometry,
+    FrameRef,
+    FrameSize,
+    KeyAction,
+    Observation,
+    ObservationEnvelope,
+    PixelPoint,
+    ScrollAction,
+    TypeAction,
+    WaitAction,
+    parse_envelope,
+)
+
+REPO = Path(__file__).resolve().parents[3]
+DIGEST = "0123456789abcdef" * 4
+
+
+def _artifact() -> ArtifactRef:
+    return ArtifactRef(sha256=DIGEST, media_type="image/png", byte_count=1234)
+
+
+def _frame(*, frame_id: str = "frame-1") -> FrameRef:
+    return FrameRef(
+        frame_id=frame_id,
+        artifact=_artifact(),
+        geometry=FrameGeometry(
+            native=FrameSize(width=1920, height=1080),
+            model_visible=FrameSize(width=1280, height=720),
+        ),
+    )
+
+
+def _observation() -> Observation:
+    return Observation(
+        task_id="task-1",
+        episode_id="episode-1",
+        sequence=7,
+        observation_id="observation-7",
+        text="A settings window is visible.",
+        frames=(_frame(),),
+        metadata={"benchmark": "neutral", "attempt": 1, "nested": {"ready": True}},
+    )
+
+
+def _batch(*actions: object, observation_id: str = "observation-7") -> ActionBatch:
+    return ActionBatch.model_validate(
+        {
+            "task_id": "task-1",
+            "episode_id": "episode-1",
+            "observation_id": observation_id,
+            "actions": list(actions),
+        }
+    )
+
+
+def test_artifact_ref_is_content_only_and_rejects_transport_fields() -> None:
+    artifact = _artifact()
+    assert artifact.model_dump() == {
+        "sha256": DIGEST,
+        "media_type": "image/png",
+        "byte_count": 1234,
+    }
+    with pytest.raises(ValidationError):
+        ArtifactRef.model_validate(
+            {
+                **artifact.model_dump(),
+                "path": "../../secret",
+            }
+        )
+    with pytest.raises(ValidationError):
+        ArtifactRef(sha256="not-a-digest", media_type="image/png", byte_count=1)
+    with pytest.raises(ValidationError):
+        ArtifactRef(sha256=DIGEST, media_type="not a media type", byte_count=1)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("width", 0),
+        ("width", -1),
+        ("width", 1.5),
+        ("height", float("nan")),
+        ("height", float("inf")),
+    ],
+)
+def test_frame_size_rejects_nonpositive_noninteger_or_nonfinite_dimensions(
+    field: str, value: object
+) -> None:
+    payload = {"width": 100, "height": 100, field: value}
+    with pytest.raises(ValidationError):
+        FrameSize.model_validate(payload)
+
+
+def test_geometry_conversion_has_explicit_floor_and_clamp_policy() -> None:
+    geometry = FrameGeometry(
+        native=FrameSize(width=1920, height=1080),
+        model_visible=FrameSize(width=1280, height=720),
+    )
+    assert geometry.model_to_native(1, 1) == PixelPoint(x=1, y=1)
+    assert geometry.model_to_native(1279, 719) == PixelPoint(x=1918, y=1078)
+    assert geometry.model_to_native(-2, 9999) == PixelPoint(x=0, y=1079)
+    assert geometry.native_to_model(1919, 1079) == PixelPoint(x=1279, y=719)
+    for invalid in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(ValueError, match="finite"):
+            geometry.model_to_native(invalid, 1)
+
+
+def test_observation_is_strict_ordered_and_forbids_extras() -> None:
+    observation = _observation()
+    assert [frame.frame_id for frame in observation.frames] == ["frame-1"]
+    with pytest.raises(ValidationError):
+        Observation.model_validate({**observation.model_dump(), "sequence": "7"})
+    with pytest.raises(ValidationError):
+        Observation.model_validate({**observation.model_dump(), "unknown": True})
+    with pytest.raises(ValidationError, match="unique"):
+        Observation.model_validate(
+            {**observation.model_dump(), "frames": [observation.frames[0], observation.frames[0]]}
+        )
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_observation_metadata_rejects_nonfinite_numbers_at_any_depth(value: float) -> None:
+    with pytest.raises(ValidationError, match="non-finite"):
+        Observation.model_validate(
+            {**_observation().model_dump(), "metadata": {"nested": [1, {"bad": value}]}}
+        )
+
+
+def test_action_union_is_closed_and_has_no_command_escape_hatches() -> None:
+    base = {
+        "task_id": "task-1",
+        "episode_id": "episode-1",
+        "observation_id": "observation-7",
+    }
+    with pytest.raises(ValidationError):
+        ActionBatch.model_validate(
+            {
+                **base,
+                "actions": [{"kind": "shell", "observation_id": "observation-7", "command": "id"}],
+            }
+        )
+    with pytest.raises(ValidationError):
+        ActionBatch.model_validate(
+            {
+                **base,
+                "actions": [
+                    {
+                        "kind": "click",
+                        "observation_id": "observation-7",
+                        "frame_id": "frame-1",
+                        "x": 2,
+                        "y": 3,
+                        "pyautogui": "click(2, 3)",
+                    }
+                ],
+            }
+        )
+
+
+def test_each_action_binds_to_batch_observation() -> None:
+    with pytest.raises(ValidationError, match="different observation_id"):
+        _batch(TypeAction(observation_id="stale", text="hello"))
+
+
+def test_batch_validate_for_rejects_stale_identity_and_bad_frame_coordinates() -> None:
+    observation = _observation()
+    with pytest.raises(ValueError, match="current task, episode, and observation"):
+        _batch(
+            WaitAction(observation_id="stale", duration_ms=1), observation_id="stale"
+        ).validate_for(observation)
+    with pytest.raises(ValueError, match="unknown frame_id"):
+        _batch(
+            ClickAction(
+                observation_id=observation.observation_id,
+                frame_id="old-frame",
+                x=1,
+                y=1,
+            )
+        ).validate_for(observation)
+    with pytest.raises(ValueError, match="outside model-visible"):
+        _batch(
+            ClickAction(
+                observation_id=observation.observation_id,
+                frame_id="frame-1",
+                x=1280,
+                y=719,
+            )
+        ).validate_for(observation)
+
+
+def test_terminal_actions_are_isolated_and_empty_batches_are_invalid() -> None:
+    finish = FinishAction(observation_id="observation-7", status="done", reason="Task completed")
+    ask = AskUserAction(
+        observation_id="observation-7",
+        request_id="request-1",
+        question="Which account should I use?",
+    )
+    for terminal in (finish, ask):
+        assert _batch(terminal).actions == (terminal,)
+        with pytest.raises(ValidationError, match="only action"):
+            _batch(WaitAction(observation_id="observation-7", duration_ms=1), terminal)
+        with pytest.raises(ValidationError, match="only action"):
+            _batch(terminal, WaitAction(observation_id="observation-7", duration_ms=1))
+    with pytest.raises(ValidationError):
+        _batch()
+
+
+def test_batch_size_status_mouse_and_numeric_bounds_are_closed() -> None:
+    with pytest.raises(ValidationError):
+        _batch(*[WaitAction(observation_id="observation-7", duration_ms=1)] * (MAX_BATCH_SIZE + 1))
+    with pytest.raises(ValidationError):
+        FinishAction(observation_id="observation-7", status="maybe", reason="uncertain")  # type: ignore[arg-type]
+    with pytest.raises(ValidationError):
+        ClickAction(
+            observation_id="observation-7", frame_id="frame-1", x=1, y=2, button="primary"  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValidationError):
+        ScrollAction(
+            observation_id="observation-7",
+            frame_id="frame-1",
+            x=1,
+            y=2,
+            delta_y=0,
+        )
+    with pytest.raises(ValidationError):
+        WaitAction(observation_id="observation-7", duration_ms=float("nan"))  # type: ignore[arg-type]
+
+
+def test_key_validation_and_historical_double_click_are_explicit() -> None:
+    assert KeyAction(observation_id="observation-7", keys=("CTRL", "a")).keys == ("CTRL", "a")
+    assert (
+        DoubleClickAction(observation_id="observation-7", frame_id="frame-1", x=10, y=20).kind
+        == "double_click"
+    )
+    with pytest.raises(ValidationError, match="unknown key"):
+        KeyAction(observation_id="observation-7", keys=("NOT_A_KEY",))
+
+
+def test_batch_preserves_action_order_across_canonical_round_trip() -> None:
+    batch = _batch(
+        ClickAction(observation_id="observation-7", frame_id="frame-1", x=3, y=4),
+        TypeAction(observation_id="observation-7", text="hello"),
+        KeyAction(observation_id="observation-7", keys=("ENTER",)),
+    )
+    decoded = ActionBatch.from_canonical_json(batch.to_canonical_json())
+    assert [action.kind for action in decoded.actions] == ["click", "type", "key"]
+    decoded.validate_for(_observation())
+
+
+def test_canonical_observation_fixture_is_stable_and_requires_exact_encoding() -> None:
+    envelope = ObservationEnvelope(observation=_observation())
+    expected = (
+        '{"kind":"observation","observation":{"episode_id":"episode-1","frames":'
+        '[{"artifact":{"byte_count":1234,"media_type":"image/png","sha256":"'
+        + DIGEST
+        + '"},"frame_id":"frame-1","geometry":{"model_visible":{"height":720,'
+        '"origin":"top_left","unit":"pixel","width":1280},"native":{"height":1080,'
+        '"origin":"top_left","unit":"pixel","width":1920}}}],"metadata":{"attempt":1,'
+        '"benchmark":"neutral","nested":{"ready":true}},"observation_id":"observation-7",'
+        '"sequence":7,"task_id":"task-1","text":"A settings window is visible."},'
+        '"protocol_version":"1.0"}'
+    ).encode()
+    assert envelope.to_canonical_json() == expected
+    assert ObservationEnvelope.from_canonical_json(expected) == envelope
+    assert parse_envelope(expected) == envelope
+    noncanonical = json.dumps(json.loads(expected), ensure_ascii=False).encode()
+    with pytest.raises(ValueError, match="not canonical"):
+        ObservationEnvelope.from_canonical_json(noncanonical)
+
+
+@pytest.mark.parametrize("module", ["local_operator.cli", "local_operator.session_factory"])
+def test_startup_imports_do_not_load_evaluation(module: str) -> None:
+    imported = _fresh_import_modules(module)
+    assert not {name for name in imported if name.startswith("local_operator.evaluation")}
+
+
+def test_evaluation_package_import_is_inert() -> None:
+    imported = _fresh_import_modules("local_operator.evaluation")
+    forbidden_prefixes = (
+        "PIL",
+        "boto3",
+        "gymnasium",
+        "osworld",
+        "OSWorld",
+        "local_operator.evaluation.protocol",
+        "local_operator.evaluation.adapter",
+    )
+    assert not {
+        name
+        for name in imported
+        if any(name == prefix or name.startswith(prefix + ".") for prefix in forbidden_prefixes)
+    }
+
+
+def _fresh_import_modules(module: str) -> set[str]:
+    probe = (
+        "import importlib,json,sys;"
+        "importlib.import_module(sys.argv[1]);"
+        "print(json.dumps(sorted(sys.modules)))"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe, module],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr[-3000:]
+    return set(json.loads(completed.stdout.strip().splitlines()[-1]))

--- a/tests/unit/evaluation/test_protocol.py
+++ b/tests/unit/evaluation/test_protocol.py
@@ -414,6 +414,43 @@ def test_observation_snapshots_top_level_and_nested_mappings_once() -> None:
     assert observation.to_canonical_json() == before
 
 
+def test_unhashable_nonstring_mapping_keys_fail_with_controlled_validation_errors() -> None:
+    class UnhashableKeyMapping(Mapping[object, int]):
+        def __iter__(self):
+            return iter(([],))
+
+        def __len__(self) -> int:
+            return 1
+
+        def __getitem__(self, key: object) -> int:
+            return 1
+
+    hostile = UnhashableKeyMapping()
+    with pytest.raises(ValueError, match="object keys must be strings"):
+        FrozenMapping(hostile)  # type: ignore[arg-type]
+    with pytest.raises(ValidationError, match="object keys must be strings"):
+        Observation.model_validate({**_observation().model_dump(), "metadata": hostile})
+
+
+def test_invalid_string_keys_fail_before_duplicate_detection() -> None:
+    class InvalidStringMapping(Mapping[str, int]):
+        def __iter__(self):
+            return iter(("bad key", "bad key"))
+
+        def __len__(self) -> int:
+            return 2
+
+        def __getitem__(self, key: str) -> int:
+            return 1
+
+    with pytest.raises(ValueError, match="keys must match"):
+        FrozenMapping(InvalidStringMapping())
+    with pytest.raises(ValidationError, match="keys must match"):
+        Observation.model_validate(
+            {**_observation().model_dump(), "metadata": InvalidStringMapping()}
+        )
+
+
 def test_observation_rejects_duplicate_keys_from_hostile_mapping() -> None:
     class DuplicateMapping(Mapping[str, int]):
         def __iter__(self):

--- a/tests/unit/evaluation/test_protocol.py
+++ b/tests/unit/evaluation/test_protocol.py
@@ -7,6 +7,7 @@ import json
 import pickle
 import subprocess
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from types import MappingProxyType
 
@@ -301,13 +302,64 @@ def test_frozen_mapping_equality_preserves_recursive_json_scalar_types() -> None
     ]
     for boolean_map, integer_map in pairs:
         assert boolean_map != integer_map
-        assert boolean_map != dict(integer_map)
         assert len({boolean_map, integer_map}) == 2
         assert {boolean_map: "bool", integer_map: "int"}[boolean_map] == "bool"
     left = FrozenMapping({"value": [True, {"count": 1}]})
     right = FrozenMapping({"value": (True, FrozenMapping({"count": 1}))})
     assert left == right
     assert hash(left) == hash(right)
+
+
+def test_frozen_mapping_never_equals_ordinary_or_custom_mappings() -> None:
+    frozen = FrozenMapping({"value": True})
+    ordinary = {"value": True}
+    custom = MappingProxyType(ordinary)
+    assert not frozen == ordinary
+    assert not ordinary == frozen
+    assert not frozen == custom
+    assert not custom == frozen
+    assert FrozenMapping.__eq__(frozen, ordinary) is NotImplemented
+
+
+def test_frozen_mapping_snapshots_stateful_mapping_exactly_once() -> None:
+    class ChangingMapping(Mapping[str, object]):
+        def __init__(self) -> None:
+            self.iterations = 0
+
+        def __iter__(self):
+            self.iterations += 1
+            return iter(("value",))
+
+        def __len__(self) -> int:
+            return 1
+
+        def __getitem__(self, key: str) -> object:
+            if key != "value":
+                raise KeyError(key)
+            return True if self.iterations == 1 else float("nan")
+
+    source = ChangingMapping()
+    frozen = FrozenMapping(source)
+    assert source.iterations == 1
+    assert frozen == FrozenMapping({"value": True})
+    assert frozen["value"] is True
+    assert hash(pickle.loads(pickle.dumps(frozen))) == hash(frozen)
+    assert copy.deepcopy(frozen) is frozen
+
+
+def test_frozen_mapping_rejects_duplicate_keys_from_hostile_mapping() -> None:
+    class DuplicateMapping(Mapping[str, int]):
+        def __iter__(self):
+            return iter(("same", "same"))
+
+        def __len__(self) -> int:
+            return 2
+
+        def __getitem__(self, key: str) -> int:
+            return 1
+
+    with pytest.raises(ValueError, match="duplicate keys"):
+        FrozenMapping(DuplicateMapping())
 
 
 def test_protocol_model_equality_tracks_type_distinct_canonical_metadata() -> None:

--- a/tests/unit/evaluation/test_protocol.py
+++ b/tests/unit/evaluation/test_protocol.py
@@ -8,6 +8,7 @@ import pickle
 import subprocess
 import sys
 from pathlib import Path
+from types import MappingProxyType
 
 import pytest
 from pydantic import ValidationError
@@ -26,6 +27,7 @@ from local_operator.evaluation.protocol import (
     FrameGeometry,
     FrameRef,
     FrameSize,
+    FrozenMapping,
     KeyAction,
     Observation,
     ObservationEnvelope,
@@ -123,7 +125,7 @@ def test_geometry_conversion_has_explicit_floor_and_clamp_policy() -> None:
         model_visible=FrameSize(width=1280, height=720),
     )
     assert geometry.model_to_native(1, 1) == PixelPoint(x=1, y=1)
-    assert geometry.model_to_native(1279, 719) == PixelPoint(x=1918, y=1078)
+    assert geometry.model_to_native(1279, 719) == PixelPoint(x=1919, y=1079)
     assert geometry.model_to_native(-2, 9999) == PixelPoint(x=0, y=1079)
     assert geometry.native_to_model(1919, 1079) == PixelPoint(x=1279, y=719)
     for invalid in (float("nan"), float("inf"), float("-inf")):
@@ -144,8 +146,39 @@ def test_geometry_conversion_edges_and_round_trip_are_directional() -> None:
     assert asymmetric.model_to_native(1, 998) == PixelPoint(x=333333, y=0)
     point = asymmetric.native_to_model(999999, 0)
     assert point == PixelPoint(x=2, y=0)
-    # Scaling with floor is intentionally lossy, not an inverse transform.
-    assert asymmetric.model_to_native(point.x, point.y) == PixelPoint(x=666666, y=0)
+    # Endpoint clamping preserves boundary pixels even though interior
+    # downscale/upscale round trips remain lossy.
+    assert asymmetric.model_to_native(point.x, point.y) == PixelPoint(x=999999, y=0)
+
+
+@pytest.mark.parametrize("value", [-1e308, 1e308, -(10**400), 10**400])
+def test_geometry_clamps_huge_finite_values_before_scaling(value: int | float) -> None:
+    geometry = FrameGeometry(
+        native=FrameSize(width=1_000_000, height=1),
+        model_visible=FrameSize(width=3, height=999),
+    )
+    expected_native_x = 0 if value < 0 else 999_999
+    expected_model_y = 0 if value < 0 else 998
+    assert geometry.model_to_native(value, value) == PixelPoint(x=expected_native_x, y=0)
+    assert geometry.native_to_model(value, value) == PixelPoint(
+        x=0 if value < 0 else 2, y=expected_model_y
+    )
+
+
+def test_geometry_conversion_rejects_bool_and_nonfinite_but_clamps_boundaries() -> None:
+    geometry = FrameGeometry(
+        native=FrameSize(width=10, height=20),
+        model_visible=FrameSize(width=5, height=4),
+    )
+    assert geometry.model_to_native(0, 0) == PixelPoint(x=0, y=0)
+    assert geometry.model_to_native(4, 3) == PixelPoint(x=9, y=19)
+    assert geometry.native_to_model(9, 19) == PixelPoint(x=4, y=3)
+    for value in (True, False):
+        with pytest.raises(TypeError):
+            geometry.model_to_native(value, 0)
+    for value in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(ValueError, match="finite"):
+            geometry.native_to_model(value, 0)
 
 
 def test_observation_is_strict_ordered_and_forbids_extras() -> None:
@@ -229,6 +262,27 @@ def test_metadata_is_recursively_immutable_and_serializes_canonically() -> None:
     assert Observation.from_canonical_json(before) == observation
 
 
+def test_frozen_mapping_has_only_immutable_backing_and_is_hashable() -> None:
+    left = FrozenMapping({"z": [1, {"safe": True}], "a": "value"})
+    right = FrozenMapping({"a": "value", "z": (1, FrozenMapping({"safe": True}))})
+    assert left == right
+    assert hash(left) == hash(right)
+    assert {left: "found"}[right] == "found"
+    assert isinstance(left._items, tuple)
+    assert all(isinstance(pair, tuple) for pair in left._items)
+    assert not hasattr(left, "_data")
+    with pytest.raises(TypeError):
+        left._items[0] = ("a", "changed")  # type: ignore[index]
+    with pytest.raises(AttributeError):
+        left._items = ()  # type: ignore[misc]
+    observation = _observation()
+    assert hash(observation)
+    before = observation.to_canonical_json()
+    with pytest.raises(TypeError):
+        observation.metadata["nested"]["ready"] = False  # type: ignore[index]
+    assert observation.to_canonical_json() == before
+
+
 def test_metadata_survives_copy_deepcopy_pickle_and_validated_model_updates() -> None:
     observation = _observation()
     canonical = observation.to_canonical_json()
@@ -246,11 +300,49 @@ def test_metadata_survives_copy_deepcopy_pickle_and_validated_model_updates() ->
     with pytest.raises(TypeError):
         updated.metadata["items"][1]["safe"] = False  # type: ignore[index]
     assert updated.model_dump(mode="json")["metadata"] == {"items": [1, {"safe": True}]}
+    reused = observation.model_copy(update={"metadata": observation.metadata})
+    assert reused.metadata == observation.metadata
+    with pytest.raises(TypeError):
+        reused.metadata["new"] = 1  # type: ignore[index]
 
     with pytest.raises(ValidationError):
         observation.model_copy(update={"metadata": {"bad": [float("nan")]}})
     with pytest.raises(ValidationError):
         observation.model_copy(update={"sequence": MAX_SAFE_JSON_INTEGER + 1})
+
+
+def test_metadata_accepts_mapping_and_tuple_inputs_but_rejects_invalid_mapping_keys() -> None:
+    observation = Observation.model_validate(
+        {
+            **_observation().model_dump(),
+            "metadata": MappingProxyType({"items": (1, FrozenMapping({"safe": True}))}),
+        }
+    )
+    assert observation.model_dump(mode="json")["metadata"] == {"items": [1, {"safe": True}]}
+    for metadata in (
+        MappingProxyType({1: "bad"}),
+        MappingProxyType({"bad key": "bad"}),
+    ):
+        with pytest.raises(ValidationError):
+            Observation.model_validate({**_observation().model_dump(), "metadata": metadata})
+
+
+def test_model_copy_preserves_fields_set_and_exclude_unset_semantics() -> None:
+    minimal = Observation(
+        task_id="task-1",
+        episode_id="episode-1",
+        sequence=0,
+        observation_id="observation-0",
+    )
+    expected = {"task_id", "episode_id", "sequence", "observation_id"}
+    assert minimal.model_fields_set == expected
+    for copied in (minimal.model_copy(), minimal.model_copy(deep=True)):
+        assert copied.model_fields_set == expected
+        assert copied.model_dump(exclude_unset=True) == minimal.model_dump(exclude_unset=True)
+    updated = minimal.model_copy(update={"text": "hello"})
+    assert updated.model_fields_set == expected | {"text"}
+    assert updated.model_dump(exclude_unset=True)["text"] == "hello"
+    assert "metadata" not in updated.model_dump(exclude_unset=True)
 
 
 def test_metadata_depth_is_bounded_before_recursive_model_validation() -> None:
@@ -482,6 +574,25 @@ def test_canonical_observation_fixture_is_stable_and_requires_exact_encoding() -
             ObservationEnvelope.from_canonical_json(noncanonical)
         with pytest.raises(ValueError, match="not canonical"):
             parse_envelope(noncanonical)
+
+
+def test_metadata_schema_matches_portable_recursive_runtime_subset() -> None:
+    schema = Observation.model_json_schema()
+    metadata = schema["properties"]["metadata"]
+    assert metadata["propertyNames"]["pattern"] == r"^[A-Za-z0-9_.:-]{1,256}$"
+    assert "depth 16" in metadata["description"]
+    assert "64000 bytes" in metadata["description"]
+    value = schema["$defs"]["PortableMetadataValue"]
+    branches = value["anyOf"]
+    assert not any(branch.get("type") == "number" for branch in branches)
+    integer = next(branch for branch in branches if branch.get("type") == "integer")
+    assert integer == {
+        "type": "integer",
+        "minimum": -MAX_SAFE_JSON_INTEGER,
+        "maximum": MAX_SAFE_JSON_INTEGER,
+    }
+    object_branch = next(branch for branch in branches if branch.get("type") == "object")
+    assert object_branch["propertyNames"] == {"pattern": r"^[A-Za-z0-9_.:-]{1,256}$"}
 
 
 def test_metadata_keys_are_portable_ascii_and_values_remain_unicode() -> None:

--- a/tests/unit/evaluation/test_protocol.py
+++ b/tests/unit/evaluation/test_protocol.py
@@ -417,11 +417,21 @@ def test_canonical_observation_fixture_is_stable_and_requires_exact_encoding() -
     assert envelope.to_canonical_json() == expected
     assert ObservationEnvelope.from_canonical_json(expected) == envelope
     assert parse_envelope(expected) == envelope
-    noncanonical = json.dumps(json.loads(expected), ensure_ascii=False).encode()
-    with pytest.raises(ValueError, match="not canonical"):
-        ObservationEnvelope.from_canonical_json(noncanonical)
-    with pytest.raises(ValueError, match="not canonical"):
-        parse_envelope(noncanonical)
+    noncanonical_whitespace = json.dumps(json.loads(expected), ensure_ascii=False).encode()
+    noncanonical_order = expected.replace(
+        b'{"kind":"observation","observation":',
+        b'{"observation":',
+        1,
+    ).replace(
+        b'},"protocol_version":"1.0"}',
+        b'},"kind":"observation","protocol_version":"1.0"}',
+        1,
+    )
+    for noncanonical in (noncanonical_whitespace, noncanonical_order):
+        with pytest.raises(ValueError, match="not canonical"):
+            ObservationEnvelope.from_canonical_json(noncanonical)
+        with pytest.raises(ValueError, match="not canonical"):
+            parse_envelope(noncanonical)
 
 
 def test_generic_parser_requires_explicit_version_and_rejects_normalized_actions() -> None:

--- a/tests/unit/evaluation/test_protocol.py
+++ b/tests/unit/evaluation/test_protocol.py
@@ -229,10 +229,18 @@ def test_batch_size_status_mouse_and_numeric_bounds_are_closed() -> None:
     with pytest.raises(ValidationError):
         _batch(*[WaitAction(observation_id="observation-7", duration_ms=1)] * (MAX_BATCH_SIZE + 1))
     with pytest.raises(ValidationError):
-        FinishAction(observation_id="observation-7", status="maybe", reason="uncertain")  # type: ignore[arg-type]
+        FinishAction(
+            observation_id="observation-7",
+            status="maybe",  # type: ignore[arg-type]
+            reason="uncertain",
+        )
     with pytest.raises(ValidationError):
         ClickAction(
-            observation_id="observation-7", frame_id="frame-1", x=1, y=2, button="primary"  # type: ignore[arg-type]
+            observation_id="observation-7",
+            frame_id="frame-1",
+            x=1,
+            y=2,
+            button="primary",  # type: ignore[arg-type]
         )
     with pytest.raises(ValidationError):
         ScrollAction(
@@ -243,7 +251,10 @@ def test_batch_size_status_mouse_and_numeric_bounds_are_closed() -> None:
             delta_y=0,
         )
     with pytest.raises(ValidationError):
-        WaitAction(observation_id="observation-7", duration_ms=float("nan"))  # type: ignore[arg-type]
+        WaitAction(
+            observation_id="observation-7",
+            duration_ms=float("nan"),  # type: ignore[arg-type]
+        )
 
 
 def test_key_validation_and_historical_double_click_are_explicit() -> None:

--- a/tests/unit/evaluation/test_protocol.py
+++ b/tests/unit/evaluation/test_protocol.py
@@ -7,6 +7,7 @@ import json
 import pickle
 import subprocess
 import sys
+from collections import UserDict
 from collections.abc import Mapping
 from pathlib import Path
 from types import MappingProxyType
@@ -311,14 +312,43 @@ def test_frozen_mapping_equality_preserves_recursive_json_scalar_types() -> None
 
 
 def test_frozen_mapping_never_equals_ordinary_or_custom_mappings() -> None:
-    frozen = FrozenMapping({"value": True})
-    ordinary = {"value": True}
-    custom = MappingProxyType(ordinary)
-    assert not frozen == ordinary
-    assert not ordinary == frozen
-    assert not frozen == custom
-    assert not custom == frozen
-    assert FrozenMapping.__eq__(frozen, ordinary) is NotImplemented
+    class CustomMapping(Mapping[str, object]):
+        def __init__(self, value: object) -> None:
+            self.value = value
+
+        def __iter__(self):
+            return iter(("value",))
+
+        def __len__(self) -> int:
+            return 1
+
+        def __getitem__(self, key: str) -> object:
+            if key != "value":
+                raise KeyError(key)
+            return self.value
+
+    frozen_true = FrozenMapping({"value": True})
+    frozen_one = FrozenMapping({"value": 1})
+    adversaries = (
+        {"value": True},
+        MappingProxyType({"value": True}),
+        UserDict({"value": True}),
+        CustomMapping(True),
+        CustomMapping(1),
+    )
+    for other in adversaries:
+        assert not frozen_true == other
+        assert not other == frozen_true
+        assert FrozenMapping.__eq__(frozen_true, other) is False
+    assert frozen_true != frozen_one
+    assert len({frozen_true, frozen_one}) == 2
+    frozen_set = {frozen_true, frozen_one}
+    assert frozen_true in frozen_set and frozen_one in frozen_set
+    # An untyped mapping may bridge True and 1 internally, but it cannot create
+    # transitivity through the closed FrozenMapping equality relation.
+    assert UserDict({"value": True}) == UserDict({"value": 1})
+    assert frozen_true != UserDict({"value": True})
+    assert UserDict({"value": 1}) != frozen_one
 
 
 def test_frozen_mapping_snapshots_stateful_mapping_exactly_once() -> None:


### PR DESCRIPTION
## Summary

Adds the benchmark-neutral, typed computer-use protocol foundation under `local_operator.evaluation`. This is protocol-only infrastructure: it contains no OSWorld-specific code and does not activate evaluation on any normal Local Operator path.

- **Change class:** C2 standard, pre-authorized
- **Base:** `efbf3c3ffb8b6eac957d9df9c99d9db88b103838`
- **Package version:** `0.44.3`

## What changed

- Added strict, frozen models for content-addressed artifacts, native/model-visible frame geometry, ordered observations, and versioned envelopes.
- Added a closed computer-action union for click, double-click, type, key, scroll, wait, finish, and `ask_user`.
- Bound every action to its source observation, isolated terminal actions within batches, and validated coordinates against each referenced frame.
- Added exact canonical UTF-8 JSON parsing with explicit protocol versions, duplicate-key rejection, bounded envelopes, immutable metadata, and portable numeric/key restrictions.
- Kept `local_operator.evaluation` inert at package import; there are no CLI, Session, provider, dependency, config, TUI, mobile, or default-tool changes.

## Architecture and security decisions

- **Benchmark-neutral boundary:** the protocol describes screenshots/assets, geometry, observations, and structured actions only. Benchmark adapters remain outside this PR.
- **No executable escape hatches:** actions cannot carry raw code, shell commands, `eval`, pyautogui strings, paths, or arbitrary commands.
- **Evidence-ready artifacts:** frame bytes are represented by SHA-256, media type, and byte count rather than inline base64 or transport-specific locations.
- **Stale-action rejection:** task, episode, observation, and frame identities are explicit and validated before execution.
- **Portable canonical wire:** envelopes require exact canonical JSON, explicit versioning, duplicate-key rejection, safe integers, bounded ASCII metadata keys, immutable recursive values, and a 16 MiB raw envelope limit.
- **Explicit geometry:** conversions use captured native/model-visible dimensions with documented directed floor-and-clamp behavior; they never infer from the current display.
- **Startup isolation:** neither CLI nor session composition imports evaluation, and importing the evaluation package does not load image, cloud, gym, benchmark-adapter, or protocol-model stacks.

## Validation

- Focused evaluation and browser-protocol/import suite: **69 passed**.
- Whole-tree static gates passed: flake8, Black 26.1.0, isort 5.13.2, and pyright with 0 errors.
- Built the `0.44.3` wheel and source distribution; `twine check` passed and installed archive metadata reports `local-operator==0.44.3`.
- Fresh-subprocess import-graph probes confirmed `local_operator.cli` and `local_operator.session_factory` do not import `local_operator.evaluation`; the evaluation package root remains inert.
- Independent review rounds repeatedly ran the whole unit suite. Those runs reached the full suite with only isolated, unrelated resource/timing flakes; each reported failure passed when isolated. No protocol regression was identified.
- Real-path protocol smoke checks exercised canonical envelope round-trips, stale and invalid action rejection, coordinate conversion, immutable copy/pickle behavior, hostile mapping inputs, envelope bounds, and schema composition.
- Import overhead was measured during review, but this PR makes no performance claim from that measurement.

## Install

```bash
pip install local-operator==0.44.3
# or
uv tool install local-operator==0.44.3
```

## Rollback

Revert this PR and restore `local-operator==0.44.2` while publishing the next patch from the restored tree. The package is not imported or activated by normal Local Operator paths, so rollback removes the opt-in protocol models and tests without a data migration, configuration change, compatibility shim, or runtime state cleanup.
