### PR TITLE
chore(release): bump version to 0.44.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.8"
+version = "0.44.9"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Version-only bump from `0.44.8` to `0.44.9` to release the usage-scroll fix (#489, merged at 77575c4a).

The `v0.44.8` tag was already published by the compaction perf release (PR #459, target commit 94118cff), which was cut from a `pyproject.toml` that still carried `0.44.8`. The usage-scroll fix merged after that release, so a fresh bump is needed for it to ship under its own version.

Established pattern: PR #487.

## Changes

- `pyproject.toml`: `version = "0.44.8"` -> `0.44.9`

## Validation

Pure version bump, no code changes. Full-tree quality gates run exactly as CI does:

- `python -m flake8 .` — clean
- `uvx --from black==26.1.0 black --check .` — 671 files unchanged
- `uvx isort==5.13.2 --check .` — clean
- `python -m pyright --pythonpath .venv/bin/python .` — 0 errors, 0 warnings

No runtime behaviour changes, so no runtime re-validation applies.
