### PR TITLE
fix(tui): r on a setting already at its default no longer writes config.yml

### DIFF
--- a/local_operator/tui/widgets/settings_view.py
+++ b/local_operator/tui/widgets/settings_view.py
@@ -866,6 +866,10 @@ class SettingsView(Vertical):
         The mitigation for immediate-write having no undo. Deletes the stored
         key rather than writing the default over it, so a config file carries
         only what its owner actually chose (see ``settings_io.reset_setting``).
+
+        A row already at its default is reported, not written — see the
+        ``is_default`` guard below, which is what keeps the page's own undo key
+        from being the only gesture in a session that touched config.yml.
         """
         # Disarms a pending delete for the reason `action_activate` records.
         # Captured BEFORE the early returns below, because a disarm is a change
@@ -924,6 +928,40 @@ class SettingsView(Vertical):
                 self._repaint()
             return
         setting = row.setting
+        if settings_io.is_default(self._manager, setting):
+            # A row already at its default has NOTHING to restore, so `r` must
+            # not reach the writer. It did: `reset_setting` deletes the key and
+            # `_delete` writes the file back unconditionally, so pressing `r` on
+            # an untouched row rewrote config.yml — and on a machine with no
+            # config.yml at all it CREATED a 1005-byte one out of a key the user
+            # never set (#440). The gesture the page offers as the safe way to
+            # undo a change was itself the only thing that had changed anything.
+            #
+            # Both of those are one state here, not two: `read_setting` falls
+            # back to `setting.default` when the key is absent, so "no file yet"
+            # and "stored value equals the default" are the same answer from
+            # `is_default` — measured across the whole registry, a config dir
+            # with no file reports 0 of 52 settings off-default.
+            #
+            # Compared BY VALUE, matching `is_default`'s own contract and the
+            # `changed` test that inks the value column two panes over: a row
+            # painted dim as "this is the default" and a row `r` declines to
+            # reset are then the same row, and the page states one fact about
+            # it rather than two.
+            #
+            # It SAYS so rather than swallowing the press, for the reason the
+            # healthy-cascade branch above does — a lit hint whose key does
+            # nothing is the "nothing happens when I click" bug one step earlier
+            # (UX round 1, U5). The hint is deliberately NOT shed the way a
+            # read-only row sheds it: a retired row is permanently inert, while
+            # this one becomes resettable the moment its value changes, so
+            # shedding would flicker `r default` in and out of the footer as a
+            # user toggles a bool. Offering `r` only on off-default rows is the
+            # #440 redesign's job and needs its sign-off; this guard's job is
+            # only to stop the key from writing when it has nothing to undo.
+            self._notice = f"already at its default ({_render_value(setting.default)})"
+            self._repaint()
+            return
         if not self._save(lambda: settings_io.reset_setting(self._manager, setting)):
             return
         self.post_message(

--- a/scripts/settings_shot.py
+++ b/scripts/settings_shot.py
@@ -45,11 +45,13 @@ STATE selects what the page is showing:
     reset-default  a row that IS at its shipped default (OUT.svg), then the
                same row after pressing `r` (OUT.pressed.svg). `r` used to WRITE
                here — on a config with no file at all it created one — so the
-               subject of this pair is the footer: whether the page offers a
-               key that has nothing to restore. A third frame,
-               OUT.offdefault.svg, is the SAME row once it is off-default,
-               which is what proves the hint is being withheld by state rather
-               than removed (#440)
+               subject of this pair is the DETAIL LINE: the press now reports
+               `already at its default (...)` instead of rewriting the file.
+               A third frame, OUT.offdefault.svg, is the SAME row once it is
+               off-default, which is what proves `r` still resets when there
+               is something to undo. The footer still offers `r default` on
+               both sides — withholding it is the #440 redesign, not this
+               safety patch
     retired    scrolled to the retired section — the read-only bottom row the
                clamp now parks users on, whose footer must not advertise keys
                that cannot act on it
@@ -324,11 +326,11 @@ async def main() -> None:
             await pilot.pause()
             app.save_screenshot(out.replace(".svg", ".open.svg"))
         elif state == "reset-default":
-            # THREE frames. The `r` affordance is a footer question, and a
-            # single still of a row cannot answer it: the pair that matters is
-            # the same row at default and off-default, because only the
-            # difference between them shows the hint is state-driven rather
-            # than simply gone. `tui.shimmer` is used because `_seed_config`
+            # THREE frames. The `r` safety patch is a DETAIL-LINE question, not
+            # a footer one: the hint stays lit on a default row (withholding it
+            # is the #440 redesign), and the pair that matters is the same row
+            # at default (press reports, file unchanged) and off-default (press
+            # still resets). `display.shimmer` is used because `_seed_config`
             # writes it, so both sides are reachable on one config.
             _select(view, "display.shimmer")
             settings_io.reset_setting(view._manager, _require("display.shimmer"))

--- a/scripts/settings_shot.py
+++ b/scripts/settings_shot.py
@@ -42,6 +42,14 @@ STATE selects what the page is showing:
                painted into (D12) rather than against the settings list
     teams      the read-only teams pane
     agents     the read-only agents pane
+    reset-default  a row that IS at its shipped default (OUT.svg), then the
+               same row after pressing `r` (OUT.pressed.svg). `r` used to WRITE
+               here — on a config with no file at all it created one — so the
+               subject of this pair is the footer: whether the page offers a
+               key that has nothing to restore. A third frame,
+               OUT.offdefault.svg, is the SAME row once it is off-default,
+               which is what proves the hint is being withheld by state rather
+               than removed (#440)
     retired    scrolled to the retired section — the read-only bottom row the
                clamp now parks users on, whose footer must not advertise keys
                that cannot act on it
@@ -82,6 +90,7 @@ os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = _SCRATCH
 
 from local_operator import settings_io  # noqa: E402
 from local_operator.config import ConfigManager  # noqa: E402
+from local_operator.settings_io import Setting  # noqa: E402
 from local_operator.tui.app import OperatorApp  # noqa: E402
 from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
 from local_operator.tui.widgets.settings_view import SettingsView  # noqa: E402
@@ -314,6 +323,30 @@ async def main() -> None:
             view.action_activate()
             await pilot.pause()
             app.save_screenshot(out.replace(".svg", ".open.svg"))
+        elif state == "reset-default":
+            # THREE frames. The `r` affordance is a footer question, and a
+            # single still of a row cannot answer it: the pair that matters is
+            # the same row at default and off-default, because only the
+            # difference between them shows the hint is state-driven rather
+            # than simply gone. `tui.shimmer` is used because `_seed_config`
+            # writes it, so both sides are reachable on one config.
+            _select(view, "display.shimmer")
+            settings_io.reset_setting(view._manager, _require("display.shimmer"))
+            view._manager.reload()
+            view._repaint()
+            await pilot.pause()
+            app.save_screenshot(out)
+            geometry = _geometry(app, view, state, size)
+            view.action_reset()
+            await pilot.pause()
+            app.save_screenshot(out.replace(".svg", ".pressed.svg"))
+            geometry += f" || after r at default: notice={view.notice_text!r}"
+            settings_io.write_setting(view._manager, _require("display.shimmer"), False)
+            view._manager.reload()
+            view._repaint()
+            await pilot.pause()
+            app.save_screenshot(out.replace(".svg", ".offdefault.svg"))
+            geometry += f" || off-default hints={view.rendered_hints()!r}"
         elif state == "retired":
             for _ in range(len(view._rows)):
                 view.action_jump(1)
@@ -395,6 +428,18 @@ def _scroll_to_show_group(view: SettingsView) -> None:
         last = index
     height = view._body.size.height
     view._body.scroll_to(y=max(0, min(view._selected - 1, last - height + 2)), animate=False)
+
+
+def _require(key: str) -> Setting:
+    """Resolve a shipped setting or fail loudly.
+
+    A capture that silently skipped a missing key would produce a frame of the
+    wrong state and caption it as the right one.
+    """
+    setting = settings_io.resolve_key(key)
+    if setting is None:
+        raise SystemExit(f"no setting {key}")
+    return setting
 
 
 def _corrupt_cascade() -> None:

--- a/tests/unit/tui/test_settings_view.py
+++ b/tests/unit/tui/test_settings_view.py
@@ -250,6 +250,130 @@ async def test_reset_restores_the_default(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_reset_on_a_default_row_leaves_config_byte_identical(tmp_path: Path) -> None:
+    """#440: `r` on a row already at its default must not WRITE.
+
+    `action_reset` had no default-state guard, so the key ran `reset_setting`
+    unconditionally — and `_delete` writes config.yml back whether or not the
+    key was there. Pressing `r` on an untouched row rewrote the file, and on a
+    machine with no config.yml at all it CREATED one out of a setting the user
+    had never chosen: the page's own undo gesture was the only thing in the
+    session that changed anything.
+
+    Asserted on config.yml's BYTES, the unit the issue's audit used, rather
+    than on the stored value. "The value is still the default" is true of the
+    broken behaviour too — `reset_setting` deletes a key that was already
+    absent and the value reads the same afterwards — so a value assertion
+    passes against the very bug this pins. Only the bytes distinguish "did
+    nothing" from "rewrote the file to the same meaning".
+
+    Both halves of the boundary are covered here because they are two states,
+    not one: NO FILE AT ALL (the issue's repro) and a file that exists with the
+    row at its default. A guard that only handled the first would leave the
+    second live.
+    """
+    config = tmp_path / "config.yml"
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 32)) as pilot:
+        await pilot.pause()
+        app._open_settings_view()
+        view = app.query_one(SettingsView)
+        await pilot.pause()
+
+        # ---- state 1: no config.yml at all -----------------------------
+        # Opening the app materialises one, so it is removed to reproduce the
+        # audit's starting state exactly: a machine that has never been
+        # configured, where `r` conjured 1005 bytes from nothing.
+        config.unlink(missing_ok=True)
+        _select(view, "retry.enabled")
+        setting = settings_io.resolve_key("retry.enabled")
+        assert setting is not None
+        assert settings_io.is_default(view._manager, setting)
+
+        await pilot.press("r")
+        await pilot.pause()
+        assert not config.exists(), (
+            "`r` on a default row CREATED config.yml out of a setting the user "
+            f"never chose: {config.read_bytes()!r}"
+        )
+
+        # ---- state 2: the file exists and the row is at its default -----
+        # Written through a DIFFERENT setting, so the file on disk carries a
+        # real non-default key while the highlighted row is still untouched —
+        # the state where a rewrite would be invisible in the values but
+        # visible in the bytes (and in the file's mtime).
+        other = settings_io.resolve_key("retry.maxRetries")
+        assert other is not None
+        settings_io.write_setting(view._manager, other, 7)
+        view._manager.reload()
+        view._repaint()
+        await pilot.pause()
+
+        _select(view, "retry.enabled")
+        assert settings_io.is_default(view._manager, setting)
+        before = config.read_bytes()
+
+        await pilot.press("r")
+        await pilot.pause()
+
+        assert config.read_bytes() == before, "`r` rewrote config.yml for a row already at default"
+        # The sibling is what proves the no-op is a no-op rather than a
+        # differently-shaped write that happened to round-trip.
+        view._manager.reload()
+        assert settings_io.read_setting(view._manager, other) == 7
+        # It REPORTS rather than swallowing the press: the footer advertises
+        # `r default` on this row, and a lit hint whose key does nothing
+        # silently is the bug one step earlier (UX round 1, U5).
+        assert "default" in view.notice_text, view.notice_text
+        assert view.error_text == "", "a row at its default is not an ERROR state"
+
+
+@pytest.mark.asyncio
+async def test_reset_still_writes_on_an_off_default_row(tmp_path: Path) -> None:
+    """The guard's other boundary: `r` MUST still reset a row that is off-default.
+
+    Paired with the test above deliberately. A guard that refused every reset
+    would pass that one perfectly while destroying the feature — the page's
+    only undo — so the two are meaningful only together: one pins that `r`
+    does not write when there is nothing to undo, this pins that it does when
+    there is.
+    """
+    config = tmp_path / "config.yml"
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 32)) as pilot:
+        await pilot.pause()
+        app._open_settings_view()
+        view = app.query_one(SettingsView)
+        await pilot.pause()
+
+        setting = settings_io.resolve_key("retry.enabled")
+        assert setting is not None
+        settings_io.write_setting(view._manager, setting, False)
+        view._manager.reload()
+        view._repaint()
+        await pilot.pause()
+
+        _select(view, "retry.enabled")
+        assert not settings_io.is_default(view._manager, setting)
+        before = config.read_bytes()
+
+        await pilot.press("r")
+        await pilot.pause()
+
+        assert config.read_bytes() != before, "`r` did not write on an off-default row"
+        view._manager.reload()
+        assert "enabled" not in _values(tmp_path).get("retry", {}), (
+            "`r` left the stored key in place: " f"{_values(tmp_path).get('retry')!r}"
+        )
+        assert settings_io.is_default(view._manager, setting)
+        # A successful reset says nothing: the value column already shows the
+        # change landing, so a notice here would be noise on the common path.
+        assert view.notice_text == "", view.notice_text
+
+
+@pytest.mark.asyncio
 async def test_every_movement_on_the_page_clamps_at_the_ends() -> None:
     """The ends HOLD, under every movement this page has.
 


### PR DESCRIPTION
## Summary

**Pressing `r` on a `/settings` row that is already at its default rewrote `config.yml` — and on a machine with no config.yml at all, it CREATED one.** Reproduced against `origin/main` before anything was changed, at the byte level the issue's audit used.

`action_reset` had no default-state guard, so `r` ran `reset_setting` unconditionally. `reset_setting` deletes the stored key and `_delete` writes the file back whether or not the key was there. The page's own undo gesture was the only thing in a session that had changed anything.

`settings_io.is_default()` already existed for exactly this question and had **zero call sites** outside its own module. The guard uses it, so the row the value column paints dim as "this is the default" and the row `r` declines to reset are the same row by construction.

**Does not bump the version. Does not close #440.** That issue tracks the full editing-model redesign and must stay open.

Part of #440.

## What this PR closes, and what it does not

#440 called out two separable defects to "fix ahead of the redesign":

| # | Defect | Status |
|---|---|---|
| 1 | BLOCKER: `enter` on the cascade row destroys the failover config | **Already on main.** Closed by #449 (`9c327496`). Re-measured on this branch: seed a cascade, `enter` then `down` → config.yml identical (1102 bytes, same sha), stored value still a `dict`, `read_chains()` still returns the chains. Mutation-tested: removing the `Kind.CASCADE` activate branch alone is not enough (the `_begin_edit` allow-list is a second layer); removing **both** layers makes `test_enter_on_the_cascade_row_does_not_destroy_the_cascade` die with the exact wreckage the issue described (`"{'default': [...]}x"`). Verified real coverage. |
| 2 | `r` writes on a row already at its default | **This PR.** |

Out of scope, deliberately — they need the operator's sign-off on the spec: the `enter` opens / `enter` accepts / `esc` cancels redesign, bools expanding rather than toggling, theme preview, the footer copy changes (including offering `r` only when off-default), and the move-commits reversal.

## Reproduction, on the real page

A scratch `LOCAL_OPERATOR_CONFIG_DIR`, the real `OperatorApp`, comparing `config.yml`'s **bytes** before and after each gesture.

**Before — `origin/main`:**

```
== DEFECT 2: r on a row that is already at its default ==
  is_default(retry.enabled)=True
  r on retry.enabled with NO config.yml
    before: exists=False bytes=-1 sha=-
    after : exists=True  bytes=1006 sha=b7d0ea797fbd
    CHANGED: True
  notice='' error=''
```

That is the issue's audit, reproduced: no file, land on any row, press `r`, a ~1005-byte `config.yml` is CREATED.

**After — this branch:**

```
== DEFECT 2: r on a row that is already at its default ==
  is_default(retry.enabled)=True
  r on retry.enabled with NO config.yml
    before: exists=False bytes=-1 sha=-
    after : exists=False bytes=-1 sha=-
    CHANGED: False
  notice='already at its default (on)' error=''

== CONTROL: r on an OFF-DEFAULT row must still reset ==
  stored=False is_default=False
    CHANGED: True
  stored now=True is_default=True
  notice='' error=''

== DEFECT 2b: r again, now the row is back at default ==
    CHANGED: False
  notice='already at its default (on)' error=''

== DEFECT 2c: row at default, file HAS other non-default settings ==
  retry.enabled is_default=True retry.maxRetries=7 (off-default=True)
    before: exists=True bytes=1005 sha=40d0678efdb0
    after : exists=True bytes=1005 sha=40d0678efdb0
    CHANGED: False
  sibling retry.maxRetries preserved: 7
```

Four states, as required: no file at all; a file where the row is at default; a file where the row is off-default (`r` MUST still write); a row at default in a file that has other non-default settings (`r` must not create or rewrite anything).

## The fix

One branch in `action_reset`, immediately before the only write, after the cascade and read-only exits so their established messages keep priority:

```python
if settings_io.is_default(self._manager, setting):
    self._notice = f"already at its default ({_render_value(setting.default)})"
    self._repaint()
    return
```

Compared **by value**, matching `is_default`'s own contract and the `changed` test that inks the value column two panes over. "No file yet" and "stored value equals the default" are one state here rather than two: `read_setting` falls back to `setting.default` when the key is absent, so a config dir with no file reports 0 of 52 settings off-default.

It **says so** rather than swallowing the press — the footer advertises `r default` on this row, and a lit hint whose key does nothing silently is the "nothing happens when I click" bug one step earlier (UX round 1, U5). The hint is deliberately **not shed** the way a read-only row sheds it: a retired row is permanently inert, while this one becomes resettable the moment its value changes, so shedding would flicker `r default` in and out of the footer as a user toggles a bool. Offering `r` only on off-default rows is the #440 redesign's job.

## Mutation test

Removing the `is_default()` check makes `test_reset_on_a_default_row_leaves_config_byte_identical` die at its own boundary, with the exact wreckage the issue described:

```
AssertionError: `r` on a default row CREATED config.yml out of a setting the user never chose: b"metadata:\n  ...\nversion: 0.43.5\n"
```

The off-default test still passed under that mutation, which is the pair working: a guard that refused every reset would pass the no-write test while destroying the page's only undo.

## Visual

Captured before/after frames of the same row (`display.shimmer` at its default) after pressing `r`, from the real `OperatorApp` (the only host that loads `local_operator.tcss`):

- **Before:** press is silent. Detail line still shows the setting description. Footer still offers `r default`.
- **After:** detail line reads `already at its default (on)` in faint (informational) ink. Layout, footer, and value column are otherwise identical — the press no longer writes, and it no longer pretends nothing happened.

`r default` remains in the footer on a default row on purpose (see above). The off-default frame of the same row still offers it, and `r` there still resets.

## Gates

```
flake8 rc=0
black rc=0
isort rc=0
pyright rc=0
```

`tests/unit/tui/test_settings_view.py`: 381 passed (pre-rebase); 10 passed of the `reset or cascade` slice after rebasing onto `origin/main` (`168efe48`).
