### PR TITLE
chore(release): bump version to 0.44.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.12"
+version = "0.44.14"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
# PR Description

## Summary of Changes

Bumps `local-operator` to the next unused patch version, `0.44.14`, so merged PR #500 can be published in a new immutable release.

`v0.44.13` and the `0.44.13` PyPI artifacts target `b328ea8151e684f5c5575e7d93fb24b871c984c4`, while PR #500 merged afterward as `56e46cbd36ff4b29d0159e890b33bc9bfd60af07`. The refreshed branch includes that merge and changes only `pyproject.toml` from `0.44.13` to `0.44.14`.

Fresh checks confirmed that no `v0.44.14` remote tag, GitHub Release, or `0.44.14` PyPI artifact exists.

## Testing evidence

Focused release/version checks:

```console
$ .venv/bin/python - <<'PY'
# Parse pyproject.toml and assert project.version == "0.44.14"
PY
project.version=0.44.14
$ git diff --name-only origin/main...HEAD
pyproject.toml
$ git diff --check origin/main...HEAD
# exit 0
$ python <PyPI JSON version check>
PyPI 0.44.14 unused
$ git ls-remote --tags origin refs/tags/v0.44.14
# no output; exit 0
```

Full local quality gates over the whole tree, using the commands from `AGENTS.md`/CI:

```console
$ .venv/bin/python -m flake8 .
rc=0
$ uvx --from black==26.1.0 black --check .
687 files would be left unchanged.
rc=0
$ uvx isort==5.13.2 --check .
Skipped 1 files
rc=0
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations
rc=0
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
9886 passed, 15 skipped, 438 warnings in 422.11s (0:07:02)
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
3 passed in 13.99s
```

The first full unit run encountered two unchanged TUI timing/layout test failures after 9,884 passes. The same focused tests passed against current `main`; the complete rerun above passed all 9,886 tests. No code or tests were changed in response.
