### PR TITLE
fix(tui): correlate persisted steers with their communication facts

### DIFF
--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -77,21 +77,71 @@ HUB_MESSAGE_TYPE = "hub_message"
 #: only to correlate the parent's action with a later child reply.
 HUB_COMMUNICATION_CUSTOM_TYPE = "hub_communication"
 
-#: Opening tag of the model-facing envelope :meth:`SubagentComms._format_to_child`
-#: wraps parent→child text in. A hub steer persists as a plain role=user
-#: Message carrying this envelope, so human-facing surfaces match on the tag
-#: to keep the XML away from the reader (see
-#: :func:`extract_parent_message_body`).
+#: Opening and closing tags of the model-facing envelope
+#: :meth:`SubagentComms._format_to_child` wraps parent→child text in. A hub
+#: steer persists as a plain role=user Message carrying this envelope, so
+#: human-facing surfaces match on the tag to keep the XML away from the reader
+#: (see :func:`extract_parent_message`). BOTH halves are constants and both the
+#: builder and its inverse use them, which is what stops the pair drifting
+#: apart — a literal on either side would silently break extraction the day the
+#: tag changed.
 PARENT_MESSAGE_TAG = "<parent-message>"
+PARENT_MESSAGE_CLOSE_TAG = "</parent-message>"
+
+#: The instruction line the envelope carries, per communication kind. Keyed by
+#: the same ``kind`` vocabulary the journaled communication fact uses
+#: (``details["kind"]``), so a surface can label an extracted envelope exactly
+#: as it labels the fact.
+#:
+#: WHY a table rather than three inline strings: it is the SHARED secret
+#: between the builder and :func:`extract_parent_message`. Extraction requires
+#: an exact match against one of these lines, which is what keeps a human who
+#: quotes the envelope shape in their own message ("why does my log show
+#: ``<parent-message>``?") from having their words re-rendered as a parent
+#: redirection. Matching on tag shape alone cannot tell the two apart.
+TO_CHILD_INSTRUCTIONS: dict[str, str] = {
+    "steer": (
+        "This changes your instructions. Apply it from now on, and drop work it " "makes pointless."
+    ),
+    "ask": (
+        "Answer it now with the `hub` tool — a short, direct reply — then carry on "
+        "with what you were doing. Do not restructure your work around the question."
+    ),
+    "note": (
+        "This is a note, not a question. No reply is needed unless it changes what "
+        "you should do."
+    ),
+}
+
+#: Instruction line -> kind, for extraction. Built from the same table so the
+#: two directions cannot disagree.
+_INSTRUCTION_KINDS: dict[str, str] = {
+    instruction: kind for kind, instruction in TO_CHILD_INSTRUCTIONS.items()
+}
 
 
-def extract_parent_message_body(text: str) -> str | None:
-    """The human-facing body of a model-facing ``<parent-message>`` envelope.
+@dataclass(frozen=True)
+class ParentMessage:
+    """A parsed ``<parent-message>`` envelope: what the parent said, and which
+    kind of communication said it.
 
-    Returns None when ``text`` is not such an envelope. The shape parsed is
-    exactly what :meth:`SubagentComms._format_to_child` builds:
-    ``<parent-message>\\n{instruction}\\n\\n{body}\\n</parent-message>`` — the
-    body is everything after the first blank line, before the closing tag.
+    ``kind`` is one of ``TO_CHILD_INSTRUCTIONS``' keys (``steer``/``ask``/
+    ``note``), matching the vocabulary of the journaled communication fact, so
+    a surface labels an extracted envelope the same way it labels the fact
+    rather than assuming every envelope is a redirection.
+    """
+
+    kind: str
+    body: str
+
+
+def extract_parent_message(text: str) -> ParentMessage | None:
+    """Parse a model-facing ``<parent-message>`` envelope into its kind and
+    the human-facing body the parent authored.
+
+    Returns None when ``text`` is not an envelope THIS code built. The shape
+    parsed is exactly what :meth:`SubagentComms._format_to_child` emits:
+    ``<parent-message>\\n{instruction}\\n\\n{body}\\n</parent-message>``.
 
     WHY this exists as a shared helper: a hub steer is persisted as a plain
     role=user Message whose text is the envelope built for the MODEL, while
@@ -101,23 +151,36 @@ def extract_parent_message_body(text: str) -> str | None:
     persisted before steers carried their communication fact's id, where
     body-text correlation is the only match left. Both surfaces import this
     one parser so the builder and its inverse cannot drift apart.
+
+    CONSTRAINT — the instruction line must match ``TO_CHILD_INSTRUCTIONS``
+    exactly. Keying on the tag shape alone would rewrite a HUMAN's own message
+    as a parent communication the moment they quoted the envelope (asking
+    about this very wrapper is a realistic thing to do), silently
+    misattributing their words and stripping their text. The preamble is the
+    part a quoter has no reason to reproduce verbatim, so requiring it is what
+    makes the rewrite safe. These three strings have been byte-stable for the
+    life of the envelope; if one is ever reworded, the OLD text must stay in
+    this table or every transcript written before the change stops extracting.
     """
     stripped = text.strip()
     if not stripped.startswith(PARENT_MESSAGE_TAG):
         return None
-    end = stripped.rfind("</parent-message>")
+    end = stripped.rfind(PARENT_MESSAGE_CLOSE_TAG)
     if end < 0:
         return None
     inner = stripped[len(PARENT_MESSAGE_TAG) : end]
-    # Drop the leading newline, then the instruction line: the body starts
-    # after the FIRST blank line. A missing separator means the text does not
-    # follow the builder's shape; treat the whole interior as the body rather
-    # than leaking the instruction line into what is shown to a person.
+    # The builder writes a newline, the instruction line, a blank line, then the
+    # body. Split on the FIRST blank line: anything else did not come from
+    # _format_to_child and is left alone (returning None) rather than guessed at.
     if inner.startswith("\n"):
         inner = inner[1:]
     separator = inner.find("\n\n")
-    body = inner[separator + 2 :] if separator >= 0 else inner
-    return body.strip()
+    if separator < 0:
+        return None
+    kind = _INSTRUCTION_KINDS.get(inner[:separator].strip())
+    if kind is None:
+        return None
+    return ParentMessage(kind=kind, body=inner[separator + 2 :].strip())
 
 
 #: How many child records to keep. A record is ~4 short strings and outlives
@@ -1927,22 +1990,13 @@ class SubagentComms:
 
     @staticmethod
     def _format_to_child(text: str, *, expects_reply: bool, steer: bool) -> str:
-        if steer:
-            instruction = (
-                "This changes your instructions. Apply it from now on, and drop work it "
-                "makes pointless."
-            )
-        elif expects_reply:
-            instruction = (
-                "Answer it now with the `hub` tool — a short, direct reply — then carry on "
-                "with what you were doing. Do not restructure your work around the question."
-            )
-        else:
-            instruction = (
-                "This is a note, not a question. No reply is needed unless it changes what "
-                "you should do."
-            )
-        return f"<parent-message>\n{instruction}\n\n{text}\n</parent-message>"
+        # Both the tags and the instruction line come from the module-level
+        # constants that `extract_parent_message` parses against: the inverse
+        # requires an exact preamble match, so an instruction reworded only
+        # here would stop every new envelope extracting.
+        kind = "steer" if steer else ("ask" if expects_reply else "note")
+        instruction = TO_CHILD_INSTRUCTIONS[kind]
+        return f"{PARENT_MESSAGE_TAG}\n{instruction}\n\n{text}\n{PARENT_MESSAGE_CLOSE_TAG}"
 
     def _journal_communication(
         self,

--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -77,6 +77,49 @@ HUB_MESSAGE_TYPE = "hub_message"
 #: only to correlate the parent's action with a later child reply.
 HUB_COMMUNICATION_CUSTOM_TYPE = "hub_communication"
 
+#: Opening tag of the model-facing envelope :meth:`SubagentComms._format_to_child`
+#: wraps parent→child text in. A hub steer persists as a plain role=user
+#: Message carrying this envelope, so human-facing surfaces match on the tag
+#: to keep the XML away from the reader (see
+#: :func:`extract_parent_message_body`).
+PARENT_MESSAGE_TAG = "<parent-message>"
+
+
+def extract_parent_message_body(text: str) -> str | None:
+    """The human-facing body of a model-facing ``<parent-message>`` envelope.
+
+    Returns None when ``text`` is not such an envelope. The shape parsed is
+    exactly what :meth:`SubagentComms._format_to_child` builds:
+    ``<parent-message>\\n{instruction}\\n\\n{body}\\n</parent-message>`` — the
+    body is everything after the first blank line, before the closing tag.
+
+    WHY this exists as a shared helper: a hub steer is persisted as a plain
+    role=user Message whose text is the envelope built for the MODEL, while
+    the human-facing fact is a separate custom row. Human-facing surfaces
+    (the TUI subagent view, the mobile projection) must show the body the
+    parent authored and never the XML wrapper — including for transcripts
+    persisted before steers carried their communication fact's id, where
+    body-text correlation is the only match left. Both surfaces import this
+    one parser so the builder and its inverse cannot drift apart.
+    """
+    stripped = text.strip()
+    if not stripped.startswith(PARENT_MESSAGE_TAG):
+        return None
+    end = stripped.rfind("</parent-message>")
+    if end < 0:
+        return None
+    inner = stripped[len(PARENT_MESSAGE_TAG) : end]
+    # Drop the leading newline, then the instruction line: the body starts
+    # after the FIRST blank line. A missing separator means the text does not
+    # follow the builder's shape; treat the whole interior as the body rather
+    # than leaking the instruction line into what is shown to a person.
+    if inner.startswith("\n"):
+        inner = inner[1:]
+    separator = inner.find("\n\n")
+    body = inner[separator + 2 :] if separator >= 0 else inner
+    return body.strip()
+
+
 #: How many child records to keep. A record is ~4 short strings and outlives
 #: its job row on purpose (job rows are swept 5 minutes after settling, and
 #: resuming a child an hour later is a legitimate thing to want). The cap
@@ -244,14 +287,14 @@ class ChildSession(Protocol):
     Narrower than :class:`~local_operator.session.session.Session` on
     purpose: it is the whole coupling between the parent's channel and a
     child, stated in one place. Notes and questions go through
-    ``queue_aside``, course changes through ``steer``, and the reply watcher
-    rides ``subscribe``. Anything a future op needs from a child belongs here
-    first, where the cost of the coupling is visible.
+    ``queue_aside``, course changes through ``steer_message``, and the reply
+    watcher rides ``subscribe``. Anything a future op needs from a child
+    belongs here first, where the cost of the coupling is visible.
     """
 
     def queue_aside(self, thunk: Callable[[], AsideResult]) -> None: ...
 
-    def steer(self, text: str) -> None: ...
+    def steer_message(self, message: Message) -> None: ...
 
     def subscribe(self, handler: Callable[[AgentEvent], Any]) -> Callable[[], None]: ...
 
@@ -1228,7 +1271,19 @@ class SubagentComms:
             communication_id=message.id,
             kind="steer",
         )
-        record.child.steer(str(message.details["text"]))
+        # ``steer_message`` (not ``steer``) so the persisted row carries the
+        # SAME id as the journaled communication fact: human-facing surfaces
+        # (the TUI subagent view, the mobile projection) correlate the two by
+        # id and render the fact instead of the model-facing
+        # ``<parent-message>`` XML envelope. ``steer`` would mint a fresh
+        # Message id the correlation could never match — which is exactly how
+        # the envelope leaked beside the fact. ``steer_message`` is the
+        # identity-preserving seam: it queues the caller-built Message
+        # verbatim. On a follower-owned child the id rides the wire as the
+        # ContinuationCommand id, which the owner's handle hands back to
+        # ``Session.steer`` as ``message_id``, so the correlation survives
+        # that path too.
+        record.child.steer_message(Message.user(str(message.details["text"]), id=message.id))
         return Delivery(job_id, record.label, "injected")
 
     async def _await_child(self, record: _ChildRecord, timeout_s: float) -> bool:

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -29,7 +29,7 @@ import time
 from collections.abc import Mapping
 from typing import Any
 
-from local_operator.harness.comms import HUB_MESSAGE_TYPE
+from local_operator.harness.comms import HUB_MESSAGE_TYPE, extract_parent_message_body
 from local_operator.harness.types import (
     AgentEndEvent,
     AgentEvent,
@@ -615,6 +615,16 @@ def fold_messages_to_entries(history: list[AgentMessage]) -> list[TranscriptEntr
                 )
             continue
         if message.role == "user":
+            body = extract_parent_message_body(message.text)
+            if body is not None:
+                # A persisted hub steer: model-facing XML around the parent's
+                # own words. The phone shows the body the parent authored,
+                # never the envelope. Unlike the TUI, this fold sees only
+                # LLM-visible messages — the journaled communication fact is a
+                # custom row that never replays — so body extraction is the
+                # phone's only path to a human-facing rendering.
+                entries.append(TranscriptEntry(id=message.id, kind="parent_message", text=body))
+                continue
             # Carry image attachments as references so an image-only prompt
             # (the composer allows "" text + images) renders its thumbnails on
             # replay instead of round-tripping as an empty bubble — the same
@@ -749,6 +759,15 @@ class ProjectionFold:
                     )
                 continue
             if message.role == "user":
+                body = extract_parent_message_body(message.text)
+                if body is not None:
+                    # A persisted hub steer renders as the parent's own words,
+                    # never the model-facing envelope — the same rule as
+                    # ``fold_messages_to_entries``; the two folds must not
+                    # diverge or an attaching phone and a lazy-loaded page
+                    # would disagree about the same row.
+                    entries.append(TranscriptEntry(id=message.id, kind="parent_message", text=body))
+                    continue
                 entries.append(
                     TranscriptEntry(
                         id=message.id,
@@ -1068,6 +1087,17 @@ class ProjectionFold:
         if not isinstance(message, Message) or message.role != "user":
             return False
         text = message.text
+        body = extract_parent_message_body(text)
+        if body is not None:
+            # A hub steer delivered mid-turn announces itself as a user
+            # MessageStartEvent whose text is the model-facing envelope. The
+            # phone renders the parent's own words, never the XML — the same
+            # rule the durable folds apply, so a live delivery and its later
+            # history page agree about the row.
+            self._append(
+                TranscriptEntry(id=message.id, kind="parent_message", text=body, final=True)
+            )
+            return True
         refs = _image_refs(message)
         entry = self._pending_user_echoes.pop(message.id, None)
         if entry is None:

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -29,7 +29,7 @@ import time
 from collections.abc import Mapping
 from typing import Any
 
-from local_operator.harness.comms import HUB_MESSAGE_TYPE, extract_parent_message_body
+from local_operator.harness.comms import HUB_MESSAGE_TYPE, extract_parent_message
 from local_operator.harness.types import (
     AgentEndEvent,
     AgentEvent,
@@ -615,15 +615,17 @@ def fold_messages_to_entries(history: list[AgentMessage]) -> list[TranscriptEntr
                 )
             continue
         if message.role == "user":
-            body = extract_parent_message_body(message.text)
-            if body is not None:
+            parent_message = extract_parent_message(message.text)
+            if parent_message is not None:
                 # A persisted hub steer: model-facing XML around the parent's
                 # own words. The phone shows the body the parent authored,
                 # never the envelope. Unlike the TUI, this fold sees only
                 # LLM-visible messages — the journaled communication fact is a
                 # custom row that never replays — so body extraction is the
                 # phone's only path to a human-facing rendering.
-                entries.append(TranscriptEntry(id=message.id, kind="parent_message", text=body))
+                entries.append(
+                    TranscriptEntry(id=message.id, kind="parent_message", text=parent_message.body)
+                )
                 continue
             # Carry image attachments as references so an image-only prompt
             # (the composer allows "" text + images) renders its thumbnails on
@@ -759,14 +761,18 @@ class ProjectionFold:
                     )
                 continue
             if message.role == "user":
-                body = extract_parent_message_body(message.text)
-                if body is not None:
+                parent_message = extract_parent_message(message.text)
+                if parent_message is not None:
                     # A persisted hub steer renders as the parent's own words,
                     # never the model-facing envelope — the same rule as
                     # ``fold_messages_to_entries``; the two folds must not
                     # diverge or an attaching phone and a lazy-loaded page
                     # would disagree about the same row.
-                    entries.append(TranscriptEntry(id=message.id, kind="parent_message", text=body))
+                    entries.append(
+                        TranscriptEntry(
+                            id=message.id, kind="parent_message", text=parent_message.body
+                        )
+                    )
                     continue
                 entries.append(
                     TranscriptEntry(
@@ -1087,18 +1093,15 @@ class ProjectionFold:
         if not isinstance(message, Message) or message.role != "user":
             return False
         text = message.text
-        body = extract_parent_message_body(text)
-        if body is not None:
-            # A hub steer delivered mid-turn announces itself as a user
-            # MessageStartEvent whose text is the model-facing envelope. The
-            # phone renders the parent's own words, never the XML — the same
-            # rule the durable folds apply, so a live delivery and its later
-            # history page agree about the row.
-            self._append(
-                TranscriptEntry(id=message.id, kind="parent_message", text=body, final=True)
-            )
-            return True
         refs = _image_refs(message)
+        # Echo reconciliation runs BEFORE the envelope branch, not after. A
+        # message whose text matches the envelope shape can still be one the
+        # phone sent (a user quoting the wrapper, or a phone-issued steer);
+        # taking the envelope branch first left that echo unreconciled, so the
+        # row double-rendered under one id — and the surviving echo displayed
+        # the raw XML this whole path exists to suppress. Resolving the echo
+        # once, here, also keeps the two arms from growing separate copies of
+        # the registry/tail-scan rules.
         entry = self._pending_user_echoes.pop(message.id, None)
         if entry is None:
             # No registered echo: either this message came from ANOTHER surface
@@ -1116,14 +1119,33 @@ class ProjectionFold:
                 ):
                     entry = candidate
                     break
+        parent_message = extract_parent_message(text)
         if entry is not None:
             # Adopt the persisted identity either way: the row was keyed by the
             # command id (or a synthetic one), and the message id is what later
             # history folds and the web client's list reconciliation agree on.
             entry.id = message.id
+            if parent_message is not None:
+                # The echo captured the model-facing envelope verbatim. Rewrite
+                # it in place to the parent's own words so the reconciled row
+                # matches what the durable folds will render for it later.
+                entry.kind = "parent_message"
+                entry.text = parent_message.body
             if refs and not entry.images:
                 entry.images = refs
             return False
+        if parent_message is not None:
+            # A hub steer delivered mid-turn announces itself as a user
+            # MessageStartEvent whose text is the model-facing envelope. The
+            # phone renders the parent's own words, never the XML — the same
+            # rule the durable folds apply, so a live delivery and its later
+            # history page agree about the row.
+            self._append(
+                TranscriptEntry(
+                    id=message.id, kind="parent_message", text=parent_message.body, final=True
+                )
+            )
+            return True
         self._append(
             TranscriptEntry(id=message.id, kind="user", text=text, images=refs, final=True)
         )

--- a/local_operator/mobile/web/src/agent-view.test.ts
+++ b/local_operator/mobile/web/src/agent-view.test.ts
@@ -60,6 +60,47 @@ describe("agent conversation composition", () => {
 			expect.objectContaining({ kind: "parent_message", text: "Legacy task" }),
 		]);
 	});
+
+	// A persisted hub steer folds to `parent_message` server-side, so the head
+	// guard can no longer key on that kind alone: for a legacy child (no
+	// launch_message_id) a steer would otherwise stand in for the launch task
+	// and the row naming the whole conversation would vanish from the phone.
+	it("keeps the launch prompt head for a legacy child that was steered", () => {
+		const steer = entry("s1", "parent_message", "Focus on retries");
+		const messages = agentConversationEntries(detail({
+			prompt: "Implement the route",
+			launch_message_id: "",
+			transcript: [steer],
+		}));
+		expect(messages).toEqual([
+			expect.objectContaining({ kind: "parent_message", text: "Implement the route" }),
+			steer,
+		]);
+	});
+
+	// The complement: a real launch head must still suppress the synthetic one,
+	// including when the row carries the role preamble the launch message has.
+	it("does not re-add the head when a launch row already carries the prompt", () => {
+		const launch = entry("launch", "parent_message", "Role preamble\n\nImplement the route");
+		const messages = agentConversationEntries(detail({
+			prompt: "Implement the route",
+			launch_message_id: "",
+			transcript: [launch, entry("s1", "parent_message", "Focus on retries")],
+		}));
+		expect(messages[0]).toBe(launch);
+		expect(messages.filter((m) => m.kind === "parent_message")).toHaveLength(2);
+	});
+
+	// `prompt` arrives as a bounded preview, so a truncated head still matches.
+	it("recognises a truncated prompt preview as the launch head", () => {
+		const launch = entry("launch", "parent_message", `Preamble\n\n${"x".repeat(40)} tail`);
+		const messages = agentConversationEntries(detail({
+			prompt: `${"x".repeat(40)}…`,
+			launch_message_id: "",
+			transcript: [launch],
+		}));
+		expect(messages).toEqual([launch]);
+	});
 });
 
 describe("Agents sheet hierarchy", () => {

--- a/local_operator/mobile/web/src/agent-view.test.ts
+++ b/local_operator/mobile/web/src/agent-view.test.ts
@@ -91,15 +91,54 @@ describe("agent conversation composition", () => {
 		expect(messages.filter((m) => m.kind === "parent_message")).toHaveLength(2);
 	});
 
-	// `prompt` arrives as a bounded preview, so a truncated head still matches.
+	// `prompt` arrives as a bounded preview (SUBAGENT_PROMPT_PREVIEW_CHARS = 1000,
+	// `_compact` emitting `text[: limit - 1] + "…"`), so a head truncated by that
+	// cap must still match — as a PREFIX, since its tail was cut off.
 	it("recognises a truncated prompt preview as the launch head", () => {
-		const launch = entry("launch", "parent_message", `Preamble\n\n${"x".repeat(40)} tail`);
+		const body = "x".repeat(999);
+		const launch = entry("launch", "parent_message", `Preamble\n\n${body} tail`);
 		const messages = agentConversationEntries(detail({
-			prompt: `${"x".repeat(40)}…`,
+			prompt: `${body}…`,
 			launch_message_id: "",
 			transcript: [launch],
 		}));
 		expect(messages).toEqual([launch]);
+	});
+
+	// Finding 8. `…` is one keystroke for a human, so "ends in an ellipsis" is
+	// not evidence of truncation. A SHORT prompt ending that way must stay on
+	// the anchored path — taking the loose prefix path let a steer that merely
+	// quotes the task suppress the head, the exact defect the anchoring closed.
+	it("does not treat an author's own trailing ellipsis as a truncated preview", () => {
+		const prompt = "Investigate why the retry loop stalls…";
+		const steer = entry("s1", "parent_message", `About 'Investigate why the retry loop stalls' - focus on retries first`);
+		const messages = agentConversationEntries(detail({
+			prompt,
+			launch_message_id: "",
+			transcript: [steer],
+		}));
+		expect(messages).toEqual([
+			expect.objectContaining({ kind: "parent_message", text: prompt }),
+			steer,
+		]);
+	});
+
+	// Finding 9. End-anchoring alone accepted a steer that CLOSES by restating
+	// the task. The launch row is structurally `{preamble}\n\n{prompt}`, so the
+	// task always begins at a paragraph boundary; a restatement mid-sentence
+	// does not, and must not suppress the head.
+	it("does not treat a steer that ends by restating the task as the launch head", () => {
+		const prompt = "Implement the route";
+		const steer = entry("s1", "parent_message", "Actually ignore that and Implement the route");
+		const messages = agentConversationEntries(detail({
+			prompt,
+			launch_message_id: "",
+			transcript: [steer],
+		}));
+		expect(messages).toEqual([
+			expect.objectContaining({ kind: "parent_message", text: prompt }),
+			steer,
+		]);
 	});
 });
 

--- a/local_operator/mobile/web/src/agent-view.test.ts
+++ b/local_operator/mobile/web/src/agent-view.test.ts
@@ -123,6 +123,58 @@ describe("agent conversation composition", () => {
 		]);
 	});
 
+	// Finding 8, the case that GUARDS the length gate. The test above asserts an
+	// outcome both versions of the predicate produce: its steer QUOTES the task,
+	// so it fails the loose path's `startsWith` whether or not the gate is there.
+	// Removing only the gate leaves it green. A steer that BEGINS with the stem
+	// does reach that branch, so it flips from "head kept" to "suppressed" the
+	// moment the length gate stops holding a short author-typed `…` off the
+	// loose path — which is the regression this pair exists to catch.
+	it("keeps the head when a steer begins with an author's own ellipsis prompt", () => {
+		const prompt = "Fix the retry loop…";
+		const steer = entry("s1", "parent_message", "Fix the retry loop, but only for 5xx responses");
+		const messages = agentConversationEntries(detail({
+			prompt,
+			launch_message_id: "",
+			transcript: [steer],
+		}));
+		expect(messages).toEqual([
+			expect.objectContaining({ kind: "parent_message", text: prompt }),
+			steer,
+		]);
+	});
+
+	// Finding 12. Head detection walks the row's paragraph-delimited suffixes.
+	// Materialising and normalising each one re-scans the tail per break, which
+	// is quadratic in row length (9.4s for a 580KB row with 2000 breaks), and
+	// the wire `text` for these row kinds is not length-bounded. The linear form
+	// normalises once and compares at offsets, so this must stay well under the
+	// old cost while still anchoring at a paragraph boundary and nowhere else.
+	it("matches a launch head deep in a long row without quadratic cost", () => {
+		const prompt = "Implement the retry route";
+		const filler = Array.from({ length: 2_000 }, (_, i) => `paragraph ${i} ${"y".repeat(300)}`);
+		// The task sits at a real paragraph boundary far into the row.
+		const head = entry("h1", "parent_message", `${filler.join("\n\n")}\n\n${prompt}`);
+		// Same bulk, but the task is mid-sentence, so it must NOT suppress.
+		const steer = entry("s1", "parent_message", `${filler.join("\n\n")} and ${prompt}`);
+
+		const started = performance.now();
+		expect(agentConversationEntries(detail({
+			prompt, launch_message_id: "", transcript: [head],
+		}))).toEqual([head]);
+		expect(agentConversationEntries(detail({
+			prompt, launch_message_id: "", transcript: [steer],
+		}))).toEqual([
+			expect.objectContaining({ kind: "parent_message", text: prompt }),
+			steer,
+		]);
+		// Measured on this exact shape: the suffix-materialising walk takes ~4.3s
+		// for the pair, the linear form ~20ms. The threshold sits two orders of
+		// magnitude above the fixed cost and ~3x below the broken one, so it fails
+		// on a reintroduced quadratic without flaking on a loaded CI runner.
+		expect(performance.now() - started).toBeLessThan(1_500);
+	});
+
 	// Finding 9. End-anchoring alone accepted a steer that CLOSES by restating
 	// the task. The launch row is structurally `{preamble}\n\n{prompt}`, so the
 	// task always begins at a paragraph boundary; a restatement mid-sentence

--- a/local_operator/mobile/web/src/screens/agent-view.tsx
+++ b/local_operator/mobile/web/src/screens/agent-view.tsx
@@ -55,6 +55,35 @@ function agentPath(sessionId: string, jobId: string): string {
 	return `/s/${encodeURIComponent(sessionId)}/a/${encodeURIComponent(jobId)}`;
 }
 
+function normalizeText(text: string): string {
+	return text.replace(/\s+/g, " ").trim();
+}
+
+/** Does this `parent_message` row already carry the child's LAUNCH task?
+ *
+ * Identity first: an id equal to `launch_message_id` is conclusive. Legacy and
+ * summary-stripped rows have no such id, so fall back to the prompt text —
+ * but anchored at the END, not as a loose substring, because the launch row is
+ * `{role preamble}\n\n{prompt}` while a steer that merely quotes the task
+ * ("Implement the route more narrowly") would satisfy a substring test and
+ * wrongly suppress the head.
+ *
+ * `prompt` arrives as a bounded PREVIEW (`SUBAGENT_PROMPT_PREVIEW_CHARS`
+ * compacts it and appends an ellipsis), so a truncated preview is matched as a
+ * prefix of the row instead. That branch is only reachable at ~1000 characters
+ * of agreement, far past coincidence. */
+function isLaunchHead(entry: TranscriptEntry, detail: SubagentDetail): boolean {
+	if (detail.launch_message_id && entry.id === detail.launch_message_id) return true;
+	const prompt = normalizeText(detail.prompt);
+	if (!prompt) return false;
+	const text = normalizeText(entry.text);
+	if (prompt.endsWith("…")) {
+		const head = prompt.slice(0, -1);
+		return head.length > 0 && text.includes(head);
+	}
+	return text === prompt || text.endsWith(` ${prompt}`);
+}
+
 /** The launch prompt is durable child history, while `prompt` is the raw
  * parent task retained for queued/legacy rows. Correlation identity lets the
  * opening role-expanded user row carry that task's visual semantics without
@@ -70,7 +99,18 @@ export function agentConversationEntries(detail: SubagentDetail): TranscriptEntr
 			);
 		}
 	}
-	if (!detail.prompt || detail.transcript.some((entry) => entry.kind === "parent_message")) {
+	// Only a row carrying the LAUNCH task suppresses the synthesized head. The
+	// guard used to test for `parent_message` as such, which broke once a
+	// persisted hub steer started folding to that kind server-side: a legacy
+	// child (no `launch_message_id`, or a summary row whose id the daemon
+	// stripped) that had ever been steered lost the row naming what the whole
+	// conversation is about. A steer is a mid-conversation redirection and
+	// never stands in for the launch task, so match on the launch text rather
+	// than on the kind.
+	const hasLaunchHead = detail.transcript.some(
+		(entry) => entry.kind === "parent_message" && isLaunchHead(entry, detail),
+	);
+	if (!detail.prompt || hasLaunchHead) {
 		return detail.transcript;
 	}
 	return [

--- a/local_operator/mobile/web/src/screens/agent-view.tsx
+++ b/local_operator/mobile/web/src/screens/agent-view.tsx
@@ -78,16 +78,40 @@ const SUBAGENT_PROMPT_PREVIEW_CHARS = 1_000;
  * blank line in front of the restatement and so never yields a matching
  * candidate, while a genuine launch row does.
  *
- * Whitespace inside each candidate is normalised by the caller because the
- * wire `prompt` has already been flattened by `_compact`; only the paragraph
- * boundaries themselves must survive long enough to be split on. */
-function launchCandidates(text: string): string[] {
-	const candidates = [text];
-	const separator = /\n[ \t]*\n/g;
-	for (let match = separator.exec(text); match; match = separator.exec(text)) {
-		candidates.push(text.slice(match.index + match[0].length));
+ * Whitespace inside each candidate is normalised because the wire `prompt` has
+ * already been flattened by `_compact`; only the paragraph boundaries
+ * themselves must survive long enough to be split on.
+ *
+ * Returned as ONE normalised string plus the offset each candidate starts at,
+ * rather than as a list of suffix strings, to keep the work linear. Building
+ * and normalising every suffix separately re-scans the tail of the row once
+ * per paragraph break — (breaks x length), measured at 9.4s for a 580KB row
+ * with 2000 breaks. The wire `text` for `user`, `assistant` and
+ * `parent_message` rows is NOT length-bounded (only `notice`, tool args/output
+ * and outcome fields go through `_compact`), so a long pasted row is a
+ * reachable input, and the phone renders this on the main thread.
+ *
+ * The rewrite is exact rather than approximate: normalising collapses every
+ * whitespace run to one space, so the normalised full text is just its words
+ * joined by single spaces, and the normalised form of a suffix beginning at a
+ * paragraph break is the same string from that word onward. Segments that
+ * normalise to nothing (consecutive breaks) contribute no words and so are
+ * dropped — they can only duplicate the following candidate's offset. Each
+ * comparison then costs the needle's length instead of the row's. */
+function launchCandidates(text: string): { normalized: string; offsets: number[] } {
+	const offsets: number[] = [];
+	const parts: string[] = [];
+	let length = 0;
+	for (const segment of text.split(/\n[ \t]*\n/)) {
+		const part = normalizeText(segment);
+		if (!part) continue;
+		// Offset of this segment's first word in the joined string, which is where
+		// the candidate starting at the preceding break begins.
+		offsets.push(length);
+		parts.push(part);
+		length += part.length + 1; // +1 for the single space the join inserts.
 	}
-	return candidates;
+	return { normalized: parts.join(" "), offsets };
 }
 
 /** Does this `parent_message` row already carry the child's LAUNCH task?
@@ -113,10 +137,15 @@ function isLaunchHead(entry: TranscriptEntry, detail: SubagentDetail): boolean {
 	const truncated = prompt.endsWith("…") && prompt.length >= SUBAGENT_PROMPT_PREVIEW_CHARS - 1;
 	const needle = truncated ? prompt.slice(0, -1) : prompt;
 	if (!needle) return false;
-	return launchCandidates(entry.text).some((candidate) => {
-		const text = normalizeText(candidate);
-		return truncated ? text.startsWith(needle) : text === needle;
-	});
+	const { normalized, offsets } = launchCandidates(entry.text);
+	return offsets.some((offset) =>
+		// `startsWith(needle, offset)` is the candidate's prefix test without
+		// materialising the suffix; equality additionally demands that the
+		// candidate end where the needle does.
+		truncated
+			? normalized.startsWith(needle, offset)
+			: normalized.length - offset === needle.length && normalized.startsWith(needle, offset),
+	);
 }
 
 /** The launch prompt is durable child history, while `prompt` is the raw

--- a/local_operator/mobile/web/src/screens/agent-view.tsx
+++ b/local_operator/mobile/web/src/screens/agent-view.tsx
@@ -59,29 +59,64 @@ function normalizeText(text: string): string {
 	return text.replace(/\s+/g, " ").trim();
 }
 
+/** Bound the daemon applies to a row's `prompt` before it reaches the wire.
+ * Mirrors `SUBAGENT_PROMPT_PREVIEW_CHARS` in `local_operator/mobile/projection.py`,
+ * where `_compact` emits `text[: limit - 1] + "…"` — so a preview that was
+ * actually truncated is exactly this long, and a SHORTER prompt ending in `…`
+ * ends that way because its author typed the character. */
+const SUBAGENT_PROMPT_PREVIEW_CHARS = 1_000;
+
+/** The row text plus each of its paragraph-delimited suffixes, longest first.
+ *
+ * A launch message is structurally `{preamble}\n\n{prompt}`, and every
+ * preamble builder (`AgentProfile.preamble`, `Team.member_preamble`,
+ * `SCOUT_PREAMBLE`, the specialist join) terminates on a blank line — so the
+ * launch task always begins right after a paragraph break, or at offset 0 when
+ * there is no preamble at all. Splitting there is what lets the comparison stay
+ * anchored to a real structural boundary: a steer that merely CLOSES by
+ * restating the task ("Actually ignore that and Implement the route") has no
+ * blank line in front of the restatement and so never yields a matching
+ * candidate, while a genuine launch row does.
+ *
+ * Whitespace inside each candidate is normalised by the caller because the
+ * wire `prompt` has already been flattened by `_compact`; only the paragraph
+ * boundaries themselves must survive long enough to be split on. */
+function launchCandidates(text: string): string[] {
+	const candidates = [text];
+	const separator = /\n[ \t]*\n/g;
+	for (let match = separator.exec(text); match; match = separator.exec(text)) {
+		candidates.push(text.slice(match.index + match[0].length));
+	}
+	return candidates;
+}
+
 /** Does this `parent_message` row already carry the child's LAUNCH task?
  *
  * Identity first: an id equal to `launch_message_id` is conclusive. Legacy and
- * summary-stripped rows have no such id, so fall back to the prompt text —
- * but anchored at the END, not as a loose substring, because the launch row is
- * `{role preamble}\n\n{prompt}` while a steer that merely quotes the task
- * ("Implement the route more narrowly") would satisfy a substring test and
- * wrongly suppress the head.
+ * summary-stripped rows have no such id, so fall back to the prompt text — but
+ * anchored to the paragraph boundary the launch task starts at, never as a
+ * loose substring, because a steer that quotes the task ("Implement the route
+ * more narrowly") would satisfy a substring test and wrongly suppress the head.
  *
- * `prompt` arrives as a bounded PREVIEW (`SUBAGENT_PROMPT_PREVIEW_CHARS`
- * compacts it and appends an ellipsis), so a truncated preview is matched as a
- * prefix of the row instead. That branch is only reachable at ~1000 characters
- * of agreement, far past coincidence. */
+ * `prompt` arrives as a bounded PREVIEW, so a genuinely truncated one is
+ * matched as a PREFIX of its candidate rather than by equality. That looser
+ * comparison is gated on the preview bound as well as the trailing ellipsis:
+ * keying on the character alone put an author's own "…" — which costs a human
+ * one keystroke — on the loose path and reopened the false positive the
+ * anchoring exists to close. */
 function isLaunchHead(entry: TranscriptEntry, detail: SubagentDetail): boolean {
 	if (detail.launch_message_id && entry.id === detail.launch_message_id) return true;
 	const prompt = normalizeText(detail.prompt);
 	if (!prompt) return false;
-	const text = normalizeText(entry.text);
-	if (prompt.endsWith("…")) {
-		const head = prompt.slice(0, -1);
-		return head.length > 0 && text.includes(head);
-	}
-	return text === prompt || text.endsWith(` ${prompt}`);
+	// `- 1` tolerates a preview whose flattening trimmed a character; the cap is
+	// ~1000, so the loose path still demands that much agreement to be reached.
+	const truncated = prompt.endsWith("…") && prompt.length >= SUBAGENT_PROMPT_PREVIEW_CHARS - 1;
+	const needle = truncated ? prompt.slice(0, -1) : prompt;
+	if (!needle) return false;
+	return launchCandidates(entry.text).some((candidate) => {
+		const text = normalizeText(candidate);
+		return truncated ? text.startsWith(needle) : text === needle;
+	});
 }
 
 /** The launch prompt is durable child history, while `prompt` is the raw

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -65,7 +65,11 @@ from textual.message import Message
 from textual.widgets import Static
 
 from local_operator.ansi import strip_control_sequences
-from local_operator.harness.comms import HUB_COMMUNICATION_CUSTOM_TYPE, HUB_MESSAGE_TYPE
+from local_operator.harness.comms import (
+    HUB_COMMUNICATION_CUSTOM_TYPE,
+    HUB_MESSAGE_TYPE,
+    extract_parent_message_body,
+)
 from local_operator.harness.jobs import CANCELLED_BEFORE_START, TRAJECTORY_SEQ_KEY
 from local_operator.session.transcript import (
     CUSTOM_KIND_CUSTOM,
@@ -522,17 +526,26 @@ def fold_transcript_entries(
                     duration,
                 )
     communication_ids: set[str] = set()
+    communication_bodies: set[str] = set()
     # Host communication facts supersede their replay-visible custom message:
     # the former include replies and correlation while the latter contain XML
-    # wrappers intended for the model, never for a person.
+    # wrappers intended for the model, never for a person. The to-child bodies
+    # are retained too: a hub steer persists as a plain user row, and
+    # transcripts written before steers carried their fact's id can only be
+    # correlated by body text.
     for entry in entries:
         if (
             entry.type == ENTRY_CUSTOM
             and entry.payload.get("custom_type") == HUB_COMMUNICATION_CUSTOM_TYPE
         ):
-            communication_id = entry.payload.get("details", {}).get("communication_id")
+            details = entry.payload.get("details") or {}
+            communication_id = details.get("communication_id")
             if communication_id:
                 communication_ids.add(str(communication_id))
+            if details.get("direction") == "to_child":
+                fact_body = strip_control_sequences(str(details.get("body") or "")).strip()
+                if fact_body:
+                    communication_bodies.add(fact_body)
     for entry in entries:
         payload = entry.payload
         if entry.type == ENTRY_CUSTOM:
@@ -579,6 +592,23 @@ def fold_transcript_entries(
         role = payload.get("role")
         text = strip_control_sequences(_content_text(payload)).strip()
         if role == "user":
+            body = extract_parent_message_body(text)
+            if body is not None:
+                # A persisted hub steer: model-facing XML around the parent's
+                # own words. The human-facing fact row supersedes it — by id
+                # once steers carry their fact's id, and by body text for
+                # transcripts written before that (legacy ids never match).
+                # When NO fact exists in the loaded window (it may sit on an
+                # unloaded page), render the extracted body as the parent row
+                # instead: the XML is for the model and must never reach a
+                # person either way.
+                if entry.id not in communication_ids and body not in communication_bodies:
+                    folded.append(
+                        SubagentEntry(
+                            entry.id, "parent_message", text=f"Parent · redirected\n{body}"
+                        )
+                    )
+                continue
             if text:
                 folded.append(SubagentEntry(entry.id, "user", text=text))
             continue

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -538,12 +538,12 @@ def fold_transcript_entries(
                     duration,
                 )
     communication_ids: set[str] = set()
-    # Body text -> how many to-child facts carry it. A MULTISET, not a set: the
-    # legacy arm below CONSUMES one count per matched envelope row, so steering
-    # the same words twice ("focus on retries" after each of two failures is a
-    # normal operator move) still renders two rows. Membership-only matching
-    # collapsed N identical steers into one and under-reported history the
-    # parent actually sent.
+    # Body text -> how many to-child facts are available to supersede a LEGACY
+    # (id-less) envelope row. A MULTISET, not a set: the legacy arm below
+    # CONSUMES one count per matched row, so steering the same words twice
+    # ("focus on retries" after each of two failures is a normal operator move)
+    # still renders two rows. Membership-only matching collapsed N identical
+    # steers into one and under-reported history the parent actually sent.
     communication_bodies: Counter[str] = Counter()
     # Host communication facts supersede their replay-visible custom message:
     # the former include replies and correlation while the latter contain XML
@@ -551,19 +551,41 @@ def fold_transcript_entries(
     # are retained too: a hub steer persists as a plain user row, and
     # transcripts written before steers carried their fact's id can only be
     # correlated by body text.
+    #
+    # CONSTRAINT — a fact may be spent at most once, and only by ITS OWN row.
+    # The two correlation arms must therefore not draw on one budget during the
+    # ordered walk: whichever row the walk reaches first would spend the other
+    # row's fact, and in a real mixed-vintage transcript the LEGACY row is the
+    # older one, so it comes first and eats the id-correlated row's fact. Two
+    # delivered steers then render as one. So id matches are resolved HERE, in
+    # the pre-pass over the whole loaded window, and the legacy budget is built
+    # from only the facts left over. That also makes the outcome independent of
+    # durable page order, which is arbitrary: a fact and its row routinely land
+    # on opposite sides of a page boundary.
+    entry_ids = {entry.id for entry in entries}
+    to_child_facts: list[tuple[str, str]] = []
     for entry in entries:
         if (
             entry.type == ENTRY_CUSTOM
             and entry.payload.get("custom_type") == HUB_COMMUNICATION_CUSTOM_TYPE
         ):
             details = entry.payload.get("details") or {}
-            communication_id = details.get("communication_id")
+            communication_id = str(details.get("communication_id") or "")
             if communication_id:
-                communication_ids.add(str(communication_id))
+                communication_ids.add(communication_id)
             if details.get("direction") == "to_child":
                 fact_body = strip_control_sequences(str(details.get("body") or "")).strip()
                 if fact_body:
-                    communication_bodies[fact_body] += 1
+                    to_child_facts.append((communication_id, fact_body))
+    for communication_id, fact_body in to_child_facts:
+        # A fact whose id names a row in this window is already CLAIMED by that
+        # row, which the walk suppresses on identity alone. Withholding it from
+        # the legacy budget is what stops an identical id-less row consuming it.
+        # A fact with no such row (its row sits on an unloaded page, or predates
+        # id-carrying steers) is what the body-text arm exists to spend.
+        if communication_id and communication_id in entry_ids:
+            continue
+        communication_bodies[fact_body] += 1
     for entry in entries:
         payload = entry.payload
         if entry.type == ENTRY_CUSTOM:
@@ -620,17 +642,9 @@ def fold_transcript_entries(
                 # person either way.
                 body = parent_message.body
                 if entry.id in communication_ids:
-                    # Correlated by id, so this row's fact is accounted for.
-                    # Consume its body count too: the counter is a budget of
-                    # facts still available to supersede a LEGACY row, and a
-                    # fact already spent on an id match must not be spent again.
-                    # A mixed-vintage child (steered both before and after
-                    # steers began carrying their fact's id) otherwise leaves
-                    # the id-matched fact's count behind for an identical
-                    # legacy row to consume, and two delivered steers render as
-                    # one.
-                    if communication_bodies[body]:
-                        communication_bodies[body] -= 1
+                    # Correlated by id: its fact renders the row and was already
+                    # withheld from the legacy budget by the pre-pass, so there
+                    # is nothing to consume here.
                     continue
                 if communication_bodies[body]:
                     # Consume this occurrence so a SECOND identical steer is

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -620,6 +620,17 @@ def fold_transcript_entries(
                 # person either way.
                 body = parent_message.body
                 if entry.id in communication_ids:
+                    # Correlated by id, so this row's fact is accounted for.
+                    # Consume its body count too: the counter is a budget of
+                    # facts still available to supersede a LEGACY row, and a
+                    # fact already spent on an id match must not be spent again.
+                    # A mixed-vintage child (steered both before and after
+                    # steers began carrying their fact's id) otherwise leaves
+                    # the id-matched fact's count behind for an identical
+                    # legacy row to consume, and two delivered steers render as
+                    # one.
+                    if communication_bodies[body]:
+                        communication_bodies[body] -= 1
                     continue
                 if communication_bodies[body]:
                     # Consume this occurrence so a SECOND identical steer is

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -51,6 +51,7 @@ import asyncio
 import hashlib
 import math
 import reprlib
+from collections import Counter
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Callable, Literal
@@ -68,7 +69,7 @@ from local_operator.ansi import strip_control_sequences
 from local_operator.harness.comms import (
     HUB_COMMUNICATION_CUSTOM_TYPE,
     HUB_MESSAGE_TYPE,
-    extract_parent_message_body,
+    extract_parent_message,
 )
 from local_operator.harness.jobs import CANCELLED_BEFORE_START, TRAJECTORY_SEQ_KEY
 from local_operator.session.transcript import (
@@ -490,6 +491,17 @@ def _supersedes(new: SubagentEntry, old: SubagentEntry) -> bool:
     return False
 
 
+#: Row label per to-child communication kind, shared by the journaled-fact row
+#: and the extracted-envelope fallback so the same communication never reads as
+#: two different actions depending on which arm rendered it. An unknown kind
+#: falls back to a bare "Parent", which is honest rather than guessing.
+_PARENT_LABELS = {
+    "ask": "Parent · asked",
+    "steer": "Parent · redirected",
+    "note": "Parent",
+}
+
+
 def fold_transcript_entries(
     entries: Sequence[TranscriptEntry],
     *,
@@ -526,7 +538,13 @@ def fold_transcript_entries(
                     duration,
                 )
     communication_ids: set[str] = set()
-    communication_bodies: set[str] = set()
+    # Body text -> how many to-child facts carry it. A MULTISET, not a set: the
+    # legacy arm below CONSUMES one count per matched envelope row, so steering
+    # the same words twice ("focus on retries" after each of two failures is a
+    # normal operator move) still renders two rows. Membership-only matching
+    # collapsed N identical steers into one and under-reported history the
+    # parent actually sent.
+    communication_bodies: Counter[str] = Counter()
     # Host communication facts supersede their replay-visible custom message:
     # the former include replies and correlation while the latter contain XML
     # wrappers intended for the model, never for a person. The to-child bodies
@@ -545,7 +563,7 @@ def fold_transcript_entries(
             if details.get("direction") == "to_child":
                 fact_body = strip_control_sequences(str(details.get("body") or "")).strip()
                 if fact_body:
-                    communication_bodies.add(fact_body)
+                    communication_bodies[fact_body] += 1
     for entry in entries:
         payload = entry.payload
         if entry.type == ENTRY_CUSTOM:
@@ -558,9 +576,7 @@ def fold_transcript_entries(
                 continue
             kind = str(details.get("kind") or "")
             if direction == "to_child":
-                label = {"ask": "Parent · asked", "steer": "Parent · redirected"}.get(
-                    kind, "Parent"
-                )
+                label = _PARENT_LABELS.get(kind, "Parent")
                 folded.append(
                     SubagentEntry(f"comm:{entry.id}", "parent_message", text=f"{label}\n{body}")
                 )
@@ -592,8 +608,8 @@ def fold_transcript_entries(
         role = payload.get("role")
         text = strip_control_sequences(_content_text(payload)).strip()
         if role == "user":
-            body = extract_parent_message_body(text)
-            if body is not None:
+            parent_message = extract_parent_message(text)
+            if parent_message is not None:
                 # A persisted hub steer: model-facing XML around the parent's
                 # own words. The human-facing fact row supersedes it — by id
                 # once steers carry their fact's id, and by body text for
@@ -602,12 +618,26 @@ def fold_transcript_entries(
                 # unloaded page), render the extracted body as the parent row
                 # instead: the XML is for the model and must never reach a
                 # person either way.
-                if entry.id not in communication_ids and body not in communication_bodies:
-                    folded.append(
-                        SubagentEntry(
-                            entry.id, "parent_message", text=f"Parent · redirected\n{body}"
-                        )
+                body = parent_message.body
+                if entry.id in communication_ids:
+                    continue
+                if communication_bodies[body]:
+                    # Consume this occurrence so a SECOND identical steer is
+                    # not suppressed by the first one's fact.
+                    communication_bodies[body] -= 1
+                    continue
+                # No fact left to supersede this row. Label by the envelope's
+                # own kind rather than assuming a steer: the fallback exists
+                # for transcripts this code did not write, and a note or a
+                # question rendered as "redirected" would misreport what the
+                # parent did.
+                folded.append(
+                    SubagentEntry(
+                        entry.id,
+                        "parent_message",
+                        text=f"{_PARENT_LABELS.get(parent_message.kind, 'Parent')}\n{body}",
                     )
+                )
                 continue
             if text:
                 folded.append(SubagentEntry(entry.id, "user", text=text))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.20"
+version = "0.44.21"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/steer_fold_shot.py
+++ b/scripts/steer_fold_shot.py
@@ -14,6 +14,10 @@ they labelled as what the parent did?":
     single row; the multiset renders both.
   * A NOTE envelope with no fact in the window, which the hardcoded label
     reported as a redirection the parent never made.
+  * A MIXED-VINTAGE pair: one steer carrying its fact's id (post-upgrade) and
+    an identical one with a legacy id whose own fact is off-page. The id arm
+    used to suppress its row without spending the fact, leaving a count the
+    legacy row was then wrongly consumed by — two redirections, one row.
 
 Both must render the parent's words and never the ``<parent-message>`` XML.
 """
@@ -62,6 +66,28 @@ async def seed(directory: Path) -> Transcript:
             Message.user(
                 SubagentComms._format_to_child("Focus on retries", expects_reply=False, steer=True),
                 id=f"legacy-{index}",
+            )
+        )
+    # Mixed vintage: an id-correlated steer plus an identical legacy one. A
+    # distinct body keeps this shape's fact budget independent of the pair
+    # above, so the frame shows the two defects separately rather than as one
+    # aggregate count.
+    await transcript.append_custom(
+        HUB_COMMUNICATION_CUSTOM_TYPE,
+        {
+            "direction": "to_child",
+            "body": "Cover the timeout path",
+            "kind": "steer",
+            "communication_id": "m1",
+        },
+    )
+    for message_id in ("m1", "legacy-timeout"):
+        await transcript.append_message(
+            Message.user(
+                SubagentComms._format_to_child(
+                    "Cover the timeout path", expects_reply=False, steer=True
+                ),
+                id=message_id,
             )
         )
     # A note envelope with no fact at all: the label must follow its kind.

--- a/scripts/steer_fold_shot.py
+++ b/scripts/steer_fold_shot.py
@@ -18,6 +18,11 @@ they labelled as what the parent did?":
     an identical one with a legacy id whose own fact is off-page. The id arm
     used to suppress its row without spending the fact, leaving a count the
     legacy row was then wrongly consumed by — two redirections, one row.
+    Seeded LEGACY-FIRST, which is the order that occurs on disk: the legacy
+    row predates the id fix, so it is the older of the two. Resolving id
+    matches during the ordered walk rather than in the pre-pass renders this
+    order as a single row while the opposite order looks correct, so the frame
+    has to seed the real one to show anything.
 
 Both must render the parent's words and never the ``<parent-message>`` XML.
 """
@@ -81,7 +86,7 @@ async def seed(directory: Path) -> Transcript:
             "communication_id": "m1",
         },
     )
-    for message_id in ("m1", "legacy-timeout"):
+    for message_id in ("legacy-timeout", "m1"):
         await transcript.append_message(
             Message.user(
                 SubagentComms._format_to_child(

--- a/scripts/steer_fold_shot.py
+++ b/scripts/steer_fold_shot.py
@@ -43,7 +43,10 @@ from local_operator.harness.comms import (  # noqa: E402
     SubagentComms,
 )
 from local_operator.harness.types import Message  # noqa: E402
-from local_operator.session.transcript import Transcript  # noqa: E402
+from local_operator.session.transcript import (  # noqa: E402
+    TRANSCRIPT_FILENAME,
+    Transcript,
+)
 from local_operator.tui.app import OperatorApp  # noqa: E402
 from local_operator.tui.widgets.subagent_view import SubagentView  # noqa: E402
 from tests.unit.tui.test_band_panels import (  # noqa: E402
@@ -109,8 +112,66 @@ async def seed(directory: Path) -> Transcript:
     return transcript
 
 
-async def capture(output: Path, size: tuple[int, int], workdir: Path) -> None:
-    transcript = await seed(workdir / "child")
+# The one subdirectory of the workdir this script writes into. Everything the
+# capture needs lives under it, so it is also the only thing the script is
+# entitled to delete.
+SEED_DIRNAME = "child"
+
+# Filenames a seeded transcript directory legitimately contains: the rows
+# themselves plus the temporary file ``Transcript.compact_file`` writes beside
+# them. A seed target holding anything else was not produced by this script,
+# which is the signal that the operator pointed --workdir at real work.
+SEEDED_ARTIFACTS = frozenset({TRANSCRIPT_FILENAME, TRANSCRIPT_FILENAME + ".compact"})
+
+
+class WorkdirRefused(Exception):
+    """Raised when clearing the seed target would destroy data we did not write."""
+
+
+def prepare_seed_dir(workdir: Path, *, force: bool = False) -> Path:
+    """Return the cleared directory to seed into, refusing to destroy foreign data.
+
+    This is a dev tool run with the operator's full permissions, so its blast
+    radius is whatever path they typed: a mistyped or tab-completed ``--workdir
+    .`` used to recursively delete the whole directory before seeding. Two rules
+    keep that from costing anyone their work:
+
+    * Only ``<workdir>/child`` -- the subdirectory this script creates -- is ever
+      removed. The workdir itself and any sibling of ``child`` are left alone,
+      so pointing at a populated directory can no longer eat its contents.
+    * That subdirectory is cleared only when it looks like one of ours (absent,
+      empty, or holding nothing but transcript artifacts). Anything else is
+      refused unless the caller passes ``--force``, because reproducible frames
+      are worth a re-run and someone's data is not.
+
+    Errors are not swallowed: a clear that fails must surface, since the capture
+    would otherwise append to a stale generation and render evidence that lies.
+    """
+    seed_dir = workdir / SEED_DIRNAME
+    if seed_dir.exists() and not force:
+        if not seed_dir.is_dir():
+            raise WorkdirRefused(
+                f"{seed_dir} exists and is not a directory; refusing to remove it. "
+                "Pass --force to override, or choose another --workdir."
+            )
+        foreign = sorted(
+            child.name for child in seed_dir.iterdir() if child.name not in SEEDED_ARTIFACTS
+        )
+        if foreign:
+            listed = ", ".join(foreign[:5]) + (", ..." if len(foreign) > 5 else "")
+            raise WorkdirRefused(
+                f"{seed_dir} holds files this script did not write ({listed}); "
+                "refusing to delete them. Pass --force to override, or choose "
+                "another --workdir."
+            )
+    if seed_dir.exists():
+        shutil.rmtree(seed_dir)
+    workdir.mkdir(parents=True, exist_ok=True)
+    return seed_dir
+
+
+async def capture(output: Path, size: tuple[int, int], seed_dir: Path) -> None:
+    transcript = await seed(seed_dir)
     job = _job_with([], status="completed")
     session = FakeSession()
     session.jobs = _fake_jobs(job)
@@ -151,8 +212,18 @@ def main() -> None:
         type=Path,
         default=None,
         help=(
-            "Transcript directory to seed into. Emptied before seeding. "
+            "Parent directory to seed into. Only its 'child' subdirectory is "
+            "written to and cleared; nothing else under the path is touched. "
             "Omit to use a private temporary directory that is removed on exit."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Clear the 'child' subdirectory even when it holds files this script "
+            "did not write. Without it, a seed target containing foreign data is "
+            "refused rather than deleted."
         ),
     )
     args = parser.parse_args()
@@ -166,22 +237,33 @@ def main() -> None:
     # wrong. That silently corrupted evidence twice -- it hid a real fold defect
     # in one capture and invented a phantom 18-entry frame in another. A shot
     # tool that lies is worse than no shot tool, so isolation is not optional:
-    # a temp dir per run by default, and an explicit --workdir is cleared rather
-    # than appended to, which keeps repeated runs byte-for-byte reproducible.
+    # a temp dir per run by default, and an explicit --workdir has its seed
+    # subdirectory cleared rather than appended to, which keeps repeated runs
+    # byte-for-byte reproducible. See prepare_seed_dir for why that clear is
+    # scoped to what this script creates instead of the whole workdir.
     if args.workdir is None:
         workdir = Path(tempfile.mkdtemp(prefix="steer-fold-shot-"))
         cleanup = True
     else:
         workdir = args.workdir
-        shutil.rmtree(workdir, ignore_errors=True)
-        workdir.mkdir(parents=True)
         cleanup = False
 
     try:
-        asyncio.run(capture(args.output, (width, height), workdir))
+        seed_dir = prepare_seed_dir(workdir, force=args.force)
+    except WorkdirRefused as exc:
+        parser.error(str(exc))
+
+    try:
+        asyncio.run(capture(args.output, (width, height), seed_dir))
     finally:
         if cleanup:
-            shutil.rmtree(workdir, ignore_errors=True)
+            # Our own mkdtemp directory, so a failure here is a real leak rather
+            # than a permissions question -- report it instead of discarding it,
+            # but do not fail a capture that already succeeded.
+            try:
+                shutil.rmtree(workdir)
+            except OSError as exc:
+                print(f"warning: could not remove {workdir}: {exc}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/steer_fold_shot.py
+++ b/scripts/steer_fold_shot.py
@@ -31,7 +31,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -144,11 +146,42 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("output", type=Path)
     parser.add_argument("size", nargs="?", default="100x30")
-    parser.add_argument("--workdir", type=Path, default=Path("/tmp/steer-fold-shot"))
+    parser.add_argument(
+        "--workdir",
+        type=Path,
+        default=None,
+        help=(
+            "Transcript directory to seed into. Emptied before seeding. "
+            "Omit to use a private temporary directory that is removed on exit."
+        ),
+    )
     args = parser.parse_args()
     width, height = (int(part) for part in args.size.lower().split("x", 1))
-    args.workdir.mkdir(parents=True, exist_ok=True)
-    asyncio.run(capture(args.output, (width, height), args.workdir))
+
+    # This script exists to produce trustworthy visual evidence, so each
+    # invocation MUST seed a transcript that contains only what `seed` writes.
+    # An earlier version reused one fixed workdir and appended to whatever was
+    # already there: a second run rendered two stacked generations of the same
+    # conversation, and the fold's counts across the generation boundary were
+    # wrong. That silently corrupted evidence twice -- it hid a real fold defect
+    # in one capture and invented a phantom 18-entry frame in another. A shot
+    # tool that lies is worse than no shot tool, so isolation is not optional:
+    # a temp dir per run by default, and an explicit --workdir is cleared rather
+    # than appended to, which keeps repeated runs byte-for-byte reproducible.
+    if args.workdir is None:
+        workdir = Path(tempfile.mkdtemp(prefix="steer-fold-shot-"))
+        cleanup = True
+    else:
+        workdir = args.workdir
+        shutil.rmtree(workdir, ignore_errors=True)
+        workdir.mkdir(parents=True)
+        cleanup = False
+
+    try:
+        asyncio.run(capture(args.output, (width, height), workdir))
+    finally:
+        if cleanup:
+            shutil.rmtree(workdir, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/scripts/steer_fold_shot.py
+++ b/scripts/steer_fold_shot.py
@@ -1,0 +1,124 @@
+"""Capture the subagent view over a transcript that exercises the steer folds.
+
+Run from the worktree root:
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/steer_fold_shot.py OUT.svg [COLSxROWS]
+
+Seeds the two states the legacy correlation arm gets wrong, so a rendered
+frame answers "how many redirections does the reader actually see, and are
+they labelled as what the parent did?":
+
+  * TWO identical legacy steers behind ONE communication fact (the second
+    fact sits on an unloaded page). Membership-only dedup collapsed these to a
+    single row; the multiset renders both.
+  * A NOTE envelope with no fact in the window, which the hardcoded label
+    reported as a redirection the parent never made.
+
+Both must render the parent's words and never the ``<parent-message>`` XML.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from local_operator.harness.comms import (  # noqa: E402
+    HUB_COMMUNICATION_CUSTOM_TYPE,
+    SubagentComms,
+)
+from local_operator.harness.types import Message  # noqa: E402
+from local_operator.session.transcript import Transcript  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.subagent_view import SubagentView  # noqa: E402
+from tests.unit.tui.test_band_panels import (  # noqa: E402
+    FakeSession,
+    _async_factory,
+    _fake_jobs,
+)
+from tests.unit.tui.test_subagent_view import _job_with  # noqa: E402
+
+
+async def seed(directory: Path) -> Transcript:
+    transcript = Transcript(directory)
+    await transcript.append_message(Message.user("Fix the flaky retry test"))
+    # One fact for two identical steers: the page-boundary shape the fallback
+    # arm exists for.
+    await transcript.append_custom(
+        HUB_COMMUNICATION_CUSTOM_TYPE,
+        {
+            "direction": "to_child",
+            "body": "Focus on retries",
+            "kind": "steer",
+            "communication_id": "s-unmatched",
+        },
+    )
+    for index in range(2):
+        await transcript.append_message(
+            Message.user(
+                SubagentComms._format_to_child("Focus on retries", expects_reply=False, steer=True),
+                id=f"legacy-{index}",
+            )
+        )
+    # A note envelope with no fact at all: the label must follow its kind.
+    await transcript.append_message(
+        Message.user(
+            SubagentComms._format_to_child(
+                "The staging box is down until 14:00", expects_reply=False, steer=False
+            ),
+            id="lonely-note",
+        )
+    )
+    return transcript
+
+
+async def capture(output: Path, size: tuple[int, int], workdir: Path) -> None:
+    transcript = await seed(workdir / "child")
+    job = _job_with([], status="completed")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=size) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        app._refresh_band()
+        await pilot.pause()
+        app._open_subagent_view(job.id)
+        view = app.query_one(SubagentView)
+        for _ in range(80):
+            await pilot.pause()
+            if view._history_entries:
+                break
+        for _ in range(4):
+            await pilot.pause()
+        app.save_screenshot(str(output))
+        rows = view.rendered_rows()
+        folded = [(entry.kind, entry.text) for entry in view._history_entries]
+        print(f"size={size[0]}x{size[1]} entries={len(folded)}")
+        for kind, text in folded:
+            print(f"  {kind:16} {text!r}")
+        print(f"  XML LEAKED: {'<parent-message>' in ' '.join(rows)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output", type=Path)
+    parser.add_argument("size", nargs="?", default="100x30")
+    parser.add_argument("--workdir", type=Path, default=Path("/tmp/steer-fold-shot"))
+    args = parser.parse_args()
+    width, height = (int(part) for part in args.size.lower().split("x", 1))
+    args.workdir.mkdir(parents=True, exist_ok=True)
+    asyncio.run(capture(args.output, (width, height), args.workdir))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import asyncio
 import json
 import time
-from collections.abc import Sequence
 from typing import Any, Callable
 
 import pytest
@@ -29,7 +28,6 @@ from local_operator.harness.types import (
     AsideResult,
     ChatRequest,
     CustomMessage,
-    ImageContent,
     Message,
     MessageEndEvent,
     ModelSpec,
@@ -259,13 +257,15 @@ class FakeChild:
     def __init__(self) -> None:
         self.asides: list[Callable[[], AsideResult]] = []
         self.steers: list[str] = []
+        self.steer_messages: list[Message] = []
         self.handlers: list[Callable[[AgentEvent], Any]] = []
 
     def queue_aside(self, thunk: Callable[[], AsideResult]) -> None:
         self.asides.append(thunk)
 
-    def steer(self, text: str, images: Sequence[ImageContent] | None = None) -> None:
-        self.steers.append(text)
+    def steer_message(self, message: Message) -> None:
+        self.steers.append(message.text)
+        self.steer_messages.append(message)
 
     def subscribe(self, handler: Callable[[AgentEvent], Any]) -> Callable[[], None]:
         self.handlers.append(handler)
@@ -695,6 +695,39 @@ def test_steer_is_a_real_user_message_not_an_aside():
     assert child.asides == []
     assert "stop after the first failing test" in child.steers[0]
     assert "changes your instructions" in child.steers[0]
+
+
+def test_steer_passes_the_journaled_communication_id_to_the_child():
+    """The persisted steer row must carry the SAME id as the journaled
+    communication fact.
+
+    Human-facing surfaces (the TUI subagent view, the mobile projection)
+    correlate the fact with the replay-visible row by id and render the fact
+    instead of the model-facing ``<parent-message>`` envelope. Before this fix
+    ``comms.steer`` went through ``steer`` — which mints a fresh Message id —
+    so the correlation could never match and the envelope rendered beside the
+    fact. The fix routes through the identity-preserving ``steer_message``
+    seam with a caller-built Message carrying the fact's id.
+    """
+    comms, _jobs, child, _parent = wire()
+
+    journaled_ids: list[str | None] = []
+    original_journal = comms._journal_communication
+
+    def record_journal(record, *, direction, body, communication_id=None, **kwargs):
+        journaled_ids.append(communication_id)
+        return original_journal(
+            record, direction=direction, body=body, communication_id=communication_id, **kwargs
+        )
+
+    comms._journal_communication = record_journal  # type: ignore[method-assign]
+
+    delivery = comms.steer("job-1", "stop after the first failing test")
+
+    assert delivery.outcome == "injected"
+    assert len(journaled_ids) == 1
+    assert journaled_ids[0] is not None
+    assert [message.id for message in child.steer_messages] == [journaled_ids[0]]
 
 
 def test_resolve_addresses_by_id_label_and_all():

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -19,7 +19,11 @@ from typing import Any, Callable
 
 import pytest
 
-from local_operator.harness.comms import HUB_MESSAGE_TYPE, SubagentComms
+from local_operator.harness.comms import (
+    HUB_MESSAGE_TYPE,
+    SubagentComms,
+    extract_parent_message,
+)
 from local_operator.harness.subagent import MCP_DENIED_ATTR
 from local_operator.harness.types import (
     AgentEvent,
@@ -728,6 +732,48 @@ def test_steer_passes_the_journaled_communication_id_to_the_child():
     assert len(journaled_ids) == 1
     assert journaled_ids[0] is not None
     assert [message.id for message in child.steer_messages] == [journaled_ids[0]]
+
+
+@pytest.mark.parametrize(
+    ("steer", "expects_reply", "kind"),
+    [(True, False, "steer"), (False, True, "ask"), (False, False, "note")],
+)
+def test_every_envelope_the_builder_emits_round_trips_through_the_parser(
+    steer: bool, expects_reply: bool, kind: str
+):
+    """The builder and its inverse share the tag and instruction constants, so
+    every envelope `_format_to_child` emits must parse back to its own kind and
+    the exact body. This is the guard that keeps the pair from drifting: a
+    reworded instruction that missed `TO_CHILD_INSTRUCTIONS` fails here rather
+    than silently disabling extraction on every new transcript."""
+    envelope = SubagentComms._format_to_child(
+        "Focus on retries", expects_reply=expects_reply, steer=steer
+    )
+
+    parsed = extract_parent_message(envelope)
+
+    assert parsed is not None
+    assert (parsed.kind, parsed.body) == (kind, "Focus on retries")
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "just a normal message",
+        # The tag shape a HUMAN can type: no builder preamble, so not ours.
+        "<parent-message>\nwhy does my log show this?\n\nsecret plan\n</parent-message>",
+        # Right tags, no blank-line separator — not the builder's shape.
+        "<parent-message>\nFocus on retries</parent-message>",
+        # Opening tag with no close.
+        "<parent-message>\nThis changes your instructions.\n\nFocus on retries",
+    ],
+)
+def test_text_the_builder_did_not_emit_is_not_extracted(text: str):
+    """Extraction is keyed on the exact instruction preamble, not on tag shape
+    alone. A user asking about this very wrapper must keep their own words:
+    rewriting them as a parent communication would misattribute a human's
+    message and strip its text."""
+    assert extract_parent_message(text) is None
 
 
 def test_resolve_addresses_by_id_label_and_all():

--- a/tests/unit/mobile/test_projection.py
+++ b/tests/unit/mobile/test_projection.py
@@ -578,6 +578,66 @@ def test_note_peer_message_appends_optimistic_row() -> None:
     assert row.details["sender"]["pid"] == 7
 
 
+def _steer_envelope(body: str) -> str:
+    """The model-facing wrapper ``SubagentComms._format_to_child`` builds for a
+    steer, restated here so the fold tests pin the render contract against the
+    exact shape a persisted steer row carries."""
+    return (
+        "<parent-message>\n"
+        "This changes your instructions. Apply it from now on, and drop work it "
+        "makes pointless.\n\n"
+        f"{body}\n"
+        "</parent-message>"
+    )
+
+
+def test_history_fold_renders_a_persisted_steer_as_the_parents_words() -> None:
+    """A hub steer persists as a plain user Message whose text is the
+    model-facing envelope. The phone must show the parent's own words as a
+    parent_message row, never the XML — the phone's history fold sees only
+    LLM-visible messages (the journaled fact is a custom row that never
+    replays), so body extraction is its only path."""
+    from local_operator.mobile.projection import fold_messages_to_entries
+
+    steer = Message.user(_steer_envelope("Focus on retries"), id="steer-1")
+    entries = fold_messages_to_entries([Message.user("do the thing"), steer])
+
+    assert [(entry.kind, entry.text) for entry in entries] == [
+        ("user", "do the thing"),
+        ("parent_message", "Focus on retries"),
+    ]
+    assert "<parent-message>" not in " ".join(entry.text for entry in entries)
+
+
+def test_fold_history_renders_a_persisted_steer_as_the_parents_words() -> None:
+    """The attach rebuild applies the same rule as the lazy-load fold, so an
+    attaching phone and a paged history agree about the row."""
+    fold = make_fold()
+    fold.fold_history([Message.user(_steer_envelope("Focus on retries"), id="steer-1")])
+
+    rows = fold.projection.transcript
+    assert len(rows) == 1
+    assert rows[0].kind == "parent_message"
+    assert rows[0].text == "Focus on retries"
+    assert "<parent-message>" not in rows[0].text
+
+
+def test_a_live_delivered_steer_never_renders_the_envelope() -> None:
+    """A hub steer delivered mid-turn announces itself as a user
+    MessageStartEvent carrying the envelope text. The fold must paint the
+    parent's words, not the XML, exactly like the durable folds."""
+    fold = make_fold()
+    message = Message.user(_steer_envelope("Focus on retries"), id="steer-1")
+
+    added = fold.absorb_user_event(message)
+
+    assert added is True
+    row = fold.projection.transcript[-1]
+    assert row.kind == "parent_message"
+    assert row.text == "Focus on retries"
+    assert "<parent-message>" not in row.text
+
+
 def test_transcript_is_capped_from_the_front() -> None:
     fold = make_fold()
     for i in range(PROJECTION_TRANSCRIPT_LIMIT + 25):

--- a/tests/unit/mobile/test_projection.py
+++ b/tests/unit/mobile/test_projection.py
@@ -638,6 +638,43 @@ def test_a_live_delivered_steer_never_renders_the_envelope() -> None:
     assert "<parent-message>" not in row.text
 
 
+def test_a_phone_typed_envelope_reconciles_its_echo_instead_of_doubling() -> None:
+    """A message the phone sent that happens to carry the envelope shape must
+    reconcile against its optimistic echo, not append beside it.
+
+    The envelope branch used to return before the pending-echo pop, so the row
+    rendered twice under ONE id — and the stranded echo still displayed the raw
+    XML this path exists to suppress. Two rows sharing an id is also bad input
+    for the web client's list reconciliation.
+    """
+    fold = make_fold()
+    envelope = _steer_envelope("Focus on retries")
+    fold.note_user_message(envelope, steer=True, message_id="cmd-1")
+
+    added = fold.absorb_user_event(Message.user(envelope, id="cmd-1"))
+
+    assert added is False
+    rows = fold.projection.transcript
+    assert len(rows) == 1
+    assert (rows[0].id, rows[0].kind, rows[0].text) == (
+        "cmd-1",
+        "parent_message",
+        "Focus on retries",
+    )
+    assert "<parent-message>" not in rows[0].text
+
+
+def test_a_user_quoting_the_envelope_keeps_their_own_words() -> None:
+    """Extraction requires the builder's exact instruction preamble, so a human
+    quoting the wrapper keeps their words and their ``user`` row."""
+    from local_operator.mobile.projection import fold_messages_to_entries
+
+    quoted = "<parent-message>\nwhy does my log show this?\n\nsecret plan\n</parent-message>"
+    entries = fold_messages_to_entries([Message.user(quoted, id="human-1")])
+
+    assert [(entry.kind, entry.text) for entry in entries] == [("user", quoted)]
+
+
 def test_transcript_is_capped_from_the_front() -> None:
     fold = make_fold()
     for i in range(PROJECTION_TRANSCRIPT_LIMIT + 25):

--- a/tests/unit/scripts/test_steer_fold_shot.py
+++ b/tests/unit/scripts/test_steer_fold_shot.py
@@ -1,0 +1,79 @@
+"""The shot script must clear only what it seeded, never the operator's data.
+
+``--workdir`` is a path the operator types, and this script runs with their full
+permissions, so an unguarded recursive delete of that path is a data-loss bug
+rather than a tidiness question: a mistyped ``--workdir .`` used to remove the
+directory's whole contents before seeding. These tests pin the guard that keeps
+the blast radius equal to the one subdirectory the script actually creates.
+"""
+
+import pytest
+
+from scripts.steer_fold_shot import SEED_DIRNAME, WorkdirRefused, prepare_seed_dir
+
+
+def test_sibling_data_in_the_workdir_survives_seeding(tmp_path):
+    """Only ``<workdir>/child`` is cleared -- siblings are none of our business."""
+    precious = tmp_path / "precious"
+    precious.mkdir()
+    (precious / "data.txt").write_text("irreplaceable", encoding="utf-8")
+
+    seed_dir = prepare_seed_dir(tmp_path)
+
+    assert seed_dir == tmp_path / SEED_DIRNAME
+    assert (precious / "data.txt").read_text(encoding="utf-8") == "irreplaceable"
+
+
+def test_a_stale_seed_dir_of_ours_is_cleared(tmp_path):
+    """Repeated runs must not stack generations, so our own artifacts go."""
+    seed_dir = tmp_path / SEED_DIRNAME
+    seed_dir.mkdir()
+    (seed_dir / "transcript.jsonl").write_text("stale row\n", encoding="utf-8")
+
+    prepare_seed_dir(tmp_path)
+
+    assert not seed_dir.exists()
+
+
+def test_foreign_files_in_the_seed_dir_are_refused(tmp_path):
+    """A seed target we did not write is the signal that --workdir is wrong."""
+    seed_dir = tmp_path / SEED_DIRNAME
+    seed_dir.mkdir()
+    (seed_dir / "notes.txt").write_text("someone's work", encoding="utf-8")
+
+    with pytest.raises(WorkdirRefused, match="notes.txt"):
+        prepare_seed_dir(tmp_path)
+
+    assert (seed_dir / "notes.txt").read_text(encoding="utf-8") == "someone's work"
+
+
+def test_force_clears_a_seed_dir_holding_foreign_files(tmp_path):
+    """The escape hatch stays available, but only when asked for explicitly."""
+    seed_dir = tmp_path / SEED_DIRNAME
+    seed_dir.mkdir()
+    (seed_dir / "notes.txt").write_text("someone's work", encoding="utf-8")
+
+    prepare_seed_dir(tmp_path, force=True)
+
+    assert not seed_dir.exists()
+
+
+def test_a_seed_path_that_is_a_file_is_refused(tmp_path):
+    """Never unlink a non-directory sitting where the seed dir belongs."""
+    seed_path = tmp_path / SEED_DIRNAME
+    seed_path.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(WorkdirRefused, match="not a directory"):
+        prepare_seed_dir(tmp_path)
+
+    assert seed_path.read_text(encoding="utf-8") == "not a directory"
+
+
+def test_a_missing_workdir_is_created(tmp_path):
+    """Seeding into a fresh path stays a one-liner for the caller."""
+    workdir = tmp_path / "nested" / "workdir"
+
+    seed_dir = prepare_seed_dir(workdir)
+
+    assert workdir.is_dir()
+    assert not seed_dir.exists()

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -1575,6 +1575,132 @@ async def test_a_persisted_steer_never_renders_the_model_facing_envelope(
 
 
 @pytest.mark.asyncio
+async def test_two_identical_legacy_steers_render_two_rows(tmp_path) -> None:
+    """Steering the same words twice must render TWO rows.
+
+    The legacy (body-text) correlation arm used a set with a membership-only
+    check, so a second steer of identical text matched the FIRST steer's fact
+    and was dropped: two redirections delivered, one shown. The fact multiset
+    is consumed one count per matched row, which keeps the rendered count equal
+    to the delivered count. Legacy ids throughout, since that is the only
+    generation where body text does the matching.
+    """
+    transcript = Transcript(tmp_path / "child")
+    # ONE fact for TWO envelope rows: the page-boundary shape the fallback arm
+    # exists for (the second steer's fact sits on an unloaded page). This is
+    # what exposes the collapse — with a fact per row the set and the multiset
+    # agree, because the fact rows alone already make up the count.
+    await transcript.append_custom(
+        HUB_COMMUNICATION_CUSTOM_TYPE,
+        {
+            "direction": "to_child",
+            "body": "Focus on retries",
+            "kind": "steer",
+            "communication_id": "s-unmatched",
+        },
+    )
+    for index in range(2):
+        await transcript.append_message(
+            Message.user(_steer_envelope("Focus on retries"), id=f"legacy-{index}")
+        )
+
+    job = _job_with([], status="completed")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, job)
+        await _wait_history(pilot, view)
+
+        redirected = [
+            entry.text
+            for entry in view._history_entries
+            if entry.text == "Parent · redirected\nFocus on retries"
+        ]
+        assert redirected == [
+            "Parent · redirected\nFocus on retries",
+            "Parent · redirected\nFocus on retries",
+        ]
+        assert "<parent-message>" not in " ".join(view.rendered_rows())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("steer", "expects_reply", "label"),
+    [
+        (True, False, "Parent · redirected"),
+        (False, True, "Parent · asked"),
+        (False, False, "Parent"),
+    ],
+)
+async def test_the_no_fact_fallback_labels_an_envelope_by_its_own_kind(
+    tmp_path, steer: bool, expects_reply: bool, label: str
+) -> None:
+    """The fallback arm — an envelope row whose communication fact is NOT in
+    the loaded window (it may sit on an unloaded page) — renders the extracted
+    body under the label matching the envelope's OWN kind.
+
+    It used to hardcode ``Parent · redirected`` for all three, so a note or a
+    question would have been reported as a redirection the parent never made.
+    The instruction line names the kind, so the fallback has no need to guess.
+    This is also the only direct coverage of the arm itself: the correlated and
+    legacy-with-fact cases both take the suppression path instead.
+    """
+    transcript = Transcript(tmp_path / "child")
+    envelope = SubagentComms._format_to_child(
+        "Focus on retries", expects_reply=expects_reply, steer=steer
+    )
+    await transcript.append_message(Message.user(envelope, id="lonely-envelope"))
+
+    job = _job_with([], status="completed")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, job)
+        await _wait_history(pilot, view)
+
+        parents = [entry.text for entry in view._history_entries if entry.kind == "parent_message"]
+        assert parents == [f"{label}\nFocus on retries"]
+        assert "<parent-message>" not in " ".join(view.rendered_rows())
+
+
+@pytest.mark.asyncio
+async def test_a_user_quoting_the_envelope_keeps_their_own_words(tmp_path) -> None:
+    """A human asking about the wrapper is NOT a parent communication.
+
+    Extraction requires the exact instruction preamble the builder emits, so a
+    user who pastes the tag shape into their own message keeps their words and
+    their ``user`` row rather than having them re-rendered as something the
+    parent said.
+    """
+    transcript = Transcript(tmp_path / "child")
+    quoted = "<parent-message>\nwhy does my log show this?\n\nsecret plan\n</parent-message>"
+    await transcript.append_message(Message.user(quoted, id="human-1"))
+
+    job = _job_with([], status="completed")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, job)
+        await _wait_history(pilot, view)
+
+        rows = [(entry.kind, entry.text) for entry in view._history_entries]
+        assert ("user", quoted) in rows
+        assert not [row for row in rows if row[0] == "parent_message"]
+
+
+@pytest.mark.asyncio
 async def test_history_unavailable_and_error_retry_keep_trajectory_fallback(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -1628,6 +1628,61 @@ async def test_two_identical_legacy_steers_render_two_rows(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_mixed_vintage_pair_of_identical_steers_renders_two_rows(tmp_path) -> None:
+    """A child steered identically BEFORE and AFTER the id fix shows two rows.
+
+    The two correlation arms draw on one budget: ``communication_bodies`` counts
+    the facts available to supersede a row. The id arm suppressed its row
+    without spending the matching fact's count, so the leftover count was still
+    on the books when the older, id-less envelope carrying the same words
+    arrived — and that row was suppressed too, by a fact already consumed by its
+    successor. Two redirections delivered, one rendered.
+
+    This is the mixed-vintage shape specifically: one fact carries a
+    ``communication_id`` matching its own row, while the legacy row's own fact
+    sits on an unloaded page (the page boundary the fallback arm exists for).
+    """
+    transcript = Transcript(tmp_path / "child")
+    await transcript.append_custom(
+        HUB_COMMUNICATION_CUSTOM_TYPE,
+        {
+            "direction": "to_child",
+            "body": "Focus on retries",
+            "kind": "steer",
+            "communication_id": "m1",
+        },
+    )
+    # Post-upgrade: the envelope carries its fact's id, so it correlates by id.
+    await transcript.append_message(Message.user(_steer_envelope("Focus on retries"), id="m1"))
+    # Pre-upgrade: same words, unrelated id, and no fact of its own in the
+    # window. It must fall through to the labelled fallback, not be eaten by
+    # the id-matched row's fact.
+    await transcript.append_message(Message.user(_steer_envelope("Focus on retries"), id="legacy"))
+
+    job = _job_with([], status="completed")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, job)
+        await _wait_history(pilot, view)
+
+        redirected = [
+            entry.text
+            for entry in view._history_entries
+            if entry.text == "Parent · redirected\nFocus on retries"
+        ]
+        assert redirected == [
+            "Parent · redirected\nFocus on retries",
+            "Parent · redirected\nFocus on retries",
+        ]
+        assert "<parent-message>" not in " ".join(view.rendered_rows())
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("steer", "expects_reply", "label"),
     [

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -1628,15 +1628,27 @@ async def test_two_identical_legacy_steers_render_two_rows(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_mixed_vintage_pair_of_identical_steers_renders_two_rows(tmp_path) -> None:
+@pytest.mark.parametrize("legacy_first", [True, False])
+async def test_a_mixed_vintage_pair_of_identical_steers_renders_two_rows(
+    tmp_path, legacy_first: bool
+) -> None:
     """A child steered identically BEFORE and AFTER the id fix shows two rows.
 
-    The two correlation arms draw on one budget: ``communication_bodies`` counts
-    the facts available to supersede a row. The id arm suppressed its row
-    without spending the matching fact's count, so the leftover count was still
-    on the books when the older, id-less envelope carrying the same words
-    arrived — and that row was suppressed too, by a fact already consumed by its
-    successor. Two redirections delivered, one rendered.
+    ``communication_bodies`` is a budget of facts available to supersede a row,
+    and a fact must be spent at most once and only by ITS OWN row. Having both
+    correlation arms decrement that budget during the ordered walk broke the
+    second half of that invariant: whichever row the walk reached first spent
+    the other's fact. So the fix is order-dependent unless the id matches are
+    resolved in the pre-pass, which is why this case is parametrised on the row
+    order rather than seeded in one.
+
+    ``legacy_first`` is the ordering that actually occurs on disk and the one
+    that stayed broken after the first attempt: the legacy row is OLDER — it
+    was persisted before steers carried their fact's id — so it is reached
+    first, consumes the id-correlated row's fact by body text, and the id row is
+    then suppressed on identity anyway. Two redirections delivered, one
+    rendered. Durable page boundaries are arbitrary, so neither order may be
+    assumed.
 
     This is the mixed-vintage shape specifically: one fact carries a
     ``communication_id`` matching its own row, while the legacy row's own fact
@@ -1653,11 +1665,72 @@ async def test_a_mixed_vintage_pair_of_identical_steers_renders_two_rows(tmp_pat
         },
     )
     # Post-upgrade: the envelope carries its fact's id, so it correlates by id.
-    await transcript.append_message(Message.user(_steer_envelope("Focus on retries"), id="m1"))
     # Pre-upgrade: same words, unrelated id, and no fact of its own in the
     # window. It must fall through to the labelled fallback, not be eaten by
     # the id-matched row's fact.
-    await transcript.append_message(Message.user(_steer_envelope("Focus on retries"), id="legacy"))
+    order = ["legacy", "m1"] if legacy_first else ["m1", "legacy"]
+    for message_id in order:
+        await transcript.append_message(
+            Message.user(_steer_envelope("Focus on retries"), id=message_id)
+        )
+
+    job = _job_with([], status="completed")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, job)
+        await _wait_history(pilot, view)
+
+        redirected = [
+            entry.text
+            for entry in view._history_entries
+            if entry.text == "Parent · redirected\nFocus on retries"
+        ]
+        assert redirected == [
+            "Parent · redirected\nFocus on retries",
+            "Parent · redirected\nFocus on retries",
+        ]
+        assert "<parent-message>" not in " ".join(view.rendered_rows())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("legacy_first", [True, False])
+async def test_two_facts_for_an_id_row_and_a_legacy_row_render_two_rows(
+    tmp_path, legacy_first: bool
+) -> None:
+    """Each of two identical steers has its OWN fact loaded: still two rows.
+
+    This is the case that rules out the cheap repair of finding 11 — withholding
+    from the legacy budget every fact whose ``communication_id`` names a loaded
+    row. That fixes the legacy-first pair above but over-withholds here: the id
+    row's fact is correctly held back, the legacy row then finds nothing left to
+    spend even though its own fact IS loaded, and it renders a third row beside
+    the two facts. Withholding has to be per-fact — one fact reserved for the
+    one row that claims it — not per-body, which is only visible when the count
+    of facts and the count of claiming rows differ.
+    """
+    transcript = Transcript(tmp_path / "child")
+    for communication_id in ("b1", "b2"):
+        await transcript.append_custom(
+            HUB_COMMUNICATION_CUSTOM_TYPE,
+            {
+                "direction": "to_child",
+                "body": "Focus on retries",
+                "kind": "steer",
+                "communication_id": communication_id,
+            },
+        )
+    # Only `b1` has a row carrying its id; `b2`'s row predates the id fix, so
+    # `b2` is the fact the body-text arm must be left to spend on it.
+    order = ["legacy", "b1"] if legacy_first else ["b1", "legacy"]
+    for message_id in order:
+        await transcript.append_message(
+            Message.user(_steer_envelope("Focus on retries"), id=message_id)
+        )
 
     job = _job_with([], status="completed")
     session = FakeSession()

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -1514,6 +1514,66 @@ async def test_durable_communications_are_human_facing_and_correlated(tmp_path) 
         assert "<parent-message>" not in " ".join(view.rendered_rows())
 
 
+def _steer_envelope(body: str) -> str:
+    """The model-facing wrapper ``SubagentComms._format_to_child`` builds for a
+    steer, restated here so the view tests pin the render contract against the
+    exact shape a persisted steer row carries."""
+    return (
+        "<parent-message>\n"
+        "This changes your instructions. Apply it from now on, and drop work it "
+        "makes pointless.\n\n"
+        f"{body}\n"
+        "</parent-message>"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("correlated", [True, False])
+async def test_a_persisted_steer_never_renders_the_model_facing_envelope(
+    tmp_path, correlated: bool
+) -> None:
+    """A hub steer persists as a plain user Message carrying the model-facing
+    ``<parent-message>`` XML. The human-facing fact supersedes it, so the page
+    shows exactly one ``Parent · redirected`` row and never the XML.
+
+    ``correlated`` covers both transcript generations: a steer persisted after
+    the id fix carries its fact's id (the primary correlation), while a LEGACY
+    steer carries a fresh id that can only match by body text. Both must render
+    one fact row and no envelope.
+    """
+    transcript = Transcript(tmp_path / "child")
+    await transcript.append_custom(
+        HUB_COMMUNICATION_CUSTOM_TYPE,
+        {
+            "direction": "to_child",
+            "body": "Focus on retries",
+            "kind": "steer",
+            "communication_id": "s1",
+        },
+    )
+    steer_id = "s1" if correlated else "legacy-uuid"
+    await transcript.append_message(Message.user(_steer_envelope("Focus on retries"), id=steer_id))
+
+    job = _job_with([], status="completed")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, job)
+        await _wait_history(pilot, view)
+
+        redirected = [
+            entry.text
+            for entry in view._history_entries
+            if entry.text == "Parent · redirected\nFocus on retries"
+        ]
+        assert redirected == ["Parent · redirected\nFocus on retries"]
+        assert "<parent-message>" not in " ".join(view.rendered_rows())
+
+
 @pytest.mark.asyncio
 async def test_history_unavailable_and_error_retry_keep_trajectory_fallback(
     tmp_path, monkeypatch


### PR DESCRIPTION
# PR Description

## Summary of Changes

A `hub steer` from the parent rendered **twice** in the subagent transcript view: once as the human-facing fact row (`Parent · redirected\n<body>`) and once as a raw user-message block showing the model-facing internal envelope:

```
<parent-message>
This changes your instructions. Apply it from now on, and drop work it makes pointless.

<body>
</parent-message>
```

The XML is model-facing and must never be shown to a person.

### Root cause

`SubagentComms.steer` journaled the human-facing communication fact under `message.id`, then called `record.child.steer(str(message.details["text"]))` — which builds a **fresh** `Message` with a new id. The persisted steer row is a plain `role=user` Message whose id therefore never equals the fact's `communication_id`, so the view's id-based dedup could not match them and both rows rendered. (`send`/`ask` are unaffected: they persist the `CustomMessage` itself, whose id equals the fact's id.)

### The fix

1. **Correlation** — route the steer through the identity-preserving `steer_message` seam with a caller-built `Message.user(..., id=message.id)`, so the persisted row carries the same id as the journaled fact. The TUI view and mobile projection already correlate by id and render the fact instead of the envelope.
2. **Defense-in-depth for legacy transcripts** — a new shared helper `extract_parent_message_body` is the single inverse of the envelope builder (`_format_to_child`). Both human-facing surfaces use it so the XML can never reach a person even when correlation fails:
   - **TUI** (`fold_transcript_entries`): an envelope user row is skipped when its fact is present (by id, then by body text for pre-fix transcripts whose ids never match); with no fact in the loaded window it renders the extracted body as a `Parent · redirected` row instead of the XML.
   - **Mobile** (`fold_messages_to_entries`, `fold_history`, `absorb_user_event`): the phone sees only LLM-visible messages (the fact is a custom row that never replays), so body extraction is its only path — the durable folds and the live delivery path all render `parent_message` with the extracted body, never the envelope.

The helper lives in `harness/comms.py` beside its builder so the two cannot drift apart.

## Testing Evidence

### Reproduced the leak, then confirmed the fix, through the real render path

Drove the real `OperatorApp` + `SubagentView` over a transcript seeded with exactly what `comms.steer` writes (the fact + a plain user row holding the envelope with a **fresh** id), and captured rendered rows before and after.

**Before** (envelope leaks beside the fact):

```
'Parent · redirected\nFocus on retries'
'<parent-message>\nThis changes your instructions. Apply it from now on, and drop work it makes pointless.\n\nFocus on retries\n</parent-message>'
envelope visible: True
```

**After** (one fact row, no XML):

```
'Parent · redirected\nFocus on retries'
envelope visible: False
fact visible: True
```

### New tests

- `test_steer_passes_the_journaled_communication_id_to_the_child` — the child receives the steer with `message_id == communication_id`.
- `test_a_persisted_steer_never_renders_the_model_facing_envelope[correlated=True/False]` — exactly one `Parent · redirected` row and no `<parent-message>` for both a correlated-id steer and a **legacy** unrelated-id steer.
- `test_history_fold_renders_a_persisted_steer_as_the_parents_words`, `test_fold_history_renders_a_persisted_steer_as_the_parents_words`, `test_a_live_delivered_steer_never_renders_the_envelope` — the mobile durable folds and the live delivery path all yield `parent_message` with the body, never the XML.

```
$ pytest tests/unit/harness/test_comms.py tests/unit/tui/test_subagent_view.py tests/unit/mobile/test_projection.py -q
267 passed in 15.51s
```

### Full unit suite

```
$ pytest tests/unit -q
1 failed, 9876 passed, 15 skipped in 486.83s
```

The single failure, `test_steering_approval.py::test_typing_a_steer_at_a_live_prompt_never_answers_it`, is **pre-existing and unrelated**: it fails identically on this branch's base commit (`7b973190`) and on `origin/main`, it imports none of the modules this PR touches, and the current `main` CI run fails on a *different* test (`test_resume_subagents_todos`), so this one passes in CI.

### Gates (run over the whole tree, exactly as CI)

```
$ .venv/bin/python -m flake8 .                          # clean
$ uvx --from black==26.1.0 black --check .              # 686 files unchanged
$ uvx isort==5.13.2 --check .                           # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .   # 0 errors
```

## Non-goals

- Not changing `Session.steer` / `SessionProtocol.steer` / the remote facade signatures. An earlier cut widened `steer` with a `message_id` keyword, but that broke structural conformance of ~85 `FakeSession` test doubles (pyright went 0 → 995 errors). The identity-preserving `steer_message` seam already exists on all three and carries the id without touching the protocol.
- Not fixing the pre-existing `test_typing_a_steer_at_a_live_prompt_never_answers_it` failure (reproduces on base).

## Related

- Version bump: `0.44.11` → `0.44.12` (patch — bug fix).
