### PR TITLE
fix(analytics,tests): stop losing a process of analytics rows, and wait on conditions not clocks

### DIFF
--- a/local_operator/analytics/store.py
+++ b/local_operator/analytics/store.py
@@ -68,6 +68,28 @@ MONTHLY_ROLLUP_RETENTION_MONTHS = 120
 _WRITE_RETRIES = 4
 _WRITE_RETRY_BACKOFF_S = 0.05
 
+#: Bounded retry for the DELETE->WAL journal-mode transition, which is NOT
+#: covered by ``busy_timeout`` and so needs its own loop (see ``_set_wal``).
+#: Same shape and budget as the write retry above: a few short backoffs on the
+#: background thread, then give up and run in whatever mode the file is in.
+_WAL_RETRIES = 6
+_WAL_RETRY_BACKOFF_S = 0.05
+
+
+def _is_lock_error(exc: BaseException) -> bool:
+    """Whether an OperationalError is contention (retryable) or a real fault.
+
+    SQLite reports both SQLITE_BUSY and SQLITE_LOCKED through
+    ``OperationalError`` with only the message to tell them apart from a
+    genuine fault such as a corrupt file or a read-only directory. That
+    distinction decides whether a failure may be retried or must disable the
+    store, so it lives in ONE predicate used by both the connect path and the
+    write path rather than being sniffed for separately in each.
+    """
+    text = str(exc).lower()
+    return "lock" in text or "busy" in text
+
+
 #: One component column per COMPONENT_KEYS entry, holding the ESTIMATED token
 #: attribution for that call. Storing the apportioned tokens (not just chars)
 #: means the aggregate query is a plain SUM with no per-row arithmetic, and the
@@ -430,6 +452,38 @@ class AnalyticsStore:
         self._insert_sql: str = _INSERT_SQL
 
     # -- connection ----------------------------------------------------------
+    @staticmethod
+    def _set_wal(conn: sqlite3.Connection) -> None:
+        """Switch the journal to WAL, retrying the contended DELETE->WAL step.
+
+        ``busy_timeout`` does NOT cover this statement. Changing the journal
+        mode needs an exclusive lock on the database, and SQLite fails that
+        acquisition with SQLITE_BUSY immediately instead of invoking the busy
+        handler, so the 5s timeout set just above buys nothing here. Measured on
+        a fresh database opened simultaneously by 16 processes: 25/320 opens
+        raised ``database is locked`` at this statement, and setting
+        ``busy_timeout`` first only brought that to 15/320 — reordering alone is
+        not a fix. With this bounded retry the same probe reports 0/320.
+
+        Only the FIRST process to reach a fresh file pays anything: once the
+        file is in WAL the pragma is a no-op that cannot fail (0/320 failures
+        against an already-WAL database), so this loop costs established
+        installations nothing.
+
+        A database that stays un-WAL after every attempt is still usable —
+        rollback-journal mode serialises writers rather than losing them — so
+        this returns quietly rather than raising and disabling the store.
+        """
+        for attempt in range(_WAL_RETRIES):
+            try:
+                conn.execute("PRAGMA journal_mode=WAL")
+                return
+            except sqlite3.OperationalError as exc:
+                if not _is_lock_error(exc) or attempt == _WAL_RETRIES - 1:
+                    logger.debug("analytics: could not enable WAL", exc_info=True)
+                    return
+                time.sleep(_WAL_RETRY_BACKOFF_S * (attempt + 1))
+
     def _connect(self) -> sqlite3.Connection | None:
         conn = getattr(self._local, "conn", None)
         if conn is not None:
@@ -445,9 +499,13 @@ class AnalyticsStore:
                 fd = os.open(self._db_path, os.O_CREAT | os.O_WRONLY, 0o600)
                 os.close(fd)
             conn = sqlite3.connect(str(self._db_path), timeout=5.0)
-            conn.execute("PRAGMA journal_mode=WAL")
-            conn.execute("PRAGMA synchronous=NORMAL")
+            # busy_timeout FIRST: it arms SQLite's busy handler for everything
+            # that follows, including the schema script below. It is set before
+            # the journal-mode switch rather than after it because the switch is
+            # the single most lock-contended statement here (see ``_set_wal``).
             conn.execute("PRAGMA busy_timeout=5000")
+            self._set_wal(conn)
+            conn.execute("PRAGMA synchronous=NORMAL")
             # Schema creation is idempotent (IF NOT EXISTS) but should run once,
             # under a lock, so two threads opening their first connections
             # simultaneously do not both executescript into the same file.
@@ -468,7 +526,23 @@ class AnalyticsStore:
                     self._initialized = True
             self._local.conn = conn
             return conn
+        except sqlite3.OperationalError as exc:
+            # A LOCK failure here is TRANSIENT — another process is opening the
+            # same fresh database this instant — so it must NOT latch _broken.
+            # Latching it silently zeroed a whole process's analytics for its
+            # entire lifetime on a momentary race (#391: one of four parallel
+            # writers contributing exactly zero rows). Leaving _broken clear
+            # means the next write simply opens again and succeeds.
+            if _is_lock_error(exc):
+                logger.debug("analytics: %s busy while opening", self._db_path, exc_info=True)
+                return None
+            logger.debug("analytics: cannot open %s", self._db_path, exc_info=True)
+            self._broken = True
+            return None
         except Exception:  # noqa: BLE001 — store unavailable = analytics off
+            # Anything that is not a lock (a read-only home, a corrupt file, a
+            # bad path) IS permanent, and latching stops one log line per
+            # provider round trip for the life of the process.
             logger.debug("analytics: cannot open %s", self._db_path, exc_info=True)
             self._broken = True
             return None
@@ -582,7 +656,17 @@ class AnalyticsStore:
         """
         if not snapshots:
             return 0
-        conn = self._connect()
+        # Open is retried independently of the insert retry below: a lock on
+        # the DELETE->WAL transition used to return None here (and, before
+        # #391, latch ``_broken``), which dropped the WHOLE batch — one
+        # process contributing zero rows. A genuinely broken store still
+        # returns 0 on the first attempt (``_broken`` is sticky for those).
+        conn: sqlite3.Connection | None = None
+        for attempt in range(_WRITE_RETRIES):
+            conn = self._connect()
+            if conn is not None or self._broken:
+                break
+            time.sleep(_WRITE_RETRY_BACKOFF_S * (attempt + 1))
         if conn is None:
             return 0
         # Price each snapshot ONCE here (writer thread), then feed that figure
@@ -635,7 +719,7 @@ class AnalyticsStore:
                     conn.rollback()
                 except Exception:  # noqa: BLE001
                     pass
-                if "lock" not in str(exc).lower() and "busy" not in str(exc).lower():
+                if not _is_lock_error(exc):
                     logger.debug("analytics: batch insert failed", exc_info=True)
                     return 0
                 if attempt == _WRITE_RETRIES - 1:

--- a/tests/unit/analytics/test_store.py
+++ b/tests/unit/analytics/test_store.py
@@ -621,3 +621,122 @@ def _days(n):
     from datetime import timedelta
 
     return timedelta(days=n)
+
+
+# ---------------------------------------------------------------------------
+# Opening the database under cross-process contention (#391).
+#
+# The failure these guard is DATA LOSS, not an exception: a momentary lock on
+# the very first open latched ``_broken``, and every write for the rest of that
+# process then returned 0 silently. With four parallel writers that surfaces as
+# exactly one of them contributing zero rows.
+#
+# Both tests inject the failure rather than racing for it, so they are
+# deterministic; the real contended measurement is in the PR's evidence.
+# ---------------------------------------------------------------------------
+
+
+def test_a_locked_first_open_does_not_disable_the_store(tmp_path, monkeypatch):
+    """A BUSY at open is transient: the next write must still land.
+
+    This is the #391 defect itself. ``_connect`` caught every exception and set
+    ``_broken``, which is correct for a read-only directory and catastrophic for
+    a lock another process releases microseconds later.
+    """
+    import sqlite3
+
+    from local_operator.analytics import store as store_mod
+
+    store = AnalyticsStore(tmp_path / "a.db")
+    real_connect = sqlite3.connect
+    calls = {"n": 0}
+
+    def flaky_connect(*args, **kwargs):
+        # Fail ONLY the first open, the way a real lock race does.
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise sqlite3.OperationalError("database is locked")
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(store_mod.sqlite3, "connect", flaky_connect)
+
+    # The open is retried, so a single lock does not drop the batch — and
+    # ``_broken`` stays clear so a later write would also succeed.
+    assert store.record_batch([_snap()]) == 1
+    assert not store._broken
+
+    monkeypatch.undo()
+    assert store.record_batch([_snap(), _snap()]) == 2
+    assert store.aggregate().calls == 3
+    store.close()
+
+
+def test_a_real_open_fault_still_disables_the_store(tmp_path, monkeypatch):
+    """The complement: a NON-lock fault must still latch ``_broken``.
+
+    Without this, the #391 fix would turn one log line into one per provider
+    round trip for the life of the process against a genuinely unusable path.
+    """
+    import sqlite3
+
+    from local_operator.analytics import store as store_mod
+
+    store = AnalyticsStore(tmp_path / "a.db")
+
+    def broken_connect(*args, **kwargs):
+        raise sqlite3.OperationalError("unable to open database file")
+
+    monkeypatch.setattr(store_mod.sqlite3, "connect", broken_connect)
+    assert store.record_batch([_snap()]) == 0
+    assert store._broken
+    store.close()
+
+
+def test_wal_is_enabled_despite_a_busy_journal_transition(tmp_path, monkeypatch):
+    """The DELETE->WAL switch is retried, because busy_timeout does not cover it.
+
+    Changing the journal mode needs an exclusive lock, and SQLite fails that
+    acquisition with SQLITE_BUSY immediately instead of calling the busy
+    handler — so the 5s ``busy_timeout`` set beside it buys nothing. Measured on
+    a fresh database opened by 16 processes at once: 25/320 opens raised here.
+    """
+    import sqlite3
+
+    from local_operator.analytics import store as store_mod
+
+    store = AnalyticsStore(tmp_path / "a.db")
+    real_connect = sqlite3.connect
+    busied = {"n": 0}
+
+    class _FlakyConn:
+        """Wraps a real connection because ``sqlite3.Connection`` is immutable
+        (its ``execute`` cannot be monkeypatched), so the injection has to
+        happen at the ``connect`` boundary instead."""
+
+        def __init__(self, conn):
+            self._conn = conn
+
+        def execute(self, sql, *args, **kwargs):
+            # Fail the journal switch twice, which the bounded retry must absorb.
+            if "journal_mode=WAL" in sql and busied["n"] < 2:
+                busied["n"] += 1
+                raise sqlite3.OperationalError("database is locked")
+            return self._conn.execute(sql, *args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+    monkeypatch.setattr(
+        store_mod.sqlite3, "connect", lambda *a, **kw: _FlakyConn(real_connect(*a, **kw))
+    )
+    assert store.record_batch([_snap()]) == 1
+    monkeypatch.undo()
+    store.close()
+
+    # The REAL property first: the database ended up in WAL despite the busy
+    # transition. Asserting the injection count before this would let the test
+    # die on its own proxy rather than on the behaviour it guards.
+    conn = sqlite3.connect(str(tmp_path / "a.db"))
+    assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+    conn.close()
+    assert busied["n"] == 2  # and the retry was genuinely exercised, not skipped

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import gc
 import json
+import time
 import weakref
 
 import pytest
@@ -2143,87 +2144,78 @@ async def test_the_loop_stays_responsive_while_several_subagents_run(tmp_path, m
     with 116 of 121 stall samples inside the tokenizer). The user-visible
     symptom was an agent reporting that its subagents "only run when I yield".
 
-    The measurement is a watchdog that asks to be woken every 5 ms and records
-    how late it actually was. That overshoot IS the window in which nothing
-    else on the loop could be serviced, which is exactly what a starved
-    sibling experiences. Asserting on the watchdog rather than on wall-clock
-    time keeps this about responsiveness and not about machine speed.
+    WHY THIS MEASURES LOOP-THREAD CPU AND NOT WALL-CLOCK LATENESS.
+
+    The obvious probe — a watchdog that asks to be woken every 5 ms and
+    records how late it actually was — measures the wrong thing, and two
+    attempts to bound it failed in the same way (#418 raised a flat 1.0 s
+    bound to a calibrated one; #373 is that calibrated bound still going red
+    on unmodified ``main``). Wall lateness goes wide whenever the loop thread
+    is not SCHEDULED, which is a different property from the loop thread being
+    BUSY, and only the second one is a starved sibling.
+
+    Measured on this exact workload, worst sample per run:
+
+    ======================  ==================  ==================
+    condition               wall lateness       loop-thread CPU
+    ======================  ==================  ==================
+    healthy, idle           440-684 ms          373-533 ms
+    healthy, 8 CPU hogs     943-2034 ms         393-492 ms
+    regressed (see below)   1376-1672 ms        1363-1444 ms
+    ======================  ==================  ==================
+
+    The wall column is why this test was flaky: under load a HEALTHY tree
+    produces 943-2034 ms, which overlaps the regressed range outright, so no
+    bound can separate them — the calibrated one failed 3 of 12 runs under six
+    spinners with margins of 1.07-1.22x, i.e. it was reporting scheduler noise.
+    The CPU column does not move with load (393-492 ms loaded vs 373-533 ms
+    idle) while still showing the regression at 2.6x clear of the healthy
+    ceiling. ``time.thread_time`` is per-thread and excludes time asleep or
+    waiting on the GIL, so a sample grows only when the loop thread genuinely
+    ran without yielding.
+
+    That is the same statistic, for the same reason, that
+    ``tests/unit/tools/test_loop_liveness.py`` adopted in #136 after its
+    wall-clock gap bound (``MAX_GAP_S = 0.12``) proved unfixable; see that
+    module's docstring for the fuller argument. This test now follows it
+    rather than keeping a second, load-sensitive convention beside it.
+
+    "REGRESSED" above is the seam from 70e66526 put back: forcing the
+    compaction rulers inline on the loop by lifting ``OFFLOAD_MIN_CHARS``
+    above any history this workload builds. That is the reproduction to use
+    when changing this test — a bound that does not fail against it is not
+    guarding anything.
+
+    WHY ``max()``. A synchronous stall blocks the watchdog itself, so the whole
+    stretch collapses into exactly ONE oversized sample rather than spreading
+    across the distribution. A percentile is blind here: measured against the
+    regressed tree, p99 is 114-189 ms against a healthy p99 of 108-273 ms,
+    because nearest-rank p99 discards the top 1% and the top 1% is the entire
+    evidence.
 
     The workload is calibrated, not arbitrary. It has to build a history big
     enough that the gate's tokenizer pass is expensive, because that is the
     stretch under test; at a smaller size both variants pass and the test
-    proves nothing. Measured on this workload against the pre-fix tree and
-    this one: worst stall 1353 ms before, 139 ms after.
-
-    WHY `max()`, AND WHY THE BOUND IS CALIBRATED RATHER THAN CONSTANT. Both
-    were got wrong once, so the measurements are recorded here.
-
-    `max()` is the ONLY statistic that sees this regression. A synchronous
-    stall blocks the watchdog itself, so the whole stretch collapses into
-    exactly ONE oversized sample instead of spreading across the distribution.
-    Measured by forcing the compaction rulers back inline (reverting the seam
-    from 70e66526) and running this test unmodified: regressed max is
-    1372-1832 ms while regressed p99 is only 114-189 ms, against a HEALTHY p99
-    of 108-273 ms. A percentile bound is blind here because nearest-rank p99
-    discards the top 1% of samples and the top 1% is the entire evidence.
-    `sum(lateness)` overlaps too: 2.67-3.67 s regressed vs 1.17-2.64 s healthy.
-
-    The "116 of 121 samples inside the tokenizer" figure above is a PROFILER
-    attribution of where time was spent, not a count of late watchdog samples.
-    It is not evidence that the regression moves the whole distribution.
-
-    The bound cannot be a constant. The original `max() < 1.0` was correct on
-    a dev box (healthy peaks ~0.56 s, regression starts ~1.38 s) but sat
-    INSIDE the healthy noise of a shared CI runner, which was observed red at
-    1029, 1033, 1167, 1169, 1337, 1446 and 1503 ms on commits touching nothing
-    near the loop, and with the same commit both passing and failing across
-    reruns. Raising the constant far enough for CI (>=2 s) would make it miss
-    the real regression on the machine where the bug was found.
-
-    So the test times a fixed CPU quantum first and scales the bound by it.
-    `calib` is ~75 ms on a 2024 laptop, where the 1.0 s floor applies and
-    separates healthy from regressed 10/10. CI is roughly 2.7x slower, so
-    `calib` grows and 8x lifts the bound to ~1.6 s there — above that runner's
-    healthy noise, still below a regression, which scales with the hardware in
-    the same direction. The multiplier only engages on machines slow enough to
-    need it.
-
-    If this fires, read the reported calibration alongside the stall: a stall
-    close to the bound on an unusually large `calib` is a loaded runner, while
-    a stall several times the bound is the real thing.
+    proves nothing.
     """
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
     parent = make_session(tmp_path, LongStream())
 
     stop = asyncio.Event()
-    lateness: list[float] = []
+    #: CPU time the loop thread accumulated between two watchdog wakes. A
+    #: synchronous stretch on the loop IS the loop thread running without
+    #: yielding, so it lands as one sample the size of the stretch.
+    loop_cpu: list[float] = []
 
     async def watchdog() -> None:
-        loop = asyncio.get_running_loop()
+        last = time.thread_time()
         while not stop.is_set():
-            before = loop.time()
             await asyncio.sleep(0.005)
-            lateness.append(loop.time() - before - 0.005)
+            now = time.thread_time()
+            loop_cpu.append(now - last)
+            last = now
 
     watcher = asyncio.create_task(watchdog())
-
-    # CONTROL PHASE. Characterise THIS box before launching anything, so the
-    # bound is relative to the machine actually running the test rather than
-    # to a constant that only suits the author's laptop. The control does the
-    # same *kind* of work the subagent phase does — brief synchronous CPU on
-    # the loop, interleaved with awaits — so it captures scheduler noise,
-    # contention from parallel pytest workers, and a throttled CI core.
-    # CALIBRATION. Time a fixed CPU quantum on THIS box to learn how fast it
-    # is, then scale the bound by that. A GitHub runner is several times
-    # slower than a dev laptop, and its stalls scale with it, which is exactly
-    # why a hardcoded millisecond bound cannot hold on both: 1.0 s was inside
-    # CI's healthy noise while still above this machine's regressed signal.
-    calib_start = asyncio.get_running_loop().time()
-    for _ in range(20):
-        sum(i * i for i in range(150_000))
-        await asyncio.sleep(0)
-    calib = asyncio.get_running_loop().time() - calib_start
-    lateness.clear()
 
     job_ids = [parent._launch_subagent(label=f"c{i}", prompt="do the work") for i in range(6)]
 
@@ -2232,30 +2224,27 @@ async def test_the_loop_stays_responsive_while_several_subagents_run(tmp_path, m
         return all(job is not None and job.status != "running" for job in jobs)
 
     try:
-        await wait_for(all_settled, timeout=60.0)
+        # Waits on the children settling, never on a frame or time budget: the
+        # timeout is a deadlock guard, and a run that reaches it has no result
+        # to assert on rather than a slow one.
+        await wait_for(all_settled, timeout=120.0)
     finally:
         stop.set()
         await watcher
 
-    assert lateness, "the watchdog never ran — the measurement itself is broken"
-    worst = max(lateness)
-    # The bound scales with measured machine speed, with a floor.
-    #
-    # On a fast box `calib` is ~75 ms, so the 1.0 s FLOOR is what applies:
-    # healthy peaks at ~0.56 s and the regression starts at ~1.38 s, so 1.0 s
-    # sits in the middle of that gap and separates 10/10.
-    #
-    # On CI the same run is ~2.7x noisier (healthy max observed up to 1503 ms,
-    # which is why the old flat 1.0 s bound failed there). `calib` grows with
-    # the box, so 8x lifts the bound to ~1.6 s on that hardware — above CI's
-    # healthy noise, still below a regression that scales with the machine too.
-    # The multiplier only ever engages on hardware slow enough to need it.
-    allowed = max(calib * 8.0, 1.0)
-    assert worst < allowed, (
-        f"the event loop stalled for {worst * 1000:.0f} ms while subagents ran "
-        f"(bound {allowed * 1000:.0f} ms, from a {calib * 1000:.0f} ms CPU "
-        f"calibration on this machine, {len(lateness)} samples); "
-        "a synchronous stretch is starving concurrent children"
+    assert loop_cpu, "the watchdog never ran — the measurement itself is broken"
+    worst = max(loop_cpu)
+    #: Halfway between the measured healthy ceiling (533 ms) and the cheapest
+    #: observed regression (1363 ms), in the gap the table above establishes.
+    #: A CONSTANT is correct here where it was not for wall lateness, because
+    #: this statistic does not scale with machine load; a slower machine
+    #: spends more wall time on the same work but not more un-yielded CPU.
+    MAX_LOOP_CPU_S = 0.95
+    assert worst < MAX_LOOP_CPU_S, (
+        f"the loop thread burned {worst * 1000:.0f} ms of CPU without yielding "
+        f"while subagents ran (bound {MAX_LOOP_CPU_S * 1000:.0f} ms, "
+        f"{len(loop_cpu)} samples); a synchronous stretch is starving "
+        "concurrent children"
     )
     await parent.dispose()
 

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 import gc
 import json
-import time
+import threading
 import weakref
 
 import pytest
@@ -2144,78 +2144,68 @@ async def test_the_loop_stays_responsive_while_several_subagents_run(tmp_path, m
     with 116 of 121 stall samples inside the tokenizer). The user-visible
     symptom was an agent reporting that its subagents "only run when I yield".
 
-    WHY THIS MEASURES LOOP-THREAD CPU AND NOT WALL-CLOCK LATENESS.
+    WHY THIS IS A STRUCTURAL SPY AND NOT A TIME BOUND.
 
-    The obvious probe — a watchdog that asks to be woken every 5 ms and
-    records how late it actually was — measures the wrong thing, and two
-    attempts to bound it failed in the same way (#418 raised a flat 1.0 s
-    bound to a calibrated one; #373 is that calibrated bound still going red
-    on unmodified ``main``). Wall lateness goes wide whenever the loop thread
-    is not SCHEDULED, which is a different property from the loop thread being
-    BUSY, and only the second one is a starved sibling.
+    Two attempts to bound a watchdog failed in the same way. #418 replaced a
+    flat 1.0 s wall-clock bound with a calibrated one; #373 is that calibrated
+    bound still going red on unmodified ``main`` (reproduced here: 3 of 12
+    under six CPU spinners, margins 1.07-1.22x). Converting the watchdog to
+    ``time.thread_time`` (the statistic ``test_loop_liveness.py`` adopted in
+    #136) removed the *load* sensitivity — wall lateness under 8 CPU hogs
+    exploded to 943-2034 ms while loop-thread CPU stayed at 393-492 ms — but
+    not the *core-speed* sensitivity. A slower CI core burns more CPU-seconds
+    on the same tokenizer pass: ubuntu-latest 3.13 reported 1056 ms and
+    1156 ms of loop-thread CPU against a 950 ms bound, on an unmodified
+    healthy tree, while the same SHA's parallel run passed. No portable
+    numeric bound can sit above CI's healthy 1156 ms and below this box's
+    1315 ms regression.
 
-    Measured on this exact workload, worst sample per run:
-
-    ======================  ==================  ==================
-    condition               wall lateness       loop-thread CPU
-    ======================  ==================  ==================
-    healthy, idle           440-684 ms          373-533 ms
-    healthy, 8 CPU hogs     943-2034 ms         393-492 ms
-    regressed (see below)   1376-1672 ms        1363-1444 ms
-    ======================  ==================  ==================
-
-    The wall column is why this test was flaky: under load a HEALTHY tree
-    produces 943-2034 ms, which overlaps the regressed range outright, so no
-    bound can separate them — the calibrated one failed 3 of 12 runs under six
-    spinners with margins of 1.07-1.22x, i.e. it was reporting scheduler noise.
-    The CPU column does not move with load (393-492 ms loaded vs 373-533 ms
-    idle) while still showing the regression at 2.6x clear of the healthy
-    ceiling. ``time.thread_time`` is per-thread and excludes time asleep or
-    waiting on the GIL, so a sample grows only when the loop thread genuinely
-    ran without yielding.
-
-    That is the same statistic, for the same reason, that
-    ``tests/unit/tools/test_loop_liveness.py`` adopted in #136 after its
-    wall-clock gap bound (``MAX_GAP_S = 0.12``) proved unfixable; see that
-    module's docstring for the fuller argument. This test now follows it
-    rather than keeping a second, load-sensitive convention beside it.
-
-    "REGRESSED" above is the seam from 70e66526 put back: forcing the
-    compaction rulers inline on the loop by lifting ``OFFLOAD_MIN_CHARS``
-    above any history this workload builds. That is the reproduction to use
-    when changing this test — a bound that does not fail against it is not
-    guarding anything.
-
-    WHY ``max()``. A synchronous stall blocks the watchdog itself, so the whole
-    stretch collapses into exactly ONE oversized sample rather than spreading
-    across the distribution. A percentile is blind here: measured against the
-    regressed tree, p99 is 114-189 ms against a healthy p99 of 108-273 ms,
-    because nearest-rank p99 discards the top 1% and the top 1% is the entire
-    evidence.
+    The contract this test can actually pin, load-immune and core-speed-
+    immune, is the one ``test_loop_liveness.py`` already pins for the image
+    path: the function that moved OFF the loop is observed running on a
+    thread that is not the loop's. ``Session._offloaded`` hops
+    ``estimate_messages_tokens`` / ``find_cut_point`` through
+    ``asyncio.to_thread`` once the history crosses ``OFFLOAD_MIN_CHARS``.
+    Spying those two names on ``local_operator.compaction.api`` (the module
+    ``_offloaded`` resolves by name) records the thread they ran on; the
+    assertion is that every call of a history large enough to offload ran
+    off-loop. Putting the rulers back inline (lifting ``OFFLOAD_MIN_CHARS``
+    above any history this workload builds — the 70e66526 seam reversed) is
+    the reproduction: the spy then sees the loop thread and the test dies.
 
     The workload is calibrated, not arbitrary. It has to build a history big
-    enough that the gate's tokenizer pass is expensive, because that is the
-    stretch under test; at a smaller size both variants pass and the test
-    proves nothing.
+    enough that the gate's tokenizer pass is expensive AND crosses the
+    offload threshold, because that is the stretch under test; at a smaller
+    size both variants pass and the test proves nothing.
     """
+    import local_operator.compaction.api as compaction_api
+
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
     parent = make_session(tmp_path, LongStream())
 
-    stop = asyncio.Event()
-    #: CPU time the loop thread accumulated between two watchdog wakes. A
-    #: synchronous stretch on the loop IS the loop thread running without
-    #: yielding, so it lands as one sample the size of the stretch.
-    loop_cpu: list[float] = []
+    loop_thread = threading.get_ident()
+    seen: dict[str, list[int]] = {
+        "estimate_messages_tokens": [],
+        "find_cut_point": [],
+    }
 
-    async def watchdog() -> None:
-        last = time.thread_time()
-        while not stop.is_set():
-            await asyncio.sleep(0.005)
-            now = time.thread_time()
-            loop_cpu.append(now - last)
-            last = now
+    def _wrap(name: str, real):
+        def spy(*args, **kwargs):
+            seen[name].append(threading.get_ident())
+            return real(*args, **kwargs)
 
-    watcher = asyncio.create_task(watchdog())
+        return spy
+
+    monkeypatch.setattr(
+        compaction_api,
+        "estimate_messages_tokens",
+        _wrap("estimate_messages_tokens", compaction_api.estimate_messages_tokens),
+    )
+    monkeypatch.setattr(
+        compaction_api,
+        "find_cut_point",
+        _wrap("find_cut_point", compaction_api.find_cut_point),
+    )
 
     job_ids = [parent._launch_subagent(label=f"c{i}", prompt="do the work") for i in range(6)]
 
@@ -2223,28 +2213,26 @@ async def test_the_loop_stays_responsive_while_several_subagents_run(tmp_path, m
         jobs = [parent.jobs.get(job_id) for job_id in job_ids]
         return all(job is not None and job.status != "running" for job in jobs)
 
-    try:
-        # Waits on the children settling, never on a frame or time budget: the
-        # timeout is a deadlock guard, and a run that reaches it has no result
-        # to assert on rather than a slow one.
-        await wait_for(all_settled, timeout=120.0)
-    finally:
-        stop.set()
-        await watcher
+    # Waits on the children settling, never on a frame or time budget: the
+    # timeout is a deadlock guard, and a run that reaches it has no result
+    # to assert on rather than a slow one.
+    await wait_for(all_settled, timeout=120.0)
 
-    assert loop_cpu, "the watchdog never ran — the measurement itself is broken"
-    worst = max(loop_cpu)
-    #: Halfway between the measured healthy ceiling (533 ms) and the cheapest
-    #: observed regression (1363 ms), in the gap the table above establishes.
-    #: A CONSTANT is correct here where it was not for wall lateness, because
-    #: this statistic does not scale with machine load; a slower machine
-    #: spends more wall time on the same work but not more un-yielded CPU.
-    MAX_LOOP_CPU_S = 0.95
-    assert worst < MAX_LOOP_CPU_S, (
-        f"the loop thread burned {worst * 1000:.0f} ms of CPU without yielding "
-        f"while subagents ran (bound {MAX_LOOP_CPU_S * 1000:.0f} ms, "
-        f"{len(loop_cpu)} samples); a synchronous stretch is starving "
-        "concurrent children"
+    # At least one ruler must have run — otherwise the workload no longer
+    # crosses the offload threshold and this test is watching nothing.
+    total = sum(len(idents) for idents in seen.values())
+    assert total, (
+        "neither compaction ruler ran — the history this workload builds is "
+        "no longer large enough to exercise the offload seam, so the "
+        "assertion below would pass vacuously"
+    )
+    on_loop = {
+        name: sum(1 for ident in idents if ident == loop_thread) for name, idents in seen.items()
+    }
+    assert all(n == 0 for n in on_loop.values()), (
+        f"a compaction ruler ran on the event-loop thread "
+        f"({on_loop}; {total} calls total) — the asyncio.to_thread hop is "
+        "gone and a child's tokenizer pass is starving its siblings"
     )
     await parent.dispose()
 

--- a/tests/unit/session/test_resume_subagents_todos.py
+++ b/tests/unit/session/test_resume_subagents_todos.py
@@ -249,9 +249,15 @@ async def test_live_continuation_preserves_prior_accounting_across_restart(tmp_p
     new_id, error = resumed.subagent_comms.resume(old_id, "continue")
     assert error is None and new_id is not None
     await hanging.started.wait()
+    # Wait on the ACCOUNTING itself, not on the identity bind that precedes
+    # it. ``bind_logical_identity`` sets ``logical_id`` and then folds the
+    # predecessor's usage into ``prior_attempt_usage``; asserting on the
+    # second after waiting on the first is wait-on-a-proxy-then-assert-on-
+    # the-real-thing, and under load the fold has not landed when the
+    # identity has (#463: ``assert 0 == 4`` on an otherwise-green commit).
     await wait_for(
-        lambda: resumed.jobs.get(new_id) is not None
-        and resumed.jobs.get(new_id).logical_id is not None  # type: ignore[union-attr]
+        lambda: sum(item.input_tokens for item in resumed.jobs.accounting_components()) == 4,
+        timeout=30.0,
     )
     assert sum(item.input_tokens for item in resumed.jobs.accounting_components()) == 4
     await resumed._persist_subagent_roster()

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -678,10 +678,22 @@ def test_fold_survives_junk_without_raising() -> None:
 
 
 async def _open(pilot: Any, app: OperatorApp, job: Any) -> SubagentView:
-    for _ in range(80):
-        await pilot.pause()
-        if app._session is not None:
-            break
+    """Open the child page once the boot worker has adopted a session.
+
+    Waits on the WORKER, not on a frame budget. ``on_mount`` hands
+    ``_boot_session`` to ``run_worker(group="session")`` so first paint does
+    not wait on the factory; every assertion below reads through that session,
+    so an unbooted app is a different test. The previous 80-pause loop was a
+    bet that 80 frames outlast the factory, the same class #461 converted
+    everywhere else in this file.
+    """
+    workers = [w for w in app.workers if w.group == "session"]
+    if workers:
+        await app.workers.wait_for_complete(workers)
+    assert app._session is not None, (
+        "no session worker is pending and no session was adopted — the "
+        "boot worker never ran, so waiting here would have waited on nothing"
+    )
     app._append_block(UserBlock("audit the ingest path"))
     app._refresh_band()
     await pilot.pause()
@@ -1403,10 +1415,12 @@ async def test_history_unavailable_and_error_retry_keep_trajectory_fallback(
         await _wait_history(pilot, view)
         assert HISTORY_ERROR_NOTE in view._history_state_text()
         failed_attempts = attempts
-        # Repaints and the top-edge watcher may run freely, but the advertised
-        # retry must remain a user decision rather than an implicit hot loop.
-        for _ in range(50):
-            await asyncio.sleep(0.005)
+        # The advertised retry must remain a user decision rather than an
+        # implicit hot loop. After the worker has settled, a handful of extra
+        # loop turns is enough for a hot-looping retry to have fired; a 250 ms
+        # wall-clock window was the previous discriminator and is what went
+        # red under swap thrashing (#403).
+        for _ in range(8):
             await pilot.pause()
         assert attempts == failed_attempts == 1
 
@@ -1414,11 +1428,17 @@ async def test_history_unavailable_and_error_retry_keep_trajectory_fallback(
         await pilot.pause()
         assert app.focused is view._body
         await pilot.press("home")
-        for _ in range(100):
-            await asyncio.sleep(0.005)
-            await pilot.pause()
-            if attempts == 2 and not view._history_loading:
+        # Wait on the retry actually happening (``attempts`` advancing), not
+        # on a 500 ms budget and not on a worker that may not have been
+        # spawned yet. Bounded by loop turns: contention stretches how long
+        # a turn takes, not how many the key-press needs.
+        for _ in range(200):
+            if attempts == 2:
                 break
+            await pilot.pause()
+        else:
+            raise AssertionError("the explicit Home retry never ran")
+        await _wait_history(pilot, view)
         assert attempts == 2
         assert view._history_unavailable
 

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -2197,53 +2197,59 @@ async def _composer_multi_click(
     Worse, `pilot.click` resolves the offset to SCREEN coordinates ONCE and
     then pauses between each event of the chain, so a dock that moves partway
     through sends the later clicks of a triple-click to a coordinate that is no
-    longer the row they were aimed at. Waiting for the region to hold still
-    across several consecutive frames — not merely to differ from the last one
-    — is what makes a row-aimed click land where it says.
+    longer the row they were aimed at.
+
+    Waiting on a STABLE REGION for N frames (#419's previous shape) is still a
+    budget: under load the dock can hold still for 8 frames and then move
+    between the last pause and the click, which is exactly the self-diagnosing
+    assertion this helper used to raise ("aimed at row 1 but landed on row 0").
+    The wait below is on the RESOLVER itself — the same
+    ``get_target_document_location`` the handler uses — reporting the intended
+    row for several consecutive frames, so a click that then lands elsewhere
+    is a product defect rather than a layout race.
     """
-    stable = 0
-    previous = None
-    for _ in range(40):
-        await pilot.pause()
-        current = editor.region
-        stable = stable + 1 if current == previous and editor.size.height > row else 0
-        previous = current
-        if stable >= 8:
-            break
-    assert editor.size.height > row, f"the composer never grew to row {row}"
-    offset = (editor.gutter.left + column, editor.gutter.top + row)
-
-    # VERIFY THE AIM, do not merely wait for it. `stable >= 4` was not always
-    # enough for the taller fixtures: the dock was still migrating when
-    # `pilot.click` resolved its offset, so a row-1 click landed on row 0 about
-    # 14% of the time and the D2 regression test failed intermittently while the
-    # product was correct (design review round 2, D2-2). A flaky test pinning a
-    # data-loss fix is worse than no test, because the next real regression
-    # reads as "that one's just flaky".
-    #
-    # Recording where the click will ACTUALLY land — through the same resolver
-    # the handler uses — turns a mis-aimed gesture into a loud setup failure
-    # naming the row it hit, instead of a confusing assertion about a selection
+    # The existing guard already detects a mis-aimed click precisely; it now
+    # DRIVES A RE-RESOLVE instead of failing (#419). A dock that moves between
+    # resolving the offset and delivering the click is a layout race, not a
+    # product defect, so the helper retries the gesture against the current
+    # region rather than reporting it as a failed assertion about a selection
     # the test never really made.
-    landed: list[int] = []
     original = type(editor)._on_click
+    last_landed: list[int] = []
 
-    async def _record(self: Editor, event: Any) -> None:
-        landed.append(self.get_target_document_location(event)[0])
-        await original(self, event)
+    def _bind(bucket: list[int]):
+        async def _record(self: Editor, event: Any) -> None:
+            bucket.append(self.get_target_document_location(event)[0])
+            await original(self, event)
 
-    type(editor)._on_click = _record
-    try:
-        await pilot.click(editor, offset=offset, times=times)
-        await pilot.pause()
-        await pilot.pause()
-    finally:
-        type(editor)._on_click = original
-    assert landed, "the click never reached the editor's chain handler"
-    assert landed[-1] == row, (
-        f"the click was aimed at row {row} but landed on row {landed[-1]} — "
-        "the composer dock moved between resolving the offset and delivering "
-        "the click, so this run tested a different gesture"
+        return _record
+
+    for _attempt in range(12):
+        for _ in range(40):
+            await pilot.pause()
+            if editor.size.height > row:
+                break
+        else:
+            raise AssertionError(f"the composer never grew to row {row}")
+        offset = (editor.gutter.left + column, editor.gutter.top + row)
+        landed: list[int] = []
+        type(editor)._on_click = _bind(landed)
+        try:
+            await pilot.click(editor, offset=offset, times=times)
+            await pilot.pause()
+            await pilot.pause()
+        finally:
+            type(editor)._on_click = original
+        last_landed = landed
+        if landed and landed[-1] == row:
+            return
+        # The dock moved; the next attempt re-resolves against the current
+        # region rather than asserting on a gesture the test did not make.
+    assert last_landed, "the click never reached the editor's chain handler"
+    raise AssertionError(
+        f"the click was aimed at row {row} but landed on row {last_landed[-1]} "
+        "across 12 re-resolves — the composer dock never held still long "
+        "enough to deliver the intended gesture"
     )
 
 

--- a/tests/unit/tui/test_word_caret.py
+++ b/tests/unit/tui/test_word_caret.py
@@ -53,13 +53,23 @@ GAMMA_START = SAMPLE.index("gamma")
 
 
 async def _boot(pilot: Any, app: OperatorApp) -> Editor:
-    """Wait for the session and focus the composer, as the app's own tests do."""
-    for _ in range(200):
-        if app._session is not None:
-            break
-        await pilot.pause()
-        await asyncio.sleep(0.01)
-    assert app._session is not None, "the session never booted"
+    """Wait for the session and focus the composer.
+
+    Waits on the boot WORKER, not on a 2 s frame budget. ``on_mount`` hands
+    ``_boot_session`` to ``run_worker(group="session")`` so first paint does
+    not wait on the factory, and every assertion below reads through that
+    session. The previous 200 × 10 ms loop was a bet that 2 s outlasts the
+    factory, which is the same class #461 converted in ``test_subagent_stats``.
+    Under contention that budget lost as a stylesheet lookup against an
+    unmounted editor (``KeyError: No 'text-area--gutter' key``, #463).
+    """
+    workers = [w for w in app.workers if w.group == "session"]
+    if workers:
+        await app.workers.wait_for_complete(workers)
+    assert app._session is not None, (
+        "no session worker is pending and no session was adopted — the "
+        "boot worker never ran, so waiting here would have waited on nothing"
+    )
     editor = app.query_one(Editor)
     editor.focus()
     await pilot.pause()
@@ -322,7 +332,19 @@ async def test_real_teardown_settles_a_held_escape_and_leaks_no_callback() -> No
         assert editor._pending_escape is not None, "the escape is held"
 
         await editor.remove()
-        await _settle(pilot)
+        # Wait on the REAL unmount conditions, not on a handful of pauses.
+        # ``_settle`` of 5 turns was enough on an idle box and lost under CI
+        # load (#463): a CSS refresh timer then restyled the removed editor
+        # (``KeyError: text-area--gutter``) on the way out of ``run_test``.
+        for _ in range(80):
+            if not editor.is_attached and editor._pending_escape is None:
+                break
+            await pilot.pause()
+        else:
+            raise AssertionError(
+                f"teardown never settled (attached={editor.is_attached}, "
+                f"pending={editor._pending_escape is not None})"
+            )
 
         assert fired == ["escape"], "blur wins the race and flushes"
         assert editor._pending_escape is None, "nothing is left pending"


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** One product-path fix in the analytics
store (silent data loss under concurrent first-open) plus test-only wait
conversions of the same class as #461. Rollback is `git revert`.

## Summary of Changes

Five issues, two defect shapes. #391 is a **product bug the test was correctly
catching**. The other four are the class #461 already converted: a test that
waits on a frame or wall-clock budget, then asserts as though the budget were
a guarantee.

### 1. `#391` — a whole process of analytics rows silently dropped

`test_parallel_processes_write_atomically` asserts `agg.calls == 4 * 150` and
fails as `assert 450 == 600` — exactly one of four processes contributing
**zero** rows. The issue argued this was a genuine SQLite/WAL atomicity bug,
not a bad assertion. That hypothesis is half-right: it is genuine data loss,
but the write path (WAL + `busy_timeout` + bounded retry) is fine. The loss
is at **open**.

`AnalyticsStore._connect` runs `PRAGMA journal_mode=WAL` on a fresh file.
Changing the journal mode needs an exclusive lock, and SQLite fails that
acquisition with `SQLITE_BUSY` **immediately** instead of invoking the busy
handler, so the 5 s `busy_timeout` set *after* the pragma bought nothing.
The whole `_connect` body is wrapped in `except Exception: self._broken = True`,
so a momentary lock latched the store as permanently unusable and every
subsequent write returned 0 silently — all-or-nothing, exactly the observed
shape.

Measured, 16 processes opening one fresh database simultaneously:

| condition | failed opens |
| --- | --- |
| db already in WAL | 0/320 |
| fresh db, current code | **25/320** (`journal_mode: database is locked`) |
| `busy_timeout` set first (reorder only) | **15/320** — reordering alone is not a fix |
| busy_timeout first + bounded WAL retry | **0/320** |

Driving the product path (`AnalyticsStore.record_batch`) behind a barrier:

```
BASE  20 trials × 16 procs = 320 opens:  17/320 stores latched _broken
                                         45450 / 48000 rows written
                                         8 of 20 trials lost at least one process
HEAD  20 trials × 16 procs = 320 opens:   0/320 broken
                                         48000 / 48000 rows written
```

The original 4-process test, 20 sequential runs at HEAD: 20/20 passed.

Three independent guards, each mutation-tested:

- `_set_wal` retries the DELETE→WAL transition (`_WAL_RETRIES=1` → test dies
  on `assert 'delete' == 'wal'`).
- A lock at open does **not** latch `_broken` (forcing the latch →
  `assert not store._broken` dies).
- A non-lock fault **still** latches `_broken` (the complement, so a
  read-only home does not become one log line per provider round trip).

`record_batch` also retries the open itself, so a single lock no longer
drops the whole batch.

### 2. `#373` — loop-stall watchdog measuring scheduler noise

`test_the_loop_stays_responsive_while_several_subagents_run` asserted
`worst < max(calib * 8, 1.0)` on **wall-clock** watchdog lateness. #418
already replaced the flat 1.0 s bound with that calibration; it is still
red on unmodified `main`. Reproduced here: **3 failed / 9 passed of 12**
under 6 CPU spinners, margins 1.07–1.22× (e.g. 1563 ms stall vs 1279 ms
bound).

A first conversion to `time.thread_time` (the statistic
`test_loop_liveness.py` adopted in #136) removed the *load* sensitivity —
wall lateness under 8 CPU hogs exploded to 943–2034 ms while loop-thread
CPU stayed at 393–492 ms — but not the *core-speed* sensitivity. CI on
this PR's first SHA reported 1056 ms and 1156 ms of loop-thread CPU
against a 950 ms bound, on an unmodified healthy tree, while the same
SHA's parallel run passed. No portable numeric bound sits above CI's
healthy 1156 ms and below this box's 1315 ms regression.

The contract this test can actually pin, load-immune and core-speed-immune,
is the one `test_loop_liveness.py` already pins for the image path: the
function that moved OFF the loop is observed running on a thread that is
not the loop's. A spy on `estimate_messages_tokens` / `find_cut_point`
(the names `Session._offloaded` resolves) records the thread they ran on;
the assertion is that every call of a history large enough to offload ran
off-loop. There is no elapsed-time comparison anywhere on the success path.

Mutation: forcing `OFFLOAD_MIN_CHARS` above any history (the 70e66526 seam
put back) → dies with `estimate_messages_tokens: 6, find_cut_point: 6` on
the loop thread. HEAD under 6 spinners: **12 passed / 0 failed of 12**.

### 3. `#403` — remaining 5 ms budgets in the history-retry test

#461 already converted `_wait_history` to `wait_for_complete` on the
`subagent-history` worker (and fixed the shared-state TRAJECTORY leak). Two
5 ms-budget loops remained in
`test_history_unavailable_and_error_retry_keep_trajectory_fallback`: a 250 ms
window asserting no implicit retry, and a 500 ms window waiting for the
explicit Home retry. Both are now loop-turn bounded / wait-on-`attempts`.
`_open` also waits on the session boot worker rather than 80 pauses.

Did not reproduce a failure on this box (10/10 on base under 6 spinners) —
honest, same as #461's reading of #122. The change stands on the mechanism:
there is no elapsed-time comparison left on the success path. Mutation:
`_wait_history` as a no-op → dies on `assert 'load failed · Home retry' in
'loading earlier… · read-only'`. HEAD: 12/12.

### 4. `#419` — multi-click aimed at row 1 landing on row 0

The helper waited for the composer region to hold still for 8 frames, then
clicked, then *reported* a mis-aim as a failure. That is still a budget:
under load the dock can hold still for 8 frames and then move between the
last pause and the click. Observed in CI on #461 itself (`test (3.12)` of
`f5f77cee`). The existing guard now **drives a re-resolve** instead of
failing — up to 12 attempts against the current region. Mutation: the
recorder always reports row 0 → dies on the re-resolve exhaustion message.
HEAD: 12/12. Did not reproduce locally on base (10/10); CI evidence is the
reproduction.

### 5. `#463` — two tests, two races, same commit passing and failing in CI

- `test_live_continuation_preserves_prior_accounting_across_restart` waited
  on `logical_id is not None` then immediately asserted
  `accounting_components() == 4`. Wait-on-a-proxy-then-assert-on-the-real-
  thing: `bind_logical_identity` sets the identity and *then* folds the
  predecessor's usage. CI: `assert 0 == 4`. Now waits on the accounting
  itself. Mutation: stub `accounting_components` empty → wait times out.
- `test_real_teardown_settles_a_held_escape_and_leaks_no_callback` settled
  teardown with 5 pauses. Under load a CSS refresh timer restyled the
  removed editor on the way out of `run_test`
  (`KeyError: No 'text-area--gutter' key`). Reproduced here: **1 failed /
  9 passed of 10** on base under 6 spinners, same KeyError as CI. Now waits
  on `not editor.is_attached and pending is None`. `_boot` waits on the
  session worker rather than a 2 s frame budget.

HEAD of both: 12/12.

## Related Issue(s)

Closes #373
Closes #391
Closes #403
Closes #419
Closes #463

## Testing Evidence

Host: 14 cores, load 20–70 across these runs (sibling agents sharing the
box). Every comparison is either paired or reports the load it ran at.
Spinners = tight CPU loops; pytest `-n0` on targeted files only.

### Gates (whole tree, CI commands, exit codes)

```
flake8 rc=0
black rc=0
isort rc=0
pyright rc=0
```

Touched modules: `87 passed in 17.22s`.

### #391, the product bug

```
BASE  20×16 barrier opens: 17/320 stores latched _broken, 2550 rows lost
HEAD  20×16 barrier opens:  0/320 broken, 48000/48000 rows
HEAD  original 4-proc test × 20: 20 passed / 0 failed
HEAD  10×16 after rebase: 0/160 broken, 24000/24000 rows
```

Mutation matrix (each kills its matching test, caches purged so a same-size
edit cannot reuse a stale `.pyc`):

| mutation | dying test | assertion |
| --- | --- | --- |
| `_WAL_RETRIES = 1` | `test_wal_is_enabled_despite_a_busy_journal_transition` | `'delete' == 'wal'` |
| always latch `_broken` | `test_a_locked_first_open_does_not_disable_the_store` | `assert not True` |
| `_is_lock_error` always false | both of the above | `'delete' == 'wal'` + `_broken` |

### #373

```
BASE  12 runs, 6 spinners:  9 passed / 3 failed  (1563/1279, 1571/1449, 1197/1122 ms)
HEAD (CPU bound, first SHA): CI 3.12/3.13 red at 1056/1156 ms vs 950 ms bound
HEAD (structural spy): 12 passed / 0 failed of 12 under 6 spinners
```

Mutation: rulers forced inline via `OFFLOAD_MIN_CHARS = 10**12` →
`a compaction ruler ran on the event-loop thread ({'estimate_messages_tokens': 6, 'find_cut_point': 6}; 12 calls total)`.

### #403 / #419 / #463

```
#403  BASE 10/10, HEAD 12/12  (not reproduced locally; mechanism converted)
#419  BASE 10/10, HEAD 12/12  (CI reproduction on f5f77cee; helper now re-resolves)
#463  BASE  9/10 (word_caret KeyError), HEAD 12/12
```

Mutations: `_wait_history` no-op dies; click recorder always-row-0 dies;
empty `accounting_components` times out.

## Out of scope / not addressed

- `test_live_progress_never_schedules_the_roster_writer` still has a 0.25 s
  wall-clock bound on a *negative* (the coalescer must fire within 250 ms).
  Not in the five issues; left alone.
- `wait_for` in `test_resume_subagents_todos.py` is still a 5 s (now 30 s
  at one call site) wall-clock poll. Converted the *predicate* it waits on,
  not the helper itself — that helper is the file's established pattern and
  converting it is a follow-up, not this slice.
- #391 body item 2 (`test_task_wait_jobs.py` literal `215.0s`) is a different
  flake, untouched. The titled analytics-loss defect is what `Closes #391`
  refers to.
- #463 also names `test_redundant_roster_events_skip_the_sidecar_write` as a
  CI failure on `main`. This PR converts the two diagnosed races (accounting
  proxy, word-caret teardown); that third test is unchanged.
- No version bump (manager releases after PRs land). Not merged.
