### PR TITLE
fix(fork): isolate fork runtime ownership

### DIFF
--- a/local_operator/fork.py
+++ b/local_operator/fork.py
@@ -79,6 +79,25 @@ BOOT_PROMPT_NAME = "boot-prompt.json"
 #: added without a second format, matching the title/attachment sidecars.
 BOOT_PROMPT_VERSION = 1
 
+#: One-shot context-tail marker consumed by ``Session`` before the fork's first
+#: request. It is separate from the optional boot prompt because a BARE fork
+#: still needs the model-visible lineage boundary on the first instruction the
+#: user eventually types, while remaining idle until then.
+FORK_BOUNDARY_NAME = "fork-boundary.json"
+FORK_BOUNDARY_VERSION = 1
+
+#: The exact non-persistent instruction appended after inherited history. Keep
+#: this stable: the inherited transcript remains byte-identical and cacheable;
+#: only this new tail distinguishes the branch from the still-running parent.
+FORK_BOUNDARY_INSTRUCTION = (
+    "<fork-boundary>\n"
+    "This session is a fork of an existing conversation. Work inherited in the "
+    "transcript may still be continuing in the original session; do not continue "
+    "or duplicate it here on your own. Wait for and follow the next divergent "
+    "instruction given in this fork.\n"
+    "</fork-boundary>"
+)
+
 #: Files a fork inherits from its parent, and nothing else. Ordered by what they
 #: are FOR, because each entry earns its place differently:
 #:
@@ -203,6 +222,13 @@ def fork_session(config_dir: Path, parent_id: str, *, message: str = "") -> str:
     except OSError as exc:
         raise ForkError(f"cannot copy the conversation into the fork: {exc}") from exc
 
+    # Written for EVERY fork, including a bare one. The marker is consumed into
+    # memory by the fork's first ``Session`` construction and never enters the
+    # transcript, preserving both the parent's bytes and its prompt-cache prefix.
+    _write_json_sidecar(
+        fork_dir / FORK_BOUNDARY_NAME,
+        {"version": FORK_BOUNDARY_VERSION, "created_at": time.time()},
+    )
     if message.strip():
         write_boot_prompt(fork_dir, message)
 
@@ -242,6 +268,40 @@ def fork_session(config_dir: Path, parent_id: str, *, message: str = "") -> str:
     return new_id
 
 
+def _write_json_sidecar(path: Path, payload: dict[str, object]) -> None:
+    """Best-effort atomic-enough JSON write for disposable fork boot state."""
+    try:
+        path.write_text(json.dumps(payload), encoding="utf-8")
+    except OSError:
+        logger.debug("fork: cannot write sidecar %s", path, exc_info=True)
+
+
+def consume_fork_boundary(session_dir: Path) -> str:
+    """Consume the fork's one-shot model boundary, returning its instruction.
+
+    Unlink before returning for the same safer-than-repetition rule as the boot
+    prompt: a crash after construction may lose the boundary, but a resume must
+    never inject it repeatedly into an established fork.
+    """
+    sidecar = session_dir / FORK_BOUNDARY_NAME
+    try:
+        raw = sidecar.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    finally:
+        try:
+            sidecar.unlink()
+        except OSError:
+            pass
+    try:
+        payload = json.loads(raw)
+    except ValueError:
+        return ""
+    if not isinstance(payload, dict) or payload.get("version") != FORK_BOUNDARY_VERSION:
+        return ""
+    return FORK_BOUNDARY_INSTRUCTION
+
+
 def write_boot_prompt(session_dir: Path, text: str) -> None:
     """Park ``text`` as the session's first user turn, for its next boot.
 
@@ -255,10 +315,7 @@ def write_boot_prompt(session_dir: Path, text: str) -> None:
         "text": text,
         "created_at": time.time(),
     }
-    try:
-        (session_dir / BOOT_PROMPT_NAME).write_text(json.dumps(payload), encoding="utf-8")
-    except OSError:
-        logger.debug("fork: cannot write the boot prompt for %s", session_dir, exc_info=True)
+    _write_json_sidecar(session_dir / BOOT_PROMPT_NAME, payload)
 
 
 def consume_boot_prompt(session_dir: Path) -> str:

--- a/local_operator/multiplexer/cmux.py
+++ b/local_operator/multiplexer/cmux.py
@@ -99,6 +99,10 @@ CALL_TIMEOUT_S = 5.0
 SURFACE_ENV = "CMUX_SURFACE_ID"
 WORKSPACE_ENV = "CMUX_WORKSPACE_ID"
 
+#: Placement vocabulary shared with ``spawn.cmux`` without importing that
+#: package back into the multiplexer layer.
+_FORK_SURFACE_PLACEMENT = "surface"
+
 #: cmux mints these as UUIDs. Validated before use because they are
 #: interpolated into a JSON payload handed to a socket that acts on them, and
 #: an inherited-but-stale value (a container, an ssh hop) should read as "no
@@ -260,6 +264,47 @@ def _rpc(binary: str, method: str, params: dict[str, object]) -> dict[str, objec
 # They DELEGATE to the underscore functions rather than replacing them: those
 # are the definitions the existing tests monkeypatch, and a promotion that moved
 # the body would silently make every one of those patches a no-op.
+
+
+def rename_fork_target(env: EnvMap, title: str, *, placement: str) -> bool:
+    """Best-effort rename of the cmux target owned by this fork process.
+
+    cmux 0.64.22+ exposes ``workspace rename <id> --title`` and
+    ``rename-tab --surface <id> <title>``. Target explicit ids from THIS
+    process's environment: defaults could rename whichever workspace the user
+    selected meanwhile. Callers additionally gate on fork provenance, which is
+    what prevents an ordinary/parent session from ever reaching this mutation.
+    """
+    target = _surface_target(env)
+    binary = _cmux_binary()
+    clean = " ".join(str(title).split()).strip()
+    if target is None or binary is None or not clean:
+        return False
+    if placement == _FORK_SURFACE_PLACEMENT:
+        argv = [binary, "rename-tab", "--surface", target["surface_id"], clean]
+    else:
+        argv = [
+            binary,
+            "workspace",
+            "rename",
+            target["workspace_id"],
+            "--title",
+            clean,
+        ]
+    try:
+        completed = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=CALL_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        logger.debug("cmux fork rename failed to spawn", exc_info=True)
+        return False
+    if completed.returncode != 0:
+        logger.debug("cmux fork rename exited %s: %s", completed.returncode, completed.stderr[:200])
+        return False
+    return True
 
 
 def cmux_binary() -> str | None:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1594,9 +1594,24 @@ class Session:
         self._ask_user: AskUserFn | None = None
 
         self._loop = AgentLoop()
+        replayed_messages = list(transcript.build_llm_history())
+        # A fork's inherited bytes stay untouched for prompt-cache continuity;
+        # its lineage warning exists only at the live context tail and is
+        # consumed once, so resume never accumulates synthetic transcript rows.
+        from local_operator.fork import consume_fork_boundary
+
+        fork_boundary = consume_fork_boundary(transcript.directory)
+        if fork_boundary:
+            replayed_messages.append(
+                CustomMessage(
+                    custom_type="fork_boundary",
+                    attribution="system",
+                    details={"text": fork_boundary},
+                )
+            )
         self._context = LoopContext(
             system_blocks=[],
-            messages=list(transcript.build_llm_history()),
+            messages=replayed_messages,
             tools=self._tools,
         )
         self._handlers: list[EventHandler] = []
@@ -7831,6 +7846,14 @@ class Session:
     # -- wakes -------------------------------------------------------------------
 
     def _load_wake_schedules(self) -> None:
+        # A wake is active ownership, not conversation history. The copied
+        # transcript may contain legacy/current schedule snapshots alongside
+        # ordinary wake tool calls/results; a fork must keep the latter visible
+        # while starting with no schedules it could fire or cancel for its parent.
+        from local_operator.fork import fork_parent
+
+        if fork_parent(self._transcript.directory):
+            return
         details = self._transcript.latest_custom(WAKE_SCHEDULES_CUSTOM_TYPE)
         if not details:
             return
@@ -8131,6 +8154,15 @@ class Session:
         in the CHILD's own transcript and is recovered by resuming or
         ``hub op='peek'``-ing it, never by re-reading it here.
         """
+        # Forks inherit historical transcript content, not process ownership.
+        # This provenance gate suppresses BOTH the modern sidecar and legacy
+        # ``subagent_roster`` customs, including when a seed sidecar write was
+        # lost. New children launched by this session still populate the empty
+        # manager/comms objects normally and persist under the fork directory.
+        from local_operator.fork import fork_parent
+
+        if fork_parent(self._transcript.directory):
+            return
         details = _read_roster_sidecar(self._transcript.directory / SUBAGENT_ROSTER_SIDECAR)
         loaded_sidecar = details is not None
         if details is None:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -483,10 +483,11 @@ def _default_convert_to_llm(messages: list[AgentMessage]) -> list[Message]:
     ``compaction_summary`` markers become a user message carrying the summary;
     a snapcompact archive in ``preserve_data`` is rendered back into
     text_head → imaged middle → text_tail blocks (base64 ``ImageContent``
-    between ``TextContent`` edges). ``wake_prompt`` deliveries become user
-    messages of their formatted text, and the newest ``todo_reminder`` (only
-    the newest) becomes one too; other custom entries are dropped (bookkeeping
-    never enters LLM context). ``provider_payload`` rides along untouched.
+    between ``TextContent`` edges). ``fork_boundary`` and ``wake_prompt``
+    deliveries become user messages of their formatted text, and the newest
+    ``todo_reminder`` (only the newest) becomes one too; other custom entries
+    are dropped (bookkeeping never enters LLM context). ``provider_payload``
+    rides along untouched.
     """
     out: list[Message] = []
     # Only the NEWEST todo reminder survives the render. An earlier one asserts
@@ -534,6 +535,7 @@ def _default_convert_to_llm(messages: list[AgentMessage]) -> list[Message]:
                 )
             )
         elif message.custom_type in (
+            "fork_boundary",
             WAKE_PROMPT_MESSAGE_TYPE,
             HUB_MESSAGE_TYPE,
             JOB_RESULT_MESSAGE_TYPE,
@@ -7846,15 +7848,18 @@ class Session:
     # -- wakes -------------------------------------------------------------------
 
     def _load_wake_schedules(self) -> None:
-        # A wake is active ownership, not conversation history. The copied
-        # transcript may contain legacy/current schedule snapshots alongside
-        # ordinary wake tool calls/results; a fork must keep the latter visible
-        # while starting with no schedules it could fire or cancel for its parent.
-        from local_operator.fork import fork_parent
+        # A wake is active ownership, not conversation history. A fork declines
+        # only snapshots copied at its creation boundary; snapshots appended
+        # afterwards belong to the fork and must survive its next resume.
+        from local_operator.fork import fork_instant
 
-        if fork_parent(self._transcript.directory):
+        entry = self._transcript.latest_custom_entry(WAKE_SCHEDULES_CUSTOM_TYPE)
+        if entry is None:
             return
-        details = self._transcript.latest_custom(WAKE_SCHEDULES_CUSTOM_TYPE)
+        forked_at = fork_instant(self._transcript.directory)
+        if forked_at is not None and not entry.ts > forked_at:
+            return
+        details = dict(entry.payload.get("details", {}))
         if not details:
             return
         schedules: list[WakeSchedule] = []
@@ -8155,18 +8160,20 @@ class Session:
         ``hub op='peek'``-ing it, never by re-reading it here.
         """
         # Forks inherit historical transcript content, not process ownership.
-        # This provenance gate suppresses BOTH the modern sidecar and legacy
-        # ``subagent_roster`` customs, including when a seed sidecar write was
-        # lost. New children launched by this session still populate the empty
-        # manager/comms objects normally and persist under the fork directory.
-        from local_operator.fork import fork_parent
+        # The modern sidecar is excluded from the clone, so one present here was
+        # written by this fork. For the legacy transcript fallback, compare its
+        # append time with the fork boundary so a descendant declines its
+        # parent's roster while still restoring one it later writes itself.
+        from local_operator.fork import fork_instant
 
-        if fork_parent(self._transcript.directory):
-            return
         details = _read_roster_sidecar(self._transcript.directory / SUBAGENT_ROSTER_SIDECAR)
         loaded_sidecar = details is not None
         if details is None:
-            details = self._transcript.latest_custom(SUBAGENT_ROSTER_CUSTOM_TYPE)
+            entry = self._transcript.latest_custom_entry(SUBAGENT_ROSTER_CUSTOM_TYPE)
+            forked_at = fork_instant(self._transcript.directory)
+            if entry is None or (forked_at is not None and not entry.ts > forked_at):
+                return
+            details = dict(entry.payload.get("details", {}))
         if not details:
             return
         self._subagent_roster_generation = int(details.get("generation") or 0)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -10259,23 +10259,38 @@ class OperatorApp(App[None]):
             return
         self._fork_cmux_name = clean
 
+        if getattr(self, "_fork_cmux_name_worker_running", False):
+            return
+        self._fork_cmux_name_worker_running = True
+
         async def rename() -> None:
             from local_operator.multiplexer.cmux import rename_fork_target
             from local_operator.spawn.policy import fork_cmux_placement
 
+            applied = ""
             try:
-                await asyncio.to_thread(
-                    rename_fork_target,
-                    dict(os.environ),
-                    clean,
-                    placement=fork_cmux_placement(self._config_values()),
-                )
-            except Exception:
-                # A label is decoration; cmux restart/closure must never disturb
-                # the conversation or roll back the title already stored.
-                logger.debug("fork cmux rename failed", exc_info=True)
+                # One serial drain owns the subprocess boundary. A newer title
+                # arriving during a slow rename replaces the pending value; the
+                # old call may finish, but the drain always applies the newest
+                # value afterwards, making the externally visible result latest-wins.
+                while applied != getattr(self, "_fork_cmux_name", ""):
+                    pending = self._fork_cmux_name
+                    try:
+                        await asyncio.to_thread(
+                            rename_fork_target,
+                            dict(os.environ),
+                            pending,
+                            placement=fork_cmux_placement(self._config_values()),
+                        )
+                    except Exception:
+                        # A label is decoration; cmux restart/closure must never
+                        # disturb the conversation or roll back the stored title.
+                        logger.debug("fork cmux rename failed", exc_info=True)
+                    applied = pending
+            finally:
+                self._fork_cmux_name_worker_running = False
 
-        self.run_worker(rename(), exclusive=False)
+        self.run_worker(rename(), group="fork-cmux-name", exclusive=False, exit_on_error=False)
 
     def _clock(self) -> float:
         """Monotonic seconds, as one overridable seam.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2127,6 +2127,10 @@ class OperatorApp(App[None]):
         # next substantive message retries, which is bounded by the user's own
         # sends and only ever fires while no name exists to displace.
         self._name_requested: bool = False
+        #: Last cmux label dispatched for THIS fork process. Name updates can
+        #: arrive provisionally, generated, and manually within seconds; exact
+        #: coalescing avoids three socket calls for an unchanged stored title.
+        self._fork_cmux_name: str = ""
         #: A receipt that must survive a session transition, as
         #: ``(fork_id, text)``. `fork.mode=switch` reboots onto the fork, which
         #: wipes the ledger about half a second after the notice is written, so
@@ -10225,11 +10229,53 @@ class OperatorApp(App[None]):
             return
         self._provisional_name = label
         self._status.update(conversation_name=label)
+        self._sync_fork_cmux_name(label)
         # The band is DISPLAY-only; the phone reads the session store, which
         # is still empty. Push the stand-in so the list and header name the
         # conversation the same frame the tab does, instead of "untitled"
         # until a generated title lands (or forever, if naming 429s).
         self._notify_mobile_title(label)
+
+    def _sync_fork_cmux_name(self, title: str) -> None:
+        """Rename only the cmux target this fork process owns, best-effort.
+
+        Terminal OSC titles identify the live surface but cmux workspace labels
+        do not follow them. Provenance is the safety gate: a parent/ordinary
+        session never calls the mutating cmux command, even when it happens to
+        run in the workspace from which a fork was created.
+        """
+        session = self._session
+        session_id = str(getattr(session, "session_id", "") or "") if session else ""
+        clean = " ".join(str(title).split()).strip()
+        if not session_id or not clean or clean == getattr(self, "_fork_cmux_name", ""):
+            return
+        try:
+            from local_operator.fork import fork_parent
+            from local_operator.paths import config_dir
+
+            if not fork_parent(config_dir() / "sessions" / session_id):
+                return
+        except Exception:
+            return
+        self._fork_cmux_name = clean
+
+        async def rename() -> None:
+            from local_operator.multiplexer.cmux import rename_fork_target
+            from local_operator.spawn.policy import fork_cmux_placement
+
+            try:
+                await asyncio.to_thread(
+                    rename_fork_target,
+                    dict(os.environ),
+                    clean,
+                    placement=fork_cmux_placement(self._config_values()),
+                )
+            except Exception:
+                # A label is decoration; cmux restart/closure must never disturb
+                # the conversation or roll back the title already stored.
+                logger.debug("fork cmux rename failed", exc_info=True)
+
+        self.run_worker(rename(), exclusive=False)
 
     def _clock(self) -> float:
         """Monotonic seconds, as one overridable seam.
@@ -10526,6 +10572,7 @@ class OperatorApp(App[None]):
                 conversation_name=stored,
                 forked=bool(getattr(session, "wears_inherited_title", False)),
             )
+        self._sync_fork_cmux_name(stored)
         # The title lands on a detached worker AFTER the last turn event, so
         # the mobile fold never re-reads it on its own. Push now so the
         # phone's header and list update the same moment the band does.
@@ -10590,6 +10637,7 @@ class OperatorApp(App[None]):
                 conversation_name=stored,
                 forked=bool(getattr(session, "wears_inherited_title", False)),
             )
+        self._sync_fork_cmux_name(stored)
         self._notify_mobile_title(stored)
         # `stored`, not `arg`: the store collapses whitespace and caps the length
         # (`MAX_TITLE_CHARS`), and the receipt's whole job is to show the title

--- a/local_operator/tui/widgets/welcome.py
+++ b/local_operator/tui/widgets/welcome.py
@@ -357,7 +357,7 @@ TIPS: tuple[str, ...] = (
     "Ask for parallel work and the agent fans out subagents",
     "! on an empty composer runs a shell command",
     "/fork branches; /fork <message> starts divergent work",
-    "/settings → Fork → Where a fork opens changes default",
+    "/settings → Fork → Where a fork opens sets placement",
     "Under cmux, Where it opens sets workspace or surface",
     "lop detects terminal or multiplexer, then picks placement",
 )

--- a/local_operator/tui/widgets/welcome.py
+++ b/local_operator/tui/widgets/welcome.py
@@ -350,16 +350,16 @@ TIP_PASTE = "ctrl+v attaches an image from the system clipboard"
 TIPS: tuple[str, ...] = (
     "/resume picks up a recent session where you left off",
     "/team <name> <message> sends work to the manager",
-    "Ask to create an agent with its own instruction set",
     "/model <provider>/<id> switches this session only",
-    "/usage shows how much provider quota is left",
     TIP_PASTE,
     "/approvals <ask|auto> sets whether tools ask first",
-    "ctrl+c copies what you highlight in the composer",
     "esc stops the agent without ending the session",
     "Ask for parallel work and the agent fans out subagents",
     "! on an empty composer runs a shell command",
-    "/goal sets the objective that /loop iterates toward",
+    "/fork branches; /fork <message> starts divergent work",
+    "/settings → Fork → Where a fork opens changes default",
+    "Under cmux, Where it opens sets workspace or surface",
+    "lop detects terminal or multiplexer, then picks placement",
 )
 
 #: The tip the SETUP state opens on, in place of the pinned ``TIPS[0]``. The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.12"
+version = "0.44.13"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/test_fork.py
+++ b/tests/unit/test_fork.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from textual.widgets import Static
@@ -31,8 +31,11 @@ from local_operator.fork import (
     BOOT_PROMPT_NAME,
     COPIED_SIDECARS,
     EXCLUDED_SIDECARS,
+    FORK_BOUNDARY_INSTRUCTION,
+    FORK_BOUNDARY_NAME,
     ForkError,
     consume_boot_prompt,
+    consume_fork_boundary,
     fork_parent,
     fork_session,
     write_boot_prompt,
@@ -115,6 +118,7 @@ class TestTheCloneItself:
             TRANSCRIPT_NAME,
             ATTACHMENT_SIDECAR_NAME,
             TITLE_SIDECAR_NAME,
+            FORK_BOUNDARY_NAME,  # written by the fork, not inherited
             "origin.json",  # written by the fork itself, not copied
         }
 
@@ -211,6 +215,51 @@ class TestProvenance:
         assert "cccccccccccc" not in listed
 
 
+class TestTheForkBoundary:
+    def test_every_fork_gets_exactly_one_nonpersistent_context_boundary(
+        self, tmp_path: Path
+    ) -> None:
+        parent = _seed_parent(tmp_path)
+        before = (parent / TRANSCRIPT_NAME).read_bytes()
+        fork_id = fork_session(tmp_path, PARENT_ID)
+        fork_dir = tmp_path / "sessions" / fork_id
+
+        assert (fork_dir / TRANSCRIPT_NAME).read_bytes() == before
+        assert consume_fork_boundary(fork_dir) == FORK_BOUNDARY_INSTRUCTION
+        assert consume_fork_boundary(fork_dir) == ""
+        assert (fork_dir / TRANSCRIPT_NAME).read_bytes() == before
+
+    @pytest.mark.asyncio
+    async def test_session_places_the_boundary_once_at_the_inherited_context_tail(
+        self, tmp_path: Path
+    ) -> None:
+        from local_operator.session.transcript import Transcript
+
+        parent = tmp_path / "sessions" / PARENT_ID
+        parent.mkdir(parents=True)
+        transcript = Transcript(parent)
+        await transcript.append_message(_user("read the loader"))
+        await transcript.append_message(_assistant("It parses YAML."))
+        fork_id = fork_session(tmp_path, PARENT_ID)
+        fork_dir = tmp_path / "sessions" / fork_id
+
+        first = _build_session(fork_dir)
+        inherited = first.history()
+        assert [getattr(message, "role", "") for message in inherited[:2]] == [
+            "user",
+            "assistant",
+        ]
+        boundary = inherited[-1]
+        assert getattr(boundary, "custom_type", "") == "fork_boundary"
+        assert getattr(boundary, "details", {})["text"] == FORK_BOUNDARY_INSTRUCTION
+        assert (fork_dir / TRANSCRIPT_NAME).read_text(encoding="utf-8").count("fork_boundary") == 0
+
+        resumed = _build_session(fork_dir)
+        assert all(
+            getattr(message, "custom_type", "") != "fork_boundary" for message in resumed.history()
+        )
+
+
 class TestTheBootPrompt:
     def test_the_message_round_trips_and_fires_exactly_once(self, tmp_path: Path) -> None:
         """T6. The delete is the load-bearing half.
@@ -271,6 +320,122 @@ class TestTheBootPrompt:
         session_dir.mkdir(parents=True)
         write_boot_prompt(session_dir, "refactor the café loader — twice")
         assert consume_boot_prompt(session_dir) == "refactor the café loader — twice"
+
+
+class TestForkRuntimeOwnership:
+    @pytest.mark.asyncio
+    async def test_parent_runtime_ownership_stays_parent_only(self, tmp_path: Path) -> None:
+        from local_operator.harness.wake import WakeSchedule
+        from local_operator.session.session import WAKE_SCHEDULES_CUSTOM_TYPE
+        from local_operator.session.transcript import Transcript
+
+        parent = tmp_path / "sessions" / PARENT_ID
+        parent.mkdir(parents=True)
+        transcript = Transcript(parent)
+        await transcript.append_message(_user("schedule the audit and delegate research"))
+        await transcript.append_custom(
+            WAKE_SCHEDULES_CUSTOM_TYPE,
+            {
+                "schedules": [
+                    {
+                        "id": "w-parent",
+                        "message": "audit now",
+                        "next_due_at": 9_999_999_999_999,
+                        "created_at": 1,
+                    }
+                ]
+            },
+        )
+        await transcript.append_custom(
+            "subagent_roster",
+            {
+                "generation": 4,
+                "records": [{"job_id": "parent-job", "session_dir": "child-parent"}],
+                "jobs": [],
+            },
+        )
+        parent_session = _build_session(parent)
+        assert [wake.id for wake in parent_session.wake_scheduler.schedules] == ["w-parent"]
+        assert parent_session.subagent_comms.session_dir_of("parent-job") == Path("child-parent")
+
+        fork_id = fork_session(tmp_path, PARENT_ID)
+        fork = _build_session(tmp_path / "sessions" / fork_id)
+        assert fork.wake_scheduler.schedules == ()
+        assert fork.jobs.get("parent-job") is None
+        assert fork.subagent_comms.session_dir_of("parent-job") is None
+        # Parent ownership was read, never moved or cancelled.
+        assert [wake.id for wake in parent_session.wake_scheduler.schedules] == ["w-parent"]
+        assert parent_session.subagent_comms.session_dir_of("parent-job") == Path("child-parent")
+
+        own = WakeSchedule(
+            id="w-fork", message="divergent audit", next_due_at=9_999_999_999_999, created_at=2
+        )
+        await fork.set_wake_schedules([own])
+        assert [wake.id for wake in fork.wake_scheduler.schedules] == ["w-fork"]
+        assert [wake.id for wake in parent_session.wake_scheduler.schedules] == ["w-parent"]
+
+        # Isolation must not disable the capability: the fork owns children it
+        # launches after boot, while the inherited parent's child stays absent.
+        fork.subagent_comms.restore(
+            [{"job_id": "fork-job", "session_dir": "child-fork", "label": "new research"}]
+        )
+        assert fork.subagent_comms.session_dir_of("fork-job") == Path("child-fork")
+        assert fork.subagent_comms.session_dir_of("parent-job") is None
+        assert parent_session.subagent_comms.session_dir_of("fork-job") is None
+
+
+class TestForkCmuxOwnership:
+    def test_parent_never_schedules_a_cmux_rename(self, tmp_path: Path, monkeypatch) -> None:
+        from local_operator.tui.app import OperatorApp
+
+        parent = _seed_parent(tmp_path)
+        scheduled: list[Any] = []
+        app = cast(
+            OperatorApp,
+            type(
+                "ForkNameHarness",
+                (),
+                {
+                    "_session": type("SessionStub", (), {"session_id": parent.name})(),
+                    "_fork_cmux_name": "",
+                    "run_worker": lambda self, awaitable, **kwargs: scheduled.append(awaitable),
+                },
+            )(),
+        )
+        monkeypatch.setattr("local_operator.paths.config_dir", lambda: tmp_path)
+
+        OperatorApp._sync_fork_cmux_name(app, "Parent work")
+
+        assert scheduled == []
+        assert app._fork_cmux_name == ""
+
+    def test_fork_schedules_only_its_owned_target_rename(self, tmp_path: Path, monkeypatch) -> None:
+        from local_operator.tui.app import OperatorApp
+
+        _seed_parent(tmp_path)
+        fork_id = fork_session(tmp_path, PARENT_ID)
+        scheduled: list[Any] = []
+        app = cast(
+            OperatorApp,
+            type(
+                "ForkNameHarness",
+                (),
+                {
+                    "_session": type("SessionStub", (), {"session_id": fork_id})(),
+                    "_fork_cmux_name": "",
+                    "run_worker": lambda self, awaitable, **kwargs: scheduled.append(awaitable),
+                },
+            )(),
+        )
+        monkeypatch.setattr("local_operator.paths.config_dir", lambda: tmp_path)
+
+        OperatorApp._sync_fork_cmux_name(app, "  Divergent   work ")
+
+        assert app._fork_cmux_name == "Divergent work"
+        assert len(scheduled) == 1
+        # The harness deliberately does not run the worker: argv construction is
+        # covered separately, and closing avoids a false un-awaited warning.
+        scheduled[0].close()
 
 
 class TestTheClonedTranscriptIsLegalOnTheWire:

--- a/tests/unit/test_fork.py
+++ b/tests/unit/test_fork.py
@@ -252,7 +252,67 @@ class TestTheForkBoundary:
         boundary = inherited[-1]
         assert getattr(boundary, "custom_type", "") == "fork_boundary"
         assert getattr(boundary, "details", {})["text"] == FORK_BOUNDARY_INSTRUCTION
+        wire = first._render_history(inherited)
+        assert [message.role for message in wire] == ["user", "assistant", "user"]
+        assert wire[-1].text == FORK_BOUNDARY_INSTRUCTION
         assert (fork_dir / TRANSCRIPT_NAME).read_text(encoding="utf-8").count("fork_boundary") == 0
+
+        # Exercise every native body builder rather than stopping at harness
+        # history: this is the boundary the actual provider receives.
+        from local_operator.harness.types import ChatRequest
+        from local_operator.providers.clients import (
+            AnthropicClient,
+            GoogleClient,
+            OpenAICompatClient,
+        )
+
+        request = ChatRequest(model=_model_spec(), messages=wire)
+        anthropic = AnthropicClient()._build_body(request)["messages"]
+        openai = OpenAICompatClient("https://example.invalid")._build_body(request)["messages"]
+        responses = OpenAICompatClient("https://example.invalid")._build_responses_body(request)[
+            "input"
+        ]
+        google = GoogleClient()._build_body(request)["contents"]
+        assert [message["role"] for message in anthropic] == ["user", "assistant", "user"]
+        assert anthropic[-1]["content"][-1]["text"] == FORK_BOUNDARY_INSTRUCTION
+        assert [message["role"] for message in openai] == ["user", "assistant", "user"]
+        assert openai[-1]["content"] == FORK_BOUNDARY_INSTRUCTION
+        assert [message["role"] for message in responses] == ["user", "assistant", "user"]
+        assert responses[-1]["content"][-1]["text"] == FORK_BOUNDARY_INSTRUCTION
+        assert [message["role"] for message in google] == ["user", "model", "user"]
+        assert google[-1]["parts"][-1]["text"] == FORK_BOUNDARY_INSTRUCTION
+        # The inherited prefix remains byte-for-byte equivalent at every wire;
+        # only the non-persistent tail is new.
+        inherited_wire = first._render_history(inherited[:2])
+        baseline = ChatRequest(model=_model_spec(), messages=inherited_wire)
+
+        def without_cache_markers(value):
+            if isinstance(value, dict):
+                return {
+                    key: without_cache_markers(item)
+                    for key, item in value.items()
+                    if key != "cache_control"
+                }
+            if isinstance(value, list):
+                return [without_cache_markers(item) for item in value]
+            return value
+
+        baseline_anthropic = AnthropicClient()._build_body(baseline)["messages"]
+        assert without_cache_markers(anthropic[:-1]) == without_cache_markers(baseline_anthropic)
+        # Adding the boundary moves, rather than loses, Anthropic's warm-prefix
+        # breakpoint: the inherited final user turn remains cacheable.
+        assert anthropic[0]["content"][-1]["cache_control"] == {"type": "ephemeral"}
+        assert (
+            openai[:-1]
+            == OpenAICompatClient("https://example.invalid")._build_body(baseline)["messages"]
+        )
+        assert (
+            responses[:-1]
+            == OpenAICompatClient("https://example.invalid")._build_responses_body(baseline)[
+                "input"
+            ]
+        )
+        assert google[:-1] == GoogleClient()._build_body(baseline)["contents"]
 
         resumed = _build_session(fork_dir)
         assert all(
@@ -383,6 +443,41 @@ class TestForkRuntimeOwnership:
         assert fork.subagent_comms.session_dir_of("parent-job") is None
         assert parent_session.subagent_comms.session_dir_of("fork-job") is None
 
+        # Persist and reconstruct the fork: provenance suppresses only the
+        # inherited baseline, never ownership created after the fork instant.
+        fork._schedule_subagent_persist()
+        await fork._await_subagent_roster_writer()
+        resumed = _build_session(tmp_path / "sessions" / fork_id)
+        assert [wake.id for wake in resumed.wake_scheduler.schedules] == ["w-fork"]
+        assert resumed.subagent_comms.session_dir_of("fork-job") == Path("child-fork")
+        assert resumed.subagent_comms.session_dir_of("parent-job") is None
+
+        # A descendant starts empty again even though its parent fork now owns
+        # durable state; the descendant may subsequently create its own state.
+        descendant_id = fork_session(tmp_path, fork_id)
+        descendant_dir = tmp_path / "sessions" / descendant_id
+        descendant = _build_session(descendant_dir)
+        assert descendant.wake_scheduler.schedules == ()
+        assert descendant.subagent_comms.session_dir_of("fork-job") is None
+        descendant_wake = WakeSchedule(
+            id="w-descendant",
+            message="branch audit",
+            next_due_at=9_999_999_999_999,
+            created_at=3,
+        )
+        await descendant.set_wake_schedules([descendant_wake])
+        descendant.subagent_comms.restore(
+            [{"job_id": "descendant-job", "session_dir": "child-descendant"}]
+        )
+        descendant._schedule_subagent_persist()
+        await descendant._await_subagent_roster_writer()
+        descendant_resume = _build_session(descendant_dir)
+        assert [wake.id for wake in descendant_resume.wake_scheduler.schedules] == ["w-descendant"]
+        assert descendant_resume.subagent_comms.session_dir_of("descendant-job") == Path(
+            "child-descendant"
+        )
+        assert descendant_resume.subagent_comms.session_dir_of("fork-job") is None
+
 
 class TestForkCmuxOwnership:
     def test_parent_never_schedules_a_cmux_rename(self, tmp_path: Path, monkeypatch) -> None:
@@ -423,6 +518,7 @@ class TestForkCmuxOwnership:
                 {
                     "_session": type("SessionStub", (), {"session_id": fork_id})(),
                     "_fork_cmux_name": "",
+                    "_fork_cmux_name_worker_running": False,
                     "run_worker": lambda self, awaitable, **kwargs: scheduled.append(awaitable),
                 },
             )(),
@@ -436,6 +532,59 @@ class TestForkCmuxOwnership:
         # The harness deliberately does not run the worker: argv construction is
         # covered separately, and closing avoids a false un-awaited warning.
         scheduled[0].close()
+
+    @pytest.mark.asyncio
+    async def test_out_of_order_requests_converge_on_the_latest_title(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        import asyncio
+
+        from local_operator.tui.app import OperatorApp
+
+        _seed_parent(tmp_path)
+        fork_id = fork_session(tmp_path, PARENT_ID)
+        started = asyncio.Event()
+        release = asyncio.Event()
+        applied: list[str] = []
+        tasks: list[asyncio.Task[None]] = []
+
+        async def to_thread(func, env, title, **kwargs):
+            if title == "Old title":
+                started.set()
+                await release.wait()
+            applied.append(title)
+            return True
+
+        app = cast(
+            OperatorApp,
+            type(
+                "ForkNameHarness",
+                (),
+                {
+                    "_session": type("SessionStub", (), {"session_id": fork_id})(),
+                    "_fork_cmux_name": "",
+                    "_fork_cmux_name_worker_running": False,
+                    "_config_values": lambda self: {},
+                    "run_worker": lambda self, awaitable, **kwargs: tasks.append(
+                        asyncio.create_task(awaitable)
+                    ),
+                },
+            )(),
+        )
+        monkeypatch.setattr("local_operator.paths.config_dir", lambda: tmp_path)
+        monkeypatch.setattr("local_operator.tui.app.asyncio.to_thread", to_thread)
+
+        OperatorApp._sync_fork_cmux_name(app, "Old title")
+        await started.wait()
+        OperatorApp._sync_fork_cmux_name(app, "Newest title")
+        OperatorApp._sync_fork_cmux_name(app, "Newest title")
+        assert len(tasks) == 1
+        release.set()
+        await tasks[0]
+
+        assert applied == ["Old title", "Newest title"]
+        assert app._fork_cmux_name == "Newest title"
+        assert app._fork_cmux_name_worker_running is False
 
 
 class TestTheClonedTranscriptIsLegalOnTheWire:

--- a/tests/unit/test_multiplexer.py
+++ b/tests/unit/test_multiplexer.py
@@ -41,7 +41,11 @@ from local_operator.multiplexer.broadcast import (
     resume_executable,
     retire_session,
 )
-from local_operator.multiplexer.cmux import REASSERT_INTERVAL_S, CmuxBackend
+from local_operator.multiplexer.cmux import (
+    REASSERT_INTERVAL_S,
+    CmuxBackend,
+    rename_fork_target,
+)
 from local_operator.multiplexer.markers import (
     COMMAND_OPTION,
     SESSION_OPTION,
@@ -1037,6 +1041,51 @@ class TestCmuxPayload:
         monkeypatch.setattr("local_operator.multiplexer.cmux._cmux_binary", lambda: "/bin/cmux")
         assert CmuxBackend().detect(env) is False
         assert CmuxBackend().publish(_binding(), env) is False
+
+
+class TestForkTargetRename:
+    @pytest.mark.parametrize(
+        ("placement", "expected"),
+        [
+            (
+                "workspace",
+                ["/bin/cmux", "workspace", "rename", WORKSPACE, "--title", "Divergent work"],
+            ),
+            (
+                "surface",
+                ["/bin/cmux", "rename-tab", "--surface", SURFACE, "Divergent work"],
+            ),
+        ],
+    )
+    def test_renames_the_owned_target_for_each_placement(
+        self, monkeypatch, placement: str, expected: list[str]
+    ) -> None:
+        calls: list[list[str]] = []
+        monkeypatch.setattr("local_operator.multiplexer.cmux._cmux_binary", lambda: "/bin/cmux")
+
+        class Completed:
+            returncode = 0
+            stderr = ""
+
+        monkeypatch.setattr(
+            "local_operator.multiplexer.cmux.subprocess.run",
+            lambda argv, **kwargs: calls.append(list(argv)) or Completed(),
+        )
+        env = {"CMUX_WORKSPACE_ID": WORKSPACE, "CMUX_SURFACE_ID": SURFACE}
+
+        assert rename_fork_target(env, "  Divergent   work ", placement=placement) is True
+        assert calls == [expected]
+        if placement == "surface":
+            assert "workspace" not in calls[0]
+
+    def test_failure_is_nonfatal(self, monkeypatch) -> None:
+        monkeypatch.setattr("local_operator.multiplexer.cmux._cmux_binary", lambda: "/bin/cmux")
+        monkeypatch.setattr(
+            "local_operator.multiplexer.cmux.subprocess.run",
+            lambda *args, **kwargs: (_ for _ in ()).throw(OSError("gone")),
+        )
+        env = {"CMUX_WORKSPACE_ID": WORKSPACE, "CMUX_SURFACE_ID": SURFACE}
+        assert rename_fork_target(env, "name", placement="workspace") is False
 
 
 class TestMarkerBackends:

--- a/tests/unit/tui/test_welcome.py
+++ b/tests/unit/tui/test_welcome.py
@@ -1145,6 +1145,29 @@ def test_the_tip_is_quieter_than_the_hints_it_sits_under() -> None:
     assert _contrast(glyph, ground) < _contrast(body, ground)
 
 
+def test_fork_tips_cover_commands_settings_and_backend_detection() -> None:
+    """Discovery names the real entry points without promising one backend's UI.
+
+    The cmux-only placement is qualified explicitly; terminal detection stays
+    capability-shaped because not every supported backend has workspaces.
+    """
+    fork_tips = [
+        tip
+        for tip in TIPS
+        if any(token in tip.lower() for token in ("fork", "cmux", "multiplexer"))
+    ]
+    joined = "\n".join(fork_tips)
+
+    assert "/fork branches" in joined
+    assert "/fork <message> starts divergent work" in joined
+    assert "/settings → Fork → Where a fork opens" in joined
+    assert "Under cmux, Where it opens" in joined
+    assert "workspace or surface" in joined
+    assert "detects terminal or multiplexer" in joined
+    assert "then picks placement" in joined
+    assert all(word not in joined.lower() for word in ("always", "unsupported"))
+
+
 def test_advancing_the_rotation_changes_the_tip_and_never_the_row_count() -> None:
     """THE constraint. Every tip, at every size, draws the same number of rows.
 
@@ -1184,7 +1207,7 @@ def test_a_narrow_terminal_omits_the_tip_rather_than_wrapping_it() -> None:
     one, truncated into the box.
 
     Omitted on WIDTH and never on the current tip's own length — that is what
-    keeps the row count the same answer for all twelve, which the rotation
+    keeps the row count the same answer for every entry, which the rotation
     depends on.
     """
     for width in range(1, TIP_MIN_WIDTH):


### PR DESCRIPTION
## Summary

Forks now diverge safely instead of accidentally inheriting live ownership from their parent. The inherited transcript remains byte-identical for prompt-cache continuity, while a one-shot, non-persistent context-tail boundary tells the model not to continue work that may still be running in the original session.

The fork starts with no inherited wake schedules, jobs, or child routing, but can create and own new wakes and subagents normally. When the fork gets its own title, cmux now renames the explicit workspace or surface owned by that fork; an ordinary/parent session never reaches the mutating command.

This is a patch release: `0.44.13`.

## Implementation

- write and consume a versioned one-shot fork-boundary sidecar without changing transcript bytes
- suppress wake and subagent-roster restoration when `origin.json` identifies a fork
- preserve new fork-owned wake and child registration after boot
- map `fork.cmux_placement=workspace` to `cmux workspace rename <id> --title <name>` and `surface` to `cmux rename-tab --surface <id> <name>`
- gate title synchronization on fork provenance, explicit cmux IDs, normalized names, and best-effort failure handling
- add rotating splash guidance for `/fork`, `/fork <message>`, the exact `/settings → Fork` controls, cmux workspace/surface placement, and terminal/multiplexer detection

## Real-path evidence

### Transcript boundary and runtime ownership

A standalone proof drove real `fork_session()`, `Transcript`, and `Session` construction, then resumed the fork and created fork-owned work:

```json
{
  "transcript_byte_identical_at_fork": true,
  "boundary_count_first_boot": 1,
  "boundary_at_context_tail": true,
  "boundary_text_exact": true,
  "boundary_count_resume": 0,
  "parent_wakes": ["w-parent"],
  "parent_child": "child-parent",
  "fork_inherited_wakes": [],
  "fork_inherited_child": null,
  "fork_owned_wakes": ["w-fork"],
  "fork_owned_child": "child-fork",
  "parent_sees_fork_child": null
}
```

This covers inherited transcript/cache-prefix behavior, exactly-once boundary semantics, parent/fork wake and subagent isolation, and the fact that the fork still owns new work it creates.

### cmux naming and negative behavior

The proof executed `rename_fork_target()` through a captured subprocess boundary with explicit IDs:

```text
before terminal title:  Cancel Session Wakes Reliably
before workspace title: fork · Article search service integration
workspace argv: ["/opt/bin/cmux", "workspace", "rename", "11111111-2222-3333-4444-555555555555", "--title", "Cancel Session Wakes Reliably"]
surface argv:   ["/opt/bin/cmux", "rename-tab", "--surface", "66666666-7777-8888-9999-000000000000", "Cancel Session Wakes Reliably"]
parent workspace rename attempted: false
```

Unit coverage also verifies missing cmux targets/binary, empty titles, subprocess failures, and non-zero exits return false without disturbing the session. The TUI ownership tests verify a parent schedules no rename while a proven fork schedules exactly one normalized rename.

### Rendered before/after

The real `OperatorApp` was rendered with `run_test` before and after at 98×28, then both SVGs were rendered in the real browser and inspected as PNGs.

- before: the rotating pool had no fork discoverability; the captured frame shows the prior final tip (`/goal sets the objective that /loop iterates toward`)
- after: the captured frame shows `/fork branches; /fork <message> starts divergent work`
- geometry remained screen/virtual 98×28 with `max_scroll_y=0`; the new entries remain one row and fit the existing 60-cell whole-tip constraint

A separate before/after frame pair for the lifecycle-only portion is intentionally pixel-identical (SHA-256 `3bdedaf1…f8ef66`): contextual model behavior and the external cmux label do not alter in-frame TUI layout. The observed pre-fix mismatch is captured above: the terminal title had settled while the containing workspace kept its provisional fork label.

## Verification

Focused splash suite:

```text
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui/test_welcome.py -q
56 passed in 20.34s
```

Focused fork and multiplexer suite:

```text
.venv/bin/python -m pytest tests/unit/test_fork.py tests/unit/test_multiplexer.py -q
137 passed
```

Assembled application e2e:

```text
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
3 passed in 14.04s
```

Whole-tree CI gates:

```text
.venv/bin/python -m flake8 .                                      # exit 0
uvx --from black==26.1.0 black --check .                          # 686 files unchanged
uvx isort==5.13.2 --check .                                       # exit 0; 1 skipped
.venv/bin/python -m pyright --pythonpath .venv/bin/python .       # 0 errors, 0 warnings
```

Full unit suite:

```text
ulimit -n 4096
# raised from the macOS shell default after a prior run exhausted descriptors under xdist
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
9880 passed, 15 skipped in 956.40s
```

The unchanged suite emits its existing warning set. An earlier run under the low macOS descriptor limit cascaded with `OSError: [Errno 24] Too many open files`; raising only the shell resource limit produced the clean full-tree result above without code changes.


## Review round 1 remediation

Commit `6151ea6cc5780c642570d46764fde3da6750f402` closes R1-1, R1-2, R1-3, and D1:

- the one-shot boundary now passes through the shared transcript renderer and was asserted in Anthropic Messages, OpenAI chat/completions, OpenAI Responses, and Gemini `generateContent` request bodies; the inherited provider prefix is unchanged apart from cache-breakpoint relocation, and the boundary remains absent from `transcript.jsonl`
- wake snapshots are accepted only when written after the fork instant; fork-owned roster sidecars restore normally, while inherited legacy roster entries remain cutoff by timestamp, including in descendant forks
- cmux renames now use one serialized drain that coalesces duplicates and always applies a newer title after any older in-flight subprocess returns
- the splash tip now reads `/settings → Fork → Where a fork opens sets placement`

### Real-path remediation evidence

A standalone proof exercised real `fork_session()`, `Session` construction, all native provider body builders, wake persistence, roster sidecar persistence, and reconstruction of the same fork:

```json
{
  "wire_roles": ["user", "assistant", "user"],
  "all_provider_boundaries_exact": true,
  "boundary_persisted": false,
  "resume_wakes": ["fork-wake"],
  "resume_child": "child-fork"
}
```

The delayed-old/fast-new regression executes the worker coroutine through the production synchronization method and observes `Old title` followed by `Newest title`, with only one worker and the latest title retained.

### Rendered D1 validation

The real `OperatorApp` was rendered before and after at 80×24 with the settings tip selected. Both frames measured screen 80×24, virtual 78×22, and `max_scroll_y=0`. Visual inspection confirmed the clarified phrase remains one centered row with no wrapping, truncation, scrollbar, or composer displacement. Artifacts: `/tmp/lop501-before.svg`, `/tmp/lop501-after.svg`, `/tmp/lop501-before.png`, `/tmp/lop501-after.png`.

### Remediation verification

```text
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/test_fork.py tests/unit/test_multiplexer.py tests/unit/tui/test_welcome.py -q
194 passed, 2 existing warnings in 27.07s

.venv/bin/python -m flake8 .                                      # exit 0
uvx --from black==26.1.0 black --check .                          # 686 files unchanged
uvx isort==5.13.2 --check .                                       # exit 0; 1 skipped
.venv/bin/python -m pyright --pythonpath .venv/bin/python .       # 0 errors, 0 warnings
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
3 passed in 16.65s
```

After rebasing onto `origin/main` at `0f9f9ed6`, the full unit run reached `9883 passed, 15 skipped` with three failures in the pre-existing timing-sensitive approval-key tests. A focused serial retry passed all three (`3 passed`); none imports or exercises fork lifecycle/title code. The fork source/test patch is byte-identical to the previously reviewed patch, the only overlapping upstream file was the release version in `pyproject.toml`, and no code was changed for these unrelated failures.

