### PR TITLE
fix(tui): copy a quoted list item and a bar-led quote as written

### DIFF
--- a/local_operator/tui/widgets/_copy_markdown.py
+++ b/local_operator/tui/widgets/_copy_markdown.py
@@ -120,6 +120,41 @@ def _first_word(text: str) -> str:
     return fallback
 
 
+#: A whitespace-delimited token that is ONLY quote-bar glyphs. In a SOURCE line
+#: such a token is the model's own text -- a document may legitimately open a
+#: quoted line with ``▌`` -- but the row Rich paints from it is
+#: indistinguishable from the bar Rich paints as furniture, and ``_row_word``
+#: skips both. The source-side anchor has to skip it too, or the two sides can
+#: never agree on a word and the row is left unplaced (issue #392).
+_BAR_TOKEN_RE = re.compile(r"▌+")
+
+
+def _source_anchor(line: str) -> str:
+    """The word :func:`align` anchors a rendered row to, for source ``line``.
+
+    ``_row_word`` reads the rendered side and skips every leading structure
+    glyph, the quote bar included. Reading the source side with ``_first_word``
+    alone is therefore ASYMMETRIC: a quoted line whose own text opens with
+    ``▌`` anchors on that bar while its rendered row anchors on the word after
+    it, so the two never match and the row is never placed. ``align`` then hands
+    ``furniture_width`` no source line, its documented ``source_line is None``
+    branch strips nothing, and the whole rendered row -- painted bar included --
+    reaches the clipboard (issue #392).
+
+    Skipping the bar tokens restores the symmetry. It is safe in the direction
+    that matters: ``_row_word`` can never RETURN a bar (they are all in
+    ``_MARKER_TOKEN_RE``), so an anchor of ``▌`` could only ever have matched
+    nothing. The original chain is kept as the fallback so a line that is
+    NOTHING but bars still has something to anchor on rather than an empty word,
+    which matches no row and would silently lose the line.
+    """
+    body = _strip_markup(line)
+    tokens = body.split()
+    while tokens and _BAR_TOKEN_RE.fullmatch(tokens[0]):
+        tokens.pop(0)
+    return _first_word(" ".join(tokens)) or _first_word(body) or _first_word(line)
+
+
 def _row_word(rendered_row: str) -> str:
     """A rendered row's first content word, structure markers stripped.
 
@@ -263,7 +298,7 @@ def align(source: str, rendered_rows: list[str]) -> list[int | None]:
                     # the ``•`` (design round 2, D2-4).
                     if _QUOTE_RE.match(line) and not _strip_markup(line):
                         continue
-                    anchor = _first_word(_strip_markup(line)) or _first_word(line)
+                    anchor = _source_anchor(line)
                     if word and anchor and word == anchor:
                         starts_structural = True
                     break
@@ -319,7 +354,7 @@ def align(source: str, rendered_rows: list[str]) -> list[int | None]:
                     continue
                 if not line.strip():
                     continue  # content is further on; blanks pair with blank rows
-                anchor = _first_word(_strip_markup(line)) or _first_word(line)
+                anchor = _source_anchor(line)
                 if word and anchor and word == anchor:
                     placed = look
                     break
@@ -558,10 +593,48 @@ def _number_opens_row(rendered_row: str, first_cell: str, table_column: int | No
     return head == number
 
 
-#: The quote bar as Rich paints it, repeated once per nesting level. A quote's
-#: CONTINUATION rows carry it too, which is what makes it furniture on every row
-#: of the construct rather than a marker that identifies the first one.
-_RENDERED_QUOTE_PREFIX_RE = re.compile(r"^(?:▌ ?)+")
+#: One level of source quote marker, so the levels on a line can be COUNTED.
+#: ``_QUOTE_RE`` matches the whole run at once and cannot report its depth.
+_QUOTE_LEVEL_RE = re.compile(r">\s?")
+
+
+def _quote_depth(source_line: str) -> int:
+    """How many quote levels ``source_line`` opens with.
+
+    Rich paints exactly one ``▌`` per level, so this is the number of bars on
+    the row that are FURNITURE. Every bar after them is the model's own text.
+    """
+    match = _QUOTE_RE.match(source_line)
+    if match is None:
+        return 0
+    return len(_QUOTE_LEVEL_RE.findall(match.group(0)))
+
+
+def _painted_quote_width(row: str, depth: int) -> int:
+    """Leading cells of ``row`` that are the quote bars RICH painted.
+
+    Counted by DEPTH rather than matched by glyph, which is the distinction
+    issue #392 is about. ``_RENDERED_QUOTE_PREFIX_RE`` is greedy and the glyph
+    carries no evidence of who wrote it, so on ``> ▌ literal bar`` -- painted
+    ``▌ ▌ literal bar`` -- it consumed BOTH bars and the copy lost the one the
+    model typed. The source line says how many levels Rich opened, and that is
+    the only thing that can tell a painted bar from a literal one.
+
+    Stops early if the row runs out of bars, so a row whose furniture Rich
+    painted differently than the depth suggests strips what is actually there
+    rather than slicing into content.
+    """
+    width = 0
+    for _ in range(depth):
+        if not row.startswith("▌", width):
+            break
+        width += 1
+        # The single space Rich puts after each bar. Guarded rather than assumed:
+        # the last bar of a row whose content is empty carries no trailing space.
+        if row.startswith(" ", width):
+            width += 1
+    return width
+
 
 #: A rendered list marker and the space after it, with its leading indent. Only
 #: the row that OPENS the item carries this; a continuation is indented to the
@@ -645,9 +718,10 @@ def furniture_width(row: str, source_line: str | None, *, opens_line: bool, fenc
     width = 0
     remainder = source_line
     if _QUOTE_RE.match(remainder):
-        match = _RENDERED_QUOTE_PREFIX_RE.match(row)
-        if match:
-            width = match.end()
+        # By the source line's quote DEPTH, not by a greedy glyph match: the two
+        # differ exactly when the model's own quoted text opens with ``▌``, and
+        # the greedy match then strips a bar the reader typed (issue #392).
+        width = _painted_quote_width(row, _quote_depth(remainder))
         # Peel the quote marker so the line can be re-tested for what it CONTAINS
         # — the same source line is both a quote line and a list item.
         remainder = _QUOTE_RE.sub("", remainder, count=1)
@@ -988,17 +1062,45 @@ def slice_markdown(source: str, mapping: list[int | None], first_row: int, last_
     if last_row >= n_rows - 1:
         picked.update(range(hi, len(lines)))
 
-    # Rich renders a quote's consecutive ``>`` lines as ONE wrapped block, so a
-    # selection that reaches into a quote has highlighted the WHOLE merged block
-    # even though only the first source line anchored. Extend the slice to the
-    # end of the quote run — stopping at the first line that is not itself a
-    # quote (a blank ends the run, so a following paragraph or heading is never
-    # absorbed). The run-stop is what the F1 finding's blanket fill lacked.
+    # Rich REFLOWS a quote's consecutive ``>`` lines into one paragraph, so a
+    # rendered row can carry text from two source lines and a selection that
+    # lights one row has highlighted both. Extend the slice over the lines that
+    # were merged into the picked one so the copy states what the reader lit.
+    #
+    # Bounded to lines the mapping placed NOWHERE, which is what makes the
+    # extension answer the merge instead of the whole construct. A merged line
+    # has no rendered row of its own -- its text was folded into a sibling's
+    # rows -- so ``align`` never places it, and that absence is the evidence
+    # this needs. A line that DID get its own row is a separate item the reader
+    # did not light, and absorbing it is issue #416: every item of a quoted list
+    # renders on its own row and every one was placed, so a one-row take on the
+    # first of three copied all three. Measured across widths 30-72: the merged
+    # paragraph leaves its second line unplaced at every width, while the quoted
+    # list places all three items at every width -- so the narrower rule is
+    # exactly as strong on the merge and silent on the list.
+    #
+    # ``placed_lines`` is read from the WHOLE mapping rather than from the
+    # selected rows: a line placed on a row outside this selection is still a
+    # line with its own row, and judging only the selection would call it
+    # unplaced and re-absorb it.
+    #
+    # A quote line with no text of its own (a bare ``>`` separating two quoted
+    # paragraphs) is excluded for the same reason, one step further: it paints
+    # nothing, so it was never reflowed into anybody's row and is unplaced for
+    # a different reason than a merged line is. Absorbing it appended a stray
+    # ``>`` to the copy. This is the predicate ``align`` already applies to a
+    # bare ``>`` in its structural scan.
     n = len(lines)
+    placed_lines = {source for source in mapping if source is not None}
     last = max(picked)
     if _QUOTE_RE.match(lines[last]):
         j = last + 1
-        while j < n and _QUOTE_RE.match(lines[j]):
+        while (
+            j < n
+            and _QUOTE_RE.match(lines[j])
+            and j not in placed_lines
+            and _strip_markup(lines[j])
+        ):
             picked.add(j)
             j += 1
 

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -3980,6 +3980,324 @@ async def test_a_mis_mapped_quoted_continuation_still_measures_its_furniture() -
                 ), f"width {width} row {index}: format flips with start cell: {answers}"
 
 
+#: A quote whose own text OPENS with the glyph Rich paints for the quote bar.
+#: Rich paints ``▌ ▌ literal bar ...`` -- the first bar is furniture, the second
+#: is the model's text -- and nothing about the glyph says which is which.
+LITERAL_BAR_QUOTE = "> ▌ literal bar in the quote text here"
+
+#: The same shape one nesting level deeper, so the depth count is exercised
+#: rather than a hard-coded "strip one bar".
+LITERAL_BAR_NESTED_QUOTE = "> > ▌ literal bar inside a nested quote here"
+
+#: Three quoted list items, the fixture issue #416 was measured on. Each item
+#: renders on its OWN row, which is what distinguishes it from a quoted
+#: PARAGRAPH whose consecutive lines Rich reflows into one.
+QUOTED_LIST_THREE_ITEMS = "> - first quoted item\n> - second quoted item\n> - third quoted item"
+
+#: The unquoted twin of the above. It already returned one line per row on
+#: base, which is what made #416 specific to the quoted form -- so it is the
+#: control that says the fix moved the quoted case ONTO the correct behaviour
+#: rather than inventing a new one.
+UNQUOTED_LIST_THREE_ITEMS = "- first quoted item\n- second quoted item\n- third quoted item"
+
+#: A quoted PARAGRAPH written as two source lines. Rich REFLOWS these into one
+#: paragraph, so a rendered row can carry text from both and the second line
+#: gets no row of its own. This is the construct ``slice_markdown``'s quote-run
+#: extension exists for, and the case that must NOT regress when #416 narrows
+#: that extension.
+MERGED_QUOTE_PARAGRAPH = (
+    "> a quoted paragraph that is long enough to wrap across several rows\n"
+    "> and continues here with more text inside of it to force a fold"
+)
+
+
+@pytest.mark.asyncio
+async def test_a_quote_opening_with_a_bar_keeps_the_bar_it_wrote() -> None:
+    """Issue #392: a literal ``▌`` survives, and the painted one does not.
+
+    ``align`` could not place this row at all: ``_row_word`` skips every leading
+    marker glyph to find the row's content word, while the SOURCE side anchored
+    on the bar the model typed, so the two could never agree. With no placement
+    ``furniture_width`` took its ``source_line is None`` branch, stripped
+    nothing, and the whole painted row -- both bars -- reached the clipboard.
+
+    The assertion is EQUALITY against the source line, not a bar count: the
+    payload is that the copy is the markdown the model wrote, and a count would
+    pass on a copy that stripped the right number of bars off the wrong text.
+    """
+    for width in (44, 60, 80):
+        app = StyledTranscriptApp()
+        async with app.run_test(size=(width, 40)) as pilot:
+            block = AssistantBlock()
+            await _mounted(app, block)
+            block.update_text(LITERAL_BAR_QUOTE)
+            block.finalize_text()
+            await pilot.pause()
+
+            rows = _rendered_rows(block)
+            index, _, _ = _find(rows, "literal bar")
+            # The frame really does paint two bars, or this proves nothing.
+            assert rows[index].count("▌") == 2, f"width {width}: {rows[index]!r}"
+
+            selection = Selection.from_offsets(
+                Offset(x=0, y=index), Offset(x=len(rows[index].rstrip()), y=index)
+            )
+            copied = block.get_selection(selection)
+            assert copied is not None
+            assert (
+                copied[0] == LITERAL_BAR_QUOTE
+            ), f"width {width}: a quote opening with a bar did not round-trip: {copied[0]!r}"
+
+
+@pytest.mark.asyncio
+async def test_a_nested_quote_opening_with_a_bar_strips_only_painted_bars() -> None:
+    """#392 at depth two: the strip is COUNTED, not matched.
+
+    Rich paints one ``▌`` per quote level, so this row opens with three bars of
+    which two are furniture. A glyph match is greedy and cannot stop at the
+    right one; the source line's quote DEPTH is the only thing that can say how
+    many Rich painted, which is why ``_painted_quote_width`` counts levels
+    instead of matching ``_RENDERED_QUOTE_PREFIX_RE``.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(60, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(LITERAL_BAR_NESTED_QUOTE)
+        block.finalize_text()
+        await pilot.pause()
+
+        rows = _rendered_rows(block)
+        index, _, _ = _find(rows, "literal bar")
+        assert rows[index].count("▌") == 3, f"the fixture must paint three bars: {rows[index]!r}"
+
+        selection = Selection.from_offsets(
+            Offset(x=0, y=index), Offset(x=len(rows[index].rstrip()), y=index)
+        )
+        copied = block.get_selection(selection)
+        assert copied is not None
+        assert copied[0] == LITERAL_BAR_NESTED_QUOTE, f"{copied[0]!r}"
+
+
+@pytest.mark.asyncio
+async def test_a_sub_line_take_on_a_bar_led_quote_keeps_the_literal_bar() -> None:
+    """The depth count, asserted on the GLYPH path where it is the only answer.
+
+    A whole-row take copies the SOURCE line, so it cannot tell a greedy glyph
+    strip from a counted one: both round-trip to the same markdown. A sub-line
+    take copies the painted cells past the furniture, so the furniture WIDTH
+    is the payload: greedy ``_RENDERED_QUOTE_PREFIX_RE`` eats the model's bar
+    along with Rich's and the copy loses it; counting by the source line's
+    quote depth keeps it.
+
+    The drag is from column 0 to a column SHORT of the row's last glyph, which
+    is what sends it down the glyph path. The word ``literal`` is located on
+    the frame rather than hard-coded as a column, so a change in how Rich
+    paints the bar cannot silently shift the assertion onto the wrong cells.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(60, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(LITERAL_BAR_QUOTE)
+        block.finalize_text()
+        await pilot.pause()
+
+        rows = _rendered_rows(block)
+        index, start, end = _find(rows, "literal")
+        # Stop short of the row's last glyph so this is a sub-line take, not a
+        # whole-row one that would go down the markdown path and hide the
+        # furniture-width difference this exists to pin.
+        selection = Selection.from_offsets(Offset(x=0, y=index), Offset(x=end, y=index))
+        copied = block.get_selection(selection)
+        assert copied is not None
+        assert (
+            copied[0] == "▌ literal"
+        ), f"the model's bar was eaten with the furniture: {copied[0]!r}"
+
+
+@pytest.mark.asyncio
+async def test_one_row_of_a_quoted_list_copies_only_that_item() -> None:
+    """Issue #416: a one-row gesture takes ONE item, not the rest of the list.
+
+    ``slice_markdown`` extended every quoted slice to the end of the quote run,
+    which is right for a quoted PARAGRAPH (Rich reflows its lines, so one row
+    carries two) and wrong for a quoted LIST (every item gets its own row). A
+    whole-row take on item 1 of three therefore copied all three.
+
+    Asserted as an exact source-line match per row rather than a line COUNT: a
+    count passes on a copy that returns one line of the wrong item, which is the
+    substitution this path's earlier rounds were repeatedly bitten by.
+    """
+    items = QUOTED_LIST_THREE_ITEMS.split("\n")
+    for width in (44, 60, 80):
+        app = StyledTranscriptApp()
+        async with app.run_test(size=(width, 40)) as pilot:
+            block = AssistantBlock()
+            await _mounted(app, block)
+            block.update_text(QUOTED_LIST_THREE_ITEMS)
+            block.finalize_text()
+            await pilot.pause()
+
+            rows = _rendered_rows(block)
+            for item in items:
+                text = item.removeprefix("> - ")
+                index, _, _ = _find(rows, text)
+                selection = Selection.from_offsets(
+                    Offset(x=0, y=index), Offset(x=len(rows[index].rstrip()), y=index)
+                )
+                copied = block.get_selection(selection)
+                assert copied is not None
+                assert copied[0] == item, (
+                    f"width {width}: a one-row take on {text!r} copied "
+                    f"{len(copied[0].split(chr(10)))} line(s): {copied[0]!r}"
+                )
+
+
+@pytest.mark.asyncio
+async def test_the_quoted_list_matches_its_unquoted_twin() -> None:
+    """#416's differential: quoting a list must not change how much a row takes.
+
+    The unquoted list already returned exactly one line per row, and that
+    asymmetry is what identified the defect as specific to the quoted form.
+    Asserting the two forms agree row-for-row pins the fix to that reading, so a
+    future change that re-widens the quoted branch fails here even if the
+    absolute assertions above were somehow satisfied.
+    """
+    for width in (44, 60):
+        app = StyledTranscriptApp()
+        async with app.run_test(size=(width, 40)) as pilot:
+            quoted, plain = AssistantBlock(), AssistantBlock()
+            await _mounted(app, quoted, plain)
+            quoted.update_text(QUOTED_LIST_THREE_ITEMS)
+            quoted.finalize_text()
+            plain.update_text(UNQUOTED_LIST_THREE_ITEMS)
+            plain.finalize_text()
+            await pilot.pause()
+
+            for block, prefix in ((quoted, "> - "), (plain, "- ")):
+                rows = _rendered_rows(block)
+                for item in (
+                    QUOTED_LIST_THREE_ITEMS if prefix.startswith(">") else UNQUOTED_LIST_THREE_ITEMS
+                ).split("\n"):
+                    text = item.removeprefix(prefix)
+                    index, _, _ = _find(rows, text)
+                    selection = Selection.from_offsets(
+                        Offset(x=0, y=index), Offset(x=len(rows[index].rstrip()), y=index)
+                    )
+                    copied = block.get_selection(selection)
+                    assert copied is not None
+                    assert len(copied[0].split("\n")) == 1, (
+                        f"width {width}: {prefix!r} form took "
+                        f"{len(copied[0].split(chr(10)))} lines for one row: {copied[0]!r}"
+                    )
+
+
+@pytest.mark.asyncio
+async def test_a_reflowed_quote_paragraph_still_copies_both_its_lines() -> None:
+    """The case #416's narrowing must NOT break, asserted where it is reachable.
+
+    Rich reflows a blockquote's consecutive ``>`` lines into one paragraph, so
+    at the right widths the second source line gets no rendered row of its own
+    and a reader lighting any row has highlighted both lines. That is why the
+    quote-run extension exists, and narrowing it to lines the mapping placed
+    NOWHERE has to leave this intact.
+
+    The widths are chosen by MEASUREMENT, not by taste: the reflow only hides a
+    line at widths where it happens, so the test asserts the precondition (the
+    second line is genuinely unplaced) before asserting the payload. Without
+    that guard this would pass vacuously at any width where both lines render
+    separately -- exactly the shape of a guard that cannot fail at its boundary.
+    """
+    for width in (48, 56, 64, 72):
+        app = StyledTranscriptApp()
+        async with app.run_test(size=(width, 40)) as pilot:
+            block = AssistantBlock()
+            await _mounted(app, block)
+            block.update_text(MERGED_QUOTE_PARAGRAPH)
+            block.finalize_text()
+            await pilot.pause()
+
+            rows = _rendered_rows(block)
+            mapping = _copy_markdown.align(block._full_text, rows)
+            placed = {source for source in mapping if source is not None}
+            assert 1 not in placed, (
+                f"width {width}: the second quote line got its own row, so this "
+                f"width does not exercise the reflow: {mapping}"
+            )
+
+            index, _, _ = _find(rows, "a quoted paragraph")
+            selection = Selection.from_offsets(
+                Offset(x=0, y=index), Offset(x=len(rows[index].rstrip()), y=index)
+            )
+            copied = block.get_selection(selection)
+            assert copied is not None
+            assert (
+                copied[0] == MERGED_QUOTE_PARAGRAPH
+            ), f"width {width}: the reflowed line was dropped from the copy: {copied[0]!r}"
+
+
+@pytest.mark.asyncio
+async def test_a_bare_quote_separator_is_not_appended_to_the_copy() -> None:
+    """A bare ``>`` between quoted paragraphs paints nothing and copies nothing.
+
+    It is unplaced like a reflowed line, but for a different reason -- it has no
+    text to reflow -- so the run extension has to exclude it by the same
+    predicate ``align`` already uses for a bare ``>``. Absorbing it appended a
+    stray ``>`` to the clipboard.
+    """
+    source = "> first quoted paragraph here\n>\n> second quoted paragraph here"
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(60, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(source)
+        block.finalize_text()
+        await pilot.pause()
+
+        rows = _rendered_rows(block)
+        index, _, _ = _find(rows, "first quoted paragraph")
+        selection = Selection.from_offsets(
+            Offset(x=0, y=index), Offset(x=len(rows[index].rstrip()), y=index)
+        )
+        copied = block.get_selection(selection)
+        assert copied is not None
+        assert copied[0] == "> first quoted paragraph here", f"{copied[0]!r}"
+
+
+@pytest.mark.asyncio
+async def test_a_multi_row_quoted_list_drag_still_takes_every_lit_item() -> None:
+    """Narrowing the run extension must not cost a GENUINE multi-row selection.
+
+    #416 is about taking more than was lit; the opposite failure -- a drag over
+    two items copying one -- would be worse, because a silently short paste is
+    not visible to the reader the way an over-copy is. Swept over every start
+    and end pair so an off-by-one at either edge fails here.
+    """
+    items = QUOTED_LIST_THREE_ITEMS.split("\n")
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(44, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(QUOTED_LIST_THREE_ITEMS)
+        block.finalize_text()
+        await pilot.pause()
+
+        rows = _rendered_rows(block)
+        indices = [_find(rows, item.removeprefix("> - "))[0] for item in items]
+        for first in range(len(items)):
+            for last in range(first, len(items)):
+                selection = Selection.from_offsets(
+                    Offset(x=0, y=indices[first]),
+                    Offset(x=len(rows[indices[last]].rstrip()), y=indices[last]),
+                )
+                copied = block.get_selection(selection)
+                assert copied is not None
+                assert copied[0] == "\n".join(
+                    items[first : last + 1]
+                ), f"a drag over items {first}..{last} copied {copied[0]!r}"
+
+
 @pytest.mark.asyncio
 async def test_a_wrapped_items_continuation_row_does_not_flip_format() -> None:
     """Issue #395: the D2-4 property, asserted on a CONTINUATION row.


### PR DESCRIPTION
# PR Description

## Summary of Changes

Two copy defects on quoted content, both pre-existing and deliberately deferred
from PRs #386 and #412. They are **not one bug**, but they share a family: the
copy path treated quoted structure as a run rather than as the rows Rich
actually painted.

### #392 — a quote whose own text opens with `▌` leaks a painted bar

```
source : > ▌ literal bar in the quote text here
frame  : ▌ ▌ literal bar in the quote text here
copied : ▌ ▌ literal bar in the quote text here   <- one bar too many
```

Two independent failures stacked:

1. **`align` could not place the row.** `_row_word` skips every leading marker
   glyph (the quote bar included) to find the row's content word. The SOURCE
   side anchored with `_first_word(_strip_markup(line))`, which for this line
   is the bar the model typed. The two never agreed, so `mapping[i] is None`.
2. **`furniture_width` then stripped nothing.** Its documented `source_line is
   None` branch returns 0 — with no alignment there is no evidence about what a
   leading glyph means, and returning the row verbatim is the conservative
   direction. That branch is behaving as intended; the row just never reached
   it with a source line.

The first is restored by `_source_anchor`, which skips bar tokens on the source
side the same way `_row_word` skips them on the rendered side, so the two agree
on `literal`. The second then needs a **counted** strip rather than a greedy
glyph match: `_RENDERED_QUOTE_PREFIX_RE` cannot tell a painted bar from a
literal one, so on `▌ ▌ text` it ate both. `_painted_quote_width` counts the
source line's quote DEPTH (Rich paints one `▌` per `>`) and stops there, so the
model's bar survives.

A whole-row take now copies `> ▌ literal bar in the quote text here`. A
sub-line take from column 0 copies `▌ literal` — the model's bar, not Rich's.

### #416 — a one-row gesture on a quoted list copies every following item

Measured at width 44 on a three-item quoted list:

| gesture | copied (base) | copied (head) |
| --- | --- | --- |
| whole-row take on item 1 | 3 lines | 1 line |
| whole-row take on item 2 | 2 lines | 1 line |
| whole-row take on item 3 | 1 line | 1 line |

The unquoted twin already returned 1 line for every row. The cause is
`slice_markdown`'s quote-run extension, which existed because Rich REFLOWS a
blockquote's consecutive `>` lines into one paragraph, so a rendered row can
carry text from two source lines. That is true of a quoted **paragraph** and
false of a quoted **list** — every item of a list gets its own row.

The extension now only absorbs quote lines the mapping placed **nowhere**. A
merged paragraph line has no row of its own, so `align` never places it, and
that absence is the evidence the extension needs. A line that DID get its own
row is a separate item the reader did not light. Measured across widths 30–72:
the merged paragraph leaves its second line unplaced at every width, while the
quoted list places all three items at every width — so the narrower rule is
exactly as strong on the merge and silent on the list.

A genuine multi-row drag still takes every lit item (items 1–2 copy two lines;
items 1–3 copy three). A bare `>` separating two quoted paragraphs is excluded
by the same predicate `align` already uses for it — it paints nothing, so it
was never reflowed into anybody's row.

### They are not one bug

#392 is an **anchor / furniture-width** failure on a single unplaceable row.
#416 is a **slice-widening** failure on rows that WERE placed. The quote bar
does not shift the column mapping on a quoted list — furniture is 5 on every
item both before and after. A single correct fix for both would have been
preferable; what the investigation found is two independent defects in the
quoted copy path, both of which this PR closes.

## Testing evidence

### Reproduction on base (`168efe48`)

```
=== #392 literal-bar quote  (width 60) ===
   row[1] map= None furn=0 '▌ ▌ literal bar in the quote text here'
   row[1] -> 1 line(s): '▌ ▌ literal bar in the quote text here'

=== #416 three-item QUOTED list  (width 44) ===
   row[1] map=    0 furn=5 '▌  • first quoted item'
   row[2] map=    1 furn=5 '▌  • second quoted item'
   row[3] map=    2 furn=5 '▌  • third quoted item'
   row[1] -> 3 line(s): '> - first quoted item\n> - second quoted item\n> - third quoted item'
   row[2] -> 2 line(s): '> - second quoted item\n> - third quoted item'
   row[3] -> 1 line(s): '> - third quoted item'

=== #416 unquoted twin  (width 44) ===
   row[1] -> 1 line(s): '- first quoted item'
   row[2] -> 1 line(s): '- second quoted item'
   row[3] -> 1 line(s): '- third quoted item'
```

### After the fix (this branch)

```
=== #392 literal-bar quote  (width 60) ===
   row[1] map=    0 furn=2 '▌ ▌ literal bar in the quote text here'
   row[1] -> 1 line(s): '> ▌ literal bar in the quote text here'

=== #416 three-item QUOTED list  (width 44) ===
   row[1] -> 1 line(s): '> - first quoted item'
   row[2] -> 1 line(s): '> - second quoted item'
   row[3] -> 1 line(s): '> - third quoted item'
```

The painted FRAME is byte-identical before and after (the two quote rows sit at
the same y-positions with the same glyphs). This is a clipboard fix, not a
paint fix.

### Must-not-regress

- Ordinary quote with no literal bar: still copies `> an ordinary quote ...`.
- Nested quote: a one-row take on the outer copies only the outer; on the inner
  copies only the inner. (Base absorbed the inner into the outer — the same
  #416 over-widen, now gone.)
- Merged quote paragraph (the construct the run-extension exists for): at
  widths 48/56/64/72 the second source line is genuinely unplaced, and every
  whole-row take still copies BOTH source lines.
- Genuine multi-row drag on the quoted list: items 1–2 copy two lines; 1–3 copy
  three.
- Unquoted twin: unchanged, still 1 line per row.

### Differential sweep

247 case/width combinations (19 constructs × widths 32–80 step 4). Frame
changed **nowhere**. Behaviour changed only on the quoted shapes this PR
targets (`literal_bar_*`, `quoted_list_3`, `list_in_quote`, `nested_quote`,
`quote`, `quote_blank_quote`) plus one related correction: a **bar-led
paragraph** (`▌ a paragraph that itself opens with a bar glyph here`) now
places the way every other wrapped paragraph already did. Format-flip
invariant (whole-row take identical wherever inside the painted furniture the
drag began): 0 flips at head, 0 at base. No copy went empty.

### Mutation tests (each new test dies when its own guard is broken)

| mutation | result |
| --- | --- |
| `_source_anchor` no longer skips bar tokens | `test_a_quote_opening_with_a_bar_keeps_the_bar_it_wrote` and the nested twin FAIL (copy is `▌ ▌ literal bar ...`) |
| greedy `_RENDERED_QUOTE_PREFIX_RE` restored in `furniture_width` | `test_a_sub_line_take_on_a_bar_led_quote_keeps_the_literal_bar` FAILS (`'literal'` instead of `'▌ literal'`) — this is the only path that can tell a counted strip from a greedy one; a whole-row take copies the source line either way |
| blanket quote-run extension restored | `test_one_row_of_a_quoted_list_copies_only_that_item` and the twin/multi-row tests FAIL (item 1 copies 3 lines) |
| `_strip_markup` guard dropped from the run-extension | `test_a_bare_quote_separator_is_not_appended_to_the_copy` FAILS (copy is `> first ...\n>`) |

### Gates (whole tree, repo config, no narrowing)

```
flake8 rc=0
black rc=0
isort rc=0
pyright rc=0
```

71 copy/quote/list tests in `test_transcript_selection.py` passed, including
the 8 new ones.

## Out of scope (pre-existing, byte-identical on base and head)

A **quoted ordered list** (`> 1. first quoted step` …) is never placed at any
width 32–80. `_row_word` reads the leading `1` as content because the row is
not space-indented (`▌  1 first ...` starts with `▌`, so the indented-marker
gate is False), while `_source_anchor` reads `first`. The two never agree, so
`furniture_width` returns 0 and a whole-row take copies the painted glyphs
(`▌  1 first quoted step`) rather than the markdown. The unquoted twin places
correctly. Distinct from both #392 (the bar is skipped on both sides there)
and #416 (those rows WERE placed). Not touched.

Closes #392
Closes #416
