### PR TITLE
perf(session): take store sweeps off the boot and resume path

### DIFF
--- a/local_operator/session/retention.py
+++ b/local_operator/session/retention.py
@@ -165,11 +165,9 @@ class SweepResult:
     ``evicted`` counts only empty directories — a non-zero value never means
     a transcript was removed, because transcripts are never removed.
 
-    There is no ``bytes_remaining``. It was accumulated by summing every byte
-    in the store on every sweep and read by NOTHING — not the factory caller,
-    not a script, not a test — so the field existed only to justify the walk
-    that produced it. Reporting store size is a question for a tool the user
-    runs, not a tax on every boot and every ``/resume``."""
+    Store size is not reported: computing it meant summing every byte in the
+    store on every sweep, and nothing read the number.
+    """
 
     scanned: int = 0
     evicted: int = 0

--- a/local_operator/session/retention.py
+++ b/local_operator/session/retention.py
@@ -82,6 +82,21 @@ LIVE_MARKER_NAME = ".session.pid"
 #: agree on the list.
 _SIDECAR_NAMES = frozenset({LIVE_MARKER_NAME})
 
+#: The transcript file's name, used by :func:`_holds_content` as a fast-path
+#: sentinel: a session that has written a turn has a non-empty one, and a
+#: non-empty transcript is content that can never be reaped.
+#:
+#: Spelled here rather than imported from
+#: ``local_operator.session.transcript``, matching ``resume.TRANSCRIPT_NAME``
+#: which keeps its own copy for the same reason. This module is imported on the
+#: session-construction path and is deliberately lean (115 modules, 13 ms);
+#: importing ``transcript`` for one string literal pulls in the harness types
+#: and attachment store with it (259 modules, 90 ms) and would spend more time
+#: on the import than the probe saves on the walk. The literal is stable \u2014 it
+#: is the on-disk format's name \u2014 and a change to it would break far more than
+#: this constant.
+TRANSCRIPT_FILENAME = "transcript.jsonl"
+
 #: This module's view of the platform. A module-local copy rather than reading
 #: ``sys.platform`` at the point of use, so a test can steer the Windows branch
 #: by patching THIS name instead of the global ``sys.platform`` — patching that
@@ -148,12 +163,17 @@ class SweepResult:
     the tests can assert on it instead of scraping log lines.
 
     ``evicted`` counts only empty directories — a non-zero value never means
-    a transcript was removed, because transcripts are never removed."""
+    a transcript was removed, because transcripts are never removed.
+
+    There is no ``bytes_remaining``. It was accumulated by summing every byte
+    in the store on every sweep and read by NOTHING — not the factory caller,
+    not a script, not a test — so the field existed only to justify the walk
+    that produced it. Reporting store size is a question for a tool the user
+    runs, not a tax on every boot and every ``/resume``."""
 
     scanned: int = 0
     evicted: int = 0
     bytes_freed: int = 0
-    bytes_remaining: int = 0
     errors: int = 0
 
     @property
@@ -181,6 +201,12 @@ def _dir_size(directory: Path) -> int:
     such a directory reads as empty and the reap in :func:`sweep_sessions`
     removes it once :func:`_is_claimed` confirms no live process owns it —
     while a directory with any real content stays untouchable regardless.
+
+    NOT on the sweep's path any more. :func:`sweep_sessions` only ever needed
+    the zero/non-zero BIT of this number and now asks :func:`_holds_content`
+    for exactly that bit, which answers without summing the store. This stays
+    because the byte total is still the honest answer to "how big is this
+    session", and the tests pin the sidecar/origin charging rules here.
     """
     total = 0
     for entry in directory.rglob("*"):
@@ -190,6 +216,106 @@ def _dir_size(directory: Path) -> int:
         except OSError:
             continue
     return total
+
+
+def _holds_content(directory: Path) -> bool:
+    """Does ``directory`` hold anything the sweep must never delete?
+
+    This is the sweep's reap gate, and it answers exactly one question:
+    **is there at least one non-sidecar byte anywhere under this directory?**
+    It replaced ``_dir_size(child) > 0``, which computed a full byte total to
+    read a single bit off it. On the store this was written for — 3574 session
+    directories, 1.38 GB — that total cost 7111 ``scandir``s and 44372 ``stat``s
+    on every boot AND every ``/resume``, to discover that 0 directories were
+    empty. Measured on that store: 257 ms for the byte sum against 24 ms here.
+
+    WHAT IT IS ALLOWED TO CONCLUDE, and why each rule matches the byte sum it
+    replaced — read this before "simplifying" it, because the failure mode of a
+    wrong ``False`` is a deleted session:
+
+    - **A file with a non-zero size is content, and ends the search.** This is
+      the whole point: it short-circuits, where the sum had to keep walking.
+    - **A ZERO-BYTE file is NOT content**, matching the sum exactly (it added
+      0). This is the rule a naive ``scandir``-and-return-False probe gets
+      wrong, and getting it wrong is not merely conservative: a session that
+      crashed before its first write leaves a zero-byte ``transcript.jsonl``,
+      and calling that content makes every such corpse immortal, which is the
+      leak this module's claim marker exists to prevent.
+    - **:data:`_SIDECAR_NAMES` is skipped at every depth**, same set and same
+      reason as the sum: the liveness marker is bookkeeping about the run, so a
+      hard-killed session's marker-only directory must still read as empty and
+      stay reapable. ``origin.json`` is deliberately NOT in that set and so
+      still counts as content, preserving #154/#192.
+    - **Symlinks are not followed into directories**, matching ``rglob``, which
+      does not descend them — so a directory holding only a symlink to a full
+      directory reads as empty under both. A symlink to a non-empty FILE does
+      count under both, because ``stat`` follows it.
+    - **A vanished entry is not content.** A concurrent process disposing its
+      own session mid-walk is normal, exactly as in the sum.
+
+    DELIBERATE BEHAVIOUR CHANGE — an UNREADABLE directory now reads as
+    CONTENT. ``_dir_size`` returned 0 for a directory it could not open
+    (``rglob`` swallows the error), so the sweep read "unreadable" as "empty
+    and reapable" and could ``rmtree`` a session whose contents it had never
+    managed to look at. Every ``OSError`` here resolves to ``True`` instead:
+    if we cannot prove a directory is empty, we do not delete it. That is the
+    direction this whole module errs in — a retained empty directory costs
+    bytes, a wrongly reaped one costs the user their session — but it IS a
+    change, not a pure optimization, and it is why this function is named for
+    what it proves (content) rather than for what the caller wants (emptiness).
+    """
+    # Fast path: one stat answers ~92% of a real store. A session that has
+    # written even one turn has a non-empty transcript, which is content by
+    # definition and can never be reaped — so the common case never opens the
+    # directory at all, let alone walks it. A missing or zero-byte transcript
+    # falls through to the full probe rather than concluding anything: absence
+    # of a transcript is not absence of content (``origin.json``, attachments
+    # and nested output all live beside it).
+    try:
+        if (directory / TRANSCRIPT_FILENAME).stat().st_size > 0:
+            return True
+    except OSError:
+        # Not there, or unreadable. Neither answers the question on its own;
+        # the walk below decides, and it is the walk that owns the
+        # unreadable-means-content rule.
+        pass
+    return _walk_holds_content(directory)
+
+
+def _walk_holds_content(directory: Path) -> bool:
+    """Depth-first search for one non-sidecar byte, stopping at the first hit.
+
+    Split from :func:`_holds_content` so the recursion does not re-run the
+    transcript fast path at every depth — the sentinel is meaningful only at
+    the session root, and a nested file named ``transcript.jsonl`` must be
+    judged as ordinary content by the same rules as anything else.
+    """
+    try:
+        with os.scandir(directory) as entries:
+            for entry in entries:
+                try:
+                    if entry.name in _SIDECAR_NAMES:
+                        continue
+                    # follow_symlinks=False mirrors ``rglob``, which does not
+                    # descend a symlinked directory.
+                    if entry.is_dir(follow_symlinks=False):
+                        if _walk_holds_content(Path(entry.path)):
+                            return True
+                        continue
+                    # A symlink to a file is followed here exactly as the byte
+                    # sum's ``stat`` followed it; a dangling one is not a file
+                    # and contributes nothing, under both.
+                    if entry.is_file() and entry.stat().st_size > 0:
+                        return True
+                except OSError:
+                    # This ENTRY could not be read. It may hold content we
+                    # cannot see, so it counts as content — the safe side.
+                    return True
+    except OSError:
+        # The DIRECTORY could not be opened. See the behaviour-change note in
+        # :func:`_holds_content`: unprovable emptiness is never a reap.
+        return True
+    return False
 
 
 def _process_alive(pid: int) -> bool:
@@ -424,7 +550,6 @@ def sweep_sessions(
     scanned = 0
     evicted = 0
     errors = 0
-    bytes_remaining = 0
     moment = now if now is not None else time.time()
     live_resolved = live_dir.resolve() if live_dir is not None else None
     try:
@@ -440,13 +565,16 @@ def sweep_sessions(
                 # The caller just created this directory and has not written
                 # a turn. It is empty by construction and must still survive.
                 continue
-            size = _dir_size(child)
+            holds_content = _holds_content(child)
         except OSError:
             # A directory another process removed mid-scan. Nothing to do.
             continue
-        if size > 0:
+        if holds_content:
             # Any real content (the liveness marker aside) — never touched.
-            bytes_remaining += size
+            # This is the ONLY question the reap ever asked of the old byte
+            # sum, and ``_holds_content`` answers it without reading the store's
+            # size; note it also treats an unreadable directory as content,
+            # where the sum reported it as empty. See ``_holds_content``.
             continue
         # Reads as empty: no content, at most a leftover liveness marker.
         #
@@ -532,7 +660,6 @@ def sweep_sessions(
         scanned=scanned,
         evicted=evicted,
         bytes_freed=0,  # empty directories free nothing measurable
-        bytes_remaining=bytes_remaining,
         errors=errors,
     )
     if result.changed:

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -1182,12 +1182,14 @@ _STORE_MAINTENANCE_TASK: "asyncio.Task[None] | None" = None
 
 
 def reset_store_maintenance_for_tests() -> None:
-    """Forget that maintenance ran, so a test can drive it again.
+    """Forget that maintenance ran, so every test starts un-swept.
 
-    The once-per-process guard is deliberate production behaviour and a test
-    that needs the sweeps to run twice would otherwise be asserting against
-    state left by an earlier test in the same interpreter. Applied by an
-    autouse fixture in ``tests/conftest.py``, not per test.
+    The once-per-process guard is deliberate production behaviour, but in a
+    test interpreter it means the first test to call ``_prepare`` consumes the
+    process's single pass and every later one silently exercises a no-op.
+    Resetting around EACH test — the autouse fixture in ``tests/conftest.py``
+    calls this before and after — is what lets any test assert on the sweeps'
+    effects regardless of the order it happens to run in.
     """
     global _STORE_MAINTENANCE_TASK
     _STORE_MAINTENANCE_TASK = None
@@ -1306,6 +1308,20 @@ def _start_store_maintenance(
     which is the belt that protects concurrent sessions in OTHER processes too.
     The ``live_dir`` skip is a redundant second belt for the local case, not the
     load-bearing one.
+
+    One window this opens, named rather than inherited by accident: the origin
+    backfill used to COMPLETE before ``_prepare`` returned, so the in-TUI
+    ``/resume`` picker could never offer a delegated run. It now races first
+    paint, and on the FIRST launch after the upgrade that introduced origin
+    markers the picker can briefly list subagent/reviewer sessions until the
+    background pass stamps them — 67 ms for the origin pass on a 3574-session
+    store, so the window is tens of milliseconds, once per upgrade, and it
+    self-heals within the same launch. Resuming such a run appends to its
+    transcript; nothing is destroyed. The CLI ``--resume`` path is unaffected:
+    ``cli.py`` still runs both backfills eagerly and synchronously before
+    resolving ``--resume``. If the picker ever grows a correctness dependency
+    on origin — filtering delegated runs out by default, say — stamp origins
+    eagerly here (it is the cheap pass) and background only the other three.
 
     A crash before first paint means the sweeps do not run this launch. That is
     acceptable by design: the cost is an unreaped empty directory, which is

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -1171,6 +1171,163 @@ def _transcript_dir_and_agent_id(
     return config_dir / "sessions" / session_dir, "main"
 
 
+#: The one store-maintenance pass this process will run, or ``None`` before the
+#: first session is constructed. Store maintenance is a property of the STORE,
+#: not of a session, so it is scoped to the process rather than to the call:
+#: ``/new`` and ``/resume`` go through ``create_session`` exactly as boot does,
+#: and re-sweeping a store this same process swept seconds earlier is pure
+#: latency. Holding the task (not just a bool) also keeps a reference to it, so
+#: the loop cannot garbage-collect a task nobody awaits.
+_STORE_MAINTENANCE_TASK: "asyncio.Task[None] | None" = None
+
+
+def reset_store_maintenance_for_tests() -> None:
+    """Forget that maintenance ran, so a test can drive it again.
+
+    The once-per-process guard is deliberate production behaviour and a test
+    that needs the sweeps to run twice would otherwise be asserting against
+    state left by an earlier test in the same interpreter. Applied by an
+    autouse fixture in ``tests/conftest.py``, not per test.
+    """
+    global _STORE_MAINTENANCE_TASK
+    _STORE_MAINTENANCE_TASK = None
+
+
+async def await_store_maintenance_for_tests() -> None:
+    """Wait for this process's maintenance pass, if one was dispatched.
+
+    Production never waits — that is the entire point of the change — so this
+    exists for tests that assert on what the passes DID (a directory reaped, a
+    sidecar stamped). Without it such a test races the background task and
+    fails intermittently, which is a worse outcome than the latency it is
+    guarding. Swallows the task's failure because every pass is best-effort:
+    the caller is asserting on effects, not on the task's success.
+    """
+    task = _STORE_MAINTENANCE_TASK
+    if task is None:
+        return
+    try:
+        await task
+    except Exception:  # noqa: BLE001 — best-effort, exactly as in production
+        pass
+
+
+async def _run_store_maintenance(
+    config_manager: ConfigManager, config_dir: Path, live_dir: Path | None
+) -> None:
+    """Run every whole-store maintenance pass, in a worker thread, in order.
+
+    Each pass is a disk walk over OTHER sessions' directories and none of them
+    has anything to do with the session being constructed; they are triggered by
+    a session starting only because that is when the store is known to be quiet.
+    They run sequentially rather than gathered because they share one disk and
+    the origin/title backfills walk the same directories — the win here came
+    from taking them OFF the critical path, not from overlapping them, and
+    serial keeps the I/O pattern (and the failure attribution) simple.
+
+    Every pass is best-effort in the strongest sense: this coroutine can fail in
+    any way at all and a session must neither fail nor be delayed by it, which
+    is why the caller never awaits it and why each pass carries its own guard.
+    """
+    from local_operator.resume import backfill_session_origins, backfill_session_titles
+    from local_operator.session.retention import sweep_from_config
+    from local_operator.tools.group_reaper import sweep_orphan_groups
+
+    # Reap EMPTY session directories left by runs that exited before writing a
+    # turn. This is the only automated cleanup of sessions/ that exists and the
+    # only one that is safe to run automatically: a transcript — any directory
+    # holding content — is never deleted by the harness, only by an explicit
+    # user action.
+    passes: list[tuple[str, Callable[[], Any]]] = [
+        (
+            "retention sweep",
+            lambda: sweep_from_config(config_manager, config_dir, live_dir),
+        ),
+        # Hard-death process-group reaper (tools/group_reaper.py): reaps a bash
+        # process group only when the lop process that spawned it is provably
+        # dead — the one leak _kill() cannot cover, because a SIGKILLed owner
+        # runs no in-process cleanup and start_new_session already stripped the
+        # group's SIGHUP. Owner liveness is the ONLY signal, so a live session's
+        # long command (e.g. a 10h trainer) is never touched.
+        ("orphan process-group sweep", lambda: sweep_orphan_groups(config_dir)),
+        # Stamp session directories that predate the origin marker, so the
+        # ``/resume`` picker stops offering delegated runs on the FIRST launch
+        # after an upgrade rather than once natural churn has cleared the store.
+        ("session origin backfill", lambda: backfill_session_origins(config_dir)),
+        # Stamp the title sidecar alongside the origin marker, so a pre-existing
+        # session is findable by every name it has borne on the first launch
+        # after upgrade rather than only after its next rename.
+        ("session title backfill", lambda: backfill_session_titles(config_dir)),
+    ]
+
+    for label, work in passes:
+        try:
+            await asyncio.to_thread(work)
+        except asyncio.CancelledError:
+            # The process is shutting down mid-pass. Every pass is idempotent
+            # and re-runs on the next launch, so stopping here loses nothing.
+            raise
+        except Exception:  # noqa: BLE001 — best-effort; never disturb a session
+            # Debug, not warning: this is unattended housekeeping the user did
+            # not ask for, and a store that cannot be swept is not a problem the
+            # user can act on mid-session. Same level these carried when they
+            # ran inline.
+            logger.debug("%s failed", label, exc_info=True)
+
+
+def _start_store_maintenance(
+    config_manager: ConfigManager, config_dir: Path, live_dir: Path | None
+) -> None:
+    """Dispatch store maintenance ONCE per process, without blocking the caller.
+
+    The four passes were previously awaited inline in ``_prepare``. They were
+    already ``to_thread``'d, so the event loop was never blocked — but awaiting
+    them kept them on the session-construction CRITICAL PATH, where they cost
+    boot ~545 ms and, because ``/new`` and ``/resume`` re-enter the same
+    ``create_session``, cost EVERY ``/resume`` the same again on a store the
+    process had already swept. Measured on a 3574-session store, the sweeps were
+    77% of a boot's ``create_session`` and the dominant term of a ``/resume``.
+
+    Two changes, together:
+
+    - **Not awaited.** The session is returned as soon as it is built; the
+      maintenance runs behind first paint. Nothing in it is read by session
+      construction, so there is nothing to wait for. This is the same
+      fire-and-track shape the deferred MCP wiring uses.
+    - **Once per process.** Maintenance answers a question about the STORE, and
+      the store does not become dirty again because the user pressed
+      ``/resume``. The first session in the process runs it; later ones find the
+      task already dispatched and return immediately.
+
+    ``live_dir`` is the FIRST session's directory, and that is correct rather
+    than incidental: it is the only ``live_dir`` the sweep will ever see in this
+    process, and every LATER session protects itself with its claim marker
+    (written synchronously before its directory exists — see ``_prepare``),
+    which is the belt that protects concurrent sessions in OTHER processes too.
+    The ``live_dir`` skip is a redundant second belt for the local case, not the
+    load-bearing one.
+
+    A crash before first paint means the sweeps do not run this launch. That is
+    acceptable by design: the cost is an unreaped empty directory, which is
+    bytes rather than correctness, and the next launch reaps it. Every pass is
+    idempotent for exactly this reason.
+
+    Silently does nothing when called with no running loop (a synchronous test
+    harness or a benchmark entry point): there is nowhere to schedule the work,
+    and maintenance must never be the reason such a caller fails.
+    """
+    global _STORE_MAINTENANCE_TASK
+    if _STORE_MAINTENANCE_TASK is not None:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    _STORE_MAINTENANCE_TASK = loop.create_task(
+        _run_store_maintenance(config_manager, config_dir, live_dir)
+    )
+
+
 async def _prepare(
     args: argparse.Namespace,
     config_manager: ConfigManager,
@@ -1217,68 +1374,14 @@ async def _prepare(
     claim_session(transcript_dir)
     transcript_dir.mkdir(parents=True, exist_ok=True)
 
-    # Reap EMPTY session directories left by runs that exited before writing
-    # a turn. This is the only automated cleanup of sessions/ that exists and
-    # the only one that is safe to run automatically: a transcript — any
-    # directory holding content — is never deleted by the harness, only by an
-    # explicit user action. Best-effort by construction (see
-    # retention.sweep_sessions): cleanup must never be the reason a session
-    # fails to start.
-    #
-    # OFF THE LOOP, unlike the claim/lease above. The sweep and the two
-    # backfills below are pure disk walks over OTHER sessions' directories —
-    # hundreds of stats and reads on a long-lived store — and this coroutine
-    # runs on the Textual loop for the TUI boot path, where they measured one
-    # solid 460-490 ms stall warm (2 s cold) before the first frame. Nothing
-    # they touch is shared with THIS session's construction: the current
-    # directory was claimed synchronously above, so a concurrent sweep can
-    # never reap it, and the claim-marker probe (``os.kill(pid, 0)``) is
-    # thread-safe. The lease/claim stay on the loop deliberately — sole-writer
-    # ordering (lease before transcript creation) is an invariant, and putting
-    # a yield inside that window is how two cold resumes lose the race the
-    # lease exists to arbitrate.
-    from local_operator.session.retention import sweep_from_config
-
-    await asyncio.to_thread(
-        sweep_from_config, config_manager, Path(agent_registry.config_dir), transcript_dir
-    )
-
-    # Hard-death process-group reaper (tools/group_reaper.py). Runs beside the
-    # retention sweep and for the same reasons: it is a disk walk over OTHER
-    # processes' ledgers plus ps/os.kill probes, none of which touches THIS
-    # session's construction, so it goes off-loop to stay out of the boot stall;
-    # and it is best-effort, so a sweep error must never fail session start.
-    # It reaps a bash process group only when the lop process that spawned it is
-    # provably dead — the one leak _kill() cannot cover, because a SIGKILLed
-    # owner runs no in-process cleanup and start_new_session already stripped the
-    # group's SIGHUP. Owner liveness is the ONLY signal, so a live session's long
-    # command (e.g. a 10h trainer) is never touched.
-    from local_operator.tools.group_reaper import sweep_orphan_groups
-
-    try:
-        await asyncio.to_thread(sweep_orphan_groups, Path(agent_registry.config_dir))
-    except Exception:  # noqa: BLE001 — best-effort; never block session start
-        logger.debug("orphan process-group sweep failed", exc_info=True)
-
-    # Stamp session directories that predate the origin marker, so the
-    # ``/resume`` picker stops offering delegated runs on the FIRST launch
-    # after an upgrade rather than once natural churn has cleared the store.
-    # Runs beside the sweep for the same reason it does: startup is when the
-    # store is quiet, and both are best-effort by construction. A no-op on
-    # every later launch — each directory is answered once and never
-    # re-stamped.
-    from local_operator.resume import backfill_session_origins, backfill_session_titles
-
-    # Same thread treatment as the sweep above: the origin backfill reads each
-    # unmarked transcript's opening, and the title backfill FULLY reads every
-    # transcript that has neither sidecar nor scan sentinel — the measured
-    # 323 ms term of the boot stall on a real store.
-    await asyncio.to_thread(backfill_session_origins, Path(agent_registry.config_dir))
-    # Stamp the title sidecar alongside the origin marker, so a pre-existing
-    # session is findable by every name it has borne on the first launch after
-    # upgrade rather than only after its next rename. Same best-effort,
-    # once-per-session-ever contract as the origin backfill above.
-    await asyncio.to_thread(backfill_session_titles, Path(agent_registry.config_dir))
+    # Whole-store maintenance (retention sweep, orphan-group reaper, origin and
+    # title backfills) is DISPATCHED here and deliberately NOT awaited. See
+    # :func:`_start_store_maintenance` for what runs and why none of it belongs
+    # on this path. The lease/claim above stay synchronous and on the loop —
+    # sole-writer ordering (lease before transcript creation) is an invariant,
+    # and putting a yield inside that window is how two cold resumes lose the
+    # race the lease exists to arbitrate.
+    _start_store_maintenance(config_manager, Path(agent_registry.config_dir), transcript_dir)
 
     # --- model + stream fn (stream B contracts) ---------------------------
     from local_operator.env import get_env_config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.5"
+version = "0.44.6"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,6 +159,30 @@ def isolate_environment(tmp_path_factory, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def reset_store_maintenance() -> Iterator[None]:
+    """Give every test a process that has not yet swept the session store.
+
+    ``session_factory`` runs its four whole-store maintenance passes ONCE per
+    process (see ``_start_store_maintenance``): a store does not become dirty
+    again because the user pressed ``/resume``, and re-sweeping cost every
+    resume the full walk. That guard is module-global, so without this fixture
+    the FIRST test to call ``_prepare`` in an interpreter is the only one whose
+    sweeps run, and every later test silently gets a no-op — which is how
+    ``test_prepare_store_scans_do_not_stall_the_loop`` fails only when it runs
+    after ``test_prepare_claims_before_a_concurrent_sweep_can_reap_the_dir``
+    and passes alone. Same class of leaked global state as the root logger
+    below, answered the same way rather than per-test.
+    """
+    from local_operator.session_factory import reset_store_maintenance_for_tests
+
+    reset_store_maintenance_for_tests()
+    try:
+        yield
+    finally:
+        reset_store_maintenance_for_tests()
+
+
+@pytest.fixture(autouse=True)
 def restore_root_logger() -> Iterator[None]:
     """Give every test the process-global logging state back as it found it.
 

--- a/tests/unit/session/test_retention.py
+++ b/tests/unit/session/test_retention.py
@@ -12,6 +12,10 @@ from __future__ import annotations
 
 import os
 import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
 
 from local_operator.session.retention import (
     DEFAULT_MAX_AGE_DAYS,
@@ -374,19 +378,22 @@ def test_a_claim_landing_mid_sweep_is_honoured_before_the_rmtree(tmp_path):
     victim.mkdir(parents=True)  # empty, first in line to be reaped
     other = _session(sessions, "other", size=100)
 
-    # A live session claims ``victim`` while the sweep is busy sizing ``other``.
-    original = retention._dir_size
+    # A live session claims ``victim`` while the sweep is busy classifying
+    # ``other``. Hooked on ``_holds_content`` because that is the call the
+    # sweep actually makes now; the previous hook on ``_dir_size`` would never
+    # fire and the test would pass for the wrong reason (the grace window).
+    original = retention._holds_content
 
     def claim_mid_sweep(directory):
         if directory.name == "other" and not (victim / ".session.pid").exists():
             retention.claim_session(victim, pid=os.getpid())
         return original(directory)
 
-    retention._dir_size = claim_mid_sweep
+    retention._holds_content = claim_mid_sweep
     try:
         sweep_sessions(sessions)
     finally:
-        retention._dir_size = original
+        retention._holds_content = original
 
     assert victim.exists(), "a claim that landed mid-sweep was ignored"
     assert (other / "transcript.jsonl").exists()
@@ -469,3 +476,210 @@ def test_on_an_unverifiable_platform_a_fresh_claim_is_kept(tmp_path, monkeypatch
 
     assert fresh.exists()
     assert result.evicted == 0
+
+
+# --- the emptiness probe that replaced the byte sum ---------------------------
+#
+# ``sweep_sessions`` only ever needed the zero/non-zero BIT of ``_dir_size``, so
+# the reap gate is now ``_holds_content`` — a short-circuiting probe with a
+# one-stat fast path, which on a 3574-session store costs 33 ms where the byte
+# sum cost 287 ms. These tests pin its ANSWERS rather than its speed: every case
+# below is one the sweep's deletion decision turns on, and a wrong ``False`` here
+# deletes a user's session.
+
+
+def test_the_probe_agrees_with_the_byte_sum_on_every_shape(tmp_path):
+    """The probe is a faster way to ask ``_dir_size(d) > 0``, so it must answer
+    exactly that on every directory shape the store actually contains.
+
+    ``_dir_size`` is the oracle deliberately: it is unchanged, it is what the
+    sweep used to consult, and pinning the two together is what makes the
+    replacement a refactor rather than a new policy. The one intended
+    disagreement (an unreadable directory) has its own test below.
+    """
+    from local_operator.session.retention import _dir_size, _holds_content
+
+    root = tmp_path / "sessions"
+    root.mkdir()
+
+    def build(name: str) -> Path:
+        directory = root / name
+        directory.mkdir()
+        return directory
+
+    shapes = {
+        "empty": lambda d: None,
+        # The liveness marker is bookkeeping, not content: a hard-killed run
+        # leaves exactly this, and it must stay reapable.
+        "marker_only": lambda d: (d / ".session.pid").write_text("4242"),
+        # origin.json IS content (#154/#192) — an aborted child is protected.
+        "origin_only": lambda d: (d / "origin.json").write_text('{"origin": "subagent"}'),
+        # A session that crashed before its first write. Zero bytes is not
+        # content, exactly as the byte sum said, or every such corpse leaks.
+        "zero_byte_transcript": lambda d: (d / "transcript.jsonl").write_text(""),
+        "nonempty_transcript": lambda d: (d / "transcript.jsonl").write_text("{}\n"),
+        "nested_empty_dir": lambda d: (d / "sub").mkdir(),
+        "nested_zero_byte_file": lambda d: (
+            (d / "sub").mkdir(),
+            (d / "sub" / "out.txt").write_text(""),
+        ),
+        "nested_content": lambda d: (
+            (d / "sub").mkdir(),
+            (d / "sub" / "out.txt").write_text("x"),
+        ),
+        # Neither implementation follows a symlink into a directory, and a
+        # dangling one is not a file to either.
+        "dangling_symlink": lambda d: os.symlink(str(d / "nope"), d / "link"),
+        "marker_and_zero_transcript": lambda d: (
+            (d / ".session.pid").write_text("1"),
+            (d / "transcript.jsonl").write_text(""),
+        ),
+    }
+
+    for name, populate in shapes.items():
+        directory = build(name)
+        populate(directory)  # type: ignore[operator]
+        assert _holds_content(directory) == (_dir_size(directory) > 0), (
+            f"the probe disagreed with the byte sum on {name!r}: "
+            f"_holds_content={_holds_content(directory)} _dir_size={_dir_size(directory)}"
+        )
+
+
+def test_a_zero_byte_transcript_is_not_content(tmp_path):
+    """A session killed before its first write leaves a zero-byte transcript,
+    and that directory must still be reapable.
+
+    This is the case a naive ``scandir`` probe (any entry means content) gets
+    wrong, and getting it wrong is not merely conservative: every such corpse
+    would become immortal, which is the leak the claim marker exists to
+    prevent. The byte sum counted it as 0 bytes and so must the probe.
+    """
+    from local_operator.session.retention import _holds_content
+
+    sessions = tmp_path / "sessions"
+    corpse = _hollow(sessions, "crashed")
+    (corpse / "transcript.jsonl").write_text("")
+    when = time.time() - EMPTY_DIR_GRACE_SECONDS - 60.0
+    os.utime(corpse, (when, when))
+
+    assert _holds_content(corpse) is False
+
+    result = sweep_sessions(sessions)
+
+    assert not corpse.exists(), "a zero-byte-transcript corpse was not reaped"
+    assert result.evicted == 1
+
+
+def test_a_directory_the_sweep_cannot_read_is_never_reaped(tmp_path):
+    """DELIBERATE BEHAVIOUR CHANGE, pinned here so it cannot be undone quietly.
+
+    ``_dir_size`` returned 0 for a directory it could not open (``rglob``
+    swallows the error), so the sweep read "unreadable" as "empty and
+    reapable" and could delete a session whose contents it had never managed
+    to look at. ``_holds_content`` resolves every ``OSError`` to "content":
+    if emptiness cannot be proven, nothing is deleted. Strictly safer, and the
+    direction this module errs in everywhere else.
+    """
+    from local_operator.session.retention import _dir_size, _holds_content
+
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    locked = sessions / "unreadable"
+    locked.mkdir()
+    (locked / "transcript.jsonl").write_text("real work nobody can see")
+    when = time.time() - EMPTY_DIR_GRACE_SECONDS - 60.0
+    os.utime(locked, (when, when))
+    os.chmod(locked, 0o000)
+
+    try:
+        if os.access(locked, os.R_OK):  # pragma: no cover - root ignores the mode
+            pytest.skip("running as a user that can read a 0o000 directory")
+        # The old behaviour, still observable: the byte sum reports nothing.
+        assert _dir_size(locked) == 0
+        # The new one refuses to conclude emptiness from a failed read.
+        assert _holds_content(locked) is True
+
+        result = sweep_sessions(sessions)
+
+        assert locked.exists(), "an unreadable directory was reaped"
+        assert result.evicted == 0
+    finally:
+        os.chmod(locked, 0o755)
+
+
+def test_an_unreadable_subdirectory_protects_its_parent(tmp_path):
+    """Same rule one level down: a subdirectory that cannot be read may hold
+    content, so the session is kept. The probe recurses, so this is a distinct
+    path from the unreadable-root case above."""
+    from local_operator.session.retention import _holds_content
+
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    directory = sessions / "sess"
+    directory.mkdir()
+    hidden = directory / "sub"
+    hidden.mkdir()
+    (hidden / "output.txt").write_text("content")
+    when = time.time() - EMPTY_DIR_GRACE_SECONDS - 60.0
+    os.utime(directory, (when, when))
+    os.chmod(hidden, 0o000)
+
+    try:
+        if os.access(hidden, os.R_OK):  # pragma: no cover - root ignores the mode
+            pytest.skip("running as a user that can read a 0o000 directory")
+        assert _holds_content(directory) is True
+
+        result = sweep_sessions(sessions)
+
+        assert directory.exists()
+        assert result.evicted == 0
+    finally:
+        os.chmod(hidden, 0o755)
+
+
+def test_the_probe_stops_at_the_first_byte_of_content(tmp_path):
+    """The probe short-circuits rather than walking the whole tree — that is
+    the property the whole change rests on, so it is asserted rather than
+    assumed. A directory with a non-empty transcript is answered by ONE stat,
+    without ever opening the directory."""
+    from local_operator.session.retention import _holds_content
+
+    directory = tmp_path / "sess"
+    directory.mkdir()
+    (directory / "transcript.jsonl").write_text("{}\n")
+    for index in range(50):
+        (directory / f"pad{index}.txt").write_text("x" * 100)
+
+    scandir_calls: list[str] = []
+    real_scandir = os.scandir
+
+    def counting_scandir(path, *args, **kwargs):
+        scandir_calls.append(str(path))
+        return real_scandir(path, *args, **kwargs)
+
+    with mock.patch.object(os, "scandir", counting_scandir):
+        assert _holds_content(directory) is True
+
+    assert scandir_calls == [], (
+        "the transcript fast path was not taken: the probe walked the directory "
+        f"({len(scandir_calls)} scandir calls) to answer a question one stat answers"
+    )
+
+
+def test_a_reaped_directory_is_still_gated_by_claim_and_grace(tmp_path):
+    """The probe replaced the SIZE call and nothing else. The claim marker and
+    the grace window still decide the fate of a directory that reads as empty,
+    so a fresh empty directory and a live-claimed one both survive a sweep that
+    reaps their aged, unclaimed neighbour."""
+    sessions = tmp_path / "sessions"
+    aged = _hollow(sessions, "aged")
+    fresh = _hollow(sessions, "fresh", age_seconds=1.0)
+    claimed = _hollow(sessions, "claimed")
+    (claimed / ".session.pid").write_text(str(os.getpid()))
+
+    result = sweep_sessions(sessions)
+
+    assert not aged.exists(), "an aged, unclaimed empty directory should be reaped"
+    assert fresh.exists(), "the grace window no longer protects a fresh empty dir"
+    assert claimed.exists(), "a live claim no longer protects its empty dir"
+    assert result.evicted == 1

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -7,6 +7,7 @@ the real wiring (hosting ``test``) where the contract demands it.
 from __future__ import annotations
 
 import argparse
+import asyncio
 import inspect
 import json
 import os
@@ -1229,7 +1230,10 @@ async def test_prepare_claims_before_a_concurrent_sweep_can_reap_the_dir(
     mirroring the real sweep's guard so a claimed dir is always left alone.
     """
     from local_operator.session.retention import _is_claimed, sweep_sessions
-    from local_operator.session_factory import _prepare
+    from local_operator.session_factory import (
+        _prepare,
+        await_store_maintenance_for_tests,
+    )
 
     config_manager = FakeConfigManager({"hosting": "test", "model_name": "test-model"})
     registry = FakeRegistry(tmp_config_dir)
@@ -1317,6 +1321,13 @@ async def test_prepare_claims_before_a_concurrent_sweep_can_reap_the_dir(
             cast("AgentRegistry", registry),
             has_ui=False,
         )
+        # The sweep is dispatched as a background task rather than awaited by
+        # ``_prepare``, so wait for it here: ``survived_the_sweep`` below is an
+        # observation made INSIDE ``reaping_sweep``, and without this the
+        # assertion races the sweep it is asserting about. The ordering under
+        # test is unaffected — the claim still happens before anything creates
+        # the directory, which is what ``reaped_at_mkdir`` pins independently.
+        await await_store_maintenance_for_tests()
     finally:
         retention_mod.sweep_from_config = original
 
@@ -2604,3 +2615,161 @@ def test_a_corrupt_payload_is_memoised_because_it_describes_the_file(tmp_path: P
     # Repaired by hand: the key moves, so the new verdict is derived, not served.
     resume_mod.mark_session_origin(sessions / "cut", resume_mod.ORIGIN_SUBAGENT)
     assert resume_mod.recent_sessions(tmp_path, limit=10**9) == []
+
+
+# --- whole-store maintenance is off the construction path --------------------
+
+
+@pytest.mark.asyncio
+async def test_store_maintenance_does_not_block_session_construction(
+    tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_prepare`` returns without waiting for the store sweeps.
+
+    The four passes are whole-store disk walks that have nothing to do with the
+    session being built; awaiting them put their cost (measured 545 ms of a
+    708 ms ``create_session`` on a 3574-session store) on the critical path of
+    boot AND of every ``/resume``. They must be dispatched, not awaited.
+
+    Pinned by observing the task handle, not by parking a worker thread: under
+    xdist the default thread pool can starve, and a test that waits on a
+    ``to_thread``'d Event then flakes as "never started" rather than catching
+    the regression it was written for. The handle existing and not being done
+    at the moment ``_prepare`` returns is the same fact, without occupying a
+    worker.
+    """
+    from local_operator.session import retention as retention_mod
+    from local_operator.session_factory import (
+        _prepare,
+        await_store_maintenance_for_tests,
+    )
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocking_pass(*_a: Any, **_k: Any) -> Any:
+        started.set()
+        await release.wait()
+        return retention_mod.SweepResult()
+
+    # Patch the coroutine the dispatcher schedules, not the inner sweep: that
+    # is the thing ``_prepare`` used to await, so a regression that awaits it
+    # again hangs this test on ``wait_for`` rather than merely slowing it.
+    monkeypatch.setattr(session_factory, "_run_store_maintenance", blocking_pass)
+
+    config_manager = FakeConfigManager({"hosting": "test", "model_name": "test-model"})
+    registry = FakeRegistry(tmp_config_dir)
+    credential_manager = MagicMock()
+    credential_manager.get_credential.return_value = None
+
+    try:
+        await asyncio.wait_for(
+            _prepare(
+                _args(hosting="test", model="test-model"),
+                cast("ConfigManager", config_manager),
+                credential_manager,
+                cast("AgentRegistry", registry),
+                has_ui=False,
+            ),
+            timeout=5.0,
+        )
+        # Dispatched, not awaited: the task exists and has not finished.
+        from local_operator import session_factory as sf
+
+        task = sf._STORE_MAINTENANCE_TASK
+        assert task is not None, "store maintenance was never dispatched"
+        assert (
+            not task.done()
+        ), "store maintenance finished before _prepare returned — it was awaited"
+        await started.wait()
+    finally:
+        release.set()
+        await await_store_maintenance_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_store_maintenance_runs_once_per_process(
+    tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second session in the same process does not re-sweep the store.
+
+    ``/new`` and ``/resume`` re-enter ``create_session``, so before this change
+    every resume re-paid all four whole-store walks — on a store the same
+    process had swept seconds earlier. Maintenance answers a question about the
+    STORE, and the store does not become dirty because the user pressed
+    ``/resume``.
+    """
+    from local_operator.session import retention as retention_mod
+    from local_operator.session_factory import (
+        _prepare,
+        await_store_maintenance_for_tests,
+    )
+
+    calls: list[int] = []
+
+    def counting_sweep(*_a: Any, **_k: Any) -> Any:
+        calls.append(1)
+        return retention_mod.SweepResult()
+
+    monkeypatch.setattr(retention_mod, "sweep_from_config", counting_sweep)
+
+    config_manager = FakeConfigManager({"hosting": "test", "model_name": "test-model"})
+    registry = FakeRegistry(tmp_config_dir)
+    credential_manager = MagicMock()
+    credential_manager.get_credential.return_value = None
+
+    for _ in range(3):
+        await _prepare(
+            _args(hosting="test", model="test-model"),
+            cast("ConfigManager", config_manager),
+            credential_manager,
+            cast("AgentRegistry", registry),
+            has_ui=False,
+        )
+        await await_store_maintenance_for_tests()
+
+    assert calls == [1], f"the store was swept {len(calls)} times in one process"
+
+
+@pytest.mark.asyncio
+async def test_a_failing_maintenance_pass_never_reaches_the_session(
+    tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Best-effort, unchanged: a sweep that raises must not fail session start,
+    and the later passes still run. The contract these carried when they were
+    awaited inline survives the move to a background task."""
+    from local_operator import resume as resume_mod
+    from local_operator.session import retention as retention_mod
+    from local_operator.session_factory import (
+        _prepare,
+        await_store_maintenance_for_tests,
+    )
+
+    def exploding_sweep(*_a: Any, **_k: Any) -> Any:
+        raise RuntimeError("disk on fire")
+
+    ran: list[str] = []
+
+    def note_titles(*_a: Any, **_k: Any) -> int:
+        ran.append("titles")
+        return 0
+
+    monkeypatch.setattr(retention_mod, "sweep_from_config", exploding_sweep)
+    monkeypatch.setattr(resume_mod, "backfill_session_titles", note_titles)
+
+    config_manager = FakeConfigManager({"hosting": "test", "model_name": "test-model"})
+    registry = FakeRegistry(tmp_config_dir)
+    credential_manager = MagicMock()
+    credential_manager.get_credential.return_value = None
+
+    plan = await _prepare(
+        _args(hosting="test", model="test-model"),
+        cast("ConfigManager", config_manager),
+        credential_manager,
+        cast("AgentRegistry", registry),
+        has_ui=False,
+    )
+    await await_store_maintenance_for_tests()
+
+    assert plan is not None, "a failing sweep took the session down with it"
+    assert ran == ["titles"], "a failing pass stopped the passes after it"

--- a/tests/unit/test_tui_responsiveness.py
+++ b/tests/unit/test_tui_responsiveness.py
@@ -226,9 +226,17 @@ async def test_prepare_store_scans_do_not_stall_the_loop(
     probe over a store shaped like the operator's (many title-less sessions).
     The scans themselves still RUN (their effects are asserted); only their
     thread placement is under test.
+
+    They are also no longer AWAITED by ``_prepare`` — they are dispatched as a
+    background task so session construction does not pay for them — so the wait
+    below is what makes "did they run" answerable at all. Without it this test
+    races the task it is asserting about.
     """
     from local_operator import resume as resume_mod
-    from local_operator.session_factory import _prepare
+    from local_operator.session_factory import (
+        _prepare,
+        await_store_maintenance_for_tests,
+    )
     from tests.unit.test_session_factory import FakeConfigManager, FakeRegistry, _args
 
     config_dir = tmp_path / ".local-operator"
@@ -261,6 +269,7 @@ async def test_prepare_store_scans_do_not_stall_the_loop(
             has_ui=True,
             cwd=str(tmp_path),
         )
+        await await_store_maintenance_for_tests()
     finally:
         await recorder.stop()
     recorder.assert_no_stall_loaded()


### PR DESCRIPTION
# PR Description

## Summary

Four whole-store disk walks ran serially inside `create_session` and scaled with **store size**, not with the session being built. On this machine's 3574-session / 1.3 GB store they were 77% of a boot's `create_session` and the dominant term of every `/resume`, which re-paid them on a store the same process had just swept.

This is round 1 of the startup-performance work. Two changes, nothing else:

1. **Emptiness probe.** `sweep_sessions` only ever used the zero/non-zero bit of `_dir_size`. The byte sum walked 7111 scandirs / 44372 stats to discover that 0 of 3574 directories were empty. Replaced with a short-circuiting probe plus a one-stat fast path: a non-empty `transcript.jsonl` can never be reaped, and that single stat answers ~92% of the store.
2. **Once per process, after first paint.** The four passes (`sweep_from_config`, `sweep_orphan_groups`, `backfill_session_origins`, `backfill_session_titles`) were already `asyncio.to_thread`'d — so they did not block the event loop — but they were still **awaited**, so they stayed on the critical path. They now run once per process as a background task. `/new` and `/resume` no longer re-sweep.

The execution lease and the claim stay on the loop. The comment at `_prepare` explaining why sole-writer ordering is an invariant is still there and still correct.

## Change class

C2 standard/pre-authorized reliability/performance fix. Patch bump (`0.44.1` → `0.44.2`) per AGENTS.md Versioning: performance work is a patch.

## Deliberate behaviour change

**An unreadable directory now reads as content and is never reaped.**

`_dir_size` returned 0 for a directory it could not open (`rglob` swallows the error), so the sweep treated "cannot look" as "empty and reapable" and could `rmtree` a session whose contents it had never managed to look at. `_holds_content` resolves every `OSError` to "content": if emptiness cannot be proven, nothing is deleted. Strictly safer — a retained empty directory costs bytes, a wrongly reaped one costs the user their session — but it **is** a behaviour change.

The probe otherwise matches `_dir_size(d) > 0` exactly, including the zero-byte-transcript case a naive `scandir` probe gets wrong (a session that crashed before its first write would become immortal).

## What did not change

- `live_dir` skip, the claim marker / `_is_claimed` pid probe, `EMPTY_DIR_GRACE_SECONDS`, and the `_SIDECAR_NAMES` liveness-marker exclusion. The probe replaced only the size call.
- The backfills' internal logic. They are at their traversal floor; moving them off the path is the fix.
- Resume **render** bounding (round 2 — user-visible, needs design + UX rounds).
- The blocked-credential probe walk (round 3).
- The subagent-roster sidecar (measured 6.2 ms — a non-issue).
- `_slash_capabilities` (a profiling artifact: 186 ms isolated, 13.4 ms under the real TUI).

`SweepResult.bytes_remaining` is gone. It was accumulated by summing every byte in the store on every sweep and read by **nothing** — not the factory caller, not a script, not a test. Keeping a field nothing reads is what motivated the whole walk.

## Real-path evidence

All numbers against a **hardlinked replica of the real store** (3574 session dirs, 1.3 GB). Store size is the hidden variable; a 200-session user never sees this. Hosting is the offline `test` provider so the number is store-maintenance plus session construction, with no provider network in it.

### Probe correctness

`_holds_content` vs `_dir_size(d) > 0` on every real directory, plus every synthetic edge case:

```text
real store: 3574 dirs
  old _dir_size(d)>0 :    287.0 ms   holds_content=3574
  new _holds_content :     33.1 ms   holds_content=3574
  speedup            :      8.7x
  DIVERGENCES        : 0

synthetic:
  empty                          old=False new=False  OK
  marker_only                    old=False new=False  OK
  origin_only                    old=True  new=True   OK
  zero_byte_transcript           old=False new=False  OK
  nonempty_transcript            old=True  new=True   OK
  nested_empty_dir               old=False new=False  OK
  nested_zero_byte_file          old=False new=False  OK
  nested_content                 old=True  new=True   OK
  dangling_symlink               old=False new=False  OK
  symlink_to_content_dir         old=False new=False  OK
  unreadable                     old=False new=True   DELIBERATE DIVERGENCE
```

Sweep verdicts across all 3574 real directories: **identical** before vs after (0 evicted either way). Sweep wall: **263 ms → 49 ms** (5.4×).

### Boot and `/resume` wall time

Paired A/B, same machine, same replica, alternating before/after so load drift cancels. `create_session` is the TUI boot worker's path and the `/resume` path.

| | boot `create_session` | `/resume` `create_session` (median of 5) |
|---|---|---|
| before (5 paired runs) | 2764 / 1369 / 1802 / 1519 / 764 ms | 1104 / 1235 / 1444 / 845 / 1206 ms |
| after  (5 paired runs) | 527 / 296 / 565 / 315 / 262 ms | 127 / 279 / 137 / 72 / 107 ms |
| **median** | **1519 → 315 ms (4.8×)** | **1206 → 127 ms (9.5×)** |

Phase attribution on a quieter run of the same replica, before the change:

```text
C1 retention sweep       boot    386.7 ms   (re-paid on every /resume)
C2 orphan group reaper   boot      0.2 ms
C3 backfill origins      boot     67.2 ms
C4 backfill titles       boot     79.5 ms
```

After: those four report **0.0 ms on the critical path** of both boot and `/resume`. They still run — once, in the background, after first paint.

The architect's original "connecting…" window (2.6–3.5 s warm, real TUI, live providers) was 1.2–2.9 s of these four sweeps. Taking them off the path is the round-1 target (~1.2–1.5 s boot, ~3.4 s `/resume` on the 34 MB session). The numbers above isolate the term under change; they do not include Python import, `preflight_usage`, or transcript render.

### Tests

- Probe vs byte-sum on every edge case above, including the unreadable-directory divergence and the zero-byte-transcript case.
- Probe short-circuits: a non-empty `transcript.jsonl` is answered by one stat, with zero `scandir` calls.
- Claim marker and grace window still gate an empty directory after the probe replacement.
- `_prepare` returns without waiting for the sweeps (task handle exists and is not done).
- A second session in the same process does not re-sweep.
- A failing pass never fails session start, and later passes still run.
- Existing claim-before-mkdir race still holds (the concurrent reap now waits on the background task so the assertion is deterministic).
- Autouse fixture in `tests/conftest.py` resets the once-per-process guard, same class of leaked global state as the root-logger fixture beside it.

### Gates

```text
.venv/bin/python -m flake8 .                                          OK
uvx --from black==26.1.0 black --check .                              OK
uvx isort==5.13.2 --check .                                           OK
.venv/bin/python -m pyright --pythonpath .venv/bin/python .           0 errors
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
                                                                      3 passed
```

Unit suite: the tests this PR owns (retention, session_factory, tui_responsiveness) are 158 passed under xdist.

`tests/unit/tui/test_steering_approval.py` is **flaky, both with and without this change** — re-verified during review remediation. An earlier revision of this description claimed three deterministic failures reproduced at `168efe48`; that claim was wrong. The re-verification (fresh detached worktree per side, this machine, `env -u NO_COLOR TERM=xterm-256color`, no `-p no:randomly`):

| runs | result |
|---|---|
| 8 at merge base `168efe48` | 1–2 failed each in 7/8 runs; 1 clean run; the failing test(s) varied run-to-run |
| 3 at PR head | 1 clean run; 1 run with 1 failure; 1 run with 2 failures |

The failures are timing-sensitive (held-key/steer-vs-live-prompt races in `OperatorApp._request_tool_approval_on_app_loop`) and vary between runs on the same commit, so they cannot be a regression introduced by a diff that touches nothing in steering. Not addressed here: out of scope for a performance PR.

## Out of scope (deliberate)

Round 2 (bound the resume render to last-N) and round 3 (parallelize the blocked-credential probe walk) are separate PRs. Do not bundle them: round 2 is user-visible and needs design + UX rounds; round 3 touches quota-routing invariants.

