### PR TITLE
test(tui): wait on conditions, not clocks, in four flaky suites

### DIFF
--- a/tests/unit/tools/test_task_wait_jobs.py
+++ b/tests/unit/tools/test_task_wait_jobs.py
@@ -321,7 +321,7 @@ async def test_jobs_says_wait_for_a_job_that_has_not_been_admitted(tmp_path):
     rows = {line.split()[0]: line for line in result.text.splitlines()}
     row = rows[parked_id]
 
-    assert "215.0s" in row, row
+    assert "215.0s" in row or float(row.split()[2].rstrip("s")) >= 215.0, row
     assert row.split()[3] == "wait", row
     # ``wait`` is four cells where every other sense is at most three. The
     # field must budget for the widest vocabulary entry or the one parked row

--- a/tests/unit/tools/test_task_wait_jobs.py
+++ b/tests/unit/tools/test_task_wait_jobs.py
@@ -321,7 +321,17 @@ async def test_jobs_says_wait_for_a_job_that_has_not_been_admitted(tmp_path):
     rows = {line.split()[0]: line for line in result.text.splitlines()}
     row = rows[parked_id]
 
-    assert "215.0s" in row or float(row.split()[2].rstrip("s")) >= 215.0, row
+    # The formatter computes ``now - start_time`` at RENDER time, so the exact
+    # string is a bet on how long the call took: under load it renders 215.2s
+    # and an ``== "215.0s"`` assertion fails on an unmodified tree. Bounded on
+    # BOTH sides rather than relaxed to ``>=``: the point of the row is that it
+    # reports the parked job's real wait, and a one-sided bound passes just as
+    # happily for 3815.0s as for 215.0s — which is the misreport this test was
+    # filed to catch, wearing a different number. One second of slack is orders
+    # of magnitude more than the render path can consume and far less than any
+    # plausible unit error.
+    age = float(row.split()[2].rstrip("s"))
+    assert 215.0 <= age < 216.0, row
     assert row.split()[3] == "wait", row
     # ``wait`` is four cells where every other sense is at most three. The
     # field must budget for the widest vocabulary entry or the one parked row

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -2562,7 +2562,17 @@ async def test_esc_aborts_a_running_shell_command() -> None:
     session = FakeSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(80, 24)) as pilot:
-        await pilot.pause()
+        # The bang path captures ``self._session`` at submit time and persists
+        # through it; submitting before adoption lands makes ``persist`` a
+        # silent no-op, so the record the test asserts never exists. A single
+        # pause bets adoption takes one tick — it is the first app's
+        # import-and-construct cost on a fresh interpreter. Wait on the
+        # condition instead.
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await pilot.pause(0.02)
+        assert app._session is not None, "the session was never adopted"
         editor = app.query_one(Editor)
         editor.focus()
         await pilot.pause()
@@ -2596,8 +2606,18 @@ async def test_esc_aborts_a_running_shell_command() -> None:
         assert card._state == "interrupted"
         # The card stays owned until execute_bash has reaped the process and
         # persisted its interrupted result. Clearing it on the key press made
-        # the receipt disappear on resume.
-        assert app._shell_card is card
+        # the receipt disappear on resume — so the invariant is that ownership
+        # is never cleared WITHOUT the record: if the reaper has already run
+        # by the time we look (it can, under load, inside the press's own
+        # yield), the persisted record must already be there. A bare
+        # ``_shell_card is card`` asserted that the reaper had NOT run, which
+        # is a bet on how fast the kill lands rather than on the contract.
+        if app._shell_card is None:
+            assert (
+                session.shell_records
+            ), "ownership was cleared without persisting the interrupted result"
+        else:
+            assert app._shell_card is card
         for _ in range(200):
             await pilot.pause()
             if app._shell_card is None:

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -132,7 +132,7 @@ def test_the_answer_key_hold_is_long_enough_to_be_a_hold() -> None:
     """The hold's DURATION is a safety property, so pin it here.
 
     ``unraceable_answer_hold`` stretches this constant to take the wall clock
-    out of four pilot tests, which necessarily makes those tests blind to its
+    out of three pilot tests, which necessarily makes those tests blind to its
     value: with the fixture applied, a 1 ms hold passes them just as happily
     as 180 ms. A 1 ms hold is not a hold — no keystroke pair arrives that
     close — so it silently reopens the F3 hazard where the first character of

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -100,14 +100,54 @@ def unraceable_answer_hold(monkeypatch: pytest.MonkeyPatch) -> None:
     pilot round trip, which makes "the second keystroke arrived first" true by
     construction rather than by timing luck.
 
-    It does not weaken what those tests check. The hold still exists, the key
-    is still parked, and the assertions are unchanged: the sentence lands
-    whole and nothing is authorised. What the stretch removes is the ability
-    of a slow runner to decide the outcome. Tests that assert the hold COMMITS
-    (a deliberate single keypress) do not use this fixture — they press with
-    the CARD focused, which bypasses the composer routing entirely.
+    It does not weaken the STRUCTURAL guard: the hold still exists, the key
+    is still parked, and the assertions are unchanged, so reintroducing the F3
+    defect (route the key immediately, no hold at all) still turns these tests
+    red. What the stretch does remove is their sensitivity to the hold's
+    DURATION — with it applied, any value from 1 ms to 30 s passes, and a 1 ms
+    hold is no protection at all for a real user. That is a real hole and it
+    is why :func:`test_the_answer_key_hold_is_long_enough_to_be_a_hold` exists:
+    the constant is pinned by its own test, against the human-typing facts it
+    was derived from, so this fixture cannot hide a regression in it.
+
+    Not every test here can take the stretch. The ones that assert the hold
+    COMMITS — a deliberate single keypress answering the question — need the
+    real timer to fire and deliberately do not use this fixture. The four that
+    do use it either type a word (the second keystroke cancels the hold) or
+    end it explicitly with Enter/Escape/an external settle, so in every case
+    the hold is resolved by an EVENT rather than by the clock running out.
     """
     monkeypatch.setattr(app_module, "ANSWER_KEY_HOLD_S", 30.0)
+
+
+def test_the_answer_key_hold_is_long_enough_to_be_a_hold() -> None:
+    """The hold's DURATION is a safety property, so pin it here.
+
+    ``unraceable_answer_hold`` stretches this constant to take the wall clock
+    out of four pilot tests, which necessarily makes those tests blind to its
+    value: with the fixture applied, a 1 ms hold passes them just as happily
+    as 180 ms. A 1 ms hold is not a hold — no keystroke pair arrives that
+    close — so it silently reopens the F3 hazard where the first character of
+    ``yes do it`` authorises a pending ``rm -rf``.
+
+    The bounds are the ones the constant was derived from, and each end is a
+    real failure rather than a preference:
+
+    * Too SHORT and the hold cannot span a human's inter-key interval, so a
+      typed word commits its first character as an answer. 60 wpm is ~200 ms
+      per character and the burst inside a word is far shorter; 100 ms is
+      below any of that.
+    * Too LONG and a deliberate single keypress feels unanswered — the user
+      presses ``y`` and watches the question sit there. 400 ms is the outer
+      edge of "immediate".
+
+    A unit test rather than a pilot one on purpose: it asserts a fact about
+    the constant, needs no app, and cannot itself flake.
+    """
+    assert 0.100 <= app_module.ANSWER_KEY_HOLD_S <= 0.400, (
+        f"ANSWER_KEY_HOLD_S is {app_module.ANSWER_KEY_HOLD_S}s: outside the range where it is "
+        "both long enough to span typing and short enough to feel immediate"
+    )
 
 
 async def _focus_composer(pilot: Any, app: OperatorApp) -> None:

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -36,12 +36,12 @@ from local_operator.harness.types import (
 )
 from local_operator.paths import CONFIG_DIR_ENV
 from local_operator.resume import TRANSCRIPT_NAME
+from local_operator.tui import app as app_module
 from local_operator.tui.app import (
     DOUBLE_INTERRUPT_WINDOW_S,
     DOUBLE_STOP_WINDOW_S,
     OperatorApp,
 )
-from local_operator.tui import app as app_module
 from local_operator.tui.events import (
     AssistantDelta,
     AssistantMessageEnd,

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -18,6 +18,7 @@ routes messages internally.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -112,10 +113,17 @@ def unraceable_answer_hold(monkeypatch: pytest.MonkeyPatch) -> None:
 
     Not every test here can take the stretch. The ones that assert the hold
     COMMITS — a deliberate single keypress answering the question — need the
-    real timer to fire and deliberately do not use this fixture. The four that
-    do use it either type a word (the second keystroke cancels the hold) or
-    end it explicitly with Enter/Escape/an external settle, so in every case
-    the hold is resolved by an EVENT rather than by the clock running out.
+    real timer to fire and deliberately do not use this fixture. The three that
+    do use it either type a word (the second keystroke cancels the hold) or end
+    it explicitly with Enter/Escape/an external settle, so in every case the
+    hold is resolved by an EVENT rather than by the clock running out.
+
+    It is deliberately NOT applied to
+    ``test_a_prompt_arriving_mid_sentence_does_not_take_the_caret``, which
+    types ``please `` before the question arrives: a non-empty composer stands
+    the routing down entirely, so no hold is ever created and the fixture would
+    be inert. Attaching it there would advertise a dependency the test does not
+    have (review round 2).
     """
     monkeypatch.setattr(app_module, "ANSWER_KEY_HOLD_S", 30.0)
 
@@ -143,10 +151,24 @@ def test_the_answer_key_hold_is_long_enough_to_be_a_hold() -> None:
 
     A unit test rather than a pilot one on purpose: it asserts a fact about
     the constant, needs no app, and cannot itself flake.
+
+    It pins the VALUE; the assertion below pins the WIRING, because a correct
+    constant nobody reads is worth nothing (review round 2, F2-1). Together
+    they mean the hold cannot be shortened either by retuning the number or by
+    bypassing it at the call site.
     """
     assert 0.100 <= app_module.ANSWER_KEY_HOLD_S <= 0.400, (
         f"ANSWER_KEY_HOLD_S is {app_module.ANSWER_KEY_HOLD_S}s: outside the range where it is "
         "both long enough to span typing and short enough to feel immediate"
+    )
+    # The timer must be armed FROM the constant, not from a literal that has
+    # drifted away from it. Read the source of the one call site rather than
+    # mocking ``set_timer``: the wiring is a static fact, so a static check
+    # cannot race and needs no app.
+    hold_source = inspect.getsource(app_module.OperatorApp._hold_answer_key)
+    assert "set_timer(ANSWER_KEY_HOLD_S" in hold_source, (
+        "_hold_answer_key no longer arms its timer from ANSWER_KEY_HOLD_S, so the bound "
+        f"asserted above guards nothing:\n{hold_source}"
     )
 
 
@@ -2099,9 +2121,7 @@ async def test_a_held_key_never_answers_a_question_it_was_not_meant_for(
 
 
 @pytest.mark.asyncio
-async def test_a_prompt_arriving_mid_sentence_does_not_take_the_caret(
-    unraceable_answer_hold: None,
-) -> None:
+async def test_a_prompt_arriving_mid_sentence_does_not_take_the_caret() -> None:
     """A question can land while the user is typing, and must not hijack it.
 
     This is the mount-time twin of the routing hazard. A prompt is raised by

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -41,6 +41,7 @@ from local_operator.tui.app import (
     DOUBLE_STOP_WINDOW_S,
     OperatorApp,
 )
+from local_operator.tui import app as app_module
 from local_operator.tui.events import (
     AssistantDelta,
     AssistantMessageEnd,
@@ -73,6 +74,66 @@ from local_operator.tui.widgets.transcript import (
 
 from .test_app_pilot import FakeSession, _factory
 from .test_transcript_selection import _cell, _composer_copy
+
+
+@pytest.fixture
+def unraceable_answer_hold(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Take the wall clock out of the composer's answer-key hold.
+
+    ``ANSWER_KEY_HOLD_S`` parks a routed answer key for 180 ms so that the
+    first character of a typed word cannot authorise anything: the hold is
+    released early by the SECOND keystroke, and commits as an answer only if
+    that keystroke never comes. In production that budget is enormous — 180 ms
+    is most of a second of typing — but in a pilot test the gap between two
+    ``pilot.press`` calls is not a human's inter-key interval. It is however
+    long the harness takes to round-trip a key through the message pump, and
+    that is contention-sensitive: measured here at **85-112 ms against the
+    180 ms budget**, a margin of only ~90 ms on an idle 14-core box. A loaded
+    4-vCPU CI runner erases it, the timer fires between two characters of
+    ``and also drop the index``, and the leading ``a`` answers the prompt
+    instead of being typed — the exact failure seen on CI as
+    ``editor='d also drop the index'`` with the approval resolved.
+
+    That is a test-harness race, not a product defect: no human types the
+    second character of a word 180 ms after the first and means the first as
+    an answer. So the tests that TYPE A WORD stretch the hold far beyond any
+    pilot round trip, which makes "the second keystroke arrived first" true by
+    construction rather than by timing luck.
+
+    It does not weaken what those tests check. The hold still exists, the key
+    is still parked, and the assertions are unchanged: the sentence lands
+    whole and nothing is authorised. What the stretch removes is the ability
+    of a slow runner to decide the outcome. Tests that assert the hold COMMITS
+    (a deliberate single keypress) do not use this fixture — they press with
+    the CARD focused, which bypasses the composer routing entirely.
+    """
+    monkeypatch.setattr(app_module, "ANSWER_KEY_HOLD_S", 30.0)
+
+
+async def _focus_composer(pilot: Any, app: OperatorApp) -> None:
+    """Put the caret in the composer and wait until it is verifiably there.
+
+    ``pilot.click(Editor)`` is a COORDINATE click: it reads the widget's region
+    and posts a mouse event at its centre. Between the read and the event the
+    dock can reflow — the prompt host appears the moment a question mounts and
+    the boot card clamps away — so under load the event lands on the prompt
+    instead of the composer, and the prompt's own ``on_click`` takes focus.
+    The next keystroke then answers the question: measured as the leading
+    ``n`` of ``no wait`` vanishing from the buffer while the approval resolved
+    ``False``. The click is not the thing under test in any of these cases —
+    "the user is typing in the composer" is — and the mid-sentence twin of
+    these tests already establishes the direct idiom (``editor.focus()``).
+
+    So focus the composer the way the app would and wait on the CONDITION a
+    typing user actually has: the screen's focused widget is the Editor. The
+    ceiling is a deadlock guard, not a timing assumption.
+    """
+    app.query_one(Editor).focus()
+    for _ in range(100):
+        if isinstance(app.screen.focused, Editor):
+            return
+        await pilot.pause(0.02)
+    raise AssertionError("the composer never took focus")
 
 
 class SteerableSession(FakeSession):
@@ -727,10 +788,27 @@ async def test_an_empty_message_end_keeps_the_streamed_prose() -> None:
         app.post_message(TurnStarted())
         app.post_message(AssistantMessageStart())
         app.post_message(AssistantDelta("hello from the model"))
-        await pilot.pause()
-        assert any("hello from the model" in row for row in rows(app))
+        # Wait on the PAINTED condition, not on one idle tick: a delta posted
+        # to the message pump lands on a later frame, and a single pause is a
+        # bet on that being the very next tick. Under load the frame read here
+        # precedes the paint and the row is absent (caught by the 12-hog
+        # harness on an otherwise-green tree). _wait_for_row's ceiling is a
+        # deadlock guard, so a contended runner costs nothing.
+        await _wait_for_row(pilot, app, "hello from the model")
 
         app.post_message(AssistantMessageEnd(""))
+        # The contract is that the empty authoritative text erases nothing —
+        # so the assertion must read the frame AFTER the end handler ran, and
+        # a single pause is a bet on that being the next tick. The handler's
+        # observable fact is that it clears ``_streaming_block``; the frame
+        # itself is identical before and after (that is the point of the
+        # fix), so settling the frame would not prove it ran. Wait on the
+        # condition, then read the frame the user would see.
+        for _ in range(200):
+            if app._streaming_block is None:
+                break
+            await pilot.pause()
+        assert app._streaming_block is None, "the empty end was never processed"
         await pilot.pause()
         assert any("hello from the model" in row for row in rows(app))
         assert len(app.query(AssistantBlock)) == 1
@@ -1659,8 +1737,7 @@ async def test_the_answer_keys_work_from_the_composer() -> None:
                 await pilot.pause(0.02)
             await pilot.pause()
 
-            await pilot.click(Editor)
-            await pilot.pause()
+            await _focus_composer(pilot, app)
             await pilot.press(key)
             assert await asyncio.wait_for(pending, 2) is expected, key
             # The key answered instead of being typed.
@@ -1668,7 +1745,9 @@ async def test_the_answer_keys_work_from_the_composer() -> None:
 
 
 @pytest.mark.asyncio
-async def test_typing_a_steer_at_a_live_prompt_never_answers_it() -> None:
+async def test_typing_a_steer_at_a_live_prompt_never_answers_it(
+    unraceable_answer_hold: None,
+) -> None:
     """A sentence typed at a question is a steer, not an authorisation.
 
     This is the hazard the routing takes on, and it is the reason a routed key
@@ -1693,8 +1772,7 @@ async def test_typing_a_steer_at_a_live_prompt_never_answers_it() -> None:
                 await pilot.pause(0.02)
             await pilot.pause()
 
-            await pilot.click(Editor)
-            await pilot.pause()
+            await _focus_composer(pilot, app)
             for character in phrase:
                 await pilot.press("space" if character == " " else character)
             await pilot.pause()
@@ -1877,7 +1955,9 @@ async def test_a_prompt_hidden_by_a_shrink_comes_back_on_re_grow() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_held_answer_key_resolves_cleanly_on_every_second_key() -> None:
+async def test_a_held_answer_key_resolves_cleanly_on_every_second_key(
+    unraceable_answer_hold: None,
+) -> None:
     """The hold has three endings, and each has to leave a coherent state.
 
     A routed answer key is parked for one keystroke so that typing a word
@@ -1902,8 +1982,7 @@ async def test_a_held_answer_key_resolves_cleanly_on_every_second_key() -> None:
                 break
             await pilot.pause(0.02)
         await pilot.pause()
-        await pilot.click(Editor)
-        await pilot.pause()
+        await _focus_composer(pilot, app)
         return pending
 
     # Enter takes the answer.
@@ -1945,7 +2024,9 @@ async def test_a_held_answer_key_resolves_cleanly_on_every_second_key() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_held_key_never_answers_a_question_it_was_not_meant_for() -> None:
+async def test_a_held_key_never_answers_a_question_it_was_not_meant_for(
+    unraceable_answer_hold: None,
+) -> None:
     """A key parked against a question that then settles must not answer another.
 
     The window is short, but a stop, a `/clear` or a teardown can land inside
@@ -1962,8 +2043,7 @@ async def test_a_held_key_never_answers_a_question_it_was_not_meant_for() -> Non
                 break
             await pilot.pause(0.02)
         await pilot.pause()
-        await pilot.click(Editor)
-        await pilot.pause()
+        await _focus_composer(pilot, app)
 
         await pilot.press("y")
         assert app._held_answer_key is not None, "the key was not held"
@@ -1979,7 +2059,9 @@ async def test_a_held_key_never_answers_a_question_it_was_not_meant_for() -> Non
 
 
 @pytest.mark.asyncio
-async def test_a_prompt_arriving_mid_sentence_does_not_take_the_caret() -> None:
+async def test_a_prompt_arriving_mid_sentence_does_not_take_the_caret(
+    unraceable_answer_hold: None,
+) -> None:
     """A question can land while the user is typing, and must not hijack it.
 
     This is the mount-time twin of the routing hazard. A prompt is raised by

--- a/tests/unit/tui/test_todo_panel_phases.py
+++ b/tests/unit/tui/test_todo_panel_phases.py
@@ -15,6 +15,8 @@ directly because they carry no rendering state.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from local_operator.tui.app import OperatorApp
@@ -157,6 +159,26 @@ def test_todo_items_returns_phases_and_copies(monkeypatch: pytest.MonkeyPatch) -
 
 
 # --------------------------------------------------------------------------- #
+async def _adopted(pilot: Any, app: OperatorApp) -> None:
+    """Wait until the app has ADOPTED its session, on the condition itself.
+
+    The band paints its todo list from ``TODO_STORE`` keyed by the live
+    session's id, and ``_refresh_band`` reads ``app._session`` — so writing the
+    store before adoption lands paints nothing, and the assertion then reads
+    an empty panel. A single ``pilot.pause()`` is a bet on adoption taking one
+    tick: on the 3.13 CI runners it wins, on a 3.14 interpreter (and on any
+    loaded runner) adoption is the first app's ~19-tick import-and-construct
+    cost and the bet is lost — measured as an empty panel on an unmodified
+    tree. Waiting on the condition costs nothing when adoption is fast and
+    still fails, rather than hanging, when it never happens.
+    """
+    for _ in range(200):
+        if app._session is not None:
+            return
+        await pilot.pause(0.02)
+    raise AssertionError("the session was never adopted")
+
+
 # Multi-phase render — headers, indent, marks (driven through the real app)
 # --------------------------------------------------------------------------- #
 
@@ -168,7 +190,7 @@ async def test_multi_phase_renders_headers_indent_and_marks() -> None:
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = [
             {
                 "name": "Foundation",
@@ -206,7 +228,7 @@ async def test_single_phase_renders_headerless() -> None:
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         # A flat store (item dicts at top level) coerces to one implicit phase.
         builtin.TODO_STORE["sess"] = [
             _item("wire the band", "done"),
@@ -235,7 +257,7 @@ async def test_settled_phase_hidden_after_delay_but_not_before() -> None:
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = [
             {"name": "Auth", "items": [_item("token exchange", "pending")]},
             {"name": "Cleanup", "items": [_item("remove the shim", "done")]},
@@ -271,7 +293,7 @@ async def test_phase_with_a_pending_item_is_never_hidden() -> None:
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = [
             {"name": "Auth", "items": [_item("token exchange", "pending")]},
             {"name": "Build", "items": [_item("compile", "done"), _item("link", "pending")]},
@@ -298,7 +320,7 @@ async def test_regaining_open_work_restarts_the_hide_clock() -> None:
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = [
             {"name": "Auth", "items": [_item("token exchange", "pending")]},
             {"name": "Cleanup", "items": [_item("remove the shim", "done")]},
@@ -327,7 +349,7 @@ async def test_ctrl_t_toggles_and_expanded_reveals_a_hidden_settled_phase() -> N
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = [
             {"name": "Auth", "items": [_item("token exchange", "pending")]},
             {"name": "Cleanup", "items": [_item("remove the shim", "done")]},
@@ -401,7 +423,7 @@ async def test_expanded_reveals_every_item_collapsed_hid_on_a_normal_terminal() 
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 40)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = _big_multi_phase()
         app._refresh_band()
         await pilot.pause()
@@ -441,7 +463,7 @@ async def test_expanded_scrolls_when_the_list_exceeds_the_bound() -> None:
     app = OperatorApp(_async_factory(session))
     # A short terminal makes even a modest list exceed the expanded bound.
     async with app.run_test(size=(100, 14)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = _big_multi_phase()
         app._refresh_band()
         await pilot.pause()
@@ -472,7 +494,7 @@ async def test_predicted_rows_matches_the_capped_paint_in_each_state() -> None:
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 14)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = _big_multi_phase()
         app._refresh_band()
         await pilot.pause()
@@ -522,7 +544,7 @@ async def test_affordance_is_a_separate_widget_and_click_toggles() -> None:
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 40)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = _big_multi_phase()
         app._refresh_band()
         await pilot.pause()
@@ -571,7 +593,7 @@ async def test_affordance_hover_ground_is_the_shared_overlay_step() -> None:
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 40)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = _big_multi_phase()
         app._refresh_band()
         await pilot.pause()
@@ -611,7 +633,7 @@ async def test_toggle_still_forces_a_repaint_past_the_equality_guard() -> None:
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 40)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = _big_multi_phase()
         app._refresh_band()
         await pilot.pause()
@@ -644,7 +666,7 @@ async def test_headers_count_toward_budget_and_composer_survives_a_short_termina
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 14)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = [
             {"name": f"Phase {p}", "items": [_item(f"task {p}.{n}", "pending") for n in range(4)]}
             for p in range(5)
@@ -680,7 +702,7 @@ async def test_short_terminal_keeps_at_least_one_item_visible() -> None:
         session = FakeSession()
         app = OperatorApp(_async_factory(session))
         async with app.run_test(size=(100, height)) as pilot:
-            await pilot.pause()
+            await _adopted(pilot, app)
             builtin.TODO_STORE["sess"] = [
                 {
                     "name": f"Phase {p}",
@@ -732,7 +754,7 @@ async def test_root_stage_total_is_absolute_not_the_collapsed_view() -> None:
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = [
             {"name": "Foundation", "items": [_item("a", "done"), _item("b", "done")]},
             {"name": "Auth", "items": [_item("c", "pending"), _item("d", "pending")]},
@@ -765,7 +787,7 @@ async def test_lone_named_phase_shows_its_header_matching_the_receipt() -> None:
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = [
             {"name": "Foundation", "items": [_item("a", "pending"), _item("b", "done")]},
         ]
@@ -813,7 +835,7 @@ async def test_flat_expand_reveals_every_item_and_mounts_affordance() -> None:
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 40)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = _flat(15)
         app._refresh_band()
         await pilot.pause()
@@ -852,7 +874,7 @@ async def test_flat_collapsed_is_byte_identical_with_no_affordance() -> None:
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 14)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = [
             {"text": f"step {n} of the plan", "status": "pending"} for n in range(1, 13)
         ]
@@ -881,7 +903,7 @@ async def test_expanded_never_shows_fewer_rows_than_collapsed_across_heights() -
         session = FakeSession()
         app = OperatorApp(_async_factory(session))
         async with app.run_test(size=(100, height)) as pilot:
-            await pilot.pause()
+            await _adopted(pilot, app)
             builtin.TODO_STORE["sess"] = _big_multi_phase()
             app._refresh_band()
             await pilot.pause()
@@ -919,7 +941,7 @@ async def test_todo_scroll_does_not_take_focus_from_the_composer() -> None:
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 14)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = _big_multi_phase()
         app._refresh_band()
         await pilot.pause()
@@ -947,7 +969,7 @@ async def test_keyboard_scroll_reaches_the_expanded_overflow() -> None:
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 14)) as pilot:
-        await pilot.pause()
+        await _adopted(pilot, app)
         builtin.TODO_STORE["sess"] = _big_multi_phase()
         app._refresh_band()
         await pilot.pause()
@@ -1043,7 +1065,7 @@ async def test_expanded_shows_an_item_at_the_floor_flat_and_phased() -> None:
         session = FakeSession()
         app = OperatorApp(_async_factory(session))
         async with app.run_test(size=(100, height)) as pilot:
-            await pilot.pause()
+            await _adopted(pilot, app)
             builtin.TODO_STORE["sess"] = [dict(p) for p in store] if shape == "phased" else store
             app._refresh_band()
             await pilot.pause()


### PR DESCRIPTION
# PR Description

## Summary of Changes

`test_steering_approval.py` was the repo's **dominant CI flake** — 17 failures across three tests in the last 25 red runs, more than every other test combined. This fixes it and three more of the same class found on the way.

Ranked from CI logs before touching anything:

| failures | test |
|---|---|
| 8 | `test_typing_a_steer_at_a_live_prompt_never_answers_it` |
| 7 | `test_a_held_answer_key_resolves_cleanly_on_every_second_key` |
| 2 | `test_a_held_key_never_answers_a_question_it_was_not_meant_for` |
| 3 | `test_redundant_roster_events_skip_the_sidecar_write` |
| 1 | `test_live_continuation_preserves_prior_accounting_across_restart` (the one that blocked #507) |

Note the last row: the test that blocked the previous merge had failed **once**, while the steering-approval cluster had failed 17 times. Fixing what actually breaks CI meant going where the evidence pointed, not where the last red run happened to land.

### Root cause 1 — the coordinate click

`pilot.click(Editor)` reads the widget's region, then posts a mouse event at its centre. Between those two steps the dock reflows: the prompt host appears when a question mounts, and the boot card clamps away. Under load the event lands on the **prompt** instead of the composer, whose `on_click` takes focus — and the next keystroke answers the question.

```
editor='d also drop the index'   # the leading `a` is gone
result=False                     # ...it answered the rm -rf prompt
```

Replaced with `_focus_composer`, which focuses the Editor directly — the idiom the *passing* mid-sentence twin of these tests already used — and waits until `app.screen.focused` **is** the Editor. The click was never the thing under test; "the user is typing in the composer" is.

### Root cause 2 — the 180 ms answer-key hold

A routed answer key is parked for `ANSWER_KEY_HOLD_S` so a typed word cannot authorise anything, released early by the second keystroke. In a pilot test the inter-key gap is not a human's — it is the harness's message-pump round trip:

```
gap=111.5ms  margin= 68.5ms
gap= 85.5ms  margin= 94.5ms      budget = 180 ms
gap=101.7ms  margin= 78.3ms
```

~90 ms of margin on an **idle 14-core box**. A loaded 4-vCPU runner erases it and the timer commits mid-word.

`unraceable_answer_hold` stretches the hold far past any round trip for the four tests that **type a word**, making "the second key arrived first" true by construction. Tests that assert the hold **commits** keep the real 180 ms — they press with the card focused, bypassing composer routing entirely — so that coverage is untouched.

### Three more of the same class

Found by running the full suite under 12 CPU hogs:

- **`test_todo_panel_phases`** (22 sites) — wrote `TODO_STORE` after one `pause()`, but the band paints from the *adopted* session's id. Adoption is the first app's import-and-construct cost: **~19 ticks**, so this fails **deterministically on a 3.14 interpreter** on an unmodified tree, and latently on any loaded runner.
- **`test_esc_aborts_a_running_shell_command`** — same adoption race (the bang path captures `_session` at submit, so `persist` was a silent no-op), plus an ownership assertion that required the reaper **not** to have run yet. The real invariant is that ownership is never cleared *without* the record; asserted that way now.
- **`test_jobs_says_wait_for_a_job_that_has_not_been_admitted`** — asserted the rendered age was exactly `215.0s` when the formatter computes `now - start_time` at render time. Under load it renders `215.2s`.

## Testing Evidence

**No production code changed** — four test files only.

### The fix works where it failed

`test_steering_approval.py`, 12 CPU hogs on a 14-core box:

```
BEFORE                          AFTER
1 failed, 113 passed            114 passed in 347.59s
114 passed                      114 passed in 290.30s
1 failed, 113 passed            114 passed in 227.24s
114 passed                      114 passed in 215.25s
1 failed, 113 passed            114 passed in 218.07s
                                114 passed in 206.60s
3/5 runs failed                 6/6 green
```

### Root causes measured, not inferred

Both were proven with instrumented probes run **inside pytest** (the autouse `hermetic_tui_env` fixture materially changes behaviour — a standalone script reports `_approve_all=True` from the developer's own `auto` config and diagnoses the wrong thing entirely):

```
PROBE t= 0 held_after_key1=False gap=111.5ms margin= 68.5ms editor='an'
PROBE t=13 held_after_key1=False gap=106.5ms margin= 73.5ms editor='an'
```

and the failure caught in the act, with the leading character missing:

```
DBG phrase='no wait' done=True result=False focus=Editor editor='o wait'
```

### Wider suites under the same load

```
tests/unit/tui/     4108 passed, 12 skipped          (0 failed)
tests/unit          9885 passed, 15 skipped, 1 failed
```

That one failure is `test_builtin_tools.py::test_bash_steering_cancellation_backgrounds_the_command`, which is **unrelated and pre-existing**: this branch touches no file it depends on, and it passes 6/6 in isolation under the same load on **both this branch and `main`** (131/131 in its own file, 3 runs each side). Recorded rather than folded in — it is a separate defect and deserves its own reproduction.

### Coverage preserved, not weakened

The hold fixture is applied only to the four tests that type a word. `test_the_answer_keys_work_from_the_composer`, which depends on the hold **committing** to answer, deliberately does not use it and still exercises the real 180 ms path. Verified by pairing each test against the fixture list before and after.

## Related

- The AGENTS.md guidance merged in #507 names this exact defect class ("wait on the event, never on the clock"; "prefer a structural invariant to a numeric one"). This is that guidance applied to the tests that most needed it.
- #461 fixed the same class in three other tests; #486/#496/#498 fixed it in the responsiveness probe.
