### PR TITLE
fix(tui): make shell mode legible without colour, and keep a settings row at 16 lines

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1098,13 +1098,31 @@ ASIDE_LAYOUT_CLASS = "aside"
 #: ``OperatorApp._sync_composer_focus``.
 COMPOSER_FOCUSED_CLASS = "-composer-focused"
 
-#: Class the input dock carries while bang-mode is on. The chevron stays the
-#: same glyph — ``composer_cells`` finds the row by it — and the class is
-#: what the stylesheet reads to paint it ``string`` rather than the focus
+#: Class the input dock carries while bang-mode is on. The class is what the
+#: stylesheet reads to paint the marker ``string`` rather than the focus
 #: brightness. ``string`` is the ramp's command/success green, a step off
 #: the accent, so a shell-mode composer does not spend the "turn is live"
 #: ink (D5) and still reads as a different MODE from the resting field.
+#:
+#: The GLYPH also changes (``PROMPT_CHEVRON`` → ``SHELL_CHEVRON``). Hue
+#: alone is invisible to a colourblind reader, under ``NO_COLOR``, and on a
+#: monochrome terminal — and bang-mode changes what Enter does, so that
+#: silence is a safety gap, not polish (#385). Shape carries the mode;
+#: colour remains a redundant cue for readers who can see it.
 COMPOSER_SHELL_CLASS = "-composer-shell"
+
+#: The composer's resting prompt marker. One cell, and the glyph
+#: ``composer_cells`` (and the command picker, deliberately) locate the
+#: row by. Bang-mode swaps it for :data:`SHELL_CHEVRON` rather than
+#: recoloring this one: a hue-only swap is invisible without colour.
+PROMPT_CHEVRON = "❯"
+
+#: Bang-mode's prompt marker. The POSIX shell prompt, one cell, so it
+#: fits the same 2-cell ``#prompt-chevron`` box and does not shift the
+#: editor. Chosen over ``!`` because ``!`` is the KEY that enters the
+#: mode; using it as the marker would make the frame look like the bang
+#: was inserted into the buffer (it is consumed, not typed).
+SHELL_CHEVRON = "$"
 
 #: How long after a terminal resize the floating overlay cards re-measure
 #: themselves. They are hosted in `width: auto` containers, so Textual sends
@@ -2298,7 +2316,7 @@ class OperatorApp(App[None]):
                 yield Band(id="status-band")
                 editor = Editor(commands=SLASH_COMMANDS)
                 with Horizontal(id="input-row"):
-                    yield Chrome("❯", id="prompt-chevron")
+                    yield Chrome(PROMPT_CHEVRON, id="prompt-chevron")
                     yield editor
                 # The picker is the editor's, but it cannot be the editor's
                 # CHILD: it has to draw across the full panel width, outside the
@@ -6833,12 +6851,20 @@ class OperatorApp(App[None]):
         dock.set_class(focused, COMPOSER_FOCUSED_CLASS)
 
     def on_shell_mode_changed(self, message: ShellModeChanged) -> None:
-        """Follow the composer's bang-mode onto the dock class the sheet reads."""
+        """Follow the composer's bang-mode onto the dock class AND the glyph.
+
+        The class is the colour cue (``string`` green). The glyph is the
+        colour-independent one: ``$`` instead of ``❯``, so a reader who
+        cannot see the hue still knows Enter will run a command (#385).
+        Both flip on the same message so they cannot drift apart.
+        """
         try:
             dock = self.query_one("#input-dock")
+            chevron = self.query_one("#prompt-chevron", Chrome)
         except NoMatches:
             return
         dock.set_class(message.active, COMPOSER_SHELL_CLASS)
+        chevron.update(SHELL_CHEVRON if message.active else PROMPT_CHEVRON)
 
     def on_interrupt_requested(self, message: InterruptRequested) -> None:
         """Ctrl+C from the composer — the NORMAL path, since it holds focus.
@@ -15601,6 +15627,49 @@ class OperatorApp(App[None]):
             style=dim,
         )
         lines.append(cmd_paste_note)
+
+        # The rest of the key reference. Same surface, same two-column
+        # gutter, same 74-cell ceiling at 80 columns as the copy/paste
+        # rows above — `/help` is the in-app place a user already opens
+        # when lost, and until these rows existed the README was the only
+        # channel documenting the chords (#385). Tightly scoped additions
+        # rather than a second surface: another agent is concurrently
+        # working #430 against the same block, so a wholesale rewrite of
+        # this method would collide.
+        #
+        # Descriptions are budgeted against `name_width` (currently 20,
+        # derived from `/settings, /config`) so `name_width + description`
+        # stays <= 74. Continuation lines use the same empty-gutter
+        # indent the `ctrl+c` row already established.
+
+        def _key_row(key: str, description: str) -> Text:
+            row = Text()
+            row.append(key.ljust(name_width), style=muted)
+            row.append(description, style=dim)
+            return row
+
+        def _key_more(description: str) -> Text:
+            row = Text()
+            row.append("".ljust(name_width), style=muted)
+            row.append(description, style=dim)
+            return row
+
+        # Bang-mode's marker is named here because the glyph is the
+        # colour-independent signal (#385) and a user who cannot see the
+        # hue still needs to know what `$` on the composer means. The
+        # description is 47 cells (67 composed) so it has headroom.
+        lines.append(_key_row("!", "run the buffer as a local shell command"))
+        lines.append(_key_more("the composer shows $ instead of ❯; esc leaves"))
+        lines.append(_key_row("option+left/right", "move by word; +shift selects"))
+        lines.append(_key_more("ctrl+left/right is the same on Linux/Windows"))
+        lines.append(_key_row("option+up/down", "same as up/down (history, lists)"))
+        lines.append(_key_row("shift+tab", "cycle reasoning effort"))
+        lines.append(_key_row("ctrl+l", "clear the transcript (history stays)"))
+        lines.append(_key_row("ctrl+t", "expand or collapse the todo panel"))
+        lines.append(_key_row("ctrl+g", "expand or collapse the subagent panel"))
+        lines.append(_key_row("ctrl+b", "open an aside; ctrl+f forks it in"))
+        lines.append(_key_row("esc", "stop the agent; leave a mode"))
+        lines.append(_key_row("ctrl+d", "quit, on an empty composer"))
         # Where the logs went. Console logging is off while the TUI owns the
         # terminal (see `local_operator.logger.file_logging`), so without this
         # line the file is unfindable without reading the source. `/help` and

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -427,7 +427,7 @@ ToolCard:focus, WakeBlock:focus {
 /* Bang-mode recolors the marker AND swaps the glyph (`❯` → `$`; see
  * `OperatorApp.on_shell_mode_changed`). Colour is the redundant cue for
  * readers who can see it; the glyph is the one that survives `NO_COLOR`,
- * a monochrome terminal, and red-green colour vision deficiency (#385).
+ * a monochrome terminal, and red-green colour vision deficiency (issue 385).
  * `string` is the ramp's command/success green — a step off the accent,
  * so a shell-mode composer does not spend the "turn is live" ink (D5).
  * Outranks the focus brightness: the mode is the louder fact, and a
@@ -1533,7 +1533,7 @@ Screen.org-chart #input-dock #prompt-chevron {
     /* Default quiet row above the list. `SettingsView._apply_height_ladder`
      * CLEARS this padding on a short terminal so the body keeps a setting
      * row — a 1-row shed, so restoring it as the terminal grows never
-     * drops the body (#431). Do not raise this to 2: a 2-row unit is the
+     * drops the body (issue 431). Do not raise this to 2: a 2-row unit is the
      * non-monotonic move that issue forbids. */
     padding: 1 0 0 0;
 }

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -424,14 +424,15 @@ ToolCard:focus, WakeBlock:focus {
     color: $lo-fg;
 }
 
-/* Bang-mode recolors the chevron, not the glyph. `composer_cells` finds the
- * row by `❯`, and swapping the character would make every focus/caret test
- * miss the composer the moment the mode was on. `string` is the ramp's
- * command/success green — a step off the accent, so a shell-mode composer
- * does not spend the "turn is live" ink (D5) and still reads as a different
- * MODE from the resting field. Outranks the focus brightness: the mode is
- * the louder fact, and a focused shell-mode chevron that went `fg` would
- * look identical to a focused prompt. */
+/* Bang-mode recolors the marker AND swaps the glyph (`❯` → `$`; see
+ * `OperatorApp.on_shell_mode_changed`). Colour is the redundant cue for
+ * readers who can see it; the glyph is the one that survives `NO_COLOR`,
+ * a monochrome terminal, and red-green colour vision deficiency (#385).
+ * `string` is the ramp's command/success green — a step off the accent,
+ * so a shell-mode composer does not spend the "turn is live" ink (D5).
+ * Outranks the focus brightness: the mode is the louder fact, and a
+ * focused shell-mode marker that went `fg` would look identical to a
+ * focused prompt on a colour-capable terminal. */
 #input-dock.-composer-shell #prompt-chevron {
     color: $lo-string;
 }
@@ -1529,6 +1530,11 @@ Screen.org-chart #input-dock #prompt-chevron {
  * have (an empty registry would otherwise leave a wide blank gutter). */
 .settings-view-columns {
     height: 1fr;
+    /* Default quiet row above the list. `SettingsView._apply_height_ladder`
+     * CLEARS this padding on a short terminal so the body keeps a setting
+     * row — a 1-row shed, so restoring it as the terminal grows never
+     * drops the body (#431). Do not raise this to 2: a 2-row unit is the
+     * non-monotonic move that issue forbids. */
     padding: 1 0 0 0;
 }
 

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -875,10 +875,12 @@ ASIDE_PLACEHOLDER = "Ask the aside…"
 
 #: What the composer says in bang-mode. The first clause is opencode's
 #: sentence — what typing here WILL DO — and the second names the way out,
-#: because entry is taught three ways (tip, placeholder, green chevron) while
-#: exit was taught by nothing on screen (design round 1, D2): the placeholder
-#: is the one surface guaranteed visible the moment the mode opens on an
-#: empty buffer, which is exactly when a first-timer looks for the door.
+#: because entry is taught three ways (tip, placeholder, and the ``$``
+#: marker — a shape change, not a hue, so it survives ``NO_COLOR``; #385)
+#: while exit was taught by nothing on screen (design round 1, D2): the
+#: placeholder is the one surface guaranteed visible the moment the mode
+#: opens on an empty buffer, which is exactly when a first-timer looks
+#: for the door.
 SHELL_PLACEHOLDER = "Run a command… — esc to leave"
 
 

--- a/local_operator/tui/widgets/settings_view.py
+++ b/local_operator/tui/widgets/settings_view.py
@@ -135,7 +135,28 @@ _LABEL_BUDGET = _VALUE_COLUMN - _ROW_INDENT - _MARKER_WIDTH - 1
 #: — `_repaint` runs from `on_mount`, before layout, where every child size is
 #: still 0, and a pane budgeted against 0 rows paints a different first frame
 #: from its settled one.
+#:
+#: This is the FULL-chrome count. On a short terminal
+#: :meth:`SettingsView._apply_height_ladder` sheds 1-row units (padding,
+#: then the rule) so the body keeps at least :data:`_BODY_MIN_ROWS`, and
+#: :meth:`SettingsView._pane_height` subtracts the live count rather than
+#: this constant — otherwise the pane would keep claiming rows the body
+#: just reclaimed (#431).
 _PANE_CHROME_ROWS = 7
+
+#: Fewest setting rows the body may paint. Below this the page is honest
+#: about being a settings page and silent about every setting — header,
+#: rule, detail, hints, and a blank band (#431). Chrome pays for this
+#: floor, one row at a time: a 2-row shed (the detail line) at 16 rows
+#: would give the body 2 rows, and restoring that chrome at 17 would
+#: drop the body to 1, so the page would get worse as the terminal grew.
+_BODY_MIN_ROWS = 1
+
+#: What the detail line says when even the 1-row sheds cannot free a
+#: body row (terminal ≲ 14). A blank band here would repeat #431 at a
+#: smaller size; naming the constraint is the other option the issue
+#: offered, and it is the one that stays monotonic.
+_TOO_SHORT = "terminal too short for settings — make it taller"
 
 #: The right-hand pane's two read-only tabs. Read-only on purpose: teams and
 #: agents are configured in files, and a page that showed an editable-looking
@@ -307,6 +328,13 @@ class SettingsView(Vertical):
         self._list_text = Text()
         self._detail_text = Text()
         self._pane_text = Text()
+        #: Live height-ladder flags, so `_pane_height` and `_paint_detail`
+        #: read the same decision `_apply_height_ladder` just made rather
+        #: than re-deriving it against a size that may not have settled.
+        self._chrome_rule = True
+        self._chrome_pad = True
+        self._chrome_columns = True
+        self._too_short = False
 
     # -- composition --------------------------------------------------------
     def compose(self):  # type: ignore[override]
@@ -336,8 +364,19 @@ class SettingsView(Vertical):
 
     def on_resize(self) -> None:
         # The rule spans the page and the hints shed against a width only the
-        # layout knows, so both are repainted on resize.
+        # layout knows, so both are repainted on resize. Parking a 1-row
+        # body on the selected setting has to wait until AFTER this
+        # refresh: `_body.size.height` is still the previous layout's
+        # during `on_resize`, so scrolling now at 17 rows (body about to
+        # become 2) used the stale height of 1 and hid the section header
+        # the extra row had just made room for.
         self._repaint()
+        # Immediate, and `_scroll_to_selection` uses the DERIVED body
+        # height rather than `_body.size` — during resize the child
+        # size is still the previous layout, so a 16→17 grow would
+        # scroll as if the body were still 1 row and hide the header
+        # the extra row had just made room for.
+        self._scroll_to_selection(immediate=True)
 
     # -- data ---------------------------------------------------------------
     def load(
@@ -633,10 +672,7 @@ class SettingsView(Vertical):
         write rather than merely painted in the same frame — see
         :meth:`_reveal_cursor`.
         """
-        try:
-            height = self._body.size.height
-        except Exception:
-            return
+        height = self._body_rows()
         if height <= 0:
             return
         offset = self._body.scroll_offset.y
@@ -649,9 +685,17 @@ class SettingsView(Vertical):
         # users dwell there long enough to notice (UX round 1, U1). Only the
         # contiguous run of headers directly above the row is included, so this
         # reveals the row's own title and never scrolls past unrelated content.
+        #
+        # SKIPPED when the body is a single row. Including the header then
+        # parks the viewport on the header and clips the selected setting —
+        # at 16 rows that is the whole body, so the page would still show
+        # chrome and no setting, which is #431 with a header in the blank
+        # band. The selected row wins; the header returns the moment there
+        # is a second body row to hold it.
         top = self._selected
-        while top > 0 and self._rows[top - 1].kind == "header":
-            top -= 1
+        if height > 1:
+            while top > 0 and self._rows[top - 1].kind == "header":
+                top -= 1
         if top < offset:
             self._body.scroll_to(y=top, animate=False, immediate=immediate)
         elif self._selected >= offset + height:
@@ -1691,6 +1735,10 @@ class SettingsView(Vertical):
 
     # -- painting -----------------------------------------------------------
     def _repaint(self) -> None:
+        # Height ladder BEFORE the paints: it toggles `display` / padding
+        # on the chrome widgets, which is what the layout reads, and the
+        # paints (detail text, pane budget) have to see the same decision.
+        self._apply_height_ladder()
         self._rows = self._build_rows()
         indices = self._selectable()
         if indices and self._selected not in indices:
@@ -2011,7 +2059,12 @@ class SettingsView(Vertical):
         text = Text(no_wrap=True, overflow="ellipsis")
         row = self._current()
         question, contract = self._confirm_parts()
-        if question:
+        if self._too_short:
+            # The body is hidden: there is no row to explain, and a help
+            # string about an invisible setting would repeat #431's lie
+            # in words. The constraint is the only useful thing to say.
+            text.append(_TOO_SHORT, style=faint)
+        elif question:
             # Above the error and above the help: an unanswered destructive
             # question is the only thing the user needs the row to say.
             #
@@ -2514,10 +2567,104 @@ class SettingsView(Vertical):
         # have on a very short terminal — at 16 rows the view is 7 tall and the
         # pane is laid out 1 row high, so a budget of 4 overpainted it by three
         # lines however carefully the caller then measured (review round 2, D6).
-        # Measured against the laid-out `_pane_view.size.height` at every height
-        # from 16 to 44: `view height - _PANE_CHROME_ROWS` matches it exactly
-        # once the floor stops interfering.
-        return max(height - _PANE_CHROME_ROWS, 1)
+        # Subtracts the LIVE chrome count rather than `_PANE_CHROME_ROWS`:
+        # the height ladder sheds 1-row units (padding, then the rule) so
+        # the body keeps a setting row, and a pane still budgeted against
+        # the full 7 would claim rows the body just reclaimed (#431).
+        return max(height - self._chrome_rows(), 1)
+
+    def _body_rows(self) -> int:
+        """Rows the settings list occupies, derived from the VIEW's height.
+
+        Derived rather than read off ``self._body.size`` for the same
+        reason :meth:`_pane_height` records: during ``on_resize`` the
+        child's size is still the previous layout, and a scroll computed
+        against that stale height parks a 2-row body as if it were 1
+        (hiding the section header the extra row had just made room for).
+        """
+        try:
+            height = self.size.height
+        except Exception:
+            return 0
+        if height <= 0:
+            return 0
+        return max(height - self._chrome_rows(), 0)
+
+    def _chrome_rows(self) -> int:
+        """Rows of page chrome currently shown, for the pane's height budget.
+
+        Title + detail + hints are never shed (5). The rule and the
+        columns' top padding are the 1-row units the height ladder
+        spends; counting them live is what keeps the pane's budget
+        honest after a shed.
+        """
+        rows = _PANE_CHROME_ROWS
+        if not self._chrome_rule:
+            rows -= 1
+        if not self._chrome_pad:
+            rows -= 1
+        return rows
+
+    def _apply_height_ladder(self) -> None:
+        """Shed 1-row chrome units until the body can paint a setting row.
+
+        The width ladder in :meth:`_paint_hints` already sheds whole
+        hints so a narrow terminal keeps ``esc``. The vertical analogue
+        was missing: at 16 rows the view is 7 tall, the 1fr columns
+        resolved to 0 content rows, and the page kept its full chrome
+        around a blank band (#431).
+
+        Units, first to last, each 1 row so restoring one never drops
+        the body — a 2-row shed (the detail line) at 16 would give the
+        body 2 rows, and putting it back at 17 would drop the body to
+        1, so the page would get worse as the terminal grew:
+
+        1. the columns' top padding (the quiet row above the list),
+        2. the rule.
+
+        Title, ``esc``, and the detail line stay: the detail is where
+        a validation error and a delete ask live, and shedding 2 rows
+        is the non-monotonic move above. Below even that (view ≲ 5)
+        the columns hide and the detail names the constraint rather
+        than describing a row the user cannot see.
+
+        ``self.size.height`` is 0 on the mount paint, before layout.
+        Leaving chrome at stylesheet defaults there is what keeps the
+        first frame at a normal size identical to the settled one
+        (the opening-frame test); ``on_resize`` applies the ladder
+        against the real height.
+        """
+        try:
+            height = self.size.height
+        except Exception:
+            height = 0
+        if height <= 0:
+            return
+        # Fixed chrome: title (1) + detail (2) + hints (2) = 5.
+        # Full chrome is 7 (those plus rule and pad). Restore a unit
+        # only when the body would still meet its floor WITH that unit
+        # on — otherwise a growing terminal spends the new row on
+        # padding instead of a second setting, which is chrome winning
+        # the trade the issue forbids.
+        #
+        #   height 6: no rule, no pad, body 1
+        #   height 7: rule,    no pad, body 1
+        #   height 8: rule,    no pad, body 2
+        #   height 9: rule,    pad,    body 2   ← pad returns, body holds
+        show_rule = height - 5 - 1 >= _BODY_MIN_ROWS
+        show_pad = height - 5 - 1 - 1 >= 2
+        body = height - 5 - (1 if show_rule else 0) - (1 if show_pad else 0)
+        too_short = body < _BODY_MIN_ROWS
+        self._chrome_pad = show_pad and not too_short
+        self._chrome_rule = show_rule and not too_short
+        self._chrome_columns = not too_short
+        self._too_short = too_short
+        self._rule.display = self._chrome_rule
+        self._columns.display = self._chrome_columns
+        # Stylesheet default is `padding: 1 0 0 0`. Clearing it is the
+        # first 1-row shed; restoring it is a 1-row cost, so a terminal
+        # growing from 16 to 17 never loses the body row it just gained.
+        self._columns.styles.padding = (1, 0, 0, 0) if self._chrome_pad else (0, 0, 0, 0)
 
     def _paint_chrome(self) -> None:
         muted = Style(color=theme_mod.semantic_color("muted"))

--- a/tests/unit/tui/conftest.py
+++ b/tests/unit/tui/conftest.py
@@ -86,10 +86,11 @@ class StyledTranscriptApp(App[None]):
         yield TranscriptView()
 
 
-#: The composer's prompt marker. The pickers repeat the glyph — deliberately,
-#: so a highlighted row sits in the prompt's own column — but they mount BELOW
-#: the input row, so the FIRST match down the frame is always the composer's.
+#: Mirrored from ``local_operator.tui.app`` so this helper does not import
+#: the app module (conftest loads for every TUI test). The match is pinned
+#: by ``test_composer_markers_match_the_app``.
 PROMPT_CHEVRON = "❯"
+SHELL_CHEVRON = "$"
 
 
 def composer_cells(app: App[None]) -> list[tuple[str, str | None, str | None]]:
@@ -100,28 +101,29 @@ def composer_cells(app: App[None]) -> list[tuple[str, str | None, str | None]]:
     a colour the stylesheet resolved. Both are only answerable from what the
     terminal was SENT, which is what ``render_strips`` returns.
 
-    Located by the chevron rather than by the copy so the same reader works in
-    every mode the composer has words for — ``Read-only — press esc to reply``
-    and ``Aside — esc returns to the chat`` are composer rows too.
-
-    The FIRST match is the composer's even with a picker open. Both pickers
-    repeat the glyph, deliberately in the prompt's own column, but ``compose``
-    yields them AFTER ``#input-row`` in ``#input-shell``'s normal flow, so they
-    can only render below it. The ``/resume`` picker is a pushed Screen, so
-    while it is up the composer is genuinely off the frame and the raise is the
-    honest answer rather than a missed row.
+    Located by ``#prompt-chevron``'s laid-out row rather than by scanning
+    for a glyph. Bang-mode paints ``$`` instead of ``❯`` (#385), and ``$``
+    is ordinary prose — a scan would steal the first dollar in the
+    transcript. The widget's ``region.y`` is the compositor strip index
+    (measured); the ``/resume`` picker is a pushed Screen, so while it is
+    up the composer is genuinely off the frame and the raise is the honest
+    answer rather than a missed row.
     """
-    for strip in app.screen._compositor.render_strips():
-        if PROMPT_CHEVRON not in strip.text:
-            continue
-        cells = []
-        for segment in strip._segments:
-            style = segment.style
-            fg = style.color.get_truecolor().hex.lower() if style and style.color else None
-            bg = style.bgcolor.get_truecolor().hex.lower() if style and style.bgcolor else None
-            cells.append((segment.text, fg, bg))
-        return cells
-    raise AssertionError("the composer row is not on the frame at all")
+    try:
+        chevron = app.query_one("#prompt-chevron")
+    except Exception as exc:
+        raise AssertionError("the composer row is not on the frame at all") from exc
+    y = chevron.region.y
+    strips = list(app.screen._compositor.render_strips())
+    if y < 0 or y >= len(strips):
+        raise AssertionError("the composer row is not on the frame at all")
+    cells = []
+    for segment in strips[y]._segments:
+        style = segment.style
+        fg = style.color.get_truecolor().hex.lower() if style and style.color else None
+        bg = style.bgcolor.get_truecolor().hex.lower() if style and style.bgcolor else None
+        cells.append((segment.text, fg, bg))
+    return cells
 
 
 def caret_cells(cells: list[tuple[str, str | None, str | None]]) -> list[str]:
@@ -143,4 +145,7 @@ def chevron_colour(cells: list[tuple[str, str | None, str | None]]) -> str | Non
     the same neutral ramp, which is a 3.86x luminance move against `dim` where
     the accent was 2.15x.
     """
-    return next(fg for text, fg, _ in cells if PROMPT_CHEVRON in text)
+    markers = {PROMPT_CHEVRON, SHELL_CHEVRON}
+    # Exact cell, not a substring: `$` is ordinary prose, so a typed
+    # `$ ls` on the same strip must not steal the marker's ink.
+    return next(fg for text, fg, _ in cells if text.strip() in markers)

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -37,6 +37,8 @@ from local_operator.tui.app import (
     COMPOSER_SHELL_CLASS,
     MODEL_SWITCH_MID_TURN_NOTICE,
     PERSIST_HINT,
+    PROMPT_CHEVRON,
+    SHELL_CHEVRON,
     SLASH_COMMANDS,
     OperatorApp,
     _splash_toast_headline,
@@ -2344,6 +2346,63 @@ async def test_bang_on_empty_composer_enters_shell_mode() -> None:
         assert app.query_one("#input-dock").has_class(COMPOSER_SHELL_CLASS)
         assert chevron_colour(composer_cells(app)) == theme_mod.semantic_color("string").lower()
         assert chevron_colour(composer_cells(app)) != theme_mod.semantic_color("accent").lower()
+        # Shape, not hue: bang-mode changes what Enter does, and a colour-only
+        # cue is invisible under NO_COLOR / monochrome / colour-vision
+        # deficiency (#385). The glyph is the surviving signal.
+        cells = composer_cells(app)
+        assert any(SHELL_CHEVRON in text for text, _fg, _bg in cells)
+        assert not any(PROMPT_CHEVRON in text for text, _fg, _bg in cells)
+
+
+@pytest.mark.asyncio
+async def test_shell_mode_is_legible_without_hue_once_the_buffer_has_text() -> None:
+    """The placeholder is gone the moment the buffer has text, so the mode
+    has to be carried by the frame itself — a hue-only chevron was the
+    whole remaining signal, and two frames that differed only in ink
+    were TEXT-IDENTICAL (#385).
+
+    Asserted against the compositor, not against the widget: a reader
+    who cannot see colour sees the glyphs, and the glyphs have to
+    disagree. Mutation-checked: restoring ``❯`` while the mode is on
+    fails this test, which is the defect.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await pilot.press("l", "s")
+        await pilot.pause()
+        prompt = "".join(text for text, _fg, _bg in composer_cells(app))
+        editor.clear_content()
+        await pilot.press("!")
+        await pilot.press("l", "s")
+        await pilot.pause()
+        shell = "".join(text for text, _fg, _bg in composer_cells(app))
+        assert editor.shell_mode is True
+        assert SHELL_CHEVRON in shell
+        assert PROMPT_CHEVRON not in shell
+        assert PROMPT_CHEVRON in prompt
+        assert SHELL_CHEVRON not in prompt
+        # The two frames must disagree in TEXT, not only in ink. A
+        # colour-only swap made this comparison True, which is the gap.
+        assert prompt != shell, (
+            "shell-mode and prompt-mode frames are text-identical once the "
+            "buffer has text, so a reader who cannot see hue has no cue "
+            "that Enter will run a command (#385)"
+        )
+
+
+def test_composer_markers_match_the_app() -> None:
+    """``conftest`` mirrors the glyphs so it does not import the app
+    module. Drift here would make every colour/caret assertion look at
+    the wrong cell the moment bang-mode is on."""
+    from tests.unit.tui import conftest as tui_conftest
+
+    assert tui_conftest.PROMPT_CHEVRON == PROMPT_CHEVRON
+    assert tui_conftest.SHELL_CHEVRON == SHELL_CHEVRON
+    assert PROMPT_CHEVRON != SHELL_CHEVRON
 
 
 @pytest.mark.asyncio
@@ -7726,6 +7785,10 @@ async def test_the_paste_key_rows_do_not_wrap_at_eighty_columns() -> None:
     for key, tail in (
         ("ctrl+v", "system clipboard"),
         ("cmd+v", "not Terminal.app"),
+        ("!", "shell command"),
+        ("option+left/right", "by word"),
+        ("shift+tab", "reasoning effort"),
+        ("ctrl+d", "empty composer"),
     ):
         row = next(
             (row for row in painted if row.strip().startswith(f"{key} ")),
@@ -9415,4 +9478,86 @@ async def test_help_documents_the_composer_copy_key_and_its_release() -> None:
         # 76 cannot fire at the boundary where the defect first appears (review
         # round 2, F3).
         for row in (rows[index], release):
+            assert len(row) <= 74, f"{row!r} is {len(row)} cells and wraps at 80 columns"
+
+
+@pytest.mark.asyncio
+async def test_help_documents_shell_mode_and_the_composer_chords() -> None:
+    """``/help`` is the in-app key reference (#385). Until these rows
+    existed the README was the only channel, and a user already inside
+    the TUI had no way to ask what keys exist.
+
+    Tightly scoped: another change (#430) may also add discovery for
+    ``ctrl+v`` against this same block, so this asserts CONTENT of the
+    new rows rather than their exact neighbours. The wrap ceiling is
+    the same 74-cell bound the copy/paste rows pin, mutation-checked
+    the same way: a row padded to 75 fails it.
+    """
+    from rich.console import Group
+    from rich.padding import Padding
+    from rich.text import Text
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        padding = cast(Padding, app._help_block().renderable)
+        group = cast(Group, padding.renderable)
+        rows = [cast(Text, row).plain for row in group.renderables]
+        text = "\n".join(rows)
+
+        # Bang-mode's marker is named because the glyph is the
+        # colour-independent signal. A row that names ``!`` without
+        # saying what ``$`` on the composer means leaves the same gap
+        # the hue-only chevron did.
+        bang = next((row for row in rows if row.lstrip().startswith("! ")), None)
+        assert bang is not None, "/help must name bang-mode"
+        assert "shell" in bang.lower() or "command" in bang.lower(), bang
+        marker = next((row for row in rows if "$" in row and "❯" in row), None)
+        assert marker is not None, "/help must name the $ / ❯ swap"
+
+        required = (
+            "option+left/right",
+            "option+up/down",
+            "shift+tab",
+            "ctrl+l",
+            "ctrl+t",
+            "ctrl+g",
+            "ctrl+b",
+            "esc",
+            "ctrl+d",
+        )
+        missing = [key for key in required if key not in text]
+        assert not missing, f"/help is missing key rows: {missing}"
+
+        # Same wrap ceiling as the copy/paste rows. A hanging tail at
+        # column 0 reads as another key row (#402 D2). Continuations
+        # (empty gutter) are included: they wrap at the same bound.
+        keys = (
+            "ctrl+c",
+            "ctrl+v",
+            "cmd+v",
+            "!",
+            "option+left/right",
+            "option+up/down",
+            "shift+tab",
+            "ctrl+l",
+            "ctrl+t",
+            "ctrl+g",
+            "ctrl+b",
+            "esc",
+            "ctrl+d",
+        )
+        keyed: list[str] = []
+        capturing = False
+        for row in rows:
+            lead = row[:20].strip()
+            if lead in keys or (lead == "!" and "!" in keys):
+                capturing = True
+                keyed.append(row)
+            elif capturing and not lead:
+                keyed.append(row)
+            else:
+                capturing = False
+        assert keyed, "no key-reference rows found in /help"
+        for row in keyed:
             assert len(row) <= 74, f"{row!r} is {len(row)} cells and wraps at 80 columns"

--- a/tests/unit/tui/test_settings_view.py
+++ b/tests/unit/tui/test_settings_view.py
@@ -661,6 +661,133 @@ async def test_pane_sheds_on_a_narrow_terminal() -> None:
         assert "esc" in view.rendered_hints()
 
 
+def _settings_rows_on_frame(app: OperatorApp, view: SettingsView) -> int:
+    """How many of the view's painted list rows survived onto the frame.
+
+    ``_list_text`` is what the Static holds; the compositor is what the
+    terminal was sent. At 16 rows they used to disagree — the body's
+    parent resolved to zero content rows, so a painted row was clipped
+    away and the page showed chrome around a blank band (#431). Counting
+    compositor hits is the only honest measure of "the user can see a
+    setting".
+    """
+    lines = [strip.text for strip in app.screen._compositor.render_strips()]
+    on_frame = 0
+    for row in view._list_text.plain.split("\n"):
+        stripped = row.strip()
+        if not stripped:
+            continue
+        # Match a distinctive interior of the painted row, not a single
+        # token: "Model" is also in the title path on some machines, and
+        # a one-word match would count chrome as content.
+        needle = stripped.lstrip("› ").strip()
+        if len(needle) < 8:
+            continue
+        needle = needle[:18]
+        if any(needle in line for line in lines):
+            on_frame += 1
+    return on_frame
+
+
+@pytest.mark.asyncio
+async def test_settings_keeps_a_body_row_on_a_short_terminal() -> None:
+    """At 16 rows the page used to paint header, rule, detail, hints and
+    a blank band — honest about being a settings page, silent about
+    every setting (#431). Chrome pays for a body row, one row at a
+    time, so restoring a unit as the terminal grows never drops the
+    body.
+
+    Asserted against the compositor, not ``body.size``: at 16 rows the
+    body widget reported height 1 while painting zero rows onto the
+    frame, which is how a size assertion would have shipped the defect.
+    """
+    from local_operator.tui.widgets.settings_view import _TOO_SHORT
+
+    counts: dict[int, int] = {}
+    for height in (14, 15, 16, 17, 18, 20, 24):
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(100, height)) as pilot:
+            await pilot.pause()
+            app._open_settings_view()
+            view = app.query_one(SettingsView)
+            await pilot.pause()
+            await pilot.pause()
+            on_frame = _settings_rows_on_frame(app, view)
+            counts[height] = on_frame
+            painted = "\n".join(strip.text for strip in app.screen._compositor.render_strips())
+            if height >= 15:
+                assert on_frame >= 1, (
+                    f"at {height} rows the body painted {on_frame} setting "
+                    "rows onto the frame — chrome around a blank band (#431)"
+                )
+                assert not view._too_short
+                # A section header alone is not a setting. At 16 rows the
+                # one body row used to be `Model`; parking on the selected
+                # row is what makes the floor a setting the user can act on.
+                if height == 16:
+                    assert "Default provider" in painted, painted
+            else:
+                assert on_frame == 0
+                assert view._too_short
+                assert _TOO_SHORT in view._detail_text.plain
+                assert _TOO_SHORT in painted
+            assert "esc" in view.rendered_hints()
+            assert view._title.display
+
+    # Monotonic: growing the terminal never loses a body row. A 2-row
+    # shed (the detail line) at 16 would give the body 2 rows and
+    # restoring it at 17 would drop the body to 1 — the non-monotonic
+    # move the issue forbids.
+    heights = sorted(counts)
+    for earlier, later in zip(heights, heights[1:]):
+        assert counts[later] >= counts[earlier], (
+            f"body rows dropped from {counts[earlier]} at {earlier} to "
+            f"{counts[later]} at {later}: the page got worse as the "
+            f"terminal grew ({counts})"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_height_ladder_dies_when_the_body_floor_is_broken() -> None:
+    """Mutation test for the 16-row guard. A test keyed on today's
+    chrome flags would keep passing if `_BODY_MIN_ROWS` were raised
+    (or the ladder inverted) and 16 rows went back to a blank band.
+
+    Break the floor: force full chrome at 16 rows, the way the page
+    used to look, and confirm THIS test's sibling assertion would
+    die. Restored afterwards so the rest of the suite is unaffected.
+    """
+    from local_operator.tui.widgets import settings_view as sv
+
+    original = sv.SettingsView._apply_height_ladder
+
+    def full_chrome(self: SettingsView) -> None:
+        self._chrome_pad = True
+        self._chrome_rule = True
+        self._chrome_columns = True
+        self._too_short = False
+        self._rule.display = True
+        self._columns.display = True
+        self._columns.styles.padding = (1, 0, 0, 0)
+
+    sv.SettingsView._apply_height_ladder = full_chrome  # type: ignore[method-assign]
+    try:
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(100, 16)) as pilot:
+            await pilot.pause()
+            app._open_settings_view()
+            view = app.query_one(SettingsView)
+            await pilot.pause()
+            await pilot.pause()
+            on_frame = _settings_rows_on_frame(app, view)
+            assert on_frame == 0, (
+                "the mutation did not reproduce the blank band; this "
+                f"test is not guarding the 16-row floor (on_frame={on_frame})"
+            )
+    finally:
+        sv.SettingsView._apply_height_ladder = original  # type: ignore[method-assign]
+
+
 @pytest.mark.asyncio
 async def test_footer_sheds_but_always_names_esc() -> None:
     """The footer concatenates with no per-clause shedding downstream, so the


### PR DESCRIPTION
# PR Description

## Summary of Changes

Two TUI legibility/layout gaps, both pre-existing, both visual.

**#385 — shell mode is signalled only by one glyph's hue.** Bang-mode (`!`)
changes what Enter does, but once the buffer has text the placeholder is gone
and the only remaining difference in the entire frame is the chevron's colour
(`#57c785` vs `#e9e5db`). That is invisible to a colourblind reader, under
`NO_COLOR`, and on a monochrome terminal. A user who cannot see the hue has
no way to know Enter will run a command rather than talk to the agent.

The chevron now swaps **shape** as well as colour: `❯` (prompt) → `$` (shell).
Colour remains a redundant cue for readers who can see it. `/help` gains a
tightly-scoped keybindings section (same two-column gutter as the existing
`ctrl+c` / `ctrl+v` rows) covering bang-mode, word movement, effort, panels,
aside, esc, and quit.

**Overlap with #430.** Another agent is concurrently adding discovery for
`ctrl+v` and may touch `/help`. This PR only *appends* key rows after the
existing `cmd+v` note; it does not rewrite `_help_block`. Sequence the
merges so #430's copy/paste wording lands first if it also edits those
rows.

**#431 — `/settings` at 16 rows paints chrome and zero setting rows.** At
`100x16` the body resolved to one row tall and rendered nothing settable:
header, rule, detail, hints, dock, and a blank band. Measured identically
on both sides of #425, so it was deliberately not fixed there.

Chrome now pays for a body row, one row at a time, so restoring a unit as
the terminal grows never drops the body:

| terminal | view | body rows on frame | chrome shed |
|---|---|---|---|
| 14 | 5 | 0 (honest "too short" line) | rule + pad; columns hidden |
| 15 | 6 | 1 | rule + pad |
| 16 | 7 | 1 | pad |
| 17 | 8 | 2 | pad |
| 18 | 9 | 2 | none |
| 20 | 11 | 4 | none |
| 24 | 15 | 8 | none |

A 2-row shed (the detail line) at 16 would give the body 2 rows and
restoring it at 17 would drop the body to 1 — the non-monotonic move the
issue forbids. Title, `esc`, and the detail line stay: the detail is where
a validation error and a delete ask live.

Closes #385
Closes #431

## Testing evidence

### Gates (exit codes, whole tree, repo config)

```
flake8 rc=0
black rc=0
isort rc=0
pyright rc=0
```

### #385 — shell mode without hue

**Before** (base `origin/main`): prompt-typed and shell-typed frames were
**text-identical**. The only difference was the chevron's ink.

```
before-prompt-typed  row_head='  ❯  l'  ink=#e9e5db
before-shell-typed   row_head='  ❯  l'  ink=#57c785
prompt-typed vs shell-typed: identical text = True
```

**After**, colour:

```
after-prompt-typed   row_head='  ❯  l'  ink=#e9e5db
after-shell-typed    row_head='  $  l'  ink=#57c785
text identical? False
  row 16: '❯ls' != '$ls'
```

**After**, `NO_COLOR=1 TERM=dumb` (monochrome):

```
after-mono-prompt-typed  row_head='  ❯  l'  ink=#e5e5e5
after-mono-shell-typed   row_head='  $  l'  ink=#aaaaaa
```

The `$` is still there when hue is gone. Looked at the rendered PNGs of
both colour and monochrome frames.

`/help` at 80x44 paints the new key rows on one line each (`!`,
`option+left/right`, `shift+tab`, `ctrl+l/t/g/b`, `esc`, `ctrl+d`), with
the `$` / `❯` swap named on the bang-mode continuation. Looked at the
rendered `/help` frame.

### #431 — `/settings` height ladder

**Before** (compositor, `100xH`):

```
h=16 view= 7 cols= 0 body= 1 rows_on_frame= 0
h=18 view= 9 cols= 2 body= 2 rows_on_frame= 2
h=20 view=11 cols= 4 body= 4 rows_on_frame= 4
h=24 view=15 cols= 8 body= 8 rows_on_frame= 8
```

**After** (same probe, compositor):

```
h=14 view= 5 cols= 0 body= 0 rows_on_frame= 0  too_short=True
h=15 view= 6 cols= 1 body= 1 rows_on_frame= 1
h=16 view= 7 cols= 1 body= 1 rows_on_frame= 1  "Default provider" on frame
h=17 view= 8 cols= 2 body= 2 rows_on_frame= 2
h=18 view= 9 cols= 2 body= 2 rows_on_frame= 2
h=20 view=11 cols= 4 body= 4 rows_on_frame= 4
h=24 view=15 cols= 8 body= 8 rows_on_frame= 8
```

Monotonic: growing the terminal never loses a body row. Looked at the
rendered 16/18/20/24 frames — 16 now shows `› Default provider  anthropic`
instead of a blank band.

### Mutation test (height guard)

Forcing full chrome at 16 rows (the pre-fix layout) paints **0** setting
rows onto the frame. `test_the_height_ladder_dies_when_the_body_floor_is_broken`
asserts that, then restores the ladder. Breaking the floor makes the
sibling assertion die — the test is not keyed on today's chrome flags.

### Unit

```
tests/unit/tui/test_settings_view.py                          (full file)
tests/unit/tui/test_word_caret.py
tests/unit/tui/test_boot_layout.py
plus the new /help and shell-mode tests in test_app_pilot.py
468 passed
```

## Notes for review

- User-visible: needs a **design round**. Shell-mode changes how a mode is
  communicated, so a **UX round** as well.
- Do not bump the version; the manager runs one release after PRs land.
- Do not merge this PR from here.
