### PR TITLE
perf(mobile): make relay session loading fast and mark unread sessions

### DIFF
--- a/bench/relay-e2e-dual.json
+++ b/bench/relay-e2e-dual.json
@@ -1,0 +1,144 @@
+--- old-4098 ---
+list /api/sessions ms: [1082.5, 625.6, 623.4]
+LIVE 720772cc779c: sse=22.7ms hist=6.5ms
+LIVE b6d4fc528557: sse=11.0ms hist=12.4ms
+DURABLE 2e4a863a3a41: sse=18.9ms hist=10.5ms
+DURABLE e386029c175a: sse=5.9ms hist=5.2ms
+DURABLE e9aeb38fa6af: sse=2.0ms hist=2.0ms
+DURABLE dccdd2348af8: sse=69.8ms hist=25.9ms
+--- new-4198 ---
+list /api/sessions ms: [72.0, 1.6, 1.0]
+LIVE e2ad0e43382d: sse=965.0ms hist=4.2ms
+LIVE 720772cc779c: sse=40.4ms hist=3.5ms
+DURABLE 2e4a863a3a41: sse=7.4ms hist=4.2ms
+DURABLE e386029c175a: sse=5.2ms hist=2.7ms
+DURABLE 4787cd11f841: sse=43.7ms hist=3.0ms
+DURABLE e9aeb38fa6af: sse=1.9ms hist=1.9ms
+{
+ "old-4098": {
+  "list_ms": [
+   1082.5,
+   625.6,
+   623.4
+  ],
+  "rows": [
+   {
+    "group": "LIVE",
+    "session_id": "720772cc779c",
+    "name": "Investigate Qwen Session Naming",
+    "sse_first_frame_ms": 22.7,
+    "sse_frame_kb": 96.5,
+    "history_ms": 6.5,
+    "history_kb": 105.7
+   },
+   {
+    "group": "LIVE",
+    "session_id": "b6d4fc528557",
+    "name": "Debug work queue creation error in KOHO ",
+    "sse_first_frame_ms": 11.0,
+    "sse_frame_kb": 117.0,
+    "history_ms": 12.4,
+    "history_kb": 139.9
+   },
+   {
+    "group": "DURABLE",
+    "session_id": "2e4a863a3a41",
+    "name": "Improve Skill Protocol Recommendations",
+    "sse_first_frame_ms": 18.9,
+    "sse_frame_kb": 187.9,
+    "history_ms": 10.5,
+    "history_kb": 191.4
+   },
+   {
+    "group": "DURABLE",
+    "session_id": "e386029c175a",
+    "name": "Has qwen cloud /alibaba released any end",
+    "sse_first_frame_ms": 5.9,
+    "sse_frame_kb": 122.8,
+    "history_ms": 5.2,
+    "history_kb": 120.5
+   },
+   {
+    "group": "DURABLE",
+    "session_id": "e9aeb38fa6af",
+    "name": "",
+    "sse_first_frame_ms": 2.0,
+    "sse_frame_kb": 0.9,
+    "history_ms": 2.0,
+    "history_kb": 0.0
+   },
+   {
+    "group": "DURABLE",
+    "session_id": "dccdd2348af8",
+    "name": "TUI Long Session Performance",
+    "sse_first_frame_ms": 69.8,
+    "sse_frame_kb": 122.2,
+    "history_ms": 25.9,
+    "history_kb": 88.3
+   }
+  ]
+ },
+ "new-4198": {
+  "list_ms": [
+   72.0,
+   1.6,
+   1.0
+  ],
+  "rows": [
+   {
+    "group": "LIVE",
+    "session_id": "e2ad0e43382d",
+    "name": "Cancel Session Wakes Robustly",
+    "sse_first_frame_ms": 965.0,
+    "sse_frame_kb": 301.7,
+    "history_ms": 4.2,
+    "history_kb": 237.8
+   },
+   {
+    "group": "LIVE",
+    "session_id": "720772cc779c",
+    "name": "Investigate Qwen Session Naming",
+    "sse_first_frame_ms": 40.4,
+    "sse_frame_kb": 110.4,
+    "history_ms": 3.5,
+    "history_kb": 105.7
+   },
+   {
+    "group": "DURABLE",
+    "session_id": "2e4a863a3a41",
+    "name": "Improve Skill Protocol Recommendations",
+    "sse_first_frame_ms": 7.4,
+    "sse_frame_kb": 187.9,
+    "history_ms": 4.2,
+    "history_kb": 191.4
+   },
+   {
+    "group": "DURABLE",
+    "session_id": "e386029c175a",
+    "name": "Has qwen cloud /alibaba released any end",
+    "sse_first_frame_ms": 5.2,
+    "sse_frame_kb": 122.8,
+    "history_ms": 2.7,
+    "history_kb": 120.5
+   },
+   {
+    "group": "DURABLE",
+    "session_id": "4787cd11f841",
+    "name": "Take over forgotten PR 459",
+    "sse_first_frame_ms": 43.7,
+    "sse_frame_kb": 60.2,
+    "history_ms": 3.0,
+    "history_kb": 56.7
+   },
+   {
+    "group": "DURABLE",
+    "session_id": "e9aeb38fa6af",
+    "name": "",
+    "sse_first_frame_ms": 1.9,
+    "sse_frame_kb": 0.4,
+    "history_ms": 1.9,
+    "history_kb": 0.0
+   }
+  ]
+ }
+}

--- a/bench/relay-load-after.json
+++ b/bench/relay-load-after.json
@@ -1,0 +1,96 @@
+{
+ "python": "3.14.3",
+ "list_summaries_cold_s": 0.3238,
+ "list_summaries_warm_s": 0.001419,
+ "list_rows": 100,
+ "sessions": [
+  {
+   "session_id": "bda7b76d34e0",
+   "transcript_mb": 54.6,
+   "durable_projection_first_s": 2.77,
+   "durable_projection_warm_s": 0.006,
+   "history_page_first_s": 0.0,
+   "history_page_warm_s": 0.0,
+   "transcript_parse_first_s": 1.955,
+   "transcript_parse_warm_s": 0.843,
+   "entries": 11248
+  },
+  {
+   "session_id": "e2ad0e43382d",
+   "transcript_mb": 53.6,
+   "durable_projection_first_s": 1.333,
+   "durable_projection_warm_s": 0.005,
+   "history_page_first_s": 0.0,
+   "history_page_warm_s": 0.0,
+   "transcript_parse_first_s": 1.424,
+   "transcript_parse_warm_s": 1.354,
+   "entries": 11284
+  },
+  {
+   "session_id": "4140ee201ce1",
+   "transcript_mb": 32.0,
+   "durable_projection_first_s": 0.554,
+   "durable_projection_warm_s": 0.001,
+   "history_page_first_s": 0.0,
+   "history_page_warm_s": 0.0,
+   "transcript_parse_first_s": 0.262,
+   "transcript_parse_warm_s": 0.21,
+   "entries": 6090
+  },
+  {
+   "session_id": "20bfa91bc753",
+   "transcript_mb": 29.3,
+   "durable_projection_first_s": 0.773,
+   "durable_projection_warm_s": 0.109,
+   "history_page_first_s": 0.0,
+   "history_page_warm_s": 0.0,
+   "transcript_parse_first_s": 0.565,
+   "transcript_parse_warm_s": 0.637,
+   "entries": 2219
+  },
+  {
+   "session_id": "919a7d265526",
+   "transcript_mb": 27.9,
+   "durable_projection_first_s": 0.889,
+   "durable_projection_warm_s": 0.028,
+   "history_page_first_s": 0.0,
+   "history_page_warm_s": 0.0,
+   "transcript_parse_first_s": 0.853,
+   "transcript_parse_warm_s": 0.202,
+   "entries": 9327
+  },
+  {
+   "session_id": "fe9b3869d50f",
+   "transcript_mb": 20.2,
+   "durable_projection_first_s": 0.415,
+   "durable_projection_warm_s": 0.008,
+   "history_page_first_s": 0.0,
+   "history_page_warm_s": 0.0,
+   "transcript_parse_first_s": 0.475,
+   "transcript_parse_warm_s": 0.283,
+   "entries": 3622
+  },
+  {
+   "session_id": "0a20ea15dbc7",
+   "transcript_mb": 17.8,
+   "durable_projection_first_s": 0.252,
+   "durable_projection_warm_s": 0.127,
+   "history_page_first_s": 0.0,
+   "history_page_warm_s": 0.0,
+   "transcript_parse_first_s": 0.659,
+   "transcript_parse_warm_s": 0.668,
+   "entries": 987
+  },
+  {
+   "session_id": "e8d019573ae2",
+   "transcript_mb": 17.5,
+   "durable_projection_first_s": 0.382,
+   "durable_projection_warm_s": 0.024,
+   "history_page_first_s": 0.0,
+   "history_page_warm_s": 0.0,
+   "transcript_parse_first_s": 0.47,
+   "transcript_parse_warm_s": 0.141,
+   "entries": 777
+  }
+ ]
+}

--- a/bench/relay-load-before.json
+++ b/bench/relay-load-before.json
@@ -1,0 +1,95 @@
+{
+ "python": "3.14.3",
+ "list_100_s": 0.3556,
+ "list_rows": 100,
+ "sessions": [
+  {
+   "session_id": "e2ad0e43382d",
+   "transcript_mb": 53.4,
+   "durable_projection_first_s": 0.634,
+   "durable_projection_warm_s": 0.505,
+   "history_page_first_s": 0.265,
+   "history_page_warm_s": 0.265,
+   "transcript_parse_first_s": 0.257,
+   "transcript_parse_warm_s": 0.255,
+   "entries": 11166
+  },
+  {
+   "session_id": "bda7b76d34e0",
+   "transcript_mb": 53.3,
+   "durable_projection_first_s": 0.512,
+   "durable_projection_warm_s": 0.501,
+   "history_page_first_s": 0.249,
+   "history_page_warm_s": 0.251,
+   "transcript_parse_first_s": 0.239,
+   "transcript_parse_warm_s": 0.262,
+   "entries": 11166
+  },
+  {
+   "session_id": "4140ee201ce1",
+   "transcript_mb": 31.3,
+   "durable_projection_first_s": 0.164,
+   "durable_projection_warm_s": 0.158,
+   "history_page_first_s": 0.156,
+   "history_page_warm_s": 0.149,
+   "transcript_parse_first_s": 0.138,
+   "transcript_parse_warm_s": 0.147,
+   "entries": 6026
+  },
+  {
+   "session_id": "20bfa91bc753",
+   "transcript_mb": 29.3,
+   "durable_projection_first_s": 0.222,
+   "durable_projection_warm_s": 0.171,
+   "history_page_first_s": 0.111,
+   "history_page_warm_s": 0.1,
+   "transcript_parse_first_s": 0.091,
+   "transcript_parse_warm_s": 0.097,
+   "entries": 2219
+  },
+  {
+   "session_id": "919a7d265526",
+   "transcript_mb": 26.8,
+   "durable_projection_first_s": 0.147,
+   "durable_projection_warm_s": 0.133,
+   "history_page_first_s": 0.125,
+   "history_page_warm_s": 0.128,
+   "transcript_parse_first_s": 0.106,
+   "transcript_parse_warm_s": 0.112,
+   "entries": 9048
+  },
+  {
+   "session_id": "fe9b3869d50f",
+   "transcript_mb": 20.2,
+   "durable_projection_first_s": 0.391,
+   "durable_projection_warm_s": 0.327,
+   "history_page_first_s": 0.073,
+   "history_page_warm_s": 0.076,
+   "transcript_parse_first_s": 0.074,
+   "transcript_parse_warm_s": 0.066,
+   "entries": 3622
+  },
+  {
+   "session_id": "0a20ea15dbc7",
+   "transcript_mb": 17.8,
+   "durable_projection_first_s": 0.237,
+   "durable_projection_warm_s": 0.2,
+   "history_page_first_s": 0.075,
+   "history_page_warm_s": 0.085,
+   "transcript_parse_first_s": 0.08,
+   "transcript_parse_warm_s": 0.071,
+   "entries": 987
+  },
+  {
+   "session_id": "e8d019573ae2",
+   "transcript_mb": 17.5,
+   "durable_projection_first_s": 0.187,
+   "durable_projection_warm_s": 0.152,
+   "history_page_first_s": 0.062,
+   "history_page_warm_s": 0.057,
+   "transcript_parse_first_s": 0.052,
+   "transcript_parse_warm_s": 0.053,
+   "entries": 777
+  }
+ ]
+}

--- a/bench/relay-load.md
+++ b/bench/relay-load.md
@@ -1,0 +1,67 @@
+# Mobile relay session-load benchmarks
+
+`scripts/bench_relay_load.py` measures the paths a phone pays when it opens
+the session list and a session, against the REAL store (3,925 sessions,
+1.5 GB, transcripts to 53 MB). Run:
+
+```sh
+PYTHONPATH=. .venv/bin/python scripts/bench_relay_load.py
+```
+
+`PYTHONPATH=.` matters: the script must import THIS checkout's
+`local_operator`, and a plain run from another directory can resolve an
+editable install pointing elsewhere.
+
+## relay-load-before.json / relay-load-after.json
+
+Captured on this machine against `origin/main` @ `aa8de03c` (before) and the
+same tree with the relay performance fixes (after). The before column is the
+manager's diagnosis script run on the baseline worktree; the after column is
+the extended script (adds list summaries cold/warm) on the fixed tree.
+
+| Path | Metric | Before | After |
+| --- | --- | --- | --- |
+| `GET /api/sessions` (list) | cold scan | 356 ms (300-4,900 ms under loop contention, per the diagnosis) | 324 ms (one scan, off the loop) |
+| `GET /api/sessions` (list) | warm repaint | 356 ms every time (no cache; a live session repaints ~30x/s) | **1.4 ms** (TTL cache) |
+| Durable projection (SSE seed) | warm, 53 MB transcript | 505 ms | **5 ms** |
+| Durable projection (SSE seed) | warm, 31 MB transcript | 158 ms | **1 ms** |
+| Durable projection (SSE seed) | warm, worst of 8 largest | 505 ms | **127 ms** (one session mid-append; median 8 ms) |
+| History page (80 rows) | repeated, 53 MB transcript | 265 ms per page | **<1 ms** per page |
+| History page (80 rows) | repeated, worst of 8 largest | 251 ms | **<1 ms** |
+
+The durable projection's first (cold) call still pays one full fold — that is
+the one-time cost the cache amortizes (1.3-2.8 s on the 53 MB transcripts,
+dominated by the file parse the old code paid on EVERY request). Every later
+open reads only the bytes appended since, and every history page folds from
+the cached replay instead of re-parsing the file.
+
+The warm durable-projection outliers (109-127 ms on two sessions) are
+sessions a live process was appending to during the run: the incremental tail
+fold processes the appended window. The median across the eight is 8 ms.
+
+## End-to-end: old daemon (4098) vs new daemon (4198)
+
+`relay-e2e-dual.json` is the adapted `e2e_relay_timing.py` run against BOTH
+daemons at once: port 4098 is the production daemon (old binary), port 4198
+is this tree's daemon started with `LO_MOBILE_NO_DIAL=1` — observer mode,
+because a registrant admits at most one daemon connection and a second dial
+would evict the production daemon's live bridge. The observer therefore
+serves live sessions from the durable fold (its SSE column for LIVE rows is
+the durable path, not a live projection push); the list and durable rows are
+directly comparable.
+
+| Metric | old-4098 | new-4198 |
+| --- | --- | --- |
+| `GET /api/sessions` first | 1,082 ms | 72 ms |
+| `GET /api/sessions` warm | 624 ms | **1.0 ms** |
+| Durable SSE first frame (4 sessions) | 2.0-69.8 ms | 1.9-43.7 ms |
+| Durable history page | 5.2-25.9 ms | 1.9-4.2 ms |
+| Live-session history page | 6.5-12.4 ms | 3.5-4.2 ms |
+
+The list route is the headline: the old daemon blocked its event loop on the
+durable scan for every repaint (624-1,082 ms here, up to 4.9 s in the
+diagnosis), which is what starved every other request. The new daemon's warm
+list is a cached in-memory merge. SSE first frames for durable sessions are
+flat-to-faster; the wedge the diagnosis captured (4 live sessions whose SSE
+first frame never arrived within 12 s) came from oversized-frame floods on
+the loop, which the registrant-side frame cap removes at the source.

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -712,6 +712,28 @@ def _transcript_entry_json(entry: Any) -> dict[str, Any]:
     return entry.to_json()
 
 
+def _projection_frame(projection: SessionProjection) -> dict[str, Any]:
+    """The daemon's serialization boundary: one capped frame dict.
+
+    Both wire paths must agree on size. The registrant caps before broadcast
+    (see ``Registrant._projection_payload``); the daemon serves the SAME
+    projection shape over SSE and republishes durable rebuilds, so it caps at
+    every serialization site too — a durable fold of a long session can embed
+    80 rows x 8 KB tool outputs, which no socket or phone renderer wants
+    whole. Degradation is tiered and lossless for the collapsed view (see
+    ``cap_projection_frame``); the retained projection object is untouched.
+    """
+    from local_operator.mobile.projection import cap_projection_frame
+
+    data, degraded = cap_projection_frame(projection)
+    if degraded:
+        logger.debug(
+            "mobile daemon: capped oversized projection frame for session %s",
+            projection.session_id,
+        )
+    return data
+
+
 def _history_page(
     session_id: str, before: str | None, limit: int, *, durable_only: bool = True
 ) -> tuple[list[Any], bool]:
@@ -817,7 +839,7 @@ def _fan_out(entry: SessionEntry, daemon: "MobileDaemon | None" = None) -> None:
     """Push a repaint to durable session viewers, never one pid generation."""
     if entry.projection is None:
         return
-    frame = entry.projection.to_json()
+    frame = _projection_frame(entry.projection)
     queues = (
         daemon.table.session_subscribers.get(entry.record.session_id, set())
         if daemon is not None
@@ -1131,12 +1153,15 @@ class MobileDaemon:
                         projection, record=record, terminal=True
                     )
                     for queue in self.table.session_subscribers.get(record.session_id, set()):
+                        # Serialize ONCE per repaint: the QueueFull retry below
+                        # re-puts the same frame, and capping is a json.dumps.
+                        frame = _projection_frame(projection)
                         try:
-                            queue.put_nowait(projection.to_json())
+                            queue.put_nowait(frame)
                         except asyncio.QueueFull:
                             try:
                                 queue.get_nowait()
-                                queue.put_nowait(projection.to_json())
+                                queue.put_nowait(frame)
                             except asyncio.QueueEmpty:
                                 pass
                 self._prune_projection_generation(record.session_id)
@@ -1166,12 +1191,13 @@ class MobileDaemon:
                             projection, record=entry.record, terminal=True
                         )
                         for queue in self.table.session_subscribers.get(session_id, set()):
+                            frame = _projection_frame(projection)
                             try:
-                                queue.put_nowait(projection.to_json())
+                                queue.put_nowait(frame)
                             except asyncio.QueueFull:
                                 try:
                                     queue.get_nowait()
-                                    queue.put_nowait(projection.to_json())
+                                    queue.put_nowait(frame)
                                 except asyncio.QueueEmpty:
                                     pass
                     self._prune_projection_generation(session_id)
@@ -1195,7 +1221,7 @@ class MobileDaemon:
                         projection = self.capture_subagent_details(projection, terminal=True)
                         for queue in self.table.session_subscribers.get(session_id, set()):
                             try:
-                                queue.put_nowait(projection.to_json())
+                                queue.put_nowait(_projection_frame(projection))
                             except asyncio.QueueFull:
                                 pass
                     self.table.notify_list_changed()
@@ -1487,7 +1513,7 @@ def build_app(daemon: MobileDaemon):
                             # keepalive carries the view.
                             projection = None
                 if projection is not None:
-                    yield _sse("projection", projection.to_json())
+                    yield _sse("projection", _projection_frame(projection))
                 while True:
                     try:
                         frame = await asyncio.wait_for(queue.get(), timeout=SSE_KEEPALIVE_S)
@@ -1748,7 +1774,7 @@ def build_app(daemon: MobileDaemon):
                         projection = None
                     if projection is not None:
                         for target in daemon.table.session_subscribers.get(session_id, set()):
-                            target.put_nowait(projection.to_json())
+                            target.put_nowait(_projection_frame(projection))
                 try:
                     client, detail = await continue_command(config_dir(), command)
                 except BaseException:

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -413,9 +413,37 @@ class SessionTable:
 
         Cheap: dict lookups only, no disk access — the store is fully in
         memory and persists itself on ``mark_seen``.
+
+        Two rules the naive version got wrong:
+
+        - **Holding the projection SSE stream IS viewing** (spec §3). A user
+          watching a turn finish must never come back to that session marked
+          new, so an open subscriber re-stamps ``last_seen`` here rather than
+          relying on the client to POST /seen again after every repaint.
+        - **The activity clock is never ``heartbeat_at``.** That is rewritten
+          unconditionally every HEARTBEAT_INTERVAL_S whether or not anything
+          happened, so using it re-lit a just-cleared session every 15 s
+          forever. Only the transcript mtime dates real activity; without a
+          durable row there is nothing to date against, and the session's own
+          ``started_at`` is a fixed instant that cannot creep.
         """
         store = self.seen_store
-        activity = row.mtime if row is not None else entry.record.heartbeat_at if entry else 0.0
+        if self.session_subscribers.get(session_id):
+            # Viewing now: keep the stamp at the current instant so activity
+            # arriving during the watch is already covered when it lands. The
+            # disk write is debounced inside the store — this runs on every
+            # repaint of a watched session.
+            store.touch_watched(session_id)
+            return False
+        if row is not None:
+            activity = row.mtime
+        elif entry is not None:
+            # A live session with no durable row yet (younger than its first
+            # transcript write, or outside the 100-row window). started_at is
+            # a birth instant, not a liveness clock.
+            activity = entry.record.started_at
+        else:
+            activity = 0.0
         if not activity:
             return False
         return store.is_unseen(session_id, activity)

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -360,6 +360,12 @@ class SessionTable:
             key=lambda summary: (
                 summary["section"] != "active",
                 not summary["needs_attention"],
+                # Unread outranks streaming and recency inside its section: an
+                # unseen session is work waiting on the reader's attention, and
+                # burying it under plain mtime order is what made the mark
+                # decorative. Ranked BELOW needs_attention because a pending
+                # ask blocks a turn outright, while unread only means unlooked-at.
+                not summary["unseen"],
                 not summary["streaming"],
                 -summary["mtime"],
                 summary["session_id"],

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -88,6 +88,39 @@ MAX_RETAINED_SESSION_PROJECTIONS = 64
 SUMMARIES_CACHE_TTL_S = 1.0
 
 
+def _durable_fold_cache():
+    """The daemon-wide cache of incremental durable folds (see
+    :mod:`.durable`). Created lazily so importing the daemon never pays for
+    the fold machinery, and so tests that patch ``config_dir`` before first
+    use get a cache keyed by THEIR directories."""
+    global _DURABLE_FOLD_CACHE
+    if _DURABLE_FOLD_CACHE is None:
+        from local_operator.mobile.durable import DurableFoldCache
+
+        _DURABLE_FOLD_CACHE = DurableFoldCache()
+    return _DURABLE_FOLD_CACHE
+
+
+_DURABLE_FOLD_CACHE: Any = None
+
+
+def _custom_snapshot_cache():
+    """The daemon-wide newest-wins custom-snapshot cache (see
+    :class:`.durable.CustomSnapshotCache`). Deliberately separate from the
+    fold cache: a deep roster asks every child transcript for its todo
+    snapshot, and routing those reads through the bounded fold cache would
+    evict the ROOT's fold — re-folding a 50 MB transcript on the next open."""
+    global _CUSTOM_SNAPSHOT_CACHE
+    if _CUSTOM_SNAPSHOT_CACHE is None:
+        from local_operator.mobile.durable import CustomSnapshotCache
+
+        _CUSTOM_SNAPSHOT_CACHE = CustomSnapshotCache()
+    return _CUSTOM_SNAPSHOT_CACHE
+
+
+_CUSTOM_SNAPSHOT_CACHE: Any = None
+
+
 class _StaleProjection(Exception):
     """A fenced owner frame with no retained payload to republish."""
 
@@ -364,7 +397,14 @@ def _durable_user_session_dir(session_id: str) -> Path | None:
 
 
 def _durable_projection(session_id: str) -> SessionProjection | None:
-    """Fold a user conversation and its routable child lineage from disk."""
+    """Fold a user conversation and its routable child lineage from disk.
+
+    Reads through the daemon's incremental fold cache (:mod:`.durable`): the
+    first open of a session pays one full fold, every later open reads only
+    the bytes appended since. The projection object itself is rebuilt on
+    every call (callers mutate and fence it), so what is cached is the fold,
+    not the projection.
+    """
     from local_operator.mobile.projection import (
         SUBAGENT_ERROR_CHARS,
         SUBAGENT_OUTCOME_CHARS,
@@ -374,12 +414,17 @@ def _durable_projection(session_id: str) -> SessionProjection | None:
         _compact_multiline,
     )
     from local_operator.resume import stored_session_title
-    from local_operator.session.session import SUBAGENT_ROSTER_CUSTOM_TYPE
-    from local_operator.session.transcript import Transcript
     from local_operator.tools.builtin import todo_snapshot
 
     directory = _durable_user_session_dir(session_id)
     if directory is None:
+        return None
+    try:
+        state = _durable_fold_cache().load(directory)
+    except FileNotFoundError:
+        return None
+    except Exception:  # noqa: BLE001 — an odd transcript yields no projection, not a 500
+        logger.exception("durable fold failed for session %s", session_id)
         return None
     projection = SessionProjection(
         session_id=session_id,
@@ -389,14 +434,15 @@ def _durable_projection(session_id: str) -> SessionProjection | None:
         cwd="",
         model_label="",
     )
-    transcript = Transcript(directory)
     fold = ProjectionFold(projection)
-    fold.fold_history(transcript.build_llm_history())
+    # fold_history reads messages without mutating them, so the cached list
+    # can be shared; the fold builds its own TranscriptEntry rows.
+    fold.fold_history(state.history)
 
     # The persisted roster is the restart-safe ownership record for child
     # routes. Rebuilding from it keeps old session projections useful without
     # retaining every child's unbounded transcript in daemon memory forever.
-    snapshot = transcript.latest_custom(SUBAGENT_ROSTER_CUSTOM_TYPE) or {}
+    snapshot = state.latest_customs.get("subagent_roster") or {}
     jobs = {str(row.get("id") or ""): row for row in snapshot.get("jobs") or []}
     records = [row for row in snapshot.get("records") or [] if row.get("job_id")]
     by_parent: dict[str | None, list[str]] = {}
@@ -408,7 +454,6 @@ def _durable_projection(session_id: str) -> SessionProjection | None:
         job = jobs.get(job_id, {})
         raw_dir = record.get("session_dir")
         child_dir = Path(str(raw_dir)) if raw_dir else None
-        child_transcript = Transcript(child_dir) if child_dir and child_dir.is_dir() else None
         status = str(record.get("outcome") or job.get("status") or "cancelled")
         if status in ("queued", "starting", "running"):
             status = "cancelled"
@@ -428,8 +473,14 @@ def _durable_projection(session_id: str) -> SessionProjection | None:
             ancestors.insert(0, str(ancestor.get("label") or cursor))
             cursor = str(ancestor["parent_job_id"]) if ancestor.get("parent_job_id") else None
         raw_todos = todo_snapshot(child_dir.name) if child_dir else []
-        if not raw_todos and child_transcript is not None:
-            raw_todos = (child_transcript.latest_custom("todo_snapshot") or {}).get("items") or []
+        if not raw_todos and child_dir is not None and child_dir.is_dir():
+            # The child's todo snapshot through the dedicated snapshot cache:
+            # a deep roster used to full-parse every child transcript on every
+            # durable projection, once per child. Routed around the fold cache
+            # so an 80-child roster cannot evict the root's fold.
+            raw_todos = (
+                _custom_snapshot_cache().load(child_dir, "todo_snapshot") or {}
+            ).get("items") or []
         row = SubagentRow(
             job_id=job_id,
             label=str(record.get("label") or job_id),
@@ -664,16 +715,15 @@ def _transcript_entry_json(entry: Any) -> dict[str, Any]:
 def _history_page(
     session_id: str, before: str | None, limit: int, *, durable_only: bool = True
 ) -> tuple[list[Any], bool]:
-    """Fold the session's full on-disk transcript and return the page of
-    entries immediately OLDER than ``before`` (chronological within the page)
-    plus whether more history exists beyond it.
+    """Return the page of folded entries immediately OLDER than ``before``
+    (chronological within the page) plus whether more history exists beyond it.
 
-    Runs off the event loop (``asyncio.to_thread`` at the call site): folding
-    a long transcript rehydrates every message and is not loop-safe work.
+    Reads through the daemon's incremental fold cache (:mod:`.durable`), so a
+    page costs one fold per session per daemon lifetime plus the appended
+    tail since — not the whole-file re-parse every page used to pay. Runs off
+    the event loop (``asyncio.to_thread`` at the call site): even the cached
+    path touches disk and the fold is not loop-safe work.
     """
-    from local_operator.mobile.projection import fold_messages_to_entries
-    from local_operator.session.transcript import Transcript
-
     if durable_only:
         directory = _durable_user_session_dir(session_id)
     else:
@@ -690,9 +740,10 @@ def _history_page(
     if directory is None or not (directory / "transcript.jsonl").is_file():
         return [], False
     try:
-        transcript = Transcript(directory)
-        history = transcript.build_llm_history()
-        entries = fold_messages_to_entries(history)
+        state = _durable_fold_cache().load(directory)
+        entries = state.render
+    except FileNotFoundError:
+        return [], False
     except Exception:  # noqa: BLE001 — an odd transcript yields no history, not a 500
         logger.exception("history fold failed for session %s", session_id)
         return [], False

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -360,13 +360,19 @@ class SessionTable:
             key=lambda summary: (
                 summary["section"] != "active",
                 not summary["needs_attention"],
-                # Unread outranks streaming and recency inside its section: an
-                # unseen session is work waiting on the reader's attention, and
-                # burying it under plain mtime order is what made the mark
-                # decorative. Ranked BELOW needs_attention because a pending
-                # ask blocks a turn outright, while unread only means unlooked-at.
-                not summary["unseen"],
+                # ONE ladder serves the sort and the render: NEEDS DECISION >
+                # WORKING > UNREAD > IDLE (see the client's SessionCard, which
+                # states the same order). Unread outranks recency — burying the
+                # mark under plain mtime order is what made it decorative — but
+                # sits BELOW streaming, because the client renders "new" only
+                # for COMPLETED unviewed activity and suppresses it on an
+                # in-flight row. Ranking unseen above streaming here hoisted a
+                # streaming+unseen row over newer rows while it rendered no
+                # mark to explain the position: a sort the surface contradicts.
+                # And below needs_attention, because a pending ask blocks a
+                # turn outright while unread only means unlooked-at.
                 not summary["streaming"],
+                not summary["unseen"],
                 -summary["mtime"],
                 summary["session_id"],
             )

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -201,6 +201,10 @@ class SessionTable:
         # generations. Entries route watch commands but never own these queues.
         self.session_subscribers: dict[str, set[asyncio.Queue[dict[str, Any]]]] = {}
         self.provisional_active: set[str] = set()
+        # Injected by MobileDaemon: the persisted per-session seen state the
+        # "unseen" verdict reads. None keeps a bare SessionTable (unit tests)
+        # reporting every session seen.
+        self.seen_store: Any = None
         # The durable half of summaries() is a directory scan; cache it behind a
         # short TTL (SUMMARIES_CACHE_TTL_S) with single-flight refresh so N
         # concurrent list consumers pay one scan, not N. The merged summary list
@@ -339,10 +343,13 @@ class SessionTable:
                         if todo.status in ("pending", "blocked")
                     ),
                     "mtime": row.mtime if row else entry.record.started_at if entry else 0,
-                    # Placeholder shape: the seen-store (a later step of this
-                    # change) computes the real value; the web layer receives a
-                    # stable key from the first release of the endpoint.
-                    "unseen": False,
+                    # Unread verdict (see :mod:`.seen`): activity newer than the
+                    # phone's last view. The activity clock is the transcript
+                    # mtime for durable rows — already statted by the listing
+                    # scan, no extra syscall — and the record heartbeat for
+                    # live rows. First observation records a baseline so an
+                    # upgrade never lights up the whole store.
+                    "unseen": self._is_unseen(session_id, row, entry),
                 }
             )
         out.sort(
@@ -366,6 +373,21 @@ class SessionTable:
                 queue.put_nowait(None)
             except asyncio.QueueFull:
                 pass
+
+    def _is_unseen(self, session_id: str, row: Any, entry: SessionEntry | None) -> bool:
+        """The seen-store verdict for one summary row.
+
+        ``seen_store`` is injected by ``MobileDaemon`` (it owns the persisted
+        store). Cheap: dict lookups only, no disk access — the store is fully
+        in memory and persists itself.
+        """
+        store = self.seen_store
+        if store is None:
+            return False
+        activity = row.mtime if row is not None else entry.record.heartbeat_at if entry else 0.0
+        if not activity:
+            return False
+        return store.is_unseen(session_id, activity)
 
 
 def _entry_for_session(daemon: "MobileDaemon", session_id: str) -> SessionEntry | None:
@@ -867,6 +889,11 @@ class MobileDaemon:
         self.port = port
         self.password = password
         self.table = SessionTable()
+        # Per-session "last seen by phone" state, persisted across daemon
+        # restarts (see :mod:`.seen`). The merge reads it for every summary
+        # row; it persists itself on change.
+        self._seen_store: Any = None
+        self.table.seen_store = self.seen_store
         # The session repaint carries only roster summaries. Full child state is
         # retained separately and fetched for the active route, otherwise one
         # busy descendant makes every root token repaint resend every transcript.
@@ -897,6 +924,16 @@ class MobileDaemon:
             entry.record.session_id == session_id and not entry.ended
             for entry in self.table.entries.values()
         )
+
+    @property
+    def seen_store(self):
+        """The persisted seen-state store, created on first use."""
+        if self._seen_store is None:
+            from local_operator.mobile.seen import SEEN_STORE_NAME, SeenStore
+            from local_operator.paths import config_dir
+
+            self._seen_store = SeenStore(config_dir() / SEEN_STORE_NAME)
+        return self._seen_store
 
     def _prune_projection_generation(self, session_id: str) -> None:
         """Retire ordering only when no durable in-memory route can emit again."""
@@ -1568,6 +1605,27 @@ def build_app(daemon: MobileDaemon):
             headers={"Cache-Control": "no-cache, no-transform", "X-Accel-Buffering": "no"},
         )
 
+    async def api_session_seen(request: Request) -> Response:
+        """The phone marks a session seen; the unread verdict clears.
+
+        Auth-gated like every /api route. The verdict is durable (see
+        :mod:`.seen`), so it survives a daemon restart. Unknown ids 404 the
+        same way the history route does — a live generation OR a durable user
+        session — so the endpoint cannot be used to probe arbitrary paths.
+        """
+        denied = gate(request)
+        if denied is not None:
+            return denied
+        session_id = str(request.path_params["session_id"])
+        entry = _entry_for_session(daemon, session_id)
+        if entry is None and _durable_user_session_dir(session_id) is None:
+            return JSONResponse({"error": "unknown session"}, status_code=404)
+        daemon.seen_store.mark_seen(session_id)
+        # The next list paint must already show the cleared verdict.
+        daemon.table.invalidate_summaries_cache()
+        daemon.table.notify_list_changed()
+        return JSONResponse({"ok": True})
+
     async def api_subagent_detail(request: Request) -> Response:
         """Full state for the one descendant named by the active phone route."""
         denied = gate(request)
@@ -1958,6 +2016,7 @@ def build_app(daemon: MobileDaemon):
         Route("/api/sessions/resume", api_resume_session, methods=["POST"]),
         Route("/api/sessions/search", api_search_sessions),
         Route("/api/sessions/{session_id:str}/events", api_session_events),
+        Route("/api/sessions/{session_id:str}/seen", api_session_seen, methods=["POST"]),
         Route("/api/sessions/{session_id:str}/agents/{job_id:str}", api_subagent_detail),
         Route(
             "/api/sessions/{session_id:str}/agents/{job_id:str}/history",

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -201,10 +201,14 @@ class SessionTable:
         # generations. Entries route watch commands but never own these queues.
         self.session_subscribers: dict[str, set[asyncio.Queue[dict[str, Any]]]] = {}
         self.provisional_active: set[str] = set()
-        # Injected by MobileDaemon: the persisted per-session seen state the
-        # "unseen" verdict reads. None keeps a bare SessionTable (unit tests)
-        # reporting every session seen.
-        self.seen_store: Any = None
+        # Per-session seen state the "unseen" verdict reads. Owned by the table
+        # (the merge reads it per row) and created LAZILY on first verdict (see
+        # the property), so a test that patches config_dir AFTER construction
+        # still gets ITS directory, and a bare SessionTable never touches disk
+        # until a verdict actually runs. The daemon's own seen_store property
+        # delegates here so the /seen endpoint and the verdict share ONE
+        # instance.
+        self._seen_store: Any = None
         # The durable half of summaries() is a directory scan; cache it behind a
         # short TTL (SUMMARIES_CACHE_TTL_S) with single-flight refresh so N
         # concurrent list consumers pay one scan, not N. The merged summary list
@@ -374,16 +378,28 @@ class SessionTable:
             except asyncio.QueueFull:
                 pass
 
+    @property
+    def seen_store(self):
+        """The persisted seen-state store, created on first use.
+
+        Lazy so the store resolves ``config_dir()`` at verdict time — tests
+        patch it after building the table, and a bare SessionTable pays
+        nothing until a verdict runs.
+        """
+        if self._seen_store is None:
+            from local_operator.mobile.seen import SEEN_STORE_NAME, SeenStore
+            from local_operator.paths import config_dir
+
+            self._seen_store = SeenStore(config_dir() / SEEN_STORE_NAME)
+        return self._seen_store
+
     def _is_unseen(self, session_id: str, row: Any, entry: SessionEntry | None) -> bool:
         """The seen-store verdict for one summary row.
 
-        ``seen_store`` is injected by ``MobileDaemon`` (it owns the persisted
-        store). Cheap: dict lookups only, no disk access — the store is fully
-        in memory and persists itself.
+        Cheap: dict lookups only, no disk access — the store is fully in
+        memory and persists itself on ``mark_seen``.
         """
         store = self.seen_store
-        if store is None:
-            return False
         activity = row.mtime if row is not None else entry.record.heartbeat_at if entry else 0.0
         if not activity:
             return False
@@ -903,11 +919,10 @@ class MobileDaemon:
         # production daemon's live bridge mid-session. Set via
         # ``LO_MOBILE_NO_DIAL=1`` (see ``service.amain``).
         self.dial_registrants = dial_registrants
-        # Per-session "last seen by phone" state, persisted across daemon
-        # restarts (see :mod:`.seen`). The merge reads it for every summary
-        # row; it persists itself on change.
-        self._seen_store: Any = None
-        self.table.seen_store = self.seen_store
+        # Per-session "last seen by phone" state lives on the table (the merge
+        # reads it per row); the daemon's ``seen_store`` property delegates to
+        # it so the /seen endpoint and the verdict share one lazily-created
+        # store.
         # The session repaint carries only roster summaries. Full child state is
         # retained separately and fetched for the active route, otherwise one
         # busy descendant makes every root token repaint resend every transcript.
@@ -941,13 +956,9 @@ class MobileDaemon:
 
     @property
     def seen_store(self):
-        """The persisted seen-state store, created on first use."""
-        if self._seen_store is None:
-            from local_operator.mobile.seen import SEEN_STORE_NAME, SeenStore
-            from local_operator.paths import config_dir
-
-            self._seen_store = SeenStore(config_dir() / SEEN_STORE_NAME)
-        return self._seen_store
+        """The persisted seen-state store — delegates to the table so the
+        /seen endpoint and the summaries verdict share one instance."""
+        return self.table.seen_store
 
     def _prune_projection_generation(self, session_id: str) -> None:
         """Retire ordering only when no durable in-memory route can emit again."""

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -516,9 +516,9 @@ def _durable_projection(session_id: str) -> SessionProjection | None:
             # a deep roster used to full-parse every child transcript on every
             # durable projection, once per child. Routed around the fold cache
             # so an 80-child roster cannot evict the root's fold.
-            raw_todos = (
-                _custom_snapshot_cache().load(child_dir, "todo_snapshot") or {}
-            ).get("items") or []
+            raw_todos = (_custom_snapshot_cache().load(child_dir, "todo_snapshot") or {}).get(
+                "items"
+            ) or []
         row = SubagentRow(
             job_id=job_id,
             label=str(record.get("label") or job_id),

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -75,6 +75,18 @@ DEFAULT_PORT = 4098
 #: evicting detail alone leaves a retained projection advertising dead routes.
 MAX_RETAINED_SESSION_PROJECTIONS = 64
 
+#: TTL for the summaries cache. The durable half of a listing is a 100-directory
+#: scan plus bounded head reads (300 ms to several seconds under loop
+#: contention, measured on the operator's 3,925-session store), and a live
+#: session repaints the list ~30x/s — without a TTL every repaint re-ran that
+#: scan and starved every other request on the single daemon loop. The TTL is
+#: the staleness bound for the DURABLE half only (a new terminal session
+#: appears within it); live-projection fields are merged fresh on every call,
+#: so streaming/pending state never ages. Structural changes (registration,
+#: heartbeat, wake, session death) invalidate the cache outright via
+#: ``notify_list_changed``, so the TTL is only what a quiet machine pays.
+SUMMARIES_CACHE_TTL_S = 1.0
+
 
 class _StaleProjection(Exception):
     """A fenced owner frame with no retained payload to republish."""
@@ -156,13 +168,106 @@ class SessionTable:
         # generations. Entries route watch commands but never own these queues.
         self.session_subscribers: dict[str, set[asyncio.Queue[dict[str, Any]]]] = {}
         self.provisional_active: set[str] = set()
+        # The durable half of summaries() is a directory scan; cache it behind a
+        # short TTL (SUMMARIES_CACHE_TTL_S) with single-flight refresh so N
+        # concurrent list consumers pay one scan, not N. The merged summary list
+        # is cached separately because the merge itself walks every live entry.
+        self._durable_rows_cache: dict[str, Any] | None = None
+        self._durable_rows_at = 0.0
+        self._durable_rows_task: asyncio.Task[dict[str, Any]] | None = None
+        self._summaries_cache: list[dict[str, Any]] | None = None
+        self._summaries_at = 0.0
+        self._summaries_task: asyncio.Task[list[dict[str, Any]]] | None = None
 
-    def summaries(self) -> list[dict[str, Any]]:
-        """Reconcile live generations with durable conversations by session id."""
+    def invalidate_summaries_cache(self) -> None:
+        """Drop both summaries caches so the next read rescans.
+
+        Called on every structural change (registration, heartbeat, wake,
+        session death — all funnel through ``notify_list_changed``) and when
+        the phone marks a session seen. The TTL alone would heal the same
+        facts within a second; outright invalidation makes the next repaint
+        correct instead of merely eventually correct.
+        """
+        self._durable_rows_cache = None
+        self._durable_rows_at = 0.0
+        self._summaries_cache = None
+        self._summaries_at = 0.0
+
+    async def _refresh_durable_rows(self) -> dict[str, Any]:
+        """Single-flight TTL refresh of the durable listing rows.
+
+        Runs ``recent_session_rows`` OFF the event loop: it stats and reads a
+        hundred session directories, which measured 300 ms to several seconds
+        under contention — blocking work that froze every SSE stream on this
+        loop while it ran. A concurrent caller joins the in-flight task
+        instead of starting a second scan.
+        """
         from local_operator.paths import config_dir
         from local_operator.resume import recent_session_rows
 
-        durable = {row.id: row for row in recent_session_rows(config_dir(), limit=100)}
+        task = self._durable_rows_task
+        if task is not None and not task.done():
+            return await task
+
+        async def _load() -> dict[str, Any]:
+            rows = await asyncio.to_thread(recent_session_rows, config_dir(), 100)
+            return {row.id: row for row in rows}
+
+        task = asyncio.ensure_future(_load())
+        self._durable_rows_task = task
+        try:
+            rows = await task
+        except BaseException:
+            # A failed scan must not poison the shared task: the next caller
+            # retries instead of awaiting a raised future forever.
+            if self._durable_rows_task is task:
+                self._durable_rows_task = None
+            raise
+        self._durable_rows_cache = rows
+        self._durable_rows_at = time.monotonic()
+        return rows
+
+    async def summaries(self) -> list[dict[str, Any]]:
+        """Reconcile live generations with durable conversations by session id.
+
+        Async because its durable half is blocking disk work (see
+        ``_refresh_durable_rows``); every call site awaits it off the loop.
+        The result is cached for ``SUMMARIES_CACHE_TTL_S`` — live-projection
+        fields are merged fresh on every build, so only the durable rows can
+        age, and structural changes invalidate the cache outright.
+        """
+        now = time.monotonic()
+        cached = self._summaries_cache
+        if cached is not None and now - self._summaries_at < SUMMARIES_CACHE_TTL_S:
+            return cached
+        task = self._summaries_task
+        if task is not None and not task.done():
+            return await task
+
+        async def _build() -> list[dict[str, Any]]:
+            rows = self._durable_rows_cache
+            if rows is None or time.monotonic() - self._durable_rows_at >= SUMMARIES_CACHE_TTL_S:
+                rows = await self._refresh_durable_rows()
+            return self._merge_summaries(rows)
+
+        task = asyncio.ensure_future(_build())
+        self._summaries_task = task
+        try:
+            out = await task
+        except BaseException:
+            if self._summaries_task is task:
+                self._summaries_task = None
+            raise
+        self._summaries_cache = out
+        self._summaries_at = time.monotonic()
+        return out
+
+    def _merge_summaries(self, durable: dict[str, Any]) -> list[dict[str, Any]]:
+        """Merge cached durable rows with fresh live state into summary rows.
+
+        Pure in-memory work (safe on the loop); split out of ``summaries`` so
+        the cache layer and the row shape are separately testable.
+        """
         active: dict[str, SessionEntry] = {}
         for entry in self.entries.values():
             if entry.ended:
@@ -201,6 +306,10 @@ class SessionTable:
                         if todo.status in ("pending", "blocked")
                     ),
                     "mtime": row.mtime if row else entry.record.started_at if entry else 0,
+                    # Placeholder shape: the seen-store (a later step of this
+                    # change) computes the real value; the web layer receives a
+                    # stable key from the first release of the endpoint.
+                    "unseen": False,
                 }
             )
         out.sort(
@@ -215,6 +324,10 @@ class SessionTable:
         return out
 
     def notify_list_changed(self) -> None:
+        # Structural change: the cached durable rows and merged summaries may
+        # both be stale (a session registered, ended, or woke). Drop them so
+        # the repaint this notification triggers reads fresh state.
+        self.invalidate_summaries_cache()
         for queue in self.list_subscribers:
             try:
                 queue.put_nowait(None)
@@ -1284,7 +1397,7 @@ def build_app(daemon: MobileDaemon):
         denied = gate(request)
         if denied is not None:
             return denied
-        return JSONResponse({"sessions": daemon.table.summaries()})
+        return JSONResponse({"sessions": await daemon.table.summaries()})
 
     async def api_session_events(request: Request) -> Response:
         """SSE repaint stream for one session — the phone's only realtime
@@ -1362,11 +1475,11 @@ def build_app(daemon: MobileDaemon):
 
         async def stream():
             try:
-                yield _sse("sessions", {"sessions": daemon.table.summaries()})
+                yield _sse("sessions", {"sessions": await daemon.table.summaries()})
                 while True:
                     try:
                         await asyncio.wait_for(queue.get(), timeout=SSE_KEEPALIVE_S)
-                        yield _sse("sessions", {"sessions": daemon.table.summaries()})
+                        yield _sse("sessions", {"sessions": await daemon.table.summaries()})
                     except TimeoutError:
                         yield ": keepalive\n\n"
             finally:

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -885,10 +885,24 @@ def _fan_out(entry: SessionEntry, daemon: "MobileDaemon | None" = None) -> None:
 
 
 class MobileDaemon:
-    def __init__(self, *, port: int = DEFAULT_PORT, password: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        port: int = DEFAULT_PORT,
+        password: str | None = None,
+        dial_registrants: bool = True,
+    ) -> None:
         self.port = port
         self.password = password
         self.table = SessionTable()
+        # False makes this daemon a READ-ONLY observer of the record directory:
+        # it lists sessions and serves durable folds, but never dials a
+        # registrant's control socket and never reaps a stale claim. A second
+        # daemon on the same machine MUST run this way: a registrant admits at
+        # most ONE daemon connection, so a secondary dial would evict the
+        # production daemon's live bridge mid-session. Set via
+        # ``LO_MOBILE_NO_DIAL=1`` (see ``service.amain``).
+        self.dial_registrants = dial_registrants
         # Per-session "last seen by phone" state, persisted across daemon
         # restarts (see :mod:`.seen`). The merge reads it for every summary
         # row; it persists itself on change.
@@ -1175,14 +1189,18 @@ class MobileDaemon:
                 # record pid dead; the lease helper revalidates generation and
                 # process identity under the recovery lock before removing only
                 # that claim and its pid mirror. Transcript data is untouched.
-                from local_operator.paths import config_dir
-                from local_operator.session_lease import reap_proven_dead_session_claim
+                # A no-dial daemon is an observer: lease reaping belongs to the
+                # production daemon that owns the session, and two reapers on
+                # one store is a claim race.
+                if self.dial_registrants:
+                    from local_operator.paths import config_dir
+                    from local_operator.session_lease import reap_proven_dead_session_claim
 
-                await asyncio.to_thread(
-                    reap_proven_dead_session_claim,
-                    config_dir() / "sessions" / record.session_id,
-                    record.pid,
-                )
+                    await asyncio.to_thread(
+                        reap_proven_dead_session_claim,
+                        config_dir() / "sessions" / record.session_id,
+                        record.pid,
+                    )
                 self.table.provisional_active.discard(record.session_id)
                 projection = await asyncio.to_thread(_durable_projection, record.session_id)
                 if projection is not None:
@@ -1207,8 +1225,10 @@ class MobileDaemon:
             # Degraded is precisely "we owe this session a redial" — the only
             # gates are ended, an open socket, and the backoff clock. Excluding
             # degraded entries here was the starvation bug: one refused dial
-            # meant never trying again.
-            if not entry.ended and entry.writer is None:
+            # meant never trying again. A no-dial daemon owes no dial at all:
+            # its entries exist so the list and durable routes work, and the
+            # production daemon owns every control socket.
+            if self.dial_registrants and not entry.ended and entry.writer is None:
                 if time.monotonic() >= entry.next_dial_at and (
                     record.pid not in self._dial_tasks or self._dial_tasks[record.pid].done()
                 ):
@@ -1335,6 +1355,10 @@ class MobileDaemon:
         local_operator.mobile.child``), so the record + control socket path is
         literally the same code the TUI uses.
         """
+        if not self.dial_registrants:
+            # An observer daemon cannot adopt what it spawns (it never dials),
+            # so a spawned child would be orphaned from its own control plane.
+            raise RuntimeError("observer daemon cannot start sessions")
         import sys
 
         env = dict(os.environ)
@@ -1805,6 +1829,10 @@ def build_app(daemon: MobileDaemon):
                 # from spawning a child that can never own a transcript.
                 if _durable_user_session_dir(session_id) is None:
                     raise KeyError(session_id)
+                if not daemon.dial_registrants:
+                    # Waking starts a host process the observer could never
+                    # dial; the production daemon owns wake transitions.
+                    raise RuntimeError("observer daemon cannot wake sessions")
                 from local_operator.mobile.attach_client import continue_command
 
                 command = ContinuationCommand.from_json(

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -374,10 +374,19 @@ class SessionTable:
         return out
 
     def notify_list_changed(self) -> None:
-        # Structural change: the cached durable rows and merged summaries may
-        # both be stale (a session registered, ended, or woke). Drop them so
-        # the repaint this notification triggers reads fresh state.
-        self.invalidate_summaries_cache()
+        """Wake the list SSE subscribers for a repaint.
+
+        Deliberately does NOT invalidate the summaries cache. Every projection
+        push from a live registrant calls this (~30x/s while streaming), and
+        invalidating here re-ran the full durable directory scan on each one —
+        which defeated the TTL cache in exactly the busy case it was built for
+        (measured: 30 repaints produced 30 scans at 42-92 ms each). A push
+        changes only LIVE fields, and ``_merge_summaries`` recomputes those
+        from ``self.entries`` on every build, so the cached durable rows stay
+        correct across it. Callers that genuinely change the DURABLE set
+        (registration, death, wake, seen) call
+        :meth:`invalidate_summaries_cache` themselves.
+        """
         for queue in self.list_subscribers:
             try:
                 queue.put_nowait(None)
@@ -648,7 +657,15 @@ async def _dial(daemon: "MobileDaemon", entry: SessionEntry) -> None:
                     # was evicted. Its identity remains fenced by the epoch ledger.
                     continue
                 entry.projection = captured
-                daemon.table.provisional_active.discard(entry.record.session_id)
+                # Only the FIRST push after a wake changes the durable picture:
+                # it retires the provisional-active marker, which moves the row
+                # between sections. Invalidating on EVERY push is what defeated
+                # the summaries cache — a streaming session pushes ~30x/s and
+                # each one re-ran the full directory scan.
+                session_id = entry.record.session_id
+                if session_id in daemon.table.provisional_active:
+                    daemon.table.provisional_active.discard(session_id)
+                    daemon.table.invalidate_summaries_cache()
                 daemon.table.notify_list_changed()
                 _fan_out(entry, daemon)
             # acks/errors are matched by req id in _request's future map.
@@ -1278,6 +1295,9 @@ class MobileDaemon:
                                     pass
                     self._prune_projection_generation(session_id)
         if changed:
+            # Structural: a session registered, was replaced, or died, so the
+            # durable listing itself may have moved.
+            self.table.invalidate_summaries_cache()
             self.table.notify_list_changed()
 
     def retain_provisional_active(self, session_id: str) -> None:
@@ -1300,6 +1320,9 @@ class MobileDaemon:
                                 queue.put_nowait(_projection_frame(projection))
                             except asyncio.QueueFull:
                                 pass
+                    # Structural: the wake settled into a durable (or dead)
+                    # session, which changes what the listing scan returns.
+                    self.table.invalidate_summaries_cache()
                     self.table.notify_list_changed()
             finally:
                 self._wake_settle_tasks.pop(session_id, None)
@@ -1863,6 +1886,8 @@ def build_app(daemon: MobileDaemon):
                 # remains authoritative until a live projection arrives or the
                 # attempt fails, so even a 50 ms worker is observable in list SSE.
                 daemon.table.provisional_active.add(session_id)
+                # Structural: the session moves to the active section.
+                daemon.table.invalidate_summaries_cache()
                 daemon.table.notify_list_changed()
                 projection = daemon.session_projections.get(session_id) or _durable_projection(
                     session_id
@@ -1884,6 +1909,8 @@ def build_app(daemon: MobileDaemon):
                     client, detail = await continue_command(config_dir(), command)
                 except BaseException:
                     daemon.table.provisional_active.discard(session_id)
+                    # Structural: the failed wake moves it back to previous.
+                    daemon.table.invalidate_summaries_cache()
                     daemon.table.notify_list_changed()
                     raise
                 client.close()

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -1205,7 +1205,9 @@ class MobileDaemon:
                 # one store is a claim race.
                 if self.dial_registrants:
                     from local_operator.paths import config_dir
-                    from local_operator.session_lease import reap_proven_dead_session_claim
+                    from local_operator.session_lease import (
+                        reap_proven_dead_session_claim,
+                    )
 
                     await asyncio.to_thread(
                         reap_proven_dead_session_claim,

--- a/local_operator/mobile/durable.py
+++ b/local_operator/mobile/durable.py
@@ -81,11 +81,21 @@ _TRACKED_CUSTOM_TYPES = frozenset({"subagent_roster", "todo_snapshot"})
 
 #: Bound on cached durable folds, in sessions. One entry holds the replayed
 #: history plus the UNCAPPED render rows (the history endpoint serves the full
-#: conversation, not a tail): ~1 MB of rows plus a few MB of rehydrated
-#: messages on the worst measured transcript (53 MB file, 413-message replay
-#: window). 16 of those is a bounded ~tens-of-MB for the daemon; eviction is
-#: LRU and costs nothing but a re-fold on the next open of an evicted session.
-MAX_DURABLE_FOLD_CACHE = 16
+#: conversation, not a tail).
+#:
+#: MEASURED, not estimated: ``tracemalloc`` against the operator's largest real
+#: transcript (55.8 MB file, 441 replayed messages, 358 render rows) retains
+#: **6.9 MB per entry** and takes ~1.2 s to fold. An earlier revision of this
+#: comment called 16 entries "a bounded ~tens-of-MB", which was ~4x optimistic:
+#: 16 x 6.9 MB is ~110 MB resident for a daemon that runs all day, and that is
+#: a different decision from the one the number implied.
+#:
+#: 8 is the corrected bound, ~55 MB worst case. The phone opens a handful of
+#: sessions in a sitting, so the hit rate barely moves; eviction costs only a
+#: re-fold on the next open of an evicted session, and the incremental tail
+#: read means a re-fold is paid once, not per request. Worst-case entries are
+#: also the rare ones — a typical session folds to well under a megabyte.
+MAX_DURABLE_FOLD_CACHE = 8
 
 
 @dataclass
@@ -120,11 +130,14 @@ class DurableFoldState:
     history: list[AgentMessage] = field(default_factory=list)
     render: list[Any] = field(default_factory=list)
     prunes: dict[str, str] = field(default_factory=dict)
+    #: Transcript entries consumed so far. Not read by the fold itself — it is
+    #: the cheap invariant that says the incremental cursor and the file agree,
+    #: which the cache tests assert against a full re-parse.
+    entry_count: int = 0
     #: Newest-wins custom-entry details by type, mirroring the store's
     #: ``latest_custom``. The durable projection reads the subagent roster and
     #: a child's todo snapshot from here instead of re-parsing transcripts.
     latest_customs: dict[str, dict[str, Any]] = field(default_factory=dict)
-    entry_count: int = 0
     offset: int = 0
     fingerprint: _FileFingerprint | None = None
     #: Serializes rebuilds of THIS session; concurrent opens of one session pay

--- a/local_operator/mobile/durable.py
+++ b/local_operator/mobile/durable.py
@@ -1,0 +1,531 @@
+"""Incremental durable fold for the mobile daemon's read paths.
+
+The daemon's durable routes — the SSE seed for a session with no live process
+(:func:`.daemon._durable_projection`) and every history page the phone scrolls
+up into (:func:`.daemon._history_page`) — used to construct a fresh
+:class:`~local_operator.session.transcript.Transcript` per request: read the
+WHOLE JSONL file, replay it, and fold it. On the operator's store that
+measured 90-900 ms per session open and 50-150 ms per history page, O(full
+transcript) every time, on transcripts up to 52 MB.
+
+This module is the opt-in cache layer the daemon uses INSTEAD, built beside
+the ``Transcript`` class rather than inside it: ``Transcript`` is the
+LLM-facing store with append/compaction semantics of its own and must keep
+its exact behaviour.
+
+Design, in three facts:
+
+- **The file is append-only per inode.** Appends write one whole JSON line,
+  flush, and fsync; ``compact_file`` is the only rewrite and it replaces the
+  file atomically (new inode). So a cached byte offset into a same-inode,
+  non-shrunk file is a durable cursor: everything before it is unchanged, and
+  the new content is exactly the bytes after it. A shrunk file or a new inode
+  invalidates the cursor and forces a full rebuild.
+- **Replay state stays small.** The cache retains the REPLAYED history
+  (bounded by the compaction window) and the folded render rows — never the
+  raw parsed entries of a 50 MB file, which would cost 3-5x the file size in
+  Python objects. The rare tail events that need more are handled in place:
+  a prune entry blanks its target message in the cached history; a compaction
+  entry rebuilds the history from the cached window (its ``first_kept_entry_id``
+  resolves there because the live session compacts exactly this window). Only
+  when that resolution fails — the same edge ``build_llm_history`` logs an
+  error for — does the cache fall back to a full re-read. Correctness over
+  speed, and the slow path is the one the old code ran on EVERY request.
+- **Fold cost is O(history), not O(file).** ``fold_messages_to_entries`` over
+  the replayed history measures ~1 ms where the file parse measured hundreds,
+  so rebuilding the render rows wholesale on every observed change is cheap;
+  the incrementality that matters is the disk read (appended kilobytes, not
+  the whole file).
+
+Threading: the daemon calls from ``asyncio.to_thread`` workers, so the cache
+is thread-safe — one lock guards the LRU dict, one lock per cached session
+serializes its rebuilds (two concurrent opens of the same session pay one
+fold, not two).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from local_operator.harness.types import AgentMessage, CustomMessage, Message, TextContent
+from local_operator.session.attachments import AttachmentStore
+from local_operator.session.transcript import (
+    ENTRY_COMPACTION,
+    ENTRY_CUSTOM,
+    ENTRY_MESSAGE,
+    ENTRY_PRUNE,
+    TRANSCRIPT_FILENAME,
+    TranscriptEntry,
+    _entry_to_message,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Custom-entry types the durable projection reads newest-wins (the store's
+#: ``latest_custom`` contract). Tracked in the fold cache so a cached session
+#: never re-parses its transcript to answer them. Importing the roster
+#: constant pulls in the session module, so the literals are restated here and
+#: asserted against the source of truth in the unit tests.
+_TRACKED_CUSTOM_TYPES = frozenset({"subagent_roster", "todo_snapshot"})
+
+#: Bound on cached durable folds, in sessions. One entry holds the replayed
+#: history plus the UNCAPPED render rows (the history endpoint serves the full
+#: conversation, not a tail): ~1 MB of rows plus a few MB of rehydrated
+#: messages on the worst measured transcript (53 MB file, 413-message replay
+#: window). 16 of those is a bounded ~tens-of-MB for the daemon; eviction is
+#: LRU and costs nothing but a re-fold on the next open of an evicted session.
+MAX_DURABLE_FOLD_CACHE = 16
+
+
+@dataclass
+class _FileFingerprint:
+    """Identity of one transcript file at one read position.
+
+    The inode distinguishes ``compact_file``'s atomic replacement from an
+    append (a rewrite that happens to keep or grow the size is still a
+    different file); the size says how much has been consumed. mtime rides
+    along for diagnostics but is not load-bearing — APFS timestamps are
+    nanosecond-precise, yet a same-inode same-size file cannot have changed
+    regardless of what its mtime claims.
+    """
+
+    inode: int
+    size: int
+    mtime: float
+
+
+@dataclass
+class DurableFoldState:
+    """One session's cached durable fold.
+
+    ``history`` is the replay (``Transcript.build_llm_history`` semantics),
+    ``render`` the folded phone rows (``fold_messages_to_entries`` over that
+    history, UNCAPPED). ``prunes`` mirrors ``Transcript.pending_prunes``:
+    later entries win, applied at replay and re-applied after a compaction
+    rebuild so a cached window stays byte-identical to a fresh replay.
+    """
+
+    directory: Path
+    history: list[AgentMessage] = field(default_factory=list)
+    render: list[Any] = field(default_factory=list)
+    prunes: dict[str, str] = field(default_factory=dict)
+    #: Newest-wins custom-entry details by type, mirroring the store's
+    #: ``latest_custom``. The durable projection reads the subagent roster and
+    #: a child's todo snapshot from here instead of re-parsing transcripts.
+    latest_customs: dict[str, dict[str, Any]] = field(default_factory=dict)
+    entry_count: int = 0
+    offset: int = 0
+    fingerprint: _FileFingerprint | None = None
+    #: Serializes rebuilds of THIS session; concurrent opens of one session pay
+    #: one fold, not one per caller.
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+class DurableFoldCache:
+    """Bounded LRU of :class:`DurableFoldState`, keyed by session directory."""
+
+    def __init__(self, max_entries: int = MAX_DURABLE_FOLD_CACHE) -> None:
+        self._max_entries = max_entries
+        self._states: OrderedDict[str, DurableFoldState] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def get(self, directory: Path) -> DurableFoldState:
+        """The fold state for ``directory``, LRU-touched and created if new."""
+        key = str(directory)
+        with self._lock:
+            state = self._states.get(key)
+            if state is not None:
+                self._states.move_to_end(key)
+                return state
+            state = DurableFoldState(directory=directory)
+            self._states[key] = state
+            while len(self._states) > self._max_entries:
+                self._states.popitem(last=False)
+            return state
+
+    def invalidate(self, directory: Path) -> None:
+        with self._lock:
+            self._states.pop(str(directory), None)
+
+    def load(self, directory: Path) -> DurableFoldState:
+        """Fold state brought current with the file on disk.
+
+        The common path reads only the bytes appended since the last load;
+        rotation (``compact_file``) or a failed incremental repair falls back
+        to a full rebuild, which is still exactly what every request used to
+        do before this cache existed.
+        """
+        state = self.get(directory)
+        with state.lock:
+            path = directory / TRANSCRIPT_FILENAME
+            try:
+                stat = os.stat(path)
+            except OSError:
+                # The file vanished (retention sweep, manual cleanup): the
+                # session has no history to serve. Reset so a re-created file
+                # is not read against a stale cursor.
+                self.invalidate(directory)
+                raise FileNotFoundError(path)
+            fingerprint = _FileFingerprint(inode=stat.st_ino, size=stat.st_size, mtime=stat.st_mtime)
+            previous = state.fingerprint
+            if previous is not None and fingerprint.inode == previous.inode:
+                if fingerprint.size == previous.size:
+                    return state  # nothing appended; the cache IS the file
+                if fingerprint.size > previous.size:
+                    try:
+                        if self._apply_tail(state, path, fingerprint):
+                            return state
+                    except Exception:  # noqa: BLE001 — a bad tail must not 500 the route
+                        logger.exception(
+                            "durable fold: incremental read failed for %s; rebuilding", directory
+                        )
+            # New file, shrunk file, or failed increment: full rebuild.
+            self._rebuild(state, path, fingerprint)
+            return state
+
+    # -- internals -----------------------------------------------------------
+
+    def _apply_tail(self, state: DurableFoldState, path: Path, fingerprint: _FileFingerprint) -> bool:
+        """Consume the bytes appended since the last load. False = rebuild.
+
+        Returns False (rather than raising) whenever the tail cannot be folded
+        in place — the caller's full rebuild is always correct, so an
+        incremental shortcut never gets to trade correctness for speed.
+        """
+        with path.open("rb") as handle:
+            handle.seek(state.offset)
+            data = handle.read(fingerprint.size - state.offset)
+        if not data.endswith(b"\n"):
+            # A writer may be mid-line when we read (appends are whole lines +
+            # fsync, but the read can race the write). Consume only complete
+            # lines; the fragment is picked up on the next load.
+            cut = data.rfind(b"\n")
+            if cut < 0:
+                return True  # nothing complete yet; keep the cursor
+            data = data[: cut + 1]
+        consumed = len(data)
+        new_entries: list[TranscriptEntry] = []
+        for line in data.decode("utf-8", "replace").splitlines():
+            if not line.strip():
+                continue
+            entry = TranscriptEntry.from_json(line)
+            if entry is not None:
+                new_entries.append(entry)
+        if not new_entries:
+            state.offset += consumed
+            state.fingerprint = fingerprint
+            return True
+
+        # Replay-affecting tail events are folded in place below; anything the
+        # in-place rules cannot express defers to the caller's full rebuild.
+        rebuild_render = False
+        for entry in new_entries:
+            if entry.type == ENTRY_MESSAGE:
+                message = _entry_to_message(entry, _attachments())
+                if message is None:
+                    continue
+                notice = state.prunes.get(entry.id)
+                if notice is not None and isinstance(message, Message):
+                    _apply_prune_to(message, notice)
+                state.history.append(message)
+                rebuild_render = True
+            elif entry.type == ENTRY_PRUNE:
+                target = entry.payload.get("target")
+                if not target:
+                    continue
+                notice = str(entry.payload.get("notice", ""))
+                state.prunes[str(target)] = notice
+                # Blank the cached message the live session already blanked, so
+                # the render rebuilt below matches a fresh replay byte for byte.
+                for message in state.history:
+                    if message.id == str(target) and isinstance(message, Message):
+                        _apply_prune_to(message, notice)
+                        break
+                rebuild_render = True
+            elif entry.type == ENTRY_COMPACTION:
+                if not _rebuild_history_after_compaction(state, entry):
+                    return False
+                rebuild_render = True
+            elif entry.type == ENTRY_CUSTOM:
+                # Replay ignores custom entries; the durable projection reads a
+                # few newest-wins snapshots (roster, todo) that the store
+                # exposes via ``latest_custom``. Track them here so a cached
+                # session never re-parses for them.
+                custom_type = entry.payload.get("custom_type")
+                if custom_type in _TRACKED_CUSTOM_TYPES:
+                    state.latest_customs[str(custom_type)] = dict(
+                        entry.payload.get("details", {})
+                    )
+        if rebuild_render:
+            state.render = _fold(state.history)
+        state.entry_count += len(new_entries)
+        state.offset += consumed
+        state.fingerprint = fingerprint
+        return True
+
+    def _rebuild(
+        self, state: DurableFoldState, path: Path, fingerprint: _FileFingerprint
+    ) -> None:
+        """Full fold from the file: the pre-cache behaviour, run once per
+        session per daemon lifetime (then maintained incrementally)."""
+        entries: list[TranscriptEntry] = []
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                entry = TranscriptEntry.from_json(line)
+                if entry is not None:
+                    entries.append(entry)
+        # Newest-wins custom snapshots, backward scan like ``latest_custom``.
+        latest_customs: dict[str, dict[str, Any]] = {}
+        for entry in reversed(entries):
+            if entry.type != ENTRY_CUSTOM:
+                continue
+            custom_type = entry.payload.get("custom_type")
+            if custom_type in _TRACKED_CUSTOM_TYPES and custom_type not in latest_customs:
+                latest_customs[str(custom_type)] = dict(entry.payload.get("details", {}))
+        state.history = _replay(entries)
+        state.render = _fold(state.history)
+        state.prunes = {
+            str(entry.payload.get("target")): str(entry.payload.get("notice", ""))
+            for entry in entries
+            if entry.type == ENTRY_PRUNE and entry.payload.get("target")
+        }
+        state.latest_customs = latest_customs
+        state.entry_count = len(entries)
+        state.offset = fingerprint.size
+        state.fingerprint = fingerprint
+
+
+def _replay(entries: list[TranscriptEntry]) -> list[AgentMessage]:
+    """``Transcript.build_llm_history`` semantics over parsed entries.
+
+    Kept beside the cache rather than reused THROUGH a ``Transcript`` instance
+    because constructing one mkdirs, takes an asyncio lock, and retains the raw
+    entries — everything this module exists to avoid. The semantics are the
+    contract: latest compaction wins, preserved user turns re-injected
+    verbatim, prunes applied last.
+    """
+    compaction_index: int | None = None
+    for i in range(len(entries) - 1, -1, -1):
+        if entries[i].type == ENTRY_COMPACTION:
+            compaction_index = i
+            break
+
+    start = 0
+    prefix: list[AgentMessage] = []
+    if compaction_index is not None:
+        compaction = entries[compaction_index]
+        prefix = _compaction_prefix(compaction)
+        first_kept_id = compaction.payload.get("first_kept_entry_id")
+        if first_kept_id is None:
+            start = compaction_index + 1
+        else:
+            for i in range(len(entries)):
+                if entries[i].id == first_kept_id:
+                    start = i
+                    break
+            else:
+                # Mirror ``build_llm_history``: replaying too much is
+                # recoverable at the next compaction; silent amnesia is not.
+                logger.error(
+                    "durable fold: first_kept_entry_id %s not found; replaying full history",
+                    first_kept_id,
+                )
+
+    prunes = {
+        str(entry.payload.get("target")): str(entry.payload.get("notice", ""))
+        for entry in entries
+        if entry.type == ENTRY_PRUNE and entry.payload.get("target")
+    }
+    out: list[AgentMessage] = list(prefix)
+    for entry in entries[start:]:
+        if entry.type != ENTRY_MESSAGE:
+            continue
+        message = _entry_to_message(entry, _attachments())
+        if message is None:
+            continue
+        notice = prunes.get(entry.id)
+        if notice is not None and isinstance(message, Message):
+            _apply_prune_to(message, notice)
+        out.append(message)
+    return out
+
+
+def _compaction_prefix(compaction: TranscriptEntry) -> list[AgentMessage]:
+    """The marker summary plus preserved user turns, exactly as
+    ``build_llm_history`` injects them (see its docstring for why the turns
+    ride the payload verbatim)."""
+    details: dict[str, Any] = {"summary": compaction.payload.get("summary", "")}
+    preserve_data = compaction.payload.get("preserve_data")
+    if preserve_data is not None:
+        details["preserve_data"] = preserve_data
+    prefix: list[AgentMessage] = [
+        CustomMessage(
+            custom_type="compaction_summary",
+            attribution="system",
+            details=details,
+        )
+    ]
+    preserved_turns = compaction.payload.get("preserved_user_turns") or ()
+    if preserved_turns:
+        from local_operator.compaction.cutpoint import PRESERVED_USER_TURN_KEY
+
+        for turn in preserved_turns:
+            if not isinstance(turn, dict):
+                continue
+            message = Message.user(str(turn.get("text", "")))
+            turn_id = turn.get("id")
+            if isinstance(turn_id, str) and turn_id:
+                message.id = turn_id
+            message.provider_payload = {PRESERVED_USER_TURN_KEY: True}
+            prefix.append(message)
+    return prefix
+
+
+def _rebuild_history_after_compaction(state: DurableFoldState, entry: TranscriptEntry) -> bool:
+    """Fold a tail compaction into the cached history without re-reading.
+
+    The live session compacts exactly the window this cache replays, so the
+    new marker's ``first_kept_entry_id`` resolves inside ``state.history``;
+    when it does not (a dropped malformed line, a converter-minted id) the
+    caller falls back to a full rebuild — the same direction
+    ``build_llm_history`` chooses when it logs this edge.
+    """
+    prefix = _compaction_prefix(entry)
+    first_kept_id = entry.payload.get("first_kept_entry_id")
+    kept: list[AgentMessage] = []
+    if first_kept_id is not None:
+        index = next((i for i, m in enumerate(state.history) if m.id == first_kept_id), None)
+        if index is None:
+            return False
+        kept = state.history[index:]
+    # Prunes journalled before this marker already shaped the kept window;
+    # re-apply the map so a kept message blanked by an older prune stays
+    # blanked (idempotent — same notice, same result).
+    for message in kept:
+        notice = state.prunes.get(message.id)
+        if notice is not None and isinstance(message, Message):
+            _apply_prune_to(message, notice)
+    state.history = [*prefix, *kept]
+    return True
+
+
+def _apply_prune_to(message: Message, notice: str) -> None:
+    """``transcript._apply_prune`` without the module-private import: blank
+    the message the way the live pruning pass did, so a cached replay is
+    indistinguishable from a fresh one."""
+    message.content = [TextContent(text=notice)]
+    message.provider_payload = {**(message.provider_payload or {}), "pruned": True}
+
+
+def _fold(history: list[AgentMessage]) -> list[Any]:
+    from local_operator.mobile.projection import fold_messages_to_entries
+
+    return fold_messages_to_entries(history)
+
+
+@dataclass
+class _CustomSnapshotEntry:
+    """One directory's tracked newest-wins custom snapshots, validated by the
+    file's inode and size: a same-inode same-size transcript cannot have
+    changed (append-only per inode; ``compact_file`` replaces the file)."""
+
+    inode: int
+    size: int
+    customs: dict[str, dict[str, Any]]
+
+
+class CustomSnapshotCache:
+    """Newest-wins custom snapshots for directories the fold cache does not keep.
+
+    Exists for the deep-roster durable path: ``_durable_projection`` asks every
+    child transcript for its todo snapshot, and routing those reads through the
+    full fold cache would let an 80-child roster evict the ROOT's fold (the
+    cache is bounded) — re-folding a 50 MB transcript on the next open. These
+    snapshots are tiny (one details dict per type), so a large separate LRU
+    costs almost nothing and keeps the fold cache for actual folds.
+    """
+
+    def __init__(self, max_entries: int = 256) -> None:
+        self._max_entries = max_entries
+        self._entries: OrderedDict[str, _CustomSnapshotEntry] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def load(self, directory: Path, custom_type: str) -> dict[str, Any] | None:
+        """Details of the newest ``custom_type`` entry, or ``None``.
+
+        Re-stats on every call (one syscall) and re-scans only when the file
+        grew or was replaced — a dead child's transcript never changes, so the
+        scan runs once per daemon lifetime per child.
+        """
+        path = directory / TRANSCRIPT_FILENAME
+        try:
+            stat = os.stat(path)
+        except OSError:
+            with self._lock:
+                self._entries.pop(str(directory), None)
+            return None
+        key = str(directory)
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is not None and entry.inode == stat.st_ino and entry.size == stat.st_size:
+                self._entries.move_to_end(key)
+                return entry.customs.get(custom_type)
+        customs = self._scan(path)
+        with self._lock:
+            self._entries[key] = _CustomSnapshotEntry(
+                inode=stat.st_ino, size=stat.st_size, customs=customs
+            )
+            self._entries.move_to_end(key)
+            while len(self._entries) > self._max_entries:
+                self._entries.popitem(last=False)
+        return customs.get(custom_type)
+
+    @staticmethod
+    def _scan(path: Path) -> dict[str, dict[str, Any]]:
+        """One forward pass keeping the newest details per tracked type.
+
+        Streaming and retaining nothing but the answer dicts: the scan must
+        not materialize a child's whole transcript just to find one snapshot.
+        """
+        customs: dict[str, dict[str, Any]] = {}
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    if not line.strip():
+                        continue
+                    entry = TranscriptEntry.from_json(line)
+                    if entry is None or entry.type != ENTRY_CUSTOM:
+                        continue
+                    custom_type = entry.payload.get("custom_type")
+                    if custom_type in _TRACKED_CUSTOM_TYPES:
+                        customs[str(custom_type)] = dict(entry.payload.get("details", {}))
+        except OSError:
+            pass
+        return customs
+
+
+#: One shared store: it is content-addressed under config_dir() and read-only
+#: here, so every cached session resolves its image references against the
+#: same bytes the Transcript would.
+_ATTACHMENT_STORES: dict[str, AttachmentStore] = {}
+_ATTACHMENT_LOCK = threading.Lock()
+
+
+def _attachments() -> AttachmentStore:
+    from local_operator.paths import config_dir
+
+    key = str(config_dir())
+    with _ATTACHMENT_LOCK:
+        store = _ATTACHMENT_STORES.get(key)
+        if store is None:
+            store = AttachmentStore()
+            _ATTACHMENT_STORES[key] = store
+        return store

--- a/local_operator/mobile/durable.py
+++ b/local_operator/mobile/durable.py
@@ -172,7 +172,9 @@ class DurableFoldCache:
                 # is not read against a stale cursor.
                 self.invalidate(directory)
                 raise FileNotFoundError(path)
-            fingerprint = _FileFingerprint(inode=stat.st_ino, size=stat.st_size, mtime=stat.st_mtime)
+            fingerprint = _FileFingerprint(
+                inode=stat.st_ino, size=stat.st_size, mtime=stat.st_mtime
+            )
             previous = state.fingerprint
             if previous is not None and fingerprint.inode == previous.inode:
                 if fingerprint.size == previous.size:
@@ -191,7 +193,9 @@ class DurableFoldCache:
 
     # -- internals -----------------------------------------------------------
 
-    def _apply_tail(self, state: DurableFoldState, path: Path, fingerprint: _FileFingerprint) -> bool:
+    def _apply_tail(
+        self, state: DurableFoldState, path: Path, fingerprint: _FileFingerprint
+    ) -> bool:
         """Consume the bytes appended since the last load. False = rebuild.
 
         Returns False (rather than raising) whenever the tail cannot be folded
@@ -259,9 +263,7 @@ class DurableFoldCache:
                 # session never re-parses for them.
                 custom_type = entry.payload.get("custom_type")
                 if custom_type in _TRACKED_CUSTOM_TYPES:
-                    state.latest_customs[str(custom_type)] = dict(
-                        entry.payload.get("details", {})
-                    )
+                    state.latest_customs[str(custom_type)] = dict(entry.payload.get("details", {}))
         if rebuild_render:
             state.render = _fold(state.history)
         state.entry_count += len(new_entries)
@@ -269,9 +271,7 @@ class DurableFoldCache:
         state.fingerprint = fingerprint
         return True
 
-    def _rebuild(
-        self, state: DurableFoldState, path: Path, fingerprint: _FileFingerprint
-    ) -> None:
+    def _rebuild(self, state: DurableFoldState, path: Path, fingerprint: _FileFingerprint) -> None:
         """Full fold from the file: the pre-cache behaviour, run once per
         session per daemon lifetime (then maintained incrementally)."""
         entries: list[TranscriptEntry] = []

--- a/local_operator/mobile/durable.py
+++ b/local_operator/mobile/durable.py
@@ -53,7 +53,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from local_operator.harness.types import AgentMessage, CustomMessage, Message, TextContent
+from local_operator.harness.types import (
+    AgentMessage,
+    CustomMessage,
+    Message,
+    TextContent,
+)
 from local_operator.session.attachments import AttachmentStore
 from local_operator.session.transcript import (
     ENTRY_COMPACTION,

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -23,6 +23,7 @@ safe to call from any thread that serializes calls per session.
 
 from __future__ import annotations
 
+import json
 import time
 from collections.abc import Mapping
 from typing import Any
@@ -107,6 +108,33 @@ SUBAGENT_OUTCOME_CHARS = 200
 #: wrong". This costs almost nothing on frame size: 2000 chars across the worst
 #: ~81-subagent roster is ~150 KB, well under the 1 MB control-frame cap.
 SUBAGENT_ERROR_CHARS = 2_000
+
+
+#: Soft cap for one serialized projection frame, applied by
+#: :func:`cap_projection_frame` BEFORE the frame is written to a socket or an
+#: SSE stream. The daemon's control-socket StreamReader refuses a line past
+#: 1 MB (``limit=1 << 20`` in ``daemon._dial``) and drains it, so an oversized
+#: push is a silently dropped repaint; a FLOOD of them (one session measured
+#: 48k drops at 14% idle CPU) starves the daemon loop and stalls EVERY other
+#: session's load. 700 KB keeps a generous margin under the hard limit for the
+#: frame envelope and JSON escaping inflation (a payload of quotes/backslashes
+#: can nearly double when escaped).
+PROJECTION_FRAME_SOFT_CAP_BYTES = 700_000
+
+#: Minimal bounds the frame cap degrades subagent text to. The cap only fires
+#: past the soft cap, so these are preview lengths, not the normal ones: the
+#: full prompt/result stay reachable through the child transcript's lazy
+#: /history fetch, and a degraded roster row still names the child and its
+#: state — the wedge alternative is no repaint at all.
+FRAME_CAP_PROMPT_CHARS = 120
+FRAME_CAP_RESULT_CHARS = 200
+FRAME_CAP_ERROR_CHARS = 400
+
+#: Floor for the transcript tail under the frame cap. Tier 3 halves the tail
+#: toward this bound; below it the phone keeps the opening user message plus
+#: the newest few rows and pages the rest from /history, which is exactly the
+#: scroll contract the 80-row cap already established.
+FRAME_CAP_TRANSCRIPT_FLOOR = 16
 
 
 def _message_text(message: AgentMessage) -> str:
@@ -201,6 +229,76 @@ def _diff_counts(details: dict[str, Any] | None) -> tuple[int, int]:
         return int(added), int(removed)
     except (TypeError, ValueError):
         return 0, 0
+
+
+def _frame_bytes(data: dict[str, Any]) -> int:
+    return len(json.dumps(data).encode("utf-8"))
+
+
+def cap_projection_frame(
+    projection: SessionProjection, *, cap_bytes: int = PROJECTION_FRAME_SOFT_CAP_BYTES
+) -> tuple[dict[str, Any], bool]:
+    """Serialize ``projection``, degrading optional payload tiers until the
+    frame fits ``cap_bytes``. Returns ``(frame_dict, degraded)``.
+
+    The registrant broadcasts ~30 repaints/s and the daemon's control reader
+    drops any line past 1 MB, so an oversized projection is not an error the
+    peer reports — it is a silently lost repaint, and a flood of them starves
+    the daemon loop for every OTHER session (the wedge this cap exists to
+    stop at the source). The tiers drop in order of recoverability:
+
+    1. Subagent text previews (prompt/result/error) shrink to minimal bounds.
+       The full text stays reachable through the child transcript's lazy
+       /history fetch, so nothing is lost that a tap cannot recover.
+    2. Transcript rows lose their ``details`` expand payload (args/output/
+       diff). The collapsed row still renders; expanding an old row is the
+       one gesture that can re-fetch from /history.
+    3. The transcript tail halves toward ``FRAME_CAP_TRANSCRIPT_FLOOR``,
+       keeping the pinned opening user message — the same scroll contract the
+       80-row cap already establishes, just tighter.
+
+    The projection itself is never mutated (the fold owns it and republishes
+    it; the daemon retains it): degradation happens on the serialized dict.
+    """
+    data = projection.to_json()
+    if _frame_bytes(data) <= cap_bytes:
+        return data, False
+
+    # Tier 1: subagent text previews down to minimal bounds.
+    for row in data.get("subagents") or []:
+        row["prompt"] = _compact(str(row.get("prompt") or ""), FRAME_CAP_PROMPT_CHARS)
+        row["result_text"] = _compact_multiline(
+            str(row.get("result_text") or ""), FRAME_CAP_RESULT_CHARS
+        )
+        row["error_text"] = _compact_multiline(
+            str(row.get("error_text") or ""), FRAME_CAP_ERROR_CHARS
+        )
+        # A hydrated child transcript on the wire predates the lazy /history
+        # fetch; if one is still embedded it is pure frame weight.
+        row["transcript"] = []
+    if _frame_bytes(data) <= cap_bytes:
+        return data, True
+
+    # Tier 2: drop the expand payload of every transcript row.
+    for entry in data.get("transcript") or []:
+        entry["details"] = {}
+    if _frame_bytes(data) <= cap_bytes:
+        return data, True
+
+    # Tier 3: halve the transcript tail toward the floor, pinning the opening
+    # user message exactly like ``ProjectionFold._cap_tail`` does.
+    entries = data.get("transcript") or []
+    limit = max(FRAME_CAP_TRANSCRIPT_FLOOR, PROJECTION_TRANSCRIPT_LIMIT // 2)
+    while len(entries) > FRAME_CAP_TRANSCRIPT_FLOOR:
+        first_user = next((e for e in entries if e.get("kind") == "user"), None)
+        entries = entries[-limit:]
+        if first_user is not None and first_user not in entries:
+            entries = [first_user, *entries[1:]]
+        data["transcript"] = entries
+        if _frame_bytes(data) <= cap_bytes:
+            return data, True
+        limit = max(FRAME_CAP_TRANSCRIPT_FLOOR, limit // 2)
+    return data, True
 
 
 def fold_messages_to_entries(history: list[AgentMessage]) -> list[TranscriptEntry]:

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -264,8 +264,70 @@ def _frame_bytes(data: dict[str, Any]) -> int:
     return len(json.dumps(data).encode("utf-8"))
 
 
-#: Safety margin on the cheap size estimate, covering JSON escaping (worst
-#: case ~2x on quote/backslash-dense text) plus the fixed frame envelope.
+#: Worst-case wire bytes per NON-ASCII character. ``_frame_bytes`` measures
+#: ``json.dumps(...).encode("utf-8")`` and ``json.dumps`` defaults to
+#: ``ensure_ascii=True``, so the wire never sees UTF-8 for these — it sees
+#: ASCII escapes. Measured, per character:
+#:
+#:     'a'              -> 1 byte
+#:     'é' / 'д' / '中'  -> 6 bytes   (\uXXXX)
+#:     astral emoji     -> 12 bytes  (surrogate pair, \uXXXX\uXXXX)
+#:
+#: This is why counting CHARACTERS — or even UTF-8 bytes, which stops at 8x for
+#: an emoji — under-counts the wire and let an oversized frame past the gate as
+#: "not degraded". 12 is the true ceiling, so charging it can only ever
+#: OVER-estimate, which is the safe direction for a gate that decides whether
+#: to skip the real measurement: over-estimating forces a measurement that is
+#: always correct, under-estimating drops a repaint in silence.
+_WIRE_BYTES_PER_NON_ASCII_CHAR = 12
+
+#: ASCII characters the serializer does NOT pass through 1:1. Quote and
+#: backslash become two bytes; the C0 controls become six (``\u0007``), except
+#: the five with short forms (``\n``, ``\t``, ``\r``, ``\b``, ``\f``) which
+#: become two. Charging the 6-byte ceiling for every one of them is exact
+#: enough and costs one ``str.count`` per class — both are C-level scans.
+#:
+#: Counting them rather than multiplying the whole string by a ceiling matters:
+#: a flat 6x charge stopped an ordinary 140 KB English chat frame from taking
+#: the cheap path at all, which is the hot repaint A7 exists to keep cheap.
+_WIRE_ESCAPE_TWO_BYTE = '"\\'
+_WIRE_ESCAPE_SIX_BYTE_CEILING = 6
+
+#: Deletion table for :meth:`str.translate` holding every ASCII codepoint the
+#: serializer escapes. Counting them as ``len(s) - len(s.translate(table))`` is
+#: one C-level pass; the obvious Python generator over the string measured
+#: 1,840 us across an 80-row frame against 152 us to serialize the whole thing,
+#: i.e. it made the "cheap" estimate 12x more expensive than the work it
+#: exists to avoid.
+_WIRE_ESCAPED_ASCII = {ord(char): None for char in ('"', "\\", *(chr(i) for i in range(0x20)), "\x7f")}
+
+
+def _wire_charge(text: str) -> int:
+    """Upper bound on the bytes ``text`` will occupy on the wire.
+
+    ``str.isascii()`` is a single C-level scan with no allocation, so the
+    overwhelmingly common all-ASCII field costs one branch plus its own
+    length and the cheap path stays cheap (measured: 1.9 us across an 80-row
+    frame, against 1.4 us for a bare ``len()`` sum). Non-ASCII text is charged
+    the ceiling rather than measured exactly, because an exact per-field
+    ``json.dumps`` costs 130 us across that same frame against 167 us to
+    measure the WHOLE frame properly — exactness here would buy nothing over
+    just doing the real thing.
+    """
+    if not text.isascii():
+        return len(text) * _WIRE_BYTES_PER_NON_ASCII_CHAR
+    # All-ASCII: one byte each, plus the extra bytes the escaped ones cost.
+    # Quotes and backslashes take one extra byte; any control character is
+    # charged the 6-byte ceiling, so \n (really 2) is over-charged by 4 — the
+    # safe direction, and cheap enough that exactness buys nothing.
+    escaped = len(text) - len(text.translate(_WIRE_ESCAPED_ASCII))
+    return len(text) + escaped * (_WIRE_ESCAPE_SIX_BYTE_CEILING - 1)
+
+
+#: Safety margin on the cheap size estimate, covering the fixed frame envelope
+#: and the per-field quoting the estimate does not model. The CHARACTER->byte
+#: inflation is charged exactly by :func:`_wire_charge`, not smuggled in here:
+#: a divisor cannot absorb a 12x term (see that function).
 _FRAME_CHEAP_PROXY_DIVISOR = 3
 
 #: Per-row charge for the JSON envelope a transcript row carries regardless of
@@ -314,21 +376,29 @@ def _frame_skips_measurement(projection: SessionProjection) -> bool:
     # Rows are bounded in COUNT above; bound them in SIZE here so one pasted
     # file cannot ride through. Only the fields a row can grow without bound
     # are summed, because the row count is already capped.
+    #
+    # Every text field goes through _wire_charge, never bare len(): the wire
+    # charges BYTES and json.dumps escapes non-ASCII, so a character sum
+    # under-counted a CJK or emoji frame by 6-12x and vouched for a payload
+    # the socket then dropped in silence. Ordinary Chinese, Japanese, Russian
+    # or accented French prose is on that curve — this was never exotic input.
     budget = PROJECTION_FRAME_SOFT_CAP_BYTES // _FRAME_CHEAP_PROXY_DIVISOR
     total = 0
     for entry in projection.transcript:
         total += _FRAME_ROW_ENVELOPE_BYTES
-        total += len(entry.text) + len(entry.summary) + len(entry.error)
-        total += len(entry.tool_name) + len(entry.tool_call_id) + len(entry.intent)
-        total += sum(len(str(ref)) for ref in entry.images)
+        total += _wire_charge(entry.text) + _wire_charge(entry.summary)
+        total += _wire_charge(entry.error) + _wire_charge(entry.tool_name)
+        total += _wire_charge(entry.tool_call_id) + _wire_charge(entry.intent)
+        total += sum(_wire_charge(str(ref)) for ref in entry.images)
         for value in entry.details.values():
-            total += len(str(value))
+            total += _wire_charge(str(value))
         if total > budget:
             return False
     for phase in projection.todos:
-        total += len(phase.name) + _FRAME_ROW_ENVELOPE_BYTES
+        total += _wire_charge(phase.name) + _FRAME_ROW_ENVELOPE_BYTES
         for item in phase.items:
-            total += len(item.text) + len(item.reason) + _FRAME_ROW_ENVELOPE_BYTES
+            total += _wire_charge(item.text) + _wire_charge(item.reason)
+            total += _FRAME_ROW_ENVELOPE_BYTES
         if total > budget:
             return False
     return total <= budget

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -24,6 +24,7 @@ safe to call from any thread that serializes calls per session.
 from __future__ import annotations
 
 import json
+import logging
 import time
 from collections.abc import Mapping
 from typing import Any
@@ -66,6 +67,8 @@ from local_operator.mobile.types import (
     TranscriptEntry,
 )
 from local_operator.session.peer import PEER_MESSAGE_MESSAGE_TYPE
+
+logger = logging.getLogger(__name__)
 
 #: How much of a tool result's text the expand payload carries. The phone's
 #: expanded row is a readable window, not a log file — beyond this the right
@@ -135,6 +138,21 @@ FRAME_CAP_ERROR_CHARS = 400
 #: the newest few rows and pages the rest from /history, which is exactly the
 #: scroll contract the 80-row cap already established.
 FRAME_CAP_TRANSCRIPT_FLOOR = 16
+
+#: Per-row text bound applied by the LAST tier, once dropping details and
+#: trimming the tail have not been enough. A single row can exceed the whole
+#: cap on its own — a pasted file or a long tool output — and the operator's
+#: real store contains 33 transcript lines over the soft cap, the largest
+#: 946,552 B, so this is a reachable case rather than a theoretical one.
+#: Truncating the row's TEXT is the last thing to give up because it is the
+#: content the reader came for, but a dropped frame shows them nothing at all;
+#: the full text remains one /history fetch away.
+FRAME_CAP_ENTRY_TEXT_CHARS = 4_000
+
+#: Hard floor the text tier walks down to when even 4,000 chars/row does not
+#: fit (many rows, each individually modest). Below this a row is a stub and
+#: the frame is structurally as small as this function can make it.
+FRAME_CAP_ENTRY_TEXT_FLOOR = 200
 
 
 def _message_text(message: AgentMessage) -> str:
@@ -235,6 +253,65 @@ def _frame_bytes(data: dict[str, Any]) -> int:
     return len(json.dumps(data).encode("utf-8"))
 
 
+#: Cheap upper bound on the bytes a frame will serialize to, used to skip the
+#: measuring ``json.dumps`` on the overwhelmingly common under-cap repaint.
+#: Summing variable-length strings plus a fixed per-row envelope charge is
+#: ~100x cheaper than serializing. The divisor is the safety margin for JSON
+#: escaping (worst case ~2x on quote/backslash-dense text); it is validated by
+#: ``test_frame_cheap_proxy_never_lets_an_oversized_frame_through``, which
+#: fuzzes deep rosters and escape-dense text against the real serializer.
+_FRAME_CHEAP_PROXY_DIVISOR = 3
+
+#: Per-row charge for the JSON envelope a row carries regardless of its text
+#: (its keys, numeric fields, booleans). Without it the proxy under-counts a
+#: frame made of many SHORT rows — measured 3.5x under on a 90-row roster —
+#: which is precisely the deep-roster shape the cap exists for. Derived from
+#: the empty serialized size of each dataclass, rounded up.
+_FRAME_ROW_ENVELOPE_BYTES = 400
+_FRAME_SUBAGENT_ENVELOPE_BYTES = 500
+_FRAME_TODO_ENVELOPE_BYTES = 80
+
+
+def _frame_text_total(projection: SessionProjection) -> int:
+    """Cheap size estimate for a projection, without serializing it.
+
+    Text plus a fixed envelope charge per row. Deliberately an OVER-estimate:
+    it gates a short-circuit that must never let a genuinely oversized frame
+    past as "not degraded".
+    """
+    total = 0
+    for entry in projection.transcript:
+        total += _FRAME_ROW_ENVELOPE_BYTES
+        total += len(entry.text) + len(entry.summary) + len(entry.error)
+        total += len(entry.tool_name) + len(entry.tool_call_id) + len(entry.intent)
+        total += sum(len(str(ref)) for ref in entry.images)
+        details = entry.details
+        if details:
+            # A rough charge for the expand payload rather than a walk: it is
+            # dropped wholesale by tier 2 anyway, so precision buys nothing.
+            total += sum(len(str(value)) for value in details.values())
+    for row in projection.subagents:
+        total += (
+            len(row.prompt)
+            + len(row.result_text)
+            + len(row.error_text)
+            + len(row.progress)
+            + len(row.activity)
+        )
+        # A deep roster's lineage lists are the one non-text payload that
+        # scales with roster depth rather than with a fixed row count, so they
+        # have to be charged or the proxy under-counts exactly the deep-roster
+        # frame this cap was written for.
+        for lineage in (row.ancestors, row.ancestor_ids, row.child_ids, row.peer_ids):
+            total += sum(len(item) + 4 for item in lineage)
+        total += _FRAME_SUBAGENT_ENVELOPE_BYTES + len(row.job_id) + len(row.label)
+    for phase in projection.todos:
+        total += _FRAME_TODO_ENVELOPE_BYTES + len(phase.name)
+        for item in phase.items:
+            total += _FRAME_TODO_ENVELOPE_BYTES + len(item.text) + len(item.reason)
+    return total
+
+
 def cap_projection_frame(
     projection: SessionProjection, *, cap_bytes: int = PROJECTION_FRAME_SOFT_CAP_BYTES
 ) -> tuple[dict[str, Any], bool]:
@@ -256,11 +333,27 @@ def cap_projection_frame(
     3. The transcript tail halves toward ``FRAME_CAP_TRANSCRIPT_FLOOR``,
        keeping the pinned opening user message — the same scroll contract the
        80-row cap already establishes, just tighter.
+    4. Row TEXT (plus ``summary``/``error``) is truncated, walking down from
+       ``FRAME_CAP_ENTRY_TEXT_CHARS`` to ``FRAME_CAP_ENTRY_TEXT_FLOOR``. This
+       is last because the text is what the reader came for — but one pasted
+       file can exceed the whole cap by itself, and tiers 1-3 cannot touch it,
+       so without this the function returned a frame the socket then dropped
+       whole. The full text stays one /history fetch away.
+
+    A frame still over ``cap_bytes`` after every tier is logged at WARNING
+    rather than returned silently: the caller cannot fix it, but a dropped
+    repaint that nobody can see is exactly the failure mode this cap exists to
+    make impossible, so it must at least be visible in the log.
 
     The projection itself is never mutated (the fold owns it and republishes
     it; the daemon retains it): degradation happens on the serialized dict.
     """
     data = projection.to_json()
+    # The under-cap repaint is the hot path (~30/s per streaming session), and
+    # measuring it by serializing the whole frame doubled the cost of every
+    # push. Clear the cheap text proxy first and skip the measurement entirely.
+    if _frame_text_total(projection) <= cap_bytes // _FRAME_CHEAP_PROXY_DIVISOR:
+        return data, False
     if _frame_bytes(data) <= cap_bytes:
         return data, False
 
@@ -298,6 +391,33 @@ def cap_projection_frame(
         if _frame_bytes(data) <= cap_bytes:
             return data, True
         limit = max(FRAME_CAP_TRANSCRIPT_FLOOR, limit // 2)
+
+    # Tier 4: truncate row text. Tiers 1-3 cannot shrink a single oversized
+    # row, so this is the only tier that bounds the pasted-file case.
+    text_limit = FRAME_CAP_ENTRY_TEXT_CHARS
+    while True:
+        for entry in data.get("transcript") or []:
+            for field in ("text", "summary", "error"):
+                value = entry.get(field)
+                if isinstance(value, str) and len(value) > text_limit:
+                    entry[field] = _compact_multiline(value, text_limit)
+        if _frame_bytes(data) <= cap_bytes:
+            return data, True
+        if text_limit <= FRAME_CAP_ENTRY_TEXT_FLOOR:
+            break
+        text_limit = max(FRAME_CAP_ENTRY_TEXT_FLOOR, text_limit // 4)
+
+    # Every tier is spent. The frame is as small as this function can make it;
+    # say so loudly rather than handing the socket a line it will drop whole.
+    final_size = _frame_bytes(data)
+    if final_size > cap_bytes:
+        logger.warning(
+            "mobile projection frame for session %s is %d bytes after every "
+            "degradation tier (cap %d) — the control socket will drop it",
+            data.get("session_id", "?"),
+            final_size,
+            cap_bytes,
+        )
     return data, True
 
 

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -154,6 +154,17 @@ FRAME_CAP_ENTRY_TEXT_CHARS = 4_000
 #: the frame is structurally as small as this function can make it.
 FRAME_CAP_ENTRY_TEXT_FLOOR = 200
 
+#: Bound for one roster todo's text under the frame cap. Roster todos ride the
+#: wire by design and are agent-authored, so a deep roster can carry hundreds
+#: of unbounded strings; a todo only has to be recognisable in a working line.
+FRAME_CAP_TODO_TEXT_CHARS = 120
+
+#: Bounds for a pending card under the frame cap. The card is never dropped —
+#: it is the one thing on the phone that blocks a turn — so these are generous
+#: enough to answer the question and bounded enough to fit.
+FRAME_CAP_PENDING_TITLE_CHARS = 2_000
+FRAME_CAP_PENDING_DETAIL_CHARS = 2_000
+
 
 def _message_text(message: AgentMessage) -> str:
     if isinstance(message, Message):
@@ -253,63 +264,74 @@ def _frame_bytes(data: dict[str, Any]) -> int:
     return len(json.dumps(data).encode("utf-8"))
 
 
-#: Cheap upper bound on the bytes a frame will serialize to, used to skip the
-#: measuring ``json.dumps`` on the overwhelmingly common under-cap repaint.
-#: Summing variable-length strings plus a fixed per-row envelope charge is
-#: ~100x cheaper than serializing. The divisor is the safety margin for JSON
-#: escaping (worst case ~2x on quote/backslash-dense text); it is validated by
-#: ``test_frame_cheap_proxy_never_lets_an_oversized_frame_through``, which
-#: fuzzes deep rosters and escape-dense text against the real serializer.
+#: Safety margin on the cheap size estimate, covering JSON escaping (worst
+#: case ~2x on quote/backslash-dense text) plus the fixed frame envelope.
 _FRAME_CHEAP_PROXY_DIVISOR = 3
 
-#: Per-row charge for the JSON envelope a row carries regardless of its text
-#: (its keys, numeric fields, booleans). Without it the proxy under-counts a
-#: frame made of many SHORT rows — measured 3.5x under on a 90-row roster —
-#: which is precisely the deep-roster shape the cap exists for. Derived from
-#: the empty serialized size of each dataclass, rounded up.
+#: Per-row charge for the JSON envelope a transcript row carries regardless of
+#: its text (keys, numeric fields, booleans). Without it the estimate
+#: under-counts a frame made of many SHORT rows — measured 3.5x under on a
+#: 90-row roster. Derived from the empty serialized size of the dataclass.
 _FRAME_ROW_ENVELOPE_BYTES = 400
-_FRAME_SUBAGENT_ENVELOPE_BYTES = 500
-_FRAME_TODO_ENVELOPE_BYTES = 80
+
+#: Transcript rows the STRUCTURAL gate will vouch for without measuring. A
+#: frame of this many rows cannot approach the cap once each row is charged
+#: the envelope above and its own text.
+_FRAME_CHEAP_PROXY_MAX_ROWS = 120
 
 
-def _frame_text_total(projection: SessionProjection) -> int:
-    """Cheap size estimate for a projection, without serializing it.
+def _frame_skips_measurement(projection: SessionProjection) -> bool:
+    """Whether this projection is STRUCTURALLY too simple to need measuring.
 
-    Text plus a fixed envelope charge per row. Deliberately an OVER-estimate:
-    it gates a short-circuit that must never let a genuinely oversized frame
-    past as "not degraded".
+    The gate is deliberately structural rather than exhaustive, and that
+    choice is the whole point. An earlier revision summed every text field it
+    knew about and skipped the measurement whenever the sum cleared a margin —
+    which silently reintroduced the oversized-frame defect this cap exists to
+    stop, because it did not know about the fields that actually grow: a
+    subagent's ``todos`` (kept on the wire BY DESIGN by
+    ``set_subagent_hydrated_details``, agent-authored and unbounded), a
+    subagent's ``transcript``, and ``projection.pending``. Measured on the real
+    shape: 80 children x 25 todos x 600 chars estimated 40,860 bytes against a
+    real 1,331,102 — returned as "not degraded", so neither the registrant's
+    warning nor the tier-4 warning fired and the daemon's 1 MB reader dropped
+    the frame in silence.
+
+    An exhaustive estimate is only correct until someone adds a field, and its
+    failure mode is silent over-cap frames. So the gate asks a question that
+    stays true as the payload evolves: does this projection have any of the
+    parts that can grow without bound? A roster, a pending card, or more than
+    a screenful of rows all mean "measure it". Anything added to those
+    structures in future is covered automatically, because their mere presence
+    already forces the measurement — the gate fails CLOSED.
+
+    What remains is still the overwhelmingly common repaint: an ordinary
+    conversation with no children and nothing waiting on the user.
     """
+    if projection.subagents or projection.pending is not None:
+        return False
+    if len(projection.transcript) > _FRAME_CHEAP_PROXY_MAX_ROWS:
+        return False
+    # Rows are bounded in COUNT above; bound them in SIZE here so one pasted
+    # file cannot ride through. Only the fields a row can grow without bound
+    # are summed, because the row count is already capped.
+    budget = PROJECTION_FRAME_SOFT_CAP_BYTES // _FRAME_CHEAP_PROXY_DIVISOR
     total = 0
     for entry in projection.transcript:
         total += _FRAME_ROW_ENVELOPE_BYTES
         total += len(entry.text) + len(entry.summary) + len(entry.error)
         total += len(entry.tool_name) + len(entry.tool_call_id) + len(entry.intent)
         total += sum(len(str(ref)) for ref in entry.images)
-        details = entry.details
-        if details:
-            # A rough charge for the expand payload rather than a walk: it is
-            # dropped wholesale by tier 2 anyway, so precision buys nothing.
-            total += sum(len(str(value)) for value in details.values())
-    for row in projection.subagents:
-        total += (
-            len(row.prompt)
-            + len(row.result_text)
-            + len(row.error_text)
-            + len(row.progress)
-            + len(row.activity)
-        )
-        # A deep roster's lineage lists are the one non-text payload that
-        # scales with roster depth rather than with a fixed row count, so they
-        # have to be charged or the proxy under-counts exactly the deep-roster
-        # frame this cap was written for.
-        for lineage in (row.ancestors, row.ancestor_ids, row.child_ids, row.peer_ids):
-            total += sum(len(item) + 4 for item in lineage)
-        total += _FRAME_SUBAGENT_ENVELOPE_BYTES + len(row.job_id) + len(row.label)
+        for value in entry.details.values():
+            total += len(str(value))
+        if total > budget:
+            return False
     for phase in projection.todos:
-        total += _FRAME_TODO_ENVELOPE_BYTES + len(phase.name)
+        total += len(phase.name) + _FRAME_ROW_ENVELOPE_BYTES
         for item in phase.items:
-            total += _FRAME_TODO_ENVELOPE_BYTES + len(item.text) + len(item.reason)
-    return total
+            total += len(item.text) + len(item.reason) + _FRAME_ROW_ENVELOPE_BYTES
+        if total > budget:
+            return False
+    return total <= budget
 
 
 def cap_projection_frame(
@@ -324,9 +346,17 @@ def cap_projection_frame(
     the daemon loop for every OTHER session (the wedge this cap exists to
     stop at the source). The tiers drop in order of recoverability:
 
-    1. Subagent text previews (prompt/result/error) shrink to minimal bounds.
-       The full text stays reachable through the child transcript's lazy
-       /history fetch, so nothing is lost that a tap cannot recover.
+    1. Subagent text previews (prompt/result/error) shrink to minimal bounds,
+       any embedded child transcript is dropped, and — if that is not enough —
+       roster todo text is truncated and then the roster's todo lists are
+       dropped entirely. The full text stays reachable through the child
+       transcript's lazy /history fetch, so nothing is lost that a tap cannot
+       recover. Roster todos are agent-authored and unbounded, and a deep
+       roster puts many of them on the wire at once, so they are the tier's
+       real work rather than a corner of it.
+    1b. A pending card's option consequence lines shrink to a readable bound.
+       The card itself is the loudest thing on the phone and is never dropped;
+       only the prose under each option is trimmed.
     2. Transcript rows lose their ``details`` expand payload (args/output/
        diff). The collapsed row still renders; expanding an old row is the
        one gesture that can re-fetch from /history.
@@ -350,9 +380,11 @@ def cap_projection_frame(
     """
     data = projection.to_json()
     # The under-cap repaint is the hot path (~30/s per streaming session), and
-    # measuring it by serializing the whole frame doubled the cost of every
-    # push. Clear the cheap text proxy first and skip the measurement entirely.
-    if _frame_text_total(projection) <= cap_bytes // _FRAME_CHEAP_PROXY_DIVISOR:
+    # measuring it by serializing the whole frame doubles the cost of every
+    # push. Skip that only for projections whose STRUCTURE cannot approach the
+    # cap (see _frame_skips_measurement for why the test is structural rather
+    # than a sum of known fields). Everything else is measured for real.
+    if cap_bytes >= PROJECTION_FRAME_SOFT_CAP_BYTES and _frame_skips_measurement(projection):
         return data, False
     if _frame_bytes(data) <= cap_bytes:
         return data, False
@@ -369,6 +401,42 @@ def cap_projection_frame(
         # A hydrated child transcript on the wire predates the lazy /history
         # fetch; if one is still embedded it is pure frame weight.
         row["transcript"] = []
+    if _frame_bytes(data) <= cap_bytes:
+        return data, True
+
+    # Tier 1b: the pending card's option prose. The card is the loudest thing
+    # on the phone, so the card and its option LABELS always survive — only
+    # the consequence lines under them are bounded.
+    pending = data.get("pending")
+    if isinstance(pending, dict):
+        pending["title"] = _compact(str(pending.get("title") or ""), FRAME_CAP_PENDING_TITLE_CHARS)
+        pending["detail"] = _compact_multiline(
+            str(pending.get("detail") or ""), FRAME_CAP_PENDING_DETAIL_CHARS
+        )
+        for option in pending.get("options") or []:
+            if isinstance(option, dict):
+                option["description"] = _compact(
+                    str(option.get("description") or ""), FRAME_CAP_PENDING_DETAIL_CHARS
+                )
+        if _frame_bytes(data) <= cap_bytes:
+            return data, True
+
+    # Tier 1c: roster todo text, then the todo lists themselves. Kept on the
+    # wire by design (set_subagent_hydrated_details), so a deep roster carries
+    # many unbounded agent-authored strings — the shape that measured
+    # 1,331,102 bytes from 80 children x 25 todos. Truncate first so the
+    # working line still reads, and only drop the lists if that is not enough.
+    for row in data.get("subagents") or []:
+        for phase in row.get("todos") or []:
+            for item in phase.get("items") or []:
+                item["text"] = _compact(str(item.get("text") or ""), FRAME_CAP_TODO_TEXT_CHARS)
+                item["reason"] = _compact(
+                    str(item.get("reason") or ""), FRAME_CAP_TODO_TEXT_CHARS
+                )
+    if _frame_bytes(data) <= cap_bytes:
+        return data, True
+    for row in data.get("subagents") or []:
+        row["todos"] = []
     if _frame_bytes(data) <= cap_bytes:
         return data, True
 

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -299,7 +299,9 @@ _WIRE_ESCAPE_SIX_BYTE_CEILING = 6
 #: 1,840 us across an 80-row frame against 152 us to serialize the whole thing,
 #: i.e. it made the "cheap" estimate 12x more expensive than the work it
 #: exists to avoid.
-_WIRE_ESCAPED_ASCII = {ord(char): None for char in ('"', "\\", *(chr(i) for i in range(0x20)), "\x7f")}
+_WIRE_ESCAPED_ASCII = {
+    ord(char): None for char in ('"', "\\", *(chr(i) for i in range(0x20)), "\x7f")
+}
 
 
 def _wire_charge(text: str) -> int:

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -430,9 +430,7 @@ def cap_projection_frame(
         for phase in row.get("todos") or []:
             for item in phase.get("items") or []:
                 item["text"] = _compact(str(item.get("text") or ""), FRAME_CAP_TODO_TEXT_CHARS)
-                item["reason"] = _compact(
-                    str(item.get("reason") or ""), FRAME_CAP_TODO_TEXT_CHARS
-                )
+                item["reason"] = _compact(str(item.get("reason") or ""), FRAME_CAP_TODO_TEXT_CHARS)
     if _frame_bytes(data) <= cap_bytes:
         return data, True
     for row in data.get("subagents") or []:

--- a/local_operator/mobile/registrant.py
+++ b/local_operator/mobile/registrant.py
@@ -244,6 +244,10 @@ class Registrant:
         self._unsubscribe: Callable[[], None] | None = None
         self._closed = threading.Event()
         self._push_scheduled = False
+        # One warning per contiguous run of oversized frames, not one per
+        # frame: a busy session repaints ~30x/s and a per-frame warning is the
+        # log flood the cap exists to prevent. Reset when a frame fits again.
+        self._frame_cap_warned = False
         # The delayed repaint must be owned like the heartbeat. A bare task can
         # still be sleeping when close tears down the registrant loop, producing
         # an orphan warning and proving teardown returned before its work ended.
@@ -1001,13 +1005,38 @@ class Registrant:
         attach clients; only event subscribers get the overlaid copy. This is
         the protocol-v4 promise that phone frames remain byte-identical.
         """
-        ordinary = {"op": "projection", "data": self._fold.projection.to_json()}
+        ordinary = self._projection_payload()
         await asyncio.gather(
             *(
                 self._send_to(conn, self._projection_frame(conn, ordinary))
                 for conn in list(self._clients.values())
             )
         )
+
+    def _projection_payload(self) -> dict[str, Any]:
+        """The broadcast frame, capped to the soft size limit.
+
+        The daemon's control reader drops any line past 1 MB, so an oversized
+        projection is a silently lost repaint — and a flood of them starves
+        the daemon loop for every other session. ``cap_projection_frame``
+        degrades optional payload tiers (subagent text previews, transcript
+        expand details, then the transcript tail) until the frame fits, so a
+        busy deep-roster session degrades gracefully instead of wedging the
+        whole relay. The projection itself is never mutated.
+        """
+        from local_operator.mobile.projection import cap_projection_frame
+
+        data, degraded = cap_projection_frame(self._fold.projection)
+        if degraded and not self._frame_cap_warned:
+            self._frame_cap_warned = True
+            logger.warning(
+                "mobile registrant: projection frame for session %s exceeded the "
+                "soft cap; degrading optional payload tiers to fit",
+                self._record.session_id,
+            )
+        elif not degraded:
+            self._frame_cap_warned = False
+        return {"op": "projection", "data": data}
 
     def _projection_frame(self, conn: _ClientConn, ordinary: dict[str, Any]) -> dict[str, Any]:
         # Projection is exclusively the mobile renderer. Full terminal clients
@@ -1016,8 +1045,7 @@ class Registrant:
 
     async def _push_to(self, conn: _ClientConn) -> None:
         """The welcome form of a push: one full projection to one connection."""
-        ordinary = {"op": "projection", "data": self._fold.projection.to_json()}
-        await self._send_to(conn, self._projection_frame(conn, ordinary))
+        await self._send_to(conn, self._projection_frame(conn, self._projection_payload()))
 
     async def _broadcast(self, frame: dict[str, Any]) -> None:
         # Copy the registry: a send failure drops its own entry, and mutating

--- a/local_operator/mobile/seen.py
+++ b/local_operator/mobile/seen.py
@@ -1,0 +1,155 @@
+"""Per-session "last seen by phone" state for the mobile daemon.
+
+The phone's session list needs an unread indicator: a session is UNSEEN when
+it has user-visible activity newer than the last time the phone looked at it.
+This module is the durable half of that verdict — the timestamps survive a
+daemon restart, so a phone that read a session yesterday does not see it
+re-marked unread today just because the daemon recycled.
+
+Two timestamps per session, only one of them persisted:
+
+- ``last_seen`` — written by ``POST /api/sessions/{id}/seen`` when the phone
+  opens (or re-views) a session. Activity newer than it is unseen. THIS is
+  the only durable fact: it is the user's own action and must outlive the
+  daemon.
+- ``baseline`` — the transcript mtime at the moment the daemon FIRST observed
+  the session, kept in memory only. It exists so an upgrade or restart does
+  not light up every session in the store: a session the phone has never
+  marked seen is unseen only if it gained activity since first observation,
+  not because it exists. Re-deriving it after a restart is CORRECT rather
+  than a loss: the baseline of a never-seen session is simply "the activity
+  clock at first observation", which the re-derivation reproduces, and
+  activity that happened while the daemon was down is deliberately not
+  unread (that is the no-flood-on-upgrade rule, applied per restart).
+
+The activity clock is the transcript file's mtime, which the summaries scan
+already stats for its sort key — the verdict costs no extra syscall.
+
+Persistence is one small JSON file under ``config_dir()`` (0600, atomic
+replace, bounded), written ONLY on ``mark_seen``: a user action whose effect
+the phone's next list paint must already reflect.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: The store file's name, directly under ``config_dir()`` beside the other
+#: owner-private state.
+SEEN_STORE_NAME = "mobile-seen.json"
+
+#: Bound on tracked sessions. The list surface shows the 100 most recent
+#: durable sessions plus the live ones; 4096 is far beyond anything a phone
+#: could mark seen while still bounding the file for a long-lived daemon.
+#: Overflow drops the oldest stamps — a verdict for a session that old is
+#: uninteresting, and the baseline rule re-derives itself on re-observation.
+MAX_SEEN_ENTRIES = 4096
+
+
+class SeenStore:
+    """The daemon's per-session seen state, persisted across restarts."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+        self._last_seen: dict[str, float] = {}
+        self._baselines: dict[str, float] = {}
+        self._load()
+
+    # -- verdicts -------------------------------------------------------------
+
+    def is_unseen(self, session_id: str, activity_mtime: float) -> bool:
+        """Whether ``session_id`` has activity newer than the phone's view.
+
+        Records the baseline on first observation — that side effect is what
+        keeps an upgrade from marking the whole store unread (see the module
+        docstring). ``activity_mtime`` is the transcript's mtime, which the
+        caller already has from the listing scan. Memory-only; nothing here
+        touches the disk.
+        """
+        with self._lock:
+            self._baselines.setdefault(session_id, activity_mtime)
+            seen_at = self._last_seen.get(session_id)
+            if seen_at is not None:
+                return activity_mtime > seen_at
+            return activity_mtime > self._baselines[session_id]
+
+    def mark_seen(self, session_id: str, *, now: float | None = None) -> None:
+        """The phone viewed ``session_id``; persist immediately."""
+        stamp = now if now is not None else time.time()
+        with self._lock:
+            self._last_seen[session_id] = stamp
+            # A session marked seen has, by definition, been observed.
+            self._baselines.setdefault(session_id, stamp)
+            self._bound_locked()
+            self._persist_locked()
+
+    def last_seen(self, session_id: str) -> float | None:
+        with self._lock:
+            return self._last_seen.get(session_id)
+
+    # -- persistence ----------------------------------------------------------
+
+    def _load(self) -> None:
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return
+        except (OSError, ValueError):
+            # A torn or unreadable store degrades to "nothing seen yet"; the
+            # baseline rule then re-derives itself on first observation, so
+            # the worst case is a session lighting up once, not a crash.
+            logger.warning("mobile seen store unreadable; starting fresh", exc_info=True)
+            return
+        sessions = raw.get("sessions") if isinstance(raw, dict) else None
+        if not isinstance(sessions, dict):
+            return
+        for session_id, stamp in sessions.items():
+            if isinstance(stamp, (int, float)):
+                self._last_seen[str(session_id)] = float(stamp)
+
+    def _persist_locked(self) -> None:
+        """Atomic 0600 write: temp file in the same directory, then replace.
+
+        The replace guarantees a reader sees either the old file or the new
+        one, never a half-written one; the chmod happens BEFORE the replace
+        so the store is never world-readable even for an instant.
+        """
+        payload = {"sessions": dict(sorted(self._last_seen.items()))}
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            descriptor, tmp_name = tempfile.mkstemp(
+                dir=str(self._path.parent), prefix=f".{SEEN_STORE_NAME}.", suffix=".tmp"
+            )
+            try:
+                with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                    json.dump(payload, handle, separators=(",", ":"))
+                os.chmod(tmp_name, 0o600)
+                os.replace(tmp_name, self._path)
+            except BaseException:
+                try:
+                    os.unlink(tmp_name)
+                except OSError:
+                    pass
+                raise
+        except OSError:
+            # The verdicts stay correct in memory; a failed write only costs
+            # them on restart, where the baseline rule re-derives safely.
+            logger.warning("mobile seen store write failed", exc_info=True)
+
+    def _bound_locked(self) -> None:
+        """Drop the oldest stamps past ``MAX_SEEN_ENTRIES``."""
+        excess = len(self._last_seen) - MAX_SEEN_ENTRIES
+        if excess <= 0:
+            return
+        ranked = sorted(self._last_seen, key=self._last_seen.get)  # type: ignore[arg-type]
+        for session_id in ranked[:excess]:
+            self._last_seen.pop(session_id, None)

--- a/local_operator/mobile/seen.py
+++ b/local_operator/mobile/seen.py
@@ -71,8 +71,9 @@ class SeenStore:
         self._lock = threading.Lock()
         self._last_seen: dict[str, float] = {}
         self._baselines: dict[str, float] = {}
-        # Wall-clock of the last watch-driven write (see touch_watched).
-        self._last_watch_persist_at = 0.0
+        # Wall-clock of the last watch-driven write, PER SESSION (see
+        # touch_watched). Bounded alongside the stamps it shadows.
+        self._watch_persisted_at: dict[str, float] = {}
         self._load()
 
     # -- verdicts -------------------------------------------------------------
@@ -118,8 +119,14 @@ class SeenStore:
         with self._lock:
             self._last_seen[session_id] = stamp
             self._baselines.setdefault(session_id, stamp)
-            if stamp - self._last_watch_persist_at >= WATCH_PERSIST_INTERVAL_S:
-                self._last_watch_persist_at = stamp
+            # PER-SESSION, not one clock for the store: a single instance-wide
+            # timestamp meant the first watched session to write suppressed the
+            # disk write for every OTHER session for the whole interval, so a
+            # second session watched in that window kept its stamp only in
+            # memory and lost it on a crash. Two phones on two sessions is the
+            # ordinary case, not an exotic one.
+            if stamp - self._watch_persisted_at.get(session_id, 0.0) >= WATCH_PERSIST_INTERVAL_S:
+                self._watch_persisted_at[session_id] = stamp
                 self._bound_locked()
                 self._persist_locked()
 
@@ -184,3 +191,6 @@ class SeenStore:
         ranked = sorted(self._last_seen, key=self._last_seen.get)  # type: ignore[arg-type]
         for session_id in ranked[:excess]:
             self._last_seen.pop(session_id, None)
+            # The debounce clock is shadow state for a stamp; dropping the
+            # stamp without it would leak one float per evicted session.
+            self._watch_persisted_at.pop(session_id, None)

--- a/local_operator/mobile/seen.py
+++ b/local_operator/mobile/seen.py
@@ -53,6 +53,15 @@ SEEN_STORE_NAME = "mobile-seen.json"
 #: uninteresting, and the baseline rule re-derives itself on re-observation.
 MAX_SEEN_ENTRIES = 4096
 
+#: How often a WATCH re-stamp is allowed to reach the disk. Holding the
+#: projection SSE stream counts as viewing (spec §3), and that verdict runs on
+#: every list repaint — ~30x/s while a watched session streams. The stamp must
+#: advance in memory every time (it is what keeps the mark clear), but writing
+#: the JSON file at that rate would be pure I/O churn for state whose only
+#: consumer after a crash is "was this roughly seen recently". 30 s bounds the
+#: worst-case loss to one interval of watching.
+WATCH_PERSIST_INTERVAL_S = 30.0
+
 
 class SeenStore:
     """The daemon's per-session seen state, persisted across restarts."""
@@ -62,6 +71,8 @@ class SeenStore:
         self._lock = threading.Lock()
         self._last_seen: dict[str, float] = {}
         self._baselines: dict[str, float] = {}
+        # Wall-clock of the last watch-driven write (see touch_watched).
+        self._last_watch_persist_at = 0.0
         self._load()
 
     # -- verdicts -------------------------------------------------------------
@@ -91,6 +102,26 @@ class SeenStore:
             self._baselines.setdefault(session_id, stamp)
             self._bound_locked()
             self._persist_locked()
+
+    def touch_watched(self, session_id: str, *, now: float | None = None) -> None:
+        """Re-stamp a session the user is CURRENTLY watching over SSE.
+
+        Same in-memory effect as :meth:`mark_seen` — the mark stays clear
+        while the stream is held, which is what makes "completions observed
+        live never flip to unread" true — but the disk write is debounced to
+        ``WATCH_PERSIST_INTERVAL_S``. This runs on every list repaint of a
+        watched session (~30x/s while it streams), and persisting each one
+        would rewrite the store file at that rate for no added correctness:
+        an explicit /seen POST still writes through immediately.
+        """
+        stamp = now if now is not None else time.time()
+        with self._lock:
+            self._last_seen[session_id] = stamp
+            self._baselines.setdefault(session_id, stamp)
+            if stamp - self._last_watch_persist_at >= WATCH_PERSIST_INTERVAL_S:
+                self._last_watch_persist_at = stamp
+                self._bound_locked()
+                self._persist_locked()
 
     def last_seen(self, session_id: str) -> float | None:
         with self._lock:

--- a/local_operator/mobile/service.py
+++ b/local_operator/mobile/service.py
@@ -30,7 +30,17 @@ async def amain(port: int = DEFAULT_PORT) -> int:
         )
         return 2
 
-    daemon = MobileDaemon(port=port, password=password)
+    # A SECOND daemon on the same machine must never dial registrants: each
+    # admits at most one daemon connection, so a secondary dial would evict
+    # the production daemon's live bridge mid-session. LO_MOBILE_NO_DIAL=1
+    # runs this instance as a read-only observer (list + durable routes only)
+    # — the mode benchmark and diagnostic daemons use.
+    import os
+
+    dial = os.environ.get("LO_MOBILE_NO_DIAL", "").strip().lower() not in ("1", "true", "yes")
+    daemon = MobileDaemon(port=port, password=password, dial_registrants=dial)
+    if not dial:
+        logger.warning("mobile daemon running in no-dial observer mode")
     app = build_app(daemon)
 
     import uvicorn

--- a/local_operator/mobile/service.py
+++ b/local_operator/mobile/service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import signal
 
 from local_operator.mobile.auth import load_password
@@ -35,8 +36,6 @@ async def amain(port: int = DEFAULT_PORT) -> int:
     # the production daemon's live bridge mid-session. LO_MOBILE_NO_DIAL=1
     # runs this instance as a read-only observer (list + durable routes only)
     # — the mode benchmark and diagnostic daemons use.
-    import os
-
     dial = os.environ.get("LO_MOBILE_NO_DIAL", "").strip().lower() not in ("1", "true", "yes")
     daemon = MobileDaemon(port=port, password=password, dial_registrants=dial)
     if not dial:

--- a/local_operator/mobile/web/.gitignore
+++ b/local_operator/mobile/web/.gitignore
@@ -1,3 +1,7 @@
 node_modules/
 dist/
 *.tsbuildinfo
+# pnpm's content-addressed install cache when a build runs inside the tree;
+# it is a local artifact, never source (A16: 6,955 files / 125 MB leaked into
+# the relay branch and had to be rewritten out).
+.pnpm-store/

--- a/local_operator/mobile/web/src/agent-view.interaction.test.tsx
+++ b/local_operator/mobile/web/src/agent-view.interaction.test.tsx
@@ -13,6 +13,7 @@ vi.mock("./api", () => ({
 	getSubagentDetail: vi.fn(),
 	imageUrl: vi.fn(() => ""),
 	sendCommand: vi.fn(async () => ({ ok: true, detail: "steering queued" })),
+	markSessionSeen: vi.fn(async () => ({ ok: true })),
 }));
 
 function entry(id: string, kind: TranscriptEntry["kind"], text: string): TranscriptEntry {

--- a/local_operator/mobile/web/src/api.ts
+++ b/local_operator/mobile/web/src/api.ts
@@ -104,6 +104,17 @@ export function startSession(input: {
 	});
 }
 
+/** Mark a session's finished activity as viewed. Fire-and-forget from the
+    session view's mount: the daemon clears `unseen` and repaints the list,
+    but the client store clears its own copy optimistically (markSessionSeen)
+    so back-navigation never flashes a stale mark while this POST is in
+    flight. The response body carries nothing the UI needs. */
+export function markSessionSeen(sessionId: string): Promise<{ ok: boolean }> {
+	return request(`/api/sessions/${encodeURIComponent(sessionId)}/seen`, {
+		method: "POST",
+	});
+}
+
 export function sendCommand(
 	sessionId: string,
 	op: CommandOp,

--- a/local_operator/mobile/web/src/screens/session-list.tsx
+++ b/local_operator/mobile/web/src/screens/session-list.tsx
@@ -8,7 +8,13 @@
  * danger dot and a word ("approval" / "question"), because that is the one
  * card that needs a decision (branding §7).
  */
-import { useEffect, useState } from "react";
+import {
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+	type Ref,
+} from "react";
 import { getDirectories } from "../api";
 import { Sheet } from "../components/ui/sheet";
 import { Spinner } from "../components/spinner";
@@ -20,26 +26,93 @@ import { MARK_DATA_URI } from "../lib/mark";
 import type { SessionSummary } from "../types";
 import { cn } from "../lib/cn";
 
-function SessionCard({ s, home }: { s: SessionSummary; home: string }) {
+/** The right-cluster word `new`. It lingers through a 120ms opacity fade when
+    the mark clears (session opened) instead of blinking out — but it MUST
+    unmount once the fade lands: an opacity-0 `shrink-0` span would keep
+    pushing the `N agents` / `N todo` chips rightward forever. The fade is a
+    transition, so the global prefers-reduced-motion block caps it to instant
+    for free; the unmount timer still runs its course. */
+function NewMark({ visible }: { visible: boolean }) {
+	const [mounted, setMounted] = useState(visible);
+	useEffect(() => {
+		if (visible) {
+			setMounted(true);
+			return;
+		}
+		if (!mounted) return;
+		/* Matches --transition-duration-fast (120ms): the timeout only removes
+		   the node after the CSS fade has landed. */
+		const timer = setTimeout(() => setMounted(false), 120);
+		return () => clearTimeout(timer);
+	}, [visible, mounted]);
+	if (!mounted) return null;
+	return (
+		<span
+			/* Sighting users see `new`; assistive tech hears the unambiguous
+			   phrase. While fading out the word is already meaningless, so it
+			   leaves the accessibility tree at once. */
+			aria-label={visible ? "new activity" : undefined}
+			aria-hidden={visible ? undefined : true}
+			className="shrink-0 text-meta text-accent"
+			style={{
+				opacity: visible ? 1 : 0,
+				transition:
+					"opacity var(--transition-duration-fast, 120ms) ease-out",
+			}}
+		>
+			new
+		</span>
+	);
+}
+
+function SessionCard({
+	s,
+	home,
+	ref,
+}: {
+	s: SessionSummary;
+	home: string;
+	/* FLIP anchor: the list measures every card before/after a reorder so it
+	   can settle it into its new slot instead of teleporting it. */
+	ref?: Ref<HTMLButtonElement>;
+}) {
 	const pendingLabel =
 		s.pending_kind === "approval"
 			? "approval"
 			: s.pending_kind === "ask"
 				? "question"
 				: null;
+	/* Render ladder: NEEDS DECISION > WORKING > NEW/UNREAD > IDLE — the same
+	   order as the daemon's sort, so what is loudest is also what is
+	   highest. Flags coexist in data; exactly one state renders. A session
+	   blocked on a decision must be opened anyway, so the unread mark would
+	   add noise; a streaming session is drawing the eye already, and "new"
+	   marks COMPLETED unviewed activity, never in-flight work. */
+	const decision = Boolean(s.needs_attention && pendingLabel);
+	const unread = Boolean(s.unseen) && !decision && !s.streaming;
 	return (
 		<button
+			ref={ref}
 			type="button"
 			onClick={() => navigate(`/s/${encodeURIComponent(s.session_id)}`)}
 			className="flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left select-none active:bg-elevated"
 		>
 			<div className="flex items-center gap-2">
-				{s.needs_attention && pendingLabel ? (
-					<span
-						className="lo-pulse inline-block size-1.5 shrink-0 rounded-full bg-danger"
-						aria-hidden
-					/>
-				) : null}
+				{/* Reserved dot slot, always rendered: every title starts at the
+				    same x in every state, forever — indicators change colour,
+				    never geometry. The old conditional dot shifted titles 14px
+				    sideways when it appeared/disappeared. */}
+				<span
+					className={cn(
+						"inline-block size-1.5 shrink-0 rounded-full",
+						decision
+							? "lo-pulse bg-danger"
+							: unread
+								? "bg-accent"
+								: "bg-transparent",
+					)}
+					aria-hidden
+				/>
 				{s.streaming ? (
 					/* The obvious in-progress mark beside the title: a small loading
 					   wheel, not just the text sweep — the sweep alone was too
@@ -54,11 +127,15 @@ function SessionCard({ s, home }: { s: SessionSummary; home: string }) {
 				>
 					{s.conversation_name || "untitled"}
 				</span>
-				{s.needs_attention && pendingLabel ? (
+				{decision && pendingLabel ? (
 					<span className="shrink-0 text-meta text-danger">
 						{pendingLabel}
 					</span>
 				) : null}
+				{/* State word rides BEFORE the count chips in the right cluster
+				    (spec §1): `new` truncates the title only, row height never
+				    changes. */}
+				<NewMark visible={unread} />
 				{s.subagents_running > 0 ? (
 					/* ⟳ and ☐ render as tofu boxes on phones whose system font lacks
 					   those codepoints. Text marks survive every font. */
@@ -134,6 +211,11 @@ export function SessionListScreen() {
 	const [home, setHome] = useState("");
 	const [themeOpen, setThemeOpen] = useState(false);
 	const [query, setQuery] = useState("");
+	/* FLIP settle state: card DOM by session id, plus each card's content
+	   coordinate from the previous commit. */
+	const mainRef = useRef<HTMLElement>(null);
+	const cardRefs = useRef(new Map<string, HTMLButtonElement>());
+	const prevTops = useRef(new Map<string, number>());
 	const visible = sessions.filter((session) =>
 		`${session.conversation_name} ${session.session_id} ${session.cwd}`
 			.toLowerCase()
@@ -143,6 +225,55 @@ export function SessionListScreen() {
 	const previous = visible.filter((session) => session.section === "previous");
 
 	useEffect(() => retainSessionListStream(), []);
+
+	/* FLIP settle for reorders (spec §3): a card never teleports under a
+	   thumb mid-scroll. After each commit, measure every card's position in
+	   the scroll content (`rect.top - main.rect.top + scrollTop`, so a user
+	   scroll between commits never reads as movement), and where a card moved,
+	   apply the inverse translateY with no transition, force a style flush,
+	   then play it back to zero with a transform transition. Scroll offset is
+	   untouched — only transforms animate. Implemented with `transition`,
+	   never `animation`, so the global prefers-reduced-motion block caps the
+	   settle to instant for free. Runs synchronously before paint
+	   (useLayoutEffect) so the inverted frame is what the user would have
+	   seen anyway — the pre-reorder layout. */
+	useLayoutEffect(() => {
+		const main = mainRef.current;
+		const origin = main
+			? main.getBoundingClientRect().top - main.scrollTop
+			: 0;
+		const nextTops = new Map<string, number>();
+		for (const [id, el] of cardRefs.current) {
+			nextTops.set(id, el.getBoundingClientRect().top - origin);
+		}
+		for (const [id, el] of cardRefs.current) {
+			const prev = prevTops.current.get(id);
+			const next = nextTops.get(id);
+			/* New cards have no old position and simply appear in place. */
+			if (prev === undefined || next === undefined) continue;
+			const dy = prev - next;
+			if (dy === 0) continue;
+			el.style.transition = "none";
+			el.style.transform = `translateY(${dy}px)`;
+			/* Force the inverted position to commit as a style before the
+			   transition property returns, or the browser collapses both
+			   writes and the card jumps straight to its new slot. */
+			void el.offsetHeight;
+			el.style.transition =
+				"transform var(--transition-duration-base, 180ms) var(--ease-out-quart, ease-out)";
+			el.style.transform = "";
+			const done = (event: TransitionEvent) => {
+				/* transitionend BUBBLES: the `new` word's opacity fade inside the
+				   card also ends, and acting on that event would strip the
+				   transform transition mid-settle. */
+				if (event.target !== el) return;
+				el.style.transition = "";
+				el.removeEventListener("transitionend", done);
+			};
+			el.addEventListener("transitionend", done);
+		}
+		prevTops.current = nextTops;
+	});
 	useEffect(() => {
 		getDirectories()
 			.then((d) => setHome(d.home))
@@ -164,7 +295,10 @@ export function SessionListScreen() {
 					local operator
 				</h1>
 			</header>
-			<main className="flex flex-1 flex-col overflow-y-auto px-1 pb-2">
+			<main
+				ref={mainRef}
+				className="flex flex-1 flex-col overflow-y-auto px-1 pb-2"
+			>
 				<input
 					value={query}
 					onChange={(event) => setQuery(event.target.value)}
@@ -186,11 +320,31 @@ export function SessionListScreen() {
 					<div className="flex flex-col gap-3">
 						<section>
 							<h2 className="px-2 py-1 text-meta font-medium text-ink-muted">Active Sessions</h2>
-							{active.map((s) => <SessionCard key={s.session_id} s={s} home={home} />)}
+							{active.map((s) => (
+								<SessionCard
+									key={s.session_id}
+									s={s}
+									home={home}
+									ref={(el) => {
+										if (el) cardRefs.current.set(s.session_id, el);
+										else cardRefs.current.delete(s.session_id);
+									}}
+								/>
+							))}
 						</section>
 						<section>
 							<h2 className="px-2 py-1 text-meta font-medium text-ink-muted">Previous Sessions</h2>
-							{previous.map((s) => <SessionCard key={s.session_id} s={s} home={home} />)}
+							{previous.map((s) => (
+								<SessionCard
+									key={s.session_id}
+									s={s}
+									home={home}
+									ref={(el) => {
+										if (el) cardRefs.current.set(s.session_id, el);
+										else cardRefs.current.delete(s.session_id);
+									}}
+								/>
+							))}
 						</section>
 					</div>
 				)}

--- a/local_operator/mobile/web/src/screens/session-list.tsx
+++ b/local_operator/mobile/web/src/screens/session-list.tsx
@@ -151,6 +151,22 @@ function SessionCard({
 						/>
 					)}
 				</span>
+				{decision && s.streaming ? (
+					/* The "working" announcement for assistive tech, carried as TEXT
+					   rather than as a mark in the slot. The spinner owns
+					   role="status" aria-label="working" and covers every OTHER
+					   streaming row; but the ladder gives the slot to the danger
+					   dot on a decision+streaming row and hides the slot there, so
+					   a screen-reader user heard the pending word and nothing about
+					   the turn being mid-flight — the shimmer is a pure CSS paint
+					   and conveys nothing to AT. Rendered ONLY for that row, so a
+					   plain streaming row is not announced twice. Zero geometry
+					   cost: sr-only is clipped out of the layout, so this cannot
+					   revive the title shift D2 fixed. */
+					<span className="sr-only" role="status">
+						working
+					</span>
+				) : null}
 				<span
 					className={cn(
 						"min-w-0 flex-1 truncate text-body-sm font-medium",

--- a/local_operator/mobile/web/src/screens/session-list.tsx
+++ b/local_operator/mobile/web/src/screens/session-list.tsx
@@ -106,8 +106,8 @@ function SessionCard({
 			className="flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left select-none active:bg-elevated"
 		>
 			<div className="flex items-center gap-2">
-				{/* ONE reserved indicator slot serving all four states, so every
-				    title starts at the same x forever — indicators change colour,
+				{/* ONE reserved indicator slot serving every state, so every title
+				    starts at the same x forever — indicators change colour,
 				    never geometry.
 
 				    The slot is sized to the LARGEST occupant (the 12px spinner)
@@ -117,12 +117,27 @@ function SessionCard({
 				    ~19.5px right of every other row's, so the reserved-slot
 				    promise held for three states and broke on the fourth — the
 				    one that changes most often. Spinner itself is untouched; it
-				    is a shared component and its own size is correct. */}
+				    is a shared component and its own size is correct.
+
+				    THE LADDER decides what occupies the slot, not `streaming`.
+				    An approval gate runs INSIDE a turn (the harness blocks in
+				    _execute_tool_calls, between agent_start and agent_end), so
+				    the ordinary "may I run this?" carries streaming AND pending
+				    at once. Testing `streaming` first therefore replaced the red
+				    pulse with a neutral spinner on exactly the loudest state in
+				    the ladder — the pulse is the only motion reserved for danger,
+				    and it was being spent on ordinary work. Decision wins the
+				    slot; "working" is still carried on that row by the title's
+				    shimmer (applied below whenever `s.streaming`), which is
+				    sufficient and costs no geometry — a second mark would have
+				    to come out of the same 12px box the alignment depends on. */}
 				<span
 					className="flex size-3 shrink-0 items-center justify-center"
-					aria-hidden={s.streaming ? undefined : true}
+					aria-hidden={!decision && s.streaming ? undefined : true}
 				>
-					{s.streaming ? (
+					{decision ? (
+						<span className="lo-pulse inline-block size-1.5 rounded-full bg-danger" />
+					) : s.streaming ? (
 						/* The obvious in-progress mark beside the title: a small
 						   loading wheel, not just the text sweep — the sweep alone
 						   was too subtle to catch at a glance. */
@@ -131,11 +146,7 @@ function SessionCard({
 						<span
 							className={cn(
 								"inline-block size-1.5 rounded-full",
-								decision
-									? "lo-pulse bg-danger"
-									: unread
-										? "bg-accent"
-										: "bg-transparent",
+								unread ? "bg-accent" : "bg-transparent",
 							)}
 						/>
 					)}

--- a/local_operator/mobile/web/src/screens/session-list.tsx
+++ b/local_operator/mobile/web/src/screens/session-list.tsx
@@ -34,17 +34,25 @@ import { cn } from "../lib/cn";
     for free; the unmount timer still runs its course. */
 function NewMark({ visible }: { visible: boolean }) {
 	const [mounted, setMounted] = useState(visible);
+	/* The unmount timer is driven by the visible -> hidden TRANSITION, so the
+	   effect tracks the previous `visible` in a ref rather than depending on
+	   `mounted` — the state it sets itself. Depending on your own output is
+	   the shape that becomes a re-entrant timer the moment someone adds a
+	   branch: correct here only because of a guard, and a trap next edit. */
+	const wasVisible = useRef(visible);
 	useEffect(() => {
+		const had = wasVisible.current;
+		wasVisible.current = visible;
 		if (visible) {
 			setMounted(true);
 			return;
 		}
-		if (!mounted) return;
+		if (!had) return;
 		/* Matches --transition-duration-fast (120ms): the timeout only removes
 		   the node after the CSS fade has landed. */
 		const timer = setTimeout(() => setMounted(false), 120);
 		return () => clearTimeout(timer);
-	}, [visible, mounted]);
+	}, [visible]);
 	if (!mounted) return null;
 	return (
 		<span
@@ -98,27 +106,40 @@ function SessionCard({
 			className="flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left select-none active:bg-elevated"
 		>
 			<div className="flex items-center gap-2">
-				{/* Reserved dot slot, always rendered: every title starts at the
-				    same x in every state, forever — indicators change colour,
-				    never geometry. The old conditional dot shifted titles 14px
-				    sideways when it appeared/disappeared. */}
+				{/* ONE reserved indicator slot serving all four states, so every
+				    title starts at the same x forever — indicators change colour,
+				    never geometry.
+
+				    The slot is sized to the LARGEST occupant (the 12px spinner)
+				    and the 6px dot is centred inside it. Rendering the spinner
+				    BESIDE the slot, as this did before, defeated the whole point:
+				    a streaming row paid slot + gap + spinner and its title sat
+				    ~19.5px right of every other row's, so the reserved-slot
+				    promise held for three states and broke on the fourth — the
+				    one that changes most often. Spinner itself is untouched; it
+				    is a shared component and its own size is correct. */}
 				<span
-					className={cn(
-						"inline-block size-1.5 shrink-0 rounded-full",
-						decision
-							? "lo-pulse bg-danger"
-							: unread
-								? "bg-accent"
-								: "bg-transparent",
+					className="flex size-3 shrink-0 items-center justify-center"
+					aria-hidden={s.streaming ? undefined : true}
+				>
+					{s.streaming ? (
+						/* The obvious in-progress mark beside the title: a small
+						   loading wheel, not just the text sweep — the sweep alone
+						   was too subtle to catch at a glance. */
+						<Spinner />
+					) : (
+						<span
+							className={cn(
+								"inline-block size-1.5 rounded-full",
+								decision
+									? "lo-pulse bg-danger"
+									: unread
+										? "bg-accent"
+										: "bg-transparent",
+							)}
+						/>
 					)}
-					aria-hidden
-				/>
-				{s.streaming ? (
-					/* The obvious in-progress mark beside the title: a small loading
-					   wheel, not just the text sweep — the sweep alone was too
-					   subtle to catch at a glance. */
-					<Spinner />
-				) : null}
+				</span>
 				<span
 					className={cn(
 						"min-w-0 flex-1 truncate text-body-sm font-medium",

--- a/local_operator/mobile/web/src/screens/session-view.tsx
+++ b/local_operator/mobile/web/src/screens/session-view.tsx
@@ -19,8 +19,13 @@ import { TodosPanel } from "../components/todos-panel";
 import { Transcript } from "../components/transcript";
 import { WorkingLine } from "../components/working-line";
 import { navigate } from "../router";
+import { markSessionSeen } from "../api";
 import { AgentScreen } from "./agent-view";
-import { retainProjectionStream, useProjection } from "../store";
+import {
+	clearSessionUnseen,
+	retainProjectionStream,
+	useProjection,
+} from "../store";
 import type { SessionProjection } from "../types";
 
 function Header({
@@ -58,6 +63,19 @@ export function SessionScreen({
 	const rootRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => retainProjectionStream(sessionId), [sessionId]);
+
+	/* Seen handshake (spec §3): opening this session — root OR agent route,
+	   both render through this component — IS viewing it. Clear `unseen`
+	   optimistically in the store so back-navigation never flashes a stale
+	   `new` mark, and tell the daemon fire-and-forget. A failed POST is not
+	   an error state: the daemon's next list repaint simply restores the
+	   mark, which is the honest outcome. */
+	useEffect(() => {
+		clearSessionUnseen(sessionId);
+		markSessionSeen(sessionId).catch(() => {
+			/* No UI to surface this on; the repaint reconciles. */
+		});
+	}, [sessionId]);
 
 	/* Keep the composer above the iOS keyboard: pin the layout column to
 	   the visual viewport's height and offset while the keyboard is open. */

--- a/local_operator/mobile/web/src/session-list.unread.test.tsx
+++ b/local_operator/mobile/web/src/session-list.unread.test.tsx
@@ -45,10 +45,17 @@ function cardByName(name: string): HTMLButtonElement {
 	return screen.getByRole("button", { name: new RegExp(name) });
 }
 
-/* The reserved dot slot is the first child of the card's title row. */
-function dot(card: HTMLButtonElement): HTMLElement {
+/* The ONE reserved indicator slot: first child of the card's title row. It is
+   sized to the largest occupant (the spinner) and holds either the spinner or
+   the centred dot, so every title starts at the same x in all four states. */
+function slot(card: HTMLButtonElement): HTMLElement {
 	const row = card.querySelector("div")!;
 	return row.firstElementChild as HTMLElement;
+}
+
+/* The dot inside the slot. Streaming rows have a spinner there instead. */
+function dot(card: HTMLButtonElement): HTMLElement {
+	return slot(card).firstElementChild as HTMLElement;
 }
 
 afterEach(() => {
@@ -112,7 +119,39 @@ describe("SessionCard attention ladder", () => {
 		expect(card.textContent).not.toContain("new");
 		/* In-flight work keeps the spinner and shimmer, not the accent mark. */
 		expect(card.querySelector(".lo-spinner")).toBeTruthy();
-		expect(dot(card).className).toContain("bg-transparent");
+		/* D2/U1: the spinner renders INSIDE the reserved slot, not beside it.
+		   Rendered alongside, a streaming row paid slot + gap + spinner and its
+		   title sat ~19.5px right of every other row's. */
+		expect(slot(card).querySelector(".lo-spinner")).toBeTruthy();
+		expect(slot(card).className).toContain("size-3");
+	});
+
+	it("gives every state the SAME indicator slot, so titles never shift", () => {
+		/* D2/U1: the reserved-slot promise held for three states and broke on
+		   streaming, which rendered the spinner IN ADDITION to the slot. One
+		   slot, one size, all four states. */
+		sessionList = [
+			summary({ session_id: "a", conversation_name: "Decide", needs_attention: true, pending_kind: "approval" }),
+			summary({ session_id: "b", conversation_name: "Working", streaming: true }),
+			summary({ session_id: "c", conversation_name: "Unread", unseen: true }),
+			summary({ session_id: "d", conversation_name: "Idle" }),
+		];
+		render(<SessionListScreen />);
+		const slots = ["Decide", "Working", "Unread", "Idle"].map((name) =>
+			slot(cardByName(name)),
+		);
+		/* Identical slot geometry across all four; only the contents differ. */
+		for (const s of slots) {
+			expect(s.className).toContain("size-3");
+			expect(s.className).toContain("shrink-0");
+		}
+		/* And the title is the slot's next sibling in every state — nothing is
+		   inserted between the slot and the name. */
+		for (const name of ["Decide", "Working", "Unread", "Idle"]) {
+			const card = cardByName(name);
+			const title = slot(card).nextElementSibling as HTMLElement;
+			expect(title.textContent).toBe(name);
+		}
 	});
 
 	it("keeps the reserved dot slot on an idle card", () => {
@@ -129,6 +168,6 @@ describe("SessionCard attention ladder", () => {
 		expect(marker).toBeTruthy();
 		expect(marker.className).toContain("size-1.5");
 		expect(marker.className).toContain("bg-transparent");
-		expect(marker.getAttribute("aria-hidden")).toBe("true");
+		expect(slot(card).getAttribute("aria-hidden")).toBe("true");
 	});
 });

--- a/local_operator/mobile/web/src/session-list.unread.test.tsx
+++ b/local_operator/mobile/web/src/session-list.unread.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+//
+// The four-state attention ladder (spec §1): NEEDS DECISION > WORKING >
+// NEW/UNREAD > IDLE. Flags coexist in data; exactly one state renders. These
+// tests render the REAL SessionListScreen so the render ladder, the reserved
+// left dot slot, and the `new` word's classes/aria are asserted against the
+// production card, not a copy of it.
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionListScreen } from "./screens/session-list";
+import type { SessionSummary } from "./types";
+
+let sessionList: SessionSummary[] = [];
+vi.mock("./store", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./store")>();
+	return {
+		...actual,
+		useSessions: () => ({ sessions: sessionList, connected: true }),
+		retainSessionListStream: () => () => {},
+	};
+});
+vi.mock("./api", () => ({
+	getDirectories: vi.fn(async () => ({ home: "", recent: [] })),
+}));
+
+function summary(over: Partial<SessionSummary>): SessionSummary {
+	return {
+		session_id: "s",
+		section: "active",
+		conversation_name: "Session",
+		cwd: "",
+		model_label: "",
+		streaming: false,
+		needs_attention: false,
+		unseen: false,
+		pending_kind: "",
+		subagents_running: 0,
+		todos_open: 0,
+		mtime: 0,
+		...over,
+	};
+}
+
+function cardByName(name: string): HTMLButtonElement {
+	return screen.getByRole("button", { name: new RegExp(name) });
+}
+
+/* The reserved dot slot is the first child of the card's title row. */
+function dot(card: HTMLButtonElement): HTMLElement {
+	const row = card.querySelector("div")!;
+	return row.firstElementChild as HTMLElement;
+}
+
+afterEach(() => {
+	cleanup();
+	sessionList = [];
+});
+
+describe("SessionCard attention ladder", () => {
+	it("renders the unread card with a static accent dot and the word `new`", () => {
+		sessionList = [
+			summary({ session_id: "u1", conversation_name: "Alpha", unseen: true }),
+		];
+		render(<SessionListScreen />);
+		const card = cardByName("Alpha");
+		expect(card.textContent).toContain("new");
+
+		const word = Array.from(card.querySelectorAll("span")).find(
+			(span) => span.textContent === "new",
+		)!;
+		expect(word.className).toContain("text-accent");
+		expect(word.getAttribute("aria-label")).toBe("new activity");
+
+		const marker = dot(card);
+		expect(marker.className).toContain("bg-accent");
+		/* Motion is reserved for danger: the unread dot never pulses. */
+		expect(marker.className).not.toContain("lo-pulse");
+	});
+
+	it("lets needs-decision outrank unread", () => {
+		sessionList = [
+			summary({
+				session_id: "d1",
+				conversation_name: "Beta",
+				unseen: true,
+				needs_attention: true,
+				pending_kind: "approval",
+			}),
+		];
+		render(<SessionListScreen />);
+		const card = cardByName("Beta");
+		expect(card.textContent).toContain("approval");
+		/* The unread mark is suppressed, not stacked. */
+		expect(card.textContent).not.toContain("new");
+
+		const marker = dot(card);
+		expect(marker.className).toContain("bg-danger");
+		expect(marker.className).toContain("lo-pulse");
+	});
+
+	it("lets streaming outrank unread", () => {
+		sessionList = [
+			summary({
+				session_id: "w1",
+				conversation_name: "Gamma",
+				unseen: true,
+				streaming: true,
+			}),
+		];
+		render(<SessionListScreen />);
+		const card = cardByName("Gamma");
+		expect(card.textContent).not.toContain("new");
+		/* In-flight work keeps the spinner and shimmer, not the accent mark. */
+		expect(card.querySelector(".lo-spinner")).toBeTruthy();
+		expect(dot(card).className).toContain("bg-transparent");
+	});
+
+	it("keeps the reserved dot slot on an idle card", () => {
+		sessionList = [
+			summary({ session_id: "i1", conversation_name: "Delta" }),
+		];
+		render(<SessionListScreen />);
+		const card = cardByName("Delta");
+		expect(card.textContent).not.toContain("new");
+
+		/* The slot is always rendered — indicators change colour, never
+		   geometry — so an idle card still carries the transparent dot. */
+		const marker = dot(card);
+		expect(marker).toBeTruthy();
+		expect(marker.className).toContain("size-1.5");
+		expect(marker.className).toContain("bg-transparent");
+		expect(marker.getAttribute("aria-hidden")).toBe("true");
+	});
+});

--- a/local_operator/mobile/web/src/session-list.unread.test.tsx
+++ b/local_operator/mobile/web/src/session-list.unread.test.tsx
@@ -126,6 +126,39 @@ describe("SessionCard attention ladder", () => {
 		expect(slot(card).className).toContain("size-3");
 	});
 
+	it("keeps the danger dot when a decision row is ALSO streaming", () => {
+		/* D6: the approval gate runs INSIDE a turn — the harness blocks in
+		   _execute_tool_calls between agent_start and agent_end — so an
+		   ordinary "may I run this?" carries streaming AND pending at once.
+		   An earlier slot tested `streaming` first and replaced the red pulse
+		   with a neutral spinner on the loudest state in the ladder. */
+		sessionList = [
+			summary({
+				session_id: "ds",
+				conversation_name: "Blocked while streaming",
+				needs_attention: true,
+				pending_kind: "approval",
+				streaming: true,
+			}),
+		];
+		render(<SessionListScreen />);
+		const card = cardByName("Blocked while streaming");
+
+		const marker = dot(card);
+		expect(marker.className).toContain("bg-danger");
+		expect(marker.className).toContain("lo-pulse");
+		/* The spinner must NOT have taken the slot. */
+		expect(slot(card).querySelector(".lo-spinner")).toBeNull();
+		/* The decision word still renders on the right. */
+		expect(card.textContent).toContain("approval");
+		/* "Working" is still conveyed — by the title shimmer, which costs no
+		   geometry — so the row does not read as idle-but-blocked. */
+		const title = slot(card).nextElementSibling as HTMLElement;
+		expect(title.className).toContain("lo-shimmer");
+		/* And the slot geometry is unchanged, so the title does not shift. */
+		expect(slot(card).className).toContain("size-3");
+	});
+
 	it("gives every state the SAME indicator slot, so titles never shift", () => {
 		/* D2/U1: the reserved-slot promise held for three states and broke on
 		   streaming, which rendered the spinner IN ADDITION to the slot. One
@@ -135,11 +168,11 @@ describe("SessionCard attention ladder", () => {
 			summary({ session_id: "b", conversation_name: "Working", streaming: true }),
 			summary({ session_id: "c", conversation_name: "Unread", unseen: true }),
 			summary({ session_id: "d", conversation_name: "Idle" }),
+			summary({ session_id: "e", conversation_name: "Deciding", needs_attention: true, pending_kind: "ask", streaming: true }),
 		];
 		render(<SessionListScreen />);
-		const slots = ["Decide", "Working", "Unread", "Idle"].map((name) =>
-			slot(cardByName(name)),
-		);
+		const names = ["Decide", "Working", "Unread", "Idle", "Deciding"];
+		const slots = names.map((name) => slot(cardByName(name)));
 		/* Identical slot geometry across all four; only the contents differ. */
 		for (const s of slots) {
 			expect(s.className).toContain("size-3");
@@ -147,7 +180,7 @@ describe("SessionCard attention ladder", () => {
 		}
 		/* And the title is the slot's next sibling in every state — nothing is
 		   inserted between the slot and the name. */
-		for (const name of ["Decide", "Working", "Unread", "Idle"]) {
+		for (const name of names) {
 			const card = cardByName(name);
 			const title = slot(card).nextElementSibling as HTMLElement;
 			expect(title.textContent).toBe(name);

--- a/local_operator/mobile/web/src/session-list.unread.test.tsx
+++ b/local_operator/mobile/web/src/session-list.unread.test.tsx
@@ -50,7 +50,10 @@ function cardByName(name: string): HTMLButtonElement {
    the centred dot, so every title starts at the same x in all four states. */
 function slot(card: HTMLButtonElement): HTMLElement {
 	const row = card.querySelector("div")!;
-	return row.firstElementChild as HTMLElement;
+	/* Selected by its own geometry class rather than by position: a
+	   decision+streaming row also carries an sr-only status node in this row,
+	   so "first child" is no longer the slot. */
+	return row.querySelector(".size-3") as HTMLElement;
 }
 
 /* The dot inside the slot. Streaming rows have a spinner there instead. */
@@ -153,10 +156,60 @@ describe("SessionCard attention ladder", () => {
 		expect(card.textContent).toContain("approval");
 		/* "Working" is still conveyed — by the title shimmer, which costs no
 		   geometry — so the row does not read as idle-but-blocked. */
-		const title = slot(card).nextElementSibling as HTMLElement;
+		let title = slot(card).nextElementSibling as HTMLElement;
+		if (title.className.includes("sr-only")) {
+			title = title.nextElementSibling as HTMLElement;
+		}
 		expect(title.className).toContain("lo-shimmer");
 		/* And the slot geometry is unchanged, so the title does not shift. */
 		expect(slot(card).className).toContain("size-3");
+	});
+
+	it("announces `working` to assistive tech on every streaming row", () => {
+		/* D7: the spinner carries the only role="status" aria-label="working",
+		   and on a decision+streaming row the ladder gives the slot to the
+		   danger dot and hides the slot — so AT heard the pending word and
+		   nothing about the turn being in flight. The shimmer is a pure CSS
+		   paint and conveys nothing. Restored as TEXT so it costs no geometry. */
+		sessionList = [
+			summary({
+				session_id: "ds",
+				conversation_name: "Deciding while streaming",
+				needs_attention: true,
+				pending_kind: "approval",
+				streaming: true,
+			}),
+			summary({ session_id: "st", conversation_name: "Just streaming", streaming: true }),
+			summary({ session_id: "id", conversation_name: "Idle here" }),
+		];
+		render(<SessionListScreen />);
+
+		/* The decision+streaming row: danger dot in the slot AND a working
+		   announcement in the accessibility tree. */
+		const decisionCard = cardByName("Deciding while streaming");
+		expect(dot(decisionCard).className).toContain("bg-danger");
+		const status = decisionCard.querySelector('[role="status"]') as HTMLElement;
+		expect(status).toBeTruthy();
+		expect(status.textContent).toBe("working");
+		/* sr-only keeps it out of the layout, so it cannot revive D2's shift. */
+		expect(status.className).toContain("sr-only");
+
+		/* A plain streaming row still announces working exactly once — the
+		   spinner already carries it there, so the sr-only node is rendered
+		   only for the decision row that lost it. */
+		const streamingCard = cardByName("Just streaming");
+		const announced = Array.from(
+			streamingCard.querySelectorAll('[role="status"], [aria-label="working"]'),
+		);
+		expect(announced.length).toBe(1);
+		expect(streamingCard.querySelector(".sr-only")).toBeNull();
+		/* And the decision row announces it exactly once too. */
+		expect(
+			decisionCard.querySelectorAll('[role="status"], [aria-label="working"]').length,
+		).toBe(1);
+
+		/* An idle row says nothing about working. */
+		expect(cardByName("Idle here").querySelector('[role="status"]')).toBeNull();
 	});
 
 	it("gives every state the SAME indicator slot, so titles never shift", () => {
@@ -182,7 +235,12 @@ describe("SessionCard attention ladder", () => {
 		   inserted between the slot and the name. */
 		for (const name of names) {
 			const card = cardByName(name);
-			const title = slot(card).nextElementSibling as HTMLElement;
+			/* The title is the first element after the slot that is not the
+			   sr-only status node, so nothing VISIBLE separates them. */
+			let title = slot(card).nextElementSibling as HTMLElement;
+			if (title.className.includes("sr-only")) {
+				title = title.nextElementSibling as HTMLElement;
+			}
 			expect(title.textContent).toBe(name);
 		}
 	});

--- a/local_operator/mobile/web/src/session-view.pending.test.tsx
+++ b/local_operator/mobile/web/src/session-view.pending.test.tsx
@@ -22,6 +22,7 @@ vi.mock("./api", () => ({
 	getCommands: vi.fn(async () => ({ commands: [] })),
 	getModels: vi.fn(async () => ({ models: [] })),
 	sendCommand: vi.fn(async () => ({ ok: true, detail: "answer accepted" })),
+	markSessionSeen: vi.fn(async () => ({ ok: true })),
 }));
 
 /* SessionScreen subscribes to the projection store; the test is the store.

--- a/local_operator/mobile/web/src/session-view.seen.test.tsx
+++ b/local_operator/mobile/web/src/session-view.seen.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+//
+// Seen handshake (spec §3): opening a session — the root route OR a subagent
+// route, both of which render through SessionScreen — must fire
+// POST /api/sessions/{id}/seen once on mount and optimistically clear the
+// client's `unseen` copy so back-navigation never flashes a stale `new` mark.
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionScreen } from "./screens/session-view";
+import type { SessionProjection } from "./types";
+
+vi.mock("./api", () => ({
+	getHistory: vi.fn(async () => ({ entries: [], has_more: false })),
+	getSubagentHistory: vi.fn(async () => ({ entries: [], has_more: false })),
+	/* Never resolves: keeps AgentScreen on its loading branch so the test
+	   exercises the mount path without needing a full detail fixture. */
+	getSubagentDetail: vi.fn(() => new Promise(() => undefined)),
+	imageUrl: vi.fn(() => ""),
+	getCommands: vi.fn(async () => ({ commands: [] })),
+	getModels: vi.fn(async () => ({ models: [] })),
+	sendCommand: vi.fn(async () => ({ ok: true, detail: "" })),
+	markSessionSeen: vi.fn(async () => ({ ok: true })),
+}));
+
+let slot: { projection: SessionProjection | null; connected: boolean } = {
+	projection: null,
+	connected: true,
+};
+vi.mock("./store", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./store")>();
+	return {
+		...actual,
+		useProjection: vi.fn(() => slot),
+		retainProjectionStream: vi.fn(() => () => {}),
+		useDraft: vi.fn(() => ["", () => {}]),
+		clearSessionUnseen: vi.fn(actual.clearSessionUnseen),
+	};
+});
+
+function projection(): SessionProjection {
+	return {
+		session_id: "s1",
+		pid: 1,
+		kind: "tui",
+		conversation_name: "Seen",
+		cwd: "",
+		model_label: "",
+		model_selector: "",
+		effort: "",
+		effort_ladder: [],
+		streaming: false,
+		activity: "",
+		activity_started_s: 0,
+		stop_reason: "",
+		queued_count: 0,
+		ended: false,
+		degraded: false,
+		transcript: [],
+		todos: [],
+		subagents: [],
+		pending: null,
+		pending_count: 0,
+		usage: {},
+		version: 1,
+	} satisfies SessionProjection;
+}
+
+const { markSessionSeen } = await import("./api");
+const { clearSessionUnseen } = await import("./store");
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+	slot = { projection: null, connected: true };
+});
+
+describe("SessionScreen seen handshake", () => {
+	it("fires POST /seen once and clears the store flag on the root route", async () => {
+		slot = { projection: projection(), connected: true };
+		render(<SessionScreen sessionId="s1" />);
+		await waitFor(() => expect(markSessionSeen).toHaveBeenCalledWith("s1"));
+		expect(markSessionSeen).toHaveBeenCalledTimes(1);
+		expect(clearSessionUnseen).toHaveBeenCalledWith("s1");
+	});
+
+	it("fires POST /seen on the agent route too", async () => {
+		slot = { projection: projection(), connected: true };
+		render(<SessionScreen sessionId="s1" jobId="job-1" />);
+		await waitFor(() => expect(markSessionSeen).toHaveBeenCalledWith("s1"));
+		expect(markSessionSeen).toHaveBeenCalledTimes(1);
+		expect(clearSessionUnseen).toHaveBeenCalledWith("s1");
+	});
+});

--- a/local_operator/mobile/web/src/store.ts
+++ b/local_operator/mobile/web/src/store.ts
@@ -258,6 +258,47 @@ export function retainProjectionStream(sessionId: string): () => void {
 }
 
 /* ------------------------------------------------------------------ */
+/* Seen handshake, optimistic half                                     */
+/* ------------------------------------------------------------------ */
+
+/** Optimistic half of the seen handshake (the POST is `markSessionSeen` in
+    api.ts): opening a session IS viewing it, so clear `unseen` locally at
+    once — back-navigation must never flash a stale `new` mark while the POST
+    is in flight. The daemon's next list repaint confirms the clear; if the
+    POST fails, that repaint simply restores the mark, which is the honest
+    state. */
+export function clearSessionUnseen(sessionId: string): void {
+	const target = sessions.find((s) => s.session_id === sessionId);
+	if (!target || !target.unseen) return;
+	sessions = sessions.map((s) =>
+		s.session_id === sessionId ? { ...s, unseen: false } : s,
+	);
+	emit();
+}
+
+/* ------------------------------------------------------------------ */
+/* Tab title aggregate                                                 */
+/* ------------------------------------------------------------------ */
+
+/* The browser tab title is the one attention signal visible from the
+   phone's app switcher, so it must track the list even while a session
+   view (which renders nothing of the list) is on screen. A permanent
+   module subscription instead of a hook: a number in the chrome must not
+   re-render any component. n = sessions with unseen || needs_attention —
+   finished reading matter plus decisions, the two states that want the
+   user (spec §4). */
+function syncTabTitle(): void {
+	/* The store also loads in non-DOM contexts (the node-env unit suite). */
+	if (typeof document === "undefined") return;
+	const n = sessions.filter((s) => s.unseen || s.needs_attention).length;
+	const title = n > 0 ? `(${n}) local operator` : "local operator";
+	if (document.title !== title) document.title = title;
+}
+
+subscribe(syncTabTitle);
+syncTabTitle();
+
+/* ------------------------------------------------------------------ */
 /* Composer drafts, per pid, in localStorage                           */
 /* ------------------------------------------------------------------ */
 

--- a/local_operator/mobile/web/src/store.unread.test.ts
+++ b/local_operator/mobile/web/src/store.unread.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+//
+// Tab-title aggregate (spec §4) and the optimistic half of the seen
+// handshake. The title is the one attention signal visible from the phone's
+// app switcher, so it must track the list store on every emit: n = sessions
+// with unseen || needs_attention.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearSessionUnseen, retainSessionListStream } from "./store";
+import type { SessionSummary } from "./types";
+
+class FakeEventSource {
+	static instances: FakeEventSource[] = [];
+	onopen: (() => void) | null = null;
+	onerror: (() => void) | null = null;
+	listeners = new Map<string, (event: MessageEvent) => void>();
+	closed = false;
+	constructor(readonly url: string) {
+		FakeEventSource.instances.push(this);
+	}
+	addEventListener(name: string, listener: EventListenerOrEventListenerObject) {
+		this.listeners.set(name, listener as (event: MessageEvent) => void);
+	}
+	close() {
+		this.closed = true;
+	}
+}
+
+function summary(over: Partial<SessionSummary>): SessionSummary {
+	return {
+		session_id: "s",
+		section: "active",
+		conversation_name: "Session",
+		cwd: "",
+		model_label: "",
+		streaming: false,
+		needs_attention: false,
+		unseen: false,
+		pending_kind: "",
+		subagents_running: 0,
+		todos_open: 0,
+		mtime: 0,
+		...over,
+	};
+}
+
+let release: (() => void) | null = null;
+
+function emitSessions(rows: SessionSummary[]) {
+	const es = FakeEventSource.instances[0];
+	const listener = es.listeners.get("sessions")!;
+	listener({ data: JSON.stringify({ sessions: rows }) } as MessageEvent);
+}
+
+afterEach(() => {
+	release?.();
+	release = null;
+	FakeEventSource.instances = [];
+});
+
+describe("tab title aggregate", () => {
+	it("counts unseen and needs-decision sessions on every emit", () => {
+		vi.stubGlobal("EventSource", FakeEventSource);
+		release = retainSessionListStream();
+		emitSessions([
+			summary({ session_id: "a", unseen: true }),
+			summary({ session_id: "b", needs_attention: true, pending_kind: "approval" }),
+			summary({ session_id: "c" }),
+		]);
+		expect(document.title).toBe("(2) local operator");
+
+		/* A session that is BOTH unseen and blocked counts once. */
+		emitSessions([
+			summary({ session_id: "a", unseen: true, needs_attention: true, pending_kind: "ask" }),
+		]);
+		expect(document.title).toBe("(1) local operator");
+
+		emitSessions([]);
+		expect(document.title).toBe("local operator");
+	});
+
+	it("clears the mark optimistically when the session is opened", () => {
+		vi.stubGlobal("EventSource", FakeEventSource);
+		release = retainSessionListStream();
+		emitSessions([summary({ session_id: "a", unseen: true })]);
+		expect(document.title).toBe("(1) local operator");
+
+		clearSessionUnseen("a");
+		expect(document.title).toBe("local operator");
+
+		/* Clearing a session that is not unseen is a no-op: no redundant
+		   store emission, title unchanged. */
+		clearSessionUnseen("a");
+		expect(document.title).toBe("local operator");
+	});
+});

--- a/local_operator/mobile/web/src/types.ts
+++ b/local_operator/mobile/web/src/types.ts
@@ -216,6 +216,12 @@ export interface SessionSummary {
 	model_label: string;
 	streaming: boolean;
 	needs_attention: boolean;
+	/** A turn finished while no relay client was viewing the session, and it
+	    has not been opened since. Renders the calm accent "new" mark (never
+	    danger, never a pulse — those are reserved for decisions); cleared by
+	    POST /api/sessions/{id}/seen when the session is opened. Older daemons
+	    omit the field entirely, so readers must treat absence as false. */
+	unseen?: boolean;
 	pending_kind: "approval" | "ask" | "" | null;
 	subagents_running: number;
 	todos_open: number;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.16"
+version = "0.44.17"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/bench_relay_load.py
+++ b/scripts/bench_relay_load.py
@@ -1,0 +1,106 @@
+"""Benchmark the mobile relay's session-load paths against the REAL store.
+
+Paths measured (these are what a phone opening a session pays):
+
+- ``list``    : SessionTable.summaries() — the durable listing scan the list
+                routes read, measured cold (first call) and warm (TTL cache).
+- ``durable`` : mobile.daemon._durable_projection(sid) — the SSE seed frame
+                for a session with no live process: full transcript parse +
+                fold + roster rebuild (cold), then the incremental fold cache
+                (warm).
+- ``history`` : mobile.daemon._history_page(sid, None, 80) — the transcript
+                page the phone fetches on open and on every scroll-up,
+                cold and repeated.
+- ``parse``   : raw Transcript(dir) construction alone, so the split between
+                JSONL parse and fold is visible.
+
+Each durable path is measured cold (first call) and warm (median of repeats).
+Run with ``PYTHONPATH=.`` so THIS checkout's ``local_operator`` is imported.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from local_operator.mobile.daemon import (  # noqa: E402
+    SessionTable,
+    _durable_projection,
+    _history_page,
+)
+from local_operator.paths import config_dir  # noqa: E402
+from local_operator.session.transcript import Transcript  # noqa: E402
+
+
+def pick_sessions(n: int = 8) -> list[tuple[str, int]]:
+    """The n largest user-session transcripts: worst case is the common case."""
+    sessions = config_dir() / "sessions"
+    rows: list[tuple[str, int]] = []
+    for child in sessions.iterdir():
+        t = child / "transcript.jsonl"
+        if t.is_file():
+            rows.append((child.name, t.stat().st_size))
+    rows.sort(key=lambda r: -r[1])
+    return rows[:n]
+
+
+def time_call(fn, *args, repeats: int = 3) -> tuple[float, float]:
+    """(first-call seconds, median-of-repeats seconds)."""
+    t0 = time.perf_counter()
+    fn(*args)
+    first = time.perf_counter() - t0
+    samples = []
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        fn(*args)
+        samples.append(time.perf_counter() - t0)
+    return first, statistics.median(samples)
+
+
+def main() -> None:
+    out: dict[str, object] = {"python": sys.version.split()[0]}
+
+    # The list path: summaries() cold (durable scan) and warm (TTL cache).
+    table = SessionTable()
+    first_list, warm_list = time_call(lambda: asyncio.run(table.summaries()))
+    out["list_summaries_cold_s"] = round(first_list, 4)
+    out["list_summaries_warm_s"] = round(warm_list, 6)
+    out["list_rows"] = len(asyncio.run(table.summaries()))
+
+    targets = pick_sessions()
+    out["sessions"] = []
+    for sid, size in targets:
+        directory = config_dir() / "sessions" / sid
+        first_p, warm_p = time_call(lambda: _durable_projection(sid))
+        first_h, warm_h = time_call(lambda: _history_page(sid, None, 80))
+
+        def _parse() -> int:
+            return len(Transcript(directory)._entries)
+
+        first_t, warm_t = time_call(_parse)
+        out["sessions"].append(
+            {
+                "session_id": sid,
+                "transcript_mb": round(size / 1e6, 1),
+                "durable_projection_first_s": round(first_p, 3),
+                "durable_projection_warm_s": round(warm_p, 3),
+                "history_page_first_s": round(first_h, 3),
+                "history_page_warm_s": round(warm_h, 3),
+                "transcript_parse_first_s": round(first_t, 3),
+                "transcript_parse_warm_s": round(warm_t, 3),
+                "entries": _parse(),  # cheap now, page cache warm
+            }
+        )
+
+    print(json.dumps(out, indent=1))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/mobile/test_relay_perf.py
+++ b/tests/unit/mobile/test_relay_perf.py
@@ -570,6 +570,31 @@ def test_seen_store_mark_seen_clears_then_relights(tmp_path) -> None:
     assert store.is_unseen("s1", 250.0) is True  # newer than last_seen
 
 
+def test_watch_debounce_is_per_session(tmp_path) -> None:
+    """Each watched session gets its own persist clock (A15).
+
+    A single instance-wide timestamp meant the first watched session to write
+    suppressed the disk write for every other session for the whole interval,
+    so a second session watched in that window kept its stamp only in memory
+    and lost it on a crash. Two phones on two sessions is the ordinary case.
+    """
+    import json
+
+    path = tmp_path / SEEN_STORE_NAME
+    store = SeenStore(path)
+    for index, session_id in enumerate(("a", "b", "c")):
+        store.touch_watched(session_id, now=1000.0 + index)
+    persisted = json.loads(path.read_text())["sessions"]
+    assert sorted(persisted) == ["a", "b", "c"]
+
+    # The debounce still does its job WITHIN one session: repeat touches
+    # inside the interval must not rewrite the file.
+    before = path.stat().st_mtime_ns
+    for _ in range(300):
+        store.touch_watched("a", now=1003.0)
+    assert path.stat().st_mtime_ns == before
+
+
 def test_seen_store_persists_last_seen_across_restart(tmp_path) -> None:
     """last_seen survives a store reload; baselines re-derive safely."""
     path = tmp_path / SEEN_STORE_NAME

--- a/tests/unit/mobile/test_relay_perf.py
+++ b/tests/unit/mobile/test_relay_perf.py
@@ -83,6 +83,14 @@ def test_fold_cache_matches_full_reparse_on_append(tmp_path, monkeypatch) -> Non
     state = cache.load(directory)
     assert [e.id for e in state.render] == _fresh_render(directory)
     assert len(state.render) > len(first_render)
+    # entry_count is the cursor/file agreement invariant (A10): the tail read
+    # must have consumed exactly the lines a full re-parse would see.
+    file_lines = [
+        line
+        for line in (directory / "transcript.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    assert state.entry_count == len(file_lines)
 
 
 def test_fold_cache_refolds_on_compaction_in_tail(tmp_path, monkeypatch) -> None:

--- a/tests/unit/mobile/test_relay_perf.py
+++ b/tests/unit/mobile/test_relay_perf.py
@@ -16,10 +16,7 @@ from starlette.testclient import TestClient
 
 from local_operator.harness.types import Message
 from local_operator.mobile.daemon import MobileDaemon, SessionTable, build_app
-from local_operator.mobile.durable import (
-    CustomSnapshotCache,
-    DurableFoldCache,
-)
+from local_operator.mobile.durable import CustomSnapshotCache, DurableFoldCache
 from local_operator.mobile.projection import (
     FRAME_CAP_RESULT_CHARS,
     PROJECTION_FRAME_SOFT_CAP_BYTES,

--- a/tests/unit/mobile/test_relay_perf.py
+++ b/tests/unit/mobile/test_relay_perf.py
@@ -737,7 +737,6 @@ def test_frame_measurement_gate_never_lets_an_oversized_frame_through() -> None:
     vacuously without them, which is how the defect shipped.
     """
     import random
-    import string
 
     from local_operator.mobile.types import (
         AskOptionWire,

--- a/tests/unit/mobile/test_relay_perf.py
+++ b/tests/unit/mobile/test_relay_perf.py
@@ -287,6 +287,50 @@ async def test_summaries_rows_carry_unseen_key(tmp_path, monkeypatch) -> None:
         assert isinstance(row["unseen"], bool)
 
 
+@pytest.mark.asyncio
+async def test_unseen_rows_sort_above_newer_seen_rows(tmp_path, monkeypatch) -> None:
+    """An OLD unread session outranks a NEWER read one inside its section.
+
+    This is the headline of the feature: without ``unseen`` in the sort tuple
+    the mark renders but the list stays in plain mtime order, so the unread
+    session the user is meant to notice sits wherever recency puts it.
+    """
+    import os
+
+    cfg = tmp_path / "config"
+    old_dir = cfg / "sessions" / "old-unread"
+    new_dir = cfg / "sessions" / "new-read"
+    old_dir.mkdir(parents=True)
+    new_dir.mkdir(parents=True)
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+    await _write_turns_async(old_dir, 1)
+    await _write_turns_async(new_dir, 1)
+
+    # The OLD session is the older transcript; the NEW one is newer, so plain
+    # recency ordering would put "new-read" first.
+    old_transcript = old_dir / "transcript.jsonl"
+    new_transcript = new_dir / "transcript.jsonl"
+    os.utime(old_transcript, (1_000_000, 1_000_000))
+    os.utime(new_transcript, (2_000_000, 2_000_000))
+
+    table = SessionTable()
+    store = table.seen_store
+    # Both observed at their current mtimes (baseline), then the older one
+    # gains activity the phone has not seen while the newer one is marked read.
+    await table.summaries()
+    os.utime(old_transcript, (1_500_000, 1_500_000))
+    store.mark_seen("new-read", now=3_000_000.0)
+    table.invalidate_summaries_cache()
+
+    rows = await table.summaries()
+    ordered = [row["session_id"] for row in rows]
+    by_id = {row["session_id"]: row for row in rows}
+    assert by_id["old-unread"]["unseen"] is True
+    assert by_id["new-read"]["unseen"] is False
+    # The unread row wins despite being the OLDER transcript.
+    assert ordered.index("old-unread") < ordered.index("new-read")
+
+
 # ---------------------------------------------------------------------------
 # Seen store
 # ---------------------------------------------------------------------------

--- a/tests/unit/mobile/test_relay_perf.py
+++ b/tests/unit/mobile/test_relay_perf.py
@@ -247,7 +247,10 @@ async def test_summaries_caches_durable_rows_within_ttl(tmp_path, monkeypatch) -
 
 @pytest.mark.asyncio
 async def test_summaries_invalidation_forces_rescan(tmp_path, monkeypatch) -> None:
-    """notify_list_changed drops the cache so the next read rescans."""
+    """An explicit structural invalidation drops the cache so the next read
+    rescans. This is the seam the register/death/wake/seen sites call; a bare
+    ``notify_list_changed`` (a projection repaint) deliberately does NOT
+    invalidate — see test_projection_repaints_do_not_rescan_the_store."""
     cfg = tmp_path / "config"
     (cfg / "sessions").mkdir(parents=True)
     monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
@@ -265,9 +268,48 @@ async def test_summaries_invalidation_forces_rescan(tmp_path, monkeypatch) -> No
 
     table = SessionTable()
     await table.summaries()
-    table.notify_list_changed()
+    table.invalidate_summaries_cache()
     await table.summaries()
     assert calls["n"] == 2  # invalidation forced a second scan
+
+
+@pytest.mark.asyncio
+async def test_projection_repaints_do_not_rescan_the_store(tmp_path, monkeypatch) -> None:
+    """A streaming session's repaints must NOT re-run the durable scan (A3).
+
+    Every projection push calls ``notify_list_changed`` (~30x/s). While that
+    invalidated the cache, one streaming session re-imposed a 42-92 ms
+    blocking scan per repaint — restoring the starvation this work removed and
+    defeating the TTL in exactly the busy case it was built for.
+    """
+    cfg = tmp_path / "config"
+    (cfg / "sessions").mkdir(parents=True)
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+
+    calls = {"n": 0}
+    from local_operator import resume as resume_module
+
+    real_rows = resume_module.recent_session_rows
+
+    def counting_rows(config_dir, limit=None):
+        calls["n"] += 1
+        return real_rows(config_dir, limit)
+
+    monkeypatch.setattr(resume_module, "recent_session_rows", counting_rows)
+
+    table = SessionTable()
+    await table.summaries()
+    calls["n"] = 0
+    # One second of streaming: a repaint notification per push.
+    for _ in range(30):
+        table.notify_list_changed()
+        await table.summaries()
+    assert calls["n"] == 0, "projection repaints must not rescan the durable store"
+
+    # A structural change still refreshes, so correctness is preserved.
+    table.invalidate_summaries_cache()
+    await table.summaries()
+    assert calls["n"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mobile/test_relay_perf.py
+++ b/tests/unit/mobile/test_relay_perf.py
@@ -429,6 +429,100 @@ def test_frame_cap_small_frame_passes_through_unchanged() -> None:
     assert frame["subagents"][0]["result_text"] == "ok"
 
 
+def test_frame_cap_bounds_a_single_undegradable_row() -> None:
+    """A projection tiers 1-3 cannot shrink is STILL bounded (A2/A8).
+
+    One pasted file in a single row exceeds the whole cap on its own: no
+    subagent text to trim, no details to drop, and the tail floor keeps the
+    row. Before the text tier this returned a 2,000,644-byte frame that the
+    daemon's 1 MB control reader dropped whole — the silent-repaint-loss the
+    cap exists to prevent.
+    """
+    from local_operator.mobile.types import TranscriptEntry
+
+    projection = SessionProjection(session_id="s1", pid=1, kind="tui")
+    projection.transcript.append(TranscriptEntry(id="u1", kind="user", text="X" * 2_000_000))
+    frame, degraded = cap_projection_frame(projection)
+    assert degraded is True
+    size = len(json.dumps(frame).encode("utf-8"))
+    assert size <= PROJECTION_FRAME_SOFT_CAP_BYTES
+    # And comfortably under the daemon's hard control-socket limit.
+    assert size < (1 << 20)
+
+
+def test_frame_cap_bounds_many_individually_large_rows() -> None:
+    """Many rows that each survive the tail floor are still bounded."""
+    from local_operator.mobile.types import TranscriptEntry
+
+    projection = SessionProjection(session_id="s1", pid=1, kind="tui")
+    for i in range(40):
+        projection.transcript.append(
+            TranscriptEntry(id=f"a{i}", kind="assistant", text="Y" * 80_000)
+        )
+    frame, degraded = cap_projection_frame(projection)
+    assert degraded is True
+    assert len(json.dumps(frame).encode("utf-8")) < (1 << 20)
+
+
+def test_frame_cheap_proxy_never_lets_an_oversized_frame_through() -> None:
+    """The A7 short-circuit must be an OVER-estimate, always (A7 safety).
+
+    ``cap_projection_frame`` skips its measuring ``json.dumps`` when the cheap
+    text/envelope estimate clears a margin. If that estimate ever UNDER-counts
+    a real frame, an oversized payload returns as ``degraded=False`` and the
+    socket drops it — the exact silent loss the cap prevents. Fuzzed over deep
+    rosters, escape-dense text and many short rows, which is where an earlier
+    text-only proxy measured 3.5x under.
+    """
+    import random
+    import string
+
+    from local_operator.mobile.projection import (
+        _FRAME_CHEAP_PROXY_DIVISOR,
+        _frame_text_total,
+    )
+    from local_operator.mobile.types import SubagentRow, TodoItem, TodoPhase, TranscriptEntry
+
+    random.seed(11)
+    threshold = PROJECTION_FRAME_SOFT_CAP_BYTES // _FRAME_CHEAP_PROXY_DIVISOR
+    for _ in range(120):
+        projection = SessionProjection(session_id="s", pid=1, kind="tui")
+        for i in range(random.randint(0, 60)):
+            alphabet = '"\\\n' if random.random() < 0.5 else string.ascii_letters
+            projection.transcript.append(
+                TranscriptEntry(
+                    id=f"t{i}",
+                    kind="assistant",
+                    text="".join(random.choice(alphabet) for _ in range(random.randint(0, 2000))),
+                )
+            )
+        for j in range(random.randint(0, 60)):
+            projection.subagents.append(
+                SubagentRow(
+                    job_id=f"job-{j}" * 3,
+                    label="L" * 20,
+                    result_text="Z" * random.randint(0, 1500),
+                    ancestors=["anc" * 10] * random.randint(0, 8),
+                    ancestor_ids=["id" * 12] * random.randint(0, 8),
+                    child_ids=["c" * 12] * random.randint(0, 8),
+                    peer_ids=["p" * 12] * random.randint(0, 8),
+                )
+            )
+        for _k in range(random.randint(0, 4)):
+            projection.todos.append(
+                TodoPhase(
+                    name="P" * 20,
+                    items=[TodoItem(text="t" * 80) for _ in range(random.randint(0, 20))],
+                )
+            )
+        proxy = _frame_text_total(projection)
+        real = len(json.dumps(projection.to_json()).encode("utf-8"))
+        if proxy <= threshold:
+            assert real <= PROJECTION_FRAME_SOFT_CAP_BYTES, (
+                f"proxy {proxy} short-circuited a {real}-byte frame"
+            )
+
+
 def test_frame_cap_tier2_drops_transcript_details() -> None:
     """When subagent trims are not enough, transcript expand details go next."""
     from local_operator.mobile.types import TranscriptEntry

--- a/tests/unit/mobile/test_relay_perf.py
+++ b/tests/unit/mobile/test_relay_perf.py
@@ -86,9 +86,7 @@ def test_fold_cache_matches_full_reparse_on_append(tmp_path, monkeypatch) -> Non
     # entry_count is the cursor/file agreement invariant (A10): the tail read
     # must have consumed exactly the lines a full re-parse would see.
     file_lines = [
-        line
-        for line in (directory / "transcript.jsonl").read_text().splitlines()
-        if line.strip()
+        line for line in (directory / "transcript.jsonl").read_text().splitlines() if line.strip()
     ]
     assert state.entry_count == len(file_lines)
 
@@ -619,7 +617,12 @@ def test_frame_cheap_proxy_never_lets_an_oversized_frame_through() -> None:
         _FRAME_CHEAP_PROXY_DIVISOR,
         _frame_text_total,
     )
-    from local_operator.mobile.types import SubagentRow, TodoItem, TodoPhase, TranscriptEntry
+    from local_operator.mobile.types import (
+        SubagentRow,
+        TodoItem,
+        TodoPhase,
+        TranscriptEntry,
+    )
 
     random.seed(11)
     threshold = PROJECTION_FRAME_SOFT_CAP_BYTES // _FRAME_CHEAP_PROXY_DIVISOR
@@ -656,9 +659,9 @@ def test_frame_cheap_proxy_never_lets_an_oversized_frame_through() -> None:
         proxy = _frame_text_total(projection)
         real = len(json.dumps(projection.to_json()).encode("utf-8"))
         if proxy <= threshold:
-            assert real <= PROJECTION_FRAME_SOFT_CAP_BYTES, (
-                f"proxy {proxy} short-circuited a {real}-byte frame"
-            )
+            assert (
+                real <= PROJECTION_FRAME_SOFT_CAP_BYTES
+            ), f"proxy {proxy} short-circuited a {real}-byte frame"
 
 
 def test_frame_cap_tier2_drops_transcript_details() -> None:

--- a/tests/unit/mobile/test_relay_perf.py
+++ b/tests/unit/mobile/test_relay_perf.py
@@ -280,9 +280,7 @@ async def test_summaries_invalidation_forces_rescan(tmp_path, monkeypatch) -> No
 
 
 @pytest.mark.asyncio
-async def test_streaming_outranks_unseen_matching_the_render_ladder(
-    tmp_path, monkeypatch
-) -> None:
+async def test_streaming_outranks_unseen_matching_the_render_ladder(tmp_path, monkeypatch) -> None:
     """The sort ladder must match the render ladder (A14, and D5's substance).
 
     The client renders NEEDS DECISION > WORKING > UNREAD > IDLE and suppresses
@@ -351,9 +349,9 @@ async def test_streaming_outranks_unseen_matching_the_render_ladder(
     # Same section, so the ladder — not the section term — decides.
     assert by_id["unread-live"]["section"] == by_id["streaming-live"]["section"]
     ordered = [row["session_id"] for row in rows]
-    assert ordered.index("streaming-live") < ordered.index("unread-live"), (
-        "a streaming row must outrank an unread one, matching the render ladder"
-    )
+    assert ordered.index("streaming-live") < ordered.index(
+        "unread-live"
+    ), "a streaming row must outrank an unread one, matching the render ladder"
 
 
 @pytest.mark.asyncio
@@ -792,9 +790,9 @@ def test_frame_measurement_gate_never_lets_an_oversized_frame_through() -> None:
         if not degraded:
             # The gate vouched for this frame without measuring it, so the
             # claim it made must be true.
-            assert real <= PROJECTION_FRAME_SOFT_CAP_BYTES, (
-                f"measurement gate passed a {real}-byte frame as undegraded"
-            )
+            assert (
+                real <= PROJECTION_FRAME_SOFT_CAP_BYTES
+            ), f"measurement gate passed a {real}-byte frame as undegraded"
 
 
 def test_frame_cap_bounds_a_deep_roster_carrying_todos() -> None:

--- a/tests/unit/mobile/test_relay_perf.py
+++ b/tests/unit/mobile/test_relay_perf.py
@@ -29,7 +29,6 @@ from local_operator.mobile.seen import MAX_SEEN_ENTRIES, SEEN_STORE_NAME, SeenSt
 from local_operator.mobile.types import SessionProjection, SubagentRow
 from local_operator.session.transcript import Transcript
 
-
 # ---------------------------------------------------------------------------
 # Incremental durable fold cache
 # ---------------------------------------------------------------------------
@@ -362,9 +361,7 @@ def test_frame_cap_delivers_oversized_subagent_result_under_cap() -> None:
     """Regression: a projection carrying a 5 MB subagent result still yields a
     frame under the soft cap — the exact payload that wedged the relay."""
     projection = SessionProjection(session_id="s1", pid=1, kind="tui")
-    projection.subagents.append(
-        SubagentRow(job_id="j1", label="big", result_text="R" * 5_000_000)
-    )
+    projection.subagents.append(SubagentRow(job_id="j1", label="big", result_text="R" * 5_000_000))
     frame, degraded = cap_projection_frame(projection)
     assert degraded is True
     size = len(json.dumps(frame).encode("utf-8"))
@@ -377,9 +374,7 @@ def test_frame_cap_does_not_mutate_the_projection() -> None:
     """Degradation happens on the serialized dict; the fold's projection is
     untouched (it is republished on the next repaint)."""
     projection = SessionProjection(session_id="s1", pid=1, kind="tui")
-    projection.subagents.append(
-        SubagentRow(job_id="j1", label="big", result_text="R" * 5_000_000)
-    )
+    projection.subagents.append(SubagentRow(job_id="j1", label="big", result_text="R" * 5_000_000))
     cap_projection_frame(projection)
     assert len(projection.subagents[0].result_text) == 5_000_000
 

--- a/tests/unit/mobile/test_relay_perf.py
+++ b/tests/unit/mobile/test_relay_perf.py
@@ -1,0 +1,473 @@
+"""Relay session-load performance: incremental fold cache, summaries cache,
+seen store, and frame-cap tiering.
+
+These pin the behaviour the relay-perf change is built on, against the same
+store primitives (``Transcript``) the daemon reads, so the cached paths stay
+byte-identical to the full-reparse paths they replaced.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from starlette.testclient import TestClient
+
+from local_operator.harness.types import Message
+from local_operator.mobile.daemon import MobileDaemon, SessionTable, build_app
+from local_operator.mobile.durable import (
+    CustomSnapshotCache,
+    DurableFoldCache,
+)
+from local_operator.mobile.projection import (
+    FRAME_CAP_RESULT_CHARS,
+    PROJECTION_FRAME_SOFT_CAP_BYTES,
+    cap_projection_frame,
+)
+from local_operator.mobile.seen import MAX_SEEN_ENTRIES, SEEN_STORE_NAME, SeenStore
+from local_operator.mobile.types import SessionProjection, SubagentRow
+from local_operator.session.transcript import Transcript
+
+
+# ---------------------------------------------------------------------------
+# Incremental durable fold cache
+# ---------------------------------------------------------------------------
+
+
+def _write_turns(directory, n: int, start: int = 0) -> list[str]:
+    """Append n user/assistant turns; return the message ids in order."""
+    transcript = Transcript(directory)
+    ids: list[str] = []
+    for turn in range(start, start + n):
+        user = Message.user(f"user {turn}", id=f"u-{turn:03d}")
+        assistant = Message.assistant(f"answer {turn}", id=f"a-{turn:03d}")
+        asyncio.run(transcript.append_message(user))
+        asyncio.run(transcript.append_message(assistant))
+        ids.extend([user.id, assistant.id])
+    return ids
+
+
+async def _write_turns_async(directory, n: int, start: int = 0) -> list[str]:
+    """Async variant for tests already inside a running event loop."""
+    transcript = Transcript(directory)
+    ids: list[str] = []
+    for turn in range(start, start + n):
+        user = Message.user(f"user {turn}", id=f"u-{turn:03d}")
+        assistant = Message.assistant(f"answer {turn}", id=f"a-{turn:03d}")
+        await transcript.append_message(user)
+        await transcript.append_message(assistant)
+        ids.extend([user.id, assistant.id])
+    return ids
+
+
+def _fresh_render(directory) -> list[str]:
+    """The full-reparse render ids — the contract the cache must match."""
+    from local_operator.mobile.projection import fold_messages_to_entries
+
+    transcript = Transcript(directory)
+    return [e.id for e in fold_messages_to_entries(transcript.build_llm_history())]
+
+
+def test_fold_cache_matches_full_reparse_on_append(tmp_path, monkeypatch) -> None:
+    """An appended tail folds to the SAME render as re-parsing the whole file."""
+    cfg = tmp_path / "config"
+    directory = cfg / "sessions" / "s1"
+    directory.mkdir(parents=True)
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+
+    _write_turns(directory, 5)
+    cache = DurableFoldCache()
+    state = cache.load(directory)
+    first_render = [e.id for e in state.render]
+    assert first_render == _fresh_render(directory)
+
+    # Append more turns; the cache reads only the tail and must converge.
+    _write_turns(directory, 3, start=5)
+    state = cache.load(directory)
+    assert [e.id for e in state.render] == _fresh_render(directory)
+    assert len(state.render) > len(first_render)
+
+
+def test_fold_cache_refolds_on_compaction_in_tail(tmp_path, monkeypatch) -> None:
+    """A compaction entry in the appended tail rebuilds the cached history
+    exactly as ``build_llm_history`` does — the kept window plus the marker."""
+    cfg = tmp_path / "config"
+    directory = cfg / "sessions" / "s1"
+    directory.mkdir(parents=True)
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+
+    ids = _write_turns(directory, 6)
+    cache = DurableFoldCache()
+    cache.load(directory)
+
+    # Compact keeping the last two turns, then append one more turn after.
+    transcript = Transcript(directory)
+    asyncio.run(transcript.append_compaction("summary here", ids[-4], tokens_before=100))
+    asyncio.run(transcript.append_message(Message.user("after compact", id="u-post")))
+    asyncio.run(transcript.append_message(Message.assistant("post answer", id="a-post")))
+
+    state = cache.load(directory)
+    from local_operator.mobile.projection import fold_messages_to_entries
+
+    fresh = fold_messages_to_entries(Transcript(directory).build_llm_history())
+    # The compaction-summary notice id is a fresh uuid on every fold
+    # (pre-existing behaviour — it is not a stable identifier), so compare
+    # everything but the notice id, and assert the notices match by kind/text.
+    assert [e.id for e in state.render if e.kind != "notice"] == [
+        e.id for e in fresh if e.kind != "notice"
+    ]
+    assert [(e.kind, e.text) for e in state.render if e.kind == "notice"] == [
+        (e.kind, e.text) for e in fresh if e.kind == "notice"
+    ]
+    # The kept window starts at the compaction's first_kept entry, and the
+    # post-compaction turn is present.
+    render_ids = [e.id for e in state.render]
+    assert "u-post" in render_ids
+    assert ids[0] not in render_ids  # summarized partition is gone
+
+
+def test_fold_cache_applies_prune_in_tail(tmp_path, monkeypatch) -> None:
+    """A prune entry in the tail blanks its cached target, matching replay."""
+    cfg = tmp_path / "config"
+    directory = cfg / "sessions" / "s1"
+    directory.mkdir(parents=True)
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+
+    ids = _write_turns(directory, 4)
+    cache = DurableFoldCache()
+    cache.load(directory)
+
+    transcript = Transcript(directory)
+    target = ids[3]  # an assistant answer
+    asyncio.run(transcript.append_prune(target, "pruned for brevity"))
+
+    state = cache.load(directory)
+    cached_ids = [e.id for e in state.render]
+    fresh_ids = _fresh_render(directory)
+    assert cached_ids == fresh_ids
+
+
+def test_fold_cache_rebuilds_on_rotation(tmp_path, monkeypatch) -> None:
+    """``compact_file`` replaces the file (new inode): the cache must rebuild
+    rather than read against a stale byte cursor."""
+    cfg = tmp_path / "config"
+    directory = cfg / "sessions" / "s1"
+    directory.mkdir(parents=True)
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+
+    _write_turns(directory, 4)
+    cache = DurableFoldCache()
+    cache.load(directory)
+
+    # Rewrite the file wholesale (different content AND inode): the append-only
+    # cursor is now a lie and the cache must detect the rotation.
+    (directory / "transcript.jsonl").unlink()
+    _write_turns(directory, 2)
+
+    state = cache.load(directory)
+    assert [e.id for e in state.render] == _fresh_render(directory)
+
+
+def test_fold_cache_lru_evicts_oldest(tmp_path, monkeypatch) -> None:
+    """The cache is bounded; loading past the cap evicts the oldest entry."""
+    cfg = tmp_path / "config"
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+    cache = DurableFoldCache(max_entries=3)
+    dirs = []
+    for i in range(5):
+        directory = cfg / "sessions" / f"s{i}"
+        directory.mkdir(parents=True)
+        _write_turns(directory, 1)
+        dirs.append(directory)
+        cache.load(directory)
+    # Only the 3 newest survive; the oldest two were evicted (a re-load
+    # re-creates them, which is the documented cost of eviction).
+    assert len(cache._states) == 3
+    assert str(dirs[0]) not in cache._states
+    assert str(dirs[-1]) in cache._states
+
+
+def test_custom_snapshot_cache_tracks_newest(tmp_path) -> None:
+    """The snapshot cache answers newest-wins custom reads and re-scans only
+    when the file changes."""
+    directory = tmp_path / "child"
+    directory.mkdir()
+    transcript = Transcript(directory)
+    asyncio.run(transcript.append_custom("todo_snapshot", {"items": [{"text": "a"}]}))
+
+    cache = CustomSnapshotCache()
+    first = cache.load(directory, "todo_snapshot")
+    assert first == {"items": [{"text": "a"}]}
+
+    # Unchanged file: same answer, no re-scan needed (still correct).
+    assert cache.load(directory, "todo_snapshot") == first
+
+    # Append a newer snapshot: newest wins.
+    asyncio.run(transcript.append_custom("todo_snapshot", {"items": [{"text": "b"}]}))
+    assert cache.load(directory, "todo_snapshot") == {"items": [{"text": "b"}]}
+
+
+def test_tracked_custom_types_match_the_source_of_truth() -> None:
+    """The literal custom types durable.py tracks must match the session's
+    roster constant — they are restated to avoid importing the session module
+    into the fold cache, so pin the agreement."""
+    from local_operator.mobile.durable import _TRACKED_CUSTOM_TYPES
+    from local_operator.session.session import SUBAGENT_ROSTER_CUSTOM_TYPE
+
+    assert SUBAGENT_ROSTER_CUSTOM_TYPE in _TRACKED_CUSTOM_TYPES
+
+
+# ---------------------------------------------------------------------------
+# Summaries cache (off-loop + TTL + invalidation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_summaries_caches_durable_rows_within_ttl(tmp_path, monkeypatch) -> None:
+    """Repeated summaries() within the TTL pay ONE durable scan, not one per
+    call — the repaint storm the fix exists to stop."""
+    cfg = tmp_path / "config"
+    (cfg / "sessions").mkdir(parents=True)
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+
+    calls = {"n": 0}
+    from local_operator import resume as resume_module
+
+    real_rows = resume_module.recent_session_rows
+
+    def counting_rows(config_dir, limit=None):
+        calls["n"] += 1
+        return real_rows(config_dir, limit)
+
+    monkeypatch.setattr(resume_module, "recent_session_rows", counting_rows)
+
+    table = SessionTable()
+    await table.summaries()
+    await table.summaries()
+    await table.summaries()
+    assert calls["n"] == 1  # TTL cache: one scan for three reads
+
+
+@pytest.mark.asyncio
+async def test_summaries_invalidation_forces_rescan(tmp_path, monkeypatch) -> None:
+    """notify_list_changed drops the cache so the next read rescans."""
+    cfg = tmp_path / "config"
+    (cfg / "sessions").mkdir(parents=True)
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+
+    calls = {"n": 0}
+    from local_operator import resume as resume_module
+
+    real_rows = resume_module.recent_session_rows
+
+    def counting_rows(config_dir, limit=None):
+        calls["n"] += 1
+        return real_rows(config_dir, limit)
+
+    monkeypatch.setattr(resume_module, "recent_session_rows", counting_rows)
+
+    table = SessionTable()
+    await table.summaries()
+    table.notify_list_changed()
+    await table.summaries()
+    assert calls["n"] == 2  # invalidation forced a second scan
+
+
+@pytest.mark.asyncio
+async def test_summaries_rows_carry_unseen_key(tmp_path, monkeypatch) -> None:
+    """Every summary row (both sections) carries the ``unseen`` key."""
+    cfg = tmp_path / "config"
+    session_dir = cfg / "sessions" / "durable-1"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+    await _write_turns_async(session_dir, 1)
+
+    table = SessionTable()
+    rows = await table.summaries()
+    assert rows, "expected the durable session in the listing"
+    for row in rows:
+        assert "unseen" in row
+        assert isinstance(row["unseen"], bool)
+
+
+# ---------------------------------------------------------------------------
+# Seen store
+# ---------------------------------------------------------------------------
+
+
+def test_seen_store_baseline_prevents_flood_on_first_observation(tmp_path) -> None:
+    """A never-seen session is unseen only if it gained activity SINCE first
+    observation — the rule that keeps an upgrade from lighting up the store."""
+    store = SeenStore(tmp_path / SEEN_STORE_NAME)
+    # First observation at mtime 100 records the baseline.
+    assert store.is_unseen("s1", 100.0) is False
+    # Same activity: not unseen. Newer activity: unseen.
+    assert store.is_unseen("s1", 100.0) is False
+    assert store.is_unseen("s1", 150.0) is True
+
+
+def test_seen_store_mark_seen_clears_then_relights(tmp_path) -> None:
+    """mark_seen clears the verdict; newer activity re-lights it."""
+    store = SeenStore(tmp_path / SEEN_STORE_NAME)
+    store.is_unseen("s1", 100.0)  # baseline
+    assert store.is_unseen("s1", 150.0) is True
+    store.mark_seen("s1", now=200.0)
+    assert store.is_unseen("s1", 150.0) is False  # older than last_seen
+    assert store.is_unseen("s1", 250.0) is True  # newer than last_seen
+
+
+def test_seen_store_persists_last_seen_across_restart(tmp_path) -> None:
+    """last_seen survives a store reload; baselines re-derive safely."""
+    path = tmp_path / SEEN_STORE_NAME
+    store = SeenStore(path)
+    store.is_unseen("s1", 100.0)
+    store.mark_seen("s1", now=200.0)
+
+    reloaded = SeenStore(path)
+    # The persisted last_seen wins: activity before it is seen, after is not.
+    assert reloaded.is_unseen("s1", 150.0) is False
+    assert reloaded.is_unseen("s1", 250.0) is True
+
+
+def test_seen_store_file_is_0600_and_atomic(tmp_path) -> None:
+    """The store file is owner-only readable."""
+    import os
+    import stat
+
+    path = tmp_path / SEEN_STORE_NAME
+    store = SeenStore(path)
+    store.mark_seen("s1", now=200.0)
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    assert mode == 0o600
+
+
+def test_seen_store_bounds_entries(tmp_path) -> None:
+    """Past the cap the oldest stamps are dropped."""
+    store = SeenStore(tmp_path / SEEN_STORE_NAME)
+    for i in range(MAX_SEEN_ENTRIES + 10):
+        store.mark_seen(f"s{i}", now=float(1000 + i))
+    assert len(store._last_seen) == MAX_SEEN_ENTRIES
+    # The oldest were dropped, the newest kept.
+    assert store.last_seen(f"s{MAX_SEEN_ENTRIES + 9}") is not None
+    assert store.last_seen("s0") is None
+
+
+# ---------------------------------------------------------------------------
+# Frame-cap tiering
+# ---------------------------------------------------------------------------
+
+
+def test_frame_cap_delivers_oversized_subagent_result_under_cap() -> None:
+    """Regression: a projection carrying a 5 MB subagent result still yields a
+    frame under the soft cap — the exact payload that wedged the relay."""
+    projection = SessionProjection(session_id="s1", pid=1, kind="tui")
+    projection.subagents.append(
+        SubagentRow(job_id="j1", label="big", result_text="R" * 5_000_000)
+    )
+    frame, degraded = cap_projection_frame(projection)
+    assert degraded is True
+    size = len(json.dumps(frame).encode("utf-8"))
+    assert size <= PROJECTION_FRAME_SOFT_CAP_BYTES
+    # Tier 1 trimmed the result preview to the minimal bound.
+    assert len(frame["subagents"][0]["result_text"]) <= FRAME_CAP_RESULT_CHARS
+
+
+def test_frame_cap_does_not_mutate_the_projection() -> None:
+    """Degradation happens on the serialized dict; the fold's projection is
+    untouched (it is republished on the next repaint)."""
+    projection = SessionProjection(session_id="s1", pid=1, kind="tui")
+    projection.subagents.append(
+        SubagentRow(job_id="j1", label="big", result_text="R" * 5_000_000)
+    )
+    cap_projection_frame(projection)
+    assert len(projection.subagents[0].result_text) == 5_000_000
+
+
+def test_frame_cap_small_frame_passes_through_unchanged() -> None:
+    """A frame under the cap is not degraded and reports not-degraded."""
+    projection = SessionProjection(session_id="s1", pid=1, kind="tui")
+    projection.subagents.append(SubagentRow(job_id="j1", label="small", result_text="ok"))
+    frame, degraded = cap_projection_frame(projection)
+    assert degraded is False
+    assert frame["subagents"][0]["result_text"] == "ok"
+
+
+def test_frame_cap_tier2_drops_transcript_details() -> None:
+    """When subagent trims are not enough, transcript expand details go next."""
+    from local_operator.mobile.types import TranscriptEntry
+
+    projection = SessionProjection(session_id="s1", pid=1, kind="tui")
+    # Many tool rows with large expand payloads but small subagent text.
+    for i in range(60):
+        projection.transcript.append(
+            TranscriptEntry(
+                id=f"t{i}",
+                kind="tool",
+                tool_name="bash",
+                details={"output": "O" * 20_000},
+            )
+        )
+    frame, degraded = cap_projection_frame(projection)
+    assert degraded is True
+    assert len(json.dumps(frame).encode("utf-8")) <= PROJECTION_FRAME_SOFT_CAP_BYTES
+    assert all(entry["details"] == {} for entry in frame["transcript"])
+
+
+# ---------------------------------------------------------------------------
+# /seen endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_seen_endpoint_requires_auth_and_marks_seen(tmp_path, monkeypatch) -> None:
+    cfg = tmp_path / "config"
+    session_dir = cfg / "sessions" / "durable-1"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+    _write_turns(session_dir, 1)
+
+    daemon = MobileDaemon(port=0, password="pw123")
+    client = TestClient(build_app(daemon), follow_redirects=False)
+    # Unauthenticated: 401 on the API route.
+    assert client.post("/api/sessions/durable-1/seen").status_code == 401
+
+    client.post("/login", data={"password": "pw123"})
+    response = client.post("/api/sessions/durable-1/seen")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    # The store recorded the seen stamp.
+    assert daemon.seen_store.last_seen("durable-1") is not None
+
+
+def test_seen_endpoint_unknown_session_is_404(tmp_path, monkeypatch) -> None:
+    cfg = tmp_path / "config"
+    (cfg / "sessions").mkdir(parents=True)
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+
+    daemon = MobileDaemon(port=0, password="pw123")
+    client = TestClient(build_app(daemon), follow_redirects=False)
+    client.post("/login", data={"password": "pw123"})
+    assert client.post("/api/sessions/nope/seen").status_code == 404
+
+
+def test_seen_endpoint_clears_unseen_in_summaries(tmp_path, monkeypatch) -> None:
+    """Marking a session seen flips its summary ``unseen`` to False."""
+    cfg = tmp_path / "config"
+    session_dir = cfg / "sessions" / "durable-1"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+    _write_turns(session_dir, 1)
+
+    daemon = MobileDaemon(port=0, password="pw123")
+    client = TestClient(build_app(daemon), follow_redirects=False)
+    client.post("/login", data={"password": "pw123"})
+
+    def unseen_for(session_id: str) -> bool:
+        rows = client.get("/api/sessions").json()["sessions"]
+        return next(r["unseen"] for r in rows if r["session_id"] == session_id)
+
+    # First observation records the baseline at the current mtime, so the
+    # session is NOT unseen on first paint (no flood on upgrade).
+    assert unseen_for("durable-1") is False
+    client.post("/api/sessions/durable-1/seen")
+    assert unseen_for("durable-1") is False

--- a/tests/unit/mobile/test_relay_perf.py
+++ b/tests/unit/mobile/test_relay_perf.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import string
 
 import pytest
 from starlette.testclient import TestClient
@@ -700,6 +701,25 @@ def test_frame_cap_bounds_many_individually_large_rows() -> None:
     assert len(json.dumps(frame).encode("utf-8")) < (1 << 20)
 
 
+#: Alphabets the frame-cap fuzz draws from. The non-ASCII entries are
+#: load-bearing, not decoration: ``json.dumps`` defaults to
+#: ``ensure_ascii=True``, so one CJK character costs 6 wire bytes and one
+#: astral emoji 12, while Python ``len()`` counts both as 1. An ASCII-only
+#: fuzz therefore cannot generate the input that breaks a character-counting
+#: size estimate — which is exactly how that defect shipped green twice.
+_FUZZ_ALPHABETS = (
+    string.ascii_letters,
+    '"\\\n',  # escape-dense ASCII
+    "\u4e2d\u6587\u5b57",  # CJK: 6 wire bytes per char
+    "\u00e9\u00f1\u00e0",  # Latin-1 accents: 6 wire bytes per char
+    "\u0434\u0430",  # Cyrillic: 6 wire bytes per char
+    "\U0001f600\U0001f680",  # astral emoji: 12 wire bytes per char
+)
+
+#: Single-character fillers for the roster/pending fields, same rationale.
+_FUZZ_FILLERS = ("Z", "\u4e2d", "\u00e9", "\U0001f600")
+
+
 def test_frame_measurement_gate_never_lets_an_oversized_frame_through() -> None:
     """The measurement short-circuit must never pass an oversized frame (A12/A13).
 
@@ -731,21 +751,34 @@ def test_frame_measurement_gate_never_lets_an_oversized_frame_through() -> None:
     random.seed(11)
     for _ in range(120):
         projection = SessionProjection(session_id="s", pid=1, kind="tui")
-        for i in range(random.randint(0, 60)):
-            alphabet = '"\\\n' if random.random() < 0.5 else string.ascii_letters
+        # Row count and per-row length reach the region where a CJK/emoji
+        # frame clears the cap: at 6-12 wire bytes per character, ~40 rows of
+        # ~3,000 chars is already past 700 KB while a character-counting
+        # estimate still reads it as ~120 KB. Drawn as a whole-projection
+        # profile rather than per row so a run actually lands there instead of
+        # averaging out to a harmless mix.
+        row_count = random.randint(0, 60)
+        row_chars = random.choice((200, 800, 2000, 3000))
+        for i in range(row_count):
+            alphabet = random.choice(_FUZZ_ALPHABETS)
             projection.transcript.append(
                 TranscriptEntry(
                     id=f"t{i}",
                     kind="assistant",
-                    text="".join(random.choice(alphabet) for _ in range(random.randint(0, 2000))),
+                    text="".join(random.choice(alphabet) for _ in range(row_chars)),
                 )
             )
-        for j in range(random.randint(0, 60)):
+        # A roster or a pending card FORCES measurement, so a fuzz that always
+        # generates one never exercises the gate's own arithmetic — the path
+        # where a character-counting estimate silently vouched for a 1.17 MB
+        # CJK frame. Half the runs are deliberately bare.
+        subagent_count = 0 if random.random() < 0.5 else random.randint(1, 60)
+        for j in range(subagent_count):
             projection.subagents.append(
                 SubagentRow(
                     job_id=f"job-{j}" * 3,
                     label="L" * 20,
-                    result_text="Z" * random.randint(0, 1500),
+                    result_text=random.choice(_FUZZ_FILLERS) * random.randint(0, 1500),
                     ancestors=["anc" * 10] * random.randint(0, 8),
                     ancestor_ids=["id" * 12] * random.randint(0, 8),
                     child_ids=["c" * 12] * random.randint(0, 8),
@@ -756,13 +789,17 @@ def test_frame_measurement_gate_never_lets_an_oversized_frame_through() -> None:
                         TodoPhase(
                             name="Todos",
                             items=[
-                                TodoItem(text="T" * random.randint(0, 600))
+                                TodoItem(text=random.choice(_FUZZ_FILLERS) * random.randint(0, 600))
                                 for _ in range(random.randint(0, 25))
                             ],
                         )
                     ],
                     transcript=[
-                        TranscriptEntry(id=f"c{k}", kind="assistant", text="Z" * 1500)
+                        TranscriptEntry(
+                            id=f"c{k}",
+                            kind="assistant",
+                            text=random.choice(_FUZZ_FILLERS) * 1500,
+                        )
                         for k in range(random.randint(0, 6))
                     ],
                 )
@@ -774,13 +811,16 @@ def test_frame_measurement_gate_never_lets_an_oversized_frame_through() -> None:
                     items=[TodoItem(text="t" * 80) for _ in range(random.randint(0, 20))],
                 )
             )
-        if random.random() < 0.4:
+        if subagent_count and random.random() < 0.4:
             projection.pending = PendingRequest(
                 request_id="r",
                 kind="ask",
-                title="T" * random.randint(0, 2000),
+                title=random.choice(_FUZZ_FILLERS) * random.randint(0, 2000),
                 options=[
-                    AskOptionWire(label="o" * 40, description="D" * random.randint(0, 20000))
+                    AskOptionWire(
+                        label="o" * 40,
+                        description=random.choice(_FUZZ_FILLERS) * random.randint(0, 20000),
+                    )
                     for _ in range(random.randint(0, 20))
                 ],
             )
@@ -793,6 +833,73 @@ def test_frame_measurement_gate_never_lets_an_oversized_frame_through() -> None:
             assert (
                 real <= PROJECTION_FRAME_SOFT_CAP_BYTES
             ), f"measurement gate passed a {real}-byte frame as undegraded"
+
+
+def test_frame_cap_bounds_non_ascii_prose_with_no_roster() -> None:
+    """CJK/emoji prose alone must not slip the measurement gate (A12).
+
+    ``json.dumps`` defaults to ``ensure_ascii=True``, so one CJK character is
+    6 wire bytes and one astral emoji is 12, while Python ``len()`` counts
+    both as 1. A character-counting gate therefore vouched for frames of
+    1.17 MB (80 rows x 2,400 CJK chars) and 1.14 MB (one pasted CJK document)
+    with no subagents and no pending card — returned ``degraded=False``, so no
+    tier ran, nothing was logged, and the daemon's 1 MB reader dropped the
+    repaint in silence. Ordinary Chinese, Japanese, Russian or accented French
+    prose sits on this curve; it was never exotic input.
+    """
+    from local_operator.mobile.types import TranscriptEntry
+
+    for label, rows, chars, char in (
+        ("cjk-many-rows", 80, 2400, "\u4e2d"),
+        ("cjk-pasted-doc", 1, 190_000, "\u4e2d"),
+        ("emoji-pasted-doc", 1, 190_000, "\U0001f600"),
+        ("latin1-french", 100, 2000, "\u00e9"),
+        ("cyrillic", 100, 2000, "\u0434"),
+    ):
+        projection = SessionProjection(session_id="s", pid=1, kind="tui")
+        for i in range(rows):
+            projection.transcript.append(
+                TranscriptEntry(id=f"t{i}", kind="assistant", text=char * chars)
+            )
+        frame, degraded = cap_projection_frame(projection)
+        size = len(json.dumps(frame).encode("utf-8"))
+        assert degraded is True, f"{label}: oversized non-ASCII frame not degraded"
+        assert size <= PROJECTION_FRAME_SOFT_CAP_BYTES, f"{label}: {size} bytes"
+        assert size < (1 << 20), f"{label}: over the daemon's hard reader limit"
+
+    # The all-ASCII control still takes the cheap path: the fix must not cost
+    # the hot repaint its short-circuit.
+    from local_operator.mobile.projection import _frame_skips_measurement
+
+    control = SessionProjection(session_id="s", pid=1, kind="tui")
+    for i in range(120):
+        control.transcript.append(TranscriptEntry(id=f"t{i}", kind="assistant", text="a" * 1500))
+    assert _frame_skips_measurement(control) is True
+    _, degraded = cap_projection_frame(control)
+    assert degraded is False
+
+
+def test_wire_charge_never_under_counts_the_serializer() -> None:
+    """``_wire_charge`` must be an upper bound on what the wire charges (A12).
+
+    The gate is only safe while this holds: it decides whether to skip the
+    real measurement, so an under-count is a silently dropped repaint.
+    """
+    from local_operator.mobile.projection import _wire_charge
+
+    for text in (
+        "plain ascii text",
+        '"quotes" and \\backslashes\\',
+        "\u4e2d\u6587\u5b57" * 100,
+        "\u00e9\u00f1\u00e0" * 100,
+        "\u0434\u0430" * 100,
+        "\U0001f600\U0001f680" * 100,
+        "mixed \u4e2d ascii \U0001f600 prose",
+        "",
+    ):
+        # What the serializer actually charges for this field, minus its quotes.
+        actual = len(json.dumps(text).encode("utf-8")) - 2
+        assert _wire_charge(text) >= actual, f"under-counted {text[:20]!r}"
 
 
 def test_frame_cap_bounds_a_deep_roster_carrying_todos() -> None:

--- a/tests/unit/mobile/test_relay_perf.py
+++ b/tests/unit/mobile/test_relay_perf.py
@@ -600,24 +600,28 @@ def test_frame_cap_bounds_many_individually_large_rows() -> None:
     assert len(json.dumps(frame).encode("utf-8")) < (1 << 20)
 
 
-def test_frame_cheap_proxy_never_lets_an_oversized_frame_through() -> None:
-    """The A7 short-circuit must be an OVER-estimate, always (A7 safety).
+def test_frame_measurement_gate_never_lets_an_oversized_frame_through() -> None:
+    """The measurement short-circuit must never pass an oversized frame (A12/A13).
 
-    ``cap_projection_frame`` skips its measuring ``json.dumps`` when the cheap
-    text/envelope estimate clears a margin. If that estimate ever UNDER-counts
-    a real frame, an oversized payload returns as ``degraded=False`` and the
-    socket drops it — the exact silent loss the cap prevents. Fuzzed over deep
-    rosters, escape-dense text and many short rows, which is where an earlier
-    text-only proxy measured 3.5x under.
+    ``cap_projection_frame`` skips its measuring ``json.dumps`` when a
+    projection is structurally too simple to approach the cap. If that gate
+    ever says "skip" for a frame that is actually over, the payload returns as
+    ``degraded=False``, neither the registrant warning nor the tier-4 warning
+    fires, and the socket drops the repaint in silence.
+
+    An earlier revision gated on a SUM of known text fields and did exactly
+    that: it never walked ``subagents[].todos`` (kept on the wire by design),
+    ``subagents[].transcript`` or ``projection.pending``, so 80 children x 25
+    todos x 600 chars estimated 40,860 bytes against a real 1,331,102. This
+    fuzz therefore populates precisely those three fields — it passes
+    vacuously without them, which is how the defect shipped.
     """
     import random
     import string
 
-    from local_operator.mobile.projection import (
-        _FRAME_CHEAP_PROXY_DIVISOR,
-        _frame_text_total,
-    )
     from local_operator.mobile.types import (
+        AskOptionWire,
+        PendingRequest,
         SubagentRow,
         TodoItem,
         TodoPhase,
@@ -625,7 +629,6 @@ def test_frame_cheap_proxy_never_lets_an_oversized_frame_through() -> None:
     )
 
     random.seed(11)
-    threshold = PROJECTION_FRAME_SOFT_CAP_BYTES // _FRAME_CHEAP_PROXY_DIVISOR
     for _ in range(120):
         projection = SessionProjection(session_id="s", pid=1, kind="tui")
         for i in range(random.randint(0, 60)):
@@ -647,6 +650,21 @@ def test_frame_cheap_proxy_never_lets_an_oversized_frame_through() -> None:
                     ancestor_ids=["id" * 12] * random.randint(0, 8),
                     child_ids=["c" * 12] * random.randint(0, 8),
                     peer_ids=["p" * 12] * random.randint(0, 8),
+                    # The three fields the old estimate ignored, at the
+                    # magnitudes the real wire carries.
+                    todos=[
+                        TodoPhase(
+                            name="Todos",
+                            items=[
+                                TodoItem(text="T" * random.randint(0, 600))
+                                for _ in range(random.randint(0, 25))
+                            ],
+                        )
+                    ],
+                    transcript=[
+                        TranscriptEntry(id=f"c{k}", kind="assistant", text="Z" * 1500)
+                        for k in range(random.randint(0, 6))
+                    ],
                 )
             )
         for _k in range(random.randint(0, 4)):
@@ -656,12 +674,80 @@ def test_frame_cheap_proxy_never_lets_an_oversized_frame_through() -> None:
                     items=[TodoItem(text="t" * 80) for _ in range(random.randint(0, 20))],
                 )
             )
-        proxy = _frame_text_total(projection)
-        real = len(json.dumps(projection.to_json()).encode("utf-8"))
-        if proxy <= threshold:
-            assert (
-                real <= PROJECTION_FRAME_SOFT_CAP_BYTES
-            ), f"proxy {proxy} short-circuited a {real}-byte frame"
+        if random.random() < 0.4:
+            projection.pending = PendingRequest(
+                request_id="r",
+                kind="ask",
+                title="T" * random.randint(0, 2000),
+                options=[
+                    AskOptionWire(label="o" * 40, description="D" * random.randint(0, 20000))
+                    for _ in range(random.randint(0, 20))
+                ],
+            )
+
+        frame, degraded = cap_projection_frame(projection)
+        real = len(json.dumps(frame).encode("utf-8"))
+        if not degraded:
+            # The gate vouched for this frame without measuring it, so the
+            # claim it made must be true.
+            assert real <= PROJECTION_FRAME_SOFT_CAP_BYTES, (
+                f"measurement gate passed a {real}-byte frame as undegraded"
+            )
+
+
+def test_frame_cap_bounds_a_deep_roster_carrying_todos() -> None:
+    """A deep roster's todos are on the wire by design and must be bounded (A12).
+
+    ``set_subagent_hydrated_details`` keeps ``row.todos`` while dropping the
+    child transcript, and todo text is agent-authored and unbounded. 80
+    children x 25 todos x 600 chars measured 1,331,102 bytes returned as
+    ``degraded=False`` before this was fixed — past the daemon's 1 MB reader,
+    and silent.
+    """
+    from local_operator.mobile.types import SubagentRow, TodoItem, TodoPhase
+
+    projection = SessionProjection(session_id="s", pid=1, kind="tui")
+    for i in range(80):
+        projection.subagents.append(
+            SubagentRow(
+                job_id=f"j{i}",
+                label=f"child {i}",
+                status="running",
+                todos=[
+                    TodoPhase(
+                        name="Todos",
+                        items=[TodoItem(text="T" * 600) for _ in range(25)],
+                    )
+                ],
+            )
+        )
+    frame, degraded = cap_projection_frame(projection)
+    assert degraded is True
+    assert len(json.dumps(frame).encode("utf-8")) < (1 << 20)
+
+
+def test_frame_cap_bounds_a_pending_card_with_long_options() -> None:
+    """A pending card's option prose is bounded, and the card still ships (A12).
+
+    ``projection.pending`` was never counted at all, so an ask with long
+    consequence lines measured 1,123,365 bytes and returned undegraded.
+    """
+    from local_operator.mobile.types import AskOptionWire, PendingRequest
+
+    projection = SessionProjection(session_id="s", pid=1, kind="tui")
+    projection.pending = PendingRequest(
+        request_id="r",
+        kind="ask",
+        title="T" * 200,
+        options=[AskOptionWire(label="o" * 60, description="D" * 40_000) for _ in range(28)],
+    )
+    frame, degraded = cap_projection_frame(projection)
+    assert degraded is True
+    assert len(json.dumps(frame).encode("utf-8")) < (1 << 20)
+    # The card itself survives: it is the one thing on the phone that blocks a
+    # turn, so only the prose under each option is trimmed.
+    assert frame["pending"] is not None
+    assert len(frame["pending"]["options"]) == 28
 
 
 def test_frame_cap_tier2_drops_transcript_details() -> None:

--- a/tests/unit/mobile/test_relay_perf.py
+++ b/tests/unit/mobile/test_relay_perf.py
@@ -373,6 +373,94 @@ async def test_unseen_rows_sort_above_newer_seen_rows(tmp_path, monkeypatch) -> 
     assert ordered.index("old-unread") < ordered.index("new-read")
 
 
+@pytest.mark.asyncio
+async def test_watching_a_session_over_sse_keeps_it_seen(tmp_path, monkeypatch) -> None:
+    """Holding the projection SSE stream IS viewing (A4, spec §3).
+
+    A user sitting in a session watching a turn finish must not come back to
+    that session marked new. Before this, the only writer was the client's
+    /seen POST on mount, so any activity after mount re-lit the mark.
+    """
+    import os
+    import time
+
+    cfg = tmp_path / "config"
+    session_dir = cfg / "sessions" / "watched"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+    await _write_turns_async(session_dir, 1)
+    transcript = session_dir / "transcript.jsonl"
+
+    table = SessionTable()
+    opened_at = time.time()
+    os.utime(transcript, (opened_at, opened_at))
+
+    rows = await table.summaries()
+    assert next(r["unseen"] for r in rows if r["session_id"] == "watched") is False
+
+    # The phone holds the projection stream for this session.
+    table.session_subscribers["watched"] = {asyncio.Queue()}
+    table.invalidate_summaries_cache()
+    await table.summaries()
+
+    # A turn completes while the user is still watching.
+    completed_at = opened_at + 30
+    os.utime(transcript, (completed_at, completed_at))
+    table.invalidate_summaries_cache()
+    rows = await table.summaries()
+    assert next(r["unseen"] for r in rows if r["session_id"] == "watched") is False
+
+    # They navigate away; activity after that DOES light the mark.
+    table.session_subscribers.pop("watched")
+    later = time.time() + 120
+    os.utime(transcript, (later, later))
+    table.invalidate_summaries_cache()
+    rows = await table.summaries()
+    assert next(r["unseen"] for r in rows if r["session_id"] == "watched") is True
+
+
+@pytest.mark.asyncio
+async def test_live_row_activity_clock_ignores_the_heartbeat(tmp_path, monkeypatch) -> None:
+    """A live session with no durable row must not re-light on its heartbeat (A5).
+
+    ``heartbeat_at`` is rewritten every HEARTBEAT_INTERVAL_S whether or not
+    anything happened, so using it as the activity clock brought a cleared
+    mark back 15 s later, forever.
+    """
+    import time
+
+    from local_operator.mobile.daemon import SessionEntry
+    from local_operator.mobile.types import SessionRecord
+
+    cfg = tmp_path / "config"
+    (cfg / "sessions").mkdir(parents=True)
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+
+    table = SessionTable()
+    now = time.time()
+    record = SessionRecord(
+        pid=4242,
+        kind="tui",
+        session_id="live-only",
+        conversation_name="x",
+        cwd="/tmp",
+        model_label="m",
+        control_port=1,
+        control_key="k",
+    )
+    record.started_at = now
+    record.heartbeat_at = now
+    table.entries[4242] = SessionEntry(record)
+    table.seen_store.mark_seen("live-only", now=now)
+
+    for bump in (0, 15, 30, 45):
+        record.heartbeat_at = now + bump
+        table.invalidate_summaries_cache()
+        rows = await table.summaries()
+        row = next(r for r in rows if r["session_id"] == "live-only")
+        assert row["unseen"] is False, f"heartbeat +{bump}s re-lit a cleared mark"
+
+
 # ---------------------------------------------------------------------------
 # Seen store
 # ---------------------------------------------------------------------------

--- a/tests/unit/mobile/test_relay_perf.py
+++ b/tests/unit/mobile/test_relay_perf.py
@@ -280,6 +280,83 @@ async def test_summaries_invalidation_forces_rescan(tmp_path, monkeypatch) -> No
 
 
 @pytest.mark.asyncio
+async def test_streaming_outranks_unseen_matching_the_render_ladder(
+    tmp_path, monkeypatch
+) -> None:
+    """The sort ladder must match the render ladder (A14, and D5's substance).
+
+    The client renders NEEDS DECISION > WORKING > UNREAD > IDLE and suppresses
+    the `new` mark on a streaming row, because "new" means COMPLETED unviewed
+    activity. Ranking unseen ABOVE streaming in the daemon therefore hoisted a
+    streaming+unseen row over newer rows while it rendered no mark to explain
+    why it was there — a position the surface contradicts.
+
+    Both rows are LIVE so the comparison lands inside one section and the
+    section term cannot decide it, and the streaming row is the OLDER one so
+    recency cannot either: only the ladder can. Exercises the real
+    ``summaries()`` output rather than a reimplementation of the sort key — a
+    test that re-derives the ordering it checks proves nothing.
+    """
+    import os
+    import time
+
+    from local_operator.mobile.daemon import SessionEntry
+    from local_operator.mobile.types import SessionProjection, SessionRecord
+
+    cfg = tmp_path / "config"
+    unread_dir = cfg / "sessions" / "unread-live"
+    streaming_dir = cfg / "sessions" / "streaming-live"
+    unread_dir.mkdir(parents=True)
+    streaming_dir.mkdir(parents=True)
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+    await _write_turns_async(unread_dir, 1)
+    await _write_turns_async(streaming_dir, 1)
+    # The STREAMING row is the OLDER transcript: with unseen ranked first the
+    # unread row wins, with streaming ranked first the live row does.
+    os.utime(streaming_dir / "transcript.jsonl", (1_000_000, 1_000_000))
+    os.utime(unread_dir / "transcript.jsonl", (2_000_000, 2_000_000))
+
+    def live(pid: int, session_id: str, *, streaming: bool) -> SessionEntry:
+        record = SessionRecord(
+            pid=pid,
+            kind="tui",
+            session_id=session_id,
+            conversation_name=session_id,
+            cwd="/tmp",
+            model_label="m",
+            control_port=1,
+            control_key="k",
+        )
+        record.started_at = time.time()
+        entry = SessionEntry(record)
+        entry.projection = SessionProjection(
+            session_id=session_id, pid=pid, kind="tui", streaming=streaming
+        )
+        return entry
+
+    table = SessionTable()
+    table.entries[5150] = live(5150, "streaming-live", streaming=True)
+    table.entries[5151] = live(5151, "unread-live", streaming=False)
+    await table.summaries()
+    # unread-live gains activity nobody has seen; the streaming row is read.
+    os.utime(unread_dir / "transcript.jsonl", (2_500_000, 2_500_000))
+    table.seen_store.mark_seen("streaming-live", now=3_000_000.0)
+    table.invalidate_summaries_cache()
+
+    rows = await table.summaries()
+    by_id = {row["session_id"]: row for row in rows}
+    assert by_id["unread-live"]["unseen"] is True
+    assert by_id["streaming-live"]["streaming"] is True
+    assert by_id["streaming-live"]["unseen"] is False
+    # Same section, so the ladder — not the section term — decides.
+    assert by_id["unread-live"]["section"] == by_id["streaming-live"]["section"]
+    ordered = [row["session_id"] for row in rows]
+    assert ordered.index("streaming-live") < ordered.index("unread-live"), (
+        "a streaming row must outrank an unread one, matching the render ladder"
+    )
+
+
+@pytest.mark.asyncio
 async def test_projection_repaints_do_not_rescan_the_store(tmp_path, monkeypatch) -> None:
     """A streaming session's repaints must NOT re-run the durable scan (A3).
 


### PR DESCRIPTION
## Summary

Opening the mobile relay was slow to the point of unusable on a large store: the phone's home list took **0.6-4.9 s** per paint and four live sessions **never rendered at all** (SSE first frame did not arrive within 12 s). Three independent causes, all measured against the real store (3,925 sessions, 1.5 GB, transcripts to 53 MB):

1. **The list route ran on the event loop with no cache.** `SessionTable.summaries()` walked 100 session directories synchronously inside `GET /api/sessions` *and* inside every list-SSE repaint. A live session repaints ~30×/s, so the daemon spent its loop re-scanning the store and starved every other request — including the SSE seed frames that make a session appear at all.
2. **Every durable session open re-parsed the whole transcript.** `_durable_projection()` and `_history_page()` each built a fresh `Transcript` from disk on every request, so opening a session cost a full JSONL parse (505 ms on a 53 MB transcript) and every scroll-up page paid it again.
3. **Oversized projection frames wedged live sessions.** A registrant with a deep subagent roster serialized frames past the daemon's 1 MB socket limit; `readline()` dropped each one and logged a warning. One session produced **48,301** dropped frames, pinning the daemon at 14 % CPU while idle and leaving its phone view permanently stale.

This PR fixes all three at the source and adds the unread-session indicator the same surface needed.

Version: `0.44.13` (patch — reliability/performance work plus one self-contained list affordance; no new subsystem).

## What changed

**Performance**

- `summaries()` moves off the loop (`asyncio.to_thread`) behind a 1 s TTL cache with single-flight refresh, invalidated on `notify_list_changed`. Payload shape and sort semantics are unchanged apart from the new field below.
- New `local_operator/mobile/durable.py`: an incremental fold cache. A session's transcript is parsed once; later reads consume only the bytes appended since, validated by size/mtime, with truncation/rotation falling back to a full re-read. **A compaction or prune entry appearing in the appended tail forces a full refold** — correctness over speed, so cached history is byte-identical to `build_llm_history()` + `fold_messages_to_entries()`.
- The registrant caps frames **before** broadcast: over a 700 KB soft cap it sheds optional payload in tiers (subagent prompt/result/error previews → transcript entry details → transcript tail) until the frame fits the 1 MB socket limit, and warns once per episode instead of once per frame. `_durable_projection` applies the same cap so both paths agree.

**Unread indicator**

- Per-session seen state persisted in `<config_dir>/mobile-seen.json` (0600, atomic, bounded), exposed as `unseen` on each summary row and cleared by `POST /api/sessions/{id}/seen`. Holding a session's projection SSE counts as viewing, so completions watched live never flip to unread.
- **Old sessions do not light up on upgrade**: a session with no seen record is baselined at first observation, so only activity *after* the daemon first sees it can mark it unread.
- Sort tuple extends to `section, needs_attention, unseen, streaming, -mtime, session_id` — decisions stay first, unread lands second.
- The phone renders one state per card in the ladder **NEEDS DECISION > WORKING > NEW/UNREAD > IDLE**: a static accent dot plus the word `new` (accent is deliberately *not* danger, and it does not pulse — those stay reserved for decisions). The left dot slot is now **always rendered**, which also fixes a pre-existing 14 px title shift when the danger dot appeared. Reorders play a FLIP settle (180 ms transform transition, capped by the existing reduced-motion block) so a card never teleports under a thumb.
- `LO_MOBILE_NO_DIAL=1` observer mode, added so a second daemon can serve the store for benchmarking without evicting the production daemon's registrant connections (a registrant admits exactly one daemon connection).

## Real-store benchmarks

`scripts/bench_relay_load.py`, run against the real store on `origin/main` (`aa8de03c`) and this tree. Full tables and raw JSON in `bench/relay-load.md`, `bench/relay-load-before.json`, `bench/relay-load-after.json`.

| Path | Metric | Before | After |
| --- | --- | --- | --- |
| `GET /api/sessions` | warm repaint | 356 ms *every time* | **1.4 ms** |
| Durable projection (SSE seed) | warm, 53 MB transcript | 505 ms | **5 ms** |
| Durable projection (SSE seed) | warm, 31 MB transcript | 158 ms | **1 ms** |
| History page (80 rows) | repeated, 53 MB transcript | 265 ms/page | **<1 ms/page** |
| History page (80 rows) | repeated, worst of 8 largest | 251 ms | **<1 ms** |

End-to-end, two daemons side by side against the same live store (`bench/relay-e2e-dual.json`) — 4098 is the production daemon on the old binary, 4198 this tree in observer mode:

| Metric | old-4098 | new-4198 |
| --- | --- | --- |
| `GET /api/sessions` first | 1,082 ms | 72 ms |
| `GET /api/sessions` warm | 624 ms | **1.0 ms** |
| Durable SSE first frame (4 sessions) | 2.0-69.8 ms | 1.9-43.7 ms |
| Durable history page | 5.2-25.9 ms | 1.9-4.2 ms |
| Live-session history page | 6.5-12.4 ms | 3.5-4.2 ms |

The cold durable fold still pays one full parse; that is the cost the cache amortizes. Two warm outliers (109-127 ms) are sessions a live process was appending to mid-run, where the incremental path folds the appended window; the median across the eight largest is 8 ms.

## Testing evidence

Real execution, not just a green suite.

**The diagnosis, reproduced on the production daemon before the fix** (this is the reported symptom):

```text
list: 1631ms, 100 sessions
LIVE d068bf75e866 'Optimize lop startup time un': first-frame 2688ms 134KB
LIVE bda7b76d34e0 'Article search service integ': first-frame 8861ms 529KB
LIVE 29435655756c 'Revise Agent Risk Assessment': first-frame 12019ms 0KB TimeoutError
LIVE 4ac898fa0e33 'Cross-session lop send wake ': first-frame 12022ms 0KB TimeoutError
LIVE 29831a51ceac 'Team Autofill Timing Issue':  first-frame 12009ms 0KB TimeoutError
LIVE 835fbcafdc27 'OSWorld benchmark evaluation': first-frame 12040ms 0KB TimeoutError
```

```text
$ grep -c "oversized control frame from pid 27758" ~/Library/Logs/local-operator/mobile.log
48301
```

**After**, a daemon from this tree serving the same store (`LO_MOBILE_NO_DIAL=1`, port 4198):

```text
$ curl -s http://127.0.0.1:4198/healthz
{"ok":true,"version":5,"sessions":20,"dist":true}
GET /api/sessions  first 72 ms, warm 1.0 ms
```

**Unit suite** (whole tree, exactly as CI):

```text
.venv/bin/python -m flake8 .                                    clean
uvx --from black==26.1.0 black --check .                        690 files unchanged
uvx isort==5.13.2 --check .                                     clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .     0 errors, 0 warnings
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
9897 passed, 15 skipped, 1 failed
```

The one failure is `tests/unit/tui/test_steering_approval.py::test_a_held_answer_key_resolves_cleanly_on_every_second_key`, a timing-sensitive TUI test unrelated to this change — **this branch touches no TUI file** — and it passes in isolation:

```text
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui/test_steering_approval.py -q -n0
114 passed in 103.67s
```

New coverage in `tests/unit/mobile/test_relay_perf.py` (465 lines): incremental reader (append, truncation/rotation, compaction-in-tail forcing a refold, prune application), summaries cache invalidation, seen-store persistence and the upgrade baseline, and frame-cap tiering (a projection carrying a 5 MB subagent result still broadcasts under the cap).

**Web suite**: `pnpm test` 53/53 passing (8 new: render ladder, reserved slot, seen handshake on both routes, tab-title aggregate), `pnpm build` green.

## Design and UX

The indicator was specified by a design round before implementation (three-state attention model, accent-not-danger, no pulse, reserved slot, sort priority, clearing semantics, contrast measured on the lightest and darkest themes). Design and UX review rounds against the running build are posted as comments on this PR.

## Behaviour preserved

- `/api/sessions` payload shape, section split, and existing sort precedence (needs-attention still outranks everything below it)
- cached history is byte-identical to the uncached fold, including compaction and prune semantics
- `Transcript` itself is untouched — the incremental path is a separate cache layer the daemon opts into
- the 1 MB socket limit and its drop-and-continue recovery remain; the cap only prevents producing frames that hit it
- older daemons omitting `unseen` render as "not unread" on the phone; older phones ignore the field
