### PR TITLE
fix(tui): preserve provisional session names

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2847,7 +2847,17 @@ class OperatorApp(App[None]):
             cost=(
                 self._spend_text(cost) if cost is not None else ("$—" if billed_unknown else None)
             ),
-            conversation_name=str(getattr(state, "conversation_title", "") or ""),
+            # A local opener label is DISPLAY state until a generated title is
+            # accepted. Canonical snapshots correctly keep their persisted title
+            # empty during that interval, but must not turn "empty in storage"
+            # into "erase the better label already painted": todo/model-route
+            # updates arrive throughout the first turn, and one otherwise sends
+            # the terminal tab back to its cwd (often the unhelpful `tmp`). A
+            # real canonical title still wins immediately; reload/session swaps
+            # clear `_provisional_name` before adopting their replacement.
+            conversation_name=(
+                str(getattr(state, "conversation_title", "") or "") or self._provisional_name
+            ),
             # The fork tag follows the name, not the band's memory: a snapshot
             # arrives with EVERY name change, and `StatusLine.update` treats a
             # missing `forked=` as leave-alone — so a rename that cleared the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.12"
+version = "0.44.13"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -327,6 +327,65 @@ async def test_the_band_is_named_from_the_opener_before_any_provider_call() -> N
 
 
 @pytest.mark.asyncio
+async def test_frontend_updates_preserve_the_provisional_name() -> None:
+    """Canonical control snapshots must not repaint an unnamed tab as its cwd.
+
+    The persisted title remains empty while naming is in flight (and forever
+    when the isolated call returns no usable title). Todo and active-model
+    updates publish that truthful empty value during the first turn; it means
+    "not stored", not "discard the opener label the local host is wearing".
+    """
+    from local_operator.session.frontend_state import FrontendSessionState
+
+    app, session = await _boot(title="")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        app._submit_prompt("fix the session naming fallback repaint")
+
+        assert app._status is not None
+        assert app._status._conversation_name == "Fix the session naming fallback repaint"
+        assert session.conversation_name == ""
+
+        app._apply_frontend_state(
+            FrontendSessionState(
+                session_id="session",
+                epoch="owner",
+                cwd="/private/tmp",
+                conversation_title="",
+            )
+        )
+
+        assert app._status._conversation_name == "Fix the session naming fallback repaint"
+        # The snapshot remains canonical: only the display overlay supplies the
+        # label, so a later generated/user title can still win normally.
+        assert session.conversation_name == ""
+        session.gate.set()
+
+
+@pytest.mark.asyncio
+async def test_a_canonical_title_supersedes_the_provisional_name() -> None:
+    """A persisted name remains authoritative over the local display overlay."""
+    from local_operator.session.frontend_state import FrontendSessionState
+
+    app, session = await _boot(title="")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        app._show_provisional_name("fix the session naming fallback repaint")
+        assert app._status is not None
+
+        app._apply_frontend_state(
+            FrontendSessionState(
+                session_id="session",
+                epoch="owner",
+                conversation_title="Reliable session naming",
+            )
+        )
+
+        assert app._status._conversation_name == "Reliable session naming"
+        session.gate.set()
+
+
+@pytest.mark.asyncio
 async def test_a_dead_naming_call_leaves_the_opener_on_the_band() -> None:
     """A provider failure costs the better title, not the label.
 


### PR DESCRIPTION
# PR Description

## Summary of Changes

Preserves the opener-derived provisional session name when canonical frontend-state updates truthfully report that no title has been persisted yet. A real persisted or user-assigned title still supersedes the provisional display immediately.

This fixes sessions whose tab/status name reverted to the working-directory fallback (`tmp`) during their first turn, especially when the isolated model naming call returned no usable title.

## Incident and Root Cause Evidence

Sanitized local transcript metadata established the distinction between model behavior and the control-message failure:

- A reported titleless session (`53c7fcef842f`) recorded `active_model_route` from `anthropic/claude-opus-5` to `alibaba-token-plan/qwen3.8-max`, then a substantive user prompt and many successful Qwen assistant/tool responses, but no `conversation_name` entry or `title.json`.
- Adjacent sessions on the same persisted Qwen route generated and journalled valid names 5.3–5.8 seconds after their first user prompt, including `Cross-session lop send wake agents`, `Improve Mobile Relay Session Loading Performance`, and `Fix parent-message tag rendering`. Qwen naming therefore works and model failover itself did not produce `tmp`.
- `tmp` is the terminal title's documented cwd fallback for an empty display name. The app paints a provisional opener label synchronously, but `_apply_frontend_state()` then wrote the canonical snapshot's still-empty `conversation_title` over it whenever todo/model-route/job control state arrived. If isolated naming later returned no usable title, no subsequent update restored the label.

No transcript body, credentials, provider tokens, or secrets are included here.

## Testing Evidence

### Real rendered path

A real `OperatorApp.run_test()` frame applied the exact sequence: paint a substantive opener-derived label, then apply a canonical frontend snapshot with an empty persisted title.

Before (`/tmp/naming-before.svg`, rendered and inspected as PNG):

```text
painted_name=''
provisional_name='Fix the session naming fallback repaint'
status band: /private/tmp (no conversation name)
```

After (`/tmp/naming-after.svg`, rendered and inspected as PNG):

```text
painted_name='Fix the session naming fallback repaint'
provisional_name='Fix the session naming fallback repaint'
status band: /private/tmp … Fix the session naming fallback repaint
```

The frame geometry stayed 100×30; the change only restores the existing label in the status/title state.

### Regression coverage

```text
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
    tests/unit/tui/test_conversation_naming.py -q
41 passed in 12.30s

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
    tests/e2e -m e2e -n0 -q
3 passed in 14.72s
```

The new tests prove both sides of precedence: empty control snapshots preserve the provisional label, while a canonical persisted title supersedes it.

### Rebase and version

Rebased onto current `origin/main` at `0f9f9ed6410869032d5a22d64569998daa8550dd`. Version `0.44.12` was already tagged and published while verification was running, so this patch uses the next available release version, `0.44.13`.

### Whole-tree gates

```text
flake8 .                                        passed
black==26.1.0 --check .                         686 files unchanged
isort==5.13.2 --check .                         passed
pyright --pythonpath .venv/bin/python .         0 errors, 0 warnings
```

The required full unit suite is clean on the final rebased head:

```text
9878 passed, 15 skipped in 572.60s (0:09:32)
```

An earlier run before the final test-only main update exposed the pre-existing held-key timing race; the unchanged test passed on exact `origin/main`, and the final whole-suite run above is clean. No code in the approval/steering path differs in this PR.

## Non-goals

- No change to provider failover, Qwen routing, or title parsing.
- No persistence of provisional excerpts; they remain display-only so generated/user titles retain precedence.
- No fixes or issues for unrelated unit-suite flakes.


