### PR TITLE
chore(release): bump version to 0.44.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.1"
+version = "0.44.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Version bump so the TUI rendering-performance work in #455 can ship.

#455 merged as `168efe48`, but `v0.44.1` had already been tagged and published to PyPI from `f82c2f5e` (#464) while #455 was completing its review rounds. `168efe48` is therefore on `main` but is **not** contained in any released tag — `git merge-base --is-ancestor 168efe48 v0.44.1` is false — so the performance work is currently unreleased.

Patch bump per AGENTS.md "Versioning": #455 is perf/reliability work (fewer compositor reflows, no animation on a blurred terminal) with no step-function capability.

Release-mechanics only; no code change.