### PR TITLE
test(tui): restore the 500 ms loaded ceiling after s1-boot CI calibration

### DIFF
--- a/tests/unit/test_tui_responsiveness.py
+++ b/tests/unit/test_tui_responsiveness.py
@@ -71,10 +71,22 @@ class StallRecorder:
 
     Call-site ceilings are site-appropriate, not global. The reconnect and
     connect tests use the strict 50 ms CPU bar (healthy sample 0 ms,
-    regression 90-130 ms). The loaded default is 200 ms of CPU, which suits
-    the boot and turn paths that record ~0 ms healthy CPU. The wall ceiling is
-    2000 ms everywhere: 3× the worst observed scheduler-noise gap, and still
-    well below the multi-second regressions.
+    Call-site ceilings are site-appropriate, not global. The reconnect and
+    connect tests use the strict 50 ms CPU bar (healthy sample 0 ms,
+    regression 90-130 ms). The loaded default is 500 ms of CPU, because the
+    sites that use it drive real app work with legitimate loop CPU. The
+    FULL CI dataset (every run that has flaked a lower ceiling on a green
+    tree): title-scan 206 ms and 264 ms, s1-boot 321 ms, s2 413 ms — so 413 ms
+    is the observed healthy max and 500 ms carries ~20% headroom over it.
+    That margin is thin: the same site has swung ~30% between runs, so a
+    green tree may yet exceed 500 ms; if it does, raise the ceiling again on
+    evidence rather than assuming the probe is wrong. (The historical 549 ms
+    layout-pass figure is WALL-CLOCK, from the pre-#486 probe this CPU clock
+    replaced — useful as an upper bound on the class of work, not as a CPU
+    precedent.) The wall ceiling is 2000 ms everywhere: 3× the worst
+    observed scheduler-noise gap, and still well below the multi-second
+    regressions.
+    """
     """
 
     def __init__(self, stall_ms: float = STALL_MS) -> None:
@@ -140,12 +152,19 @@ class StallRecorder:
         )
 
     def assert_no_stall_loaded(
-        self, cpu_ceiling_ms: float = 200.0, wall_ceiling_ms: float = 2000.0
+        self, cpu_ceiling_ms: float = 500.0, wall_ceiling_ms: float = 2000.0
     ) -> None:
-        """Loaded bar: 200 ms of loop-thread CPU, same 2 s wall backstop.
+        """Loaded bar: 500 ms of loop-thread CPU, same 2 s wall backstop.
 
-        200 ms suits the boot and turn paths, which record ~0 ms of healthy
-        loop CPU, and keeps their sensitivity to a 200-500 ms stall.
+        The sites that use this helper drive real app work with legitimate
+        loop CPU, and lower ceilings flaked green trees repeatedly on CI.
+        The full dataset: title-scan 206 ms and 264 ms, s1-boot 321 ms, s2
+        413 ms — 413 ms is the observed healthy max, so 500 ms carries ~20%
+        headroom. That is thin; see the class docstring for what to do if a
+        green tree exceeds it. (The historical 549 ms layout-pass figure is
+        WALL-CLOCK, from the pre-#486 probe — an upper bound on the class of
+        work, not a CPU precedent.)
+
 
         The wall ceiling is the same catastrophic backstop as
         :meth:`assert_no_stall`: a pure blocking sleep is invisible to the

--- a/tests/unit/test_tui_responsiveness.py
+++ b/tests/unit/test_tui_responsiveness.py
@@ -71,8 +71,6 @@ class StallRecorder:
 
     Call-site ceilings are site-appropriate, not global. The reconnect and
     connect tests use the strict 50 ms CPU bar (healthy sample 0 ms,
-    Call-site ceilings are site-appropriate, not global. The reconnect and
-    connect tests use the strict 50 ms CPU bar (healthy sample 0 ms,
     regression 90-130 ms). The loaded default is 500 ms of CPU, because the
     sites that use it drive real app work with legitimate loop CPU. The
     FULL CI dataset (every run that has flaked a lower ceiling on a green
@@ -86,7 +84,6 @@ class StallRecorder:
     precedent.) The wall ceiling is 2000 ms everywhere: 3× the worst
     observed scheduler-noise gap, and still well below the multi-second
     regressions.
-    """
     """
 
     def __init__(self, stall_ms: float = STALL_MS) -> None:
@@ -164,7 +161,6 @@ class StallRecorder:
         green tree exceeds it. (The historical 549 ms layout-pass figure is
         WALL-CLOCK, from the pre-#486 probe — an upper bound on the class of
         work, not a CPU precedent.)
-
 
         The wall ceiling is the same catastrophic backstop as
         :meth:`assert_no_stall`: a pure blocking sleep is invisible to the
@@ -1073,9 +1069,9 @@ async def test_s1_boot_paints_and_stays_responsive_over_the_first_seconds() -> N
     MCP" report was made of. The boot session is a fake (the real factory's
     loop work is covered by the unit tests above); what this test measures
     is the app's own boot composition — paint, adoption, timers. The loaded
-    bar (200 ms CPU / 2 s wall) is the right one here: boot has legitimate
-    loop CPU from Textual layout, and the reconnect/connect tests are the
-    ones that assert the strict 50 ms CPU bar against the parse regression.
+    bar (500 ms CPU / 2 s wall) is the right one here: boot recorded 321 ms
+    of healthy Textual-layout CPU on CI, and the reconnect/connect tests are
+    the ones that assert the strict 50 ms CPU bar against the parse regression.
     """
     from local_operator.tui.app import OperatorApp
     from tests.unit.tui.test_app_pilot import FakeSession, _factory
@@ -1167,10 +1163,11 @@ async def test_s2_send_to_agent_end_keeps_the_loop_under_the_bar() -> None:
             await asyncio.sleep(0.02)
         discovery.available_models = original  # type: ignore[assignment]
         configure.invalidate_model_info_cache()
-        # Loaded bar (200 ms CPU / 2 s wall): this path has legitimate loop
-        # CPU from Textual layout, and the reconnect/connect tests are the
-        # ones that assert the strict 50 ms CPU bar against the parse
-        # regression. Bench numbers live in bench/before.json vs after.json.
+        # Loaded bar (500 ms CPU / 2 s wall): this path has legitimate loop
+        # CPU from Textual layout (413 ms recorded on CI), and the
+        # reconnect/connect tests are the ones that assert the strict 50 ms
+        # CPU bar against the parse regression. Bench numbers live in
+        # bench/before.json vs after.json.
         recorder.assert_no_stall_loaded()
 
 


### PR DESCRIPTION
# PR Description

## Summary of Changes

The site-specific ceiling fix (#496's second commit) restored a 200 ms loaded default on the premise that only the title-scan site had legitimate loop CPU and the boot/turn paths recorded ~0 ms. The merge run of that fix **disproved the premise**: `test_s1_boot` failed `test (3.13)` with

```
event loop consumed 321 ms of CPU without yielding (ceiling 200 ms)
```

### The full calibration dataset

Every run that has flaked a lower ceiling on a green tree:

| Site | Healthy loop CPU on CI | Run |
|---|---|---|
| title-scan (`_prepare`) | 206 ms | **#486** merge run (`aa8de03c`) |
| title-scan (`_prepare`) | 264 ms | **#495** merge run (`c74eb53e`) |
| s1-boot (Textual layout) | 321 ms | **#496** merge run (`7b973190`) |
| s2 (Textual layout) | 413 ms | **#495** merge run (`c74eb53e`) |

The observed healthy max is therefore **413 ms**, and 500 ms carries **~20% headroom** over it. That margin is thin — the same site has swung ~30% between runs — so the docstrings state the full dataset, name the margin explicitly, and say what to do if a green tree exceeds 500 ms: raise it again on evidence rather than assuming the probe is wrong.

(The historical 549 ms layout-pass figure is **wall-clock**, from the pre-#486 probe this CPU clock replaced. It remains useful as an upper bound on the class of work — 321 ms of CPU is in the expected range — but it is not a CPU precedent.)

### The fix

The loaded default goes back to **500 ms**, above the observed healthy CPU max of 413 ms, still well below the multi-second regressions (a 2 s scan, a 5 s pricing block). The title-scan site's explicit `cpu_ceiling_ms=500` becomes redundant and is removed.

**What this accepts, stated plainly:** s1-boot and s2 have no guard other than the loaded helper, so a 200-500 ms stall at those sites passes. The multi-second regressions are still caught, and the strict 50 ms bar on reconnect/connect (the parse regression this probe exists for) is untouched.

The title-scan test's **structural guard** (`threading_get_ident() not in seen_threads`) remains its primary protection, independent of any ceiling.

---

## Testing Evidence

### Healthy

```
$ pytest tests/unit/test_tui_responsiveness.py -q -n0
19 passed, 2 warnings in 40.03s
```

### Both regression guards still fire

**Title-scan regression** (backfill forced onto the loop):

```
tests/unit/test_tui_responsiveness.py: AssertionError
  (threading_get_ident() not in seen_threads — the structural guard)
```

**Reconnect regression** (synchronous 60 MB parse on the loop):

```
AssertionError: event loop consumed 140 ms of CPU without yielding (ceiling 50 ms)
```

### Lint

`black --check` and `flake8` clean.

## Non-goals

- Not touching the strict 50 ms bar on reconnect/connect.
- Not touching the 2000 ms wall backstop.
- Not adding per-site inline wall-clock asserts at s1-boot/s2 — the loaded helper is their guard by design, and the multi-second regressions are what it exists to catch.

## Related

- #486 introduced the dual-signal probe with a 500 ms loaded default.
- #496 first raised it globally (correct value, wrong scope), then scoped it to 200 ms + title-scan override (correct scope, wrong value for s1-boot and s2). This PR settles on 500 ms globally, which the full four-point CI dataset supports.
- The oscillation is recorded rather than hidden: the 200 ms restore was based on local ~0 ms measurements that CI disproved at 321 ms and 413 ms.
