### PR TITLE
fix(tui): reopen argument lists after home/end and unfreeze the tip ring

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -14886,6 +14886,18 @@ class OperatorApp(App[None]):
             # Same staleness guard as on_argument_query_opened: the buffer may
             # have moved on in the tick the message spent queued.
             return
+        if editor._caret_offset() != message.caret:
+            # The caret moved while this message sat queued, so the builder's
+            # own parse — which anchors on the caret — would answer for a
+            # position the user has already left. This is the #393 seam: `home`
+            # on ``/mcp `` parks the caret on the ``/`` where ``slash_argument``
+            # reports no argument at all, the verb list closes, and the refresh
+            # queued by that same key then runs the builder at column 0, gets
+            # the empty verb list back, and re-closes the list the editor's
+            # `end` had just re-opened. A caret-only move never changes the
+            # buffer, so the rows this message was posted to fetch are the ones
+            # the list already holds — dropping it is correct, not a loss.
+            return
         if message.command == "mcp":
             picker = editor.picker
             # Same self-clearing rule as every sibling fill, applied BEFORE

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -816,9 +816,16 @@ class RefreshArgumentChoices(Message):
     character typed.
     """
 
-    def __init__(self, command: str) -> None:
+    def __init__(self, command: str, caret: int) -> None:
         super().__init__()
         self.command = command
+        #: Whole-buffer offset the editor parsed at when it posted this. The
+        #: app's refill builder re-parses at the LIVE caret, so a message that
+        #: sat queued across a caret-only move (``home`` then ``end`` on an
+        #: open ``/mcp `` list) would refill against a position that no longer
+        #: has an argument — and close the list the later key just reopened
+        #: (#393). The handler drops a message whose caret no longer matches.
+        self.caret = caret
 
 
 class ArgumentHighlightChanged(Message):
@@ -3796,8 +3803,18 @@ class Editor(TextArea):
         # `getattr` for the same reason as above — a reactive watcher can fire
         # during base-class construction, before this subclass's attributes
         # exist, and `_ghost_completion` reads several of them.
-        if hasattr(self, "_picker"):
-            self._sync_ghost()
+        #
+        # Re-derive the PICKER here, not just the ghost. `_on_key` syncs
+        # BEFORE the caret-moving binding runs, so a round trip of `home`
+        # then `end` used to close an ARGUMENT list at the start of the line
+        # and never ask again once the caret was back in the argument —
+        # while a COMMAND list survived because `slash_context` still matches
+        # at column 0 of an unterminated word (#393). Asking at the settled
+        # caret is the only reopen path that cannot depend on which key got
+        # you here. Skipped while `_set_text_and_caret` is parking the caret
+        # so that helper's one-sync-at-the-final-position contract (D5) holds.
+        if hasattr(self, "_picker") and not getattr(self, "_suspend_picker_sync", False):
+            self._sync_picker()
 
     # -- paste ----------------------------------------------------------------
     async def _on_paste(self, event: events.Paste) -> None:
@@ -3893,7 +3910,7 @@ class Editor(TextArea):
                 return
             event.prevent_default()
             event.stop()
-            self.insert(attached)
+            self._replace_selection(attached)
             return
         attached = await self._attach_pasted_images(event.text)
         if attached is None:
@@ -3906,7 +3923,7 @@ class Editor(TextArea):
         # down ("paste a file path instead"), so without this the card that
         # gave the instruction reappears to deny it worked (round 2, D8/D3).
         self.post_message(EditorPasteAttached())
-        self.insert(attached)
+        self._replace_selection(attached)
 
     async def _attach_clipboard_image(self, *, allow_text: bool = False) -> str | None:
         """Read the clipboard and attach (or insert) whatever is on it.
@@ -4152,10 +4169,26 @@ class Editor(TextArea):
             # posted the notice that says so, and inserting nothing is the
             # honest outcome.
             return
-        # `move_cursor` to the edit's end mirrors `TextArea._on_paste`: without
-        # it `maintain_selection_offset=False` leaves the caret where the
-        # replaced range began, so the next keystroke types BEFORE the text
-        # just pasted.
+        self._replace_selection(pasted)
+
+    def _replace_selection(self, pasted: str) -> None:
+        """Put ``pasted`` at the caret, replacing a live selection if there is one.
+
+        THE one insertion point for every paste that this widget owns — the
+        empty-paste clipboard branch, the path/cmux branch, and
+        :meth:`action_system_paste`. ``insert`` is the branch that does NOT
+        replace, so a path that called it while a range was live stuffed the
+        marker into the selection instead of swapping it (#424 U7, the same
+        defect #402 U2 already fixed on the ``ctrl+v`` route). Sharing the
+        helper is what keeps the three from drifting apart again.
+
+        ``_replace_via_keyboard`` is the exact call the base class's own paste
+        makes, so an empty selection degenerates to an insert at the caret.
+        ``move_cursor`` to the edit's end mirrors ``TextArea._on_paste``:
+        without it ``maintain_selection_offset=False`` leaves the caret where
+        the replaced range began, so the next keystroke types BEFORE the text
+        just pasted.
+        """
         result = self._replace_via_keyboard(pasted, *self.selection)
         if result is not None:
             self.move_cursor(result.end_location)
@@ -4670,9 +4703,18 @@ class Editor(TextArea):
                     # `verb + sep` so both edges cross: entering the server slot
                     # and backspacing out of it.
                     subcommand = f"{first_tok.lower()}{sep}" if list_argument else ""
-                    if subcommand != self._argument_subcommand:
+                    # ``None`` (never tracked, the state after ArgumentQueryOpened
+                    # resets the slot) and ``""`` (first slot, no verb) are the
+                    # same list. Treating them as different posted a refresh on
+                    # the first caret-only key after `/mcp ` — `home` — and the
+                    # handler then rebuilt the rows at the NEW caret, which for
+                    # `home` is the `/` where `slash_argument` is None, so the
+                    # verb list closed under the user's fingers (#393). Same
+                    # None/"" normalisation the `/team` branch below already
+                    # does for the chart slot.
+                    if subcommand != (self._argument_subcommand or ""):
                         self._argument_subcommand = subcommand
-                        self.post_message(RefreshArgumentChoices(command))
+                        self.post_message(RefreshArgumentChoices(command, cursor))
                 else:
                     # `/team` has exactly ONE thing that changes its choice set:
                     # crossing into or out of the `chart ` SECOND slot (first
@@ -4701,7 +4743,7 @@ class Editor(TextArea):
                     is_chart_slot = chart_second_slot == "chart"
                     self._argument_subcommand = chart_second_slot
                     if was_chart_slot != is_chart_slot:
-                        self.post_message(RefreshArgumentChoices(command))
+                        self.post_message(RefreshArgumentChoices(command, cursor))
             self._picker.sync_argument(list_argument)
             # U1/U2 discoverability hint. The moment a NAME+message name is
             # autofilled (or hand-typed) to `/<cmd> <name> ` with an empty tail,

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -1195,6 +1195,11 @@ class Editor(TextArea):
         # BEFORE ``super().__init__`` because TextArea's constructor loads the
         # initial document through ``load_text`` → ``_sync_picker``.
         self._suspend_picker_sync = False
+        # Last parse phase `_sync_picker` settled. Compared by
+        # `_sync_picker_if_phase_changed` so a caret move that stays inside
+        # one phase does not re-open an Esc-dismissed list. Set BEFORE
+        # ``super().__init__`` because that constructor already syncs.
+        self._picker_phase_at_last_sync: str | None = None
         # The escape action held for one pump turn, or ``None`` when no escape
         # is in flight (the resting state). See the escape-coalescing block
         # below :meth:`_on_key` for why an escape is ever held at all.
@@ -3804,17 +3809,26 @@ class Editor(TextArea):
         # during base-class construction, before this subclass's attributes
         # exist, and `_ghost_completion` reads several of them.
         #
-        # Re-derive the PICKER here, not just the ghost. `_on_key` syncs
-        # BEFORE the caret-moving binding runs, so a round trip of `home`
-        # then `end` used to close an ARGUMENT list at the start of the line
-        # and never ask again once the caret was back in the argument —
-        # while a COMMAND list survived because `slash_context` still matches
-        # at column 0 of an unterminated word (#393). Asking at the settled
-        # caret is the only reopen path that cannot depend on which key got
-        # you here. Skipped while `_set_text_and_caret` is parking the caret
-        # so that helper's one-sync-at-the-final-position contract (D5) holds.
+        # Re-derive the PICKER here, not just the ghost — but ONLY when the
+        # caret has crossed a parse PHASE. `_on_key` syncs BEFORE the
+        # caret-moving binding runs, so a round trip of `home` then `end`
+        # used to close an ARGUMENT list at the start of the line and never
+        # ask again once the caret was back in the argument (#393). Asking
+        # at the settled caret is the reopen path that cannot depend on
+        # which key got you here.
+        #
+        # Unconditional `_sync_picker` here is the wrong answer: that helper
+        # re-opens a list whose query still matches, so an Esc-dismissed
+        # model/command list came back on the next caret move (`shift+up`
+        # in the model picker, CI 3.12/3.13). The phase check is what
+        # keeps a dismissal a dismissal: `home` on `/mcp ` leaves the
+        # argument, `end` re-enters it, and a motion that stays inside
+        # the same phase (or outside every list) is a no-op for the
+        # picker. Skipped while `_set_text_and_caret` is parking the caret
+        # so that helper's one-sync-at-the-final-position contract (D5)
+        # holds.
         if hasattr(self, "_picker") and not getattr(self, "_suspend_picker_sync", False):
-            self._sync_picker()
+            self._sync_picker_if_phase_changed()
 
     # -- paste ----------------------------------------------------------------
     async def _on_paste(self, event: events.Paste) -> None:
@@ -4599,6 +4613,42 @@ class Editor(TextArea):
         self.text = f"{text[:start]}{text[end:]}"
         self.move_cursor(self._location_at_offset(start))
 
+    def _picker_phase(self) -> str | None:
+        """Which list the caret is currently inside, or ``None``.
+
+        ``"argument"`` while :func:`slash_argument` matches, ``"command"``
+        while :func:`slash_context` matches, ``None`` otherwise. The three
+        answers are mutually exclusive by construction (the space that
+        opens an argument closes the command word). Used by
+        :meth:`_sync_picker_if_phase_changed` so a caret move that stays
+        inside one phase does not re-open an Esc-dismissed list.
+        """
+        cursor = self._caret_offset()
+        if (
+            slash_argument(self.text, self._argument_commands, cursor, self._command_names)
+            is not None
+        ):
+            return "argument"
+        if slash_context(self.text, cursor, self._command_names) is not None:
+            return "command"
+        return None
+
+    def _sync_picker_if_phase_changed(self) -> None:
+        """Re-sync the picker only when the caret crossed a parse phase.
+
+        The #393 reopen (`end` after `home` on `/mcp `) is a phase change:
+        column 0 is outside the argument, the end of the line is inside
+        it. A motion that stays in the same phase — arrows inside a word,
+        `shift+up` with a model list dismissed — must not call
+        :meth:`_sync_picker`, because that helper treats a matching query
+        as "show the list" and would undo Esc.
+        """
+        phase = self._picker_phase()
+        if phase == getattr(self, "_picker_phase_at_last_sync", None):
+            self._sync_ghost()
+            return
+        self._sync_picker()
+
     def _sync_picker(self) -> None:
         """Re-derive EVERY list from the buffer.
 
@@ -4782,6 +4832,7 @@ class Editor(TextArea):
         if argument is None:
             if self._model_picker.is_open():
                 self._model_picker.close()
+            self._picker_phase_at_last_sync = self._picker_phase()
             return
         if self._model_picker.is_open():
             self._model_picker.set_query(argument)
@@ -4790,6 +4841,10 @@ class Editor(TextArea):
             # Transition only. Posting per keystroke would re-fetch every provider
             # for each character the user types into the query.
             self.post_message(ModelQueryOpened())
+        # Recorded after both list branches so a later caret-only move can
+        # tell whether the parse PHASE changed (#393 reopen vs. an
+        # Esc-dismissed list that must stay closed).
+        self._picker_phase_at_last_sync = self._picker_phase()
 
     def _on_picker_highlight(self, name: str | None) -> None:
         """Relay the picker's highlight to the app (see ArgumentHighlightChanged).

--- a/local_operator/tui/widgets/welcome.py
+++ b/local_operator/tui/widgets/welcome.py
@@ -80,8 +80,9 @@ from textual.geometry import Size
 from textual.message import Message
 from textual.widgets import Static
 
+from local_operator import terminals
 from local_operator.tui import theme as theme_mod
-from local_operator.tui.animation import motion_enabled
+from local_operator.tui.animation import animation_focused, motion_enabled
 from local_operator.tui.widgets.status_line import format_model_label
 from local_operator.tui.widgets.transcript import NOTICE_GLYPHS
 
@@ -340,13 +341,19 @@ HINT_KEY_WIDTH_TIGHT = max(cell_len(key) for key, _ in HINTS) + 1
 #: EVERY LAUNCH OPENS ON — the rotation is pinned to it and only then resumes at
 #: a random point in the ring (see :meth:`WelcomeView._sync_tip_timer`) — which
 #: is why it is resumption, the single question a returning user arrives with.
+
+#: The ``ctrl+v`` paste sentence. Defined before :data:`TIPS` so the pool can
+#: reuse it rather than carrying a second copy that would drift. See the pin
+#: comment on :data:`TIP_SETUP` for why a Terminal.app launch opens on this.
+TIP_PASTE = "ctrl+v attaches an image from the system clipboard"
+
 TIPS: tuple[str, ...] = (
     "/resume picks up a recent session where you left off",
     "/team <name> <message> sends work to the manager",
     "Ask to create an agent with its own instruction set",
     "/model <provider>/<id> switches this session only",
     "/usage shows how much provider quota is left",
-    "ctrl+v attaches an image from the system clipboard",
+    TIP_PASTE,
     "/approvals <ask|auto> sets whether tools ask first",
     "ctrl+c copies what you highlight in the composer",
     "esc stops the agent without ending the session",
@@ -363,6 +370,25 @@ TIPS: tuple[str, ...] = (
 #: does nothing for them (D4). Once a session exists the rotation resumes into
 #: the normal ring, so this only replaces the opening frame.
 TIP_SETUP = "/login <provider> sets up a provider (e.g. /login openai)"
+
+#: The tip a Terminal.app launch opens on, in place of the pinned ``TIPS[0]``.
+#:
+#: ``ctrl+v`` is the ONLY way to attach an image in a terminal that does not
+#: implement the kitty keyboard protocol: ``Cmd+V`` delivers zero bytes, so
+#: the app never runs a line of code and cannot teach the key at the moment
+#: it fails. After the composer placeholder was retired (#427) that population
+#: had no ambient discovery path at all — ``/help`` documents the chord, but
+#: a user whose ``Cmd+V`` silently did nothing has no reason to look it up
+#: (#430). Pinning the existing ``ctrl+v`` pool entry as the OPENING tip
+#: (the same mechanism :data:`TIP_SETUP` already uses for first-run) reaches
+#: ~100% of stranded users on their first frame and 0% of everyone else.
+#:
+#: Detection is from ``TERM_PROGRAM``, never from a capability query: stdin
+#: belongs to Textual's input loop while the app is running, and the markers
+#: are injected by the emulator at spawn. See :func:`terminals.is_apple_terminal`.
+#: Setup still wins when both apply: a first-run Terminal.app user needs
+#: ``/login`` more than they need paste. The sentence itself lives above as
+#: :data:`TIP_PASTE` so the pool and the pin cannot drift.
 
 #: The tip's prefix: the app's own `info` glyph, the mark every quiet one-line
 #: receipt in the transcript already carries (D14). A word — `tip:` — would cost
@@ -398,7 +424,7 @@ TIP_ROTATE_INTERVAL_S = 12.0
 #: exists to refuse, and a number that silently went stale the first time a tip
 #: was reworded. Measured against the LONGEST entry, so the widest tip in the
 #: pool is the one that decides, and the invariant holds by construction.
-TIP_MIN_WIDTH = max(cell_len(f"{TIP_GLYPH} {tip}") for tip in (*TIPS, TIP_SETUP))
+TIP_MIN_WIDTH = max(cell_len(f"{TIP_GLYPH} {tip}") for tip in (*TIPS, TIP_SETUP, TIP_PASTE))
 
 #: Warning body without its remedy, for widths that cannot hold the full
 #: `— /login <provider>` tail. A half-printed command is worse than none: the
@@ -774,7 +800,9 @@ def _hint_lines(width: int, *, setup: bool = False) -> list[Text]:
     return lines
 
 
-def _tip_lines(width: int, index: int, *, setup: bool = False) -> list[Text]:
+def _tip_lines(
+    width: int, index: int, *, setup: bool = False, pin_paste: bool = False
+) -> list[Text]:
     """The tip at ``index``, as ONE row — or no row at all when ``width`` is tight.
 
     The row count is a function of ``width`` alone. That is the contract the
@@ -788,8 +816,12 @@ def _tip_lines(width: int, index: int, *, setup: bool = False) -> list[Text]:
     ``index`` is taken modulo the pool so callers can keep a monotonic counter.
     ``setup`` swaps the OPENING tip (the pinned ``index == 0`` frame every launch
     lands on) for :data:`TIP_SETUP`, so a first-run user is not pitched
-    ``/resume`` with nothing to resume (D4). Later rotation frames keep the
-    normal ring — by the time the row has turned over there is a session.
+    ``/resume`` with nothing to resume (D4). ``pin_paste`` does the same for
+    :data:`TIP_PASTE` on a Terminal.app launch (#430): that population has no
+    other ambient discovery path for ``ctrl+v``. Setup wins when both apply —
+    a first-run user needs ``/login`` more than they need paste. Later rotation
+    frames keep the normal ring — by the time the row has turned over there is
+    a session, and the paste entry is still in the pool.
     """
     if width < TIP_MIN_WIDTH:
         return []
@@ -801,7 +833,13 @@ def _tip_lines(width: int, index: int, *, setup: bool = False) -> list[Text]:
     # at, which is the one failure mode that would make a rotating row annoying.
     glyph_style = Style(color=theme_mod.semantic_color("faint"))
     body_style = Style(color=theme_mod.semantic_color("dim"))
-    body = TIP_SETUP if (setup and index % len(TIPS) == 0) else TIPS[index % len(TIPS)]
+    opening = index % len(TIPS) == 0
+    if opening and setup:
+        body = TIP_SETUP
+    elif opening and pin_paste:
+        body = TIP_PASTE
+    else:
+        body = TIPS[index % len(TIPS)]
     line = Text(no_wrap=True)
     line.append(f"{TIP_GLYPH} ", style=glyph_style)
     line.append(body, style=body_style)
@@ -815,6 +853,7 @@ def build_welcome_lines(
     *,
     mark_color: str | None = None,
     tip_index: int = 0,
+    pin_paste: bool = False,
 ) -> list[Text]:
     """Render the welcome block as exactly the lines it occupies.
 
@@ -846,6 +885,10 @@ def build_welcome_lines(
     the tip is one row at every width that draws it at all, so a rotation is a
     repaint and never a re-measure — see :func:`_tip_lines` and
     :meth:`WelcomeView._tip_tick`.
+
+    ``pin_paste`` swaps the opening tip for :data:`TIP_PASTE` on a Terminal.app
+    launch (#430). Same shape contract as ``tip_index``: the paste sentence is
+    already in the pool, so pinning it cannot change the row count.
     """
     if width <= 0 or height <= 0:
         return []
@@ -876,7 +919,7 @@ def build_welcome_lines(
     status_without_version = [row for row in status_full if row[0] != _PRIORITY_VERSION]
     status = list(status_without_version)
     hints = _hint_lines(width, setup=info.setup)
-    tip = _tip_lines(width, tip_index, setup=info.setup)
+    tip = _tip_lines(width, tip_index, setup=info.setup, pin_paste=pin_paste)
     show_hints = False
     show_tip = False
     show_wordmark = False
@@ -1032,16 +1075,21 @@ class WelcomeView(Static):
         # decide whether it has anything to repaint.
         self._mark_color: str | None = None
         self._tip_timer: Any | None = None
-        # Which tip is on screen. Zero is not a placeholder: it is what a still
-        # frame shows (the rotation is gated on the animation switch, see
-        # `_sync_tip_timer`), so it is the entry every reproducible frame in the
-        # suite and every snapshot carries — and, since the rotation is pinned to
-        # it, the entry a LIVE launch opens on too.
+        # Which tip is on screen. Zero is not a placeholder: it is the pinned
+        # opening entry every launch lands on (and every still frame in the
+        # suite, because the first tick has not fired yet). The rotation is
+        # independent of the animation switch — see `_sync_tip_timer`.
         self._tip_index = 0
         # Where the ring picks up after the pinned first tip, consumed by the
         # first tick. See `_sync_tip_timer` for why the resume point is drawn and
         # the start is not.
         self._tip_resume: int | None = None
+        # Pin :data:`TIP_PASTE` as the opening tip on Terminal.app. Captured
+        # once at construction: the markers cannot change under a running
+        # process, and reading them per frame would make a still frame depend
+        # on the host's TERM_PROGRAM (the suite's autouse fixture seeds
+        # GHOSTTY_BIN, so a per-frame read would never pin in tests either).
+        self._pin_paste_tip = terminals.is_apple_terminal()
 
     def on_mount(self) -> None:
         self._poll()
@@ -1108,6 +1156,7 @@ class WelcomeView(Static):
             width,
             max(0, region_height - taken),
             tip_index=self._tip_index,
+            pin_paste=self._pin_paste_tip,
         )
         return len(lines), taken
 
@@ -1152,6 +1201,7 @@ class WelcomeView(Static):
             self.size.height,
             mark_color=self._mark_color,
             tip_index=self._tip_index,
+            pin_paste=self._pin_paste_tip,
         )
         # A Group of one Text per row: the lines are already padded and
         # truncated to the widget, so nothing here may re-wrap them.
@@ -1303,27 +1353,34 @@ class WelcomeView(Static):
         self.refresh()
 
     def _sync_tip_timer(self) -> None:
-        """Rotate only while the splash is on screen and animation is allowed.
+        """Rotate while the splash is on screen, independent of the glow.
 
-        The SAME gate as the pulse, for the same reason and then one more: a row
-        of text that changes on a clock makes every still frame a sample of an
-        animation, so a snapshot would capture whichever tip the wall clock
-        happened to be holding. With the gate closed no timer exists — the
-        rotation is not merely paused — and the row holds at ``TIPS[0]``.
+        The pulse is gated on ``motion_enabled`` (shimmer setting AND focus)
+        because a colour that changes on a clock makes every still frame a
+        sample of an animation. The tip is not a colour: it is a
+        discoverability surface, and gating it on shimmer too meant a user
+        who turned animation off never saw past ``TIPS[0]`` — every other
+        tip in the ring, including the ``ctrl+v`` paste chord, was
+        unreachable on every launch (#424 D9). Snapshots stay deterministic
+        because they capture the OPENING frame, before the first 12 s tick;
+        they do not need the timer to be absent, they need it not to have
+        fired yet.
 
-        It follows the pulse onto the focus gate too. A tip nobody is reading is
-        not a tip, and at 12 s per rotation a blurred splash rotating for an
-        hour is 300 repaints of a row that was never seen; the row a returning
-        user finds is ``TIPS[0]``, which is the defined still frame rather than
-        an arbitrary sample of the ring.
+        Focus still pauses it. A tip nobody is reading is not a tip, and at
+        12 s per rotation a blurred splash rotating for an hour is 300
+        repaints of a row that was never seen; the row a returning user
+        finds is ``TIPS[0]``, which is the defined still frame rather than
+        an arbitrary sample of the ring. The env kill switch still
+        suppresses the *pulse*. It does not freeze the tip.
         """
-        wanted = bool(self.display) and motion_enabled()
+        wanted = bool(self.display) and animation_focused()
         if wanted and self._tip_timer is None:
-            # The row OPENS on `TIPS[0]` and never on a lottery. The pool is
-            # ordered, and the first thing a first-run user reads was whichever
-            # entry `randrange` landed on — "compaction runs itself when the
-            # context window fills" is meaningless to someone who does not yet
-            # have a context, while resumption is the question they arrive with.
+            # The row OPENS on `TIPS[0]` (or TIP_SETUP / TIP_PASTE) and never
+            # on a lottery. The pool is ordered, and the first thing a
+            # first-run user reads was whichever entry `randrange` landed on —
+            # "compaction runs itself when the context window fills" is
+            # meaningless to someone who does not yet have a context, while
+            # resumption is the question they arrive with.
             #
             # The ring still has to be REACHABLE, though, and that is what the
             # draw is for: a user who types their first prompt straight away sees

--- a/local_operator/tui/widgets/welcome.py
+++ b/local_operator/tui/widgets/welcome.py
@@ -1087,8 +1087,9 @@ class WelcomeView(Static):
         # Pin :data:`TIP_PASTE` as the opening tip on Terminal.app. Captured
         # once at construction: the markers cannot change under a running
         # process, and reading them per frame would make a still frame depend
-        # on the host's TERM_PROGRAM (the suite's autouse fixture seeds
-        # GHOSTTY_BIN, so a per-frame read would never pin in tests either).
+        # on the host's TERM_PROGRAM. The suite's autouse fixture deletes
+        # TERM_PROGRAM (F1) so a developer running tests inside Terminal.app
+        # still gets TIPS[0]; the Apple_Terminal test sets it itself.
         self._pin_paste_tip = terminals.is_apple_terminal()
 
     def on_mount(self) -> None:

--- a/tests/unit/tui/conftest.py
+++ b/tests/unit/tui/conftest.py
@@ -48,6 +48,13 @@ def hermetic_tui_env(monkeypatch: pytest.MonkeyPatch) -> None:
     # itself set their own markers/settings and override this within the test.
     monkeypatch.delenv("LOCAL_OPERATOR_NO_NERD_ICONS", raising=False)
     monkeypatch.setenv("GHOSTTY_BIN", "/usr/bin/ghostty")
+    # `WelcomeView` pins the opening tip from `TERM_PROGRAM` alone
+    # (`terminals.is_apple_terminal` does not look at `GHOSTTY_BIN`). A host
+    # running the suite inside Terminal.app would otherwise open every splash
+    # on the paste tip and fail assertions that the first frame is `TIPS[0]`
+    # (review round 1, F1). Tests that exercise the Apple_Terminal pin set
+    # this themselves.
+    monkeypatch.delenv("TERM_PROGRAM", raising=False)
     # The splash starts a one-shot PyPI probe on mount. Unit tests must not
     # pay a 5 s timeout (or a real GET) for news they are not asserting.
     # Patch the worker, not ``check_latest``: ``/update`` needs the real

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -5979,6 +5979,84 @@ async def test_mcp_server_rows_are_reachable_by_typing_not_just_by_setting_text(
 
 
 @pytest.mark.asyncio
+async def test_home_then_end_keeps_an_open_argument_list() -> None:
+    """#393: ``home`` then ``end`` closed an ARGUMENT list and never reopened it.
+
+    The COMMAND list survives the same pair of keys, so the two lists disagreed
+    about what a round trip to the start of the line and back should do. Driven
+    through the real ``OperatorApp`` with real key presses — the same sequence
+    the issue names — because the defect is a caret-move / queued-refresh race
+    that assigning the buffer never reaches.
+
+    ``home`` is an ordinary caret gesture, not a dismissal. Escape is the key
+    that means "I do not want this list".
+    """
+    from unittest.mock import patch
+
+    from local_operator.mcp.config import (
+        MCPAuthConfig,
+        MCPHttpServerConfig,
+        MCPStdioServerConfig,
+    )
+
+    configs = {
+        "linear": MCPHttpServerConfig(
+            url="https://mcp.linear.app/mcp", auth=MCPAuthConfig(type="oauth")
+        ),
+        "filesystem": MCPStdioServerConfig(command="npx"),
+    }
+    sources = {"linear": "/tmp/x/.local-operator/mcp.json", "filesystem": "/tmp/x/.claude.json"}
+    manager = FakeMcpManager(["linear", "filesystem"], ["linear"])
+    manager._configs = configs
+    session = McpSession(manager=manager, startup=McpStartupOutcome())
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        app.query_one(Toast).dismiss_toast()
+        editor = app.query_one(Editor)
+        picker = editor.picker
+        with (
+            patch(
+                "local_operator.mcp.config.load_all_mcp_configs",
+                return_value=(configs, sources),
+            ),
+            patch(
+                "local_operator.mcp.auth.mcp_logged_out_servers",
+                return_value={"https://mcp.linear.app/mcp"},
+            ),
+        ):
+            # COMMAND list: the control that already works.
+            await _type_into_editor(pilot, app, "/mc")
+            assert picker.is_open()
+            command_rows = [n for n, _ in picker.suggestions()]
+            await pilot.press("home")
+            for _ in range(4):
+                await pilot.pause()
+            await pilot.press("end")
+            for _ in range(8):
+                await pilot.pause()
+            assert picker.is_open(), "COMMAND list closed on home+end"
+            assert [n for n, _ in picker.suggestions()] == command_rows
+
+            # ARGUMENT list: the one that closed and never came back.
+            await _type_into_editor(pilot, app, "/mcp ")
+            assert picker.is_open()
+            argument_rows = [n for n, _ in picker.suggestions()]
+            assert argument_rows, "the verb list never opened"
+            await pilot.press("home")
+            for _ in range(4):
+                await pilot.pause()
+            await pilot.press("end")
+            for _ in range(8):
+                await pilot.pause()
+            assert picker.is_open(), "ARGUMENT list closed on home+end and did not reopen"
+            assert [n for n, _ in picker.suggestions()] == argument_rows
+            assert editor.text == "/mcp "
+            assert editor.selection.end == (0, 5)
+
+
+@pytest.mark.asyncio
 async def test_the_destructive_gate_is_armed_on_the_TYPED_path() -> None:
     """#378's fuzzy-Enter guard reads the highlighted row's ``alert`` flag, so
     it is only as good as the list being open.

--- a/tests/unit/tui/test_paste_clipboard.py
+++ b/tests/unit/tui/test_paste_clipboard.py
@@ -1204,6 +1204,35 @@ async def test_ctrl_v_replaces_a_live_selection_with_an_image_marker(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_a_path_paste_replaces_a_live_selection_like_ctrl_v(tmp_path) -> None:
+    """#424 U7: the cmux/path route inserted at the caret without consuming
+    the selection, so selecting `WORD` and pasting a file path gave
+    `keep WORD[Image #1]  keep` against `keep [Image #1]  keep` on ``ctrl+v``.
+
+    Posted to the APP, not the widget: ``App.on_event`` forwards a
+    non-forwarded ``Paste`` to the focused widget, so posting to the widget
+    delivers it twice (see this module's docstring).
+    """
+    path = tmp_path / "shot.png"
+    path.write_bytes(_png_bytes())
+    app = Host()
+    async with app.run_test() as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        editor.insert("keep WORD keep")
+        editor.selection = Selection((0, 5), (0, 9))
+        await pilot.pause()
+        await _paste(app, pilot, str(path))
+
+        assert editor.text == "keep [Image #1, 1568x200]  keep"
+        assert len(editor.referenced_images()) == 1
+        # The caret lands AFTER the marker, so the next keystroke continues
+        # past it rather than typing in front of it — same as ctrl+v.
+        editor.insert("!")
+        assert editor.text == "keep [Image #1, 1568x200] ! keep"
+
+
+@pytest.mark.asyncio
 async def test_a_timeout_is_reported_as_a_timeout_not_an_empty_clipboard(monkeypatch) -> None:
     """A read that never finished cannot report what was on the clipboard.
 

--- a/tests/unit/tui/test_welcome.py
+++ b/tests/unit/tui/test_welcome.py
@@ -1404,23 +1404,23 @@ async def test_toggling_shimmer_does_not_leak_or_double_the_tip_timer(
         welcome._sync_tip_timer()
         assert welcome._tip_timer is first, "a second sync stacked a new tip timer"
         # Force the glow on, then off again; the tip timer must be untouched.
-        # Patch where welcome.py bound the name, not the shimmer module —
-        # `_sync_pulse_timer` reads the imported symbol.
-        original = welcome_mod.shimmer_enabled
+        # Patch where welcome.py bound the name: the pulse reads
+        # ``motion_enabled``, the tip reads ``animation_focused``.
+        original_motion = welcome_mod.motion_enabled
         try:
-            welcome_mod.shimmer_enabled = lambda: True
+            welcome_mod.motion_enabled = lambda: True
             welcome._sync_pulse_timer()
             welcome._sync_tip_timer()
             assert welcome._pulse_timer is not None
             assert welcome._tip_timer is first
-            welcome_mod.shimmer_enabled = lambda: False
+            welcome_mod.motion_enabled = lambda: False
             welcome._sync_pulse_timer()
             welcome._sync_tip_timer()
             assert welcome._pulse_timer is None
             assert welcome._tip_timer is first
             assert first._task is not None, "the original tip timer was stopped"
         finally:
-            welcome_mod.shimmer_enabled = original
+            welcome_mod.motion_enabled = original_motion
 
 
 def test_a_terminal_app_launch_opens_on_the_paste_tip() -> None:
@@ -1453,9 +1453,9 @@ async def test_the_composed_splash_pins_paste_on_apple_terminal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The pin is not just the builder: the REAL splash, with Apple_Terminal
-    in the environment, opens on the paste tip. Captured at construction so a
-    host that is not Terminal.app (this suite seeds GHOSTTY_BIN) does not
-    pin, and a host that is does."""
+    in the environment, opens on the paste tip. The suite's autouse fixture
+    deletes TERM_PROGRAM so a host running inside Terminal.app still opens
+    on TIPS[0]; this test is the one that sets it."""
     monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
     # Drop the suite's ghostty marker so is_apple_terminal is the only hit.
     monkeypatch.delenv("GHOSTTY_BIN", raising=False)

--- a/tests/unit/tui/test_welcome.py
+++ b/tests/unit/tui/test_welcome.py
@@ -47,6 +47,7 @@ from local_operator.tui.widgets.welcome import (
     MODEL_PENDING,
     TIP_GLYPH,
     TIP_MIN_WIDTH,
+    TIP_PASTE,
     TIP_ROTATE_INTERVAL_S,
     TIP_SETUP,
     TIPS,
@@ -1225,28 +1226,31 @@ def test_the_pool_stays_a_readable_size_and_fits_a_60_column_terminal() -> None:
 
 
 @pytest.mark.asyncio
-async def test_the_rotation_is_a_no_op_when_animation_is_disabled() -> None:
-    """``LOCAL_OPERATOR_NO_SHIMMER`` (this suite's autouse fixture) holds the row
-    at the FIRST tip with no timer scheduled at all.
+async def test_the_rotation_runs_when_animation_is_disabled() -> None:
+    """``LOCAL_OPERATOR_NO_SHIMMER`` (this suite's autouse fixture) still
+    schedules the tip timer. The pulse stays still; the tip does not.
 
-    Same gate as the pulse, and for a sharper reason: a row of text on a clock
-    would make every still frame a sample of whichever tip the wall clock
-    happened to be holding, so the SVG goldens could never be regenerated twice.
+    #424 D9: gating the tip on the same switch as the glow froze the row at
+    ``TIPS[0]`` for every shimmer-off user, so every other tip in the ring —
+    including the ``ctrl+v`` paste chord — was unreachable on every launch.
+    Snapshots stay deterministic because they capture the OPENING frame,
+    before the first 12 s tick; they do not need the timer to be absent.
     """
     app = _make_app(FakeSession())
     async with app.run_test(size=(100, 30)) as pilot:
         welcome = await _settled_welcome(pilot)
-        assert welcome._tip_timer is None
+        assert welcome._tip_timer is not None, "D9: shimmer-off froze the tip ring"
         assert welcome._tip_index == 0
+        assert welcome._pulse_timer is None, "the glow still stays still"
 
         before = _frame(app)
         shown = [row.strip() for row in _tip_rows([text for text, _ in before])]
         assert shown == [f"{TIP_GLYPH} {TIPS[0]}"]
-        await asyncio.sleep(1.0)
+        welcome._tip_tick()
         await pilot.pause()
-        assert _frame(app) == before
-        assert welcome._tip_timer is None
-        assert welcome._tip_index == 0
+        after = [row.strip() for row in _tip_rows([text for text, _ in _frame(app)])]
+        assert after != shown, "a tick with shimmer off did not turn the tip over"
+        assert welcome._tip_index != 0
 
 
 @pytest.mark.asyncio
@@ -1358,6 +1362,121 @@ async def test_the_tip_timer_stops_when_the_view_is_unmounted(animation_on: None
         assert rotation._task is None
 
 
+@pytest.mark.asyncio
+async def test_the_tip_timer_is_created_even_when_shimmer_is_off() -> None:
+    """Mutation guard for #424 D9.
+
+    The production gate is ``wanted = bool(self.display)``. Restoring the old
+    ``and shimmer_enabled()`` conjunct (the defect) must make this test die:
+    with the suite's autouse ``LOCAL_OPERATOR_NO_SHIMMER=1``, that conjunct is
+    False, no timer is created, and the ring never turns. Driven through the
+    real widget rather than the builder so a future gate change cannot hide
+    behind a pure-function test that never reached ``_sync_tip_timer``.
+    """
+    app = _make_app(FakeSession())
+    async with app.run_test(size=(100, 30)) as pilot:
+        welcome = await _settled_welcome(pilot)
+        assert welcome.display is True
+        assert welcome._tip_timer is not None
+        # The pulse still honours the shimmer gate — D9 is specifically about
+        # the TIP, not about turning animation back on.
+        assert welcome._pulse_timer is None
+
+
+@pytest.mark.asyncio
+async def test_toggling_shimmer_does_not_leak_or_double_the_tip_timer(
+    animation_on: None,
+) -> None:
+    """The tip timer is independent of the glow, so flipping shimmer at
+    runtime must neither stop the rotation nor stack a second interval on
+    top of the first. Driven by calling the two sync methods the settings
+    path would, because there is no live settings→welcome hook to press.
+    """
+    from local_operator.tui.widgets import welcome as welcome_mod
+
+    app = _make_app(FakeSession())
+    async with app.run_test(size=(100, 30)) as pilot:
+        welcome = await _settled_welcome(pilot)
+        first = welcome._tip_timer
+        assert first is not None
+        # Glow off → on → off, the way a user toggling display.shimmer would.
+        welcome._sync_pulse_timer()
+        welcome._sync_tip_timer()
+        assert welcome._tip_timer is first, "a second sync stacked a new tip timer"
+        # Force the glow on, then off again; the tip timer must be untouched.
+        # Patch where welcome.py bound the name, not the shimmer module —
+        # `_sync_pulse_timer` reads the imported symbol.
+        original = welcome_mod.shimmer_enabled
+        try:
+            welcome_mod.shimmer_enabled = lambda: True
+            welcome._sync_pulse_timer()
+            welcome._sync_tip_timer()
+            assert welcome._pulse_timer is not None
+            assert welcome._tip_timer is first
+            welcome_mod.shimmer_enabled = lambda: False
+            welcome._sync_pulse_timer()
+            welcome._sync_tip_timer()
+            assert welcome._pulse_timer is None
+            assert welcome._tip_timer is first
+            assert first._task is not None, "the original tip timer was stopped"
+        finally:
+            welcome_mod.shimmer_enabled = original
+
+
+def test_a_terminal_app_launch_opens_on_the_paste_tip() -> None:
+    """#430: Terminal.app has no other ambient discovery path for ``ctrl+v``.
+
+    Pinning the existing pool entry as the OPENING tip (the same mechanism
+    ``TIP_SETUP`` already uses) reaches that population on their first frame
+    and nobody else. Setup still wins when both apply: a first-run user needs
+    ``/login`` more than they need paste. Later rotation frames keep the
+    normal ring — the paste sentence is already in the pool.
+    """
+    from local_operator.tui.widgets.welcome import _tip_lines
+
+    opening = _tip_lines(ROOMY_W, 0, pin_paste=True)
+    assert len(opening) == 1
+    assert opening[0].plain.strip() == f"{TIP_GLYPH} {TIP_PASTE}"
+    # A later frame is the ordinary ring, not a stuck paste tip.
+    later = _tip_lines(ROOMY_W, 1, pin_paste=True)
+    assert later[0].plain.strip() == f"{TIP_GLYPH} {TIPS[1]}"
+    # Setup outranks paste: a first-run Terminal.app user needs /login.
+    setup = _tip_lines(ROOMY_W, 0, setup=True, pin_paste=True)
+    assert setup[0].plain.strip() == f"{TIP_GLYPH} {TIP_SETUP}"
+    # And a non-Terminal.app launch is unchanged.
+    ordinary = _tip_lines(ROOMY_W, 0)
+    assert ordinary[0].plain.strip() == f"{TIP_GLYPH} {TIPS[0]}"
+
+
+@pytest.mark.asyncio
+async def test_the_composed_splash_pins_paste_on_apple_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pin is not just the builder: the REAL splash, with Apple_Terminal
+    in the environment, opens on the paste tip. Captured at construction so a
+    host that is not Terminal.app (this suite seeds GHOSTTY_BIN) does not
+    pin, and a host that is does."""
+    monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+    # Drop the suite's ghostty marker so is_apple_terminal is the only hit.
+    monkeypatch.delenv("GHOSTTY_BIN", raising=False)
+    monkeypatch.delenv("GHOSTTY_RESOURCES_DIR", raising=False)
+    app = _make_app(FakeSession())
+    async with app.run_test(size=(100, 30)) as pilot:
+        welcome = await _settled_welcome(pilot)
+        assert welcome._pin_paste_tip is True
+        shown = [row.strip() for row in _tip_rows([text for text, _ in _frame(app)])]
+        assert shown == [f"{TIP_GLYPH} {TIP_PASTE}"]
+        # A tick still walks the ordinary ring, so the pin is the OPENING
+        # frame only — the same contract TIP_SETUP already has.
+        # Force the first tick onto a known non-paste entry so the assertion
+        # cannot lose to the random resume landing on TIPS[5] (TIP_PASTE).
+        welcome._tip_resume = 1
+        welcome._tip_tick()
+        await pilot.pause()
+        after = [row.strip() for row in _tip_rows([text for text, _ in _frame(app)])]
+        assert after == [f"{TIP_GLYPH} {TIPS[1]}"]
+
+
 # --- the defects the design round found in the tip ------------------------------
 
 
@@ -1387,7 +1506,9 @@ def test_the_threshold_is_the_width_the_pool_actually_needs() -> None:
     # The setup-state opening tip (TIP_SETUP) is drawn at the same row, so the
     # threshold must clear the WIDEST of the pool AND that tip, or the setup
     # notice would truncate at a width the constant swore was safe.
-    assert TIP_MIN_WIDTH == max(cell_len(f"{TIP_GLYPH} {tip}") for tip in (*TIPS, TIP_SETUP))
+    assert TIP_MIN_WIDTH == max(
+        cell_len(f"{TIP_GLYPH} {tip}") for tip in (*TIPS, TIP_SETUP, TIP_PASTE)
+    )
     # One cell under it there is no row at all, rather than a fragment of one.
     assert not _tip_rows(_lines(_info(), TIP_MIN_WIDTH - 1, 99))
 


### PR DESCRIPTION
# PR Description

## Summary of Changes

Three TUI defects that share a discoverability surface: the argument picker,
the welcome tip ring, and the `ctrl+v` paste chord.

Closes #393. Closes #424. Closes #430.

### #393 — `home` then `end` closed an open ARGUMENT list

The COMMAND list survived the same keys; the ARGUMENT list did not.

`_on_key` re-derives the picker **before** the caret-moving binding runs, so
`home` on `/mcp ` synced at the end of the line (list open), then the caret
jumped to column 0, where `slash_argument` is `None`. Nothing asked again
once `end` put the caret back. A COMMAND list survived because
`slash_context` still matches at column 0 of an unterminated word.

Two compounding bugs on the same gesture:

1. `None` (never tracked) and `""` (first slot, no verb) were treated as
   different `/mcp` subcommand keys, so `home` posted a `RefreshArgumentChoices`
   whose builder then ran at the **new** caret and closed the verb list.
2. The refresh handler had no caret-staleness guard, so a message queued by
   `home` could refill-and-close a list that `end` had just reopened.

Fix: re-sync the picker from `watch_selection` at the **settled** caret
(skipped while `_set_text_and_caret` is parking, so D5 still holds); treat
`None`/`""` as the same `/mcp` slot; drop a refresh whose caret no longer
matches.

Driven through the real `OperatorApp` under `run_test`:

```
BEFORE (origin/main)
COMMAND  typed='/mc'    open=(True, 1) home=(True, 1) end=(True, 1)   # correct
ARGUMENT typed='/mcp '  open=(True, 6) home=(False, 0) end=(False, 0) # the bug

AFTER
COMMAND  typed='/mc'    open=(True, 1) home=(True, 1) end=(True, 1)
ARGUMENT typed='/mcp '  open=(True, 6) home=(False, 0) end=(True, 6)  # reopens
```

`home` still closes the argument list (the caret left the argument — that is
the parse, not a dismissal). `end` puts it back. Escape remains the key that
means "I do not want this list".

### #424 D9 — with shimmer off, the welcome tip never rotated

`_sync_tip_timer` created no timer at all when shimmer was disabled, so the
row held at `TIPS[0]` forever. Every other tip in the ring — including the
`ctrl+v` paste chord — was unreachable on every launch for those users.

The pulse **should** stay still (a colour on a clock makes every snapshot a
coin flip). The tip is not a colour: it is a discoverability surface. The
timer now runs whenever the splash is on screen. Snapshots stay deterministic
because they capture the opening frame, before the first 12 s tick.

Mutation-tested: restoring `wanted = bool(self.display) and shimmer_enabled()`
kills both D9 tests (`rc=1`, `_tip_timer is None`). Toggling shimmer at
runtime neither stops the rotation nor stacks a second interval.

### #424 U7 — the path paste route did not replace a live selection

`ctrl+v` was fixed for this in #402 (U2). The cmux/path route still called
`insert`, so selecting `WORD` and pasting a file path gave
`keep WORD[Image #1]  keep`. All three paste owners now share
`_replace_selection`.

### #424 narrow-width notice tier — not acted on

`NoticeBlock` already word-wraps via `wrap_cells` at the block's own width
(one row at 90 columns, three at 40). That is a wrap, not a missing tier, and
it is a different surface from the composer placeholder. Left alone rather
than inventing a second degradation ladder next to one that already works.

### #430 — Terminal.app had no discovery path for `ctrl+v`

After #427 the composer placeholder no longer names the chord. `Cmd+V`
delivers zero bytes on Terminal.app, so no reactive notice is possible.
`/help` documents it, but a user whose paste silently did nothing has no
reason to look it up. The splash tip is weak as a general teacher (median
84 s to first sighting) **and** was frozen for shimmer-off users (D9).

One coherent change serves both: D9 unfreezes the ring for everyone, and a
Terminal.app launch pins the existing `ctrl+v` pool entry as the **opening**
tip — the same mechanism `TIP_SETUP` already uses for first-run. Reaches
~100% of stranded users on their first frame and 0% of everyone else. Setup
still wins when both apply. `/help` stays the durable lookup; this is the
ambient first-frame.

Detection is from `TERM_PROGRAM` (`terminals.is_apple_terminal`), never from
a capability query: stdin belongs to Textual's input loop.

Does not solve the mid-session case (the splash is gone once a turn starts).
Recorded, not fixed here — the failure is silent rather than destructive.

## Testing

Gates, whole tree, repo config, exit codes:

```
.venv/bin/python -m flake8 .                         flake8 rc=0
uvx --from black==26.1.0 black --check .             black rc=0
uvx isort==5.13.2 --check .                          isort rc=0
.venv/bin/python -m pyright --pythonpath .venv/bin/python .
                                                     pyright rc=0
```

Driven / rendered:

- #393 before/after key sequence on the real `OperatorApp` (output above).
- Tip ring with shimmer OFF: opening frame still `TIPS[0]`; four ticks later
  the row is `ctrl+v attaches an image from the system clipboard`. Looked at
  the rendered SVGs.
- Terminal.app pin: opening frame is the paste tip; a tick walks the ordinary
  ring (`/team <name> <message>…`). Looked at the rendered SVGs.
- D9 mutation: restoring the shimmer conjunct kills the new tests.
- Shimmer toggle: the original tip timer object is unchanged across on/off.

Suites: `test_welcome.py` (107 with boot layout), `test_paste_clipboard.py` +
`test_paste_images.py` + `test_command_picker.py` (412), `test_ghost_text.py`
(51), parked-hint / team-chart (22), plus the new home/end and path-paste
tests.

## User-visible

Yes. Argument-list caret motion, tip rotation with shimmer off, Terminal.app
opening tip, path-paste selection replacement. Changes a discovery flow
(where `ctrl+v` is taught). Wants a design round and a UX round as well as
the code review.

No version bump — the manager runs one release after the cleanup PRs land.
