### PR TITLE
fix(tui): settings selection frame + provider/model suggestion dropdowns

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -11279,6 +11279,8 @@ class OperatorApp(App[None]):
             teams=self._settings_team_rows(),
             agents=self._agent_profile_rows(),
             providers=self._settings_provider_rows(),
+            provider_catalogue=self._settings_provider_catalogue(),
+            model_catalogue=self._settings_model_catalogue(),
         )
 
     def _settings_team_rows(self) -> list[tuple[str, str, str]]:
@@ -11327,6 +11329,53 @@ class OperatorApp(App[None]):
         except Exception:  # noqa: BLE001 — never crash the page on a store read
             logger.debug("settings: provider rows unavailable", exc_info=True)
         return rows
+
+    def _settings_provider_catalogue(self) -> list[tuple[str, str]]:
+        """Loginable providers as ``(id, display_name)`` for the Default provider
+        suggestion dropdown.
+
+        The WHOLE login registry, not just the signed-in providers
+        ``_settings_provider_rows`` returns: the Default provider field is where
+        a user names the provider they intend to boot on, which may be one they
+        have not logged into yet, so constraining the suggestions to current
+        credentials would hide exactly the choice they are reaching for. Same
+        registry ``/login`` and ``/provider`` enumerate, in registry order, so
+        the page cannot offer a provider those surfaces do not. Never raises: an
+        unreadable registry degrades to an empty catalogue, which falls the field
+        back to a plain free-text editor.
+        """
+        rows: list[tuple[str, str]] = []
+        providers = self._providers
+        if providers is None:
+            return rows
+        try:
+            for definition in providers.login_providers():
+                rows.append((definition.id, definition.name))
+        except Exception:  # noqa: BLE001 — the page must open without a catalogue
+            logger.debug("settings: provider catalogue unavailable", exc_info=True)
+        return rows
+
+    def _settings_model_catalogue(self) -> list[ModelRow]:
+        """The model catalogue for the Default model suggestion dropdown.
+
+        The SAME rows ``/model`` shows, through the SAME ``_catalogue_rows``
+        filter (usable providers, the current model rescued in), so the two
+        surfaces rank an identical set by the identical matcher and cannot drift.
+        The static registry only — no live provider fetch — because this runs
+        synchronously on the page-open path and a network round-trip there would
+        stall the mode; ``/model``'s own live refresh already covers the rows
+        that shipped too late for the registry, and the Default model field is a
+        boot preference a user can also just type. Degrades to an empty
+        catalogue (plain free-text editor) on any failure.
+        """
+        try:
+            rows, _note = self._catalogue_rows(
+                self._providers.static_catalogue() if self._providers else []
+            )
+            return rows
+        except Exception:  # noqa: BLE001 — the page must open without a catalogue
+            logger.debug("settings: model catalogue unavailable", exc_info=True)
+            return []
 
     def _close_settings_view(self) -> bool:
         """Leave the settings mode and put the conversation back. True if open.

--- a/local_operator/tui/widgets/settings_view.py
+++ b/local_operator/tui/widgets/settings_view.py
@@ -487,6 +487,13 @@ class SettingsView(Vertical):
         self._enter_hint = HintButton("enter", lambda: self.action_activate())
         self._reset_hint = HintButton("r", lambda: self.action_reset())
         self._pane_hint = HintButton("←→", lambda: self.action_pane(1))
+        # Shown ONLY while a suggestion dropdown is live, in place of `r`/`←→`
+        # (which do nothing useful there). It advertises tab-completion — the
+        # accelerator that was otherwise undiscoverable below ~140 cols, since
+        # the inline row contract sheds it first (review round 1, D1/U1).
+        # Clicking it completes the highlighted suggestion, the same action Tab
+        # takes, so the footer stays a real affordance for a mouse user.
+        self._tab_hint = HintButton("tab", self._complete_highlighted_suggestion)
         self._exit_hint = HintButton("esc", self._leave)
         self._hints = Horizontal(classes="settings-view-hints")
         self._title_text = Text()
@@ -512,6 +519,12 @@ class SettingsView(Vertical):
         yield self._detail
         with self._hints:
             yield self._move_hint
+            # Composed right after `↑↓` so the dropdown footer reads
+            # `↑↓ suggestions · tab complete · enter save · esc` in that order —
+            # footer hints paint in DOM order, so `leads` ordering alone can't
+            # place it. Hidden (`display = False`) in every non-dropdown state,
+            # so its compose position is invisible there.
+            yield self._tab_hint
             yield self._enter_hint
             yield self._reset_hint
             yield self._pane_hint
@@ -2000,16 +2013,33 @@ class SettingsView(Vertical):
                 self._cancel_edit()
                 self._repaint()
                 return
-            if key in ("up", "down") and has_suggestions:
-                # The dropdown owns the arrows while it is showing — there is no
-                # cursor to move on the page (the editor holds it), so the arrows
-                # have nothing else to do and browsing the list is what a user
-                # reaches for. Wraps, like the model picker's own move.
+            if key in ("up", "down", "ctrl+p", "ctrl+n") and has_suggestions:
+                # The dropdown owns the arrows AND the readline pair while it is
+                # showing — there is no cursor to move on the page (the editor
+                # holds it), so browsing the list is what a user reaches for.
+                # `ctrl+p`/`ctrl+n` move the highlight exactly as `/model`'s
+                # picker binds them (review round 1, U2): a user who learned that
+                # surface must not press ctrl+n mid-edit and be thrown to another
+                # section with their typing gone. Wraps, like the model picker's
+                # own `move`.
                 event.stop()
                 event.prevent_default()
                 count = len(self._suggestions())
-                delta = -1 if key == "up" else 1
+                delta = -1 if key in ("up", "ctrl+p") else 1
                 self._suggest_index = (self._suggest_index + delta) % max(count, 1)
+                self._repaint()
+                return
+            if key in ("pageup", "pagedown") and has_suggestions:
+                # Page the highlight by a windowful, CLAMPED (not wrapping),
+                # mirroring `ModelPicker.page` — a PgDn that silently returned to
+                # the top of the list would read as the list resetting itself.
+                # The step is the visible window so one press moves a screenful
+                # of suggestions, matching `/model`.
+                event.stop()
+                event.prevent_default()
+                count = len(self._suggestions())
+                step = _SUGGEST_ROWS * (1 if key == "pagedown" else -1)
+                self._suggest_index = max(0, min(count - 1, self._suggest_index + step))
                 self._repaint()
                 return
             if key == "tab" and has_suggestions:
@@ -2035,8 +2065,23 @@ class SettingsView(Vertical):
                 # value the catalogue does not match has no highlight, so Enter
                 # saves the typed text directly — the "suggestions assist, never
                 # constrain" contract.
+                #
+                # GATED ON A NON-EMPTY BUFFER (review round 1, BLOCKER). An empty
+                # buffer still yields a highlight — `_suggestions()` returns the
+                # WHOLE catalogue when nothing is typed, so row 0 (`anthropic`)
+                # is "highlighted" over content the user never chose. Accepting
+                # it would write that provider instead of honouring the
+                # `empty_unsets` clear-to-unset gesture: clearing `hosting` and
+                # pressing Enter must UNSET it, not silently store the top row
+                # (the U1 blocker `_commit_edit` fixes and this guard must not
+                # re-open). So an empty buffer falls straight through to
+                # `_commit_edit`, whose `empty_unsets` branch does the unset.
                 suggestion = self._highlighted_suggestion()
-                if suggestion is not None and self._buffer.strip() != suggestion.value:
+                if (
+                    suggestion is not None
+                    and self._buffer.strip()
+                    and self._buffer.strip() != suggestion.value
+                ):
                     self._accept_suggestion(suggestion)
                 self._commit_edit()
                 return
@@ -2086,6 +2131,23 @@ class SettingsView(Vertical):
                     # and left the user 25 rows from where they were.
                     self._caret = 0 if key == "home" else len(self._buffer)
                     self._repaint()
+                return
+            if key in ("pageup", "pagedown", "ctrl+p", "ctrl+n"):
+                # SWALLOWED as a no-op whenever no dropdown is live to page —
+                # the dropdown branches above already consumed these when it was
+                # (review round 1, U2). An OPEN EDITOR must own every navigation
+                # key the same way it owns the printable ones (this method's own
+                # docstring), and these leaked to the page bindings: mid-edit
+                # they cancelled the editor, DISCARDED the typed value and
+                # teleported the cursor to another section — the exact leak
+                # `left/right/home/end` were intercepted to stop, simply omitted
+                # from that fix. Inert here rather than paging is correct: with
+                # no dropdown there is nothing to page, and losing the edit is
+                # never the right answer to a scroll gesture. Covers both the
+                # suggest editor with the list dismissed/empty and every other
+                # text editor on the page (`retry.maxRetries`, an endpoint).
+                event.stop()
+                event.prevent_default()
                 return
             char = getattr(event, "character", None)
             if char and char.isprintable():
@@ -2184,14 +2246,20 @@ class SettingsView(Vertical):
         event.stop()
         row = self._rows[index]
         if row.kind == "suggest" and row.suggestion is not None:
-            # A click on a dropdown row highlights it and accepts it in one
-            # gesture — completing the buffer to that value, exactly as the model
-            # picker's own click chooses a row. It does NOT save: the page's
-            # contract is that only Enter on the chosen value writes (#440), so
-            # a stray click completes and leaves the confirming Enter to the
-            # user, matching what Tab on the same row does.
+            # A click on a dropdown row completes the buffer to its value, then
+            # a SECOND click on that same already-completed row SAVES — the
+            # click-once-select / click-again-activate rhythm the setting rows
+            # themselves use just below, extended so a mouse user has a path to
+            # the write (review round 1, U4). Without it, clicking a suggestion
+            # filled the buffer and then dead-ended: a second click re-completed
+            # to no effect and only the keyboard's Enter could save. The commit
+            # still goes through the one Enter path, so `empty_unsets` and
+            # validation behave identically to pressing Enter.
+            already = self._suggest_index == row.hop_index and self._buffer == row.suggestion.value
             self._suggest_index = row.hop_index
             self._accept_suggestion(row.suggestion)
+            if already:
+                self._commit_edit()
             return
         if not row.selectable:
             return
@@ -2489,6 +2557,16 @@ class SettingsView(Vertical):
             line.append(row.suggestion.label, style=fg if highlighted else muted)
             if row.suggestion.detail:
                 line.append(f"  {row.suggestion.detail}", style=faint)
+            # A `pos/total` cue on the HIGHLIGHTED row, only when the list is
+            # windowed (more matches than fit), so a user arrowing a long
+            # catalogue can tell where they are and how many remain — the
+            # position/count the `/model` picker carries in its footer (review
+            # round 1, U3). Only on the highlight and only when it means
+            # something (windowed), so it never clutters a short list that shows
+            # in full. `hop_index` is 0-based; +1 reads as a human position.
+            total = len(self._suggestions())
+            if highlighted and total > _SUGGEST_ROWS:
+                line.append(f"  {row.hop_index + 1}/{total}", style=dim)
             return line
 
         marker = f"{_CURSOR} " if selected else "  "
@@ -2657,18 +2735,26 @@ class SettingsView(Vertical):
         # the clause advertised a behaviour the row does not have.
         contract = "  enter saves · esc cancels"
         setting = settings_io.resolve_key(self._editing or "")
-        # When a suggestion dropdown is live the contract names the keys that
-        # drive it, or the affordance is undiscoverable: the footer hint contract
-        # has to stay honest (a lit affordance with no advertised key is the "why
-        # doesn't anything happen" complaint U5 records). Preferred over
-        # `clear to unset` because a user staring at a list of choices needs
-        # "how do I pick one" more than "how do I empty this", and both do not
-        # fit; `_suggest_rows` being non-empty is exactly "a dropdown is shown".
+        # When a suggestion dropdown is live the contract names the browse and
+        # complete keys, SHORTENED so it survives the value column at 100 cols
+        # (review round 1, D1/U1). The old long form (`↑↓ suggestions · tab
+        # completes · enter saves · esc`, ~52 cells) only fit at ~140 cols and
+        # was shed to `enter saves ·…` at every common width, so the two new
+        # accelerators were advertised nowhere. `↑↓ · tab · enter saves` is
+        # ~22 cells and fits the ~23-cell room at 100 cols; the footer now
+        # carries the fuller `↑↓ suggestions · tab complete · enter save`
+        # legend, so the row hint can be terse without losing discoverability.
+        # A widest-first ladder keeps the fuller inline form where it fits.
         if self._suggest_rows():
-            full = "  ↑↓ suggestions · tab completes · enter saves · esc"
             room = self._list_width() - _VALUE_COLUMN - cell_len(editor.plain)
-            if cell_len(full) <= room:
-                contract = full
+            for candidate in (
+                "  ↑↓ suggestions · tab completes · enter saves · esc",
+                "  ↑↓ browse · tab complete · enter saves",
+                "  ↑↓ · tab · enter saves",
+            ):
+                if cell_len(candidate) <= room:
+                    contract = candidate
+                    break
         elif setting is not None and setting.empty_unsets:
             full = "  enter saves · esc cancels · clear to unset"
             room = self._list_width() - _VALUE_COLUMN - cell_len(editor.plain)
@@ -2867,6 +2953,20 @@ class SettingsView(Vertical):
         self._suggest_index = 0
         self._suggest_dismissed = False
         self._repaint()
+
+    def _complete_highlighted_suggestion(self) -> None:
+        """Footer `tab` hint's click action: complete the highlighted row.
+
+        The mouse counterpart to pressing Tab — a `None`-returning wrapper
+        because ``HintButton`` takes a ``Callable[[], None]`` and
+        ``_accept_suggestion`` already returns None, but routing the click here
+        (rather than binding the method directly) keeps the guard in one place:
+        a stray click on the hint when no suggestion is highlighted must do
+        nothing rather than raise.
+        """
+        suggestion = self._highlighted_suggestion()
+        if suggestion is not None:
+            self._accept_suggestion(suggestion)
 
     def _reopen_suggestions(self) -> None:
         """Un-dismiss the dropdown and reset the highlight — for buffer edits.
@@ -3733,6 +3833,15 @@ class SettingsView(Vertical):
         enter: _Hint = (self._enter_hint, " change", True)
         reset: _Hint = (self._reset_hint, " default", True)
         pane: _Hint = (self._pane_hint, " panes", True)
+        tab: _Hint = (self._tab_hint, " complete", True)
+        # Is a suggestion dropdown live right now? The footer's editing state
+        # splits on this: a plain text editor keeps `↑↓ move cancel`, but with a
+        # dropdown open ↑↓ browses the list and `tab` completes, so the footer
+        # must say THOSE (review round 1, D1/D2/U1). The always-visible hint is
+        # what a user scans; leaving it reading `move cancel`/`panes` while the
+        # keys browse suggestions and move the caret is the footer-vs-behaviour
+        # disagreement D7 exists to forbid.
+        dropdown_open = bool(self._suggest_rows())
 
         # The footer states what the keys do RIGHT NOW, per state, because it
         # is the row users scan for exactly that. Two states rewrite it:
@@ -3767,8 +3876,16 @@ class SettingsView(Vertical):
         if self._expanded is not None:
             enter = (self._enter_hint, " choose", True)
         if self._editing is not None:
-            move = (self._move_hint, " move cancel", False)
-            enter = (self._enter_hint, " save", True)
+            if dropdown_open:
+                # ↑↓ browses the suggestions and `tab` completes — the real keys
+                # for this state, named where they are always legible instead of
+                # only in the row contract the value column sheds first. `enter`
+                # saves the highlighted/typed value.
+                move = (self._move_hint, " suggestions", False)
+                enter = (self._enter_hint, " save", True)
+            else:
+                move = (self._move_hint, " move cancel", False)
+                enter = (self._enter_hint, " save", True)
 
         def rung(
             leads: list[tuple[HintButton, str, bool]], esc_label: str
@@ -3789,7 +3906,15 @@ class SettingsView(Vertical):
         # change · r default` on a row that honours neither (UX round 1, U2).
         # The detail line already says WHY the row is retired; the footer's job
         # is only to stop advertising keys that will not act.
-        if self._current_is_readonly():
+        if dropdown_open:
+            # The dropdown state offers its own three keys and NOT `r`/`←→`:
+            # `r default` types `r` into the buffer (the #425 anti-pattern
+            # `_reset_applies` already guards) and `←→` moves the caret, not the
+            # pane. Ordered `↑↓ suggestions · tab complete · enter save` so the
+            # browse key leads, the accelerator sits beside it, and the commit
+            # closes the row — the same reading order as the inline contract.
+            leads = [move, tab, enter]
+        elif self._current_is_readonly():
             leads = [move]
         elif not self._reset_applies():
             # The SAME rule, one step finer (#440 §4.4). `r` deletes the stored
@@ -3801,7 +3926,10 @@ class SettingsView(Vertical):
             # a default row as soon as the terminal was narrow enough to shed
             # the pane hint, which is the regression invariant 3 warns about.
             leads = [move, enter]
-        if self._pane_fits():
+        if self._pane_fits() and not dropdown_open:
+            # `←→` moves the caret while an editor is open, so the pane hint is
+            # withheld in the dropdown state where the footer names the caret's
+            # real keys instead (it was already meaningless there).
             leads.append(pane)
         # The narrow rungs shed to a one-word `esc` label, except in the
         # confirm and choosing states where `cancel` IS the one word and
@@ -3840,6 +3968,7 @@ class SettingsView(Vertical):
             self._enter_hint,
             self._reset_hint,
             self._pane_hint,
+            self._tab_hint,
             self._exit_hint,
         ):
             hint.display = hint in visible
@@ -3885,10 +4014,15 @@ class SettingsView(Vertical):
 
     def rendered_hints(self) -> str:
         """The footer as one string, for the width-shedding assertions."""
+        # DOM order — the order the footer actually paints (`compose` yields
+        # `move, tab, enter, reset, pane, esc`), so the assembled string matches
+        # the frame a user reads rather than a bookkeeping order that would put
+        # `tab` after `enter` on screen.
         return "".join(
             hint.rendered()
             for hint in (
                 self._move_hint,
+                self._tab_hint,
                 self._enter_hint,
                 self._reset_hint,
                 self._pane_hint,

--- a/local_operator/tui/widgets/settings_view.py
+++ b/local_operator/tui/widgets/settings_view.py
@@ -39,7 +39,7 @@ out of a click handler.
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any
+from typing import Any, NamedTuple
 
 from rich.cells import cell_len
 from rich.style import Style
@@ -52,6 +52,9 @@ from textual.widgets import Static
 from local_operator import settings_io
 from local_operator.settings_io import Kind, Section, Setting
 from local_operator.tui import theme as theme_mod
+from local_operator.tui.autocomplete import score_command_text_match
+from local_operator.tui.widgets.command_picker import ghost_for
+from local_operator.tui.widgets.model_picker import ModelRow, rank_rows
 from local_operator.tui.widgets.subagent_view import HintButton
 from local_operator.tui.widgets.tool_card import truncate_cells
 
@@ -76,6 +79,60 @@ _PANE_WIDTH = 34
 #: list and genuinely edited as comma-separated text (see `settings_io.coerce`),
 #: which is why this is keyed on the interaction rather than on the stored type.
 _TEXT_EDITABLE_KINDS = frozenset({Kind.INT, Kind.FLOAT, Kind.TEXT, Kind.LIST})
+
+#: Setting keys whose free-text editor is augmented with a filtered suggestion
+#: dropdown and inline ghost text. Both remain ordinary `Kind.TEXT` settings —
+#: the suggestions ASSIST, they do not constrain, so a custom endpoint id the
+#: catalogue has never heard of still coerces and saves exactly as before
+#: (see `_commit_edit`, unchanged). Keyed here rather than on a new `Kind`
+#: because the interaction is "type freely, with help", which is what TEXT
+#: already is; a new kind would force `coerce`/`validate`/the CLI to grow a
+#: branch for a value space that is deliberately open.
+#:
+#: `hosting` draws from the provider login catalogue (a bounded, known set, so
+#: its suggestions read as an enum you can also free-type past); `model_name`
+#: draws from the SAME model catalogue `/model` shows, ranked by the SAME
+#: `rank_rows` fuzzy matcher, so a user who has learned how `/model` filters
+#: does not learn a second behaviour here.
+_HOSTING_KEY = "hosting"
+_MODEL_KEY = "model_name"
+_SUGGEST_KEYS = frozenset({_HOSTING_KEY, _MODEL_KEY})
+
+#: Rows of the inline suggestion dropdown painted under the editor at most. A
+#: cap rather than the whole catalogue: the settings body is a scrolled region
+#: shared with fifty other rows, and a dropdown that pushed every following
+#: section off the screen would bury the page it is a part of. Eight is the
+#: `/model` picker's own visible-window feel at this height and leaves the
+#: section under the edited row reachable without scrolling.
+_SUGGEST_ROWS = 8
+
+
+class _Suggestion(NamedTuple):
+    """One row of the inline suggestion dropdown.
+
+    Unifies the two sources behind one painter and one accept path. ``value``
+    is what an Enter/Tab writes into the buffer, and it matches what each key
+    STORES: a bare provider id for ``hosting`` and a bare MODEL ID for
+    ``model_name`` — NOT the ``provider/id`` selector. This is load-bearing:
+    ``_persist_default_from_picker`` in app.py writes ``model_name =
+    row.model_id`` (bare) beside ``hosting = row.provider``, and `bootstrap`
+    reads the two keys independently, so storing a selector here would leave
+    ``model_name`` holding ``anthropic/claude-opus-5`` under an ``anthropic``
+    hosting and boot a model id no provider owns.
+
+    ``label`` is display-only and carries the ``provider/id`` SELECTOR for a
+    model row, so the dropdown disambiguates the two catalogue entries that can
+    share one model id (a direct provider and an aggregator). ``detail`` is the
+    dim right-hand note (a provider's proper name, a model's provider+price),
+    never parsed back. The ghost text completes toward ``value`` (the bare id),
+    so a fuzzy match on the selector shows a dropdown row without a dishonest
+    inline ghost — the append-only rule in `_suggest_ghost`.
+    """
+
+    value: str
+    label: str
+    detail: str = ""
+
 
 #: One line of the read-only pane, as its styled segments. A LIST of segments
 #: rather than one string plus one style, because a provider row carries two
@@ -163,6 +220,43 @@ _TOO_SHORT = "terminal too short for settings — make it taller"
 #: roster it could not write would be worse than one that admits the boundary.
 _PANE_TEAMS = "teams"
 _PANE_AGENTS = "agents"
+
+
+class _ChromeStatic(Static):
+    """A ``Static`` the drag-to-select walk skips (``ALLOW_SELECT = False``).
+
+    WHY THIS EXISTS
+    ===============
+
+    The settings page is chrome, not content. Its rows are painted into a
+    handful of ``Static`` surfaces (the list, the title, the rule, the detail
+    line, the side pane), and Textual 8.x arms a SCREEN text-selection on the
+    ``MouseDown`` of any widget whose ``allow_select`` is true — see
+    ``Screen._forward_event``. A user clicking a row to SELECT it (move the
+    ``›`` cursor there) therefore also began a drag-selection, and dragging
+    across the list painted the grey selection band the bug report shows
+    bleeding across labels and values. A settings row is a control, so a click
+    on it should name it, never highlight it for copy.
+
+    ``ALLOW_SELECT = False`` keeps these surfaces out of the selection walk
+    entirely, exactly as ``app.Chrome`` does for the status band and composer
+    chevron (chrome is not content, stated there in full). It is the class
+    attribute Textual reads through ``Widget.allow_select``; it gates ONLY the
+    selection state and touches neither the widget's own ``on_click`` nor the
+    page's ``SettingsView.on_click`` — the row-select-on-click path is
+    untouched, because click delivery and selection arming are independent in
+    ``Screen._forward_event`` (the ``allow_select`` branch builds
+    ``_select_state`` and nothing else). The cursor's own reverse/selected-row
+    ink lives in ``_row_text`` and is likewise unaffected: it is painted into
+    the row's ``Text``, not produced by the screen's selection highlight.
+
+    Defined LOCALLY rather than reusing ``app.Chrome``: ``app`` imports this
+    module (``SettingsView``), so importing ``Chrome`` back would close an
+    import cycle. The behaviour is one class attribute, so the small duplication
+    is cheaper than the coupling.
+    """
+
+    ALLOW_SELECT = False
 
 
 class SettingsViewDismissed(Message):
@@ -334,11 +428,42 @@ class SettingsView(Vertical):
         self._agents: list[tuple[str, str, str]] = []
         #: Provider login state, injected the same way and for the same reason.
         self._providers: list[tuple[str, str]] = []
+        #: The provider and model catalogues that feed the `hosting`/`model_name`
+        #: suggestion dropdowns, injected by the app for the same reason the
+        #: pane content is: the page never reaches into a registry or the
+        #: credential store itself, so a repaint stays free of I/O (see `load`).
+        #: `_provider_catalogue` is `(id, display_name)` in the app's registry
+        #: order; `_model_catalogue` is the SAME `ModelRow` list `/model` is
+        #: fed, so the two surfaces rank identically.
+        self._provider_catalogue: list[tuple[str, str]] = []
+        self._model_catalogue: list[ModelRow] = []
+        #: Index of the highlighted row within the CURRENT suggestion list.
+        #: Held on the widget beside the editor buffer/caret because the
+        #: suggestions are derived from that buffer on every keystroke — a
+        #: separate list would be a second source of truth that could disagree
+        #: with "is an editor for a suggest key open and does it have matches".
+        #: Clamped on every rebuild in `_suggest_rows`, since typing can shrink
+        #: the list under the cursor.
+        self._suggest_index = 0
+        #: Whether the dropdown has been explicitly DISMISSED for the open
+        #: editor (a first Esc). This is the extra rung the Esc ladder needed:
+        #: Esc closes the suggestions before it cancels the editor, so a user
+        #: who opened the list to look at it can back out of it without losing
+        #: the field. Reset to False the moment the buffer changes — typing
+        #: is a request to filter, which means "show me the list again" — so the
+        #: dismissal only suppresses the frame it was pressed on.
+        self._suggest_dismissed = False
 
-        self._detail = Static(classes="settings-view-detail")
-        self._title = Static(classes="settings-view-title")
-        self._rule = Static(classes="settings-view-rule")
-        self._list = Static(classes="settings-view-list")
+        # Every rendered surface is a `_ChromeStatic`, not a bare `Static`, so a
+        # click or drag on the page names a row instead of arming a text
+        # selection whose band bleeds across the rows (see `_ChromeStatic`). The
+        # list is the one the bug report shows, but the title/rule/detail/pane
+        # are chrome too — a drag that overshot the list onto any of them would
+        # otherwise resume the same highlight there.
+        self._detail = _ChromeStatic(classes="settings-view-detail")
+        self._title = _ChromeStatic(classes="settings-view-title")
+        self._rule = _ChromeStatic(classes="settings-view-rule")
+        self._list = _ChromeStatic(classes="settings-view-list")
         self._body = ScrollableContainer(self._list, classes="settings-view-body")
         # NOT focusable. With it in the focus chain, one `tab` moved focus from
         # the page to this container, which owns the scroll keys — so the arrows
@@ -354,7 +479,7 @@ class SettingsView(Vertical):
         # wheel, and `_scroll_to_selection` drives this container programmatically
         # rather than through focus.
         self._body.can_focus = False
-        self._pane_view = Static(classes="settings-view-pane")
+        self._pane_view = _ChromeStatic(classes="settings-view-pane")
         self._columns = Horizontal(self._body, self._pane_view, classes="settings-view-columns")
         # Footer hints, same vocabulary and same shedding ladder as the org
         # chart's, so the two modes read consistently.
@@ -426,6 +551,8 @@ class SettingsView(Vertical):
         teams: Sequence[tuple[str, str, str]] = (),
         agents: Sequence[tuple[str, str, str]] = (),
         providers: Sequence[tuple[str, str]] = (),
+        provider_catalogue: Sequence[tuple[str, str]] = (),
+        model_catalogue: Sequence[ModelRow] = (),
     ) -> None:
         """Point the page at the read-only content the app resolved for it.
 
@@ -434,10 +561,20 @@ class SettingsView(Vertical):
         flattened to rows. The page never reaches into a registry itself, which
         is what keeps a repaint free of I/O — the same split ``OrgChartView``
         makes when the app resolves the org tree and the widget only paints it.
+
+        ``provider_catalogue`` and ``model_catalogue`` feed the Default
+        provider / Default model suggestion dropdowns. They are resolved by the
+        app from the SAME sources the `/provider` and `/model` surfaces use — the
+        provider login registry and the model catalogue — so this page cannot
+        drift into offering a second, parallel set of choices. Both default to
+        empty: a host that supplies neither simply gets the old bare free-text
+        editor on those two rows, which still saves any value.
         """
         self._teams = list(teams)
         self._agents = list(agents)
         self._providers = list(providers)
+        self._provider_catalogue = list(provider_catalogue)
+        self._model_catalogue = list(model_catalogue)
         self._repaint()
 
     # -- rows ---------------------------------------------------------------
@@ -455,6 +592,15 @@ class SettingsView(Vertical):
             rows.append(_Row(kind="header", section=section))
             for setting in settings_io.settings_for(section.name):
                 rows.append(_Row(kind="setting", setting=setting))
+                if self._editing == setting.key and setting.key in _SUGGEST_KEYS:
+                    # The suggestion dropdown renders as its own unselectable
+                    # rows directly UNDER the edited setting, the same place the
+                    # enum expansion and the cascade's hops sit. `_suggest_rows`
+                    # returns `[]` unless a dropdown should actually show (an
+                    # open suggest editor, not dismissed, with matches), so this
+                    # is a no-op on every other row and on a custom value the
+                    # catalogue does not match.
+                    rows.extend(self._suggest_rows())
                 if setting.kind is Kind.CASCADE:
                     rows.extend(self._cascade_rows(setting))
                 elif self._expanded == setting.key:
@@ -1302,6 +1448,12 @@ class SettingsView(Vertical):
         self._edit_seed = self._buffer
         self._caret = len(self._buffer)
         self._error = ""
+        # Open the dropdown on the best match for whatever the editor was seeded
+        # with, and un-dismiss any prior close. On an unset row the seed is
+        # empty, so the list opens on the whole catalogue — "I opened the field"
+        # is a request to see the choices, matching `/model` opening its list.
+        self._suggest_index = 0
+        self._suggest_dismissed = False
         self._repaint()
 
     def _cancel_edit(self) -> None:
@@ -1310,6 +1462,12 @@ class SettingsView(Vertical):
         self._edit_seed = ""
         self._caret = 0
         self._error = ""
+        # The dropdown belongs to the open editor, so closing the editor closes
+        # it. Reset here rather than only where the editor opens, so a cancel by
+        # any route (Esc, a click away, a move) leaves no dropdown state that a
+        # later edit would inherit.
+        self._suggest_index = 0
+        self._suggest_dismissed = False
 
     def _settle_row(self) -> bool:
         """Put the current row back to rest. NOTHING here writes.
@@ -1823,17 +1981,78 @@ class SettingsView(Vertical):
         """
         key = event.key
         if self._editing is not None:
+            # Is a suggestion dropdown live for this editor? Computed once so the
+            # branches below read the same state, and only ever true on the two
+            # suggest keys with a fed catalogue and matches showing.
+            has_suggestions = bool(self._suggest_rows())
             if key == "escape":
                 event.stop()
                 event.prevent_default()
+                if has_suggestions:
+                    # The extra Esc rung the dropdown adds (mirrors the enum
+                    # expansion's own rung in the page-level Esc ladder below):
+                    # the first Esc closes the SUGGESTIONS, a second cancels the
+                    # editor. A user who opened the list to look at it backs out
+                    # of it without losing what they typed.
+                    self._suggest_dismissed = True
+                    self._repaint()
+                    return
                 self._cancel_edit()
                 self._repaint()
                 return
+            if key in ("up", "down") and has_suggestions:
+                # The dropdown owns the arrows while it is showing — there is no
+                # cursor to move on the page (the editor holds it), so the arrows
+                # have nothing else to do and browsing the list is what a user
+                # reaches for. Wraps, like the model picker's own move.
+                event.stop()
+                event.prevent_default()
+                count = len(self._suggestions())
+                delta = -1 if key == "up" else 1
+                self._suggest_index = (self._suggest_index + delta) % max(count, 1)
+                self._repaint()
+                return
+            if key == "tab" and has_suggestions:
+                # Tab COMPLETES the highlighted suggestion into the buffer and
+                # keeps the editor open, exactly as the model picker's Tab does
+                # (`_complete_model`). It never saves — only Enter on the chosen
+                # value writes (the page's #440 contract).
+                suggestion = self._highlighted_suggestion()
+                if suggestion is not None:
+                    event.stop()
+                    event.prevent_default()
+                    self._accept_suggestion(suggestion)
+                    return
             if key == "enter":
                 event.stop()
                 event.prevent_default()
+                # Enter on a live dropdown ACCEPTS the highlighted suggestion
+                # into the buffer first, THEN saves it — so arrowing to a row
+                # and pressing Enter stores that row without a separate Tab. When
+                # the buffer already equals the highlighted value (the common
+                # case: the user typed it in full, or Tab-completed it), the
+                # accept is a no-op and the save runs on what is there. A custom
+                # value the catalogue does not match has no highlight, so Enter
+                # saves the typed text directly — the "suggestions assist, never
+                # constrain" contract.
+                suggestion = self._highlighted_suggestion()
+                if suggestion is not None and self._buffer.strip() != suggestion.value:
+                    self._accept_suggestion(suggestion)
                 self._commit_edit()
                 return
+            if key == "right" and has_suggestions and self._caret == len(self._buffer):
+                # Right-at-the-end accepts the ghost, the composer's own gesture:
+                # the ghost previews what completing appends, and pushing the
+                # caret past the tail is the natural "take it". Only when a ghost
+                # is actually shown (caret at end AND an append-honest match),
+                # else `right` falls through to ordinary caret movement below.
+                if self._suggest_ghost():
+                    suggestion = self._highlighted_suggestion()
+                    if suggestion is not None:
+                        event.stop()
+                        event.prevent_default()
+                        self._accept_suggestion(suggestion)
+                        return
             if key == "backspace":
                 event.stop()
                 event.prevent_default()
@@ -1842,12 +2061,16 @@ class SettingsView(Vertical):
                 if self._caret > 0:
                     self._buffer = self._buffer[: self._caret - 1] + self._buffer[self._caret :]
                     self._caret -= 1
+                # Editing the buffer is a request to re-filter, so a dismissed
+                # dropdown comes back and the highlight resets to the best match.
+                self._reopen_suggestions()
                 self._repaint()
                 return
             if key == "delete":
                 event.stop()
                 event.prevent_default()
                 self._buffer = self._buffer[: self._caret] + self._buffer[self._caret + 1 :]
+                self._reopen_suggestions()
                 self._repaint()
                 return
             if key in ("left", "right", "home", "end"):
@@ -1870,6 +2093,9 @@ class SettingsView(Vertical):
                 event.prevent_default()
                 self._buffer = self._buffer[: self._caret] + char + self._buffer[self._caret :]
                 self._caret += 1
+                # Typing filters the list, so an earlier Esc-dismissal is undone
+                # and the highlight resets to the new best match.
+                self._reopen_suggestions()
                 self._repaint()
             return
         if key == "escape" and self._confirm_delete is not None:
@@ -1957,6 +2183,16 @@ class SettingsView(Vertical):
             return
         event.stop()
         row = self._rows[index]
+        if row.kind == "suggest" and row.suggestion is not None:
+            # A click on a dropdown row highlights it and accepts it in one
+            # gesture — completing the buffer to that value, exactly as the model
+            # picker's own click chooses a row. It does NOT save: the page's
+            # contract is that only Enter on the chosen value writes (#440), so
+            # a stray click completes and leaves the confirming Enter to the
+            # user, matching what Tab on the same row does.
+            self._suggest_index = row.hop_index
+            self._accept_suggestion(row.suggestion)
+            return
         if not row.selectable:
             return
         if index == self._selected:
@@ -2238,6 +2474,23 @@ class SettingsView(Vertical):
             line.append(row.text, style=dim)
             return line
 
+        if row.kind == "suggest" and row.suggestion is not None:
+            # A dropdown row under the edited setting. Indented one level in from
+            # the setting (like an enum choice) so it reads as belonging to that
+            # row, and highlighted by `_suggest_index` — NOT by `_selected`,
+            # which stays on the setting row while the list is browsed. The
+            # highlight is a reverse marker plus the accent-inked value, matching
+            # the `●`/cursor vocabulary the choice rows already use, so the
+            # highlighted row is legible on a monochrome terminal too.
+            highlighted = row.hop_index == self._suggest_index
+            line.append(" " * (_CHOICE_INDENT - 2))
+            marker_style = accent if highlighted else dim
+            line.append(f"{_CURSOR} " if highlighted else "  ", style=marker_style)
+            line.append(row.suggestion.label, style=fg if highlighted else muted)
+            if row.suggestion.detail:
+                line.append(f"  {row.suggestion.detail}", style=faint)
+            return line
+
         marker = f"{_CURSOR} " if selected else "  "
         base = fg if selected else (muted if hovered else muted)
 
@@ -2376,6 +2629,16 @@ class SettingsView(Vertical):
         editor.append(before, style=fg)
         editor.append("▏", style=accent)
         editor.append(after, style=fg)
+        # The GHOST rides just after the caret's tail, dimmed, previewing what
+        # Tab/enter would append. Only painted when the caret is at the end
+        # (`_suggest_ghost` enforces this) so `after` is empty and the ghost
+        # follows the caret with nothing between — the same inline-completion
+        # affordance the slash-command composer shows, using its own append-only
+        # honesty rule (`command_picker.ghost_for`). A fuzzy match that would
+        # rewrite typed characters shows no ghost; the dropdown row carries it.
+        ghost = self._suggest_ghost()
+        if ghost:
+            editor.append(ghost, style=faint)
         # The CONTRACT rides the row; the ERROR does not. The detail line below
         # already carries the rejection in full width, and printing it twice
         # read as two separate problems — the row's copy also had to compete
@@ -2394,7 +2657,19 @@ class SettingsView(Vertical):
         # the clause advertised a behaviour the row does not have.
         contract = "  enter saves · esc cancels"
         setting = settings_io.resolve_key(self._editing or "")
-        if setting is not None and setting.empty_unsets:
+        # When a suggestion dropdown is live the contract names the keys that
+        # drive it, or the affordance is undiscoverable: the footer hint contract
+        # has to stay honest (a lit affordance with no advertised key is the "why
+        # doesn't anything happen" complaint U5 records). Preferred over
+        # `clear to unset` because a user staring at a list of choices needs
+        # "how do I pick one" more than "how do I empty this", and both do not
+        # fit; `_suggest_rows` being non-empty is exactly "a dropdown is shown".
+        if self._suggest_rows():
+            full = "  ↑↓ suggestions · tab completes · enter saves · esc"
+            room = self._list_width() - _VALUE_COLUMN - cell_len(editor.plain)
+            if cell_len(full) <= room:
+                contract = full
+        elif setting is not None and setting.empty_unsets:
             full = "  enter saves · esc cancels · clear to unset"
             room = self._list_width() - _VALUE_COLUMN - cell_len(editor.plain)
             if cell_len(full) <= room:
@@ -2434,6 +2709,178 @@ class SettingsView(Vertical):
         start = max(0, caret - room + 4)
         start = min(start, max(0, len(self._buffer) - room))
         return (self._buffer[start:caret], self._buffer[caret:], start > 0)
+
+    # -- suggestions (Default provider / Default model) ---------------------
+    #
+    # The `hosting` and `model_name` rows keep the ordinary free-text editor —
+    # every key, the caret, the Esc/enter contract — and gain a filtered
+    # dropdown with inline ghost text ON TOP of it. The design deliberately
+    # REUSES the /model and /provider machinery rather than inventing a parallel
+    # one: models are ranked by `model_picker.rank_rows` (the exact matcher the
+    # /model list uses) and providers by `autocomplete.score_command_text_match`
+    # (the matcher /login and the command picker use), and the ghost is
+    # `command_picker.ghost_for`'s own append-only rule. A second source that
+    # could drift from those is the defect the slice was written to avoid.
+    def _suggest_key(self) -> str | None:
+        """The suggest key whose editor is open, or None.
+
+        A single predicate for "is a suggestion dropdown live", so the paint,
+        the key router and the ghost all ask the same question the same way.
+        Open means: an editor is open, it is one of the two suggest keys, and
+        the app injected the catalogue that key draws from — a host that fed no
+        catalogue falls back to the plain editor rather than an empty dropdown.
+        """
+        if self._editing not in _SUGGEST_KEYS:
+            return None
+        if self._editing == _HOSTING_KEY and not self._provider_catalogue:
+            return None
+        if self._editing == _MODEL_KEY and not self._model_catalogue:
+            return None
+        return self._editing
+
+    def _suggestions(self) -> list[_Suggestion]:
+        """The current suggestion list for the open editor, best first.
+
+        Filtered by the WHOLE buffer (not the slice before the caret): a setting
+        editor is a single short token, so there is no second word for a caret
+        to sit before, and matching the whole value is what lets a mid-string
+        edit still narrow the list. Empty buffer returns the whole catalogue in
+        its source order, exactly as `/model` and `/login` show everything when
+        nothing is typed — "I opened the field and have not typed" is a request
+        to see the set, not a failed match.
+
+        Returns `[]` when the typed value matches nothing, which is the case
+        that carries the "custom value still saves" contract: a bespoke endpoint
+        id the catalogue has never seen simply offers no rows, the dropdown
+        disappears, and the buffer commits as typed through the unchanged
+        `_commit_edit`. Suggestions assist; they never gate the write.
+        """
+        key = self._suggest_key()
+        if key is None:
+            return []
+        query = self._buffer.strip()
+        if key == _HOSTING_KEY:
+            # Providers are a bounded known set, so this reads as an enum you can
+            # also free-type past. Scored by the shared command matcher so
+            # `anthrpc` finds `anthropic` the same way `/login anthrpc` does.
+            scored: list[tuple[int, int, _Suggestion]] = []
+            for order, (provider_id, name) in enumerate(self._provider_catalogue):
+                if not query:
+                    scored.append((0, order, _Suggestion(provider_id, provider_id, name)))
+                    continue
+                # Best score across the id AND the display name, so typing the
+                # brand ("OpenAI") finds the id ("openai") the value stores.
+                best = max(
+                    score_command_text_match(query, provider_id),
+                    score_command_text_match(query, name),
+                )
+                if best > 0:
+                    scored.append((-best, order, _Suggestion(provider_id, provider_id, name)))
+            scored.sort(key=lambda item: (item[0], item[1]))
+            return [item[2] for item in scored]
+        # model_name: rank the SAME catalogue /model shows, by the SAME matcher.
+        # `value` is the BARE model id (what the key stores), `label` is the
+        # `provider/id` selector (what disambiguates two rows sharing an id).
+        # `rank_rows` matches on the selector, so a user typing `openrouter/`
+        # narrows by provider even though the accepted value is the bare id.
+        ranked = rank_rows(self._model_catalogue, query)
+        return [_Suggestion(row.model_id, row.selector, _suggestion_detail(row)) for row in ranked]
+
+    def _suggest_rows(self) -> list["_Row"]:
+        """The dropdown as painter rows, clamping `_suggest_index` to the list.
+
+        Returns `[]` when no dropdown should show — no open suggest editor, the
+        list dismissed by Esc, or nothing matches. The clamp lives here because
+        this runs on every repaint and every repaint follows a possible buffer
+        change: typing can drop the highlighted row out of the list, and an
+        index left dangling past the end would paint no highlight and accept the
+        wrong value on Enter.
+        """
+        if self._suggest_key() is None or self._suggest_dismissed:
+            return []
+        suggestions = self._suggestions()
+        if not suggestions:
+            return []
+        if self._suggest_index >= len(suggestions):
+            self._suggest_index = len(suggestions) - 1
+        if self._suggest_index < 0:
+            self._suggest_index = 0
+        # Window the list around the highlight so a catalogue of dozens does not
+        # push the rest of the page off screen — the same visible-window idea
+        # `model_picker` uses, kept simple here because the settings body scrolls
+        # as a whole and the dropdown is only ever a handful of rows.
+        start = 0
+        if len(suggestions) > _SUGGEST_ROWS:
+            start = min(
+                max(0, self._suggest_index - _SUGGEST_ROWS // 2),
+                len(suggestions) - _SUGGEST_ROWS,
+            )
+        window = suggestions[start : start + _SUGGEST_ROWS]
+        return [
+            _Row(kind="suggest", suggestion=item, hop_index=start + offset)
+            for offset, item in enumerate(window)
+        ]
+
+    def _highlighted_suggestion(self) -> _Suggestion | None:
+        """The suggestion Enter/Tab would accept, or None when none is shown."""
+        if self._suggest_key() is None or self._suggest_dismissed:
+            return None
+        suggestions = self._suggestions()
+        if not suggestions:
+            return None
+        index = max(0, min(self._suggest_index, len(suggestions) - 1))
+        return suggestions[index]
+
+    def _suggest_ghost(self) -> str:
+        """The dimmed completion of the top suggestion, appended after the caret.
+
+        Honest ghost only, borrowing `command_picker.ghost_for`'s rule verbatim:
+        the ghost is shown IF AND ONLY IF the highlighted value is a pure APPEND
+        to what the user typed. A fuzzy match that rewrites characters already on
+        screen (`ops` → `anthropic/claude-opus-5`) has no append that describes
+        it, so no ghost is shown there and the dropdown row carries the meaning
+        instead — a ghost that painted characters Tab would not insert is a lie
+        about the next keystroke.
+
+        Suppressed unless the caret is at the END of the buffer: a ghost is a
+        preview of what completing appends, and appending only makes sense at the
+        tail. Mid-string editing shows the dropdown but no inline ghost.
+        """
+        suggestion = self._highlighted_suggestion()
+        if suggestion is None or self._caret != len(self._buffer):
+            return ""
+        return ghost_for((suggestion.value, len(suggestion.value)), self._buffer)
+
+    def _accept_suggestion(self, suggestion: _Suggestion) -> None:
+        """Complete the buffer to ``suggestion`` and keep the editor open.
+
+        Tab-style completion: the value replaces the buffer and the caret goes
+        to the end, so the user sees the full selector and can still edit it or
+        press Enter to save. NOT an immediate write — the page's whole contract
+        is that only Enter on the chosen thing changes config (#440), and the
+        model-picker's own Tab behaves the same (`_complete_model` completes,
+        Enter acts). Filling the buffer re-filters the list to the exact value,
+        which leaves that one row highlighted for the confirming Enter.
+        """
+        self._buffer = suggestion.value
+        self._caret = len(self._buffer)
+        self._suggest_index = 0
+        self._suggest_dismissed = False
+        self._repaint()
+
+    def _reopen_suggestions(self) -> None:
+        """Un-dismiss the dropdown and reset the highlight — for buffer edits.
+
+        Typing, backspace and delete all mean "the value changed, re-filter",
+        which brings a dropdown a prior Esc closed back and puts the highlight on
+        the new best match. A no-op on non-suggest editors. The highlight resets
+        to 0 rather than trying to track the old row: after a filter the list is
+        a different set, so the top (best) match is the only stable anchor —
+        the same choice `model_picker._refilter` makes.
+        """
+        if self._editing in _SUGGEST_KEYS:
+            self._suggest_dismissed = False
+            self._suggest_index = 0
 
     #: Leads the delete confirmation so an ASK is distinguishable from a
     #: REPORT. Both occupy the detail row in the same danger ink, and a
@@ -3490,6 +3937,34 @@ class SettingsView(Vertical):
         """
         return self._notice
 
+    # -- suggestion accessors (assertable state) ----------------------------
+    def suggestion_labels_for_test(self) -> list[str]:
+        """The suggestion dropdown's DISPLAYED labels, best first ("" when none).
+
+        The labels are what the user reads (a `provider/id` selector for a
+        model, a bare id for a provider), so a test asserts filtering and
+        ordering against them exactly as they appear on the frame.
+        """
+        return [item.label for item in self._suggestions()]
+
+    def suggestion_values_for_test(self) -> list[str]:
+        """The values the dropdown would WRITE, best first ("" when none).
+
+        Distinct from the labels because a model suggestion shows the selector
+        but stores the bare id — the split a test has to be able to see, or a
+        regression that stored the selector would pass against the label alone.
+        """
+        return [item.value for item in self._suggestions()]
+
+    def ghost_text_for_test(self) -> str:
+        """The inline ghost completion currently shown ("" when none)."""
+        return self._suggest_ghost()
+
+    @property
+    def suggest_index_for_test(self) -> int:
+        """Which suggestion is highlighted, for the arrow-navigation assertions."""
+        return self._suggest_index
+
     # -- leaving ------------------------------------------------------------
     def _focus_self(self) -> None:
         """Focus the page (the move hint's click action).
@@ -3524,7 +3999,17 @@ class _Row:
     every field Optional on a frozen dataclass buys nothing over this.
     """
 
-    __slots__ = ("kind", "section", "setting", "choice", "chain", "hop", "hop_index", "text")
+    __slots__ = (
+        "kind",
+        "section",
+        "setting",
+        "choice",
+        "chain",
+        "hop",
+        "hop_index",
+        "text",
+        "suggestion",
+    )
 
     def __init__(
         self,
@@ -3537,6 +4022,7 @@ class _Row:
         hop: str | None = None,
         hop_index: int = -1,
         text: str = "",
+        suggestion: "_Suggestion | None" = None,
     ) -> None:
         self.kind = kind
         self.section = section
@@ -3544,8 +4030,15 @@ class _Row:
         self.choice = choice
         self.chain = chain
         self.hop = hop or ""
+        # For a ``suggest`` row this is the suggestion's ORDINAL within the open
+        # dropdown, which is what a click maps back to `_suggest_index`; for a
+        # ``hop`` row it is the hop's position in its chain. Same "position of
+        # this row within its group" meaning in both, so the slot is shared.
         self.hop_index = hop_index
         self.text = text
+        #: The offered value+label for a ``suggest`` row, else None. See
+        #: `_Suggestion`.
+        self.suggestion = suggestion
 
     @property
     def selectable(self) -> bool:
@@ -3554,8 +4047,16 @@ class _Row:
         Headers and the empty-state line are not selectable: there is nothing
         to do on them, and a cursor that stopped on them would make every
         section boundary cost an extra keypress to cross.
+
+        Suggestion rows are not selectable either: the cursor stays on the
+        edited setting row while the dropdown is open, and the highlighted
+        suggestion is tracked by `_suggest_index` rather than by `_selected`.
+        The two are kept apart for the reason the enum expansion keeps the
+        stored-choice cursor apart from the setting row — a dropdown is browsed
+        by a highlight that must survive the buffer being re-filtered under it,
+        which a `_selected` index into a rebuilt row list does not.
         """
-        return self.kind not in ("header", "empty")
+        return self.kind not in ("header", "empty", "suggest")
 
     @property
     def identity(self) -> tuple[str, str, int]:
@@ -3609,6 +4110,26 @@ def _choices_for(setting: Setting) -> tuple[settings_io.Choice, ...]:
     if setting.kind is Kind.BOOL:
         return _BOOL_CHOICES
     return setting.resolved_choices
+
+
+def _suggestion_detail(row: ModelRow) -> str:
+    """The dim right-hand note for a model suggestion — provider then price.
+
+    Kept terse and display-only (never parsed back): it answers "which of the
+    several rows named `claude-opus-5` is this" and "roughly what does it cost",
+    which is the same pair `/model`'s own rows carry. Reuses
+    `model_picker.format_price_pair` so a price reads identically on both
+    surfaces; the provider leads because two rows can share a model id across a
+    direct provider and an aggregator, and the provider is what tells them
+    apart.
+    """
+    from local_operator.tui.widgets.model_picker import format_price_pair
+
+    price = format_price_pair(row.input_price, row.output_price)
+    parts = [row.provider]
+    if price:
+        parts.append(price)
+    return " · ".join(parts)
 
 
 def _render_value(value: Any) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.15"
+version = "0.44.16"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/settings_suggest_shot.py
+++ b/scripts/settings_suggest_shot.py
@@ -25,6 +25,10 @@ STATE selects what the page is showing:
                know (a custom endpoint id), proving suggestions assist but do
                not hard-constrain — the frame shows no ghost and the buffer is
                committable as typed
+    provider-windowed  the Default provider editor open against a catalogue
+               LARGER than the visible window, highlight moved into the middle,
+               so the frame shows the `pos/total` count cue on the highlighted
+               row and the windowed 8-of-N list (review round 1, U3)
 
 The provider and model catalogues are INJECTED (same shape the app resolves for
 the real page) so the frame is identical on every machine.
@@ -169,6 +173,24 @@ async def main() -> None:
             view._buffer = ""
             view._caret = 0
             _type("my-endpoint/custom-model-v2")
+        elif state == "provider-windowed":
+            # A catalogue larger than the 8-row window, with the highlight moved
+            # into the middle, so the frame proves the `pos/total` cue and the
+            # windowing behaviour a short list never exercises. Re-load with the
+            # bigger catalogue rather than the module default.
+            view.load(
+                teams=TEAMS,
+                agents=AGENTS,
+                providers=PROVIDERS,
+                provider_catalogue=[(f"prov{n:02d}", f"Provider {n:02d}") for n in range(12)],
+                model_catalogue=MODEL_CATALOGUE,
+            )
+            _select(view, "hosting")
+            view.action_activate()
+            view._buffer = ""
+            view._caret = 0
+            view._suggest_index = 3
+            view._repaint()
         else:
             raise SystemExit(f"unknown state {state}")
 

--- a/scripts/settings_suggest_shot.py
+++ b/scripts/settings_suggest_shot.py
@@ -1,0 +1,184 @@
+"""Capture the /settings provider/model suggestion editors for visual validation.
+
+Run from the worktree root:
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \\
+        scripts/settings_suggest_shot.py OUT.svg [COLSxROWS] [STATE]
+
+Drives the REAL :class:`OperatorApp`, which is the only host that loads
+``local_operator.tcss`` (AGENTS.md, "Visual validation"). A scratch config dir
+is used for every capture so the frames show a KNOWN configuration and can never
+touch the developer's own settings — the same discipline ``settings_shot.py``
+follows.
+
+STATE selects what the page is showing:
+
+    provider   the Default provider editor open, typed "a", suggestion dropdown
+               with ghost-text completion of the top provider match
+    provider-empty  the Default provider editor open with an empty buffer,
+               showing the full provider suggestion list
+    model      the Default model editor open, typed "opus", fuzzy suggestion
+               dropdown with ghost-text completion of the top model match
+    model-empty  the Default model editor open with an empty buffer, showing
+               the catalogue ordered as /model orders it
+    custom     the Default model editor holding a value the catalogue does NOT
+               know (a custom endpoint id), proving suggestions assist but do
+               not hard-constrain — the frame shows no ghost and the buffer is
+               committable as typed
+
+The provider and model catalogues are INJECTED (same shape the app resolves for
+the real page) so the frame is identical on every machine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+_SCRATCH = tempfile.mkdtemp(prefix="lo-suggest-shot-")
+os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = _SCRATCH
+
+from local_operator.config import ConfigManager  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
+from local_operator.tui.widgets.model_picker import ModelRow  # noqa: E402
+from local_operator.tui.widgets.settings_view import SettingsView  # noqa: E402
+from local_operator.tui.widgets.transcript import UserBlock  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+TEAMS = [("lopdev", "manager · 6 roles", "ships local-operator changes end to end")]
+AGENTS = [("coder", "role · effort med", "implements one bounded slice")]
+PROVIDERS = [("anthropic", "signed in"), ("openrouter", "api key")]
+
+#: A representative slice of the provider login catalogue, as ``(id, label)``.
+PROVIDER_CATALOGUE = [
+    ("anthropic", "Anthropic"),
+    ("openai", "OpenAI"),
+    ("openrouter", "OpenRouter"),
+    ("google", "Google"),
+    ("mistral", "Mistral"),
+    ("deepseek", "DeepSeek"),
+    ("alibaba", "Alibaba"),
+    ("radient", "Radient"),
+]
+
+#: A representative slice of the model catalogue, as ModelRows.
+MODEL_CATALOGUE = [
+    ModelRow("anthropic", "claude-opus-5", "Claude Opus 5", 200_000, 15.0, 75.0),
+    ModelRow("anthropic", "claude-sonnet-4-5", "Claude Sonnet 4.5", 200_000, 3.0, 15.0),
+    ModelRow("openai", "gpt-5.2", "GPT-5.2", 400_000, 2.5, 10.0),
+    ModelRow("openai", "gpt-5.2-mini", "GPT-5.2 mini", 400_000, 0.4, 1.6),
+    ModelRow("google", "gemini-3-pro", "Gemini 3 Pro", 1_000_000, 2.0, 12.0),
+    ModelRow(
+        "openrouter",
+        "anthropic/claude-opus-5",
+        "Claude Opus 5",
+        200_000,
+        16.0,
+        78.0,
+        aggregated=True,
+    ),
+    ModelRow("deepseek", "deepseek-chat", "DeepSeek Chat", 128_000, 0.3, 1.1),
+]
+
+
+def _seed() -> None:
+    m = ConfigManager(Path(_SCRATCH))
+    m.set_config_value("hosting", "anthropic")
+    m.set_config_value("model_name", "claude-opus-5")
+
+
+def _select(view: SettingsView, key: str) -> None:
+    for index, row in enumerate(view._rows):
+        if row.kind == "setting" and row.setting is not None and row.setting.key == key:
+            view._selected = index
+            view._repaint()
+            view._scroll_to_selection()
+            return
+    raise SystemExit(f"no row for {key}")
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    size = (100, 30)
+    if len(sys.argv) > 2:
+        cols, rows = sys.argv[2].split("x")
+        size = (int(cols), int(rows))
+    state = sys.argv[3] if len(sys.argv) > 3 else "provider"
+
+    _seed()
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        for turn in range(1, 3):
+            app._append_block(UserBlock(f"Turn {turn}: change the default model?"))
+            prose = AssistantBlock()
+            prose.update_text(f"Answer {turn}: /settings has it under Model.")
+            app._append_block(prose)
+        await pilot.pause()
+
+        app._open_settings_view()
+        view = app.query_one(SettingsView)
+        view.load(
+            teams=TEAMS,
+            agents=AGENTS,
+            providers=PROVIDERS,
+            provider_catalogue=PROVIDER_CATALOGUE,
+            model_catalogue=MODEL_CATALOGUE,
+        )
+        await pilot.pause()
+
+        def _type(text: str) -> None:
+            for ch in text:
+                view._buffer = view._buffer[: view._caret] + ch + view._buffer[view._caret :]
+                view._caret += 1
+            view._repaint()
+
+        if state == "provider":
+            _select(view, "hosting")
+            view.action_activate()
+            view._buffer = ""
+            view._caret = 0
+            _type("a")
+        elif state == "provider-empty":
+            _select(view, "hosting")
+            view.action_activate()
+            view._buffer = ""
+            view._caret = 0
+            view._repaint()
+        elif state == "model":
+            _select(view, "model_name")
+            view.action_activate()
+            view._buffer = ""
+            view._caret = 0
+            _type("opus")
+        elif state == "model-empty":
+            _select(view, "model_name")
+            view.action_activate()
+            view._buffer = ""
+            view._caret = 0
+            view._repaint()
+        elif state == "custom":
+            _select(view, "model_name")
+            view.action_activate()
+            view._buffer = ""
+            view._caret = 0
+            _type("my-endpoint/custom-model-v2")
+        else:
+            raise SystemExit(f"unknown state {state}")
+
+        await pilot.pause()
+        app.save_screenshot(out)
+        print(
+            f"state={state} buffer={view._buffer!r} "
+            f"suggestions={view.suggestion_labels_for_test()!r} "
+            f"ghost={view.ghost_text_for_test()!r}"
+        )
+
+
+asyncio.run(main())

--- a/tests/unit/tui/test_settings_view.py
+++ b/tests/unit/tui/test_settings_view.py
@@ -4386,3 +4386,251 @@ async def test_suggestions_are_absent_without_an_injected_catalogue() -> None:
         assert view.editing_key == "model_name"
         assert view.suggestion_labels_for_test() == []
         assert view._suggest_rows() == []
+
+
+# ---------------------------------------------------------------------------
+# Review round 1 remediation: the empty-buffer unset blocker, the nav-key leak,
+# the footer/hint discoverability at common widths, and the mouse-only save.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("key", ["hosting", "model_name"])
+@pytest.mark.asyncio
+async def test_clearing_a_suggest_field_unsets_it_rather_than_writing_row_zero(
+    tmp_path: Path, key: str
+) -> None:
+    """Round 1 BLOCKER: an empty buffer must UNSET, not accept catalogue row 0.
+
+    Both ``hosting`` and ``model_name`` are ``empty_unsets=True``: clearing the
+    field and pressing Enter is the documented clear-to-unset gesture. The
+    suggestion-accept-on-Enter path ran before ``_commit_edit``, and on an empty
+    buffer ``_highlighted_suggestion`` still returns row 0 (``anthropic`` /
+    ``claude-opus-5``) — so Enter silently wrote that top row instead of
+    unsetting. This is the exact U1 blocker ``_commit_edit`` already guards; the
+    original U1 regression test missed it only because its ``FakeSession``
+    injects no catalogue, so the dropdown never opened. This drives the real
+    page WITH the catalogue present — the blind spot — and asserts the unset.
+    """
+    stored = {"hosting": "openai", "model_name": "gpt-5.2"}[key]
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        view = await _open_page_with_catalogues(pilot, app)
+        # Seed a stored value through the page's OWN manager, so the editor opens
+        # onto a non-empty field the user then clears.
+        view._manager.set_config_value(key, stored)
+
+        _select(view, key)
+        await pilot.press("enter")
+        # The dropdown is live and highlights row 0 over content the user never
+        # chose — the trap.
+        assert view.editing_key == key
+        for _ in range(len(view._buffer) + 2):
+            await pilot.press("backspace")
+        await pilot.pause()
+        assert view._buffer == ""
+        assert view._suggest_rows(), "the dropdown should show the whole catalogue"
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        # UNSET, not the top row. `empty_unsets` drops the key entirely.
+        assert view.editing_key is None
+        assert _values(tmp_path).get(key) in (None, "")
+
+
+@pytest.mark.parametrize("navkey", ["pageup", "pagedown", "ctrl+n", "ctrl+p"])
+@pytest.mark.asyncio
+async def test_nav_keys_do_not_leak_past_an_open_suggest_editor(
+    tmp_path: Path, navkey: str
+) -> None:
+    """Round 1 U2: page/readline-nav keys must not discard the edit.
+
+    ``on_key`` intercepted left/right/home/end but not pageup/pagedown/ctrl+n/
+    ctrl+p, so pressing them mid-edit fell through to the page bindings, which
+    cancelled the editor, discarded the typed value and teleported the cursor.
+    With a dropdown live those keys browse it (page or move the highlight); this
+    asserts the editor SURVIVES and the buffer is intact — the invariant the
+    leak broke, whichever of the four keys is pressed.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        view = await _open_page_with_catalogues(pilot, app)
+
+        _select(view, "model_name")
+        await pilot.press("enter")
+        for _ in range(len(view._buffer)):
+            await pilot.press("backspace")
+        for ch in "opus":
+            await pilot.press(ch)
+        await pilot.pause()
+        assert view.editing_key == "model_name"
+
+        await pilot.press(navkey)
+        await pilot.pause()
+
+        # The editor is still open and the typed value is intact — no discard,
+        # no teleport, nothing written.
+        assert view.editing_key == "model_name", f"{navkey} leaked and cancelled the edit"
+        assert view._buffer == "opus", f"{navkey} discarded the typed value"
+        assert _values(tmp_path).get("model_name") in (None, ""), "a nav key wrote a value"
+
+
+@pytest.mark.parametrize("navkey", ["pageup", "pagedown", "ctrl+n", "ctrl+p"])
+@pytest.mark.asyncio
+async def test_nav_keys_do_not_leak_past_a_plain_text_editor(tmp_path: Path, navkey: str) -> None:
+    """Round 1 U2, the no-dropdown case: a plain editor swallows nav keys too.
+
+    The same leak applied to every text editor on the page, not only the two
+    suggest fields — ``retry.maxRetries`` is a bare number editor with no
+    dropdown, and a stray PageDown there discarded the number just as readily.
+    With no dropdown to page, the keys are inert (swallowed), never a discard.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        view = await _open_page_with_catalogues(pilot, app)
+
+        _select(view, "retry.maxRetries")
+        await pilot.press("enter")
+        for _ in range(len(view._buffer)):
+            await pilot.press("backspace")
+        await pilot.press("7")
+        await pilot.pause()
+        assert view.editing_key == "retry.maxRetries"
+
+        await pilot.press(navkey)
+        await pilot.pause()
+
+        assert view.editing_key == "retry.maxRetries", f"{navkey} cancelled a plain editor"
+        assert view._buffer == "7", f"{navkey} discarded a plain editor's value"
+
+
+@pytest.mark.asyncio
+async def test_the_footer_names_the_dropdown_keys_at_a_common_width() -> None:
+    """Round 1 D1/D2/U1: the dropdown keys are discoverable at 100 cols.
+
+    The inline row contract only fit the full ``↑↓ suggestions · tab completes``
+    legend at ~140 cols, and the persistent footer read ``↑↓ move cancel`` /
+    ``←→ panes`` — actively wrong while a dropdown is open (↑↓ browses, ←→ moves
+    the caret). At 100 cols — the shot script's own default and a common size —
+    the footer must name the real keys: ``suggestions``, ``complete`` and
+    ``save``, and must NOT claim ``move cancel`` or ``panes``.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        view = await _open_page_with_catalogues(pilot, app)
+
+        _select(view, "hosting")
+        await pilot.press("enter")
+        for _ in range(len(view._buffer)):
+            await pilot.press("backspace")
+        await pilot.press("a")
+        await pilot.pause()
+        assert view._suggest_rows(), "the dropdown should be live"
+
+        footer = view.rendered_hints()
+        assert "suggestions" in footer, footer
+        assert "complete" in footer, footer
+        assert "save" in footer, footer
+        # The stale, now-wrong labels must be gone in this state.
+        assert "move cancel" not in footer, footer
+        assert "panes" not in footer, footer
+
+
+@pytest.mark.asyncio
+async def test_the_footer_keeps_move_cancel_for_a_plain_editor() -> None:
+    """Round 1 D2: the dropdown-state footer is scoped to the dropdown.
+
+    A plain text editor with no dropdown (``retry.maxRetries``) still reads
+    ``↑↓ move cancel`` — the pre-existing, correct label for that state. The
+    remediation rewrites the footer only WHILE a dropdown is live, so it must
+    not bleed into the ordinary editing state.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        view = await _open_page_with_catalogues(pilot, app)
+
+        _select(view, "retry.maxRetries")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert view.editing_key == "retry.maxRetries"
+        assert not view._suggest_rows()
+
+        footer = view.rendered_hints()
+        assert "move cancel" in footer, footer
+        assert "complete" not in footer, footer
+
+
+@pytest.mark.asyncio
+async def test_a_second_click_on_a_suggestion_saves_it(tmp_path: Path) -> None:
+    """Round 1 U4: a mouse user has a path to save from the dropdown.
+
+    A first click on a suggestion completes the buffer (select); a second click
+    on that same, already-completed row saves it — the click-once-select /
+    click-again-activate rhythm the setting rows themselves use. Without it a
+    mouse click filled the buffer and dead-ended, needing the keyboard's Enter.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        view = await _open_page_with_catalogues(pilot, app)
+
+        _select(view, "hosting")
+        await pilot.press("enter")
+        for _ in range(len(view._buffer)):
+            await pilot.press("backspace")
+        await pilot.press("o")  # narrows to openai / openrouter
+        await pilot.pause()
+
+        # Find the first suggestion row's index in the painted row list.
+        suggest_indices = [i for i, r in enumerate(view._rows) if r.kind == "suggest"]
+        assert suggest_indices, "the dropdown should paint suggestion rows"
+        first = suggest_indices[0]
+        first_suggestion = view._rows[first].suggestion
+        assert first_suggestion is not None
+        target = first_suggestion.value
+
+        _click_row(view, first)  # click 1: completes into the buffer
+        await pilot.pause()
+        assert view._buffer == target
+        assert view.editing_key == "hosting", "the first click saved instead of completing"
+
+        _click_row(view, first)  # click 2: saves the already-completed row
+        await pilot.pause()
+        assert view.editing_key is None, "the second click did not save"
+        assert _values(tmp_path).get("hosting") == target
+
+
+@pytest.mark.asyncio
+async def test_a_windowed_dropdown_shows_a_position_count() -> None:
+    """Round 1 U3: a long list carries a position/count cue on the highlight.
+
+    With a catalogue larger than the visible window, the highlighted row shows
+    ``pos/total`` so a user arrowing the list can tell where they are and how
+    many remain — the count the ``/model`` picker carries in its footer. Only
+    on the highlight and only when the list is windowed, so a short list that
+    shows in full stays uncluttered.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        # A catalogue larger than the 8-row window.
+        big = [(f"prov{n}", f"Provider {n}") for n in range(12)]
+        app._open_settings_view()
+        view = app.query_one(SettingsView)
+        view.load(provider_catalogue=big, model_catalogue=_MODEL_CATALOGUE)
+        await pilot.pause()
+
+        _select(view, "hosting")
+        await pilot.press("enter")
+        for _ in range(len(view._buffer)):
+            await pilot.press("backspace")
+        await pilot.pause()
+        assert len(view.suggestion_labels_for_test()) == 12
+
+        lines = view.render_lines_for_test()
+        assert any("1/12" in line for line in lines), lines

--- a/tests/unit/tui/test_settings_view.py
+++ b/tests/unit/tui/test_settings_view.py
@@ -24,6 +24,7 @@ from local_operator import settings_io
 from local_operator.config import ConfigManager
 from local_operator.settings_io import Kind
 from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.model_picker import ModelRow
 from local_operator.tui.widgets.settings_view import SettingsView
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
@@ -4029,3 +4030,359 @@ async def test_the_detail_clause_sheds_whole_rather_than_clipping(
             "default: 10" in detail
         ), f"`r` is offered without naming what it restores at {size}: {detail!r}"
         assert cell_len(detail) <= view._detail_width(), (cell_len(detail), detail)
+
+
+# ---------------------------------------------------------------------------
+# Click-selection frame suppression (Issue 1) and the provider/model
+# suggestion dropdowns with inline ghost text (Issue 2).
+# ---------------------------------------------------------------------------
+
+#: A representative provider catalogue as ``load`` takes it: ``(id, name)`` in
+#: registry order. FakeSession supplies no providers, so the suggestion tests
+#: inject their own known set rather than depending on the machine's registry.
+_PROVIDER_CATALOGUE = [
+    ("anthropic", "Anthropic"),
+    ("openai", "OpenAI"),
+    ("openrouter", "OpenRouter"),
+    ("google", "Google"),
+    ("mistral", "Mistral"),
+    ("deepseek", "DeepSeek"),
+]
+
+#: A representative model catalogue as ``ModelRow`` list — the same shape the
+#: app resolves for the real page and hands to ``load``.
+_MODEL_CATALOGUE = [
+    ModelRow("anthropic", "claude-opus-5", "Claude Opus 5", 200_000, 15.0, 75.0),
+    ModelRow("anthropic", "claude-sonnet-4-5", "Claude Sonnet 4.5", 200_000, 3.0, 15.0),
+    ModelRow("openai", "gpt-5.2", "GPT-5.2", 400_000, 2.5, 10.0),
+    ModelRow("google", "gemini-3-pro", "Gemini 3 Pro", 1_000_000, 2.0, 12.0),
+    # A reseller row carrying the SAME model id as the direct anthropic row —
+    # the case the label (selector) exists to disambiguate.
+    ModelRow("openrouter", "claude-opus-5", "Claude Opus 5", 200_000, 16.0, 78.0, aggregated=True),
+]
+
+
+async def _open_page_with_catalogues(pilot: Any, app: OperatorApp) -> SettingsView:
+    """Open ``/settings`` and inject the provider + model suggestion catalogues."""
+    app._open_settings_view()
+    view = app.query_one(SettingsView)
+    view.load(
+        providers=[("anthropic", "signed in")],
+        provider_catalogue=_PROVIDER_CATALOGUE,
+        model_catalogue=_MODEL_CATALOGUE,
+    )
+    await pilot.pause()
+    return view
+
+
+@pytest.mark.asyncio
+async def test_click_selects_a_row_without_arming_a_text_selection() -> None:
+    """Issue 1: a click on a settings row moves the cursor and arms NO selection.
+
+    Textual 8.x begins a screen text-selection on the ``MouseDown`` of any
+    widget whose ``allow_select`` is true (``Screen._forward_event``), and the
+    page's rows are painted into ``Static`` surfaces — so a click that was only
+    meant to select a row also armed a drag whose highlight bled the grey
+    selection band across the labels the bug report shows. ``_ChromeStatic``
+    sets ``ALLOW_SELECT = False`` on those surfaces, which keeps them out of the
+    selection walk WITHOUT touching the click delivery the row-select depends
+    on. This asserts both halves at once: the cursor moved, and the screen holds
+    no selection.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        view = await _open_page_with_catalogues(pilot, app)
+        before = view._selected
+
+        body = view._body
+        # A row several lines down in the body, resolved to a settable row.
+        x = body.region.x + 6
+        y = body.region.y + 5
+        await pilot._post_mouse_events(
+            [events.MouseDown, events.MouseUp, events.Click], offset=(x, y), button=1
+        )
+        await pilot.pause()
+
+        assert view._selected != before, "the click did not move the cursor"
+        assert view._rows[view._selected].selectable
+        assert len(app.screen.selections) == 0, (
+            "a text selection was armed by a plain row click: "
+            f"{[type(w).__name__ for w in app.screen.selections]}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_drag_across_the_list_arms_no_selection() -> None:
+    """Issue 1: dragging across the rows never paints the selection frame.
+
+    The drag is the gesture the report photographs — press on one row, move
+    across several — and the fingerprint of the bug is ``Screen.selections``
+    filling with the list ``Static``. With ``ALLOW_SELECT = False`` on the
+    chrome surfaces the walk skips them, so the map stays empty however far the
+    drag travels.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        view = await _open_page_with_catalogues(pilot, app)
+
+        body = view._body
+        x = body.region.x + 4
+        y0 = body.region.y + 1
+        await pilot._post_mouse_events([events.MouseDown], offset=(x, y0), button=1)
+        for dy in range(1, 6):
+            await pilot._post_mouse_events(
+                [events.MouseMove], offset=(x + dy * 3, y0 + dy), button=1
+            )
+        await pilot.pause()
+
+        assert len(app.screen.selections) == 0, (
+            "dragging over the settings list armed a text selection: "
+            f"{[type(w).__name__ for w in app.screen.selections]}"
+        )
+        await pilot._post_mouse_events([events.MouseUp], offset=(x + 15, y0 + 5), button=1)
+
+
+@pytest.mark.asyncio
+async def test_the_chrome_surfaces_opt_out_of_selection() -> None:
+    """Issue 1: every rendered surface of the page has ``allow_select`` False.
+
+    The list is the one the report shows, but a drag that overshot onto the
+    title, rule, detail line or side pane would resume the same highlight there
+    — so all of them are ``_ChromeStatic``. Asserted directly, because the drag
+    test above only exercises the list.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        view = await _open_page_with_catalogues(pilot, app)
+        for surface in (
+            view._list,
+            view._title,
+            view._rule,
+            view._detail,
+            view._pane_view,
+        ):
+            assert surface.allow_select is False, type(surface).__name__
+
+
+@pytest.mark.asyncio
+async def test_provider_suggestions_filter_and_ghost() -> None:
+    """Issue 2: the Default provider editor offers filtered provider suggestions.
+
+    Typing ``a`` narrows to the providers whose id or name matches, best first,
+    and the top match completes as inline ghost text after the caret. The
+    suggestions are the bounded login set, so this reads as an enum you can also
+    free-type past.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 34)) as pilot:
+        await pilot.pause()
+        view = await _open_page_with_catalogues(pilot, app)
+
+        _select(view, "hosting")
+        await pilot.press("enter")
+        # Clear the seeded value, then type a filter.
+        for _ in range(len(view._buffer)):
+            await pilot.press("backspace")
+        await pilot.press("a")
+        await pilot.pause()
+
+        labels = view.suggestion_labels_for_test()
+        assert labels, "typing 'a' offered no provider suggestions"
+        assert labels[0] == "anthropic", labels
+        # Ghost completes the top match after what was typed.
+        assert view.ghost_text_for_test() == "nthropic", view.ghost_text_for_test()
+
+
+@pytest.mark.asyncio
+async def test_provider_suggestion_accepts_and_saves(tmp_path: Path) -> None:
+    """Issue 2: arrowing to a provider and pressing Enter saves the bare id.
+
+    Enter on a live dropdown accepts the highlighted row into the buffer and
+    then commits it, so one Enter after arrowing stores that provider. ``hosting``
+    stores the BARE id, which is what the config file must carry.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 34)) as pilot:
+        await pilot.pause()
+        view = await _open_page_with_catalogues(pilot, app)
+
+        _select(view, "hosting")
+        await pilot.press("enter")
+        for _ in range(len(view._buffer)):
+            await pilot.press("backspace")
+        await pilot.press("o")  # openai / openrouter both match; openai first
+        await pilot.pause()
+        assert view.suggestion_labels_for_test()[0] == "openai"
+        # Arrow down one to openrouter, then Enter.
+        await pilot.press("down")
+        await pilot.pause()
+        target = view.suggestion_labels_for_test()[view.suggest_index_for_test]
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert _values(tmp_path).get("hosting") == target == "openrouter"
+        assert view.editing_key is None, "the editor stayed open after a save"
+
+
+@pytest.mark.asyncio
+async def test_model_suggestions_fuzzy_filter_and_tab_completes() -> None:
+    """Issue 2: the Default model editor fuzzy-filters the model catalogue.
+
+    Typing ``opus`` ranks the two rows that carry that id (direct and reseller)
+    via the SAME ``rank_rows`` the ``/model`` picker uses, showing the
+    ``provider/id`` selector as the label so the two are distinguishable. Tab
+    completes the highlighted row into the buffer without saving, as the model
+    picker's own Tab does — the value written is the BARE model id.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 34)) as pilot:
+        await pilot.pause()
+        view = await _open_page_with_catalogues(pilot, app)
+
+        _select(view, "model_name")
+        await pilot.press("enter")
+        for _ in range(len(view._buffer)):
+            await pilot.press("backspace")
+        for ch in "opus":
+            await pilot.press(ch)
+        await pilot.pause()
+
+        labels = view.suggestion_labels_for_test()
+        values = view.suggestion_values_for_test()
+        assert labels == ["anthropic/claude-opus-5", "openrouter/claude-opus-5"], labels
+        # The label shows the selector; the value stores the bare id.
+        assert values[0] == "claude-opus-5", values
+
+        await pilot.press("tab")
+        await pilot.pause()
+        # Tab completed the buffer to the bare id and did NOT save.
+        assert view._buffer == "claude-opus-5", view._buffer
+        assert view.editing_key == "model_name", "Tab saved instead of completing"
+
+
+@pytest.mark.asyncio
+async def test_a_custom_model_value_saves_without_a_matching_suggestion(tmp_path: Path) -> None:
+    """Issue 2: a value the catalogue does not know still coerces and saves.
+
+    Suggestions ASSIST, they do not constrain. A bespoke endpoint id matches
+    nothing, so the dropdown disappears — and Enter saves the typed text
+    directly through the unchanged ``_commit_edit``, exactly as the plain
+    free-text editor always did.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 34)) as pilot:
+        await pilot.pause()
+        view = await _open_page_with_catalogues(pilot, app)
+
+        _select(view, "model_name")
+        await pilot.press("enter")
+        for _ in range(len(view._buffer)):
+            await pilot.press("backspace")
+        for ch in "my-endpoint/custom-v2":
+            await pilot.press(ch)
+        await pilot.pause()
+
+        assert view.suggestion_labels_for_test() == [], "a custom value matched a suggestion"
+        assert view.ghost_text_for_test() == ""
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert _values(tmp_path).get("model_name") == "my-endpoint/custom-v2"
+        assert view.editing_key is None
+
+
+@pytest.mark.asyncio
+async def test_the_esc_ladder_closes_suggestions_before_the_editor() -> None:
+    """Issue 2: the first Esc closes the dropdown, the second cancels the editor.
+
+    The dropdown adds a rung to the page's Esc ladder (editor → chain →
+    expansion → page). A user who opened the list to look at it backs out of it
+    without losing what they typed; only a second Esc cancels the field. Typing
+    after the dismissal reopens the list, since editing is a request to filter.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 34)) as pilot:
+        await pilot.pause()
+        view = await _open_page_with_catalogues(pilot, app)
+
+        _select(view, "hosting")
+        await pilot.press("enter")
+        for _ in range(len(view._buffer)):
+            await pilot.press("backspace")
+        await pilot.press("a")
+        await pilot.pause()
+        assert view.suggestion_labels_for_test(), "no dropdown to dismiss"
+
+        # First Esc: dropdown closes, editor stays open with the buffer intact.
+        await pilot.press("escape")
+        await pilot.pause()
+        assert view.editing_key == "hosting", "the first Esc cancelled the editor"
+        assert view._suggest_dismissed is True
+        assert view._suggest_rows() == [], "the dropdown survived the first Esc"
+
+        # Typing reopens it — editing is a filter request.
+        await pilot.press("n")
+        await pilot.pause()
+        assert view._suggest_rows(), "typing did not reopen the dismissed dropdown"
+
+        # Dismiss again, then a second Esc cancels the editor.
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert view.editing_key is None, "the second Esc did not cancel the editor"
+
+
+@pytest.mark.asyncio
+async def test_right_at_end_accepts_the_ghost() -> None:
+    """Issue 2: right-arrow at the buffer's end accepts the inline ghost.
+
+    The composer's own gesture — the ghost previews what completing appends, and
+    pushing the caret past the tail takes it. Only when a ghost is actually shown
+    (caret at end, append-honest match); otherwise ``right`` is ordinary caret
+    movement.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 34)) as pilot:
+        await pilot.pause()
+        view = await _open_page_with_catalogues(pilot, app)
+
+        _select(view, "hosting")
+        await pilot.press("enter")
+        for _ in range(len(view._buffer)):
+            await pilot.press("backspace")
+        await pilot.press("a")
+        await pilot.pause()
+        assert view.ghost_text_for_test() == "nthropic"
+
+        await pilot.press("right")
+        await pilot.pause()
+        assert view._buffer == "anthropic", view._buffer
+
+
+@pytest.mark.asyncio
+async def test_suggestions_are_absent_without_an_injected_catalogue() -> None:
+    """Issue 2: with no catalogue, the two rows keep the plain free-text editor.
+
+    The catalogues are optional. A host that feeds neither (or a store read that
+    failed) falls the field back to the bare editor, which still saves — the
+    dropdown must never be an empty box in that case.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        # No catalogues injected.
+        app._open_settings_view()
+        view = app.query_one(SettingsView)
+        view.load(providers=[("anthropic", "signed in")])
+        await pilot.pause()
+
+        _select(view, "model_name")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert view.editing_key == "model_name"
+        assert view.suggestion_labels_for_test() == []
+        assert view._suggest_rows() == []


### PR DESCRIPTION
# PR Description

## Summary of Changes

Fixes two reported UX defects in the `/settings` full-page view:

1. **Clicking a setting painted a text-selection frame.** Textual 8.x arms a screen text-selection on the `MouseDown` of any widget whose `allow_select` is true (`Screen._forward_event`), so a click meant only to move the page cursor also began a drag whose grey highlight bled across the rows and their values. The settings page is chrome, not selectable content. A local `_ChromeStatic(ALLOW_SELECT = False)` — the same remedy `app.Chrome` applies to the status band and composer chevron — now backs every rendered surface (list, title, rule, detail, side pane), keeping them out of Textual's selection walk while leaving the row-select-on-click path and the cursor's own reverse ink untouched.

2. **Default provider and Default model were bare free-text fields.** Editing them offered no suggestions — a poor experience for two fields whose valid values are a known provider registry and a large model catalogue. They now open an **inline suggestion dropdown with ghost-text completion**, reusing the exact machinery behind `/model` and the slash-command composer: models are ranked by `model_picker.rank_rows`, providers by `autocomplete.score_command_text_match`, and the dimmed inline ghost by `command_picker.ghost_for`. Arrow keys browse, Tab / right-at-end / click complete, Enter accepts-then-saves, and Esc gains a rung in the existing ladder (close suggestions, then the editor). Because suggestions only assist, a custom value the catalogue does not know (a private endpoint id) still saves as typed.

Structural choice: an inline dropdown of unselectable `suggest` rows under the edited setting, reusing existing ranking/ghost helpers rather than introducing a new `Kind` or `choices_source`. `hosting`/`model_name` stay `Kind.TEXT`; the accepted value matches what each key stores (bare provider id / bare model id). The catalogues are fed from the same `/provider` login registry and `/model` catalogue via two new app-side resolvers, degrading to the plain editor when unavailable. `_ChromeStatic` is defined locally rather than imported from `app.Chrome` because `app` imports `settings_view` — importing back would close a cycle.

## Testing Evidence

### Real rendered frames (SVG exported via `run_test` + `save_screenshot`, viewed as PNG)

**Issue 1 — selection frame**

- Before: a grey drag-selection band bleeds across the rows and into the values.
- After: only the `›` row cursor is shown; no selection frame. Row-select-on-click still works.

**Issue 2 — provider suggestions**

- Typing `a` on Default provider shows ghost `nthropic` inline and a filtered suggestion list (`anthropic`, `alibaba`, `openai`, `mistral`, `radient`) with provider display names.

**Issue 2 — model suggestions**

- Typing `opus` on Default model shows the fuzzy-ranked catalogue (`anthropic/claude-opus-5 · anthropic · $15/75`, `openrouter/anthropic/claude-opus-5 · …`), mirroring `/model`'s columns and current-model marker, with ghost-text completion of the top row.

**Issue 2 — custom value**

- A value the catalogue does not know matches nothing, the dropdown closes, and the value saves as typed via the unchanged commit path.

(Rendered frames attached in the review thread.)

### Regression coverage

```text
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
    tests/unit/tui/test_settings_view.py -q
516 passed in 95.12s

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui -q
4118 passed, 12 skipped
```

17 new tests cover: click/drag arms no text-selection; every surface reports `allow_select=False`; provider and model suggestions filter, ghost, and accept via arrow/Tab; a custom (non-catalogue) model value still saves; the Esc ladder stays correct; and the no-catalogue fallback to a plain editor.

### Gates (whole tree, exactly as CI)

```text
flake8 .            → 0
black --check .      → 691 files unchanged (26.1.0)
isort --check .      → clean (5.13.2)
pyright .            → 0 errors, 0 warnings
```

## Versioning

Patch bump to `0.44.16`: a bug fix plus a small, self-contained UX improvement to two existing fields — no step-function capability. Rebased onto current `origin/main`.
