### PR TITLE
test(tui): raise the loaded CPU ceiling to 500 ms after CI calibration

### DIFF
--- a/tests/unit/test_tui_responsiveness.py
+++ b/tests/unit/test_tui_responsiveness.py
@@ -71,13 +71,16 @@ class StallRecorder:
 
     Call-site ceilings are site-appropriate, not global. The reconnect and
     connect tests use the strict 50 ms CPU bar (healthy sample 0 ms,
-    regression 116 ms). Sites with legitimate loop CPU — the title-scan
-    test records a healthy 36-38 ms — use a 200 ms CPU bar, because the
-    same work measured 2.4× slower on ubuntu-latest in
-    ``test_launch_subagent.py`` (393-492 ms on a dev box, 1056-1156 ms on
-    CI), and a 50 ms bar would flake a green tree. The wall ceiling is
-    2000 ms everywhere: 3× the worst observed scheduler-noise gap, and
-    still well below the multi-second regressions.
+    regression 90-130 ms). Sites with legitimate loop CPU use a 500 ms CPU
+    bar: ``_prepare`` records a healthy 130-206 ms of loop CPU on a loaded
+    CI runner (measured on the merge run of this probe), so any ceiling
+    below that flakes a green tree, while a multi-second block still blows
+    through it. The title-scan test's REAL guard is structural, not the
+    ceiling — ``threading_get_ident() not in seen_threads`` proves the scan
+    ran off the loop, and it catches the regression even when the CPU
+    numbers overlap. The wall ceiling is 2000 ms everywhere: 3× the worst
+    observed scheduler-noise gap, and still well below the multi-second
+    regressions.
     """
 
     def __init__(self, stall_ms: float = STALL_MS) -> None:
@@ -143,17 +146,20 @@ class StallRecorder:
         )
 
     def assert_no_stall_loaded(
-        self, cpu_ceiling_ms: float = 200.0, wall_ceiling_ms: float = 2000.0
+        self, cpu_ceiling_ms: float = 500.0, wall_ceiling_ms: float = 2000.0
     ) -> None:
-        """Loaded bar: 200 ms of loop-thread CPU, same 2 s wall backstop.
+        """Loaded bar: 500 ms of loop-thread CPU, same 2 s wall backstop.
 
-        The title-scan test records a healthy 36-38 ms of loop CPU for a
-        120-session scan. The same class of CPU-bound work measured 2.4×
-        slower on ubuntu-latest than on a dev box
-        (``test_launch_subagent.py``, 393-492 ms vs 1056-1156 ms), so a
-        50 ms bar would flake a green tree on a slow CI core (~90 ms).
-        200 ms is 2× that projected CI cost and still well below the
-        multi-second regressions (a 2 s scan, a 5 s pricing block).
+        ``_prepare`` records a healthy 130-206 ms of loop CPU on a loaded CI
+        runner (measured on the merge run of this probe, where a 200 ms
+        ceiling flaked a green tree at 206 ms). 500 ms is 2.4× that observed
+        healthy max and still well below the multi-second regressions (a 2 s
+        scan, a 5 s pricing block).
+
+        For the title-scan test specifically, this ceiling is a catastrophic
+        backstop, not the primary guard: ``threading_get_ident() not in
+        seen_threads`` proves the scan ran off the loop and catches the
+        regression even when healthy and regressed CPU numbers overlap.
 
         The wall ceiling is the same catastrophic backstop as
         :meth:`assert_no_stall`: a pure blocking sleep is invisible to the

--- a/tests/unit/test_tui_responsiveness.py
+++ b/tests/unit/test_tui_responsiveness.py
@@ -71,16 +71,17 @@ class StallRecorder:
 
     Call-site ceilings are site-appropriate, not global. The reconnect and
     connect tests use the strict 50 ms CPU bar (healthy sample 0 ms,
-    regression 90-130 ms). Sites with legitimate loop CPU use a 500 ms CPU
-    bar: ``_prepare`` records a healthy 130-206 ms of loop CPU on a loaded
-    CI runner (measured on the merge run of this probe), so any ceiling
-    below that flakes a green tree, while a multi-second block still blows
-    through it. The title-scan test's REAL guard is structural, not the
-    ceiling — ``threading_get_ident() not in seen_threads`` proves the scan
-    ran off the loop, and it catches the regression even when the CPU
-    numbers overlap. The wall ceiling is 2000 ms everywhere: 3× the worst
-    observed scheduler-noise gap, and still well below the multi-second
-    regressions.
+    regression 90-130 ms). The loaded default is 200 ms of CPU, which suits
+    the boot and turn paths that record ~0 ms healthy CPU. The ONE exception
+    is the title-scan test, which drives ``_prepare`` and records a healthy
+    206 ms of loop CPU on a loaded CI runner (measured on the merge run of
+    this probe; 130-206 ms locally), so it passes ``cpu_ceiling_ms=500``
+    explicitly rather than raising the shared default. Its REAL guard is
+    structural, not the ceiling — ``threading_get_ident() not in
+    seen_threads`` proves the scan ran off the loop, and it catches the
+    regression even when the CPU numbers overlap. The wall ceiling is
+    2000 ms everywhere: 3× the worst observed scheduler-noise gap, and
+    still well below the multi-second regressions.
     """
 
     def __init__(self, stall_ms: float = STALL_MS) -> None:
@@ -146,20 +147,21 @@ class StallRecorder:
         )
 
     def assert_no_stall_loaded(
-        self, cpu_ceiling_ms: float = 500.0, wall_ceiling_ms: float = 2000.0
+        self, cpu_ceiling_ms: float = 200.0, wall_ceiling_ms: float = 2000.0
     ) -> None:
-        """Loaded bar: 500 ms of loop-thread CPU, same 2 s wall backstop.
+        """Loaded bar: 200 ms of loop-thread CPU, same 2 s wall backstop.
 
-        ``_prepare`` records a healthy 130-206 ms of loop CPU on a loaded CI
-        runner (measured on the merge run of this probe, where a 200 ms
-        ceiling flaked a green tree at 206 ms). 500 ms is 2.4× that observed
-        healthy max and still well below the multi-second regressions (a 2 s
-        scan, a 5 s pricing block).
+        200 ms suits the boot and turn paths, which record ~0 ms of healthy
+        loop CPU, and keeps their sensitivity to a 200-500 ms stall. The one
+        site that legitimately exceeds it — the title-scan test, whose
+        ``_prepare`` records a healthy 206 ms on a loaded CI runner — passes
+        ``cpu_ceiling_ms=500`` explicitly rather than raising this default,
+        so the other sites do not lose coverage.
 
-        For the title-scan test specifically, this ceiling is a catastrophic
-        backstop, not the primary guard: ``threading_get_ident() not in
-        seen_threads`` proves the scan ran off the loop and catches the
-        regression even when healthy and regressed CPU numbers overlap.
+        For the title-scan test specifically, even the 500 ms ceiling is a
+        catastrophic backstop, not the primary guard: ``threading_get_ident()
+        not in seen_threads`` proves the scan ran off the loop and catches
+        the regression even when healthy and regressed CPU numbers overlap.
 
         The wall ceiling is the same catastrophic backstop as
         :meth:`assert_no_stall`: a pure blocking sleep is invisible to the
@@ -346,7 +348,12 @@ async def test_prepare_store_scans_do_not_stall_the_loop(
         await await_store_maintenance_for_tests()
     finally:
         await recorder.stop()
-    recorder.assert_no_stall_loaded()
+    # 500 ms, not the 200 ms loaded default: this test drives ``_prepare``,
+    # which records a healthy 206 ms of loop CPU on a loaded CI runner
+    # (measured on the merge run of the dual-signal probe). The default would
+    # flake a green tree here, and the real guard is the structural assertion
+    # below anyway — the ceiling is only a catastrophic backstop.
+    recorder.assert_no_stall_loaded(cpu_ceiling_ms=500)
     # And the scan genuinely ran — in a worker thread, not on the loop.
     assert seen_threads, "the title backfill never executed"
     assert threading_get_ident() not in seen_threads


### PR DESCRIPTION
# PR Description

## Summary of Changes

The merge run of the dual-signal stall probe (#486, `aa8de03c`) failed `test (3.12)` on `test_prepare_store_scans_do_not_stall_the_loop`:

```
event loop consumed 206 ms of CPU without yielding (ceiling 200 ms)
```

That is a **green tree failing its own ceiling**. The 200 ms loaded default was calibrated from a local measurement of 36-38 ms, but the CI runner records **206 ms of legitimate loop CPU** during `_prepare` under `-n auto` contention (local runs show 130-206 ms) — the same 2.4× core-speed spread `test_launch_subagent.py` documented, now measured on this probe's own merge run.

(The 3.13 leg of that same merge run failed on an **unrelated** timing flake in `test_task_wait_jobs.py`, not this ceiling — corrected from the original description.)

### Why no tighter ceiling works at this site

Measured locally, healthy and regressed CPU **overlap** for the title-scan test: forcing the title backfill onto the loop adds only ~41 ms of CPU, while legitimate `_prepare` work already reaches 130-206 ms. No CPU ceiling can separate them.

That is by design — the title-scan test's real guard is **structural**, not the ceiling:

```python
assert threading_get_ident() not in seen_threads
```

which proves the scan ran off the loop and catches the regression even when the numbers overlap. The CPU ceiling at this site is therefore a **catastrophic backstop**, not the primary guard.

### The fix: site-specific, not global

The title-scan site passes `cpu_ceiling_ms=500` **explicitly** — 2.4× the observed healthy max (206 ms), still well below the multi-second regressions. The shared loaded default **stays at 200 ms**, so the other loaded-bar sites (s1-boot, s2, s3-harvest, turn-cost), which record ~0 ms healthy CPU and have no other guard, keep their sensitivity to a 200-500 ms stall.

The **strict 50 ms bar on reconnect/connect is unchanged** — those sites have 0 ms healthy samples and a 90-130 ms regression, a clean separation.

---

## Testing Evidence

### Healthy

```
$ pytest tests/unit/test_tui_responsiveness.py -q -n0
19 passed, 2 warnings in 28.12s
```

### CI green on the final head

All 8 jobs pass on `5bb1d8bd`, including `test (3.12)` — the exact job that failed at 206 ms on the merge run.

### Both regression guards still fire

**Reconnect regression** (synchronous 60 MB parse on the loop):

```
AssertionError: event loop consumed 130 ms of CPU without yielding (ceiling 50 ms)
```

**Title-scan regression** (backfill forced onto the loop):

```
tests/unit/test_tui_responsiveness.py:359: AssertionError
  (threading_get_ident() not in seen_threads — the structural guard)
```

The structural guard catches it regardless of ceiling, which is exactly why the site-specific 500 ms is safe.

### Lint

`black --check` and `flake8` clean.

## Non-goals

- Not touching the strict 50 ms bar on reconnect/connect.
- Not touching the 2000 ms wall backstop.
- Not fixing the unrelated `test_task_wait_jobs.py` flake from the merge run's 3.13 leg — separate concern.

## Related

- #486 introduced the dual-signal probe; its merge run is what produced the 206 ms calibration data this PR acts on.
- Round-1 review of #486 (F1-3) predicted this class of failure; round-1 review of this PR (C1-2) caught that the first cut raised the ceiling globally instead of site-specifically.
