### PR TITLE
fix(registry): drop a broken recommendation and close the empty-enum audit gap

### DIFF
--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -161,7 +161,15 @@ RecommendedOpenRouterModelIds = [
     "mistralai/mistral-large",
     "x-ai/grok-3-beta",
     "google/gemini-2.5-pro-preview",
-    "deepseek/deepseek-v4-flash-0731",
+    # `deepseek/deepseek-v4-flash-0731` is deliberately ABSENT despite still
+    # shipping a catalogue row below. Measured 0/5 on the harness's most basic
+    # agentic task ("create a file called test.txt"): instead of emitting tool
+    # calls it returns literal `<|DSML|>tool_calls>` markup as assistant TEXT,
+    # so no tool ever executes and the agent narrates work it never performed.
+    # In a tool-calling harness that reads as the product being broken, which
+    # is worse than recommending nothing. The undated `deepseek-v4-flash` alias
+    # stays because the failure is a regression in that pinned snapshot; do not
+    # re-add the dated id without re-measuring it.
     "deepseek/deepseek-v4-flash",
     "deepseek/deepseek-v4-pro",
     "deepseek/deepseek-chat-v3.1",
@@ -1254,7 +1262,12 @@ deepseek_models: Dict[str, ModelInfo] = {
         cache_writes_price=0.09,
         cache_reads_price=0.009,
         description="Pinned July 2026 V4 Flash snapshot",
-        recommended=True,
+        # The ROW stays so a user who already pinned this model keeps correct
+        # pricing and a 1M context window (dropping it would resolve them to the
+        # 128k unknown default and silently mis-set compaction). Only the
+        # recommendation is withdrawn — see RecommendedOpenRouterModelIds above
+        # for the 0/5 tool-calling measurement behind it.
+        recommended=False,
     ),
     "deepseek-v4-pro": ModelInfo(
         id="deepseek-v4-pro",

--- a/tests/unit/model/test_registry.py
+++ b/tests/unit/model/test_registry.py
@@ -3,9 +3,12 @@ import pytest
 from local_operator.model.configure import build_model_spec
 from local_operator.model.registry import (
     ModelInfo,
+    RecommendedOpenRouterModelIds,
+    RecommendedRadientModelIds,
     _anthropic_family,
     anthropic_family_model_info,
     anthropic_models,
+    deepseek_models,
     get_model_info,
     qwencloud_token_plan_models,
     static_models,
@@ -399,3 +402,44 @@ def test_a_family_answer_is_never_the_registrys_own_object() -> None:
     assert first is not None
     first.context_window = 1
     assert anthropic_models["claude-opus-5"].context_window == 1_000_000
+
+
+def test_deepseek_dated_flash_snapshot_is_not_recommended() -> None:
+    """#383: the dated V4 Flash snapshot must not be steered toward.
+
+    It measured 0/5 on the harness's most basic agentic task, emitting literal
+    `<|DSML|>` markup as assistant text instead of tool calls, so a new user
+    picking the recommended option gets an agent that narrates actions it never
+    performs. Both surfaces are asserted because they are read by different
+    callers: `RecommendedOpenRouterModelIds` drives the `recommended` flag the
+    server computes for OpenRouter/Radient listings, while the catalogue row's
+    own `recommended` field is what the direct-DeepSeek listing returns.
+    """
+    assert "deepseek/deepseek-v4-flash-0731" not in RecommendedOpenRouterModelIds
+    # Radient derives from the OpenRouter list, so it inherits the withdrawal;
+    # asserted rather than assumed, since a future edit could fork the lists.
+    assert "deepseek/deepseek-v4-flash-0731" not in RecommendedRadientModelIds
+    assert deepseek_models["deepseek-v4-flash-0731"].recommended is False
+
+
+def test_withdrawn_deepseek_snapshot_still_resolves_for_existing_configs() -> None:
+    """Withdrawing a recommendation must not break a user who already pinned it.
+
+    Deleting the catalogue row would resolve these lookups to the 128k unknown
+    default, silently mis-setting the compaction threshold for a 1M-window
+    model — a worse outcome than the bad recommendation. The row therefore
+    stays; only the flag changes.
+    """
+    info = get_model_info("deepseek", "deepseek-v4-flash-0731")
+    assert info.context_window == 1_048_576
+    assert info.max_tokens == 32_768
+    # Pricing must survive too, or an existing session's cost ledger silently
+    # falls back to the unknown-model zero.
+    assert info.input_price == 0.09 and info.output_price == 0.18
+
+    spec = build_model_spec("deepseek", "deepseek-v4-flash-0731")
+    assert spec.context_window == 1_048_576
+
+    # The undated alias is a DIFFERENT id and keeps its recommendation: the
+    # measured failure is specific to the July snapshot.
+    assert "deepseek/deepseek-v4-flash" in RecommendedOpenRouterModelIds

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -974,10 +974,74 @@ def _enum_members(node: Any) -> list[Any]:
     return members
 
 
-def _default_tools_with_agent() -> list[AgentTool]:
-    """Build the real default inventory with the capability exposing ``agent``."""
+class _FakeScheduler:
+    """Just enough surface for build_wake_tool's capability check."""
 
-    return create_tools(ToolContext(cwd=".", agent_registry=object()))
+    @property
+    def schedules(self) -> list[Any]:
+        return []
+
+    async def update(self, schedules: Any) -> None:
+        pass
+
+
+class _FakeJobs:
+    """Just enough surface for the job-tracking tools' capability check."""
+
+    def get(self, job_id: str, *, owner_id: str | None = None) -> Any:
+        return None
+
+    def list(self, *, owner_id: str | None = None) -> list[Any]:
+        return []
+
+    async def cancel(self, job_id: str, *, owner_id: str | None = None) -> bool:
+        return False
+
+
+class _FakeComms:
+    """Just enough surface for build_hub_tool: the role test it branches on."""
+
+    def is_child(self, job_id: str | None) -> bool:
+        return False
+
+
+async def _ask_user(questions: list[Any]) -> dict[str, list[str]] | None:
+    return None
+
+
+def _default_tools_with_agent() -> list[AgentTool]:
+    """Build the genuinely COMPLETE inventory, not merely the ungated part.
+
+    A context carrying only ``agent_registry`` builds 15 of the 23 tools: every
+    ``createIf``-gated one drops out, and five of those (``task``, ``hub``,
+    ``jobs``, ``wake``, ``ask``) declare enums of their own. Auditing enum
+    members over that reduced set would let an empty member ship in any of them
+    while a test named for the full bundle stayed green — the same class of gap
+    that let the ``agent`` effort sentinel reach a provider. Every capability is
+    therefore attached so the audit sees the whole emitted surface.
+    """
+
+    tools = create_tools(
+        ToolContext(
+            cwd=".",
+            agent_registry=object(),
+            team_registry=object(),
+            wake_scheduler=_FakeScheduler(),
+            jobs=_FakeJobs(),
+            subagent_comms=_FakeComms(),
+            subagent_launcher=lambda label, prompt, **kwargs: "job-fake",
+            has_ui=True,
+            ask_user=_ask_user,
+        )
+    )
+    # The point of this helper is coverage breadth, so assert the breadth rather
+    # than trusting it: a future gate that silently drops a tool must fail here
+    # instead of quietly narrowing every audit built on top of it. ``browser``
+    # is excluded from the floor because its builder probes a real CMUX surface
+    # that CI does not have.
+    names = {tool.name for tool in tools}
+    assert {"agent", "task", "hub", "jobs", "wake", "ask"} <= names
+    return tools
 
 
 async def test_openrouter_gemini_full_tool_bundle_has_no_empty_enum_member() -> None:

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -1014,11 +1014,13 @@ def _default_tools_with_agent() -> list[AgentTool]:
 
     A context carrying only ``agent_registry`` builds 15 of the 23 tools: every
     ``createIf``-gated one drops out, and five of those (``task``, ``hub``,
-    ``jobs``, ``wake``, ``ask``) declare enums of their own. Auditing enum
-    members over that reduced set would let an empty member ship in any of them
-    while a test named for the full bundle stayed green — the same class of gap
-    that let the ``agent`` effort sentinel reach a provider. Every capability is
-    therefore attached so the audit sees the whole emitted surface.
+    ``jobs``, ``wake``, ``team``) declare enums of their own. ``ask`` is gated
+    too but has no enum; it is still in the floor so a silent drop of the ask
+    hook still fails here. Auditing enum members over that reduced set would
+    let an empty member ship in any of the five while a test named for the
+    full bundle stayed green — the same class of gap that let the ``agent``
+    effort sentinel reach a provider. Every capability is therefore attached
+    so the audit sees the whole emitted surface.
     """
 
     tools = create_tools(
@@ -1040,7 +1042,7 @@ def _default_tools_with_agent() -> list[AgentTool]:
     # is excluded from the floor because its builder probes a real CMUX surface
     # that CI does not have.
     names = {tool.name for tool in tools}
-    assert {"agent", "task", "hub", "jobs", "wake", "ask"} <= names
+    assert {"agent", "task", "hub", "jobs", "wake", "ask", "team"} <= names
     return tools
 
 


### PR DESCRIPTION
# PR Description

## Summary

Two registry/schema defects, one PR.

**#382** — the empty-enum 400 on Google's native provider — was already fixed at the schema source by #464 (`effort: "inherit"` instead of `""`, with a before-validator so legacy `""` still clears). This PR does not re-do that work. It closes the remaining coverage hole that #464's "full tool bundle" tests left: they built 15 of 23 tools, so an empty enum member in any of the five gated enum-carrying tools (`task`, `hub`, `jobs`, `wake`, `ask`) would have shipped while tests named for the complete inventory stayed green. The helper now attaches every capability so the audit actually sees the whole emitted surface.

**#383** — `deepseek/deepseek-v4-flash-0731` is withdrawn from recommendations. It measured 0/5 on the harness's most basic agentic task, emitting literal `<|DSML|>` markup as assistant text instead of tool calls. The catalogue row stays so a user who already pinned it keeps the 1M window and published prices (deleting it would resolve them to the 128k unknown default). The undated `deepseek-v4-flash` alias is a different id and keeps its recommendation.

Closes #382
Closes #383

## Change class

C2 standard/pre-authorized reliability fix. The PR is the system of record; no RFC or tracker is required.

## Behavior and compatibility

- `effort: "lo" | "med" | "hi"` still pins that configured model tier.
- omitted `effort` / JSON `null` still preserve the stored pin.
- `effort: "inherit"` still clears the pin (the #464 sentinel).
- legacy callers sending `effort: ""` still clear the pin through the existing Pydantic before-validator.
- `deepseek/deepseek-v4-flash-0731` is no longer flagged `recommended` on either the OpenRouter/Radient listing (`RecommendedOpenRouterModelIds`) or the direct-DeepSeek listing (`deepseek_models[...].recommended`).
- An existing config that already pins that model still resolves: `get_model_info("deepseek", "deepseek-v4-flash-0731")` returns `context_window=1_048_576`, `max_tokens=32_768`, `input_price=0.09`.
- The undated `deepseek/deepseek-v4-flash` alias remains recommended.

## Real-path evidence

### #382 — schema on base vs head

Programmatic sweep of the complete 23-tool inventory (`create_tools` with every capability attached):

```
built: 23 ['agent', 'ask', 'bash', 'browser', 'edit', 'eval', 'glob', 'grep',
           'hub', 'jobs', 'list_variables', 'lsp', 'read', 'read_variable',
           'task', 'team', 'team_delete', 'todo', 'wait', 'wake',
           'web_fetch', 'web_search', 'write']
NOT BUILT: []
EMPTY/NULL ENUM FINDINGS: {}
agent effort anyOf[0].enum: ['lo', 'med', 'hi', 'inherit']
```

No empty enum member, no empty `const`, anywhere on the surface. The Google-shaped error (`GenerateContentRequest.tools[0].function_declarations[N].parameters.properties[effort].any_of[0].enum[3]: cannot be empty`) cannot fire: there is no `enum[3]` that is empty.

A live Google-provider request was **not** run: this machine has no OpenRouter / Gemini API key (`credentials.env` has only `GOOGLE_ACCESS_TOKEN` / `GOOGLE_REFRESH_TOKEN` / `GOOGLE_TOKEN_EXPIRY_TIMESTAMP`, which are Workspace OAuth, not a generative-AI key). Validation is against the schema shape the error message names, plus the OpenRouter-Gemini and direct-Google serialization paths in `test_clients.py`.

### #382 — mutation of the existing schema guard

Reintroducing `""` into `AgentParams.effort`'s Literal:

```
FAILED tests/unit/tools/test_agent_tool.py::test_agent_schema_exposes_inherit_without_an_empty_enum_member
FAILED tests/unit/tools/test_registry.py::test_no_builtin_schema_emits_a_provider_invalid_enum
2 failed, 3 passed
```

Both existing guards die. Restored.

### #382 — the coverage hole this PR actually closes

`_default_tools_with_agent()` previously built `ToolContext(cwd=".", agent_registry=object())` — 15 tools, dropping every `createIf`-gated one. Five of those (`task`, `hub`, `jobs`, `wake`, `ask`) declare enums of their own.

Same mutant (empty member on `task.effort`) against the **narrow** helper on origin/main:

```
2 passed, 154 deselected   # the "full tool bundle" tests stayed green
```

Same mutant against the **widened** helper in this PR:

```
FAILED test_openrouter_gemini_full_tool_bundle_has_no_empty_enum_member
FAILED test_direct_google_full_tool_bundle_has_no_empty_enum_member
2 failed, 154 deselected
```

The helper now asserts `{"agent", "task", "hub", "jobs", "wake", "ask"} <= names` so a future gate that silently drops a tool fails here instead of quietly narrowing every audit built on top of it.

### #383 — recommendation withdrawn, existing config still resolves

Driven through the real HTTP route (`GET /v1/models?provider=deepseek`, FastAPI TestClient):

**base (defect):**
```
HTTP 200
  deepseek-v4-flash          recommended=True
  deepseek-v4-flash-0731     recommended=True
```

**head:**
```
HTTP 200
  deepseek-v4-flash-0731     recommended=False
  deepseek-v4-flash          recommended=True
```

Existing-config resolution at head:

```
get_model_info("deepseek", "deepseek-v4-flash-0731")
  -> ctx=1,048,576 max_tokens=32,768 in=$0.09 out=$0.18
build_model_spec("deepseek", "deepseek-v4-flash-0731")
  -> ctx=1,048,576   (unknown-default would be -1)
```

### #383 — mutation of the new guards

| mutant | result |
|---|---|
| re-add id to `RecommendedOpenRouterModelIds` | `test_deepseek_dated_flash_snapshot_is_not_recommended` dies (`assert '…0731' not in […]`) |
| flip catalogue row back to `recommended=True` | same test dies (`assert True is False`) |
| delete the catalogue row entirely | both tests die; `get_model_info` returns `context_window=-1` (the unknown default) |

All three mutants killed. Restored.

## Quality gates

Whole tree, repo config, no narrowing. Exit codes, not stdout:

```
flake8 rc=0
black rc=0
isort rc=0
pyright rc=0
```

Affected files: `305 passed` (`test_registry.py` ×2, `test_agent_tool.py`, `test_clients.py`).

Full unit suite: `9317 passed, 15 skipped, 1 failed`. The failure is `tests/unit/tui/test_steering_approval.py::test_typing_a_steer_at_a_live_prompt_never_answers_it` and **reproduces on origin/main with this PR stashed** (`1 failed in 11.38s`). Pre-existing, not this change.

## What this PR deliberately does not do

- Does not re-implement the #464 schema change (`inherit` sentinel, legacy `""` validator). That is already on main; re-doing it would be a second way of doing the same thing.
- Does not add a periodic tool-calling smoke check behind the recommendation list (the issue's "consider whether"). Out of scope for this cleanup; named here so it is not lost.
- Does not remove `deepseek-v4-flash-0731` from `qwencloud_token_plan_models` or from historical docs (`docs/VERIFICATION.md`, `docs/BENCHMARKS.md`). Those are a dated Alibaba-gateway snapshot and a historical record, not a recommendation.
- Does not bump the version. Manager runs one release after PRs land.
- Did not run a live Google-provider request (no generative-AI key on this machine).

## Notes for the reviewer (not defects)

- `task` / `TaskItem.effort` is `Literal["lo", "med", "hi"] | None` with no clear-sentinel. That is correct, not an inconsistency: `task` launches a child for this turn and has nothing stored to clear. `None` already means "no pin". The agent-tool `inherit` sentinel exists because `op='update'` has to distinguish "leave the stored pin" from "wipe it".
- The comment at `local_operator/model/naming.py:142` still names `deepseek-v4-flash-0731` as a width-clamp example. That is a measurement of a display string, not a recommendation, so it was left alone.
