### PR TITLE
fix(skills): enforce concrete resource protocol

### DIFF
--- a/local_operator/skills/index.py
+++ b/local_operator/skills/index.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 from local_operator.skills.discovery import Skill
 from local_operator.skills.embeddings import EmbeddingBackend, LocalEmbedder
+from local_operator.skills.protocol import resource_url
 from local_operator.skills.vectors import VectorMatrix, deserialize
 
 logger = logging.getLogger(__name__)
@@ -284,7 +285,7 @@ def render_block(skills: list[Skill]) -> str:
         # Naming the already-selected resources removes the inference step that
         # led models to search the filesystem for SKILL.md instead of using the
         # virtual resource protocol. This cost stays local to selected skills.
-        selected_urls = ", ".join(f"`skill://{skill.name}`" for skill in user_skills)
+        selected_urls = ", ".join(f"`{resource_url('skill', skill.name)}`" for skill in user_skills)
         lines = [
             f"Read these selected skills before proceeding: {selected_urls}. The skill "
             "body ends with its reference files; read those with "

--- a/local_operator/skills/index.py
+++ b/local_operator/skills/index.py
@@ -256,11 +256,10 @@ def _backend_meta(backend: EmbeddingBackend) -> Mapping[str, object]:
 def render_block(skills: list[Skill]) -> str:
     """Render selected guides and skills without rendering private hints.
 
-    Skill-only output remains byte-compatible. The stable base prompt still
-    owns the ``guide://`` protocol rule in full; the one-line imperative here
-    is the local reminder that a selected guide is meant to be READ, which the
-    guides section previously left implicit while the skills section stated it
-    outright.
+    The stable base prompt still owns the ``guide://`` protocol rule in full;
+    the one-line imperative here is the local reminder that a selected guide is
+    meant to be READ. Selected skills use concrete protocol URLs rather than a
+    placeholder because the router has already established which ones match.
     """
     guides = [item for item in skills if item.resource_type == "guide"]
     user_skills = [item for item in skills if item.resource_type == "skill"]
@@ -282,11 +281,14 @@ def render_block(skills: list[Skill]) -> str:
         lines.append("</guides>")
         sections.append("\n".join(lines))
     if user_skills:
+        # Naming the already-selected resources removes the inference step that
+        # led models to search the filesystem for SKILL.md instead of using the
+        # virtual resource protocol. This cost stays local to selected skills.
+        selected_urls = ", ".join(f"`skill://{skill.name}`" for skill in user_skills)
         lines = [
-            "Skills are specialized knowledge. If one matches your task, you MUST read "
-            "`skill://<name>` before proceeding. The skill body ends with its "
-            "reference files; read those with `skill://<name>/<path>`, never a "
-            "raw filesystem path.",
+            f"Read these selected skills before proceeding: {selected_urls}. The skill "
+            "body ends with its reference files; read those with "
+            "`skill://<name>/<path>`, never a raw filesystem path.",
             "<skills>",
         ]
         lines.extend(f"- {skill.name}: {skill.description}" for skill in user_skills)

--- a/local_operator/skills/protocol.py
+++ b/local_operator/skills/protocol.py
@@ -366,6 +366,11 @@ def _reference_listing(resource: Skill, *, scheme: str) -> str:
     return "\n".join(lines)
 
 
+def resource_url(scheme: str, name: str) -> str:
+    """Build a resolver-compatible URL without letting names alter its structure."""
+    return f"{scheme}://{quote(name, safe='')}"
+
+
 def resolve_resource_url(
     url: str,
     resources: Mapping[str, Skill],

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -3250,9 +3250,17 @@ async def execute_glob(
         # Correct only this observed misuse so every ordinary glob error keeps
         # its concise, generic diagnostic.
         if Path(pattern).is_absolute() and pattern.lower().endswith("skill.md"):
+            # A conservative resource segment avoids reflecting path syntax or
+            # prose into a URL while still covering normal catalog names.
+            skill_name = Path(pattern).parent.name
+            resource = (
+                f"skill://{skill_name}"
+                if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", skill_name)
+                else "skill://<name>"
+            )
             message += (
                 " Do not scan the filesystem for SKILL.md; read the selected skill "
-                "directly with `skill://<name>`."
+                f"directly with `{resource}`."
             )
         return _error(tool_call_id, "glob", message)
 

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -3249,7 +3249,7 @@ async def execute_glob(
         # Skills are virtual resources, not files the model should discover.
         # Correct only this observed misuse so every ordinary glob error keeps
         # its concise, generic diagnostic.
-        if Path(pattern).is_absolute() and pattern.lower().endswith("skill.md"):
+        if Path(pattern).is_absolute() and Path(pattern).name.casefold() == "skill.md":
             # A conservative resource segment avoids reflecting path syntax or
             # prose into a URL while still covering normal catalog names.
             skill_name = Path(pattern).parent.name

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -3242,12 +3242,19 @@ async def execute_glob(
     if not pattern:
         return _error(tool_call_id, "glob", "pattern must be a non-empty string")
     if Path(pattern).is_absolute() or ".." in Path(pattern).parts:
-        return _error(
-            tool_call_id,
-            "glob",
+        message = (
             "pattern must be a relative glob within the working directory "
-            "(no absolute paths, no '..').",
+            "(no absolute paths, no '..')."
         )
+        # Skills are virtual resources, not files the model should discover.
+        # Correct only this observed misuse so every ordinary glob error keeps
+        # its concise, generic diagnostic.
+        if Path(pattern).is_absolute() and pattern.lower().endswith("skill.md"):
+            message += (
+                " Do not scan the filesystem for SKILL.md; read the selected skill "
+                "directly with `skill://<name>`."
+            )
+        return _error(tool_call_id, "glob", message)
 
     root = Path(_safe_cwd(context))
     # An unbounded ``**`` walk is filesystem work that can freeze the session;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.11"
+version = "0.44.12"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/skills/test_index.py
+++ b/tests/unit/skills/test_index.py
@@ -300,6 +300,20 @@ class TestRenderBlock:
             "</skills>"
         )
 
+    def test_selected_url_encodes_frontmatter_name_for_resolver(self) -> None:
+        skill = Skill(
+            name="team/support",
+            description="support workflow",
+            file_path=Path("/x/support/SKILL.md"),
+            base_dir=Path("/x/support"),
+            source="test",
+        )
+
+        block = render_block([skill])
+
+        assert "`skill://team%2Fsupport`" in block
+        assert "`skill://team/support`" not in block
+
     def test_empty_list_returns_empty_string(self) -> None:
         assert render_block([]) == ""
 

--- a/tests/unit/skills/test_index.py
+++ b/tests/unit/skills/test_index.py
@@ -247,10 +247,9 @@ class TestRenderBlock:
             ),
         ]
         assert render_block(skills) == (
-            "Skills are specialized knowledge. If one matches your task, you MUST read "
-            "`skill://<name>` before proceeding. The skill body ends with its "
-            "reference files; read those with `skill://<name>/<path>`, never a "
-            "raw filesystem path.\n"
+            "Read these selected skills before proceeding: `skill://alpha`, "
+            "`skill://beta`. The skill body ends with its reference files; read those "
+            "with `skill://<name>/<path>`, never a raw filesystem path.\n"
             "<skills>\n"
             "- alpha: first skill\n"
             "- beta: second skill\n"

--- a/tests/unit/skills/test_index.py
+++ b/tests/unit/skills/test_index.py
@@ -158,6 +158,50 @@ class TestSelect:
         assert banana_skill not in matches
 
     @pytest.mark.asyncio
+    async def test_routes_slack_tenant_hotfix_to_both_workflows(self, tmp_path: Path) -> None:
+        # Synthetic metadata keeps this regression deterministic and proves the
+        # router contract without depending on one developer's installed catalog.
+        skills = [
+            _make_skill(
+                tmp_path,
+                "minerva-software-development",
+                "Use for Minerva software development changes, production hotfixes, "
+                "tenant configuration, testing, code review, GitLab merge requests, "
+                "and releases.",
+            ),
+            _make_skill(
+                tmp_path,
+                "minerva-support-workspace",
+                "Use for Minerva customer support requests involving Slack "
+                "conversations, tenant workspace configuration, customer incidents, "
+                "and drafting support replies.",
+            ),
+            _make_skill(
+                tmp_path,
+                "minerva-credentials",
+                "Use for securely loading API keys, OAuth tokens, passwords, and "
+                "environment credentials.",
+            ),
+            _make_skill(
+                tmp_path,
+                "calendar-planning",
+                "Use for calendar scheduling, meeting availability, invitations, and "
+                "timezone planning.",
+            ),
+        ]
+        index = SkillIndex(skills, LocalEmbedder(), cache_dir=tmp_path / "cache")
+
+        matches = await index.select(
+            "Please investigate the customer report in Slack, hotfix the tenant "
+            "configuration bug in Minerva, validate it, and draft the support reply."
+        )
+
+        assert [skill.name for skill in matches] == [
+            "minerva-software-development",
+            "minerva-support-workspace",
+        ]
+
+    @pytest.mark.asyncio
     async def test_threshold_respected(self, tmp_path: Path) -> None:
         skill = _make_skill(tmp_path, "pytest-helper", "pytest unit tests in python")
         index = SkillIndex([skill], LocalEmbedder(), cache_dir=tmp_path / "cache")

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -937,6 +937,21 @@ async def test_glob_redirects_absolute_skill_search_to_protocol(tools, context) 
 
 
 @pytest.mark.asyncio
+async def test_glob_does_not_redirect_skill_md_suffix(tools, context) -> None:
+    result = await _call(
+        tools,
+        "glob",
+        {"pattern": "/tmp/catalog/README-NOTSKILL.md"},
+        context,
+    )
+
+    assert result.is_error is True
+    assert "relative" in result.text.lower()
+    assert "skill://" not in result.text
+    assert "Do not scan" not in result.text
+
+
+@pytest.mark.asyncio
 async def test_glob_uses_placeholder_for_unsafe_skill_name(tools, context) -> None:
     result = await _call(
         tools,

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -918,6 +918,22 @@ async def test_glob_rejects_absolute_and_parent_patterns(tools, context) -> None
         result = await _call(tools, "glob", {"pattern": pattern}, context)
         assert result.is_error is True
         assert "relative" in result.text.lower()
+        assert "skill://" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_glob_redirects_absolute_skill_search_to_protocol(tools, context) -> None:
+    result = await _call(
+        tools,
+        "glob",
+        {"pattern": "/Users/example/**/minerva-support-workspace/SKILL.md"},
+        context,
+    )
+
+    assert result.is_error is True
+    assert "relative" in result.text.lower()
+    assert "Do not scan the filesystem for SKILL.md" in result.text
+    assert "`skill://<name>`" in result.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -933,7 +933,21 @@ async def test_glob_redirects_absolute_skill_search_to_protocol(tools, context) 
     assert result.is_error is True
     assert "relative" in result.text.lower()
     assert "Do not scan the filesystem for SKILL.md" in result.text
+    assert "`skill://minerva-support-workspace`" in result.text
+
+
+@pytest.mark.asyncio
+async def test_glob_uses_placeholder_for_unsafe_skill_name(tools, context) -> None:
+    result = await _call(
+        tools,
+        "glob",
+        {"pattern": "/Users/example/**/unsafe name/SKILL.md"},
+        context,
+    )
+
+    assert result.is_error is True
     assert "`skill://<name>`" in result.text
+    assert "unsafe name" not in result.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Session `64a3966a8ec6` exposed a compliance failure after recommendation had already succeeded: the router selected `minerva-software-development` and `minerva-support-workspace`, and the rendered block said skills MUST be read through `skill://<name>`, but the model instead attempted three absolute `**/SKILL.md` globs and then scanned `$HOME` with `find`.

This patch removes the substitution step from selected-skill guidance by rendering each exact `skill://…` URL. If a model still submits an absolute glob ending in `SKILL.md`, glob validation now stops it before filesystem traversal and recovers the concrete protocol URL from a safely validated parent directory name. Unsafe names retain the generic `skill://<name>` fallback, and ordinary glob errors remain concise and unchanged.

This is a patch release: `0.44.12`.

## Root cause

Recommendation was not the failing subsystem: realistic routing metadata selects both intended skills. Compliance failed because the local instruction named a placeholder even though the router already knew the selected names, leaving an unnecessary inference step. The generic absolute-glob diagnostic then explained only that patterns must be relative, without correcting the mistaken assumption that skills should be discovered on disk.

## Acceptance criteria

- selected skills are named as exact `skill://<name>` resources in the rendered prompt block
- an absolute `*/<skill-name>/SKILL.md` glob is rejected before traversal and recommends the concrete `skill://<skill-name>` URL
- extracted names accept only a conservative resource-safe character set; unsafe names fall back to `skill://<name>`
- ordinary absolute and parent-directory glob errors keep their generic behavior
- a realistic Slack plus tenant-configuration hotfix request selects the software-development and support skills while excluding unrelated synthetic skills
- prompt overhead remains local to selected skills and the corrective diagnostic remains conditional on the observed misuse

## Non-goals

- changing skill discovery, selection thresholds, or catalog contents
- listing more skills in the system prompt
- adding broad prompt instructions or scanning the filesystem to locate skill files
- changing generic glob behavior outside absolute `SKILL.md` misuse

## Implementation

- render exact protocol URLs for every already-selected skill
- derive a validated skill resource name from the parent of an absolute `SKILL.md` pattern
- return the correction from validation before `_glob_walk` can start
- add deterministic synthetic routing, concrete recovery, unsafe-name fallback, and generic-error regression coverage

## Real-path evidence

The following command imported and executed the production `render_block()` and `execute_glob()` paths from the worktree. `execute_glob()` rejected the absolute pattern in validation, before `_glob_walk` is reached:

```text
$ .venv/bin/python <protocol proof script>
SELECTED BLOCK
Read these selected skills before proceeding: `skill://minerva-software-development`, `skill://minerva-support-workspace`. The skill body ends with its reference files; read those with `skill://<name>/<path>`, never a raw filesystem path.
<skills>
- minerva-software-development: Minerva SDLC
- minerva-support-workspace: Minerva support
</skills>

GLOB RESULT
is_error=True
pattern must be a relative glob within the working directory (no absolute paths, no '..'). Do not scan the filesystem for SKILL.md; read the selected skill directly with `skill://minerva-support-workspace`.
filesystem_walk_started=No
```

This reproduces both caller-visible behaviors: selected guidance contains concrete URLs, and the mistaken absolute lookup receives concrete recovery without a disk scan.

## Token impact

Measured with `cl100k_base` for the exact two-skill incident selection:

- old selected-skill instruction: 50 tokens
- new concrete selected-skill instruction: 52 tokens
- always-present delta when those skills are selected: **+2 tokens**
- targeted glob correction: 23 tokens, emitted only after an invalid absolute `SKILL.md` search

## Testing

Focused regressions:

```text
6 passed in 8.17s
```

Whole-tree quality gates, run exactly as CI documents:

```text
.venv/bin/python -m flake8 .
# clean

uvx --from black==26.1.0 black --check .
# 686 files would be left unchanged

uvx isort==5.13.2 --check .
# clean; 1 file skipped

.venv/bin/python -m pyright --pythonpath .venv/bin/python .
# 0 errors, 0 warnings, 0 informations
```

Full unit suite:

```text
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
# 9873 passed, 15 skipped; 1 unrelated failure in
# test_a_narrow_viewport_opens_on_a_row_head_not_a_wrap_fragment
```

The sole failure was transient and unrelated to this diff. Its observed assertion was `landing sits 3 rows into a block (offset=28, owner_top=25, max=28)`. The exact case then passed five consecutive isolated runs:

```text
run 1: 1 passed
run 2: 1 passed
run 3: 1 passed
run 4: 1 passed
run 5: 1 passed
```

## Rollout and rollback

No migration or persistent format change. Rollout is the normal `0.44.12` package release. Reverting the two implementation commits restores the prior prompt and generic glob diagnostic.
