### PR TITLE
feat(evaluation): add dependency and lifecycle contracts

### DIFF
--- a/local_operator/evaluation/lifecycle.py
+++ b/local_operator/evaluation/lifecycle.py
@@ -38,6 +38,7 @@ MAX_CLEANUP_ATTEMPTS = 32
 MAX_CLEANUP_TIMEOUT_MS = 3_600_000
 MAX_FAILURE_LENGTH = 2_000
 _PERMIT_FACTORY = object()
+_CLEANUP_RESULT_FACTORY = object()
 _LIFECYCLE_FACTORY = object()
 
 
@@ -176,6 +177,11 @@ def record_cleanup(
 
 
 class CleanupResult(ProtocolModel):
+    """Factory-only aggregate over exact cleanup receipt evidence."""
+
+    _authority: object = PrivateAttr()
+    _receipts: tuple[CleanupReceipt, ...] = PrivateAttr()
+
     cleanup_plan_id: Digest
     succeeded_action_ids: tuple[StrictIdentifier, ...]
     not_needed_action_ids: tuple[StrictIdentifier, ...]
@@ -196,7 +202,10 @@ class CleanupResult(ProtocolModel):
         return tuple(value) if isinstance(value, list) else value
 
     @model_validator(mode="after")
-    def _validate_result(self) -> Self:
+    def _validate_result(self, info: ValidationInfo) -> Self:
+        context = info.context if isinstance(info.context, dict) else {}
+        if context.get("cleanup_result_factory") is not _CLEANUP_RESULT_FACTORY:
+            raise ValueError("cleanup results can only be minted from validated receipts")
         groups = (
             self.succeeded_action_ids,
             self.not_needed_action_ids,
@@ -217,7 +226,44 @@ class CleanupResult(ProtocolModel):
         )
         if self.cleanup_result_id != expected:
             raise ValueError("cleanup result identity does not match its receipts")
+        receipts = context.get("cleanup_receipts")
+        if not isinstance(receipts, tuple) or not all(
+            isinstance(receipt, CleanupReceipt) for receipt in receipts
+        ):
+            raise ValueError("cleanup result factory requires exact receipt evidence")
+        object.__setattr__(self, "_authority", _CLEANUP_RESULT_FACTORY)
+        object.__setattr__(self, "_receipts", receipts)
         return self
+
+    def __copy__(self) -> Self:
+        raise TypeError("cleanup result authority cannot be copied")
+
+    def __deepcopy__(self, memo: dict[int, Any] | None = None) -> Self:
+        raise TypeError("cleanup result authority cannot be copied")
+
+    def __reduce__(self) -> Any:
+        raise TypeError("cleanup result authority cannot be pickled")
+
+    def assert_authority(self) -> None:
+        if getattr(self, "_authority", None) is not _CLEANUP_RESULT_FACTORY:
+            raise ValueError("cleanup result lacks factory authority")
+        actual: list[str] = []
+        for receipt in getattr(self, "_receipts", ()):
+            expected = _identity(
+                "cleanup-receipt-v1",
+                receipt.model_dump(mode="json", exclude={"receipt_id"}),
+            )
+            if receipt.receipt_id != expected:
+                raise ValueError("cleanup receipt authority was mutated")
+            actual.append(receipt.receipt_id)
+        if tuple(sorted(actual)) != self.receipt_digests:
+            raise ValueError("cleanup result receipt evidence does not match")
+        expected_result = _identity(
+            "cleanup-result-v1",
+            self.model_dump(mode="json", exclude={"cleanup_result_id"}),
+        )
+        if self.cleanup_result_id != expected_result:
+            raise ValueError("cleanup result authority was mutated")
 
 
 def aggregate_cleanup(
@@ -237,10 +283,13 @@ def aggregate_cleanup(
         raise ValueError("cleanup requires exactly one receipt for every action")
     actions = {action.action_id: action for action in plan.actions}
     for action_id, receipt in by_id.items():
+        action = actions[action_id]
         if receipt.cleanup_plan_id != plan.cleanup_plan_id:
             raise ValueError("cleanup receipt belongs to another cleanup plan")
-        if receipt.action_digest != actions[action_id].action_digest:
+        if receipt.action_digest != action.action_digest:
             raise ValueError("cleanup receipt belongs to another action declaration")
+        if receipt.status == "succeeded" and receipt.duration_ms > action.timeout_ms:
+            raise ValueError("cleanup cannot succeed after its action timeout")
     succeeded = tuple(sorted(key for key, item in by_id.items() if item.status == "succeeded"))
     not_needed = tuple(sorted(key for key, item in by_id.items() if item.status == "not_needed"))
     incomplete = tuple(
@@ -254,14 +303,19 @@ def aggregate_cleanup(
         "receipt_digests": tuple(sorted(item.receipt_id for item in snapshot)),
         "rescue_required": bool(incomplete),
     }
-    return CleanupResult(
-        **payload,
-        cleanup_result_id=_identity("cleanup-result-v1", payload),
+    return CleanupResult.model_validate(
+        {**payload, "cleanup_result_id": _identity("cleanup-result-v1", payload)},
+        context={
+            "cleanup_result_factory": _CLEANUP_RESULT_FACTORY,
+            "cleanup_receipts": snapshot,
+        },
     )
 
 
 class SideEffectPermit(ProtocolModel):
-    """Unforgeable-by-validation authority bound to one sealed episode budget."""
+    """Factory-only authority bound to one sealed episode budget."""
+
+    _authority: object = PrivateAttr()
 
     episode_id: StrictIdentifier
     plan_id: Digest
@@ -280,7 +334,27 @@ class SideEffectPermit(ProtocolModel):
         )
         if self.permit_id != expected:
             raise ValueError("side-effect permit identity does not match its authorities")
+        object.__setattr__(self, "_authority", _PERMIT_FACTORY)
         return self
+
+    def __copy__(self) -> Self:
+        raise TypeError("side-effect permit authority cannot be copied")
+
+    def __deepcopy__(self, memo: dict[int, Any] | None = None) -> Self:
+        raise TypeError("side-effect permit authority cannot be copied")
+
+    def __reduce__(self) -> Any:
+        raise TypeError("side-effect permit authority cannot be pickled")
+
+    def assert_authority(self) -> None:
+        if getattr(self, "_authority", None) is not _PERMIT_FACTORY:
+            raise ValueError("side-effect permit lacks factory authority")
+        expected = _identity(
+            "side-effect-permit-v1",
+            self.model_dump(mode="json", exclude={"permit_id"}),
+        )
+        if self.permit_id != expected:
+            raise ValueError("side-effect permit authority was mutated")
 
 
 def mint_side_effect_permit(
@@ -292,6 +366,7 @@ def mint_side_effect_permit(
 ) -> SideEffectPermit:
     """Mint authority only after successful preflight and explicit budget authorization."""
 
+    preflight.assert_authority()
     if not preflight.successful:
         raise ValueError("failed preflight cannot authorize side effects")
     if preflight.plan_id != plan_id:
@@ -483,10 +558,11 @@ class EpisodeLifecycle(ProtocolModel):
     def __reduce__(self) -> Any:
         raise TypeError("episode lifecycle authority cannot be pickled")
 
+    def __copy__(self) -> Self:
+        raise TypeError("episode lifecycle authority cannot be copied")
+
     def __deepcopy__(self, memo: dict[int, Any] | None = None) -> Self:
-        if memo is not None:
-            memo[id(self)] = self
-        return self
+        raise TypeError("episode lifecycle authority cannot be copied")
 
     def model_copy(self, *, update: Any = None, deep: bool = False) -> Self:
         if update:
@@ -513,6 +589,7 @@ class EpisodeLifecycle(ProtocolModel):
         )
 
     def preflight(self, seal: SealedPreflight) -> Self:
+        seal.assert_authority()
         if not seal.successful:
             raise ValueError("failed preflight cannot enter preflighted state")
         if seal.plan_id != self.plan_id:
@@ -524,6 +601,7 @@ class EpisodeLifecycle(ProtocolModel):
     def authorize(
         self, seal: SealedPreflight, budget: BudgetAuthorization
     ) -> tuple[Self, SideEffectPermit]:
+        seal.assert_authority()
         if self.state != "preflighted" or self.preflight_seal_id != seal.seal_id:
             raise ValueError("illegal or mismatched episode authorization")
         if budget.budget_id != self.budget_id:
@@ -553,6 +631,7 @@ class EpisodeLifecycle(ProtocolModel):
         self._assert_authority()
         if self.state != "authorized":
             raise ValueError(f"illegal episode transition from {self.state}")
+        permit.assert_authority()
         commitment.assert_authority(authorization)
         if commitment.budget_id != self.budget_id:
             raise ValueError("budget commitment does not match this episode")
@@ -563,12 +642,16 @@ class EpisodeLifecycle(ProtocolModel):
             or permit.permit_id != self.permit_id
         ):
             raise ValueError("side-effect permit does not match this episode")
-        return self._transition(
+        running = self._transition(
             "authorized",
             "start-episode",
             state="running",
             reservation_ids=commitment.reservation_ids,
         )
+        # A state node is single-use authority. Consuming it prevents two
+        # independently valid commitments from creating sibling executions.
+        object.__setattr__(self, "_authority", None)
+        return running
 
     def begin_finalization(self) -> Self:
         return self._transition("running", "begin-finalization", state="finalizing")
@@ -609,8 +692,10 @@ class EpisodeLifecycle(ProtocolModel):
         )
 
     def crash(self, reason: str) -> Self:
+        if self.state not in ("running", "finalizing"):
+            raise ValueError(f"illegal episode transition from {self.state}")
         return self._transition(
-            "running",
+            self.state,
             "record-crash",
             state="cleaning",
             terminal_intent="fail",
@@ -619,8 +704,10 @@ class EpisodeLifecycle(ProtocolModel):
         )
 
     def cancel(self, reason: str) -> Self:
+        if self.state not in ("running", "finalizing"):
+            raise ValueError(f"illegal episode transition from {self.state}")
         return self._transition(
-            "running",
+            self.state,
             "record-cancellation",
             state="cleaning",
             terminal_intent="cancel",
@@ -644,6 +731,7 @@ class EpisodeLifecycle(ProtocolModel):
         )
 
     def finish_cleanup(self, result: CleanupResult) -> Self:
+        result.assert_authority()
         if result.cleanup_plan_id != self.cleanup_plan_id:
             raise ValueError("cleanup result belongs to another plan")
         updates: dict[str, Any] = {

--- a/local_operator/evaluation/lifecycle.py
+++ b/local_operator/evaluation/lifecycle.py
@@ -90,6 +90,7 @@ def _state_identity(payload: dict[str, Any]) -> str:
     complete.setdefault("preflight_seal_id", None)
     complete.setdefault("permit_id", None)
     complete.setdefault("reservation_ids", ())
+    complete.setdefault("commitment_id", None)
     complete.setdefault("reconciliation_id", None)
     complete.setdefault("reconciliation_reportable", None)
     complete.setdefault("score_id", None)
@@ -449,6 +450,7 @@ class EpisodeLifecycle(AuthorityModel):
     preflight_seal_id: Digest | None = None
     permit_id: Digest | None = None
     reservation_ids: tuple[Digest, ...] = ()
+    commitment_id: Digest | None = None
     reconciliation_id: Digest | None = None
     reconciliation_reportable: bool | None = None
     score_id: Digest | None = None
@@ -483,6 +485,12 @@ class EpisodeLifecycle(AuthorityModel):
         if tuple(sorted(self.reservation_ids)) != self.reservation_ids:
             raise ValueError("episode reservations must be canonical")
         before_running = self.state in ("planned", "preflighted", "authorized")
+        if before_running and self.commitment_id is not None:
+            raise ValueError("pre-running state cannot carry a budget commitment")
+        if self.reservation_ids and self.commitment_id is None:
+            raise ValueError("post-start state requires its exact budget commitment")
+        if self.commitment_id is not None and not self.reservation_ids:
+            raise ValueError("budget commitment requires reserved resources")
         if before_running and any(
             value is not None
             for value in (
@@ -692,6 +700,7 @@ class EpisodeLifecycle(AuthorityModel):
                 "start-episode",
                 state="running",
                 reservation_ids=commitment.reservation_ids,
+                commitment_id=commitment.commitment_id,
             )
             self._consume_source()
             _lookup_authority(permit, "side-effect-permit").consumed = True
@@ -847,6 +856,7 @@ class EpisodeLifecycle(AuthorityModel):
             or reconciliation.authorization_digest != self.budget_id
             or reconciliation.authorization.budget_id != self.budget_id
             or reconciliation.reservation_ids != self.reservation_ids
+            or reconciliation.commitment_id != self.commitment_id
         ):
             raise ValueError("cost reconciliation does not match this episode")
 

--- a/local_operator/evaluation/lifecycle.py
+++ b/local_operator/evaluation/lifecycle.py
@@ -22,7 +22,6 @@ from local_operator.evaluation.receipts import (
     MAX_DECLARATIONS,
     ZERO_DIGEST,
     AuthorityModel,
-    AuthorityRecord,
     BudgetAuthorization,
     BudgetCommitment,
     BudgetReconciliation,
@@ -31,6 +30,7 @@ from local_operator.evaluation.receipts import (
     SafeCount,
     SealedPreflight,
     StrictIdentifier,
+    _AuthorityRecord,
     _lookup_authority,
     _register_authority,
 )
@@ -71,7 +71,7 @@ def _identity(kind: str, payload: Any) -> str:
 
 
 @contextmanager
-def _authority_locks(*records: AuthorityRecord) -> Iterator[None]:
+def _authority_locks(*records: _AuthorityRecord) -> Iterator[None]:
     """Acquire process-local authority locks in one deadlock-safe order."""
 
     ordered = sorted({id(record): record for record in records}.values(), key=id)
@@ -262,12 +262,9 @@ class CleanupResult(AuthorityModel):
     def __reduce__(self) -> Any:
         raise TypeError("cleanup result authority cannot be pickled")
 
-    def authority_record(self) -> AuthorityRecord:
-        return _lookup_authority(self, "cleanup-result")
-
     def assert_authority(self) -> None:
         try:
-            record = self.authority_record()
+            record = _lookup_authority(self, "cleanup-result")
         except ValueError as error:
             raise ValueError("cleanup result lacks factory authority") from error
         actual: list[str] = []
@@ -287,9 +284,6 @@ class CleanupResult(AuthorityModel):
         )
         if self.cleanup_result_id != expected_result:
             raise ValueError("cleanup result authority was mutated")
-
-    def consume_authority(self) -> None:
-        self.authority_record().consumed = True
 
 
 def aggregate_cleanup(
@@ -364,12 +358,9 @@ class SideEffectPermit(AuthorityModel):
     def __reduce__(self) -> Any:
         raise TypeError("side-effect permit authority cannot be pickled")
 
-    def authority_record(self) -> AuthorityRecord:
-        return _lookup_authority(self, "side-effect-permit")
-
     def assert_authority(self) -> None:
         try:
-            self.authority_record()
+            _lookup_authority(self, "side-effect-permit")
         except ValueError as error:
             raise ValueError("side-effect permit lacks factory authority") from error
         expected = _identity(
@@ -379,11 +370,8 @@ class SideEffectPermit(AuthorityModel):
         if self.permit_id != expected:
             raise ValueError("side-effect permit authority was mutated")
 
-    def consume_authority(self) -> None:
-        self.authority_record().consumed = True
 
-
-def mint_side_effect_permit(
+def _mint_side_effect_permit(
     *,
     episode_id: StrictIdentifier,
     plan_id: Digest,
@@ -585,7 +573,7 @@ class EpisodeLifecycle(AuthorityModel):
     def __deepcopy__(self, memo: dict[int, Any] | None = None) -> Self:
         raise TypeError("episode lifecycle authority cannot be copied")
 
-    def _authority_record(self) -> AuthorityRecord:
+    def _authority_record(self) -> _AuthorityRecord:
         try:
             return _lookup_authority(self, "episode-lifecycle")
         except ValueError as error:
@@ -652,7 +640,9 @@ class EpisodeLifecycle(AuthorityModel):
                 raise ValueError("illegal or mismatched episode authorization")
             if budget.budget_id != self.budget_id:
                 raise ValueError("budget authorization does not match the planned budget")
-            permit = mint_side_effect_permit(
+            # Permit minting is deliberately private and only reachable while
+            # this single-use preflighted parent is locked for authorization.
+            permit = _mint_side_effect_permit(
                 episode_id=self.episode_id,
                 plan_id=self.plan_id,
                 preflight=seal,
@@ -678,8 +668,8 @@ class EpisodeLifecycle(AuthorityModel):
         # never recreates authority in another process.
         with _authority_locks(
             self._authority_record(),
-            permit.authority_record(),
-            commitment.authority_record(),
+            _lookup_authority(permit, "side-effect-permit"),
+            _lookup_authority(commitment, "budget-commitment"),
         ):
             self._assert_authority()
             if self.state != "authorized":
@@ -704,8 +694,8 @@ class EpisodeLifecycle(AuthorityModel):
                 reservation_ids=commitment.reservation_ids,
             )
             self._consume_source()
-            permit.consume_authority()
-            commitment.consume_authority()
+            _lookup_authority(permit, "side-effect-permit").consumed = True
+            _lookup_authority(commitment, "budget-commitment").consumed = True
             return running
 
     def begin_finalization(self) -> Self:
@@ -790,7 +780,9 @@ class EpisodeLifecycle(AuthorityModel):
             )
         if permit is None:
             raise ValueError("authorized failure requires its side-effect permit")
-        with _authority_locks(self._authority_record(), permit.authority_record()):
+        with _authority_locks(
+            self._authority_record(), _lookup_authority(permit, "side-effect-permit")
+        ):
             self._assert_authority()
             permit.assert_authority()
             if (
@@ -809,11 +801,13 @@ class EpisodeLifecycle(AuthorityModel):
                 failure_reason=reason,
             )
             self._consume_source()
-            permit.consume_authority()
+            _lookup_authority(permit, "side-effect-permit").consumed = True
             return failed
 
     def finish_cleanup(self, result: CleanupResult) -> Self:
-        with _authority_locks(self._authority_record(), result.authority_record()):
+        with _authority_locks(
+            self._authority_record(), _lookup_authority(result, "cleanup-result")
+        ):
             self._assert_authority()
             result.assert_authority()
             if result.cleanup_plan_id != self.cleanup_plan_id:
@@ -843,7 +837,7 @@ class EpisodeLifecycle(AuthorityModel):
             # validation error leaves lifecycle and result retryable together.
             terminal = self._transition("cleaning", "finish-cleanup", **updates)
             self._consume_source()
-            result.consume_authority()
+            _lookup_authority(result, "cleanup-result").consumed = True
             return terminal
 
     def _validate_reconciliation(self, reconciliation: BudgetReconciliation) -> None:

--- a/local_operator/evaluation/lifecycle.py
+++ b/local_operator/evaluation/lifecycle.py
@@ -27,6 +27,7 @@ from local_operator.evaluation.protocol import ArtifactRef, ProtocolModel
 from local_operator.evaluation.receipts import (
     MAX_DECLARATIONS,
     ZERO_DIGEST,
+    AuthorityModel,
     BudgetAuthorization,
     BudgetCommitment,
     BudgetReconciliation,
@@ -212,7 +213,7 @@ def record_cleanup(
     )
 
 
-class CleanupResult(ProtocolModel):
+class CleanupResult(AuthorityModel):
     """Factory-only aggregate over exact cleanup receipt evidence."""
 
     _authority: object = PrivateAttr()
@@ -357,7 +358,7 @@ def aggregate_cleanup(
     )
 
 
-class SideEffectPermit(ProtocolModel):
+class SideEffectPermit(AuthorityModel):
     """Single-use in-process authority bound to one sealed episode budget."""
 
     _authority: object = PrivateAttr()
@@ -472,7 +473,7 @@ EpisodeState = Literal[
 TerminalIntent = Literal["complete", "fail", "cancel"]
 
 
-class EpisodeLifecycle(ProtocolModel):
+class EpisodeLifecycle(AuthorityModel):
     """Factory-only state authority with a content-addressed transition chain.
 
     Pydantic's ``model_construct`` can fabricate an object, but it lacks the
@@ -624,11 +625,6 @@ class EpisodeLifecycle(ProtocolModel):
 
     def __deepcopy__(self, memo: dict[int, Any] | None = None) -> Self:
         raise TypeError("episode lifecycle authority cannot be copied")
-
-    def model_copy(self, *, update: Any = None, deep: bool = False) -> Self:
-        if update:
-            raise TypeError("episode lifecycle authority cannot be updated by copying")
-        return self
 
     def _assert_authority(self) -> None:
         if self._consumed or getattr(self, "_authority", None) is not _LIFECYCLE_FACTORY:

--- a/local_operator/evaluation/lifecycle.py
+++ b/local_operator/evaluation/lifecycle.py
@@ -15,13 +15,7 @@ from threading import RLock
 from typing import Any, Literal, Self, cast
 from weakref import WeakValueDictionary
 
-from pydantic import (
-    Field,
-    PrivateAttr,
-    ValidationInfo,
-    field_validator,
-    model_validator,
-)
+from pydantic import Field, PrivateAttr, field_validator, model_validator
 
 from local_operator.evaluation.protocol import ArtifactRef, ProtocolModel
 from local_operator.evaluation.receipts import (
@@ -41,9 +35,6 @@ from local_operator.evaluation.receipts import (
 MAX_CLEANUP_ATTEMPTS = 32
 MAX_CLEANUP_TIMEOUT_MS = 3_600_000
 MAX_FAILURE_LENGTH = 2_000
-_PERMIT_FACTORY = object()
-_CLEANUP_RESULT_FACTORY = object()
-_LIFECYCLE_FACTORY = object()
 
 
 class _EpisodeLineage:
@@ -63,6 +54,14 @@ class _EpisodeLineage:
 
 _LINEAGE_REGISTRY_LOCK = RLock()
 _LIVE_LINEAGES: WeakValueDictionary[str, _EpisodeLineage] = WeakValueDictionary()
+
+
+def _attach_lifecycle_authority(model: AuthorityModel, **private_values: Any) -> None:
+    """Attach fresh process-local authority after ordinary model validation."""
+
+    object.__setattr__(model, "_authority", object())
+    for name, value in private_values.items():
+        object.__setattr__(model, name, value)
 
 
 def _identity(kind: str, payload: Any) -> str:
@@ -241,10 +240,7 @@ class CleanupResult(AuthorityModel):
         return tuple(value) if isinstance(value, list) else value
 
     @model_validator(mode="after")
-    def _validate_result(self, info: ValidationInfo) -> Self:
-        context = info.context if isinstance(info.context, dict) else {}
-        if context.get("cleanup_result_factory") is not _CLEANUP_RESULT_FACTORY:
-            raise ValueError("cleanup results can only be minted from validated receipts")
+    def _validate_result(self) -> Self:
         groups = (
             self.succeeded_action_ids,
             self.not_needed_action_ids,
@@ -265,13 +261,6 @@ class CleanupResult(AuthorityModel):
         )
         if self.cleanup_result_id != expected:
             raise ValueError("cleanup result identity does not match its receipts")
-        receipts = context.get("cleanup_receipts")
-        if not isinstance(receipts, tuple) or not all(
-            isinstance(receipt, CleanupReceipt) for receipt in receipts
-        ):
-            raise ValueError("cleanup result factory requires exact receipt evidence")
-        object.__setattr__(self, "_authority", _CLEANUP_RESULT_FACTORY)
-        object.__setattr__(self, "_receipts", receipts)
         return self
 
     def __copy__(self) -> Self:
@@ -287,7 +276,7 @@ class CleanupResult(AuthorityModel):
         return self._lock
 
     def assert_authority(self) -> None:
-        if self._consumed or getattr(self, "_authority", None) is not _CLEANUP_RESULT_FACTORY:
+        if self._consumed or getattr(self, "_authority", None) is None:
             raise ValueError("cleanup result lacks factory authority")
         actual: list[str] = []
         for receipt in getattr(self, "_receipts", ()):
@@ -349,13 +338,16 @@ def aggregate_cleanup(
         "receipt_digests": tuple(sorted(item.receipt_id for item in snapshot)),
         "rescue_required": bool(incomplete),
     }
-    return CleanupResult.model_validate(
-        {**payload, "cleanup_result_id": _identity("cleanup-result-v1", payload)},
-        context={
-            "cleanup_result_factory": _CLEANUP_RESULT_FACTORY,
-            "cleanup_receipts": snapshot,
-        },
+    result = CleanupResult.model_validate(
+        {**payload, "cleanup_result_id": _identity("cleanup-result-v1", payload)}
     )
+    _attach_lifecycle_authority(
+        result,
+        _receipts=snapshot,
+        _lock=RLock(),
+        _consumed=False,
+    )
+    return result
 
 
 class SideEffectPermit(AuthorityModel):
@@ -372,17 +364,13 @@ class SideEffectPermit(AuthorityModel):
     permit_id: Digest
 
     @model_validator(mode="after")
-    def _factory_only(self, info: ValidationInfo) -> Self:
-        context = info.context if isinstance(info.context, dict) else {}
-        if context.get("permit_factory") is not _PERMIT_FACTORY:
-            raise ValueError("side-effect permits can only be minted from validated authorities")
+    def _validate_permit(self) -> Self:
         expected = _identity(
             "side-effect-permit-v1",
             self.model_dump(mode="json", exclude={"permit_id"}),
         )
         if self.permit_id != expected:
             raise ValueError("side-effect permit identity does not match its authorities")
-        object.__setattr__(self, "_authority", _PERMIT_FACTORY)
         return self
 
     def __copy__(self) -> Self:
@@ -398,7 +386,7 @@ class SideEffectPermit(AuthorityModel):
         return self._lock
 
     def assert_authority(self) -> None:
-        if self._consumed or getattr(self, "_authority", None) is not _PERMIT_FACTORY:
+        if self._consumed or getattr(self, "_authority", None) is None:
             raise ValueError("side-effect permit lacks factory authority")
         expected = _identity(
             "side-effect-permit-v1",
@@ -434,10 +422,11 @@ def mint_side_effect_permit(
         "preflight_seal_id": preflight.seal_id,
         "budget_id": budget.budget_id,
     }
-    return SideEffectPermit.model_validate(
-        {**payload, "permit_id": _identity("side-effect-permit-v1", payload)},
-        context={"permit_factory": _PERMIT_FACTORY},
+    permit = SideEffectPermit.model_validate(
+        {**payload, "permit_id": _identity("side-effect-permit-v1", payload)}
     )
+    _attach_lifecycle_authority(permit, _lock=RLock(), _consumed=False)
+    return permit
 
 
 class ScoreReceipt(ProtocolModel):
@@ -522,13 +511,7 @@ class EpisodeLifecycle(AuthorityModel):
         return tuple(value) if isinstance(value, list) else value
 
     @model_validator(mode="after")
-    def _validate_state_evidence(self, info: ValidationInfo) -> Self:
-        context = info.context if isinstance(info.context, dict) else {}
-        if context.get("lifecycle_factory") is not _LIFECYCLE_FACTORY:
-            raise ValueError("episode lifecycle authority can only be factory minted")
-        lineage = context.get("episode_lineage")
-        if not isinstance(lineage, _EpisodeLineage) or lineage.episode_id != self.episode_id:
-            raise ValueError("episode lifecycle requires its process-live lineage lease")
+    def _validate_state_evidence(self) -> Self:
         if len(self.reservation_ids) != len(set(self.reservation_ids)):
             raise ValueError("episode contains duplicate reservations")
         if tuple(sorted(self.reservation_ids)) != self.reservation_ids:
@@ -594,8 +577,6 @@ class EpisodeLifecycle(AuthorityModel):
         expected = _state_identity(self.model_dump(mode="json", exclude={"state_id"}))
         if self.state_id != expected:
             raise ValueError("episode lifecycle state identity does not match its evidence")
-        object.__setattr__(self, "_authority", _LIFECYCLE_FACTORY)
-        object.__setattr__(self, "_lineage", lineage)
         return self
 
     @classmethod
@@ -627,7 +608,7 @@ class EpisodeLifecycle(AuthorityModel):
         raise TypeError("episode lifecycle authority cannot be copied")
 
     def _assert_authority(self) -> None:
-        if self._consumed or getattr(self, "_authority", None) is not _LIFECYCLE_FACTORY:
+        if self._consumed or getattr(self, "_authority", None) is None:
             raise ValueError("episode lifecycle lacks transition authority")
         expected = _state_identity(self.model_dump(mode="json", exclude={"state_id"}))
         if self.state_id != expected:
@@ -647,13 +628,14 @@ class EpisodeLifecycle(AuthorityModel):
         payload = self.model_dump(mode="python", exclude={"state_id"})
         payload.update(previous_state_id=self.state_id, operation=operation, **updates)
         payload["state_id"] = _state_identity(payload)
-        return type(self).model_validate(
-            payload,
-            context={
-                "lifecycle_factory": _LIFECYCLE_FACTORY,
-                "episode_lineage": self._lineage,
-            },
+        child = type(self).model_validate(payload)
+        _attach_lifecycle_authority(
+            child,
+            _lineage=self._lineage,
+            _lock=RLock(),
+            _consumed=False,
         )
+        return child
 
     def _consume_source(self) -> None:
         self._consumed = True
@@ -807,16 +789,43 @@ class EpisodeLifecycle(AuthorityModel):
         *,
         kind: Literal["preflight", "infrastructure"],
         reason: str,
+        permit: SideEffectPermit | None = None,
     ) -> Self:
         if self.state not in ("planned", "preflighted", "authorized"):
             raise ValueError("post-start failure must enter cleaning first")
-        return self._consume_transition(
-            self.state,
-            "fail-before-running",
-            state="failed",
-            failure_kind=kind,
-            failure_reason=reason,
-        )
+        if self.state != "authorized":
+            if permit is not None:
+                raise ValueError("pre-authorization failure cannot consume a permit")
+            return self._consume_transition(
+                self.state,
+                "fail-before-running",
+                state="failed",
+                failure_kind=kind,
+                failure_reason=reason,
+            )
+        if permit is None:
+            raise ValueError("authorized failure requires its side-effect permit")
+        with _authority_locks(self._lock, permit.authority_lock()):
+            self._assert_authority()
+            permit.assert_authority()
+            if (
+                permit.episode_id != self.episode_id
+                or permit.plan_id != self.plan_id
+                or permit.budget_id != self.budget_id
+                or permit.preflight_seal_id != self.preflight_seal_id
+                or permit.permit_id != self.permit_id
+            ):
+                raise ValueError("side-effect permit does not match this episode")
+            failed = self._transition(
+                "authorized",
+                "fail-before-running",
+                state="failed",
+                failure_kind=kind,
+                failure_reason=reason,
+            )
+            self._consume_source()
+            permit.consume_authority()
+            return failed
 
     def finish_cleanup(self, result: CleanupResult) -> Self:
         with _authority_locks(self._lock, result.authority_lock()):
@@ -891,10 +900,11 @@ def plan_episode(
         payload["state_id"] = _state_identity(
             {key: value for key, value in payload.items() if key != "state_id"}
         )
-        return EpisodeLifecycle.model_validate(
-            payload,
-            context={
-                "lifecycle_factory": _LIFECYCLE_FACTORY,
-                "episode_lineage": lineage,
-            },
+        root = EpisodeLifecycle.model_validate(payload)
+        _attach_lifecycle_authority(
+            root,
+            _lineage=lineage,
+            _lock=RLock(),
+            _consumed=False,
         )
+        return root

--- a/local_operator/evaluation/lifecycle.py
+++ b/local_operator/evaluation/lifecycle.py
@@ -613,6 +613,13 @@ class EpisodeLifecycle(ProtocolModel):
             raise ValueError("episode lifecycle authority was mutated")
 
     def _transition(self, expected: EpisodeState, operation: str, **updates: Any) -> Self:
+        """Construct a child while the caller holds this authority's lock.
+
+        Consumption deliberately happens only after this method returns. A
+        validator or injected construction failure therefore leaves the parent
+        live and retryable.
+        """
+
         self._assert_authority()
         if self.state != expected:
             raise ValueError(f"illegal episode transition from {self.state}")
@@ -624,39 +631,54 @@ class EpisodeLifecycle(ProtocolModel):
             context={"lifecycle_factory": _LIFECYCLE_FACTORY},
         )
 
+    def _consume_source(self) -> None:
+        self._consumed = True
+        object.__setattr__(self, "_authority", None)
+
+    def _consume_transition(self, expected: EpisodeState, operation: str, **updates: Any) -> Self:
+        """Atomically mint one child and consume this process-local authority."""
+
+        with self._lock:
+            child = self._transition(expected, operation, **updates)
+            self._consume_source()
+            return child
+
     def preflight(self, seal: SealedPreflight) -> Self:
         seal.assert_authority()
         if not seal.successful:
             raise ValueError("failed preflight cannot enter preflighted state")
         if seal.plan_id != self.plan_id:
             raise ValueError("preflight seal belongs to another dependency plan")
-        return self._transition(
+        return self._consume_transition(
             "planned", "seal-preflight", state="preflighted", preflight_seal_id=seal.seal_id
         )
 
     def authorize(
         self, seal: SealedPreflight, budget: BudgetAuthorization
     ) -> tuple[Self, SideEffectPermit]:
-        seal.assert_authority()
-        if self.state != "preflighted" or self.preflight_seal_id != seal.seal_id:
-            raise ValueError("illegal or mismatched episode authorization")
-        if budget.budget_id != self.budget_id:
-            raise ValueError("budget authorization does not match the planned budget")
-        permit = mint_side_effect_permit(
-            episode_id=self.episode_id,
-            plan_id=self.plan_id,
-            preflight=seal,
-            budget=budget,
-        )
-        return (
-            self._transition(
+        # The seal is reusable plan evidence; the episode parent is the
+        # single-use authority that prevents two authorized children.
+        with self._lock:
+            self._assert_authority()
+            seal.assert_authority()
+            if self.state != "preflighted" or self.preflight_seal_id != seal.seal_id:
+                raise ValueError("illegal or mismatched episode authorization")
+            if budget.budget_id != self.budget_id:
+                raise ValueError("budget authorization does not match the planned budget")
+            permit = mint_side_effect_permit(
+                episode_id=self.episode_id,
+                plan_id=self.plan_id,
+                preflight=seal,
+                budget=budget,
+            )
+            authorized = self._transition(
                 "preflighted",
                 "authorize-side-effects",
                 state="authorized",
                 permit_id=permit.permit_id,
-            ),
-            permit,
-        )
+            )
+            self._consume_source()
+            return authorized, permit
 
     def start(
         self,
@@ -690,14 +712,13 @@ class EpisodeLifecycle(ProtocolModel):
                 state="running",
                 reservation_ids=commitment.reservation_ids,
             )
-            self._consumed = True
-            object.__setattr__(self, "_authority", None)
+            self._consume_source()
             permit.consume_authority()
             commitment.consume_authority()
             return running
 
     def begin_finalization(self) -> Self:
-        return self._transition("running", "begin-finalization", state="finalizing")
+        return self._consume_transition("running", "begin-finalization", state="finalizing")
 
     def finish_finalization(
         self,
@@ -707,7 +728,7 @@ class EpisodeLifecycle(ProtocolModel):
         self._validate_reconciliation(reconciliation)
         if score.episode_id != self.episode_id or score.plan_id != self.plan_id:
             raise ValueError("score receipt does not match this episode")
-        return self._transition(
+        return self._consume_transition(
             "finalizing",
             "finish-finalization",
             state="cleaning",
@@ -723,7 +744,7 @@ class EpisodeLifecycle(ProtocolModel):
         reason: str,
     ) -> Self:
         self._validate_reconciliation(reconciliation)
-        return self._transition(
+        return self._consume_transition(
             "finalizing",
             "finish-finalization",
             state="cleaning",
@@ -737,7 +758,7 @@ class EpisodeLifecycle(ProtocolModel):
     def crash(self, reason: str) -> Self:
         if self.state not in ("running", "finalizing"):
             raise ValueError(f"illegal episode transition from {self.state}")
-        return self._transition(
+        return self._consume_transition(
             self.state,
             "record-crash",
             state="cleaning",
@@ -749,7 +770,7 @@ class EpisodeLifecycle(ProtocolModel):
     def cancel(self, reason: str) -> Self:
         if self.state not in ("running", "finalizing"):
             raise ValueError(f"illegal episode transition from {self.state}")
-        return self._transition(
+        return self._consume_transition(
             self.state,
             "record-cancellation",
             state="cleaning",
@@ -765,7 +786,7 @@ class EpisodeLifecycle(ProtocolModel):
     ) -> Self:
         if self.state not in ("planned", "preflighted", "authorized"):
             raise ValueError("post-start failure must enter cleaning first")
-        return self._transition(
+        return self._consume_transition(
             self.state,
             "fail-before-running",
             state="failed",
@@ -803,8 +824,7 @@ class EpisodeLifecycle(ProtocolModel):
             # Terminal construction precedes both consumes: a construction or
             # validation error leaves lifecycle and result retryable together.
             terminal = self._transition("cleaning", "finish-cleanup", **updates)
-            self._consumed = True
-            object.__setattr__(self, "_authority", None)
+            self._consume_source()
             result.consume_authority()
             return terminal
 

--- a/local_operator/evaluation/lifecycle.py
+++ b/local_operator/evaluation/lifecycle.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from threading import RLock
 from typing import Any, Literal, Self, cast
 
 from pydantic import (
@@ -51,6 +53,20 @@ def _identity(kind: str, payload: Any) -> str:
         sort_keys=True,
     ).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
+
+
+@contextmanager
+def _authority_locks(*locks: RLock) -> Iterator[None]:
+    """Acquire process-local authority locks in one deadlock-safe order."""
+
+    ordered = sorted({id(lock): lock for lock in locks}.values(), key=id)
+    for lock in ordered:
+        lock.acquire()
+    try:
+        yield
+    finally:
+        for lock in reversed(ordered):
+            lock.release()
 
 
 def _state_identity(payload: dict[str, Any]) -> str:
@@ -181,6 +197,8 @@ class CleanupResult(ProtocolModel):
 
     _authority: object = PrivateAttr()
     _receipts: tuple[CleanupReceipt, ...] = PrivateAttr()
+    _lock: RLock = PrivateAttr(default_factory=RLock)
+    _consumed: bool = PrivateAttr(default=False)
 
     cleanup_plan_id: Digest
     succeeded_action_ids: tuple[StrictIdentifier, ...]
@@ -244,8 +262,11 @@ class CleanupResult(ProtocolModel):
     def __reduce__(self) -> Any:
         raise TypeError("cleanup result authority cannot be pickled")
 
+    def authority_lock(self) -> RLock:
+        return self._lock
+
     def assert_authority(self) -> None:
-        if getattr(self, "_authority", None) is not _CLEANUP_RESULT_FACTORY:
+        if self._consumed or getattr(self, "_authority", None) is not _CLEANUP_RESULT_FACTORY:
             raise ValueError("cleanup result lacks factory authority")
         actual: list[str] = []
         for receipt in getattr(self, "_receipts", ()):
@@ -264,6 +285,10 @@ class CleanupResult(ProtocolModel):
         )
         if self.cleanup_result_id != expected_result:
             raise ValueError("cleanup result authority was mutated")
+
+    def consume_authority(self) -> None:
+        self._consumed = True
+        object.__setattr__(self, "_authority", None)
 
 
 def aggregate_cleanup(
@@ -313,9 +338,11 @@ def aggregate_cleanup(
 
 
 class SideEffectPermit(ProtocolModel):
-    """Factory-only authority bound to one sealed episode budget."""
+    """Single-use in-process authority bound to one sealed episode budget."""
 
     _authority: object = PrivateAttr()
+    _lock: RLock = PrivateAttr(default_factory=RLock)
+    _consumed: bool = PrivateAttr(default=False)
 
     episode_id: StrictIdentifier
     plan_id: Digest
@@ -346,8 +373,11 @@ class SideEffectPermit(ProtocolModel):
     def __reduce__(self) -> Any:
         raise TypeError("side-effect permit authority cannot be pickled")
 
+    def authority_lock(self) -> RLock:
+        return self._lock
+
     def assert_authority(self) -> None:
-        if getattr(self, "_authority", None) is not _PERMIT_FACTORY:
+        if self._consumed or getattr(self, "_authority", None) is not _PERMIT_FACTORY:
             raise ValueError("side-effect permit lacks factory authority")
         expected = _identity(
             "side-effect-permit-v1",
@@ -355,6 +385,10 @@ class SideEffectPermit(ProtocolModel):
         )
         if self.permit_id != expected:
             raise ValueError("side-effect permit authority was mutated")
+
+    def consume_authority(self) -> None:
+        self._consumed = True
+        object.__setattr__(self, "_authority", None)
 
 
 def mint_side_effect_permit(
@@ -427,6 +461,8 @@ class EpisodeLifecycle(ProtocolModel):
     """
 
     _authority: object = PrivateAttr()
+    _lock: RLock = PrivateAttr(default_factory=RLock)
+    _consumed: bool = PrivateAttr(default=False)
 
     episode_id: StrictIdentifier
     plan_id: Digest
@@ -570,7 +606,7 @@ class EpisodeLifecycle(ProtocolModel):
         return self
 
     def _assert_authority(self) -> None:
-        if getattr(self, "_authority", None) is not _LIFECYCLE_FACTORY:
+        if self._consumed or getattr(self, "_authority", None) is not _LIFECYCLE_FACTORY:
             raise ValueError("episode lifecycle lacks transition authority")
         expected = _state_identity(self.model_dump(mode="json", exclude={"state_id"}))
         if self.state_id != expected:
@@ -628,30 +664,37 @@ class EpisodeLifecycle(ProtocolModel):
         authorization: BudgetAuthorization,
         commitment: BudgetCommitment,
     ) -> Self:
-        self._assert_authority()
-        if self.state != "authorized":
-            raise ValueError(f"illegal episode transition from {self.state}")
-        permit.assert_authority()
-        commitment.assert_authority(authorization)
-        if commitment.budget_id != self.budget_id:
-            raise ValueError("budget commitment does not match this episode")
-        if (
-            permit.episode_id != self.episode_id
-            or permit.plan_id != self.plan_id
-            or permit.budget_id != self.budget_id
-            or permit.permit_id != self.permit_id
-        ):
-            raise ValueError("side-effect permit does not match this episode")
-        running = self._transition(
-            "authorized",
-            "start-episode",
-            state="running",
-            reservation_ids=commitment.reservation_ids,
-        )
-        # A state node is single-use authority. Consuming it prevents two
-        # independently valid commitments from creating sibling executions.
-        object.__setattr__(self, "_authority", None)
-        return running
+        # These guards are deliberately process-local. Cooperative adapters get
+        # exactly-once authority within this runtime; serialized evidence alone
+        # never recreates authority in another process.
+        with _authority_locks(self._lock, permit.authority_lock(), commitment.authority_lock()):
+            self._assert_authority()
+            if self.state != "authorized":
+                raise ValueError(f"illegal episode transition from {self.state}")
+            permit.assert_authority()
+            commitment.assert_authority(authorization)
+            if commitment.budget_id != self.budget_id:
+                raise ValueError("budget commitment does not match this episode")
+            if (
+                permit.episode_id != self.episode_id
+                or permit.plan_id != self.plan_id
+                or permit.budget_id != self.budget_id
+                or permit.permit_id != self.permit_id
+            ):
+                raise ValueError("side-effect permit does not match this episode")
+            # Child construction is the last fallible step. Only after it works
+            # are all three authorities consumed, so validation errors can retry.
+            running = self._transition(
+                "authorized",
+                "start-episode",
+                state="running",
+                reservation_ids=commitment.reservation_ids,
+            )
+            self._consumed = True
+            object.__setattr__(self, "_authority", None)
+            permit.consume_authority()
+            commitment.consume_authority()
+            return running
 
     def begin_finalization(self) -> Self:
         return self._transition("running", "begin-finalization", state="finalizing")
@@ -731,31 +774,39 @@ class EpisodeLifecycle(ProtocolModel):
         )
 
     def finish_cleanup(self, result: CleanupResult) -> Self:
-        result.assert_authority()
-        if result.cleanup_plan_id != self.cleanup_plan_id:
-            raise ValueError("cleanup result belongs to another plan")
-        updates: dict[str, Any] = {
-            "cleanup_result_id": result.cleanup_result_id,
-            "rescue_required": result.rescue_required,
-        }
-        if self.terminal_intent == "cancel":
-            updates["state"] = "cancelled"
-        elif (
-            self.terminal_intent == "complete"
-            and not result.rescue_required
-            and self.reconciliation_reportable is True
-            and self.score_id is not None
-        ):
-            updates["state"] = "completed"
-        else:
-            updates["state"] = "failed"
-            if result.rescue_required:
-                updates["failure_kind"] = "cleanup"
-                updates["failure_reason"] = "cleanup requires operator rescue"
-            elif self.reconciliation_reportable is False and self.failure_kind is None:
-                updates["failure_kind"] = "unreportable"
-                updates["failure_reason"] = "required usage was unavailable"
-        return self._transition("cleaning", "finish-cleanup", **updates)
+        with _authority_locks(self._lock, result.authority_lock()):
+            self._assert_authority()
+            result.assert_authority()
+            if result.cleanup_plan_id != self.cleanup_plan_id:
+                raise ValueError("cleanup result belongs to another plan")
+            updates: dict[str, Any] = {
+                "cleanup_result_id": result.cleanup_result_id,
+                "rescue_required": result.rescue_required,
+            }
+            if self.terminal_intent == "cancel":
+                updates["state"] = "cancelled"
+            elif (
+                self.terminal_intent == "complete"
+                and not result.rescue_required
+                and self.reconciliation_reportable is True
+                and self.score_id is not None
+            ):
+                updates["state"] = "completed"
+            else:
+                updates["state"] = "failed"
+                if result.rescue_required:
+                    updates["failure_kind"] = "cleanup"
+                    updates["failure_reason"] = "cleanup requires operator rescue"
+                elif self.reconciliation_reportable is False and self.failure_kind is None:
+                    updates["failure_kind"] = "unreportable"
+                    updates["failure_reason"] = "required usage was unavailable"
+            # Terminal construction precedes both consumes: a construction or
+            # validation error leaves lifecycle and result retryable together.
+            terminal = self._transition("cleaning", "finish-cleanup", **updates)
+            self._consumed = True
+            object.__setattr__(self, "_authority", None)
+            result.consume_authority()
+            return terminal
 
     def _validate_reconciliation(self, reconciliation: BudgetReconciliation) -> None:
         if (

--- a/local_operator/evaluation/lifecycle.py
+++ b/local_operator/evaluation/lifecycle.py
@@ -10,18 +10,25 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Sequence
-from typing import Any, Literal, Self
+from typing import Any, Literal, Self, cast
 
-from pydantic import Field, ValidationInfo, field_validator, model_validator
+from pydantic import (
+    Field,
+    PrivateAttr,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 
 from local_operator.evaluation.protocol import ArtifactRef, ProtocolModel
 from local_operator.evaluation.receipts import (
     MAX_DECLARATIONS,
     ZERO_DIGEST,
     BudgetAuthorization,
+    BudgetCommitment,
     BudgetReconciliation,
-    BudgetReservation,
     Digest,
+    PositiveSafeCount,
     SafeCount,
     SealedPreflight,
     StrictIdentifier,
@@ -31,6 +38,7 @@ MAX_CLEANUP_ATTEMPTS = 32
 MAX_CLEANUP_TIMEOUT_MS = 3_600_000
 MAX_FAILURE_LENGTH = 2_000
 _PERMIT_FACTORY = object()
+_LIFECYCLE_FACTORY = object()
 
 
 def _identity(kind: str, payload: Any) -> str:
@@ -42,6 +50,24 @@ def _identity(kind: str, payload: Any) -> str:
         sort_keys=True,
     ).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _state_identity(payload: dict[str, Any]) -> str:
+    complete = dict(payload)
+    complete.setdefault("state", "planned")
+    complete.setdefault("preflight_seal_id", None)
+    complete.setdefault("permit_id", None)
+    complete.setdefault("reservation_ids", ())
+    complete.setdefault("reconciliation_id", None)
+    complete.setdefault("reconciliation_reportable", None)
+    complete.setdefault("score_id", None)
+    complete.setdefault("cleanup_result_id", None)
+    complete.setdefault("rescue_required", None)
+    complete.setdefault("terminal_intent", None)
+    complete.setdefault("failure_kind", None)
+    complete.setdefault("failure_reason", None)
+    complete.setdefault("previous_state_id", None)
+    return _identity("episode-lifecycle-state-v1", complete)
 
 
 CleanupActionKind = Literal[
@@ -60,8 +86,20 @@ class CleanupAction(ProtocolModel):
     action_id: StrictIdentifier
     kind: CleanupActionKind
     resource_ref: StrictIdentifier
-    timeout_ms: SafeCount = Field(le=MAX_CLEANUP_TIMEOUT_MS)
+    timeout_ms: PositiveSafeCount = Field(le=MAX_CLEANUP_TIMEOUT_MS)
     max_attempts: int = Field(ge=1, le=MAX_CLEANUP_ATTEMPTS)
+    action_digest: Digest = ZERO_DIGEST
+
+    @model_validator(mode="after")
+    def _identify(self) -> Self:
+        expected = _identity(
+            "cleanup-action-v1",
+            self.model_dump(mode="json", exclude={"action_digest"}),
+        )
+        if self.action_digest not in (ZERO_DIGEST, expected):
+            raise ValueError("cleanup action identity does not match its declaration")
+        object.__setattr__(self, "action_digest", expected)
+        return self
 
 
 class CleanupPlan(ProtocolModel):
@@ -96,7 +134,9 @@ class CleanupPlan(ProtocolModel):
 
 
 class CleanupReceipt(ProtocolModel):
+    cleanup_plan_id: Digest
     action_id: StrictIdentifier
+    action_digest: Digest
     status: Literal["not_needed", "attempted", "succeeded", "failed"]
     evidence_code: StrictIdentifier
     duration_ms: SafeCount
@@ -110,6 +150,29 @@ class CleanupReceipt(ProtocolModel):
             raise ValueError("cleanup receipt identity does not match its result")
         object.__setattr__(self, "receipt_id", expected)
         return self
+
+
+def record_cleanup(
+    plan: CleanupPlan,
+    action_id: StrictIdentifier,
+    *,
+    status: Literal["not_needed", "attempted", "succeeded", "failed"],
+    evidence_code: StrictIdentifier,
+    duration_ms: int,
+) -> CleanupReceipt:
+    """Bind cleanup evidence to one exact symbolic action and plan."""
+
+    action = next((item for item in plan.actions if item.action_id == action_id), None)
+    if action is None:
+        raise ValueError("cleanup action is not selected by the cleanup plan")
+    return CleanupReceipt(
+        cleanup_plan_id=plan.cleanup_plan_id,
+        action_id=action_id,
+        action_digest=action.action_digest,
+        status=status,
+        evidence_code=evidence_code,
+        duration_ms=duration_ms,
+    )
 
 
 class CleanupResult(ProtocolModel):
@@ -172,6 +235,12 @@ def aggregate_cleanup(
     expected_ids = {action.action_id for action in plan.actions}
     if set(by_id) != expected_ids:
         raise ValueError("cleanup requires exactly one receipt for every action")
+    actions = {action.action_id: action for action in plan.actions}
+    for action_id, receipt in by_id.items():
+        if receipt.cleanup_plan_id != plan.cleanup_plan_id:
+            raise ValueError("cleanup receipt belongs to another cleanup plan")
+        if receipt.action_digest != actions[action_id].action_digest:
+            raise ValueError("cleanup receipt belongs to another action declaration")
     succeeded = tuple(sorted(key for key, item in by_id.items() if item.status == "succeeded"))
     not_needed = tuple(sorted(key for key, item in by_id.items() if item.status == "not_needed"))
     incomplete = tuple(
@@ -275,7 +344,14 @@ TerminalIntent = Literal["complete", "fail", "cancel"]
 
 
 class EpisodeLifecycle(ProtocolModel):
-    """Immutable episode state whose methods enforce the only legal transition graph."""
+    """Factory-only state authority with a content-addressed transition chain.
+
+    Pydantic's ``model_construct`` can fabricate an object, but it lacks the
+    private marker checked by every transition. This constrains cooperative
+    adapters rather than hostile code which ignores the contract entirely.
+    """
+
+    _authority: object = PrivateAttr()
 
     episode_id: StrictIdentifier
     plan_id: Digest
@@ -303,6 +379,9 @@ class EpisodeLifecycle(ProtocolModel):
         | None
     ) = None
     failure_reason: str | None = Field(default=None, min_length=1, max_length=MAX_FAILURE_LENGTH)
+    previous_state_id: Digest | None = None
+    operation: StrictIdentifier
+    state_id: Digest
 
     @field_validator("reservation_ids", mode="before")
     @classmethod
@@ -310,7 +389,10 @@ class EpisodeLifecycle(ProtocolModel):
         return tuple(value) if isinstance(value, list) else value
 
     @model_validator(mode="after")
-    def _validate_state_evidence(self) -> Self:
+    def _validate_state_evidence(self, info: ValidationInfo) -> Self:
+        context = info.context if isinstance(info.context, dict) else {}
+        if context.get("lifecycle_factory") is not _LIFECYCLE_FACTORY:
+            raise ValueError("episode lifecycle authority can only be factory minted")
         if len(self.reservation_ids) != len(set(self.reservation_ids)):
             raise ValueError("episode contains duplicate reservations")
         if tuple(sorted(self.reservation_ids)) != self.reservation_ids:
@@ -368,6 +450,15 @@ class EpisodeLifecycle(ProtocolModel):
             raise ValueError("preflight and infrastructure failures cannot carry a score")
         if self.state == "cancelled" and self.terminal_intent != "cancel":
             raise ValueError("cancelled state requires cancellation intent")
+        if self.state == "planned":
+            if self.previous_state_id is not None or self.operation != "plan":
+                raise ValueError("planned lifecycle must be the transition-chain root")
+        elif self.previous_state_id is None:
+            raise ValueError("non-planned lifecycle requires a previous state identity")
+        expected = _state_identity(self.model_dump(mode="json", exclude={"state_id"}))
+        if self.state_id != expected:
+            raise ValueError("episode lifecycle state identity does not match its evidence")
+        object.__setattr__(self, "_authority", _LIFECYCLE_FACTORY)
         return self
 
     @classmethod
@@ -379,26 +470,56 @@ class EpisodeLifecycle(ProtocolModel):
         budget_id: Digest,
         cleanup_plan_id: Digest,
     ) -> Self:
-        return cls(
-            episode_id=episode_id,
-            plan_id=plan_id,
-            budget_id=budget_id,
-            cleanup_plan_id=cleanup_plan_id,
+        return cast(
+            Self,
+            plan_episode(
+                episode_id=episode_id,
+                plan_id=plan_id,
+                budget_id=budget_id,
+                cleanup_plan_id=cleanup_plan_id,
+            ),
         )
 
-    def _transition(self, expected: EpisodeState, **updates: Any) -> Self:
+    def __reduce__(self) -> Any:
+        raise TypeError("episode lifecycle authority cannot be pickled")
+
+    def __deepcopy__(self, memo: dict[int, Any] | None = None) -> Self:
+        if memo is not None:
+            memo[id(self)] = self
+        return self
+
+    def model_copy(self, *, update: Any = None, deep: bool = False) -> Self:
+        if update:
+            raise TypeError("episode lifecycle authority cannot be updated by copying")
+        return self
+
+    def _assert_authority(self) -> None:
+        if getattr(self, "_authority", None) is not _LIFECYCLE_FACTORY:
+            raise ValueError("episode lifecycle lacks transition authority")
+        expected = _state_identity(self.model_dump(mode="json", exclude={"state_id"}))
+        if self.state_id != expected:
+            raise ValueError("episode lifecycle authority was mutated")
+
+    def _transition(self, expected: EpisodeState, operation: str, **updates: Any) -> Self:
+        self._assert_authority()
         if self.state != expected:
             raise ValueError(f"illegal episode transition from {self.state}")
-        payload = self.model_dump(mode="python")
-        payload.update(updates)
-        return type(self).model_validate(payload)
+        payload = self.model_dump(mode="python", exclude={"state_id"})
+        payload.update(previous_state_id=self.state_id, operation=operation, **updates)
+        payload["state_id"] = _state_identity(payload)
+        return type(self).model_validate(
+            payload,
+            context={"lifecycle_factory": _LIFECYCLE_FACTORY},
+        )
 
     def preflight(self, seal: SealedPreflight) -> Self:
         if not seal.successful:
             raise ValueError("failed preflight cannot enter preflighted state")
         if seal.plan_id != self.plan_id:
             raise ValueError("preflight seal belongs to another dependency plan")
-        return self._transition("planned", state="preflighted", preflight_seal_id=seal.seal_id)
+        return self._transition(
+            "planned", "seal-preflight", state="preflighted", preflight_seal_id=seal.seal_id
+        )
 
     def authorize(
         self, seal: SealedPreflight, budget: BudgetAuthorization
@@ -414,20 +535,27 @@ class EpisodeLifecycle(ProtocolModel):
             budget=budget,
         )
         return (
-            self._transition("preflighted", state="authorized", permit_id=permit.permit_id),
+            self._transition(
+                "preflighted",
+                "authorize-side-effects",
+                state="authorized",
+                permit_id=permit.permit_id,
+            ),
             permit,
         )
 
     def start(
         self,
         permit: SideEffectPermit,
-        reservations: Sequence[BudgetReservation],
+        authorization: BudgetAuthorization,
+        commitment: BudgetCommitment,
     ) -> Self:
+        self._assert_authority()
         if self.state != "authorized":
             raise ValueError(f"illegal episode transition from {self.state}")
-        snapshot = tuple(reservations)
-        if not snapshot:
-            raise ValueError("episode start requires a prior budget reservation")
+        commitment.assert_authority(authorization)
+        if commitment.budget_id != self.budget_id:
+            raise ValueError("budget commitment does not match this episode")
         if (
             permit.episode_id != self.episode_id
             or permit.plan_id != self.plan_id
@@ -435,18 +563,15 @@ class EpisodeLifecycle(ProtocolModel):
             or permit.permit_id != self.permit_id
         ):
             raise ValueError("side-effect permit does not match this episode")
-        if any(
-            item.episode_id != self.episode_id or item.budget_id != self.budget_id
-            for item in snapshot
-        ):
-            raise ValueError("budget reservation does not match this episode")
-        ids = tuple(sorted(item.reservation_id for item in snapshot))
-        if len(ids) != len(set(ids)):
-            raise ValueError("episode start contains duplicate reservations")
-        return self._transition("authorized", state="running", reservation_ids=ids)
+        return self._transition(
+            "authorized",
+            "start-episode",
+            state="running",
+            reservation_ids=commitment.reservation_ids,
+        )
 
     def begin_finalization(self) -> Self:
-        return self._transition("running", state="finalizing")
+        return self._transition("running", "begin-finalization", state="finalizing")
 
     def finish_finalization(
         self,
@@ -458,6 +583,7 @@ class EpisodeLifecycle(ProtocolModel):
             raise ValueError("score receipt does not match this episode")
         return self._transition(
             "finalizing",
+            "finish-finalization",
             state="cleaning",
             terminal_intent="complete",
             reconciliation_id=reconciliation.reconciliation_id,
@@ -473,6 +599,7 @@ class EpisodeLifecycle(ProtocolModel):
         self._validate_reconciliation(reconciliation)
         return self._transition(
             "finalizing",
+            "finish-finalization",
             state="cleaning",
             terminal_intent="fail",
             reconciliation_id=reconciliation.reconciliation_id,
@@ -484,6 +611,7 @@ class EpisodeLifecycle(ProtocolModel):
     def crash(self, reason: str) -> Self:
         return self._transition(
             "running",
+            "record-crash",
             state="cleaning",
             terminal_intent="fail",
             failure_kind="crash",
@@ -493,6 +621,7 @@ class EpisodeLifecycle(ProtocolModel):
     def cancel(self, reason: str) -> Self:
         return self._transition(
             "running",
+            "record-cancellation",
             state="cleaning",
             terminal_intent="cancel",
             failure_reason=reason,
@@ -506,9 +635,13 @@ class EpisodeLifecycle(ProtocolModel):
     ) -> Self:
         if self.state not in ("planned", "preflighted", "authorized"):
             raise ValueError("post-start failure must enter cleaning first")
-        payload = self.model_dump(mode="python")
-        payload.update(state="failed", failure_kind=kind, failure_reason=reason)
-        return type(self).model_validate(payload)
+        return self._transition(
+            self.state,
+            "fail-before-running",
+            state="failed",
+            failure_kind=kind,
+            failure_reason=reason,
+        )
 
     def finish_cleanup(self, result: CleanupResult) -> Self:
         if result.cleanup_plan_id != self.cleanup_plan_id:
@@ -534,12 +667,41 @@ class EpisodeLifecycle(ProtocolModel):
             elif self.reconciliation_reportable is False and self.failure_kind is None:
                 updates["failure_kind"] = "unreportable"
                 updates["failure_reason"] = "required usage was unavailable"
-        return self._transition("cleaning", **updates)
+        return self._transition("cleaning", "finish-cleanup", **updates)
 
     def _validate_reconciliation(self, reconciliation: BudgetReconciliation) -> None:
         if (
             reconciliation.episode_id != self.episode_id
             or reconciliation.budget_id != self.budget_id
+            or reconciliation.authorization_digest != self.budget_id
+            or reconciliation.authorization.budget_id != self.budget_id
             or reconciliation.reservation_ids != self.reservation_ids
         ):
             raise ValueError("cost reconciliation does not match this episode")
+
+
+def plan_episode(
+    *,
+    episode_id: StrictIdentifier,
+    plan_id: Digest,
+    budget_id: Digest,
+    cleanup_plan_id: Digest,
+) -> EpisodeLifecycle:
+    """Mint the public plan as the root of a private transition authority chain."""
+
+    payload = {
+        "episode_id": episode_id,
+        "plan_id": plan_id,
+        "budget_id": budget_id,
+        "cleanup_plan_id": cleanup_plan_id,
+        "state": "planned",
+        "operation": "plan",
+        "state_id": ZERO_DIGEST,
+    }
+    payload["state_id"] = _state_identity(
+        {key: value for key, value in payload.items() if key != "state_id"}
+    )
+    return EpisodeLifecycle.model_validate(
+        payload,
+        context={"lifecycle_factory": _LIFECYCLE_FACTORY},
+    )

--- a/local_operator/evaluation/lifecycle.py
+++ b/local_operator/evaluation/lifecycle.py
@@ -15,13 +15,14 @@ from threading import RLock
 from typing import Any, Literal, Self, cast
 from weakref import WeakValueDictionary
 
-from pydantic import Field, PrivateAttr, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from local_operator.evaluation.protocol import ArtifactRef, ProtocolModel
 from local_operator.evaluation.receipts import (
     MAX_DECLARATIONS,
     ZERO_DIGEST,
     AuthorityModel,
+    AuthorityRecord,
     BudgetAuthorization,
     BudgetCommitment,
     BudgetReconciliation,
@@ -30,6 +31,8 @@ from local_operator.evaluation.receipts import (
     SafeCount,
     SealedPreflight,
     StrictIdentifier,
+    _lookup_authority,
+    _register_authority,
 )
 
 MAX_CLEANUP_ATTEMPTS = 32
@@ -56,14 +59,6 @@ _LINEAGE_REGISTRY_LOCK = RLock()
 _LIVE_LINEAGES: WeakValueDictionary[str, _EpisodeLineage] = WeakValueDictionary()
 
 
-def _attach_lifecycle_authority(model: AuthorityModel, **private_values: Any) -> None:
-    """Attach fresh process-local authority after ordinary model validation."""
-
-    object.__setattr__(model, "_authority", object())
-    for name, value in private_values.items():
-        object.__setattr__(model, name, value)
-
-
 def _identity(kind: str, payload: Any) -> str:
     encoded = json.dumps(
         {"identity_kind": kind, "payload": payload},
@@ -76,17 +71,17 @@ def _identity(kind: str, payload: Any) -> str:
 
 
 @contextmanager
-def _authority_locks(*locks: RLock) -> Iterator[None]:
+def _authority_locks(*records: AuthorityRecord) -> Iterator[None]:
     """Acquire process-local authority locks in one deadlock-safe order."""
 
-    ordered = sorted({id(lock): lock for lock in locks}.values(), key=id)
-    for lock in ordered:
-        lock.acquire()
+    ordered = sorted({id(record): record for record in records}.values(), key=id)
+    for record in ordered:
+        record.lock.acquire()
     try:
         yield
     finally:
-        for lock in reversed(ordered):
-            lock.release()
+        for record in reversed(ordered):
+            record.lock.release()
 
 
 def _state_identity(payload: dict[str, Any]) -> str:
@@ -215,11 +210,6 @@ def record_cleanup(
 class CleanupResult(AuthorityModel):
     """Factory-only aggregate over exact cleanup receipt evidence."""
 
-    _authority: object = PrivateAttr()
-    _receipts: tuple[CleanupReceipt, ...] = PrivateAttr()
-    _lock: RLock = PrivateAttr(default_factory=RLock)
-    _consumed: bool = PrivateAttr(default=False)
-
     cleanup_plan_id: Digest
     succeeded_action_ids: tuple[StrictIdentifier, ...]
     not_needed_action_ids: tuple[StrictIdentifier, ...]
@@ -272,14 +262,16 @@ class CleanupResult(AuthorityModel):
     def __reduce__(self) -> Any:
         raise TypeError("cleanup result authority cannot be pickled")
 
-    def authority_lock(self) -> RLock:
-        return self._lock
+    def authority_record(self) -> AuthorityRecord:
+        return _lookup_authority(self, "cleanup-result")
 
     def assert_authority(self) -> None:
-        if self._consumed or getattr(self, "_authority", None) is None:
-            raise ValueError("cleanup result lacks factory authority")
+        try:
+            record = self.authority_record()
+        except ValueError as error:
+            raise ValueError("cleanup result lacks factory authority") from error
         actual: list[str] = []
-        for receipt in getattr(self, "_receipts", ()):
+        for receipt in record.receipts:
             expected = _identity(
                 "cleanup-receipt-v1",
                 receipt.model_dump(mode="json", exclude={"receipt_id"}),
@@ -297,8 +289,7 @@ class CleanupResult(AuthorityModel):
             raise ValueError("cleanup result authority was mutated")
 
     def consume_authority(self) -> None:
-        self._consumed = True
-        object.__setattr__(self, "_authority", None)
+        self.authority_record().consumed = True
 
 
 def aggregate_cleanup(
@@ -341,21 +332,12 @@ def aggregate_cleanup(
     result = CleanupResult.model_validate(
         {**payload, "cleanup_result_id": _identity("cleanup-result-v1", payload)}
     )
-    _attach_lifecycle_authority(
-        result,
-        _receipts=snapshot,
-        _lock=RLock(),
-        _consumed=False,
-    )
+    _register_authority(result, "cleanup-result", receipts=snapshot)
     return result
 
 
 class SideEffectPermit(AuthorityModel):
     """Single-use in-process authority bound to one sealed episode budget."""
-
-    _authority: object = PrivateAttr()
-    _lock: RLock = PrivateAttr(default_factory=RLock)
-    _consumed: bool = PrivateAttr(default=False)
 
     episode_id: StrictIdentifier
     plan_id: Digest
@@ -382,12 +364,14 @@ class SideEffectPermit(AuthorityModel):
     def __reduce__(self) -> Any:
         raise TypeError("side-effect permit authority cannot be pickled")
 
-    def authority_lock(self) -> RLock:
-        return self._lock
+    def authority_record(self) -> AuthorityRecord:
+        return _lookup_authority(self, "side-effect-permit")
 
     def assert_authority(self) -> None:
-        if self._consumed or getattr(self, "_authority", None) is None:
-            raise ValueError("side-effect permit lacks factory authority")
+        try:
+            self.authority_record()
+        except ValueError as error:
+            raise ValueError("side-effect permit lacks factory authority") from error
         expected = _identity(
             "side-effect-permit-v1",
             self.model_dump(mode="json", exclude={"permit_id"}),
@@ -396,8 +380,7 @@ class SideEffectPermit(AuthorityModel):
             raise ValueError("side-effect permit authority was mutated")
 
     def consume_authority(self) -> None:
-        self._consumed = True
-        object.__setattr__(self, "_authority", None)
+        self.authority_record().consumed = True
 
 
 def mint_side_effect_permit(
@@ -425,7 +408,7 @@ def mint_side_effect_permit(
     permit = SideEffectPermit.model_validate(
         {**payload, "permit_id": _identity("side-effect-permit-v1", payload)}
     )
-    _attach_lifecycle_authority(permit, _lock=RLock(), _consumed=False)
+    _register_authority(permit, "side-effect-permit")
     return permit
 
 
@@ -469,11 +452,6 @@ class EpisodeLifecycle(AuthorityModel):
     private marker checked by every transition. This constrains cooperative
     adapters rather than hostile code which ignores the contract entirely.
     """
-
-    _authority: object = PrivateAttr()
-    _lock: RLock = PrivateAttr(default_factory=RLock)
-    _consumed: bool = PrivateAttr(default=False)
-    _lineage: _EpisodeLineage = PrivateAttr()
 
     episode_id: StrictIdentifier
     plan_id: Digest
@@ -607,9 +585,14 @@ class EpisodeLifecycle(AuthorityModel):
     def __deepcopy__(self, memo: dict[int, Any] | None = None) -> Self:
         raise TypeError("episode lifecycle authority cannot be copied")
 
+    def _authority_record(self) -> AuthorityRecord:
+        try:
+            return _lookup_authority(self, "episode-lifecycle")
+        except ValueError as error:
+            raise ValueError("episode lifecycle lacks transition authority") from error
+
     def _assert_authority(self) -> None:
-        if self._consumed or getattr(self, "_authority", None) is None:
-            raise ValueError("episode lifecycle lacks transition authority")
+        self._authority_record()
         expected = _state_identity(self.model_dump(mode="json", exclude={"state_id"}))
         if self.state_id != expected:
             raise ValueError("episode lifecycle authority was mutated")
@@ -629,22 +612,20 @@ class EpisodeLifecycle(AuthorityModel):
         payload.update(previous_state_id=self.state_id, operation=operation, **updates)
         payload["state_id"] = _state_identity(payload)
         child = type(self).model_validate(payload)
-        _attach_lifecycle_authority(
+        _register_authority(
             child,
-            _lineage=self._lineage,
-            _lock=RLock(),
-            _consumed=False,
+            "episode-lifecycle",
+            lineage=self._authority_record().lineage,
         )
         return child
 
     def _consume_source(self) -> None:
-        self._consumed = True
-        object.__setattr__(self, "_authority", None)
+        self._authority_record().consumed = True
 
     def _consume_transition(self, expected: EpisodeState, operation: str, **updates: Any) -> Self:
         """Atomically mint one child and consume this process-local authority."""
 
-        with self._lock:
+        with self._authority_record().lock:
             child = self._transition(expected, operation, **updates)
             self._consume_source()
             return child
@@ -664,7 +645,7 @@ class EpisodeLifecycle(AuthorityModel):
     ) -> tuple[Self, SideEffectPermit]:
         # The seal is reusable plan evidence; the episode parent is the
         # single-use authority that prevents two authorized children.
-        with self._lock:
+        with self._authority_record().lock:
             self._assert_authority()
             seal.assert_authority()
             if self.state != "preflighted" or self.preflight_seal_id != seal.seal_id:
@@ -695,7 +676,11 @@ class EpisodeLifecycle(AuthorityModel):
         # These guards are deliberately process-local. Cooperative adapters get
         # exactly-once authority within this runtime; serialized evidence alone
         # never recreates authority in another process.
-        with _authority_locks(self._lock, permit.authority_lock(), commitment.authority_lock()):
+        with _authority_locks(
+            self._authority_record(),
+            permit.authority_record(),
+            commitment.authority_record(),
+        ):
             self._assert_authority()
             if self.state != "authorized":
                 raise ValueError(f"illegal episode transition from {self.state}")
@@ -805,7 +790,7 @@ class EpisodeLifecycle(AuthorityModel):
             )
         if permit is None:
             raise ValueError("authorized failure requires its side-effect permit")
-        with _authority_locks(self._lock, permit.authority_lock()):
+        with _authority_locks(self._authority_record(), permit.authority_record()):
             self._assert_authority()
             permit.assert_authority()
             if (
@@ -828,7 +813,7 @@ class EpisodeLifecycle(AuthorityModel):
             return failed
 
     def finish_cleanup(self, result: CleanupResult) -> Self:
-        with _authority_locks(self._lock, result.authority_lock()):
+        with _authority_locks(self._authority_record(), result.authority_record()):
             self._assert_authority()
             result.assert_authority()
             if result.cleanup_plan_id != self.cleanup_plan_id:
@@ -901,10 +886,5 @@ def plan_episode(
             {key: value for key, value in payload.items() if key != "state_id"}
         )
         root = EpisodeLifecycle.model_validate(payload)
-        _attach_lifecycle_authority(
-            root,
-            _lineage=lineage,
-            _lock=RLock(),
-            _consumed=False,
-        )
+        _register_authority(root, "episode-lifecycle", lineage=lineage)
         return root

--- a/local_operator/evaluation/lifecycle.py
+++ b/local_operator/evaluation/lifecycle.py
@@ -1,0 +1,545 @@
+"""Pure cleanup contracts and the evaluation episode state machine.
+
+The permit boundary constrains cooperative adapters: Python cannot stop hostile
+code from bypassing a type contract, but normal allocation and execution APIs
+can make possession of a factory-minted permit a mandatory argument.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+from typing import Any, Literal, Self
+
+from pydantic import Field, ValidationInfo, field_validator, model_validator
+
+from local_operator.evaluation.protocol import ArtifactRef, ProtocolModel
+from local_operator.evaluation.receipts import (
+    MAX_DECLARATIONS,
+    ZERO_DIGEST,
+    BudgetAuthorization,
+    BudgetReconciliation,
+    BudgetReservation,
+    Digest,
+    SafeCount,
+    SealedPreflight,
+    StrictIdentifier,
+)
+
+MAX_CLEANUP_ATTEMPTS = 32
+MAX_CLEANUP_TIMEOUT_MS = 3_600_000
+MAX_FAILURE_LENGTH = 2_000
+_PERMIT_FACTORY = object()
+
+
+def _identity(kind: str, payload: Any) -> str:
+    encoded = json.dumps(
+        {"identity_kind": kind, "payload": payload},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+CleanupActionKind = Literal[
+    "release_instance",
+    "delete_volume",
+    "delete_artifact",
+    "revoke_lease",
+    "close_session",
+    "restore_snapshot",
+]
+
+
+class CleanupAction(ProtocolModel):
+    """Bounded symbolic cleanup; commands and provider parameters stay in adapters."""
+
+    action_id: StrictIdentifier
+    kind: CleanupActionKind
+    resource_ref: StrictIdentifier
+    timeout_ms: SafeCount = Field(le=MAX_CLEANUP_TIMEOUT_MS)
+    max_attempts: int = Field(ge=1, le=MAX_CLEANUP_ATTEMPTS)
+
+
+class CleanupPlan(ProtocolModel):
+    episode_id: StrictIdentifier
+    actions: tuple[CleanupAction, ...] = Field(min_length=1, max_length=MAX_DECLARATIONS)
+    cleanup_plan_id: Digest = ZERO_DIGEST
+
+    @field_validator("actions", mode="before")
+    @classmethod
+    def _freeze_actions(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _canonicalize_and_identify(self) -> Self:
+        ordered = tuple(sorted(self.actions, key=lambda item: item.action_id))
+        ids = [item.action_id for item in ordered]
+        if len(ids) != len(set(ids)):
+            raise ValueError("cleanup plan contains duplicate action IDs")
+        targets = [(item.kind, item.resource_ref) for item in ordered]
+        if len(targets) != len(set(targets)):
+            raise ValueError("cleanup plan contains conflicting duplicate actions")
+        object.__setattr__(self, "actions", ordered)
+        payload = {
+            "episode_id": self.episode_id,
+            "actions": [item.model_dump(mode="json") for item in ordered],
+        }
+        expected = _identity("cleanup-plan-v1", payload)
+        if self.cleanup_plan_id not in (ZERO_DIGEST, expected):
+            raise ValueError("cleanup plan identity does not match its actions")
+        object.__setattr__(self, "cleanup_plan_id", expected)
+        return self
+
+
+class CleanupReceipt(ProtocolModel):
+    action_id: StrictIdentifier
+    status: Literal["not_needed", "attempted", "succeeded", "failed"]
+    evidence_code: StrictIdentifier
+    duration_ms: SafeCount
+    receipt_id: Digest = ZERO_DIGEST
+
+    @model_validator(mode="after")
+    def _identify(self) -> Self:
+        payload = self.model_dump(mode="json", exclude={"receipt_id"})
+        expected = _identity("cleanup-receipt-v1", payload)
+        if self.receipt_id not in (ZERO_DIGEST, expected):
+            raise ValueError("cleanup receipt identity does not match its result")
+        object.__setattr__(self, "receipt_id", expected)
+        return self
+
+
+class CleanupResult(ProtocolModel):
+    cleanup_plan_id: Digest
+    succeeded_action_ids: tuple[StrictIdentifier, ...]
+    not_needed_action_ids: tuple[StrictIdentifier, ...]
+    incomplete_action_ids: tuple[StrictIdentifier, ...]
+    receipt_digests: tuple[Digest, ...]
+    rescue_required: bool
+    cleanup_result_id: Digest
+
+    @field_validator(
+        "succeeded_action_ids",
+        "not_needed_action_ids",
+        "incomplete_action_ids",
+        "receipt_digests",
+        mode="before",
+    )
+    @classmethod
+    def _freeze_lists(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _validate_result(self) -> Self:
+        groups = (
+            self.succeeded_action_ids,
+            self.not_needed_action_ids,
+            self.incomplete_action_ids,
+        )
+        flattened = [item for group in groups for item in group]
+        if len(flattened) != len(set(flattened)):
+            raise ValueError("cleanup result action IDs must be unique")
+        if any(tuple(sorted(group)) != group for group in groups):
+            raise ValueError("cleanup result action IDs must be canonical")
+        if tuple(sorted(self.receipt_digests)) != self.receipt_digests:
+            raise ValueError("cleanup receipt digests must be canonical")
+        if self.rescue_required != bool(self.incomplete_action_ids):
+            raise ValueError("cleanup rescue flag disagrees with incomplete actions")
+        expected = _identity(
+            "cleanup-result-v1",
+            self.model_dump(mode="json", exclude={"cleanup_result_id"}),
+        )
+        if self.cleanup_result_id != expected:
+            raise ValueError("cleanup result identity does not match its receipts")
+        return self
+
+
+def aggregate_cleanup(
+    plan: CleanupPlan,
+    receipts: Sequence[CleanupReceipt],
+) -> CleanupResult:
+    """Require exact action coverage; attempted alone is never evidence of cleanup."""
+
+    snapshot = tuple(receipts)
+    by_id: dict[str, CleanupReceipt] = {}
+    for receipt in snapshot:
+        if receipt.action_id in by_id:
+            raise ValueError("cleanup has duplicate receipts")
+        by_id[receipt.action_id] = receipt
+    expected_ids = {action.action_id for action in plan.actions}
+    if set(by_id) != expected_ids:
+        raise ValueError("cleanup requires exactly one receipt for every action")
+    succeeded = tuple(sorted(key for key, item in by_id.items() if item.status == "succeeded"))
+    not_needed = tuple(sorted(key for key, item in by_id.items() if item.status == "not_needed"))
+    incomplete = tuple(
+        sorted(key for key, item in by_id.items() if item.status in ("attempted", "failed"))
+    )
+    payload = {
+        "cleanup_plan_id": plan.cleanup_plan_id,
+        "succeeded_action_ids": succeeded,
+        "not_needed_action_ids": not_needed,
+        "incomplete_action_ids": incomplete,
+        "receipt_digests": tuple(sorted(item.receipt_id for item in snapshot)),
+        "rescue_required": bool(incomplete),
+    }
+    return CleanupResult(
+        **payload,
+        cleanup_result_id=_identity("cleanup-result-v1", payload),
+    )
+
+
+class SideEffectPermit(ProtocolModel):
+    """Unforgeable-by-validation authority bound to one sealed episode budget."""
+
+    episode_id: StrictIdentifier
+    plan_id: Digest
+    preflight_seal_id: Digest
+    budget_id: Digest
+    permit_id: Digest
+
+    @model_validator(mode="after")
+    def _factory_only(self, info: ValidationInfo) -> Self:
+        context = info.context if isinstance(info.context, dict) else {}
+        if context.get("permit_factory") is not _PERMIT_FACTORY:
+            raise ValueError("side-effect permits can only be minted from validated authorities")
+        expected = _identity(
+            "side-effect-permit-v1",
+            self.model_dump(mode="json", exclude={"permit_id"}),
+        )
+        if self.permit_id != expected:
+            raise ValueError("side-effect permit identity does not match its authorities")
+        return self
+
+
+def mint_side_effect_permit(
+    *,
+    episode_id: StrictIdentifier,
+    plan_id: Digest,
+    preflight: SealedPreflight,
+    budget: BudgetAuthorization,
+) -> SideEffectPermit:
+    """Mint authority only after successful preflight and explicit budget authorization."""
+
+    if not preflight.successful:
+        raise ValueError("failed preflight cannot authorize side effects")
+    if preflight.plan_id != plan_id:
+        raise ValueError("preflight seal belongs to another dependency plan")
+    if budget.episode_id != episode_id:
+        raise ValueError("budget authorization belongs to another episode")
+    payload = {
+        "episode_id": episode_id,
+        "plan_id": plan_id,
+        "preflight_seal_id": preflight.seal_id,
+        "budget_id": budget.budget_id,
+    }
+    return SideEffectPermit.model_validate(
+        {**payload, "permit_id": _identity("side-effect-permit-v1", payload)},
+        context={"permit_factory": _PERMIT_FACTORY},
+    )
+
+
+class ScoreReceipt(ProtocolModel):
+    """Content-addressed final score evidence bound to one episode and plan."""
+
+    episode_id: StrictIdentifier
+    plan_id: Digest
+    score_artifact: ArtifactRef
+    finalized_at_ms: SafeCount
+    score_id: Digest = ZERO_DIGEST
+
+    @model_validator(mode="after")
+    def _identify(self) -> Self:
+        payload = self.model_dump(mode="json", exclude={"score_id"})
+        expected = _identity("score-receipt-v1", payload)
+        if self.score_id not in (ZERO_DIGEST, expected):
+            raise ValueError("score receipt identity does not match its artifact")
+        object.__setattr__(self, "score_id", expected)
+        return self
+
+
+EpisodeState = Literal[
+    "planned",
+    "preflighted",
+    "authorized",
+    "running",
+    "finalizing",
+    "cleaning",
+    "completed",
+    "failed",
+    "cancelled",
+]
+TerminalIntent = Literal["complete", "fail", "cancel"]
+
+
+class EpisodeLifecycle(ProtocolModel):
+    """Immutable episode state whose methods enforce the only legal transition graph."""
+
+    episode_id: StrictIdentifier
+    plan_id: Digest
+    budget_id: Digest
+    cleanup_plan_id: Digest
+    state: EpisodeState = "planned"
+    preflight_seal_id: Digest | None = None
+    permit_id: Digest | None = None
+    reservation_ids: tuple[Digest, ...] = ()
+    reconciliation_id: Digest | None = None
+    reconciliation_reportable: bool | None = None
+    score_id: Digest | None = None
+    cleanup_result_id: Digest | None = None
+    rescue_required: bool | None = None
+    terminal_intent: TerminalIntent | None = None
+    failure_kind: (
+        Literal[
+            "preflight",
+            "infrastructure",
+            "crash",
+            "ambiguous_finalization",
+            "cleanup",
+            "unreportable",
+        ]
+        | None
+    ) = None
+    failure_reason: str | None = Field(default=None, min_length=1, max_length=MAX_FAILURE_LENGTH)
+
+    @field_validator("reservation_ids", mode="before")
+    @classmethod
+    def _freeze_reservations(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _validate_state_evidence(self) -> Self:
+        if len(self.reservation_ids) != len(set(self.reservation_ids)):
+            raise ValueError("episode contains duplicate reservations")
+        if tuple(sorted(self.reservation_ids)) != self.reservation_ids:
+            raise ValueError("episode reservations must be canonical")
+        before_running = self.state in ("planned", "preflighted", "authorized")
+        if before_running and any(
+            value is not None
+            for value in (
+                self.reconciliation_id,
+                self.score_id,
+                self.cleanup_result_id,
+                self.terminal_intent,
+            )
+        ):
+            raise ValueError("pre-run state cannot carry finalization or cleanup evidence")
+        if self.state == "planned" and any(
+            value is not None for value in (self.preflight_seal_id, self.permit_id)
+        ):
+            raise ValueError("planned state cannot carry preflight authority")
+        if self.state == "preflighted" and (
+            self.preflight_seal_id is None or self.permit_id is not None
+        ):
+            raise ValueError("preflighted state requires only a preflight seal")
+        if self.state in ("authorized", "running", "finalizing", "cleaning", "completed") and (
+            self.preflight_seal_id is None or self.permit_id is None
+        ):
+            raise ValueError("post-authorization state requires preflight and permit identities")
+        if self.state == "running" and not self.reservation_ids:
+            raise ValueError("running state requires a prior budget reservation")
+        if self.state == "finalizing" and self.terminal_intent is not None:
+            raise ValueError("finalizing state cannot already carry a terminal intent")
+        if self.state == "cleaning" and self.terminal_intent is None:
+            raise ValueError("cleaning state requires a terminal intent")
+        if self.state in ("completed", "cancelled") and self.cleanup_result_id is None:
+            raise ValueError("post-run terminal state requires cleanup evidence")
+        if self.state == "completed":
+            if any(
+                value is None
+                for value in (
+                    self.reconciliation_id,
+                    self.score_id,
+                    self.cleanup_result_id,
+                )
+            ):
+                raise ValueError("completed state requires cost, score, and cleanup evidence")
+            if self.reconciliation_reportable is not True or self.rescue_required is not False:
+                raise ValueError("completed state must be reportable and fully cleaned")
+            if self.failure_kind is not None or self.terminal_intent != "complete":
+                raise ValueError("completed state cannot carry failure evidence")
+        if self.state in ("failed", "cancelled") and self.failure_reason is None:
+            raise ValueError("failed or cancelled state requires a reason")
+        if self.state == "failed" and self.reservation_ids and self.cleanup_result_id is None:
+            raise ValueError("post-start failure requires cleanup evidence")
+        if self.failure_kind in ("preflight", "infrastructure") and self.score_id is not None:
+            raise ValueError("preflight and infrastructure failures cannot carry a score")
+        if self.state == "cancelled" and self.terminal_intent != "cancel":
+            raise ValueError("cancelled state requires cancellation intent")
+        return self
+
+    @classmethod
+    def planned(
+        cls,
+        *,
+        episode_id: StrictIdentifier,
+        plan_id: Digest,
+        budget_id: Digest,
+        cleanup_plan_id: Digest,
+    ) -> Self:
+        return cls(
+            episode_id=episode_id,
+            plan_id=plan_id,
+            budget_id=budget_id,
+            cleanup_plan_id=cleanup_plan_id,
+        )
+
+    def _transition(self, expected: EpisodeState, **updates: Any) -> Self:
+        if self.state != expected:
+            raise ValueError(f"illegal episode transition from {self.state}")
+        payload = self.model_dump(mode="python")
+        payload.update(updates)
+        return type(self).model_validate(payload)
+
+    def preflight(self, seal: SealedPreflight) -> Self:
+        if not seal.successful:
+            raise ValueError("failed preflight cannot enter preflighted state")
+        if seal.plan_id != self.plan_id:
+            raise ValueError("preflight seal belongs to another dependency plan")
+        return self._transition("planned", state="preflighted", preflight_seal_id=seal.seal_id)
+
+    def authorize(
+        self, seal: SealedPreflight, budget: BudgetAuthorization
+    ) -> tuple[Self, SideEffectPermit]:
+        if self.state != "preflighted" or self.preflight_seal_id != seal.seal_id:
+            raise ValueError("illegal or mismatched episode authorization")
+        if budget.budget_id != self.budget_id:
+            raise ValueError("budget authorization does not match the planned budget")
+        permit = mint_side_effect_permit(
+            episode_id=self.episode_id,
+            plan_id=self.plan_id,
+            preflight=seal,
+            budget=budget,
+        )
+        return (
+            self._transition("preflighted", state="authorized", permit_id=permit.permit_id),
+            permit,
+        )
+
+    def start(
+        self,
+        permit: SideEffectPermit,
+        reservations: Sequence[BudgetReservation],
+    ) -> Self:
+        if self.state != "authorized":
+            raise ValueError(f"illegal episode transition from {self.state}")
+        snapshot = tuple(reservations)
+        if not snapshot:
+            raise ValueError("episode start requires a prior budget reservation")
+        if (
+            permit.episode_id != self.episode_id
+            or permit.plan_id != self.plan_id
+            or permit.budget_id != self.budget_id
+            or permit.permit_id != self.permit_id
+        ):
+            raise ValueError("side-effect permit does not match this episode")
+        if any(
+            item.episode_id != self.episode_id or item.budget_id != self.budget_id
+            for item in snapshot
+        ):
+            raise ValueError("budget reservation does not match this episode")
+        ids = tuple(sorted(item.reservation_id for item in snapshot))
+        if len(ids) != len(set(ids)):
+            raise ValueError("episode start contains duplicate reservations")
+        return self._transition("authorized", state="running", reservation_ids=ids)
+
+    def begin_finalization(self) -> Self:
+        return self._transition("running", state="finalizing")
+
+    def finish_finalization(
+        self,
+        reconciliation: BudgetReconciliation,
+        score: ScoreReceipt,
+    ) -> Self:
+        self._validate_reconciliation(reconciliation)
+        if score.episode_id != self.episode_id or score.plan_id != self.plan_id:
+            raise ValueError("score receipt does not match this episode")
+        return self._transition(
+            "finalizing",
+            state="cleaning",
+            terminal_intent="complete",
+            reconciliation_id=reconciliation.reconciliation_id,
+            reconciliation_reportable=reconciliation.reportable,
+            score_id=score.score_id,
+        )
+
+    def mark_ambiguous_finalization(
+        self,
+        reconciliation: BudgetReconciliation,
+        reason: str,
+    ) -> Self:
+        self._validate_reconciliation(reconciliation)
+        return self._transition(
+            "finalizing",
+            state="cleaning",
+            terminal_intent="fail",
+            reconciliation_id=reconciliation.reconciliation_id,
+            reconciliation_reportable=reconciliation.reportable,
+            failure_kind="ambiguous_finalization",
+            failure_reason=reason,
+        )
+
+    def crash(self, reason: str) -> Self:
+        return self._transition(
+            "running",
+            state="cleaning",
+            terminal_intent="fail",
+            failure_kind="crash",
+            failure_reason=reason,
+        )
+
+    def cancel(self, reason: str) -> Self:
+        return self._transition(
+            "running",
+            state="cleaning",
+            terminal_intent="cancel",
+            failure_reason=reason,
+        )
+
+    def fail_before_running(
+        self,
+        *,
+        kind: Literal["preflight", "infrastructure"],
+        reason: str,
+    ) -> Self:
+        if self.state not in ("planned", "preflighted", "authorized"):
+            raise ValueError("post-start failure must enter cleaning first")
+        payload = self.model_dump(mode="python")
+        payload.update(state="failed", failure_kind=kind, failure_reason=reason)
+        return type(self).model_validate(payload)
+
+    def finish_cleanup(self, result: CleanupResult) -> Self:
+        if result.cleanup_plan_id != self.cleanup_plan_id:
+            raise ValueError("cleanup result belongs to another plan")
+        updates: dict[str, Any] = {
+            "cleanup_result_id": result.cleanup_result_id,
+            "rescue_required": result.rescue_required,
+        }
+        if self.terminal_intent == "cancel":
+            updates["state"] = "cancelled"
+        elif (
+            self.terminal_intent == "complete"
+            and not result.rescue_required
+            and self.reconciliation_reportable is True
+            and self.score_id is not None
+        ):
+            updates["state"] = "completed"
+        else:
+            updates["state"] = "failed"
+            if result.rescue_required:
+                updates["failure_kind"] = "cleanup"
+                updates["failure_reason"] = "cleanup requires operator rescue"
+            elif self.reconciliation_reportable is False and self.failure_kind is None:
+                updates["failure_kind"] = "unreportable"
+                updates["failure_reason"] = "required usage was unavailable"
+        return self._transition("cleaning", **updates)
+
+    def _validate_reconciliation(self, reconciliation: BudgetReconciliation) -> None:
+        if (
+            reconciliation.episode_id != self.episode_id
+            or reconciliation.budget_id != self.budget_id
+            or reconciliation.reservation_ids != self.reservation_ids
+        ):
+            raise ValueError("cost reconciliation does not match this episode")

--- a/local_operator/evaluation/lifecycle.py
+++ b/local_operator/evaluation/lifecycle.py
@@ -13,6 +13,7 @@ from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from threading import RLock
 from typing import Any, Literal, Self, cast
+from weakref import WeakValueDictionary
 
 from pydantic import (
     Field,
@@ -42,6 +43,25 @@ MAX_FAILURE_LENGTH = 2_000
 _PERMIT_FACTORY = object()
 _CLEANUP_RESULT_FACTORY = object()
 _LIFECYCLE_FACTORY = object()
+
+
+class _EpisodeLineage:
+    """Process-live uniqueness lease shared by every state in one episode.
+
+    The weak registry prevents two cooperative roots while any state from the
+    lineage remains reachable. It is intentionally not durable replay defense:
+    a future evidence store must provide cross-process exactly-once semantics.
+    """
+
+    __slots__ = ("__weakref__", "episode_id", "root_lock")
+
+    def __init__(self, episode_id: str) -> None:
+        self.episode_id = episode_id
+        self.root_lock = RLock()
+
+
+_LINEAGE_REGISTRY_LOCK = RLock()
+_LIVE_LINEAGES: WeakValueDictionary[str, _EpisodeLineage] = WeakValueDictionary()
 
 
 def _identity(kind: str, payload: Any) -> str:
@@ -463,6 +483,7 @@ class EpisodeLifecycle(ProtocolModel):
     _authority: object = PrivateAttr()
     _lock: RLock = PrivateAttr(default_factory=RLock)
     _consumed: bool = PrivateAttr(default=False)
+    _lineage: _EpisodeLineage = PrivateAttr()
 
     episode_id: StrictIdentifier
     plan_id: Digest
@@ -504,6 +525,9 @@ class EpisodeLifecycle(ProtocolModel):
         context = info.context if isinstance(info.context, dict) else {}
         if context.get("lifecycle_factory") is not _LIFECYCLE_FACTORY:
             raise ValueError("episode lifecycle authority can only be factory minted")
+        lineage = context.get("episode_lineage")
+        if not isinstance(lineage, _EpisodeLineage) or lineage.episode_id != self.episode_id:
+            raise ValueError("episode lifecycle requires its process-live lineage lease")
         if len(self.reservation_ids) != len(set(self.reservation_ids)):
             raise ValueError("episode contains duplicate reservations")
         if tuple(sorted(self.reservation_ids)) != self.reservation_ids:
@@ -570,6 +594,7 @@ class EpisodeLifecycle(ProtocolModel):
         if self.state_id != expected:
             raise ValueError("episode lifecycle state identity does not match its evidence")
         object.__setattr__(self, "_authority", _LIFECYCLE_FACTORY)
+        object.__setattr__(self, "_lineage", lineage)
         return self
 
     @classmethod
@@ -628,7 +653,10 @@ class EpisodeLifecycle(ProtocolModel):
         payload["state_id"] = _state_identity(payload)
         return type(self).model_validate(
             payload,
-            context={"lifecycle_factory": _LIFECYCLE_FACTORY},
+            context={
+                "lifecycle_factory": _LIFECYCLE_FACTORY,
+                "episode_lineage": self._lineage,
+            },
         )
 
     def _consume_source(self) -> None:
@@ -846,21 +874,31 @@ def plan_episode(
     budget_id: Digest,
     cleanup_plan_id: Digest,
 ) -> EpisodeLifecycle:
-    """Mint the public plan as the root of a private transition authority chain."""
+    """Mint one process-live root; unreachable lineages release the weak lease."""
 
-    payload = {
-        "episode_id": episode_id,
-        "plan_id": plan_id,
-        "budget_id": budget_id,
-        "cleanup_plan_id": cleanup_plan_id,
-        "state": "planned",
-        "operation": "plan",
-        "state_id": ZERO_DIGEST,
-    }
-    payload["state_id"] = _state_identity(
-        {key: value for key, value in payload.items() if key != "state_id"}
-    )
-    return EpisodeLifecycle.model_validate(
-        payload,
-        context={"lifecycle_factory": _LIFECYCLE_FACTORY},
-    )
+    with _LINEAGE_REGISTRY_LOCK:
+        if episode_id in _LIVE_LINEAGES:
+            # Episode IDs are fail-closed global identities within this process;
+            # a different plan does not make reusing one safe.
+            raise ValueError("episode identity already has a live lineage")
+        lineage = _EpisodeLineage(episode_id)
+        _LIVE_LINEAGES[episode_id] = lineage
+        payload = {
+            "episode_id": episode_id,
+            "plan_id": plan_id,
+            "budget_id": budget_id,
+            "cleanup_plan_id": cleanup_plan_id,
+            "state": "planned",
+            "operation": "plan",
+            "state_id": ZERO_DIGEST,
+        }
+        payload["state_id"] = _state_identity(
+            {key: value for key, value in payload.items() if key != "state_id"}
+        )
+        return EpisodeLifecycle.model_validate(
+            payload,
+            context={
+                "lifecycle_factory": _LIFECYCLE_FACTORY,
+                "episode_lineage": lineage,
+            },
+        )

--- a/local_operator/evaluation/receipts.py
+++ b/local_operator/evaluation/receipts.py
@@ -8,15 +8,22 @@ side-effect boundary.
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 from collections.abc import Iterable, Mapping, Sequence
+from datetime import date as Date
+from datetime import datetime, timezone
 from typing import Annotated, Any, Literal, TypeAlias
+from urllib.parse import quote
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from pydantic import (
     Field,
     JsonValue,
+    PrivateAttr,
     TypeAdapter,
+    ValidationInfo,
     field_serializer,
     field_validator,
     model_validator,
@@ -38,6 +45,7 @@ MAX_TOOLS = 128
 MAX_REASON_LENGTH = 2_000
 MAX_CANARIES = 256
 ZERO_DIGEST = "0" * 64
+_BUDGET_COMMITMENT_FACTORY = object()
 
 StrictIdentifier = Annotated[
     str,
@@ -213,6 +221,25 @@ class ClockRequirement(_RequirementBase):
             raise ValueError("clock requirement needs a date or fixed clock")
         if self.date is not None and self.fixed_clock is not None:
             raise ValueError("clock requirement chooses either date or fixed clock")
+        try:
+            ZoneInfo(self.timezone)
+        except (ZoneInfoNotFoundError, ValueError) as error:
+            raise ValueError("clock timezone must be a canonical IANA zone") from error
+        if self.date is not None:
+            try:
+                parsed_date = Date.fromisoformat(self.date)
+            except ValueError as error:
+                raise ValueError("clock date must be a valid ISO calendar date") from error
+            if parsed_date.isoformat() != self.date:
+                raise ValueError("clock date must use canonical ISO syntax")
+        if self.fixed_clock is not None:
+            try:
+                parsed_clock = datetime.fromisoformat(self.fixed_clock.replace("Z", "+00:00"))
+            except ValueError as error:
+                raise ValueError("fixed clock must be a valid UTC instant") from error
+            canonical = parsed_clock.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            if parsed_clock.microsecond or canonical != self.fixed_clock:
+                raise ValueError("fixed clock must use canonical UTC second syntax")
         return self
 
     def conflict_key(self) -> tuple[str, ...]:
@@ -296,8 +323,16 @@ class DependencyPlan(ProtocolModel):
         return self
 
 
+def requirement_digest(requirement: Requirement) -> str:
+    """Bind observations to the entire selected declaration, not only its label."""
+
+    return _identity("requirement-v1", requirement.model_dump(mode="json"))
+
+
 class PreflightReceipt(_MetadataModel):
+    plan_id: Digest
     requirement_id: StrictIdentifier
+    requirement_digest: Digest
     necessity: RequirementNecessity
     status: Literal["pass", "fail", "skip"]
     evidence: PortableMetadataObject = Field(default_factory=dict, validate_default=True)
@@ -329,8 +364,46 @@ class PreflightReceipt(_MetadataModel):
         return self
 
 
+def record_preflight(
+    plan: DependencyPlan,
+    requirement_id: StrictIdentifier,
+    *,
+    status: Literal["pass", "fail", "skip"],
+    evidence: Mapping[str, JsonValue] | None = None,
+    started_at_ms: int | None = None,
+    ended_at_ms: int | None = None,
+    duration_ms: int | None = None,
+) -> PreflightReceipt:
+    """Record evidence against the exact declaration selected by this plan."""
+
+    requirement = next(
+        (item for item in plan.requirements if item.requirement_id == requirement_id), None
+    )
+    if requirement is None:
+        raise ValueError("preflight requirement is not selected by the dependency plan")
+    return PreflightReceipt.model_validate(
+        {
+            "plan_id": plan.plan_id,
+            "requirement_id": requirement_id,
+            "requirement_digest": requirement_digest(requirement),
+            "necessity": requirement.necessity,
+            "status": status,
+            "evidence": {} if evidence is None else dict(evidence),
+            "started_at_ms": started_at_ms,
+            "ended_at_ms": ended_at_ms,
+            "duration_ms": duration_ms,
+        }
+    )
+
+
 class RedactionSet:
-    """Ephemeral resolved canaries used only while sealing portable evidence."""
+    """Ephemeral plaintext and common deterministic encodings checked at sealing.
+
+    This bounded substring check is not a general secret scanner. It covers the
+    resolved plaintext plus UTF-8 base64, URL-safe base64, percent-encoding, and
+    hexadecimal variants generated here; transformations outside that set remain
+    an adapter responsibility.
+    """
 
     __slots__ = ("_canaries",)
 
@@ -344,7 +417,26 @@ class RedactionSet:
             raise ValueError("too many redaction canaries")
         if any(not isinstance(value, str) or not value for value in snapshot):
             raise ValueError("redaction canaries must be non-empty strings")
-        return cls(tuple(sorted(set(snapshot), key=lambda value: (-len(value), value))))
+        variants: set[str] = set(snapshot)
+        for value in snapshot:
+            raw = value.encode("utf-8")
+            # Short encoded fragments collide too readily with ordinary evidence;
+            # plaintext is still checked regardless of this conservative floor.
+            if len(raw) < 8:
+                continue
+            standard = base64.b64encode(raw).decode("ascii")
+            urlsafe = base64.urlsafe_b64encode(raw).decode("ascii")
+            variants.update(
+                {
+                    standard,
+                    standard.rstrip("="),
+                    urlsafe,
+                    urlsafe.rstrip("="),
+                    quote(value, safe=""),
+                    raw.hex(),
+                }
+            )
+        return cls(tuple(sorted(variants, key=lambda value: (-len(value), value))))
 
     def __repr__(self) -> str:
         return f"RedactionSet(count={len(self._canaries)})"
@@ -448,6 +540,10 @@ def seal_preflight(
     requirements = {item.requirement_id: item for item in plan.requirements}
     for requirement_id, receipt in by_id.items():
         requirement = requirements[requirement_id]
+        if receipt.plan_id != plan.plan_id:
+            raise ValueError("preflight receipt belongs to another dependency plan")
+        if receipt.requirement_digest != requirement_digest(requirement):
+            raise ValueError("preflight receipt belongs to another requirement declaration")
         if receipt.necessity != requirement.necessity:
             raise ValueError("preflight receipt necessity disagrees with its requirement")
         if receipt.status == "skip" and requirement.necessity != "optional":
@@ -571,6 +667,7 @@ class ResourceAmount(ProtocolModel):
 class BudgetReservation(ProtocolModel):
     episode_id: StrictIdentifier
     budget_id: Digest
+    reservation_key: StrictIdentifier
     amounts: tuple[ResourceAmount, ...] = Field(min_length=1, max_length=len(BUDGET_RESOURCES))
     reservation_id: Digest = ZERO_DIGEST
 
@@ -594,36 +691,136 @@ class BudgetReservation(ProtocolModel):
         return self
 
 
+def _validate_reservations(
+    authorization: BudgetAuthorization,
+    reservations: Sequence[BudgetReservation],
+) -> dict[BudgetResource, int]:
+    totals: dict[BudgetResource, int] = {resource: 0 for resource in BUDGET_RESOURCES}
+    keys: set[str] = set()
+    for reservation in reservations:
+        if (
+            reservation.budget_id != authorization.budget_id
+            or reservation.episode_id != authorization.episode_id
+        ):
+            raise ValueError("reservation belongs to another budget authorization")
+        if reservation.reservation_key in keys:
+            # Keys are operation-level idempotency identities. Reusing one is an
+            # ambiguous retry, so callers must retrieve the first reservation.
+            raise ValueError("duplicate reservation key")
+        keys.add(reservation.reservation_key)
+        for amount in reservation.amounts:
+            totals[amount.resource] += amount.value
+    for resource, total in totals.items():
+        allowance = authorization.allowance_for(resource)
+        if isinstance(allowance, CappedAllowance) and total > allowance.value:
+            raise ValueError("reservation exceeds an authorized cap")
+    return totals
+
+
 def reserve_budget(
     authorization: BudgetAuthorization,
+    reservation_key: StrictIdentifier,
     request: Sequence[ResourceAmount],
     existing: Sequence[BudgetReservation] = (),
 ) -> BudgetReservation:
-    """Reserve capacity before work; a zero cap remains distinct from uncapped."""
+    """Reserve capacity before work; unique keys distinguish equal operations."""
 
     requested = tuple(request)
     if not requested:
         raise ValueError("reservation request must not be empty")
-    totals: dict[BudgetResource, int] = {resource: 0 for resource in BUDGET_RESOURCES}
-    for reservation in existing:
-        if reservation.budget_id != authorization.budget_id:
-            raise ValueError("existing reservation belongs to another budget")
-        for amount in reservation.amounts:
-            totals[amount.resource] += amount.value
+    prior = tuple(existing)
+    _validate_reservations(authorization, prior)
+    if any(item.reservation_key == reservation_key for item in prior):
+        raise ValueError("duplicate reservation key")
     seen: set[BudgetResource] = set()
     for amount in requested:
         if amount.resource in seen:
             raise ValueError("reservation request contains duplicate resources")
         seen.add(amount.resource)
-        totals[amount.resource] += amount.value
-    for resource, total in totals.items():
-        allowance = authorization.allowance_for(resource)
-        if isinstance(allowance, CappedAllowance) and total > allowance.value:
-            raise ValueError("reservation exceeds an authorized cap")
-    return BudgetReservation(
+    reservation = BudgetReservation(
         episode_id=authorization.episode_id,
         budget_id=authorization.budget_id,
+        reservation_key=reservation_key,
         amounts=requested,
+    )
+    _validate_reservations(authorization, (*prior, reservation))
+    return reservation
+
+
+class BudgetCommitment(ProtocolModel):
+    """Factory-only authority over the complete validated reservation set."""
+
+    _authority: object = PrivateAttr()
+
+    episode_id: StrictIdentifier
+    budget_id: Digest
+    authorization_digest: Digest
+    reservation_ids: tuple[Digest, ...]
+    reserved: tuple[ResourceAmount, ...]
+    commitment_id: Digest
+
+    @field_validator("reservation_ids", "reserved", mode="before")
+    @classmethod
+    def _freeze_lists(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _factory_only(self, info: ValidationInfo) -> "BudgetCommitment":
+        context = info.context if isinstance(info.context, dict) else {}
+        if context.get("budget_commitment_factory") is not _BUDGET_COMMITMENT_FACTORY:
+            raise ValueError("budget commitments can only be minted from validated reservations")
+        resources = tuple(item.resource for item in self.reserved)
+        if resources != tuple(sorted(BUDGET_RESOURCES)):
+            raise ValueError("budget commitment requires every resource exactly once")
+        if self.reservation_ids != tuple(sorted(self.reservation_ids)):
+            raise ValueError("budget commitment reservation IDs must be canonical")
+        expected = _identity(
+            "budget-commitment-v1",
+            self.model_dump(mode="json", exclude={"commitment_id"}),
+        )
+        if self.commitment_id != expected:
+            raise ValueError("budget commitment identity does not match reservations")
+        object.__setattr__(self, "_authority", _BUDGET_COMMITMENT_FACTORY)
+        return self
+
+    def assert_authority(self, authorization: BudgetAuthorization) -> None:
+        if getattr(self, "_authority", None) is not _BUDGET_COMMITMENT_FACTORY:
+            raise ValueError("budget commitment lacks factory authority")
+        if (
+            self.episode_id != authorization.episode_id
+            or self.budget_id != authorization.budget_id
+            or self.authorization_digest != authorization.budget_id
+        ):
+            raise ValueError("budget commitment belongs to another authorization")
+        expected = _identity(
+            "budget-commitment-v1",
+            self.model_dump(mode="json", exclude={"commitment_id"}),
+        )
+        if self.commitment_id != expected:
+            raise ValueError("budget commitment authority was mutated")
+
+
+def commit_budget(
+    authorization: BudgetAuthorization,
+    reservations: Sequence[BudgetReservation],
+) -> BudgetCommitment:
+    """Seal the exact reservation set cooperative adapters may allocate against."""
+
+    snapshot = tuple(reservations)
+    totals = _validate_reservations(authorization, snapshot)
+    payload = {
+        "episode_id": authorization.episode_id,
+        "budget_id": authorization.budget_id,
+        "authorization_digest": authorization.budget_id,
+        "reservation_ids": tuple(sorted(item.reservation_id for item in snapshot)),
+        "reserved": tuple(
+            ResourceAmount(resource=resource, value=totals[resource]).model_dump(mode="json")
+            for resource in sorted(BUDGET_RESOURCES)
+        ),
+    }
+    return BudgetCommitment.model_validate(
+        {**payload, "commitment_id": _identity("budget-commitment-v1", payload)},
+        context={"budget_commitment_factory": _BUDGET_COMMITMENT_FACTORY},
     )
 
 
@@ -660,6 +857,9 @@ class ReconciliationEntry(ProtocolModel):
 class BudgetReconciliation(ProtocolModel):
     episode_id: StrictIdentifier
     budget_id: Digest
+    authorization_digest: Digest
+    authorization: BudgetAuthorization
+    commitment_id: Digest
     reservation_ids: tuple[Digest, ...]
     entries: tuple[ReconciliationEntry, ...]
     reportable: bool
@@ -680,6 +880,36 @@ class BudgetReconciliation(ProtocolModel):
             raise ValueError("reconciliation contains duplicate reservations")
         object.__setattr__(self, "entries", entries)
         object.__setattr__(self, "reservation_ids", reservations)
+        if self.authorization.episode_id != self.episode_id:
+            raise ValueError("reconciliation authorization belongs to another episode")
+        if self.authorization.budget_id != self.budget_id:
+            raise ValueError("reconciliation budget identity disagrees with authorization")
+        if self.authorization_digest != self.authorization.budget_id:
+            raise ValueError("reconciliation authorization digest is invalid")
+        commitment_payload = {
+            "episode_id": self.episode_id,
+            "budget_id": self.budget_id,
+            "authorization_digest": self.authorization_digest,
+            "reservation_ids": reservations,
+            "reserved": tuple(
+                ResourceAmount(resource=entry.resource, value=entry.reserved).model_dump(
+                    mode="json"
+                )
+                for entry in entries
+            ),
+        }
+        if self.commitment_id != _identity("budget-commitment-v1", commitment_payload):
+            raise ValueError("reconciliation commitment does not match reservations")
+        for entry in entries:
+            if entry.allowance != self.authorization.allowance_for(entry.resource):
+                raise ValueError("reconciliation allowance disagrees with authorization")
+            expected_overrun = 0
+            if isinstance(entry.usage, AvailableUsage) and isinstance(
+                entry.allowance, CappedAllowance
+            ):
+                expected_overrun = max(0, entry.usage.value - entry.allowance.value)
+            if entry.overrun != expected_overrun:
+                raise ValueError("reconciliation overrun disagrees with actual usage")
         expected_reportable = all(
             not (
                 entry.allowance.reporting == "required"
@@ -705,12 +935,8 @@ def reconcile_budget(
     """Record exact/under/over usage; integer USD micros avoid floating ambiguity."""
 
     reservation_snapshot = tuple(reservations)
-    reserved: dict[BudgetResource, int] = {resource: 0 for resource in BUDGET_RESOURCES}
-    for item in reservation_snapshot:
-        if item.budget_id != authorization.budget_id:
-            raise ValueError("reservation belongs to another budget")
-        for amount in item.amounts:
-            reserved[amount.resource] += amount.value
+    totals = _validate_reservations(authorization, reservation_snapshot)
+    commitment = commit_budget(authorization, reservation_snapshot)
     parsed_usage = tuple(_USAGE_ADAPTER.validate_python(item, strict=True) for item in usage)
     by_resource = {item.resource: item for item in parsed_usage}
     if len(by_resource) != len(parsed_usage) or set(by_resource) != set(BUDGET_RESOURCES):
@@ -726,7 +952,7 @@ def reconcile_budget(
             ReconciliationEntry(
                 resource=resource,
                 allowance=allowance,
-                reserved=reserved[resource],
+                reserved=totals[resource],
                 usage=actual,
                 overrun=overrun,
             )
@@ -738,6 +964,9 @@ def reconcile_budget(
     return BudgetReconciliation(
         episode_id=authorization.episode_id,
         budget_id=authorization.budget_id,
+        authorization_digest=authorization.budget_id,
+        authorization=authorization,
+        commitment_id=commitment.commitment_id,
         reservation_ids=tuple(item.reservation_id for item in reservation_snapshot),
         entries=tuple(entries),
         reportable=reportable,

--- a/local_operator/evaluation/receipts.py
+++ b/local_operator/evaluation/receipts.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import re
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import date as Date
 from datetime import datetime, timezone
@@ -408,6 +409,15 @@ def record_preflight(
     )
 
 
+_PERCENT_ESCAPE_RE = re.compile(r"%([0-9A-Fa-f]{2})")
+
+
+def _canonical_percent_escapes(value: str) -> str:
+    """Normalize escape digits without changing literal plaintext case."""
+
+    return _PERCENT_ESCAPE_RE.sub(lambda match: "%" + match.group(1).upper(), value)
+
+
 class RedactionSet:
     """Ephemeral plaintext and common deterministic encodings checked at sealing.
 
@@ -417,17 +427,24 @@ class RedactionSet:
     an adapter responsibility.
     """
 
-    __slots__ = ("_exact_encoded_canaries", "_folded_encoded_canaries", "_plaintext_canaries")
+    __slots__ = (
+        "_exact_encoded_canaries",
+        "_hex_canaries",
+        "_percent_canaries",
+        "_plaintext_canaries",
+    )
 
     def __init__(
         self,
         plaintext_canaries: tuple[str, ...],
         exact_encoded_canaries: tuple[str, ...],
-        folded_encoded_canaries: tuple[str, ...],
+        percent_canaries: tuple[str, ...],
+        hex_canaries: tuple[str, ...],
     ) -> None:
         self._plaintext_canaries = plaintext_canaries
         self._exact_encoded_canaries = exact_encoded_canaries
-        self._folded_encoded_canaries = folded_encoded_canaries
+        self._percent_canaries = percent_canaries
+        self._hex_canaries = hex_canaries
 
     @classmethod
     def from_resolved_values(cls, values: Iterable[str]) -> "RedactionSet":
@@ -437,7 +454,8 @@ class RedactionSet:
         if any(not isinstance(value, str) or not value for value in snapshot):
             raise ValueError("redaction canaries must be non-empty strings")
         exact_encoded_variants: set[str] = set()
-        folded_encoded_variants: set[str] = set()
+        percent_variants: set[str] = set()
+        hex_variants: set[str] = set()
         for value in snapshot:
             raw = value.encode("utf-8")
             # Short encoded fragments collide too readily with ordinary evidence;
@@ -449,13 +467,15 @@ class RedactionSet:
             exact_encoded_variants.update(
                 {standard, standard.rstrip("="), urlsafe, urlsafe.rstrip("=")}
             )
-            # Percent escapes and hexadecimal digits are semantically
-            # case-insensitive, unlike base64 and the original secret text.
-            folded_encoded_variants.update({quote(value, safe="").casefold(), raw.hex().casefold()})
+            # Escape DIGITS are case-insensitive, while unescaped literals are
+            # not. Raw hexadecimal has no literal/plaintext distinction.
+            percent_variants.add(_canonical_percent_escapes(quote(value, safe="")))
+            hex_variants.add(raw.hex().casefold())
         return cls(
             tuple(sorted(set(snapshot), key=lambda value: (-len(value), value))),
             tuple(sorted(exact_encoded_variants, key=lambda value: (-len(value), value))),
-            tuple(sorted(folded_encoded_variants, key=lambda value: (-len(value), value))),
+            tuple(sorted(percent_variants, key=lambda value: (-len(value), value))),
+            tuple(sorted(hex_variants, key=lambda value: (-len(value), value))),
         )
 
     def __repr__(self) -> str:
@@ -477,7 +497,11 @@ class RedactionSet:
             if (
                 any(canary in candidate for canary in self._plaintext_canaries)
                 or any(canary in candidate for canary in self._exact_encoded_canaries)
-                or any(canary in candidate.casefold() for canary in self._folded_encoded_canaries)
+                or any(
+                    canary in _canonical_percent_escapes(candidate)
+                    for canary in self._percent_canaries
+                )
+                or any(canary in candidate.casefold() for canary in self._hex_canaries)
             ):
                 # Never include the candidate or canary: validation errors often
                 # cross process boundaries and become durable logs.

--- a/local_operator/evaluation/receipts.py
+++ b/local_operator/evaluation/receipts.py
@@ -370,6 +370,7 @@ class RedactionSet:
 
 class SealedPreflight(ProtocolModel):
     plan_id: Digest
+    required_requirement_ids: tuple[StrictIdentifier, ...]
     passed_requirement_ids: tuple[StrictIdentifier, ...]
     failed_requirement_ids: tuple[StrictIdentifier, ...]
     skipped_requirement_ids: tuple[StrictIdentifier, ...]
@@ -378,6 +379,7 @@ class SealedPreflight(ProtocolModel):
     seal_id: Digest
 
     @field_validator(
+        "required_requirement_ids",
         "passed_requirement_ids",
         "failed_requirement_ids",
         "skipped_requirement_ids",
@@ -400,6 +402,16 @@ class SealedPreflight(ProtocolModel):
             raise ValueError("sealed requirement outcome IDs must be unique")
         if any(tuple(sorted(group)) != group for group in groups):
             raise ValueError("sealed requirement outcome IDs must be canonical")
+        if tuple(sorted(self.required_requirement_ids)) != self.required_requirement_ids:
+            raise ValueError("sealed required requirement IDs must be canonical")
+        if len(self.required_requirement_ids) != len(set(self.required_requirement_ids)):
+            raise ValueError("sealed required requirement IDs must be unique")
+        if not set(self.required_requirement_ids).issubset(flattened):
+            raise ValueError("sealed required requirement IDs must have outcomes")
+        if set(self.required_requirement_ids).intersection(self.failed_requirement_ids):
+            raise ValueError("sealed preflight cannot contain required failures")
+        if set(self.required_requirement_ids).intersection(self.skipped_requirement_ids):
+            raise ValueError("sealed preflight cannot contain required skips")
         if tuple(sorted(self.receipt_digests)) != self.receipt_digests:
             raise ValueError("sealed receipt digests must be canonical")
         expected = _identity(
@@ -412,7 +424,9 @@ class SealedPreflight(ProtocolModel):
 
     @property
     def successful(self) -> bool:
-        return not self.failed_requirement_ids
+        # Required failures and skips are structurally forbidden. Optional
+        # failures remain visible without blocking cooperative adapters.
+        return True
 
 
 def seal_preflight(
@@ -448,6 +462,11 @@ def seal_preflight(
         raise ValueError("required dependency failure prevents preflight sealing")
     payload = {
         "plan_id": plan.plan_id,
+        "required_requirement_ids": tuple(
+            sorted(
+                item.requirement_id for item in plan.requirements if item.necessity == "required"
+            )
+        ),
         "passed_requirement_ids": passed,
         "failed_requirement_ids": failed,
         "skipped_requirement_ids": skipped,

--- a/local_operator/evaluation/receipts.py
+++ b/local_operator/evaluation/receipts.py
@@ -46,6 +46,7 @@ MAX_REASON_LENGTH = 2_000
 MAX_CANARIES = 256
 ZERO_DIGEST = "0" * 64
 _BUDGET_COMMITMENT_FACTORY = object()
+_PREFLIGHT_SEAL_FACTORY = object()
 
 StrictIdentifier = Annotated[
     str,
@@ -205,9 +206,19 @@ class ModelCapabilityRequirement(_RequirementBase):
         return (self.kind, self.role)
 
 
+TimezoneName = Annotated[
+    str,
+    Field(
+        min_length=1,
+        max_length=255,
+        pattern=r"^[A-Za-z0-9_+-]+(?:/[A-Za-z0-9_+-]+)*$",
+    ),
+]
+
+
 class ClockRequirement(_RequirementBase):
     kind: Literal["clock"] = "clock"
-    timezone: StrictIdentifier
+    timezone: TimezoneName
     date: str | None = Field(default=None, pattern=r"^\d{4}-\d{2}-\d{2}$")
     fixed_clock: str | None = Field(
         default=None,
@@ -461,6 +472,11 @@ class RedactionSet:
 
 
 class SealedPreflight(ProtocolModel):
+    """Factory-only attestation over the exact validated preflight receipts."""
+
+    _authority: object = PrivateAttr()
+    _receipts: tuple[PreflightReceipt, ...] = PrivateAttr()
+
     plan_id: Digest
     required_requirement_ids: tuple[StrictIdentifier, ...]
     passed_requirement_ids: tuple[StrictIdentifier, ...]
@@ -483,7 +499,10 @@ class SealedPreflight(ProtocolModel):
         return tuple(value) if isinstance(value, list) else value
 
     @model_validator(mode="after")
-    def _validate_seal(self) -> "SealedPreflight":
+    def _validate_seal(self, info: ValidationInfo) -> "SealedPreflight":
+        context = info.context if isinstance(info.context, dict) else {}
+        if context.get("preflight_seal_factory") is not _PREFLIGHT_SEAL_FACTORY:
+            raise ValueError("preflight seals can only be minted from validated receipts")
         groups = (
             self.passed_requirement_ids,
             self.failed_requirement_ids,
@@ -512,7 +531,45 @@ class SealedPreflight(ProtocolModel):
         )
         if self.seal_id != expected:
             raise ValueError("preflight seal identity does not match its receipts")
+        receipts = context.get("preflight_receipts")
+        if not isinstance(receipts, tuple) or not all(
+            isinstance(receipt, PreflightReceipt) for receipt in receipts
+        ):
+            raise ValueError("preflight seal factory requires exact receipt evidence")
+        object.__setattr__(self, "_authority", _PREFLIGHT_SEAL_FACTORY)
+        object.__setattr__(self, "_receipts", receipts)
         return self
+
+    def __copy__(self) -> "SealedPreflight":
+        raise TypeError("preflight seal authority cannot be copied")
+
+    def __deepcopy__(self, memo: dict[int, Any] | None = None) -> "SealedPreflight":
+        raise TypeError("preflight seal authority cannot be copied")
+
+    def __reduce__(self) -> Any:
+        raise TypeError("preflight seal authority cannot be pickled")
+
+    def assert_authority(self) -> None:
+        if getattr(self, "_authority", None) is not _PREFLIGHT_SEAL_FACTORY:
+            raise ValueError("preflight seal lacks factory authority")
+        receipts = getattr(self, "_receipts", ())
+        actual_digests: list[str] = []
+        for receipt in receipts:
+            expected = _identity(
+                "preflight-receipt-v1",
+                receipt.model_dump(mode="json", exclude={"receipt_id"}),
+            )
+            if receipt.receipt_id != expected:
+                raise ValueError("preflight receipt authority was mutated")
+            actual_digests.append(receipt.receipt_id)
+        if tuple(sorted(actual_digests)) != self.receipt_digests:
+            raise ValueError("preflight seal receipt evidence does not match")
+        expected_seal = _identity(
+            "sealed-preflight-v1",
+            self.model_dump(mode="json", exclude={"seal_id"}),
+        )
+        if self.seal_id != expected_seal:
+            raise ValueError("preflight seal authority was mutated")
 
     @property
     def successful(self) -> bool:
@@ -570,9 +627,12 @@ def seal_preflight(
         "redaction_attested": True,
     }
     redactions.assert_clear(payload)
-    return SealedPreflight(
-        **payload,
-        seal_id=_identity("sealed-preflight-v1", payload),
+    return SealedPreflight.model_validate(
+        {**payload, "seal_id": _identity("sealed-preflight-v1", payload)},
+        context={
+            "preflight_seal_factory": _PREFLIGHT_SEAL_FACTORY,
+            "preflight_receipts": snapshot,
+        },
     )
 
 
@@ -782,6 +842,15 @@ class BudgetCommitment(ProtocolModel):
             raise ValueError("budget commitment identity does not match reservations")
         object.__setattr__(self, "_authority", _BUDGET_COMMITMENT_FACTORY)
         return self
+
+    def __copy__(self) -> "BudgetCommitment":
+        raise TypeError("budget commitment authority cannot be copied")
+
+    def __deepcopy__(self, memo: dict[int, Any] | None = None) -> "BudgetCommitment":
+        raise TypeError("budget commitment authority cannot be copied")
+
+    def __reduce__(self) -> Any:
+        raise TypeError("budget commitment authority cannot be pickled")
 
     def assert_authority(self, authorization: BudgetAuthorization) -> None:
         if getattr(self, "_authority", None) is not _BUDGET_COMMITMENT_FACTORY:

--- a/local_operator/evaluation/receipts.py
+++ b/local_operator/evaluation/receipts.py
@@ -25,7 +25,6 @@ from pydantic import (
     JsonValue,
     PrivateAttr,
     TypeAdapter,
-    ValidationInfo,
     field_serializer,
     field_validator,
     model_validator,
@@ -47,9 +46,6 @@ MAX_TOOLS = 128
 MAX_REASON_LENGTH = 2_000
 MAX_CANARIES = 256
 ZERO_DIGEST = "0" * 64
-_BUDGET_COMMITMENT_FACTORY = object()
-_PREFLIGHT_SEAL_FACTORY = object()
-
 StrictIdentifier = Annotated[
     str,
     Field(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$"),
@@ -113,6 +109,14 @@ class AuthorityModel(ProtocolModel):
 
     def __reduce__(self) -> Any:
         raise TypeError("authority models cannot be pickled")
+
+
+def _attach_authority(model: AuthorityModel, **private_values: Any) -> None:
+    """Attach non-serializable live authority after ordinary public validation."""
+
+    object.__setattr__(model, "_authority", object())
+    for name, value in private_values.items():
+        object.__setattr__(model, name, value)
 
 
 class _MetadataModel(ProtocolModel):
@@ -580,10 +584,7 @@ class SealedPreflight(AuthorityModel):
         return tuple(value) if isinstance(value, list) else value
 
     @model_validator(mode="after")
-    def _validate_seal(self, info: ValidationInfo) -> "SealedPreflight":
-        context = info.context if isinstance(info.context, dict) else {}
-        if context.get("preflight_seal_factory") is not _PREFLIGHT_SEAL_FACTORY:
-            raise ValueError("preflight seals can only be minted from validated receipts")
+    def _validate_seal(self) -> "SealedPreflight":
         groups = (
             self.passed_requirement_ids,
             self.failed_requirement_ids,
@@ -612,13 +613,6 @@ class SealedPreflight(AuthorityModel):
         )
         if self.seal_id != expected:
             raise ValueError("preflight seal identity does not match its receipts")
-        receipts = context.get("preflight_receipts")
-        if not isinstance(receipts, tuple) or not all(
-            isinstance(receipt, PreflightReceipt) for receipt in receipts
-        ):
-            raise ValueError("preflight seal factory requires exact receipt evidence")
-        object.__setattr__(self, "_authority", _PREFLIGHT_SEAL_FACTORY)
-        object.__setattr__(self, "_receipts", receipts)
         return self
 
     def __copy__(self) -> "SealedPreflight":
@@ -631,7 +625,7 @@ class SealedPreflight(AuthorityModel):
         raise TypeError("preflight seal authority cannot be pickled")
 
     def assert_authority(self) -> None:
-        if getattr(self, "_authority", None) is not _PREFLIGHT_SEAL_FACTORY:
+        if getattr(self, "_authority", None) is None:
             raise ValueError("preflight seal lacks factory authority")
         receipts = getattr(self, "_receipts", ())
         actual_digests: list[str] = []
@@ -708,13 +702,11 @@ def seal_preflight(
         "redaction_attested": True,
     }
     redactions.assert_clear(payload)
-    return SealedPreflight.model_validate(
-        {**payload, "seal_id": _identity("sealed-preflight-v1", payload)},
-        context={
-            "preflight_seal_factory": _PREFLIGHT_SEAL_FACTORY,
-            "preflight_receipts": snapshot,
-        },
+    sealed = SealedPreflight.model_validate(
+        {**payload, "seal_id": _identity("sealed-preflight-v1", payload)}
     )
+    _attach_authority(sealed, _receipts=snapshot)
+    return sealed
 
 
 BudgetResource = Literal[
@@ -908,10 +900,7 @@ class BudgetCommitment(AuthorityModel):
         return tuple(value) if isinstance(value, list) else value
 
     @model_validator(mode="after")
-    def _factory_only(self, info: ValidationInfo) -> "BudgetCommitment":
-        context = info.context if isinstance(info.context, dict) else {}
-        if context.get("budget_commitment_factory") is not _BUDGET_COMMITMENT_FACTORY:
-            raise ValueError("budget commitments can only be minted from validated reservations")
+    def _validate_commitment(self) -> "BudgetCommitment":
         resources = tuple(item.resource for item in self.reserved)
         if resources != tuple(sorted(BUDGET_RESOURCES)):
             raise ValueError("budget commitment requires every resource exactly once")
@@ -923,7 +912,6 @@ class BudgetCommitment(AuthorityModel):
         )
         if self.commitment_id != expected:
             raise ValueError("budget commitment identity does not match reservations")
-        object.__setattr__(self, "_authority", _BUDGET_COMMITMENT_FACTORY)
         return self
 
     def __copy__(self) -> "BudgetCommitment":
@@ -939,7 +927,7 @@ class BudgetCommitment(AuthorityModel):
         return self._lock
 
     def assert_authority(self, authorization: BudgetAuthorization) -> None:
-        if self._consumed or getattr(self, "_authority", None) is not _BUDGET_COMMITMENT_FACTORY:
+        if self._consumed or getattr(self, "_authority", None) is None:
             raise ValueError("budget commitment lacks factory authority")
         if (
             self.episode_id != authorization.episode_id
@@ -977,10 +965,11 @@ def commit_budget(
             for resource in sorted(BUDGET_RESOURCES)
         ),
     }
-    return BudgetCommitment.model_validate(
-        {**payload, "commitment_id": _identity("budget-commitment-v1", payload)},
-        context={"budget_commitment_factory": _BUDGET_COMMITMENT_FACTORY},
+    commitment = BudgetCommitment.model_validate(
+        {**payload, "commitment_id": _identity("budget-commitment-v1", payload)}
     )
+    _attach_authority(commitment, _lock=RLock(), _consumed=False)
+    return commitment
 
 
 class AvailableUsage(ProtocolModel):

--- a/local_operator/evaluation/receipts.py
+++ b/local_operator/evaluation/receipts.py
@@ -16,7 +16,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from datetime import date as Date
 from datetime import datetime, timezone
 from threading import RLock
-from typing import Annotated, Any, Literal, TypeAlias
+from typing import Annotated, Any, Literal, Self, TypeAlias
 from urllib.parse import quote
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -69,6 +69,50 @@ def _thaw(value: Any) -> JsonValue:
     if isinstance(value, (list, tuple)):
         return [_thaw(item) for item in value]
     return value
+
+
+class AuthorityModel(ProtocolModel):
+    """Guard normal Python/Pydantic APIs from recreating private authority.
+
+    These controls constrain cooperative in-process callers. Python code that
+    deliberately mutates ``PrivateAttr`` storage through low-level object APIs is
+    hostile and outside this contract; serialized fields never contain a token.
+    """
+
+    def copy(
+        self,
+        *,
+        include: Any = None,
+        exclude: Any = None,
+        update: dict[str, Any] | None = None,
+        deep: bool = False,
+    ) -> Self:
+        raise ValueError("authority models cannot be copied")
+
+    def model_copy(
+        self,
+        *,
+        update: Mapping[str, Any] | None = None,
+        deep: bool = False,
+    ) -> Self:
+        raise ValueError("authority models cannot be copied")
+
+    @classmethod
+    def model_construct(cls, _fields_set: set[str] | None = None, **values: Any) -> Self:
+        # model_construct intentionally skips validation. Permit pure evidence
+        # construction, but discard every attempted private marker so the result
+        # can never pass assert_authority or transition methods.
+        public_values = {key: value for key, value in values.items() if not key.startswith("_")}
+        return super().model_construct(_fields_set=_fields_set, **public_values)
+
+    def __copy__(self) -> Self:
+        raise TypeError("authority models cannot be copied")
+
+    def __deepcopy__(self, memo: dict[int, Any] | None = None) -> Self:
+        raise TypeError("authority models cannot be copied")
+
+    def __reduce__(self) -> Any:
+        raise TypeError("authority models cannot be pickled")
 
 
 class _MetadataModel(ProtocolModel):
@@ -508,7 +552,7 @@ class RedactionSet:
                 raise ValueError("secret canary survived evidence redaction")
 
 
-class SealedPreflight(ProtocolModel):
+class SealedPreflight(AuthorityModel):
     """Factory-only attestation over the exact validated preflight receipts."""
 
     _authority: object = PrivateAttr()
@@ -844,7 +888,7 @@ def reserve_budget(
     return reservation
 
 
-class BudgetCommitment(ProtocolModel):
+class BudgetCommitment(AuthorityModel):
     """Factory-only authority over the complete validated reservation set."""
 
     _authority: object = PrivateAttr()

--- a/local_operator/evaluation/receipts.py
+++ b/local_operator/evaluation/receipts.py
@@ -12,7 +12,9 @@ import base64
 import hashlib
 import json
 import re
+import weakref
 from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
 from datetime import date as Date
 from datetime import datetime, timezone
 from threading import RLock
@@ -23,7 +25,6 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from pydantic import (
     Field,
     JsonValue,
-    PrivateAttr,
     TypeAdapter,
     field_serializer,
     field_validator,
@@ -67,12 +68,76 @@ def _thaw(value: Any) -> JsonValue:
     return value
 
 
-class AuthorityModel(ProtocolModel):
-    """Guard normal Python/Pydantic APIs from recreating private authority.
+@dataclass(slots=True)
+class AuthorityRecord:
+    """Non-serializable process-local capability stored outside model instances."""
 
-    These controls constrain cooperative in-process callers. Python code that
-    deliberately mutates ``PrivateAttr`` storage through low-level object APIs is
-    hostile and outside this contract; serialized fields never contain a token.
+    kind: str
+    lock: RLock = field(default_factory=RLock)
+    consumed: bool = False
+    lineage: Any = None
+    receipts: tuple[Any, ...] = ()
+
+
+_AUTHORITY_REGISTRY_LOCK = RLock()
+_AUTHORITY_REGISTRY: dict[int, tuple[weakref.ReferenceType[AuthorityModel], AuthorityRecord]] = {}
+
+
+def _remove_authority(model_id: int, reference: weakref.ReferenceType[AuthorityModel]) -> None:
+    """Drop only the exact dead reference, protecting a subsequently reused id."""
+
+    with _AUTHORITY_REGISTRY_LOCK:
+        current = _AUTHORITY_REGISTRY.get(model_id)
+        if current is not None and current[0] is reference:
+            del _AUTHORITY_REGISTRY[model_id]
+
+
+def _register_authority(
+    model: AuthorityModel,
+    kind: str,
+    *,
+    lineage: Any = None,
+    receipts: tuple[Any, ...] = (),
+) -> AuthorityRecord:
+    model_id = id(model)
+
+    def remove(reference: weakref.ReferenceType[AuthorityModel]) -> None:
+        _remove_authority(model_id, reference)
+
+    reference = weakref.ref(model, remove)
+    record = AuthorityRecord(kind=kind, lineage=lineage, receipts=receipts)
+    with _AUTHORITY_REGISTRY_LOCK:
+        _AUTHORITY_REGISTRY[model_id] = (reference, record)
+    return record
+
+
+def _lookup_authority(
+    model: AuthorityModel,
+    kind: str,
+    *,
+    allow_consumed: bool = False,
+) -> AuthorityRecord:
+    with _AUTHORITY_REGISTRY_LOCK:
+        current = _AUTHORITY_REGISTRY.get(id(model))
+        if current is None or current[0]() is not model or current[1].kind != kind:
+            raise ValueError("model lacks process-local authority")
+        record = current[1]
+    if record.consumed and not allow_consumed:
+        raise ValueError("model lacks process-local authority")
+    return record
+
+
+def _authority_registry_size() -> int:
+    with _AUTHORITY_REGISTRY_LOCK:
+        return len(_AUTHORITY_REGISTRY)
+
+
+class AuthorityModel(ProtocolModel):
+    """Guard normal APIs while authority lives only in an identity registry.
+
+    Cooperative callers cannot mint or duplicate capabilities through model
+    APIs. Hostile Python mutating this private module registry is out of scope;
+    durable cross-process authority belongs to a future evidence store.
     """
 
     def copy(
@@ -109,14 +174,6 @@ class AuthorityModel(ProtocolModel):
 
     def __reduce__(self) -> Any:
         raise TypeError("authority models cannot be pickled")
-
-
-def _attach_authority(model: AuthorityModel, **private_values: Any) -> None:
-    """Attach non-serializable live authority after ordinary public validation."""
-
-    object.__setattr__(model, "_authority", object())
-    for name, value in private_values.items():
-        object.__setattr__(model, name, value)
 
 
 class _MetadataModel(ProtocolModel):
@@ -559,9 +616,6 @@ class RedactionSet:
 class SealedPreflight(AuthorityModel):
     """Factory-only attestation over the exact validated preflight receipts."""
 
-    _authority: object = PrivateAttr()
-    _receipts: tuple[PreflightReceipt, ...] = PrivateAttr()
-
     plan_id: Digest
     required_requirement_ids: tuple[StrictIdentifier, ...]
     passed_requirement_ids: tuple[StrictIdentifier, ...]
@@ -625,9 +679,11 @@ class SealedPreflight(AuthorityModel):
         raise TypeError("preflight seal authority cannot be pickled")
 
     def assert_authority(self) -> None:
-        if getattr(self, "_authority", None) is None:
-            raise ValueError("preflight seal lacks factory authority")
-        receipts = getattr(self, "_receipts", ())
+        try:
+            record = _lookup_authority(self, "preflight-seal")
+        except ValueError as error:
+            raise ValueError("preflight seal lacks factory authority") from error
+        receipts = record.receipts
         actual_digests: list[str] = []
         for receipt in receipts:
             expected = _identity(
@@ -705,7 +761,7 @@ def seal_preflight(
     sealed = SealedPreflight.model_validate(
         {**payload, "seal_id": _identity("sealed-preflight-v1", payload)}
     )
-    _attach_authority(sealed, _receipts=snapshot)
+    _register_authority(sealed, "preflight-seal", receipts=snapshot)
     return sealed
 
 
@@ -883,10 +939,6 @@ def reserve_budget(
 class BudgetCommitment(AuthorityModel):
     """Factory-only authority over the complete validated reservation set."""
 
-    _authority: object = PrivateAttr()
-    _lock: RLock = PrivateAttr(default_factory=RLock)
-    _consumed: bool = PrivateAttr(default=False)
-
     episode_id: StrictIdentifier
     budget_id: Digest
     authorization_digest: Digest
@@ -923,12 +975,14 @@ class BudgetCommitment(AuthorityModel):
     def __reduce__(self) -> Any:
         raise TypeError("budget commitment authority cannot be pickled")
 
-    def authority_lock(self) -> RLock:
-        return self._lock
+    def authority_record(self) -> AuthorityRecord:
+        try:
+            return _lookup_authority(self, "budget-commitment")
+        except ValueError as error:
+            raise ValueError("budget commitment lacks factory authority") from error
 
     def assert_authority(self, authorization: BudgetAuthorization) -> None:
-        if self._consumed or getattr(self, "_authority", None) is None:
-            raise ValueError("budget commitment lacks factory authority")
+        self.authority_record()
         if (
             self.episode_id != authorization.episode_id
             or self.budget_id != authorization.budget_id
@@ -943,8 +997,7 @@ class BudgetCommitment(AuthorityModel):
             raise ValueError("budget commitment authority was mutated")
 
     def consume_authority(self) -> None:
-        self._consumed = True
-        object.__setattr__(self, "_authority", None)
+        self.authority_record().consumed = True
 
 
 def commit_budget(
@@ -968,7 +1021,7 @@ def commit_budget(
     commitment = BudgetCommitment.model_validate(
         {**payload, "commitment_id": _identity("budget-commitment-v1", payload)}
     )
-    _attach_authority(commitment, _lock=RLock(), _consumed=False)
+    _register_authority(commitment, "budget-commitment")
     return commitment
 
 

--- a/local_operator/evaluation/receipts.py
+++ b/local_operator/evaluation/receipts.py
@@ -14,6 +14,7 @@ import json
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import date as Date
 from datetime import datetime, timezone
+from threading import RLock
 from typing import Annotated, Any, Literal, TypeAlias
 from urllib.parse import quote
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -416,10 +417,17 @@ class RedactionSet:
     an adapter responsibility.
     """
 
-    __slots__ = ("_canaries",)
+    __slots__ = ("_exact_encoded_canaries", "_folded_encoded_canaries", "_plaintext_canaries")
 
-    def __init__(self, canaries: tuple[str, ...]) -> None:
-        self._canaries = canaries
+    def __init__(
+        self,
+        plaintext_canaries: tuple[str, ...],
+        exact_encoded_canaries: tuple[str, ...],
+        folded_encoded_canaries: tuple[str, ...],
+    ) -> None:
+        self._plaintext_canaries = plaintext_canaries
+        self._exact_encoded_canaries = exact_encoded_canaries
+        self._folded_encoded_canaries = folded_encoded_canaries
 
     @classmethod
     def from_resolved_values(cls, values: Iterable[str]) -> "RedactionSet":
@@ -428,7 +436,8 @@ class RedactionSet:
             raise ValueError("too many redaction canaries")
         if any(not isinstance(value, str) or not value for value in snapshot):
             raise ValueError("redaction canaries must be non-empty strings")
-        variants: set[str] = set(snapshot)
+        exact_encoded_variants: set[str] = set()
+        folded_encoded_variants: set[str] = set()
         for value in snapshot:
             raw = value.encode("utf-8")
             # Short encoded fragments collide too readily with ordinary evidence;
@@ -437,20 +446,20 @@ class RedactionSet:
                 continue
             standard = base64.b64encode(raw).decode("ascii")
             urlsafe = base64.urlsafe_b64encode(raw).decode("ascii")
-            variants.update(
-                {
-                    standard,
-                    standard.rstrip("="),
-                    urlsafe,
-                    urlsafe.rstrip("="),
-                    quote(value, safe=""),
-                    raw.hex(),
-                }
+            exact_encoded_variants.update(
+                {standard, standard.rstrip("="), urlsafe, urlsafe.rstrip("=")}
             )
-        return cls(tuple(sorted(variants, key=lambda value: (-len(value), value))))
+            # Percent escapes and hexadecimal digits are semantically
+            # case-insensitive, unlike base64 and the original secret text.
+            folded_encoded_variants.update({quote(value, safe="").casefold(), raw.hex().casefold()})
+        return cls(
+            tuple(sorted(set(snapshot), key=lambda value: (-len(value), value))),
+            tuple(sorted(exact_encoded_variants, key=lambda value: (-len(value), value))),
+            tuple(sorted(folded_encoded_variants, key=lambda value: (-len(value), value))),
+        )
 
     def __repr__(self) -> str:
-        return f"RedactionSet(count={len(self._canaries)})"
+        return f"RedactionSet(count={len(self._plaintext_canaries)})"
 
     def assert_clear(self, value: Any) -> None:
         def strings(item: Any) -> Iterable[str]:
@@ -465,7 +474,11 @@ class RedactionSet:
                     yield from strings(nested)
 
         for candidate in strings(value):
-            if any(canary in candidate for canary in self._canaries):
+            if (
+                any(canary in candidate for canary in self._plaintext_canaries)
+                or any(canary in candidate for canary in self._exact_encoded_canaries)
+                or any(canary in candidate.casefold() for canary in self._folded_encoded_canaries)
+            ):
                 # Never include the candidate or canary: validation errors often
                 # cross process boundaries and become durable logs.
                 raise ValueError("secret canary survived evidence redaction")
@@ -811,6 +824,8 @@ class BudgetCommitment(ProtocolModel):
     """Factory-only authority over the complete validated reservation set."""
 
     _authority: object = PrivateAttr()
+    _lock: RLock = PrivateAttr(default_factory=RLock)
+    _consumed: bool = PrivateAttr(default=False)
 
     episode_id: StrictIdentifier
     budget_id: Digest
@@ -852,8 +867,11 @@ class BudgetCommitment(ProtocolModel):
     def __reduce__(self) -> Any:
         raise TypeError("budget commitment authority cannot be pickled")
 
+    def authority_lock(self) -> RLock:
+        return self._lock
+
     def assert_authority(self, authorization: BudgetAuthorization) -> None:
-        if getattr(self, "_authority", None) is not _BUDGET_COMMITMENT_FACTORY:
+        if self._consumed or getattr(self, "_authority", None) is not _BUDGET_COMMITMENT_FACTORY:
             raise ValueError("budget commitment lacks factory authority")
         if (
             self.episode_id != authorization.episode_id
@@ -867,6 +885,10 @@ class BudgetCommitment(ProtocolModel):
         )
         if self.commitment_id != expected:
             raise ValueError("budget commitment authority was mutated")
+
+    def consume_authority(self) -> None:
+        self._consumed = True
+        object.__setattr__(self, "_authority", None)
 
 
 def commit_budget(

--- a/local_operator/evaluation/receipts.py
+++ b/local_operator/evaluation/receipts.py
@@ -69,7 +69,7 @@ def _thaw(value: Any) -> JsonValue:
 
 
 @dataclass(slots=True)
-class AuthorityRecord:
+class _AuthorityRecord:
     """Non-serializable process-local capability stored outside model instances."""
 
     kind: str
@@ -80,7 +80,7 @@ class AuthorityRecord:
 
 
 _AUTHORITY_REGISTRY_LOCK = RLock()
-_AUTHORITY_REGISTRY: dict[int, tuple[weakref.ReferenceType[AuthorityModel], AuthorityRecord]] = {}
+_AUTHORITY_REGISTRY: dict[int, tuple[weakref.ReferenceType[AuthorityModel], _AuthorityRecord]] = {}
 
 
 def _remove_authority(model_id: int, reference: weakref.ReferenceType[AuthorityModel]) -> None:
@@ -98,14 +98,14 @@ def _register_authority(
     *,
     lineage: Any = None,
     receipts: tuple[Any, ...] = (),
-) -> AuthorityRecord:
+) -> _AuthorityRecord:
     model_id = id(model)
 
     def remove(reference: weakref.ReferenceType[AuthorityModel]) -> None:
         _remove_authority(model_id, reference)
 
     reference = weakref.ref(model, remove)
-    record = AuthorityRecord(kind=kind, lineage=lineage, receipts=receipts)
+    record = _AuthorityRecord(kind=kind, lineage=lineage, receipts=receipts)
     with _AUTHORITY_REGISTRY_LOCK:
         _AUTHORITY_REGISTRY[model_id] = (reference, record)
     return record
@@ -116,7 +116,7 @@ def _lookup_authority(
     kind: str,
     *,
     allow_consumed: bool = False,
-) -> AuthorityRecord:
+) -> _AuthorityRecord:
     with _AUTHORITY_REGISTRY_LOCK:
         current = _AUTHORITY_REGISTRY.get(id(model))
         if current is None or current[0]() is not model or current[1].kind != kind:
@@ -975,14 +975,11 @@ class BudgetCommitment(AuthorityModel):
     def __reduce__(self) -> Any:
         raise TypeError("budget commitment authority cannot be pickled")
 
-    def authority_record(self) -> AuthorityRecord:
+    def assert_authority(self, authorization: BudgetAuthorization) -> None:
         try:
-            return _lookup_authority(self, "budget-commitment")
+            _lookup_authority(self, "budget-commitment")
         except ValueError as error:
             raise ValueError("budget commitment lacks factory authority") from error
-
-    def assert_authority(self, authorization: BudgetAuthorization) -> None:
-        self.authority_record()
         if (
             self.episode_id != authorization.episode_id
             or self.budget_id != authorization.budget_id
@@ -995,9 +992,6 @@ class BudgetCommitment(AuthorityModel):
         )
         if self.commitment_id != expected:
             raise ValueError("budget commitment authority was mutated")
-
-    def consume_authority(self) -> None:
-        self.authority_record().consumed = True
 
 
 def commit_budget(

--- a/local_operator/evaluation/receipts.py
+++ b/local_operator/evaluation/receipts.py
@@ -1,0 +1,725 @@
+"""Pure dependency, preflight, and budget contracts for evaluation episodes.
+
+These models deliberately describe facts and authorities without discovering or
+executing anything.  Adapters remain responsible for performing work, but a
+cooperative adapter can require the receipts and permits defined here at every
+side-effect boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Annotated, Any, Literal, TypeAlias
+
+from pydantic import (
+    Field,
+    JsonValue,
+    TypeAdapter,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
+
+from local_operator.evaluation.protocol import (
+    MAX_METADATA_BYTES,
+    MAX_SAFE_JSON_INTEGER,
+    ArtifactRef,
+    FrozenMapping,
+    PortableMetadataObject,
+    ProtocolModel,
+)
+
+MAX_DECLARATIONS = 256
+MAX_PORTS = 32
+MAX_MODALITIES = 16
+MAX_TOOLS = 128
+MAX_REASON_LENGTH = 2_000
+MAX_CANARIES = 256
+ZERO_DIGEST = "0" * 64
+
+StrictIdentifier = Annotated[
+    str,
+    Field(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$"),
+]
+Digest = Annotated[str, Field(pattern=r"^[0-9a-f]{64}$")]
+SafeCount = Annotated[int, Field(ge=0, le=MAX_SAFE_JSON_INTEGER)]
+PositiveSafeCount = Annotated[int, Field(ge=1, le=MAX_SAFE_JSON_INTEGER)]
+RequirementNecessity = Literal["required", "optional"]
+ReportabilityClass = Literal["required", "optional"]
+
+
+def _thaw(value: Any) -> JsonValue:
+    if isinstance(value, FrozenMapping):
+        return {key: _thaw(item) for key, item in value.items()}
+    if isinstance(value, Mapping):
+        return {key: _thaw(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_thaw(item) for item in value]
+    return value
+
+
+class _MetadataModel(ProtocolModel):
+    """Apply protocol metadata bounds to every declarative metadata field."""
+
+    @field_validator("metadata", "evidence", mode="before", check_fields=False)
+    @classmethod
+    def _snapshot_metadata(cls, value: Any) -> dict[str, JsonValue]:
+        if not isinstance(value, (FrozenMapping, Mapping)):
+            raise ValueError("portable metadata must be a mapping")
+        thawed = _thaw(value if isinstance(value, FrozenMapping) else FrozenMapping(value))
+        assert isinstance(thawed, dict)
+        return thawed
+
+    @field_validator("metadata", "evidence", check_fields=False)
+    @classmethod
+    def _freeze_metadata(cls, value: Mapping[str, JsonValue]) -> FrozenMapping:
+        frozen = FrozenMapping(value)
+        encoded = json.dumps(
+            _thaw(frozen),
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        if len(encoded) > MAX_METADATA_BYTES:
+            raise ValueError(f"portable metadata exceeds {MAX_METADATA_BYTES} canonical bytes")
+        return frozen
+
+    @field_serializer("metadata", "evidence", check_fields=False)
+    def _serialize_metadata(self, value: FrozenMapping) -> dict[str, JsonValue]:
+        thawed = _thaw(value)
+        assert isinstance(thawed, dict)
+        return thawed
+
+
+class DisplayRequirement(ProtocolModel):
+    """Display geometry and symbolic platform capability, never an instance SKU."""
+
+    native_width: PositiveSafeCount
+    native_height: PositiveSafeCount
+    model_width: PositiveSafeCount
+    model_height: PositiveSafeCount
+    platform_capability: StrictIdentifier
+
+
+class _RequirementBase(_MetadataModel):
+    requirement_id: StrictIdentifier
+    necessity: RequirementNecessity
+    reportability: ReportabilityClass
+    metadata: PortableMetadataObject = Field(default_factory=dict, validate_default=True)
+
+    def conflict_key(self) -> tuple[str, ...]:
+        raise NotImplementedError
+
+
+class ComputeRequirement(_RequirementBase):
+    kind: Literal["compute"] = "compute"
+    cpu_class: StrictIdentifier
+    memory_class: StrictIdentifier
+    disk_bytes: SafeCount
+    display: DisplayRequirement | None = None
+
+    def conflict_key(self) -> tuple[str, ...]:
+        return (self.kind, "episode-compute")
+
+
+class NetworkRequirement(_RequirementBase):
+    kind: Literal["network"] = "network"
+    endpoint_id: StrictIdentifier
+    service_id: StrictIdentifier
+    protocol: Literal["http", "https", "tcp", "udp", "websocket"]
+    ports: tuple[Annotated[int, Field(ge=1, le=65535)], ...] = Field(
+        min_length=1, max_length=MAX_PORTS
+    )
+    proxy_capability: Literal["forbidden", "allowed", "required"]
+    geography: StrictIdentifier | None = None
+
+    @field_validator("ports", mode="before")
+    @classmethod
+    def _freeze_ports(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _unique_ports(self) -> "NetworkRequirement":
+        if len(self.ports) != len(set(self.ports)):
+            raise ValueError("network ports must be unique")
+        return self
+
+    def conflict_key(self) -> tuple[str, ...]:
+        return (self.kind, self.service_id, self.endpoint_id)
+
+
+class ExternalServiceRequirement(_RequirementBase):
+    kind: Literal["external_service"] = "external_service"
+    service_id: StrictIdentifier
+    capability: StrictIdentifier
+    # This is a lookup key only. Resolved credentials must never enter a model.
+    account_ref: StrictIdentifier
+
+    def conflict_key(self) -> tuple[str, ...]:
+        return (self.kind, self.service_id, self.capability)
+
+
+class ModelCapabilityRequirement(_RequirementBase):
+    kind: Literal["model_capability"] = "model_capability"
+    role: Literal["agent", "judge", "user_simulator"]
+    modalities: tuple[StrictIdentifier, ...] = Field(min_length=1, max_length=MAX_MODALITIES)
+    tools: tuple[StrictIdentifier, ...] = Field(default=(), max_length=MAX_TOOLS)
+    min_context_tokens: SafeCount
+    min_output_tokens: SafeCount
+    route_pin: StrictIdentifier | None = None
+    fallback_policy: Literal["forbid", "same_capability", "explicit_routes"]
+    fallback_routes: tuple[StrictIdentifier, ...] = Field(default=(), max_length=16)
+
+    @field_validator("modalities", "tools", "fallback_routes", mode="before")
+    @classmethod
+    def _freeze_lists(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _validate_routes(self) -> "ModelCapabilityRequirement":
+        for name, values in (
+            ("modalities", self.modalities),
+            ("tools", self.tools),
+            ("fallback routes", self.fallback_routes),
+        ):
+            if len(values) != len(set(values)):
+                raise ValueError(f"{name} must be unique")
+        if self.fallback_policy == "explicit_routes" and not self.fallback_routes:
+            raise ValueError("explicit fallback policy requires fallback routes")
+        if self.fallback_policy != "explicit_routes" and self.fallback_routes:
+            raise ValueError("fallback routes require the explicit_routes policy")
+        return self
+
+    def conflict_key(self) -> tuple[str, ...]:
+        return (self.kind, self.role)
+
+
+class ClockRequirement(_RequirementBase):
+    kind: Literal["clock"] = "clock"
+    timezone: StrictIdentifier
+    date: str | None = Field(default=None, pattern=r"^\d{4}-\d{2}-\d{2}$")
+    fixed_clock: str | None = Field(
+        default=None,
+        max_length=64,
+        pattern=r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$",
+    )
+
+    @model_validator(mode="after")
+    def _require_clock_constraint(self) -> "ClockRequirement":
+        if self.date is None and self.fixed_clock is None:
+            raise ValueError("clock requirement needs a date or fixed clock")
+        if self.date is not None and self.fixed_clock is not None:
+            raise ValueError("clock requirement chooses either date or fixed clock")
+        return self
+
+    def conflict_key(self) -> tuple[str, ...]:
+        return (self.kind, "episode-clock")
+
+
+class PinnedInputRequirement(_RequirementBase):
+    kind: Literal["pinned_input"] = "pinned_input"
+    release_id: StrictIdentifier
+    artifact: ArtifactRef
+    content_sha256: Digest
+
+    def conflict_key(self) -> tuple[str, ...]:
+        return (self.kind, self.release_id)
+
+
+Requirement: TypeAlias = Annotated[
+    ComputeRequirement
+    | NetworkRequirement
+    | ExternalServiceRequirement
+    | ModelCapabilityRequirement
+    | ClockRequirement
+    | PinnedInputRequirement,
+    Field(discriminator="kind"),
+]
+_REQUIREMENT_ADAPTER = TypeAdapter(Requirement)
+
+
+def _identity(kind: str, payload: Any) -> str:
+    encoded = json.dumps(
+        {"identity_kind": kind, "payload": payload},
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class DependencyPlan(ProtocolModel):
+    """Canonical selected episode dependencies with an order-independent identity."""
+
+    release_id: StrictIdentifier
+    task_id: StrictIdentifier
+    attempt_id: StrictIdentifier
+    requirements: tuple[Requirement, ...] = Field(min_length=1, max_length=MAX_DECLARATIONS)
+    plan_id: Digest = ZERO_DIGEST
+
+    @field_validator("requirements", mode="before")
+    @classmethod
+    def _parse_requirements(cls, value: Any) -> Any:
+        if isinstance(value, list):
+            value = tuple(value)
+        if not isinstance(value, tuple):
+            return value
+        return tuple(_REQUIREMENT_ADAPTER.validate_python(item, strict=True) for item in value)
+
+    @model_validator(mode="after")
+    def _canonicalize_and_identify(self) -> "DependencyPlan":
+        ordered = tuple(sorted(self.requirements, key=lambda item: item.requirement_id))
+        ids = [item.requirement_id for item in ordered]
+        if len(ids) != len(set(ids)):
+            raise ValueError("dependency plan contains duplicate requirement IDs")
+        seen_targets: dict[tuple[str, ...], Requirement] = {}
+        for item in ordered:
+            target = item.conflict_key()
+            if target in seen_targets:
+                raise ValueError("dependency plan contains conflicting requirements")
+            seen_targets[target] = item
+        object.__setattr__(self, "requirements", ordered)
+        payload = {
+            "release_id": self.release_id,
+            "task_id": self.task_id,
+            "attempt_id": self.attempt_id,
+            "requirements": [item.model_dump(mode="json") for item in ordered],
+        }
+        expected = _identity("dependency-plan-v1", payload)
+        if self.plan_id not in (ZERO_DIGEST, expected):
+            raise ValueError("dependency plan identity does not match its declarations")
+        object.__setattr__(self, "plan_id", expected)
+        return self
+
+
+class PreflightReceipt(_MetadataModel):
+    requirement_id: StrictIdentifier
+    necessity: RequirementNecessity
+    status: Literal["pass", "fail", "skip"]
+    evidence: PortableMetadataObject = Field(default_factory=dict, validate_default=True)
+    started_at_ms: SafeCount | None = None
+    ended_at_ms: SafeCount | None = None
+    duration_ms: SafeCount | None = None
+    receipt_id: Digest = ZERO_DIGEST
+
+    @model_validator(mode="after")
+    def _validate_timing_and_identity(self) -> "PreflightReceipt":
+        if self.status == "skip" and self.necessity != "optional":
+            raise ValueError("only optional requirements may be skipped")
+        has_range = self.started_at_ms is not None or self.ended_at_ms is not None
+        if has_range:
+            if self.started_at_ms is None or self.ended_at_ms is None:
+                raise ValueError("preflight timing range requires both start and end")
+            if self.ended_at_ms < self.started_at_ms:
+                raise ValueError("preflight end must not precede start")
+            elapsed = self.ended_at_ms - self.started_at_ms
+            if self.duration_ms is not None and self.duration_ms != elapsed:
+                raise ValueError("preflight duration disagrees with start/end")
+        elif self.duration_ms is None:
+            raise ValueError("preflight receipt requires a duration or start/end range")
+        payload = self.model_dump(mode="json", exclude={"receipt_id"})
+        expected = _identity("preflight-receipt-v1", payload)
+        if self.receipt_id not in (ZERO_DIGEST, expected):
+            raise ValueError("preflight receipt identity does not match its evidence")
+        object.__setattr__(self, "receipt_id", expected)
+        return self
+
+
+class RedactionSet:
+    """Ephemeral resolved canaries used only while sealing portable evidence."""
+
+    __slots__ = ("_canaries",)
+
+    def __init__(self, canaries: tuple[str, ...]) -> None:
+        self._canaries = canaries
+
+    @classmethod
+    def from_resolved_values(cls, values: Iterable[str]) -> "RedactionSet":
+        snapshot = tuple(values)
+        if len(snapshot) > MAX_CANARIES:
+            raise ValueError("too many redaction canaries")
+        if any(not isinstance(value, str) or not value for value in snapshot):
+            raise ValueError("redaction canaries must be non-empty strings")
+        return cls(tuple(sorted(set(snapshot), key=lambda value: (-len(value), value))))
+
+    def __repr__(self) -> str:
+        return f"RedactionSet(count={len(self._canaries)})"
+
+    def assert_clear(self, value: Any) -> None:
+        def strings(item: Any) -> Iterable[str]:
+            if isinstance(item, str):
+                yield item
+            elif isinstance(item, Mapping):
+                for key, nested in item.items():
+                    yield str(key)
+                    yield from strings(nested)
+            elif isinstance(item, (list, tuple)):
+                for nested in item:
+                    yield from strings(nested)
+
+        for candidate in strings(value):
+            if any(canary in candidate for canary in self._canaries):
+                # Never include the candidate or canary: validation errors often
+                # cross process boundaries and become durable logs.
+                raise ValueError("secret canary survived evidence redaction")
+
+
+class SealedPreflight(ProtocolModel):
+    plan_id: Digest
+    passed_requirement_ids: tuple[StrictIdentifier, ...]
+    failed_requirement_ids: tuple[StrictIdentifier, ...]
+    skipped_requirement_ids: tuple[StrictIdentifier, ...]
+    receipt_digests: tuple[Digest, ...]
+    redaction_attested: Literal[True]
+    seal_id: Digest
+
+    @field_validator(
+        "passed_requirement_ids",
+        "failed_requirement_ids",
+        "skipped_requirement_ids",
+        "receipt_digests",
+        mode="before",
+    )
+    @classmethod
+    def _freeze_lists(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _validate_seal(self) -> "SealedPreflight":
+        groups = (
+            self.passed_requirement_ids,
+            self.failed_requirement_ids,
+            self.skipped_requirement_ids,
+        )
+        flattened = [item for group in groups for item in group]
+        if len(flattened) != len(set(flattened)):
+            raise ValueError("sealed requirement outcome IDs must be unique")
+        if any(tuple(sorted(group)) != group for group in groups):
+            raise ValueError("sealed requirement outcome IDs must be canonical")
+        if tuple(sorted(self.receipt_digests)) != self.receipt_digests:
+            raise ValueError("sealed receipt digests must be canonical")
+        expected = _identity(
+            "sealed-preflight-v1",
+            self.model_dump(mode="json", exclude={"seal_id"}),
+        )
+        if self.seal_id != expected:
+            raise ValueError("preflight seal identity does not match its receipts")
+        return self
+
+    @property
+    def successful(self) -> bool:
+        return not self.failed_requirement_ids
+
+
+def seal_preflight(
+    plan: DependencyPlan,
+    receipts: Sequence[PreflightReceipt],
+    redactions: RedactionSet,
+) -> SealedPreflight:
+    """Validate complete exact evidence and attest that resolved canaries are absent."""
+
+    snapshot = tuple(receipts)
+    by_id: dict[str, PreflightReceipt] = {}
+    for receipt in snapshot:
+        if receipt.requirement_id in by_id:
+            raise ValueError("preflight has duplicate receipts")
+        by_id[receipt.requirement_id] = receipt
+    expected_ids = {item.requirement_id for item in plan.requirements}
+    if set(by_id) != expected_ids:
+        raise ValueError("preflight requires exactly one receipt for every selected requirement")
+    requirements = {item.requirement_id: item for item in plan.requirements}
+    for requirement_id, receipt in by_id.items():
+        requirement = requirements[requirement_id]
+        if receipt.necessity != requirement.necessity:
+            raise ValueError("preflight receipt necessity disagrees with its requirement")
+        if receipt.status == "skip" and requirement.necessity != "optional":
+            raise ValueError("required dependencies cannot be skipped")
+    redactions.assert_clear(plan.model_dump(mode="json"))
+    redactions.assert_clear([receipt.model_dump(mode="json") for receipt in snapshot])
+    passed = tuple(sorted(key for key, value in by_id.items() if value.status == "pass"))
+    failed = tuple(sorted(key for key, value in by_id.items() if value.status == "fail"))
+    skipped = tuple(sorted(key for key, value in by_id.items() if value.status == "skip"))
+    required_failures = [key for key in failed if requirements[key].necessity == "required"]
+    if required_failures:
+        raise ValueError("required dependency failure prevents preflight sealing")
+    payload = {
+        "plan_id": plan.plan_id,
+        "passed_requirement_ids": passed,
+        "failed_requirement_ids": failed,
+        "skipped_requirement_ids": skipped,
+        "receipt_digests": tuple(sorted(receipt.receipt_id for receipt in snapshot)),
+        "redaction_attested": True,
+    }
+    redactions.assert_clear(payload)
+    return SealedPreflight(
+        **payload,
+        seal_id=_identity("sealed-preflight-v1", payload),
+    )
+
+
+BudgetResource = Literal[
+    "provider_input_tokens",
+    "provider_output_tokens",
+    "provider_cache_tokens",
+    "provider_usd_micros",
+    "cloud_usd_micros",
+    "instance_milliseconds",
+    "wall_milliseconds",
+    "model_cycles",
+    "guest_actions",
+    "user_simulator_turns",
+]
+BUDGET_RESOURCES: tuple[BudgetResource, ...] = (
+    "provider_input_tokens",
+    "provider_output_tokens",
+    "provider_cache_tokens",
+    "provider_usd_micros",
+    "cloud_usd_micros",
+    "instance_milliseconds",
+    "wall_milliseconds",
+    "model_cycles",
+    "guest_actions",
+    "user_simulator_turns",
+)
+
+
+class CappedAllowance(ProtocolModel):
+    kind: Literal["capped"] = "capped"
+    resource: BudgetResource
+    value: SafeCount
+    reporting: ReportabilityClass
+
+
+class UncappedAllowance(ProtocolModel):
+    kind: Literal["uncapped"] = "uncapped"
+    resource: BudgetResource
+    reason: str = Field(min_length=1, max_length=MAX_REASON_LENGTH, pattern=r"\S")
+    authorized_by: StrictIdentifier
+    authorized_at_ms: SafeCount
+    reporting: ReportabilityClass
+
+
+Allowance: TypeAlias = Annotated[CappedAllowance | UncappedAllowance, Field(discriminator="kind")]
+_ALLOWANCE_ADAPTER = TypeAdapter(Allowance)
+
+
+class BudgetAuthorization(ProtocolModel):
+    episode_id: StrictIdentifier
+    allowances: tuple[Allowance, ...] = Field(
+        min_length=len(BUDGET_RESOURCES), max_length=len(BUDGET_RESOURCES)
+    )
+    budget_id: Digest = ZERO_DIGEST
+
+    @field_validator("allowances", mode="before")
+    @classmethod
+    def _parse_allowances(cls, value: Any) -> Any:
+        if isinstance(value, list):
+            value = tuple(value)
+        if not isinstance(value, tuple):
+            return value
+        return tuple(_ALLOWANCE_ADAPTER.validate_python(item, strict=True) for item in value)
+
+    @model_validator(mode="after")
+    def _canonicalize_and_identify(self) -> "BudgetAuthorization":
+        ordered = tuple(sorted(self.allowances, key=lambda item: item.resource))
+        resources = [item.resource for item in ordered]
+        if set(resources) != set(BUDGET_RESOURCES) or len(resources) != len(set(resources)):
+            raise ValueError("budget authorization requires each resource exactly once")
+        object.__setattr__(self, "allowances", ordered)
+        payload = {
+            "episode_id": self.episode_id,
+            "allowances": [item.model_dump(mode="json") for item in ordered],
+        }
+        expected = _identity("budget-authorization-v1", payload)
+        if self.budget_id not in (ZERO_DIGEST, expected):
+            raise ValueError("budget identity does not match its allowances")
+        object.__setattr__(self, "budget_id", expected)
+        return self
+
+    def allowance_for(self, resource: BudgetResource) -> Allowance:
+        return next(item for item in self.allowances if item.resource == resource)
+
+
+class ResourceAmount(ProtocolModel):
+    resource: BudgetResource
+    value: SafeCount
+
+
+class BudgetReservation(ProtocolModel):
+    episode_id: StrictIdentifier
+    budget_id: Digest
+    amounts: tuple[ResourceAmount, ...] = Field(min_length=1, max_length=len(BUDGET_RESOURCES))
+    reservation_id: Digest = ZERO_DIGEST
+
+    @field_validator("amounts", mode="before")
+    @classmethod
+    def _freeze_amounts(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _canonicalize_and_identify(self) -> "BudgetReservation":
+        ordered = tuple(sorted(self.amounts, key=lambda item: item.resource))
+        resources = [item.resource for item in ordered]
+        if len(resources) != len(set(resources)):
+            raise ValueError("reservation contains duplicate resources")
+        object.__setattr__(self, "amounts", ordered)
+        payload = self.model_dump(mode="json", exclude={"reservation_id"})
+        expected = _identity("budget-reservation-v1", payload)
+        if self.reservation_id not in (ZERO_DIGEST, expected):
+            raise ValueError("reservation identity does not match its amounts")
+        object.__setattr__(self, "reservation_id", expected)
+        return self
+
+
+def reserve_budget(
+    authorization: BudgetAuthorization,
+    request: Sequence[ResourceAmount],
+    existing: Sequence[BudgetReservation] = (),
+) -> BudgetReservation:
+    """Reserve capacity before work; a zero cap remains distinct from uncapped."""
+
+    requested = tuple(request)
+    if not requested:
+        raise ValueError("reservation request must not be empty")
+    totals: dict[BudgetResource, int] = {resource: 0 for resource in BUDGET_RESOURCES}
+    for reservation in existing:
+        if reservation.budget_id != authorization.budget_id:
+            raise ValueError("existing reservation belongs to another budget")
+        for amount in reservation.amounts:
+            totals[amount.resource] += amount.value
+    seen: set[BudgetResource] = set()
+    for amount in requested:
+        if amount.resource in seen:
+            raise ValueError("reservation request contains duplicate resources")
+        seen.add(amount.resource)
+        totals[amount.resource] += amount.value
+    for resource, total in totals.items():
+        allowance = authorization.allowance_for(resource)
+        if isinstance(allowance, CappedAllowance) and total > allowance.value:
+            raise ValueError("reservation exceeds an authorized cap")
+    return BudgetReservation(
+        episode_id=authorization.episode_id,
+        budget_id=authorization.budget_id,
+        amounts=requested,
+    )
+
+
+class AvailableUsage(ProtocolModel):
+    kind: Literal["available"] = "available"
+    resource: BudgetResource
+    value: SafeCount
+
+
+class UnavailableUsage(ProtocolModel):
+    kind: Literal["unavailable"] = "unavailable"
+    resource: BudgetResource
+    reason: str = Field(min_length=1, max_length=MAX_REASON_LENGTH, pattern=r"\S")
+
+
+Usage: TypeAlias = Annotated[AvailableUsage | UnavailableUsage, Field(discriminator="kind")]
+_USAGE_ADAPTER = TypeAdapter(Usage)
+
+
+class ReconciliationEntry(ProtocolModel):
+    resource: BudgetResource
+    allowance: Allowance
+    reserved: SafeCount
+    usage: Usage
+    overrun: SafeCount
+
+    @model_validator(mode="after")
+    def _same_resource(self) -> "ReconciliationEntry":
+        if self.allowance.resource != self.resource or self.usage.resource != self.resource:
+            raise ValueError("reconciliation entry resources disagree")
+        return self
+
+
+class BudgetReconciliation(ProtocolModel):
+    episode_id: StrictIdentifier
+    budget_id: Digest
+    reservation_ids: tuple[Digest, ...]
+    entries: tuple[ReconciliationEntry, ...]
+    reportable: bool
+    reconciliation_id: Digest = ZERO_DIGEST
+
+    @field_validator("reservation_ids", "entries", mode="before")
+    @classmethod
+    def _freeze_lists(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _canonicalize_and_identify(self) -> "BudgetReconciliation":
+        entries = tuple(sorted(self.entries, key=lambda item: item.resource))
+        if tuple(item.resource for item in entries) != tuple(sorted(BUDGET_RESOURCES)):
+            raise ValueError("reconciliation requires every resource exactly once")
+        reservations = tuple(sorted(self.reservation_ids))
+        if len(reservations) != len(set(reservations)):
+            raise ValueError("reconciliation contains duplicate reservations")
+        object.__setattr__(self, "entries", entries)
+        object.__setattr__(self, "reservation_ids", reservations)
+        expected_reportable = all(
+            not (
+                entry.allowance.reporting == "required"
+                and isinstance(entry.usage, UnavailableUsage)
+            )
+            for entry in entries
+        )
+        if self.reportable != expected_reportable:
+            raise ValueError("reconciliation reportability disagrees with required usage")
+        payload = self.model_dump(mode="json", exclude={"reconciliation_id"})
+        expected = _identity("budget-reconciliation-v1", payload)
+        if self.reconciliation_id not in (ZERO_DIGEST, expected):
+            raise ValueError("reconciliation identity does not match usage")
+        object.__setattr__(self, "reconciliation_id", expected)
+        return self
+
+
+def reconcile_budget(
+    authorization: BudgetAuthorization,
+    reservations: Sequence[BudgetReservation],
+    usage: Sequence[Usage],
+) -> BudgetReconciliation:
+    """Record exact/under/over usage; integer USD micros avoid floating ambiguity."""
+
+    reservation_snapshot = tuple(reservations)
+    reserved: dict[BudgetResource, int] = {resource: 0 for resource in BUDGET_RESOURCES}
+    for item in reservation_snapshot:
+        if item.budget_id != authorization.budget_id:
+            raise ValueError("reservation belongs to another budget")
+        for amount in item.amounts:
+            reserved[amount.resource] += amount.value
+    parsed_usage = tuple(_USAGE_ADAPTER.validate_python(item, strict=True) for item in usage)
+    by_resource = {item.resource: item for item in parsed_usage}
+    if len(by_resource) != len(parsed_usage) or set(by_resource) != set(BUDGET_RESOURCES):
+        raise ValueError("reconciliation requires one usage result per resource")
+    entries: list[ReconciliationEntry] = []
+    for resource in BUDGET_RESOURCES:
+        allowance = authorization.allowance_for(resource)
+        actual = by_resource[resource]
+        overrun = 0
+        if isinstance(actual, AvailableUsage) and isinstance(allowance, CappedAllowance):
+            overrun = max(0, actual.value - allowance.value)
+        entries.append(
+            ReconciliationEntry(
+                resource=resource,
+                allowance=allowance,
+                reserved=reserved[resource],
+                usage=actual,
+                overrun=overrun,
+            )
+        )
+    reportable = all(
+        not (entry.allowance.reporting == "required" and isinstance(entry.usage, UnavailableUsage))
+        for entry in entries
+    )
+    return BudgetReconciliation(
+        episode_id=authorization.episode_id,
+        budget_id=authorization.budget_id,
+        reservation_ids=tuple(item.reservation_id for item in reservation_snapshot),
+        entries=tuple(entries),
+        reportable=reportable,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.9"
+version = "0.44.10"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/evaluation/test_lifecycle.py
+++ b/tests/unit/evaluation/test_lifecycle.py
@@ -288,7 +288,7 @@ def test_side_effect_start_is_impossible_before_seal_permit_and_reservation() ->
     reservation = _reservation(budget)
     with pytest.raises(ValueError, match="illegal episode transition"):
         planned.start(permit, budget, _commitment(budget, reservation))
-    with pytest.raises(ValueError, match="factory authority"):
+    with pytest.raises(ValueError, match="factory authority|process-local authority"):
         authorized.start(permit, budget, BudgetCommitment.model_construct())
     forged_payload = {**permit.model_dump(), "episode_id": "episode-other"}
     with pytest.raises(ValidationError):
@@ -604,7 +604,7 @@ def test_direct_overcap_reservation_and_forged_commitment_cannot_start() -> None
     legitimate = _reservation(budget)
     commitment = _commitment(budget, legitimate)
     forged = BudgetCommitment.model_construct(**commitment.model_dump())
-    with pytest.raises(ValueError, match="factory authority"):
+    with pytest.raises(ValueError, match="factory authority|process-local authority"):
         authorized.start(permit, budget, forged)
 
 
@@ -1424,7 +1424,7 @@ def test_registry_dead_callback_cannot_remove_reused_identity_entry() -> None:
     from local_operator.evaluation.receipts import (
         _AUTHORITY_REGISTRY,
         _AUTHORITY_REGISTRY_LOCK,
-        AuthorityRecord,
+        _AuthorityRecord,
         _remove_authority,
     )
 
@@ -1436,7 +1436,7 @@ def test_registry_dead_callback_cannot_remove_reused_identity_entry() -> None:
     with _AUTHORITY_REGISTRY_LOCK:
         _AUTHORITY_REGISTRY[synthetic_id] = (
             current_reference,
-            AuthorityRecord(kind="preflight-seal"),
+            _AuthorityRecord(kind="preflight-seal"),
         )
     _remove_authority(synthetic_id, stale_reference)
     with _AUTHORITY_REGISTRY_LOCK:
@@ -1485,3 +1485,69 @@ def test_base_copy_duplicate_path_rejects_and_originals_complete_once() -> None:
     with pytest.raises(ValueError, match="process-local authority"):
         cleaning.finish_cleanup(cloned_result)
     assert cleaning.finish_cleanup(result).state == "completed"
+
+
+def test_permit_minting_has_no_public_api_and_cannot_repeat() -> None:
+    import inspect
+
+    from local_operator.evaluation import lifecycle as lifecycle_module
+
+    public_functions = {
+        name
+        for name, value in vars(lifecycle_module).items()
+        if inspect.isfunction(value) and not name.startswith("_")
+    }
+    assert "mint_side_effect_permit" not in public_functions
+    assert not hasattr(lifecycle_module, "mint_side_effect_permit")
+    source = inspect.getsource(lifecycle_module)
+    assert source.count("_mint_side_effect_permit(") == 2  # definition + authorize call
+
+    plan, budget, _cleanup_value, planned = _planned()
+    seal = _seal(plan)
+    preflighted = planned.preflight(seal)
+    authorized, permit = preflighted.authorize(seal, budget)
+    with pytest.raises(ValueError, match="transition authority"):
+        preflighted.authorize(seal, budget)
+    permit.assert_authority()
+    assert authorized.permit_id == permit.permit_id
+
+
+def test_authority_models_do_not_expose_mutable_records() -> None:
+    import inspect
+
+    from local_operator.evaluation.receipts import AuthorityModel, _AuthorityRecord
+
+    plan, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    models = (
+        _seal(plan),
+        _commitment(budget, reservation),
+        _cleanup(cleanup),
+        permit,
+        authorized,
+    )
+    for model in models:
+        assert not hasattr(model, "authority_record")
+        for name, member in inspect.getmembers(type(model)):
+            if name.startswith("_") or not callable(member):
+                continue
+            annotation = inspect.signature(member).return_annotation
+            assert annotation not in (_AuthorityRecord, "_AuthorityRecord")
+    source = inspect.getsource(AuthorityModel)
+    assert "return _lookup_authority" not in source
+
+
+def test_revoked_permit_has_no_public_revival_path() -> None:
+    _plan_value, _budget_value, _cleanup_value, authorized, permit = _authorized()
+    failed = authorized.fail_before_running(
+        kind="infrastructure",
+        reason="allocator unavailable",
+        permit=permit,
+    )
+    assert failed.state == "failed"
+    with pytest.raises(ValueError, match="factory authority|process-local authority"):
+        permit.assert_authority()
+    assert not hasattr(permit, "authority_record")
+    for method in (permit.copy, permit.model_copy):
+        with pytest.raises(ValueError, match="cannot be copied"):
+            method()

--- a/tests/unit/evaluation/test_lifecycle.py
+++ b/tests/unit/evaluation/test_lifecycle.py
@@ -8,7 +8,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import pytest
 from pydantic import ValidationError
@@ -23,9 +23,10 @@ from local_operator.evaluation.lifecycle import (
     aggregate_cleanup,
     record_cleanup,
 )
-from local_operator.evaluation.protocol import ArtifactRef, ProtocolModel
+from local_operator.evaluation.protocol import ArtifactRef
 from local_operator.evaluation.receipts import (
     BUDGET_RESOURCES,
+    AuthorityModel,
     AvailableUsage,
     BudgetAuthorization,
     BudgetCommitment,
@@ -256,7 +257,7 @@ def test_cleanup_requires_exactly_one_receipt_and_attempted_is_not_clean() -> No
     assert attempted.rescue_required
     assert attempted.incomplete_action_ids == ("session",)
     parsed = CleanupResult.from_canonical_json(attempted.to_canonical_json())
-    with pytest.raises(ValueError, match="lacks factory authority"):
+    with pytest.raises(ValueError, match="lacks factory authority|process-local authority"):
         parsed.assert_authority()
     clean = _cleanup(plan)
     assert not clean.rescue_required
@@ -269,7 +270,7 @@ def test_permit_cannot_be_constructed_or_deserialized_by_callers() -> None:
         SideEffectPermit.model_validate(payload),
         SideEffectPermit.from_canonical_json(permit.to_canonical_json()),
     ):
-        with pytest.raises(ValueError, match="lacks factory authority"):
+        with pytest.raises(ValueError, match="lacks factory authority|process-local authority"):
             parsed.assert_authority()
     with pytest.raises(ValidationError):
         SideEffectPermit(
@@ -639,10 +640,10 @@ def test_forged_preflight_seal_cannot_preflight_or_authorize() -> None:
     plan, budget, _cleanup_value, planned = _planned()
     seal = _seal(plan)
     forged = SealedPreflight.model_construct(**seal.model_dump())
-    with pytest.raises(ValueError, match="lacks factory authority"):
+    with pytest.raises(ValueError, match="lacks factory authority|process-local authority"):
         planned.preflight(forged)
     preflighted = planned.preflight(seal)
-    with pytest.raises(ValueError, match="lacks factory authority"):
+    with pytest.raises(ValueError, match="lacks factory authority|process-local authority"):
         preflighted.authorize(forged, budget)
 
 
@@ -656,7 +657,7 @@ def test_forged_cleanup_result_cannot_complete_episode() -> None:
     )
     result = _cleanup(cleanup)
     forged = CleanupResult.model_construct(**result.model_dump())
-    with pytest.raises(ValueError, match="lacks factory authority"):
+    with pytest.raises(ValueError, match="lacks factory authority|process-local authority"):
         cleaning.finish_cleanup(forged)
 
 
@@ -688,7 +689,7 @@ def test_forged_side_effect_permit_cannot_start() -> None:
     _plan_value, budget, _cleanup_value, authorized, permit = _authorized()
     reservation = _reservation(budget)
     forged = SideEffectPermit.model_construct(**permit.model_dump())
-    with pytest.raises(ValueError, match="lacks factory authority"):
+    with pytest.raises(ValueError, match="lacks factory authority|process-local authority"):
         authorized.start(forged, budget, _commitment(budget, reservation))
 
 
@@ -828,7 +829,7 @@ def test_finish_cleanup_is_atomic_and_rolls_back_construction_failure(
         .begin_finalization()
         .finish_finalization(_reconciliation(budget2, reservation2), _score(plan2))
     )
-    with pytest.raises(ValueError, match="lacks factory authority"):
+    with pytest.raises(ValueError, match="lacks factory authority|process-local authority"):
         cleaning2.finish_cleanup(result)
     assert cleanup2.episode_id != cleanup.episode_id
 
@@ -1095,6 +1096,7 @@ def test_unreachable_lineage_releases_weak_registry_lease() -> None:
     import weakref
 
     from local_operator.evaluation.lifecycle import _LIVE_LINEAGES
+    from local_operator.evaluation.receipts import _lookup_authority
 
     episode_id = f"lineage-gc-{next(_EPISODES)}"
     plan = _plan(episode_id)
@@ -1107,7 +1109,7 @@ def test_unreachable_lineage_releases_weak_registry_lease() -> None:
         cleanup_plan_id=cleanup.cleanup_plan_id,
     )
     child = root.preflight(_seal(plan))
-    lineage_ref = weakref.ref(child._lineage)
+    lineage_ref = weakref.ref(_lookup_authority(child, "episode-lifecycle").lineage)
     assert episode_id in _LIVE_LINEAGES
     del root
     gc.collect()
@@ -1128,7 +1130,12 @@ def test_unreachable_lineage_releases_weak_registry_lease() -> None:
 def test_lineage_is_private_unforgeable_and_shared_by_children() -> None:
     plan, budget, _cleanup_value, root = _planned()
     child = root.preflight(_seal(plan))
-    assert root._lineage is child._lineage
+    from local_operator.evaluation.receipts import _lookup_authority
+
+    assert (
+        _lookup_authority(root, "episode-lifecycle", allow_consumed=True).lineage
+        is _lookup_authority(child, "episode-lifecycle").lineage
+    )
     payload = child.model_dump()
     assert "lineage" not in payload
     forged = EpisodeLifecycle.model_construct(**payload)
@@ -1160,9 +1167,7 @@ def test_every_authority_model_blocks_copy_and_constructed_private_injection() -
         }
         construct: Any = type(live).model_construct
         constructed = construct(**live.model_dump(), **private_values)
-        assert getattr(constructed, "_authority", None) is not getattr(live, "_authority", None)
-        if isinstance(live, EpisodeLifecycle):
-            assert getattr(constructed, "_lineage", None) is not live._lineage
+        assert constructed.__pydantic_private__ in (None, {})
         if isinstance(constructed, EpisodeLifecycle):
             with pytest.raises(ValueError, match="lacks transition authority"):
                 constructed.begin_finalization()
@@ -1178,8 +1183,8 @@ def test_every_authority_model_blocks_copy_and_constructed_private_injection() -
         for module in (receipts_module, lifecycle_module)
         for value in vars(module).values()
         if inspect.isclass(value)
-        and issubclass(value, ProtocolModel)
-        and "_authority" in value.__private_attributes__
+        and issubclass(value, AuthorityModel)
+        and value is not AuthorityModel
     }
     assert authority_classes == {
         SealedPreflight,
@@ -1200,36 +1205,17 @@ def test_constructed_authority_clones_cannot_consume_originals() -> None:
     plan, budget, cleanup, authorized, permit = _authorized()
     reservation = _reservation(budget)
     commitment = _commitment(budget, reservation)
-    cloned_lifecycle = EpisodeLifecycle.model_construct(
-        **authorized.model_dump(),
-        _authority=authorized._authority,
-        _lineage=authorized._lineage,
-        _lock=authorized._lock,
-        _consumed=False,
-    )
-    cloned_permit = SideEffectPermit.model_construct(
-        **permit.model_dump(), _authority=permit._authority, _lock=permit._lock, _consumed=False
-    )
-    cloned_commitment = BudgetCommitment.model_construct(
-        **commitment.model_dump(),
-        _authority=commitment._authority,
-        _lock=commitment._lock,
-        _consumed=False,
-    )
+    cloned_lifecycle = EpisodeLifecycle.model_construct(**authorized.model_dump())
+    cloned_permit = SideEffectPermit.model_construct(**permit.model_dump())
+    cloned_commitment = BudgetCommitment.model_construct(**commitment.model_dump())
     with pytest.raises(ValueError, match="lacks transition authority"):
         cloned_lifecycle.start(cloned_permit, budget, cloned_commitment)
     running = authorized.start(permit, budget, commitment)
     finalizing = running.begin_finalization()
     cleaning = finalizing.finish_finalization(_reconciliation(budget, reservation), _score(plan))
     result = _cleanup(cleanup)
-    cloned_result = CleanupResult.model_construct(
-        **result.model_dump(),
-        _authority=result._authority,
-        _lock=result._lock,
-        _consumed=False,
-        _receipts=result._receipts,
-    )
-    with pytest.raises(ValueError, match="lacks factory authority"):
+    cloned_result = CleanupResult.model_construct(**result.model_dump())
+    with pytest.raises(ValueError, match="lacks factory authority|process-local authority"):
         cleaning.finish_cleanup(cloned_result)
     assert cleaning.finish_cleanup(result).state == "completed"
 
@@ -1269,15 +1255,19 @@ def test_validation_context_never_mints_authority_for_any_model() -> None:
             adapter.validate_json(encoded, context=hostile_context),
         )
         for parsed in parsed_values:
-            assert getattr(parsed, "_authority", None) is None
+            assert parsed.__pydantic_private__ in (None, {})
             if isinstance(parsed, EpisodeLifecycle):
                 with pytest.raises(ValueError, match="lacks transition authority"):
                     parsed.begin_finalization()
             elif isinstance(parsed, BudgetCommitment):
-                with pytest.raises(ValueError, match="lacks factory authority"):
+                with pytest.raises(
+                    ValueError, match="lacks factory authority|process-local authority"
+                ):
                     parsed.assert_authority(budget)
             else:
-                with pytest.raises(ValueError, match="lacks factory authority"):
+                with pytest.raises(
+                    ValueError, match="lacks factory authority|process-local authority"
+                ):
                     parsed.assert_authority()
 
 
@@ -1301,11 +1291,22 @@ def test_factory_objects_retain_live_receipts_lineage_and_authority() -> None:
     seal = _seal(plan)
     commitment = _commitment(budget, reservation)
     result = _cleanup(cleanup)
-    for live in (seal, commitment, result, permit, authorized):
-        assert getattr(live, "_authority", None) is not None
-    assert seal._receipts
-    assert result._receipts
-    assert authorized._lineage.episode_id == authorized.episode_id
+    from local_operator.evaluation.receipts import _lookup_authority
+
+    records = (
+        _lookup_authority(seal, "preflight-seal"),
+        _lookup_authority(commitment, "budget-commitment"),
+        _lookup_authority(result, "cleanup-result"),
+        _lookup_authority(permit, "side-effect-permit"),
+        _lookup_authority(authorized, "episode-lifecycle"),
+    )
+    assert all(
+        live.__pydantic_private__ in (None, {})
+        for live in (seal, commitment, result, permit, authorized)
+    )
+    assert records[0].receipts
+    assert records[2].receipts
+    assert records[4].lineage.episode_id == authorized.episode_id
 
 
 def test_authorized_failure_revokes_permit_and_wrong_permit_is_retryable() -> None:
@@ -1320,7 +1321,7 @@ def test_authorized_failure_revokes_permit_and_wrong_permit_is_retryable() -> No
         kind="infrastructure", reason="allocator unavailable", permit=permit
     )
     assert failed.state == "failed"
-    with pytest.raises(ValueError, match="lacks factory authority"):
+    with pytest.raises(ValueError, match="lacks factory authority|process-local authority"):
         permit.assert_authority()
     assert failed.score_id is None
     assert plan.plan_id == failed.plan_id
@@ -1354,3 +1355,133 @@ def test_authorized_fail_and_start_race_has_exactly_one_child() -> None:
     assert len(errors) == 1
     assert children[0].state in ("running", "failed")
     assert "authority" in str(errors[0])
+
+
+def test_base_model_copy_paths_never_copy_registry_authority() -> None:
+    from pydantic import BaseModel
+
+    from local_operator.evaluation.receipts import _lookup_authority
+
+    plan, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    originals = (
+        _seal(plan),
+        _commitment(budget, reservation),
+        _cleanup(cleanup),
+        permit,
+        authorized,
+    )
+    for original in originals:
+        with pytest.raises(TypeError, match="cannot be copied"):
+            BaseModel.model_copy(original)
+        clones = (
+            BaseModel.copy(original),
+            BaseModel.__copy__(original),
+            BaseModel.__deepcopy__(original),
+        )
+        for clone in clones:
+            clone = cast(AuthorityModel, clone)
+            assert clone is not original
+            with pytest.raises(ValueError, match="process-local authority"):
+                _lookup_authority(clone, "episode-lifecycle")
+            assert clone.__pydantic_private__ in (None, {})
+        # TypeAdapter may return the same already-validated instance; this is
+        # aliasing and still leaves only one consumable registry identity.
+        from pydantic import TypeAdapter
+
+        assert TypeAdapter(type(original)).validate_python(original) is original
+
+
+def test_registry_is_identity_keyed_and_weakly_releases_retained_receipts() -> None:
+    import gc
+    import weakref
+
+    from pydantic import BaseModel
+
+    from local_operator.evaluation.receipts import (
+        _authority_registry_size,
+        _lookup_authority,
+    )
+
+    plan = _plan(f"registry-gc-{next(_EPISODES)}")
+    seal = _seal(plan)
+    receipt_ref = weakref.ref(_lookup_authority(seal, "preflight-seal").receipts[0])
+    baseline = _authority_registry_size()
+    clone = cast(SealedPreflight, BaseModel.copy(seal))
+    assert clone == seal and clone is not seal
+    with pytest.raises(ValueError, match="process-local authority"):
+        _lookup_authority(clone, "preflight-seal")
+    del clone
+    del seal
+    gc.collect()
+    assert receipt_ref() is None
+    assert _authority_registry_size() < baseline
+
+
+def test_registry_dead_callback_cannot_remove_reused_identity_entry() -> None:
+    import weakref
+
+    from local_operator.evaluation.receipts import (
+        _AUTHORITY_REGISTRY,
+        _AUTHORITY_REGISTRY_LOCK,
+        AuthorityRecord,
+        _remove_authority,
+    )
+
+    first = _seal(_plan(f"callback-first-{next(_EPISODES)}"))
+    second = _seal(_plan(f"callback-second-{next(_EPISODES)}"))
+    stale_reference: Any = weakref.ref(first)
+    current_reference: Any = weakref.ref(second)
+    synthetic_id = -1
+    with _AUTHORITY_REGISTRY_LOCK:
+        _AUTHORITY_REGISTRY[synthetic_id] = (
+            current_reference,
+            AuthorityRecord(kind="preflight-seal"),
+        )
+    _remove_authority(synthetic_id, stale_reference)
+    with _AUTHORITY_REGISTRY_LOCK:
+        assert _AUTHORITY_REGISTRY[synthetic_id][0] is current_reference
+        del _AUTHORITY_REGISTRY[synthetic_id]
+
+
+def test_authority_models_store_no_private_capabilities_or_serialized_state() -> None:
+    from local_operator.evaluation.receipts import AuthorityModel
+
+    plan, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    models = (
+        _seal(plan),
+        _commitment(budget, reservation),
+        _cleanup(cleanup),
+        permit,
+        authorized,
+    )
+    forbidden = ("authority", "lineage", "lock", "consumed", "receipts")
+    for model in models:
+        assert isinstance(model, AuthorityModel)
+        assert model.__pydantic_private__ in (None, {})
+        canonical = model.to_canonical_json().decode()
+        assert not any(name in canonical for name in forbidden)
+
+
+def test_base_copy_duplicate_path_rejects_and_originals_complete_once() -> None:
+    from pydantic import BaseModel
+
+    plan, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    commitment = _commitment(budget, reservation)
+    cloned_lifecycle = cast(EpisodeLifecycle, BaseModel.copy(authorized))
+    cloned_permit = cast(SideEffectPermit, BaseModel.copy(permit))
+    cloned_commitment = cast(BudgetCommitment, BaseModel.copy(commitment))
+    with pytest.raises(ValueError, match="transition authority|process-local authority"):
+        cloned_lifecycle.start(cloned_permit, budget, cloned_commitment)
+    cleaning = (
+        authorized.start(permit, budget, commitment)
+        .begin_finalization()
+        .finish_finalization(_reconciliation(budget, reservation), _score(plan))
+    )
+    result = _cleanup(cleanup)
+    cloned_result = cast(CleanupResult, BaseModel.copy(result))
+    with pytest.raises(ValueError, match="process-local authority"):
+        cleaning.finish_cleanup(cloned_result)
+    assert cleaning.finish_cleanup(result).state == "completed"

--- a/tests/unit/evaluation/test_lifecycle.py
+++ b/tests/unit/evaluation/test_lifecycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import itertools
 import json
 import subprocess
 import sys
@@ -45,13 +46,14 @@ from local_operator.evaluation.receipts import (
 
 REPO = Path(__file__).resolve().parents[3]
 DIGEST = "0123456789abcdef" * 4
+_EPISODES = itertools.count(1)
 
 
-def _plan() -> DependencyPlan:
+def _plan(episode_id: str = "episode-1") -> DependencyPlan:
     return DependencyPlan(
         release_id="release-1",
         task_id="task-1",
-        attempt_id="attempt-1",
+        attempt_id=episode_id,
         requirements=(
             ComputeRequirement(
                 requirement_id="compute",
@@ -76,9 +78,9 @@ def _seal(plan: DependencyPlan) -> SealedPreflight:
     return seal_preflight(plan, (receipt,), RedactionSet.from_resolved_values(()))
 
 
-def _budget() -> BudgetAuthorization:
+def _budget(episode_id: str = "episode-1") -> BudgetAuthorization:
     return BudgetAuthorization(
-        episode_id="episode-1",
+        episode_id=episode_id,
         allowances=tuple(
             CappedAllowance(resource=resource, value=100, reporting="required")
             for resource in BUDGET_RESOURCES
@@ -86,9 +88,9 @@ def _budget() -> BudgetAuthorization:
     )
 
 
-def _cleanup_plan() -> CleanupPlan:
+def _cleanup_plan(episode_id: str = "episode-1") -> CleanupPlan:
     return CleanupPlan(
-        episode_id="episode-1",
+        episode_id=episode_id,
         actions=(
             CleanupAction(
                 action_id="session",
@@ -168,7 +170,7 @@ def _reconciliation(
 
 def _score(plan: DependencyPlan) -> ScoreReceipt:
     return ScoreReceipt(
-        episode_id="episode-1",
+        episode_id=plan.attempt_id,
         plan_id=plan.plan_id,
         score_artifact=ArtifactRef(
             sha256=DIGEST,
@@ -179,6 +181,24 @@ def _score(plan: DependencyPlan) -> ScoreReceipt:
     )
 
 
+def _planned() -> tuple[DependencyPlan, BudgetAuthorization, CleanupPlan, EpisodeLifecycle]:
+    episode_id = f"episode-{next(_EPISODES)}"
+    plan = _plan(episode_id)
+    budget = _budget(episode_id)
+    cleanup = _cleanup_plan(episode_id)
+    return (
+        plan,
+        budget,
+        cleanup,
+        EpisodeLifecycle.planned(
+            episode_id=episode_id,
+            plan_id=plan.plan_id,
+            budget_id=budget.budget_id,
+            cleanup_plan_id=cleanup.cleanup_plan_id,
+        ),
+    )
+
+
 def _authorized() -> tuple[
     DependencyPlan,
     BudgetAuthorization,
@@ -186,12 +206,13 @@ def _authorized() -> tuple[
     EpisodeLifecycle,
     SideEffectPermit,
 ]:
-    plan = _plan()
+    episode_id = f"episode-{next(_EPISODES)}"
+    plan = _plan(episode_id)
     seal = _seal(plan)
-    budget = _budget()
-    cleanup = _cleanup_plan()
+    budget = _budget(episode_id)
+    cleanup = _cleanup_plan(episode_id)
     episode = EpisodeLifecycle.planned(
-        episode_id="episode-1",
+        episode_id=episode_id,
         plan_id=plan.plan_id,
         budget_id=budget.budget_id,
         cleanup_plan_id=cleanup.cleanup_plan_id,
@@ -258,16 +279,8 @@ def test_permit_cannot_be_constructed_or_deserialized_by_callers() -> None:
 
 
 def test_side_effect_start_is_impossible_before_seal_permit_and_reservation() -> None:
-    plan = _plan()
-    budget = _budget()
-    cleanup = _cleanup_plan()
-    planned = EpisodeLifecycle.planned(
-        episode_id="episode-1",
-        plan_id=plan.plan_id,
-        budget_id=budget.budget_id,
-        cleanup_plan_id=cleanup.cleanup_plan_id,
-    )
-    _, _, _, authorized, permit = _authorized()
+    _plan_value, _budget_value, _cleanup_value, planned = _planned()
+    _, budget, _, authorized, permit = _authorized()
     reservation = _reservation(budget)
     with pytest.raises(ValueError, match="illegal episode transition"):
         planned.start(permit, budget, _commitment(budget, reservation))
@@ -343,26 +356,13 @@ def test_crash_and_cancel_after_running_must_flow_through_cleanup() -> None:
 
 
 def test_preflight_and_infrastructure_failures_are_unscored() -> None:
-    plan = _plan()
-    budget = _budget()
-    cleanup = _cleanup_plan()
-    planned = EpisodeLifecycle.planned(
-        episode_id="episode-1",
-        plan_id=plan.plan_id,
-        budget_id=budget.budget_id,
-        cleanup_plan_id=cleanup.cleanup_plan_id,
-    )
+    plan, budget, cleanup, planned = _planned()
     failed = planned.fail_before_running(kind="preflight", reason="display unavailable")
     assert failed.state == "failed"
     assert failed.score_id is None
     with pytest.raises(ValueError, match="illegal"):
         failed.begin_finalization()
-    planned = EpisodeLifecycle.planned(
-        episode_id="episode-1",
-        plan_id=plan.plan_id,
-        budget_id=budget.budget_id,
-        cleanup_plan_id=cleanup.cleanup_plan_id,
-    )
+    plan, budget, cleanup, planned = _planned()
     preflighted = planned.preflight(_seal(plan))
     infrastructure = preflighted.fail_before_running(
         kind="infrastructure", reason="allocator unavailable"
@@ -406,19 +406,10 @@ def test_illegal_transition_table(state: str, operation: str) -> None:
     plan, budget, cleanup, authorized, permit = _authorized()
     reservation = _reservation(budget)
     if state == "planned":
-        episode = EpisodeLifecycle.planned(
-            episode_id="episode-1",
-            plan_id=plan.plan_id,
-            budget_id=budget.budget_id,
-            cleanup_plan_id=cleanup.cleanup_plan_id,
-        )
+        _other_plan, _other_budget, _other_cleanup, episode = _planned()
     elif state == "preflighted":
-        episode = EpisodeLifecycle.planned(
-            episode_id="episode-1",
-            plan_id=plan.plan_id,
-            budget_id=budget.budget_id,
-            cleanup_plan_id=cleanup.cleanup_plan_id,
-        ).preflight(_seal(plan))
+        other_plan, _other_budget, _other_cleanup, other_planned = _planned()
+        episode = other_planned.preflight(_seal(other_plan))
     elif state == "authorized":
         episode = authorized
     else:
@@ -640,16 +631,8 @@ def test_lifecycle_rejects_reconciliation_from_mutated_authorization() -> None:
 
 
 def test_forged_preflight_seal_cannot_preflight_or_authorize() -> None:
-    plan = _plan()
+    plan, budget, _cleanup_value, planned = _planned()
     seal = _seal(plan)
-    budget = _budget()
-    cleanup = _cleanup_plan()
-    planned = EpisodeLifecycle.planned(
-        episode_id="episode-1",
-        plan_id=plan.plan_id,
-        budget_id=budget.budget_id,
-        cleanup_plan_id=cleanup.cleanup_plan_id,
-    )
     forged = SealedPreflight.model_construct(**seal.model_dump())
     with pytest.raises(ValueError, match="lacks factory authority"):
         planned.preflight(forged)
@@ -842,7 +825,7 @@ def test_finish_cleanup_is_atomic_and_rolls_back_construction_failure(
     )
     with pytest.raises(ValueError, match="lacks factory authority"):
         cleaning2.finish_cleanup(result)
-    assert cleanup2.cleanup_plan_id == cleanup.cleanup_plan_id
+    assert cleanup2.episode_id != cleanup.episode_id
 
     plan3, budget3, cleanup3, authorized3, permit3 = _authorized()
     reservation3 = _reservation(budget3)
@@ -910,16 +893,9 @@ def test_authorize_and_finalization_edges_are_atomic_under_race() -> None:
     from concurrent.futures import ThreadPoolExecutor
     from threading import Barrier
 
-    plan = _plan()
+    plan, budget, _cleanup_value, planned = _planned()
     seal = _seal(plan)
-    budget = _budget()
-    cleanup = _cleanup_plan()
-    preflighted = EpisodeLifecycle.planned(
-        episode_id=budget.episode_id,
-        plan_id=plan.plan_id,
-        budget_id=budget.budget_id,
-        cleanup_plan_id=cleanup.cleanup_plan_id,
-    ).preflight(seal)
+    preflighted = planned.preflight(seal)
     barrier = Barrier(2)
 
     def authorize() -> object:
@@ -1008,15 +984,12 @@ def test_running_competing_edges_and_constructor_rollback(
 
 
 def test_reusable_seal_stays_plan_bound_while_episode_authorities_do_not_cross() -> None:
-    plan = _plan()
+    plan = _plan("shared-plan-attempt")
     seal = _seal(plan)
-    cleanup = _cleanup_plan()
+    cleanup = _cleanup_plan("shared-plan-attempt")
     budgets = (
-        _budget(),
-        BudgetAuthorization(
-            episode_id="episode-2",
-            allowances=_budget().allowances,
-        ),
+        _budget(f"seal-reuse-{next(_EPISODES)}"),
+        _budget(f"seal-reuse-{next(_EPISODES)}"),
     )
     episodes = tuple(
         EpisodeLifecycle.planned(
@@ -1040,3 +1013,119 @@ def test_reusable_seal_stays_plan_bound_while_episode_authorities_do_not_cross()
     with pytest.raises(ValueError, match="does not match this episode"):
         authorized2.start(permit1, budgets[1], commit_budget(budgets[1], (reservation2,)))
     assert authorized1.episode_id != authorized2.episode_id
+
+
+def test_live_episode_lineage_rejects_duplicate_root_and_full_duplicate_path() -> None:
+    episode_id = f"lineage-live-{next(_EPISODES)}"
+    plan = _plan(episode_id)
+    budget = _budget(episode_id)
+    cleanup = _cleanup_plan(episode_id)
+    root = EpisodeLifecycle.planned(
+        episode_id=episode_id,
+        plan_id=plan.plan_id,
+        budget_id=budget.budget_id,
+        cleanup_plan_id=cleanup.cleanup_plan_id,
+    )
+    with pytest.raises(ValueError, match="already has a live lineage"):
+        EpisodeLifecycle.planned(
+            episode_id=episode_id,
+            plan_id=plan.plan_id,
+            budget_id=budget.budget_id,
+            cleanup_plan_id=cleanup.cleanup_plan_id,
+        )
+    child = root.preflight(_seal(plan))
+    with pytest.raises(ValueError, match="already has a live lineage"):
+        EpisodeLifecycle.planned(
+            episode_id=episode_id,
+            plan_id=DIGEST,
+            budget_id=budget.budget_id,
+            cleanup_plan_id=cleanup.cleanup_plan_id,
+        )
+    assert child.episode_id == episode_id
+
+
+def test_episode_root_mint_is_atomic_and_independent_by_identity() -> None:
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Barrier
+
+    episode_id = f"lineage-race-{next(_EPISODES)}"
+    plan = _plan(episode_id)
+    budget = _budget(episode_id)
+    cleanup = _cleanup_plan(episode_id)
+    barrier = Barrier(2)
+
+    def mint() -> object:
+        barrier.wait()
+        try:
+            return EpisodeLifecycle.planned(
+                episode_id=episode_id,
+                plan_id=plan.plan_id,
+                budget_id=budget.budget_id,
+                cleanup_plan_id=cleanup.cleanup_plan_id,
+            )
+        except ValueError as error:
+            return error
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = tuple(executor.map(lambda _index: mint(), (0, 1)))
+    assert sum(isinstance(item, EpisodeLifecycle) for item in outcomes) == 1
+    assert sum(isinstance(item, ValueError) for item in outcomes) == 1
+
+    first = f"lineage-independent-{next(_EPISODES)}"
+    second = f"lineage-independent-{next(_EPISODES)}"
+    roots = tuple(
+        EpisodeLifecycle.planned(
+            episode_id=value,
+            plan_id=_plan(value).plan_id,
+            budget_id=_budget(value).budget_id,
+            cleanup_plan_id=_cleanup_plan(value).cleanup_plan_id,
+        )
+        for value in (first, second)
+    )
+    assert roots[0].episode_id != roots[1].episode_id
+
+
+def test_unreachable_lineage_releases_weak_registry_lease() -> None:
+    import gc
+    import weakref
+
+    from local_operator.evaluation.lifecycle import _LIVE_LINEAGES
+
+    episode_id = f"lineage-gc-{next(_EPISODES)}"
+    plan = _plan(episode_id)
+    budget = _budget(episode_id)
+    cleanup = _cleanup_plan(episode_id)
+    root = EpisodeLifecycle.planned(
+        episode_id=episode_id,
+        plan_id=plan.plan_id,
+        budget_id=budget.budget_id,
+        cleanup_plan_id=cleanup.cleanup_plan_id,
+    )
+    child = root.preflight(_seal(plan))
+    lineage_ref = weakref.ref(child._lineage)
+    assert episode_id in _LIVE_LINEAGES
+    del root
+    gc.collect()
+    assert episode_id in _LIVE_LINEAGES
+    del child
+    gc.collect()
+    assert lineage_ref() is None
+    assert episode_id not in _LIVE_LINEAGES
+    retry = EpisodeLifecycle.planned(
+        episode_id=episode_id,
+        plan_id=plan.plan_id,
+        budget_id=budget.budget_id,
+        cleanup_plan_id=cleanup.cleanup_plan_id,
+    )
+    assert retry.episode_id == episode_id
+
+
+def test_lineage_is_private_unforgeable_and_shared_by_children() -> None:
+    plan, budget, _cleanup_value, root = _planned()
+    child = root.preflight(_seal(plan))
+    assert root._lineage is child._lineage
+    payload = child.model_dump()
+    assert "lineage" not in payload
+    forged = EpisodeLifecycle.model_construct(**payload)
+    with pytest.raises(ValueError, match="lacks transition authority"):
+        forged.authorize(_seal(plan), budget)

--- a/tests/unit/evaluation/test_lifecycle.py
+++ b/tests/unit/evaluation/test_lifecycle.py
@@ -858,16 +858,8 @@ def test_finish_cleanup_is_atomic_and_rolls_back_construction_failure(
 
 
 def test_every_lifecycle_parent_is_sequentially_single_use() -> None:
-    plan = _plan()
+    plan, budget, cleanup, planned = _planned()
     seal = _seal(plan)
-    budget = _budget()
-    cleanup = _cleanup_plan()
-    planned = EpisodeLifecycle.planned(
-        episode_id=budget.episode_id,
-        plan_id=plan.plan_id,
-        budget_id=budget.budget_id,
-        cleanup_plan_id=cleanup.cleanup_plan_id,
-    )
     preflighted = planned.preflight(seal)
     with pytest.raises(ValueError, match="lacks transition authority"):
         planned.preflight(seal)

--- a/tests/unit/evaluation/test_lifecycle.py
+++ b/tests/unit/evaluation/test_lifecycle.py
@@ -1,0 +1,489 @@
+"""Transition and cleanup contracts for benchmark-neutral evaluation episodes."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from local_operator.evaluation.lifecycle import (
+    CleanupAction,
+    CleanupPlan,
+    CleanupReceipt,
+    CleanupResult,
+    EpisodeLifecycle,
+    ScoreReceipt,
+    SideEffectPermit,
+    aggregate_cleanup,
+)
+from local_operator.evaluation.protocol import ArtifactRef
+from local_operator.evaluation.receipts import (
+    BUDGET_RESOURCES,
+    AvailableUsage,
+    BudgetAuthorization,
+    BudgetReconciliation,
+    CappedAllowance,
+    ComputeRequirement,
+    DependencyPlan,
+    PreflightReceipt,
+    RedactionSet,
+    ResourceAmount,
+    SealedPreflight,
+    reconcile_budget,
+    reserve_budget,
+    seal_preflight,
+)
+
+REPO = Path(__file__).resolve().parents[3]
+DIGEST = "0123456789abcdef" * 4
+
+
+def _plan() -> DependencyPlan:
+    return DependencyPlan(
+        release_id="release-1",
+        task_id="task-1",
+        attempt_id="attempt-1",
+        requirements=(
+            ComputeRequirement(
+                requirement_id="compute",
+                necessity="required",
+                reportability="required",
+                cpu_class="standard",
+                memory_class="standard",
+                disk_bytes=1_000,
+            ),
+        ),
+    )
+
+
+def _seal(plan: DependencyPlan) -> SealedPreflight:
+    receipt = PreflightReceipt(
+        requirement_id="compute",
+        necessity="required",
+        status="pass",
+        evidence={"probe": "safe"},
+        duration_ms=1,
+    )
+    return seal_preflight(plan, (receipt,), RedactionSet.from_resolved_values(()))
+
+
+def _budget() -> BudgetAuthorization:
+    return BudgetAuthorization(
+        episode_id="episode-1",
+        allowances=tuple(
+            CappedAllowance(resource=resource, value=100, reporting="required")
+            for resource in BUDGET_RESOURCES
+        ),
+    )
+
+
+def _cleanup_plan() -> CleanupPlan:
+    return CleanupPlan(
+        episode_id="episode-1",
+        actions=(
+            CleanupAction(
+                action_id="session",
+                kind="close_session",
+                resource_ref="session-lease",
+                timeout_ms=1_000,
+                max_attempts=3,
+            ),
+            CleanupAction(
+                action_id="volume",
+                kind="delete_volume",
+                resource_ref="volume-lease",
+                timeout_ms=5_000,
+                max_attempts=2,
+            ),
+        ),
+    )
+
+
+def _cleanup(
+    plan: CleanupPlan,
+    *,
+    session: str = "succeeded",
+    volume: str = "not_needed",
+) -> CleanupResult:
+    receipts = (
+        CleanupReceipt.model_validate(
+            {
+                "action_id": "session",
+                "status": session,
+                "evidence_code": "adapter-confirmed",
+                "duration_ms": 2,
+            }
+        ),
+        CleanupReceipt.model_validate(
+            {
+                "action_id": "volume",
+                "status": volume,
+                "evidence_code": "adapter-confirmed",
+                "duration_ms": 1,
+            }
+        ),
+    )
+    return aggregate_cleanup(plan, receipts)
+
+
+def _reservation(budget: BudgetAuthorization):  # type annotation inferred from factory
+    return reserve_budget(
+        budget,
+        tuple(ResourceAmount(resource=resource, value=10) for resource in BUDGET_RESOURCES),
+    )
+
+
+def _reconciliation(
+    budget: BudgetAuthorization,
+    reservation: Any,
+    *,
+    unavailable: bool = False,
+) -> BudgetReconciliation:
+    usage = [AvailableUsage(resource=resource, value=5) for resource in BUDGET_RESOURCES]
+    if unavailable:
+        from local_operator.evaluation.receipts import UnavailableUsage
+
+        return reconcile_budget(
+            budget,
+            (reservation,),
+            (
+                UnavailableUsage(resource="provider_input_tokens", reason="provider omitted usage"),
+                *usage[1:],
+            ),
+        )
+    return reconcile_budget(budget, (reservation,), usage)
+
+
+def _score(plan: DependencyPlan) -> ScoreReceipt:
+    return ScoreReceipt(
+        episode_id="episode-1",
+        plan_id=plan.plan_id,
+        score_artifact=ArtifactRef(
+            sha256=DIGEST,
+            media_type="application/json",
+            byte_count=100,
+        ),
+        finalized_at_ms=10,
+    )
+
+
+def _authorized() -> tuple[
+    DependencyPlan,
+    BudgetAuthorization,
+    CleanupPlan,
+    EpisodeLifecycle,
+    SideEffectPermit,
+]:
+    plan = _plan()
+    seal = _seal(plan)
+    budget = _budget()
+    cleanup = _cleanup_plan()
+    episode = EpisodeLifecycle.planned(
+        episode_id="episode-1",
+        plan_id=plan.plan_id,
+        budget_id=budget.budget_id,
+        cleanup_plan_id=cleanup.cleanup_plan_id,
+    ).preflight(seal)
+    authorized, permit = episode.authorize(seal, budget)
+    return plan, budget, cleanup, authorized, permit
+
+
+def test_cleanup_plan_is_symbolic_bounded_canonical_and_stable() -> None:
+    plan = _cleanup_plan()
+    shuffled = CleanupPlan(episode_id="episode-1", actions=tuple(reversed(plan.actions)))
+    assert shuffled.cleanup_plan_id == plan.cleanup_plan_id
+    assert CleanupPlan.from_canonical_json(plan.to_canonical_json()) == plan
+    assert b"command" not in plan.to_canonical_json()
+    assert b"api_params" not in plan.to_canonical_json()
+    with pytest.raises(ValidationError, match="duplicate action IDs"):
+        CleanupPlan(episode_id="episode-1", actions=(plan.actions[0], plan.actions[0]))
+    with pytest.raises(ValidationError):
+        CleanupAction.model_validate(
+            {
+                **plan.actions[0].model_dump(),
+                "raw_command": "rm -rf /",
+            }
+        )
+
+
+def test_cleanup_requires_exactly_one_receipt_and_attempted_is_not_clean() -> None:
+    plan = _cleanup_plan()
+    receipt = CleanupReceipt(
+        action_id="session",
+        status="succeeded",
+        evidence_code="confirmed",
+        duration_ms=1,
+    )
+    with pytest.raises(ValueError, match="exactly one"):
+        aggregate_cleanup(plan, (receipt,))
+    with pytest.raises(ValueError, match="duplicate"):
+        aggregate_cleanup(plan, (receipt, receipt))
+    attempted = _cleanup(plan, session="attempted")
+    assert attempted.rescue_required
+    assert attempted.incomplete_action_ids == ("session",)
+    assert CleanupResult.from_canonical_json(attempted.to_canonical_json()) == attempted
+    clean = _cleanup(plan)
+    assert not clean.rescue_required
+
+
+def test_permit_cannot_be_constructed_or_deserialized_by_callers() -> None:
+    plan, budget, _cleanup_plan_value, _episode, permit = _authorized()
+    payload = permit.model_dump()
+    with pytest.raises(ValidationError, match="only be minted"):
+        SideEffectPermit.model_validate(payload)
+    with pytest.raises(ValidationError, match="only be minted"):
+        SideEffectPermit.from_canonical_json(permit.to_canonical_json())
+    with pytest.raises(ValidationError):
+        SideEffectPermit(
+            episode_id="episode-1",
+            plan_id=plan.plan_id,
+            preflight_seal_id=DIGEST,
+            budget_id=budget.budget_id,
+            permit_id=DIGEST,
+        )
+
+
+def test_side_effect_start_is_impossible_before_seal_permit_and_reservation() -> None:
+    plan = _plan()
+    budget = _budget()
+    cleanup = _cleanup_plan()
+    planned = EpisodeLifecycle.planned(
+        episode_id="episode-1",
+        plan_id=plan.plan_id,
+        budget_id=budget.budget_id,
+        cleanup_plan_id=cleanup.cleanup_plan_id,
+    )
+    _, _, _, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    with pytest.raises(ValueError, match="illegal episode transition"):
+        planned.start(permit, (reservation,))
+    with pytest.raises(ValueError, match="prior budget reservation"):
+        authorized.start(permit, ())
+    forged_payload = {**permit.model_dump(), "episode_id": "episode-other"}
+    with pytest.raises(ValidationError):
+        SideEffectPermit.model_validate(forged_payload)
+    running = authorized.start(permit, (reservation,))
+    assert running.state == "running"
+    assert running.reservation_ids == (reservation.reservation_id,)
+
+
+def test_legal_happy_path_requires_cost_score_and_clean_result() -> None:
+    plan, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    running = authorized.start(permit, (reservation,))
+    finalizing = running.begin_finalization()
+    reconciliation = _reconciliation(budget, reservation)
+    cleaning = finalizing.finish_finalization(reconciliation, _score(plan))
+    assert cleaning.state == "cleaning"
+    completed = cleaning.finish_cleanup(_cleanup(cleanup))
+    assert completed.state == "completed"
+    assert completed.reconciliation_id == reconciliation.reconciliation_id
+    assert completed.score_id is not None
+    assert completed.rescue_required is False
+    assert EpisodeLifecycle.from_canonical_json(completed.to_canonical_json()) == completed
+
+
+def test_unreportable_usage_or_incomplete_cleanup_cannot_complete() -> None:
+    plan, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    finalizing = authorized.start(permit, (reservation,)).begin_finalization()
+    unreportable = _reconciliation(budget, reservation, unavailable=True)
+    cleaning = finalizing.finish_finalization(unreportable, _score(plan))
+    failed = cleaning.finish_cleanup(_cleanup(cleanup))
+    assert failed.state == "failed"
+    assert failed.failure_kind == "unreportable"
+    reportable = _reconciliation(budget, reservation)
+    cleaning = finalizing.finish_finalization(reportable, _score(plan))
+    rescue = cleaning.finish_cleanup(_cleanup(cleanup, volume="failed"))
+    assert rescue.state == "failed"
+    assert rescue.failure_kind == "cleanup"
+    assert rescue.rescue_required
+
+
+def test_crash_and_cancel_after_running_must_flow_through_cleanup() -> None:
+    _plan_value, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    running = authorized.start(permit, (reservation,))
+    crashed = running.crash("adapter process exited")
+    assert crashed.state == "cleaning"
+    failed = crashed.finish_cleanup(_cleanup(cleanup))
+    assert failed.state == "failed"
+    assert failed.cleanup_result_id is not None
+    cancelled = running.cancel("operator requested cancellation")
+    assert cancelled.state == "cleaning"
+    terminal = cancelled.finish_cleanup(_cleanup(cleanup))
+    assert terminal.state == "cancelled"
+    assert terminal.cleanup_result_id is not None
+
+
+def test_preflight_and_infrastructure_failures_are_unscored() -> None:
+    plan = _plan()
+    budget = _budget()
+    cleanup = _cleanup_plan()
+    planned = EpisodeLifecycle.planned(
+        episode_id="episode-1",
+        plan_id=plan.plan_id,
+        budget_id=budget.budget_id,
+        cleanup_plan_id=cleanup.cleanup_plan_id,
+    )
+    failed = planned.fail_before_running(kind="preflight", reason="display unavailable")
+    assert failed.state == "failed"
+    assert failed.score_id is None
+    with pytest.raises(ValueError, match="illegal"):
+        failed.begin_finalization()
+    preflighted = planned.preflight(_seal(plan))
+    infrastructure = preflighted.fail_before_running(
+        kind="infrastructure", reason="allocator unavailable"
+    )
+    assert infrastructure.score_id is None
+
+
+def test_ambiguous_finalization_is_terminal_after_cleanup_and_cannot_rescore() -> None:
+    plan, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    finalizing = authorized.start(permit, (reservation,)).begin_finalization()
+    ambiguous = finalizing.mark_ambiguous_finalization(
+        _reconciliation(budget, reservation),
+        "judge response committed but acknowledgement was lost",
+    )
+    assert ambiguous.state == "cleaning"
+    with pytest.raises(ValueError, match="illegal"):
+        ambiguous.finish_finalization(_reconciliation(budget, reservation), _score(plan))
+    failed = ambiguous.finish_cleanup(_cleanup(cleanup))
+    assert failed.state == "failed"
+    assert failed.failure_kind == "ambiguous_finalization"
+
+
+@pytest.mark.parametrize(
+    ("state", "operation"),
+    [
+        ("planned", "begin_finalization"),
+        ("preflighted", "begin_finalization"),
+        ("authorized", "begin_finalization"),
+        ("running", "preflight"),
+        ("finalizing", "begin_finalization"),
+        ("cleaning", "begin_finalization"),
+        ("completed", "begin_finalization"),
+        ("failed", "begin_finalization"),
+        ("cancelled", "begin_finalization"),
+    ],
+)
+def test_illegal_transition_table(state: str, operation: str) -> None:
+    plan, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    running = authorized.start(permit, (reservation,))
+    reconciliation = _reconciliation(budget, reservation)
+    finalizing = running.begin_finalization()
+    cleaning = finalizing.finish_finalization(reconciliation, _score(plan))
+    episodes = {
+        "planned": EpisodeLifecycle.planned(
+            episode_id="episode-1",
+            plan_id=plan.plan_id,
+            budget_id=budget.budget_id,
+            cleanup_plan_id=cleanup.cleanup_plan_id,
+        ),
+        "preflighted": EpisodeLifecycle.planned(
+            episode_id="episode-1",
+            plan_id=plan.plan_id,
+            budget_id=budget.budget_id,
+            cleanup_plan_id=cleanup.cleanup_plan_id,
+        ).preflight(_seal(plan)),
+        "authorized": authorized,
+        "running": running,
+        "finalizing": finalizing,
+        "cleaning": cleaning,
+        "completed": cleaning.finish_cleanup(_cleanup(cleanup)),
+        "failed": running.crash("crash").finish_cleanup(_cleanup(cleanup)),
+        "cancelled": running.cancel("cancel").finish_cleanup(_cleanup(cleanup)),
+    }
+    episode = episodes[state]
+    if operation == "preflight":
+        with pytest.raises(ValueError, match="illegal"):
+            episode.preflight(_seal(plan))
+    else:
+        with pytest.raises(ValueError, match="illegal"):
+            episode.begin_finalization()
+
+
+def test_direct_snapshots_cannot_claim_completion_without_all_evidence() -> None:
+    plan, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    base = authorized.start(permit, (reservation,)).model_dump()
+    for missing in ("preflight_seal_id", "permit_id", "reconciliation_id", "score_id"):
+        payload = {
+            **base,
+            "state": "completed",
+            "terminal_intent": "complete",
+            "reconciliation_id": DIGEST,
+            "reconciliation_reportable": True,
+            "score_id": DIGEST,
+            "cleanup_result_id": DIGEST,
+            "rescue_required": False,
+            missing: None,
+        }
+        with pytest.raises(ValidationError):
+            EpisodeLifecycle.model_validate(payload)
+    assert cleanup.cleanup_plan_id == base["cleanup_plan_id"]
+
+
+def test_imports_are_isolated_and_evaluation_root_remains_inert() -> None:
+    forbidden = (
+        "PIL",
+        "boto3",
+        "botocore",
+        "gymnasium",
+        "osworld",
+        "OSWorld",
+        "subprocess",
+        "local_operator.config",
+        "local_operator.providers",
+        "local_operator.tools",
+        "local_operator.tui",
+        "local_operator.mobile",
+    )
+    for module in (
+        "local_operator.evaluation.receipts",
+        "local_operator.evaluation.lifecycle",
+    ):
+        imported = _fresh_import_modules(module)
+        assert not {
+            name
+            for name in imported
+            if any(name == prefix or name.startswith(prefix + ".") for prefix in forbidden)
+        }
+    root_imports = _fresh_import_modules("local_operator.evaluation")
+    assert "local_operator.evaluation.receipts" not in root_imports
+    assert "local_operator.evaluation.lifecycle" not in root_imports
+    for startup in ("local_operator.cli", "local_operator.session_factory"):
+        imported = _fresh_import_modules(startup)
+        assert "local_operator.evaluation.receipts" not in imported
+        assert "local_operator.evaluation.lifecycle" not in imported
+
+
+def _fresh_import_modules(module: str) -> set[str]:
+    probe = (
+        "import importlib,json,sys;"
+        "importlib.import_module(sys.argv[1]);"
+        "print(json.dumps(sorted(sys.modules)))"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe, module],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr[-3_000:]
+    return set(json.loads(completed.stdout.strip().splitlines()[-1]))
+
+
+def test_evaluation_root_source_stays_inert() -> None:
+    root = importlib.import_module("local_operator.evaluation")
+    assert not hasattr(root, "EpisodeLifecycle")
+    assert not hasattr(root, "DependencyPlan")

--- a/tests/unit/evaluation/test_lifecycle.py
+++ b/tests/unit/evaluation/test_lifecycle.py
@@ -234,7 +234,8 @@ def test_cleanup_requires_exactly_one_receipt_and_attempted_is_not_clean() -> No
     attempted = _cleanup(plan, session="attempted")
     assert attempted.rescue_required
     assert attempted.incomplete_action_ids == ("session",)
-    assert CleanupResult.from_canonical_json(attempted.to_canonical_json()) == attempted
+    with pytest.raises(ValidationError, match="validated receipts"):
+        CleanupResult.from_canonical_json(attempted.to_canonical_json())
     clean = _cleanup(plan)
     assert not clean.rescue_required
 
@@ -419,7 +420,7 @@ def test_illegal_transition_table(state: str, operation: str) -> None:
         with pytest.raises(ValueError, match="illegal"):
             episode.preflight(_seal(plan))
     else:
-        with pytest.raises(ValueError, match="illegal"):
+        with pytest.raises(ValueError, match="illegal|lacks transition authority"):
             episode.begin_finalization()
 
 
@@ -556,7 +557,10 @@ def test_lifecycle_authority_rejects_every_public_construction_and_mutation_path
         forged.begin_finalization()
     with pytest.raises(TypeError, match="cannot be updated"):
         authorized.model_copy(update={"state": "completed"})
-    assert copy.deepcopy(authorized) is authorized
+    with pytest.raises(TypeError, match="cannot be copied"):
+        copy.copy(authorized)
+    with pytest.raises(TypeError, match="cannot be copied"):
+        copy.deepcopy(authorized)
     with pytest.raises(TypeError, match="cannot be pickled"):
         pickle.dumps(authorized)
     assert authorized.previous_state_id is not None
@@ -609,3 +613,110 @@ def test_lifecycle_rejects_reconciliation_from_mutated_authorization() -> None:
             }
         )
     assert plan.plan_id == finalizing.plan_id
+
+
+def test_forged_preflight_seal_cannot_preflight_or_authorize() -> None:
+    plan = _plan()
+    seal = _seal(plan)
+    budget = _budget()
+    cleanup = _cleanup_plan()
+    planned = EpisodeLifecycle.planned(
+        episode_id="episode-1",
+        plan_id=plan.plan_id,
+        budget_id=budget.budget_id,
+        cleanup_plan_id=cleanup.cleanup_plan_id,
+    )
+    forged = SealedPreflight.model_construct(**seal.model_dump())
+    with pytest.raises(ValueError, match="lacks factory authority"):
+        planned.preflight(forged)
+    preflighted = planned.preflight(seal)
+    with pytest.raises(ValueError, match="lacks factory authority"):
+        preflighted.authorize(forged, budget)
+
+
+def test_forged_cleanup_result_cannot_complete_episode() -> None:
+    plan, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    cleaning = (
+        authorized.start(permit, budget, _commitment(budget, reservation))
+        .begin_finalization()
+        .finish_finalization(_reconciliation(budget, reservation), _score(plan))
+    )
+    result = _cleanup(cleanup)
+    forged = CleanupResult.model_construct(**result.model_dump())
+    with pytest.raises(ValueError, match="lacks factory authority"):
+        cleaning.finish_cleanup(forged)
+
+
+def test_authorized_lifecycle_is_single_use_across_sibling_commitments() -> None:
+    import copy
+
+    _plan_value, budget, _cleanup_value, authorized, permit = _authorized()
+    first = reserve_budget(
+        budget,
+        "sibling-a",
+        (ResourceAmount(resource="guest_actions", value=10),),
+    )
+    second = reserve_budget(
+        budget,
+        "sibling-b",
+        (ResourceAmount(resource="guest_actions", value=10),),
+    )
+    copied = None
+    with pytest.raises(TypeError, match="cannot be copied"):
+        copied = copy.copy(authorized)
+    assert copied is None
+    first_running = authorized.start(permit, budget, commit_budget(budget, (first,)))
+    assert first_running.state == "running"
+    with pytest.raises(ValueError, match="lacks transition authority"):
+        authorized.start(permit, budget, commit_budget(budget, (second,)))
+
+
+def test_forged_side_effect_permit_cannot_start() -> None:
+    _plan_value, budget, _cleanup_value, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    forged = SideEffectPermit.model_construct(**permit.model_dump())
+    with pytest.raises(ValueError, match="lacks factory authority"):
+        authorized.start(forged, budget, _commitment(budget, reservation))
+
+
+def test_finalizing_crash_and_cancel_still_require_cleanup() -> None:
+    _plan_value, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    finalizing = authorized.start(
+        permit, budget, _commitment(budget, reservation)
+    ).begin_finalization()
+    crashed = finalizing.crash("judge process exited")
+    assert crashed.state == "cleaning"
+    assert crashed.finish_cleanup(_cleanup(cleanup)).state == "failed"
+
+    # Each state node is single use only at side-effect start; independent test
+    # setup provides a second finalizing authority for cancellation.
+    _plan_value, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    finalizing = authorized.start(
+        permit, budget, _commitment(budget, reservation)
+    ).begin_finalization()
+    cancelled = finalizing.cancel("operator cancelled during judging")
+    assert cancelled.state == "cleaning"
+    assert cancelled.finish_cleanup(_cleanup(cleanup)).state == "cancelled"
+
+
+def test_cleanup_cannot_succeed_after_timeout() -> None:
+    plan = _cleanup_plan()
+    late = record_cleanup(
+        plan,
+        "session",
+        status="succeeded",
+        evidence_code="late-confirmation",
+        duration_ms=plan.actions[0].timeout_ms + 1,
+    )
+    other = record_cleanup(
+        plan,
+        "volume",
+        status="not_needed",
+        evidence_code="not-allocated",
+        duration_ms=0,
+    )
+    with pytest.raises(ValueError, match="after its action timeout"):
+        aggregate_cleanup(plan, (late, other))

--- a/tests/unit/evaluation/test_lifecycle.py
+++ b/tests/unit/evaluation/test_lifecycle.py
@@ -23,7 +23,7 @@ from local_operator.evaluation.lifecycle import (
     aggregate_cleanup,
     record_cleanup,
 )
-from local_operator.evaluation.protocol import ArtifactRef
+from local_operator.evaluation.protocol import ArtifactRef, ProtocolModel
 from local_operator.evaluation.receipts import (
     BUDGET_RESOURCES,
     AvailableUsage,
@@ -570,7 +570,7 @@ def test_lifecycle_authority_rejects_every_public_construction_and_mutation_path
     forged = EpisodeLifecycle.model_construct(**payload)
     with pytest.raises(ValueError, match="lacks transition authority"):
         forged.begin_finalization()
-    with pytest.raises(TypeError, match="cannot be updated"):
+    with pytest.raises(ValueError, match="cannot be copied"):
         authorized.model_copy(update={"state": "completed"})
     with pytest.raises(TypeError, match="cannot be copied"):
         copy.copy(authorized)
@@ -1129,3 +1129,101 @@ def test_lineage_is_private_unforgeable_and_shared_by_children() -> None:
     forged = EpisodeLifecycle.model_construct(**payload)
     with pytest.raises(ValueError, match="lacks transition authority"):
         forged.authorize(_seal(plan), budget)
+
+
+def test_every_authority_model_blocks_copy_and_constructed_private_injection() -> None:
+    import inspect
+
+    from local_operator.evaluation import lifecycle as lifecycle_module
+    from local_operator.evaluation import receipts as receipts_module
+    from local_operator.evaluation.receipts import AuthorityModel
+
+    plan, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    commitment = _commitment(budget, reservation)
+    seal = _seal(plan)
+    cleanup_result = _cleanup(cleanup)
+    live_models = (authorized, permit, commitment, seal, cleanup_result)
+    for live in live_models:
+        with pytest.raises(ValueError, match="cannot be copied"):
+            live.copy()
+        with pytest.raises(ValueError, match="cannot be copied"):
+            live.model_copy()
+        private_values = {
+            name: getattr(live, name, object())
+            for name in ("_authority", "_lineage", "_lock", "_consumed", "_receipts")
+        }
+        construct: Any = type(live).model_construct
+        constructed = construct(**live.model_dump(), **private_values)
+        assert getattr(constructed, "_authority", None) is not getattr(live, "_authority", None)
+        if isinstance(live, EpisodeLifecycle):
+            assert getattr(constructed, "_lineage", None) is not live._lineage
+        if isinstance(constructed, EpisodeLifecycle):
+            with pytest.raises(ValueError, match="lacks transition authority"):
+                constructed.begin_finalization()
+        elif hasattr(constructed, "assert_authority"):
+            with pytest.raises((ValueError, AttributeError)):
+                if isinstance(constructed, BudgetCommitment):
+                    constructed.assert_authority(budget)
+                else:
+                    constructed.assert_authority()
+
+    authority_classes = {
+        value
+        for module in (receipts_module, lifecycle_module)
+        for value in vars(module).values()
+        if inspect.isclass(value)
+        and issubclass(value, ProtocolModel)
+        and "_authority" in value.__private_attributes__
+    }
+    assert authority_classes == {
+        SealedPreflight,
+        BudgetCommitment,
+        CleanupResult,
+        SideEffectPermit,
+        EpisodeLifecycle,
+    }
+    assert all(issubclass(value, AuthorityModel) for value in authority_classes)
+    assert all(value.copy is AuthorityModel.copy for value in authority_classes)
+    assert all(
+        value.model_construct.__func__ is AuthorityModel.model_construct.__func__
+        for value in authority_classes
+    )
+
+
+def test_constructed_authority_clones_cannot_consume_originals() -> None:
+    plan, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    commitment = _commitment(budget, reservation)
+    cloned_lifecycle = EpisodeLifecycle.model_construct(
+        **authorized.model_dump(),
+        _authority=authorized._authority,
+        _lineage=authorized._lineage,
+        _lock=authorized._lock,
+        _consumed=False,
+    )
+    cloned_permit = SideEffectPermit.model_construct(
+        **permit.model_dump(), _authority=permit._authority, _lock=permit._lock, _consumed=False
+    )
+    cloned_commitment = BudgetCommitment.model_construct(
+        **commitment.model_dump(),
+        _authority=commitment._authority,
+        _lock=commitment._lock,
+        _consumed=False,
+    )
+    with pytest.raises(ValueError, match="lacks transition authority"):
+        cloned_lifecycle.start(cloned_permit, budget, cloned_commitment)
+    running = authorized.start(permit, budget, commitment)
+    finalizing = running.begin_finalization()
+    cleaning = finalizing.finish_finalization(_reconciliation(budget, reservation), _score(plan))
+    result = _cleanup(cleanup)
+    cloned_result = CleanupResult.model_construct(
+        **result.model_dump(),
+        _authority=result._authority,
+        _lock=result._lock,
+        _consumed=False,
+        _receipts=result._receipts,
+    )
+    with pytest.raises(ValueError, match="lacks factory authority"):
+        cleaning.finish_cleanup(cloned_result)
+    assert cleaning.finish_cleanup(result).state == "completed"

--- a/tests/unit/evaluation/test_lifecycle.py
+++ b/tests/unit/evaluation/test_lifecycle.py
@@ -720,3 +720,125 @@ def test_cleanup_cannot_succeed_after_timeout() -> None:
     )
     with pytest.raises(ValueError, match="after its action timeout"):
         aggregate_cleanup(plan, (late, other))
+
+
+def test_start_is_atomic_across_threads_and_rolls_back_construction_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Barrier
+
+    for iteration in range(12):
+        _plan_value, budget, _cleanup_value, authorized, permit = _authorized()
+        reservations = tuple(
+            reserve_budget(
+                budget,
+                f"race-{iteration}-{suffix}",
+                (ResourceAmount(resource="guest_actions", value=10),),
+            )
+            for suffix in ("a", "b")
+        )
+        commitments = tuple(commit_budget(budget, (item,)) for item in reservations)
+        barrier = Barrier(2)
+
+        def attempt(index: int) -> object:
+            barrier.wait()
+            try:
+                return authorized.start(permit, budget, commitments[index])
+            except ValueError as error:
+                return error
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            outcomes = tuple(executor.map(attempt, (0, 1)))
+        running = [item for item in outcomes if isinstance(item, EpisodeLifecycle)]
+        rejected = [item for item in outcomes if isinstance(item, ValueError)]
+        assert len(running) == 1
+        assert len(rejected) == 1
+        assert running[0].state == "running"
+        assert "authority" in str(rejected[0])
+
+    _plan_value, budget, _cleanup_value, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    commitment = _commitment(budget, reservation)
+    original = EpisodeLifecycle._transition
+    calls = 0
+
+    def fail_once(self, expected, operation, **updates):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ValueError("injected child construction failure")
+        return original(self, expected, operation, **updates)
+
+    monkeypatch.setattr(EpisodeLifecycle, "_transition", fail_once)
+    with pytest.raises(ValueError, match="injected child construction failure"):
+        authorized.start(permit, budget, commitment)
+    assert authorized.start(permit, budget, commitment).state == "running"
+
+
+def test_finish_cleanup_is_atomic_and_rolls_back_construction_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Barrier
+
+    plan, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    cleaning = (
+        authorized.start(permit, budget, _commitment(budget, reservation))
+        .begin_finalization()
+        .finish_finalization(_reconciliation(budget, reservation), _score(plan))
+    )
+    result = _cleanup(cleanup)
+    barrier = Barrier(2)
+
+    def attempt() -> object:
+        barrier.wait()
+        try:
+            return cleaning.finish_cleanup(result)
+        except ValueError as error:
+            return error
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = tuple(executor.map(lambda _index: attempt(), (0, 1)))
+    terminal = [item for item in outcomes if isinstance(item, EpisodeLifecycle)]
+    rejected = [item for item in outcomes if isinstance(item, ValueError)]
+    assert len(terminal) == 1
+    assert len(rejected) == 1
+    assert terminal[0].state == "completed"
+
+    # A cleanup result is single-use even against a separately minted but
+    # content-identical cleaning authority.
+    plan2, budget2, cleanup2, authorized2, permit2 = _authorized()
+    reservation2 = _reservation(budget2)
+    cleaning2 = (
+        authorized2.start(permit2, budget2, _commitment(budget2, reservation2))
+        .begin_finalization()
+        .finish_finalization(_reconciliation(budget2, reservation2), _score(plan2))
+    )
+    with pytest.raises(ValueError, match="lacks factory authority"):
+        cleaning2.finish_cleanup(result)
+    assert cleanup2.cleanup_plan_id == cleanup.cleanup_plan_id
+
+    plan3, budget3, cleanup3, authorized3, permit3 = _authorized()
+    reservation3 = _reservation(budget3)
+    cleaning3 = (
+        authorized3.start(permit3, budget3, _commitment(budget3, reservation3))
+        .begin_finalization()
+        .finish_finalization(_reconciliation(budget3, reservation3), _score(plan3))
+    )
+    retryable_result = _cleanup(cleanup3)
+    original = EpisodeLifecycle._transition
+    calls = 0
+
+    def fail_once(self, expected, operation, **updates):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ValueError("injected terminal construction failure")
+        return original(self, expected, operation, **updates)
+
+    monkeypatch.setattr(EpisodeLifecycle, "_transition", fail_once)
+    with pytest.raises(ValueError, match="injected terminal construction failure"):
+        cleaning3.finish_cleanup(retryable_result)
+    assert cleaning3.finish_cleanup(retryable_result).state == "completed"

--- a/tests/unit/evaluation/test_lifecycle.py
+++ b/tests/unit/evaluation/test_lifecycle.py
@@ -255,8 +255,9 @@ def test_cleanup_requires_exactly_one_receipt_and_attempted_is_not_clean() -> No
     attempted = _cleanup(plan, session="attempted")
     assert attempted.rescue_required
     assert attempted.incomplete_action_ids == ("session",)
-    with pytest.raises(ValidationError, match="validated receipts"):
-        CleanupResult.from_canonical_json(attempted.to_canonical_json())
+    parsed = CleanupResult.from_canonical_json(attempted.to_canonical_json())
+    with pytest.raises(ValueError, match="lacks factory authority"):
+        parsed.assert_authority()
     clean = _cleanup(plan)
     assert not clean.rescue_required
 
@@ -264,10 +265,12 @@ def test_cleanup_requires_exactly_one_receipt_and_attempted_is_not_clean() -> No
 def test_permit_cannot_be_constructed_or_deserialized_by_callers() -> None:
     plan, budget, _cleanup_plan_value, _episode, permit = _authorized()
     payload = permit.model_dump()
-    with pytest.raises(ValidationError, match="only be minted"):
-        SideEffectPermit.model_validate(payload)
-    with pytest.raises(ValidationError, match="only be minted"):
-        SideEffectPermit.from_canonical_json(permit.to_canonical_json())
+    for parsed in (
+        SideEffectPermit.model_validate(payload),
+        SideEffectPermit.from_canonical_json(permit.to_canonical_json()),
+    ):
+        with pytest.raises(ValueError, match="lacks factory authority"):
+            parsed.assert_authority()
     with pytest.raises(ValidationError):
         SideEffectPermit(
             episode_id="episode-1",
@@ -307,8 +310,9 @@ def test_legal_happy_path_requires_cost_score_and_clean_result() -> None:
     assert completed.reconciliation_id == reconciliation.reconciliation_id
     assert completed.score_id is not None
     assert completed.rescue_required is False
-    with pytest.raises(ValidationError, match="factory minted"):
-        EpisodeLifecycle.from_canonical_json(completed.to_canonical_json())
+    parsed = EpisodeLifecycle.from_canonical_json(completed.to_canonical_json())
+    with pytest.raises(ValueError, match="lacks transition authority"):
+        parsed.begin_finalization()
 
 
 def test_unreportable_usage_or_incomplete_cleanup_cannot_complete() -> None:
@@ -561,12 +565,13 @@ def test_lifecycle_authority_rejects_every_public_construction_and_mutation_path
 
     plan, budget, cleanup, authorized, _permit = _authorized()
     payload = authorized.model_dump()
-    with pytest.raises(ValidationError, match="factory minted"):
-        EpisodeLifecycle.model_validate(payload)
-    with pytest.raises(ValidationError, match="factory minted"):
-        EpisodeLifecycle.model_validate_json(authorized.to_canonical_json())
-    with pytest.raises(ValidationError, match="factory minted"):
-        EpisodeLifecycle.from_canonical_json(authorized.to_canonical_json())
+    for parsed in (
+        EpisodeLifecycle.model_validate(payload),
+        EpisodeLifecycle.model_validate_json(authorized.to_canonical_json()),
+        EpisodeLifecycle.from_canonical_json(authorized.to_canonical_json()),
+    ):
+        with pytest.raises(ValueError, match="lacks transition authority"):
+            parsed.begin_finalization()
     forged = EpisodeLifecycle.model_construct(**payload)
     with pytest.raises(ValueError, match="lacks transition authority"):
         forged.begin_finalization()
@@ -1227,3 +1232,125 @@ def test_constructed_authority_clones_cannot_consume_originals() -> None:
     with pytest.raises(ValueError, match="lacks factory authority"):
         cleaning.finish_cleanup(cloned_result)
     assert cleaning.finish_cleanup(result).state == "completed"
+
+
+def test_validation_context_never_mints_authority_for_any_model() -> None:
+    from pydantic import TypeAdapter
+
+    plan, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    live_models = (
+        _seal(plan),
+        _commitment(budget, reservation),
+        _cleanup(cleanup),
+        permit,
+        authorized,
+    )
+    hostile_context = {
+        "preflight_seal_factory": object(),
+        "preflight_receipts": object(),
+        "budget_commitment_factory": object(),
+        "cleanup_result_factory": object(),
+        "cleanup_receipts": object(),
+        "permit_factory": object(),
+        "lifecycle_factory": object(),
+        "episode_lineage": object(),
+        "_FACTORY_TOKEN": object(),
+        "_LIFECYCLE_TOKEN": object(),
+    }
+    for live in live_models:
+        adapter = TypeAdapter(type(live))
+        payload = live.model_dump(mode="json")
+        encoded = live.to_canonical_json()
+        parsed_values = (
+            type(live).model_validate(payload, context=hostile_context),
+            type(live).model_validate_json(encoded, context=hostile_context),
+            adapter.validate_python(payload, context=hostile_context),
+            adapter.validate_json(encoded, context=hostile_context),
+        )
+        for parsed in parsed_values:
+            assert getattr(parsed, "_authority", None) is None
+            if isinstance(parsed, EpisodeLifecycle):
+                with pytest.raises(ValueError, match="lacks transition authority"):
+                    parsed.begin_finalization()
+            elif isinstance(parsed, BudgetCommitment):
+                with pytest.raises(ValueError, match="lacks factory authority"):
+                    parsed.assert_authority(budget)
+            else:
+                with pytest.raises(ValueError, match="lacks factory authority"):
+                    parsed.assert_authority()
+
+
+def test_authority_validators_do_not_read_context_or_factory_tokens() -> None:
+    import inspect
+
+    from local_operator.evaluation import lifecycle as lifecycle_module
+    from local_operator.evaluation import receipts as receipts_module
+
+    source = inspect.getsource(receipts_module) + inspect.getsource(lifecycle_module)
+    assert "ValidationInfo" not in source
+    assert ".context" not in source
+    assert "_FACTORY_TOKEN" not in source
+    assert "_LIFECYCLE_TOKEN" not in source
+    assert "context=" not in source
+
+
+def test_factory_objects_retain_live_receipts_lineage_and_authority() -> None:
+    plan, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    seal = _seal(plan)
+    commitment = _commitment(budget, reservation)
+    result = _cleanup(cleanup)
+    for live in (seal, commitment, result, permit, authorized):
+        assert getattr(live, "_authority", None) is not None
+    assert seal._receipts
+    assert result._receipts
+    assert authorized._lineage.episode_id == authorized.episode_id
+
+
+def test_authorized_failure_revokes_permit_and_wrong_permit_is_retryable() -> None:
+    plan, budget, _cleanup_value, authorized, permit = _authorized()
+    _other_plan, _other_budget, _other_cleanup, _other_authorized, wrong = _authorized()
+    with pytest.raises(ValueError, match="does not match this episode"):
+        authorized.fail_before_running(
+            kind="infrastructure", reason="allocator unavailable", permit=wrong
+        )
+    permit.assert_authority()
+    failed = authorized.fail_before_running(
+        kind="infrastructure", reason="allocator unavailable", permit=permit
+    )
+    assert failed.state == "failed"
+    with pytest.raises(ValueError, match="lacks factory authority"):
+        permit.assert_authority()
+    assert failed.score_id is None
+    assert plan.plan_id == failed.plan_id
+
+
+def test_authorized_fail_and_start_race_has_exactly_one_child() -> None:
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Barrier
+
+    _plan_value, budget, _cleanup_value, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    commitment = _commitment(budget, reservation)
+    barrier = Barrier(2)
+
+    def attempt(operation: str) -> object:
+        barrier.wait()
+        try:
+            if operation == "start":
+                return authorized.start(permit, budget, commitment)
+            return authorized.fail_before_running(
+                kind="infrastructure", reason="allocator unavailable", permit=permit
+            )
+        except ValueError as error:
+            return error
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = tuple(executor.map(attempt, ("start", "fail")))
+    children = [item for item in outcomes if isinstance(item, EpisodeLifecycle)]
+    errors = [item for item in outcomes if isinstance(item, ValueError)]
+    assert len(children) == 1
+    assert len(errors) == 1
+    assert children[0].state in ("running", "failed")
+    assert "authority" in str(errors[0])

--- a/tests/unit/evaluation/test_lifecycle.py
+++ b/tests/unit/evaluation/test_lifecycle.py
@@ -608,6 +608,60 @@ def test_direct_overcap_reservation_and_forged_commitment_cannot_start() -> None
         authorized.start(permit, budget, forged)
 
 
+def test_finalization_rejects_reconciliation_from_different_commitment() -> None:
+    plan, budget, _cleanup_value, authorized, permit = _authorized()
+    reservation = reserve_budget(
+        budget,
+        "exact-commitment",
+        (ResourceAmount(resource="guest_actions", value=10),),
+    )
+    commitment = commit_budget(budget, (reservation,))
+    finalizing = authorized.start(permit, budget, commitment).begin_finalization()
+    valid = _reconciliation(budget, reservation)
+    payload = valid.model_dump(mode="json")
+    entries = [dict(entry) for entry in payload["entries"]]
+    guest = next(entry for entry in entries if entry["resource"] == "guest_actions")
+    guest["reserved"] = 99
+    forged_payload = {
+        **payload,
+        "entries": entries,
+        "commitment_id": "0" * 64,
+        "reconciliation_id": "0" * 64,
+    }
+    # Let the pure reconciliation validator derive the distinct internally
+    # consistent identities from the changed reserved totals.
+    from local_operator.evaluation.receipts import _identity as receipt_identity
+
+    commitment_payload = {
+        "episode_id": budget.episode_id,
+        "budget_id": budget.budget_id,
+        "authorization_digest": budget.budget_id,
+        "reservation_ids": tuple(item.reservation_id for item in (reservation,)),
+        "reserved": tuple(
+            ResourceAmount(resource=entry["resource"], value=entry["reserved"]).model_dump(
+                mode="json"
+            )
+            for entry in sorted(entries, key=lambda item: item["resource"])
+        ),
+    }
+    forged_payload["commitment_id"] = receipt_identity("budget-commitment-v1", commitment_payload)
+    forged_without_id = {
+        key: value for key, value in forged_payload.items() if key != "reconciliation_id"
+    }
+    forged_payload["reconciliation_id"] = receipt_identity(
+        "budget-reconciliation-v1", forged_without_id
+    )
+    forged = BudgetReconciliation.model_validate(forged_payload)
+    assert forged.reservation_ids == finalizing.reservation_ids
+    assert forged.commitment_id != finalizing.commitment_id
+    with pytest.raises(ValueError, match="does not match this episode"):
+        finalizing.finish_finalization(forged, _score(plan))
+    # Rejection happens before lifecycle consumption, so exact evidence can retry.
+    cleaning = finalizing.finish_finalization(valid, _score(plan))
+    assert cleaning.state == "cleaning"
+    assert cleaning.commitment_id == commitment.commitment_id
+
+
 def test_lifecycle_rejects_reconciliation_from_mutated_authorization() -> None:
     plan, budget, _cleanup_value, authorized, permit = _authorized()
     reservation = _reservation(budget)

--- a/tests/unit/evaluation/test_lifecycle.py
+++ b/tests/unit/evaluation/test_lifecycle.py
@@ -309,8 +309,14 @@ def test_unreportable_usage_or_incomplete_cleanup_cannot_complete() -> None:
     failed = cleaning.finish_cleanup(_cleanup(cleanup))
     assert failed.state == "failed"
     assert failed.failure_kind == "unreportable"
+    plan, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
     reportable = _reconciliation(budget, reservation)
-    cleaning = finalizing.finish_finalization(reportable, _score(plan))
+    cleaning = (
+        authorized.start(permit, budget, _commitment(budget, reservation))
+        .begin_finalization()
+        .finish_finalization(reportable, _score(plan))
+    )
     rescue = cleaning.finish_cleanup(_cleanup(cleanup, volume="failed"))
     assert rescue.state == "failed"
     assert rescue.failure_kind == "cleanup"
@@ -326,6 +332,9 @@ def test_crash_and_cancel_after_running_must_flow_through_cleanup() -> None:
     failed = crashed.finish_cleanup(_cleanup(cleanup))
     assert failed.state == "failed"
     assert failed.cleanup_result_id is not None
+    _plan_value, budget, cleanup, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    running = authorized.start(permit, budget, _commitment(budget, reservation))
     cancelled = running.cancel("operator requested cancellation")
     assert cancelled.state == "cleaning"
     terminal = cancelled.finish_cleanup(_cleanup(cleanup))
@@ -348,6 +357,12 @@ def test_preflight_and_infrastructure_failures_are_unscored() -> None:
     assert failed.score_id is None
     with pytest.raises(ValueError, match="illegal"):
         failed.begin_finalization()
+    planned = EpisodeLifecycle.planned(
+        episode_id="episode-1",
+        plan_id=plan.plan_id,
+        budget_id=budget.budget_id,
+        cleanup_plan_id=cleanup.cleanup_plan_id,
+    )
     preflighted = planned.preflight(_seal(plan))
     infrastructure = preflighted.fail_before_running(
         kind="infrastructure", reason="allocator unavailable"
@@ -390,32 +405,41 @@ def test_ambiguous_finalization_is_terminal_after_cleanup_and_cannot_rescore() -
 def test_illegal_transition_table(state: str, operation: str) -> None:
     plan, budget, cleanup, authorized, permit = _authorized()
     reservation = _reservation(budget)
-    running = authorized.start(permit, budget, _commitment(budget, reservation))
-    reconciliation = _reconciliation(budget, reservation)
-    finalizing = running.begin_finalization()
-    cleaning = finalizing.finish_finalization(reconciliation, _score(plan))
-    episodes = {
-        "planned": EpisodeLifecycle.planned(
+    if state == "planned":
+        episode = EpisodeLifecycle.planned(
             episode_id="episode-1",
             plan_id=plan.plan_id,
             budget_id=budget.budget_id,
             cleanup_plan_id=cleanup.cleanup_plan_id,
-        ),
-        "preflighted": EpisodeLifecycle.planned(
+        )
+    elif state == "preflighted":
+        episode = EpisodeLifecycle.planned(
             episode_id="episode-1",
             plan_id=plan.plan_id,
             budget_id=budget.budget_id,
             cleanup_plan_id=cleanup.cleanup_plan_id,
-        ).preflight(_seal(plan)),
-        "authorized": authorized,
-        "running": running,
-        "finalizing": finalizing,
-        "cleaning": cleaning,
-        "completed": cleaning.finish_cleanup(_cleanup(cleanup)),
-        "failed": running.crash("crash").finish_cleanup(_cleanup(cleanup)),
-        "cancelled": running.cancel("cancel").finish_cleanup(_cleanup(cleanup)),
-    }
-    episode = episodes[state]
+        ).preflight(_seal(plan))
+    elif state == "authorized":
+        episode = authorized
+    else:
+        running = authorized.start(permit, budget, _commitment(budget, reservation))
+        if state == "running":
+            episode = running
+        elif state == "failed":
+            episode = running.crash("crash").finish_cleanup(_cleanup(cleanup))
+        elif state == "cancelled":
+            episode = running.cancel("cancel").finish_cleanup(_cleanup(cleanup))
+        else:
+            finalizing = running.begin_finalization()
+            if state == "finalizing":
+                episode = finalizing
+            else:
+                cleaning = finalizing.finish_finalization(
+                    _reconciliation(budget, reservation), _score(plan)
+                )
+                episode = (
+                    cleaning.finish_cleanup(_cleanup(cleanup)) if state == "completed" else cleaning
+                )
     if operation == "preflight":
         with pytest.raises(ValueError, match="illegal"):
             episode.preflight(_seal(plan))
@@ -842,3 +866,177 @@ def test_finish_cleanup_is_atomic_and_rolls_back_construction_failure(
     with pytest.raises(ValueError, match="injected terminal construction failure"):
         cleaning3.finish_cleanup(retryable_result)
     assert cleaning3.finish_cleanup(retryable_result).state == "completed"
+
+
+def test_every_lifecycle_parent_is_sequentially_single_use() -> None:
+    plan = _plan()
+    seal = _seal(plan)
+    budget = _budget()
+    cleanup = _cleanup_plan()
+    planned = EpisodeLifecycle.planned(
+        episode_id=budget.episode_id,
+        plan_id=plan.plan_id,
+        budget_id=budget.budget_id,
+        cleanup_plan_id=cleanup.cleanup_plan_id,
+    )
+    preflighted = planned.preflight(seal)
+    with pytest.raises(ValueError, match="lacks transition authority"):
+        planned.preflight(seal)
+
+    authorized, permit = preflighted.authorize(seal, budget)
+    with pytest.raises(ValueError, match="lacks transition authority"):
+        preflighted.authorize(seal, budget)
+
+    reservation = reserve_budget(
+        budget,
+        "linear-reservation",
+        tuple(ResourceAmount(resource=resource, value=10) for resource in BUDGET_RESOURCES),
+    )
+    running = authorized.start(permit, budget, commit_budget(budget, (reservation,)))
+    finalizing = running.begin_finalization()
+    with pytest.raises(ValueError, match="lacks transition authority"):
+        running.crash("late sibling")
+
+    cleaning = finalizing.finish_finalization(_reconciliation(budget, reservation), _score(plan))
+    with pytest.raises(ValueError, match="lacks transition authority"):
+        finalizing.finish_finalization(_reconciliation(budget, reservation), _score(plan))
+    terminal = cleaning.finish_cleanup(_cleanup(cleanup))
+    assert terminal.state == "completed"
+    with pytest.raises(ValueError, match="lacks transition authority"):
+        cleaning.finish_cleanup(_cleanup(cleanup))
+
+
+def test_authorize_and_finalization_edges_are_atomic_under_race() -> None:
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Barrier
+
+    plan = _plan()
+    seal = _seal(plan)
+    budget = _budget()
+    cleanup = _cleanup_plan()
+    preflighted = EpisodeLifecycle.planned(
+        episode_id=budget.episode_id,
+        plan_id=plan.plan_id,
+        budget_id=budget.budget_id,
+        cleanup_plan_id=cleanup.cleanup_plan_id,
+    ).preflight(seal)
+    barrier = Barrier(2)
+
+    def authorize() -> object:
+        barrier.wait()
+        try:
+            return preflighted.authorize(seal, budget)
+        except ValueError as error:
+            return error
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = tuple(executor.map(lambda _index: authorize(), (0, 1)))
+    assert sum(isinstance(item, tuple) for item in outcomes) == 1
+    assert sum(isinstance(item, ValueError) for item in outcomes) == 1
+
+    plan, budget, _cleanup_value, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    finalizing = authorized.start(
+        permit, budget, _commitment(budget, reservation)
+    ).begin_finalization()
+    reconciliation = _reconciliation(budget, reservation)
+    score = _score(plan)
+    barrier = Barrier(2)
+
+    def finalize() -> object:
+        barrier.wait()
+        try:
+            return finalizing.finish_finalization(reconciliation, score)
+        except ValueError as error:
+            return error
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = tuple(executor.map(lambda _index: finalize(), (0, 1)))
+    assert sum(isinstance(item, EpisodeLifecycle) for item in outcomes) == 1
+    assert sum(isinstance(item, ValueError) for item in outcomes) == 1
+
+
+def test_running_competing_edges_and_constructor_rollback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Barrier
+
+    _plan_value, budget, _cleanup_value, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    running = authorized.start(permit, budget, _commitment(budget, reservation))
+    barrier = Barrier(2)
+
+    def compete(operation: str) -> object:
+        barrier.wait()
+        try:
+            return (
+                running.begin_finalization() if operation == "finalize" else running.crash("boom")
+            )
+        except ValueError as error:
+            return error
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = tuple(executor.map(compete, ("finalize", "crash")))
+    assert sum(isinstance(item, EpisodeLifecycle) for item in outcomes) == 1
+    assert sum(isinstance(item, ValueError) for item in outcomes) == 1
+
+    plan = _plan()
+    seal = _seal(plan)
+    budget = _budget()
+    cleanup = _cleanup_plan()
+    planned = EpisodeLifecycle.planned(
+        episode_id="episode-construction-retry",
+        plan_id=plan.plan_id,
+        budget_id=budget.budget_id,
+        cleanup_plan_id=cleanup.cleanup_plan_id,
+    )
+    original = EpisodeLifecycle._transition
+    calls = 0
+
+    def fail_once(self, expected, operation, **updates):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ValueError("injected edge construction failure")
+        return original(self, expected, operation, **updates)
+
+    monkeypatch.setattr(EpisodeLifecycle, "_transition", fail_once)
+    with pytest.raises(ValueError, match="injected edge construction failure"):
+        planned.preflight(seal)
+    assert planned.preflight(seal).state == "preflighted"
+
+
+def test_reusable_seal_stays_plan_bound_while_episode_authorities_do_not_cross() -> None:
+    plan = _plan()
+    seal = _seal(plan)
+    cleanup = _cleanup_plan()
+    budgets = (
+        _budget(),
+        BudgetAuthorization(
+            episode_id="episode-2",
+            allowances=_budget().allowances,
+        ),
+    )
+    episodes = tuple(
+        EpisodeLifecycle.planned(
+            episode_id=budget.episode_id,
+            plan_id=plan.plan_id,
+            budget_id=budget.budget_id,
+            cleanup_plan_id=CleanupPlan(
+                episode_id=budget.episode_id,
+                actions=cleanup.actions,
+            ).cleanup_plan_id,
+        ).preflight(seal)
+        for budget in budgets
+    )
+    authorized1, permit1 = episodes[0].authorize(seal, budgets[0])
+    authorized2, _permit2 = episodes[1].authorize(seal, budgets[1])
+    reservation2 = reserve_budget(
+        budgets[1],
+        "episode-2-reservation",
+        (ResourceAmount(resource="guest_actions", value=1),),
+    )
+    with pytest.raises(ValueError, match="does not match this episode"):
+        authorized2.start(permit1, budgets[1], commit_budget(budgets[1], (reservation2,)))
+    assert authorized1.episode_id != authorized2.episode_id

--- a/tests/unit/evaluation/test_lifecycle.py
+++ b/tests/unit/evaluation/test_lifecycle.py
@@ -7,7 +7,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 from pydantic import ValidationError
@@ -15,27 +15,30 @@ from pydantic import ValidationError
 from local_operator.evaluation.lifecycle import (
     CleanupAction,
     CleanupPlan,
-    CleanupReceipt,
     CleanupResult,
     EpisodeLifecycle,
     ScoreReceipt,
     SideEffectPermit,
     aggregate_cleanup,
+    record_cleanup,
 )
 from local_operator.evaluation.protocol import ArtifactRef
 from local_operator.evaluation.receipts import (
     BUDGET_RESOURCES,
     AvailableUsage,
     BudgetAuthorization,
+    BudgetCommitment,
     BudgetReconciliation,
+    BudgetReservation,
     CappedAllowance,
     ComputeRequirement,
     DependencyPlan,
-    PreflightReceipt,
     RedactionSet,
     ResourceAmount,
     SealedPreflight,
+    commit_budget,
     reconcile_budget,
+    record_preflight,
     reserve_budget,
     seal_preflight,
 )
@@ -63,9 +66,9 @@ def _plan() -> DependencyPlan:
 
 
 def _seal(plan: DependencyPlan) -> SealedPreflight:
-    receipt = PreflightReceipt(
-        requirement_id="compute",
-        necessity="required",
+    receipt = record_preflight(
+        plan,
+        "compute",
         status="pass",
         evidence={"probe": "safe"},
         duration_ms=1,
@@ -108,25 +111,23 @@ def _cleanup_plan() -> CleanupPlan:
 def _cleanup(
     plan: CleanupPlan,
     *,
-    session: str = "succeeded",
-    volume: str = "not_needed",
+    session: Literal["not_needed", "attempted", "succeeded", "failed"] = "succeeded",
+    volume: Literal["not_needed", "attempted", "succeeded", "failed"] = "not_needed",
 ) -> CleanupResult:
     receipts = (
-        CleanupReceipt.model_validate(
-            {
-                "action_id": "session",
-                "status": session,
-                "evidence_code": "adapter-confirmed",
-                "duration_ms": 2,
-            }
+        record_cleanup(
+            plan,
+            "session",
+            status=session,
+            evidence_code="adapter-confirmed",
+            duration_ms=2,
         ),
-        CleanupReceipt.model_validate(
-            {
-                "action_id": "volume",
-                "status": volume,
-                "evidence_code": "adapter-confirmed",
-                "duration_ms": 1,
-            }
+        record_cleanup(
+            plan,
+            "volume",
+            status=volume,
+            evidence_code="adapter-confirmed",
+            duration_ms=1,
         ),
     )
     return aggregate_cleanup(plan, receipts)
@@ -135,8 +136,13 @@ def _cleanup(
 def _reservation(budget: BudgetAuthorization):  # type annotation inferred from factory
     return reserve_budget(
         budget,
+        "episode-reservation",
         tuple(ResourceAmount(resource=resource, value=10) for resource in BUDGET_RESOURCES),
     )
+
+
+def _commitment(budget: BudgetAuthorization, reservation: Any) -> BudgetCommitment:
+    return commit_budget(budget, (reservation,))
 
 
 def _reconciliation(
@@ -214,8 +220,9 @@ def test_cleanup_plan_is_symbolic_bounded_canonical_and_stable() -> None:
 
 def test_cleanup_requires_exactly_one_receipt_and_attempted_is_not_clean() -> None:
     plan = _cleanup_plan()
-    receipt = CleanupReceipt(
-        action_id="session",
+    receipt = record_cleanup(
+        plan,
+        "session",
         status="succeeded",
         evidence_code="confirmed",
         duration_ms=1,
@@ -262,13 +269,13 @@ def test_side_effect_start_is_impossible_before_seal_permit_and_reservation() ->
     _, _, _, authorized, permit = _authorized()
     reservation = _reservation(budget)
     with pytest.raises(ValueError, match="illegal episode transition"):
-        planned.start(permit, (reservation,))
-    with pytest.raises(ValueError, match="prior budget reservation"):
-        authorized.start(permit, ())
+        planned.start(permit, budget, _commitment(budget, reservation))
+    with pytest.raises(ValueError, match="factory authority"):
+        authorized.start(permit, budget, BudgetCommitment.model_construct())
     forged_payload = {**permit.model_dump(), "episode_id": "episode-other"}
     with pytest.raises(ValidationError):
         SideEffectPermit.model_validate(forged_payload)
-    running = authorized.start(permit, (reservation,))
+    running = authorized.start(permit, budget, _commitment(budget, reservation))
     assert running.state == "running"
     assert running.reservation_ids == (reservation.reservation_id,)
 
@@ -276,7 +283,7 @@ def test_side_effect_start_is_impossible_before_seal_permit_and_reservation() ->
 def test_legal_happy_path_requires_cost_score_and_clean_result() -> None:
     plan, budget, cleanup, authorized, permit = _authorized()
     reservation = _reservation(budget)
-    running = authorized.start(permit, (reservation,))
+    running = authorized.start(permit, budget, _commitment(budget, reservation))
     finalizing = running.begin_finalization()
     reconciliation = _reconciliation(budget, reservation)
     cleaning = finalizing.finish_finalization(reconciliation, _score(plan))
@@ -286,13 +293,16 @@ def test_legal_happy_path_requires_cost_score_and_clean_result() -> None:
     assert completed.reconciliation_id == reconciliation.reconciliation_id
     assert completed.score_id is not None
     assert completed.rescue_required is False
-    assert EpisodeLifecycle.from_canonical_json(completed.to_canonical_json()) == completed
+    with pytest.raises(ValidationError, match="factory minted"):
+        EpisodeLifecycle.from_canonical_json(completed.to_canonical_json())
 
 
 def test_unreportable_usage_or_incomplete_cleanup_cannot_complete() -> None:
     plan, budget, cleanup, authorized, permit = _authorized()
     reservation = _reservation(budget)
-    finalizing = authorized.start(permit, (reservation,)).begin_finalization()
+    finalizing = authorized.start(
+        permit, budget, _commitment(budget, reservation)
+    ).begin_finalization()
     unreportable = _reconciliation(budget, reservation, unavailable=True)
     cleaning = finalizing.finish_finalization(unreportable, _score(plan))
     failed = cleaning.finish_cleanup(_cleanup(cleanup))
@@ -309,7 +319,7 @@ def test_unreportable_usage_or_incomplete_cleanup_cannot_complete() -> None:
 def test_crash_and_cancel_after_running_must_flow_through_cleanup() -> None:
     _plan_value, budget, cleanup, authorized, permit = _authorized()
     reservation = _reservation(budget)
-    running = authorized.start(permit, (reservation,))
+    running = authorized.start(permit, budget, _commitment(budget, reservation))
     crashed = running.crash("adapter process exited")
     assert crashed.state == "cleaning"
     failed = crashed.finish_cleanup(_cleanup(cleanup))
@@ -347,7 +357,9 @@ def test_preflight_and_infrastructure_failures_are_unscored() -> None:
 def test_ambiguous_finalization_is_terminal_after_cleanup_and_cannot_rescore() -> None:
     plan, budget, cleanup, authorized, permit = _authorized()
     reservation = _reservation(budget)
-    finalizing = authorized.start(permit, (reservation,)).begin_finalization()
+    finalizing = authorized.start(
+        permit, budget, _commitment(budget, reservation)
+    ).begin_finalization()
     ambiguous = finalizing.mark_ambiguous_finalization(
         _reconciliation(budget, reservation),
         "judge response committed but acknowledgement was lost",
@@ -377,7 +389,7 @@ def test_ambiguous_finalization_is_terminal_after_cleanup_and_cannot_rescore() -
 def test_illegal_transition_table(state: str, operation: str) -> None:
     plan, budget, cleanup, authorized, permit = _authorized()
     reservation = _reservation(budget)
-    running = authorized.start(permit, (reservation,))
+    running = authorized.start(permit, budget, _commitment(budget, reservation))
     reconciliation = _reconciliation(budget, reservation)
     finalizing = running.begin_finalization()
     cleaning = finalizing.finish_finalization(reconciliation, _score(plan))
@@ -414,7 +426,7 @@ def test_illegal_transition_table(state: str, operation: str) -> None:
 def test_direct_snapshots_cannot_claim_completion_without_all_evidence() -> None:
     plan, budget, cleanup, authorized, permit = _authorized()
     reservation = _reservation(budget)
-    base = authorized.start(permit, (reservation,)).model_dump()
+    base = authorized.start(permit, budget, _commitment(budget, reservation)).model_dump()
     for missing in ("preflight_seal_id", "permit_id", "reconciliation_id", "score_id"):
         payload = {
             **base,
@@ -487,3 +499,113 @@ def test_evaluation_root_source_stays_inert() -> None:
     root = importlib.import_module("local_operator.evaluation")
     assert not hasattr(root, "EpisodeLifecycle")
     assert not hasattr(root, "DependencyPlan")
+
+
+def test_cleanup_receipt_replay_rejects_changed_plan_or_action() -> None:
+    plan = _cleanup_plan()
+    receipt = record_cleanup(
+        plan,
+        "session",
+        status="succeeded",
+        evidence_code="confirmed",
+        duration_ms=1,
+    )
+    changed_action = CleanupAction.model_validate(
+        {
+            **plan.actions[0].model_dump(exclude={"action_digest"}),
+            "resource_ref": "other-lease",
+        }
+    )
+    changed_plan = CleanupPlan(
+        episode_id=plan.episode_id,
+        actions=(changed_action, plan.actions[1]),
+    )
+    other = record_cleanup(
+        changed_plan,
+        "volume",
+        status="not_needed",
+        evidence_code="confirmed",
+        duration_ms=1,
+    )
+    with pytest.raises(ValueError, match="another cleanup plan|another action"):
+        aggregate_cleanup(changed_plan, (receipt, other))
+    with pytest.raises(ValidationError):
+        CleanupAction(
+            action_id="zero",
+            kind="close_session",
+            resource_ref="lease",
+            timeout_ms=0,
+            max_attempts=1,
+        )
+
+
+def test_lifecycle_authority_rejects_every_public_construction_and_mutation_path() -> None:
+    import copy
+    import pickle
+
+    plan, budget, cleanup, authorized, _permit = _authorized()
+    payload = authorized.model_dump()
+    with pytest.raises(ValidationError, match="factory minted"):
+        EpisodeLifecycle.model_validate(payload)
+    with pytest.raises(ValidationError, match="factory minted"):
+        EpisodeLifecycle.model_validate_json(authorized.to_canonical_json())
+    with pytest.raises(ValidationError, match="factory minted"):
+        EpisodeLifecycle.from_canonical_json(authorized.to_canonical_json())
+    forged = EpisodeLifecycle.model_construct(**payload)
+    with pytest.raises(ValueError, match="lacks transition authority"):
+        forged.begin_finalization()
+    with pytest.raises(TypeError, match="cannot be updated"):
+        authorized.model_copy(update={"state": "completed"})
+    assert copy.deepcopy(authorized) is authorized
+    with pytest.raises(TypeError, match="cannot be pickled"):
+        pickle.dumps(authorized)
+    assert authorized.previous_state_id is not None
+    assert authorized.state_id != authorized.previous_state_id
+    assert plan.plan_id == payload["plan_id"]
+    assert budget.budget_id == payload["budget_id"]
+    assert cleanup.cleanup_plan_id == payload["cleanup_plan_id"]
+
+
+def test_direct_overcap_reservation_and_forged_commitment_cannot_start() -> None:
+    _plan_value, budget, _cleanup_value, authorized, permit = _authorized()
+    overcap = BudgetReservation(
+        episode_id=budget.episode_id,
+        budget_id=budget.budget_id,
+        reservation_key="forged-overcap",
+        amounts=(ResourceAmount(resource="guest_actions", value=101),),
+    )
+    with pytest.raises(ValueError, match="exceeds"):
+        commit_budget(budget, (overcap,))
+    legitimate = _reservation(budget)
+    commitment = _commitment(budget, legitimate)
+    forged = BudgetCommitment.model_construct(**commitment.model_dump())
+    with pytest.raises(ValueError, match="factory authority"):
+        authorized.start(permit, budget, forged)
+
+
+def test_lifecycle_rejects_reconciliation_from_mutated_authorization() -> None:
+    plan, budget, _cleanup_value, authorized, permit = _authorized()
+    reservation = _reservation(budget)
+    finalizing = authorized.start(
+        permit, budget, _commitment(budget, reservation)
+    ).begin_finalization()
+    reconciliation = _reconciliation(budget, reservation)
+    changed_allowances = list(budget.allowances)
+    first = changed_allowances[0]
+    assert isinstance(first, CappedAllowance)
+    changed_allowances[0] = first.model_copy(update={"value": first.value + 1})
+    changed_budget = BudgetAuthorization(
+        episode_id=budget.episode_id,
+        allowances=tuple(changed_allowances),
+    )
+    payload = reconciliation.model_dump()
+    with pytest.raises(ValidationError):
+        BudgetReconciliation.model_validate(
+            {
+                **payload,
+                "budget_id": changed_budget.budget_id,
+                "authorization_digest": changed_budget.budget_id,
+                "authorization": changed_budget,
+            }
+        )
+    assert plan.plan_id == finalizing.plan_id

--- a/tests/unit/evaluation/test_receipts.py
+++ b/tests/unit/evaluation/test_receipts.py
@@ -1,0 +1,373 @@
+"""Contract tests for pure dependency, preflight, and budget receipts."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from local_operator.evaluation.protocol import ArtifactRef
+from local_operator.evaluation.receipts import (
+    BUDGET_RESOURCES,
+    AvailableUsage,
+    BudgetAuthorization,
+    BudgetReservation,
+    CappedAllowance,
+    ClockRequirement,
+    ComputeRequirement,
+    DependencyPlan,
+    DisplayRequirement,
+    ExternalServiceRequirement,
+    ModelCapabilityRequirement,
+    NetworkRequirement,
+    PinnedInputRequirement,
+    PreflightReceipt,
+    RedactionSet,
+    Requirement,
+    ResourceAmount,
+    SealedPreflight,
+    UnavailableUsage,
+    UncappedAllowance,
+    Usage,
+    reconcile_budget,
+    reserve_budget,
+    seal_preflight,
+)
+
+DIGEST = "0123456789abcdef" * 4
+
+
+def _requirements() -> tuple[Requirement, ...]:
+    common: dict[str, Any] = {"necessity": "required", "reportability": "required"}
+    return (
+        ComputeRequirement(
+            requirement_id="compute",
+            cpu_class="high-throughput",
+            memory_class="large",
+            disk_bytes=10_000,
+            display=DisplayRequirement(
+                native_width=1920,
+                native_height=1080,
+                model_width=1280,
+                model_height=720,
+                platform_capability="desktop.linux",
+            ),
+            **common,
+        ),
+        NetworkRequirement(
+            requirement_id="network",
+            endpoint_id="model-api",
+            service_id="provider",
+            protocol="https",
+            ports=(443,),
+            proxy_capability="allowed",
+            geography="us",
+            **common,
+        ),
+        ExternalServiceRequirement(
+            requirement_id="service",
+            service_id="workspace",
+            capability="read",
+            account_ref="WORKSPACE_ACCOUNT",
+            **common,
+        ),
+        ModelCapabilityRequirement(
+            requirement_id="model-agent",
+            role="agent",
+            modalities=("text", "image"),
+            tools=("computer",),
+            min_context_tokens=100_000,
+            min_output_tokens=4_096,
+            route_pin="provider.route-1",
+            fallback_policy="forbid",
+            **common,
+        ),
+        ClockRequirement(
+            requirement_id="clock",
+            timezone="UTC",
+            fixed_clock="2026-08-30T12:00:00Z",
+            **common,
+        ),
+        PinnedInputRequirement(
+            requirement_id="input",
+            release_id="benchmark-v1",
+            artifact=ArtifactRef(sha256=DIGEST, media_type="application/json", byte_count=42),
+            content_sha256=DIGEST,
+            **common,
+        ),
+    )
+
+
+def _plan(requirements: tuple[Requirement, ...] | None = None) -> DependencyPlan:
+    return DependencyPlan.model_validate(
+        {
+            "release_id": "release-1",
+            "task_id": "task-1",
+            "attempt_id": "attempt-1",
+            "requirements": requirements or _requirements(),
+        }
+    )
+
+
+def _receipts(plan: DependencyPlan) -> tuple[PreflightReceipt, ...]:
+    return tuple(
+        PreflightReceipt(
+            requirement_id=item.requirement_id,
+            necessity=item.necessity,
+            status="pass",
+            evidence={"nested": ["safe", {"ok": True}]},
+            duration_ms=1,
+        )
+        for item in plan.requirements
+    )
+
+
+def _authorization(*, cap: int = 100, uncapped: set[str] | None = None) -> BudgetAuthorization:
+    uncapped = uncapped or set()
+    allowances = []
+    for resource in reversed(BUDGET_RESOURCES):
+        if resource in uncapped:
+            allowances.append(
+                UncappedAllowance(
+                    resource=resource,
+                    reason="operator approved exploratory run",
+                    authorized_by="operator",
+                    authorized_at_ms=1,
+                    reporting="required",
+                )
+            )
+        else:
+            allowances.append(CappedAllowance(resource=resource, value=cap, reporting="required"))
+    return BudgetAuthorization(episode_id="episode-1", allowances=tuple(allowances))
+
+
+def _usage(value: int = 50) -> tuple[AvailableUsage, ...]:
+    return tuple(AvailableUsage(resource=resource, value=value) for resource in BUDGET_RESOURCES)
+
+
+def test_every_requirement_kind_round_trips_canonically() -> None:
+    for requirement in _requirements():
+        parsed = type(requirement).from_canonical_json(requirement.to_canonical_json())
+        assert parsed == requirement
+        assert parsed.to_canonical_json() == requirement.to_canonical_json()
+
+
+def test_dependency_identity_is_stable_under_declaration_shuffle() -> None:
+    requirements = _requirements()
+    expected = _plan(requirements)
+    for offset in range(len(requirements)):
+        shuffled = requirements[offset:] + requirements[:offset]
+        candidate = _plan(shuffled)
+        assert candidate.plan_id == expected.plan_id
+        assert [item.requirement_id for item in candidate.requirements] == sorted(
+            item.requirement_id for item in requirements
+        )
+    assert DependencyPlan.from_canonical_json(expected.to_canonical_json()) == expected
+
+
+def test_dependency_plan_rejects_duplicate_ids_and_conflicting_targets() -> None:
+    compute = _requirements()[0]
+    with pytest.raises(ValidationError, match="duplicate requirement IDs"):
+        _plan((compute, compute))
+    conflicting = compute.model_copy(update={"requirement_id": "other", "cpu_class": "small"})
+    with pytest.raises(ValidationError, match="conflicting requirements"):
+        _plan((compute, conflicting))
+
+
+def test_requirement_metadata_is_bounded_portable_and_frozen() -> None:
+    requirement = _requirements()[0]
+    assert "aws" not in requirement.to_canonical_json().decode().lower()
+    with pytest.raises(ValidationError):
+        requirement.model_copy(update={"metadata": {"bad": 1.5}})
+    with pytest.raises(ValidationError):
+        NetworkRequirement.model_validate({**_requirements()[1].model_dump(), "ports": [443, 443]})
+    with pytest.raises(ValidationError):
+        ExternalServiceRequirement.model_validate(
+            {**_requirements()[2].model_dump(), "account_ref": "raw secret value"}
+        )
+
+
+def test_receipts_enforce_skip_and_safe_timing() -> None:
+    with pytest.raises(ValidationError, match="only optional"):
+        PreflightReceipt(requirement_id="r", necessity="required", status="skip", duration_ms=0)
+    receipt = PreflightReceipt(
+        requirement_id="r",
+        necessity="optional",
+        status="skip",
+        started_at_ms=10,
+        ended_at_ms=12,
+        duration_ms=2,
+    )
+    assert PreflightReceipt.from_canonical_json(receipt.to_canonical_json()) == receipt
+    with pytest.raises(ValidationError, match="disagrees"):
+        receipt.model_copy(update={"duration_ms": 3})
+
+
+def test_preflight_requires_exactly_one_receipt_and_blocks_required_failure() -> None:
+    plan = _plan()
+    receipts = _receipts(plan)
+    redactions = RedactionSet.from_resolved_values(("definitely-not-present",))
+    sealed = seal_preflight(plan, receipts, redactions)
+    assert sealed.successful
+    assert SealedPreflight.from_canonical_json(sealed.to_canonical_json()) == sealed
+    with pytest.raises(ValueError, match="exactly one"):
+        seal_preflight(plan, receipts[:-1], redactions)
+    with pytest.raises(ValueError, match="duplicate"):
+        seal_preflight(plan, receipts + (receipts[0],), redactions)
+    failed = PreflightReceipt.model_validate(
+        {**receipts[0].model_dump(exclude={"receipt_id"}), "status": "fail"}
+    )
+    with pytest.raises(ValueError, match="required dependency failure"):
+        seal_preflight(plan, (failed,) + receipts[1:], redactions)
+
+
+def test_optional_failure_or_skip_seals_but_is_not_successful() -> None:
+    optional = _requirements()[0].model_copy(
+        update={"requirement_id": "optional-compute", "necessity": "optional"}
+    )
+    plan = _plan((optional,))
+    for status in ("fail", "skip"):
+        receipt = PreflightReceipt(
+            requirement_id=optional.requirement_id,
+            necessity="optional",
+            status=status,
+            duration_ms=0,
+        )
+        sealed = seal_preflight(plan, (receipt,), RedactionSet.from_resolved_values(()))
+        assert sealed.successful is (status == "skip")
+
+
+@pytest.mark.parametrize(
+    "location",
+    ["requirement_id", "metadata_value", "metadata_list", "metadata_map", "evidence_value"],
+)
+def test_secret_canaries_fail_at_every_nested_location_without_echo(
+    location: str,
+) -> None:
+    secret = "CANARY-super-secret-42"
+    requirement = _requirements()[0]
+    if location == "requirement_id":
+        requirement = requirement.model_copy(update={"requirement_id": f"id-{secret}"})
+    elif location == "metadata_value":
+        requirement = requirement.model_copy(update={"metadata": {"value": secret}})
+    elif location == "metadata_list":
+        requirement = requirement.model_copy(update={"metadata": {"values": ["safe", secret]}})
+    elif location == "metadata_map":
+        requirement = requirement.model_copy(update={"metadata": {"nested": {"value": secret}}})
+    plan = _plan((requirement,))
+    receipt = PreflightReceipt(
+        requirement_id=requirement.requirement_id,
+        necessity=requirement.necessity,
+        status="pass",
+        evidence={"value": secret} if location == "evidence_value" else {"value": "safe"},
+        duration_ms=1,
+    )
+    with pytest.raises(ValueError) as caught:
+        seal_preflight(plan, (receipt,), RedactionSet.from_resolved_values((secret,)))
+    assert secret not in str(caught.value)
+
+
+def test_secret_reference_names_serialize_but_resolved_values_never_seal() -> None:
+    secret = "resolved-token-value"
+    requirement = _requirements()[2]
+    plan = _plan((requirement,))
+    assert b'"account_ref":"WORKSPACE_ACCOUNT"' in plan.to_canonical_json()
+    safe = PreflightReceipt(
+        requirement_id=requirement.requirement_id,
+        necessity="required",
+        status="pass",
+        evidence={"account_ref": "WORKSPACE_ACCOUNT"},
+        duration_ms=1,
+    )
+    assert seal_preflight(plan, (safe,), RedactionSet.from_resolved_values((secret,))).successful
+    unsafe = PreflightReceipt.model_validate(
+        {
+            **safe.model_dump(exclude={"receipt_id"}),
+            "evidence": {"result": f"prefix-{secret}-suffix"},
+        }
+    )
+    with pytest.raises(ValueError, match="secret canary survived"):
+        seal_preflight(plan, (unsafe,), RedactionSet.from_resolved_values((secret,)))
+    assert secret not in repr(RedactionSet.from_resolved_values((secret,)))
+
+
+def test_capped_zero_and_explicit_uncapped_are_distinct_closed_union() -> None:
+    authorization = _authorization(cap=0, uncapped={"wall_milliseconds"})
+    capped = authorization.allowance_for("provider_usd_micros")
+    uncapped = authorization.allowance_for("wall_milliseconds")
+    assert capped.kind == "capped" and capped.value == 0
+    assert uncapped.kind == "uncapped" and uncapped.authorized_by == "operator"
+    payload = json.loads(authorization.to_canonical_json())
+    assert all("value" in item or item["kind"] == "uncapped" for item in payload["allowances"])
+    with pytest.raises(ValidationError):
+        BudgetAuthorization.model_validate(
+            {"episode_id": "e", "allowances": [{"kind": "capped", "resource": "x"}]}
+        )
+
+
+def test_reservation_prevents_overcommit_and_identities_round_trip() -> None:
+    authorization = _authorization(cap=10)
+    first = reserve_budget(
+        authorization,
+        (ResourceAmount(resource="provider_usd_micros", value=6),),
+    )
+    second = reserve_budget(
+        authorization,
+        (ResourceAmount(resource="provider_usd_micros", value=4),),
+        (first,),
+    )
+    assert BudgetReservation.from_canonical_json(first.to_canonical_json()) == first
+    assert first.reservation_id != second.reservation_id
+    with pytest.raises(ValueError, match="exceeds"):
+        reserve_budget(
+            authorization,
+            (ResourceAmount(resource="provider_usd_micros", value=5),),
+            (first,),
+        )
+    uncapped = _authorization(cap=0, uncapped={"provider_usd_micros"})
+    reserve_budget(
+        uncapped,
+        (ResourceAmount(resource="provider_usd_micros", value=10**9),),
+    )
+
+
+@pytest.mark.parametrize(("actual", "overrun"), [(5, 0), (10, 0), (11, 1)])
+def test_reconciliation_records_under_exact_and_over_cap(actual: int, overrun: int) -> None:
+    authorization = _authorization(cap=10)
+    reservation = reserve_budget(
+        authorization,
+        tuple(ResourceAmount(resource=resource, value=10) for resource in BUDGET_RESOURCES),
+    )
+    reconciliation = reconcile_budget(authorization, (reservation,), _usage(actual))
+    assert reconciliation.reportable
+    assert all(entry.overrun == overrun for entry in reconciliation.entries)
+    assert (
+        type(reconciliation).from_canonical_json(reconciliation.to_canonical_json())
+        == reconciliation
+    )
+
+
+def test_unknown_required_usage_is_explicit_and_not_reportable() -> None:
+    authorization = _authorization()
+    usage: list[Usage] = list(_usage())
+    usage[0] = UnavailableUsage(resource=usage[0].resource, reason="provider omitted usage")
+    reconciliation = reconcile_budget(authorization, (), usage)
+    assert not reconciliation.reportable
+    assert reconciliation.entries[0].usage.kind in ("available", "unavailable")
+    assert b'"kind":"unavailable"' in reconciliation.to_canonical_json()
+    with pytest.raises(ValueError, match="one usage"):
+        reconcile_budget(authorization, (), usage[:-1])
+
+
+def test_money_is_integer_micros_and_has_no_hidden_seventy_five_dollar_default() -> None:
+    with pytest.raises(ValidationError):
+        CappedAllowance.model_validate(
+            {"resource": "provider_usd_micros", "value": 1.5, "reporting": "required"}
+        )
+    source = __import__("local_operator.evaluation.receipts", fromlist=["x"]).__file__
+    assert source is not None
+    text = open(source, encoding="utf-8").read()  # noqa: SIM115 - test fixture inspection
+    assert "75000000" not in text
+    assert "$75" not in text

--- a/tests/unit/evaluation/test_receipts.py
+++ b/tests/unit/evaluation/test_receipts.py
@@ -218,8 +218,9 @@ def test_preflight_requires_exactly_one_receipt_and_blocks_required_failure() ->
     redactions = RedactionSet.from_resolved_values(("definitely-not-present",))
     sealed = seal_preflight(plan, receipts, redactions)
     assert sealed.successful
-    with pytest.raises(ValidationError, match="validated receipts"):
-        SealedPreflight.from_canonical_json(sealed.to_canonical_json())
+    parsed = SealedPreflight.from_canonical_json(sealed.to_canonical_json())
+    with pytest.raises(ValueError, match="lacks factory authority"):
+        parsed.assert_authority()
     with pytest.raises(ValueError, match="exactly one"):
         seal_preflight(plan, receipts[:-1], redactions)
     with pytest.raises(ValueError, match="duplicate"):

--- a/tests/unit/evaluation/test_receipts.py
+++ b/tests/unit/evaluation/test_receipts.py
@@ -475,3 +475,38 @@ def test_redaction_rejects_common_encoded_canary_variants(encoded: str) -> None:
     with pytest.raises(ValueError) as caught:
         seal_preflight(plan, (receipt,), RedactionSet.from_resolved_values((secret,)))
     assert secret not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        lambda value: value.lower(),
+        lambda value: value.upper(),
+        lambda value: "".join(
+            character.upper() if index % 2 else character.lower()
+            for index, character in enumerate(value)
+        ),
+    ],
+    ids=("lower", "upper", "mixed"),
+)
+@pytest.mark.parametrize("encoding", ["percent", "hex"])
+def test_redaction_matches_percent_and_hex_case_insensitively(
+    encoding: str,
+    transform: object,
+) -> None:
+    from urllib.parse import quote
+
+    secret = "Secret/Value+42"
+    encoded = quote(secret, safe="") if encoding == "percent" else secret.encode().hex()
+    candidate = transform(encoded)  # type: ignore[operator]
+    plan = _plan((_requirements()[0],))
+    receipt = record_preflight(
+        plan,
+        "compute",
+        status="pass",
+        evidence={"nested": ["safe", {"encoded": candidate}]},
+        duration_ms=1,
+    )
+    with pytest.raises(ValueError) as caught:
+        seal_preflight(plan, (receipt,), RedactionSet.from_resolved_values((secret,)))
+    assert secret not in str(caught.value)

--- a/tests/unit/evaluation/test_receipts.py
+++ b/tests/unit/evaluation/test_receipts.py
@@ -218,7 +218,8 @@ def test_preflight_requires_exactly_one_receipt_and_blocks_required_failure() ->
     redactions = RedactionSet.from_resolved_values(("definitely-not-present",))
     sealed = seal_preflight(plan, receipts, redactions)
     assert sealed.successful
-    assert SealedPreflight.from_canonical_json(sealed.to_canonical_json()) == sealed
+    with pytest.raises(ValidationError, match="validated receipts"):
+        SealedPreflight.from_canonical_json(sealed.to_canonical_json())
     with pytest.raises(ValueError, match="exactly one"):
         seal_preflight(plan, receipts[:-1], redactions)
     with pytest.raises(ValueError, match="duplicate"):
@@ -435,6 +436,8 @@ def test_reconciliation_rejects_allowance_overrun_and_commitment_mutation() -> N
 
 def test_clock_values_are_real_and_canonical() -> None:
     base = _requirements()[4].model_dump()
+    for zone in ("UTC", "America/New_York"):
+        assert ClockRequirement.model_validate({**base, "timezone": zone}).timezone == zone
     for field, value in (
         ("date", "2026-02-30"),
         ("fixed_clock", "2026-13-30T12:00:00Z"),
@@ -443,8 +446,10 @@ def test_clock_values_are_real_and_canonical() -> None:
         payload = {**base, "date": None, "fixed_clock": "2026-08-30T12:00:00Z", field: value}
         if field == "date":
             payload["fixed_clock"] = None
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError) as caught:
             ClockRequirement.model_validate(payload)
+        if field == "timezone":
+            assert "IANA zone" in str(caught.value)
 
 
 @pytest.mark.parametrize("encoded", ["base64", "urlsafe", "hex", "percent"])

--- a/tests/unit/evaluation/test_receipts.py
+++ b/tests/unit/evaluation/test_receipts.py
@@ -236,7 +236,8 @@ def test_optional_failure_or_skip_seals_but_is_not_successful() -> None:
             duration_ms=0,
         )
         sealed = seal_preflight(plan, (receipt,), RedactionSet.from_resolved_values(()))
-        assert sealed.successful is (status == "skip")
+        assert sealed.successful
+        assert (optional.requirement_id in sealed.failed_requirement_ids) is (status == "fail")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/evaluation/test_receipts.py
+++ b/tests/unit/evaluation/test_receipts.py
@@ -478,27 +478,24 @@ def test_redaction_rejects_common_encoded_canary_variants(encoded: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "transform",
+    ("encoding", "candidate"),
     [
-        lambda value: value.lower(),
-        lambda value: value.upper(),
-        lambda value: "".join(
-            character.upper() if index % 2 else character.lower()
-            for index, character in enumerate(value)
+        ("percent", "Secret%2fValue%2b42"),
+        ("percent", "Secret%2FValue%2B42"),
+        ("percent", "Secret%2fValue%2B42"),
+        ("hex", "Secret/Value+42".encode().hex().lower()),
+        ("hex", "Secret/Value+42".encode().hex().upper()),
+        (
+            "hex",
+            "".join(
+                character.upper() if index % 2 else character.lower()
+                for index, character in enumerate("Secret/Value+42".encode().hex())
+            ),
         ),
     ],
-    ids=("lower", "upper", "mixed"),
 )
-@pytest.mark.parametrize("encoding", ["percent", "hex"])
-def test_redaction_matches_percent_and_hex_case_insensitively(
-    encoding: str,
-    transform: object,
-) -> None:
-    from urllib.parse import quote
-
+def test_redaction_matches_encoded_case_semantics(encoding: str, candidate: str) -> None:
     secret = "Secret/Value+42"
-    encoded = quote(secret, safe="") if encoding == "percent" else secret.encode().hex()
-    candidate = transform(encoded)  # type: ignore[operator]
     plan = _plan((_requirements()[0],))
     receipt = record_preflight(
         plan,
@@ -510,3 +507,16 @@ def test_redaction_matches_percent_and_hex_case_insensitively(
     with pytest.raises(ValueError) as caught:
         seal_preflight(plan, (receipt,), RedactionSet.from_resolved_values((secret,)))
     assert secret not in str(caught.value)
+
+
+def test_percent_redaction_preserves_unescaped_literal_case() -> None:
+    secret = "Secret/Value+42"
+    plan = _plan((_requirements()[0],))
+    receipt = record_preflight(
+        plan,
+        "compute",
+        status="pass",
+        evidence={"nested": {"encoded": "secret%2fvalue%2b42"}},
+        duration_ms=1,
+    )
+    assert seal_preflight(plan, (receipt,), RedactionSet.from_resolved_values((secret,))).successful

--- a/tests/unit/evaluation/test_receipts.py
+++ b/tests/unit/evaluation/test_receipts.py
@@ -13,6 +13,7 @@ from local_operator.evaluation.receipts import (
     BUDGET_RESOURCES,
     AvailableUsage,
     BudgetAuthorization,
+    BudgetReconciliation,
     BudgetReservation,
     CappedAllowance,
     ClockRequirement,
@@ -32,6 +33,7 @@ from local_operator.evaluation.receipts import (
     UncappedAllowance,
     Usage,
     reconcile_budget,
+    record_preflight,
     reserve_budget,
     seal_preflight,
 )
@@ -113,9 +115,9 @@ def _plan(requirements: tuple[Requirement, ...] | None = None) -> DependencyPlan
 
 def _receipts(plan: DependencyPlan) -> tuple[PreflightReceipt, ...]:
     return tuple(
-        PreflightReceipt(
-            requirement_id=item.requirement_id,
-            necessity=item.necessity,
+        record_preflight(
+            plan,
+            item.requirement_id,
             status="pass",
             evidence={"nested": ["safe", {"ok": True}]},
             duration_ms=1,
@@ -190,11 +192,16 @@ def test_requirement_metadata_is_bounded_portable_and_frozen() -> None:
 
 
 def test_receipts_enforce_skip_and_safe_timing() -> None:
+    required_plan = _plan((_requirements()[0],))
     with pytest.raises(ValidationError, match="only optional"):
-        PreflightReceipt(requirement_id="r", necessity="required", status="skip", duration_ms=0)
-    receipt = PreflightReceipt(
-        requirement_id="r",
-        necessity="optional",
+        record_preflight(required_plan, "compute", status="skip", duration_ms=0)
+    optional = _requirements()[0].model_copy(
+        update={"requirement_id": "optional-compute", "necessity": "optional"}
+    )
+    optional_plan = _plan((optional,))
+    receipt = record_preflight(
+        optional_plan,
+        "optional-compute",
         status="skip",
         started_at_ms=10,
         ended_at_ms=12,
@@ -229,9 +236,9 @@ def test_optional_failure_or_skip_seals_but_is_not_successful() -> None:
     )
     plan = _plan((optional,))
     for status in ("fail", "skip"):
-        receipt = PreflightReceipt(
-            requirement_id=optional.requirement_id,
-            necessity="optional",
+        receipt = record_preflight(
+            plan,
+            optional.requirement_id,
             status=status,
             duration_ms=0,
         )
@@ -258,9 +265,9 @@ def test_secret_canaries_fail_at_every_nested_location_without_echo(
     elif location == "metadata_map":
         requirement = requirement.model_copy(update={"metadata": {"nested": {"value": secret}}})
     plan = _plan((requirement,))
-    receipt = PreflightReceipt(
-        requirement_id=requirement.requirement_id,
-        necessity=requirement.necessity,
+    receipt = record_preflight(
+        plan,
+        requirement.requirement_id,
         status="pass",
         evidence={"value": secret} if location == "evidence_value" else {"value": "safe"},
         duration_ms=1,
@@ -275,9 +282,9 @@ def test_secret_reference_names_serialize_but_resolved_values_never_seal() -> No
     requirement = _requirements()[2]
     plan = _plan((requirement,))
     assert b'"account_ref":"WORKSPACE_ACCOUNT"' in plan.to_canonical_json()
-    safe = PreflightReceipt(
-        requirement_id=requirement.requirement_id,
-        necessity="required",
+    safe = record_preflight(
+        plan,
+        requirement.requirement_id,
         status="pass",
         evidence={"account_ref": "WORKSPACE_ACCOUNT"},
         duration_ms=1,
@@ -312,10 +319,12 @@ def test_reservation_prevents_overcommit_and_identities_round_trip() -> None:
     authorization = _authorization(cap=10)
     first = reserve_budget(
         authorization,
+        "reservation-1",
         (ResourceAmount(resource="provider_usd_micros", value=6),),
     )
     second = reserve_budget(
         authorization,
+        "reservation-2",
         (ResourceAmount(resource="provider_usd_micros", value=4),),
         (first,),
     )
@@ -324,12 +333,14 @@ def test_reservation_prevents_overcommit_and_identities_round_trip() -> None:
     with pytest.raises(ValueError, match="exceeds"):
         reserve_budget(
             authorization,
+            "reservation-over",
             (ResourceAmount(resource="provider_usd_micros", value=5),),
             (first,),
         )
     uncapped = _authorization(cap=0, uncapped={"provider_usd_micros"})
     reserve_budget(
         uncapped,
+        "reservation-uncapped",
         (ResourceAmount(resource="provider_usd_micros", value=10**9),),
     )
 
@@ -339,6 +350,7 @@ def test_reconciliation_records_under_exact_and_over_cap(actual: int, overrun: i
     authorization = _authorization(cap=10)
     reservation = reserve_budget(
         authorization,
+        "reservation-all",
         tuple(ResourceAmount(resource=resource, value=10) for resource in BUDGET_RESOURCES),
     )
     reconciliation = reconcile_budget(authorization, (reservation,), _usage(actual))
@@ -372,3 +384,89 @@ def test_money_is_integer_micros_and_has_no_hidden_seventy_five_dollar_default()
     text = open(source, encoding="utf-8").read()  # noqa: SIM115 - test fixture inspection
     assert "75000000" not in text
     assert "$75" not in text
+
+
+def test_preflight_receipt_replay_rejects_changed_plan_or_declaration() -> None:
+    plan = _plan((_requirements()[0],))
+    receipt = record_preflight(plan, "compute", status="pass", duration_ms=1)
+    changed_requirement = _requirements()[0].model_copy(update={"disk_bytes": 10_001})
+    changed = _plan((changed_requirement,))
+    with pytest.raises(ValueError, match="another dependency plan|another requirement"):
+        seal_preflight(changed, (receipt,), RedactionSet.from_resolved_values(()))
+    mutated = PreflightReceipt.model_validate(
+        {**receipt.model_dump(exclude={"receipt_id"}), "requirement_digest": DIGEST}
+    )
+    with pytest.raises(ValueError, match="another requirement"):
+        seal_preflight(plan, (mutated,), RedactionSet.from_resolved_values(()))
+
+
+def test_reservation_keys_disambiguate_equal_amounts_and_reject_retry() -> None:
+    authorization = _authorization(cap=10)
+    amount = (ResourceAmount(resource="guest_actions", value=5),)
+    first = reserve_budget(authorization, "operation-a", amount)
+    second = reserve_budget(authorization, "operation-b", amount, (first,))
+    assert first.reservation_id != second.reservation_id
+    with pytest.raises(ValueError, match="duplicate reservation key"):
+        reserve_budget(authorization, "operation-a", amount, (first,))
+
+
+def test_reconciliation_rejects_allowance_overrun_and_commitment_mutation() -> None:
+    authorization = _authorization(cap=10)
+    reservation = reserve_budget(
+        authorization,
+        "operation",
+        (ResourceAmount(resource="guest_actions", value=5),),
+    )
+    reconciliation = reconcile_budget(authorization, (reservation,), _usage(11))
+    payload = reconciliation.model_dump()
+    entries = [dict(entry) for entry in payload["entries"]]
+    entries[0]["overrun"] = 0
+    with pytest.raises(ValidationError, match="overrun"):
+        BudgetReconciliation.model_validate({**payload, "entries": entries})
+    entries = [dict(entry) for entry in payload["entries"]]
+    entries[0]["allowance"] = CappedAllowance(
+        resource=entries[0]["resource"], value=9, reporting="required"
+    )
+    with pytest.raises(ValidationError, match="allowance"):
+        BudgetReconciliation.model_validate({**payload, "entries": entries})
+    with pytest.raises(ValidationError, match="commitment"):
+        BudgetReconciliation.model_validate({**payload, "commitment_id": DIGEST})
+
+
+def test_clock_values_are_real_and_canonical() -> None:
+    base = _requirements()[4].model_dump()
+    for field, value in (
+        ("date", "2026-02-30"),
+        ("fixed_clock", "2026-13-30T12:00:00Z"),
+        ("timezone", "Mars/Olympus"),
+    ):
+        payload = {**base, "date": None, "fixed_clock": "2026-08-30T12:00:00Z", field: value}
+        if field == "date":
+            payload["fixed_clock"] = None
+        with pytest.raises(ValidationError):
+            ClockRequirement.model_validate(payload)
+
+
+@pytest.mark.parametrize("encoded", ["base64", "urlsafe", "hex", "percent"])
+def test_redaction_rejects_common_encoded_canary_variants(encoded: str) -> None:
+    import base64
+    from urllib.parse import quote
+
+    secret = "s3cret/value+42"
+    variants = {
+        "base64": base64.b64encode(secret.encode()).decode(),
+        "urlsafe": base64.urlsafe_b64encode(secret.encode()).decode().rstrip("="),
+        "hex": secret.encode().hex(),
+        "percent": quote(secret, safe=""),
+    }
+    plan = _plan((_requirements()[0],))
+    receipt = record_preflight(
+        plan,
+        "compute",
+        status="pass",
+        evidence={"encoded": variants[encoded]},
+        duration_ms=1,
+    )
+    with pytest.raises(ValueError) as caught:
+        seal_preflight(plan, (receipt,), RedactionSet.from_resolved_values((secret,)))
+    assert secret not in str(caught.value)


### PR DESCRIPTION
## Summary

This PR adds the second slice of Local Operator's benchmark-neutral evaluation platform: pure dependency, preflight, budget, cleanup, and episode-lifecycle contracts. It does not execute benchmarks, discover machines, call providers, read credentials, allocate cloud resources, or add CLI/UI/configuration behavior.

The new contracts make the evidence and authority boundaries explicit:

- closed requirement declarations for compute, network, external-service readiness, model capabilities, clocks, and pinned inputs
- canonical dependency plans with stable identities independent of declaration order
- exact preflight receipts and redaction-attested seals bound to the selected plan and declaration digests
- explicit capped versus operator-authorized uncapped budgets across tokens, integer USD micros, instance/wall time, model cycles, guest actions, and simulator turns
- keyed reservations, cumulative cap validation, reconciliation, and explicit unavailable usage
- symbolic bounded cleanup plans and exact action-bound cleanup receipts
- a linear episode lifecycle that gates side effects on successful preflight, an explicit budget authorization, and a sealed reservation commitment
- running and finalization evidence retain and verify the exact consumed budget `commitment_id`, not only reservation IDs

This is a standard C2 change and is pre-authorized. The PR is the system of record; there is no Linear ticket or RFC.

## Contract details

### Dependencies and preflight

Requirement IDs, selected release/task/attempt identities, declaration digests, receipt identities, and aggregate seals are canonical and content-addressed. Required failures or skips cannot produce a successful seal. Optional outcomes remain visible without silently becoming required dependencies.

Resolved secrets never enter model fields. External services carry strict reference names only. `RedactionSet` receives resolved canaries ephemerally at sealing time and rejects surviving plaintext plus bounded base64, URL-safe base64, percent-encoded, and hexadecimal variants without echoing canary values in errors.

### Budgets and reconciliation

Every allowance is explicitly `capped(value)` or `uncapped(reason, authorized_by, authorized_at)`. A zero cap is distinct from uncapped, and there is no hidden/default `$75` ceiling.

Provider and cloud money use integer USD micros, never floats. Provider input/output/cache tokens are separate dimensions. Unknown usage is explicit `unavailable(reason)` and makes required reporting non-reportable. Reservations carry stable operation keys, reject ambiguous retries and cumulative overcommit, and reconcile exact/under/over-cap actuals.

### Cleanup and lifecycle

Cleanup actions are symbolic and bounded: kind, resource reference, timeout, and maximum attempts. They contain no commands, code, API parameters, credential values, or provider payloads. Attempted cleanup is not successful cleanup, and late "success" after the action timeout is rejected.

Lifecycle state is linear and single-use: `planned → preflighted → authorized → running → finalizing → cleaning → completed`, with explicit failure and cancellation paths. Every transition constructs the child before consuming the parent, so failed validation remains retryable; concurrent sibling transitions yield one winner. Crash or cancellation after execution, including during finalization, must pass through cleanup. Infrastructure/preflight failures never become scored zero, and ambiguous finalization cannot be rescored into a win.

Live authority is process-local and held outside Pydantic models in an identity-keyed weak registry. Public validation, canonical JSON, `TypeAdapter`, Pydantic copy/construct APIs, and pickle cannot mint or duplicate authority. A weak episode-lineage lease prevents duplicate live roots in one process without creating an unbounded registry. These controls constrain cooperative adapters, not hostile Python that directly mutates private module state. A future evidence store must provide durable cross-process exactly-once behavior.

## Non-goals

- No OSWorld or benchmark-specific models
- No cloud/provider/network execution or discovery
- No credentials, secret values, or proxy values
- No filesystem, subprocess-adapter, configuration, CLI, TUI, or mobile integration
- No change to `ProtocolEnvelope` or `evaluation/protocol.py`
- No import from `local_operator.evaluation` package root; it remains inert

## Review history

The implementation received repeated adversarial review before PR creation. Remediation covered exact receipt/plan/action binding, cap and reconciliation replay, lifecycle construction forgery, aggregate authority forgery, sibling starts, finalization crash/cancel cleanup, atomic authority consumption, linear every-edge transitions, process-live episode uniqueness, Pydantic copy/construct/context bypasses, external authority storage, private permit minting, mutable-record exposure, encoded redaction variants, and deterministic race/rollback tests. The resulting focused suite contains 150 tests.

The mandatory PR-recorded agent review round will still be run on this PR's current head; this summary is not a substitute for that gate.

## Real-path evidence

A complete caller path was executed against the assembled public contract factories:

```text
DependencyPlan
→ record_preflight / seal_preflight
→ BudgetAuthorization / reserve_budget / commit_budget
→ plan_episode / authorize / start
→ reconcile_budget / finish_finalization
→ record_cleanup / aggregate_cleanup / finish_cleanup

{'state': 'completed', 'reportable': True, 'rescue_required': False, 'overruns': 0, 'version': '0.44.10'}
```

The same suite exercises invalid plans, duplicate and replayed receipts, secret canaries at nested locations, encoded canaries, zero versus uncapped budgets, over-reservation, unavailable usage, forged/copy-constructed authority, concurrent transitions, crash/cancel cleanup, ambiguous finalization, cleanup rescue, and weak-registry cleanup.

## Verification

Focused evaluation contracts after round-1 remediation:

```text
.venv/bin/python -m pytest tests/unit/evaluation -q -n0
151 passed, 10 warnings in 1.29s
```

The ten warnings are expected `PydanticDeprecatedSince20` warnings from tests deliberately invoking deprecated `BaseModel.copy` to prove that bypass clones receive no authority.

Whole-tree CI gates on the final rebased head:

```text
.venv/bin/python -m flake8 .
# exit 0
uvx --from black==26.1.0 black --check .
# 675 files would be left unchanged
uvx isort==5.13.2 --check .
# exit 0 (1 skipped)
.venv/bin/python -m pyright --pythonpath .venv/bin/python .
# 0 errors, 0 warnings, 0 informations
```

Full unit evidence:

```text
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
9731 passed, 15 skipped, 446 warnings in 310.20s
```

That clean full run was captured before the final upstream-only rebase and lineage-fixture isolation commit. A current-head rerun progressed to `8580 passed, 7 skipped` before the host hit `OSError: [Errno 24] Too many open files`; 1162 unrelated tests then failed at fixture setup with the same `EMFILE` error. The changed evaluation suite and all static gates are clean on the current head. CI is expected to provide fresh current-head whole-suite evidence.

Distribution validation:

```text
uvx --from build pyproject-build
uvx twine check dist/*
# local_operator-0.44.10-py3-none-any.whl: PASSED
# local_operator-0.44.10.tar.gz: PASSED
# wheel METADATA Version: 0.44.10
# sdist PKG-INFO Version: 0.44.10
```

## Risk, rollout, and rollback

This patch is based on released `0.44.9` (`95c905b093ca039213a8de1c1ce039fe8e3761e1`) and packages the contracts as `0.44.10`.

This introduces inert Python modules and pure model/function contracts. Normal CLI/session imports do not load them, and importing the evaluation package root remains inert. There is no deployment migration, persisted format, network call, or external side effect.

Rollout is the normal patch release path after review. Rollback is reverting this PR; no data or infrastructure rollback is required.


