### PR TITLE
fix(compaction,tui): cancel an in-flight pass at the ceiling, and scope toast retirements

### DIFF
--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -6392,44 +6392,57 @@ class Session:
         cleared the latch in its ``finally``, so this is a no-op and the
         ceiling path continues as it always did.
 
-        Does not await the cancelled task past one event-loop tick: that
-        tick is what delivers ``CancelledError`` to the pass so the new
-        summarization does not overlap it; waiting for the provider to
+        Bounded wait (0.1 s), not one event-loop tick: that bound is what
+        delivers ``CancelledError`` to the pass so the new summarization
+        does not overlap it, then proceeds. Waiting for the provider to
         acknowledge the cancel would reintroduce the unbounded wait.
         """
         task = self._compaction_pass_task
         self._compaction_pass_task = None
-        if task is not None and not task.done():
-            task.cancel()
-            # Bounded wait so the cancelled pass can unwind its in-flight
-            # summarization before we start another. Shielded: awaiting a
-            # cancelled task without a shield would CancelledError THIS
-            # (ceiling) pass, which is the one that must complete. Timed:
-            # if cancellation were swallowed, an unbounded await would be
-            # the wait this method exists to avoid.
-            try:
-                await asyncio.wait_for(asyncio.shield(task), timeout=0.1)
-            except asyncio.TimeoutError:
-                pass
-            except asyncio.CancelledError:
-                # Awaiting a cancelled task raises CancelledError even
-                # through ``shield``. That is the inner pass unwinding,
-                # which is success — unless WE were cancelled (dispose
-                # mid-ceiling), in which case the ceiling pass must not
-                # swallow it. ``Task.cancelling()`` is 3.11+; this
-                # project requires 3.12.
-                me = asyncio.current_task()
-                if me is not None and me.cancelling():
-                    raise
-        # Whatever the background pass produced is about to be stale: we are
-        # committing a different pass against the live history. Drop it so a
-        # later boundary cannot apply a summary of a prefix we are about to
-        # replace. Also covers the race where cancel was requested after the
-        # summary returned and the write of ``_pending_compaction`` ran
-        # anyway (no await between those two, so CancelledError is not
-        # delivered until the next yield).
-        self._pending_compaction = None
-        self._compaction_pass_in_flight = False
+        try:
+            if task is not None and not task.done():
+                task.cancel()
+                # Bounded wait so the cancelled pass can unwind its in-flight
+                # summarization before we start another. Shielded: awaiting a
+                # cancelled task without a shield would CancelledError THIS
+                # (ceiling) pass, which is the one that must complete. Timed:
+                # if cancellation were swallowed, an unbounded await would be
+                # the wait this method exists to avoid.
+                try:
+                    await asyncio.wait_for(asyncio.shield(task), timeout=0.1)
+                except asyncio.TimeoutError:
+                    pass
+                except asyncio.CancelledError:
+                    # Awaiting a cancelled task raises CancelledError even
+                    # through ``shield``. That is the inner pass unwinding,
+                    # which is success — unless WE were cancelled (dispose
+                    # mid-ceiling), in which case the ceiling pass must not
+                    # swallow it. ``Task.cancelling()`` is 3.11+; this
+                    # project requires 3.12.
+                    me = asyncio.current_task()
+                    if me is not None and me.cancelling():
+                        raise
+                except Exception:
+                    # The inner pass's swallows currently keep this path
+                    # dead. If they ever stop, ``wait_for`` would raise
+                    # into ``_run_compaction`` BEFORE the ceiling starts —
+                    # the missed-compaction trap #413 named as worse than
+                    # a double-bill (review round 1, F1). Cancel still
+                    # happened; the ceiling must proceed.
+                    pass
+        finally:
+            # Whatever the background pass produced is about to be stale:
+            # we are committing a different pass against the live history.
+            # Drop it so a later boundary cannot apply a summary of a
+            # prefix we are about to replace. Also covers the race where
+            # cancel was requested after the summary returned and the
+            # write of ``_pending_compaction`` ran anyway (no await
+            # between those two, so CancelledError is not delivered until
+            # the next yield). In ``finally`` so a surprise from
+            # ``wait_for`` cannot skip the latch-clear and then skip the
+            # ceiling pass (F1).
+            self._pending_compaction = None
+            self._compaction_pass_in_flight = False
 
     async def _summarize_for_compaction(
         self, plan: _CompactionPlan

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1721,6 +1721,11 @@ class Session:
         # ``_advisor_in_flight``, and is what stops a boundary that fires every
         # tool batch from spawning a pass per batch while the first still runs.
         self._compaction_pass_in_flight = False
+        # The Task wrapping that pass, so a ceiling pass can CANCEL it rather
+        # than run a second summarization alongside it (issue #413). Identity,
+        # not a generation: there is at most one, and the latch already
+        # enforces that. ``None`` whenever nothing is in flight.
+        self._compaction_pass_task: asyncio.Task[Any] | None = None
         # Last completed provider request (epoch ms). Distinct from
         # _last_activity_ms: the idle-flush pruning must measure provider-cache
         # age, and stamping turn bookkeeping right before the check made the
@@ -4879,12 +4884,17 @@ class Session:
             await self._run_turn([message])
             continuations += 1
 
-    def _spawn_background(self, coro: Coroutine[Any, Any, Any]) -> None:
+    def _spawn_background(self, coro: Coroutine[Any, Any, Any]) -> asyncio.Task[Any] | None:
         """Route a fire-and-forget coroutine through the session task group
         when one is open (wake deliveries, aside persistence); otherwise fall
         back to ``ensure_future``. Every spawned task is tracked so
         :meth:`dispose` can cancel and await it. After dispose nothing is
         spawned, so a late wake delivery cannot raise into an unobserved task.
+
+        Returns the Task so a caller that later needs to CANCEL this one
+        specifically (the ceiling compaction pass, issue #413) can, without
+        walking ``_background_tasks``. ``None`` after dispose: nothing was
+        spawned.
 
         The coroutine is wrapped so its failure is logged, never raised: an
         exception escaping into a TaskGroup would cancel every sibling task.
@@ -4898,7 +4908,7 @@ class Session:
             # path (the runner schedules a roster persist just as teardown
             # flips this flag).
             coro.close()
-            return
+            return None
 
         started = False
 
@@ -4932,6 +4942,7 @@ class Session:
                 coro.close()
 
         task.add_done_callback(_on_done)
+        return task
 
     def _build_tool_context(self) -> ToolContext:
         # This context is REBUILT on every turn, so anything that must outlive
@@ -6353,9 +6364,72 @@ class Session:
         reaches the threshold the turn cannot safely continue, so the pass that
         relieves it must complete before the next request is built. Making the
         ceiling asynchronous would remove the one safety net that has to block.
+
+        Cancels an in-flight background pass first (issue #413). Running
+        alongside it double-bills a summarization of the same history; awaiting
+        it would make this safety net wait on a call with no deadline.
         """
+        await self._cancel_background_compaction()
         await self._emit(CompactionStartEvent(reason=reason))
         return await self._finish_compaction(plan, reason=reason, summarized=None)
+
+    async def _cancel_background_compaction(self) -> None:
+        """Stop an in-flight background pass so a synchronous one does not double-bill.
+
+        Issue #413: a ceiling (or manual) pass starting while a background
+        pass is summarizing used to run alongside it. The background result
+        was discarded as stale, so correctness held and only spend was
+        affected — two summarization calls over the same history.
+
+        Awaiting the background pass was rejected in review: it would make
+        the safety net wait on a call with no deadline. Cancelling it
+        instead stops the spend we can still stop, and the synchronous pass
+        proceeds immediately. Tokens already in flight are lost either way.
+
+        Failure of the background pass is NOT a reason to skip the ceiling
+        one: this method only cancels, it never decides whether the
+        synchronous pass runs. A background pass that already FAILED has
+        cleared the latch in its ``finally``, so this is a no-op and the
+        ceiling path continues as it always did.
+
+        Does not await the cancelled task past one event-loop tick: that
+        tick is what delivers ``CancelledError`` to the pass so the new
+        summarization does not overlap it; waiting for the provider to
+        acknowledge the cancel would reintroduce the unbounded wait.
+        """
+        task = self._compaction_pass_task
+        self._compaction_pass_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            # Bounded wait so the cancelled pass can unwind its in-flight
+            # summarization before we start another. Shielded: awaiting a
+            # cancelled task without a shield would CancelledError THIS
+            # (ceiling) pass, which is the one that must complete. Timed:
+            # if cancellation were swallowed, an unbounded await would be
+            # the wait this method exists to avoid.
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=0.1)
+            except asyncio.TimeoutError:
+                pass
+            except asyncio.CancelledError:
+                # Awaiting a cancelled task raises CancelledError even
+                # through ``shield``. That is the inner pass unwinding,
+                # which is success — unless WE were cancelled (dispose
+                # mid-ceiling), in which case the ceiling pass must not
+                # swallow it. ``Task.cancelling()`` is 3.11+; this
+                # project requires 3.12.
+                me = asyncio.current_task()
+                if me is not None and me.cancelling():
+                    raise
+        # Whatever the background pass produced is about to be stale: we are
+        # committing a different pass against the live history. Drop it so a
+        # later boundary cannot apply a summary of a prefix we are about to
+        # replace. Also covers the race where cancel was requested after the
+        # summary returned and the write of ``_pending_compaction`` ran
+        # anyway (no await between those two, so CancelledError is not
+        # delivered until the next yield).
+        self._pending_compaction = None
+        self._compaction_pass_in_flight = False
 
     async def _summarize_for_compaction(
         self, plan: _CompactionPlan
@@ -6795,16 +6869,15 @@ class Session:
         would spawn a summarization call per batch — each against a snapshot
         the next one invalidates, and all of them billed.
 
-        KNOWN, ACCEPTED (issue #413): the latch bounds background passes
-        against each other, not against a synchronous one. If the context
-        crosses the ceiling while a legitimately sub-ceiling pass is running,
-        the next boundary correctly runs a synchronous pass alongside it and
-        two summarizations are billed over the same history — the background
-        one is then discarded as stale, so correctness holds and only spend is
-        affected. Having the ceiling AWAIT the background pass instead was
-        considered and rejected in agent review round 5: it would make the one
+        The latch still only bounds BACKGROUND passes against each other. A
+        ceiling pass that starts while one is in flight CANCELS it rather than
+        awaiting it or running alongside it — see
+        :meth:`_cancel_background_compaction`. Awaiting was independently
+        rejected in agent review round 5 (#413): it would make the one
         non-deferrable pass wait on a call this design deliberately leaves
-        unbounded, which is round 4's MAJOR-1 in a subtler form.
+        unbounded, which is round 4's MAJOR-1 in a subtler form. Running
+        alongside bills two summarizations of the same history, and the
+        background result is then discarded as stale.
         """
         if self._disposed or self._compaction_pass_in_flight:
             return
@@ -6824,7 +6897,13 @@ class Session:
             # replace, guaranteeing the loser is discarded as stale.
             return
         self._compaction_pass_in_flight = True
-        self._spawn_background(self._run_compaction_async(plan, reason=reason))
+        task = self._spawn_background(self._run_compaction_async(plan, reason=reason))
+        # Dispose can race the spawn and return None; the latch still has to
+        # drop or a later session would think a pass was outstanding.
+        if task is None:
+            self._compaction_pass_in_flight = False
+            return
+        self._compaction_pass_task = task
 
     async def _run_compaction_async(self, plan: _CompactionPlan, *, reason: str) -> None:
         """The detached half: summarize against the snapshot, park the result.
@@ -6838,12 +6917,20 @@ class Session:
 
         Total, like the advisor call it descends from: every failure is a
         missing pending pass, which is exactly the state the session was in
-        before. The ceiling path is untouched and still fires synchronously if
-        the context actually reaches the threshold.
+        before. A ceiling pass that starts while this is in flight cancels
+        it (issue #413) rather than running alongside; the identity check
+        below is what stops a cancelled pass from parking a stale result.
         """
         try:
             summary, preserve_data = await self._summarize_for_compaction(plan)
-            if self._disposed:
+            # Identity, not a disposed flag: a ceiling pass that cancelled us
+            # has already dropped the handle (issue #413), and there is no
+            # await between this return and the write below, so CancelledError
+            # may not have been delivered yet. Writing pending then would park
+            # a summary the ceiling pass is about to make stale. Same shape as
+            # the steer-receipt guard (PR #452): drop the delivery when the
+            # owner is no longer the current one.
+            if self._disposed or self._compaction_pass_task is not asyncio.current_task():
                 return
             self._pending_compaction = _PendingCompaction(
                 plan=plan,
@@ -6854,13 +6941,23 @@ class Session:
             )
         except asyncio.CancelledError:
             # Caught for the reason ``_run_advisor`` catches it: this task is
-            # detached and routinely cancelled at dispose, and a teardown
-            # traceback for a pass nobody awaited is noise.
-            pass
+            # detached and routinely cancelled at dispose AND when a ceiling
+            # pass starts (issue #413). A traceback for a pass nobody awaited
+            # is noise. Re-raise so the wrapping ``_spawn_background`` task
+            # still settles as cancelled — ``Task.cancel()`` is how the
+            # ceiling path stops the call, and swallowing here would leave
+            # that Task running until the provider returned.
+            raise
         except Exception:  # noqa: BLE001 — a speculative pass must never break a turn
             logger.debug("asynchronous compaction pass failed", exc_info=True)
         finally:
-            self._compaction_pass_in_flight = False
+            # Only clear the latch if it still names US. A ceiling pass that
+            # cancelled this one has already dropped both, and a later spawn
+            # must not have its latch stolen by our finally — the same
+            # identity check as the pending write above.
+            if self._compaction_pass_task is asyncio.current_task():
+                self._compaction_pass_task = None
+                self._compaction_pass_in_flight = False
 
     def _pending_is_applicable(self, pending: _PendingCompaction, live: list[Message]) -> bool:
         """Whether a finished pass still describes the conversation it planned against.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1305,6 +1305,14 @@ COMPOSER_PASTE_NOTICE = object()
 #: retirement can only ever reach the progress card, whatever the timing. The
 #: failure notices keep `COMPOSER_PASTE_NOTICE` so `EditorPasteAttached` still
 #: retires a held one through the machinery it already used.
+#:
+#: This object is the FALLBACK owner for a host that does not mint a
+#: per-paste token. The live path mints a fresh token per raise (issue
+#: #422 / D15): two overlapping pastes sharing this object is how paste 1's
+#: deferred timer killed paste 2's progress card. Identity, not a
+#: generation — ``Toast.generation`` names a painted card and is unchanged
+#: by a declined ``show``, which is the case that made it unusable for the
+#: copy receipt.
 COMPOSER_READING_NOTICE = object()
 
 #: What the composer says while a clipboard read is in flight. 22 cells, so it
@@ -5911,7 +5919,9 @@ class OperatorApp(App[None]):
         """
         self.query_one(Toast).withdraw(COMPOSER_COPY)
 
-    def show_clipboard_reading_notice(self, reading: bool) -> None:
+    def show_clipboard_reading_notice(
+        self, reading: bool, owner: object | None = None
+    ) -> object | None:
         """Raise or retire the in-flight clipboard-read card.
 
         **Called DIRECTLY by the composer, not driven by a message, and the
@@ -5932,9 +5942,11 @@ class OperatorApp(App[None]):
 
         A COURTESY, not a failure: the user just pressed a key and this is news
         about their own gesture, so `yield_to_actionable` keeps it from
-        evicting an MCP error they have not read. It takes the paste notices'
-        owner, so a later outcome replaces or withdraws it through the
-        machinery those notices already use.
+        evicting an MCP error they have not read. Each raise mints its own
+        owner token so a deferred retirement cannot dismiss a later paste's
+        card (D15 / issue #422); the outcome notices keep
+        `COMPOSER_PASTE_NOTICE` so `EditorPasteAttached` still retires a
+        held one through the machinery it already used.
         """
         from local_operator.tui.widgets.toast import TOAST_DEFAULT_MS
 
@@ -5955,19 +5967,33 @@ class OperatorApp(App[None]):
             # that took the slot while the read ran is never pulled out from
             # under the user — and, since this owner is the READING card's
             # alone, neither is the paste outcome's own notice. That separation
-            # is what makes the deferred retirement safe (see
-            # `COMPOSER_READING_NOTICE`): by the time a delayed withdrawal
-            # fires, the slot may already belong to the failure card that
-            # replaced this one, and owner matching is the only thing standing
-            # between that card and a `dismiss_toast` (D14).
-            toast.withdraw(COMPOSER_READING_NOTICE)
-            return
+            # is what makes the deferred retirement safe against a DIFFERENT
+            # owner (see `COMPOSER_READING_NOTICE` / D14).
+            #
+            # It is not enough against a LATER card of the SAME owner: a
+            # second ctrl+v raises another progress card, and paste 1's
+            # deferred timer would retire it (D15 / issue #422). Same class
+            # as the steer-receipt guard (PR #452): the owner names the
+            # operation that scheduled the retirement, and a mismatch drops
+            # the delivery. ``COMPOSER_READING_NOTICE`` is the fallback for
+            # a host that never minted a per-paste token.
+            toast.withdraw(owner if owner is not None else COMPOSER_READING_NOTICE)
+            return None
+        # A fresh token per raise, so two overlapping pastes cannot share an
+        # owner. Identity, not a generation: ``Toast.generation`` names a
+        # painted card and is unchanged by a declined ``show``, which is
+        # exactly the case that made it unusable for the copy receipt
+        # (design round 4, D14 on that path). Object identity answers
+        # "which paste scheduled this timer?" the same way PR #452 answers
+        # "which session posted this event?".
+        paste_owner = object() if owner is None else owner
         toast.show(
             CLIPBOARD_READING_NOTICE,
             duration_ms=TOAST_DEFAULT_MS,
             yield_to_actionable=True,
-            owner=COMPOSER_READING_NOTICE,
+            owner=paste_owner,
         )
+        return paste_owner
 
     def on_editor_paste_empty(self, message: EditorPasteEmpty) -> None:
         """A paste that could only have been an image attached nothing — say so.

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -188,6 +188,13 @@ PASTE_READING_NOTICE_DELAY_S = 0.35
 #: their own text. It only ever DELAYS the retirement, never the paste itself:
 #: the marker or text lands the instant the read returns, and only the card
 #: lingers.
+#:
+#: The floor binds on the attach / retire-in-finally routes. Failure
+#: notices that ``Toast.show`` a replacement card early are not held to
+#: it — the slot stays occupied, so there is no flash to prevent. "The
+#: floor guarantees 400 ms" is therefore a statement about the progress
+#: card's own lifetime, not about every notice that can occupy the slot
+#: (issue #422).
 PASTE_READING_NOTICE_MIN_S = 0.4
 
 #: A paste is treated as paths only if EVERY segment looks like one. Requiring
@@ -548,16 +555,21 @@ class EditorCopyStale(Message):
 #: ``self.app.set_timer``         1.510 s      after the read
 #: =============================  ==========  ================================
 #:
-#: So it is NOT that "the Editor's pump is blocked and the App's is free", and
-#: it is NOT a direct call: ``MessagePump.set_timer`` wraps every callback in
-#: ``partial(self.call_next, callback)``, so this is a ``call_next`` on the
-#: EDITOR's pump. ``call_next`` queues onto ``_next_callbacks``, which is
-#: flushed by ``_flush_next_callbacks`` after each dispatched message rather
-#: than through the message queue \u2014 and the Editor is the pump whose flush
-#: still runs while this action is suspended. The App's does not, which is why
-#: ``self.app.set_timer`` and ``self.app.call_next`` both land late; a message
-#: posted to THIS widget is late too, because messages take the queue and the
-#: queue is what the awaited handler is holding.
+#: The discriminator is WHICH PUMP the awaited action occupies, not "the
+#: Editor's pump is blocked and the App's is free". Bindings dispatch via
+#: ``App._check_bindings``, so the awaited ``action_system_paste`` runs on
+#: the App's pump; ``MessagePump.set_timer`` wraps every callback in
+#: ``partial(self.call_next, callback)``, so ``self.set_timer`` is a
+#: ``call_next`` on the EDITOR's pump. ``call_next`` queues onto
+#: ``_next_callbacks``, which is flushed by ``_flush_next_callbacks`` after
+#: each dispatched message rather than through the message queue — and the
+#: Editor is the pump whose flush still runs while this action is
+#: suspended on the App. The App's flush does not, which is why
+#: ``self.app.set_timer`` and ``self.app.call_next`` both land late. A
+#: message posted to THIS widget and handled by THIS widget arrives on
+#: time at 0.000 s rather than late: messages take the queue, and the
+#: queue that is held is the App's, not the Editor's. The late cases in
+#: the table are the ones that occupy the App's pump.
 #:
 #: The practical consequence, stated plainly because it is the thing a future
 #: reader will get wrong: **"simplify" this to ``self.app.set_timer`` and U3
@@ -3980,20 +3992,26 @@ class Editor(TextArea):
         # the common one and a card that appears and vanishes on every paste is
         # worse than the pause it explains. `set_timer` is stopped in the
         # `finally`, so a read that beats the delay never raises anything.
-        notice: Callable[[bool], None] | None = getattr(self.app, PASTE_READING_HOOK, None)
+        notice: Callable[..., object | None] | None = getattr(self.app, PASTE_READING_HOOK, None)
         raised = False
         raised_at = 0.0
         reading_notice = None
+        # The owner of the card THIS paste raised, returned by the hook.
+        # Carried onto the deferred retirement so a later paste's card
+        # cannot be dismissed by this one's timer (D15 / issue #422). Same
+        # class as the steer-receipt guard (PR #452): the owning context
+        # rides the event, and a mismatch drops the delivery.
+        paste_owner: object | None = None
 
-        def _raise_reading_notice(show: Callable[[bool], None]) -> None:
+        def _raise_reading_notice(show: Callable[..., object | None]) -> None:
             # Nonlocal rather than a return value: a timer callback's result
             # goes nowhere, and the `finally` below has to know whether there
             # is a card to retire. Retiring one that was never raised would
             # withdraw whatever else happens to hold the shared slot.
-            nonlocal raised, raised_at
+            nonlocal raised, raised_at, paste_owner
             raised = True
             raised_at = time.monotonic()
-            show(True)
+            paste_owner = show(True)
 
         if notice is not None:
             # `notice` is bound as an argument rather than closed over, so the
@@ -4029,12 +4047,26 @@ class Editor(TextArea):
                 # `[DELAY, DELAY + MIN)`, showing the failure card for 0 ms at a
                 # 0.74 s read: a keypress with a visible pause and no response,
                 # which is issue #372's own symptom (design round 3, D14).
-                # `self.set_timer` for the same pump reason as above.
+                #
+                # Owner matching is not enough against a LATER card of the
+                # SAME owner (D15): a second ctrl+v raises another progress
+                # card, and this timer would retire it. The per-paste token
+                # the hook returned at raise is what names THIS paste's card;
+                # a mismatch is a no-op. `self.set_timer` for the same pump
+                # reason as above.
                 shown_for = time.monotonic() - raised_at
+                owned = paste_owner
+
+                def _retire_this_card(
+                    show: Callable[..., object | None] = notice,
+                    token: object | None = owned,
+                ) -> None:
+                    show(False, owner=token)
+
                 if shown_for >= PASTE_READING_NOTICE_MIN_S:
-                    notice(False)
+                    _retire_this_card()
                 else:
-                    self.set_timer(PASTE_READING_NOTICE_MIN_S - shown_for, lambda: notice(False))
+                    self.set_timer(PASTE_READING_NOTICE_MIN_S - shown_for, _retire_this_card)
         if contents.image is not None:
             markers = await self._attach_image_bytes([contents.image.data])
             if markers is not None:

--- a/tests/unit/session/test_async_compaction.py
+++ b/tests/unit/session/test_async_compaction.py
@@ -15,7 +15,9 @@ the next safe boundary. What is pinned here is the part that makes that safe:
 - history added while the pass ran survives it;
 - the ceiling path and manual ``/compact`` stay SYNCHRONOUS — the safety net
   must not become async-only;
-- a failed background pass leaves the session exactly as if none had run.
+- a failed background pass leaves the session exactly as if none had run;
+- a ceiling pass starting while a background pass is in flight CANCELS it
+  rather than double-billing (issue #413).
 
 Real compaction throughout, as in ``test_compaction_advisor.py``: only the
 ruler and the provider stream are substituted, never the gate.
@@ -735,4 +737,106 @@ async def test_a_consumed_hint_still_widens_the_cut_on_a_size_pass(tmp_path, mon
         f"the consumed hint widened to {max(widths)}, expected the clamp at {cap} "
         "(_advisor_floor_cap bounds a hint wider than the cap)"
     )
+    await session.dispose()
+
+
+# --- A CEILING PASS MUST NOT DOUBLE-BILL AN IN-FLIGHT BACKGROUND PASS ------
+#
+# Issue #413. The in-flight latch bounds background passes against each other,
+# not against a synchronous one. A sub-ceiling advisory pass still running
+# when the context crosses the ceiling used to let the ceiling path start a
+# second summarization of the same history; the background result was then
+# discarded as stale. Correctness held; spend did not.
+#
+# Awaiting the background pass was rejected in review (unbounded wait on the
+# safety net). The ceiling path now CANCELS the in-flight pass and runs its
+# own. The number of model calls is the whole point, so the assertions count
+# them rather than inspecting a flag.
+
+
+@pytest.mark.asyncio
+async def test_a_ceiling_pass_does_not_run_alongside_an_in_flight_background_pass(
+    tmp_path, monkeypatch
+):
+    """THE #413 interleaving: background in flight, then the ceiling fires.
+
+    Against the pre-fix latch this FAILS: both calls run at once
+    (``peak_concurrent_summaries == 2``) and both complete. After the fix
+    the background call is cancelled, concurrency stays at 1, and only the
+    ceiling pass commits.
+    """
+    stream = SlowSummaryStream()
+    session = make_session(tmp_path, stream=stream)
+    await talk(session)
+    events: list[Any] = []
+    session.subscribe(events.append)
+    pin_measured_context(monkeypatch, 400_000)
+    seed_hint(session)
+
+    stream.gate = asyncio.Event()
+    await asyncio.wait_for(drive_boundary(session, 400_000), timeout=5.0)
+    await _until(lambda: stream.summary_calls == 1, "the background summarization never started")
+    assert session._compaction_pass_in_flight
+    assert stream.peak_concurrent_summaries == 1
+
+    # Context has now crossed the ceiling while that call is still open.
+    pin_measured_context(monkeypatch, 700_000)
+    ceiling = asyncio.ensure_future(drive_boundary(session, 700_000))
+    # The gate stays closed until the ceiling path has cancelled the
+    # background pass. Opening it first would let both calls run at
+    # once and hide the double-bill this test exists to catch.
+    await _until(
+        lambda: not session._compaction_pass_in_flight,
+        "the ceiling pass did not cancel the in-flight background pass",
+    )
+    stream.gate.set()
+    await asyncio.wait_for(ceiling, timeout=10.0)
+
+    assert stream.peak_concurrent_summaries == 1, (
+        f"{stream.peak_concurrent_summaries} summarization calls ran at once — "
+        "the ceiling pass ran alongside the background one rather than "
+        "cancelling it, which is the double-bill #413 records"
+    )
+    ends = [event for event in events if isinstance(event, CompactionEndEvent) and event.success]
+    assert len(ends) == 1, (
+        f"{len(ends)} successful compaction commits — the cancelled background "
+        "pass must not also land, and the ceiling pass must"
+    )
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_failed_in_flight_pass_does_not_skip_the_ceiling_pass(tmp_path, monkeypatch):
+    """The failure mode #413 names: trading a double-bill for a missed
+    compaction is worse — it means running into the context ceiling.
+
+    A background pass that FAILS must leave the latch clear so a subsequent
+    ceiling boundary still runs its own summarization. Counted on the stream,
+    not inferred from a flag: the ceiling call has to actually happen.
+    """
+    stream = SlowSummaryStream()
+    stream.fail_summary = True
+    session = make_session(tmp_path, stream=stream)
+    await talk(session)
+    events: list[Any] = []
+    session.subscribe(events.append)
+    pin_measured_context(monkeypatch, 400_000)
+    seed_hint(session)
+
+    await drive_boundary(session, 400_000)
+    await settle_background(session)
+    assert stream.summary_calls == 1
+    assert not session._compaction_pass_in_flight
+
+    stream.fail_summary = False
+    pin_measured_context(monkeypatch, 700_000)
+    await asyncio.wait_for(drive_boundary(session, 700_000), timeout=10.0)
+
+    assert stream.summary_calls == 2, (
+        f"{stream.summary_calls} summarization calls — the ceiling pass did not "
+        "run after the in-flight background pass failed, which is a missed "
+        "compaction"
+    )
+    ends = [event for event in events if isinstance(event, CompactionEndEvent) and event.success]
+    assert ends, "the ceiling pass never committed after the background failure"
     await session.dispose()

--- a/tests/unit/session/test_async_compaction.py
+++ b/tests/unit/session/test_async_compaction.py
@@ -840,3 +840,60 @@ async def test_a_failed_in_flight_pass_does_not_skip_the_ceiling_pass(tmp_path, 
     ends = [event for event in events if isinstance(event, CompactionEndEvent) and event.success]
     assert ends, "the ceiling pass never committed after the background failure"
     await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_background_failure_during_cancel_does_not_skip_the_ceiling(tmp_path, monkeypatch):
+    """The overlapping failure #413 names, not the sequential one.
+
+    ``test_a_failed_in_flight_pass_does_not_skip_the_ceiling_pass`` settles
+    the failed pass BEFORE the ceiling fires, so it only pins "a finished
+    failure leaves the latch clear." The sharp case is the in-flight pass
+    failing (or being cancelled into failure) WHILE the ceiling is inside
+    ``_cancel_background_compaction`` — if that wait re-raises, the ceiling
+    never starts (review round 1, F2).
+
+    ``fail`` is captured at the background call, then ``fail_summary`` is
+    flipped off so only that call is bound to fail. The gate opens after
+    cancel has started (handle dropped, latch not yet cleared). Counted
+    on the stream: the ceiling call has to actually happen, concurrency
+    stays at 1, one successful commit.
+    """
+    stream = SlowSummaryStream()
+    stream.fail_summary = True
+    session = make_session(tmp_path, stream=stream)
+    await talk(session)
+    events: list[Any] = []
+    session.subscribe(events.append)
+    pin_measured_context(monkeypatch, 400_000)
+    seed_hint(session)
+
+    stream.gate = asyncio.Event()
+    await asyncio.wait_for(drive_boundary(session, 400_000), timeout=5.0)
+    await _until(lambda: stream.summary_calls == 1, "the background summarization never started")
+    assert session._compaction_pass_in_flight
+    # Captured on the background call already. The ceiling's own call must
+    # succeed, or a missed compaction and a failed summarization look the
+    # same in the commit count.
+    stream.fail_summary = False
+
+    pin_measured_context(monkeypatch, 700_000)
+    ceiling = asyncio.ensure_future(drive_boundary(session, 700_000))
+    await _until(
+        lambda: session._compaction_pass_task is None,
+        "the ceiling pass never entered cancel",
+    )
+    stream.gate.set()
+    await asyncio.wait_for(ceiling, timeout=10.0)
+
+    assert stream.peak_concurrent_summaries == 1, (
+        f"{stream.peak_concurrent_summaries} summarization calls ran at once — "
+        "a background failure during cancel let the ceiling overlap it"
+    )
+    assert stream.summary_calls == 2, (
+        f"{stream.summary_calls} summarization calls — the ceiling pass did not "
+        "run while the in-flight pass was failing, which is a missed compaction"
+    )
+    ends = [event for event in events if isinstance(event, CompactionEndEvent) and event.success]
+    assert ends, "the ceiling pass never committed after a background failure during cancel"
+    await session.dispose()

--- a/tests/unit/tui/test_paste_clipboard.py
+++ b/tests/unit/tui/test_paste_clipboard.py
@@ -94,8 +94,11 @@ class Host(App[None]):
     def on_editor_paste_attached(self, message: EditorPasteAttached) -> None:
         self.attached_notices.append(message)
 
-    def show_clipboard_reading_notice(self, reading: bool) -> None:
+    def show_clipboard_reading_notice(
+        self, reading: bool, owner: object | None = None
+    ) -> object | None:
         self.reading_calls.append(reading)
+        return owner
 
 
 async def _paste(app: App[None], pilot, text: str) -> None:
@@ -1688,3 +1691,124 @@ async def test_the_reading_card_and_the_outcome_notice_do_not_share_an_owner() -
     assert (
         COMPOSER_READING_NOTICE is not COMPOSER_PASTE_NOTICE
     ), "the progress card's deferred retirement would reach the outcome notice"
+
+
+@pytest.mark.asyncio
+async def test_two_reading_cards_do_not_share_an_owner() -> None:
+    """The structural half of D15: each raise mints its own owner.
+
+    ``Toast.withdraw`` matches on owner and nothing else, so two pastes
+    sharing ``COMPOSER_READING_NOTICE`` is how paste 1's deferred timer
+    kills paste 2's card. Distinct tokens make that unrepresentable.
+    Mutation-tested: pinning both raises to ``COMPOSER_READING_NOTICE``
+    makes this fail.
+    """
+    from local_operator.tui.app import CLIPBOARD_READING_NOTICE, OperatorApp
+    from local_operator.tui.widgets.toast import Toast
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        first = app.show_clipboard_reading_notice(True)
+        second = app.show_clipboard_reading_notice(True)
+        assert first is not None and second is not None
+        assert first is not second, (
+            "two overlapping pastes minted the same owner — paste 1's "
+            "deferred retirement can name paste 2's card (D15 / #422)"
+        )
+        toast = app.query_one(Toast)
+        app.show_clipboard_reading_notice(False, owner=first)
+        assert toast.display, (
+            "withdrawing paste 1's owner dismissed paste 2's card — the "
+            "owners were not actually distinct at the toast"
+        )
+        assert toast.message == CLIPBOARD_READING_NOTICE
+
+
+@pytest.mark.asyncio
+async def test_a_deferred_retirement_does_not_kill_a_later_pastes_progress_card() -> None:
+    """THE D15 interleaving, constructed at the hook the editor calls.
+
+    The editor schedules ``show(False, owner=paste_1_token)`` after the
+    minimum-display floor. That is the late event. This test fires it
+    AFTER paste 2 has taken the slot, which is the exact order the
+    designer measured (~24 ms of paste-2 visibility, then blank). Driving
+    two real ``ctrl+v``s cannot produce that overlap under ``run_test``:
+    ``pilot.press`` waits for the awaited action, so paste 2 cannot start
+    until paste 1 has returned.
+
+    Mutation-tested: pinning both raises to ``COMPOSER_READING_NOTICE``
+    makes the withdraw below hide the card.
+    """
+    from local_operator.tui.app import CLIPBOARD_READING_NOTICE, OperatorApp
+    from local_operator.tui.widgets.toast import Toast
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        toast = app.query_one(Toast)
+        first = app.show_clipboard_reading_notice(True)
+        await pilot.pause()
+        second = app.show_clipboard_reading_notice(True)
+        await pilot.pause()
+        assert toast.display and toast.message == CLIPBOARD_READING_NOTICE
+
+        # Paste 1's deferred timer, arriving late.
+        app.show_clipboard_reading_notice(False, owner=first)
+        await pilot.pause()
+
+        assert toast.display, (
+            "paste 1's deferred retirement dismissed paste 2's progress card " "(D15 / issue #422)"
+        )
+        assert toast.message == CLIPBOARD_READING_NOTICE
+        # And paste 2's own retirement still works.
+        app.show_clipboard_reading_notice(False, owner=second)
+        await pilot.pause()
+        assert not toast.display or toast.message != CLIPBOARD_READING_NOTICE
+
+
+@pytest.mark.asyncio
+async def test_a_scoped_retirement_still_dismisses_its_own_progress_card(
+    monkeypatch,
+) -> None:
+    """The normal case of #422: a single paste's card still retires.
+
+    Scoping the timer to the operation that scheduled it must not leave the
+    progress card sitting over a completed paste (D7). One paste, empty
+    clipboard, well past the floor: the outcome is on screen and the
+    progress card is gone.
+    """
+    monkeypatch.setattr(editor_module, "PASTE_READING_NOTICE_DELAY_S", 0.15)
+    monkeypatch.setattr(editor_module, "PASTE_READING_NOTICE_MIN_S", 0.3)
+
+    def slow(*args, **kwargs):
+        time.sleep(0.2)
+        return ClipboardContents()
+
+    monkeypatch.setattr(editor_module, "read_clipboard", slow)
+
+    from local_operator.tui.app import CLIPBOARD_READING_NOTICE, OperatorApp
+    from local_operator.tui.widgets.toast import Toast
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.query_one(Editor).focus()
+        await pilot.pause()
+        toast = app.query_one(Toast)
+
+        await _ctrl_v(app, pilot)
+        deadline = time.monotonic() + 0.6
+        while time.monotonic() < deadline:
+            await pilot.pause()
+            await asyncio.sleep(0.02)
+
+        assert toast.display, "the outcome notice was never raised"
+        assert toast.message != CLIPBOARD_READING_NOTICE, (
+            "the progress card outlived the paste that raised it — scoping "
+            "the retirement to the operation left the card stuck"
+        )
+        assert toast.message == "Nothing on the clipboard to paste."

--- a/tests/unit/tui/test_toast.py
+++ b/tests/unit/tui/test_toast.py
@@ -991,3 +991,35 @@ async def test_none_is_not_an_owner(method: str) -> None:
 
         assert toast.message == "⊙ MCP failed: github"
         assert toast.display
+
+
+@pytest.mark.asyncio
+async def test_withdraw_of_one_owner_does_not_retire_another_owners_card() -> None:
+    """THE D15 guard at the toast: identity, not a shared tag.
+
+    Two operations, two owners, one slot. Withdrawing the first must leave
+    the second showing. This is the mechanism the paste path now uses
+    (issue #422): a deferred timer carries the owner it scheduled against,
+    and a mismatch is a no-op. Mutation-tested: matching on a shared
+    sentinel instead of the per-raise token makes this fail.
+    """
+    first = object()
+    second = object()
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        toast.show("Reading the clipboard…", owner=first)
+        await pilot.pause()
+        toast.show("Reading the clipboard…", owner=second)
+        await pilot.pause()
+        assert toast.display
+        held = toast.generation
+
+        toast.withdraw(first)
+        await pilot.pause()
+
+        assert toast.display, "withdrawing paste 1's owner hid paste 2's card"
+        assert toast.message == "Reading the clipboard…"
+        assert toast.generation == held, (
+            "withdrawing a stale owner dismissed and re-raised the current "
+            "card — the identity check is not holding"
+        )


### PR DESCRIPTION
# PR Description

## Summary of Changes

Two correctness defects of the same class: a late event from a disposed
context settling state that now belongs to something else. Same pattern as
the steer-receipt guard in PR #452 (`7f3bf654`) — carry the owning context
on the event, drop the delivery when the owner is not the current one.

### #413 — a ceiling pass starting while a background pass runs bills two summarizations

The compaction advisor (BETA) runs an early pass in the background. A pass
at the ordinary ceiling stays synchronous, because that one is the safety
net. Those two facts can overlap: a legitimately sub-ceiling advisory pass
still running when the context crosses the ceiling used to let the ceiling
path start a **second** summarization of the same history. The background
result was then discarded as stale, so correctness held and only spend was
affected.

Awaiting the background pass was independently rejected in review: it would
make the one non-deferrable pass wait on a call with no deadline (round 4
MAJOR-1 in a subtler form). The ceiling path now **cancels** the in-flight
pass and runs its own. Tokens already in flight are lost either way; the
ones not yet spent are not billed twice.

A background pass that **fails** still leaves the latch clear, so a later
ceiling boundary runs. Trading a double-bill for a missed compaction would
be worse — it means running into the context ceiling. Dispose mid-pass
still cancels via the existing background-task teardown.

### #422 — deferred toast retirements are not scoped to the operation that scheduled them

D15 from #402: on a fast double `ctrl+v`, paste 1's stale retirement kills
paste 2's progress card. The designer measured it dying ~24 ms in, leaving
~2.6 s blank. Owner matching (D14) is not enough against a **later card of
the same owner**. Each raise now mints a fresh owner token; the deferred
timer carries that token, and a mismatch is a no-op.

Also tightens the `PASTE_READING_HOOK` comment (F8 / U11): the discriminator
is which pump the awaited action occupies, not "the Editor's pump is blocked
and the App's is free". And records that `PASTE_READING_NOTICE_MIN_S` binds
on the attach/retire-in-finally routes, not on failure notices that
`Toast.show` a replacement card early.

Closes #413
Closes #422

## Change class

C2 reliability. No version bump — the manager runs one release after the
cleanup PRs land.

## Decision: cancel, do not join or skip

| option | why not |
| --- | --- |
| await the in-flight pass | unbounded wait on the safety net (rejected in #365 round 5) |
| skip the ceiling pass | missed compaction if the in-flight one fails |
| cancel | stops the spend we can still stop; ceiling proceeds immediately |

## Real-path evidence

### #413 — summarization call counts

Same interleaving on origin/main (`6f8cae2e`) and at HEAD, counted on the
stream (not inferred from a flag):

```
# origin/main
after_bg        summary_calls=1 peak=1 in_flight=True
during_ceiling  summary_calls=2 peak=2 live=2 in_flight=True
after_ceiling   summary_calls=2 peak=2 commits=1

# HEAD
after_bg        summary_calls=1 peak=1 in_flight=True
during_ceiling  summary_calls=2 peak=1 live=1 in_flight=False
after_ceiling   summary_calls=2 peak=1 commits=1
```

Two sequential calls at HEAD is the cancelled background plus the ceiling
pass; concurrency stays at 1. Failure case: in-flight pass fails, ceiling
still runs (`summary_calls` 1 → 2, one successful commit).

### #422 — cross-operation retirement

Constructed at the hook the editor calls (two real `ctrl+v`s cannot overlap
under `run_test` because `pilot.press` waits for the awaited action):

- paste 1 raises, paste 2 raises, paste 1's deferred `show(False, owner=token_1)`
  fires. On origin/main both raises share `COMPOSER_READING_NOTICE` and the
  card vanishes. At HEAD paste 2's card stays.
- Single paste still retires correctly: empty clipboard, well past the
  floor, outcome on screen, progress card gone.

Rendered frames (OperatorApp, 100x30, real stylesheet):

- **before (shared owner):** no toast — paste 1's retirement hid paste 2's card
- **after (per-paste owner):** `Reading the clipboard…` still showing
- **normal retire:** `Nothing on the clipboard to paste.`

### Mutation tests

| guard broken | test dies on |
| --- | --- |
| skip `_cancel_background_compaction` entirely | `_until(not in_flight)` |
| clear the latch, leave the task running | `peak_concurrent_summaries == 2` |
| pin both raises to `COMPOSER_READING_NOTICE` | `first is not second` AND `toast.display` after stale withdraw |

### Gates (whole tree, repo config, exit codes)

```
flake8 rc=0
black rc=0
isort rc=0
pyright rc=0
```

`tests/unit/session/test_async_compaction.py` + paste/toast suites: 158 passed.

## Design round?

#422 is user-visible (toasts) but the copy, placement, and duration are
unchanged — only which card a deferred timer is allowed to retire. I do
not think it needs a design round; the frames are in the evidence above
if a designer wants to look. #413 is not visual.
