### PR TITLE
ci: stop disarming the freeze guard when test is red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8==7.1.0 black==26.1.0 isort==5.13.2 pyright==1.1.408
+          pip install flake8==7.1.0 black==26.1.0 isort==5.13.2
 
       - name: Run flake8
         run: flake8 .
@@ -111,8 +111,12 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      PYRIGHT_PYTHON_FORCE_VERSION: latest
+    # pyright's version is the pin in pyproject.toml's dev extra. Do NOT
+    # set PYRIGHT_PYTHON_FORCE_VERSION: that env var makes the wrapper
+    # ignore the bundled analyzer and download whatever npm currently
+    # calls latest, which is how this job drifted onto 1.1.413 while the
+    # package (and every local run) stayed on 1.1.411. Bump the pin, not
+    # an env override.
     steps:
       - uses: actions/checkout@v4
 
@@ -427,11 +431,25 @@ jobs:
     # compositor, so there is no window, no display server and no TTY beyond
     # what the harness makes itself. It needs no `xvfb` and must never grow a
     # real browser or terminal dependency.
+    #
+    # lint + type-check only. This job is the freeze regression guard (#401);
+    # it exists BECAUSE a green unit suite did not catch a total event-loop
+    # deadlock. Gating it on `test` (or `pip-audit`) disarms the guard
+    # whenever that cheaper stage is red — which is exactly when you most
+    # want the freeze signal. Observed on PR #426: both CI runs skipped
+    # tui-e2e because `test` was flaky, so a deadlock fix landed with the
+    # deadlock guard never executed. PR #461 reduced that flake; it does
+    # not make the structural dependency right.
+    #
+    # lint/type-check stay: they are cheap syntax gates and a broken
+    # install is not a freeze. `test` and `pip-audit` do not: a flake or a
+    # newly-published CVE must not skip the macOS resume-liveness
+    # assertion. The job installs the package itself, so it does not need
+    # those stages to have built anything. cli-sanity/server-sanity keep
+    # the full `needs` list — they are live-LLM cost, not freeze guards.
     needs:
       - lint
       - type-check
-      - test
-      - pip-audit
     # Generous relative to the ~11 s the stage takes when healthy (~14 s on a
     # macOS runner, which is slower and queues longer). The failure mode under
     # test is a hang, and each test carries its own tighter `faulthandler`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,13 @@ stage because boot, the write-turn artifacts and the transcript replay are
 platform-neutral, but **do not drop the macOS leg** — without it this stage goes
 green against the exact commit it exists to catch.
 
+The `tui-e2e` job must not `need` the unit `test` job or `pip-audit`. It exists
+because a green unit suite did not catch #401; gating it on `test` skipped the
+freeze guard on every red unit run (observed on PR #426, which *fixed* a
+deadlock while `tui-e2e` reported `skipping`). It needs only `lint` and
+`type-check` — cheap syntax gates. A flake or a newly-published CVE must not
+disarm the macOS resume-liveness assertion.
+
 Gates, all of which must be clean before a PR. **Run them over the whole tree,
 exactly as CI does** — these are the commands from `.github/workflows/ci.yml`:
 
@@ -119,6 +126,16 @@ uvx --from black==26.1.0 black --check .
 uvx isort==5.13.2 --check .
 .venv/bin/python -m pyright --pythonpath .venv/bin/python .
 ```
+
+Do **not** invoke `.venv/bin/black`, `.venv/bin/flake8`, `.venv/bin/isort`, or
+`.venv/bin/pyright` directly. Those console scripts carry a shebang baked in
+at install time; after a parallel-agent worktree that owned the venv is
+deleted they fail with `bad interpreter` and exit **126**. `rc=126` is
+swallowed by a pipeline (`cmd | tail` reports `tail`'s 0), so a lint or
+format gate that never actually ran looks green. `python -m` and `uvx`
+cannot hit that path — that is why the commands above are spelled that way,
+and why `make lint` / `make format` / `make type-check` go through them
+rather than the console scripts.
 
 Narrowing the last two to `local_operator tests`, or passing `--profile black`
 instead of letting isort read the repo's own config, checks something CI does

--- a/Makefile
+++ b/Makefile
@@ -95,18 +95,26 @@ coverage: ## Generate test coverage report
 # ============================================================================
 # Code Quality Commands
 # ============================================================================
-# Format code with black and isort
+# Invoke formatters/linters the same way AGENTS.md documents the gates.
+# Bare `.venv/bin/black` (and flake8/isort/pyright) console scripts carry a
+# shebang baked in at install time; after a worktree that owned the venv
+# is deleted they fail with `bad interpreter` and exit 126. `rc=126`
+# disappears inside a pipeline (`cmd | tail` reports tail's 0), so a gate
+# that never ran looks green. `python -m` uses the interpreter's module
+# path; `uvx` fetches a pinned tool into an isolated cache. Neither reads
+# those shebangs. black/isort are deliberately NOT in the dev extra, so
+# format goes through uvx at the versions CI pins.
 format: ## Format code with black and isort
-	black .
-	isort .
+	uvx --from black==26.1.0 black .
+	uvx isort==5.13.2 .
 
 # Run linting with flake8
 lint: ## Run linting with flake8
-	flake8
+	.venv/bin/python -m flake8 .
 
 # Run type checking with pyright
 type-check: ## Run type checking with pyright
-	pyright
+	.venv/bin/python -m pyright --pythonpath .venv/bin/python .
 
 # Run security audit with pip-audit
 security: ## Run security audit with pip-audit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,17 @@ dev = [
     # accepts, or accept code CI flags, and either way the local gate stops
     # predicting the remote one. Bump this and the ci.yml pin together.
     "flake8==7.1.0",
-    "pyright",
+    # Same discipline as flake8: one version across the type-check job,
+    # the local gate, and this extra. Unpinned, the wrapper
+    # (PYRIGHT_PYTHON_FORCE_VERSION=latest used to live on the type-check
+    # job) downloaded whatever npm called latest (1.1.413) while pip
+    # resolved 1.1.411 and the lint job — which never even ran pyright —
+    # pinned 1.1.408. The restated `[tool.pyright] exclude` defaults are
+    # version-specific; three versions means the restatement is a guess.
+    # Bump this pin, not an env override, and keep the exclude-superset
+    # guard in tests/unit/test_ci_hygiene.py green against the new
+    # analyzer.
+    "pyright==1.1.411",
     "pytest",
     "pytest-asyncio",
     "pytest-cov",

--- a/tests/unit/test_ci_hygiene.py
+++ b/tests/unit/test_ci_hygiene.py
@@ -1,0 +1,283 @@
+"""Guards for CI topology and local-gate invocation.
+
+These exist because three defects all produced a *silent* green:
+
+- #428: ``tui-e2e`` needed ``test``, so a flaky unit suite skipped the freeze
+  guard (observed on PR #426, which *fixed* a deadlock while the deadlock
+  job reported ``skipping``).
+- #423: a stale ``.venv/bin/black`` shebang exits 126, and ``cmd | tail``
+  reports ``tail``'s 0, so a lint gate that never ran looks passing.
+- #381: ``[tool.pyright] exclude`` *replaces* pyright's built-in defaults.
+  Dropping ``**/.*`` makes a local run type-check all of site-packages.
+
+A comment in ci.yml is not a test. Each assertion below is mutation-tested
+against the defect it claims to catch.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+CI_YML = REPO / ".github" / "workflows" / "ci.yml"
+PYPROJECT = REPO / "pyproject.toml"
+MAKEFILE = REPO / "Makefile"
+
+
+def _ci_jobs() -> dict[str, Any]:
+    jobs = yaml.safe_load(CI_YML.read_text())["jobs"]
+    assert isinstance(jobs, dict)
+    return jobs
+
+
+def _needs(job: str) -> set[str]:
+    """`needs` of a CI job, as a set. A missing key is an empty set, which
+    is a legitimate topology (no dependencies), not an error."""
+    declared = _ci_jobs()[job].get("needs") or []
+    assert isinstance(declared, list)
+    return set(declared)
+
+
+def _steps(job: str) -> list[dict[str, Any]]:
+    steps = _ci_jobs()[job]["steps"]
+    assert isinstance(steps, list)
+    return steps
+
+
+def test_tui_e2e_does_not_need_the_unit_suite_or_pip_audit() -> None:
+    """The freeze guard must still run when `test` is red.
+
+    `needs: test` is how GitHub Actions *skips* a job, not how it waits
+    politely. A skipped freeze guard is indistinguishable from a passing
+    one on the PR checks list. `pip-audit` has the same shape: a CVE
+    published today would skip the macOS resume-liveness assertion on an
+    unmodified tree. lint/type-check stay — they are cheap syntax gates
+    and a broken install is not a freeze.
+    """
+    needs = _needs("tui-e2e")
+    assert "test" not in needs, (
+        "tui-e2e needs `test`, so a flaky unit suite skips the freeze "
+        "guard (the #428 defect, observed on PR #426)"
+    )
+    assert "pip-audit" not in needs, (
+        "tui-e2e needs `pip-audit`, so a newly-published CVE skips the "
+        "freeze guard — the same latent disarm as `needs: test`"
+    )
+    assert needs == {"lint", "type-check"}, (
+        f"tui-e2e.needs={sorted(needs)!r}; expected only lint and "
+        "type-check (cheap syntax gates the job does not install itself)"
+    )
+
+
+def test_cli_and_server_sanity_still_wait_on_the_cheap_gates() -> None:
+    """Live-LLM jobs are cost, not freeze guards; they keep the full needs.
+
+    Dropping `test` from those too would be a different change. Pin the
+    current contract so a drive-by edit of every `needs:` block at once
+    cannot silently re-couple tui-e2e by copying the sanity list.
+    """
+    expected = {"lint", "type-check", "test", "pip-audit"}
+    for name in ("cli-sanity", "server-sanity"):
+        assert _needs(name) == expected, (
+            f"{name}.needs drifted; live-LLM jobs are supposed to keep "
+            "the full cheap-gate list, unlike tui-e2e"
+        )
+
+
+def test_type_check_does_not_force_latest_pyright() -> None:
+    """FORCE_VERSION=latest ignores the bundled analyzer.
+
+    That is how CI drifted onto npm 1.1.413 while pip resolved 1.1.411
+    and the lint job (which never ran pyright) pinned 1.1.408. The pin
+    lives in the dev extra; bump that, not an env override.
+    """
+    job = _ci_jobs()["type-check"]
+    assert isinstance(job, dict)
+    env = job.get("env") or {}
+    assert "PYRIGHT_PYTHON_FORCE_VERSION" not in env, (
+        "type-check sets PYRIGHT_PYTHON_FORCE_VERSION, which downloads "
+        "whatever npm currently calls latest instead of the pinned "
+        f"analyzer (env={env!r})"
+    )
+    # The lint job used to install pyright==1.1.408 and never invoke it.
+    # A third unused pin is how the versions diverged in the first place.
+    lint_install = "\n".join(step.get("run", "") for step in _steps("lint"))
+    assert "pyright" not in lint_install, (
+        "lint job still installs pyright — it does not run it, and a "
+        "second pin is how 1.1.408 / 1.1.411 / latest coexisted"
+    )
+
+
+def test_dev_extra_pins_the_same_pyright_the_type_check_job_installs() -> None:
+    """One version across the extra, the local gate, and CI.
+
+    An unpinned `pyright` in the extra is what let FORCE_VERSION=latest
+    and a leftover lint-job pin silently disagree.
+    """
+    extras = tomllib.loads(PYPROJECT.read_text())["project"]["optional-dependencies"]["dev"]
+    pins = [dep for dep in extras if dep.startswith("pyright")]
+    assert pins == ["pyright==1.1.411"], (
+        f"dev extra pyright pin drifted: {pins!r}. Bump this together "
+        "with the exclude-superset guard, not by setting FORCE_VERSION."
+    )
+
+
+def test_configured_pyright_excludes_are_a_superset_of_the_running_defaults() -> None:
+    """`exclude` replaces pyright's built-in defaults, it does not extend them.
+
+    The running analyzer reports those defaults on `--verbose` as
+    `Auto-excluding <pattern>` — that is a behavioural source, not a
+    restatement of an upstream constant we would then have to keep in
+    sync by hand. If a future pyright adds a fourth default, this test
+    goes red until we restate it.
+
+    The probe runs against an empty config so our restated `exclude`
+    cannot mask a missing default: with `exclude` set, pyright does not
+    auto-exclude anything (the replacement semantics this test exists
+    to catch).
+    """
+    configured = set(tomllib.loads(PYPROJECT.read_text())["tool"]["pyright"]["exclude"])
+    with tempfile.TemporaryDirectory() as tmp:
+        (Path(tmp) / "pyrightconfig.json").write_text("{}")
+        proc = subprocess.run(
+            [sys.executable, "-m", "pyright", "--verbose", "."],
+            cwd=tmp,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    auto = {
+        line.split("Auto-excluding ", 1)[1].strip()
+        for line in (proc.stdout + proc.stderr).splitlines()
+        if "Auto-excluding " in line
+    }
+    assert auto, (
+        "pyright --verbose printed no Auto-excluding lines; the "
+        "defaults probe cannot see drift if the analyzer stopped "
+        f"reporting them (rc={proc.returncode}, stderr={proc.stderr!r})"
+    )
+    missing = sorted(auto - configured)
+    assert not missing, (
+        f"[tool.pyright] exclude is missing pyright's built-in "
+        f"defaults {missing}. exclude REPLACES the defaults, so these "
+        "patterns are currently type-checked. Restate them alongside "
+        f"`docs`. configured={sorted(configured)}"
+    )
+
+
+def test_pipeline_does_not_swallow_a_126_from_a_broken_console_script() -> None:
+    """`cmd | tail` reports tail's 0 even when cmd exited 126.
+
+    That is the #423 mechanism: a stale shebang makes `.venv/bin/black`
+    fail with `bad interpreter` / rc=126, and a gate script that pipes
+    the output looks green. The documented gates (`python -m`, `uvx`)
+    and `make lint`/`format`/`type-check` must not be that pipeline.
+
+    This test does not invoke the real `.venv/bin/black` — that would
+    pass on a healthy venv and fail only on a stale one, which is the
+    opposite of a guard. It builds a 126-exiting fake and shows that
+    (a) a pipeline swallows it and (b) `python -m` does not consult
+    that shebang at all.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        # flake8, not black: black is deliberately absent from the dev
+        # extra (the documented gate is `uvx`), so `python -m black`
+        # would fail on CI for a reason that has nothing to do with
+        # shebangs. flake8 is in the extra and is one of the three
+        # console scripts the issue named.
+        fake = Path(tmp) / "flake8"
+        # A shebang pointing at a path that does not exist is how the
+        # real console scripts fail after a worktree is deleted. The
+        # kernel returns 126 ("bad interpreter") before the script body
+        # runs, so the body here is unreachable on purpose.
+        fake.write_text("#!/this/interpreter/does/not/exist\n")
+        fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+
+        piped = subprocess.run(
+            f"{fake} --version | tail -1",
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+        assert piped.returncode == 0, (
+            "the #423 mechanism itself changed: a 126 inside a pipeline "
+            f"no longer reports 0 (rc={piped.returncode}). If shells "
+            "started honouring pipefail by default this test would need "
+            "rewriting, but the Makefile still must not pipe."
+        )
+
+        # 126 is a *shell* translation of ENOENT on the shebang
+        # interpreter. Direct execve raises FileNotFoundError, which
+        # is not the rc a gate script sees. Invoke through a shell
+        # the same way `make` / a copied command line would.
+        env = {**os.environ, "PATH": tmp + os.pathsep + os.environ.get("PATH", "")}
+        via_path = subprocess.run(
+            "flake8 --version",
+            shell=True,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        # 126 is bash-on-macOS for a bad shebang; Linux bash has been
+        # seen to report 127 (command not found) for the same ENOENT.
+        # Either is a failed gate. The defect is that the pipeline
+        # above reported 0 regardless.
+        assert via_path.returncode != 0, (
+            "the fake console script succeeded when found on PATH "
+            f"(rc={via_path.returncode}); the rest of this test is "
+            "not exercising the defect"
+        )
+        via_module = subprocess.run(
+            [sys.executable, "-m", "flake8", "--version"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert via_module.returncode == 0, (
+            "`python -m flake8` consulted the stale PATH shebang "
+            f"(rc={via_module.returncode}, stderr={via_module.stderr!r})"
+        )
+
+
+def test_makefile_quality_targets_do_not_invoke_console_scripts() -> None:
+    """`make lint` used to be a bare `flake8`, which is the 126 path.
+
+    After this change the quality targets go through `python -m` / `uvx`,
+    matching AGENTS.md. A regression to `black .` / `flake8` / `pyright`
+    re-exposes every agent on this machine to a swallowed 126.
+    """
+    recipes = [
+        line.lstrip("\t")
+        for line in MAKEFILE.read_text().splitlines()
+        if line.startswith("\t") and not line.lstrip().startswith("#")
+    ]
+    for tool in ("black", "flake8", "isort", "pyright"):
+        # A recipe whose first token is the tool name is the console
+        # script. `python -m flake8` and `uvx --from black==… black`
+        # have a different first token.
+        bare = [r for r in recipes if r == tool or r.startswith(tool + " ")]
+        assert not bare, (
+            f"Makefile still invokes the `{tool}` console script "
+            f"({bare!r}); that is the #423 shebang path. Use "
+            "`python -m` or `uvx`."
+        )
+
+
+def test_tui_e2e_still_runs_on_macos() -> None:
+    """The freeze is a macOS/BSD property; dropping the leg disarms the guard
+    more thoroughly than `needs: test` ever did."""
+    matrix = _ci_jobs()["tui-e2e"]["strategy"]["matrix"]["os"]
+    assert isinstance(matrix, list)
+    assert "macos-latest" in matrix, (
+        "tui-e2e lost its macOS leg; the freeze this stage exists to "
+        f"catch cannot go red on Linux (os={matrix!r})"
+    )

--- a/tests/unit/test_ci_hygiene.py
+++ b/tests/unit/test_ci_hygiene.py
@@ -187,14 +187,20 @@ def test_pipeline_does_not_swallow_a_126_from_a_broken_console_script() -> None:
     opposite of a guard. It builds a 126-exiting fake and shows that
     (a) a pipeline swallows it and (b) `python -m` does not consult
     that shebang at all.
+
+    The fake is invoked by absolute path, not via PATH lookup. Linux
+    bash/dash continue searching PATH after a bad shebang, so a fake
+    named `flake8` on PATH is skipped and the real flake8 in the venv
+    runs (rc=0) — which is how this assertion passed locally on macOS
+    (no PATH continuation) and then failed on CI 3.12 by detecting it
+    was not exercising the defect. An absolute path cannot be skipped.
     """
     with tempfile.TemporaryDirectory() as tmp:
-        # flake8, not black: black is deliberately absent from the dev
-        # extra (the documented gate is `uvx`), so `python -m black`
-        # would fail on CI for a reason that has nothing to do with
-        # shebangs. flake8 is in the extra and is one of the three
-        # console scripts the issue named.
-        fake = Path(tmp) / "flake8"
+        # Unique name, not `flake8`: even with an absolute-path
+        # invocation we must not share a name with a real console
+        # script, because a future edit that switches back to PATH
+        # lookup would silently start testing the real flake8 again.
+        fake = Path(tmp) / "lop-stale-script"
         # A shebang pointing at a path that does not exist is how the
         # real console scripts fail after a worktree is deleted. The
         # kernel returns 126 ("bad interpreter") before the script body
@@ -202,9 +208,24 @@ def test_pipeline_does_not_swallow_a_126_from_a_broken_console_script() -> None:
         fake.write_text("#!/this/interpreter/does/not/exist\n")
         fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
 
+        # Direct execve of a missing-interpreter shebang raises
+        # FileNotFoundError; a gate script sees the *shell*
+        # translation, which is 126. Drive bash explicitly so we are
+        # not at the mercy of `/bin/sh` being dash vs bash.
+        bash = ["/bin/bash", "-c"]
+        direct = subprocess.run(
+            [*bash, f"{fake} --version"],
+            capture_output=True,
+            text=True,
+        )
+        assert direct.returncode == 126, (
+            "the fake did not fail with 126 at its own boundary "
+            f"(rc={direct.returncode}, stderr={direct.stderr!r}); "
+            "the rest of this test is not exercising the defect"
+        )
+
         piped = subprocess.run(
-            f"{fake} --version | tail -1",
-            shell=True,
+            [*bash, f"{fake} --version | tail -1"],
             capture_output=True,
             text=True,
         )
@@ -215,27 +236,10 @@ def test_pipeline_does_not_swallow_a_126_from_a_broken_console_script() -> None:
             "rewriting, but the Makefile still must not pipe."
         )
 
-        # 126 is a *shell* translation of ENOENT on the shebang
-        # interpreter. Direct execve raises FileNotFoundError, which
-        # is not the rc a gate script sees. Invoke through a shell
-        # the same way `make` / a copied command line would.
+        # `python -m` looks up the module on sys.path; it never execs
+        # a console-script shebang. Pointing PATH at the fake must
+        # therefore not change the module invocation's rc.
         env = {**os.environ, "PATH": tmp + os.pathsep + os.environ.get("PATH", "")}
-        via_path = subprocess.run(
-            "flake8 --version",
-            shell=True,
-            env=env,
-            capture_output=True,
-            text=True,
-        )
-        # 126 is bash-on-macOS for a bad shebang; Linux bash has been
-        # seen to report 127 (command not found) for the same ENOENT.
-        # Either is a failed gate. The defect is that the pipeline
-        # above reported 0 regardless.
-        assert via_path.returncode != 0, (
-            "the fake console script succeeded when found on PATH "
-            f"(rc={via_path.returncode}); the rest of this test is "
-            "not exercising the defect"
-        )
         via_module = subprocess.run(
             [sys.executable, "-m", "flake8", "--version"],
             env=env,

--- a/tests/unit/test_ci_hygiene.py
+++ b/tests/unit/test_ci_hygiene.py
@@ -175,51 +175,46 @@ def test_configured_pyright_excludes_are_a_superset_of_the_running_defaults() ->
 
 
 def test_pipeline_does_not_swallow_a_126_from_a_broken_console_script() -> None:
-    """`cmd | tail` reports tail's 0 even when cmd exited 126.
+    """`cmd | tail` reports tail's 0 even when cmd failed.
 
     That is the #423 mechanism: a stale shebang makes `.venv/bin/black`
-    fail with `bad interpreter` / rc=126, and a gate script that pipes
-    the output looks green. The documented gates (`python -m`, `uvx`)
-    and `make lint`/`format`/`type-check` must not be that pipeline.
+    fail (macOS bash: 126 "bad interpreter"; Linux bash: 127 "required
+    file not found"), and a gate script that pipes the output looks
+    green because it reports `tail`'s 0. The documented gates
+    (`python -m`, `uvx`) and `make lint`/`format`/`type-check` must
+    not be that pipeline.
 
-    This test does not invoke the real `.venv/bin/black` — that would
-    pass on a healthy venv and fail only on a stale one, which is the
-    opposite of a guard. It builds a 126-exiting fake and shows that
-    (a) a pipeline swallows it and (b) `python -m` does not consult
-    that shebang at all.
+    Pinning rc==126 is how this assertion passed on macOS 3.14, then
+    failed on CI 3.12 (PATH continuation found the real flake8, rc=0)
+    and CI 3.13 (absolute path, rc=127). The defect is the swallow,
+    not the errno. Accept any non-zero from the fake as "the script
+    failed"; assert the pipeline then reports 0.
 
-    The fake is invoked by absolute path, not via PATH lookup. Linux
+    The fake is a unique name invoked by absolute path. Linux
     bash/dash continue searching PATH after a bad shebang, so a fake
-    named `flake8` on PATH is skipped and the real flake8 in the venv
-    runs (rc=0) — which is how this assertion passed locally on macOS
-    (no PATH continuation) and then failed on CI 3.12 by detecting it
-    was not exercising the defect. An absolute path cannot be skipped.
+    named `flake8` on PATH is skipped and the real flake8 runs —
+    which is not the defect.
     """
     with tempfile.TemporaryDirectory() as tmp:
-        # Unique name, not `flake8`: even with an absolute-path
-        # invocation we must not share a name with a real console
-        # script, because a future edit that switches back to PATH
-        # lookup would silently start testing the real flake8 again.
         fake = Path(tmp) / "lop-stale-script"
         # A shebang pointing at a path that does not exist is how the
         # real console scripts fail after a worktree is deleted. The
-        # kernel returns 126 ("bad interpreter") before the script body
-        # runs, so the body here is unreachable on purpose.
+        # body is unreachable on purpose.
         fake.write_text("#!/this/interpreter/does/not/exist\n")
         fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
 
         # Direct execve of a missing-interpreter shebang raises
         # FileNotFoundError; a gate script sees the *shell*
-        # translation, which is 126. Drive bash explicitly so we are
-        # not at the mercy of `/bin/sh` being dash vs bash.
+        # translation. Drive bash explicitly so we are not at the
+        # mercy of `/bin/sh` being dash vs bash.
         bash = ["/bin/bash", "-c"]
         direct = subprocess.run(
             [*bash, f"{fake} --version"],
             capture_output=True,
             text=True,
         )
-        assert direct.returncode == 126, (
-            "the fake did not fail with 126 at its own boundary "
+        assert direct.returncode != 0, (
+            "the fake succeeded at its own boundary "
             f"(rc={direct.returncode}, stderr={direct.stderr!r}); "
             "the rest of this test is not exercising the defect"
         )
@@ -230,10 +225,12 @@ def test_pipeline_does_not_swallow_a_126_from_a_broken_console_script() -> None:
             text=True,
         )
         assert piped.returncode == 0, (
-            "the #423 mechanism itself changed: a 126 inside a pipeline "
-            f"no longer reports 0 (rc={piped.returncode}). If shells "
-            "started honouring pipefail by default this test would need "
-            "rewriting, but the Makefile still must not pipe."
+            "the #423 mechanism itself changed: a failing console "
+            "script inside a pipeline no longer reports 0 "
+            f"(direct rc={direct.returncode}, piped rc={piped.returncode}). "
+            "If shells started honouring pipefail by default this "
+            "test would need rewriting, but the Makefile still must "
+            "not pipe."
         )
 
         # `python -m` looks up the module on sys.path; it never execs


### PR DESCRIPTION
# PR Description

Successor of #478. That PR's remote branch was deleted after a merge-conflict GraphQL failure; this is the same three commits rebased onto `origin/main` (`d8a8c833`, #479). Behaviour unchanged: kept main's `type-check` `timeout-minutes: 15`, dropped `PYRIGHT_PYTHON_FORCE_VERSION: latest`, kept `pyright==1.1.411`. Round 1 on #478 was CLEAN/TERMINAL; this rebase does not change behaviour.

Agent review: https://github.com/damianvtran/local-operator/pull/478#issuecomment-5472190019
Remediation: https://github.com/damianvtran/local-operator/pull/478#issuecomment-5472203082

## Change classification

**C2 — standard / pre-authorized.** CI topology, a pinned dev-extra, Makefile
invocation, and a unit guard. No runtime path under `local_operator/` changes.
Rollback is `git revert`.

## Summary of Changes

Three CI/tooling hygiene defects, one silent-green shape: a gate that looks
passing because it never actually ran, or ran the wrong tool.

### 1. `#428` — `tui-e2e` freeze guard disarmed whenever `test` is red

`tui-e2e` declared `needs: [lint, type-check, test, pip-audit]`. GitHub Actions
**skips** a job whose needed jobs failed — it does not wait politely. A skipped
freeze guard is indistinguishable from a passing one on the PR checks list.

This is not theoretical. On PR #426 — which *fixed* an event-loop freeze —
both CI runs (33284918639, 33284954232) reported `tui-e2e` as `skipping`
because `test` was flaky, so the deadlock guard never executed on a deadlock
fix. Per AGENTS.md the macOS leg of this stage is the regression guard for
#401 (a blocking `flock` in the MCP OAuth refresh lock deadlocking the event
loop on `/resume`), and it is deliberately fork-gate-free so it runs on every
PR. A guard that silently disarms when an unrelated stage is flaky is
structurally backwards.

PR #461 (`f5f77cee`) landed test-determinism fixes that reduce `test`
flakiness. That does **not** make this issue moot: the structural dependency
is still wrong and will disarm the guard on the next flake.

**Fix:** `tui-e2e` now needs only `lint` and `type-check` (cheap syntax gates;
a broken install is not a freeze). `test` and `pip-audit` are dropped —
`pip-audit` has the same latent disarm (a CVE published today would skip the
macOS resume-liveness assertion on an unmodified tree). The job installs the
package itself, so it does not need those stages to have built anything.
`cli-sanity` / `server-sanity` keep the full `needs` list — they are live-LLM
cost, not freeze guards.

```
before:  lint, type-check, test, pip-audit  ──needs──►  tui-e2e
after:   lint, type-check                   ──needs──►  tui-e2e
         test, pip-audit                    (independent; a red does not skip the guard)
```

Failure modes that now still run the freeze guard: unit-suite flake, unit-suite
real failure, pip-audit CVE, pip-audit infra blip. Failure modes that still
skip it (intentionally): lint red, type-check red — those are "the package
does not even parse / type-check", not a freeze.

### 2. `#423` — stale `.venv` console-script shebangs silently pass lint/format gates

The console scripts in the repo `.venv` have shebangs pointing at **deleted**
worktrees, so they fail with `bad interpreter` and exit **126**. `rc=126`
disappears inside a pipeline — `cmd | tail` reports `tail`'s 0 — so a lint or
format gate that never actually ran looks green.

Reproduced on this machine at HEAD, against the real venv:

```
$ .venv/bin/black --version; echo "black rc=$?"
/bin/sh: .venv/bin/black: /private/tmp/lop-resume-team/.venv/bin/python: bad interpreter: No such file or directory
black rc=126

$ .venv/bin/black --version | tail -1; echo "piped rc=$?"
piped rc=0

$ .venv/bin/python -m flake8 --version >/dev/null; echo "python -m flake8 rc=$?"
python -m flake8 rc=0
$ uvx --from black==26.1.0 black --version >/dev/null; echo "uvx black rc=$?"
uvx black rc=0
```

**Fix:** `make lint` / `make format` / `make type-check` now go through
`python -m` / `uvx` at the versions CI pins, matching the documented gate
commands in AGENTS.md. A note in AGENTS.md names the shebang trap so the next
agent does not "simplify" back to `.venv/bin/black`.

### 3. `#381` — pin one pyright version and stop restating upstream defaults by hope

Three pyright versions across one gate:

| surface | version |
| --- | --- |
| lint job (`pip install pyright==1.1.408`) | 1.1.408, **never invoked** |
| type-check job (`PYRIGHT_PYTHON_FORCE_VERSION: latest`) | npm 1.1.413 |
| local `.venv` / pip-resolved extra | 1.1.411 |

`[tool.pyright] exclude` *replaces* pyright's built-in defaults rather than
extending them, so the restated `"**/node_modules"`, `"**/__pycache__"`,
`"**/.*"` are version-specific constants. Three versions means the restatement
is a guess. Dropping `**/.*` makes pyright follow the `.venv` symlink and
type-check all of site-packages (29466 files / ~30 min instead of ~636 files /
~15 s) — CI never creates a `.venv`, so it stays green while every local run
of the gate becomes unusable.

**Fix:**

- Pin `pyright==1.1.411` in the dev extra (what CI currently resolves from
  PyPI; measured identical to 1.1.413 on this tree: 636 files, 0 errors).
- Drop the unused `pyright==1.1.408` from the lint job.
- Drop `PYRIGHT_PYTHON_FORCE_VERSION: latest` from type-check so CI uses the
  bundled analyzer, not whatever npm currently calls latest.
- Guard: `tests/unit/test_ci_hygiene.py` asserts `[tool.pyright] exclude` is a
  **superset of the running analyzer's defaults**, sourced behaviourally from
  `pyright --verbose` (`Auto-excluding <pattern>`). If a future pyright adds a
  fourth default, the test goes red until we restate it.

Pyright file count / result, same tree, same invocation
(`.venv/bin/python -m pyright --pythonpath .venv/bin/python .`):

| | version | filesAnalyzed | errors |
| --- | --- | --- | --- |
| before pin (this tree at origin/main) | 1.1.411 | 636 | 0 |
| after pin + new test file | 1.1.411 | 637 | 0 |

The +1 is `tests/unit/test_ci_hygiene.py`. Not the 29466-file site-packages
walk. `**/.*` is still in `exclude`.

## Testing evidence

### Mutation tests (each guard dies at its own boundary)

Run against a scratch copy of the tree; the worktree itself is unmodified.

| mutation | test that died |
| --- | --- |
| restore `tui-e2e needs: [lint, type-check, test, pip-audit]` | `test_tui_e2e_does_not_need_the_unit_suite_or_pip_audit` |
| drop `**/.*` from `[tool.pyright] exclude` | `test_configured_pyright_excludes_are_a_superset_of_the_running_defaults` |
| unpin `pyright` in the dev extra | `test_dev_extra_pins_the_same_pyright_the_type_check_job_installs` |
| restore `PYRIGHT_PYTHON_FORCE_VERSION: latest` | `test_type_check_does_not_force_latest_pyright` |
| restore unused lint-job `pyright==1.1.408` | `test_type_check_does_not_force_latest_pyright` |
| `Makefile` `lint:` back to bare `flake8` | `test_makefile_quality_targets_do_not_invoke_console_scripts` |
| drop `macos-latest` from the `tui-e2e` matrix | `test_tui_e2e_still_runs_on_macos` |

The 126-pipeline assertion is itself a reproduction: a fake console script
with a missing-interpreter shebang exits non-zero, `| tail` reports 0, and
`python -m flake8` still succeeds with that fake on `PATH`.

### Quality gates (whole tree, repo config, exit codes)

```
.venv/bin/python -m flake8 .                         flake8 rc=0
uvx --from black==26.1.0 black --check .             black rc=0
uvx isort==5.13.2 --check .                          isort rc=0
.venv/bin/python -m pyright --pythonpath .venv/bin/python .
                                                     pyright rc=0  (0 errors, 637 files)
env -u NO_COLOR TERM=xterm-256color \
  .venv/bin/python -m pytest tests/unit/test_ci_hygiene.py -n0 -q
                                                     8 passed
make lint                                            make lint rc=0
                                                     (.venv/bin/python -m flake8 .)
```

isort printed `Skipped 1 files` on both pass and fail last wave; the rc is
the signal. black's "All done!" banner is on stderr.

### DAG evidence for #428

This is a workflow-topology change. I did not push a deliberately-red `test`
branch (four sibling agents are pushing at the same time; a broken workflow
blocks all of them). The `needs` graph is the behaviour under test, and it is
pinned by `test_tui_e2e_does_not_need_the_unit_suite_or_pip_audit` so a
drive-by copy of the sanity-job `needs` list cannot recouple them.

## Out of scope / deliberately not done

- Did not drop `needs` from `cli-sanity` / `server-sanity`. Those are live-LLM
  cost; a flake skipping them is annoying, not a freeze reaching `main`.
- Did not `uv pip install --force-reinstall` the stale console scripts in the
  shared `.venv`. That is a local-machine repair, not a repo change, and it
  would recur the next time a worktree is deleted. The invocation change is
  the durable fix.
- Did not bump the version. The manager runs one release after PRs land.
- Did not merge.

Closes #381
Closes #423
Closes #428

