### PR TITLE
perf(session): delay background store maintenance

### DIFF
--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -1180,6 +1180,17 @@ def _transcript_dir_and_agent_id(
 #: the loop cannot garbage-collect a task nobody awaits.
 _STORE_MAINTENANCE_TASK: "asyncio.Task[None] | None" = None
 
+#: Give session construction and the front end a bounded uncontended window
+#: before four whole-store walks enter the worker pool. A single ``sleep(0)``
+#: only yields to ``_prepare``'s next ``to_thread`` and lets both paths race on a
+#: cold filesystem cache; the elapsed delay is the contention barrier.
+_STORE_MAINTENANCE_IDLE_DELAY_SECONDS = 0.75
+
+
+async def _wait_for_store_maintenance_idle_window() -> None:
+    """Wait until first paint can win the disk/thread-pool contention race."""
+    await asyncio.sleep(_STORE_MAINTENANCE_IDLE_DELAY_SECONDS)
+
 
 def reset_store_maintenance_for_tests() -> None:
     """Forget that maintenance ran, so every test starts un-swept.
@@ -1192,6 +1203,11 @@ def reset_store_maintenance_for_tests() -> None:
     effects regardless of the order it happens to run in.
     """
     global _STORE_MAINTENANCE_TASK
+    task = _STORE_MAINTENANCE_TASK
+    if task is not None and not task.done():
+        # Most session-factory tests return before the production idle window;
+        # do not let their delayed task enter a later test's temporary store.
+        task.cancel()
     _STORE_MAINTENANCE_TASK = None
 
 
@@ -1219,6 +1235,13 @@ async def _run_store_maintenance(
 ) -> None:
     """Run every whole-store maintenance pass, in a worker thread, in order.
 
+    The initial idle window is load-bearing rather than cosmetic. Merely putting
+    this coroutine in the background still lets it begin at ``_prepare``'s next
+    ``to_thread`` and contend with model/session construction on a cold
+    filesystem cache. Maintenance is unrelated to the current session, so it
+    yields a short, explicit window for ``create_session`` to return and its
+    caller to paint before the first disk walk reaches the worker pool.
+
     Each pass is a disk walk over OTHER sessions' directories and none of them
     has anything to do with the session being constructed; they are triggered by
     a session starting only because that is when the store is known to be quiet.
@@ -1231,6 +1254,11 @@ async def _run_store_maintenance(
     any way at all and a session must neither fail nor be delayed by it, which
     is why the caller never awaits it and why each pass carries its own guard.
     """
+    # Delay before imports and callback construction too: on a cold cache even
+    # loading maintenance-only modules can steal I/O from session construction.
+    # Exit during this best-effort window is harmless; the next process retries.
+    await _wait_for_store_maintenance_idle_window()
+
     from local_operator.resume import backfill_session_origins, backfill_session_titles
     from local_operator.session.retention import sweep_from_config
     from local_operator.tools.group_reaper import sweep_orphan_groups
@@ -1292,10 +1320,14 @@ def _start_store_maintenance(
 
     Two changes, together:
 
-    - **Not awaited.** The session is returned as soon as it is built; the
-      maintenance runs behind first paint. Nothing in it is read by session
-      construction, so there is nothing to wait for. This is the same
-      fire-and-track shape the deferred MCP wiring uses.
+    - **Dispatched after construction, not awaited, and delayed.** Every
+      ``create_session`` path dispatches at its last synchronous point before
+      return, after deferred/eager MCP setup has reached its intended state. The
+      task therefore cannot execute until the completed coroutine gives control
+      back to its caller. It then waits through a short idle window before the
+      store walks, giving the TUI time to adopt the session and paint. Nothing in
+      maintenance is read by session construction, so there is nothing to wait
+      for. This is the same fire-and-track shape the deferred MCP wiring uses.
     - **Once per process.** Maintenance answers a question about the STORE, and
       the store does not become dirty again because the user pressed
       ``/resume``. The first session in the process runs it; later ones find the
@@ -1390,14 +1422,12 @@ async def _prepare(
     claim_session(transcript_dir)
     transcript_dir.mkdir(parents=True, exist_ok=True)
 
-    # Whole-store maintenance (retention sweep, orphan-group reaper, origin and
-    # title backfills) is DISPATCHED here and deliberately NOT awaited. See
-    # :func:`_start_store_maintenance` for what runs and why none of it belongs
-    # on this path. The lease/claim above stay synchronous and on the loop —
-    # sole-writer ordering (lease before transcript creation) is an invariant,
-    # and putting a yield inside that window is how two cold resumes lose the
-    # race the lease exists to arbitrate.
-    _start_store_maintenance(config_manager, Path(agent_registry.config_dir), transcript_dir)
+    # The lease/claim above stay synchronous and on the loop — sole-writer
+    # ordering (lease before transcript creation) is an invariant, and putting a
+    # yield inside that window is how two cold resumes lose the race the lease
+    # exists to arbitrate. Whole-store maintenance is dispatched only after
+    # ``create_session`` finishes ALL construction; starting it here lets the
+    # runner contend as soon as the model configuration below yields to a worker.
 
     # --- model + stream fn (stream B contracts) ---------------------------
     from local_operator.env import get_env_config
@@ -2088,6 +2118,14 @@ async def create_session(
         # ``session.dispose()`` once, so this is the one place teardown can
         # live without teaching each caller about the boot path.
         session.add_dispose_hook(_cancel_task(wiring_task))
+        # Dispatch at the last synchronous point before returning. A task cannot
+        # execute until this coroutine gives the loop back to its caller, so the
+        # runner's idle window begins only after construction has completed.
+        _start_store_maintenance(
+            config_manager,
+            Path(agent_registry.config_dir),
+            Path(session._transcript.directory),
+        )
         return session
 
     mcp_manager = await wire_mcp_into_session(
@@ -2100,6 +2138,14 @@ async def create_session(
     )
     if mcp_manager is not None:
         attach_mcp_dispose(session, mcp_manager)
+    # Headless and exec callers wire MCP eagerly, so dispatch after that await as
+    # well: every successful create_session return gets the same uncontended
+    # construction boundary regardless of front end.
+    _start_store_maintenance(
+        config_manager,
+        Path(agent_registry.config_dir),
+        Path(session._transcript.directory),
+    )
     return session
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.7"
+version = "0.44.8"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -1232,6 +1232,7 @@ async def test_prepare_claims_before_a_concurrent_sweep_can_reap_the_dir(
     from local_operator.session.retention import _is_claimed, sweep_sessions
     from local_operator.session_factory import (
         _prepare,
+        _start_store_maintenance,
         await_store_maintenance_for_tests,
     )
 
@@ -1314,19 +1315,21 @@ async def test_prepare_claims_before_a_concurrent_sweep_can_reap_the_dir(
     retention_mod.sweep_from_config = reaping_sweep
     monkeypatch.setattr(Path, "mkdir", mkdir_with_concurrent_reap)
     try:
-        await _prepare(
+        plan = await _prepare(
             _args(hosting="test", model="test-model"),
             cast("ConfigManager", config_manager),
             credential_manager,
             cast("AgentRegistry", registry),
             has_ui=False,
         )
-        # The sweep is dispatched as a background task rather than awaited by
-        # ``_prepare``, so wait for it here: ``survived_the_sweep`` below is an
-        # observation made INSIDE ``reaping_sweep``, and without this the
-        # assertion races the sweep it is asserting about. The ordering under
-        # test is unaffected — the claim still happens before anything creates
-        # the directory, which is what ``reaped_at_mkdir`` pins independently.
+        # Production dispatches only once create_session has turned this plan
+        # into a live Session. This lower-level ordering test stops at _prepare,
+        # so trigger the same sweep explicitly before asserting its observation.
+        _start_store_maintenance(
+            cast("ConfigManager", config_manager),
+            tmp_config_dir,
+            plan.session_kwargs["transcript"].directory,
+        )
         await await_store_maintenance_for_tests()
     finally:
         retention_mod.sweep_from_config = original
@@ -2624,25 +2627,21 @@ def test_a_corrupt_payload_is_memoised_because_it_describes_the_file(tmp_path: P
 async def test_store_maintenance_does_not_block_session_construction(
     tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``_prepare`` returns without waiting for the store sweeps.
+    """``create_session`` returns without waiting for the store sweeps.
 
     The four passes are whole-store disk walks that have nothing to do with the
     session being built; awaiting them put their cost (measured 545 ms of a
     708 ms ``create_session`` on a 3574-session store) on the critical path of
     boot AND of every ``/resume``. They must be dispatched, not awaited.
 
-    Pinned by observing the task handle, not by parking a worker thread: under
-    xdist the default thread pool can starve, and a test that waits on a
-    ``to_thread``'d Event then flakes as "never started" rather than catching
-    the regression it was written for. The handle existing and not being done
-    at the moment ``_prepare`` returns is the same fact, without occupying a
-    worker.
+    Pinned by observing the task handle rather than parking a worker thread:
+    under xdist the default thread pool can starve, and a test that blocks a
+    ``to_thread`` callback can flake as "never started" instead of catching the
+    regression. A live task at return proves the same contract without holding
+    a worker.
     """
     from local_operator.session import retention as retention_mod
-    from local_operator.session_factory import (
-        _prepare,
-        await_store_maintenance_for_tests,
-    )
+    from local_operator.session_factory import await_store_maintenance_for_tests
 
     started = asyncio.Event()
     release = asyncio.Event()
@@ -2652,39 +2651,113 @@ async def test_store_maintenance_does_not_block_session_construction(
         await release.wait()
         return retention_mod.SweepResult()
 
-    # Patch the coroutine the dispatcher schedules, not the inner sweep: that
-    # is the thing ``_prepare`` used to await, so a regression that awaits it
-    # again hangs this test on ``wait_for`` rather than merely slowing it.
+    # Patch the coroutine the dispatcher schedules, not the inner sweep: a
+    # regression that awaits it in create_session hangs on ``wait_for`` rather
+    # than merely slowing the test.
     monkeypatch.setattr(session_factory, "_run_store_maintenance", blocking_pass)
 
-    config_manager = FakeConfigManager({"hosting": "test", "model_name": "test-model"})
-    registry = FakeRegistry(tmp_config_dir)
-    credential_manager = MagicMock()
-    credential_manager.get_credential.return_value = None
+    from local_operator.agents import AgentRegistry
+    from local_operator.config import ConfigManager
+    from local_operator.credentials import CredentialManager
 
+    session = await asyncio.wait_for(
+        create_session(
+            _args(hosting="test", model="test-model", yolo=True),
+            ConfigManager(tmp_config_dir),
+            CredentialManager(tmp_config_dir),
+            AgentRegistry(tmp_config_dir),
+            has_ui=True,
+            defer_mcp_wiring=True,
+        ),
+        timeout=5.0,
+    )
     try:
-        await asyncio.wait_for(
-            _prepare(
-                _args(hosting="test", model="test-model"),
-                cast("ConfigManager", config_manager),
-                credential_manager,
-                cast("AgentRegistry", registry),
-                has_ui=False,
-            ),
-            timeout=5.0,
-        )
         # Dispatched, not awaited: the task exists and has not finished.
         from local_operator import session_factory as sf
 
         task = sf._STORE_MAINTENANCE_TASK
         assert task is not None, "store maintenance was never dispatched"
-        assert (
-            not task.done()
-        ), "store maintenance finished before _prepare returned — it was awaited"
+        assert not task.done(), "store maintenance was awaited before session return"
         await started.wait()
     finally:
         release.set()
         await await_store_maintenance_for_tests()
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_store_maintenance_waits_until_create_session_can_return(
+    tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No maintenance filesystem callback may race session construction.
+
+    The runner used to begin at ``_prepare``'s next ``to_thread``. That was
+    technically background work, but on a cold store it contended with model
+    configuration and made first paint miss its latency target. An event-backed
+    idle window makes the ordering deterministic without sleeping in this test.
+    """
+    from local_operator import resume as resume_mod
+    from local_operator.model import configure as configure_mod
+    from local_operator.session import retention as retention_mod
+    from local_operator.session_factory import await_store_maintenance_for_tests
+
+    delay_entered = asyncio.Event()
+    release_delay = asyncio.Event()
+    callback_started = asyncio.Event()
+    model_work_completed: list[bool] = []
+
+    async def controlled_idle_window() -> None:
+        delay_entered.set()
+        await release_delay.wait()
+
+    def note_filesystem_callback(*_a: Any, **_k: Any) -> Any:
+        callback_started.set()
+        return retention_mod.SweepResult()
+
+    real_configure_model = configure_mod.configure_model
+
+    def note_model_work(*args: Any, **kwargs: Any) -> Any:
+        configured = real_configure_model(*args, **kwargs)
+        model_work_completed.append(True)
+        return configured
+
+    monkeypatch.setattr(
+        session_factory, "_wait_for_store_maintenance_idle_window", controlled_idle_window
+    )
+    monkeypatch.setattr(retention_mod, "sweep_from_config", note_filesystem_callback)
+    monkeypatch.setattr(configure_mod, "configure_model", note_model_work)
+    monkeypatch.setattr(resume_mod, "backfill_session_origins", lambda *_a, **_k: 0)
+    monkeypatch.setattr(resume_mod, "backfill_session_titles", lambda *_a, **_k: 0)
+
+    from local_operator.agents import AgentRegistry
+    from local_operator.config import ConfigManager
+    from local_operator.credentials import CredentialManager
+
+    session = await create_session(
+        _args(hosting="test", model="test-model", yolo=True),
+        ConfigManager(tmp_config_dir),
+        CredentialManager(tmp_config_dir),
+        AgentRegistry(tmp_config_dir),
+        has_ui=True,
+        defer_mcp_wiring=True,
+    )
+    try:
+        assert (
+            not delay_entered.is_set()
+        ), "maintenance task executed before create_session returned"
+        assert (
+            model_work_completed
+        ), "create_session did not complete its post-dispatch to_thread work"
+        await asyncio.wait_for(delay_entered.wait(), timeout=5.0)
+        assert (
+            not callback_started.is_set()
+        ), "maintenance filesystem work started before the idle window elapsed"
+    finally:
+        release_delay.set()
+        await await_store_maintenance_for_tests()
+        await session.dispose()
+
+    assert callback_started.is_set(), "maintenance did not run after the idle window"
 
 
 @pytest.mark.asyncio
@@ -2700,10 +2773,7 @@ async def test_store_maintenance_runs_once_per_process(
     ``/resume``.
     """
     from local_operator.session import retention as retention_mod
-    from local_operator.session_factory import (
-        _prepare,
-        await_store_maintenance_for_tests,
-    )
+    from local_operator.session_factory import await_store_maintenance_for_tests
 
     calls: list[int] = []
 
@@ -2713,20 +2783,25 @@ async def test_store_maintenance_runs_once_per_process(
 
     monkeypatch.setattr(retention_mod, "sweep_from_config", counting_sweep)
 
-    config_manager = FakeConfigManager({"hosting": "test", "model_name": "test-model"})
-    registry = FakeRegistry(tmp_config_dir)
-    credential_manager = MagicMock()
-    credential_manager.get_credential.return_value = None
+    from local_operator.agents import AgentRegistry
+    from local_operator.config import ConfigManager
+    from local_operator.credentials import CredentialManager
+
+    config_manager = ConfigManager(tmp_config_dir)
+    registry = AgentRegistry(tmp_config_dir)
+    credential_manager = CredentialManager(tmp_config_dir)
 
     for _ in range(3):
-        await _prepare(
-            _args(hosting="test", model="test-model"),
-            cast("ConfigManager", config_manager),
+        session = await create_session(
+            _args(hosting="test", model="test-model", yolo=True),
+            config_manager,
             credential_manager,
-            cast("AgentRegistry", registry),
-            has_ui=False,
+            registry,
+            has_ui=True,
+            defer_mcp_wiring=True,
         )
         await await_store_maintenance_for_tests()
+        await session.dispose()
 
     assert calls == [1], f"the store was swept {len(calls)} times in one process"
 
@@ -2740,10 +2815,7 @@ async def test_a_failing_maintenance_pass_never_reaches_the_session(
     awaited inline survives the move to a background task."""
     from local_operator import resume as resume_mod
     from local_operator.session import retention as retention_mod
-    from local_operator.session_factory import (
-        _prepare,
-        await_store_maintenance_for_tests,
-    )
+    from local_operator.session_factory import await_store_maintenance_for_tests
 
     def exploding_sweep(*_a: Any, **_k: Any) -> Any:
         raise RuntimeError("disk on fire")
@@ -2757,19 +2829,20 @@ async def test_a_failing_maintenance_pass_never_reaches_the_session(
     monkeypatch.setattr(retention_mod, "sweep_from_config", exploding_sweep)
     monkeypatch.setattr(resume_mod, "backfill_session_titles", note_titles)
 
-    config_manager = FakeConfigManager({"hosting": "test", "model_name": "test-model"})
-    registry = FakeRegistry(tmp_config_dir)
-    credential_manager = MagicMock()
-    credential_manager.get_credential.return_value = None
+    from local_operator.agents import AgentRegistry
+    from local_operator.config import ConfigManager
+    from local_operator.credentials import CredentialManager
 
-    plan = await _prepare(
-        _args(hosting="test", model="test-model"),
-        cast("ConfigManager", config_manager),
-        credential_manager,
-        cast("AgentRegistry", registry),
-        has_ui=False,
+    session = await create_session(
+        _args(hosting="test", model="test-model", yolo=True),
+        ConfigManager(tmp_config_dir),
+        CredentialManager(tmp_config_dir),
+        AgentRegistry(tmp_config_dir),
+        has_ui=True,
+        defer_mcp_wiring=True,
     )
     await await_store_maintenance_for_tests()
 
-    assert plan is not None, "a failing sweep took the session down with it"
+    assert session is not None, "a failing sweep took the session down with it"
     assert ran == ["titles"], "a failing pass stopped the passes after it"
+    await session.dispose()

--- a/tests/unit/test_tui_responsiveness.py
+++ b/tests/unit/test_tui_responsiveness.py
@@ -235,6 +235,7 @@ async def test_prepare_store_scans_do_not_stall_the_loop(
     from local_operator import resume as resume_mod
     from local_operator.session_factory import (
         _prepare,
+        _start_store_maintenance,
         await_store_maintenance_for_tests,
     )
     from tests.unit.test_session_factory import FakeConfigManager, FakeRegistry, _args
@@ -261,13 +262,18 @@ async def test_prepare_store_scans_do_not_stall_the_loop(
     recorder = StallRecorder()
     await recorder.start()
     try:
-        await _prepare(
+        plan = await _prepare(
             args,
             cast_config(FakeConfigManager({"hosting": "test", "model_name": "test-model"})),
             CredentialManager(config_dir),
             cast_registry(FakeRegistry(config_dir)),
             has_ui=True,
             cwd=str(tmp_path),
+        )
+        _start_store_maintenance(
+            cast_config(FakeConfigManager({"hosting": "test", "model_name": "test-model"})),
+            config_dir,
+            plan.session_kwargs["transcript"].directory,
         )
         await await_store_maintenance_for_tests()
     finally:


### PR DESCRIPTION
## Summary

Store maintenance was backgrounded in #475, but its task was created inside `_prepare`. The next `asyncio.to_thread` during model setup yielded to that task, so on a cold filesystem cache the first retention walk still competed with session construction for disk, GIL, and worker-pool time.

This patch moves once-per-process dispatch to the last synchronous point before each successful `create_session` return, then keeps a documented 750 ms idle window before maintenance-only imports or filesystem callbacks. The task cannot execute until construction has returned control to its caller, and the idle window gives the TUI time to adopt the session and paint the model label. Headless, exec, eager-MCP, and deferred-MCP callers retain the same once-per-process contract.

Version: `0.44.8` (patch).

## Behavior preserved

- execution lease and session claim stay synchronous on the event loop
- maintenance dispatch remains once per process
- the task remains strongly referenced so it cannot be garbage-collected
- each maintenance pass remains isolated and debug-logged; later passes continue after failures
- process exit during the idle window is harmless; the next launch retries idempotent work

## Regression evidence

The deterministic regression replaces the production idle wait with events. It proves:

1. model configuration's post-dispatch `to_thread` work completes before return;
2. the maintenance task itself has not executed when `create_session` returns;
3. no filesystem callback begins while the controlled idle window is held;
4. callbacks run after the window is released.

```text
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
  tests/unit/test_session_factory.py -k 'store_maintenance or concurrent_sweep' -q
4 passed

... .venv/bin/python -m pytest tests/unit/test_tui_responsiveness.py -k store_scans -q
1 passed

... .venv/bin/python -m pytest tests/unit/test_session_factory.py -n0 -q
111 passed
```

## Real-store benchmark

Harness: `/tmp/lopperf/m11_installed.py` concept, instrumented to record whether each maintenance callback starts before or after `create_session` returns; worktree source inserted first on `sys.path`. Store: the real ~3,500-session / 1.3 GB store. Metric: process start through `tui.app` import plus `create_session`.

Released installed `0.44.7` ordering probe:

```text
import=683.5 ms, create_session=473.3 ms
retention callback: after_create_return=False
```

A detached `origin/main` probe reproduced the same ordering: retention began with `after_create_return=False`.

Patched worktree, five runs:

| Run | Import | create_session | Import + create | All 4 callbacks after return? |
|---:|---:|---:|---:|:---:|
| 1 | 229.8 ms | 186.7 ms | 416.5 ms | yes |
| 2 | 216.6 ms | 140.7 ms | 357.3 ms | yes |
| 3 | 213.6 ms | 143.3 ms | 356.9 ms | yes |
| 4 | 228.1 ms | 140.5 ms | 368.6 ms | yes |
| 5 | 226.3 ms | 143.2 ms | 369.5 ms | yes |

**Median: 368.6 ms. Max: 416.5 ms.** Every measured run is below the 3 s target. An exact end-to-end timestamp on an additional run measured process start → `create_session` return at 456.6 ms; the first maintenance callback began at 1212.5 ms, after return and the 750 ms idle window.

The supplied post-release cold-cache baseline remains the before evidence for the target miss: import 2.49 s + create 2.39 s = ~4.9 s, with maintenance spanning 2.88 s retention + 0.38 s reaper + 0.51 s origins + 1.03 s titles. The current macOS session could not invoke `purge` without an interactive sudo password, so the five after runs are warm-cache runs plus deterministic callback-order proof rather than a synthetic claim of a cold-cache run.

## Verification

```text
.venv/bin/python -m flake8 .
# exit 0
uvx --from black==26.1.0 black --check .
# 671 files would be left unchanged
uvx isort==5.13.2 --check .
# exit 0 (1 skipped)
.venv/bin/python -m pyright --pythonpath .venv/bin/python .
# 0 errors, 0 warnings, 0 informations

env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
# 3 passed
```

The first whole-unit run encountered the host's macOS soft limit of 256 open files in one xdist worker, causing cascading setup errors unrelated to this diff; the changed file passed 111/111 sequentially. Re-running the exact xdist suite with only the shell soft limit raised to 4096 (matching a normal CI resource ceiling) completed cleanly:

```text
ulimit -n 4096
... .venv/bin/python -m pytest tests/unit -q
9637 passed, 15 skipped, 436 warnings in 320.52s
```
