### PR TITLE
chore(release): bump version to 0.44.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.5"
+version = "0.44.6"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
# PR Description

## Summary of Changes

Version bump for the 0.44.6 release. Five already-reviewed merges on `main` since v0.44.5:

- #485 shell mode `$` glyph and `/settings` at 16 rows
- #481 compaction cancel-at-ceiling and scoped toast retirement
- #482 genuine subagent notice repeats distinguished from a render bug
- #483 argument-list reopen after home/end, tip ring with shimmer off, Terminal.app `ctrl+v` tip
- #484 `tui-e2e` no longer skipped when `test` is red

No functional change in this PR. Patch bump: user-facing fixes, not a step-function capability.

## Testing evidence

Gates on this branch, verified by exit code (isort stdout is byte-identical on pass and fail; black's banner goes to stderr):

```console
$ .venv/bin/python -m flake8 .; echo "flake8 rc=$?"
flake8 rc=0
$ uvx --from black==26.1.0 black --check .; echo "black rc=$?"
black rc=0
$ uvx isort==5.13.2 --check .; echo "isort rc=$?"
isort rc=0
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .; echo "pyright rc=$?"
0 errors, 0 warnings, 0 informations
pyright rc=0
```

The only change is `version = "0.44.5"` to `"0.44.6"` in `pyproject.toml`.
