### PR TITLE
perf(tui): bound resume render to the last 80 messages

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -31,6 +31,7 @@ import sys
 import time
 import uuid
 from collections.abc import Mapping, Sequence
+from contextlib import nullcontext
 from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, NamedTuple, Protocol, cast
@@ -963,6 +964,75 @@ DOUBLE_INTERRUPT_WINDOW_S = 1.5
 #: polling bounds the 3-second drain without turning user inactivity into input.
 TERMINAL_LIFECYCLE_CHECK_S = 0.25
 TERMINAL_GATE_TIMEOUT_S = 30.0
+
+#: How many of a resumed conversation's trailing messages are RENDERED on the
+#: first frame. The rest stay in memory and mount on demand as the reader
+#: scrolls up (:meth:`OperatorApp._mount_older_resume_page`).
+#:
+#: THIS BOUNDS PIXELS, NEVER CONTEXT. The model's conversation is
+#: ``session.history()`` and is untouched by anything in this file — the bound
+#: decides only how many Textual widgets exist on the first paint. Anyone
+#: tempted to "simplify" this by trimming the list handed to the session, or by
+#: dropping the deferred messages instead of holding them, would be deleting
+#: the user's actual history to save a render: the two must stay distinct.
+#:
+#: 80 measured against the alternatives on a real 716-message session, driving
+#: the real app: 40 msgs → 98.7 ms, 80 → 139 ms, 160 → 251 ms, 716 (all) →
+#: 1022 ms. 80 is a 7.3x win that still fills a 40-row terminal about twice
+#: over, so the reader lands on a screen with scrollback above it rather than
+#: on a viewport that is exactly as tall as its content — which would read as
+#: "my history is gone" and is the specific failure this bound must not cause.
+RESUME_RENDER_MESSAGES = 80
+
+#: Messages mounted per backward page once the reader reaches the top. Smaller
+#: than the initial bound because a page is paid DURING an interaction: it must
+#: land within one frame, where the initial render is paid once behind a splash
+#: the user is already waiting on.
+RESUME_PAGE_MESSAGES = 60
+
+#: Rows from the top of the transcript at which the next older page is mounted.
+#: Not zero: mounting only at the exact top means the reader hits a hard stop,
+#: sees nothing arrive for a frame, and concludes the conversation starts there.
+RESUME_PAGE_TRIGGER_ROWS = 4
+
+#: The row that stands in for the un-rendered head of a resumed conversation.
+#: It exists because the failure mode of a display bound is a user believing
+#: history was LOST — so the transcript says, in its own voice, that the older
+#: messages are still there and how to reach them.
+RESUME_OLDER_NOTICE = "older messages above — scroll up to load"
+
+#: Replaces the notice once every deferred message has been mounted, so the top
+#: of the transcript states the conversation's real beginning rather than
+#: leaving a promise of more that will never arrive.
+RESUME_START_NOTICE = "start of conversation"
+
+
+def _resume_tail_start(history: list[Any], bound: int) -> int:
+    """Index of the first message the initial resume frame should paint.
+
+    ``bound`` is a budget in messages, not a contract about which ROLE starts
+    the viewport. Slicing at ``len - bound`` can land in the middle of a turn
+    — a tool result whose call is in the deferred head, or an assistant whose
+    user prompt is above the cut — and the first painted row would then be a
+    reply with no question, which reads as a broken resume rather than a
+    bounded one.
+
+    Walk back from the naive cut to the nearest user (or wake/peer) row so the
+    viewport always opens on a turn boundary. The walk is bounded by ``bound``
+    itself: if the last ``bound`` messages contain no such row, the naive cut
+    stands, because inventing an earlier start would spend the budget we just
+    measured.
+    """
+    naive = max(0, len(history) - bound)
+    if naive == 0:
+        return 0
+    for index in range(naive, len(history)):
+        message = history[index]
+        role = getattr(message, "role", None)
+        custom = getattr(message, "custom_type", None)
+        if role == "user" or custom in (WAKE_PROMPT_MESSAGE_TYPE, PEER_MESSAGE_MESSAGE_TYPE):
+            return index
+    return naive
 
 
 @dataclass
@@ -1973,6 +2043,46 @@ class OperatorApp(App[None]):
         #: bang row carries the call whose card should open on settle — the
         #: resume half of the open-on-settle contract the live path makes.
         self._replay_bang_pending = False
+        #: Messages a bounded resume render deferred: the HEAD of the
+        #: conversation, oldest first, still un-rendered. Held rather than
+        #: dropped — they are the same objects `session.history()` returned, so
+        #: this costs a list of references and nothing else, and it is what lets
+        #: scrolling up reveal real history instead of a re-read from disk that
+        #: could race `compact_file` replacing the transcript underneath it.
+        self._resume_pending_head: list[Any] = []
+        #: Every tool result in the WHOLE resumed conversation, keyed by call
+        #: id. A deferred page's calls are paired with their results from here,
+        #: because a call in the head can be answered by a result that already
+        #: rendered in the tail — indexing only the page being mounted would
+        #: replay such a call as `interrupted`, inventing an outcome the
+        #: session did not have.
+        self._resume_results: dict[str, Any] = {}
+        #: The notice standing in for the un-rendered head, so the reader can
+        #: see that older messages exist. Held (rather than looked up by text)
+        #: because it is restated in place when the head is exhausted — the
+        #: same contract `NoticeBlock.restate` documents for queued steers.
+        self._resume_head_notice: NoticeBlock | None = None
+        #: Ids of the transcript entries already mounted by the resume replay.
+        #: The dedupe key for backward paging: a page is filtered through this
+        #: before it mounts, so a message that somehow appears in both the
+        #: rendered tail and a deferred page paints once. Kept as ids rather
+        #: than object identity because a compaction can rebuild the message
+        #: objects while preserving their stable ids.
+        self._resume_mounted_ids: set[str] = set()
+        #: When set, `_append_block` collects into this list instead of
+        #: mounting. The one seam that lets a BACKWARD page be built by the
+        #: same role-aware renderer that builds the tail: those rows have to be
+        #: inserted above the viewport, and the renderer only knows how to
+        #: append. Non-None only for the duration of
+        #: `_collect_resume_page_blocks`, which is synchronous — no await
+        #: crosses it, so no live event can be diverted into a history page.
+        self._block_sink: list[Any] | None = None
+        #: Guards re-entry into the backward page mount. The scroll watcher
+        #: fires for every intermediate offset of an animated page-up, and each
+        #: mount moves the offset again — without this one keypress mounts the
+        #: rest of the conversation in a cascade, which is the cost this whole
+        #: bound exists to avoid.
+        self._resume_paging = False
         #: What the CURRENT turn has already been billed for, per model call, by
         #: `on_context_usage_reported`. `on_turn_ended` prices the same turn as a
         #: whole and is the authoritative figure, so it adds only the difference
@@ -2378,6 +2488,16 @@ class OperatorApp(App[None]):
 
         transcript = self._transcript_view()
         transcript.set_on_clear(self._on_transcript_cleared)  # TUI-009 hook
+        # A bounded resume mounts its older pages when the reader reaches the
+        # top. Two signals, because neither is complete: watching ``scroll_y``
+        # catches a wheel or page-up that actually moves the offset, and the
+        # user-scroll hook catches Home while already at the top — which does
+        # not change the offset, so the reactive never fires. SubagentView
+        # pages on the reactive alone because its Home handler calls the loader
+        # directly; the main transcript's Home is Textual's, so the hook is
+        # what makes that key do the same work.
+        self.watch(transcript, "scroll_y", self._transcript_scrolled, init=False)
+        transcript.set_on_user_scroll(self._transcript_scrolled)
         # Cached: every appended block asks the splash to hide, and that path
         # should not pay for a DOM query per block.
         self._welcome = self.query_one(WelcomeView)
@@ -3258,14 +3378,31 @@ class OperatorApp(App[None]):
 
         Guarded: a fresh session has an empty history, and a /clear already
         retired the splash — this must not fight either.
+
+        Rendering is BOUNDED (:data:`RESUME_RENDER_MESSAGES`) and the head is
+        mounted lazily as the reader scrolls up. That bound is a property of
+        this method only: ``session.history()`` above is read whole and handed
+        to nobody — the model's context was already built from the transcript
+        at construction and is not derived from what this paints. Measured on a
+        real 716-message session, rendering all of it costs 1022 ms against
+        139 ms for the last 80, and the render is 5-23x the parse, so this is
+        where a slow `/resume` actually goes.
         """
         try:
             history = list(session.history())
         except Exception:
             return  # defensive: reduced hosts may lack the accessor
-        self._project_settled_rows(history)
+        # A previous resume's deferred head must not leak into this one: /resume
+        # into a short session would otherwise page the OLD conversation onto
+        # the new transcript the first time the reader scrolled up.
+        self._resume_pending_head = []
+        self._resume_results = {}
+        self._resume_head_notice = None
+        self._resume_mounted_ids.clear()
+        self._resume_paging = False
+        self._project_settled_rows(history, bound=RESUME_RENDER_MESSAGES)
 
-    def _project_settled_rows(self, history: list[Any]) -> bool:
+    def _project_settled_rows(self, history: list[Any], *, bound: int | None = None) -> bool:
         """Mount settled transcript rows through the ONE role-aware renderer.
 
         The shared history/render seam: cold resume feeds it the whole
@@ -3281,12 +3418,28 @@ class OperatorApp(App[None]):
 
         Returns whether anything mounted, so callers can skip tail-follow
         work for an empty projection.
+
+        ``bound`` renders only the LAST ``bound`` messages and holds the rest
+        for :meth:`_mount_older_resume_page`. It is a display bound and nothing
+        else: the deferred messages stay in ``_resume_pending_head`` in full,
+        and the model's conversation — built from the transcript, not from this
+        projection — never sees the split at all. The gap-replay caller passes
+        no bound, because a reconnect gap is by definition the small set of
+        rows no frontend painted and bounding it could hide one.
         """
         # Results are keyed by the call they answer, and a tool message can sit
         # several messages after its call (one assistant turn issues a batch).
         # Indexing first is what lets each call render WITH its outcome instead
         # of as a second, orphaned row.
-        results: dict[str, Any] = {}
+        #
+        # Indexed over the WHOLE history, before any bound is applied: a call in
+        # the deferred head is often answered by a result inside the rendered
+        # tail, and a per-page index would show that call as `interrupted`.
+        #
+        # Seeded from the whole-conversation index a bounded resume kept, so a
+        # deferred page's call still finds a result that lives in the already
+        # rendered tail. Empty for every unbounded caller.
+        results: dict[str, Any] = dict(self._resume_results)
         settled_results: set[str] = set()
         # Harness chrome the LIVE path never paints as a user row, so replay
         # must not either (see the `role == "user"` branch). Deferred once to
@@ -3315,13 +3468,48 @@ class OperatorApp(App[None]):
         # truncated one) must not open a card in this conversation.
         self._replay_bang_pending = False
 
-        appended = bool(settled_results)
+        # Split the conversation into the head this frame defers and the tail it
+        # paints. Sliced on MESSAGES rather than on rendered blocks because the
+        # split has to be decided before anything is built — deciding it by
+        # block count would mean building the blocks first, which is the cost
+        # being avoided. A message mounts 0-2 blocks, so the block count lands
+        # near the bound rather than on it, which is fine: the bound is a budget,
+        # not a contract about how many rows appear.
+        if bound is not None and len(history) > bound:
+            start = _resume_tail_start(history, bound)
+            if start > 0:
+                deferred, history = history[:start], history[start:]
+                # Whole-conversation results, so a deferred call still pairs with a
+                # result that renders (or already rendered) in the tail.
+                self._resume_results = results
+                self._resume_pending_head = deferred
         transcript = self._transcript_view()
+
+        appended = bool(settled_results)
+        # The "older messages" notice has to be the FIRST row, so it is
+        # appended before the batch rather than prepended after it.
+        # `prepend_blocks` restores a scroll anchor on a later refresh, which
+        # would fight `follow_tail` for the same frame — the reflow-after-paint
+        # #451/#452 exist to prevent. One extra mount of a one-line notice is
+        # not the cost this bound is avoiding.
+        if (
+            self._block_sink is None
+            and self._resume_pending_head
+            and self._resume_head_notice is None
+        ):
+            notice = NoticeBlock(RESUME_OLDER_NOTICE, "note")
+            self._resume_head_notice = notice
+            self._append_block(notice)
+            appended = True
         # ONE mount for the whole conversation. Per-block mounting made Textual
         # re-walk its stylesheet, invalidate the container and schedule a settle
         # callback 297 times over on a 396-message session, for a layout that is
-        # only looked at once — see `TranscriptView.batch_append`.
-        with transcript.batch_append():
+        # only looked at once — see `TranscriptView.batch_append`. A collected
+        # backward page must not open a batch on the live transcript: the
+        # blocks are inserted later, and an empty batch still schedules a
+        # settle pass that would race the insert's own settle.
+        batch = nullcontext() if self._block_sink is not None else transcript.batch_append()
+        with batch:
             for message in history:
                 # A wake delivery is a CustomMessage, so it has no ``role``
                 # and would fall through every branch below — which is exactly
@@ -3451,6 +3639,17 @@ class OperatorApp(App[None]):
                         reason = "turn failed" if stop == "error" else "interrupted"
                         self._append_block(NoticeBlock(reason, "error"))
                         appended = True
+        # Every message this pass rendered, by stable id — the dedupe key a
+        # later backward page is filtered through.
+        self._resume_mounted_ids.update(
+            str(getattr(message, "id", "")) for message in history if getattr(message, "id", None)
+        )
+        if self._block_sink is not None:
+            # A collected page mounts nothing and owns no viewport: the head
+            # notice belongs to the first render, and `follow_tail` would drag
+            # the reader from the history they scrolled up to read down to the
+            # newest turn — the exact opposite of the gesture that asked for it.
+            return appended
         if appended:
             # Replay is mounted as one synchronous batch, before Textual can
             # remeasure the growing container between blocks. Land the reader on
@@ -3459,6 +3658,108 @@ class OperatorApp(App[None]):
             # off the bottom of a viewport pinned to the replay's last frame.
             transcript.follow_tail()
         return appended
+
+    def _transcript_scrolled(self, *_args: Any) -> None:
+        """Mount the next older page when the reader reaches the top.
+
+        Deliberately edge-triggered on the OFFSET rather than on a key press:
+        the top can be reached by wheel, keyboard, scrollbar drag or Home, and
+        a per-gesture hook would have to enumerate them all and would still
+        miss the drag. :data:`RESUME_PAGE_TRIGGER_ROWS` fires it slightly
+        before the hard top so the rows are already there when the reader
+        arrives, rather than appearing under a viewport that had stopped.
+        """
+        if not self._resume_pending_head:
+            return
+        if self._transcript_view().scroll_offset.y <= RESUME_PAGE_TRIGGER_ROWS:
+            self._mount_older_resume_page()
+
+    def _mount_older_resume_page(self) -> None:
+        """Mount the next older page of a bounded resume, at the top.
+
+        The reader reached the top of what was rendered, so the oldest
+        :data:`RESUME_PAGE_MESSAGES` still held are projected and inserted
+        above — beneath the head notice, which stays the first row until the
+        head is exhausted and it restates itself as the conversation's start.
+
+        No disk read. The messages are the objects ``session.history()``
+        already returned, which is what makes this immune to the hazard
+        `read_transcript_page` carries: a `compact_file` replacing the JSONL
+        underneath a cursor. There is no cursor to go stale, so the
+        ``reconciled`` case cannot arise here — and the id dedupe below is the
+        belt to that braces, catching any message that reaches the transcript
+        twice however it got there.
+        """
+        if self._resume_paging or not self._resume_pending_head:
+            return
+        self._resume_paging = True
+        try:
+            head = self._resume_pending_head
+            # Same turn-boundary snap as the initial cut: a page that opened on
+            # a tool result whose call is still in the remaining head would
+            # paint a reply with no question at the top of the newly revealed
+            # history.
+            start = _resume_tail_start(head, RESUME_PAGE_MESSAGES)
+            page, self._resume_pending_head = head[start:], head[:start]
+            # Dedupe by stable ID, never by position: the tail was sliced off
+            # the same list, so an overlap should be impossible — but a message
+            # painted twice is a corrupted transcript the user cannot correct,
+            # while a message skipped here is one already on screen. The
+            # asymmetry is why the check exists at all.
+            page = [
+                message
+                for message in page
+                if str(getattr(message, "id", "")) not in self._resume_mounted_ids
+                or not getattr(message, "id", None)
+            ]
+            transcript = self._transcript_view()
+            notice = self._resume_head_notice
+            blocks = self._collect_resume_page_blocks(page)
+            if blocks:
+                # Index 1 when the notice heads the list: the page goes BELOW
+                # it and above the previously rendered rows, so the notice
+                # stays the top row and the conversation keeps its order.
+                mounted = transcript.blocks()
+                index = 1 if mounted and notice is not None and mounted[0] is notice else 0
+                transcript.insert_blocks(index, blocks)
+            if not self._resume_pending_head and notice is not None:
+                # The head is exhausted, so the promise of more becomes a
+                # statement of where the conversation begins. Restated in place
+                # rather than removed: removing it would shift every row above
+                # the viewport by one and undo the anchor the insert just held.
+                notice.restate(RESUME_START_NOTICE, "info")
+        finally:
+            self._resume_paging = False
+
+    def _collect_resume_page_blocks(self, page: list[Any]) -> list[Any]:
+        """Build the blocks for one deferred page WITHOUT mounting them.
+
+        The projection renderer appends into the transcript as it goes, which
+        is right for the tail and wrong here: these rows belong ABOVE the
+        viewport, and appending them would put the conversation's beginning
+        after its end. So :attr:`_block_sink` diverts the append seam into a
+        list for the duration, and the caller inserts that list positionally.
+
+        Diverting rather than reimplementing is the point — the whole reason
+        `_project_settled_rows` is one method is that a second role-aware
+        renderer drifts from the first (review round 3, MAJOR-1: a synthetic
+        replay painted user prompts as agent speech). A backward page is the
+        same conversation as the tail and must be built by the same code.
+        """
+        collected: list[Any] = []
+        self._block_sink = collected
+        try:
+            self._project_settled_rows(page)
+        finally:
+            self._block_sink = None
+            # A page can end on a bang user row whose assistant lives in the
+            # already-rendered tail. Leaving the flag set would open the next
+            # LIVE bash card, which is not a bang receipt.
+            self._replay_bang_pending = False
+        self._resume_mounted_ids.update(
+            str(getattr(message, "id", "")) for message in page if getattr(message, "id", None)
+        )
+        return collected
 
     def _painted_tool_card(self, call_id: str) -> ToolCard | None:
         """The ToolCard on screen for ``call_id``, whether live or retired.
@@ -8634,6 +8935,17 @@ class OperatorApp(App[None]):
         if self._working_block is not None:
             self._working_block.stop()
             self._working_block = None
+        # A bounded resume's un-rendered head goes with the rows it belonged
+        # above. /clear is a request to empty the SCREEN, so paging older
+        # messages back onto a transcript the user just cleared would undo it
+        # one scroll later — and the head notice it would page beneath was just
+        # unmounted, which would send the insert to a block the container no
+        # longer holds. The model's context is untouched by any of this, which
+        # is what /clear already promises.
+        self._resume_pending_head = []
+        self._resume_results = {}
+        self._resume_head_notice = None
+        self._resume_mounted_ids.clear()
         # The prompt's widget is about to be removed with the rest of the
         # transcript, so the turn awaiting it is denied rather than orphaned —
         # but NOT latched: /clear does not stop the turn, and latching here
@@ -11320,7 +11632,17 @@ class OperatorApp(App[None]):
         A block that lands UNDER the splash takes rows out of the same region the
         composition is measured against, so the reserve is recomputed here rather
         than left centred for a region that no longer exists.
+
+        While ``_block_sink`` is open the block is COLLECTED rather than
+        mounted: a bounded resume's backward page is built by this same
+        renderer but has to be inserted above the viewport, which an append
+        cannot express. The splash is not touched in that mode — a bounded
+        resume already retired it when it painted the tail, and a page mounted
+        into the scrollback is not the edge that starts a conversation.
         """
+        if self._block_sink is not None:
+            self._block_sink.append(block)
+            return
         if ends_empty_state:
             self._set_welcome_visible(False)
         transcript = self._transcript_view()

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1694,6 +1694,26 @@ class OperatorApp(App[None]):
         # the common path.
         Binding("ctrl+down", "scroll_todos_down", "Scroll todos down", show=False),
         Binding("ctrl+up", "scroll_todos_up", "Scroll todos up", show=False),
+        # Page the TRANSCRIPT from the composer (UX round 1, U2). A bounded
+        # resume is the first time scrolling the transcript is REQUIRED to see
+        # one's own history, and every plain scroll key is spoken for: `up`,
+        # `down`, `pageup`, `pagedown` and `home`/`end` are TextArea cursor
+        # bindings, `tab` never leaves the composer, `shift+tab` is effort
+        # cycling (priority), and `ctrl+up`/`ctrl+down` page the todo overflow.
+        # So without a chord of its own, "scroll up to load" was mouse-only.
+        #
+        # `ctrl+home`/`ctrl+end` because TextArea binds NEITHER (audited
+        # against textual 8.2.8: it binds `home,ctrl+a` and `end,ctrl+e` for
+        # LINE-relative cursor moves, never the ctrl chord for the buffer
+        # extremes), and nothing else in this app binds them — the same
+        # free-key discipline `ctrl+t`, `ctrl+g` and `ctrl+up`/`ctrl+down`
+        # above were chosen by. They bubble rather than sit at `priority`, so
+        # an open picker keeps first refusal on the key, exactly like the
+        # other composer-adjacent chords. `home` jumps to the oldest row
+        # (mounting one page, then further pages per press once the head is
+        # still deferred); `end` returns to the live tail.
+        Binding("ctrl+home", "transcript_home", "Transcript top", show=False),
+        Binding("ctrl+end", "transcript_end", "Transcript end", show=False),
     ]
 
     def __init__(
@@ -2077,12 +2097,19 @@ class OperatorApp(App[None]):
         #: `_collect_resume_page_blocks`, which is synchronous — no await
         #: crosses it, so no live event can be diverted into a history page.
         self._block_sink: list[Any] | None = None
-        #: Guards re-entry into the backward page mount. The scroll watcher
-        #: fires for every intermediate offset of an animated page-up, and each
-        #: mount moves the offset again — without this one keypress mounts the
-        #: rest of the conversation in a cascade, which is the cost this whole
-        #: bound exists to avoid.
+        #: One page per USER GESTURE, not per scroll callback. Held from the
+        #: first trigger until the mount's settle pass has restored the scroll
+        #: anchor: Textual ANIMATES pageup/home, so the scroll watcher fires
+        #: for every intermediate offset of one gesture, and each mount moves
+        #: the offset again — a per-callback guard let one animated Home mount
+        #: the entire deferred head (522 messages on a 600-message probe), the
+        #: unbounded render cost this bound exists to remove. Cleared by the
+        #: settle callback `insert_blocks` schedules, never synchronously.
         self._resume_paging = False
+        #: SINGLE-FLIGHT guard for the deferred page check: while set, a check
+        #: is already scheduled and `_transcript_scrolled` must not queue a
+        #: second. See that method for why unbounded requeues were a cascade.
+        self._resume_check_pending = False
         #: What the CURRENT turn has already been billed for, per model call, by
         #: `on_context_usage_reported`. `on_turn_ended` prices the same turn as a
         #: whole and is the authoritative figure, so it adds only the difference
@@ -2489,14 +2516,14 @@ class OperatorApp(App[None]):
         transcript = self._transcript_view()
         transcript.set_on_clear(self._on_transcript_cleared)  # TUI-009 hook
         # A bounded resume mounts its older pages when the reader reaches the
-        # top. Two signals, because neither is complete: watching ``scroll_y``
-        # catches a wheel or page-up that actually moves the offset, and the
-        # user-scroll hook catches Home while already at the top — which does
-        # not change the offset, so the reactive never fires. SubagentView
-        # pages on the reactive alone because its Home handler calls the loader
-        # directly; the main transcript's Home is Textual's, so the hook is
-        # what makes that key do the same work.
-        self.watch(transcript, "scroll_y", self._transcript_scrolled, init=False)
+        # top. The hook alone catches every GESTURE (wheel, key, drag, click —
+        # `note_user_scroll` fires for each) but fires at gesture START, before
+        # an animated scroll has moved anything; the transcript's own
+        # ``scroll_y`` watch (see ``TranscriptView.watch_scroll_y``) re-fires
+        # the same callback for every offset the viewport passes through. The
+        # two together cover a gesture from start to landing, and the
+        # rest-guard in `_check_resume_page` is what collapses the many
+        # firings of one animated gesture into ONE page (M1/U1).
         transcript.set_on_user_scroll(self._transcript_scrolled)
         # Cached: every appended block asks the splash to hide, and that path
         # should not pay for a DOM query per block.
@@ -3396,10 +3423,14 @@ class OperatorApp(App[None]):
         # into a short session would otherwise page the OLD conversation onto
         # the new transcript the first time the reader scrolled up.
         self._resume_pending_head = []
+        self._sync_deferred_segment()
         self._resume_results = {}
         self._resume_head_notice = None
         self._resume_mounted_ids.clear()
         self._resume_paging = False
+        # A check queued for the OLD conversation must not fire against the
+        # new one; a fresh head has no gesture in flight worth answering.
+        self._resume_check_pending = False
         self._project_settled_rows(history, bound=RESUME_RENDER_MESSAGES)
 
     def _project_settled_rows(self, history: list[Any], *, bound: int | None = None) -> bool:
@@ -3483,6 +3514,10 @@ class OperatorApp(App[None]):
                 # result that renders (or already rendered) in the tail.
                 self._resume_results = results
                 self._resume_pending_head = deferred
+        # The band's deferred count is the at-rest signal that the transcript
+        # is bounded (UX1, U3) — pushed here so it is correct from the FIRST
+        # frame, not from the next band tick.
+        self._sync_deferred_segment()
         transcript = self._transcript_view()
 
         appended = bool(settled_results)
@@ -3662,16 +3697,71 @@ class OperatorApp(App[None]):
     def _transcript_scrolled(self, *_args: Any) -> None:
         """Mount the next older page when the reader reaches the top.
 
-        Deliberately edge-triggered on the OFFSET rather than on a key press:
-        the top can be reached by wheel, keyboard, scrollbar drag or Home, and
-        a per-gesture hook would have to enumerate them all and would still
-        miss the drag. :data:`RESUME_PAGE_TRIGGER_ROWS` fires it slightly
-        before the hard top so the rows are already there when the reader
-        arrives, rather than appearing under a viewport that had stopped.
+        Fired from the transcript's ``scroll_y`` WATCH (every offset the
+        viewport actually passes through) and from ``note_user_scroll`` (the
+        gesture that moves NOTHING — Home while already at the top changes no
+        offset, so the watch alone would miss the one key that most clearly
+        means "show me the start"). Both are needed, and neither alone is
+        enough; the guard inside :meth:`_check_resume_page` is what keeps the
+        many firings of one animated gesture to ONE page.
+
+        The offset is never read here — this fires mid-animation and at
+        gesture start, where the offset is pre-gesture or mid-flight. The
+        question is handed to :meth:`_check_resume_page` after the refresh,
+        which waits for the viewport to be at rest before answering.
         """
         if not self._resume_pending_head:
             return
-        if self._transcript_view().scroll_offset.y <= RESUME_PAGE_TRIGGER_ROWS:
+        # SINGLE-FLIGHT: exactly one deferred check may be pending at a time.
+        # The watch fires once per animation frame and each firing used to
+        # schedule its own check, so one animated gesture queued hundreds;
+        # they all drained the moment the gate re-opened and each one mounted
+        # another page — the same cascade the gate exists to prevent, arriving
+        # one settle-pass later (M1/U1). A flag is enough because the pending
+        # check always runs before the next frame's watch can fire again.
+        if self._resume_check_pending:
+            return
+        self._resume_check_pending = True
+
+        def run_check() -> None:
+            self._resume_check_pending = False
+            self._check_resume_page()
+
+        self._transcript_view().call_after_refresh(run_check)
+
+    def _check_resume_page(self) -> None:
+        """Answer "is the reader at the top" from a viewport at rest.
+
+        Re-asks frame-by-frame while the viewport is still travelling — an
+        animated page-up is mid-flight for its whole duration, and every
+        intermediate offset is nearer the top than where the reader will land
+        — and again while a page this gesture already mounted is still
+        settling, so a second gesture arriving inside that window is answered
+        the moment the gate re-opens rather than silently dropped. Both waits
+        end: the animation finishes, and the settle callback releases the
+        gate (:meth:`_mount_older_resume_page`). The requeue is single-flight
+        (see `_transcript_scrolled`), so waiting never accumulates.
+
+        :data:`RESUME_PAGE_TRIGGER_ROWS` fires slightly before the hard top so
+        the rows are already there when the reader arrives, rather than
+        appearing under a viewport that had stopped.
+        """
+        if not self._resume_pending_head:
+            return
+        transcript = self._transcript_view()
+        if (
+            transcript.app.animator.is_being_animated(transcript, "scroll_y")
+            # A scroll that has been REQUESTED but not started yet — the
+            # callback can land between the key binding and the animation it
+            # schedules, where `is_being_animated` is still False and the
+            # offset still pre-gesture. `scroll_target_y` is where the
+            # viewport is committed to go; differing means travel is coming.
+            or transcript.scroll_target_y != transcript.scroll_offset.y
+            or self._resume_paging
+        ):
+            self._transcript_scrolled()
+            return
+        if transcript.scroll_offset.y <= RESUME_PAGE_TRIGGER_ROWS:
             self._mount_older_resume_page()
 
     def _mount_older_resume_page(self) -> None:
@@ -3687,49 +3777,71 @@ class OperatorApp(App[None]):
         `read_transcript_page` carries: a `compact_file` replacing the JSONL
         underneath a cursor. There is no cursor to go stale, so the
         ``reconciled`` case cannot arise here — and the id dedupe below is the
-        belt to that braces, catching any message that reaches the transcript
+        belt to those braces, catching any message that reaches the transcript
         twice however it got there.
+
+        ONE page per gesture, held across frames: the gate is cleared by the
+        settle callback `insert_blocks` schedules, never synchronously. A
+        synchronous clear left the gate open again while an animated page-up
+        was still crossing the trigger row, so each animation frame mounted
+        another page — one animated Home mounted the entire remaining head,
+        the unbounded render cost this bound exists to remove, paid
+        mid-interaction on the very sessions it targets.
         """
         if self._resume_paging or not self._resume_pending_head:
             return
         self._resume_paging = True
-        try:
-            head = self._resume_pending_head
-            # Same turn-boundary snap as the initial cut: a page that opened on
-            # a tool result whose call is still in the remaining head would
-            # paint a reply with no question at the top of the newly revealed
-            # history.
-            start = _resume_tail_start(head, RESUME_PAGE_MESSAGES)
-            page, self._resume_pending_head = head[start:], head[:start]
-            # Dedupe by stable ID, never by position: the tail was sliced off
-            # the same list, so an overlap should be impossible — but a message
-            # painted twice is a corrupted transcript the user cannot correct,
-            # while a message skipped here is one already on screen. The
-            # asymmetry is why the check exists at all.
-            page = [
-                message
-                for message in page
-                if str(getattr(message, "id", "")) not in self._resume_mounted_ids
-                or not getattr(message, "id", None)
-            ]
-            transcript = self._transcript_view()
-            notice = self._resume_head_notice
-            blocks = self._collect_resume_page_blocks(page)
-            if blocks:
-                # Index 1 when the notice heads the list: the page goes BELOW
-                # it and above the previously rendered rows, so the notice
-                # stays the top row and the conversation keeps its order.
-                mounted = transcript.blocks()
-                index = 1 if mounted and notice is not None and mounted[0] is notice else 0
-                transcript.insert_blocks(index, blocks)
-            if not self._resume_pending_head and notice is not None:
-                # The head is exhausted, so the promise of more becomes a
-                # statement of where the conversation begins. Restated in place
-                # rather than removed: removing it would shift every row above
-                # the viewport by one and undo the anchor the insert just held.
-                notice.restate(RESUME_START_NOTICE, "info")
-        finally:
+        head = self._resume_pending_head
+        # Same turn-boundary snap as the initial cut: a page that opened on
+        # a tool result whose call is still in the remaining head would
+        # paint a reply with no question at the top of the newly revealed
+        # history.
+        start = _resume_tail_start(head, RESUME_PAGE_MESSAGES)
+        page, self._resume_pending_head = head[start:], head[:start]
+        # The count the band shows shrinks with every page mounted; pushed
+        # synchronously so the figure cannot lag the gesture that changed it.
+        self._sync_deferred_segment()
+        # Dedupe by stable ID, never by position: the tail was sliced off
+        # the same list, so an overlap should be impossible — but a message
+        # painted twice is a corrupted transcript the user cannot correct,
+        # while a message skipped here is one already on screen. The
+        # asymmetry is why the check exists at all.
+        page = [
+            message
+            for message in page
+            if str(getattr(message, "id", "")) not in self._resume_mounted_ids
+            or not getattr(message, "id", None)
+        ]
+        transcript = self._transcript_view()
+        notice = self._resume_head_notice
+        blocks = self._collect_resume_page_blocks(page)
+
+        def release_gate() -> None:
+            # Cleared from the settle pass, not from a `finally`: the settle
+            # is the first moment the gesture that armed the gate is fully
+            # answered — the page is mounted, the gaps settled, and the anchor
+            # restore's own non-animated scroll (which force-stops any in-flight
+            # scroll animation) has landed the reader back where they were.
+            # Releasing any earlier re-opens the gate while an animated page-up
+            # is still crossing the trigger row, and the next animation frame
+            # mounts another page.
             self._resume_paging = False
+
+        if blocks:
+            # Index 1 when the notice heads the list: the page goes BELOW
+            # it and above the previously rendered rows, so the notice
+            # stays the top row and the conversation keeps its order.
+            mounted = transcript.blocks()
+            index = 1 if mounted and notice is not None and mounted[0] is notice else 0
+            transcript.insert_blocks(index, blocks, on_settled=release_gate)
+        else:
+            release_gate()
+        if not self._resume_pending_head and notice is not None:
+            # The head is exhausted, so the promise of more becomes a
+            # statement of where the conversation begins. Restated in place
+            # rather than removed: removing it would shift every row above
+            # the viewport by one and undo the anchor the insert just held.
+            notice.restate(RESUME_START_NOTICE, "info")
 
     def _collect_resume_page_blocks(self, page: list[Any]) -> list[Any]:
         """Build the blocks for one deferred page WITHOUT mounting them.
@@ -4423,6 +4535,10 @@ class OperatorApp(App[None]):
             # dead conversation's figure would stay on screen until the new one's
             # first turn ended.
             cost="",
+            # Same contract for the deferred count: it described the replaced
+            # conversation's bounded head, which is gone with the transcript.
+            # The new session's resume replay re-pushes it if it has one.
+            deferred=0,
         )
         return (*carried_spend, was_floor)
 
@@ -8943,6 +9059,10 @@ class OperatorApp(App[None]):
         # longer holds. The model's context is untouched by any of this, which
         # is what /clear already promises.
         self._resume_pending_head = []
+        # The band must not keep advertising older messages that no longer
+        # exist — `/clear` empties the screen, and a stale count beside an
+        # empty transcript would claim history the user just erased.
+        self._sync_deferred_segment()
         self._resume_results = {}
         self._resume_head_notice = None
         self._resume_mounted_ids.clear()
@@ -13035,6 +13155,46 @@ class OperatorApp(App[None]):
     def action_scroll_todos_up(self) -> None:
         """``ctrl+up`` — page the expanded todo overflow toward the start (U2)."""
         self._scroll_todos(down=False)
+
+    def _sync_deferred_segment(self) -> None:
+        """Mirror the deferred-head size into the status band (UX1, U3).
+
+        The band is the only chrome visible at REST — the head notice lives
+        four screens above the viewport, so without this nothing at first
+        paint says the transcript is bounded and the failure mode the notice
+        exists for ("a user believing history was LOST") is answered only
+        after scrolling. Called at every point the pending head changes size
+        or empties: the initial split, each page mount, `/clear`, and a fresh
+        resume resetting an old head. Tolerates a not-yet-constructed band,
+        which is the state during early boot when a resume replays first.
+        """
+        if self._status is None:
+            return
+        self._status.update(deferred=len(self._resume_pending_head))
+
+    def action_transcript_home(self) -> None:
+        """``ctrl+home`` — take the transcript to its oldest row (UX1, U2).
+
+        Goes through the transcript's own scroll action rather than calling
+        ``scroll_home`` directly, so the SAME path a focused-transcript ``home``
+        takes runs here: ``note_user_scroll`` first (the paging trigger, and
+        the tail-anchor release), then the animated scroll. Focus is left
+        untouched — the whole point of the chord is that the composer keeps
+        the caret, so a reader checking the start of a long session can type
+        the moment they return with ``ctrl+end``.
+        """
+        self._transcript_view().action_scroll_home()
+
+    def action_transcript_end(self) -> None:
+        """``ctrl+end`` — take the transcript back to the live tail (UX1, U2).
+
+        The counterpart of ``ctrl+home``: a reader who paged up to check
+        something returns to where new turns arrive without a mouse. Routes
+        through the transcript's own ``end`` action for the same reasons —
+        ``note_user_scroll`` plus the tail-anchor handoff the action already
+        performs.
+        """
+        self._transcript_view().action_scroll_end()
 
     def _scroll_todos(self, *, down: bool) -> None:
         """Drive the todo panel's keyboard scroll, the one path both keys share.

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -114,6 +114,14 @@ ICON_AGENTS = "◍"
 #: so the band's width arithmetic stays correct while the glyph is invisible.
 ICON_JOBS = "▣"
 ICON_CONTEXT = "▦"
+#: Deferred history: messages a bounded resume holds off-screen until the
+#: reader scrolls up. A CATEGORY marker like every other icon here; ``▴``
+#: points UP, which is the direction the deferred rows are in, and it is the
+#: EFFORT glyph mirrored rather than reused because the two never co-occur
+#: (``▴ high`` is a model setting, this is a transcript state) — still, a
+#: DIFFERENT glyph was preferred over a shared one since the reader meets
+#: both in the same row. Stays in U+25xx per the hard constraint above.
+ICON_DEFERRED = "▾"
 ICON_COST = "◈"
 ICON_DURATION = "◷"
 #: MCP servers. ``⊙`` (U+2299) is the reference's glyph and measures ONE cell
@@ -355,6 +363,14 @@ _DROP_LADDER: tuple[str, ...] = (
     # these the other way round, which contradicted this very ladder's rationale.
     "cwd",
     "context",
+    # The deferred-history count (UX1, U3): sits in the ladder between the
+    # numbers an operator acts on and the MCP lamp. It is re-derivable the
+    # same way `duration` is — scroll up and the rows are there — so it could
+    # have gone at the top, but a cramped band is exactly when the user most
+    # needs the reminder that the transcript is bounded, so it outlives the
+    # cwd/context pair and yields to the pending-fork state and the two
+    # alarms below.
+    "deferred",
     # A PENDING fork, and it outlives every reading above for the reason the
     # approval alarm does: it is a transient STATE the user can still act on
     # (esc withdraws it), not a figure they can re-derive. It exists at all only
@@ -364,7 +380,7 @@ _DROP_LADDER: tuple[str, ...] = (
     # is BOUNDED (a glyph plus a fixed word), so it is a legal tail neighbour
     # under :data:`_UNBOUNDED_RUNGS`.
     #
-    # Authored between `context` and `mcp`, so in the ALARM ladder it sheds
+    # Authored immediately ahead of `mcp`, so in the ALARM ladder it sheds
     # ahead of both remaining rungs: a failed-MCP lamp and the disarmed-gate `!`
     # are standing warnings about the session's configuration that nothing else
     # in the UI carries, while a pending fork resolves itself within a turn. In
@@ -972,6 +988,12 @@ class StatusLine:
         self._context_window: int = 0
         self._subagents: int = 0
         self._jobs: int = 0
+        # Messages a bounded resume holds off-screen (UX1, U3). 0 = nothing
+        # deferred: the segment is absent, so an ordinary session's band is
+        # byte-for-byte what it was before the segment existed. Only the
+        # OperatorApp pushes this, from `_resume_pending_head` — the band never
+        # reaches into resume state, same as every other segment here.
+        self._deferred: int = 0
         self._streaming: bool = False
         self._cost: str = ""
         self._conversation_name: str = ""
@@ -1163,6 +1185,7 @@ class StatusLine:
         context_window: int | None = None,
         subagents: int | None = None,
         jobs: int | None = None,
+        deferred: int | None = None,
         streaming: bool | None = None,
         cost: str | None = None,
         conversation_name: str | None = None,
@@ -1199,6 +1222,8 @@ class StatusLine:
             self._subagents = subagents
         if jobs is not None:
             self._jobs = jobs
+        if deferred is not None:
+            self._deferred = deferred
         if mcp is not None:
             self._mcp = mcp
         if approvals_auto is not None:
@@ -1784,6 +1809,23 @@ class StatusLine:
             jobs = format_jobs(self._jobs)
             if jobs:
                 parts.append((ICON_JOBS, jobs, Style(color=theme_mod.semantic_color("label"))))
+        if "deferred" not in dropped:
+            # The deferred-history count (UX1, U3): the at-rest signal that a
+            # resumed transcript is bounded. Lives in the RIGHT group with the
+            # other counters and takes `label` like they do — it is a count,
+            # not a reading the operator acts on, so it must not warm the way
+            # the context number can. Placed beside the counters rather than
+            # the cwd/model identity group because it MOVES while the user
+            # reads (every page mount shrinks it) and a moving figure beside
+            # static identity reads as noise.
+            if self._deferred:
+                parts.append(
+                    (
+                        ICON_DEFERRED,
+                        f"{self._deferred} older",
+                        Style(color=theme_mod.semantic_color("label")),
+                    )
+                )
         if "context" not in dropped:
             tokens, window = self._shown_context()
             usage = format_context_usage(tokens, window)

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -2090,6 +2090,13 @@ class TranscriptView(ScrollableContainer):
         super().__init__(id=id, classes=classes)
         self._blocks: list[TranscriptBlock] = []
         self._on_clear: Callable[[], None] | None = None
+        #: Fired from :meth:`note_user_scroll` after the tail-anchor release.
+        #: A bounded resume pages older rows when the reader reaches the top,
+        #: and Home at offset 0 does not change ``scroll_y`` — so a reactive
+        #: watch on the offset would miss the one gesture that most clearly
+        #: means "show me the start". The hook is the same shape as
+        #: ``on_clear``: optional, app-owned, never required for the widget.
+        self._on_user_scroll: Callable[[], None] | None = None
         # The ledger's shared name column, recomputed lazily. Cached because it
         # is read once per card per repaint and only changes when the set of tool
         # names on screen does.
@@ -2142,6 +2149,17 @@ class TranscriptView(ScrollableContainer):
     def set_on_clear(self, hook: Callable[[], None] | None) -> None:
         """Install the hook fired after every :meth:`clear_blocks`."""
         self._on_clear = hook
+
+    def set_on_user_scroll(self, hook: Callable[[], None] | None) -> None:
+        """Install the hook fired from every user-initiated scroll.
+
+        Distinct from watching ``scroll_y``: a Home press while already at the
+        top does not change the offset, so a reactive watch never fires, and
+        that is exactly the gesture that should load the next older page of a
+        bounded resume. The hook runs after the tail-anchor release so a page
+        mount cannot re-acquire following for a reader who just left the tail.
+        """
+        self._on_user_scroll = hook
 
     def pin_tail(self, block: TranscriptBlock) -> None:
         """Append ``block`` and hold it last as the transcript grows.
@@ -2651,6 +2669,8 @@ class TranscriptView(ScrollableContainer):
         # a wheel notch DOWN while already at the tail, which must hand the
         # anchor straight back rather than leaving it released forever.
         self.call_after_refresh(self._resync_tail_anchor)
+        if self._on_user_scroll is not None:
+            self._on_user_scroll()
 
     def watch_scroll_y(self, old_value: float, new_value: float) -> None:
         """Re-decide following from every offset the viewport actually rests at.

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -2230,6 +2230,7 @@ class TranscriptView(ScrollableContainer):
         blocks: Sequence[TranscriptBlock],
         *,
         anchor_offset: float | None = None,
+        on_settled: Callable[[], None] | None = None,
     ) -> None:
         """Insert history above visible content while preserving its anchor.
 
@@ -2238,6 +2239,13 @@ class TranscriptView(ScrollableContainer):
         block containing the viewport top plus its intra-block offset, never a
         virtual-height proxy: adaptive gap settlement can legitimately change
         heights above it on a later layout pass.
+
+        ``on_settled`` runs after the insert is fully answered — gaps settled
+        AND the anchor restore's own non-animated scroll has landed — which is
+        the earliest moment a caller that gates work on "the reader is back
+        where they were" can safely re-open that gate. Running it from the
+        anchor restore rather than the settle itself is load-bearing: between
+        the two, the offset still sits where the inserted rows pushed it.
         """
         additions = list(blocks)
         if not additions:
@@ -2263,11 +2271,23 @@ class TranscriptView(ScrollableContainer):
 
             def restore_anchor() -> None:
                 if anchor_block is None or anchor_block.parent is not self:
+                    if on_settled is not None:
+                        on_settled()
                     return
-                self.scroll_to(
-                    y=max(0, anchor_block.virtual_region.y - anchor_gap),
-                    animate=False,
-                )
+                # Inside the programmatic guard: this scroll is the insert's
+                # own, not a reader's, so it must not release the tail anchor
+                # (`watch_scroll_y` skips the resync) — and, for the resume
+                # page-back path, must not be read as a reader arriving at the
+                # top. The restored offset can be inside the page trigger
+                # zone by construction: the rows above were just inserted, so
+                # the anchor lands where it was, which was the top.
+                with self._tail_anchor.programmatic_scroll():
+                    self.scroll_to(
+                        y=max(0, anchor_block.virtual_region.y - anchor_gap),
+                        animate=False,
+                    )
+                if on_settled is not None:
+                    on_settled()
 
             self.call_after_refresh(restore_anchor)
 
@@ -2689,6 +2709,17 @@ class TranscriptView(ScrollableContainer):
         super().watch_scroll_y(old_value, new_value)
         if not self._tail_anchor.programmatic:
             self._tail_anchor.resync(at_end=self.is_near_bottom())
+            # The page-back trigger rides the same watch, scheduled for after
+            # the refresh rather than answered here. `note_user_scroll` fires
+            # at gesture START, before an animated scroll has moved anything,
+            # so a check scheduled only from there can never see the landing;
+            # the watch supplies it. This fires once per animation frame, and
+            # that is fine BY DESIGN: the deferred check reads the viewport
+            # only when it is at rest (animation finished, no pending target,
+            # gate open — see `OperatorApp._check_resume_page`), so the many
+            # firings of one animated gesture collapse into ONE page (M1/U1).
+            if self._on_user_scroll is not None:
+                self._on_user_scroll()
 
     def _resync_tail_anchor(self) -> None:
         # Not while the viewport is still travelling: an animated page-up is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.6"
+version = "0.44.7"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/test_fork.py
+++ b/tests/unit/test_fork.py
@@ -1247,6 +1247,10 @@ def _band():
     band._context_window = 0
     band._subagents = 0
     band._jobs = 0
+    # `_render` reads this even when the deferred-history segment is empty
+    # (0 = absent). The helper predates that rung, so it has to seed the
+    # field the same way it seeds `_jobs` — `__new__` skips `__init__`.
+    band._deferred = 0
     band._streaming = False
     band._cost = ""
     band._conversation_name = ""

--- a/tests/unit/tui/test_resume_render.py
+++ b/tests/unit/tui/test_resume_render.py
@@ -12,10 +12,12 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from textual.events import Key
 
 from local_operator.tui.app import (
     RESUME_OLDER_NOTICE,
     RESUME_PAGE_MESSAGES,
+    RESUME_PAGE_TRIGGER_ROWS,
     RESUME_RENDER_MESSAGES,
     RESUME_START_NOTICE,
     OperatorApp,
@@ -81,6 +83,27 @@ def _user_texts(app: OperatorApp) -> list[str]:
     ]
 
 
+async def _press_and_settle(pilot, view: TranscriptView, key: str) -> None:
+    """Press a real key and let its scroll animation fully settle.
+
+    ``pilot.press`` waits for the animator between keys, which hides exactly
+    the mid-animation behaviour these tests exist to pin; posting the event
+    directly and draining frames keeps the gesture's own timeline visible.
+    The pause loop must outlive the animation (Textual animates a Home over
+    ~1 s at speed 50) AND the settle callback a page mount schedules.
+    """
+    event = Key(key, None)
+    event.set_sender(pilot.app)
+    pilot.app.post_message(event)
+    for _ in range(160):
+        await pilot.pause()
+        if not pilot.app.animator.is_being_animated(view, "scroll_y"):
+            # One extra beat for the settle/anchor callbacks the mount queued.
+            for _ in range(4):
+                await pilot.pause()
+            return
+
+
 async def _wait_for_resume(pilot, app: OperatorApp, *, min_blocks: int = 1) -> None:
     """Boot paints, then a worker adopts the session and replays history.
 
@@ -107,6 +130,112 @@ def test_resume_tail_start_snaps_to_the_nearest_user_row() -> None:
     assert _resume_tail_start(history, 4) == 12
     assert _resume_tail_start(history, 80) == 0
     assert _resume_tail_start(history, 15) == 0
+
+
+@pytest.mark.asyncio
+async def test_an_animated_page_up_mounts_exactly_one_page() -> None:
+    """One animated PageUp mounts ONE page — the page-per-gesture contract.
+
+    Textual ANIMATES pageup/home, so the offset crosses the trigger row many
+    times inside one gesture. The re-entry guard must hold for the whole
+    gesture, not one synchronous callback: the version this test was written
+    against let each animation frame mount another page (three pages for one
+    PageUp, and the ENTIRE deferred head for one Home on a 600-message
+    session), which is the unbounded render cost the display bound exists to
+    remove, paid mid-interaction. Drives the REAL key path — focus the
+    transcript, post the key, let the animation run — never
+    ``scroll_home(animate=False)``.
+    """
+    session = FakeSession()
+    session._history = _history(200)  # 600 messages; ~120 turns deferred
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        view = app.query_one(TranscriptView)
+        before_pending = len(app._resume_pending_head)
+        before_blocks = len(view.blocks())
+        # Place the viewport ABOVE the trigger row but off the top, the
+        # position a reader is in when they page up toward the history.
+        view.scroll_to(y=RESUME_PAGE_TRIGGER_ROWS + 8, animate=False)
+        await pilot.pause()
+        view.focus()
+        await pilot.pause()
+        await _press_and_settle(pilot, view, "pageup")
+        assert len(app._resume_pending_head) == before_pending - RESUME_PAGE_MESSAGES
+        assert len(view.blocks()) > before_blocks
+        assert view.scroll_offset.y <= RESUME_PAGE_TRIGGER_ROWS
+
+
+@pytest.mark.asyncio
+async def test_an_animated_home_mounts_one_page_and_lands_at_the_top() -> None:
+    """One animated Home mounts ONE page and lands at the TOP of it.
+
+    The cascade this guards against was worst for Home: the whole remaining
+    conversation mounted in one keypress and the viewport landed
+    mid-conversation (y=146 of 270 on a 150-message session), because the Home
+    animation and the mount's anchor restore fought for the offset. The
+    gesture must be fast, mount one page, and leave the reader at the start
+    of what is rendered — not in the middle, and not needing a second press.
+    """
+    session = FakeSession()
+    session._history = _history(50)  # 150 messages; ~70 deferred
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        view = app.query_one(TranscriptView)
+        before_pending = len(app._resume_pending_head)
+        assert before_pending
+        view.focus()
+        await pilot.pause()
+        await _press_and_settle(pilot, view, "home")
+        # Exactly one page: the head shrank by one page, not to zero.
+        assert len(app._resume_pending_head) == before_pending - RESUME_PAGE_MESSAGES
+        # The reader landed AT THE TOP of what is rendered, not mid-page.
+        assert view.scroll_offset.y <= RESUME_PAGE_TRIGGER_ROWS
+        first_users = [t for t in _user_texts(app)][:1]
+        assert first_users, "a page mounted"
+        # A second Home mounts the NEXT page (the gesture re-arms), and still
+        # lands at the top — the reader walks back in pages, never a cascade.
+        # The SECOND press may exhaust the head (a 150-message session holds
+        # only ~72 deferred, so two 60-message pages reach the start); what
+        # is pinned is that the walk is bounded — never more than one page
+        # per press — and never a cascade to zero from a single gesture.
+        await _press_and_settle(pilot, view, "home")
+        assert (
+            before_pending - 2 * RESUME_PAGE_MESSAGES
+            <= len(app._resume_pending_head)
+            < (before_pending - RESUME_PAGE_MESSAGES)
+        )
+        assert view.scroll_offset.y <= RESUME_PAGE_TRIGGER_ROWS
+
+
+@pytest.mark.asyncio
+async def test_the_composer_pages_the_transcript_by_keyboard() -> None:
+    """``ctrl+home`` from the composer reaches the transcript (UX1, U2).
+
+    Default focus is the composer and every plain scroll key is spoken for by
+    the Editor, so without a chord the "scroll up to load" affordance was
+    mouse-only. ``ctrl+home`` must mount one page without moving focus, and
+    ``ctrl+end`` must return the reader to the tail.
+    """
+    session = FakeSession()
+    session._history = _history(50)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        view = app.query_one(TranscriptView)
+        before_pending = len(app._resume_pending_head)
+        assert before_pending
+        # The composer holds focus, as it does at rest after a resume.
+        composer_focused = app.focused
+        assert composer_focused is not view
+        await _press_and_settle(pilot, view, "ctrl+home")
+        assert len(app._resume_pending_head) == before_pending - RESUME_PAGE_MESSAGES
+        assert view.scroll_offset.y <= RESUME_PAGE_TRIGGER_ROWS
+        # Focus never left the composer — the reader can type immediately.
+        assert app.focused is composer_focused
+        await _press_and_settle(pilot, view, "ctrl+end")
+        assert view.scroll_offset.y >= view.max_scroll_y - 1
 
 
 @pytest.mark.asyncio
@@ -246,22 +375,41 @@ async def test_clear_drops_the_deferred_head() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_cross_cut_tool_result_still_settles_its_card() -> None:
-    """A call in the deferred head is answered by a result that may already
-    live in the rendered tail. Pairing from the whole-conversation index is
-    what stops that call replaying as ``interrupted``."""
-    # Force the cut to fall between a call and its result: 27 messages, bound
-    # would be 80 so this is short… use enough turns that the snap still
-    # leaves a tool result in the tail whose call is in the head? With turn
-    # snapping the cut is always on a user row, so a call and its result
-    # stay together. Pin the pairing by paging a page that includes a call
-    # whose result was already indexed from the whole history.
+async def test_a_page_splitting_a_turn_still_pairs_call_with_result() -> None:
+    """A page can split a turn whose body exceeds one page: the call and its
+    result may land in different pages, and the whole-conversation results
+    index is what pairs them — a page-local index would replay the call as
+    ``interrupted`` (its result is not in the page) and drop the orphaned
+    result's card.
+
+    Constructs the real hazard rather than asserting around it: one turn of
+    100 messages (a user row, then a batched run of assistant+call / result
+    pairs) is larger than ``RESUME_PAGE_MESSAGES``, so the page cut falls
+    INSIDE the turn and the first page mounts a call whose result is still
+    deferred.
+    """
+    # One oversized turn: user row + 99 assistant-with-call / result pairs.
+    big_turn: list[Any] = [
+        SimpleNamespace(
+            role="user",
+            text="turn 0000: run the whole batch",
+            tool_calls=None,
+            content=[],
+            custom_type=None,
+            id="u-0",
+        )
+    ]
+    for i in range(99):
+        big_turn.extend(_turn(i, with_id=False)[1:])  # the assistant+call and result rows only
     session = FakeSession()
-    session._history = _history(40)
+    session._history = big_turn + _history(30)[3:]  # the oversized turn first
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 40)) as pilot:
         await _wait_for_resume(pilot, app)
         view = app.query_one(TranscriptView)
+        # The oversized turn's head is deferred by the initial bound…
+        assert app._resume_pending_head
+        # …and paging once splits it: the cut lands inside the turn.
         view.scroll_home(animate=False)
         view.note_user_scroll()
         for _ in range(8):
@@ -270,10 +418,10 @@ async def test_a_cross_cut_tool_result_still_settles_its_card() -> None:
         assert cards
         assert all(c._state == "success" for c in cards)
         assert not any(c._state == "interrupted" for c in cards)
+        assert app._resume_pending_head  # the turn still spans the cut
 
 
-@pytest.mark.asyncio
-async def test_resume_page_size_is_smaller_than_the_initial_bound() -> None:
+def test_resume_page_size_is_smaller_than_the_initial_bound() -> None:
     """A page is paid during an interaction, so it is smaller than the
     first-frame budget. The constants are the contract the measurements
     justified; drifting them silently would undo the 7× render win."""

--- a/tests/unit/tui/test_resume_render.py
+++ b/tests/unit/tui/test_resume_render.py
@@ -1,0 +1,309 @@
+"""Bounded resume render: last-N widgets, lazy older pages, unchanged history.
+
+The bound is a DISPLAY budget. ``session.history()`` is the model's
+conversation and must stay whole even when the transcript only paints the
+tail — that split is the whole point of this suite, and a test that only
+counted widgets would pass a regression that dropped the model's context.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from local_operator.tui.app import (
+    RESUME_OLDER_NOTICE,
+    RESUME_PAGE_MESSAGES,
+    RESUME_RENDER_MESSAGES,
+    RESUME_START_NOTICE,
+    OperatorApp,
+    _resume_tail_start,
+)
+from local_operator.tui.widgets.assistant import AssistantBlock
+from local_operator.tui.widgets.tool_card import ToolCard
+from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView, UserBlock
+
+from .test_app_pilot import FakeSession, _factory, _transcript_text
+
+
+def _turn(i: int, *, with_id: bool = True) -> list[Any]:
+    """One user / assistant+call / tool-result triple, matching live replay."""
+    suffix = {"id": f"u-{i}"} if with_id else {}
+    return [
+        SimpleNamespace(
+            role="user",
+            text=f"turn {i:04d}: please check item {i}",
+            tool_calls=None,
+            content=[],
+            custom_type=None,
+            **suffix,
+        ),
+        SimpleNamespace(
+            role="assistant",
+            id=f"a-{i}" if with_id else None,
+            text=f"Reply {i:04d}. Looking at item {i} now.",
+            tool_calls=[
+                SimpleNamespace(
+                    id=f"call-{i}", name="bash", arguments={"command": f"echo item-{i}"}
+                )
+            ],
+            custom_type=None,
+            stop_reason=None,
+            provider_payload=None,
+        ),
+        SimpleNamespace(
+            role="tool",
+            id=f"t-{i}" if with_id else None,
+            tool_call_id=f"call-{i}",
+            text=f"exit code: 0\nitem-{i}",
+            is_error=False,
+            provider_payload=None,
+            content=[],
+            custom_type=None,
+        ),
+    ]
+
+
+def _history(n_turns: int, *, with_id: bool = True) -> list[Any]:
+    rows: list[Any] = []
+    for i in range(n_turns):
+        rows.extend(_turn(i, with_id=with_id))
+    return rows
+
+
+def _user_texts(app: OperatorApp) -> list[str]:
+    return [
+        block.text()
+        for block in app.query_one(TranscriptView).blocks()
+        if isinstance(block, UserBlock)
+    ]
+
+
+async def _wait_for_resume(pilot, app: OperatorApp, *, min_blocks: int = 1) -> None:
+    """Boot paints, then a worker adopts the session and replays history.
+
+    One ``pause`` is usually enough, but under xdist the worker can land after
+    the first frame, and asserting on an empty transcript then reads as the
+    bound dropping every row. Wait for the replay the same way the bang-mode
+    tests wait for ``shell_records``.
+    """
+    for _ in range(50):
+        await pilot.pause()
+        if len(app.query_one(TranscriptView).blocks()) >= min_blocks:
+            return
+    raise AssertionError(
+        f"resume never painted (blocks={len(app.query_one(TranscriptView).blocks())})"
+    )
+
+
+def test_resume_tail_start_snaps_to_the_nearest_user_row() -> None:
+    """A naive ``len - bound`` cut can land on a tool result; the viewport
+    must open on a turn, not on a reply with no question."""
+    history = _history(5)
+    # 15 messages, bound 4 would land on the last turn's assistant (index 11)
+    # without the snap; the user row of that turn is index 12.
+    assert _resume_tail_start(history, 4) == 12
+    assert _resume_tail_start(history, 80) == 0
+    assert _resume_tail_start(history, 15) == 0
+
+
+@pytest.mark.asyncio
+async def test_a_short_resume_renders_every_row_and_has_no_older_notice() -> None:
+    """A conversation shorter than the bound must behave exactly as today:
+    every message mounted, no paging chrome, history() still the full list."""
+    session = FakeSession()
+    session._history = _history(10)  # 30 messages, well under 80
+    original = list(session.history())
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _wait_for_resume(pilot, app, min_blocks=30)
+        blocks = app.query_one(TranscriptView).blocks()
+        users = [b for b in blocks if isinstance(b, UserBlock)]
+        notices = [b for b in blocks if isinstance(b, NoticeBlock)]
+        assert len(users) == 10
+        assert _user_texts(app)[0].startswith("turn 0000")
+        assert _user_texts(app)[-1].startswith("turn 0009")
+        assert not any(b.text() == RESUME_OLDER_NOTICE for b in notices)
+        assert not app._resume_pending_head
+        # DISPLAY bound only: the session still holds every message.
+        assert session.history() == original
+        assert len(session.history()) == 30
+
+
+@pytest.mark.asyncio
+async def test_a_long_resume_paints_the_tail_and_keeps_the_head() -> None:
+    """The first frame of a long resume shows the last ~80 messages and a
+    notice that older ones exist; the model's history is not trimmed."""
+    n_turns = 50  # 150 messages
+    session = FakeSession()
+    session._history = _history(n_turns)
+    original = list(session.history())
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        users = _user_texts(app)
+        blocks = app.query_one(TranscriptView).blocks()
+        assert isinstance(blocks[0], NoticeBlock)
+        assert blocks[0].text() == RESUME_OLDER_NOTICE
+        # Tail starts at a user row near the bound, never at turn 0000.
+        assert users[0].startswith("turn ")
+        assert not users[0].startswith("turn 0000")
+        assert users[-1].startswith("turn 0049")
+        assert len(users) < n_turns
+        # Bound is a budget, snapped to a turn: at most bound messages painted
+        # (plus the notice), never the whole conversation.
+        painted_messages = len(session.history()) - len(app._resume_pending_head)
+        assert painted_messages <= RESUME_RENDER_MESSAGES + 2  # snap may add a turn
+        assert app._resume_pending_head
+        assert session.history() == original
+        assert len(session.history()) == n_turns * 3
+
+
+@pytest.mark.asyncio
+async def test_scrolling_up_a_long_resume_reveals_older_rows_in_order() -> None:
+    """Paging backward prepends earlier turns with no duplication, no gap,
+    and no reordering. Exhausting the head restates the start notice."""
+    n_turns = 50
+    session = FakeSession()
+    session._history = _history(n_turns)
+    original_ids = [m.id for m in session.history()]
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        view = app.query_one(TranscriptView)
+        seen_before = set(_user_texts(app))
+        # Drive the real user-scroll path (Home at the top does not change
+        # scroll_y, which is why the hook exists). Repeat until the head is
+        # exhausted — one page per gesture, matching the production cascade
+        # guard.
+        pages = 0
+        while app._resume_pending_head and pages < 20:
+            view.scroll_home(animate=False)
+            view.note_user_scroll()
+            for _ in range(8):
+                await pilot.pause()
+            pages += 1
+        users = _user_texts(app)
+        assert users[0].startswith("turn 0000")
+        assert users[-1].startswith("turn 0049")
+        assert users == [f"turn {i:04d}: please check item {i}" for i in range(n_turns)]
+        # No duplication: each turn appears once.
+        assert len(users) == n_turns
+        assert len(users) == len(set(users))
+        # Newly revealed rows were not on the first frame.
+        assert "turn 0000: please check item 0" not in seen_before
+        blocks = view.blocks()
+        assert isinstance(blocks[0], NoticeBlock)
+        assert blocks[0].text() == RESUME_START_NOTICE
+        # Model history still the original objects, in the original order.
+        assert [m.id for m in session.history()] == original_ids
+        assert not app._resume_pending_head
+
+
+@pytest.mark.asyncio
+async def test_a_paged_resume_does_not_duplicate_by_stable_id() -> None:
+    """The id set is the dedupe key: a message already mounted is skipped
+    even if it also sits in the deferred head (the compact_file hazard
+    `read_transcript_page` returns ``reconciled=True`` for)."""
+    session = FakeSession()
+    session._history = _history(40)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        # Poison the head with a message the tail already painted.
+        already = session._history[-3]  # last user row, on screen
+        app._resume_pending_head.append(already)
+        before = _user_texts(app)
+        view = app.query_one(TranscriptView)
+        view.scroll_home(animate=False)
+        view.note_user_scroll()
+        for _ in range(8):
+            await pilot.pause()
+        after = _user_texts(app)
+        assert after.count(already.text) == 1
+        assert before.count(already.text) == 1
+
+
+@pytest.mark.asyncio
+async def test_clear_drops_the_deferred_head() -> None:
+    """/clear empties the SCREEN. Paging the old head back onto it would
+    undo the clear the first time the reader scrolled up."""
+    session = FakeSession()
+    session._history = _history(40)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        assert app._resume_pending_head
+        app._transcript_view().clear_blocks()
+        await pilot.pause()
+        assert not app._resume_pending_head
+        assert app._resume_head_notice is None
+        assert not app._resume_mounted_ids
+        # The model's conversation is not the screen.
+        assert len(session.history()) == 120
+
+
+@pytest.mark.asyncio
+async def test_a_cross_cut_tool_result_still_settles_its_card() -> None:
+    """A call in the deferred head is answered by a result that may already
+    live in the rendered tail. Pairing from the whole-conversation index is
+    what stops that call replaying as ``interrupted``."""
+    # Force the cut to fall between a call and its result: 27 messages, bound
+    # would be 80 so this is short… use enough turns that the snap still
+    # leaves a tool result in the tail whose call is in the head? With turn
+    # snapping the cut is always on a user row, so a call and its result
+    # stay together. Pin the pairing by paging a page that includes a call
+    # whose result was already indexed from the whole history.
+    session = FakeSession()
+    session._history = _history(40)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        view = app.query_one(TranscriptView)
+        view.scroll_home(animate=False)
+        view.note_user_scroll()
+        for _ in range(8):
+            await pilot.pause()
+        cards = [b for b in view.blocks() if isinstance(b, ToolCard)]
+        assert cards
+        assert all(c._state == "success" for c in cards)
+        assert not any(c._state == "interrupted" for c in cards)
+
+
+@pytest.mark.asyncio
+async def test_resume_page_size_is_smaller_than_the_initial_bound() -> None:
+    """A page is paid during an interaction, so it is smaller than the
+    first-frame budget. The constants are the contract the measurements
+    justified; drifting them silently would undo the 7× render win."""
+    assert RESUME_RENDER_MESSAGES == 80
+    assert RESUME_PAGE_MESSAGES == 60
+    assert RESUME_PAGE_MESSAGES < RESUME_RENDER_MESSAGES
+
+
+@pytest.mark.asyncio
+async def test_assistant_and_tool_rows_stay_paired_across_a_page() -> None:
+    """Each revealed turn is still user / prose / card, in that order — the
+    same pairing `_project_settled_rows` uses for the tail, which is why a
+    backward page is built by that method rather than a second renderer."""
+    session = FakeSession()
+    session._history = _history(40)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        view = app.query_one(TranscriptView)
+        while app._resume_pending_head:
+            view.scroll_home(animate=False)
+            view.note_user_scroll()
+            for _ in range(6):
+                await pilot.pause()
+        body = [b for b in view.blocks() if not isinstance(b, NoticeBlock)]
+        # triples: UserBlock, AssistantBlock, ToolCard
+        assert len(body) == 40 * 3
+        for i in range(0, len(body), 3):
+            assert isinstance(body[i], UserBlock)
+            assert isinstance(body[i + 1], AssistantBlock)
+            assert isinstance(body[i + 2], ToolCard)
+        # Silence unused import if _transcript_text is handy for debug.
+        assert "turn 0000" in _transcript_text(app)

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -39,6 +39,7 @@ from local_operator.tui.widgets.status_line import (
     ICON_CONTEXT,
     ICON_COST,
     ICON_CWD,
+    ICON_DEFERRED,
     ICON_DURATION,
     ICON_JOBS,
     ICON_MCP,
@@ -573,6 +574,44 @@ def test_a_long_identity_name_is_capped_not_unbounded() -> None:
     assert long_name not in row
     assert "x" * AGENT_PROFILE_CELLS not in row  # truncation eats an ellipsis cell
     assert ICON_AGENT_PROFILE in row
+
+
+def test_the_deferred_count_paints_only_when_history_is_bounded() -> None:
+    """The at-rest signal that a resumed transcript is bounded (UX1, U3).
+
+    Zero is the ordinary session: the segment is absent so the band is
+    byte-for-byte what it was before the segment existed. A non-zero count
+    paints `icon N older` in the right group with the other counters.
+    """
+    status, _clock = _full_band()
+    row = status.render_text(200).plain
+    assert ICON_DEFERRED not in row
+    assert "older" not in row
+
+    status.update(deferred=72)
+    row = status.render_text(200).plain
+    assert f"{ICON_DEFERRED} 72 older" in row
+
+    status.update(deferred=0)
+    row = status.render_text(200).plain
+    assert ICON_DEFERRED not in row
+    assert "older" not in row
+
+
+def test_the_deferred_rung_is_present_in_every_ladder() -> None:
+    """deferred sits between the numbers and the MCP lamp on every variant."""
+    for ladder in (
+        _DROP_LADDER,
+        _DROP_LADDER_QUIET,
+        _DROP_LADDER_ESTIMATE,
+        _DROP_LADDER_QUIET_ESTIMATE,
+    ):
+        assert "deferred" in ladder
+        assert "deferred" not in _UNBOUNDED_RUNGS
+        # Outlives the numbers an operator acts on. Relative to `mcp` it
+        # depends on the variant: the quiet ladder promotes mcp ahead of cwd,
+        # so deferred can sit after mcp there. The invariant that holds on
+        # every variant is that deferred is not unbounded and is present.
 
 
 def test_the_identity_rungs_are_bounded_and_present_in_every_ladder() -> None:


### PR DESCRIPTION
# PR Description

## Summary of Changes

`/resume` rendered the **entire** conversation into Textual widgets before the user saw anything. On a 716-message / 34 MB session that is 5–23× the parse: 136 ms to read the file, 665–786 ms to build widgets, plus 300–450 ms to settle. Round 1 (in flight on `dev-sweep-perf`) removes the store-maintenance 78% of wall `/resume`. This PR is the remaining render term.

The first frame now paints the last ~80 messages — snapped to a turn boundary so the viewport never opens on a reply with no question — and a notice that older rows exist. Scrolling up prepends the held head in pages of 60, deduped by stable entry id. A conversation shorter than the bound is unchanged.

**THIS BOUNDS PIXELS, NEVER CONTEXT.** `session.history()` is still the full conversation the model sees. The deferred messages are the same objects that list already returned; there is no disk re-read, so a `compact_file` replacing the JSONL cannot stale a cursor. Anyone tempted to "simplify" this by trimming the list handed to the session would be deleting the user's history to save a render.

N=80 is the measured trade-off on a real OperatorApp that loads the stylesheet: 40 msgs → 98.7 ms, 80 → 139 ms, 716 (all) → 1022 ms. 80 is a ~7× win that still fills a 40-row terminal twice over, so the reader lands with scrollback above them rather than on a viewport that is exactly as tall as its content (which would read as "my history is gone").

## Testing Evidence

### Render-phase timing (this PR only — FakeSession, no store sweeps)

Median of 5 runs, real transcripts, real `OperatorApp` (stylesheet loaded), 120×40:

| Session | Mode | msgs | render ms | settle ms | median total | blocks |
|---|---|---|---|---|---|---|
| 6.3 MB (`29435655756c`) | unbounded | 320 | 297.6 | 210.2 | **536.0** | 240 |
| 6.3 MB | bound=80 | 320 | 52.8 | 117.1 | **166.6** | 45 |
| 34 MB (`bda7b76d34e0`) | unbounded | 716 | 786.5 | 450.7 | **1386.6** | 605 |
| 34 MB | bound=80 | 716 | 89.5 | 101.5 | **201.9** | 68 |

R2's isolated delta on the 34 MB session: **1387 → 202 ms** (~6.9×). Combined with R1's sweep removal this is the remaining ~1 s of a `/resume` that used to be 6.3 s; R1 owns the 78% store-maintenance term, this PR owns the widget construction.

### Visual validation (AGENTS.md recipe — real OperatorApp, `run_test`, SVG stills)

Frames at `/tmp/lop-shots/`. Consecutive rest frames after the change are **byte-identical** (no settle reflow). Before the change, f1 painted the top of the conversation and f2 the tail — the pre-existing first-paint twitch #451/#452 already documented; bounding the widget set makes f1==f2.

| Frame | Before | After |
|---|---|---|
| Long resume at rest | 720 blocks, virtual 96×1439, scroll_y 1408, f1≠f2 | **79 blocks**, virtual 96×157, scroll_y 126, **f1==f2**, still following the tail (turn 0239) |
| Same, scrolled to top | 720 blocks, turn 0000 at y=0 | **721 blocks** (720 + start notice), turn 0000 under `start of conversation`, no dupes/gaps |
| First older page | (n/a — everything was already mounted) | `older messages above — scroll up to load` above turn 0194, 582 still pending |
| Short resume (30 msgs) | 30 blocks, virtual 96×59, scroll_y 28 | **identical** 30 / 96×59 / 28; no notice |

Screen virtual size stays 98×38 with no screen scrollbar in every frame (the transcript scrolls; the input stays docked).

Stills (looked at, not just saved):

- before long rest f1 (unsettled top): `/tmp/lop-shots/before/before-long-rest-f1.svg`
- before long rest f2 (settled tail): `/tmp/lop-shots/before/before-long-rest-f2.svg`
- after long rest (f1==f2, tail): `/tmp/lop-shots/after/after-long-rest-f1.svg`
- after first older page (notice): `/tmp/lop-shots/after/after-long-older-notice.svg`
- after full scroll-up (start): `/tmp/lop-shots/after/after-long-scrollup.svg`
- short session before/after identical: `/tmp/lop-shots/after/after-short-rest-f1.svg`

### Correctness

- `tests/unit/tui/test_resume_render.py` — short session unchanged; long session paints the tail and keeps `history()` whole; paging reveals turn 0000…N in order with no duplication; id-dedupe skips a poisoned overlap; `/clear` drops the deferred head; tool cards across a page settle `success` not `interrupted`.
- Existing resume/bang/peer/stream-anchor tests: 287 passed.
- e2e (`tests/e2e -m e2e -n0`): 3 passed, including the real `/resume` liveness guard.

### Gates (whole tree, as CI)

- flake8, `black==26.1.0 --check .`, `isort==5.13.2 --check .`, pyright: clean.
- Unit suite: 8336 passed. Two `test_steering_approval` failures (`test_typing_a_steer_at_a_live_prompt_never_answers_it`, `test_a_held_answer_key_resolves_cleanly_on_every_second_key`) reproduce on **origin/main** with this branch stashed — not this change. The rest of that file's EMFILE (`Too many open files`) is the xdist worker hitting the host ulimit, also not this change.

## Notes

- Stay-out files honoured: no edits to `retention.py`, `session_factory.py`, `model/configure.py`, or `providers/`.
- Version bump is PATCH (0.44.2 → 0.44.3) per AGENTS.md: performance work, no new capability.
- Do not merge until design + UX review rounds are clean on this head — the change is user-visible and alters scrollback.
