### PR TITLE
feat(evaluation): isolate benchmark adapters behind a verified process boundary

### DIFF
--- a/local_operator/evaluation/adapters/__init__.py
+++ b/local_operator/evaluation/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Out-of-process evaluation adapter boundary.
+
+The package root is intentionally inert: discovery and worker imports happen
+only when their explicit modules are requested.
+"""

--- a/local_operator/evaluation/adapters/api.py
+++ b/local_operator/evaluation/adapters/api.py
@@ -17,7 +17,7 @@ from typing import Any, Literal, Protocol, TypeAlias, runtime_checkable
 from pydantic import Field, field_validator, model_validator
 
 from local_operator.evaluation.evidence.models import ScoreArtifact, canonical_digest
-from local_operator.evaluation.lifecycle import CleanupPlan, CleanupReceipt
+from local_operator.evaluation.lifecycle import CleanupPlan
 from local_operator.evaluation.protocol import ActionBatch, Observation, ProtocolModel
 from local_operator.evaluation.receipts import (
     ZERO_DIGEST,
@@ -119,6 +119,7 @@ class AdapterSelector(ProtocolModel):
     release_digest: Digest
     python_executable: str = Field(min_length=1, max_length=4096)
     workspace: str = Field(min_length=1, max_length=4096)
+    workspace_digest: Digest
     route_capability: RouteCapability
 
     @field_validator("python_executable", "workspace")
@@ -216,6 +217,8 @@ class Handshake(ProtocolModel):
             raise ValueError("handshake does not repeat the exact adapter selection")
         if self.python.executable != selector.python_executable:
             raise ValueError("handshake resolved a different Python executable")
+        if self.workspace_digest != selector.workspace_digest:
+            raise ValueError("handshake workspace digest differs from selection")
         if self.selected_route != selector.route_capability:
             raise ValueError("handshake selected a different route")
         if self.selected_route not in metadata.capabilities.routes:
@@ -451,12 +454,21 @@ class CleanupParams(OperationParams):
         return self
 
 
-class CleanupResult(ProtocolModel):
-    receipts: tuple[CleanupReceipt, ...] = Field(max_length=MAX_RECEIPTS)
+class CleanupOutcome(ProtocolModel):
+    action_id: StrictIdentifier
+    status: Literal["not_needed", "attempted", "succeeded", "failed"]
+    evidence_code: StrictIdentifier
+    duration_ms: SafeCount
 
-    @field_validator("receipts", mode="before")
+
+class CleanupResult(ProtocolModel):
+    """Adapter evidence primitives; only the parent may mint receipts."""
+
+    outcomes: tuple[CleanupOutcome, ...] = Field(max_length=MAX_RECEIPTS)
+
+    @field_validator("outcomes", mode="before")
     @classmethod
-    def _freeze_receipts(cls, value: Any) -> Any:
+    def _freeze_outcomes(cls, value: Any) -> Any:
         return tuple(value) if isinstance(value, list) else value
 
 

--- a/local_operator/evaluation/adapters/api.py
+++ b/local_operator/evaluation/adapters/api.py
@@ -1,0 +1,556 @@
+"""Strict benchmark-neutral contracts shared by adapter hosts and workers.
+
+Adapters are untrusted infrastructure plugins.  This module therefore contains
+only immutable values, closed enums, and content-bound identities; importing it
+must not discover or import an adapter distribution.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Annotated, Any, Literal, Protocol, TypeAlias, runtime_checkable
+
+from pydantic import Field, field_validator, model_validator
+
+from local_operator.evaluation.evidence.models import ScoreArtifact, canonical_digest
+from local_operator.evaluation.lifecycle import CleanupPlan, CleanupReceipt
+from local_operator.evaluation.protocol import ActionBatch, Observation, ProtocolModel
+from local_operator.evaluation.receipts import (
+    ZERO_DIGEST,
+    Digest,
+    SafeCount,
+    StrictIdentifier,
+)
+
+ADAPTER_SCHEMA_VERSION = "1.0"
+ADAPTER_ENTRY_POINT_GROUP = "local_operator.evaluation_adapters.v1"
+MAX_RESCUE_REFS = 256
+MAX_REQUIREMENTS = 256
+MAX_RECEIPTS = 256
+
+AdapterMethod: TypeAlias = Literal[
+    "hello",
+    "inspect_requirements",
+    "prepare",
+    "reset_start",
+    "observe",
+    "execute",
+    "ask_user_exchange",
+    "score",
+    "cleanup",
+    "close",
+]
+AdapterState: TypeAlias = Literal[
+    "NEW",
+    "HANDSHAKEN",
+    "INSPECTED",
+    "PREPARED",
+    "RUNNING",
+    "FINALIZING",
+    "CLEANING",
+    "CLOSED",
+    "POISONED",
+]
+RouteCapability: TypeAlias = Literal["computer", "browser", "terminal"]
+
+# Both peers use this table.  Keeping it data, rather than distributed branches,
+# makes an invalid transition fail before plugin code can acquire authority.
+METHOD_STATES: Mapping[AdapterMethod, frozenset[AdapterState]] = {
+    "hello": frozenset({"NEW"}),
+    "inspect_requirements": frozenset({"HANDSHAKEN"}),
+    "prepare": frozenset({"INSPECTED"}),
+    "reset_start": frozenset({"PREPARED"}),
+    "observe": frozenset({"RUNNING"}),
+    "execute": frozenset({"RUNNING"}),
+    "ask_user_exchange": frozenset({"RUNNING"}),
+    "score": frozenset({"RUNNING", "FINALIZING"}),
+    "cleanup": frozenset({"PREPARED", "RUNNING", "FINALIZING", "CLEANING"}),
+    "close": frozenset(
+        {"HANDSHAKEN", "INSPECTED", "PREPARED", "RUNNING", "FINALIZING", "CLEANING"}
+    ),
+}
+METHOD_NEXT_STATE: Mapping[AdapterMethod, AdapterState] = {
+    "hello": "HANDSHAKEN",
+    "inspect_requirements": "INSPECTED",
+    "prepare": "PREPARED",
+    "reset_start": "RUNNING",
+    "observe": "RUNNING",
+    "execute": "RUNNING",
+    "ask_user_exchange": "RUNNING",
+    "score": "FINALIZING",
+    "cleanup": "CLEANING",
+    "close": "CLOSED",
+}
+KEYED_METHODS = frozenset(
+    {"prepare", "reset_start", "execute", "ask_user_exchange", "score", "cleanup", "close"}
+)
+READ_ONLY_METHODS = frozenset({"hello", "inspect_requirements", "observe"})
+
+
+def canonical_params_digest(method: AdapterMethod, params: ProtocolModel) -> Digest:
+    return canonical_digest(f"adapter-rpc-params-{method}-v1", params)
+
+
+class AdapterSelector(ProtocolModel):
+    """Exact wheel and interpreter selection; ranges and fallback are absent."""
+
+    schema_version: Literal["1.0"]
+    adapter_id: StrictIdentifier
+    distribution: StrictIdentifier
+    version: StrictIdentifier
+    entry_point: StrictIdentifier
+    package_digest: Digest
+    release_digest: Digest
+    python_executable: str = Field(min_length=1, max_length=4096)
+    workspace: str = Field(min_length=1, max_length=4096)
+    route_capability: RouteCapability
+
+    @field_validator("python_executable", "workspace")
+    @classmethod
+    def _absolute_path(cls, value: str) -> str:
+        if not os.path.isabs(value) or os.path.normpath(value) != value:
+            raise ValueError("adapter paths must be normalized absolute paths")
+        return value
+
+
+class AdapterCapabilities(ProtocolModel):
+    routes: tuple[RouteCapability, ...] = Field(min_length=1, max_length=3)
+    ask_user: bool
+    scoring: bool
+
+    @field_validator("routes", mode="before")
+    @classmethod
+    def _freeze_routes(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _unique_routes(self) -> "AdapterCapabilities":
+        if len(self.routes) != len(set(self.routes)):
+            raise ValueError("adapter routes must be unique")
+        return self
+
+
+class AdapterMetadata(ProtocolModel):
+    adapter_id: StrictIdentifier
+    distribution: StrictIdentifier
+    version: StrictIdentifier
+    entry_point: StrictIdentifier
+    package_digest: Digest
+    release_digest: Digest
+    schema_version: Literal["1.0"]
+    capabilities: AdapterCapabilities
+
+
+class PythonRuntime(ProtocolModel):
+    executable: str = Field(min_length=1, max_length=4096)
+    implementation: StrictIdentifier
+    version: StrictIdentifier
+    cache_tag: StrictIdentifier
+
+    @field_validator("executable")
+    @classmethod
+    def _absolute_executable(cls, value: str) -> str:
+        if not os.path.isabs(value) or os.path.normpath(value) != value:
+            raise ValueError("resolved Python executable must be normalized and absolute")
+        return value
+
+    @classmethod
+    def current(cls) -> "PythonRuntime":
+        cache_tag = sys.implementation.cache_tag
+        if cache_tag is None:
+            raise RuntimeError("selected Python does not expose a cache tag")
+        return cls(
+            executable=str(Path(sys.executable).resolve()),
+            implementation=platform.python_implementation(),
+            version=platform.python_version(),
+            cache_tag=cache_tag,
+        )
+
+
+class Handshake(ProtocolModel):
+    selector: AdapterSelector
+    metadata: AdapterMetadata
+    python: PythonRuntime
+    workspace_digest: Digest
+    selected_route: RouteCapability
+
+    @model_validator(mode="after")
+    def _repeat_exact_pins(self) -> "Handshake":
+        selector = self.selector
+        metadata = self.metadata
+        repeated = (
+            metadata.adapter_id,
+            metadata.distribution,
+            metadata.version,
+            metadata.entry_point,
+            metadata.package_digest,
+            metadata.release_digest,
+            metadata.schema_version,
+        )
+        selected = (
+            selector.adapter_id,
+            selector.distribution,
+            selector.version,
+            selector.entry_point,
+            selector.package_digest,
+            selector.release_digest,
+            selector.schema_version,
+        )
+        if repeated != selected:
+            raise ValueError("handshake does not repeat the exact adapter selection")
+        if self.python.executable != selector.python_executable:
+            raise ValueError("handshake resolved a different Python executable")
+        if self.selected_route != selector.route_capability:
+            raise ValueError("handshake selected a different route")
+        if self.selected_route not in metadata.capabilities.routes:
+            raise ValueError("selected route is not an adapter capability")
+        return self
+
+
+class SecretRef(ProtocolModel):
+    """An opaque name resolved by infrastructure, never secret bytes."""
+
+    name: str = Field(min_length=1, max_length=256, pattern=r"^[A-Z][A-Z0-9_]*$")
+
+
+InfraPurpose: TypeAlias = Literal[
+    "benchmark_auth",
+    "benchmark_compute",
+    "benchmark_storage",
+    "artifact_storage",
+]
+
+
+class ScopedInfraValue(ProtocolModel):
+    """Non-model infrastructure input with a closed, purpose-limited vocabulary."""
+
+    name: StrictIdentifier
+    purpose: InfraPurpose
+    value: str = Field(min_length=1, max_length=4096)
+
+
+class RescueDescriptor(ProtocolModel):
+    schema_version: Literal["1.0"]
+    selector: AdapterSelector
+    handshake: Handshake
+    episode_id: StrictIdentifier
+    cleanup_plan: CleanupPlan
+    secret_refs: tuple[SecretRef, ...] = Field(max_length=MAX_RESCUE_REFS)
+    infra_values: tuple[ScopedInfraValue, ...] = Field(max_length=MAX_RESCUE_REFS)
+    artifact_root: str = Field(min_length=1, max_length=4096)
+    descriptor_id: Digest = ZERO_DIGEST
+
+    @field_validator("secret_refs", "infra_values", mode="before")
+    @classmethod
+    def _freeze_refs(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+    @field_validator("artifact_root")
+    @classmethod
+    def _absolute_artifact_root(cls, value: str) -> str:
+        if not os.path.isabs(value) or os.path.normpath(value) != value:
+            raise ValueError("artifact root must be normalized and absolute")
+        return value
+
+    @model_validator(mode="after")
+    def _content_bind(self) -> "RescueDescriptor":
+        if self.handshake.selector != self.selector:
+            raise ValueError("rescue handshake and selector differ")
+        if self.cleanup_plan.episode_id != self.episode_id:
+            raise ValueError("rescue cleanup plan belongs to another episode")
+        refs = [item.name for item in self.secret_refs]
+        values = [(item.purpose, item.name) for item in self.infra_values]
+        if len(refs) != len(set(refs)) or len(values) != len(set(values)):
+            raise ValueError("rescue references must be unique")
+        expected = canonical_digest(
+            "adapter-rescue-descriptor-v1",
+            self.model_dump(mode="json", exclude={"descriptor_id"}),
+        )
+        if self.descriptor_id not in (ZERO_DIGEST, expected):
+            raise ValueError("rescue descriptor identity does not match its content")
+        object.__setattr__(self, "descriptor_id", expected)
+        return self
+
+
+class EmptyParams(ProtocolModel):
+    pass
+
+
+class HelloParams(ProtocolModel):
+    selector: AdapterSelector
+
+
+class InspectRequirementsParams(ProtocolModel):
+    pass
+
+
+class Requirement(ProtocolModel):
+    requirement_id: StrictIdentifier
+    kind: Literal["secret", "infra"]
+    name: StrictIdentifier
+    required: bool
+
+
+class RequirementsResult(ProtocolModel):
+    requirements: tuple[Requirement, ...] = Field(max_length=MAX_REQUIREMENTS)
+
+    @field_validator("requirements", mode="before")
+    @classmethod
+    def _freeze_requirements(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+
+class OperationParams(ProtocolModel):
+    operation_id: StrictIdentifier
+
+
+class PrepareParams(OperationParams):
+    episode_id: StrictIdentifier
+    secret_refs: tuple[SecretRef, ...] = Field(max_length=MAX_RESCUE_REFS)
+    infra_values: tuple[ScopedInfraValue, ...] = Field(max_length=MAX_RESCUE_REFS)
+
+    @field_validator("secret_refs", "infra_values", mode="before")
+    @classmethod
+    def _freeze_values(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+
+class PrepareResult(ProtocolModel):
+    cleanup_plan: CleanupPlan
+
+
+class ResetStartParams(OperationParams):
+    episode_id: StrictIdentifier
+
+
+class ObserveParams(ProtocolModel):
+    episode_id: StrictIdentifier
+
+
+class ObservationResult(ProtocolModel):
+    observation: Observation
+
+
+class ExecuteParams(OperationParams):
+    action_batch: ActionBatch
+    action_batch_id: Digest
+
+    @model_validator(mode="after")
+    def _bind_batch(self) -> "ExecuteParams":
+        expected = canonical_digest("adapter-action-batch-v1", self.action_batch)
+        if self.action_batch_id != expected:
+            raise ValueError("action batch identity does not match canonical batch")
+        return self
+
+
+class ExecutionReceipt(ProtocolModel):
+    operation_id: StrictIdentifier
+    action_batch_id: Digest
+    input_observation_id: StrictIdentifier
+    output_observation_id: StrictIdentifier
+    sequence: SafeCount
+    receipt_id: Digest = ZERO_DIGEST
+
+    @model_validator(mode="after")
+    def _identify(self) -> "ExecutionReceipt":
+        if self.input_observation_id == self.output_observation_id:
+            raise ValueError("execution must advance to a distinct observation")
+        expected = canonical_digest(
+            "adapter-execution-receipt-v1",
+            self.model_dump(mode="json", exclude={"receipt_id"}),
+        )
+        if self.receipt_id not in (ZERO_DIGEST, expected):
+            raise ValueError("execution receipt identity does not match content")
+        object.__setattr__(self, "receipt_id", expected)
+        return self
+
+
+class ExecuteResult(ProtocolModel):
+    observation: Observation
+    receipt: ExecutionReceipt
+
+
+class AskUserExchangeParams(OperationParams):
+    episode_id: StrictIdentifier
+    ask_id: StrictIdentifier
+    prompt: str = Field(min_length=1, max_length=100_000)
+    answer: str | None = Field(default=None, min_length=1, max_length=100_000)
+
+
+class AskUserExchangeResult(ProtocolModel):
+    ask_id: StrictIdentifier
+    accepted: bool
+
+
+class ScoreParams(OperationParams):
+    episode_id: StrictIdentifier
+
+
+class ScoreResult(ProtocolModel):
+    score: ScoreArtifact
+
+
+class CleanupParams(OperationParams):
+    cleanup_plan: CleanupPlan
+    action_ids: tuple[StrictIdentifier, ...] = Field(min_length=1, max_length=MAX_RECEIPTS)
+
+    @field_validator("action_ids", mode="before")
+    @classmethod
+    def _freeze_actions(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _selected_actions_exist(self) -> "CleanupParams":
+        if len(self.action_ids) != len(set(self.action_ids)):
+            raise ValueError("cleanup selection contains duplicate action IDs")
+        known = {item.action_id for item in self.cleanup_plan.actions}
+        if not set(self.action_ids) <= known:
+            raise ValueError("cleanup selection contains unknown action IDs")
+        return self
+
+
+class CleanupResult(ProtocolModel):
+    receipts: tuple[CleanupReceipt, ...] = Field(max_length=MAX_RECEIPTS)
+
+    @field_validator("receipts", mode="before")
+    @classmethod
+    def _freeze_receipts(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+
+class CloseParams(OperationParams):
+    episode_id: StrictIdentifier | None = None
+
+
+class AckResult(ProtocolModel):
+    accepted: Literal[True] = True
+
+
+AdapterParams: TypeAlias = (
+    HelloParams
+    | InspectRequirementsParams
+    | PrepareParams
+    | ResetStartParams
+    | ObserveParams
+    | ExecuteParams
+    | AskUserExchangeParams
+    | ScoreParams
+    | CleanupParams
+    | CloseParams
+)
+AdapterResult: TypeAlias = (
+    Handshake
+    | RequirementsResult
+    | PrepareResult
+    | ObservationResult
+    | ExecuteResult
+    | AskUserExchangeResult
+    | ScoreResult
+    | CleanupResult
+    | AckResult
+)
+PARAM_MODELS: Mapping[AdapterMethod, type[ProtocolModel]] = {
+    "hello": HelloParams,
+    "inspect_requirements": InspectRequirementsParams,
+    "prepare": PrepareParams,
+    "reset_start": ResetStartParams,
+    "observe": ObserveParams,
+    "execute": ExecuteParams,
+    "ask_user_exchange": AskUserExchangeParams,
+    "score": ScoreParams,
+    "cleanup": CleanupParams,
+    "close": CloseParams,
+}
+RESULT_MODELS: Mapping[AdapterMethod, type[ProtocolModel]] = {
+    "hello": Handshake,
+    "inspect_requirements": RequirementsResult,
+    "prepare": PrepareResult,
+    "reset_start": AckResult,
+    "observe": ObservationResult,
+    "execute": ExecuteResult,
+    "ask_user_exchange": AskUserExchangeResult,
+    "score": ScoreResult,
+    "cleanup": CleanupResult,
+    "close": AckResult,
+}
+
+
+class ReplayEntry(ProtocolModel):
+    request_id: int = Field(gt=0, le=2**53 - 1)
+    method: AdapterMethod
+    params_digest: Digest
+    operation_id: StrictIdentifier | None = None
+
+    @model_validator(mode="after")
+    def _keyed_operation(self) -> "ReplayEntry":
+        if (self.method in KEYED_METHODS) != (self.operation_id is not None):
+            raise ValueError("only keyed methods carry operation IDs")
+        return self
+
+
+@runtime_checkable
+class EvaluationAdapter(Protocol):
+    """Async benchmark implementation loaded only inside the worker."""
+
+    metadata: AdapterMetadata
+
+    async def inspect_requirements(
+        self, params: InspectRequirementsParams
+    ) -> RequirementsResult: ...
+
+    async def prepare(self, params: PrepareParams) -> PrepareResult: ...
+
+    async def reset_start(self, params: ResetStartParams) -> AckResult: ...
+
+    async def observe(self, params: ObserveParams) -> ObservationResult: ...
+
+    async def execute(self, params: ExecuteParams) -> ExecuteResult: ...
+
+    async def ask_user_exchange(self, params: AskUserExchangeParams) -> AskUserExchangeResult: ...
+
+    async def score(self, params: ScoreParams) -> ScoreResult: ...
+
+    async def cleanup(self, params: CleanupParams) -> CleanupResult: ...
+
+    async def close(self, params: CloseParams) -> AckResult: ...
+
+
+def observation_content_id(observation: Observation) -> Digest:
+    """Identify adapter content while excluding its self-asserted identifier."""
+
+    return canonical_digest(
+        "adapter-observation-v1",
+        observation.model_dump(mode="json", exclude={"observation_id"}),
+    )
+
+
+def validate_observation(observation: Observation) -> None:
+    if observation.observation_id != observation_content_id(observation):
+        raise ValueError("observation identity does not match canonical content")
+
+
+def validate_execution(
+    params: ExecuteParams,
+    result: ExecuteResult,
+    current: Observation,
+    *,
+    seen_sequences: set[int],
+) -> None:
+    params.action_batch.validate_for(current)
+    validate_observation(result.observation)
+    receipt = result.receipt
+    if receipt.operation_id != params.operation_id:
+        raise ValueError("execution receipt operation ID differs")
+    if receipt.action_batch_id != params.action_batch_id:
+        raise ValueError("execution receipt action batch ID differs")
+    if receipt.input_observation_id != current.observation_id:
+        raise ValueError("execution receipt input observation differs")
+    if receipt.output_observation_id != result.observation.observation_id:
+        raise ValueError("execution receipt output observation differs")
+    if receipt.sequence != result.observation.sequence or receipt.sequence in seen_sequences:
+        raise ValueError("execution receipt sequence is stale or duplicated")

--- a/local_operator/evaluation/adapters/api.py
+++ b/local_operator/evaluation/adapters/api.py
@@ -7,13 +7,12 @@ must not discover or import an adapter distribution.
 
 from __future__ import annotations
 
-import hashlib
 import os
 import platform
 import sys
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Annotated, Any, Literal, Protocol, TypeAlias, runtime_checkable
+from typing import Any, Literal, Protocol, TypeAlias, runtime_checkable
 
 from pydantic import Field, field_validator, model_validator
 

--- a/local_operator/evaluation/adapters/api.py
+++ b/local_operator/evaluation/adapters/api.py
@@ -35,6 +35,7 @@ MAX_RECEIPTS = 256
 AdapterMethod: TypeAlias = Literal[
     "hello",
     "inspect_requirements",
+    "begin_rescue",
     "prepare",
     "reset_start",
     "observe",
@@ -62,6 +63,7 @@ RouteCapability: TypeAlias = Literal["computer", "browser", "terminal"]
 METHOD_STATES: Mapping[AdapterMethod, frozenset[AdapterState]] = {
     "hello": frozenset({"NEW"}),
     "inspect_requirements": frozenset({"HANDSHAKEN"}),
+    "begin_rescue": frozenset({"HANDSHAKEN"}),
     "prepare": frozenset({"INSPECTED"}),
     "reset_start": frozenset({"PREPARED"}),
     "observe": frozenset({"RUNNING"}),
@@ -76,6 +78,7 @@ METHOD_STATES: Mapping[AdapterMethod, frozenset[AdapterState]] = {
 METHOD_NEXT_STATE: Mapping[AdapterMethod, AdapterState] = {
     "hello": "HANDSHAKEN",
     "inspect_requirements": "INSPECTED",
+    "begin_rescue": "CLEANING",
     "prepare": "PREPARED",
     "reset_start": "RUNNING",
     "observe": "RUNNING",
@@ -86,7 +89,16 @@ METHOD_NEXT_STATE: Mapping[AdapterMethod, AdapterState] = {
     "close": "CLOSED",
 }
 KEYED_METHODS = frozenset(
-    {"prepare", "reset_start", "execute", "ask_user_exchange", "score", "cleanup", "close"}
+    {
+        "begin_rescue",
+        "prepare",
+        "reset_start",
+        "execute",
+        "ask_user_exchange",
+        "score",
+        "cleanup",
+        "close",
+    }
 )
 READ_ONLY_METHODS = frozenset({"hello", "inspect_requirements", "observe"})
 
@@ -308,6 +320,31 @@ class OperationParams(ProtocolModel):
     operation_id: StrictIdentifier
 
 
+class BeginRescueParams(OperationParams):
+    """Content pins only; the worker receives no resolved secret material."""
+
+    descriptor: RescueDescriptor
+    descriptor_id: Digest
+    episode_id: StrictIdentifier
+    cleanup_plan_id: Digest
+    selector_digest: Digest
+    handshake_digest: Digest
+
+    @model_validator(mode="after")
+    def _bind_descriptor(self) -> "BeginRescueParams":
+        if (
+            self.descriptor_id != self.descriptor.descriptor_id
+            or self.episode_id != self.descriptor.episode_id
+            or self.cleanup_plan_id != self.descriptor.cleanup_plan.cleanup_plan_id
+            or self.selector_digest
+            != canonical_digest("adapter-rescue-selector-v1", self.descriptor.selector)
+            or self.handshake_digest
+            != canonical_digest("adapter-rescue-handshake-v1", self.descriptor.handshake)
+        ):
+            raise ValueError("rescue initialization pins differ from descriptor")
+        return self
+
+
 class PrepareParams(OperationParams):
     episode_id: StrictIdentifier
     secret_refs: tuple[SecretRef, ...] = Field(max_length=MAX_RESCUE_REFS)
@@ -324,6 +361,7 @@ class PrepareResult(ProtocolModel):
 
 
 class ResetStartParams(OperationParams):
+    task_id: StrictIdentifier
     episode_id: StrictIdentifier
 
 
@@ -433,6 +471,7 @@ class AckResult(ProtocolModel):
 AdapterParams: TypeAlias = (
     HelloParams
     | InspectRequirementsParams
+    | BeginRescueParams
     | PrepareParams
     | ResetStartParams
     | ObserveParams
@@ -456,6 +495,7 @@ AdapterResult: TypeAlias = (
 PARAM_MODELS: Mapping[AdapterMethod, type[ProtocolModel]] = {
     "hello": HelloParams,
     "inspect_requirements": InspectRequirementsParams,
+    "begin_rescue": BeginRescueParams,
     "prepare": PrepareParams,
     "reset_start": ResetStartParams,
     "observe": ObserveParams,
@@ -468,6 +508,7 @@ PARAM_MODELS: Mapping[AdapterMethod, type[ProtocolModel]] = {
 RESULT_MODELS: Mapping[AdapterMethod, type[ProtocolModel]] = {
     "hello": Handshake,
     "inspect_requirements": RequirementsResult,
+    "begin_rescue": AckResult,
     "prepare": PrepareResult,
     "reset_start": AckResult,
     "observe": ObservationResult,

--- a/local_operator/evaluation/adapters/discovery.py
+++ b/local_operator/evaluation/adapters/discovery.py
@@ -395,16 +395,19 @@ class _VerifiedDistributionFinder:
     pydantic, local_operator itself) returns ``None`` here and proceeds through
     the normal machinery untouched.
 
-    Coverage boundary, measured rather than assumed: the finder is active for
-    the duration of the load, so it governs the entry module, its ancestors, and
-    anything they import while executing — including imports inside the factory
-    call. It does NOT govern an import an adapter defers until after loading has
-    returned, because by then the finder has been removed so it cannot dictate
-    the worker's later imports. Modules already imported under it stay verified
-    in ``sys.modules``; a genuinely new deferred import would fall back to the
-    ordinary loader. Closing that remaining window means keeping the adapter's
-    own modules unresolvable afterwards, which is a separate decision about
-    worker-lifetime import policy, not part of load verification.
+    What this actually guarantees, stated precisely: load-time verification
+    binds the adapter's INITIAL MODULE GRAPH to the RECORD digest, so a result
+    can be attributed to an exact ``package_digest`` for reproducible
+    evaluation. It is NOT a runtime import sandbox. The finder is active only
+    for the duration of the load, so it governs the entry module, its ancestors,
+    and anything they import while executing, including imports inside the
+    factory call; an import an adapter defers until after loading returns falls
+    back to the ordinary loader. Modules already imported under the finder stay
+    verified in ``sys.modules``. Closing that window would mean governing
+    worker-lifetime imports, which is a separate policy decision, and it buys
+    little against the real threat model: an adapter is already arbitrary code
+    in an isolated worker and can simply inline whatever it wants in its own
+    verified source.
     """
 
     def __init__(
@@ -425,6 +428,25 @@ class _VerifiedDistributionFinder:
     def owned_roots(self) -> frozenset[str]:
         return frozenset(self._owned)
 
+    def _refuse_unrecorded_artifacts(self, stem: str) -> None:
+        """Reject any importable file at a stem RECORD does not cover.
+
+        The suffix list is taken from the running interpreter rather than
+        hardcoded, so a build that recognises additional extension suffixes
+        cannot smuggle one past a stale literal.
+        """
+
+        suffixes = [
+            *importlib.machinery.SOURCE_SUFFIXES,
+            *importlib.machinery.BYTECODE_SUFFIXES,
+            *importlib.machinery.EXTENSION_SUFFIXES,
+        ]
+        for suffix in suffixes:
+            if Path(str(self._distribution.locate_file(f"{stem}{suffix}"))).exists():
+                raise AdapterDiscoveryError("adapter module is not RECORD-covered")
+            if Path(str(self._distribution.locate_file(f"{stem}/__init__{suffix}"))).exists():
+                raise AdapterDiscoveryError("adapter package init is not RECORD-covered")
+
     def find_spec(self, fullname: str, path: Any = None, target: Any = None) -> Any:
         del path, target
         if fullname.split(".")[0] not in self._owned:
@@ -440,11 +462,14 @@ class _VerifiedDistributionFinder:
             raise AdapterDiscoveryError("adapter module is ambiguously RECORD-covered")
         if not matches:
             # A directory with no recorded __init__ is a genuine namespace
-            # package; anything else present on disk is unrecorded code.
-            if Path(str(self._distribution.locate_file(package_init))).exists():
-                raise AdapterDiscoveryError("adapter package init is not RECORD-covered")
-            if Path(str(self._distribution.locate_file(module_file))).exists():
-                raise AdapterDiscoveryError("adapter module is not RECORD-covered")
+            # package; anything else importable on disk is unrecorded code.
+            # Probing only the two .py names would hand the name back to the
+            # ordinary machinery, where a planted sourceless .pyc or extension
+            # module executes with no hash consulted at all -- a weaker
+            # precondition than a forged cache, since it needs only a file
+            # write. Refuse every importable artifact rather than trying to
+            # verify bytecode we have no recorded source for.
+            self._refuse_unrecorded_artifacts(stem)
             return None
         relative = matches[0]
         verified_path, source = _verify_recorded_file(self._distribution, self._rows, relative)
@@ -506,14 +531,12 @@ def load_selected_adapter(selector: AdapterSelector) -> EvaluationAdapter:
         # the entry module, its ancestors, and anything they import later during
         # execution — is served from verified bytes, so `.load()` and the
         # ordinary loader never get a chance to run a cached artifact.
-        with _verified_imports(distribution, rows):
-            for stale in [
-                name
-                for name in sys.modules
-                if name == module_name.split(".")[0]
-                or name.startswith(f"{module_name.split('.')[0]}.")
-            ]:
-                # A pre-existing entry would otherwise be returned unverified.
+        with _verified_imports(distribution, rows) as finder:
+            for stale in [name for name in sys.modules if name.split(".")[0] in finder.owned_roots]:
+                # A pre-existing entry short-circuits importlib, so the adapter
+                # would bind an object the finder never verified. The purge has
+                # to span every root the finder claims, not just the entry
+                # module's, or a second owned root survives unverified.
                 del sys.modules[stale]
             loaded = importlib.import_module(module_name)
             factory = cast(Callable[[], Any], getattr(loaded, attribute))

--- a/local_operator/evaluation/adapters/discovery.py
+++ b/local_operator/evaluation/adapters/discovery.py
@@ -299,25 +299,69 @@ def verify_distribution(selector: AdapterSelector) -> importlib.metadata.Distrib
     return distribution
 
 
-def _module_stem(filename: str) -> str:
-    """Strip an importable suffix so a file name yields its module name.
-
-    Extension suffixes are checked longest-first because ``.abi3.so`` and
-    ``.so`` overlap, and the shorter one would otherwise leave ``.abi3``
-    attached and silently fail the identifier test. Handling extensions here is
-    what makes an owned root independent of whether the module ships as source
-    or as a compiled artifact.
-    """
-
-    suffixes = sorted(
-        [*importlib.machinery.SOURCE_SUFFIXES, *importlib.machinery.EXTENSION_SUFFIXES],
+# Longest-first because ``.abi3.so`` and ``.so`` overlap: the shorter match
+# would leave ``.abi3`` attached and silently fail the identifier test. Computed
+# once here rather than per call, since the interpreter's suffixes are fixed for
+# the life of the process.
+_IMPORTABLE_SUFFIXES: tuple[str, ...] = tuple(
+    sorted(
+        {*importlib.machinery.SOURCE_SUFFIXES, *importlib.machinery.EXTENSION_SUFFIXES},
         key=len,
         reverse=True,
     )
-    for suffix in suffixes:
+)
+
+
+def _module_stem(filename: str) -> str:
+    """Strip an importable suffix so a file name yields its module name.
+
+    Handling extensions here is what makes an owned root independent of whether
+    the module ships as source or as a compiled artifact.
+    """
+
+    for suffix in _IMPORTABLE_SUFFIXES:
         if filename.endswith(suffix):
             return filename[: -len(suffix)]
     return filename
+
+
+def _resolve_module_artifact(
+    stem: str, rows: dict[str, list[str]], distribution: importlib.metadata.Distribution
+) -> tuple[str, bool] | None:
+    """Pick the one artifact to load for a module stem, or None when absent.
+
+    Returns the RECORD-relative path and whether it is a package init.
+
+    mypyc- and Cython-built wheels ship BOTH ``mod.py`` and ``mod<EXT>`` for the
+    same stem -- black, tomli and charset-normalizer all do -- so treating that
+    pair as ambiguous would refuse ordinary wheels. Source WINS: it executes
+    from the in-memory bytes that were hashed, which is the stronger of the two
+    verification paths, and it is what the import system would have used.
+
+    Genuine ambiguity is narrower and is still refused: a stem whose source sits
+    on disk UNRECORDED while an extension is recorded, because then the artifact
+    the import system would prefer is precisely the one RECORD does not attest
+    to, and silently loading the extension would misrepresent what ran.
+    """
+
+    for is_package, base in ((False, stem), (True, f"{stem}/__init__")):
+        source = f"{base}.py"
+        extensions = sorted(
+            f"{base}{suffix}"
+            for suffix in importlib.machinery.EXTENSION_SUFFIXES
+            if f"{base}{suffix}" in rows
+        )
+        if source in rows:
+            return source, is_package
+        if extensions:
+            if Path(str(distribution.locate_file(source))).exists():
+                raise AdapterDiscoveryError(
+                    "adapter module source is present but not RECORD-covered"
+                )
+            if len(extensions) > 1:
+                raise AdapterDiscoveryError("adapter module is ambiguously RECORD-covered")
+            return extensions[0], is_package
+    return None
 
 
 def _verify_recorded_file(
@@ -360,8 +404,10 @@ def _verified_entry_target(
     if not all(part.isidentifier() for part in parts):
         raise AdapterDiscoveryError("adapter entry module is not a dotted identifier")
     rows = {row[0]: row for row in _record_rows(distribution)}
-    candidates = {f"{'/'.join(parts)}.py", f"{'/'.join(parts)}/__init__.py"}
-    if len(candidates & rows.keys()) != 1:
+    # Resolved with the same rule the finder uses, so a compiled-only entry
+    # module is admitted exactly like a compiled-only submodule; a gate that
+    # accepted a narrower set here would refuse adapters the loader can load.
+    if _resolve_module_artifact("/".join(parts), rows, distribution) is None:
         raise AdapterDiscoveryError("adapter entry module is not uniquely RECORD-covered")
     return module, attribute
 
@@ -498,14 +544,8 @@ class _VerifiedDistributionFinder:
         # would reject the very artifact the pin attests to. Bytecode is
         # deliberately absent: a `.pyc` is never a match, so it always falls
         # through to refusal.
-        candidates: dict[str, bool] = {f"{stem}.py": False, f"{stem}/__init__.py": True}
-        for suffix in importlib.machinery.EXTENSION_SUFFIXES:
-            candidates[f"{stem}{suffix}"] = False
-            candidates[f"{stem}/__init__{suffix}"] = True
-        matches = sorted(candidates.keys() & self._rows.keys())
-        if len(matches) > 1:
-            raise AdapterDiscoveryError("adapter module is ambiguously RECORD-covered")
-        if not matches:
+        resolved = _resolve_module_artifact(stem, self._rows, self._distribution)
+        if resolved is None:
             # A directory with no recorded __init__ is a genuine namespace
             # package; anything else importable on disk is unrecorded code.
             # Probing only the two .py names would hand the name back to the
@@ -516,9 +556,8 @@ class _VerifiedDistributionFinder:
             # verify bytecode we have no recorded source for.
             self._refuse_unrecorded_artifacts(stem)
             return None
-        relative = matches[0]
+        relative, is_package = resolved
         verified_path, source = _verify_recorded_file(self._distribution, self._rows, relative)
-        is_package = candidates[relative]
         search = [str(verified_path.parent)] if is_package else None
         if relative.endswith(".py"):
             return importlib.util.spec_from_file_location(

--- a/local_operator/evaluation/adapters/discovery.py
+++ b/local_operator/evaluation/adapters/discovery.py
@@ -371,6 +371,13 @@ class _VerifiedSourceLoader:
         code = compile(self._source, str(self._path), "exec", dont_inherit=True)
         exec(code, module.__dict__)
 
+    def load_module(self, fullname: str) -> ModuleType:
+        # Part of the legacy loader protocol. It is refused rather than
+        # implemented because it would reintroduce the caching path this loader
+        # exists to avoid.
+        del fullname
+        raise AdapterDiscoveryError("adapter modules load only through exec_module")
+
 
 class _VerifiedDistributionFinder:
     """Serve only RECORD-covered source for one distribution's own modules.

--- a/local_operator/evaluation/adapters/discovery.py
+++ b/local_operator/evaluation/adapters/discovery.py
@@ -9,6 +9,7 @@ import importlib.metadata
 import os
 import stat
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
@@ -24,26 +25,89 @@ class AdapterDiscoveryError(RuntimeError):
     """A closed discovery failure safe to report across the RPC boundary."""
 
 
-def validate_launch_paths(selector: AdapterSelector) -> None:
-    """Reject aliases and non-regular interpreters before a process is started."""
+@dataclass(frozen=True)
+class ResolvedLaunch:
+    executable: str
+    executable_device: int
+    executable_inode: int
+    executable_mode: int
+    workspace: str
+    workspace_device: int
+    workspace_inode: int
+    workspace_mode: int
+
+
+def _symlink_free(path: Path) -> os.stat_result:
+    if not path.is_absolute() or os.path.normpath(str(path)) != str(path):
+        raise AdapterDiscoveryError("adapter launch path must be normalized and absolute")
+    try:
+        if path.resolve(strict=True) != path:
+            raise AdapterDiscoveryError("adapter launch path has a symlink or lexical alias")
+        current = Path(path.anchor)
+        for component in path.parts[1:]:
+            current /= component
+            info = os.lstat(current)
+            if stat.S_ISLNK(info.st_mode):
+                raise AdapterDiscoveryError("adapter launch path contains a symlink")
+        return os.lstat(path)
+    except AdapterDiscoveryError:
+        raise
+    except OSError as error:
+        raise AdapterDiscoveryError("adapter launch path is unavailable") from error
+
+
+def resolve_launch(selector: AdapterSelector) -> ResolvedLaunch:
+    """Capture symlink-free identities for both spawn boundaries to recheck."""
 
     executable = Path(selector.python_executable)
     workspace = Path(selector.workspace)
-    if not executable.is_absolute() or not workspace.is_absolute():
-        raise AdapterDiscoveryError("adapter launch paths must be absolute")
-    try:
-        executable_info = executable.stat()
-        workspace_info = workspace.stat()
-    except OSError as error:
-        raise AdapterDiscoveryError("adapter launch path is unavailable") from error
+    executable_info = _symlink_free(executable)
+    workspace_info = _symlink_free(workspace)
     if not stat.S_ISREG(executable_info.st_mode) or not os.access(executable, os.X_OK):
         raise AdapterDiscoveryError("adapter Python is not an executable regular file")
     if not stat.S_ISDIR(workspace_info.st_mode):
         raise AdapterDiscoveryError("adapter workspace is not a directory")
+    return ResolvedLaunch(
+        executable=str(executable),
+        executable_device=executable_info.st_dev,
+        executable_inode=executable_info.st_ino,
+        executable_mode=executable_info.st_mode,
+        workspace=str(workspace),
+        workspace_device=workspace_info.st_dev,
+        workspace_inode=workspace_info.st_ino,
+        workspace_mode=workspace_info.st_mode,
+    )
+
+
+def validate_resolved_launch(launch: ResolvedLaunch) -> None:
+    executable_info = _symlink_free(Path(launch.executable))
+    workspace_info = _symlink_free(Path(launch.workspace))
+    current = (
+        executable_info.st_dev,
+        executable_info.st_ino,
+        executable_info.st_mode,
+        workspace_info.st_dev,
+        workspace_info.st_ino,
+        workspace_info.st_mode,
+    )
+    expected = (
+        launch.executable_device,
+        launch.executable_inode,
+        launch.executable_mode,
+        launch.workspace_device,
+        launch.workspace_inode,
+        launch.workspace_mode,
+    )
+    if current != expected:
+        raise AdapterDiscoveryError("adapter launch path identity changed before spawn")
+
+
+def validate_launch_paths(selector: AdapterSelector) -> None:
+    resolve_launch(selector)
 
 
 def worker_argv(selector: AdapterSelector) -> tuple[str, ...]:
-    validate_launch_paths(selector)
+    resolve_launch(selector)
     # Isolation flags prevent user site, PYTHON* variables, and current-directory
     # imports from changing which exact wheel the worker verifies.
     return (

--- a/local_operator/evaluation/adapters/discovery.py
+++ b/local_operator/evaluation/adapters/discovery.py
@@ -39,7 +39,6 @@ class ResolvedLaunch:
     executable_mode: int
     executable_size: int
     executable_sha256: str
-    executable_nlink: int
     workspace: str
     workspace_device: int
     workspace_inode: int
@@ -47,6 +46,9 @@ class ResolvedLaunch:
 
 
 def _symlink_free(path: Path) -> os.stat_result:
+    # The selector must name the resolved real interpreter and workspace, not a
+    # convenience alias: a symlink or lexical alias is exactly the substitution
+    # the dev/inode/content pins below are meant to detect.
     if not path.is_absolute() or os.path.normpath(str(path)) != str(path):
         raise AdapterDiscoveryError("adapter launch path must be normalized and absolute")
     try:
@@ -80,12 +82,12 @@ def resolve_launch(selector: AdapterSelector) -> ResolvedLaunch:
     workspace = Path(selector.workspace)
     executable_info = _symlink_free(executable)
     workspace_info = _symlink_free(workspace)
-    if (
-        not stat.S_ISREG(executable_info.st_mode)
-        or executable_info.st_nlink != 1
-        or not os.access(executable, os.X_OK)
-    ):
-        raise AdapterDiscoveryError("adapter Python must be one executable non-hardlinked file")
+    # A link count is a packaging detail, never an integrity property: CPython
+    # ships python/python3/python3.N as hardlinks to one inode, so requiring
+    # nlink==1 rejects every normal uv and system interpreter. Substitution is
+    # caught by the device/inode/mode/size/sha256 pins revalidated before spawn.
+    if not stat.S_ISREG(executable_info.st_mode) or not os.access(executable, os.X_OK):
+        raise AdapterDiscoveryError("adapter Python is not an executable regular file")
     executable_digest = _file_sha256(executable)
     if not stat.S_ISDIR(workspace_info.st_mode):
         raise AdapterDiscoveryError("adapter workspace is not a directory")
@@ -96,7 +98,6 @@ def resolve_launch(selector: AdapterSelector) -> ResolvedLaunch:
         executable_mode=executable_info.st_mode,
         executable_size=executable_info.st_size,
         executable_sha256=executable_digest,
-        executable_nlink=executable_info.st_nlink,
         workspace=str(workspace),
         workspace_device=workspace_info.st_dev,
         workspace_inode=workspace_info.st_ino,
@@ -107,7 +108,7 @@ def resolve_launch(selector: AdapterSelector) -> ResolvedLaunch:
 def validate_resolved_launch(launch: ResolvedLaunch) -> None:
     executable_info = _symlink_free(Path(launch.executable))
     workspace_info = _symlink_free(Path(launch.workspace))
-    if not stat.S_ISREG(executable_info.st_mode) or executable_info.st_nlink != 1:
+    if not stat.S_ISREG(executable_info.st_mode):
         raise AdapterDiscoveryError("adapter Python identity is unsafe")
     executable_digest = _file_sha256(Path(launch.executable))
     current = (
@@ -116,7 +117,6 @@ def validate_resolved_launch(launch: ResolvedLaunch) -> None:
         executable_info.st_mode,
         executable_info.st_size,
         executable_digest,
-        executable_info.st_nlink,
         workspace_info.st_dev,
         workspace_info.st_ino,
         workspace_info.st_mode,
@@ -127,7 +127,6 @@ def validate_resolved_launch(launch: ResolvedLaunch) -> None:
         launch.executable_mode,
         launch.executable_size,
         launch.executable_sha256,
-        launch.executable_nlink,
         launch.workspace_device,
         launch.workspace_inode,
         launch.workspace_mode,
@@ -137,7 +136,20 @@ def validate_resolved_launch(launch: ResolvedLaunch) -> None:
 
 
 def workspace_digest(path: str) -> str:
-    """Hash every immutable workspace file without following special entries."""
+    """Hash every immutable workspace file without following special entries.
+
+    The caps are a deliberate launch-time bound, not a performance target: at
+    the 4 GiB ceiling this streams for roughly four seconds once per launch and
+    per handshake, never during ordinary startup. A hardlinked workspace file
+    stays fatal here because a second name for adapter content is a mutation
+    channel the manifest cannot observe, unlike the interpreter, whose content
+    is pinned by digest.
+
+    The workspace is hashed at resolution and re-hashed by the worker during the
+    handshake, but it is not re-verified immediately before spawn the way the
+    executable identity is. That asymmetry is a known, deliberate gap for a
+    later round to close or accept explicitly.
+    """
 
     root = Path(path)
     root_info = _symlink_free(root)

--- a/local_operator/evaluation/adapters/discovery.py
+++ b/local_operator/evaluation/adapters/discovery.py
@@ -6,6 +6,8 @@ import base64
 import csv
 import hashlib
 import importlib.metadata
+import inspect
+import json
 import os
 import stat
 from collections.abc import Callable
@@ -20,6 +22,10 @@ from local_operator.evaluation.adapters.api import (
 )
 from local_operator.evaluation.evidence.models import canonical_digest
 
+MAX_WORKSPACE_FILES = 100_000
+MAX_WORKSPACE_BYTES = 4 * 1024 * 1024 * 1024
+RELEASE_MANIFEST = "adapter-release.json"
+
 
 class AdapterDiscoveryError(RuntimeError):
     """A closed discovery failure safe to report across the RPC boundary."""
@@ -31,6 +37,9 @@ class ResolvedLaunch:
     executable_device: int
     executable_inode: int
     executable_mode: int
+    executable_size: int
+    executable_sha256: str
+    executable_nlink: int
     workspace: str
     workspace_device: int
     workspace_inode: int
@@ -63,8 +72,16 @@ def resolve_launch(selector: AdapterSelector) -> ResolvedLaunch:
     workspace = Path(selector.workspace)
     executable_info = _symlink_free(executable)
     workspace_info = _symlink_free(workspace)
-    if not stat.S_ISREG(executable_info.st_mode) or not os.access(executable, os.X_OK):
-        raise AdapterDiscoveryError("adapter Python is not an executable regular file")
+    if (
+        not stat.S_ISREG(executable_info.st_mode)
+        or executable_info.st_nlink != 1
+        or not os.access(executable, os.X_OK)
+    ):
+        raise AdapterDiscoveryError("adapter Python must be one executable non-hardlinked file")
+    executable_digest = hashlib.sha256()
+    with executable.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            executable_digest.update(chunk)
     if not stat.S_ISDIR(workspace_info.st_mode):
         raise AdapterDiscoveryError("adapter workspace is not a directory")
     return ResolvedLaunch(
@@ -72,6 +89,9 @@ def resolve_launch(selector: AdapterSelector) -> ResolvedLaunch:
         executable_device=executable_info.st_dev,
         executable_inode=executable_info.st_ino,
         executable_mode=executable_info.st_mode,
+        executable_size=executable_info.st_size,
+        executable_sha256=executable_digest.hexdigest(),
+        executable_nlink=executable_info.st_nlink,
         workspace=str(workspace),
         workspace_device=workspace_info.st_dev,
         workspace_inode=workspace_info.st_ino,
@@ -82,10 +102,19 @@ def resolve_launch(selector: AdapterSelector) -> ResolvedLaunch:
 def validate_resolved_launch(launch: ResolvedLaunch) -> None:
     executable_info = _symlink_free(Path(launch.executable))
     workspace_info = _symlink_free(Path(launch.workspace))
+    if not stat.S_ISREG(executable_info.st_mode) or executable_info.st_nlink != 1:
+        raise AdapterDiscoveryError("adapter Python identity is unsafe")
+    executable_digest = hashlib.sha256()
+    with Path(launch.executable).open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            executable_digest.update(chunk)
     current = (
         executable_info.st_dev,
         executable_info.st_ino,
         executable_info.st_mode,
+        executable_info.st_size,
+        executable_digest.hexdigest(),
+        executable_info.st_nlink,
         workspace_info.st_dev,
         workspace_info.st_ino,
         workspace_info.st_mode,
@@ -94,6 +123,9 @@ def validate_resolved_launch(launch: ResolvedLaunch) -> None:
         launch.executable_device,
         launch.executable_inode,
         launch.executable_mode,
+        launch.executable_size,
+        launch.executable_sha256,
+        launch.executable_nlink,
         launch.workspace_device,
         launch.workspace_inode,
         launch.workspace_mode,
@@ -102,12 +134,76 @@ def validate_resolved_launch(launch: ResolvedLaunch) -> None:
         raise AdapterDiscoveryError("adapter launch path identity changed before spawn")
 
 
+def workspace_digest(path: str) -> str:
+    """Hash every immutable workspace file without following special entries."""
+
+    root = Path(path)
+    root_info = _symlink_free(root)
+    if not stat.S_ISDIR(root_info.st_mode):
+        raise AdapterDiscoveryError("adapter workspace is not a directory")
+    entries: list[dict[str, Any]] = []
+    total_bytes = 0
+    for directory, directory_names, file_names in os.walk(root, followlinks=False):
+        directory_names.sort()
+        file_names.sort()
+        current = Path(directory)
+        for name in (*directory_names, *file_names):
+            candidate = current / name
+            info = os.lstat(candidate)
+            if stat.S_ISLNK(info.st_mode):
+                raise AdapterDiscoveryError("adapter workspace contains a symlink")
+            if stat.S_ISDIR(info.st_mode):
+                continue
+            if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+                raise AdapterDiscoveryError("adapter workspace contains an unsafe file")
+            if len(entries) >= MAX_WORKSPACE_FILES:
+                raise AdapterDiscoveryError("adapter workspace file count exceeds limit")
+            total_bytes += info.st_size
+            if total_bytes > MAX_WORKSPACE_BYTES:
+                raise AdapterDiscoveryError("adapter workspace bytes exceed limit")
+            digest = hashlib.sha256()
+            with candidate.open("rb") as stream:
+                while chunk := stream.read(1024 * 1024):
+                    digest.update(chunk)
+            entries.append(
+                {
+                    "path": candidate.relative_to(root).as_posix(),
+                    "mode": stat.S_IMODE(info.st_mode),
+                    "size": info.st_size,
+                    "sha256": digest.hexdigest(),
+                }
+            )
+    entries.sort(key=lambda entry: entry["path"])
+    return canonical_digest("adapter-workspace-manifest-v1", entries)
+
+
+def verify_release_manifest(selector: AdapterSelector) -> None:
+    manifest = Path(selector.workspace) / RELEASE_MANIFEST
+    try:
+        info = os.lstat(manifest)
+        raw = manifest.read_bytes()
+    except OSError as error:
+        raise AdapterDiscoveryError("adapter release manifest is unavailable") from error
+    if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1 or len(raw) > 4096:
+        raise AdapterDiscoveryError("adapter release manifest is unsafe")
+    try:
+        value = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AdapterDiscoveryError("adapter release manifest is malformed") from error
+    canonical = json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+    if raw != canonical or value != {"release_digest": selector.release_digest}:
+        raise AdapterDiscoveryError("adapter release manifest digest differs")
+
+
 def validate_launch_paths(selector: AdapterSelector) -> None:
     resolve_launch(selector)
 
 
 def worker_argv(selector: AdapterSelector) -> tuple[str, ...]:
     resolve_launch(selector)
+    verify_release_manifest(selector)
+    if workspace_digest(selector.workspace) != selector.workspace_digest:
+        raise AdapterDiscoveryError("adapter workspace content digest differs")
     # Isolation flags prevent user site, PYTHON* variables, and current-directory
     # imports from changing which exact wheel the worker verifies.
     return (
@@ -177,8 +273,30 @@ def verify_distribution(selector: AdapterSelector) -> importlib.metadata.Distrib
     return distribution
 
 
+def _verified_entry_module(
+    distribution: importlib.metadata.Distribution, selector: AdapterSelector
+) -> tuple[str, Path]:
+    module, separator, attribute = selector.entry_point.partition(":")
+    if separator != ":" or not module or not attribute or ":" in attribute:
+        raise AdapterDiscoveryError("adapter entry point must be module:attribute")
+    candidates = {f"{module.replace('.', '/')}.py", f"{module.replace('.', '/')}/__init__.py"}
+    rows = {row[0]: row for row in _record_rows(distribution)}
+    matches = sorted(candidates & rows.keys())
+    if len(matches) != 1:
+        raise AdapterDiscoveryError("adapter entry module is not uniquely RECORD-covered")
+    module_path = Path(str(distribution.locate_file(matches[0])))
+    _symlink_free(module_path)
+    encoded_hash = rows[matches[0]][1].split("=", 1)[1]
+    actual = base64.urlsafe_b64encode(hashlib.sha256(module_path.read_bytes()).digest()).rstrip(
+        b"="
+    )
+    if actual.decode() != encoded_hash:
+        raise AdapterDiscoveryError("adapter entry module RECORD hash differs")
+    return module, module_path
+
+
 def load_selected_adapter(selector: AdapterSelector) -> EvaluationAdapter:
-    """Load exactly one entry point from only the already selected distribution."""
+    """Load exactly one preverified module from the selected distribution."""
 
     distribution = verify_distribution(selector)
     matches = [
@@ -192,8 +310,15 @@ def load_selected_adapter(selector: AdapterSelector) -> EvaluationAdapter:
         raise AdapterDiscoveryError(
             "selected distribution must expose exactly one exact entry point"
         )
+    module, module_path = _verified_entry_module(distribution, selector)
     try:
         factory = cast(Callable[[], Any], matches[0].load())
+        factory_module = getattr(factory, "__module__", "")
+        source = inspect.getsourcefile(factory)
+        if factory_module != module and not factory_module.startswith(f"{module}."):
+            raise AdapterDiscoveryError("adapter factory comes from another module")
+        if source is None or Path(source).resolve(strict=True) != module_path.resolve(strict=True):
+            raise AdapterDiscoveryError("adapter factory source differs from verified module")
         adapter = factory()
     except Exception as error:
         raise AdapterDiscoveryError("selected adapter entry point failed to load") from error

--- a/local_operator/evaluation/adapters/discovery.py
+++ b/local_operator/evaluation/adapters/discovery.py
@@ -65,6 +65,14 @@ def _symlink_free(path: Path) -> os.stat_result:
         raise AdapterDiscoveryError("adapter launch path is unavailable") from error
 
 
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
 def resolve_launch(selector: AdapterSelector) -> ResolvedLaunch:
     """Capture symlink-free identities for both spawn boundaries to recheck."""
 
@@ -78,10 +86,7 @@ def resolve_launch(selector: AdapterSelector) -> ResolvedLaunch:
         or not os.access(executable, os.X_OK)
     ):
         raise AdapterDiscoveryError("adapter Python must be one executable non-hardlinked file")
-    executable_digest = hashlib.sha256()
-    with executable.open("rb") as stream:
-        while chunk := stream.read(1024 * 1024):
-            executable_digest.update(chunk)
+    executable_digest = _file_sha256(executable)
     if not stat.S_ISDIR(workspace_info.st_mode):
         raise AdapterDiscoveryError("adapter workspace is not a directory")
     return ResolvedLaunch(
@@ -90,7 +95,7 @@ def resolve_launch(selector: AdapterSelector) -> ResolvedLaunch:
         executable_inode=executable_info.st_ino,
         executable_mode=executable_info.st_mode,
         executable_size=executable_info.st_size,
-        executable_sha256=executable_digest.hexdigest(),
+        executable_sha256=executable_digest,
         executable_nlink=executable_info.st_nlink,
         workspace=str(workspace),
         workspace_device=workspace_info.st_dev,
@@ -104,16 +109,13 @@ def validate_resolved_launch(launch: ResolvedLaunch) -> None:
     workspace_info = _symlink_free(Path(launch.workspace))
     if not stat.S_ISREG(executable_info.st_mode) or executable_info.st_nlink != 1:
         raise AdapterDiscoveryError("adapter Python identity is unsafe")
-    executable_digest = hashlib.sha256()
-    with Path(launch.executable).open("rb") as stream:
-        while chunk := stream.read(1024 * 1024):
-            executable_digest.update(chunk)
+    executable_digest = _file_sha256(Path(launch.executable))
     current = (
         executable_info.st_dev,
         executable_info.st_ino,
         executable_info.st_mode,
         executable_info.st_size,
-        executable_digest.hexdigest(),
+        executable_digest,
         executable_info.st_nlink,
         workspace_info.st_dev,
         workspace_info.st_ino,

--- a/local_operator/evaluation/adapters/discovery.py
+++ b/local_operator/evaluation/adapters/discovery.py
@@ -1,0 +1,138 @@
+"""Worker-only exact distribution verification and entry-point loading."""
+
+from __future__ import annotations
+
+import base64
+import csv
+import hashlib
+import importlib.metadata
+import os
+import stat
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+from local_operator.evaluation.adapters.api import (
+    ADAPTER_ENTRY_POINT_GROUP,
+    AdapterSelector,
+    EvaluationAdapter,
+)
+from local_operator.evaluation.evidence.models import canonical_digest
+
+
+class AdapterDiscoveryError(RuntimeError):
+    """A closed discovery failure safe to report across the RPC boundary."""
+
+
+def validate_launch_paths(selector: AdapterSelector) -> None:
+    """Reject aliases and non-regular interpreters before a process is started."""
+
+    executable = Path(selector.python_executable)
+    workspace = Path(selector.workspace)
+    if not executable.is_absolute() or not workspace.is_absolute():
+        raise AdapterDiscoveryError("adapter launch paths must be absolute")
+    try:
+        executable_info = executable.stat()
+        workspace_info = workspace.stat()
+    except OSError as error:
+        raise AdapterDiscoveryError("adapter launch path is unavailable") from error
+    if not stat.S_ISREG(executable_info.st_mode) or not os.access(executable, os.X_OK):
+        raise AdapterDiscoveryError("adapter Python is not an executable regular file")
+    if not stat.S_ISDIR(workspace_info.st_mode):
+        raise AdapterDiscoveryError("adapter workspace is not a directory")
+
+
+def worker_argv(selector: AdapterSelector) -> tuple[str, ...]:
+    validate_launch_paths(selector)
+    # Isolation flags prevent user site, PYTHON* variables, and current-directory
+    # imports from changing which exact wheel the worker verifies.
+    return (
+        selector.python_executable,
+        "-I",
+        "-s",
+        "-E",
+        "-m",
+        "local_operator.evaluation.adapters.worker",
+    )
+
+
+def _record_rows(distribution: Any) -> list[list[str]]:
+    record = distribution.read_text("RECORD")
+    if record is None:
+        raise AdapterDiscoveryError("adapter distribution has no wheel RECORD")
+    rows = list(csv.reader(record.splitlines()))
+    canonical: list[list[str]] = []
+    for row in rows:
+        if len(row) != 3 or not row[0]:
+            raise AdapterDiscoveryError("adapter wheel RECORD is malformed")
+        path, encoded_hash, size = row
+        if path.endswith("/RECORD"):
+            if encoded_hash or size:
+                raise AdapterDiscoveryError("wheel RECORD self-entry must be unhashed")
+            continue
+        if not encoded_hash or not size.isdecimal():
+            raise AdapterDiscoveryError("editable or unhashed adapter distributions are forbidden")
+        algorithm, separator, digest = encoded_hash.partition("=")
+        if separator != "=" or algorithm != "sha256" or not digest:
+            raise AdapterDiscoveryError("adapter RECORD must use sha256 hashes")
+        file_path = Path(distribution.locate_file(path))
+        try:
+            info = file_path.stat()
+            data = file_path.read_bytes()
+        except OSError as error:
+            raise AdapterDiscoveryError("adapter RECORD file is unavailable") from error
+        if not stat.S_ISREG(info.st_mode) or info.st_size != int(size):
+            raise AdapterDiscoveryError("adapter RECORD size differs from installed file")
+        actual = (
+            base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode("ascii")
+        )
+        if actual != digest:
+            raise AdapterDiscoveryError("adapter RECORD hash differs from installed file")
+        canonical.append([path, encoded_hash, size])
+    if not canonical:
+        raise AdapterDiscoveryError("adapter wheel RECORD has no hashed files")
+    canonical.sort(key=lambda item: item[0])
+    return canonical
+
+
+def distribution_digest(distribution: Any) -> str:
+    """Bind selection to every installed, hashed wheel file."""
+
+    return canonical_digest("adapter-installed-wheel-record-v1", _record_rows(distribution))
+
+
+def verify_distribution(selector: AdapterSelector) -> importlib.metadata.Distribution:
+    try:
+        distribution = importlib.metadata.distribution(selector.distribution)
+    except importlib.metadata.PackageNotFoundError as error:
+        raise AdapterDiscoveryError("selected adapter distribution is not installed") from error
+    if distribution.version != selector.version:
+        raise AdapterDiscoveryError("selected adapter distribution version differs")
+    if distribution_digest(distribution) != selector.package_digest:
+        raise AdapterDiscoveryError("selected adapter package digest differs")
+    return distribution
+
+
+def load_selected_adapter(selector: AdapterSelector) -> EvaluationAdapter:
+    """Load exactly one entry point from only the already selected distribution."""
+
+    distribution = verify_distribution(selector)
+    matches = [
+        entry
+        for entry in distribution.entry_points
+        if entry.group == ADAPTER_ENTRY_POINT_GROUP
+        and entry.name == selector.adapter_id
+        and entry.value == selector.entry_point
+    ]
+    if len(matches) != 1:
+        raise AdapterDiscoveryError(
+            "selected distribution must expose exactly one exact entry point"
+        )
+    try:
+        factory = cast(Callable[[], Any], matches[0].load())
+        adapter = factory()
+    except Exception as error:
+        raise AdapterDiscoveryError("selected adapter entry point failed to load") from error
+    if not isinstance(adapter, EvaluationAdapter):
+        raise AdapterDiscoveryError("selected entry point does not implement the adapter protocol")
+    return adapter

--- a/local_operator/evaluation/adapters/discovery.py
+++ b/local_operator/evaluation/adapters/discovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import csv
 import hashlib
+import importlib.machinery
 import importlib.metadata
 import importlib.util
 import json

--- a/local_operator/evaluation/adapters/discovery.py
+++ b/local_operator/evaluation/adapters/discovery.py
@@ -6,14 +6,16 @@ import base64
 import csv
 import hashlib
 import importlib.metadata
-import inspect
+import importlib.util
 import json
 import os
 import posixpath
 import stat
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from types import ModuleType
 from typing import Any, cast
 
 from local_operator.evaluation.adapters.api import (
@@ -299,23 +301,36 @@ def _verify_recorded_file(
     distribution: importlib.metadata.Distribution,
     rows: dict[str, list[str]],
     relative: str,
-) -> Path:
+) -> tuple[Path, bytes]:
+    """Return the path and the exact bytes whose hash matched RECORD.
+
+    The bytes are returned, not re-read later, because any second read is a
+    different observation than the one that was verified.
+    """
+
     path = Path(str(distribution.locate_file(relative)))
     _symlink_free(path)
     encoded_hash = rows[relative][1].split("=", 1)[1].rstrip("=")
-    actual = (
-        base64.urlsafe_b64encode(hashlib.sha256(path.read_bytes()).digest())
-        .rstrip(b"=")
-        .decode("ascii")
-    )
+    data = path.read_bytes()
+    actual = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode("ascii")
     if actual != encoded_hash:
         raise AdapterDiscoveryError("adapter module RECORD hash differs")
-    return path
+    return path, data
 
 
-def _verified_entry_module(
+@dataclass(frozen=True)
+class _VerifiedModule:
+    name: str
+    path: Path
+    source: bytes
+    is_package: bool
+
+
+def _verified_module_chain(
     distribution: importlib.metadata.Distribution, selector: AdapterSelector
-) -> tuple[str, Path]:
+) -> tuple[str, tuple[_VerifiedModule, ...]]:
+    """Return every module that must execute, with its exact verified bytes."""
+
     module, separator, attribute = selector.entry_point.partition(":")
     if separator != ":" or not module or not attribute or ":" in attribute:
         raise AdapterDiscoveryError("adapter entry point must be module:attribute")
@@ -323,23 +338,73 @@ def _verified_entry_module(
     if not all(part.isidentifier() for part in parts):
         raise AdapterDiscoveryError("adapter entry module is not a dotted identifier")
     rows = {row[0]: row for row in _record_rows(distribution)}
+    chain: list[_VerifiedModule] = []
     # Importing pkg.sub.mod executes every ancestor __init__ first, so an
     # unrecorded ancestor would run arbitrary code before any verification.
     # Each ancestor must be RECORD-covered and hash-matched, or genuinely absent
     # from disk (a real namespace package).
     for depth in range(1, len(parts)):
+        name = ".".join(parts[:depth])
         ancestor = "/".join(parts[:depth]) + "/__init__.py"
-        on_disk = Path(str(distribution.locate_file(ancestor)))
         if ancestor in rows:
-            _verify_recorded_file(distribution, rows, ancestor)
+            path, source = _verify_recorded_file(distribution, rows, ancestor)
+            chain.append(_VerifiedModule(name=name, path=path, source=source, is_package=True))
             continue
-        if on_disk.exists():
+        if Path(str(distribution.locate_file(ancestor))).exists():
             raise AdapterDiscoveryError("adapter package init is not RECORD-covered")
     candidates = {f"{'/'.join(parts)}.py", f"{'/'.join(parts)}/__init__.py"}
     matches = sorted(candidates & rows.keys())
     if len(matches) != 1:
         raise AdapterDiscoveryError("adapter entry module is not uniquely RECORD-covered")
-    return module, _verify_recorded_file(distribution, rows, matches[0])
+    path, source = _verify_recorded_file(distribution, rows, matches[0])
+    chain.append(
+        _VerifiedModule(
+            name=module,
+            path=path,
+            source=source,
+            is_package=matches[0].endswith("/__init__.py"),
+        )
+    )
+    return attribute, tuple(chain)
+
+
+def _execute_verified_chain(chain: tuple[_VerifiedModule, ...]) -> ModuleType:
+    """Compile and run the verified bytes themselves, never a cached artifact.
+
+    Hashing ``.py`` source and then delegating to a normal import is not a
+    verification: CPython prefers ``__pycache__/<name>.<tag>.pyc`` whenever its
+    header matches the source mtime and size, both of which an attacker who can
+    write the cache also controls. The hashed bytes and the executed bytes are
+    then unrelated, and ``-I -s -E`` do not help because they constrain sys.path
+    and the environment, not bytecode trust.
+
+    Refusing to load when a ``__pycache__`` entry exists would be a denylist over
+    a cache location CPython is free to change, and it stays racy: the cache can
+    reappear between the check and the import. Compiling the verified bytes in
+    process removes the question instead of policing it — the object that runs is
+    derived from the byte string that was hashed, so the invariant is structural.
+    """
+
+    loaded: ModuleType | None = None
+    for entry in chain:
+        specification = importlib.util.spec_from_file_location(entry.name, entry.path)
+        if specification is None:
+            raise AdapterDiscoveryError("adapter module specification is unavailable")
+        created = importlib.util.module_from_spec(specification)
+        if entry.is_package:
+            created.__path__ = [str(entry.path.parent)]
+        code = compile(entry.source, str(entry.path), "exec", dont_inherit=True)
+        # Registering before execution keeps intra-package imports resolvable,
+        # exactly as the import system would during a normal package import.
+        sys.modules[entry.name] = created
+        try:
+            exec(code, created.__dict__)
+        except BaseException:
+            sys.modules.pop(entry.name, None)
+            raise
+        loaded = created
+    assert loaded is not None
+    return loaded
 
 
 def load_selected_adapter(selector: AdapterSelector) -> EvaluationAdapter:
@@ -357,16 +422,16 @@ def load_selected_adapter(selector: AdapterSelector) -> EvaluationAdapter:
         raise AdapterDiscoveryError(
             "selected distribution must expose exactly one exact entry point"
         )
-    module, module_path = _verified_entry_module(distribution, selector)
+    attribute, chain = _verified_module_chain(distribution, selector)
     try:
-        factory = cast(Callable[[], Any], matches[0].load())
-        factory_module = getattr(factory, "__module__", "")
-        source = inspect.getsourcefile(factory)
-        if factory_module != module and not factory_module.startswith(f"{module}."):
-            raise AdapterDiscoveryError("adapter factory comes from another module")
-        if source is None or Path(source).resolve(strict=True) != module_path.resolve(strict=True):
-            raise AdapterDiscoveryError("adapter factory source differs from verified module")
+        # The entry point is resolved against the module built from verified
+        # bytes, so `.load()` is never given the chance to import a cached
+        # artifact we did not hash.
+        loaded = _execute_verified_chain(chain)
+        factory = cast(Callable[[], Any], getattr(loaded, attribute))
         adapter = factory()
+    except AdapterDiscoveryError:
+        raise
     except Exception as error:
         raise AdapterDiscoveryError("selected adapter entry point failed to load") from error
     if not isinstance(adapter, EvaluationAdapter):

--- a/local_operator/evaluation/adapters/discovery.py
+++ b/local_operator/evaluation/adapters/discovery.py
@@ -12,7 +12,8 @@ import os
 import posixpath
 import stat
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
@@ -318,58 +319,33 @@ def _verify_recorded_file(
     return path, data
 
 
-@dataclass(frozen=True)
-class _VerifiedModule:
-    name: str
-    path: Path
-    source: bytes
-    is_package: bool
-
-
-def _verified_module_chain(
+def _verified_entry_target(
     distribution: importlib.metadata.Distribution, selector: AdapterSelector
-) -> tuple[str, tuple[_VerifiedModule, ...]]:
-    """Return every module that must execute, with its exact verified bytes."""
+) -> tuple[str, str]:
+    """Validate the entry point and confirm its module is RECORD-covered.
+
+    Ancestor ``__init__`` files are not walked here: the finder verifies every
+    module the distribution owns as the import system requests it, which covers
+    ancestors and their own imports alike.
+    """
 
     module, separator, attribute = selector.entry_point.partition(":")
     if separator != ":" or not module or not attribute or ":" in attribute:
         raise AdapterDiscoveryError("adapter entry point must be module:attribute")
+    if not attribute.isidentifier():
+        raise AdapterDiscoveryError("adapter entry attribute is not an identifier")
     parts = module.split(".")
     if not all(part.isidentifier() for part in parts):
         raise AdapterDiscoveryError("adapter entry module is not a dotted identifier")
     rows = {row[0]: row for row in _record_rows(distribution)}
-    chain: list[_VerifiedModule] = []
-    # Importing pkg.sub.mod executes every ancestor __init__ first, so an
-    # unrecorded ancestor would run arbitrary code before any verification.
-    # Each ancestor must be RECORD-covered and hash-matched, or genuinely absent
-    # from disk (a real namespace package).
-    for depth in range(1, len(parts)):
-        name = ".".join(parts[:depth])
-        ancestor = "/".join(parts[:depth]) + "/__init__.py"
-        if ancestor in rows:
-            path, source = _verify_recorded_file(distribution, rows, ancestor)
-            chain.append(_VerifiedModule(name=name, path=path, source=source, is_package=True))
-            continue
-        if Path(str(distribution.locate_file(ancestor))).exists():
-            raise AdapterDiscoveryError("adapter package init is not RECORD-covered")
     candidates = {f"{'/'.join(parts)}.py", f"{'/'.join(parts)}/__init__.py"}
-    matches = sorted(candidates & rows.keys())
-    if len(matches) != 1:
+    if len(candidates & rows.keys()) != 1:
         raise AdapterDiscoveryError("adapter entry module is not uniquely RECORD-covered")
-    path, source = _verify_recorded_file(distribution, rows, matches[0])
-    chain.append(
-        _VerifiedModule(
-            name=module,
-            path=path,
-            source=source,
-            is_package=matches[0].endswith("/__init__.py"),
-        )
-    )
-    return attribute, tuple(chain)
+    return module, attribute
 
 
-def _execute_verified_chain(chain: tuple[_VerifiedModule, ...]) -> ModuleType:
-    """Compile and run the verified bytes themselves, never a cached artifact.
+class _VerifiedSourceLoader:
+    """Execute the exact bytes that were hashed, never a cached artifact.
 
     Hashing ``.py`` source and then delegating to a normal import is not a
     verification: CPython prefers ``__pycache__/<name>.<tag>.pyc`` whenever its
@@ -377,34 +353,128 @@ def _execute_verified_chain(chain: tuple[_VerifiedModule, ...]) -> ModuleType:
     write the cache also controls. The hashed bytes and the executed bytes are
     then unrelated, and ``-I -s -E`` do not help because they constrain sys.path
     and the environment, not bytecode trust.
-
-    Refusing to load when a ``__pycache__`` entry exists would be a denylist over
-    a cache location CPython is free to change, and it stays racy: the cache can
-    reappear between the check and the import. Compiling the verified bytes in
-    process removes the question instead of policing it — the object that runs is
-    derived from the byte string that was hashed, so the invariant is structural.
     """
 
-    loaded: ModuleType | None = None
-    for entry in chain:
-        specification = importlib.util.spec_from_file_location(entry.name, entry.path)
-        if specification is None:
-            raise AdapterDiscoveryError("adapter module specification is unavailable")
-        created = importlib.util.module_from_spec(specification)
-        if entry.is_package:
-            created.__path__ = [str(entry.path.parent)]
-        code = compile(entry.source, str(entry.path), "exec", dont_inherit=True)
-        # Registering before execution keeps intra-package imports resolvable,
-        # exactly as the import system would during a normal package import.
-        sys.modules[entry.name] = created
-        try:
-            exec(code, created.__dict__)
-        except BaseException:
-            sys.modules.pop(entry.name, None)
-            raise
-        loaded = created
-    assert loaded is not None
-    return loaded
+    def __init__(self, path: Path, source: bytes) -> None:
+        self._path = path
+        self._source = source
+
+    def create_module(self, spec: Any) -> ModuleType | None:
+        del spec
+        return None
+
+    def get_source(self, fullname: str) -> str:
+        del fullname
+        return self._source.decode("utf-8")
+
+    def exec_module(self, module: ModuleType) -> None:
+        code = compile(self._source, str(self._path), "exec", dont_inherit=True)
+        exec(code, module.__dict__)
+
+
+class _VerifiedDistributionFinder:
+    """Serve only RECORD-covered source for one distribution's own modules.
+
+    Verifying a chain of modules can never be complete, because the chain is
+    discovered before the code that performs the importing has run: an entry
+    module doing ``from . import helper`` sends ``helper`` back through the
+    ordinary loader, which happily executes a forged cache. Scoping the rule to
+    the whole distribution removes that gap — every module the distribution owns
+    is served from verified bytes, and anything under those roots that RECORD
+    does not cover is refused rather than imported.
+
+    Scope is deliberately narrow. Only names whose top-level component is owned
+    by this distribution's RECORD are claimed; every other import (stdlib,
+    pydantic, local_operator itself) returns ``None`` here and proceeds through
+    the normal machinery untouched.
+
+    Coverage boundary, measured rather than assumed: the finder is active for
+    the duration of the load, so it governs the entry module, its ancestors, and
+    anything they import while executing — including imports inside the factory
+    call. It does NOT govern an import an adapter defers until after loading has
+    returned, because by then the finder has been removed so it cannot dictate
+    the worker's later imports. Modules already imported under it stay verified
+    in ``sys.modules``; a genuinely new deferred import would fall back to the
+    ordinary loader. Closing that remaining window means keeping the adapter's
+    own modules unresolvable afterwards, which is a separate decision about
+    worker-lifetime import policy, not part of load verification.
+    """
+
+    def __init__(
+        self,
+        distribution: importlib.metadata.Distribution,
+        rows: dict[str, list[str]],
+    ) -> None:
+        self._distribution = distribution
+        self._rows = rows
+        self._owned: set[str] = set()
+        for relative in rows:
+            head, _, tail = relative.partition("/")
+            name = head[:-3] if not tail and head.endswith(".py") else head
+            if name.isidentifier():
+                self._owned.add(name)
+
+    @property
+    def owned_roots(self) -> frozenset[str]:
+        return frozenset(self._owned)
+
+    def find_spec(self, fullname: str, path: Any = None, target: Any = None) -> Any:
+        del path, target
+        if fullname.split(".")[0] not in self._owned:
+            return None
+        parts = fullname.split(".")
+        if not all(part.isidentifier() for part in parts):
+            raise AdapterDiscoveryError("adapter module name is not a dotted identifier")
+        stem = "/".join(parts)
+        package_init = f"{stem}/__init__.py"
+        module_file = f"{stem}.py"
+        matches = sorted({package_init, module_file} & self._rows.keys())
+        if len(matches) > 1:
+            raise AdapterDiscoveryError("adapter module is ambiguously RECORD-covered")
+        if not matches:
+            # A directory with no recorded __init__ is a genuine namespace
+            # package; anything else present on disk is unrecorded code.
+            if Path(str(self._distribution.locate_file(package_init))).exists():
+                raise AdapterDiscoveryError("adapter package init is not RECORD-covered")
+            if Path(str(self._distribution.locate_file(module_file))).exists():
+                raise AdapterDiscoveryError("adapter module is not RECORD-covered")
+            return None
+        relative = matches[0]
+        verified_path, source = _verify_recorded_file(self._distribution, self._rows, relative)
+        is_package = relative.endswith("/__init__.py")
+        return importlib.util.spec_from_file_location(
+            fullname,
+            verified_path,
+            loader=_VerifiedSourceLoader(verified_path, source),
+            submodule_search_locations=[str(verified_path.parent)] if is_package else None,
+        )
+
+
+@contextmanager
+def _verified_imports(
+    distribution: importlib.metadata.Distribution,
+    rows: dict[str, list[str]],
+) -> Iterator[_VerifiedDistributionFinder]:
+    """Install the finder for the load only, unwinding whatever it created.
+
+    The finder is removed unconditionally so it cannot govern the worker's later
+    execution, and every module it introduced is dropped when the load fails, so
+    a half-imported distribution is never left behind for a retry to inherit.
+    """
+
+    finder = _VerifiedDistributionFinder(distribution, rows)
+    before = set(sys.modules)
+    sys.meta_path.insert(0, cast(Any, finder))
+    try:
+        yield finder
+    except BaseException:
+        for name in set(sys.modules) - before:
+            if name.split(".")[0] in finder.owned_roots:
+                sys.modules.pop(name, None)
+        raise
+    finally:
+        with suppress(ValueError):
+            sys.meta_path.remove(cast(Any, finder))
 
 
 def load_selected_adapter(selector: AdapterSelector) -> EvaluationAdapter:
@@ -422,14 +492,25 @@ def load_selected_adapter(selector: AdapterSelector) -> EvaluationAdapter:
         raise AdapterDiscoveryError(
             "selected distribution must expose exactly one exact entry point"
         )
-    attribute, chain = _verified_module_chain(distribution, selector)
+    module_name, attribute = _verified_entry_target(distribution, selector)
+    rows = {row[0]: row for row in _record_rows(distribution)}
     try:
-        # The entry point is resolved against the module built from verified
-        # bytes, so `.load()` is never given the chance to import a cached
-        # artifact we did not hash.
-        loaded = _execute_verified_chain(chain)
-        factory = cast(Callable[[], Any], getattr(loaded, attribute))
-        adapter = factory()
+        # Importing under the finder means every module this distribution owns —
+        # the entry module, its ancestors, and anything they import later during
+        # execution — is served from verified bytes, so `.load()` and the
+        # ordinary loader never get a chance to run a cached artifact.
+        with _verified_imports(distribution, rows):
+            for stale in [
+                name
+                for name in sys.modules
+                if name == module_name.split(".")[0]
+                or name.startswith(f"{module_name.split('.')[0]}.")
+            ]:
+                # A pre-existing entry would otherwise be returned unverified.
+                del sys.modules[stale]
+            loaded = importlib.import_module(module_name)
+            factory = cast(Callable[[], Any], getattr(loaded, attribute))
+            adapter = factory()
     except AdapterDiscoveryError:
         raise
     except Exception as error:

--- a/local_operator/evaluation/adapters/discovery.py
+++ b/local_operator/evaluation/adapters/discovery.py
@@ -9,6 +9,7 @@ import importlib.metadata
 import inspect
 import json
 import os
+import posixpath
 import stat
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -249,7 +250,12 @@ def _record_rows(distribution: Any) -> list[list[str]]:
         algorithm, separator, digest = encoded_hash.partition("=")
         if separator != "=" or algorithm != "sha256" or not digest:
             raise AdapterDiscoveryError("adapter RECORD must use sha256 hashes")
-        file_path = Path(distribution.locate_file(path))
+        # A RECORD path is attacker-controlled data: normalize before it can be
+        # joined onto the install root, so no entry escapes the distribution.
+        normalized = posixpath.normpath(path)
+        if normalized != path or posixpath.isabs(path) or normalized.split("/")[0] == "..":
+            raise AdapterDiscoveryError("adapter RECORD path is not a normalized relative path")
+        file_path = Path(str(distribution.locate_file(path)))
         try:
             info = file_path.stat()
             data = file_path.read_bytes()
@@ -260,7 +266,9 @@ def _record_rows(distribution: Any) -> list[list[str]]:
         actual = (
             base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode("ascii")
         )
-        if actual != digest:
+        # Wheel RECORD hashes are unpadded by PEP 376, but a conformant padded
+        # value must not read as a content mismatch.
+        if actual != digest.rstrip("="):
             raise AdapterDiscoveryError("adapter RECORD hash differs from installed file")
         canonical.append([path, encoded_hash, size])
     if not canonical:
@@ -287,26 +295,51 @@ def verify_distribution(selector: AdapterSelector) -> importlib.metadata.Distrib
     return distribution
 
 
+def _verify_recorded_file(
+    distribution: importlib.metadata.Distribution,
+    rows: dict[str, list[str]],
+    relative: str,
+) -> Path:
+    path = Path(str(distribution.locate_file(relative)))
+    _symlink_free(path)
+    encoded_hash = rows[relative][1].split("=", 1)[1].rstrip("=")
+    actual = (
+        base64.urlsafe_b64encode(hashlib.sha256(path.read_bytes()).digest())
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    if actual != encoded_hash:
+        raise AdapterDiscoveryError("adapter module RECORD hash differs")
+    return path
+
+
 def _verified_entry_module(
     distribution: importlib.metadata.Distribution, selector: AdapterSelector
 ) -> tuple[str, Path]:
     module, separator, attribute = selector.entry_point.partition(":")
     if separator != ":" or not module or not attribute or ":" in attribute:
         raise AdapterDiscoveryError("adapter entry point must be module:attribute")
-    candidates = {f"{module.replace('.', '/')}.py", f"{module.replace('.', '/')}/__init__.py"}
+    parts = module.split(".")
+    if not all(part.isidentifier() for part in parts):
+        raise AdapterDiscoveryError("adapter entry module is not a dotted identifier")
     rows = {row[0]: row for row in _record_rows(distribution)}
+    # Importing pkg.sub.mod executes every ancestor __init__ first, so an
+    # unrecorded ancestor would run arbitrary code before any verification.
+    # Each ancestor must be RECORD-covered and hash-matched, or genuinely absent
+    # from disk (a real namespace package).
+    for depth in range(1, len(parts)):
+        ancestor = "/".join(parts[:depth]) + "/__init__.py"
+        on_disk = Path(str(distribution.locate_file(ancestor)))
+        if ancestor in rows:
+            _verify_recorded_file(distribution, rows, ancestor)
+            continue
+        if on_disk.exists():
+            raise AdapterDiscoveryError("adapter package init is not RECORD-covered")
+    candidates = {f"{'/'.join(parts)}.py", f"{'/'.join(parts)}/__init__.py"}
     matches = sorted(candidates & rows.keys())
     if len(matches) != 1:
         raise AdapterDiscoveryError("adapter entry module is not uniquely RECORD-covered")
-    module_path = Path(str(distribution.locate_file(matches[0])))
-    _symlink_free(module_path)
-    encoded_hash = rows[matches[0]][1].split("=", 1)[1]
-    actual = base64.urlsafe_b64encode(hashlib.sha256(module_path.read_bytes()).digest()).rstrip(
-        b"="
-    )
-    if actual.decode() != encoded_hash:
-        raise AdapterDiscoveryError("adapter entry module RECORD hash differs")
-    return module, module_path
+    return module, _verify_recorded_file(distribution, rows, matches[0])
 
 
 def load_selected_adapter(selector: AdapterSelector) -> EvaluationAdapter:

--- a/local_operator/evaluation/adapters/discovery.py
+++ b/local_operator/evaluation/adapters/discovery.py
@@ -299,6 +299,27 @@ def verify_distribution(selector: AdapterSelector) -> importlib.metadata.Distrib
     return distribution
 
 
+def _module_stem(filename: str) -> str:
+    """Strip an importable suffix so a file name yields its module name.
+
+    Extension suffixes are checked longest-first because ``.abi3.so`` and
+    ``.so`` overlap, and the shorter one would otherwise leave ``.abi3``
+    attached and silently fail the identifier test. Handling extensions here is
+    what makes an owned root independent of whether the module ships as source
+    or as a compiled artifact.
+    """
+
+    suffixes = sorted(
+        [*importlib.machinery.SOURCE_SUFFIXES, *importlib.machinery.EXTENSION_SUFFIXES],
+        key=len,
+        reverse=True,
+    )
+    for suffix in suffixes:
+        if filename.endswith(suffix):
+            return filename[: -len(suffix)]
+    return filename
+
+
 def _verify_recorded_file(
     distribution: importlib.metadata.Distribution,
     rows: dict[str, list[str]],
@@ -409,6 +430,13 @@ class _VerifiedDistributionFinder:
     little against the real threat model: an adapter is already arbitrary code
     in an isolated worker and can simply inline whatever it wants in its own
     verified source.
+
+    Compiled extensions are SUPPORTED when RECORD covers them, at top level and
+    inside a package alike, because real adapter wheels ship them and the
+    package digest already attests to their bytes. Refusing them would reject
+    the exact artifact the pin covers. Bytecode is the opposite case and stays
+    refused: a ``.pyc`` is never a match, so a sourceless module always falls
+    through to ``_refuse_unrecorded_artifacts``.
     """
 
     def __init__(
@@ -421,7 +449,7 @@ class _VerifiedDistributionFinder:
         self._owned: set[str] = set()
         for relative in rows:
             head, _, tail = relative.partition("/")
-            name = head[:-3] if not tail and head.endswith(".py") else head
+            name = head if tail else _module_stem(head)
             if name.isidentifier():
                 self._owned.add(name)
 
@@ -443,10 +471,19 @@ class _VerifiedDistributionFinder:
             *importlib.machinery.EXTENSION_SUFFIXES,
         ]
         for suffix in suffixes:
-            if Path(str(self._distribution.locate_file(f"{stem}{suffix}"))).exists():
-                raise AdapterDiscoveryError("adapter module is not RECORD-covered")
-            if Path(str(self._distribution.locate_file(f"{stem}/__init__{suffix}"))).exists():
-                raise AdapterDiscoveryError("adapter package init is not RECORD-covered")
+            for relative, message in (
+                (f"{stem}{suffix}", "adapter module is not RECORD-covered"),
+                (f"{stem}/__init__{suffix}", "adapter package init is not RECORD-covered"),
+            ):
+                if relative in self._rows:
+                    # Only bytecode can reach this branch while recorded, since
+                    # source and extensions are candidates above. Saying it is
+                    # uncovered would be a lie about a file RECORD does cover.
+                    raise AdapterDiscoveryError(
+                        "adapter bytecode is never loaded even when RECORD-covered"
+                    )
+                if Path(str(self._distribution.locate_file(relative))).exists():
+                    raise AdapterDiscoveryError(message)
 
     def find_spec(self, fullname: str, path: Any = None, target: Any = None) -> Any:
         del path, target
@@ -456,9 +493,16 @@ class _VerifiedDistributionFinder:
         if not all(part.isidentifier() for part in parts):
             raise AdapterDiscoveryError("adapter module name is not a dotted identifier")
         stem = "/".join(parts)
-        package_init = f"{stem}/__init__.py"
-        module_file = f"{stem}.py"
-        matches = sorted({package_init, module_file} & self._rows.keys())
+        # Extensions are candidates alongside source because RECORD covers them
+        # and ``package_digest`` already accounts for their bytes; refusing them
+        # would reject the very artifact the pin attests to. Bytecode is
+        # deliberately absent: a `.pyc` is never a match, so it always falls
+        # through to refusal.
+        candidates: dict[str, bool] = {f"{stem}.py": False, f"{stem}/__init__.py": True}
+        for suffix in importlib.machinery.EXTENSION_SUFFIXES:
+            candidates[f"{stem}{suffix}"] = False
+            candidates[f"{stem}/__init__{suffix}"] = True
+        matches = sorted(candidates.keys() & self._rows.keys())
         if len(matches) > 1:
             raise AdapterDiscoveryError("adapter module is ambiguously RECORD-covered")
         if not matches:
@@ -474,12 +518,28 @@ class _VerifiedDistributionFinder:
             return None
         relative = matches[0]
         verified_path, source = _verify_recorded_file(self._distribution, self._rows, relative)
-        is_package = relative.endswith("/__init__.py")
+        is_package = candidates[relative]
+        search = [str(verified_path.parent)] if is_package else None
+        if relative.endswith(".py"):
+            return importlib.util.spec_from_file_location(
+                fullname,
+                verified_path,
+                loader=_VerifiedSourceLoader(verified_path, source),
+                submodule_search_locations=search,
+            )
+        # Verification of an extension means the file's bytes matched RECORD and
+        # the ordinary loader is then pointed at that exact verified path. It is
+        # weaker than the source guarantee by one specific step: source executes
+        # from the in-memory bytes that were hashed, whereas dlopen re-reads the
+        # file, so a swap between the hash and the dlopen is undetected. That
+        # residual TOCTOU is the same class as the executable one documented on
+        # ResolvedLaunch, and is accepted for the same reason -- the alternative
+        # is refusing artifacts the package digest already attests to.
         return importlib.util.spec_from_file_location(
             fullname,
             verified_path,
-            loader=_VerifiedSourceLoader(verified_path, source),
-            submodule_search_locations=[str(verified_path.parent)] if is_package else None,
+            loader=importlib.machinery.ExtensionFileLoader(fullname, str(verified_path)),
+            submodule_search_locations=search,
         )
 
 

--- a/local_operator/evaluation/adapters/discovery.py
+++ b/local_operator/evaluation/adapters/discovery.py
@@ -236,6 +236,18 @@ def worker_argv(selector: AdapterSelector) -> tuple[str, ...]:
 
 
 def _record_rows(distribution: Any) -> list[list[str]]:
+    """Return every RECORD row after verifying it against the installed file.
+
+    An adapter distribution must contain only files inside its own install root.
+    That rules out console scripts, whose RECORD rows are written as
+    ``../../../bin/<name>`` -- black and pip both have them. The rows are
+    refused rather than skipped: hashing one means following an attacker-
+    controlled path out of the distribution root, which is the traversal this
+    validation exists to stop, and skipping it silently would drop those bytes
+    from ``package_digest`` while still claiming the release was attested. An
+    adapter wheel therefore must not declare console scripts.
+    """
+
     record = distribution.read_text("RECORD")
     if record is None:
         raise AdapterDiscoveryError("adapter distribution has no wheel RECORD")
@@ -258,7 +270,10 @@ def _record_rows(distribution: Any) -> list[list[str]]:
         # joined onto the install root, so no entry escapes the distribution.
         normalized = posixpath.normpath(path)
         if normalized != path or posixpath.isabs(path) or normalized.split("/")[0] == "..":
-            raise AdapterDiscoveryError("adapter RECORD path is not a normalized relative path")
+            raise AdapterDiscoveryError(
+                f"adapter RECORD path {path!r} escapes the distribution root; adapter"
+                " wheels must not declare console scripts or other external files"
+            )
         file_path = Path(str(distribution.locate_file(path)))
         try:
             info = file_path.stat()
@@ -334,33 +349,68 @@ def _resolve_module_artifact(
 
     mypyc- and Cython-built wheels ship BOTH ``mod.py`` and ``mod<EXT>`` for the
     same stem -- black, tomli and charset-normalizer all do -- so treating that
-    pair as ambiguous would refuse ordinary wheels. Source WINS: it executes
-    from the in-memory bytes that were hashed, which is the stronger of the two
-    verification paths, and it is what the import system would have used.
+    pair as ambiguous would refuse ordinary wheels. Source WINS there, but NOT
+    because it is what CPython would pick: measured on this interpreter, an
+    ordinary import of a stem with both artifacts loads the EXTENSION. Source is
+    chosen because it executes from the in-memory bytes that were hashed, the
+    strictly stronger verification path, and because for these wheels the two
+    artifacts are built from the same code, so the choice changes how strongly
+    the module is attested rather than what it does.
 
-    Genuine ambiguity is narrower and is still refused: a stem whose source sits
-    on disk UNRECORDED while an extension is recorded, because then the artifact
-    the import system would prefer is precisely the one RECORD does not attest
-    to, and silently loading the extension would misrepresent what ran.
+    A ``mod.py`` beside a ``mod/`` package is different in kind and is REFUSED.
+    CPython's FileFinder consults directories before file loaders, so it would
+    run ``mod/__init__.py`` while any file-first rule here would verify
+    ``mod.py``: the verified artifact and the executed artifact would be
+    different files, which is precisely the divergence this subsystem exists to
+    prevent. Refusing is legible; silently picking either side is not.
+
+    Also refused: a higher-priority artifact present on disk but UNRECORDED
+    beside a recorded lower-priority one, because then the file the import
+    system ranks first is the one RECORD does not attest to.
     """
+
+    flat = f"{stem}.py"
+    package_init = f"{stem}/__init__.py"
+    if flat in rows and package_init in rows:
+        raise AdapterDiscoveryError(
+            "adapter module is ambiguously RECORD-covered as both module and package"
+        )
 
     for is_package, base in ((False, stem), (True, f"{stem}/__init__")):
         source = f"{base}.py"
-        extensions = sorted(
+        # Ranked as the import system ranks them, so "higher priority" below
+        # means what CPython would actually have reached first.
+        extensions = [
             f"{base}{suffix}"
             for suffix in importlib.machinery.EXTENSION_SUFFIXES
             if f"{base}{suffix}" in rows
-        )
+        ]
         if source in rows:
             return source, is_package
         if extensions:
+            chosen = extensions[0]
+            outranking = [
+                f"{base}{suffix}"
+                for suffix in importlib.machinery.EXTENSION_SUFFIXES[
+                    : importlib.machinery.EXTENSION_SUFFIXES.index(chosen[len(base) :])
+                ]
+            ]
+            # Source and outranking extensions get the same treatment: an
+            # unrecorded file the import system prefers over the verified one is
+            # refused whatever its suffix, rather than only when it is source.
             if Path(str(distribution.locate_file(source))).exists():
                 raise AdapterDiscoveryError(
                     "adapter module source is present but not RECORD-covered"
                 )
+            for unattested in outranking:
+                if Path(str(distribution.locate_file(unattested))).exists():
+                    raise AdapterDiscoveryError(
+                        "adapter module has a higher-priority extension that is"
+                        " not RECORD-covered"
+                    )
             if len(extensions) > 1:
                 raise AdapterDiscoveryError("adapter module is ambiguously RECORD-covered")
-            return extensions[0], is_package
+            return chosen, is_package
     return None
 
 

--- a/local_operator/evaluation/adapters/rpc.py
+++ b/local_operator/evaluation/adapters/rpc.py
@@ -1,0 +1,233 @@
+"""Canonical JSONL RPC over two inherited, one-way protocol descriptors."""
+
+from __future__ import annotations
+
+import asyncio
+import errno
+import json
+import os
+from collections.abc import Callable
+from typing import Any, Literal
+
+from pydantic import Field, model_validator
+
+from local_operator.evaluation.adapters.api import AdapterMethod
+from local_operator.evaluation.protocol import ProtocolModel
+
+MAX_RPC_BYTES = 1024 * 1024
+MAX_ERROR_MESSAGE = 2000
+MAX_SAFE_ID = 2**53 - 1
+
+
+class RpcProtocolError(RuntimeError):
+    pass
+
+
+class RpcRemoteError(RuntimeError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+
+
+class RpcError(ProtocolModel):
+    code: Literal[
+        "adapter_error",
+        "cancelled",
+        "invalid_request",
+        "invalid_state",
+        "protocol_error",
+        "timeout",
+    ]
+    message: str = Field(min_length=1, max_length=MAX_ERROR_MESSAGE)
+
+
+class RpcRequest(ProtocolModel):
+    jsonrpc: Literal["2.0"]
+    id: int = Field(gt=0, le=MAX_SAFE_ID)
+    method: AdapterMethod
+    params: dict[str, Any]
+
+
+class RpcResponse(ProtocolModel):
+    jsonrpc: Literal["2.0"]
+    id: int = Field(gt=0, le=MAX_SAFE_ID)
+    method: AdapterMethod
+    result: dict[str, Any] | None = None
+    error: RpcError | None = None
+
+    @model_validator(mode="after")
+    def _result_xor_error(self) -> "RpcResponse":
+        if (self.result is None) == (self.error is None):
+            raise ValueError("RPC response requires exactly one of result and error")
+        return self
+
+
+class CancelRequest(ProtocolModel):
+    jsonrpc: Literal["2.0"]
+    control: Literal["cancel"]
+    id: int = Field(gt=0, le=MAX_SAFE_ID)
+
+
+def _reject_duplicate(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise RpcProtocolError("duplicate JSON object key")
+        result[key] = value
+    return result
+
+
+def canonical_line(model: ProtocolModel) -> bytes:
+    payload = model.to_canonical_json()
+    if len(payload) > MAX_RPC_BYTES:
+        raise RpcProtocolError("RPC message exceeds one MiB")
+    return payload + b"\n"
+
+
+def parse_canonical_line(line: bytes, model: type[ProtocolModel]) -> ProtocolModel:
+    if not line.endswith(b"\n") or b"\r" in line:
+        raise RpcProtocolError("RPC requires LF-only complete JSON lines")
+    payload = line[:-1]
+    if not payload or len(payload) > MAX_RPC_BYTES:
+        raise RpcProtocolError("RPC message is empty or oversized")
+    try:
+        decoded = json.loads(payload, object_pairs_hook=_reject_duplicate)
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError, RpcProtocolError) as error:
+        raise RpcProtocolError("RPC message is malformed") from error
+    try:
+        parsed = model.model_validate(decoded, strict=True)
+    except Exception as error:
+        raise RpcProtocolError("RPC message shape is invalid") from error
+    if parsed.to_canonical_json() != payload:
+        raise RpcProtocolError("RPC message is not canonical JSON")
+    return parsed
+
+
+class IncrementalReader:
+    """Bound allocation before newline and reject EOF in a partial frame."""
+
+    def __init__(self, fd: int) -> None:
+        self.fd = fd
+        self._buffer = bytearray()
+
+    def read_line(self) -> bytes:
+        while True:
+            newline = self._buffer.find(b"\n")
+            if newline >= 0:
+                line = bytes(self._buffer[: newline + 1])
+                del self._buffer[: newline + 1]
+                if len(line) - 1 > MAX_RPC_BYTES:
+                    raise RpcProtocolError("RPC message exceeds one MiB")
+                return line
+            if len(self._buffer) > MAX_RPC_BYTES:
+                raise RpcProtocolError("RPC message exceeds one MiB before newline")
+            try:
+                chunk = os.read(self.fd, min(65536, MAX_RPC_BYTES + 1 - len(self._buffer)))
+            except InterruptedError:
+                continue
+            if not chunk:
+                if self._buffer:
+                    raise RpcProtocolError("partial RPC message at EOF")
+                raise EOFError
+            self._buffer.extend(chunk)
+
+
+class IncrementalWriter:
+    def __init__(self, fd: int) -> None:
+        self.fd = fd
+
+    def write(self, data: bytes) -> None:
+        view = memoryview(data)
+        while view:
+            try:
+                written = os.write(self.fd, view)
+            except InterruptedError:
+                continue
+            except OSError as error:
+                if error.errno == errno.EINTR:
+                    continue
+                raise
+            if written <= 0:
+                raise BrokenPipeError("protocol descriptor accepted no bytes")
+            view = view[written:]
+
+
+class RpcClient:
+    """One-flight host RPC with strict monotonic response correlation."""
+
+    def __init__(
+        self,
+        request_fd: int,
+        response_fd: int,
+        *,
+        terminate: Callable[[], Any],
+    ) -> None:
+        self._reader = IncrementalReader(response_fd)
+        self._writer = IncrementalWriter(request_fd)
+        self._terminate = terminate
+        self._next_id = 1
+        self._lock = asyncio.Lock()
+        self._poisoned = False
+
+    async def call(
+        self,
+        method: AdapterMethod,
+        params: ProtocolModel,
+        *,
+        timeout: float,
+    ) -> dict[str, Any]:
+        async with self._lock:
+            if self._poisoned:
+                raise RpcProtocolError("RPC channel is poisoned")
+            request_id = self._next_id
+            self._next_id += 1
+            if request_id > MAX_SAFE_ID:
+                await self._poison()
+                raise RpcProtocolError("RPC request IDs exhausted")
+            request = RpcRequest(
+                jsonrpc="2.0",
+                id=request_id,
+                method=method,
+                params=params.model_dump(mode="json"),
+            )
+            try:
+                self._writer.write(canonical_line(request))
+                response = await asyncio.wait_for(
+                    asyncio.to_thread(self._read_response, request_id, method), timeout
+                )
+            except TimeoutError:
+                try:
+                    self._writer.write(
+                        canonical_line(
+                            CancelRequest(jsonrpc="2.0", control="cancel", id=request_id)
+                        )
+                    )
+                    await asyncio.sleep(1)
+                finally:
+                    await asyncio.shield(self._poison())
+                raise
+            except asyncio.CancelledError:
+                await asyncio.shield(self._poison())
+                raise
+            except Exception:
+                await asyncio.shield(self._poison())
+                raise
+            if response.error is not None:
+                raise RpcRemoteError(response.error.code, response.error.message)
+            assert response.result is not None
+            return response.result
+
+    def _read_response(self, request_id: int, method: AdapterMethod) -> RpcResponse:
+        parsed = parse_canonical_line(self._reader.read_line(), RpcResponse)
+        assert isinstance(parsed, RpcResponse)
+        if parsed.id != request_id or parsed.method != method:
+            raise RpcProtocolError("RPC response ID or method differs from the in-flight call")
+        return parsed
+
+    async def _poison(self) -> None:
+        if self._poisoned:
+            return
+        self._poisoned = True
+        result = self._terminate()
+        if hasattr(result, "__await__"):
+            await result

--- a/local_operator/evaluation/adapters/rpc.py
+++ b/local_operator/evaluation/adapters/rpc.py
@@ -103,6 +103,24 @@ def parse_canonical_line(line: bytes, model: type[ProtocolModel]) -> ProtocolMod
     return parsed
 
 
+def parse_request_or_cancel(line: bytes) -> RpcRequest | CancelRequest:
+    """Decode the application and control planes without accepting extra shapes."""
+
+    request_error: RpcProtocolError | None = None
+    try:
+        parsed = parse_canonical_line(line, RpcRequest)
+        assert isinstance(parsed, RpcRequest)
+        return parsed
+    except RpcProtocolError as error:
+        request_error = error
+    try:
+        parsed = parse_canonical_line(line, CancelRequest)
+        assert isinstance(parsed, CancelRequest)
+        return parsed
+    except RpcProtocolError:
+        raise request_error
+
+
 class IncrementalReader:
     """Bound allocation before newline and reject EOF in a partial frame."""
 
@@ -123,6 +141,45 @@ class IncrementalReader:
                 raise RpcProtocolError("RPC message exceeds one MiB before newline")
             try:
                 chunk = os.read(self.fd, min(65536, MAX_RPC_BYTES + 1 - len(self._buffer)))
+            except InterruptedError:
+                continue
+            if not chunk:
+                if self._buffer:
+                    raise RpcProtocolError("partial RPC message at EOF")
+                raise EOFError
+            self._buffer.extend(chunk)
+
+
+class AsyncIncrementalReader:
+    """Event-loop pipe reader so cancel remains readable without executor leaks."""
+
+    def __init__(self, fd: int) -> None:
+        self.fd = fd
+        self._buffer = bytearray()
+        os.set_blocking(fd, False)
+
+    async def read_line(self) -> bytes:
+        loop = asyncio.get_running_loop()
+        while True:
+            newline = self._buffer.find(b"\n")
+            if newline >= 0:
+                line = bytes(self._buffer[: newline + 1])
+                del self._buffer[: newline + 1]
+                if len(line) - 1 > MAX_RPC_BYTES:
+                    raise RpcProtocolError("RPC message exceeds one MiB")
+                return line
+            if len(self._buffer) > MAX_RPC_BYTES:
+                raise RpcProtocolError("RPC message exceeds one MiB before newline")
+            ready = asyncio.Event()
+            loop.add_reader(self.fd, ready.set)
+            try:
+                await ready.wait()
+            finally:
+                loop.remove_reader(self.fd)
+            try:
+                chunk = os.read(self.fd, min(65536, MAX_RPC_BYTES + 1 - len(self._buffer)))
+            except BlockingIOError:
+                continue
             except InterruptedError:
                 continue
             if not chunk:

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -408,7 +408,7 @@ class HostVerifier:
         self.artifact_root = artifact_root
         self.current_observation: Any | None = None
         self._sequences: set[int] = set()
-        self._outstanding_ask: str | None = None
+        self._outstanding_ask: tuple[AskUserExchangeParams, Digest] | None = None
         self._score_ids: set[str] = set()
 
     def accept_initial(self, observation: Any) -> None:
@@ -458,17 +458,31 @@ class HostVerifier:
             raise SupervisionError("ask-user exchange belongs to another episode")
         if self._outstanding_ask is not None or params.answer is not None:
             raise SupervisionError("ask-user exchange must begin once without an answer")
-        self._outstanding_ask = params.ask_id
+        request_digest = self._ask_request_digest(params)
+        self._outstanding_ask = (params, request_digest)
 
     def finish_ask(self, params: AskUserExchangeParams, result: AskUserExchangeResult) -> None:
+        outstanding = self._outstanding_ask
+        request_digest = self._ask_request_digest(params)
         if (
             params.episode_id != self.episode_id
-            or self._outstanding_ask != params.ask_id
+            or outstanding is None
+            or outstanding[1] != request_digest
+            or outstanding[0].ask_id != params.ask_id
             or result.ask_id != params.ask_id
             or params.answer is None
         ):
             raise SupervisionError("ask-user response is stale, unsolicited, or mismatched")
         self._outstanding_ask = None
+
+    @staticmethod
+    def _ask_request_digest(params: AskUserExchangeParams) -> Digest:
+        # The answer and retry operation key are completion data. Everything
+        # model-visible in the initiating request remains immutable.
+        return canonical_digest(
+            "adapter-ask-user-request-v1",
+            params.model_dump(mode="json", exclude={"operation_id", "answer"}),
+        )
 
     def accept_score(self, result: ScoreResult) -> None:
         if result.score.score_id in self._score_ids:

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -19,12 +19,15 @@ from typing import Any
 from pydantic import field_validator, model_validator
 
 from local_operator.evaluation.adapters.api import (
+    AckResult,
     AdapterResult,
     AdapterSelector,
     AskUserExchangeParams,
     AskUserExchangeResult,
+    BeginRescueParams,
     CleanupParams,
     CleanupResult,
+    CloseParams,
     ExecuteParams,
     ExecuteResult,
     Handshake,
@@ -399,7 +402,9 @@ def _terminate_process_group(process: subprocess.Popen[bytes], pgid: int) -> Non
 class HostVerifier:
     """Parent-owned episode truth; adapters never grant lifecycle authority."""
 
-    def __init__(self, artifact_root: Path) -> None:
+    def __init__(self, task_id: str, episode_id: str, artifact_root: Path) -> None:
+        self.task_id = task_id
+        self.episode_id = episode_id
         self.artifact_root = artifact_root
         self.current_observation: Any | None = None
         self._sequences: set[int] = set()
@@ -407,6 +412,11 @@ class HostVerifier:
         self._score_ids: set[str] = set()
 
     def accept_observation(self, observation: Any) -> None:
+        if (observation.task_id, observation.episode_id) != (
+            self.task_id,
+            self.episode_id,
+        ):
+            raise SupervisionError("adapter observation belongs to another task or episode")
         validate_observation(observation)
         for frame in observation.frames:
             verify_artifact(self.artifact_root, frame.artifact)
@@ -580,6 +590,23 @@ async def run_rescue(
         handshake = await supervisor.handshake()
         if handshake != descriptor.handshake:
             raise SupervisionError("rescue worker handshake differs from persisted pins")
+        begin = await supervisor.call(
+            "begin_rescue",
+            BeginRescueParams(
+                operation_id=f"rescue-begin-{descriptor.descriptor_id[:32]}",
+                descriptor=descriptor,
+                descriptor_id=descriptor.descriptor_id,
+                episode_id=descriptor.episode_id,
+                cleanup_plan_id=descriptor.cleanup_plan.cleanup_plan_id,
+                selector_digest=canonical_digest("adapter-rescue-selector-v1", descriptor.selector),
+                handshake_digest=canonical_digest(
+                    "adapter-rescue-handshake-v1", descriptor.handshake
+                ),
+            ),
+            AckResult,
+            timeout=10.0,
+        )
+        assert isinstance(begin, AckResult)
         for action in descriptor.cleanup_plan.actions:
             # One action per call preserves each action's own timeout/attempt cap
             # and makes missing or duplicate receipts independently detectable.
@@ -605,6 +632,16 @@ async def run_rescue(
                 raise SupervisionError("rescue receipt differs from persisted cleanup action")
             receipts.append(receipt)
         cleanup = aggregate_cleanup(descriptor.cleanup_plan, receipts)
+        closed = await supervisor.call(
+            "close",
+            CloseParams(
+                operation_id=f"rescue-close-{descriptor.descriptor_id[:32]}",
+                episode_id=descriptor.episode_id,
+            ),
+            AckResult,
+            timeout=10.0,
+        )
+        assert isinstance(closed, AckResult)
         return RescueAggregate(
             descriptor_id=descriptor.descriptor_id,
             receipts=tuple(receipts),

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -58,7 +58,12 @@ from local_operator.evaluation.evidence.media import (
     validate_media,
 )
 from local_operator.evaluation.evidence.models import canonical_digest
-from local_operator.evaluation.lifecycle import CleanupReceipt, aggregate_cleanup
+from local_operator.evaluation.lifecycle import (
+    CleanupPlan,
+    CleanupReceipt,
+    aggregate_cleanup,
+    record_cleanup,
+)
 from local_operator.evaluation.protocol import ArtifactRef, ProtocolModel
 from local_operator.evaluation.receipts import ZERO_DIGEST, Digest
 
@@ -492,7 +497,11 @@ class HostVerifier:
         request_digest = self._ask_request_digest(params)
         self._outstanding_ask = (params, request_digest)
 
-    def finish_ask(self, params: AskUserExchangeParams, result: AskUserExchangeResult) -> None:
+    def validate_ask_completion(
+        self,
+        params: AskUserExchangeParams,
+        result: AskUserExchangeResult | None = None,
+    ) -> None:
         outstanding = self._outstanding_ask
         request_digest = self._ask_request_digest(params)
         if (
@@ -500,10 +509,13 @@ class HostVerifier:
             or outstanding is None
             or outstanding[1] != request_digest
             or outstanding[0].ask_id != params.ask_id
-            or result.ask_id != params.ask_id
+            or (result is not None and result.ask_id != params.ask_id)
             or params.answer is None
         ):
             raise SupervisionError("ask-user response is stale, unsolicited, or mismatched")
+
+    def finish_ask(self, params: AskUserExchangeParams, result: AskUserExchangeResult) -> None:
+        self.validate_ask_completion(params, result)
         self._outstanding_ask = None
 
     @staticmethod
@@ -533,9 +545,51 @@ class HostVerifier:
 class VerifiedAdapterSession:
     """Typed application surface that cannot bypass parent-owned verification."""
 
-    def __init__(self, supervisor: AdapterSupervisor, verifier: HostVerifier) -> None:
+    def __init__(
+        self,
+        supervisor: AdapterSupervisor,
+        verifier: HostVerifier,
+        *,
+        rescue_required: Callable[[], None] | None = None,
+    ) -> None:
         self._supervisor = supervisor
         self.verifier = verifier
+        self._rescue_required = rescue_required or (lambda: None)
+        self._rescue_descriptor_id: Digest | None = None
+        self._cleanup_plan: CleanupPlan | None = None
+        self._poisoned = False
+
+    def mark_rescue_persisted(self, descriptor_id: Digest) -> None:
+        self._rescue_descriptor_id = descriptor_id
+
+    def _ensure_usable(self) -> None:
+        if self._poisoned:
+            raise SupervisionError("adapter session is poisoned; rescue is required")
+
+    async def _poison_after_ambiguous_mutation(self) -> None:
+        if self._poisoned:
+            return
+        self._poisoned = True
+        self._rescue_required()
+        await asyncio.shield(self._supervisor.terminate())
+
+    async def _mutating_call(
+        self,
+        method: Any,
+        params: ProtocolModel,
+        result_type: type[AdapterResult],
+        *,
+        timeout: float,
+        validate: Callable[[AdapterResult], None],
+    ) -> AdapterResult:
+        self._ensure_usable()
+        try:
+            result = await self._supervisor._call_raw(method, params, result_type, timeout=timeout)
+            validate(result)
+            return result
+        except BaseException:
+            await self._poison_after_ambiguous_mutation()
+            raise
 
     async def inspect_requirements(
         self, params: InspectRequirementsParams, *, timeout: float
@@ -549,10 +603,21 @@ class VerifiedAdapterSession:
     async def prepare(self, params: PrepareParams, *, timeout: float) -> PrepareResult:
         if params.episode_id != self.verifier.episode_id:
             raise SupervisionError("prepare belongs to another episode")
-        result = await self._supervisor._call_raw("prepare", params, PrepareResult, timeout=timeout)
+        self._ensure_usable()
+        if self._rescue_descriptor_id is None:
+            raise SupervisionError("prepare requires a persisted rescue descriptor")
+
+        def validate(result: AdapterResult) -> None:
+            if not isinstance(result, PrepareResult):
+                raise SupervisionError("prepare returned the wrong result")
+            if result.cleanup_plan.episode_id != self.verifier.episode_id:
+                raise SupervisionError("cleanup plan belongs to another episode")
+
+        result = await self._mutating_call(
+            "prepare", params, PrepareResult, timeout=timeout, validate=validate
+        )
         assert isinstance(result, PrepareResult)
-        if result.cleanup_plan.episode_id != self.verifier.episode_id:
-            raise SupervisionError("cleanup plan belongs to another episode")
+        self._cleanup_plan = result.cleanup_plan
         return result
 
     async def reset_start(self, params: ResetStartParams, *, timeout: float) -> ObservationResult:
@@ -561,7 +626,18 @@ class VerifiedAdapterSession:
             self.verifier.episode_id,
         ):
             raise SupervisionError("reset belongs to another task or episode")
-        ack = await self._supervisor._call_raw("reset_start", params, AckResult, timeout=timeout)
+        self._ensure_usable()
+        ack = await self._mutating_call(
+            "reset_start",
+            params,
+            AckResult,
+            timeout=timeout,
+            validate=lambda result: (
+                None
+                if isinstance(result, AckResult)
+                else (_ for _ in ()).throw(SupervisionError("reset returned the wrong result"))
+            ),
+        )
         assert isinstance(ack, AckResult)
         initial = await self._supervisor._call_raw(
             "observe",
@@ -574,13 +650,18 @@ class VerifiedAdapterSession:
         return initial
 
     async def observe(self, params: ObserveParams, *, timeout: float) -> ObservationResult:
+        self._ensure_usable()
         if params.episode_id != self.verifier.episode_id:
             raise SupervisionError("observe belongs to another episode")
-        result = await self._supervisor._call_raw(
-            "observe", params, ObservationResult, timeout=timeout
-        )
-        assert isinstance(result, ObservationResult)
-        self.verifier.verify_current_snapshot(result.observation)
+        try:
+            result = await self._supervisor._call_raw(
+                "observe", params, ObservationResult, timeout=timeout
+            )
+            assert isinstance(result, ObservationResult)
+            self.verifier.verify_current_snapshot(result.observation)
+        except BaseException:
+            await self._poison_after_ambiguous_mutation()
+            raise
         return result
 
     async def execute(self, params: ExecuteParams, *, timeout: float) -> ExecuteResult:
@@ -588,7 +669,18 @@ class VerifiedAdapterSession:
         if current is None:
             raise SupervisionError("execute has no current observation")
         params.action_batch.validate_for(current)
-        result = await self._supervisor._call_raw("execute", params, ExecuteResult, timeout=timeout)
+        self._ensure_usable()
+        result = await self._mutating_call(
+            "execute",
+            params,
+            ExecuteResult,
+            timeout=timeout,
+            validate=lambda value: (
+                self.verifier.validate_execution_result(params, value)
+                if isinstance(value, ExecuteResult)
+                else (_ for _ in ()).throw(SupervisionError("execute returned the wrong result"))
+            ),
+        )
         assert isinstance(result, ExecuteResult)
         self.verifier.accept_execution(params, result)
         return result
@@ -599,8 +691,19 @@ class VerifiedAdapterSession:
     async def finish_ask(
         self, params: AskUserExchangeParams, *, timeout: float
     ) -> AskUserExchangeResult:
-        result = await self._supervisor._call_raw(
-            "ask_user_exchange", params, AskUserExchangeResult, timeout=timeout
+        self._ensure_usable()
+        # This prospective check rejects changed prompts before an adapter call.
+        self.verifier.validate_ask_completion(params)
+        result = await self._mutating_call(
+            "ask_user_exchange",
+            params,
+            AskUserExchangeResult,
+            timeout=timeout,
+            validate=lambda value: (
+                self.verifier.validate_ask_completion(params, value)
+                if isinstance(value, AskUserExchangeResult)
+                else (_ for _ in ()).throw(SupervisionError("ask returned the wrong result"))
+            ),
         )
         assert isinstance(result, AskUserExchangeResult)
         self.verifier.finish_ask(params, result)
@@ -609,23 +712,62 @@ class VerifiedAdapterSession:
     async def score(self, params: ScoreParams, *, timeout: float) -> ScoreResult:
         if params.episode_id != self.verifier.episode_id:
             raise SupervisionError("score belongs to another episode")
-        result = await self._supervisor._call_raw("score", params, ScoreResult, timeout=timeout)
+        self._ensure_usable()
+        result = await self._mutating_call(
+            "score",
+            params,
+            ScoreResult,
+            timeout=timeout,
+            validate=lambda value: (
+                self.verifier.accept_score(params, value)
+                if isinstance(value, ScoreResult)
+                else (_ for _ in ()).throw(SupervisionError("score returned the wrong result"))
+            ),
+        )
         assert isinstance(result, ScoreResult)
-        self.verifier.accept_score(params, result)
         return result
 
-    async def cleanup(self, params: CleanupParams, *, timeout: float) -> CleanupResult:
-        if params.cleanup_plan.episode_id != self.verifier.episode_id:
-            raise SupervisionError("cleanup belongs to another episode")
-        result = await self._supervisor._call_raw("cleanup", params, CleanupResult, timeout=timeout)
-        assert isinstance(result, CleanupResult)
-        selected = set(params.action_ids)
+    async def cleanup(self, params: CleanupParams, *, timeout: float) -> tuple[CleanupReceipt, ...]:
+        self._ensure_usable()
+        plan = self._cleanup_plan
         if (
-            len(result.receipts) != len(selected)
-            or {receipt.action_id for receipt in result.receipts} != selected
+            plan is None
+            or params.cleanup_plan != plan
+            or params.cleanup_plan.episode_id != self.verifier.episode_id
         ):
-            raise SupervisionError("cleanup receipts differ from selected actions")
-        return result
+            raise SupervisionError("cleanup differs from the prepared cleanup plan")
+        selected = {
+            action.action_id: action
+            for action in plan.actions
+            if action.action_id in params.action_ids
+        }
+        if set(selected) != set(params.action_ids):
+            raise SupervisionError("cleanup selects an action outside the prepared plan")
+        receipts: tuple[CleanupReceipt, ...] = ()
+
+        def validate(value: AdapterResult) -> None:
+            nonlocal receipts
+            if not isinstance(value, CleanupResult):
+                raise SupervisionError("cleanup returned the wrong result")
+            if len(value.outcomes) != len(selected) or {
+                outcome.action_id for outcome in value.outcomes
+            } != set(selected):
+                raise SupervisionError("cleanup outcomes differ from selected actions")
+            receipts = tuple(
+                record_cleanup(
+                    plan,
+                    outcome.action_id,
+                    status=outcome.status,
+                    evidence_code=outcome.evidence_code,
+                    duration_ms=outcome.duration_ms,
+                )
+                for outcome in value.outcomes
+            )
+
+        await self._mutating_call(
+            "cleanup", params, CleanupResult, timeout=timeout, validate=validate
+        )
+        return receipts
 
     async def close(self, params: CloseParams, *, timeout: float) -> AckResult:
         if params.episode_id not in (None, self.verifier.episode_id):
@@ -796,15 +938,18 @@ async def run_rescue(
                 timeout=action.timeout_ms / 1000 * action.max_attempts,
             )
             assert isinstance(result, CleanupResult)
-            if len(result.receipts) != 1 or result.receipts[0].action_id != action.action_id:
-                raise SupervisionError("rescue cleanup returned missing or duplicate receipts")
-            receipt = result.receipts[0]
-            if (
-                receipt.cleanup_plan_id != descriptor.cleanup_plan.cleanup_plan_id
-                or receipt.action_digest != action.action_digest
-            ):
-                raise SupervisionError("rescue receipt differs from persisted cleanup action")
-            receipts.append(receipt)
+            if len(result.outcomes) != 1 or result.outcomes[0].action_id != action.action_id:
+                raise SupervisionError("rescue cleanup returned missing or duplicate outcomes")
+            outcome = result.outcomes[0]
+            receipts.append(
+                record_cleanup(
+                    descriptor.cleanup_plan,
+                    outcome.action_id,
+                    status=outcome.status,
+                    evidence_code=outcome.evidence_code,
+                    duration_ms=outcome.duration_ms,
+                )
+            )
         cleanup = aggregate_cleanup(descriptor.cleanup_plan, receipts)
         closed = await supervisor._call_raw(
             "close",

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import signal
 import stat
@@ -46,7 +47,9 @@ from local_operator.evaluation.adapters.api import (
     validate_observation,
 )
 from local_operator.evaluation.adapters.discovery import (
-    validate_launch_paths,
+    ResolvedLaunch,
+    resolve_launch,
+    validate_resolved_launch,
     worker_argv,
 )
 from local_operator.evaluation.adapters.rpc import RpcClient
@@ -65,6 +68,7 @@ if os.name != "posix":  # pragma: no cover - import itself is the explicit diagn
 MAX_DIAGNOSTIC_TAIL = 64 * 1024
 TERM_GRACE_SECONDS = 5.0
 OWNER_FD_ENV = "LO_ADAPTER_OWNER_FD"
+LAUNCH_IDENTITY_ENV = "LO_ADAPTER_LAUNCH_IDENTITY"
 REQUEST_FD_ENV = "LO_ADAPTER_REQUEST_FD"
 RESPONSE_FD_ENV = "LO_ADAPTER_RESPONSE_FD"
 _RESCUE_FILE = "rescue.json"
@@ -189,6 +193,12 @@ def supervise_worker(argv: Sequence[str]) -> int:
         os.environ,
         protocol_fds={REQUEST_FD_ENV: request_fd, RESPONSE_FD_ENV: response_fd},
     )
+    identity_payload = os.environ.pop(LAUNCH_IDENTITY_ENV, "")
+    try:
+        resolved = ResolvedLaunch(**json.loads(identity_payload))
+    except (TypeError, ValueError, json.JSONDecodeError) as error:
+        raise SupervisionError("supervisor launch identity is missing or malformed") from error
+    validate_resolved_launch(resolved)
     child = subprocess.Popen(
         list(argv),
         stdin=subprocess.DEVNULL,
@@ -229,7 +239,7 @@ class AdapterSupervisor:
         *,
         environment: Mapping[str, str] | None = None,
     ) -> "AdapterSupervisor":
-        validate_launch_paths(selector)
+        resolved = resolve_launch(selector)
         owner_read, owner_write = os.pipe()
         request_read, request_write = os.pipe()
         response_read, response_write = os.pipe()
@@ -239,6 +249,7 @@ class AdapterSupervisor:
             RESPONSE_FD_ENV: response_write,
         }
         env = minimal_environment(environment or os.environ, protocol_fds=protocol_fds)
+        env[LAUNCH_IDENTITY_ENV] = json.dumps(resolved.__dict__, sort_keys=True)
         argv = (
             selector.python_executable,
             "-I",
@@ -251,6 +262,10 @@ class AdapterSupervisor:
         )
         process: subprocess.Popen[bytes] | None = None
         try:
+            # The supervisor cannot make subprocess.exec race-free, but comparing
+            # captured dev/inode/mode immediately before spawn closes alias and
+            # ordinary swap attacks at both parent and leader boundaries.
+            validate_resolved_launch(resolved)
             process = subprocess.Popen(
                 argv,
                 cwd=selector.workspace,

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -32,7 +32,15 @@ from local_operator.evaluation.adapters.api import (
     ExecuteResult,
     Handshake,
     HelloParams,
+    InspectRequirementsParams,
+    ObservationResult,
+    ObserveParams,
+    PrepareParams,
+    PrepareResult,
+    RequirementsResult,
     RescueDescriptor,
+    ResetStartParams,
+    ScoreParams,
     ScoreResult,
     validate_execution,
     validate_observation,
@@ -302,7 +310,7 @@ class AdapterSupervisor:
             thread.start()
             self._drainers.append(thread)
 
-    async def call(
+    async def _call_raw(
         self,
         method: Any,
         params: ProtocolModel,
@@ -316,7 +324,7 @@ class AdapterSupervisor:
         return result_type.model_validate(payload, strict=True)
 
     async def handshake(self, *, timeout: float = 10.0) -> Handshake:
-        result = await self.call(
+        result = await self._call_raw(
             "hello", HelloParams(selector=self.selector), Handshake, timeout=timeout
         )
         assert isinstance(result, Handshake)
@@ -419,10 +427,7 @@ class HostVerifier:
         self.current_observation = observation
 
     def accept_output(self, observation: Any) -> None:
-        current = self.current_observation
-        if current is None or observation.sequence != current.sequence + 1:
-            raise SupervisionError("adapter output must be the exact next sequence")
-        self._validate_observation_content(observation)
+        self._validate_output(observation)
         self._sequences.add(observation.sequence)
         self.current_observation = observation
 
@@ -442,7 +447,7 @@ class HostVerifier:
         for frame in observation.frames:
             verify_artifact(self.artifact_root, frame.artifact)
 
-    def accept_execution(self, params: ExecuteParams, result: ExecuteResult) -> None:
+    def validate_execution_result(self, params: ExecuteParams, result: ExecuteResult) -> None:
         if self.current_observation is None:
             raise SupervisionError("execution has no current observation")
         validate_execution(
@@ -451,7 +456,18 @@ class HostVerifier:
             self.current_observation,
             seen_sequences=self._sequences,
         )
-        self.accept_output(result.observation)
+        self._validate_output(result.observation)
+
+    def accept_execution(self, params: ExecuteParams, result: ExecuteResult) -> None:
+        self.validate_execution_result(params, result)
+        self._sequences.add(result.observation.sequence)
+        self.current_observation = result.observation
+
+    def _validate_output(self, observation: Any) -> None:
+        current = self.current_observation
+        if current is None or observation.sequence != current.sequence + 1:
+            raise SupervisionError("adapter output must be the exact next sequence")
+        self._validate_observation_content(observation)
 
     def begin_ask(self, params: AskUserExchangeParams) -> None:
         if params.episode_id != self.episode_id:
@@ -484,15 +500,124 @@ class HostVerifier:
             params.model_dump(mode="json", exclude={"operation_id", "answer"}),
         )
 
-    def accept_score(self, result: ScoreResult) -> None:
+    def accept_score(self, params: ScoreParams, result: ScoreResult) -> None:
+        if params.episode_id != self.episode_id:
+            raise SupervisionError("score belongs to another episode")
         if result.score.score_id in self._score_ids:
             raise SupervisionError("score artifact identity is duplicated")
-        self._score_ids.add(result.score.score_id)
         if result.score.details is not None:
             reference = ArtifactRef.model_validate(
                 result.score.details.model_dump(mode="json"), strict=True
             )
             verify_artifact(self.artifact_root, reference)
+        # Consume identity only after every referenced byte passed verification,
+        # so a missing artifact can be repaired and retried safely.
+        self._score_ids.add(result.score.score_id)
+
+
+class VerifiedAdapterSession:
+    """Typed application surface that cannot bypass parent-owned verification."""
+
+    def __init__(self, supervisor: AdapterSupervisor, verifier: HostVerifier) -> None:
+        self._supervisor = supervisor
+        self.verifier = verifier
+
+    async def inspect_requirements(
+        self, params: InspectRequirementsParams, *, timeout: float
+    ) -> RequirementsResult:
+        result = await self._supervisor._call_raw(
+            "inspect_requirements", params, RequirementsResult, timeout=timeout
+        )
+        assert isinstance(result, RequirementsResult)
+        return result
+
+    async def prepare(self, params: PrepareParams, *, timeout: float) -> PrepareResult:
+        if params.episode_id != self.verifier.episode_id:
+            raise SupervisionError("prepare belongs to another episode")
+        result = await self._supervisor._call_raw("prepare", params, PrepareResult, timeout=timeout)
+        assert isinstance(result, PrepareResult)
+        if result.cleanup_plan.episode_id != self.verifier.episode_id:
+            raise SupervisionError("cleanup plan belongs to another episode")
+        return result
+
+    async def reset_start(self, params: ResetStartParams, *, timeout: float) -> ObservationResult:
+        if (params.task_id, params.episode_id) != (
+            self.verifier.task_id,
+            self.verifier.episode_id,
+        ):
+            raise SupervisionError("reset belongs to another task or episode")
+        ack = await self._supervisor._call_raw("reset_start", params, AckResult, timeout=timeout)
+        assert isinstance(ack, AckResult)
+        initial = await self._supervisor._call_raw(
+            "observe",
+            ObserveParams(episode_id=params.episode_id),
+            ObservationResult,
+            timeout=timeout,
+        )
+        assert isinstance(initial, ObservationResult)
+        self.verifier.accept_initial(initial.observation)
+        return initial
+
+    async def observe(self, params: ObserveParams, *, timeout: float) -> ObservationResult:
+        if params.episode_id != self.verifier.episode_id:
+            raise SupervisionError("observe belongs to another episode")
+        result = await self._supervisor._call_raw(
+            "observe", params, ObservationResult, timeout=timeout
+        )
+        assert isinstance(result, ObservationResult)
+        self.verifier.verify_current_snapshot(result.observation)
+        return result
+
+    async def execute(self, params: ExecuteParams, *, timeout: float) -> ExecuteResult:
+        current = self.verifier.current_observation
+        if current is None:
+            raise SupervisionError("execute has no current observation")
+        params.action_batch.validate_for(current)
+        result = await self._supervisor._call_raw("execute", params, ExecuteResult, timeout=timeout)
+        assert isinstance(result, ExecuteResult)
+        self.verifier.accept_execution(params, result)
+        return result
+
+    def begin_ask(self, params: AskUserExchangeParams) -> None:
+        self.verifier.begin_ask(params)
+
+    async def finish_ask(
+        self, params: AskUserExchangeParams, *, timeout: float
+    ) -> AskUserExchangeResult:
+        result = await self._supervisor._call_raw(
+            "ask_user_exchange", params, AskUserExchangeResult, timeout=timeout
+        )
+        assert isinstance(result, AskUserExchangeResult)
+        self.verifier.finish_ask(params, result)
+        return result
+
+    async def score(self, params: ScoreParams, *, timeout: float) -> ScoreResult:
+        if params.episode_id != self.verifier.episode_id:
+            raise SupervisionError("score belongs to another episode")
+        result = await self._supervisor._call_raw("score", params, ScoreResult, timeout=timeout)
+        assert isinstance(result, ScoreResult)
+        self.verifier.accept_score(params, result)
+        return result
+
+    async def cleanup(self, params: CleanupParams, *, timeout: float) -> CleanupResult:
+        if params.cleanup_plan.episode_id != self.verifier.episode_id:
+            raise SupervisionError("cleanup belongs to another episode")
+        result = await self._supervisor._call_raw("cleanup", params, CleanupResult, timeout=timeout)
+        assert isinstance(result, CleanupResult)
+        selected = set(params.action_ids)
+        if (
+            len(result.receipts) != len(selected)
+            or {receipt.action_id for receipt in result.receipts} != selected
+        ):
+            raise SupervisionError("cleanup receipts differ from selected actions")
+        return result
+
+    async def close(self, params: CloseParams, *, timeout: float) -> AckResult:
+        if params.episode_id not in (None, self.verifier.episode_id):
+            raise SupervisionError("close belongs to another episode")
+        result = await self._supervisor._call_raw("close", params, AckResult, timeout=timeout)
+        assert isinstance(result, AckResult)
+        return result
 
 
 def verify_artifact(root: Path, reference: ArtifactRef) -> bytes:
@@ -624,7 +749,7 @@ async def run_rescue(
         handshake = await supervisor.handshake()
         if handshake != descriptor.handshake:
             raise SupervisionError("rescue worker handshake differs from persisted pins")
-        begin = await supervisor.call(
+        begin = await supervisor._call_raw(
             "begin_rescue",
             BeginRescueParams(
                 operation_id=f"rescue-begin-{descriptor.descriptor_id[:32]}",
@@ -645,7 +770,7 @@ async def run_rescue(
             # One action per call preserves each action's own timeout/attempt cap
             # and makes missing or duplicate receipts independently detectable.
             operation_id = f"rescue-{descriptor.descriptor_id[:16]}-{action.action_id}"
-            result = await supervisor.call(
+            result = await supervisor._call_raw(
                 "cleanup",
                 CleanupParams(
                     operation_id=operation_id,
@@ -666,7 +791,7 @@ async def run_rescue(
                 raise SupervisionError("rescue receipt differs from persisted cleanup action")
             receipts.append(receipt)
         cleanup = aggregate_cleanup(descriptor.cleanup_plan, receipts)
-        closed = await supervisor.call(
+        closed = await supervisor._call_raw(
             "close",
             CloseParams(
                 operation_id=f"rescue-close-{descriptor.descriptor_id[:32]}",

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -411,7 +411,28 @@ class HostVerifier:
         self._outstanding_ask: str | None = None
         self._score_ids: set[str] = set()
 
-    def accept_observation(self, observation: Any) -> None:
+    def accept_initial(self, observation: Any) -> None:
+        if self.current_observation is not None or observation.sequence != 0:
+            raise SupervisionError("initial adapter observation must be sequence zero")
+        self._validate_observation_content(observation)
+        self._sequences.add(observation.sequence)
+        self.current_observation = observation
+
+    def accept_output(self, observation: Any) -> None:
+        current = self.current_observation
+        if current is None or observation.sequence != current.sequence + 1:
+            raise SupervisionError("adapter output must be the exact next sequence")
+        self._validate_observation_content(observation)
+        self._sequences.add(observation.sequence)
+        self.current_observation = observation
+
+    def verify_current_snapshot(self, observation: Any) -> None:
+        current = self.current_observation
+        if current is None or observation != current:
+            raise SupervisionError("adapter snapshot differs from the current observation")
+        self._validate_observation_content(observation)
+
+    def _validate_observation_content(self, observation: Any) -> None:
         if (observation.task_id, observation.episode_id) != (
             self.task_id,
             self.episode_id,
@@ -420,10 +441,6 @@ class HostVerifier:
         validate_observation(observation)
         for frame in observation.frames:
             verify_artifact(self.artifact_root, frame.artifact)
-        if observation.sequence in self._sequences:
-            raise SupervisionError("adapter observation sequence is duplicated")
-        self._sequences.add(observation.sequence)
-        self.current_observation = observation
 
     def accept_execution(self, params: ExecuteParams, result: ExecuteResult) -> None:
         if self.current_observation is None:
@@ -434,16 +451,19 @@ class HostVerifier:
             self.current_observation,
             seen_sequences=self._sequences,
         )
-        self.accept_observation(result.observation)
+        self.accept_output(result.observation)
 
     def begin_ask(self, params: AskUserExchangeParams) -> None:
+        if params.episode_id != self.episode_id:
+            raise SupervisionError("ask-user exchange belongs to another episode")
         if self._outstanding_ask is not None or params.answer is not None:
             raise SupervisionError("ask-user exchange must begin once without an answer")
         self._outstanding_ask = params.ask_id
 
     def finish_ask(self, params: AskUserExchangeParams, result: AskUserExchangeResult) -> None:
         if (
-            self._outstanding_ask != params.ask_id
+            params.episode_id != self.episode_id
+            or self._outstanding_ask != params.ask_id
             or result.ask_id != params.ask_id
             or params.answer is None
         ):

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -1,0 +1,626 @@
+"""POSIX adapter-tree supervision, host verification, and durable rescue."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from collections import deque
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from pydantic import field_validator, model_validator
+
+from local_operator.evaluation.adapters.api import (
+    AdapterResult,
+    AdapterSelector,
+    AskUserExchangeParams,
+    AskUserExchangeResult,
+    CleanupParams,
+    CleanupResult,
+    ExecuteParams,
+    ExecuteResult,
+    Handshake,
+    HelloParams,
+    RescueDescriptor,
+    ScoreResult,
+    validate_execution,
+    validate_observation,
+)
+from local_operator.evaluation.adapters.discovery import (
+    validate_launch_paths,
+    worker_argv,
+)
+from local_operator.evaluation.adapters.rpc import RpcClient
+from local_operator.evaluation.evidence.media import (
+    MediaValidationError,
+    validate_media,
+)
+from local_operator.evaluation.evidence.models import canonical_digest
+from local_operator.evaluation.lifecycle import CleanupReceipt, aggregate_cleanup
+from local_operator.evaluation.protocol import ArtifactRef, ProtocolModel
+from local_operator.evaluation.receipts import ZERO_DIGEST, Digest
+
+if os.name != "posix":  # pragma: no cover - import itself is the explicit diagnostic
+    raise RuntimeError("evaluation adapter supervision requires POSIX process groups")
+
+MAX_DIAGNOSTIC_TAIL = 64 * 1024
+TERM_GRACE_SECONDS = 5.0
+OWNER_FD_ENV = "LO_ADAPTER_OWNER_FD"
+REQUEST_FD_ENV = "LO_ADAPTER_REQUEST_FD"
+RESPONSE_FD_ENV = "LO_ADAPTER_RESPONSE_FD"
+_RESCUE_FILE = "rescue.json"
+
+# Locale and temporary-directory settings are behavior inputs, not credentials.
+# Everything else is omitted instead of copying an ambient environment that may
+# contain paid-provider, model-route, or benchmark secrets.
+_ENV_ALLOW = frozenset({"LANG", "LC_ALL", "LC_CTYPE", "TMPDIR", "TEMP", "TMP"})
+_DENIED_MARKERS = ("OPENAI", "OPENROUTER", "ANTHROPIC", "MODEL", "PROVIDER")
+
+
+class SupervisionError(RuntimeError):
+    pass
+
+
+class _Tail:
+    def __init__(self, limit: int = MAX_DIAGNOSTIC_TAIL) -> None:
+        self._limit = limit
+        self._chunks: deque[bytes] = deque()
+        self._size = 0
+        self._lock = threading.Lock()
+
+    def append(self, chunk: bytes) -> None:
+        with self._lock:
+            self._chunks.append(chunk)
+            self._size += len(chunk)
+            while self._size > self._limit and self._chunks:
+                excess = self._size - self._limit
+                first = self._chunks[0]
+                if len(first) <= excess:
+                    self._chunks.popleft()
+                    self._size -= len(first)
+                else:
+                    self._chunks[0] = first[excess:]
+                    self._size -= excess
+
+    def bytes(self) -> bytes:
+        with self._lock:
+            return b"".join(self._chunks)
+
+
+def minimal_environment(
+    source: Mapping[str, str],
+    *,
+    protocol_fds: Mapping[str, int],
+) -> dict[str, str]:
+    """Construct, never copy, the worker environment from a closed allowlist."""
+
+    environment = {
+        name: value
+        for name, value in source.items()
+        if name in _ENV_ALLOW and not any(marker in name.upper() for marker in _DENIED_MARKERS)
+    }
+    for name, fd in protocol_fds.items():
+        if name not in {OWNER_FD_ENV, REQUEST_FD_ENV, RESPONSE_FD_ENV} or fd < 0:
+            raise ValueError("unknown or invalid protocol descriptor")
+        environment[name] = str(fd)
+    return environment
+
+
+def _reset_child_signals() -> None:
+    """Undo supervisor masks/defaults without mutating host signal state."""
+
+    signal.pthread_sigmask(signal.SIG_SETMASK, [])
+    for number in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGPIPE):
+        signal.signal(number, signal.SIG_DFL)
+
+
+def _owned_group(pgid: int) -> bool:
+    try:
+        return os.getpid() == pgid == os.getpgrp() == os.getpgid(os.getpid())
+    except ProcessLookupError:
+        return False
+
+
+def _signal_owned_group(pgid: int, number: int) -> bool:
+    """Refuse a stale/recycled PGID immediately before every signal."""
+
+    if not _owned_group(pgid):
+        return False
+    try:
+        os.killpg(pgid, number)
+    except (ProcessLookupError, PermissionError):
+        return False
+    return True
+
+
+def _owner_watch(owner_fd: int, pgid: int) -> None:
+    try:
+        while os.read(owner_fd, 4096):
+            pass
+    except OSError:
+        pass
+    finally:
+        try:
+            os.close(owner_fd)
+        except OSError:
+            pass
+    if not _signal_owned_group(pgid, signal.SIGTERM):
+        return
+    time.sleep(TERM_GRACE_SECONDS)
+    _signal_owned_group(pgid, signal.SIGKILL)
+
+
+def supervise_worker(argv: Sequence[str]) -> int:
+    """Remain group leader so descendants cannot outlive ownership loss."""
+
+    if not argv:
+        raise SupervisionError("supervisor requires a worker command")
+    owner_fd = int(os.environ.pop(OWNER_FD_ENV))
+    request_fd = int(os.environ[REQUEST_FD_ENV])
+    response_fd = int(os.environ[RESPONSE_FD_ENV])
+    pgid = os.getpid()
+    if not _owned_group(pgid):
+        raise SupervisionError("supervisor is not a fresh process-group leader")
+    # Core owns group termination.  The leader ignores TERM so its live PID keeps
+    # proving that the numeric PGID was not recycled during the grace interval.
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    watcher = threading.Thread(target=_owner_watch, args=(owner_fd, pgid), daemon=True)
+    watcher.start()
+    child_environment = minimal_environment(
+        os.environ,
+        protocol_fds={REQUEST_FD_ENV: request_fd, RESPONSE_FD_ENV: response_fd},
+    )
+    child = subprocess.Popen(
+        list(argv),
+        stdin=subprocess.DEVNULL,
+        stdout=None,
+        stderr=None,
+        env=child_environment,
+        close_fds=True,
+        pass_fds=(request_fd, response_fd),
+        preexec_fn=_reset_child_signals,
+    )
+    child.wait()
+    # Worker EOF must not release descendants.  The leader waits until owner EOF
+    # and is then removed with the entire group after the bounded grace period.
+    while True:
+        signal.pause()
+
+
+class AdapterSupervisor:
+    """Parent-owned handles for one isolated adapter process tree."""
+
+    def __init__(self, selector: AdapterSelector, process: subprocess.Popen[bytes]) -> None:
+        self.selector = selector
+        self.process = process
+        self.pgid = process.pid
+        self.stdout_tail = _Tail()
+        self.stderr_tail = _Tail()
+        self._owner_fd = -1
+        self._request_fd = -1
+        self._response_fd = -1
+        self.rpc: RpcClient | None = None
+        self._drainers: list[threading.Thread] = []
+        self._closed = False
+
+    @classmethod
+    def launch(
+        cls,
+        selector: AdapterSelector,
+        *,
+        environment: Mapping[str, str] | None = None,
+    ) -> "AdapterSupervisor":
+        validate_launch_paths(selector)
+        owner_read, owner_write = os.pipe()
+        request_read, request_write = os.pipe()
+        response_read, response_write = os.pipe()
+        protocol_fds = {
+            OWNER_FD_ENV: owner_read,
+            REQUEST_FD_ENV: request_read,
+            RESPONSE_FD_ENV: response_write,
+        }
+        env = minimal_environment(environment or os.environ, protocol_fds=protocol_fds)
+        argv = (
+            selector.python_executable,
+            "-I",
+            "-s",
+            "-E",
+            "-m",
+            "local_operator.evaluation.adapters.supervisor",
+            "--supervise",
+            *worker_argv(selector),
+        )
+        process: subprocess.Popen[bytes] | None = None
+        try:
+            process = subprocess.Popen(
+                argv,
+                cwd=selector.workspace,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+                close_fds=True,
+                pass_fds=(owner_read, request_read, response_write),
+                start_new_session=True,
+            )
+            os.close(owner_read)
+            os.close(request_read)
+            os.close(response_write)
+            owner_read = request_read = response_write = -1
+            try:
+                if process.pid != os.getpgid(process.pid):
+                    raise SupervisionError("spawned supervisor is not its process-group leader")
+            except ProcessLookupError as error:
+                raise SupervisionError("adapter supervisor exited during startup") from error
+            instance = cls(selector, process)
+            instance._owner_fd = owner_write
+            instance._request_fd = request_write
+            instance._response_fd = response_read
+            instance._start_drainers()
+            instance.rpc = RpcClient(
+                request_write,
+                response_read,
+                terminate=instance.terminate,
+            )
+            return instance
+        except Exception:
+            for fd in (
+                owner_read,
+                owner_write,
+                request_read,
+                request_write,
+                response_read,
+                response_write,
+            ):
+                if fd >= 0:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
+            if process is not None:
+                _terminate_process_group(process, process.pid)
+            raise
+
+    def _start_drainers(self) -> None:
+        assert self.process.stdout is not None and self.process.stderr is not None
+        for stream, tail in (
+            (self.process.stdout, self.stdout_tail),
+            (self.process.stderr, self.stderr_tail),
+        ):
+            thread = threading.Thread(target=_drain, args=(stream, tail), daemon=True)
+            thread.start()
+            self._drainers.append(thread)
+
+    async def call(
+        self,
+        method: Any,
+        params: ProtocolModel,
+        result_type: type[AdapterResult],
+        *,
+        timeout: float,
+    ) -> AdapterResult:
+        if self.rpc is None:
+            raise SupervisionError("adapter RPC is unavailable")
+        payload = await self.rpc.call(method, params, timeout=timeout)
+        return result_type.model_validate(payload, strict=True)
+
+    async def handshake(self, *, timeout: float = 10.0) -> Handshake:
+        result = await self.call(
+            "hello", HelloParams(selector=self.selector), Handshake, timeout=timeout
+        )
+        assert isinstance(result, Handshake)
+        # Constructing Handshake already enforces every repeated exact pin; this
+        # equality additionally prevents a caller from accepting another selector.
+        if result.selector != self.selector:
+            await self.terminate()
+            raise SupervisionError("adapter handshake selector differs")
+        return result
+
+    async def terminate(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        _terminate_process_group(self.process, self.pgid)
+        self._close_fds()
+        await asyncio.to_thread(self.process.wait)
+        for thread in self._drainers:
+            thread.join(timeout=1)
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        # Owner EOF is the normal teardown path and exercises the same rescue
+        # invariant used when the parent dies unexpectedly.
+        if self._owner_fd >= 0:
+            os.close(self._owner_fd)
+            self._owner_fd = -1
+        await asyncio.to_thread(self.process.wait)
+        self._closed = True
+        self._close_fds()
+        for thread in self._drainers:
+            thread.join(timeout=1)
+
+    def _close_fds(self) -> None:
+        for name in ("_owner_fd", "_request_fd", "_response_fd"):
+            fd = getattr(self, name)
+            if fd >= 0:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+                setattr(self, name, -1)
+
+
+def _drain(stream: Any, tail: _Tail) -> None:
+    try:
+        while chunk := stream.read(65536):
+            tail.append(chunk)
+    except OSError:
+        pass
+    finally:
+        stream.close()
+
+
+def _terminate_process_group(process: subprocess.Popen[bytes], pgid: int) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        identity_matches = process.pid == pgid == os.getpgid(process.pid)
+    except ProcessLookupError:
+        return
+    if not identity_matches:
+        raise SupervisionError("refusing to signal an unverified process group")
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        process.wait(timeout=TERM_GRACE_SECONDS)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        if process.pid != pgid or os.getpgid(process.pid) != pgid:
+            raise SupervisionError("process-group identity changed before SIGKILL")
+        os.killpg(pgid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    process.wait(timeout=TERM_GRACE_SECONDS)
+
+
+class HostVerifier:
+    """Parent-owned episode truth; adapters never grant lifecycle authority."""
+
+    def __init__(self, artifact_root: Path) -> None:
+        self.artifact_root = artifact_root
+        self.current_observation: Any | None = None
+        self._sequences: set[int] = set()
+        self._outstanding_ask: str | None = None
+        self._score_ids: set[str] = set()
+
+    def accept_observation(self, observation: Any) -> None:
+        validate_observation(observation)
+        for frame in observation.frames:
+            verify_artifact(self.artifact_root, frame.artifact)
+        if observation.sequence in self._sequences:
+            raise SupervisionError("adapter observation sequence is duplicated")
+        self._sequences.add(observation.sequence)
+        self.current_observation = observation
+
+    def accept_execution(self, params: ExecuteParams, result: ExecuteResult) -> None:
+        if self.current_observation is None:
+            raise SupervisionError("execution has no current observation")
+        validate_execution(
+            params,
+            result,
+            self.current_observation,
+            seen_sequences=self._sequences,
+        )
+        self.accept_observation(result.observation)
+
+    def begin_ask(self, params: AskUserExchangeParams) -> None:
+        if self._outstanding_ask is not None or params.answer is not None:
+            raise SupervisionError("ask-user exchange must begin once without an answer")
+        self._outstanding_ask = params.ask_id
+
+    def finish_ask(self, params: AskUserExchangeParams, result: AskUserExchangeResult) -> None:
+        if (
+            self._outstanding_ask != params.ask_id
+            or result.ask_id != params.ask_id
+            or params.answer is None
+        ):
+            raise SupervisionError("ask-user response is stale, unsolicited, or mismatched")
+        self._outstanding_ask = None
+
+    def accept_score(self, result: ScoreResult) -> None:
+        if result.score.score_id in self._score_ids:
+            raise SupervisionError("score artifact identity is duplicated")
+        self._score_ids.add(result.score.score_id)
+        if result.score.details is not None:
+            reference = ArtifactRef.model_validate(
+                result.score.details.model_dump(mode="json"), strict=True
+            )
+            verify_artifact(self.artifact_root, reference)
+
+
+def verify_artifact(root: Path, reference: ArtifactRef) -> bytes:
+    """Read one content-addressed artifact without following attacker links."""
+
+    name = reference.sha256
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    root_fd = os.open(root, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        fd = os.open(name, flags, dir_fd=root_fd)
+        try:
+            info = os.fstat(fd)
+            if not stat.S_ISREG(info.st_mode) or info.st_size != reference.byte_count:
+                raise SupervisionError("artifact is not a matching regular file")
+            data = bytearray()
+            while chunk := os.read(fd, min(65536, reference.byte_count + 1 - len(data))):
+                data.extend(chunk)
+                if len(data) > reference.byte_count:
+                    raise SupervisionError("artifact exceeds its declared size")
+        finally:
+            os.close(fd)
+    except OSError as error:
+        raise SupervisionError("artifact path is unsafe or unavailable") from error
+    finally:
+        os.close(root_fd)
+    raw = bytes(data)
+    import hashlib
+
+    if hashlib.sha256(raw).hexdigest() != name:
+        raise SupervisionError("artifact digest differs")
+    try:
+        validate_media(raw, reference.media_type)
+    except MediaValidationError as error:
+        raise SupervisionError("artifact media differs") from error
+    return raw
+
+
+def persist_rescue(root: Path, descriptor: RescueDescriptor) -> Path:
+    """Parent-owned atomic persistence before any prepare/reset side effect."""
+
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    path = root / _RESCUE_FILE
+    fd, temporary = tempfile.mkstemp(prefix=".rescue-", dir=root)
+    try:
+        os.fchmod(fd, 0o600)
+        payload = descriptor.to_canonical_json()
+        view = memoryview(payload)
+        while view:
+            written = os.write(fd, view)
+            if written <= 0:
+                raise OSError("rescue write made no progress")
+            view = view[written:]
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    try:
+        os.replace(temporary, path)
+        directory_fd = os.open(root, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+    return path
+
+
+def load_pending_rescue(root: Path) -> RescueDescriptor | None:
+    """Explicitly load one descriptor; importing or startup never scans."""
+
+    path = root / _RESCUE_FILE
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(path, flags)
+    except FileNotFoundError:
+        return None
+    except OSError as error:
+        raise SupervisionError("rescue descriptor path is unsafe") from error
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode) or stat.S_IMODE(info.st_mode) != 0o600:
+            raise SupervisionError("rescue descriptor ownership mode is unsafe")
+        payload = os.read(fd, 1024 * 1024 + 1)
+        if len(payload) > 1024 * 1024:
+            raise SupervisionError("rescue descriptor is oversized")
+    finally:
+        os.close(fd)
+    return RescueDescriptor.from_canonical_json(payload)
+
+
+class RescueAggregate(ProtocolModel):
+    descriptor_id: Digest
+    receipts: tuple[CleanupReceipt, ...]
+    cleanup_result_id: Digest
+    complete: bool
+    aggregate_id: Digest = ZERO_DIGEST
+
+    @field_validator("receipts", mode="before")
+    @classmethod
+    def _freeze_receipts(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _identify(self) -> "RescueAggregate":
+        expected = canonical_digest(
+            "adapter-rescue-aggregate-v1",
+            self.model_dump(mode="json", exclude={"aggregate_id"}),
+        )
+        if self.aggregate_id not in (ZERO_DIGEST, expected):
+            raise ValueError("rescue aggregate identity differs")
+        object.__setattr__(self, "aggregate_id", expected)
+        return self
+
+
+async def run_rescue(
+    descriptor: RescueDescriptor,
+    *,
+    launch: Callable[[AdapterSelector], AdapterSupervisor] = AdapterSupervisor.launch,
+) -> RescueAggregate:
+    """Use a fresh exact worker and reconcile every declared cleanup action."""
+
+    supervisor = launch(descriptor.selector)
+    receipts: list[CleanupReceipt] = []
+    try:
+        handshake = await supervisor.handshake()
+        if handshake != descriptor.handshake:
+            raise SupervisionError("rescue worker handshake differs from persisted pins")
+        for action in descriptor.cleanup_plan.actions:
+            # One action per call preserves each action's own timeout/attempt cap
+            # and makes missing or duplicate receipts independently detectable.
+            operation_id = f"rescue-{descriptor.descriptor_id[:16]}-{action.action_id}"
+            result = await supervisor.call(
+                "cleanup",
+                CleanupParams(
+                    operation_id=operation_id,
+                    cleanup_plan=descriptor.cleanup_plan,
+                    action_ids=(action.action_id,),
+                ),
+                CleanupResult,
+                timeout=action.timeout_ms / 1000 * action.max_attempts,
+            )
+            assert isinstance(result, CleanupResult)
+            if len(result.receipts) != 1 or result.receipts[0].action_id != action.action_id:
+                raise SupervisionError("rescue cleanup returned missing or duplicate receipts")
+            receipt = result.receipts[0]
+            if (
+                receipt.cleanup_plan_id != descriptor.cleanup_plan.cleanup_plan_id
+                or receipt.action_digest != action.action_digest
+            ):
+                raise SupervisionError("rescue receipt differs from persisted cleanup action")
+            receipts.append(receipt)
+        cleanup = aggregate_cleanup(descriptor.cleanup_plan, receipts)
+        return RescueAggregate(
+            descriptor_id=descriptor.descriptor_id,
+            receipts=tuple(receipts),
+            cleanup_result_id=cleanup.cleanup_result_id,
+            complete=not cleanup.rescue_required,
+        )
+    finally:
+        await supervisor.terminate()
+
+
+def main() -> int:
+    if len(sys.argv) >= 3 and sys.argv[1] == "--supervise":
+        return supervise_worker(sys.argv[2:])
+    print("adapter supervisor is an internal module", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import signal
@@ -686,6 +687,9 @@ class VerifiedAdapterSession:
         return result
 
     def begin_ask(self, params: AskUserExchangeParams) -> None:
+        # Every application entry point passes the same poison gate, so a
+        # poisoned session cannot accumulate new episode state locally either.
+        self._ensure_usable()
         self.verifier.begin_ask(params)
 
     async def finish_ask(
@@ -801,8 +805,6 @@ def verify_artifact(root: Path, reference: ArtifactRef) -> bytes:
     finally:
         os.close(root_fd)
     raw = bytes(data)
-    import hashlib
-
     if hashlib.sha256(raw).hexdigest() != name:
         raise SupervisionError("artifact digest differs")
     try:

--- a/local_operator/evaluation/adapters/worker.py
+++ b/local_operator/evaluation/adapters/worker.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import asyncio
 import os
 from collections import OrderedDict
-from typing import cast
+from dataclasses import dataclass
+from typing import Any, cast
 
 from local_operator.evaluation.adapters.api import (
     KEYED_METHODS,
@@ -43,6 +44,18 @@ from local_operator.evaluation.protocol import ProtocolModel
 REQUEST_FD_ENV = "LO_ADAPTER_REQUEST_FD"
 RESPONSE_FD_ENV = "LO_ADAPTER_RESPONSE_FD"
 MAX_REPLAY = 128
+# An episode may legitimately exceed the request replay window. Operation
+# records are never evicted because losing one would turn a retry into a second
+# side effect; bounded exhaustion poisons before dispatch instead.
+MAX_OPERATION_RECORDS = 4096
+
+
+@dataclass(frozen=True)
+class _OperationRecord:
+    method: AdapterMethod
+    params_digest: str
+    result: dict[str, Any] | None
+    error: RpcError | None
 
 
 def _workspace_digest(selector: AdapterSelector) -> str:
@@ -54,7 +67,13 @@ def _workspace_digest(selector: AdapterSelector) -> str:
 
 
 class Worker:
-    def __init__(self, request_fd: int, response_fd: int) -> None:
+    def __init__(
+        self,
+        request_fd: int,
+        response_fd: int,
+        *,
+        max_operation_records: int = MAX_OPERATION_RECORDS,
+    ) -> None:
         self._reader = AsyncIncrementalReader(request_fd)
         self._writer = IncrementalWriter(response_fd)
         self._state: AdapterState = "NEW"
@@ -62,7 +81,8 @@ class Worker:
         self._selector: AdapterSelector | None = None
         self._last_id = 0
         self._replay: OrderedDict[int, tuple[AdapterMethod, str, bytes]] = OrderedDict()
-        self._operations: dict[tuple[AdapterMethod, str], str] = {}
+        self._operations: dict[str, _OperationRecord] = {}
+        self._max_operation_records = max_operation_records
         self._pending_line: asyncio.Task[bytes] | None = None
 
     def _line_task(self) -> asyncio.Task[bytes]:
@@ -147,6 +167,20 @@ class Worker:
         if request.id == self._last_id:
             raise RpcProtocolError("duplicate request ID is not cached")
         self._last_id = request.id
+        operation_id = getattr(params, "operation_id", None)
+        if request.method in KEYED_METHODS:
+            assert isinstance(operation_id, str)
+            previous_operation = self._operations.get(operation_id)
+            if previous_operation is not None:
+                if (
+                    previous_operation.method != request.method
+                    or previous_operation.params_digest != digest
+                ):
+                    raise RpcProtocolError("operation ID was reused with changed content")
+                self._replay_operation(request, digest, previous_operation)
+                return
+            if len(self._operations) >= self._max_operation_records:
+                raise RpcProtocolError("operation replay capacity is exhausted")
         if self._state not in METHOD_STATES[request.method]:
             self._write_error(
                 request,
@@ -155,26 +189,30 @@ class Worker:
                 digest=digest,
             )
             return
-        operation_id = getattr(params, "operation_id", None)
-        if request.method in KEYED_METHODS:
-            assert isinstance(operation_id, str)
-            operation_key = (request.method, operation_id)
-            prior_digest = self._operations.get(operation_key)
-            if prior_digest is not None and prior_digest != digest:
-                raise RpcProtocolError("operation ID was reused with changed parameters")
-            self._operations[operation_key] = digest
         try:
             result = await self._dispatch(request.method, params)
             result_type = RESULT_MODELS[request.method]
             if not isinstance(result, result_type):
                 raise TypeError("adapter returned the wrong closed result")
         except asyncio.CancelledError:
-            self._write_error(request, "cancelled", "adapter call was cancelled", digest=digest)
+            self._write_error(
+                request,
+                "cancelled",
+                "adapter call was cancelled",
+                digest=digest,
+                operation_id=operation_id,
+            )
             return
         except (AdapterDiscoveryError, Exception):
             # Adapter exceptions may contain reprs, paths, environment values, or
             # tracebacks.  The wire exposes only a closed code and fixed text.
-            self._write_error(request, "adapter_error", "adapter operation failed", digest=digest)
+            self._write_error(
+                request,
+                "adapter_error",
+                "adapter operation failed",
+                digest=digest,
+                operation_id=operation_id,
+            )
             return
         self._state = METHOD_NEXT_STATE[request.method]
         response = RpcResponse(
@@ -183,9 +221,7 @@ class Worker:
             method=request.method,
             result=result.model_dump(mode="json"),
         )
-        encoded = canonical_line(response)
-        self._cache(request.id, request.method, digest, encoded)
-        self._writer.write(encoded)
+        self._send_response(request, digest, response, operation_id=operation_id)
 
     async def _dispatch(self, method: AdapterMethod, params: ProtocolModel) -> ProtocolModel:
         if method == "hello":
@@ -211,9 +247,46 @@ class Worker:
         message: str,
         *,
         digest: str,
+        operation_id: str | None = None,
     ) -> None:
         error = RpcError.model_validate({"code": code, "message": message}, strict=True)
         response = RpcResponse(jsonrpc="2.0", id=request.id, method=request.method, error=error)
+        self._send_response(request, digest, response, operation_id=operation_id)
+
+    def _send_response(
+        self,
+        request: RpcRequest,
+        digest: str,
+        response: RpcResponse,
+        *,
+        operation_id: str | None,
+    ) -> None:
+        if operation_id is not None:
+            self._operations[operation_id] = _OperationRecord(
+                method=request.method,
+                params_digest=digest,
+                result=response.result,
+                error=response.error,
+            )
+        encoded = canonical_line(response)
+        self._cache(request.id, request.method, digest, encoded)
+        self._writer.write(encoded)
+
+    def _replay_operation(
+        self,
+        request: RpcRequest,
+        digest: str,
+        record: _OperationRecord,
+    ) -> None:
+        # Request IDs identify transport attempts, so durable operation replay
+        # repeats the closed outcome while correlating it to this new attempt.
+        response = RpcResponse(
+            jsonrpc="2.0",
+            id=request.id,
+            method=request.method,
+            result=record.result,
+            error=record.error,
+        )
         encoded = canonical_line(response)
         self._cache(request.id, request.method, digest, encoded)
         self._writer.write(encoded)

--- a/local_operator/evaluation/adapters/worker.py
+++ b/local_operator/evaluation/adapters/worker.py
@@ -19,10 +19,12 @@ from local_operator.evaluation.adapters.api import (
     AdapterSelector,
     AdapterState,
     BeginRescueParams,
+    CleanupParams,
     EvaluationAdapter,
     Handshake,
     HelloParams,
     PythonRuntime,
+    RescueDescriptor,
     canonical_params_digest,
 )
 from local_operator.evaluation.adapters.discovery import (
@@ -82,6 +84,8 @@ class Worker:
         self._adapter: EvaluationAdapter | None = None
         self._selector: AdapterSelector | None = None
         self._handshake: Handshake | None = None
+        self._rescue_descriptor: RescueDescriptor | None = None
+        self._rescue_actions: dict[str, _OperationRecord] = {}
         self._last_id = 0
         self._replay: OrderedDict[int, tuple[AdapterMethod, str, bytes]] = OrderedDict()
         self._operations: dict[str, _OperationRecord] = {}
@@ -192,32 +196,46 @@ class Worker:
                 digest=digest,
             )
             return
+        rescue_action_id: str | None = None
+        if request.method == "cleanup" and self._rescue_descriptor is not None:
+            assert isinstance(params, CleanupParams)
+            rescue_action_id = self._validate_rescue_cleanup(params)
+            previous_action = self._rescue_actions.get(rescue_action_id)
+            if previous_action is not None:
+                if previous_action.params_digest != self._rescue_action_digest(params):
+                    raise RpcProtocolError("rescue action was reused with changed content")
+                self._replay_operation(request, digest, previous_action)
+                return
         try:
             result = await self._dispatch(request.method, params)
             result_type = RESULT_MODELS[request.method]
             if not isinstance(result, result_type):
                 raise TypeError("adapter returned the wrong closed result")
         except asyncio.CancelledError:
-            self._write_error(
+            response = self._write_error(
                 request,
                 "cancelled",
                 "adapter call was cancelled",
                 digest=digest,
                 operation_id=operation_id,
             )
+            if rescue_action_id is not None:
+                self._record_rescue_action(rescue_action_id, params, request.method, response)
             return
         except RpcProtocolError:
             raise
         except (AdapterDiscoveryError, Exception):
             # Adapter exceptions may contain reprs, paths, environment values, or
             # tracebacks.  The wire exposes only a closed code and fixed text.
-            self._write_error(
+            response = self._write_error(
                 request,
                 "adapter_error",
                 "adapter operation failed",
                 digest=digest,
                 operation_id=operation_id,
             )
+            if rescue_action_id is not None:
+                self._record_rescue_action(rescue_action_id, params, request.method, response)
             return
         self._state = METHOD_NEXT_STATE[request.method]
         response = RpcResponse(
@@ -227,6 +245,55 @@ class Worker:
             result=result.model_dump(mode="json"),
         )
         self._send_response(request, digest, response, operation_id=operation_id)
+        if rescue_action_id is not None:
+            self._record_rescue_action(rescue_action_id, params, request.method, response)
+
+    def _record_rescue_action(
+        self,
+        action_id: str,
+        params: ProtocolModel,
+        method: AdapterMethod,
+        response: RpcResponse,
+    ) -> None:
+        assert isinstance(params, CleanupParams)
+        self._rescue_actions[action_id] = _OperationRecord(
+            method=method,
+            params_digest=self._rescue_action_digest(params),
+            result=response.result,
+            error=response.error,
+        )
+
+    def _validate_rescue_cleanup(self, params: CleanupParams) -> str:
+        descriptor = self._rescue_descriptor
+        assert descriptor is not None
+        if (
+            params.cleanup_plan.episode_id != descriptor.episode_id
+            or params.cleanup_plan != descriptor.cleanup_plan
+            or params.cleanup_plan.cleanup_plan_id != descriptor.cleanup_plan.cleanup_plan_id
+            or len(params.action_ids) != 1
+        ):
+            raise RpcProtocolError("cleanup differs from the pinned rescue plan")
+        action_id = params.action_ids[0]
+        expected = next(
+            (action for action in descriptor.cleanup_plan.actions if action.action_id == action_id),
+            None,
+        )
+        actual = next(
+            (action for action in params.cleanup_plan.actions if action.action_id == action_id),
+            None,
+        )
+        if expected is None or actual != expected:
+            raise RpcProtocolError("cleanup action differs from the pinned rescue action")
+        return action_id
+
+    @staticmethod
+    def _rescue_action_digest(params: CleanupParams) -> str:
+        # Operation IDs are transport idempotency keys; rescue action identity is
+        # independently pinned so a new key cannot repeat the same effect.
+        return canonical_digest(
+            "adapter-rescue-action-call-v1",
+            params.model_dump(mode="json", exclude={"operation_id"}),
+        )
 
     async def _dispatch(self, method: AdapterMethod, params: ProtocolModel) -> ProtocolModel:
         if method == "hello":
@@ -255,6 +322,8 @@ class Worker:
                 raise RpcProtocolError("rescue pins differ from the exact handshake")
             # This transition grants cleanup routing only. Adapter code is not
             # invoked, so it cannot create resources or resolve persisted refs.
+            self._rescue_descriptor = params.descriptor
+            self._rescue_actions.clear()
             return AckResult()
         assert self._adapter is not None
         handler = getattr(self._adapter, method)
@@ -269,10 +338,11 @@ class Worker:
         *,
         digest: str,
         operation_id: str | None = None,
-    ) -> None:
+    ) -> RpcResponse:
         error = RpcError.model_validate({"code": code, "message": message}, strict=True)
         response = RpcResponse(jsonrpc="2.0", id=request.id, method=request.method, error=error)
         self._send_response(request, digest, response, operation_id=operation_id)
+        return response
 
     def _send_response(
         self,

--- a/local_operator/evaluation/adapters/worker.py
+++ b/local_operator/evaluation/adapters/worker.py
@@ -204,6 +204,15 @@ class Worker:
             if previous_action is not None:
                 if previous_action.params_digest != self._rescue_action_digest(params):
                     raise RpcProtocolError("rescue action was reused with changed content")
+                assert isinstance(operation_id, str)
+                # Reserve the alias before replying. Otherwise a second logical
+                # action could reuse this new operation key after we replayed it.
+                self._operations[operation_id] = _OperationRecord(
+                    method=request.method,
+                    params_digest=digest,
+                    result=previous_action.result,
+                    error=previous_action.error,
+                )
                 self._replay_operation(request, digest, previous_action)
                 return
         try:

--- a/local_operator/evaluation/adapters/worker.py
+++ b/local_operator/evaluation/adapters/worker.py
@@ -30,6 +30,8 @@ from local_operator.evaluation.adapters.api import (
 from local_operator.evaluation.adapters.discovery import (
     AdapterDiscoveryError,
     load_selected_adapter,
+    verify_release_manifest,
+    workspace_digest,
 )
 from local_operator.evaluation.adapters.rpc import (
     AsyncIncrementalReader,
@@ -63,11 +65,11 @@ class _OperationRecord:
 
 
 def _workspace_digest(selector: AdapterSelector) -> str:
-    info = os.stat(selector.workspace, follow_symlinks=False)
-    return canonical_digest(
-        "adapter-workspace-v1",
-        {"device": info.st_dev, "inode": info.st_ino, "mode": info.st_mode},
-    )
+    verify_release_manifest(selector)
+    digest = workspace_digest(selector.workspace)
+    if digest != selector.workspace_digest:
+        raise AdapterDiscoveryError("adapter workspace content digest differs")
+    return digest
 
 
 class Worker:

--- a/local_operator/evaluation/adapters/worker.py
+++ b/local_operator/evaluation/adapters/worker.py
@@ -14,9 +14,11 @@ from local_operator.evaluation.adapters.api import (
     METHOD_STATES,
     PARAM_MODELS,
     RESULT_MODELS,
+    AckResult,
     AdapterMethod,
     AdapterSelector,
     AdapterState,
+    BeginRescueParams,
     EvaluationAdapter,
     Handshake,
     HelloParams,
@@ -79,6 +81,7 @@ class Worker:
         self._state: AdapterState = "NEW"
         self._adapter: EvaluationAdapter | None = None
         self._selector: AdapterSelector | None = None
+        self._handshake: Handshake | None = None
         self._last_id = 0
         self._replay: OrderedDict[int, tuple[AdapterMethod, str, bytes]] = OrderedDict()
         self._operations: dict[str, _OperationRecord] = {}
@@ -203,6 +206,8 @@ class Worker:
                 operation_id=operation_id,
             )
             return
+        except RpcProtocolError:
+            raise
         except (AdapterDiscoveryError, Exception):
             # Adapter exceptions may contain reprs, paths, environment values, or
             # tracebacks.  The wire exposes only a closed code and fixed text.
@@ -228,13 +233,29 @@ class Worker:
             assert isinstance(params, HelloParams)
             self._selector = params.selector
             self._adapter = load_selected_adapter(params.selector)
-            return Handshake(
+            self._handshake = Handshake(
                 selector=params.selector,
                 metadata=self._adapter.metadata,
                 python=PythonRuntime.current(),
                 workspace_digest=_workspace_digest(params.selector),
                 selected_route=params.selector.route_capability,
             )
+            return self._handshake
+        if method == "begin_rescue":
+            assert isinstance(params, BeginRescueParams)
+            assert self._selector is not None and self._handshake is not None
+            if (
+                params.descriptor.selector != self._selector
+                or params.descriptor.handshake != self._handshake
+                or params.selector_digest
+                != canonical_digest("adapter-rescue-selector-v1", self._selector)
+                or params.handshake_digest
+                != canonical_digest("adapter-rescue-handshake-v1", self._handshake)
+            ):
+                raise RpcProtocolError("rescue pins differ from the exact handshake")
+            # This transition grants cleanup routing only. Adapter code is not
+            # invoked, so it cannot create resources or resolve persisted refs.
+            return AckResult()
         assert self._adapter is not None
         handler = getattr(self._adapter, method)
         result = await handler(params)

--- a/local_operator/evaluation/adapters/worker.py
+++ b/local_operator/evaluation/adapters/worker.py
@@ -27,14 +27,15 @@ from local_operator.evaluation.adapters.discovery import (
     load_selected_adapter,
 )
 from local_operator.evaluation.adapters.rpc import (
-    IncrementalReader,
+    AsyncIncrementalReader,
+    CancelRequest,
     IncrementalWriter,
     RpcError,
     RpcProtocolError,
     RpcRequest,
     RpcResponse,
     canonical_line,
-    parse_canonical_line,
+    parse_request_or_cancel,
 )
 from local_operator.evaluation.evidence.models import canonical_digest
 from local_operator.evaluation.protocol import ProtocolModel
@@ -54,7 +55,7 @@ def _workspace_digest(selector: AdapterSelector) -> str:
 
 class Worker:
     def __init__(self, request_fd: int, response_fd: int) -> None:
-        self._reader = IncrementalReader(request_fd)
+        self._reader = AsyncIncrementalReader(request_fd)
         self._writer = IncrementalWriter(response_fd)
         self._state: AdapterState = "NEW"
         self._adapter: EvaluationAdapter | None = None
@@ -62,19 +63,64 @@ class Worker:
         self._last_id = 0
         self._replay: OrderedDict[int, tuple[AdapterMethod, str, bytes]] = OrderedDict()
         self._operations: dict[tuple[AdapterMethod, str], str] = {}
+        self._pending_line: asyncio.Task[bytes] | None = None
+
+    def _line_task(self) -> asyncio.Task[bytes]:
+        if self._pending_line is None:
+            self._pending_line = asyncio.create_task(self._reader.read_line())
+        return self._pending_line
+
+    async def _take_line(self) -> bytes:
+        task = self._line_task()
+        raw = await task
+        # A completed adapter call may have left this exact task reading ahead.
+        # Clear only that consumed task, never a successor installed elsewhere.
+        if self._pending_line is task:
+            self._pending_line = None
+        return raw
 
     async def run(self) -> int:
         while self._state not in ("CLOSED", "POISONED"):
             try:
-                raw = await asyncio.to_thread(self._reader.read_line)
-                request = cast(RpcRequest, parse_canonical_line(raw, RpcRequest))
-                await self._handle(request)
+                raw = await self._take_line()
+                message = parse_request_or_cancel(raw)
+                if isinstance(message, CancelRequest):
+                    raise RpcProtocolError("cancel has no in-flight application call")
+                await self._handle_with_cancel(message)
             except EOFError:
+                await self._cancel_pending_line()
                 return 0
             except RpcProtocolError:
                 self._state = "POISONED"
+                await self._cancel_pending_line()
                 return 70
+        await self._cancel_pending_line()
         return 0 if self._state == "CLOSED" else 70
+
+    async def _cancel_pending_line(self) -> None:
+        task = self._pending_line
+        self._pending_line = None
+        if task is not None:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    async def _handle_with_cancel(self, request: RpcRequest) -> None:
+        task = asyncio.create_task(self._handle(request))
+        reader = self._line_task()
+        done, _ = await asyncio.wait({task, reader}, return_when=asyncio.FIRST_COMPLETED)
+        if task in done:
+            await task
+            return
+        raw = await reader
+        if self._pending_line is reader:
+            self._pending_line = None
+        control = parse_request_or_cancel(raw)
+        if not isinstance(control, CancelRequest) or control.id != request.id:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            raise RpcProtocolError("only matching cancel is valid during an application call")
+        task.cancel()
+        await task
 
     async def _handle(self, request: RpcRequest) -> None:
         if request.id < self._last_id:
@@ -83,7 +129,12 @@ class Worker:
         try:
             params = params_type.model_validate(request.params, strict=True)
         except Exception:
-            self._write_error(request, "invalid_request", "request parameters are invalid")
+            self._write_error(
+                request,
+                "invalid_request",
+                "request parameters are invalid",
+                digest=canonical_digest("adapter-invalid-request-v1", request.params),
+            )
             return
         digest = canonical_params_digest(request.method, params)
         previous = self._replay.get(request.id)
@@ -97,7 +148,12 @@ class Worker:
             raise RpcProtocolError("duplicate request ID is not cached")
         self._last_id = request.id
         if self._state not in METHOD_STATES[request.method]:
-            self._write_error(request, "invalid_state", "method is invalid in current state")
+            self._write_error(
+                request,
+                "invalid_state",
+                "method is invalid in current state",
+                digest=digest,
+            )
             return
         operation_id = getattr(params, "operation_id", None)
         if request.method in KEYED_METHODS:
@@ -113,12 +169,12 @@ class Worker:
             if not isinstance(result, result_type):
                 raise TypeError("adapter returned the wrong closed result")
         except asyncio.CancelledError:
-            self._write_error(request, "cancelled", "adapter call was cancelled")
+            self._write_error(request, "cancelled", "adapter call was cancelled", digest=digest)
             return
         except (AdapterDiscoveryError, Exception):
             # Adapter exceptions may contain reprs, paths, environment values, or
             # tracebacks.  The wire exposes only a closed code and fixed text.
-            self._write_error(request, "adapter_error", "adapter operation failed")
+            self._write_error(request, "adapter_error", "adapter operation failed", digest=digest)
             return
         self._state = METHOD_NEXT_STATE[request.method]
         response = RpcResponse(
@@ -153,16 +209,13 @@ class Worker:
         request: RpcRequest,
         code: str,
         message: str,
+        *,
+        digest: str,
     ) -> None:
         error = RpcError.model_validate({"code": code, "message": message}, strict=True)
         response = RpcResponse(jsonrpc="2.0", id=request.id, method=request.method, error=error)
         encoded = canonical_line(response)
-        self._cache(
-            request.id,
-            request.method,
-            canonical_digest("adapter-invalid-request-v1", request.params),
-            encoded,
-        )
+        self._cache(request.id, request.method, digest, encoded)
         self._writer.write(encoded)
 
     def _cache(self, request_id: int, method: AdapterMethod, digest: str, response: bytes) -> None:

--- a/local_operator/evaluation/adapters/worker.py
+++ b/local_operator/evaluation/adapters/worker.py
@@ -1,0 +1,192 @@
+"""Isolated adapter worker speaking only over inherited protocol descriptors."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections import OrderedDict
+from typing import cast
+
+from local_operator.evaluation.adapters.api import (
+    KEYED_METHODS,
+    METHOD_NEXT_STATE,
+    METHOD_STATES,
+    PARAM_MODELS,
+    RESULT_MODELS,
+    AdapterMethod,
+    AdapterSelector,
+    AdapterState,
+    EvaluationAdapter,
+    Handshake,
+    HelloParams,
+    PythonRuntime,
+    canonical_params_digest,
+)
+from local_operator.evaluation.adapters.discovery import (
+    AdapterDiscoveryError,
+    load_selected_adapter,
+)
+from local_operator.evaluation.adapters.rpc import (
+    IncrementalReader,
+    IncrementalWriter,
+    RpcError,
+    RpcProtocolError,
+    RpcRequest,
+    RpcResponse,
+    canonical_line,
+    parse_canonical_line,
+)
+from local_operator.evaluation.evidence.models import canonical_digest
+from local_operator.evaluation.protocol import ProtocolModel
+
+REQUEST_FD_ENV = "LO_ADAPTER_REQUEST_FD"
+RESPONSE_FD_ENV = "LO_ADAPTER_RESPONSE_FD"
+MAX_REPLAY = 128
+
+
+def _workspace_digest(selector: AdapterSelector) -> str:
+    info = os.stat(selector.workspace, follow_symlinks=False)
+    return canonical_digest(
+        "adapter-workspace-v1",
+        {"device": info.st_dev, "inode": info.st_ino, "mode": info.st_mode},
+    )
+
+
+class Worker:
+    def __init__(self, request_fd: int, response_fd: int) -> None:
+        self._reader = IncrementalReader(request_fd)
+        self._writer = IncrementalWriter(response_fd)
+        self._state: AdapterState = "NEW"
+        self._adapter: EvaluationAdapter | None = None
+        self._selector: AdapterSelector | None = None
+        self._last_id = 0
+        self._replay: OrderedDict[int, tuple[AdapterMethod, str, bytes]] = OrderedDict()
+        self._operations: dict[tuple[AdapterMethod, str], str] = {}
+
+    async def run(self) -> int:
+        while self._state not in ("CLOSED", "POISONED"):
+            try:
+                raw = await asyncio.to_thread(self._reader.read_line)
+                request = cast(RpcRequest, parse_canonical_line(raw, RpcRequest))
+                await self._handle(request)
+            except EOFError:
+                return 0
+            except RpcProtocolError:
+                self._state = "POISONED"
+                return 70
+        return 0 if self._state == "CLOSED" else 70
+
+    async def _handle(self, request: RpcRequest) -> None:
+        if request.id < self._last_id:
+            raise RpcProtocolError("request IDs must be positive monotonic values")
+        params_type = PARAM_MODELS[request.method]
+        try:
+            params = params_type.model_validate(request.params, strict=True)
+        except Exception:
+            self._write_error(request, "invalid_request", "request parameters are invalid")
+            return
+        digest = canonical_params_digest(request.method, params)
+        previous = self._replay.get(request.id)
+        if previous is not None:
+            prior_method, prior_digest, response = previous
+            if prior_method != request.method or prior_digest != digest:
+                raise RpcProtocolError("request ID was reused with changed content")
+            self._writer.write(response)
+            return
+        if request.id == self._last_id:
+            raise RpcProtocolError("duplicate request ID is not cached")
+        self._last_id = request.id
+        if self._state not in METHOD_STATES[request.method]:
+            self._write_error(request, "invalid_state", "method is invalid in current state")
+            return
+        operation_id = getattr(params, "operation_id", None)
+        if request.method in KEYED_METHODS:
+            assert isinstance(operation_id, str)
+            operation_key = (request.method, operation_id)
+            prior_digest = self._operations.get(operation_key)
+            if prior_digest is not None and prior_digest != digest:
+                raise RpcProtocolError("operation ID was reused with changed parameters")
+            self._operations[operation_key] = digest
+        try:
+            result = await self._dispatch(request.method, params)
+            result_type = RESULT_MODELS[request.method]
+            if not isinstance(result, result_type):
+                raise TypeError("adapter returned the wrong closed result")
+        except asyncio.CancelledError:
+            self._write_error(request, "cancelled", "adapter call was cancelled")
+            return
+        except (AdapterDiscoveryError, Exception):
+            # Adapter exceptions may contain reprs, paths, environment values, or
+            # tracebacks.  The wire exposes only a closed code and fixed text.
+            self._write_error(request, "adapter_error", "adapter operation failed")
+            return
+        self._state = METHOD_NEXT_STATE[request.method]
+        response = RpcResponse(
+            jsonrpc="2.0",
+            id=request.id,
+            method=request.method,
+            result=result.model_dump(mode="json"),
+        )
+        encoded = canonical_line(response)
+        self._cache(request.id, request.method, digest, encoded)
+        self._writer.write(encoded)
+
+    async def _dispatch(self, method: AdapterMethod, params: ProtocolModel) -> ProtocolModel:
+        if method == "hello":
+            assert isinstance(params, HelloParams)
+            self._selector = params.selector
+            self._adapter = load_selected_adapter(params.selector)
+            return Handshake(
+                selector=params.selector,
+                metadata=self._adapter.metadata,
+                python=PythonRuntime.current(),
+                workspace_digest=_workspace_digest(params.selector),
+                selected_route=params.selector.route_capability,
+            )
+        assert self._adapter is not None
+        handler = getattr(self._adapter, method)
+        result = await handler(params)
+        return cast(ProtocolModel, result)
+
+    def _write_error(
+        self,
+        request: RpcRequest,
+        code: str,
+        message: str,
+    ) -> None:
+        error = RpcError.model_validate({"code": code, "message": message}, strict=True)
+        response = RpcResponse(jsonrpc="2.0", id=request.id, method=request.method, error=error)
+        encoded = canonical_line(response)
+        self._cache(
+            request.id,
+            request.method,
+            canonical_digest("adapter-invalid-request-v1", request.params),
+            encoded,
+        )
+        self._writer.write(encoded)
+
+    def _cache(self, request_id: int, method: AdapterMethod, digest: str, response: bytes) -> None:
+        if len(response) <= 1024 * 1024:
+            self._replay[request_id] = (method, digest, response)
+            while len(self._replay) > MAX_REPLAY:
+                self._replay.popitem(last=False)
+
+
+def _descriptor(name: str) -> int:
+    value = os.environ.pop(name, "")
+    if not value.isdecimal():
+        raise RuntimeError("worker protocol descriptor is missing")
+    return int(value)
+
+
+def main() -> int:
+    request_fd = _descriptor(REQUEST_FD_ENV)
+    response_fd = _descriptor(RESPONSE_FD_ENV)
+    # stdout belongs to diagnostics, never framing.  Redirect it before metadata
+    # access because imports and native libraries may write to fd 1 directly.
+    os.dup2(2, 1)
+    return asyncio.run(Worker(request_fd, response_fd).run())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.18"
+version = "0.44.19"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/evaluation/adapters/test_api.py
+++ b/tests/unit/evaluation/adapters/test_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -79,10 +80,23 @@ def cleanup_plan() -> CleanupPlan:
 
 
 def test_package_root_does_not_import_discovery_or_worker() -> None:
-    import local_operator.evaluation.adapters  # noqa: F401
-
-    assert "local_operator.evaluation.adapters.discovery" not in sys.modules
-    assert "local_operator.evaluation.adapters.worker" not in sys.modules
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            (
+                f"import sys;sys.path.insert(0,{str(Path.cwd())!r});"
+                "import local_operator.evaluation.adapters;"
+                "assert 'local_operator.evaluation.adapters.discovery' not in sys.modules;"
+                "assert 'local_operator.evaluation.adapters.worker' not in sys.modules"
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert probe.returncode == 0, probe.stderr
 
 
 def test_selector_rejects_relative_paths(tmp_path: Path) -> None:

--- a/tests/unit/evaluation/adapters/test_api.py
+++ b/tests/unit/evaluation/adapters/test_api.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from local_operator.evaluation.adapters.api import (
+    AdapterCapabilities,
+    AdapterMetadata,
+    AdapterSelector,
+    Handshake,
+    PythonRuntime,
+    RescueDescriptor,
+    ScopedInfraValue,
+    SecretRef,
+)
+from local_operator.evaluation.lifecycle import CleanupAction, CleanupPlan
+
+DIGEST = "a" * 64
+
+
+def selector(tmp_path: Path) -> AdapterSelector:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    return AdapterSelector(
+        schema_version="1.0",
+        adapter_id="tiny",
+        distribution="tiny-adapter",
+        version="1.2.3",
+        entry_point="tiny_adapter:create",
+        package_digest=DIGEST,
+        release_digest="b" * 64,
+        python_executable=str(Path(sys.executable).resolve()),
+        workspace=str(workspace),
+        route_capability="computer",
+    )
+
+
+def metadata() -> AdapterMetadata:
+    return AdapterMetadata(
+        adapter_id="tiny",
+        distribution="tiny-adapter",
+        version="1.2.3",
+        entry_point="tiny_adapter:create",
+        package_digest=DIGEST,
+        release_digest="b" * 64,
+        schema_version="1.0",
+        capabilities=AdapterCapabilities(routes=("computer",), ask_user=True, scoring=True),
+    )
+
+
+def handshake(tmp_path: Path) -> Handshake:
+    selected = selector(tmp_path)
+    return Handshake(
+        selector=selected,
+        metadata=metadata(),
+        python=PythonRuntime.current(),
+        workspace_digest="c" * 64,
+        selected_route="computer",
+    )
+
+
+def cleanup_plan() -> CleanupPlan:
+    return CleanupPlan(
+        episode_id="episode",
+        actions=(
+            CleanupAction(
+                action_id="release",
+                kind="release_instance",
+                resource_ref="instance-ref",
+                timeout_ms=1000,
+                max_attempts=2,
+            ),
+        ),
+    )
+
+
+def test_package_root_does_not_import_discovery_or_worker() -> None:
+    import local_operator.evaluation.adapters  # noqa: F401
+
+    assert "local_operator.evaluation.adapters.discovery" not in sys.modules
+    assert "local_operator.evaluation.adapters.worker" not in sys.modules
+
+
+def test_selector_rejects_relative_paths(tmp_path: Path) -> None:
+    payload = selector(tmp_path).model_dump(mode="json")
+    payload["python_executable"] = "python"
+    with pytest.raises(ValidationError, match="normalized absolute"):
+        AdapterSelector.model_validate(payload, strict=True)
+
+
+def test_handshake_requires_every_exact_pin(tmp_path: Path) -> None:
+    selected = selector(tmp_path)
+    changed = metadata().model_copy(update={"version": "1.2.4"})
+    with pytest.raises(ValidationError, match="exact adapter selection"):
+        Handshake(
+            selector=selected,
+            metadata=changed,
+            python=PythonRuntime.current(),
+            workspace_digest="c" * 64,
+            selected_route="computer",
+        )
+
+
+def test_scoped_infra_has_no_provider_or_model_purpose() -> None:
+    schema = ScopedInfraValue.model_json_schema()
+    purposes = schema["properties"]["purpose"]["enum"]
+    assert not {"provider", "model", "openrouter"} & set(purposes)
+    with pytest.raises(ValidationError):
+        ScopedInfraValue.model_validate(
+            {"name": "route", "purpose": "provider", "value": "bad"}, strict=True
+        )
+
+
+def test_rescue_descriptor_is_content_bound_and_has_refs_not_secrets(tmp_path: Path) -> None:
+    selected = selector(tmp_path)
+    descriptor = RescueDescriptor(
+        schema_version="1.0",
+        selector=selected,
+        handshake=handshake(tmp_path),
+        episode_id="episode",
+        cleanup_plan=cleanup_plan(),
+        secret_refs=(SecretRef(name="BENCHMARK_TOKEN"),),
+        infra_values=(
+            ScopedInfraValue(name="region", purpose="benchmark_compute", value="us-test-1"),
+        ),
+        artifact_root=str(tmp_path),
+    )
+    encoded = descriptor.to_canonical_json()
+    assert b"BENCHMARK_TOKEN" in encoded
+    assert b"secret-value" not in encoded
+    changed = json.loads(encoded)
+    changed["episode_id"] = "different"
+    with pytest.raises(ValidationError):
+        RescueDescriptor.model_validate(changed, strict=True)

--- a/tests/unit/evaluation/adapters/test_api.py
+++ b/tests/unit/evaluation/adapters/test_api.py
@@ -36,6 +36,7 @@ def selector(tmp_path: Path) -> AdapterSelector:
         release_digest="b" * 64,
         python_executable=str(Path(sys.executable).resolve()),
         workspace=str(workspace),
+        workspace_digest="c" * 64,
         route_capability="computer",
     )
 

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -134,11 +134,33 @@ def test_launch_rejects_symlink_and_lexical_aliases(tmp_path: Path) -> None:
 
 
 def test_launch_identity_detects_swap(tmp_path: Path) -> None:
+    """A directory substituted at the pinned path must fail revalidation.
+
+    The swap moves the original aside instead of deleting it, and that detail is
+    load-bearing rather than stylistic. Deleting frees the inode, and ext4 hands
+    the very next mkdir the same inode number back, so a delete-and-recreate
+    swap is invisible to a dev/ino pin on Linux while APFS allocates a fresh one
+    and makes the same test look green. Keeping the original alive holds its
+    inode allocated, so the replacement must get a different one on every
+    filesystem. The precondition assert below fails loudly if some future
+    platform reuses it anyway, rather than letting this pass vacuously again.
+    """
+
     base = selected(tmp_path, "a" * 64)
     resolved = resolve_launch(base)
     workspace = Path(base.workspace)
-    shutil.rmtree(workspace)
-    workspace.mkdir()
+    before = os.lstat(workspace)
+
+    replacement = tmp_path / "replacement-workspace"
+    replacement.mkdir()
+    os.rename(workspace, tmp_path / "stashed-workspace")
+    os.rename(replacement, workspace)
+
+    after = os.lstat(workspace)
+    assert (before.st_dev, before.st_ino) != (after.st_dev, after.st_ino), (
+        "the swap reused the original identity, so this test would pass without"
+        " exercising the guard at all"
+    )
     with pytest.raises(AdapterDiscoveryError, match="identity changed"):
         validate_resolved_launch(resolved)
 
@@ -652,9 +674,19 @@ def test_record_covered_extension_loads_and_is_hash_verified(
 
     # Same size, different bytes: only a hash comparison catches this, so it
     # proves the extension is verified rather than merely located.
+    #
+    # The mutated bytes are staged in a new file and renamed into place rather
+    # than written over the original. The extension was dlopened above and its
+    # file stays mapped for the life of the process, so writing through the
+    # existing inode corrupts the live mapping and glibc faults during
+    # interpreter shutdown -- pytest reports every test passing and then exits
+    # 139, which reads as a green run with a crashed process. A rename swaps the
+    # directory entry and leaves the mapped inode untouched.
     mutated = bytearray(extension.read_bytes())
     mutated[-1] ^= 0xFF
-    extension.write_bytes(bytes(mutated))
+    staged = extension.with_name(extension.name + ".mutated")
+    staged.write_bytes(bytes(mutated))
+    staged.replace(extension)
     try:
         with pytest.raises(AdapterDiscoveryError, match="RECORD hash differs"):
             with _verified_imports(cast(importlib.metadata.Distribution, distribution), rows):

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -4,6 +4,8 @@ import base64
 import csv
 import hashlib
 import importlib.metadata
+import os
+import shutil
 import sys
 from pathlib import Path
 
@@ -18,6 +20,7 @@ from local_operator.evaluation.adapters.discovery import (
     validate_resolved_launch,
     verify_distribution,
     worker_argv,
+    workspace_digest,
 )
 
 
@@ -77,6 +80,12 @@ def fake_distribution(tmp_path: Path, entries: list[FakeEntryPoint]) -> FakeDist
 def selected(tmp_path: Path, digest: str) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
+    release_digest = "b" * 64
+    (workspace / "adapter-release.json").write_text(f'{{"release_digest":"{release_digest}"}}')
+    executable = tmp_path / "python"
+    if not executable.exists():
+        shutil.copy2(Path(sys.executable).resolve(), executable)
+        executable.chmod(0o755)
     return AdapterSelector(
         schema_version="1.0",
         adapter_id="tiny",
@@ -84,9 +93,10 @@ def selected(tmp_path: Path, digest: str) -> AdapterSelector:
         version="1.0",
         entry_point="tiny_adapter:create",
         package_digest=digest,
-        release_digest="b" * 64,
-        python_executable=str(Path(sys.executable).resolve()),
+        release_digest=release_digest,
+        python_executable=str(executable),
         workspace=str(workspace),
+        workspace_digest=workspace_digest(str(workspace)),
         route_capability="computer",
     )
 
@@ -113,10 +123,37 @@ def test_launch_identity_detects_swap(tmp_path: Path) -> None:
     base = selected(tmp_path, "a" * 64)
     resolved = resolve_launch(base)
     workspace = Path(base.workspace)
-    workspace.rmdir()
+    shutil.rmtree(workspace)
     workspace.mkdir()
     with pytest.raises(AdapterDiscoveryError, match="identity changed"):
         validate_resolved_launch(resolved)
+
+
+def test_launch_rejects_hardlink_and_content_mutation(tmp_path: Path) -> None:
+    base = selected(tmp_path, "a" * 64)
+    executable = Path(base.python_executable)
+    hardlink = tmp_path / "python-hardlink"
+    os.link(executable, hardlink)
+    with pytest.raises(AdapterDiscoveryError, match="non-hardlinked"):
+        resolve_launch(base)
+    hardlink.unlink()
+    resolved = resolve_launch(base)
+    with executable.open("r+b") as stream:
+        first = stream.read(1)
+        stream.seek(0)
+        stream.write(bytes([first[0] ^ 1]))
+    with pytest.raises(AdapterDiscoveryError, match="identity changed"):
+        validate_resolved_launch(resolved)
+
+
+def test_workspace_content_mutation_changes_digest(tmp_path: Path) -> None:
+    base = selected(tmp_path, "a" * 64)
+    workspace = Path(base.workspace)
+    before = workspace_digest(str(workspace))
+    manifest = workspace / "adapter-release.json"
+    original = manifest.read_text()
+    manifest.write_text(original.replace("b", "a", 1))
+    assert workspace_digest(str(workspace)) != before
 
 
 def test_exact_record_digest_and_worker_flags(tmp_path: Path) -> None:

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -809,7 +809,8 @@ def test_unrecorded_higher_priority_extension_is_refused(tmp_path: Path) -> None
     distribution = FakeDistribution(tmp_path, [entry_point])
     distribution.make_record()
     rows = {row[0]: row for row in _record_rows(distribution)}
-    assert _resolve_module_artifact("advpkg/helper", rows, distribution) == (
+    typed = cast(importlib.metadata.Distribution, distribution)
+    assert _resolve_module_artifact("advpkg/helper", rows, typed) == (
         f"advpkg/helper{suffixes[-1]}",
         False,
     )
@@ -817,7 +818,7 @@ def test_unrecorded_higher_priority_extension_is_refused(tmp_path: Path) -> None
     # Plant an unrecorded artifact the import system ranks above the recorded one.
     (package / f"helper{suffixes[0]}").write_bytes(b"planted")
     with pytest.raises(AdapterDiscoveryError, match="higher-priority extension"):
-        _resolve_module_artifact("advpkg/helper", rows, distribution)
+        _resolve_module_artifact("advpkg/helper", rows, typed)
 
 
 def test_compiled_only_entry_module_is_accepted(tmp_path: Path) -> None:

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -150,6 +150,71 @@ def test_hardlinked_interpreter_is_accepted_and_content_mutation_detected(
         validate_resolved_launch(resolved)
 
 
+def test_unrecorded_package_init_is_rejected_before_it_executes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An ancestor __init__ runs before the leaf module, so it must be recorded."""
+
+    marker = tmp_path / "init-executed.marker"
+    package = tmp_path / "pkg"
+    (package / "sub").mkdir(parents=True)
+    side_effect = f"from pathlib import Path\nPath({str(marker)!r}).write_text('ran')\n"
+    (package / "__init__.py").write_text(side_effect)
+    (package / "sub" / "__init__.py").write_text(side_effect)
+    leaf = package / "sub" / "mod.py"
+    leaf.write_text("def create():\n    return object()\n")
+
+    def load() -> object:
+        raise AssertionError("entry point loaded before verification")
+
+    entry = FakeEntryPoint(load)
+    entry.name = "tiny"
+    entry.value = "pkg.sub.mod:create"
+    distribution = FakeDistribution(tmp_path, [entry])
+    # RECORD covers only the leaf module, exactly like the crafted attack.
+    data = leaf.read_bytes()
+    digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+    rows = [
+        ["pkg/sub/mod.py", f"sha256={digest}", str(len(data))],
+        ["tiny_adapter-1.0.dist-info/RECORD", "", ""],
+    ]
+    target = StringIO()
+    csv.writer(target, lineterminator="\n").writerows(rows)
+    distribution._record = target.getvalue()
+    selector = selected(tmp_path, distribution_digest(distribution)).model_copy(
+        update={"entry_point": "pkg.sub.mod:create"}
+    )
+    monkeypatch.setattr(importlib.metadata, "distribution", lambda _: distribution)
+    with pytest.raises(AdapterDiscoveryError, match="not RECORD-covered"):
+        load_selected_adapter(selector)
+    assert not marker.exists()
+
+
+def test_record_rejects_absolute_and_traversal_paths(tmp_path: Path) -> None:
+    distribution = fake_distribution(tmp_path, [])
+    rows = list(csv.reader(distribution._record.splitlines()))
+    escaped = [["../outside.py", rows[0][1], rows[0][2]], rows[-1]]
+    target = StringIO()
+    csv.writer(target, lineterminator="\n").writerows(escaped)
+    distribution._record = target.getvalue()
+    with pytest.raises(AdapterDiscoveryError, match="normalized relative path"):
+        distribution_digest(distribution)
+
+
+def test_record_accepts_padded_base64_hash(tmp_path: Path) -> None:
+    distribution = fake_distribution(tmp_path, [])
+    rows = list(csv.reader(distribution._record.splitlines()))
+    padded = []
+    for row in rows:
+        if row[1].startswith("sha256="):
+            row = [row[0], row[1] + "==", row[2]]
+        padded.append(row)
+    target = StringIO()
+    csv.writer(target, lineterminator="\n").writerows(padded)
+    distribution._record = target.getvalue()
+    assert distribution_digest(distribution)
+
+
 def test_workspace_content_mutation_changes_digest(tmp_path: Path) -> None:
     base = selected(tmp_path, "a" * 64)
     workspace = Path(base.workspace)

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import base64
+import csv
+import hashlib
+import importlib.metadata
+import sys
+from pathlib import Path
+
+import pytest
+
+from local_operator.evaluation.adapters.api import AdapterSelector
+from local_operator.evaluation.adapters.discovery import (
+    AdapterDiscoveryError,
+    distribution_digest,
+    load_selected_adapter,
+    verify_distribution,
+    worker_argv,
+)
+
+
+class FakeEntryPoint:
+    group = "local_operator.evaluation_adapters.v1"
+    name = "tiny"
+    value = "tiny_adapter:create"
+
+    def __init__(self, factory: object) -> None:
+        self._factory = factory
+
+    def load(self) -> object:
+        return self._factory
+
+
+class FakeDistribution:
+    version = "1.0"
+
+    def __init__(self, root: Path, entries: list[FakeEntryPoint]) -> None:
+        self.root = root
+        self.entry_points = entries
+        self._record = ""
+
+    def read_text(self, name: str) -> str | None:
+        assert name == "RECORD"
+        return self._record
+
+    def locate_file(self, path: str) -> Path:
+        return self.root / path
+
+    def make_record(self, *, unhashed: bool = False) -> None:
+        rows: list[list[str]] = []
+        for path in sorted(self.root.rglob("*")):
+            if path.is_file():
+                relative = str(path.relative_to(self.root))
+                data = path.read_bytes()
+                digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=")
+                rows.append(
+                    [relative, "" if unhashed else f"sha256={digest.decode()}", str(len(data))]
+                )
+        rows.append(["tiny_adapter-1.0.dist-info/RECORD", "", ""])
+        from io import StringIO
+
+        target = StringIO()
+        csv.writer(target, lineterminator="\n").writerows(rows)
+        self._record = target.getvalue()
+
+
+def fake_distribution(tmp_path: Path, entries: list[FakeEntryPoint]) -> FakeDistribution:
+    package = tmp_path / "tiny_adapter.py"
+    package.write_text("VALUE = 1\n")
+    distribution = FakeDistribution(tmp_path, entries)
+    distribution.make_record()
+    return distribution
+
+
+def selected(tmp_path: Path, digest: str) -> AdapterSelector:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    return AdapterSelector(
+        schema_version="1.0",
+        adapter_id="tiny",
+        distribution="tiny-adapter",
+        version="1.0",
+        entry_point="tiny_adapter:create",
+        package_digest=digest,
+        release_digest="b" * 64,
+        python_executable=str(Path(sys.executable).resolve()),
+        workspace=str(workspace),
+        route_capability="computer",
+    )
+
+
+def test_exact_record_digest_and_worker_flags(tmp_path: Path) -> None:
+    distribution = fake_distribution(tmp_path, [])
+    selector = selected(tmp_path, distribution_digest(distribution))
+    assert worker_argv(selector)[1:5] == ("-I", "-s", "-E", "-m")
+
+
+def test_verify_uses_only_selected_distribution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    distribution = fake_distribution(tmp_path, [])
+    selector = selected(tmp_path, distribution_digest(distribution))
+    calls: list[str] = []
+
+    def exact(name: str) -> FakeDistribution:
+        calls.append(name)
+        return distribution
+
+    def forbidden() -> None:
+        raise AssertionError("global entry points must not be enumerated")
+
+    monkeypatch.setattr(importlib.metadata, "distribution", exact)
+    monkeypatch.setattr(importlib.metadata, "entry_points", forbidden)
+    assert verify_distribution(selector) is distribution
+    assert calls == ["tiny-adapter"]
+
+
+def test_unhashed_editable_distribution_is_rejected(tmp_path: Path) -> None:
+    distribution = fake_distribution(tmp_path, [])
+    distribution.make_record(unhashed=True)
+    with pytest.raises(AdapterDiscoveryError, match="unhashed"):
+        distribution_digest(distribution)
+
+
+def test_duplicate_and_similarly_named_entry_points_are_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    factory = lambda: object()  # noqa: E731
+    exact = FakeEntryPoint(factory)
+    similar = FakeEntryPoint(factory)
+    similar.name = "tiny-other"
+    distribution = fake_distribution(tmp_path, [exact, exact, similar])
+    selector = selected(tmp_path, distribution_digest(distribution))
+    monkeypatch.setattr(importlib.metadata, "distribution", lambda _: distribution)
+    with pytest.raises(AdapterDiscoveryError, match="exactly one"):
+        load_selected_adapter(selector)
+
+
+def test_host_discovery_does_not_import_adapter_module(tmp_path: Path) -> None:
+    distribution = fake_distribution(tmp_path, [])
+    selector = selected(tmp_path, distribution_digest(distribution))
+    worker_argv(selector)
+    assert "tiny_adapter" not in sys.modules

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -24,6 +24,7 @@ from local_operator.evaluation.adapters.api import AdapterSelector
 from local_operator.evaluation.adapters.discovery import (
     AdapterDiscoveryError,
     _record_rows,
+    _resolve_module_artifact,
     _verified_entry_target,
     _verified_imports,
     _VerifiedDistributionFinder,
@@ -730,6 +731,95 @@ def test_unrecorded_source_beside_recorded_extension_is_refused(
         _forget_package()
 
 
+def test_module_recorded_as_both_file_and_package_is_refused(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``mod.py`` beside ``mod/`` is refused: import and verification disagree.
+
+    CPython's FileFinder consults directories before file loaders, so an
+    ordinary import runs ``mod/__init__.py`` while a file-first rule would
+    verify ``mod.py``. The test proves that divergence is real on this host
+    before asserting the refusal, so it cannot pass on a host where the
+    precedence differs.
+    """
+
+    package = tmp_path / "advpkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("")
+    (package / "entry.py").write_text(
+        "from . import helper\n\n\ndef create():\n    return helper.ORIGIN\n"
+    )
+    (package / "helper.py").write_text("ORIGIN = 'flat-module'\n")
+    nested = package / "helper"
+    nested.mkdir()
+    (nested / "__init__.py").write_text("ORIGIN = 'package-init'\n")
+
+    def load() -> object:
+        raise AssertionError("entry point must not be imported by the import system")
+
+    entry_point = FakeEntryPoint(load)
+    entry_point.name = "adv"
+    entry_point.value = "advpkg.entry:create"
+    distribution = FakeDistribution(tmp_path, [entry_point])
+    distribution.make_record()
+    rows = {row[0]: row for row in _record_rows(distribution)}
+    assert "advpkg/helper.py" in rows and "advpkg/helper/__init__.py" in rows
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    # Precondition: the import system really prefers the package here.
+    _forget_package()
+    try:
+        assert importlib.import_module("advpkg.helper").ORIGIN == "package-init"
+    finally:
+        _forget_package()
+
+    try:
+        with pytest.raises(AdapterDiscoveryError, match="both module and package"):
+            with _verified_imports(cast(importlib.metadata.Distribution, distribution), rows):
+                importlib.import_module("advpkg.entry")
+    finally:
+        _forget_package()
+
+
+def test_unrecorded_higher_priority_extension_is_refused(tmp_path: Path) -> None:
+    """An unrecorded artifact import ranks first must refuse, not be ignored.
+
+    Source already refused loudly; a higher-priority extension used to be passed
+    over in silence. Both are the same hazard -- the file the import system
+    reaches first is the one RECORD does not attest to.
+    """
+
+    suffixes = importlib.machinery.EXTENSION_SUFFIXES
+    if len(suffixes) < 2:
+        pytest.skip("platform exposes a single extension suffix")
+
+    package = tmp_path / "advpkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("")
+    (package / "entry.py").write_text("def create():\n    return 'x'\n")
+    # Recorded under the LOWEST-priority suffix so a higher one can outrank it.
+    (package / f"helper{suffixes[-1]}").write_bytes(b"recorded-extension")
+
+    def load() -> object:
+        raise AssertionError("entry point must not be imported by the import system")
+
+    entry_point = FakeEntryPoint(load)
+    entry_point.name = "adv"
+    entry_point.value = "advpkg.entry:create"
+    distribution = FakeDistribution(tmp_path, [entry_point])
+    distribution.make_record()
+    rows = {row[0]: row for row in _record_rows(distribution)}
+    assert _resolve_module_artifact("advpkg/helper", rows, distribution) == (
+        f"advpkg/helper{suffixes[-1]}",
+        False,
+    )
+
+    # Plant an unrecorded artifact the import system ranks above the recorded one.
+    (package / f"helper{suffixes[0]}").write_bytes(b"planted")
+    with pytest.raises(AdapterDiscoveryError, match="higher-priority extension"):
+        _resolve_module_artifact("advpkg/helper", rows, distribution)
+
+
 def test_compiled_only_entry_module_is_accepted(tmp_path: Path) -> None:
     """An entry module shipping only as a verified extension must be allowed."""
 
@@ -821,7 +911,7 @@ def test_record_rejects_absolute_and_traversal_paths(tmp_path: Path) -> None:
     target = StringIO()
     csv.writer(target, lineterminator="\n").writerows(escaped)
     distribution._record = target.getvalue()
-    with pytest.raises(AdapterDiscoveryError, match="normalized relative path"):
+    with pytest.raises(AdapterDiscoveryError, match="escapes the distribution root"):
         distribution_digest(distribution)
 
 

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -4,6 +4,8 @@ import base64
 import csv
 import hashlib
 import importlib.metadata
+import importlib.util
+import marshal
 import os
 import shutil
 import sys
@@ -15,6 +17,8 @@ import pytest
 from local_operator.evaluation.adapters.api import AdapterSelector
 from local_operator.evaluation.adapters.discovery import (
     AdapterDiscoveryError,
+    _execute_verified_chain,
+    _verified_module_chain,
     distribution_digest,
     load_selected_adapter,
     resolve_launch,
@@ -161,8 +165,13 @@ def test_unrecorded_package_init_is_rejected_before_it_executes(
     side_effect = f"from pathlib import Path\nPath({str(marker)!r}).write_text('ran')\n"
     (package / "__init__.py").write_text(side_effect)
     (package / "sub" / "__init__.py").write_text(side_effect)
+    # The leaf imports through its package, so removing the ancestor check does
+    # not merely skip verification: the import system then really executes both
+    # unrecorded __init__ files. That is what makes the marker assertion below
+    # evidence rather than decoration.
+    (package / "sub" / "helper.py").write_text("VALUE = 1\n")
     leaf = package / "sub" / "mod.py"
-    leaf.write_text("def create():\n    return object()\n")
+    leaf.write_text("from . import helper\n\n\ndef create():\n    return helper.VALUE\n")
 
     def load() -> object:
         raise AssertionError("entry point loaded before verification")
@@ -185,9 +194,93 @@ def test_unrecorded_package_init_is_rejected_before_it_executes(
         update={"entry_point": "pkg.sub.mod:create"}
     )
     monkeypatch.setattr(importlib.metadata, "distribution", lambda _: distribution)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    for name in ("pkg", "pkg.sub", "pkg.sub.mod"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
     with pytest.raises(AdapterDiscoveryError, match="not RECORD-covered"):
         load_selected_adapter(selector)
     assert not marker.exists()
+
+
+def _forge_pycache(module: Path, source_code: str) -> Path:
+    """Write a cache entry whose header matches the source but whose code differs.
+
+    CPython validates a cached file by mtime and size only, both of which an
+    attacker able to write ``__pycache__`` also controls, so this forgery is
+    accepted by a normal import even though the source hash is untouched.
+    """
+
+    source = module.read_bytes()
+    attacker = compile(source_code, str(module), "exec")
+    cache = Path(importlib.util.cache_from_source(str(module)))
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    info = module.stat()
+    cache.write_bytes(
+        importlib.util.MAGIC_NUMBER
+        + (0).to_bytes(4, "little")
+        + int(info.st_mtime).to_bytes(4, "little")
+        + len(source).to_bytes(4, "little")
+        + marshal.dumps(attacker)
+    )
+    return cache
+
+
+def test_forged_bytecode_cannot_execute_in_place_of_hashed_source(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The bytes that execute must be the bytes that were hashed."""
+
+    marker = tmp_path / "attacker-ran.marker"
+
+    def load() -> object:
+        raise AssertionError("entry point must not be imported by the import system")
+
+    # Build the distribution first, then give the module its real body, so the
+    # RECORD hash and the forged cache header describe the same source bytes.
+    distribution = fake_distribution(tmp_path, [FakeEntryPoint(load)])
+    module = tmp_path / "tiny_adapter.py"
+    module.write_text("def create():\n    return 'verified'\n")
+    distribution.make_record()
+    cache = _forge_pycache(
+        module,
+        f"from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text('pwned')\n"
+        f"def create():\n    return 'attacker'\n",
+    )
+    assert cache.exists()
+    selector = selected(tmp_path, distribution_digest(distribution))
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    # A normal import of this module runs the forged cache, which is the attack
+    # this loader has to refuse; assert that first so the test cannot pass
+    # against a host where the forgery simply failed to take.
+    for name in ("tiny_adapter",):
+        sys.modules.pop(name, None)
+    try:
+        import tiny_adapter as attacked  # noqa: PLC0415
+
+        assert marker.exists(), "forged cache did not take effect on this host"
+        assert attacked.create() == "attacker"
+    finally:
+        sys.modules.pop("tiny_adapter", None)
+    marker.unlink()
+
+    # The source is genuinely RECORD-covered, so verification must succeed while
+    # still refusing to run the forged cache.
+    attribute, chain = _verified_module_chain(distribution, selector)
+    assert attribute == "create"
+    assert chain[-1].source == module.read_bytes()
+    try:
+        loaded = _execute_verified_chain(chain)
+        assert not marker.exists()
+        assert loaded.create() == "verified"
+    finally:
+        sys.modules.pop("tiny_adapter", None)
+    # The executed object descends from the verified byte string, not the cache.
+    assert (
+        hashlib.sha256(chain[-1].source).hexdigest()
+        == hashlib.sha256(module.read_bytes()).hexdigest()
+    )
 
 
 def test_record_rejects_absolute_and_traversal_paths(tmp_path: Path) -> None:

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -27,6 +27,7 @@ from local_operator.evaluation.adapters.discovery import (
     _verified_entry_target,
     _verified_imports,
     _VerifiedDistributionFinder,
+    _VerifiedSourceLoader,
     _verify_recorded_file,
     distribution_digest,
     load_selected_adapter,
@@ -553,12 +554,19 @@ def test_sourceless_bytecode_under_owned_root_never_executes(
         _forget_package()
 
 
-def _compile_extension(tmp_path: Path, module_name: str) -> Path:
-    """Compile a real extension, skipping when this host cannot build one.
+def _compile_extension(tmp_path: Path, module_name: str, marker: str) -> Path:
+    """Compile a real extension for this platform.
 
     A hand-written fake ``.so`` would prove nothing here: the point is that the
     ordinary loader really dlopens the verified path, which only a genuine
     module with a ``PyInit`` symbol exercises.
+
+    The link flags are platform-specific because Mach-O must be told that
+    ``Py*`` symbols resolve in the host interpreter at load time, while ELF
+    leaves them undefined by default. Getting this wrong on Linux used to make
+    the build fail and the test SKIP, which is the masking failure mode these
+    regression tests exist to prevent -- so a build failure on a host that has
+    both a compiler and headers is now a hard failure, never a skip.
     """
 
     compiler = shutil.which("cc") or shutil.which("gcc")
@@ -571,7 +579,7 @@ def _compile_extension(tmp_path: Path, module_name: str) -> Path:
         "#include <Python.h>\n"
         "static PyObject *value(PyObject *self, PyObject *args) {\n"
         "    (void)self; (void)args;\n"
-        '    return PyUnicode_FromString("native-verified");\n'
+        f'    return PyUnicode_FromString("{marker}");\n'
         "}\n"
         "static PyMethodDef Methods[] = {\n"
         '    {"value", value, METH_NOARGS, "marker"},\n'
@@ -582,21 +590,19 @@ def _compile_extension(tmp_path: Path, module_name: str) -> Path:
         f"PyMODINIT_FUNC PyInit_{module_name}(void) {{ return PyModule_Create(&mod); }}\n"
     )
     built = tmp_path / f"{module_name}{importlib.machinery.EXTENSION_SUFFIXES[0]}"
+    link_flags = (
+        ["-undefined", "dynamic_lookup"]
+        if sys.platform == "darwin"
+        else ["-fPIC", "-Wl,--unresolved-symbols=ignore-all"]
+    )
     result = subprocess.run(
-        [
-            compiler,
-            "-shared",
-            "-undefined",
-            "dynamic_lookup",
-            f"-I{include}",
-            "-o",
-            str(built),
-            str(source),
-        ],
+        [compiler, "-shared", *link_flags, f"-I{include}", "-o", str(built), str(source)],
         capture_output=True,
     )
-    if result.returncode != 0:
-        pytest.skip(f"extension build unsupported here: {result.stderr.decode()[:200]}")
+    assert result.returncode == 0, (
+        "extension build failed on a host with a compiler and headers; "
+        f"fix the flags rather than skipping: {result.stderr.decode()[:400]}"
+    )
     source.unlink()
     return built
 
@@ -610,7 +616,7 @@ def test_record_covered_extension_loads_and_is_hash_verified(
     package = tmp_path / "advpkg"
     package.mkdir()
     (package / "__init__.py").write_text("")
-    built = _compile_extension(tmp_path, "_speedups")
+    built = _compile_extension(tmp_path, "_speedups", "native-verified")
     if placement == "in-package":
         extension = package / built.name
         built.rename(extension)
@@ -655,6 +661,99 @@ def test_record_covered_extension_loads_and_is_hash_verified(
     finally:
         _forget_package()
         sys.modules.pop("_speedups", None)
+
+
+def _dual_artifact_distribution(tmp_path: Path) -> tuple[FakeDistribution, Path]:
+    """Build the shape mypyc and Cython wheels ship: ``.py`` AND ``.so``.
+
+    The two artifacts return DIFFERENT strings, so the assertion identifies
+    which one actually executed rather than merely that something imported.
+    """
+
+    package = tmp_path / "advpkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("")
+    (package / "entry.py").write_text(
+        "from . import helper\n\n\ndef create():\n    return helper.value()\n"
+    )
+    (package / "helper.py").write_text("def value():\n    return 'source-verified'\n")
+    built = _compile_extension(tmp_path, "helper", "native-not-preferred")
+    extension = package / built.name
+    built.rename(extension)
+
+    def load() -> object:
+        raise AssertionError("entry point must not be imported by the import system")
+
+    entry_point = FakeEntryPoint(load)
+    entry_point.name = "adv"
+    entry_point.value = "advpkg.entry:create"
+    distribution = FakeDistribution(tmp_path, [entry_point])
+    distribution.make_record()
+    return distribution, extension
+
+
+def test_dual_artifact_module_loads_verified_source(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Wheels shipping both artifacts must load, preferring hashed source."""
+
+    distribution, extension = _dual_artifact_distribution(tmp_path)
+    rows = {row[0]: row for row in _record_rows(distribution)}
+    assert "advpkg/helper.py" in rows
+    assert str(extension.relative_to(tmp_path)) in rows
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    try:
+        with _verified_imports(cast(importlib.metadata.Distribution, distribution), rows):
+            module = importlib.import_module("advpkg.entry")
+            assert module.create() == "source-verified"
+            helper = sys.modules["advpkg.helper"]
+            assert isinstance(helper.__loader__, _VerifiedSourceLoader)
+    finally:
+        _forget_package()
+
+
+def test_unrecorded_source_beside_recorded_extension_is_refused(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The artifact import would prefer is unattested, so the choice is unsafe."""
+
+    distribution, _ = _dual_artifact_distribution(tmp_path)
+    rows = {row[0]: row for row in _record_rows(distribution) if row[0] != "advpkg/helper.py"}
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    try:
+        with pytest.raises(AdapterDiscoveryError, match="present but not RECORD-covered"):
+            with _verified_imports(cast(importlib.metadata.Distribution, distribution), rows):
+                importlib.import_module("advpkg.entry")
+    finally:
+        _forget_package()
+
+
+def test_compiled_only_entry_module_is_accepted(tmp_path: Path) -> None:
+    """An entry module shipping only as a verified extension must be allowed."""
+
+    package = tmp_path / "advpkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("")
+    built = _compile_extension(tmp_path, "nativeentry", "native-entry")
+    built.rename(package / built.name)
+
+    def load() -> object:
+        raise AssertionError("entry point must not be imported by the import system")
+
+    entry_point = FakeEntryPoint(load)
+    entry_point.name = "adv"
+    entry_point.value = "advpkg.nativeentry:value"
+    distribution = FakeDistribution(tmp_path, [entry_point])
+    distribution.make_record()
+
+    selector = selected(tmp_path, distribution_digest(distribution)).model_copy(
+        update={"entry_point": "advpkg.nativeentry:value", "adapter_id": "adv"}
+    )
+    assert _verified_entry_target(
+        cast(importlib.metadata.Distribution, distribution), selector
+    ) == ("advpkg.nativeentry", "value")
 
 
 def _two_root_distribution(tmp_path: Path) -> FakeDistribution:

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -12,6 +12,7 @@ import shutil
 import sys
 from io import StringIO
 from pathlib import Path
+from types import ModuleType
 from typing import cast
 
 import pytest
@@ -22,6 +23,7 @@ from local_operator.evaluation.adapters.discovery import (
     _record_rows,
     _verified_entry_target,
     _verified_imports,
+    _VerifiedDistributionFinder,
     _verify_recorded_file,
     distribution_digest,
     load_selected_adapter,
@@ -480,6 +482,130 @@ def test_import_deferred_past_load_is_outside_the_finder_boundary(
         assert marker.exists()
     finally:
         _forget_package()
+
+
+def _write_sourceless_pyc(target: Path, source_code: str) -> None:
+    """Plant a ``.pyc`` with no ``.py`` beside it.
+
+    This needs no mtime/size forgery: ``SourcelessFileLoader`` runs whatever is
+    marshalled here, so a bare file write is the whole attack.
+    """
+
+    code = compile(source_code, str(target), "exec")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(
+        importlib.util.MAGIC_NUMBER
+        + (0).to_bytes(4, "little")
+        + (0).to_bytes(4, "little")
+        + (0).to_bytes(4, "little")
+        + marshal.dumps(code)
+    )
+
+
+@pytest.mark.parametrize(
+    "artifact, entry_body",
+    [
+        pytest.param(
+            "ghost.pyc",
+            "from . import ghost\n\n\ndef create():\n    return 'verified'\n",
+            id="sourceless-module",
+        ),
+        pytest.param(
+            "gpkg/__init__.pyc",
+            "from . import gpkg\n\n\ndef create():\n    return 'verified'\n",
+            id="sourceless-package",
+        ),
+    ],
+)
+def test_sourceless_bytecode_under_owned_root_never_executes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, artifact: str, entry_body: str
+) -> None:
+    """RECORD covers no bytecode, so nothing at an uncovered stem may import."""
+
+    marker = tmp_path / "attacker-ran.marker"
+    distribution = _multi_module_distribution(tmp_path, marker, entry_body)
+    _write_sourceless_pyc(
+        tmp_path / "advpkg" / artifact,
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('pwned')\n",
+    )
+    rows = {row[0]: row for row in _record_rows(distribution)}
+    assert f"advpkg/{artifact}" not in rows
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    # Prove the planted artifact really executes under a normal import first.
+    _forget_package()
+    try:
+        importlib.import_module("advpkg.entry")
+        assert marker.exists(), "sourceless bytecode did not execute on this host"
+    finally:
+        _forget_package()
+    marker.unlink()
+
+    try:
+        with pytest.raises(AdapterDiscoveryError, match="not RECORD-covered"):
+            with _verified_imports(cast(importlib.metadata.Distribution, distribution), rows):
+                importlib.import_module("advpkg.entry")
+        assert not marker.exists()
+    finally:
+        _forget_package()
+
+
+def _two_root_distribution(tmp_path: Path) -> FakeDistribution:
+    """A distribution owning two top-level roots, as many real wheels do."""
+
+    package = tmp_path / "advpkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("")
+    (package / "entry.py").write_text(
+        "import sidelib\n\n\ndef create():\n    return sidelib.VALUE\n"
+    )
+    (tmp_path / "sidelib.py").write_text("VALUE = 'verified'\n")
+
+    def load() -> object:
+        raise AssertionError("entry point must not be imported by the import system")
+
+    entry_point = FakeEntryPoint(load)
+    entry_point.name = "adv"
+    entry_point.value = "advpkg.entry:create"
+    distribution = FakeDistribution(tmp_path, [entry_point])
+    distribution.make_record()
+    return distribution
+
+
+def test_stale_module_in_second_owned_root_is_purged_before_load(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Every root the finder claims must be purged, not just the entry's."""
+
+    distribution = _two_root_distribution(tmp_path)
+    rows = {row[0]: row for row in _record_rows(distribution)}
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(importlib.metadata, "distribution", lambda _: distribution)
+
+    finder = _VerifiedDistributionFinder(cast(importlib.metadata.Distribution, distribution), rows)
+    assert finder.owned_roots == frozenset({"advpkg", "sidelib"})
+
+    # A prior import in this worker leaves the second root in sys.modules;
+    # importlib short-circuits on it unless the purge spans every owned root.
+    poisoned = ModuleType("sidelib")
+    poisoned.VALUE = "attacker-preexisting"
+    monkeypatch.setitem(sys.modules, "sidelib", poisoned)
+    _forget_package()
+
+    selector = selected(tmp_path, distribution_digest(distribution)).model_copy(
+        update={"entry_point": "advpkg.entry:create", "adapter_id": "adv"}
+    )
+    try:
+        # The adapter is a plain string here, so the protocol check is what
+        # rejects it; the object it bound is the point of the assertion.
+        with pytest.raises(AdapterDiscoveryError, match="does not implement"):
+            load_selected_adapter(selector)
+        bound = sys.modules["advpkg.entry"]
+        assert bound.create() == "verified"
+        assert sys.modules["sidelib"].VALUE == "verified"
+    finally:
+        _forget_package()
+        sys.modules.pop("sidelib", None)
 
 
 def test_record_rejects_absolute_and_traversal_paths(tmp_path: Path) -> None:

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -7,6 +7,7 @@ import importlib.metadata
 import os
 import shutil
 import sys
+from io import StringIO
 from pathlib import Path
 
 import pytest
@@ -62,8 +63,6 @@ class FakeDistribution:
                     [relative, "" if unhashed else f"sha256={digest.decode()}", str(len(data))]
                 )
         rows.append(["tiny_adapter-1.0.dist-info/RECORD", "", ""])
-        from io import StringIO
-
         target = StringIO()
         csv.writer(target, lineterminator="\n").writerows(rows)
         self._record = target.getvalue()
@@ -129,13 +128,18 @@ def test_launch_identity_detects_swap(tmp_path: Path) -> None:
         validate_resolved_launch(resolved)
 
 
-def test_launch_rejects_hardlink_and_content_mutation(tmp_path: Path) -> None:
+def test_hardlinked_interpreter_is_accepted_and_content_mutation_detected(
+    tmp_path: Path,
+) -> None:
     base = selected(tmp_path, "a" * 64)
     executable = Path(base.python_executable)
+    # Stock CPython ships python/python3/python3.N as hardlinks to one inode, so
+    # a link count must never be the thing that rejects an interpreter.
     hardlink = tmp_path / "python-hardlink"
     os.link(executable, hardlink)
-    with pytest.raises(AdapterDiscoveryError, match="non-hardlinked"):
-        resolve_launch(base)
+    assert os.lstat(executable).st_nlink == 2
+    resolved = resolve_launch(base)
+    validate_resolved_launch(resolved)
     hardlink.unlink()
     resolved = resolve_launch(base)
     with executable.open("r+b") as stream:

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -4,12 +4,15 @@ import base64
 import csv
 import hashlib
 import importlib
+import importlib.machinery
 import importlib.metadata
 import importlib.util
 import marshal
 import os
 import shutil
+import subprocess
 import sys
+import sysconfig
 from io import StringIO
 from pathlib import Path
 from types import ModuleType
@@ -548,6 +551,110 @@ def test_sourceless_bytecode_under_owned_root_never_executes(
         assert not marker.exists()
     finally:
         _forget_package()
+
+
+def _compile_extension(tmp_path: Path, module_name: str) -> Path:
+    """Compile a real extension, skipping when this host cannot build one.
+
+    A hand-written fake ``.so`` would prove nothing here: the point is that the
+    ordinary loader really dlopens the verified path, which only a genuine
+    module with a ``PyInit`` symbol exercises.
+    """
+
+    compiler = shutil.which("cc") or shutil.which("gcc")
+    include = sysconfig.get_paths()["include"]
+    if compiler is None or not Path(include, "Python.h").exists():
+        pytest.skip("no C compiler or CPython headers available")
+
+    source = tmp_path / f"{module_name}.c"
+    source.write_text(
+        "#include <Python.h>\n"
+        "static PyObject *value(PyObject *self, PyObject *args) {\n"
+        "    (void)self; (void)args;\n"
+        '    return PyUnicode_FromString("native-verified");\n'
+        "}\n"
+        "static PyMethodDef Methods[] = {\n"
+        '    {"value", value, METH_NOARGS, "marker"},\n'
+        "    {NULL, NULL, 0, NULL}\n"
+        "};\n"
+        "static struct PyModuleDef mod = {PyModuleDef_HEAD_INIT, "
+        f'"{module_name}", NULL, -1, Methods}};\n'
+        f"PyMODINIT_FUNC PyInit_{module_name}(void) {{ return PyModule_Create(&mod); }}\n"
+    )
+    built = tmp_path / f"{module_name}{importlib.machinery.EXTENSION_SUFFIXES[0]}"
+    result = subprocess.run(
+        [
+            compiler,
+            "-shared",
+            "-undefined",
+            "dynamic_lookup",
+            f"-I{include}",
+            "-o",
+            str(built),
+            str(source),
+        ],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"extension build unsupported here: {result.stderr.decode()[:200]}")
+    source.unlink()
+    return built
+
+
+@pytest.mark.parametrize("placement", ["in-package", "top-level"])
+def test_record_covered_extension_loads_and_is_hash_verified(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, placement: str
+) -> None:
+    """A recorded extension must load wherever it sits, and only if it matches."""
+
+    package = tmp_path / "advpkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("")
+    built = _compile_extension(tmp_path, "_speedups")
+    if placement == "in-package":
+        extension = package / built.name
+        built.rename(extension)
+        (package / "entry.py").write_text(
+            "from . import _speedups\n\n\ndef create():\n    return _speedups.value()\n"
+        )
+    else:
+        extension = built
+        (package / "entry.py").write_text(
+            "import _speedups\n\n\ndef create():\n    return _speedups.value()\n"
+        )
+
+    def load() -> object:
+        raise AssertionError("entry point must not be imported by the import system")
+
+    entry_point = FakeEntryPoint(load)
+    entry_point.name = "adv"
+    entry_point.value = "advpkg.entry:create"
+    distribution = FakeDistribution(tmp_path, [entry_point])
+    distribution.make_record()
+    rows = {row[0]: row for row in _record_rows(distribution)}
+    assert str(extension.relative_to(tmp_path)) in rows
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    try:
+        with _verified_imports(cast(importlib.metadata.Distribution, distribution), rows):
+            module = importlib.import_module("advpkg.entry")
+            assert module.create() == "native-verified"
+    finally:
+        _forget_package()
+        sys.modules.pop("_speedups", None)
+
+    # Same size, different bytes: only a hash comparison catches this, so it
+    # proves the extension is verified rather than merely located.
+    mutated = bytearray(extension.read_bytes())
+    mutated[-1] ^= 0xFF
+    extension.write_bytes(bytes(mutated))
+    try:
+        with pytest.raises(AdapterDiscoveryError, match="RECORD hash differs"):
+            with _verified_imports(cast(importlib.metadata.Distribution, distribution), rows):
+                importlib.import_module("advpkg.entry")
+    finally:
+        _forget_package()
+        sys.modules.pop("_speedups", None)
 
 
 def _two_root_distribution(tmp_path: Path) -> FakeDistribution:

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -14,6 +14,8 @@ from local_operator.evaluation.adapters.discovery import (
     AdapterDiscoveryError,
     distribution_digest,
     load_selected_adapter,
+    resolve_launch,
+    validate_resolved_launch,
     verify_distribution,
     worker_argv,
 )
@@ -87,6 +89,34 @@ def selected(tmp_path: Path, digest: str) -> AdapterSelector:
         workspace=str(workspace),
         route_capability="computer",
     )
+
+
+def test_launch_rejects_symlink_and_lexical_aliases(tmp_path: Path) -> None:
+    real_python = Path(sys.executable).resolve()
+    python_link = tmp_path / "python-link"
+    python_link.symlink_to(real_python)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    base = selected(tmp_path, "a" * 64)
+    with pytest.raises(AdapterDiscoveryError, match="symlink|alias"):
+        resolve_launch(base.model_copy(update={"python_executable": str(python_link)}))
+    workspace_link = tmp_path / "workspace-link"
+    workspace_link.symlink_to(workspace, target_is_directory=True)
+    with pytest.raises(AdapterDiscoveryError, match="symlink|alias"):
+        resolve_launch(base.model_copy(update={"workspace": str(workspace_link)}))
+    alias = str(tmp_path / "workspace" / ".." / "workspace")
+    with pytest.raises(Exception, match="normalized|alias"):
+        resolve_launch(base.model_copy(update={"workspace": alias}))
+
+
+def test_launch_identity_detects_swap(tmp_path: Path) -> None:
+    base = selected(tmp_path, "a" * 64)
+    resolved = resolve_launch(base)
+    workspace = Path(base.workspace)
+    workspace.rmdir()
+    workspace.mkdir()
+    with pytest.raises(AdapterDiscoveryError, match="identity changed"):
+        validate_resolved_launch(resolved)
 
 
 def test_exact_record_digest_and_worker_flags(tmp_path: Path) -> None:

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import csv
 import hashlib
+import importlib
 import importlib.metadata
 import importlib.util
 import marshal
@@ -11,6 +12,7 @@ import shutil
 import sys
 from io import StringIO
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -254,11 +256,9 @@ def test_forged_bytecode_cannot_execute_in_place_of_hashed_source(
     # A normal import of this module runs the forged cache, which is the attack
     # this loader has to refuse; assert that first so the test cannot pass
     # against a host where the forgery simply failed to take.
-    for name in ("tiny_adapter",):
-        sys.modules.pop(name, None)
+    sys.modules.pop("tiny_adapter", None)
     try:
-        import tiny_adapter as attacked  # noqa: PLC0415
-
+        attacked = importlib.import_module("tiny_adapter")
         assert marker.exists(), "forged cache did not take effect on this host"
         assert attacked.create() == "attacker"
     finally:
@@ -267,7 +267,9 @@ def test_forged_bytecode_cannot_execute_in_place_of_hashed_source(
 
     # The source is genuinely RECORD-covered, so verification must succeed while
     # still refusing to run the forged cache.
-    attribute, chain = _verified_module_chain(distribution, selector)
+    attribute, chain = _verified_module_chain(
+        cast(importlib.metadata.Distribution, distribution), selector
+    )
     assert attribute == "create"
     assert chain[-1].source == module.read_bytes()
     try:

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -19,8 +19,10 @@ import pytest
 from local_operator.evaluation.adapters.api import AdapterSelector
 from local_operator.evaluation.adapters.discovery import (
     AdapterDiscoveryError,
-    _execute_verified_chain,
-    _verified_module_chain,
+    _record_rows,
+    _verified_entry_target,
+    _verified_imports,
+    _verify_recorded_file,
     distribution_digest,
     load_selected_adapter,
     resolve_launch,
@@ -267,22 +269,217 @@ def test_forged_bytecode_cannot_execute_in_place_of_hashed_source(
 
     # The source is genuinely RECORD-covered, so verification must succeed while
     # still refusing to run the forged cache.
-    attribute, chain = _verified_module_chain(
+    module_name, attribute = _verified_entry_target(
         cast(importlib.metadata.Distribution, distribution), selector
     )
-    assert attribute == "create"
-    assert chain[-1].source == module.read_bytes()
+    assert (module_name, attribute) == ("tiny_adapter", "create")
+    rows = {row[0]: row for row in _record_rows(distribution)}
     try:
-        loaded = _execute_verified_chain(chain)
-        assert not marker.exists()
-        assert loaded.create() == "verified"
+        with _verified_imports(cast(importlib.metadata.Distribution, distribution), rows):
+            loaded = importlib.import_module("tiny_adapter")
+            assert not marker.exists()
+            assert loaded.create() == "verified"
     finally:
         sys.modules.pop("tiny_adapter", None)
     # The executed object descends from the verified byte string, not the cache.
-    assert (
-        hashlib.sha256(chain[-1].source).hexdigest()
-        == hashlib.sha256(module.read_bytes()).hexdigest()
+    verified_path, source = _verify_recorded_file(
+        cast(importlib.metadata.Distribution, distribution), rows, "tiny_adapter.py"
     )
+    assert verified_path == module
+    assert hashlib.sha256(source).hexdigest() == hashlib.sha256(module.read_bytes()).hexdigest()
+
+
+def _multi_module_distribution(tmp_path: Path, marker: Path, entry_body: str) -> FakeDistribution:
+    """Build a package whose helper carries forged bytecode but clean source."""
+
+    package = tmp_path / "advpkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("")
+    helper = package / "helper.py"
+    helper.write_text("VALUE = 'verified'\n")
+    (package / "entry.py").write_text(entry_body)
+
+    def load() -> object:
+        raise AssertionError("entry point must not be imported by the import system")
+
+    entry_point = FakeEntryPoint(load)
+    entry_point.name = "adv"
+    entry_point.value = "advpkg.entry:create"
+    distribution = FakeDistribution(tmp_path, [entry_point])
+    distribution.make_record()
+    _forge_pycache(
+        helper,
+        f"from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text('pwned')\n"
+        f"VALUE = 'attacker'\n",
+    )
+    return distribution
+
+
+def _forget_package() -> None:
+    for name in [key for key in sys.modules if key == "advpkg" or key.startswith("advpkg.")]:
+        del sys.modules[name]
+
+
+@pytest.mark.parametrize(
+    "entry_body",
+    [
+        pytest.param(
+            "from . import helper\n\n\ndef create():\n    return helper.VALUE\n",
+            id="sibling-imported-by-entry",
+        ),
+        pytest.param(
+            "def create():\n    from . import helper\n\n    return helper.VALUE\n",
+            id="sibling-imported-lazily-inside-factory",
+        ),
+    ],
+)
+def test_forged_bytecode_in_sibling_module_never_executes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, entry_body: str
+) -> None:
+    """Verification must cover the distribution, not just the entry chain.
+
+    A chain can never be complete: it is computed before the entry module runs,
+    so anything that module imports afterwards would reach the ordinary loader
+    and execute a forged cache.
+    """
+
+    marker = tmp_path / "attacker-ran.marker"
+    distribution = _multi_module_distribution(tmp_path, marker, entry_body)
+    selector = selected(tmp_path, distribution_digest(distribution)).model_copy(
+        update={"entry_point": "advpkg.entry:create"}
+    )
+    # The entry module itself is legitimately RECORD-covered; the attack lives
+    # entirely in the sibling's cache.
+    assert _verified_entry_target(
+        cast(importlib.metadata.Distribution, distribution), selector
+    ) == ("advpkg.entry", "create")
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    # Prove the forgery is live on this host before asserting we refuse it.
+    _forget_package()
+    try:
+        attacked = importlib.import_module("advpkg.helper")
+        assert marker.exists(), "forged cache did not take effect on this host"
+        assert attacked.VALUE == "attacker"
+    finally:
+        _forget_package()
+    marker.unlink()
+
+    rows = {row[0]: row for row in _record_rows(distribution)}
+    try:
+        with _verified_imports(cast(importlib.metadata.Distribution, distribution), rows):
+            loaded = importlib.import_module("advpkg.entry")
+            assert loaded.create() == "verified"
+            assert not marker.exists()
+            # A normal import gives the parent package the child attribute.
+            assert sys.modules["advpkg"].entry is loaded
+    finally:
+        _forget_package()
+
+
+def test_forged_bytecode_imported_from_package_init_never_executes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    marker = tmp_path / "attacker-ran.marker"
+    distribution = _multi_module_distribution(
+        tmp_path, marker, "def create():\n    return 'verified'\n"
+    )
+    # The ancestor __init__ pulls the forged sibling in before the entry module.
+    package_init = tmp_path / "advpkg" / "__init__.py"
+    package_init.write_text("from . import helper\n")
+    distribution.make_record()
+    _forge_pycache(
+        tmp_path / "advpkg" / "helper.py",
+        f"from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text('pwned')\n"
+        f"VALUE = 'attacker'\n",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    _forget_package()
+    try:
+        importlib.import_module("advpkg")
+        assert marker.exists(), "forged cache did not take effect on this host"
+    finally:
+        _forget_package()
+    marker.unlink()
+
+    rows = {row[0]: row for row in _record_rows(distribution)}
+    try:
+        with _verified_imports(cast(importlib.metadata.Distribution, distribution), rows):
+            loaded = importlib.import_module("advpkg.entry")
+            assert loaded.create() == "verified"
+            assert sys.modules["advpkg"].helper.VALUE == "verified"
+            assert not marker.exists()
+    finally:
+        _forget_package()
+
+
+def test_unrecorded_sibling_is_refused_and_finder_scope_is_narrow(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    marker = tmp_path / "attacker-ran.marker"
+    distribution = _multi_module_distribution(
+        tmp_path, marker, "from . import stowaway\n\n\ndef create():\n    return 'verified'\n"
+    )
+    # Present on disk but absent from RECORD: unrecorded code must be refused,
+    # never imported.
+    (tmp_path / "advpkg" / "stowaway.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('pwned')\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    rows = {row[0]: row for row in _record_rows(distribution)}
+    _forget_package()
+    try:
+        with pytest.raises(AdapterDiscoveryError, match="not RECORD-covered"):
+            with _verified_imports(cast(importlib.metadata.Distribution, distribution), rows):
+                importlib.import_module("advpkg.entry")
+        assert not marker.exists()
+        # Failure unwinds every module the finder introduced, so a retry cannot
+        # inherit a half-imported distribution.
+        assert not [name for name in sys.modules if name.split(".")[0] == "advpkg"]
+    finally:
+        _forget_package()
+    # Scope check: unrelated imports are untouched by the finder.
+    with _verified_imports(cast(importlib.metadata.Distribution, distribution), rows) as finder:
+        assert finder.owned_roots == frozenset({"advpkg"})
+        assert finder.find_spec("json") is None
+        assert finder.find_spec("pydantic") is None
+        assert finder.find_spec("local_operator.evaluation") is None
+        assert importlib.import_module("json").dumps({"a": 1}) == '{"a": 1}'
+    assert not any(type(entry).__name__ == "_VerifiedDistributionFinder" for entry in sys.meta_path)
+
+
+def test_import_deferred_past_load_is_outside_the_finder_boundary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Pin the documented limit so a later round changes it deliberately.
+
+    Imports performed while loading are verified; one an adapter defers until
+    after load returns is not, because the finder is removed so it cannot
+    govern the worker's later execution.
+    """
+
+    marker = tmp_path / "attacker-ran.marker"
+    distribution = _multi_module_distribution(
+        tmp_path,
+        marker,
+        "def create():\n    return 'verified'\n\n\n"
+        "def later():\n    from . import helper\n\n    return helper.VALUE\n",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    rows = {row[0]: row for row in _record_rows(distribution)}
+    _forget_package()
+    try:
+        with _verified_imports(cast(importlib.metadata.Distribution, distribution), rows):
+            loaded = importlib.import_module("advpkg.entry")
+            assert loaded.create() == "verified"
+            assert not marker.exists()
+        # Outside the load, the ordinary loader is in charge again.
+        assert loaded.later() == "attacker"
+        assert marker.exists()
+    finally:
+        _forget_package()
 
 
 def test_record_rejects_absolute_and_traversal_paths(tmp_path: Path) -> None:

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -588,7 +588,7 @@ def test_stale_module_in_second_owned_root_is_purged_before_load(
     # A prior import in this worker leaves the second root in sys.modules;
     # importlib short-circuits on it unless the purge spans every owned root.
     poisoned = ModuleType("sidelib")
-    poisoned.VALUE = "attacker-preexisting"
+    setattr(poisoned, "VALUE", "attacker-preexisting")
     monkeypatch.setitem(sys.modules, "sidelib", poisoned)
     _forget_package()
 
@@ -602,7 +602,7 @@ def test_stale_module_in_second_owned_root_is_purged_before_load(
             load_selected_adapter(selector)
         bound = sys.modules["advpkg.entry"]
         assert bound.create() == "verified"
-        assert sys.modules["sidelib"].VALUE == "verified"
+        assert getattr(sys.modules["sidelib"], "VALUE") == "verified"
     finally:
         _forget_package()
         sys.modules.pop("sidelib", None)

--- a/tests/unit/evaluation/adapters/test_launch.py
+++ b/tests/unit/evaluation/adapters/test_launch.py
@@ -1,0 +1,198 @@
+"""Real spawn coverage for the only path that can start an adapter worker.
+
+Every other adapter test drives the protocol in-process. This module builds a
+genuine interpreter and a genuine installed distribution, then launches through
+``AdapterSupervisor`` exactly as production does, because a manufactured
+single-link interpreter fixture previously hid a policy that rejected every real
+CPython install.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import csv
+import hashlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from local_operator.evaluation.adapters.api import AdapterSelector, Handshake
+from local_operator.evaluation.adapters.discovery import (
+    distribution_digest,
+    resolve_launch,
+    validate_resolved_launch,
+    workspace_digest,
+)
+from local_operator.evaluation.adapters.supervisor import AdapterSupervisor
+
+RELEASE_DIGEST = "b" * 64
+_ADAPTER_SOURCE = """from importlib.metadata import distribution
+
+from local_operator.evaluation.adapters.api import AdapterCapabilities, AdapterMetadata
+from local_operator.evaluation.adapters.discovery import distribution_digest
+
+
+class TinyAdapter:
+    def __init__(self, metadata):
+        self.metadata = metadata
+
+    async def inspect_requirements(self, params): raise NotImplementedError
+
+    async def prepare(self, params): raise NotImplementedError
+
+    async def reset_start(self, params): raise NotImplementedError
+
+    async def observe(self, params): raise NotImplementedError
+
+    async def execute(self, params): raise NotImplementedError
+
+    async def ask_user_exchange(self, params): raise NotImplementedError
+
+    async def score(self, params): raise NotImplementedError
+
+    async def cleanup(self, params): raise NotImplementedError
+
+    async def close(self, params): raise NotImplementedError
+
+
+def create():
+    installed = distribution("tiny-e2e-adapter")
+    return TinyAdapter(
+        AdapterMetadata(
+            adapter_id="tiny-e2e",
+            distribution="tiny-e2e-adapter",
+            version="1.0",
+            entry_point="tiny_e2e_adapter:create",
+            package_digest=distribution_digest(installed),
+            release_digest="%s",
+            schema_version="1.0",
+            capabilities=AdapterCapabilities(
+                routes=("computer",), ask_user=False, scoring=False
+            ),
+        )
+    )
+""" % RELEASE_DIGEST
+
+
+def _real_interpreter() -> Path:
+    """Copy a working interpreter so its content can be pinned per test run."""
+
+    candidates = [os.path.realpath(sys.executable), shutil.which("python3") or ""]
+    for base in candidates:
+        if not base or not os.path.exists(base):
+            continue
+        venv = Path(os.environ["PYTEST_LAUNCH_VENV"])
+        shutil.rmtree(venv, ignore_errors=True)
+        try:
+            subprocess.run(
+                [base, "-m", "venv", "--without-pip", "--copies", str(venv)],
+                check=True,
+                capture_output=True,
+            )
+        except (OSError, subprocess.CalledProcessError):
+            continue
+        executable = next(
+            (
+                item
+                for item in sorted((venv / "bin").glob("python3.*"))
+                if item.is_file() and not item.is_symlink()
+            ),
+            None,
+        )
+        if executable is None:
+            continue
+        probe = subprocess.run(
+            [str(executable), "-I", "-c", "print('ok')"], capture_output=True, text=True
+        )
+        if probe.returncode == 0:
+            return executable
+    pytest.skip("no usable copied interpreter is available on this host")
+
+
+def _install_adapter(site: Path) -> str:
+    repo = Path(__file__).resolve().parents[4]
+    site_packages = repo / ".venv" / f"lib/python{sys.version_info.major}.{sys.version_info.minor}"
+    (site / "_local_operator_repo.pth").write_text(f"{repo}\n{site_packages / 'site-packages'}\n")
+    module = site / "tiny_e2e_adapter.py"
+    module.write_text(_ADAPTER_SOURCE)
+    info = site / "tiny_e2e_adapter-1.0.dist-info"
+    info.mkdir(exist_ok=True)
+    (info / "METADATA").write_text("Metadata-Version: 2.1\nName: tiny-e2e-adapter\nVersion: 1.0\n")
+    (info / "entry_points.txt").write_text(
+        "[local_operator.evaluation_adapters.v1]\ntiny-e2e = tiny_e2e_adapter:create\n"
+    )
+    rows: list[list[str]] = []
+    for path in sorted([module, info / "METADATA", info / "entry_points.txt"]):
+        data = path.read_bytes()
+        digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+        rows.append([str(path.relative_to(site)), f"sha256={digest}", str(len(data))])
+    rows.append([str((info / "RECORD").relative_to(site)), "", ""])
+    target = io.StringIO()
+    csv.writer(target, lineterminator="\n").writerows(rows)
+    (info / "RECORD").write_text(target.getvalue())
+    from importlib.metadata import PathDistribution
+
+    return distribution_digest(PathDistribution(info))
+
+
+def test_real_running_interpreter_resolves_and_revalidates() -> None:
+    """A stock CPython install ships hardlinked names; it must still launch."""
+
+    executable = Path(sys.executable).resolve()
+    assert os.lstat(executable).st_nlink >= 1
+    workspace = Path(__file__).resolve().parent
+    selector = AdapterSelector.model_construct(
+        python_executable=str(executable), workspace=str(workspace)
+    )
+    resolved = resolve_launch(selector)
+    assert resolved.executable == str(executable)
+    assert resolved.executable_sha256 == hashlib.sha256(executable.read_bytes()).hexdigest()
+    validate_resolved_launch(resolved)
+
+
+@pytest.mark.asyncio
+async def test_supervisor_launch_completes_real_handshake_and_reaps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PYTEST_LAUNCH_VENV", str(tmp_path / "venv"))
+    executable = _real_interpreter()
+    site = next(executable.parent.parent.glob("lib/python*/site-packages"))
+    package_digest = _install_adapter(site)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "adapter-release.json").write_text(
+        json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
+    )
+    selector = AdapterSelector(
+        schema_version="1.0",
+        adapter_id="tiny-e2e",
+        distribution="tiny-e2e-adapter",
+        version="1.0",
+        entry_point="tiny_e2e_adapter:create",
+        package_digest=package_digest,
+        release_digest=RELEASE_DIGEST,
+        python_executable=str(executable.resolve()),
+        workspace=str(workspace),
+        workspace_digest=workspace_digest(str(workspace)),
+        route_capability="computer",
+    )
+    supervisor = AdapterSupervisor.launch(selector)
+    try:
+        handshake = await supervisor.handshake(timeout=60)
+        assert isinstance(handshake, Handshake)
+        assert handshake.selector == selector
+        assert handshake.metadata.adapter_id == "tiny-e2e"
+        assert handshake.workspace_digest == selector.workspace_digest
+    finally:
+        await supervisor.terminate()
+    assert supervisor.process.returncode is not None
+    with pytest.raises(ProcessLookupError):
+        os.killpg(supervisor.pgid, 0)
+    assert await asyncio.to_thread(supervisor.process.poll) is not None

--- a/tests/unit/evaluation/adapters/test_launch.py
+++ b/tests/unit/evaluation/adapters/test_launch.py
@@ -19,8 +19,10 @@ import os
 import shutil
 import subprocess
 import sys
+import sysconfig
 from pathlib import Path
 
+import pydantic
 import pytest
 
 from local_operator.evaluation.adapters.api import AdapterSelector, Handshake
@@ -116,10 +118,31 @@ def _real_interpreter() -> Path:
     pytest.skip("no usable copied interpreter is available on this host")
 
 
+def _dependency_roots() -> list[str]:
+    """Locate the running interpreter's real import roots.
+
+    CI installs the project with ``pip install -e`` and never creates a repo
+    ``.venv``, so a hardcoded venv path leaves the spawned worker without
+    pydantic and it dies instead of skipping. Deriving the roots from this
+    interpreter works under both layouts.
+    """
+
+    roots = [str(Path(__file__).resolve().parents[4])]
+    purelib = sysconfig.get_paths().get("purelib")
+    if purelib:
+        roots.append(purelib)
+    # Follow an actually-imported third-party dependency, which stays correct
+    # for editable installs whose packages live outside purelib.
+    roots.append(str(Path(pydantic.__file__).resolve().parent.parent))
+    seen: list[str] = []
+    for root in roots:
+        if root not in seen and Path(root).is_dir():
+            seen.append(root)
+    return seen
+
+
 def _install_adapter(site: Path) -> str:
-    repo = Path(__file__).resolve().parents[4]
-    site_packages = repo / ".venv" / f"lib/python{sys.version_info.major}.{sys.version_info.minor}"
-    (site / "_local_operator_repo.pth").write_text(f"{repo}\n{site_packages / 'site-packages'}\n")
+    (site / "_local_operator_repo.pth").write_text("\n".join(_dependency_roots()) + "\n")
     module = site / "tiny_e2e_adapter.py"
     module.write_text(_ADAPTER_SOURCE)
     info = site / "tiny_e2e_adapter-1.0.dist-info"

--- a/tests/unit/evaluation/adapters/test_rpc.py
+++ b/tests/unit/evaluation/adapters/test_rpc.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from local_operator.evaluation.adapters.api import InspectRequirementsParams
+from local_operator.evaluation.adapters.rpc import (
+    MAX_RPC_BYTES,
+    IncrementalReader,
+    IncrementalWriter,
+    RpcClient,
+    RpcProtocolError,
+    RpcRequest,
+    RpcResponse,
+    canonical_line,
+    parse_canonical_line,
+)
+
+
+def request_line() -> bytes:
+    return canonical_line(RpcRequest(jsonrpc="2.0", id=1, method="inspect_requirements", params={}))
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b'{"id":1,"id":1,"jsonrpc":"2.0","method":"inspect_requirements","params":{}}\n',
+        b'{"id":1, "jsonrpc":"2.0","method":"inspect_requirements","params":{}}\n',
+        request_line().replace(b"\n", b"\r\n"),
+        request_line()[:-1],
+        b"{" + b"x" * MAX_RPC_BYTES + b"\n",
+    ],
+)
+def test_malformed_noncanonical_and_oversized_lines_fail(payload: bytes) -> None:
+    with pytest.raises(RpcProtocolError):
+        parse_canonical_line(payload, RpcRequest)
+
+
+def test_incremental_reader_handles_short_reads_and_rejects_partial_eof() -> None:
+    read_fd, write_fd = os.pipe()
+    try:
+        encoded = request_line()
+        for byte in encoded:
+            os.write(write_fd, bytes([byte]))
+        assert IncrementalReader(read_fd).read_line() == encoded
+        os.write(write_fd, b"partial")
+        os.close(write_fd)
+        write_fd = -1
+        with pytest.raises(RpcProtocolError, match="partial"):
+            IncrementalReader(read_fd).read_line()
+    finally:
+        os.close(read_fd)
+        if write_fd >= 0:
+            os.close(write_fd)
+
+
+def test_incremental_writer_handles_short_writes(monkeypatch: pytest.MonkeyPatch) -> None:
+    chunks: list[bytes] = []
+
+    def short_write(fd: int, data: memoryview) -> int:
+        del fd
+        chunk = bytes(data[:2])
+        chunks.append(chunk)
+        return len(chunk)
+
+    monkeypatch.setattr(os, "write", short_write)
+    IncrementalWriter(9).write(b"abcdef")
+    assert b"".join(chunks) == b"abcdef"
+
+
+@pytest.mark.asyncio
+async def test_wrong_response_id_or_method_poison_and_terminate() -> None:
+    requests_read, requests_write = os.pipe()
+    responses_read, responses_write = os.pipe()
+    terminated = asyncio.Event()
+
+    async def terminate() -> None:
+        terminated.set()
+
+    client = RpcClient(requests_write, responses_read, terminate=terminate)
+
+    async def peer() -> None:
+        line = await asyncio.to_thread(IncrementalReader(requests_read).read_line)
+        request = parse_canonical_line(line, RpcRequest)
+        assert isinstance(request, RpcRequest)
+        response = RpcResponse(
+            jsonrpc="2.0",
+            id=request.id + 1,
+            method=request.method,
+            result={"requirements": []},
+        )
+        IncrementalWriter(responses_write).write(canonical_line(response))
+
+    task = asyncio.create_task(peer())
+    with pytest.raises(RpcProtocolError, match="ID or method"):
+        await client.call("inspect_requirements", InspectRequirementsParams(), timeout=1)
+    await task
+    assert terminated.is_set()
+    for fd in (requests_read, requests_write, responses_read, responses_write):
+        os.close(fd)
+
+
+@pytest.mark.asyncio
+async def test_timeout_sends_cancel_then_terminates() -> None:
+    requests_read, requests_write = os.pipe()
+    responses_read, responses_write = os.pipe()
+    terminated = asyncio.Event()
+    lines: list[bytes] = []
+
+    async def terminate() -> None:
+        terminated.set()
+
+    client = RpcClient(requests_write, responses_read, terminate=terminate)
+
+    async def peer() -> None:
+        reader = IncrementalReader(requests_read)
+        lines.append(await asyncio.to_thread(reader.read_line))
+        lines.append(await asyncio.to_thread(reader.read_line))
+
+    task = asyncio.create_task(peer())
+    with pytest.raises(TimeoutError):
+        await client.call("inspect_requirements", InspectRequirementsParams(), timeout=0.01)
+    await task
+    assert b'"control":"cancel"' in lines[1]
+    assert terminated.is_set()
+    for fd in (requests_read, requests_write, responses_read, responses_write):
+        os.close(fd)

--- a/tests/unit/evaluation/adapters/test_supervisor.py
+++ b/tests/unit/evaluation/adapters/test_supervisor.py
@@ -19,12 +19,17 @@ from local_operator.evaluation.adapters.api import (
     AdapterSelector,
     AskUserExchangeParams,
     AskUserExchangeResult,
+    CleanupOutcome,
+    CleanupParams,
     CleanupResult,
     Handshake,
     ObservationResult,
     ObserveParams,
+    PrepareParams,
+    PrepareResult,
     PythonRuntime,
     RescueDescriptor,
+    ResetStartParams,
     ScoreParams,
     ScoreResult,
     observation_content_id,
@@ -43,11 +48,7 @@ from local_operator.evaluation.adapters.supervisor import (
     verify_artifact,
 )
 from local_operator.evaluation.evidence.models import EvidenceArtifactRef, ScoreArtifact
-from local_operator.evaluation.lifecycle import (
-    CleanupAction,
-    CleanupPlan,
-    record_cleanup,
-)
+from local_operator.evaluation.lifecycle import CleanupAction, CleanupPlan
 from local_operator.evaluation.protocol import ArtifactRef, Observation
 
 
@@ -64,6 +65,7 @@ def selector(tmp_path: Path) -> AdapterSelector:
         release_digest="b" * 64,
         python_executable=str(Path(sys.executable).resolve()),
         workspace=str(workspace),
+        workspace_digest="c" * 64,
         route_capability="computer",
     )
 
@@ -209,10 +211,19 @@ def test_ask_exchange_requires_expected_episode_and_preserves_pending_on_error(
 class RawSupervisor:
     def __init__(self, responses: list[Any]) -> None:
         self.responses = responses
+        self.terminated = False
+        self.calls: list[str] = []
+
+    async def terminate(self) -> None:
+        self.terminated = True
 
     async def _call_raw(self, *args: Any, **kwargs: Any) -> Any:
-        del args, kwargs
-        return self.responses.pop(0)
+        del kwargs
+        self.calls.append(args[0])
+        response = self.responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
 
 
 def test_verified_session_rejects_bad_observe_without_mutation(tmp_path: Path) -> None:
@@ -247,6 +258,94 @@ def test_score_missing_artifact_can_retry_after_file_appears(tmp_path: Path) -> 
     verifier.accept_score(params, score)
     with pytest.raises(SupervisionError, match="duplicated"):
         verifier.accept_score(params, score)
+
+
+def test_changed_ask_prompt_is_rejected_without_dispatch(tmp_path: Path) -> None:
+    verifier = HostVerifier("task", "episode", tmp_path)
+    raw = RawSupervisor([AskUserExchangeResult(ask_id="ask", accepted=True)])
+    session = VerifiedAdapterSession(raw, verifier)  # type: ignore[arg-type]
+    begin = AskUserExchangeParams(
+        operation_id="begin", episode_id="episode", ask_id="ask", prompt="Original?"
+    )
+    session.begin_ask(begin)
+    changed = AskUserExchangeParams(
+        operation_id="finish",
+        episode_id="episode",
+        ask_id="ask",
+        prompt="Changed?",
+        answer="Answer",
+    )
+
+    async def run() -> None:
+        with pytest.raises(SupervisionError, match="mismatched"):
+            await session.finish_ask(changed, timeout=1)
+
+    import asyncio
+
+    asyncio.run(run())
+    assert raw.calls == [] and not raw.terminated
+
+
+def test_invalid_prepare_response_poisons_and_blocks_reset(tmp_path: Path) -> None:
+    verifier = HostVerifier("task", "episode", tmp_path)
+    wrong = PrepareResult(cleanup_plan=CleanupPlan(episode_id="other", actions=plan().actions))
+    raw = RawSupervisor([wrong])
+    rescue_required: list[bool] = []
+    session = VerifiedAdapterSession(
+        raw,  # pyright: ignore[reportArgumentType]
+        verifier,
+        rescue_required=lambda: rescue_required.append(True),
+    )
+    session.mark_rescue_persisted("d" * 64)
+    params = PrepareParams(
+        operation_id="prepare", episode_id="episode", secret_refs=(), infra_values=()
+    )
+
+    async def run() -> None:
+        with pytest.raises(SupervisionError, match="another episode"):
+            await session.prepare(params, timeout=1)
+        with pytest.raises(SupervisionError, match="poisoned"):
+            await session.reset_start(
+                ResetStartParams(operation_id="reset", task_id="task", episode_id="episode"),
+                timeout=1,
+            )
+
+    import asyncio
+
+    asyncio.run(run())
+    assert raw.calls == ["prepare"] and raw.terminated and rescue_required == [True]
+
+
+def test_ordinary_cleanup_rejects_forged_plan_before_dispatch(tmp_path: Path) -> None:
+    verifier = HostVerifier("task", "episode", tmp_path)
+    prepared = plan()
+    raw = RawSupervisor([])
+    session = VerifiedAdapterSession(raw, verifier)  # type: ignore[arg-type]
+    session._cleanup_plan = prepared
+    forged = CleanupPlan(
+        episode_id="episode",
+        actions=(
+            CleanupAction(
+                action_id=prepared.actions[0].action_id,
+                kind=prepared.actions[0].kind,
+                resource_ref="forged-resource",
+                timeout_ms=prepared.actions[0].timeout_ms,
+                max_attempts=prepared.actions[0].max_attempts,
+            ),
+        ),
+    )
+    params = CleanupParams(
+        operation_id="cleanup", cleanup_plan=forged, action_ids=(prepared.actions[0].action_id,)
+    )
+
+    async def run() -> None:
+        with pytest.raises(SupervisionError, match="prepared cleanup plan"):
+            await session.cleanup(params, timeout=1)
+
+    import asyncio
+
+    asyncio.run(run())
+    assert raw.calls == []
 
 
 def test_environment_is_constructed_without_parent_secrets() -> None:
@@ -379,15 +478,14 @@ class FakeSupervisor:
             return AckResult()
         assert method == "cleanup"
         action = self.expected.cleanup_plan.actions[0]
-        receipt = record_cleanup(
-            self.expected.cleanup_plan,
-            action.action_id,
+        outcome = CleanupOutcome(
+            action_id=action.action_id,
             status="succeeded",
             evidence_code="released",
             duration_ms=1,
         )
-        receipts = (receipt, receipt) if self.duplicate else (receipt,)
-        return CleanupResult(receipts=receipts)
+        outcomes = (outcome, outcome) if self.duplicate else (outcome,)
+        return CleanupResult(outcomes=outcomes)
 
     async def terminate(self) -> None:
         self.terminated = True

--- a/tests/unit/evaluation/adapters/test_supervisor.py
+++ b/tests/unit/evaluation/adapters/test_supervisor.py
@@ -450,6 +450,17 @@ def test_process_group_termination_kills_stubborn_grandchild(tmp_path: Path) -> 
     _terminate_process_group(process, process.pid)
     assert process.returncode == -signal.SIGKILL
     grandchild = int(pid_file.read_text())
+    # SIGKILL is delivered synchronously, but the orphan stays a zombie until
+    # init reaps it, and signalling a zombie still succeeds. Poll for the pid to
+    # disappear rather than asserting on the first observation, which races init
+    # and fails about once in twenty runs.
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            os.kill(grandchild, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.001)
     with pytest.raises(ProcessLookupError):
         os.kill(grandchild, 0)
 

--- a/tests/unit/evaluation/adapters/test_supervisor.py
+++ b/tests/unit/evaluation/adapters/test_supervisor.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import signal
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.evaluation.adapters.api import (
+    AckResult,
+    AdapterCapabilities,
+    AdapterMetadata,
+    AdapterSelector,
+    CleanupResult,
+    Handshake,
+    PythonRuntime,
+    RescueDescriptor,
+)
+from local_operator.evaluation.adapters.supervisor import (
+    MAX_DIAGNOSTIC_TAIL,
+    SupervisionError,
+    _Tail,
+    _terminate_process_group,
+    load_pending_rescue,
+    minimal_environment,
+    persist_rescue,
+    run_rescue,
+    verify_artifact,
+)
+from local_operator.evaluation.lifecycle import (
+    CleanupAction,
+    CleanupPlan,
+    record_cleanup,
+)
+from local_operator.evaluation.protocol import ArtifactRef
+
+
+def selector(tmp_path: Path) -> AdapterSelector:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    return AdapterSelector(
+        schema_version="1.0",
+        adapter_id="tiny",
+        distribution="tiny-adapter",
+        version="1.0",
+        entry_point="tiny_adapter:create",
+        package_digest="a" * 64,
+        release_digest="b" * 64,
+        python_executable=str(Path(sys.executable).resolve()),
+        workspace=str(workspace),
+        route_capability="computer",
+    )
+
+
+def metadata() -> AdapterMetadata:
+    return AdapterMetadata(
+        adapter_id="tiny",
+        distribution="tiny-adapter",
+        version="1.0",
+        entry_point="tiny_adapter:create",
+        package_digest="a" * 64,
+        release_digest="b" * 64,
+        schema_version="1.0",
+        capabilities=AdapterCapabilities(routes=("computer",), ask_user=False, scoring=True),
+    )
+
+
+def handshake(tmp_path: Path) -> Handshake:
+    return Handshake(
+        selector=selector(tmp_path),
+        metadata=metadata(),
+        python=PythonRuntime.current(),
+        workspace_digest="c" * 64,
+        selected_route="computer",
+    )
+
+
+def plan() -> CleanupPlan:
+    return CleanupPlan(
+        episode_id="episode",
+        actions=(
+            CleanupAction(
+                action_id="release",
+                kind="release_instance",
+                resource_ref="resource",
+                timeout_ms=100,
+                max_attempts=2,
+            ),
+        ),
+    )
+
+
+def descriptor(tmp_path: Path) -> RescueDescriptor:
+    return RescueDescriptor(
+        schema_version="1.0",
+        selector=selector(tmp_path),
+        handshake=handshake(tmp_path),
+        episode_id="episode",
+        cleanup_plan=plan(),
+        secret_refs=(),
+        infra_values=(),
+        artifact_root=str(tmp_path),
+    )
+
+
+def test_environment_is_constructed_without_parent_secrets() -> None:
+    environment = minimal_environment(
+        {
+            "LANG": "en_US.UTF-8",
+            "TMPDIR": "/tmp",
+            "PATH": "/secret/path",
+            "OPENAI_API_KEY": "marker-openai",
+            "OPENROUTER_API_KEY": "marker-openrouter",
+            "MODEL_TOKEN": "marker-model",
+        },
+        protocol_fds={
+            "LO_ADAPTER_OWNER_FD": 3,
+            "LO_ADAPTER_REQUEST_FD": 4,
+            "LO_ADAPTER_RESPONSE_FD": 5,
+        },
+    )
+    assert environment == {
+        "LANG": "en_US.UTF-8",
+        "TMPDIR": "/tmp",
+        "LO_ADAPTER_OWNER_FD": "3",
+        "LO_ADAPTER_REQUEST_FD": "4",
+        "LO_ADAPTER_RESPONSE_FD": "5",
+    }
+    assert not any("marker" in value for value in environment.values())
+
+
+def test_diagnostic_tail_is_bounded() -> None:
+    tail = _Tail()
+    tail.append(b"x" * (MAX_DIAGNOSTIC_TAIL + 10))
+    assert tail.bytes() == b"x" * MAX_DIAGNOSTIC_TAIL
+
+
+def test_persist_and_load_rescue_is_atomic_mode_0600(tmp_path: Path) -> None:
+    rescue = descriptor(tmp_path)
+    root = tmp_path / "pending"
+    path = persist_rescue(root, rescue)
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert load_pending_rescue(root) == rescue
+    assert list(root.glob(".rescue-*")) == []
+
+
+def test_load_pending_rescue_does_not_scan_and_rejects_symlink(tmp_path: Path) -> None:
+    assert load_pending_rescue(tmp_path / "missing") is None
+    target = tmp_path / "outside"
+    target.write_text("{}")
+    root = tmp_path / "pending"
+    root.mkdir()
+    (root / "rescue.json").symlink_to(target)
+    with pytest.raises(SupervisionError, match="unsafe"):
+        load_pending_rescue(root)
+
+
+def test_artifact_verification_rejects_symlink_and_digest_attack(tmp_path: Path) -> None:
+    data = b'{"ok":true}'
+    digest = hashlib.sha256(data).hexdigest()
+    reference = ArtifactRef(sha256=digest, media_type="application/json", byte_count=len(data))
+    (tmp_path / digest).write_bytes(data)
+    assert verify_artifact(tmp_path, reference) == data
+    (tmp_path / digest).unlink()
+    outside = tmp_path / "outside"
+    outside.write_bytes(data)
+    (tmp_path / digest).symlink_to(outside)
+    with pytest.raises(SupervisionError, match="unsafe"):
+        verify_artifact(tmp_path, reference)
+
+
+def test_pid_mismatch_refuses_to_signal(monkeypatch: pytest.MonkeyPatch) -> None:
+    process = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        start_new_session=True,
+    )
+    killed: list[tuple[int, int]] = []
+    monkeypatch.setattr(os, "getpgid", lambda _: process.pid + 1)
+    monkeypatch.setattr(os, "killpg", lambda pid, sig: killed.append((pid, sig)))
+    try:
+        with pytest.raises(SupervisionError, match="refusing"):
+            _terminate_process_group(process, process.pid)
+        assert killed == []
+    finally:
+        process.kill()
+        process.wait()
+
+
+def test_process_group_termination_kills_stubborn_grandchild(tmp_path: Path) -> None:
+    pid_file = tmp_path / "grandchild.pid"
+    script = (
+        "import os,signal,subprocess,sys,time;"
+        "signal.signal(signal.SIGTERM,signal.SIG_IGN);"
+        "p=subprocess.Popen([sys.executable,'-c',"
+        "'import signal,time;signal.signal(signal.SIGTERM,signal.SIG_IGN);time.sleep(30)']);"
+        "open(sys.argv[1],'w').write(str(p.pid));time.sleep(30)"
+    )
+    process = subprocess.Popen(
+        [sys.executable, "-c", script, str(pid_file)], start_new_session=True
+    )
+    deadline = time.monotonic() + 5
+    while not pid_file.exists() and time.monotonic() < deadline:
+        time.sleep(0.001)
+    assert pid_file.exists()
+    _terminate_process_group(process, process.pid)
+    assert process.returncode == -signal.SIGKILL
+    grandchild = int(pid_file.read_text())
+    with pytest.raises(ProcessLookupError):
+        os.kill(grandchild, 0)
+
+
+class FakeSupervisor:
+    def __init__(self, expected: RescueDescriptor, *, duplicate: bool = False) -> None:
+        self.expected = expected
+        self.duplicate = duplicate
+        self.terminated = False
+
+    async def handshake(self) -> Handshake:
+        return self.expected.handshake
+
+    async def call(
+        self,
+        method: Any,
+        params: Any,
+        result_type: Any,
+        *,
+        timeout: float,
+    ) -> CleanupResult | AckResult:
+        del result_type, timeout
+        assert method == "cleanup"
+        action = self.expected.cleanup_plan.actions[0]
+        receipt = record_cleanup(
+            self.expected.cleanup_plan,
+            action.action_id,
+            status="succeeded",
+            evidence_code="released",
+            duration_ms=1,
+        )
+        receipts = (receipt, receipt) if self.duplicate else (receipt,)
+        return CleanupResult(receipts=receipts)
+
+    async def terminate(self) -> None:
+        self.terminated = True
+
+
+@pytest.mark.asyncio
+async def test_rescue_reconciles_every_action_and_records_aggregate(tmp_path: Path) -> None:
+    rescue = descriptor(tmp_path)
+    fake = FakeSupervisor(rescue)
+    aggregate = await run_rescue(rescue, launch=lambda _: fake)  # type: ignore[arg-type]
+    assert aggregate.complete
+    assert len(aggregate.receipts) == 1
+    assert fake.terminated
+
+
+@pytest.mark.asyncio
+async def test_rescue_rejects_duplicate_receipts_and_reaps(tmp_path: Path) -> None:
+    rescue = descriptor(tmp_path)
+    fake = FakeSupervisor(rescue, duplicate=True)
+    with pytest.raises(SupervisionError, match="missing or duplicate"):
+        await run_rescue(rescue, launch=lambda _: fake)  # type: ignore[arg-type]
+    assert fake.terminated

--- a/tests/unit/evaluation/adapters/test_supervisor.py
+++ b/tests/unit/evaluation/adapters/test_supervisor.py
@@ -21,9 +21,11 @@ from local_operator.evaluation.adapters.api import (
     Handshake,
     PythonRuntime,
     RescueDescriptor,
+    observation_content_id,
 )
 from local_operator.evaluation.adapters.supervisor import (
     MAX_DIAGNOSTIC_TAIL,
+    HostVerifier,
     SupervisionError,
     _Tail,
     _terminate_process_group,
@@ -38,7 +40,7 @@ from local_operator.evaluation.lifecycle import (
     CleanupPlan,
     record_cleanup,
 )
-from local_operator.evaluation.protocol import ArtifactRef
+from local_operator.evaluation.protocol import ArtifactRef, Observation
 
 
 def selector(tmp_path: Path) -> AdapterSelector:
@@ -107,6 +109,29 @@ def descriptor(tmp_path: Path) -> RescueDescriptor:
         infra_values=(),
         artifact_root=str(tmp_path),
     )
+
+
+def observation(task_id: str, episode_id: str, sequence: int) -> Observation:
+    provisional = Observation(
+        task_id=task_id,
+        episode_id=episode_id,
+        sequence=sequence,
+        observation_id="provisional",
+        text="state",
+    )
+    return provisional.model_copy(update={"observation_id": observation_content_id(provisional)})
+
+
+def test_host_verifier_rejects_cross_episode_without_mutating_current(tmp_path: Path) -> None:
+    verifier = HostVerifier("task", "episode", tmp_path)
+    initial = observation("task", "episode", 0)
+    verifier.accept_observation(initial)
+    with pytest.raises(SupervisionError, match="another task or episode"):
+        verifier.accept_observation(observation("other", "episode", 1))
+    assert verifier.current_observation == initial
+    with pytest.raises(SupervisionError, match="another task or episode"):
+        verifier.accept_observation(observation("task", "other", 1))
+    assert verifier.current_observation == initial
 
 
 def test_environment_is_constructed_without_parent_secrets() -> None:
@@ -220,6 +245,7 @@ class FakeSupervisor:
         self.expected = expected
         self.duplicate = duplicate
         self.terminated = False
+        self.methods: list[str] = []
 
     async def handshake(self) -> Handshake:
         return self.expected.handshake
@@ -233,6 +259,9 @@ class FakeSupervisor:
         timeout: float,
     ) -> CleanupResult | AckResult:
         del result_type, timeout
+        self.methods.append(method)
+        if method in ("begin_rescue", "close"):
+            return AckResult()
         assert method == "cleanup"
         action = self.expected.cleanup_plan.actions[0]
         receipt = record_cleanup(
@@ -256,6 +285,7 @@ async def test_rescue_reconciles_every_action_and_records_aggregate(tmp_path: Pa
     aggregate = await run_rescue(rescue, launch=lambda _: fake)  # type: ignore[arg-type]
     assert aggregate.complete
     assert len(aggregate.receipts) == 1
+    assert fake.methods == ["begin_rescue", "cleanup", "close"]
     assert fake.terminated
 
 

--- a/tests/unit/evaluation/adapters/test_supervisor.py
+++ b/tests/unit/evaluation/adapters/test_supervisor.py
@@ -17,6 +17,8 @@ from local_operator.evaluation.adapters.api import (
     AdapterCapabilities,
     AdapterMetadata,
     AdapterSelector,
+    AskUserExchangeParams,
+    AskUserExchangeResult,
     CleanupResult,
     Handshake,
     PythonRuntime,
@@ -111,13 +113,15 @@ def descriptor(tmp_path: Path) -> RescueDescriptor:
     )
 
 
-def observation(task_id: str, episode_id: str, sequence: int) -> Observation:
+def observation(
+    task_id: str, episode_id: str, sequence: int, *, text: str = "state"
+) -> Observation:
     provisional = Observation(
         task_id=task_id,
         episode_id=episode_id,
         sequence=sequence,
         observation_id="provisional",
-        text="state",
+        text=text,
     )
     return provisional.model_copy(update={"observation_id": observation_content_id(provisional)})
 
@@ -125,13 +129,66 @@ def observation(task_id: str, episode_id: str, sequence: int) -> Observation:
 def test_host_verifier_rejects_cross_episode_without_mutating_current(tmp_path: Path) -> None:
     verifier = HostVerifier("task", "episode", tmp_path)
     initial = observation("task", "episode", 0)
-    verifier.accept_observation(initial)
+    verifier.accept_initial(initial)
     with pytest.raises(SupervisionError, match="another task or episode"):
-        verifier.accept_observation(observation("other", "episode", 1))
+        verifier.accept_output(observation("other", "episode", 1))
     assert verifier.current_observation == initial
     with pytest.raises(SupervisionError, match="another task or episode"):
-        verifier.accept_observation(observation("task", "other", 1))
+        verifier.accept_output(observation("task", "other", 1))
     assert verifier.current_observation == initial
+
+
+def test_host_verifier_enforces_initial_next_and_snapshot_modes(tmp_path: Path) -> None:
+    verifier = HostVerifier("task", "episode", tmp_path)
+    with pytest.raises(SupervisionError, match="sequence zero"):
+        verifier.accept_initial(observation("task", "episode", 99))
+    assert verifier.current_observation is None
+    initial = observation("task", "episode", 0)
+    verifier.accept_initial(initial)
+    for sequence in (0, 2, 99):
+        with pytest.raises(SupervisionError, match="exact next"):
+            verifier.accept_output(observation("task", "episode", sequence))
+        assert verifier.current_observation == initial
+    verifier.verify_current_snapshot(initial)
+    with pytest.raises(SupervisionError, match="snapshot differs"):
+        verifier.verify_current_snapshot(observation("task", "episode", 0, text="changed content"))
+    assert verifier.current_observation == initial
+    next_observation = observation("task", "episode", 1)
+    verifier.accept_output(next_observation)
+    assert verifier.current_observation == next_observation
+
+
+def test_ask_exchange_requires_expected_episode_and_preserves_pending_on_error(
+    tmp_path: Path,
+) -> None:
+    verifier = HostVerifier("task", "episode", tmp_path)
+    wrong_begin = AskUserExchangeParams(
+        operation_id="ask-wrong", episode_id="other", ask_id="ask", prompt="Question?"
+    )
+    with pytest.raises(SupervisionError, match="another episode"):
+        verifier.begin_ask(wrong_begin)
+    begin = AskUserExchangeParams(
+        operation_id="ask-begin", episode_id="episode", ask_id="ask", prompt="Question?"
+    )
+    verifier.begin_ask(begin)
+    wrong_finish = AskUserExchangeParams(
+        operation_id="ask-finish-wrong",
+        episode_id="other",
+        ask_id="ask",
+        prompt="Question?",
+        answer="Answer",
+    )
+    result = AskUserExchangeResult(ask_id="ask", accepted=True)
+    with pytest.raises(SupervisionError, match="stale, unsolicited, or mismatched"):
+        verifier.finish_ask(wrong_finish, result)
+    # The failed finish must leave the original exchange outstanding.
+    with pytest.raises(SupervisionError, match="begin once"):
+        verifier.begin_ask(begin.model_copy(update={"operation_id": "again"}))
+    correct_finish = wrong_finish.model_copy(
+        update={"operation_id": "ask-finish", "episode_id": "episode"}
+    )
+    verifier.finish_ask(correct_finish, result)
+    verifier.begin_ask(begin.model_copy(update={"operation_id": "next", "ask_id": "next"}))
 
 
 def test_environment_is_constructed_without_parent_secrets() -> None:

--- a/tests/unit/evaluation/adapters/test_supervisor.py
+++ b/tests/unit/evaluation/adapters/test_supervisor.py
@@ -181,7 +181,16 @@ def test_ask_exchange_requires_expected_episode_and_preserves_pending_on_error(
     result = AskUserExchangeResult(ask_id="ask", accepted=True)
     with pytest.raises(SupervisionError, match="stale, unsolicited, or mismatched"):
         verifier.finish_ask(wrong_finish, result)
-    # The failed finish must leave the original exchange outstanding.
+    changed_prompt = wrong_finish.model_copy(
+        update={
+            "operation_id": "ask-finish-changed",
+            "episode_id": "episode",
+            "prompt": "Different question?",
+        }
+    )
+    with pytest.raises(SupervisionError, match="stale, unsolicited, or mismatched"):
+        verifier.finish_ask(changed_prompt, result)
+    # Failed finishes must leave the original immutable request outstanding.
     with pytest.raises(SupervisionError, match="begin once"):
         verifier.begin_ask(begin.model_copy(update={"operation_id": "again"}))
     correct_finish = wrong_finish.model_copy(

--- a/tests/unit/evaluation/adapters/test_supervisor.py
+++ b/tests/unit/evaluation/adapters/test_supervisor.py
@@ -21,14 +21,19 @@ from local_operator.evaluation.adapters.api import (
     AskUserExchangeResult,
     CleanupResult,
     Handshake,
+    ObservationResult,
+    ObserveParams,
     PythonRuntime,
     RescueDescriptor,
+    ScoreParams,
+    ScoreResult,
     observation_content_id,
 )
 from local_operator.evaluation.adapters.supervisor import (
     MAX_DIAGNOSTIC_TAIL,
     HostVerifier,
     SupervisionError,
+    VerifiedAdapterSession,
     _Tail,
     _terminate_process_group,
     load_pending_rescue,
@@ -37,6 +42,7 @@ from local_operator.evaluation.adapters.supervisor import (
     run_rescue,
     verify_artifact,
 )
+from local_operator.evaluation.evidence.models import EvidenceArtifactRef, ScoreArtifact
 from local_operator.evaluation.lifecycle import (
     CleanupAction,
     CleanupPlan,
@@ -200,6 +206,49 @@ def test_ask_exchange_requires_expected_episode_and_preserves_pending_on_error(
     verifier.begin_ask(begin.model_copy(update={"operation_id": "next", "ask_id": "next"}))
 
 
+class RawSupervisor:
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = responses
+
+    async def _call_raw(self, *args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        return self.responses.pop(0)
+
+
+def test_verified_session_rejects_bad_observe_without_mutation(tmp_path: Path) -> None:
+    verifier = HostVerifier("task", "episode", tmp_path)
+    initial = observation("task", "episode", 0)
+    verifier.accept_initial(initial)
+    raw = RawSupervisor([ObservationResult(observation=observation("task", "other", 0))])
+    session = VerifiedAdapterSession(raw, verifier)  # type: ignore[arg-type]
+
+    async def run() -> None:
+        with pytest.raises(SupervisionError, match="snapshot differs"):
+            await session.observe(ObserveParams(episode_id="episode"), timeout=1)
+
+    import asyncio
+
+    asyncio.run(run())
+    assert verifier.current_observation == initial
+
+
+def test_score_missing_artifact_can_retry_after_file_appears(tmp_path: Path) -> None:
+    verifier = HostVerifier("task", "episode", tmp_path)
+    data = b'{"detail":true}'
+    digest = hashlib.sha256(data).hexdigest()
+    reference = EvidenceArtifactRef(
+        sha256=digest, media_type="application/json", byte_count=len(data)
+    )
+    score = ScoreResult(score=ScoreArtifact(status="scored", binary=1, details=reference))
+    params = ScoreParams(operation_id="score", episode_id="episode")
+    with pytest.raises(SupervisionError, match="unsafe or unavailable"):
+        verifier.accept_score(params, score)
+    (tmp_path / digest).write_bytes(data)
+    verifier.accept_score(params, score)
+    with pytest.raises(SupervisionError, match="duplicated"):
+        verifier.accept_score(params, score)
+
+
 def test_environment_is_constructed_without_parent_secrets() -> None:
     environment = minimal_environment(
         {
@@ -316,7 +365,7 @@ class FakeSupervisor:
     async def handshake(self) -> Handshake:
         return self.expected.handshake
 
-    async def call(
+    async def _call_raw(
         self,
         method: Any,
         params: Any,

--- a/tests/unit/evaluation/adapters/test_worker.py
+++ b/tests/unit/evaluation/adapters/test_worker.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from local_operator.evaluation.adapters.rpc import (
+    IncrementalReader,
+    IncrementalWriter,
+    RpcRequest,
+    RpcResponse,
+    canonical_line,
+    parse_canonical_line,
+)
+from local_operator.evaluation.adapters.worker import Worker
+
+
+async def exchange(
+    writer: IncrementalWriter,
+    reader: IncrementalReader,
+    request: RpcRequest,
+) -> RpcResponse:
+    writer.write(canonical_line(request))
+    raw = await asyncio.to_thread(reader.read_line)
+    parsed = parse_canonical_line(raw, RpcResponse)
+    assert isinstance(parsed, RpcResponse)
+    return parsed
+
+
+@pytest.mark.asyncio
+async def test_worker_rejects_invalid_state_and_changed_request_reuse() -> None:
+    request_read, request_write = os.pipe()
+    response_read, response_write = os.pipe()
+    worker = Worker(request_read, response_write)
+    task = asyncio.create_task(worker.run())
+    writer = IncrementalWriter(request_write)
+    reader = IncrementalReader(response_read)
+    try:
+        request = RpcRequest(jsonrpc="2.0", id=1, method="inspect_requirements", params={})
+        response = await exchange(writer, reader, request)
+        assert response.error is not None and response.error.code == "invalid_state"
+        # Exact request replay is byte-for-byte stable.
+        replay = await exchange(writer, reader, request)
+        assert replay == response
+        # Changed method/params under the same ID is a fatal protocol fault.
+        changed = RpcRequest(
+            jsonrpc="2.0",
+            id=1,
+            method="observe",
+            params={"episode_id": "episode"},
+        )
+        writer.write(canonical_line(changed))
+        # Protocol-fault exit abandons the blocking reader with the process; the
+        # in-process test closes its peer so asyncio can join that executor call.
+        os.close(request_write)
+        request_write = -1
+        assert await asyncio.wait_for(task, 1) == 70
+    finally:
+        for fd in (request_read, request_write, response_read, response_write):
+            try:
+                if fd >= 0:
+                    os.close(fd)
+            except OSError:
+                pass
+
+
+@pytest.mark.asyncio
+async def test_worker_rejects_cancel_without_inflight_call() -> None:
+    request_read, request_write = os.pipe()
+    response_read, response_write = os.pipe()
+    worker = Worker(request_read, response_write)
+    task = asyncio.create_task(worker.run())
+    try:
+        os.write(request_write, b'{"control":"cancel","id":1,"jsonrpc":"2.0"}\n')
+        assert await asyncio.wait_for(task, 1) == 70
+    finally:
+        for fd in (request_read, request_write, response_read, response_write):
+            try:
+                if fd >= 0:
+                    os.close(fd)
+            except OSError:
+                pass

--- a/tests/unit/evaluation/adapters/test_worker.py
+++ b/tests/unit/evaluation/adapters/test_worker.py
@@ -21,11 +21,13 @@ from local_operator.evaluation.adapters.api import (
     HelloParams,
     PrepareParams,
     PrepareResult,
+    PythonRuntime,
     RescueDescriptor,
 )
 from local_operator.evaluation.adapters.rpc import (
     IncrementalReader,
     IncrementalWriter,
+    RpcProtocolError,
     RpcRequest,
     RpcResponse,
     canonical_line,
@@ -366,12 +368,14 @@ async def test_real_worker_rescue_invokes_each_cleanup_once_and_blocks_normal_fl
             ),
         )
         assert response.result == AckResult().model_dump(mode="json")
+        first_cleanup: CleanupParams | None = None
         for request_id, action in enumerate(cleanup_plan.actions, start=3):
             params = CleanupParams(
                 operation_id=f"cleanup-{action.action_id}",
                 cleanup_plan=cleanup_plan,
                 action_ids=(action.action_id,),
             )
+            first_cleanup = first_cleanup or params
             response = await exchange(
                 writer,
                 reader,
@@ -383,6 +387,20 @@ async def test_real_worker_rescue_invokes_each_cleanup_once_and_blocks_normal_fl
                 ),
             )
             assert response.error is None
+        assert first_cleanup is not None
+        duplicate = first_cleanup.model_copy(update={"operation_id": "second-key-same-action"})
+        response = await exchange(
+            writer,
+            reader,
+            RpcRequest(
+                jsonrpc="2.0",
+                id=5,
+                method="cleanup",
+                params=duplicate.model_dump(mode="json"),
+            ),
+        )
+        assert response.error is None
+        assert adapter.cleanup_calls == ["one", "two"]
         forbidden = PrepareParams(
             operation_id="forbidden", episode_id="episode", secret_refs=(), infra_values=()
         )
@@ -391,7 +409,7 @@ async def test_real_worker_rescue_invokes_each_cleanup_once_and_blocks_normal_fl
             reader,
             RpcRequest(
                 jsonrpc="2.0",
-                id=5,
+                id=6,
                 method="prepare",
                 params=forbidden.model_dump(mode="json"),
             ),
@@ -402,6 +420,79 @@ async def test_real_worker_rescue_invokes_each_cleanup_once_and_blocks_normal_fl
         os.close(request_write)
         assert await asyncio.wait_for(task, 1) == 0
         for fd in (request_read, response_read, response_write):
+            os.close(fd)
+
+
+def test_rescue_cleanup_rejects_forged_episode_and_action_without_losing_pin(
+    tmp_path: Path,
+) -> None:
+    selected = rescue_selector(tmp_path)
+    cleanup_plan = CleanupPlan(
+        episode_id="episode",
+        actions=(
+            CleanupAction(
+                action_id="one",
+                kind="release_instance",
+                resource_ref="resource-one",
+                timeout_ms=100,
+                max_attempts=1,
+            ),
+        ),
+    )
+    pinned_handshake = Handshake(
+        selector=selected,
+        metadata=rescue_metadata(),
+        python=PythonRuntime.current(),
+        workspace_digest="c" * 64,
+        selected_route="computer",
+    )
+    descriptor = RescueDescriptor(
+        schema_version="1.0",
+        selector=selected,
+        handshake=pinned_handshake,
+        episode_id="episode",
+        cleanup_plan=cleanup_plan,
+        secret_refs=(),
+        infra_values=(),
+        artifact_root=str(tmp_path),
+    )
+    request_read, request_write = os.pipe()
+    response_read, response_write = os.pipe()
+    worker = Worker(request_read, response_write)
+    worker._rescue_descriptor = descriptor
+    try:
+        forged_episode = CleanupPlan(episode_id="episode-b", actions=cleanup_plan.actions)
+        with pytest.raises(RpcProtocolError, match="pinned rescue plan"):
+            worker._validate_rescue_cleanup(
+                CleanupParams(
+                    operation_id="forged-episode",
+                    cleanup_plan=forged_episode,
+                    action_ids=("one",),
+                )
+            )
+        modified_action = CleanupPlan(
+            episode_id="episode",
+            actions=(
+                CleanupAction(
+                    action_id="one",
+                    kind="release_instance",
+                    resource_ref="other-resource",
+                    timeout_ms=100,
+                    max_attempts=1,
+                ),
+            ),
+        )
+        with pytest.raises(RpcProtocolError, match="pinned rescue plan"):
+            worker._validate_rescue_cleanup(
+                CleanupParams(
+                    operation_id="forged-action",
+                    cleanup_plan=modified_action,
+                    action_ids=("one",),
+                )
+            )
+        assert worker._rescue_descriptor == descriptor
+    finally:
+        for fd in (request_read, request_write, response_read, response_write):
             os.close(fd)
 
 

--- a/tests/unit/evaluation/adapters/test_worker.py
+++ b/tests/unit/evaluation/adapters/test_worker.py
@@ -2,9 +2,15 @@ from __future__ import annotations
 
 import asyncio
 import os
+from typing import Any
 
 import pytest
 
+from local_operator.evaluation.adapters.api import (
+    AdapterState,
+    PrepareParams,
+    PrepareResult,
+)
 from local_operator.evaluation.adapters.rpc import (
     IncrementalReader,
     IncrementalWriter,
@@ -14,6 +20,37 @@ from local_operator.evaluation.adapters.rpc import (
     parse_canonical_line,
 )
 from local_operator.evaluation.adapters.worker import Worker
+from local_operator.evaluation.lifecycle import CleanupAction, CleanupPlan
+
+
+class CountingWorker(Worker):
+    def __init__(self, request_fd: int, response_fd: int, **kwargs: int) -> None:
+        super().__init__(request_fd, response_fd, **kwargs)
+        self.calls = 0
+        self.fail = False
+
+    def set_state(self, state: AdapterState) -> None:
+        self._state = state
+
+    async def _dispatch(self, method: Any, params: Any) -> Any:
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError("secret adapter detail")
+        assert method == "prepare" and isinstance(params, PrepareParams)
+        return PrepareResult(
+            cleanup_plan=CleanupPlan(
+                episode_id=params.episode_id,
+                actions=(
+                    CleanupAction(
+                        action_id="release",
+                        kind="release_instance",
+                        resource_ref="resource",
+                        timeout_ms=100,
+                        max_attempts=1,
+                    ),
+                ),
+            )
+        )
 
 
 async def exchange(
@@ -63,6 +100,131 @@ async def test_worker_rejects_invalid_state_and_changed_request_reuse() -> None:
                     os.close(fd)
             except OSError:
                 pass
+
+
+@pytest.mark.asyncio
+async def test_keyed_success_replays_under_new_request_id_without_dispatch() -> None:
+    request_read, request_write = os.pipe()
+    response_read, response_write = os.pipe()
+    worker = CountingWorker(request_read, response_write)
+    worker.set_state("INSPECTED")
+    task = asyncio.create_task(worker.run())
+    writer = IncrementalWriter(request_write)
+    reader = IncrementalReader(response_read)
+    params = PrepareParams(
+        operation_id="prepare-op", episode_id="episode", secret_refs=(), infra_values=()
+    )
+    try:
+        first = await exchange(
+            writer,
+            reader,
+            RpcRequest(
+                jsonrpc="2.0", id=1, method="prepare", params=params.model_dump(mode="json")
+            ),
+        )
+        replay = await exchange(
+            writer,
+            reader,
+            RpcRequest(
+                jsonrpc="2.0", id=2, method="prepare", params=params.model_dump(mode="json")
+            ),
+        )
+        assert worker.calls == 1
+        assert first.id == 1 and replay.id == 2
+        assert first.result == replay.result
+    finally:
+        os.close(request_write)
+        assert await asyncio.wait_for(task, 1) == 0
+        for fd in (request_read, response_read, response_write):
+            os.close(fd)
+
+
+@pytest.mark.asyncio
+async def test_keyed_error_replays_and_changed_params_poison() -> None:
+    request_read, request_write = os.pipe()
+    response_read, response_write = os.pipe()
+    worker = CountingWorker(request_read, response_write)
+    worker.set_state("INSPECTED")
+    worker.fail = True
+    task = asyncio.create_task(worker.run())
+    writer = IncrementalWriter(request_write)
+    reader = IncrementalReader(response_read)
+    params = PrepareParams(
+        operation_id="prepare-op", episode_id="episode", secret_refs=(), infra_values=()
+    )
+    try:
+        first = await exchange(
+            writer,
+            reader,
+            RpcRequest(
+                jsonrpc="2.0", id=1, method="prepare", params=params.model_dump(mode="json")
+            ),
+        )
+        replay = await exchange(
+            writer,
+            reader,
+            RpcRequest(
+                jsonrpc="2.0", id=2, method="prepare", params=params.model_dump(mode="json")
+            ),
+        )
+        assert worker.calls == 1
+        assert first.error == replay.error
+        changed = params.model_copy(update={"episode_id": "other"})
+        writer.write(
+            canonical_line(
+                RpcRequest(
+                    jsonrpc="2.0",
+                    id=3,
+                    method="prepare",
+                    params=changed.model_dump(mode="json"),
+                )
+            )
+        )
+        os.close(request_write)
+        request_write = -1
+        assert await asyncio.wait_for(task, 1) == 70
+        assert worker.calls == 1
+    finally:
+        for fd in (request_read, request_write, response_read, response_write):
+            if fd >= 0:
+                os.close(fd)
+
+
+@pytest.mark.asyncio
+async def test_operation_capacity_poison_precedes_dispatch() -> None:
+    request_read, request_write = os.pipe()
+    response_read, response_write = os.pipe()
+    worker = CountingWorker(request_read, response_write, max_operation_records=1)
+    worker.set_state("INSPECTED")
+    task = asyncio.create_task(worker.run())
+    writer = IncrementalWriter(request_write)
+    reader = IncrementalReader(response_read)
+    try:
+        first = PrepareParams(
+            operation_id="one", episode_id="episode", secret_refs=(), infra_values=()
+        )
+        await exchange(
+            writer,
+            reader,
+            RpcRequest(jsonrpc="2.0", id=1, method="prepare", params=first.model_dump(mode="json")),
+        )
+        worker.set_state("INSPECTED")
+        second = first.model_copy(update={"operation_id": "two"})
+        writer.write(
+            canonical_line(
+                RpcRequest(
+                    jsonrpc="2.0", id=2, method="prepare", params=second.model_dump(mode="json")
+                )
+            )
+        )
+        os.close(request_write)
+        request_write = -1
+        assert await asyncio.wait_for(task, 1) == 70
+        assert worker.calls == 1
+    finally:
+        for fd in (request_read, request_write, response_read, response_write):
+            if fd >= 0:
+                os.close(fd)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/evaluation/adapters/test_worker.py
+++ b/tests/unit/evaluation/adapters/test_worker.py
@@ -400,25 +400,39 @@ async def test_real_worker_rescue_invokes_each_cleanup_once_and_blocks_normal_fl
             ),
         )
         assert response.error is None
-        assert adapter.cleanup_calls == ["one", "two"]
-        forbidden = PrepareParams(
-            operation_id="forbidden", episode_id="episode", secret_refs=(), infra_values=()
-        )
-        response = await exchange(
+        alias_replay = await exchange(
             writer,
             reader,
             RpcRequest(
                 jsonrpc="2.0",
                 id=6,
-                method="prepare",
-                params=forbidden.model_dump(mode="json"),
+                method="cleanup",
+                params=duplicate.model_dump(mode="json"),
             ),
         )
-        assert response.error is not None and response.error.code == "invalid_state"
+        assert alias_replay.result == response.result
+        conflicting_alias = CleanupParams(
+            operation_id="second-key-same-action",
+            cleanup_plan=cleanup_plan,
+            action_ids=("two",),
+        )
+        writer.write(
+            canonical_line(
+                RpcRequest(
+                    jsonrpc="2.0",
+                    id=7,
+                    method="cleanup",
+                    params=conflicting_alias.model_dump(mode="json"),
+                )
+            )
+        )
+        os.close(request_write)
+        request_write = -1
+        assert await asyncio.wait_for(task, 1) == 70
         assert adapter.cleanup_calls == ["one", "two"]
     finally:
-        os.close(request_write)
-        assert await asyncio.wait_for(task, 1) == 0
+        if request_write >= 0:
+            os.close(request_write)
         for fd in (request_read, response_read, response_write):
             os.close(fd)
 

--- a/tests/unit/evaluation/adapters/test_worker.py
+++ b/tests/unit/evaluation/adapters/test_worker.py
@@ -15,6 +15,7 @@ from local_operator.evaluation.adapters.api import (
     AdapterSelector,
     AdapterState,
     BeginRescueParams,
+    CleanupOutcome,
     CleanupParams,
     CleanupResult,
     Handshake,
@@ -24,6 +25,7 @@ from local_operator.evaluation.adapters.api import (
     PythonRuntime,
     RescueDescriptor,
 )
+from local_operator.evaluation.adapters.discovery import workspace_digest
 from local_operator.evaluation.adapters.rpc import (
     IncrementalReader,
     IncrementalWriter,
@@ -35,11 +37,7 @@ from local_operator.evaluation.adapters.rpc import (
 )
 from local_operator.evaluation.adapters.worker import Worker
 from local_operator.evaluation.evidence.models import canonical_digest
-from local_operator.evaluation.lifecycle import (
-    CleanupAction,
-    CleanupPlan,
-    record_cleanup,
-)
+from local_operator.evaluation.lifecycle import CleanupAction, CleanupPlan
 
 
 class CountingWorker(Worker):
@@ -255,10 +253,9 @@ class RescueAdapter:
         action_id = params.action_ids[0]
         self.cleanup_calls.append(action_id)
         return CleanupResult(
-            receipts=(
-                record_cleanup(
-                    params.cleanup_plan,
-                    action_id,
+            outcomes=(
+                CleanupOutcome(
+                    action_id=action_id,
                     status="succeeded",
                     evidence_code="released",
                     duration_ms=1,
@@ -270,6 +267,8 @@ class RescueAdapter:
 def rescue_selector(tmp_path: Path) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
+    release_digest = "b" * 64
+    (workspace / "adapter-release.json").write_text(f'{{"release_digest":"{release_digest}"}}')
     return AdapterSelector(
         schema_version="1.0",
         adapter_id="rescue",
@@ -277,9 +276,10 @@ def rescue_selector(tmp_path: Path) -> AdapterSelector:
         version="1.0",
         entry_point="rescue_adapter:create",
         package_digest="a" * 64,
-        release_digest="b" * 64,
+        release_digest=release_digest,
         python_executable=str(Path(sys.executable).resolve()),
         workspace=str(workspace),
+        workspace_digest=workspace_digest(str(workspace)),
         route_capability="computer",
     )
 
@@ -457,7 +457,7 @@ def test_rescue_cleanup_rejects_forged_episode_and_action_without_losing_pin(
         selector=selected,
         metadata=rescue_metadata(),
         python=PythonRuntime.current(),
-        workspace_digest="c" * 64,
+        workspace_digest=selected.workspace_digest,
         selected_route="computer",
     )
     descriptor = RescueDescriptor(

--- a/tests/unit/evaluation/adapters/test_worker.py
+++ b/tests/unit/evaluation/adapters/test_worker.py
@@ -2,14 +2,26 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
+from pathlib import Path
 from typing import Any
 
 import pytest
 
 from local_operator.evaluation.adapters.api import (
+    AckResult,
+    AdapterCapabilities,
+    AdapterMetadata,
+    AdapterSelector,
     AdapterState,
+    BeginRescueParams,
+    CleanupParams,
+    CleanupResult,
+    Handshake,
+    HelloParams,
     PrepareParams,
     PrepareResult,
+    RescueDescriptor,
 )
 from local_operator.evaluation.adapters.rpc import (
     IncrementalReader,
@@ -20,7 +32,12 @@ from local_operator.evaluation.adapters.rpc import (
     parse_canonical_line,
 )
 from local_operator.evaluation.adapters.worker import Worker
-from local_operator.evaluation.lifecycle import CleanupAction, CleanupPlan
+from local_operator.evaluation.evidence.models import canonical_digest
+from local_operator.evaluation.lifecycle import (
+    CleanupAction,
+    CleanupPlan,
+    record_cleanup,
+)
 
 
 class CountingWorker(Worker):
@@ -225,6 +242,167 @@ async def test_operation_capacity_poison_precedes_dispatch() -> None:
         for fd in (request_read, request_write, response_read, response_write):
             if fd >= 0:
                 os.close(fd)
+
+
+class RescueAdapter:
+    def __init__(self, metadata: AdapterMetadata) -> None:
+        self.metadata = metadata
+        self.cleanup_calls: list[str] = []
+
+    async def cleanup(self, params: CleanupParams) -> CleanupResult:
+        action_id = params.action_ids[0]
+        self.cleanup_calls.append(action_id)
+        return CleanupResult(
+            receipts=(
+                record_cleanup(
+                    params.cleanup_plan,
+                    action_id,
+                    status="succeeded",
+                    evidence_code="released",
+                    duration_ms=1,
+                ),
+            )
+        )
+
+
+def rescue_selector(tmp_path: Path) -> AdapterSelector:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    return AdapterSelector(
+        schema_version="1.0",
+        adapter_id="rescue",
+        distribution="rescue-adapter",
+        version="1.0",
+        entry_point="rescue_adapter:create",
+        package_digest="a" * 64,
+        release_digest="b" * 64,
+        python_executable=str(Path(sys.executable).resolve()),
+        workspace=str(workspace),
+        route_capability="computer",
+    )
+
+
+def rescue_metadata() -> AdapterMetadata:
+    return AdapterMetadata(
+        adapter_id="rescue",
+        distribution="rescue-adapter",
+        version="1.0",
+        entry_point="rescue_adapter:create",
+        package_digest="a" * 64,
+        release_digest="b" * 64,
+        schema_version="1.0",
+        capabilities=AdapterCapabilities(routes=("computer",), ask_user=False, scoring=False),
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_worker_rescue_invokes_each_cleanup_once_and_blocks_normal_flow(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    selected = rescue_selector(tmp_path)
+    adapter = RescueAdapter(rescue_metadata())
+    monkeypatch.setattr(
+        "local_operator.evaluation.adapters.worker.load_selected_adapter", lambda _: adapter
+    )
+    request_read, request_write = os.pipe()
+    response_read, response_write = os.pipe()
+    worker = Worker(request_read, response_write)
+    task = asyncio.create_task(worker.run())
+    writer = IncrementalWriter(request_write)
+    reader = IncrementalReader(response_read)
+    try:
+        hello = await exchange(
+            writer,
+            reader,
+            RpcRequest(
+                jsonrpc="2.0",
+                id=1,
+                method="hello",
+                params=HelloParams(selector=selected).model_dump(mode="json"),
+            ),
+        )
+        assert hello.result is not None
+        handshake = Handshake.model_validate(hello.result, strict=True)
+        cleanup_plan = CleanupPlan(
+            episode_id="episode",
+            actions=tuple(
+                CleanupAction(
+                    action_id=action_id,
+                    kind="release_instance",
+                    resource_ref=f"resource-{action_id}",
+                    timeout_ms=100,
+                    max_attempts=1,
+                )
+                for action_id in ("one", "two")
+            ),
+        )
+        descriptor = RescueDescriptor(
+            schema_version="1.0",
+            selector=selected,
+            handshake=handshake,
+            episode_id="episode",
+            cleanup_plan=cleanup_plan,
+            secret_refs=(),
+            infra_values=(),
+            artifact_root=str(tmp_path),
+        )
+        begin = BeginRescueParams(
+            operation_id="begin",
+            descriptor=descriptor,
+            descriptor_id=descriptor.descriptor_id,
+            episode_id=descriptor.episode_id,
+            cleanup_plan_id=cleanup_plan.cleanup_plan_id,
+            selector_digest=canonical_digest("adapter-rescue-selector-v1", selected),
+            handshake_digest=canonical_digest("adapter-rescue-handshake-v1", handshake),
+        )
+        response = await exchange(
+            writer,
+            reader,
+            RpcRequest(
+                jsonrpc="2.0",
+                id=2,
+                method="begin_rescue",
+                params=begin.model_dump(mode="json"),
+            ),
+        )
+        assert response.result == AckResult().model_dump(mode="json")
+        for request_id, action in enumerate(cleanup_plan.actions, start=3):
+            params = CleanupParams(
+                operation_id=f"cleanup-{action.action_id}",
+                cleanup_plan=cleanup_plan,
+                action_ids=(action.action_id,),
+            )
+            response = await exchange(
+                writer,
+                reader,
+                RpcRequest(
+                    jsonrpc="2.0",
+                    id=request_id,
+                    method="cleanup",
+                    params=params.model_dump(mode="json"),
+                ),
+            )
+            assert response.error is None
+        forbidden = PrepareParams(
+            operation_id="forbidden", episode_id="episode", secret_refs=(), infra_values=()
+        )
+        response = await exchange(
+            writer,
+            reader,
+            RpcRequest(
+                jsonrpc="2.0",
+                id=5,
+                method="prepare",
+                params=forbidden.model_dump(mode="json"),
+            ),
+        )
+        assert response.error is not None and response.error.code == "invalid_state"
+        assert adapter.cleanup_calls == ["one", "two"]
+    finally:
+        os.close(request_write)
+        assert await asyncio.wait_for(task, 1) == 0
+        for fd in (request_read, response_read, response_write):
+            os.close(fd)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR adds the fourth slice of Local Operator's benchmark-neutral evaluation platform: the out-of-process **adapter boundary**. It lets the harness run a pinned, third-party benchmark adapter in a separate interpreter under an exact, content-addressed contract, and it does not activate a benchmark, OSWorld, provider, CLI, configuration, tool, cloud, or UI path.

The boundary covers five concerns:

- **Exact distribution and entry-point selection.** An `AdapterSelector` pins the distribution name, version, entry point, package digest, release digest, absolute interpreter, and workspace. There are no ranges and no fallbacks.
- **Verified-source import.** Every module the selected distribution owns is served from bytes hash-matched against its wheel `RECORD` and compiled in-process, so the bytes that execute are the bytes that were hashed.
- **Dedicated-FD canonical JSONL RPC.** Two inherited one-way pipes carry canonical sorted compact UTF-8 JSONL. `stdin` is `DEVNULL` and `stdout`/`stderr` are diagnostics only, so nothing an adapter prints can be read as protocol.
- **Process-tree supervision.** The worker and its descendants run in a fresh session and process group; owner-pipe EOF, timeout, cancellation, and startup failure all reap the entire tree.
- **Parent-owned rescue cleanup.** A `rescue.json` descriptor is persisted with fsync before any resource-creating call, so a crashed run's cleanup remains executable by a later caller. The parent derives every cleanup receipt; an adapter's claim never suppresses reconciliation.

The implementation keeps `local_operator.evaluation` and `local_operator.evaluation.adapters` inert on import and adds no dependency.

This is a standard C2 change and is pre-authorized. The PR is the system of record; there is no issue or RFC.

## Not activated

This slice is a foundation, deliberately unreachable from any running code path:

- No CLI command, configuration key, default tool, UI surface, OSWorld integration, or cloud wiring.
- Both package roots (`evaluation/__init__.py`, `evaluation/adapters/__init__.py`) are docstring-only; importing them starts nothing and spawns nothing.
- **Nothing outside the package imports it.** Verified by search: every reference to `local_operator.evaluation.adapters` lives inside the package itself or its own tests.
- No provider, model, or OpenRouter credential ever reaches an adapter. The worker environment is built from a small allowlist rather than `os.environ.copy()`, and those keys are denied even when the parent holds them.

## Contract

### API

- Strict frozen `ProtocolModel` values. `AdapterSelector` pins `adapter_id`, distribution, version, entry point, package digest, release digest, schema `1.0`, absolute interpreter and workspace, and route capability. The `Handshake` repeats every pin and adds the resolved Python implementation/version/cache-tag, workspace digest, and selected route. Any mismatch is fatal; there is no negotiation.
- Secrets appear only as `SecretRef` names. `ScopedInfraValue` structurally excludes provider and model purposes, so a benchmark can be handed infrastructure credentials without becoming a second paid-model route.
- A closed method table — `hello`, `inspect_requirements`, `prepare`, `reset_start`, `observe`, `execute`, `ask_user_exchange`, `score`, `cleanup`, `begin_rescue`, `close` — with a closed state machine (`NEW`/`HANDSHAKEN`/`INSPECTED`/`PREPARED`/`RUNNING`/`FINALIZING`/`CLEANING`/`CLOSED`/`POISONED`). Control `cancel` is separate from application calls.
- Reusing a request ID requires the same method and the same canonical params digest; a changed reuse is fatal. Keyed methods carry operation IDs so a retried operation replays its recorded outcome instead of dispatching a second side effect.

### Discovery

- The host never imports adapter code and never enumerates global entry points. It validates an absolute, regular, symlink-free interpreter and workspace, then launches `python -I -s -E -m local_operator.evaluation.adapters.worker`.
- The worker resolves exactly `importlib.metadata.distribution(selector.distribution)`, checks the version, recomputes a canonical digest over `RECORD` entries and hashes, and then reads only that distribution's exact entry-point group `local_operator.evaluation_adapters.v1` — one name, one value, exactly one match. Editable and unhashed installs are refused.
- Imports are served by a `sys.meta_path` finder scoped to the distribution's `RECORD`-owned roots and installed only for the load. Stdlib, pydantic, and `local_operator` resolve normally; anything under an owned root that `RECORD` does not cover is refused rather than imported.
- `ResolvedLaunch` pins the interpreter's sha256, size, dev/ino/mode, revalidated immediately before spawn by both the parent and the supervisor.

### RPC, worker, supervisor

- Canonical JSONL with duplicate-key rejection, LF-only framing, a 1 MiB cap enforced before allocation, and partial-EOF rejection. Responses repeat their method and carry result **xor** a closed bounded error. One application call is in flight at a time.
- Unknown, late, duplicate, wrong-ID, malformed, and oversized frames poison the session and reap the tree. A timed-out response is never reused: cancel, 1 s grace, then `SIGTERM` to the group, 5 s, then `SIGKILL`. Caller cancellation is shielded until the tree is reaped.
- The worker opens its protocol FDs and redirects fd 1 to fd 2 **before** any metadata or import work, so adapter or native `print` output can never land in the protocol stream. Adapter errors surface as closed codes with no `repr`, traceback, or environment.
- The supervisor is POSIX-only and says so explicitly. It verifies `pid == pgid == getpgid(pid)` immediately before signalling, resets signal masks and dispositions in the child, leaves host signal handling untouched, and drains bounded 64 KiB stdout/stderr tails.

### Host verification

The host recomputes rather than trusts: domain-separated observation IDs from canonical content, artifact filename/digest/regular-file/`O_NOFOLLOW`/byte/media checks through the existing evidence media validation, `ActionBatch.validate_for` against the current observation, host-assigned action-batch IDs, execution-receipt ID/digest/sequence uniqueness, single-use outstanding ask exchanges, and score/cleanup plan and action IDs. The adapter supplies no lifecycle authority.

## Review history

Twelve adversarial agent-review rounds ran before this PR. Round 12 came back clean and terminal. A fresh formal agent-review round will still be recorded on this PR before merge; the pre-PR rounds do not replace the repository review gate.

| Round | Finding | Fix |
| --- | --- | --- |
| 1 | Rescue ran through `prepare`/`reset_start` side effects; keyed operations could re-dispatch | Added `begin_rescue` (`HANDSHAKEN` → `CLEANING`); bounded operation records replay a recorded outcome and refuse on exhaustion rather than evicting a side effect |
| 2 | Rescue cleanup unpinned; observation sequence unchecked; ask exchange unbound to an episode | Pinned the rescue descriptor and per-action outcomes; split initial/output/snapshot acceptance; bound ask begin/finish to an exact episode |
| 3 | Replay alias could redirect an operation; verifier not wired into real calls; launch path aliases | Alias reservation made atomic; added `VerifiedAdapterSession` owning the verifier with raw `call` made private; launch paths lstat-checked component by component |
| 4 | Cleanup receipts trusted from the adapter; ambiguous mutations left the session usable; workspace pinned by inode | Parent derives receipts; ambiguous mutation poisons and reaps; workspace pinned by a content manifest; executable pinned by content |
| 5 | **Subsystem unlaunchable**: `st_nlink != 1` rejected every real CPython interpreter (uv nlink=3, `/usr/bin/python3` nlink=78) | Dropped the link-count rule for the executable (content hash is the real binding), kept it for workspace files; added a real-interpreter test and the first end-to-end spawn test |
| 6 | Forged `__pycache__/*.pyc` executed while `RECORD` verification passed | Load the verified bytes and `compile`/`exec` them directly; `entry.load()` never runs |
| 7 | Chain verification could not cover siblings a verified module imports | Replaced the chain with the distribution-scoped `sys.meta_path` finder |
| 8 | Sourceless `.pyc` under an owned root executed unverified; stale `sys.modules` entry in a second owned root survived | Refuse every importable artifact at an uncovered stem; purge every owned root before load |
| 9 | A `RECORD`-covered C extension was refused, and behaviour differed by placement | Extensions load hash-verified at any placement; bytecode stays refused with an accurate message |
| 10 | Dual-artifact wheels (mypyc/Cython ship both `mod.py` and `mod<EXT>`) hard-refused | Prefer verified source; one shared resolver used by both the finder and the entry gate |
| 11 | Resolver inverted CPython precedence for `mod.py` + `mod/__init__.py` | Refuse that pair as ambiguous; probe outranking extension suffixes consistently; corrected a docstring that misstated CPython's precedence |
| 12 | Clean — no blocker, no major | — |

## Real-execution evidence

Measured on Darwin 25.6.0 / arm64, Python 3.14.3. The security fixes were proven by building each attack, confirming it was **live on this host first**, and only then asserting the refusal — an assertion that cannot pass on a host where the attack silently failed to take.

```text
.venv/bin/python -m pytest tests/unit/evaluation/adapters -q -n0
68 passed
```

- **Real compiled extensions.** Tests compile genuine `.so` modules with `cc` and the CPython headers (`PyInit_*`), platform-aware link flags, and a hard failure — never a skip — when a host has a compiler and headers but the build fails. All five compile-dependent tests ran here; zero skipped.
- **Forged bytecode, proven live.** A forged `__pycache__` entry and a planted sourceless `.pyc` were each shown to execute under a normal import (attacker marker written, `create()` returning `"attacker"`) before asserting the loader refuses them.
- **Real subprocesses and process groups.** End-to-end launch through `AdapterSupervisor` completes a real handshake and reaps; stubborn `SIGTERM`-ignoring grandchildren are killed by group; PID/PGID mismatch refuses to signal; host signal handlers are unchanged.
- **Contamination and secrecy.** Adapter `stdout`, native writes, and grandchild output all stay diagnostics. Environment secret markers are absent from argv, environment, logs, and the rescue descriptor.
- **Every fix is load-bearing.** Each round's fix was reverted and the matching test observed to fail, so no test asserts something the code was already doing.

## Testing status

- **Focused adapter suite: 68 passed, zero skips**, stable across repeated consecutive runs.
- **Whole-tree static gates clean**, exactly as CI runs them: `flake8`, `black --check` (26.1.0, 703 files), `isort --check`, `pyright` (0 errors).
- **The full unit suite was NOT completed locally.** Another session on this shared machine is running 12 deliberate CPU-hog processes to reproduce a TUI flake under load (load average ~253), which starved the run; a result measured under that contention would be meaningless. **The full suite is delegated to CI**, which runs the same suite on a quiet runner. No claim of local full-suite coverage is made here.
- Packaging: `uv build` produces both artifacts, `twine check` PASSED on each, and all six adapter modules are present in both the wheel and the sdist.

## Accepted boundaries

Stated deliberately rather than left implied:

- **Load-time verification is not a runtime import sandbox.** It binds the adapter's *initial module graph* to the `RECORD` digest so a result is attributable to an exact `package_digest`. An import an adapter defers until after loading returns falls back to the ordinary loader. This is documented and pinned by a test. It buys little to close: an adapter is already arbitrary code in an isolated worker and can inline whatever it likes in its own verified source.
- **dlopen re-read TOCTOU.** Source executes from the in-memory bytes that were hashed; an extension is hash-checked and then the ordinary loader re-reads that exact path, so a swap between hash and `dlopen` is undetected. Same class as the executable TOCTOU on `ResolvedLaunch`, accepted for the same reason.
- **POSIX only.** The supervisor depends on sessions, process groups, and signal semantics, and refuses explicitly elsewhere rather than degrading.

## Deferrals

- `deferred — the both-module-and-package refusal enumerates only the .py/.py pair, so a dir-vs-flat-extension pair (mod.so + mod/__init__.py) resolves the flat module while CPython would run the package (discovery.py). No unattested code executes: the resolved artifact is always RECORD-covered and hash-verified, and no real wheel ships that shape. Raised in round 12 as a MINOR and judged not worth widening the refusal now.`

## Version

`0.44.19` — **patch**. This is an inert internal foundation: it changes nothing a user can reach, adopt, or observe, and nothing outside the adapters package imports it. Per the versioning policy, a minor is reserved for a step-function capability a user would notice, which this is not until a benchmark path is actually wired to it.

