### PR TITLE
chore(release): bump version to 0.44.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.6"
+version = "0.44.7"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
# PR Description

## Summary of Changes

Version bump for the 0.44.7 release. Three unreleased commits are present on `main` since v0.44.6:

- `f735dcfd` / #475 takes session-store sweeps off the boot and resume path
- `bc5fe0d3` / #487 bumps the project version to 0.44.6 (included because of the prior release race)
- `85b0737a` / #488 surfaces failed subagent tool calls in the TUI

No functional change in this PR. Patch bump: user-facing reliability and performance fixes, not a step-function capability.

## Testing evidence

The required whole-tree gates ran sequentially on this branch and each completed with exit code 0:

```console
$ .venv/bin/python -m flake8 .
# exit 0
$ uvx --from black==26.1.0 black --check .
All done! ✨ 🍰 ✨
670 files would be left unchanged.
# exit 0
$ uvx isort==5.13.2 --check .
Skipped 1 files
# exit 0
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations
# exit 0
```

The only change is `version = "0.44.6"` to `"0.44.7"` in `pyproject.toml`.
