### PR TITLE
fix(model): pin Sonnet 5 standard price, drop the lapsed date guard

### DIFF
--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -424,17 +424,26 @@ anthropic_models: Dict[str, ModelInfo] = {
         supports_images=True,
         supports_prompt_cache=True,
         limits_from_listing=True,
-        # The rate ACTUALLY in effect: Anthropic's introductory pricing for Sonnet
-        # 5 runs through 2026-08-31, and the standard $3/$15/$3.75/$0.30 takes over
-        # on 2026-09-01. Both rows are published on the same page, cache legs
-        # included, so this is a transcription rather than a choice between two
-        # wrong numbers — and `test_the_sonnet_5_introductory_price_has_not_expired`
-        # fails the build on the changeover date naming the exact edit, so the row
-        # cannot silently under-report by a third the way a bare comment would let it.
-        input_price=2.0,  # $2 / MTok introductory; $3 from 2026-09-01
-        output_price=10.0,  # $10 / MTok introductory; $15 from 2026-09-01
-        cache_writes_price=2.50,  # $2.50 / MTok (5m write); $3.75 from 2026-09-01
-        cache_reads_price=0.20,  # $0.20 / MTok; $0.30 from 2026-09-01
+        # These are Sonnet 5's STANDARD rates, not a promotion, and they are not
+        # dated. The history matters because it is the opposite of what an older
+        # comment here claimed: the model launched 2026-06-30 at $2/$10 billed as
+        # introductory pricing through 2026-08-31, with a rise to $3/$15/$3.75/$0.30
+        # scheduled for 2026-09-01. On 2026-08-10 Anthropic cancelled that rise and
+        # made these numbers permanent (launch-post changelog edit of 2026-08-10 on
+        # https://www.anthropic.com/news/claude-sonnet-5, and the
+        # `claude-sonnet-5-introductory-pricing` note on
+        # https://platform.claude.com/docs/en/about-claude/pricing: "The previously
+        # scheduled increase to $3/$15 ... will not occur").
+        #
+        # So do NOT "restore" $3/$15 here on the strength of a stale third-party
+        # pricing table — several still carry the cancelled increase. Anything other
+        # than these four values over-reports every Sonnet 5 call in the status band
+        # and the analytics ledger, which is what `test_sonnet_5_carries_the_standard_price`
+        # pins against.
+        input_price=2.0,  # $2 / MTok
+        output_price=10.0,  # $10 / MTok
+        cache_writes_price=2.50,  # $2.50 / MTok (5m write)
+        cache_reads_price=0.20,  # $0.20 / MTok
         description=(
             "Claude Sonnet 5: the balanced tier of the 5 generation, with the same "
             "1M-token context window and 128k output as Opus 5."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.17"
+version = "0.44.18"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/model/test_pricing.py
+++ b/tests/unit/model/test_pricing.py
@@ -10,7 +10,6 @@ own listing quotes none — so there are two separate guards here.
 
 from __future__ import annotations
 
-from datetime import date
 from typing import Any
 from unittest.mock import patch
 
@@ -388,17 +387,38 @@ def test_the_two_listing_legs_share_one_ceiling_rather_than_summing() -> None:
     )
 
 
-def test_the_sonnet_5_introductory_price_has_not_expired() -> None:
-    """Anthropic's Sonnet 5 promotion ends 2026-08-31; the row carries it.
+def test_sonnet_5_carries_the_standard_price() -> None:
+    """Sonnet 5's $2/$10/$2.50/$0.20 is the permanent standard rate — pin it.
 
-    A dated price is the one case where a correct value goes silently wrong on a
-    known day, so it gets a guard rather than a comment. When this fails, the fix
-    is the two-line edit named in the message — not a change to this test.
+    This replaces a dated guard that watched for the introductory period ending
+    2026-08-31. That expiry never happened: Anthropic cancelled the scheduled
+    2026-09-01 rise to $3/$15 and made these rates permanent on 2026-08-10
+    (launch-post changelog edit on https://www.anthropic.com/news/claude-sonnet-5,
+    and the `claude-sonnet-5-introductory-pricing` note on
+    https://platform.claude.com/docs/en/about-claude/pricing). The old guard duly
+    fired on 2026-09-01 UTC and failed every PR in the repo while instructing an
+    edit that would have over-reported every Sonnet 5 call by 50%.
+
+    With no announced end date there is no longer a date worth watching, so the
+    risk inverts: not "a correct value goes stale on a known day" but "someone
+    copies one of the many third-party tables that still print the cancelled
+    $3/$15 increase". Hence a pin on the published numbers rather than a clock —
+    deliberately time-insensitive, so it can never fail for merely being run on a
+    later date.
     """
-    assert date.today() < date(2026, 9, 1), (
-        "Claude Sonnet 5's introductory rate has lapsed. In registry.py set "
-        "input_price=3.0, output_price=15.0, cache_writes_price=3.75, "
-        "cache_reads_price=0.30, and update this guard to the next known change."
+    info = anthropic_models["claude-sonnet-5"]
+    actual = (
+        info.input_price,
+        info.output_price,
+        info.cache_writes_price,
+        info.cache_reads_price,
+    )
+    assert actual == (2.0, 10.0, 2.50, 0.20), (
+        f"Claude Sonnet 5's registry price is {actual}, not the published standard "
+        "(2.0, 10.0, 2.50, 0.20). $2/$10 is permanent as of 2026-08-10 — the "
+        "$3/$15 increase once scheduled for 2026-09-01 was cancelled. Re-verify "
+        "against https://platform.claude.com/docs/en/about-claude/pricing before "
+        "changing this, not against a third-party pricing table."
     )
 
 


### PR DESCRIPTION
## Why

**CI has been red on every PR in the repo since 2026-09-01 UTC.** `tests/unit/model/test_pricing.py::test_the_sonnet_5_introductory_price_has_not_expired` asserted `date.today() < date(2026, 9, 1)`, and that date arrived. It still passes on a US-local machine (the repo's timezone is UTC-4/5 in CI terms), which is why local runs looked clean while every pipeline failed — the guard fired for CI hours before it fired for anyone running the suite by hand.

The guard was a deliberate date-bomb: Anthropic launched Sonnet 5 at $2/$10 as introductory pricing through 2026-08-31, with a rise to $3/$15 scheduled for 2026-09-01, and the guard existed so that dated price could not go silently wrong.

## No price changed, and that is the correct outcome

**The guard's own remediation message was wrong.** It instructed setting `input_price=3.0, output_price=15.0, cache_writes_price=3.75, cache_reads_price=0.30`. Anthropic cancelled that increase:

> **Edit August 10, 2026:** Sonnet 5's introductory pricing of $2 per million input tokens and $10 per million output tokens is now permanent. The standard pricing of $3 input / $15 output previously set to take effect September 1 no longer applies.
> — [Introducing Claude Sonnet 5](https://www.anthropic.com/news/claude-sonnet-5), launch-post changelog

> The $2/$10 per million input/output token pricing for Claude Sonnet 5, announced at launch as introductory pricing through August 31, 2026, is now the standard price. The previously scheduled increase to $3/$15 per million input/output tokens on September 1, 2026 will not occur.
> — [`claude-sonnet-5-introductory-pricing` note](https://platform.claude.com/docs/en/about-claude/pricing), platform pricing page

The live pricing table confirms the cache legs too: Sonnet 5 is `$2` base input / `$2.50` 5m cache write / `$0.20` cache hit / `$10` output — exactly the four values already in the registry. Corroborated independently by [@claudeai](https://x.com/claudeai/status/2086891169217122586) ("We're making Claude Sonnet 5's introductory pricing permanent").

So following the guard's instruction would have introduced a real defect: a **50% over-report on every Sonnet 5 call**, in the `/analytics` cost overlay, the stored `cost_micro` ledger, and the TUI status band. The four prices in `registry.py` are untouched.

## What changed

- **`local_operator/model/registry.py`** — comment block above the `claude-sonnet-5` prices rewritten to record the actual history (launched introductory through 2026-08-31 → made permanent 2026-08-10 when the increase was cancelled), with the sources inline. The now-false `$X from 2026-09-01` trailing comments are gone. It explicitly warns against "restoring" $3/$15 from a stale third-party table, since many still print the cancelled increase.
- **`tests/unit/model/test_pricing.py`** — `test_the_sonnet_5_introductory_price_has_not_expired` → `test_sonnet_5_carries_the_standard_price`, now pinning the registry row to `(2.0, 10.0, 2.50, 0.20)`. The `datetime.date` import is dropped; the test has **no time dependency at all**.

## What the guard now protects

The risk inverted. There is no announced end date, so there is no longer a day on which a correct value goes stale. What remains is the opposite failure: someone updating this row from one of the many third-party pricing tables that still carry the cancelled $3/$15 increase. The pin fails the build on *any* deviation from the published numbers and points at Anthropic's page for re-verification — a silent regression back to the introductory-era assumption, or forward to the cancelled one, cannot land.

## Testing evidence

**The reported failure, reproduced.** Machine clock reads `Mon 31 Aug 2026 20:53 EDT` / `Tue 1 Sep 2026 00:53 UTC`, reproducing the local-vs-CI split:

```
$ .venv/bin/python -m pytest tests/unit/model/test_pricing.py -q      # real local clock
31 passed in 5.84s

$ # with date.today() patched to 2026-09-01, as CI sees it
FAILED tests/unit/model/test_pricing.py::test_the_sonnet_5_introductory_price_has_not_expired
AssertionError: Claude Sonnet 5's introductory rate has lapsed. In registry.py set
input_price=3.0, output_price=15.0, cache_writes_price=3.75, cache_reads_price=0.30 ...
assert datetime.date(2026, 9, 1) < datetime.date(2026, 9, 1)
```

**The new pin bites.** Perturbing the registry — including to the exact value the old guard demanded — fails it:

```
$ # input_price 2.0 -> 3.0 (the edit the old guard instructed)
1 failed   ...  +  3.0,  vs  expected 2.0
$ # cache_reads_price 0.20 -> 0.30
1 failed   ...  +  0.3,  vs  expected 0.2
$ # unperturbed
1 passed in 6.02s
```

**It is genuinely time-insensitive.** The whole file, with `date.today()` patched forward — the scenario that broke the old guard:

```
--- simulated today=2026-09-01 ---   31 passed
--- simulated today=2027-06-01 ---   31 passed
--- simulated today=2030-01-01 ---   31 passed
```

**No date bomb remains.** `grep -rn "date.today() <|date.today() >|date([0-9]" tests/ local_operator/` returns nothing.

**Gates**, whole-tree, exactly as CI runs them: `flake8` clean · `black==26.1.0 --check` 695 files unchanged · `isort==5.13.2 --check` clean · `pyright` 0 errors, 0 warnings. Full unit suite was started but the machine is under load average ~269 from a concurrent session; rather than report a starved number I am relying on this PR's CI for the whole-suite result. The focused pricing file (31 tests) passes locally.

## Noted, not changed

`openai_models`' `gpt-5.6-sol` row carries "Promotional rate through at least 2026-11-21". It is **not yet due** and carries no `date()` guard, so it is untouched here — recorded as a known future date, nothing more.

## Impact

Unblocks CI for every open PR in the repo. Patch bump to **0.44.18** — a build fix and a comment/test correction, no user-facing behaviour change and no price change.
