### PR TITLE
fix(tui): keep /usage scroll position when a refresh lands

### DIFF
--- a/local_operator/tui/widgets/usage_panel.py
+++ b/local_operator/tui/widgets/usage_panel.py
@@ -670,14 +670,22 @@ class UsagePanel(Static):
         self._repaint()
 
     def show_reports(self, reports, *, now_ms: float | None = None) -> None:  # noqa: ANN001
-        """Install a finished fetch and paint it."""
+        """Install a finished fetch and paint it, keeping the reader's place.
+
+        A refresh replaces numbers the user is already reading; snapping them
+        to the top is jostling, not a new open. A brand-new open is already at
+        0 (`start_fetch` clamps against the one-row loading body; `show_cached`
+        without ``keep_offset`` still zeros). `_compose_rows` clamps if the new
+        body is shorter.
+        """
         self._reports = list(reports)
         self._loading = False
         self._refreshing = False
         self._refresh_failed = False
         self._error = ""
         self._fetched_ms = self._now() if now_ms is None else now_ms
-        self._offset = 0
+        # Keep `_offset`. The finished-fetch path lands over an already-open
+        # panel the user may have scrolled while the worker was in flight.
         self.display = True
         self._repaint()
 
@@ -758,8 +766,9 @@ class UsagePanel(Static):
         """Restore a scroll position (clamped by the next repaint).
 
         Exists for the ``r`` path, which re-shows the standing reports after
-        ``start_fetch`` reset the offset: the reader's place in a long report
-        survives the refresh instead of snapping to the top.
+        ``start_fetch`` clamped the offset against the one-row loading body.
+        The finished fetch then keeps that restored place rather than snapping
+        to the top.
         """
         self._offset = max(0, int(offset))
         self._repaint()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.7"
+version = "0.44.8"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -4571,6 +4571,67 @@ async def test_r_refetches_without_closing_the_panel() -> None:
 
 
 @pytest.mark.asyncio
+async def test_scrolling_during_an_in_flight_usage_fetch_keeps_place_when_it_lands() -> None:
+    """Open `/usage` from cache, scroll while the confirming fetch is in flight:
+    when it lands the view must not jump to the top."""
+    from local_operator.tui.widgets.usage_panel import UsagePanel
+    from tests.unit.tui.test_usage_panel import _many_reports
+
+    class _HeldMany(FakeProviderController):
+        def __init__(self) -> None:
+            super().__init__()
+            self.release = asyncio.Event()
+            self.started = asyncio.Event()
+            self.cached_reports = _many_reports()
+
+        async def fetch_usage(self, provider_ids=None, *, force_refresh: bool = False):
+            self.usage_calls.append(provider_ids)
+            self.started.set()
+            await self.release.wait()
+            return _many_reports()
+
+    ctrl = _HeldMany()
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=ctrl)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await _run_usage_command(pilot, app)
+        panel = app.query_one(UsagePanel)
+        await ctrl.started.wait()
+        panel.action_scroll_page(1)
+        offset = panel.view_offset
+        assert offset > 0
+        ctrl.release.set()
+        for _ in range(6):
+            await pilot.pause()
+        assert panel.view_offset == offset
+        assert "refreshing…" not in "\n".join(panel.render_lines_for_test())
+
+
+@pytest.mark.asyncio
+async def test_r_on_a_scrolled_usage_panel_does_not_jump_to_the_top() -> None:
+    """`keep_offset` holds during ``refreshing…``; the finished fetch must too."""
+    from local_operator.tui.widgets.usage_panel import UsagePanel
+    from tests.unit.tui.test_usage_panel import _many_reports
+
+    ctrl = FakeProviderController()
+    ctrl.usage_reports = _many_reports()
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=ctrl)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await _run_usage_command(pilot, app)
+        panel = app.query_one(UsagePanel)
+        panel.action_scroll_page(1)
+        offset = panel.view_offset
+        assert offset > 0
+        await pilot.press("r")
+        for _ in range(6):
+            await pilot.pause()
+        assert panel.view_offset == offset
+        assert panel.is_open
+        assert "refreshing…" not in "\n".join(panel.render_lines_for_test())
+
+
+@pytest.mark.asyncio
 async def test_a_failed_fetch_is_reported_inside_the_panel() -> None:
     """The panel is what has focus and what carries the key that retries, so an
     error anywhere else asks the user to look away from the fix."""

--- a/tests/unit/tui/test_usage_panel.py
+++ b/tests/unit/tui/test_usage_panel.py
@@ -390,6 +390,22 @@ async def test_scrolling_clamps_at_both_ends_rather_than_wrapping() -> None:
 
 
 @pytest.mark.asyncio
+async def test_show_reports_keeps_the_reader_where_they_were() -> None:
+    """A refresh replaces numbers the user is already reading; snapping their
+    place is jostling, not a new open. `_repaint` still clamps if the new body
+    is shorter than the offset they held."""
+    async with _panel_app() as panel:
+        panel.show_reports(_many_reports())
+        panel.action_scroll_page(1)
+        offset = panel.view_offset
+        assert offset > 0
+        panel.show_reports(_many_reports())
+        assert panel.view_offset == offset
+        panel.show_reports([_report(_percent("a:5h", "5 hour", 5.0, shared=True))])
+        assert panel.view_offset == 0
+
+
+@pytest.mark.asyncio
 async def test_the_title_and_hints_stay_pinned_while_the_body_scrolls() -> None:
     """A user scrolling a long report must never lose the way out."""
     async with _panel_app() as panel:


### PR DESCRIPTION
# PR Description

## Summary of Changes

`/usage` jumped back to the top whenever an async fetch finished while the panel was open and scrolled.

`show_cached(..., keep_offset=True)` already held place during ``refreshing…``, and `on_usage_refresh_requested` already saved `view_offset` around `start_fetch`. **`show_reports` always did `self._offset = 0`**, so the worker landing (`_fetch_usage_worker` → `panel.show_reports(...)`) snapped the view.

That hit both:

1. Open `/usage` with cache → scroll while the confirming fetch is in flight → fetch lands → top.
2. Press `r` while scrolled → `keep_offset` holds during ``refreshing…`` → fetch lands → top.

`show_reports` now keeps `_offset`. `_compose_rows` / `_max_offset` still clamp if the new body is shorter. A brand-new open is already at 0 (`start_fetch` clamps against the one-row loading body; `show_cached` without `keep_offset` still zeros). Those paths are unchanged.

Rebased onto `origin/main` at `c4d410e6b066937c90ca6980dd7b5a2842c3dcea`. Main now owns `0.44.7`, so this patch bumps `0.44.7` → `0.44.8`.

## Related Issue(s)

None.

## Impact

- No breaking changes, no dependency updates.
- Scroll-position behaviour only; layout, colour, and chrome are unchanged.

## Testing Details

New unit coverage:

- `test_show_reports_keeps_the_reader_where_they_were` — long report, scroll (`view_offset > 0`), `show_reports` with the same-shaped list keeps the offset; a shorter body clamps to 0.
- `test_scrolling_during_an_in_flight_usage_fetch_keeps_place_when_it_lands` — cached open, scroll while the confirming fetch is held, release, still scrolled, ``refreshing…`` gone.
- `test_r_on_a_scrolled_usage_panel_does_not_jump_to_the_top` — `r` on a scrolled panel, fetch lands, still scrolled.

```
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest   tests/unit/tui/test_usage_panel.py   tests/unit/tui/test_app_pilot.py -k usage -q --tb=short
# 78 passed (focused panel and app-path usage coverage, including all three new tests)
```

Gates over the whole tree, as CI:

```
.venv/bin/python -m flake8 .
uvx --from black==26.1.0 black --check .
uvx isort==5.13.2 --check .
.venv/bin/python -m pyright --pythonpath .venv/bin/python .
# flake8 clean, black 671 files unchanged, isort clean, pyright 0 errors
```

Whole unit suite:

```
ulimit -n 8192
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
# 9639 passed, 15 skipped, 436 warnings in 402.39s
```

The first whole-suite attempt used macOS's inherited soft descriptor limit of 256 and reached 8,967 passes before pytest workers produced `Errno 24` setup errors. Raising only that process limit to 8,192 let the exact suite complete with no test failures.

Visual validation from the real `OperatorApp` (not `_PanelHost` — no CSS_PATH). Shot script at `/tmp/usage_scroll_shot.py`: paint a long report, page down, then `show_reports` again (the worker-landing path).

| | before (origin/main) | after (this branch) |
|---|---|---|
| offset after landing | 14 → **0** | 14 → **14** |
| visible providers | provider-0, 1, 2 (snapped to top) | provider-3, 4, 5 (place kept) |
| chrome | `showing 14 of 59` | `showing 28 of 59` |
| geometry | size 90×19, height 21, virtual=actual 98×28, no screen scrollbar | identical |

Stills: `/tmp/usage-scroll-before.svg` / `/tmp/usage-scroll-after.svg` (rendered views `/tmp/usage-scroll-before-view.png` / `/tmp/usage-scroll-after-view.png`). Card layout, bars, and footer are unchanged; only the window contents differ, which is the bug.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.

## Screenshots (Optional)

Before (fetch lands → jumps to provider-0): `/tmp/usage-scroll-before-view.png` — providers 0–2, `showing 14 of 59`.

After (fetch lands → still on provider-3): `/tmp/usage-scroll-after-view.png` — providers 3–5, `showing 28 of 59`. Geometry identical (90×19 card, no screen scrollbar).

