### PR TITLE
feat(evaluation): run one episode end to end behind the verified adapter boundary

### DIFF
--- a/local_operator/evaluation/runner/__init__.py
+++ b/local_operator/evaluation/runner/__init__.py
@@ -1,0 +1,7 @@
+"""Episode execution for the evaluation stack.
+
+Importing this package is deliberately inert. The evaluation subsystem is
+never loaded by an ordinary session, and ``tests/unit/evaluation`` asserts
+that startup imports pull in nothing under ``local_operator.evaluation``, so
+this module must not re-export the runner or its contracts.
+"""

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -450,6 +450,11 @@ class EpisodeRunner:
             return await self._finalize_cancelled(str(cancel) or "cancelled")
         except _EvidenceFailure:
             raise
+        except EvidenceError as error:
+            # A writer error is never an episode failure: the journal itself is
+            # unusable, so finalizing would write into a poisoned bundle. Route
+            # it to the abandonment path like any other evidence failure.
+            raise _EvidenceFailure(_diagnostic(error)) from error
         except BaseException as error:
             return await self._finalize_failure(error)
         return await self._finalize_scored(handshake)

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -118,6 +118,11 @@ EpisodeStatus = Literal[
     "failed",
     "cancelled",
     "abandoned",
+    # The writer failed AND its abandonment could not be recorded, so the bundle
+    # on disk is still "open" with no terminal. This is deliberately distinct
+    # from "abandoned": claiming a terminal that is not on disk is the exact
+    # false report this slice exists to prevent. See _abandon_for_evidence.
+    "abandonment_failed",
     "failed_pre_bundle",
 ]
 
@@ -1155,15 +1160,26 @@ class EpisodeRunner:
         await self._emergency_teardown()
         writer = self._writer
         root = Path(writer.root) if writer is not None else None
+        status: EpisodeStatus = "abandoned"
         if writer is not None:
             try:
                 writer.abandon("infrastructure_failure", "evidence-write-failed")
-            except EvidenceError:
-                # A writer this broken may not even be able to record its own
-                # abandonment; the bundle stays unsealed and recoverable.
-                pass
+            except EvidenceError as error:
+                # NEVER swallow this. `abandon()` independently re-verifies the
+                # bundle and refuses on any error-severity issue, so a terminal
+                # is not always recordable -- most commonly when an `append`
+                # failed AFTER its artifact was already published, leaving an
+                # `artifact_unreferenced` orphan that the gate rejects.
+                #
+                # Reporting "abandoned" over a bundle whose terminal_state is
+                # still "open" is precisely the false claim this slice exists to
+                # prevent, so the returned status now matches the disk and names
+                # the reason. The bundle stays unsealed and recoverable, which
+                # is a real state an operator can act on.
+                status = "abandonment_failed"
+                detail = f"{detail}; abandonment refused: {_diagnostic(error)}"
         return EpisodeOutcome(
-            status="abandoned",
+            status=status,
             episode_id=self._spec.episode_id,
             bundle_root=root,
             rescue_required=True,

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -53,6 +53,7 @@ from local_operator.evaluation.adapters.supervisor import (
     VerifiedAdapterSession,
     persist_rescue,
     run_rescue,
+    verify_artifact,
 )
 from local_operator.evaluation.evidence.models import (
     ActionBatchPayload,
@@ -240,6 +241,9 @@ class EpisodeRunner:
         self._guest_actions = 0
         self._simulator_turns = 0
         self._last_exchange_id: str | None = None
+        # Every route a provider actually served. A run whose route drifted from
+        # the pinned one is not comparable against runs that kept it.
+        self._served_routes: set[tuple[str, str, str]] = set()
         self._steps_taken = 0
         self._truncated = False
         self._last_step_terminated = False
@@ -266,10 +270,9 @@ class EpisodeRunner:
                 rescue_required=self._rescue_required,
                 diagnostic=_diagnostic(error),
             )
-        try:
-            return await self._run_with_bundle(handshake)
-        except _EvidenceFailure as error:
-            return await self._abandon_for_evidence(str(error))
+        # _run_with_bundle records its own abandonment terminal while the
+        # writer is still open, so no _EvidenceFailure escapes it here.
+        return await self._run_with_bundle(handshake)
 
     # ------------------------------------------------------------------
     # Launch, prepare, and the two-stage rescue persistence
@@ -390,8 +393,19 @@ class EpisodeRunner:
             )
         self._writer = writer
         try:
+            # The abandonment terminal MUST be recorded here, while the writer
+            # is still open. Letting _EvidenceFailure propagate to run() meant
+            # the finally below closed the writer first, so abandon() then hit
+            # "evidence writer is closed" and the bundle was left with no
+            # terminal at all -- the runner reported "abandoned" while the
+            # bundle on disk stayed open forever.
             return await self._execute(handshake)
+        except _EvidenceFailure as error:
+            return await self._abandon_for_evidence(str(error))
         finally:
+            # Still correct for FD hygiene; only its ordering against abandon()
+            # was wrong. close() after a recorded terminal is a no-op for the
+            # bundle's contents.
             writer.close()
 
     async def _execute(self, handshake: Handshake) -> EpisodeOutcome:
@@ -473,7 +487,7 @@ class EpisodeRunner:
 
         artifacts = []
         for frame in observation.frames:
-            data = _read_artifact(self._config.artifact_root, frame.artifact.sha256)
+            data = verify_artifact(self._config.artifact_root, frame.artifact)
             artifacts.append(
                 self._publish(
                     data,
@@ -584,6 +598,13 @@ class EpisodeRunner:
             ),
         )
         self._model_cycles += 1
+        self._served_routes.add(
+            (
+                decision.route.provider_id,
+                decision.route.route_id,
+                decision.route.model_id,
+            )
+        )
         self._provider_cost_micros += decision.cost_micros
         for name in (
             "input_tokens",
@@ -645,6 +666,12 @@ class EpisodeRunner:
                 receipt_id=result.receipt.receipt_id,
                 input_observation_id=result.receipt.input_observation_id,
                 output_observation_id=result.receipt.output_observation_id,
+                # PROTOCOL GAP: ``ExecutionReceipt`` carries no termination
+                # flag, so an adapter cannot currently say "the environment
+                # ended this episode" -- only the model's own FinishAction or
+                # our step cap can end the step path. If a future adapter API
+                # adds that signal, it must be plumbed through here, or an
+                # environment-initiated termination will be silently ignored.
                 terminated=False,
                 truncated=truncated,
             ),
@@ -839,7 +866,10 @@ class EpisodeRunner:
             reportable=reconciliation.reportable,
             cancelled=cancelled,
         )
-        comparability = "comparable"
+        comparability = _comparability_label(
+            requested=self._spec.requested_route,
+            served=self._served_routes,
+        )
         # ``seal`` accepts only a ``completed`` snapshot (store.py:1359); a
         # failure is carried by ``failure_kind`` plus an unscored artifact, not
         # by a ``failed`` state, which would leave the bundle unsealable.
@@ -1214,6 +1244,25 @@ def _reportability_label(
     return "reportable"
 
 
+def _comparability_label(
+    *,
+    requested: RouteIdentity,
+    served: set[tuple[str, str, str]],
+) -> str:
+    """Report a route change, which is the whole reason the served route is carried.
+
+    A silent provider fallback is exactly what invalidates a comparison against
+    runs that held the pinned route, so a run that drifted must not seal as
+    ``comparable`` however well it scored. A run that made no model call has
+    nothing to contradict its pin and stays comparable.
+    """
+
+    pinned = (requested.provider_id, requested.route_id, requested.model_id)
+    if served - {pinned}:
+        return "route_changed"
+    return "comparable"
+
+
 def _terminal_kind(batch: ActionBatch) -> Literal["finish", "ask_user"] | None:
     for action in batch.actions:
         if isinstance(action, FinishAction):
@@ -1250,10 +1299,6 @@ def _incomplete_receipt(plan: CleanupPlan, action_id: str) -> CleanupReceipt:
         evidence_code="worker-unavailable",
         duration_ms=0,
     )
-
-
-def _read_artifact(root: Path, sha256: str) -> bytes:
-    return (root / sha256).read_bytes()
 
 
 def _diagnostic(error: BaseException) -> str:

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -1,0 +1,1292 @@
+"""Run one evaluation episode and leave behind exactly one verifiable bundle.
+
+This module composes the four released foundations and adds no new invariants
+of its own:
+
+* ``protocol``/``adapters.api`` -- the observation and action wire shapes.
+* ``adapters.supervisor`` -- ``VerifiedAdapterSession``, which is parent-owned
+  truth about what the adapter did, plus durable rescue.
+* ``receipts``/``lifecycle`` -- preflight, budget, cleanup and the episode
+  state machine, all of them single-use process-local authorities.
+* ``evidence`` -- the append-only journal whose verifier is the acceptance
+  test for everything written here.
+
+**Import isolation.** Nothing here may import providers, config, tools, the
+TUI, mobile, or session code; ``tests/unit/evaluation/runner/test_isolation.py``
+asserts it. An episode must be reproducible from its pinned inputs, and a
+transitive import of session configuration is how a benchmark result silently
+starts depending on the operator's own settings. The provider-backed model
+client lives in ``provider_client.py`` for exactly this reason.
+
+**Concurrency.** One runner drives one episode, one worker, and one writer, and
+shares no mutable state. ``lifecycle._EpisodeLineage`` is process-global keyed
+by ``episode_id``, so episodes running in parallel in one process MUST use
+distinct ``episode_id`` values or they will contend for the same lineage lease.
+Run-level budget aggregation across episodes is deliberately out of scope.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Mapping, Sequence
+
+from local_operator.evaluation.adapters.api import (
+    AskUserExchangeParams,
+    CleanupParams,
+    CloseParams,
+    ExecuteParams,
+    Handshake,
+    InspectRequirementsParams,
+    PrepareParams,
+    RescueDescriptor,
+    ResetStartParams,
+    ScopedInfraValue,
+    ScoreParams,
+    SecretRef,
+)
+from local_operator.evaluation.adapters.supervisor import (
+    AdapterSupervisor,
+    HostVerifier,
+    SupervisionError,
+    VerifiedAdapterSession,
+    persist_rescue,
+    run_rescue,
+)
+from local_operator.evaluation.evidence.models import (
+    ActionBatchPayload,
+    BudgetCommitmentPayload,
+    CancelPayload,
+    CleanupPayload,
+    EnvironmentStepPayload,
+    ErrorPayload,
+    EvidenceManifest,
+    FinalizationIntent,
+    LifecycleTransitionPayload,
+    ModelRequestPayload,
+    ModelResponsePayload,
+    ObservationPayload,
+    OutcomeDraft,
+    PreflightPayload,
+    ReconciliationPayload,
+    RouteIdentity,
+    ScoreArtifact,
+    ScoringResultPayload,
+    UsageCostPayload,
+    UserSimulatorExchangePayload,
+    canonical_digest,
+)
+from local_operator.evaluation.evidence.store import (
+    EvidenceError,
+    EvidenceWriter,
+)
+from local_operator.evaluation.lifecycle import (
+    CleanupAction,
+    CleanupPlan,
+    CleanupReceipt,
+    EpisodeLifecycle,
+    ScoreReceipt,
+    aggregate_cleanup,
+    plan_episode,
+)
+from local_operator.evaluation.protocol import (
+    ActionBatch,
+    AskUserAction,
+    FinishAction,
+    Observation,
+)
+from local_operator.evaluation.receipts import (
+    AvailableUsage,
+    BudgetAuthorization,
+    BudgetReservation,
+    DependencyPlan,
+    RedactionSet,
+    ResourceAmount,
+    SealedPreflight,
+    UnavailableUsage,
+    Usage,
+    commit_budget,
+    reconcile_budget,
+)
+from local_operator.evaluation.runner.model import EpisodeModelClient
+from local_operator.evaluation.runner.responder import NullUserResponder, UserResponder
+
+# Cleanup kinds are a closed vocabulary in ``lifecycle.CleanupAction``. A worker
+# session is the one resource the parent always knows exists before the adapter
+# has described anything, which is what makes the provisional plan expressible.
+_PROVISIONAL_CLEANUP_ACTION = "close-session"
+
+EpisodeStatus = Literal[
+    "completed",
+    "failed",
+    "cancelled",
+    "abandoned",
+    "failed_pre_bundle",
+]
+
+
+@dataclass(frozen=True)
+class EpisodeSpec:
+    """Everything pinned about one episode before anything is launched.
+
+    These values identify the run in the evidence manifest, so they are inputs
+    rather than anything the adapter may assert: an adapter that could choose
+    its own ``task_digest`` could make two different tasks look like one result.
+    """
+
+    episode_id: str
+    task_id: str
+    task_digest: str
+    input_digest: str
+    benchmark_id: str
+    benchmark_release: str
+    environment_digest: str
+    environment_release: str
+    config_digest: str
+    harness_version: str
+    harness_git_revision: str
+    requested_route: RouteIdentity
+    dependency_plan: DependencyPlan
+    budget: BudgetAuthorization
+    preflight: SealedPreflight
+    reservations: tuple[BudgetReservation, ...]
+    fallback_policy: Literal["forbid", "allow_compatible", "allow_any"] = "forbid"
+    secret_refs: tuple[SecretRef, ...] = ()
+    infra_values: tuple[ScopedInfraValue, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class EpisodeConfig:
+    """Operational limits that shape execution without changing its meaning.
+
+    Timeouts are per adapter call. ``max_steps`` bounds the step loop; reaching
+    it is a truncation, which is a normal scored outcome rather than a failure,
+    so it must not be conflated with the budget's own limits.
+    """
+
+    evidence_root: Path
+    artifact_root: Path
+    rescue_root: Path
+    max_steps: int = 50
+    prepare_timeout: float = 120.0
+    reset_timeout: float = 120.0
+    step_timeout: float = 120.0
+    score_timeout: float = 120.0
+    cleanup_timeout: float = 60.0
+    ask_deadline_ms: int = 60_000
+    handshake_timeout: float = 30.0
+
+
+@dataclass(frozen=True)
+class EpisodeOutcome:
+    """What happened, and where the evidence for it lives.
+
+    ``bundle_root`` is ``None`` only for ``failed_pre_bundle``: the manifest
+    needs identifiers that do not exist until ``prepare`` has returned, so a
+    failure before that point has nowhere to write evidence.
+    """
+
+    status: EpisodeStatus
+    episode_id: str
+    bundle_root: Path | None
+    score: ScoreArtifact | None = None
+    reportability_label: str | None = None
+    comparability_label: str | None = None
+    rescue_required: bool = False
+    rescue_complete: bool | None = None
+    diagnostic: str | None = None
+
+
+class _Cancelled(Exception):
+    """Raised inside the step loop to unwind to the cancellation terminal."""
+
+
+class _EvidenceFailure(Exception):
+    """Raised when the writer itself failed and the bundle can only be abandoned."""
+
+
+class EpisodeRunner:
+    """Drives one episode from launch to a sealed or abandoned bundle."""
+
+    def __init__(
+        self,
+        spec: EpisodeSpec,
+        config: EpisodeConfig,
+        *,
+        selector: Any,
+        model: EpisodeModelClient,
+        responder: UserResponder | None = None,
+        redactions: RedactionSet | None = None,
+        launch: Any = AdapterSupervisor.launch,
+        rescue: Any = run_rescue,
+    ) -> None:
+        self._spec = spec
+        self._config = config
+        self._selector = selector
+        self._model = model
+        self._responder = responder or NullUserResponder()
+        self._redactions = redactions or RedactionSet.from_resolved_values(())
+        self._launch = launch
+        self._rescue = rescue
+
+        self._writer: EvidenceWriter | None = None
+        self._session: VerifiedAdapterSession | None = None
+        self._supervisor: Any = None
+        self._descriptor: RescueDescriptor | None = None
+        self._cleanup_plan: CleanupPlan | None = None
+        self._lifecycle: EpisodeLifecycle | None = None
+        self._rescue_required = False
+        self._transcript: list[Observation] = []
+        self._usage_totals: dict[str, int] = {}
+        self._provider_cost_micros = 0
+        self._model_cycles = 0
+        self._guest_actions = 0
+        self._simulator_turns = 0
+        self._last_exchange_id: str | None = None
+        self._steps_taken = 0
+        self._truncated = False
+        self._last_step_terminated = False
+        self._finalization_id = f"final-{spec.episode_id}"
+        self._scoring_operation_id = f"score-{spec.episode_id}"
+        self._started_ms = _now_ms()
+
+    async def run(self) -> EpisodeOutcome:
+        """Execute the episode; every exit path leaves a verifiable bundle."""
+
+        try:
+            handshake = await self._launch_and_prepare()
+        except _EvidenceFailure as error:
+            return await self._abandon_for_evidence(str(error))
+        except BaseException as error:
+            # No manifest is possible yet: it must carry the cleanup plan ID
+            # that ``prepare`` returns. There is nothing to write evidence to,
+            # so the only obligations are rescue and reaping.
+            await self._emergency_teardown()
+            return EpisodeOutcome(
+                status="failed_pre_bundle",
+                episode_id=self._spec.episode_id,
+                bundle_root=None,
+                rescue_required=self._rescue_required,
+                diagnostic=_diagnostic(error),
+            )
+        try:
+            return await self._run_with_bundle(handshake)
+        except _EvidenceFailure as error:
+            return await self._abandon_for_evidence(str(error))
+
+    # ------------------------------------------------------------------
+    # Launch, prepare, and the two-stage rescue persistence
+    # ------------------------------------------------------------------
+
+    async def _launch_and_prepare(self) -> Handshake:
+        """Bring up the worker and prepare the environment.
+
+        ADAPTER CONTRACT: ``prepare`` must not create environment resources;
+        ``reset_start`` does. The whole two-stage persistence below depends on
+        it, and an adapter that allocates during ``prepare`` can leak a
+        resource that no persisted descriptor names.
+        """
+
+        supervisor = self._launch(self._selector)
+        self._supervisor = supervisor
+        handshake = await supervisor.handshake(timeout=self._config.handshake_timeout)
+        verifier = HostVerifier(
+            self._spec.task_id,
+            self._spec.episode_id,
+            self._config.artifact_root,
+        )
+        session = VerifiedAdapterSession(
+            supervisor,
+            verifier,
+            rescue_required=self._mark_rescue_required,
+        )
+        self._session = session
+
+        await session.inspect_requirements(
+            InspectRequirementsParams(),
+            timeout=self._config.prepare_timeout,
+        )
+
+        # STAGE 1 of two-stage rescue persistence.
+        #
+        # ``VerifiedAdapterSession.prepare`` refuses to run without a persisted
+        # rescue descriptor, but a descriptor embeds the cleanup plan that only
+        # ``prepare`` can return. The circularity is resolved by persisting a
+        # PROVISIONAL descriptor first, carrying the one action the parent can
+        # author unaided: close this worker's session. That is sound precisely
+        # because ``prepare`` is declarative -- if it creates nothing, the
+        # provisional plan covers everything that could exist at this instant.
+        provisional = CleanupPlan(
+            episode_id=self._spec.episode_id,
+            actions=(
+                CleanupAction(
+                    action_id=_PROVISIONAL_CLEANUP_ACTION,
+                    kind="close_session",
+                    resource_ref=self._spec.episode_id,
+                    timeout_ms=int(self._config.cleanup_timeout * 1000),
+                    max_attempts=2,
+                ),
+            ),
+        )
+        self._persist_descriptor(handshake, provisional)
+
+        result = await session.prepare(
+            PrepareParams(
+                operation_id=f"prepare-{self._spec.episode_id}",
+                episode_id=self._spec.episode_id,
+                secret_refs=self._spec.secret_refs,
+                infra_values=self._spec.infra_values,
+            ),
+            timeout=self._config.prepare_timeout,
+        )
+
+        # STAGE 2, before any side effect exists.
+        #
+        # ``reset_start`` is the side-effect boundary, so the real plan must be
+        # durable before it is called and not merely before cleanup. Re-persist
+        # now: from here on a crashed parent can rescue every resource the
+        # adapter is about to create.
+        self._cleanup_plan = result.cleanup_plan
+        self._persist_descriptor(handshake, result.cleanup_plan)
+        return handshake
+
+    def _persist_descriptor(self, handshake: Handshake, plan: CleanupPlan) -> None:
+        descriptor = RescueDescriptor(
+            schema_version="1.0",
+            selector=self._selector,
+            handshake=handshake,
+            episode_id=self._spec.episode_id,
+            cleanup_plan=plan,
+            secret_refs=self._spec.secret_refs,
+            infra_values=self._spec.infra_values,
+            artifact_root=str(self._config.artifact_root),
+        )
+        persist_rescue(self._config.rescue_root, descriptor)
+        self._descriptor = descriptor
+        session = self._session
+        if session is not None:
+            session.mark_rescue_persisted(descriptor.descriptor_id)
+
+    def _mark_rescue_required(self) -> None:
+        self._rescue_required = True
+
+    # ------------------------------------------------------------------
+    # Bundle-backed execution
+    # ------------------------------------------------------------------
+
+    async def _run_with_bundle(self, handshake: Handshake) -> EpisodeOutcome:
+        plan = self._cleanup_plan
+        assert plan is not None
+        manifest = self._build_manifest(handshake, plan)
+        root = self._config.evidence_root / self._spec.episode_id
+        try:
+            writer = EvidenceWriter.create(root, manifest, self._redactions)
+        except EvidenceError as error:
+            # The bundle never opened, so there is nothing to abandon.
+            await self._emergency_teardown()
+            return EpisodeOutcome(
+                status="failed_pre_bundle",
+                episode_id=self._spec.episode_id,
+                bundle_root=None,
+                rescue_required=self._rescue_required,
+                diagnostic=_diagnostic(error),
+            )
+        self._writer = writer
+        try:
+            return await self._execute(handshake)
+        finally:
+            writer.close()
+
+    async def _execute(self, handshake: Handshake) -> EpisodeOutcome:
+        writer = self._require_writer()
+        session = self._require_session()
+        spec = self._spec
+
+        lifecycle = plan_episode(
+            episode_id=spec.episode_id,
+            plan_id=spec.dependency_plan.plan_id,
+            budget_id=spec.budget.budget_id,
+            cleanup_plan_id=self._require_plan().cleanup_plan_id,
+        )
+
+        # Preflight is event #0 and the commitment must precede every piece of
+        # execution evidence; both the writer's phase check and the verifier
+        # enforce this ordering independently.
+        self._append(
+            "preflight",
+            PreflightPayload(
+                sealed_preflight_id=spec.preflight.seal_id,
+                plan_id=spec.dependency_plan.plan_id,
+                receipt_ids=tuple(spec.preflight.receipt_digests),
+                passed=spec.preflight.successful,
+            ),
+        )
+        lifecycle = lifecycle.preflight(spec.preflight)
+        lifecycle, permit = lifecycle.authorize(spec.preflight, spec.budget)
+        commitment = commit_budget(spec.budget, spec.reservations)
+        self._append(
+            "budget_commitment",
+            BudgetCommitmentPayload(
+                commitment_id=commitment.commitment_id,
+                budget_id=spec.budget.budget_id,
+                reservation_ids=tuple(commitment.reservation_ids),
+                reserved_summary_digest=canonical_digest(
+                    "runner-reserved-summary-v1",
+                    [amount.model_dump(mode="json") for amount in commitment.reserved],
+                ),
+            ),
+        )
+        lifecycle = lifecycle.start(permit, spec.budget, commitment)
+        self._lifecycle = lifecycle
+        self._append_lifecycle(lifecycle, state="running")
+
+        try:
+            await self._reset_and_observe()
+            await self._step_loop()
+        except _Cancelled as cancel:
+            return await self._finalize_cancelled(str(cancel) or "cancelled")
+        except _EvidenceFailure:
+            raise
+        except BaseException as error:
+            return await self._finalize_failure(error)
+        return await self._finalize_scored(handshake)
+
+    async def _reset_and_observe(self) -> None:
+        session = self._require_session()
+        result = await session.reset_start(
+            ResetStartParams(
+                operation_id=f"reset-{self._spec.episode_id}",
+                task_id=self._spec.task_id,
+                episode_id=self._spec.episode_id,
+            ),
+            timeout=self._config.reset_timeout,
+        )
+        self._record_observation(result.observation)
+
+    def _record_observation(self, observation: Observation) -> None:
+        """Publish an observation's frames, then its event.
+
+        Artifacts are published FIRST because the verifier resolves every
+        reference an event makes; an observation event naming bytes that are
+        not yet in the bundle is an invalid bundle, not a race to be tolerated.
+        """
+
+        writer = self._require_writer()
+        artifacts = []
+        for frame in observation.frames:
+            data = _read_artifact(self._config.artifact_root, frame.artifact.sha256)
+            artifacts.append(
+                self._publish(
+                    data,
+                    media_type=frame.artifact.media_type,
+                    expected_sha256=frame.artifact.sha256,
+                )
+            )
+        text_artifact = None
+        if observation.text:
+            text_artifact = self._publish(
+                observation.text.encode("utf-8"), media_type="text/plain"
+            )
+        self._append(
+            "observation",
+            ObservationPayload(
+                observation_id=observation.observation_id,
+                sequence=observation.sequence,
+                artifacts=tuple(artifacts),
+                text_artifact=text_artifact,
+            ),
+        )
+        self._transcript.append(observation)
+
+    async def _step_loop(self) -> None:
+        session = self._require_session()
+        while True:
+            current = session.verifier.current_observation
+            assert current is not None
+            if self._steps_taken >= self._config.max_steps:
+                # Truncation is not a failure: the episode is scored on the
+                # state it reached. It is recorded on the LAST step rather than
+                # as a new event, which is why it must be applied before the
+                # step is written -- see ``_execute_batch``.
+                self._truncated = True
+                return
+            decision = await self._decide(current)
+            batch = decision.action_batch
+            terminal = _terminal_kind(batch)
+            if terminal == "finish":
+                self._append_batch(batch, terminal="finish")
+                return
+            if terminal == "ask_user":
+                await self._run_ask(batch)
+                continue
+            await self._execute_batch(batch)
+            if self._last_step_terminated:
+                return
+
+    async def _decide(self, observation: Observation) -> Any:
+        """Ask the model, writing request/response/usage in that exact order.
+
+        The verifier binds a response to its request and a usage record to that
+        response, so all three must be written even when the provider reports
+        nothing -- a missing usage record leaves an unclosed operation and the
+        bundle cannot reach a terminal.
+        """
+
+        request_id = f"req-{self._model_cycles}-{uuid.uuid4().hex[:12]}"
+        message_count = len(self._transcript)
+        # The provider is called BEFORE the request event is written, even
+        # though the three events keep their required request/response/usage
+        # order in the journal. A request written first would be left unclosed
+        # by a provider failure, and the verifier requires every request to
+        # carry its response and usage before any terminal (verify.py:760) --
+        # so recording it eagerly would make the failure path unsealable.
+        try:
+            decision = await self._model.decide(observation, tuple(self._transcript))
+        except _EvidenceFailure:
+            raise
+        except BaseException as error:
+            raise _ProviderFailure(_diagnostic(error)) from error
+        self._append(
+            "model_request",
+            ModelRequestPayload(
+                request_id=request_id,
+                requested_route=self._spec.requested_route,
+                tool_schema_digest=canonical_digest(
+                    "runner-tool-schema-v1", {"episode_id": self._spec.episode_id}
+                ),
+                input_tokens=decision.usage.input_tokens,
+                message_count=message_count,
+                tool_count=0,
+            ),
+        )
+        self._append(
+            "model_response",
+            ModelResponsePayload(
+                request_id=request_id,
+                provider_request_id=decision.provider_request_id,
+                requested_route=self._spec.requested_route,
+                served_route=decision.route,
+                stop_reason=decision.stop_reason,
+                output_tokens=decision.usage.output_tokens,
+                reasoning_tokens=decision.usage.reasoning_tokens,
+                cache_read_tokens=decision.usage.cache_read_tokens,
+                cache_write_tokens=decision.usage.cache_write_tokens,
+                tool_call_count=decision.tool_call_count,
+            ),
+        )
+        self._append(
+            "usage_cost",
+            UsageCostPayload(
+                request_id=request_id,
+                input_tokens=decision.usage.input_tokens,
+                output_tokens=decision.usage.output_tokens,
+                reasoning_tokens=decision.usage.reasoning_tokens,
+                cache_read_tokens=decision.usage.cache_read_tokens,
+                cache_write_tokens=decision.usage.cache_write_tokens,
+                cost_microusd=decision.cost_micros,
+            ),
+        )
+        self._model_cycles += 1
+        self._provider_cost_micros += decision.cost_micros
+        for name in (
+            "input_tokens",
+            "output_tokens",
+            "reasoning_tokens",
+            "cache_read_tokens",
+            "cache_write_tokens",
+        ):
+            self._usage_totals[name] = self._usage_totals.get(name, 0) + getattr(
+                decision.usage, name
+            )
+        return decision
+
+    def _append_batch(
+        self, batch: ActionBatch, *, terminal: Literal["finish", "ask_user"] | None
+    ) -> None:
+        canonical = batch.to_canonical_json()
+        artifact = self._publish(canonical, media_type="application/json")
+        self._append(
+            "action_batch",
+            ActionBatchPayload(
+                action_batch_id=_batch_id(batch),
+                observation_id=batch.observation_id,
+                action_count=len(batch.actions),
+                action_artifact=artifact,
+                terminal=terminal,
+            ),
+        )
+
+    async def _execute_batch(self, batch: ActionBatch) -> None:
+        """Execute a batch, then write its batch and step evidence.
+
+        The adapter is called BEFORE the ``action_batch`` event is written. The
+        journal still carries batch-then-step in the required order, but a
+        non-terminal batch that never produced a step is a permanently invalid
+        bundle (verify.py:762-766 requires every non-finish batch to have its
+        step), so a crash inside ``execute`` must not leave one behind.
+        """
+
+        session = self._require_session()
+        params = ExecuteParams(
+            operation_id=f"exec-{self._steps_taken}-{uuid.uuid4().hex[:12]}",
+            action_batch=batch,
+            action_batch_id=_adapter_batch_id(batch),
+        )
+        result = await session.execute(params, timeout=self._config.step_timeout)
+        self._append_batch(batch, terminal=None)
+        self._steps_taken += 1
+        self._guest_actions += len(batch.actions)
+        truncated = self._truncated or self._steps_taken >= self._config.max_steps
+        # The step event MUST precede its output observation: the verifier
+        # expects the observation it just declared, and reversing the two makes
+        # the observation unbound.
+        self._append(
+            "environment_step",
+            EnvironmentStepPayload(
+                step_id=result.receipt.operation_id,
+                action_batch_id=_batch_id(batch),
+                receipt_id=result.receipt.receipt_id,
+                input_observation_id=result.receipt.input_observation_id,
+                output_observation_id=result.receipt.output_observation_id,
+                terminated=False,
+                truncated=truncated,
+            ),
+        )
+        self._truncated = truncated
+        self._last_step_terminated = truncated
+        self._record_observation(result.observation)
+
+    async def _run_ask(self, batch: ActionBatch) -> None:
+        """Answer an ask, then execute the ask batch like any other.
+
+        The choreography is forced by the verifier's one-batch-per-observation
+        rule (verify.py:575-580): the ask cannot be a batch that is written and
+        then abandoned, so the answer is obtained FIRST and the ask batch is
+        then executed normally, producing the observation the model sees next.
+        """
+
+        session = self._require_session()
+        # The adapter exchange is keyed by the model's own request ID so the
+        # answer is traceable back to the exact action that asked for it.
+        ask_id, prompt = _ask_prompt(batch)
+        begin = AskUserExchangeParams(
+            operation_id=f"ask-begin-{ask_id}",
+            episode_id=self._spec.episode_id,
+            ask_id=ask_id,
+            prompt=prompt,
+        )
+        session.begin_ask(begin)
+        answer = await self._responder.ask(prompt, self._config.ask_deadline_ms)
+        if answer is None:
+            # An outstanding ask may not be left open, and there is no way to
+            # withdraw one. Cancelling is the only coherent resolution.
+            raise _Cancelled("ask-user was not answered")
+        finish = begin.model_copy(
+            update={"operation_id": f"ask-finish-{ask_id}", "answer": answer}
+        )
+        result = await session.finish_ask(finish, timeout=self._config.step_timeout)
+        request_artifact = self._publish(prompt.encode("utf-8"), media_type="text/plain")
+        response_artifact = self._publish(answer.encode("utf-8"), media_type="text/plain")
+        exchange_id = ask_id
+        self._append(
+            "user_simulator_exchange",
+            UserSimulatorExchangePayload(
+                exchange_id=exchange_id,
+                previous_exchange_id=self._last_exchange_id,
+                request_artifact=request_artifact,
+                response_artifact=response_artifact,
+                receipt_id=canonical_digest(
+                    "runner-ask-receipt-v1",
+                    {"ask_id": ask_id, "accepted": result.accepted},
+                ),
+            ),
+        )
+        self._last_exchange_id = exchange_id
+        self._simulator_turns += 1
+        # The ask batch is then executed like any other batch: a lone
+        # AskUserAction is a legal batch, and executing it is what produces the
+        # observation carrying the answer's effect, which the model sees next.
+        await self._execute_batch(batch)
+
+    # ------------------------------------------------------------------
+    # Terminal paths
+    # ------------------------------------------------------------------
+
+    async def _finalize_scored(self, handshake: Handshake) -> EpisodeOutcome:
+        writer = self._require_writer()
+        session = self._require_session()
+        intent = FinalizationIntent(
+            kind="score",
+            scorer_id=handshake.metadata.adapter_id,
+            # The scorer identity pins the adapter build that graded this run.
+            # ``StrictIdentifier`` forbids "+", so the digest is joined with a
+            # "-": the value only has to be exact and stable, not semver.
+            scorer_version=(
+                f"{handshake.metadata.version}-{handshake.metadata.package_digest[:16]}"
+            ),
+        )
+        self._begin_finalization(intent, self._scoring_operation_id)
+        try:
+            result = await session.score(
+                ScoreParams(
+                    operation_id=self._scoring_operation_id,
+                    episode_id=self._spec.episode_id,
+                ),
+                timeout=self._config.score_timeout,
+            )
+        except _EvidenceFailure:
+            raise
+        except BaseException as error:
+            # ADAPTER CONTRACT: ``score()`` returns a SCORED artifact or raises.
+            # "Unscored" is a harness decision expressed through the
+            # finalization intent, never an adapter return value.
+            #
+            # ``scoring_start`` is already durable and a scored-intent
+            # finalization cannot seal unscored, so no legal terminal remains.
+            # Rescue first (the worker may be poisoned), then abandon.
+            return await self._abandon_after_scoring_failure(error)
+        score = result.score
+        self._append_receipt(
+            "scoring_result",
+            ScoringResultPayload(
+                finalization_id=self._finalization_id,
+                scoring_operation_id=self._scoring_operation_id,
+                score=score,
+            ),
+        )
+        return await self._close_out(score, failure_kind=None, cancelled=False)
+
+    async def _finalize_failure(self, error: BaseException) -> EpisodeOutcome:
+        """Finalize unscored after a mid-episode failure.
+
+        Both branches begin finalization first: ``record_final_lifecycle``
+        refuses to write without the finalizing marker, so a crash path that
+        skips it has no terminal at all and the bundle can only be abandoned.
+        """
+
+        provider_failure = isinstance(error, _ProviderFailure)
+        category: Literal["adapter", "provider"] = (
+            "provider" if provider_failure else "adapter"
+        )
+        self._append(
+            "error",
+            ErrorPayload(
+                error_id=f"err-{uuid.uuid4().hex[:12]}",
+                category=category,
+                diagnostic_code=_diagnostic_code(error),
+                retryable=False,
+            ),
+        )
+        reason: Literal["crash", "infrastructure_failure"] = (
+            "infrastructure_failure" if provider_failure else "crash"
+        )
+        self._begin_finalization(FinalizationIntent(kind="unscored"), None)
+        score = ScoreArtifact(status="unscored", reason=reason)
+        return await self._close_out(
+            score,
+            failure_kind="crash" if not provider_failure else "infrastructure",
+            cancelled=False,
+            diagnostic=_diagnostic(error),
+        )
+
+    async def _finalize_cancelled(self, reason: str) -> EpisodeOutcome:
+        self._append(
+            "cancel",
+            CancelPayload(
+                cancellation_id=f"cancel-{uuid.uuid4().hex[:12]}",
+                source="harness",
+                diagnostic_code="cancelled",
+            ),
+        )
+        self._begin_finalization(FinalizationIntent(kind="unscored"), None)
+        score = ScoreArtifact(status="unscored", reason="cancelled")
+        return await self._close_out(
+            score, failure_kind="cancelled", cancelled=True, diagnostic=reason
+        )
+
+    async def _close_out(
+        self,
+        score: ScoreArtifact,
+        *,
+        failure_kind: str | None,
+        cancelled: bool,
+        diagnostic: str | None = None,
+    ) -> EpisodeOutcome:
+        """Reconcile, clean up, record the terminal snapshot, and seal."""
+
+        writer = self._require_writer()
+        reconciliation = self._reconcile()
+        self._append_receipt(
+            "reconciliation",
+            ReconciliationPayload(
+                reconciliation_id=reconciliation.reconciliation_id,
+                budget_id=reconciliation.budget_id,
+                commitment_id=reconciliation.commitment_id,
+                reportable=reconciliation.reportable,
+                provider_cost_microusd=self._provider_cost_micros,
+                environment_cost_microusd=0,
+                total_cost_microusd=self._provider_cost_micros,
+            ),
+        )
+        receipts, cleanup_result = await self._run_cleanup()
+        rescue_complete: bool | None = None
+        if cleanup_result.rescue_required or self._rescue_required:
+            rescue_complete = await self._attempt_rescue()
+        self._append_receipt(
+            "cleanup",
+            CleanupPayload(
+                cleanup_result_id=cleanup_result.cleanup_result_id,
+                cleanup_plan_id=self._require_plan().cleanup_plan_id,
+                receipt_ids=tuple(receipt.receipt_id for receipt in receipts),
+                rescue_required=cleanup_result.rescue_required,
+            ),
+        )
+        reportability = _reportability_label(
+            score=score,
+            rescue_required=cleanup_result.rescue_required,
+            reportable=reconciliation.reportable,
+            cancelled=cancelled,
+        )
+        comparability = "comparable"
+        # ``seal`` accepts only a ``completed`` snapshot (store.py:1359); a
+        # failure is carried by ``failure_kind`` plus an unscored artifact, not
+        # by a ``failed`` state, which would leave the bundle unsealable.
+        self._append_final_lifecycle(
+            score=score,
+            reconciliation_id=reconciliation.reconciliation_id,
+            reportable=reconciliation.reportable,
+            cleanup_result_id=cleanup_result.cleanup_result_id,
+            rescue_required=cleanup_result.rescue_required,
+            failure_kind=failure_kind,
+        )
+        outcome = self._seal(
+            score=score,
+            reconciliation_id=reconciliation.reconciliation_id,
+            cleanup_result_id=cleanup_result.cleanup_result_id,
+            reportability_label=reportability,
+            comparability_label=comparability,
+        )
+        await self._close_session()
+        # A leaked resource is a failed episode even when the task itself was
+        # scored: ``lifecycle.finish_cleanup`` reaches "failed" on
+        # rescue_required for the same reason, and reporting "completed" here
+        # would contradict the bundle's own cleanup_incomplete label.
+        failed = failure_kind is not None or cleanup_result.rescue_required
+        status: EpisodeStatus = (
+            "cancelled" if cancelled else ("failed" if failed else "completed")
+        )
+        return EpisodeOutcome(
+            status=status,
+            episode_id=self._spec.episode_id,
+            bundle_root=Path(writer.root),
+            score=outcome.result,
+            reportability_label=reportability,
+            comparability_label=comparability,
+            rescue_required=cleanup_result.rescue_required or self._rescue_required,
+            rescue_complete=rescue_complete,
+            diagnostic=diagnostic,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _reconcile(self) -> Any:
+        """Close the budget with real usage, marking what could not be measured.
+
+        A poisoned session cannot report environment usage, so those resources
+        are declared unavailable. That is what makes the episode
+        ``budget_unreconciled`` rather than silently reportable.
+        """
+
+        measured: dict[str, int] = {
+            "provider_input_tokens": self._usage_totals.get("input_tokens", 0),
+            "provider_output_tokens": self._usage_totals.get("output_tokens", 0),
+            "provider_cache_tokens": (
+                self._usage_totals.get("cache_read_tokens", 0)
+                + self._usage_totals.get("cache_write_tokens", 0)
+            ),
+            "provider_usd_micros": self._provider_cost_micros,
+            "cloud_usd_micros": 0,
+            "instance_milliseconds": max(0, _now_ms() - self._started_ms),
+            "wall_milliseconds": max(0, _now_ms() - self._started_ms),
+            "model_cycles": self._model_cycles,
+            "guest_actions": self._guest_actions,
+            "user_simulator_turns": self._simulator_turns,
+        }
+        unavailable = {"cloud_usd_micros", "instance_milliseconds"} if self._rescue_required else set()
+        usage: list[Usage] = []
+        for resource, value in measured.items():
+            if resource in unavailable:
+                usage.append(
+                    UnavailableUsage(
+                        resource=resource,  # pyright: ignore[reportArgumentType]
+                        reason="worker terminated before usage could be measured",
+                    )
+                )
+            else:
+                usage.append(
+                    AvailableUsage(
+                        resource=resource,  # pyright: ignore[reportArgumentType]
+                        value=value,
+                    )
+                )
+        return reconcile_budget(self._spec.budget, self._spec.reservations, usage)
+
+    async def _run_cleanup(self) -> tuple[tuple[CleanupReceipt, ...], Any]:
+        """Run cleanup on the live session, or mint incomplete receipts if dead."""
+
+        plan = self._require_plan()
+        session = self._session
+        receipts: tuple[CleanupReceipt, ...] = ()
+        if session is not None and not self._rescue_required:
+            try:
+                receipts = await session.cleanup(
+                    CleanupParams(
+                        operation_id=f"cleanup-{self._spec.episode_id}",
+                        cleanup_plan=plan,
+                        action_ids=tuple(action.action_id for action in plan.actions),
+                    ),
+                    timeout=self._config.cleanup_timeout,
+                )
+            except BaseException:
+                self._rescue_required = True
+                receipts = ()
+        if not receipts:
+            # A dead worker cannot produce evidence, and "attempted" alone is
+            # never evidence of cleanup, so these receipts aggregate as
+            # incomplete and force rescue.
+            receipts = tuple(
+                _incomplete_receipt(plan, action.action_id) for action in plan.actions
+            )
+        return receipts, aggregate_cleanup(plan, receipts)
+
+    async def _attempt_rescue(self) -> bool:
+        descriptor = self._descriptor
+        if descriptor is None:
+            return False
+        try:
+            aggregate = await self._rescue(descriptor)
+        except BaseException:
+            return False
+        return bool(aggregate.complete)
+
+    def _build_manifest(self, handshake: Handshake, plan: CleanupPlan) -> EvidenceManifest:
+        spec = self._spec
+        return EvidenceManifest(
+            episode_id=spec.episode_id,
+            harness_version=spec.harness_version,
+            harness_git_revision=spec.harness_git_revision,
+            adapter_id=handshake.metadata.adapter_id,
+            adapter_version=handshake.metadata.version,
+            benchmark_id=spec.benchmark_id,
+            benchmark_release=spec.benchmark_release,
+            task_id=spec.task_id,
+            task_digest=spec.task_digest,
+            input_digest=spec.input_digest,
+            requested_route=spec.requested_route,
+            fallback_policy=spec.fallback_policy,
+            environment_digest=spec.environment_digest,
+            environment_release=spec.environment_release,
+            dependency_plan_id=spec.dependency_plan.plan_id,
+            budget_id=spec.budget.budget_id,
+            cleanup_plan_id=plan.cleanup_plan_id,
+            config_digest=spec.config_digest,
+            created_wall_time_ms=self._started_ms,
+            metadata=dict(spec.metadata),
+        )
+
+    def _append(self, kind: Any, payload: Any) -> None:
+        writer = self._require_writer()
+        try:
+            writer.append(kind, payload)
+        except EvidenceError as error:
+            raise _EvidenceFailure(_diagnostic(error)) from error
+
+    def _append_receipt(self, kind: str, payload: Any) -> None:
+        writer = self._require_writer()
+        try:
+            if kind == "reconciliation":
+                writer.record_reconciliation(payload)
+            elif kind == "cleanup":
+                writer.record_cleanup(payload)
+            else:
+                writer.record_scoring_result(payload)
+        except EvidenceError as error:
+            raise _EvidenceFailure(_diagnostic(error)) from error
+
+    def _publish(self, data: bytes, *, media_type: str, expected_sha256: str | None = None) -> Any:
+        writer = self._require_writer()
+        try:
+            return writer.publish_artifact(
+                data, media_type=media_type, expected_sha256=expected_sha256
+            )
+        except EvidenceError as error:
+            raise _EvidenceFailure(_diagnostic(error)) from error
+
+    def _begin_finalization(self, intent: FinalizationIntent, operation: str | None) -> None:
+        writer = self._require_writer()
+        try:
+            writer.begin_finalization(self._finalization_id, operation, intent)
+        except EvidenceError as error:
+            raise _EvidenceFailure(_diagnostic(error)) from error
+
+    def _append_lifecycle(self, lifecycle: EpisodeLifecycle, *, state: str) -> None:
+        # This is the journal's FIRST lifecycle link, so it must declare no
+        # predecessor: the verifier chains lifecycle events against the events
+        # it has actually seen, not against the in-process state machine, which
+        # already advanced through planned/preflighted/authorized to get here.
+        self._append(
+            "lifecycle_transition",
+            LifecycleTransitionPayload(
+                previous_state_id=None,
+                state_id=lifecycle.state_id,
+                state=state,  # pyright: ignore[reportArgumentType]
+                preflight_seal_id=lifecycle.preflight_seal_id,
+                commitment_id=lifecycle.commitment_id,
+            ),
+        )
+
+    def _append_final_lifecycle(
+        self,
+        *,
+        score: ScoreArtifact,
+        reconciliation_id: str,
+        reportable: bool,
+        cleanup_result_id: str,
+        rescue_required: bool,
+        failure_kind: str | None,
+    ) -> None:
+        writer = self._require_writer()
+        lifecycle = self._lifecycle
+        assert lifecycle is not None
+        payload = LifecycleTransitionPayload(
+            previous_state_id=lifecycle.state_id,
+            state_id=canonical_digest(
+                "runner-terminal-state-v1",
+                {
+                    "episode_id": self._spec.episode_id,
+                    "finalization_id": self._finalization_id,
+                    "score_id": score.score_id,
+                },
+            ),
+            state="completed",
+            finalization_id=self._finalization_id,
+            preflight_seal_id=self._spec.preflight.seal_id,
+            commitment_id=lifecycle.commitment_id,
+            reconciliation_id=reconciliation_id,
+            reconciliation_reportable=reportable,
+            score_id=score.score_id,
+            cleanup_result_id=cleanup_result_id,
+            rescue_required=rescue_required,
+            failure_kind=failure_kind,  # pyright: ignore[reportArgumentType]
+        )
+        try:
+            writer.record_final_lifecycle(payload)
+        except EvidenceError as error:
+            raise _EvidenceFailure(_diagnostic(error)) from error
+
+    def _seal(
+        self,
+        *,
+        score: ScoreArtifact,
+        reconciliation_id: str,
+        cleanup_result_id: str,
+        reportability_label: str,
+        comparability_label: str,
+    ) -> Any:
+        writer = self._require_writer()
+        lifecycle = self._lifecycle
+        assert lifecycle is not None
+        draft = OutcomeDraft(
+            finalization_id=self._finalization_id,
+            preflight_seal_id=self._spec.preflight.seal_id,
+            commitment_id=lifecycle.commitment_id,
+            reconciliation_id=reconciliation_id,
+            cleanup_result_id=cleanup_result_id,
+            result=score,
+            reportability_label=reportability_label,  # pyright: ignore[reportArgumentType]
+            comparability_label=comparability_label,  # pyright: ignore[reportArgumentType]
+            ended_wall_time_ms=_now_ms(),
+        )
+        try:
+            return writer.seal(draft)
+        except EvidenceError as error:
+            raise _EvidenceFailure(_diagnostic(error)) from error
+
+    async def _abandon_after_scoring_failure(self, error: BaseException) -> EpisodeOutcome:
+        writer = self._require_writer()
+        rescue_complete = await self._attempt_rescue()
+        await self._emergency_teardown()
+        record = writer.abandon("ambiguous_finalization", _diagnostic_code(error))
+        return EpisodeOutcome(
+            status="abandoned",
+            episode_id=self._spec.episode_id,
+            bundle_root=Path(writer.root),
+            rescue_required=True,
+            rescue_complete=rescue_complete,
+            diagnostic=record.diagnostic_code,
+        )
+
+    async def _abandon_for_evidence(self, detail: str) -> EpisodeOutcome:
+        """The writer is unusable; rescue first because cloud safety needs no writer."""
+
+        rescue_complete = await self._attempt_rescue()
+        await self._emergency_teardown()
+        writer = self._writer
+        root = Path(writer.root) if writer is not None else None
+        if writer is not None:
+            try:
+                writer.abandon("infrastructure_failure", "evidence-write-failed")
+            except EvidenceError:
+                # A writer this broken may not even be able to record its own
+                # abandonment; the bundle stays unsealed and recoverable.
+                pass
+        return EpisodeOutcome(
+            status="abandoned",
+            episode_id=self._spec.episode_id,
+            bundle_root=root,
+            rescue_required=True,
+            rescue_complete=rescue_complete,
+            diagnostic=detail,
+        )
+
+    async def _close_session(self) -> None:
+        session = self._session
+        supervisor = self._supervisor
+        if session is not None and not self._rescue_required:
+            try:
+                await session.close(
+                    CloseParams(
+                        operation_id=f"close-{self._spec.episode_id}",
+                        episode_id=self._spec.episode_id,
+                    ),
+                    timeout=self._config.cleanup_timeout,
+                )
+            except BaseException:
+                pass
+        if supervisor is not None:
+            try:
+                await supervisor.terminate()
+            except BaseException:
+                pass
+
+    async def _emergency_teardown(self) -> None:
+        supervisor = self._supervisor
+        if supervisor is not None:
+            try:
+                await supervisor.terminate()
+            except BaseException:
+                pass
+
+    def _require_writer(self) -> EvidenceWriter:
+        writer = self._writer
+        assert writer is not None
+        return writer
+
+    def _require_session(self) -> VerifiedAdapterSession:
+        session = self._session
+        assert session is not None
+        return session
+
+    def _require_plan(self) -> CleanupPlan:
+        plan = self._cleanup_plan
+        assert plan is not None
+        return plan
+
+
+class _ProviderFailure(Exception):
+    """A terminal model-provider error after the client exhausted its retries."""
+
+
+def _reportability_label(
+    *,
+    score: ScoreArtifact,
+    rescue_required: bool,
+    reportable: bool,
+    cancelled: bool,
+) -> str:
+    """Pick the single most severe label.
+
+    Precedence is cleanup_incomplete > budget_unreconciled > unscored, because
+    a leaked resource is a worse claim about the run than an unclosed budget,
+    which in turn matters more than a missing score.
+    """
+
+    if rescue_required:
+        return "cleanup_incomplete"
+    if not reportable:
+        return "budget_unreconciled"
+    if cancelled:
+        return "cancelled"
+    if score.status != "scored":
+        return "unscored"
+    return "reportable"
+
+
+def _terminal_kind(batch: ActionBatch) -> Literal["finish", "ask_user"] | None:
+    for action in batch.actions:
+        if isinstance(action, FinishAction):
+            return "finish"
+        if isinstance(action, AskUserAction):
+            return "ask_user"
+    return None
+
+
+def _ask_prompt(batch: ActionBatch) -> tuple[str, str]:
+    """Return the ask's protocol request ID and its question text."""
+
+    for action in batch.actions:
+        if isinstance(action, AskUserAction):
+            return action.request_id, action.question
+    raise ValueError("batch carries no ask-user action")
+
+
+def _batch_id(batch: ActionBatch) -> str:
+    return f"batch-{_adapter_batch_id(batch)[:24]}"
+
+
+def _adapter_batch_id(batch: ActionBatch) -> str:
+    return canonical_digest("adapter-action-batch-v1", batch)
+
+
+def _incomplete_receipt(plan: CleanupPlan, action_id: str) -> CleanupReceipt:
+    from local_operator.evaluation.lifecycle import record_cleanup
+
+    return record_cleanup(
+        plan,
+        action_id,
+        status="failed",
+        evidence_code="worker-unavailable",
+        duration_ms=0,
+    )
+
+
+def _read_artifact(root: Path, sha256: str) -> bytes:
+    return (root / sha256).read_bytes()
+
+
+def _diagnostic(error: BaseException) -> str:
+    return f"{type(error).__name__}: {error}"[:500]
+
+
+def _diagnostic_code(error: BaseException) -> str:
+    """Derive a ``StrictIdentifier`` diagnostic code from an exception type.
+
+    The identifier pattern forbids a leading separator, and private exception
+    names here begin with an underscore, so the result is stripped and given a
+    stable fallback rather than being allowed to fail validation on a path that
+    is already handling a failure.
+    """
+
+    raw = "".join(
+        char if char.isalnum() else "-" for char in type(error).__name__.lower()
+    ).strip("-")
+    return raw[:64] or "unknown-error"
+
+
+def _now_ms() -> int:
+    return int(time.time_ns() // 1_000_000)

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -31,7 +31,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, Mapping, Sequence
+from typing import Any, Literal, Mapping
 
 from local_operator.evaluation.adapters.api import (
     AskUserExchangeParams,
@@ -50,7 +50,6 @@ from local_operator.evaluation.adapters.api import (
 from local_operator.evaluation.adapters.supervisor import (
     AdapterSupervisor,
     HostVerifier,
-    SupervisionError,
     VerifiedAdapterSession,
     persist_rescue,
     run_rescue,
@@ -78,16 +77,12 @@ from local_operator.evaluation.evidence.models import (
     UserSimulatorExchangePayload,
     canonical_digest,
 )
-from local_operator.evaluation.evidence.store import (
-    EvidenceError,
-    EvidenceWriter,
-)
+from local_operator.evaluation.evidence.store import EvidenceError, EvidenceWriter
 from local_operator.evaluation.lifecycle import (
     CleanupAction,
     CleanupPlan,
     CleanupReceipt,
     EpisodeLifecycle,
-    ScoreReceipt,
     aggregate_cleanup,
     plan_episode,
 )
@@ -103,7 +98,6 @@ from local_operator.evaluation.receipts import (
     BudgetReservation,
     DependencyPlan,
     RedactionSet,
-    ResourceAmount,
     SealedPreflight,
     UnavailableUsage,
     Usage,
@@ -401,8 +395,6 @@ class EpisodeRunner:
             writer.close()
 
     async def _execute(self, handshake: Handshake) -> EpisodeOutcome:
-        writer = self._require_writer()
-        session = self._require_session()
         spec = self._spec
 
         lifecycle = plan_episode(
@@ -479,7 +471,6 @@ class EpisodeRunner:
         not yet in the bundle is an invalid bundle, not a race to be tolerated.
         """
 
-        writer = self._require_writer()
         artifacts = []
         for frame in observation.frames:
             data = _read_artifact(self._config.artifact_root, frame.artifact.sha256)
@@ -492,9 +483,7 @@ class EpisodeRunner:
             )
         text_artifact = None
         if observation.text:
-            text_artifact = self._publish(
-                observation.text.encode("utf-8"), media_type="text/plain"
-            )
+            text_artifact = self._publish(observation.text.encode("utf-8"), media_type="text/plain")
         self._append(
             "observation",
             ObservationPayload(
@@ -689,9 +678,7 @@ class EpisodeRunner:
             # An outstanding ask may not be left open, and there is no way to
             # withdraw one. Cancelling is the only coherent resolution.
             raise _Cancelled("ask-user was not answered")
-        finish = begin.model_copy(
-            update={"operation_id": f"ask-finish-{ask_id}", "answer": answer}
-        )
+        finish = begin.model_copy(update={"operation_id": f"ask-finish-{ask_id}", "answer": answer})
         result = await session.finish_ask(finish, timeout=self._config.step_timeout)
         request_artifact = self._publish(prompt.encode("utf-8"), media_type="text/plain")
         response_artifact = self._publish(answer.encode("utf-8"), media_type="text/plain")
@@ -721,7 +708,6 @@ class EpisodeRunner:
     # ------------------------------------------------------------------
 
     async def _finalize_scored(self, handshake: Handshake) -> EpisodeOutcome:
-        writer = self._require_writer()
         session = self._require_session()
         intent = FinalizationIntent(
             kind="score",
@@ -773,9 +759,7 @@ class EpisodeRunner:
         """
 
         provider_failure = isinstance(error, _ProviderFailure)
-        category: Literal["adapter", "provider"] = (
-            "provider" if provider_failure else "adapter"
-        )
+        category: Literal["adapter", "provider"] = "provider" if provider_failure else "adapter"
         self._append(
             "error",
             ErrorPayload(
@@ -880,9 +864,7 @@ class EpisodeRunner:
         # rescue_required for the same reason, and reporting "completed" here
         # would contradict the bundle's own cleanup_incomplete label.
         failed = failure_kind is not None or cleanup_result.rescue_required
-        status: EpisodeStatus = (
-            "cancelled" if cancelled else ("failed" if failed else "completed")
-        )
+        status: EpisodeStatus = "cancelled" if cancelled else ("failed" if failed else "completed")
         return EpisodeOutcome(
             status=status,
             episode_id=self._spec.episode_id,
@@ -922,7 +904,9 @@ class EpisodeRunner:
             "guest_actions": self._guest_actions,
             "user_simulator_turns": self._simulator_turns,
         }
-        unavailable = {"cloud_usd_micros", "instance_milliseconds"} if self._rescue_required else set()
+        unavailable: set[str] = (
+            {"cloud_usd_micros", "instance_milliseconds"} if self._rescue_required else set()
+        )
         usage: list[Usage] = []
         for resource, value in measured.items():
             if resource in unavailable:
@@ -964,9 +948,7 @@ class EpisodeRunner:
             # A dead worker cannot produce evidence, and "attempted" alone is
             # never evidence of cleanup, so these receipts aggregate as
             # incomplete and force rescue.
-            receipts = tuple(
-                _incomplete_receipt(plan, action.action_id) for action in plan.actions
-            )
+            receipts = tuple(_incomplete_receipt(plan, action.action_id) for action in plan.actions)
         return receipts, aggregate_cleanup(plan, receipts)
 
     async def _attempt_rescue(self) -> bool:
@@ -1287,9 +1269,9 @@ def _diagnostic_code(error: BaseException) -> str:
     is already handling a failure.
     """
 
-    raw = "".join(
-        char if char.isalnum() else "-" for char in type(error).__name__.lower()
-    ).strip("-")
+    raw = "".join(char if char.isalnum() else "-" for char in type(error).__name__.lower()).strip(
+        "-"
+    )
     return raw[:64] or "unknown-error"
 
 

--- a/local_operator/evaluation/runner/model.py
+++ b/local_operator/evaluation/runner/model.py
@@ -1,0 +1,79 @@
+"""The policy boundary an episode drives, independent of any provider.
+
+``EpisodeRunner`` needs exactly one capability from a model: turn the current
+observation and the transcript so far into an :class:`ActionBatch`. Expressing
+that as a Protocol rather than a concrete client is what keeps ``episode.py``
+free of provider, config, and session imports -- the import-isolation test in
+``tests/unit/evaluation/runner`` asserts that boundary, because an evaluation
+episode must be reproducible from pinned inputs and must not inherit a user's
+live session configuration.
+
+The concrete provider-backed implementation lives in ``provider_client.py``,
+which is the only runner module permitted to import ``local_operator.model``.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, Sequence, runtime_checkable
+
+from pydantic import Field
+
+from local_operator.evaluation.evidence.models import RouteIdentity
+from local_operator.evaluation.protocol import ActionBatch, Observation, ProtocolModel
+from local_operator.evaluation.receipts import SafeCount, StrictIdentifier
+
+
+class ModelUsage(ProtocolModel):
+    """Provider-reported token consumption for exactly one decision.
+
+    These counts feed both ``model_response`` and ``usage_cost`` evidence, and
+    the verifier recomputes the bundle's counters from the latter. They are
+    therefore authoritative provider numbers, never estimates: a provider that
+    cannot report a count must surface zero here and declare the resource
+    unavailable during reconciliation instead of guessing.
+    """
+
+    input_tokens: SafeCount = 0
+    output_tokens: SafeCount = 0
+    reasoning_tokens: SafeCount = 0
+    cache_read_tokens: SafeCount = 0
+    cache_write_tokens: SafeCount = 0
+
+
+class ModelDecision(ProtocolModel):
+    """One model turn: the batch to execute plus its billing provenance.
+
+    ``route`` is the route the provider actually served. The runner compares it
+    against the requested route when labelling comparability, so a client that
+    silently fell back must report the served route here rather than echoing
+    what was asked for.
+    """
+
+    action_batch: ActionBatch
+    route: RouteIdentity
+    usage: ModelUsage = Field(default_factory=ModelUsage)
+    cost_micros: SafeCount = 0
+    stop_reason: StrictIdentifier = "stop"
+    provider_request_id: StrictIdentifier = "unknown"
+    tool_call_count: SafeCount = 0
+
+
+@runtime_checkable
+class EpisodeModelClient(Protocol):
+    """Chooses the next action batch for an episode.
+
+    ``transcript`` carries every observation already seen, oldest first, so an
+    implementation can build whatever context window it needs without the
+    runner taking a position on prompt construction.
+
+    Raising is the contract for an unrecoverable provider failure: the runner
+    treats it as ``ErrorPayload(category="provider")`` and finalizes the
+    episode unscored on a still-live session. Internal retries therefore belong
+    inside the implementation, below this boundary.
+    """
+
+    async def decide(
+        self,
+        observation: Observation,
+        transcript: Sequence[Observation],
+    ) -> ModelDecision: ...

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any, Mapping, Sequence, get_args
+from typing import Any, Mapping, Sequence, get_args, get_origin
 
 from local_operator.evaluation.evidence.models import RouteIdentity
 from local_operator.evaluation.protocol import ActionBatch, ComputerAction, Observation
@@ -58,9 +58,22 @@ def _action_schema_lines() -> list[str]:
 
 
 def _type_name(annotation: Any) -> str:
+    """Name a field's JSON shape well enough for a model to emit it correctly.
+
+    Sequences must render as arrays rather than the generic placeholder: told
+    only "value", a model emits ``"ctrl+c"`` for ``KeyAction.keys`` where the
+    protocol requires ``["ctrl", "c"]``, and that is a hard parse failure with
+    no retry -- the same terminal-failure class B2 addressed, just narrower.
+    """
+
     name = getattr(annotation, "__name__", None)
     if name in ("int", "str", "bool", "float"):
         return name
+    origin = get_origin(annotation)
+    if origin in (tuple, list, set, frozenset):
+        args = [arg for arg in get_args(annotation) if arg is not Ellipsis]
+        inner = _type_name(args[0]) if args else "value"
+        return f"[{inner}, ...]"
     args = [arg for arg in get_args(annotation) if arg is not type(None)]
     if len(args) == 1:
         return _type_name(args[0])
@@ -87,11 +100,10 @@ Where a field lists alternatives separated by "|", you must use exactly one of
 those literal values.
 
 Two actions end your turn in a special way, and each must be the ONLY action in
-its batch:
+its batch. Their fields are listed above; what the list cannot tell you is what
+they MEAN:
 
-* "finish" -- you believe the task is done. The episode is then scored. Its
-  "status" must be one of done, failed, or infeasible, and a "reason" is
-  required.
+* "finish" -- you believe the task is done. The episode is then scored.
 * "ask_user" -- you need a human answer. THE EPISODE PAUSES: a person answers
   your question, and the next observation you see is the state after that
   answer was delivered. Do not ask a question you can resolve by acting.
@@ -287,9 +299,13 @@ def _provider_request_id(provider_payload: Any) -> str:
     raw = provider_payload.get("id")
     if not isinstance(raw, str) or not raw:
         return "unknown"
-    if not _IDENTIFIER.fullmatch(raw):
+    # An over-length id is NOT truncated: a shortened id is still a valid
+    # StrictIdentifier, so it would be recorded as provenance while matching
+    # nothing in the provider's records -- a silently wrong handle is worse than
+    # an honestly absent one, which is this function's whole philosophy.
+    if len(raw) > 128 or not _IDENTIFIER.fullmatch(raw):
         return "unknown"
-    return raw[:128]
+    return raw
 
 
 def _usage_from(usage: Any) -> tuple[ModelUsage, int]:

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -13,28 +13,88 @@ and the provider that produced them stay in the same module.
 from __future__ import annotations
 
 import json
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping, Sequence, get_args
 
 from local_operator.evaluation.evidence.models import RouteIdentity
-from local_operator.evaluation.protocol import ActionBatch, Observation
+from local_operator.evaluation.protocol import ActionBatch, ComputerAction, Observation
 from local_operator.evaluation.runner.model import ModelDecision, ModelUsage
 
-_SYSTEM_PROMPT = """You are operating a computer to complete one task.
+# The batch wire version this harness speaks; pinned here rather than taken
+# from a model reply.
+PROTOCOL_VERSION = "1.0"
 
-Reply with a single JSON object and nothing else:
 
-  {"actions": [ ... ]}
+def _action_schema_lines() -> list[str]:
+    """Describe every action kind by reading the protocol models themselves.
 
-Each action is one of the protocol's action objects and must carry the
-`observation_id` of the observation you are looking at right now.
+    A parse failure is TERMINAL for an episode -- there is no retry and no
+    repair -- so a prompt that under-specifies the wire shape is a correctness
+    defect, not prompt polish. Deriving the text from ``ComputerAction`` means a
+    new action kind or a changed literal cannot silently drift out of the
+    instructions the model is given.
+    """
 
-Two actions end your turn in a special way:
+    lines: list[str] = []
+    for action in get_args(get_args(ComputerAction)[0]):
+        fields: list[str] = []
+        for name, field in action.model_fields.items():
+            if name in ("kind", "observation_id"):
+                continue
+            choices = get_args(field.annotation)
+            if choices and all(isinstance(choice, str) for choice in choices):
+                rendered = "|".join(str(choice) for choice in choices)
+            else:
+                rendered = _type_name(field.annotation)
+            optional = "" if field.is_required() else " (optional)"
+            fields.append(f"{name}: {rendered}{optional}")
+        kind = action.model_fields["kind"].default
+        detail = ", ".join(fields) if fields else "no further fields"
+        lines.append(f'  {{"kind": "{kind}", "observation_id": "<id>", {detail}}}')
+    return lines
 
-* `finish` -- you believe the task is complete. The episode is scored.
-* `ask_user` -- you need a human answer. THE EPISODE PAUSES: a person answers
+
+def _type_name(annotation: Any) -> str:
+    name = getattr(annotation, "__name__", None)
+    if name in ("int", "str", "bool", "float"):
+        return name
+    args = [arg for arg in get_args(annotation) if arg is not type(None)]
+    if len(args) == 1:
+        return _type_name(args[0])
+    return "value"
+
+
+def build_system_prompt() -> str:
+    """Compose the episode system prompt around the live protocol schema."""
+
+    return f"""You are operating a computer to complete one task.
+
+Reply with a single JSON object and nothing else, with no prose and no code
+fence:
+
+  {{"actions": [ ... ]}}
+
+Every action is an object whose type is given by the key "kind" (NOT "type"),
+and every action must carry the "observation_id" of the observation you are
+looking at right now. These are the only permitted shapes:
+
+{chr(10).join(_action_schema_lines())}
+
+Where a field lists alternatives separated by "|", you must use exactly one of
+those literal values.
+
+Two actions end your turn in a special way, and each must be the ONLY action in
+its batch:
+
+* "finish" -- you believe the task is done. The episode is then scored. Its
+  "status" must be one of done, failed, or infeasible, and a "reason" is
+  required.
+* "ask_user" -- you need a human answer. THE EPISODE PAUSES: a person answers
   your question, and the next observation you see is the state after that
   answer was delivered. Do not ask a question you can resolve by acting.
 """
+
+
+_SYSTEM_PROMPT = build_system_prompt()
 
 
 class DecisionParseError(ValueError):
@@ -73,10 +133,12 @@ def parse_decision(
     try:
         batch = ActionBatch.model_validate(
             {
+                # The wire version is pinned by the harness, never by the model:
+                # a reply cannot select which protocol it is validated against.
+                "protocol_version": PROTOCOL_VERSION,
                 "task_id": observation.task_id,
                 "episode_id": observation.episode_id,
                 "observation_id": observation.observation_id,
-                "observation_sequence": observation.sequence,
                 "actions": actions,
             },
             strict=True,
@@ -143,21 +205,23 @@ class ProviderModelClient:
         )
         text = ""
         usage = ModelUsage()
+        cost_micros = 0
         stop_reason = "stop"
         async for event in self._stream_fn(request, None):
             if event.type == "text_delta":
                 text += event.delta
             elif event.type == "usage":
-                usage = _usage_from(event.usage)
+                usage, cost_micros = _usage_from(event.usage)
             elif event.type == "end":
                 stop_reason = event.stop_reason or "stop"
                 if event.usage is not None:
-                    usage = _usage_from(event.usage)
+                    usage, cost_micros = _usage_from(event.usage)
         return parse_decision(
             text.strip(),
             observation,
             route=self._route,
             usage=usage,
+            cost_micros=cost_micros,
             stop_reason=stop_reason,
         )
 
@@ -200,18 +264,28 @@ def _render(observation: Observation, transcript: Sequence[Observation]) -> str:
     return "\n".join(lines)
 
 
-def _usage_from(usage: Any) -> ModelUsage:
-    """Copy provider counts, clamped to the non-negative evidence range.
+def _usage_from(usage: Any) -> tuple[ModelUsage, int]:
+    """Copy provider counts and cost, clamped to the non-negative evidence range.
 
     ``reasoning_tokens`` is a SUBSET of ``output_tokens`` in the harness's
     accounting, and the evidence payloads treat it the same way, so it is
     carried across unchanged rather than added on top.
+
+    ``usd_cost`` is the provider's OWN billing figure, which the harness treats
+    as ground truth over any token-times-rate reconstruction. Dropping it made
+    every reconciliation report a free episode. An unreported cost stays 0 here
+    because the evidence payload has no "unknown" encoding -- the distinction
+    upstream between ``None`` and a real ``0.0`` cannot be represented, and
+    inventing a number would be worse than under-reporting one.
     """
 
-    return ModelUsage(
+    model_usage = ModelUsage(
         input_tokens=max(0, int(usage.input_tokens or 0)),
         output_tokens=max(0, int(usage.output_tokens or 0)),
         reasoning_tokens=max(0, int(usage.reasoning_tokens or 0)),
         cache_read_tokens=max(0, int(usage.cache_read_tokens or 0)),
         cache_write_tokens=max(0, int(usage.cache_write_tokens or 0)),
     )
+    cost = getattr(usage, "usd_cost", None)
+    cost_micros = 0 if cost is None else max(0, round(float(cost) * 1_000_000))
+    return model_usage, cost_micros

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -13,6 +13,7 @@ and the provider that produced them stay in the same module.
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, Mapping, Sequence, get_args
 
 from local_operator.evaluation.evidence.models import RouteIdentity
@@ -22,6 +23,9 @@ from local_operator.evaluation.runner.model import ModelDecision, ModelUsage
 # The batch wire version this harness speaks; pinned here rather than taken
 # from a model reply.
 PROTOCOL_VERSION = "1.0"
+
+# Mirrors receipts.StrictIdentifier, which every evidence identifier must match.
+_IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]*")
 
 
 def _action_schema_lines() -> list[str]:
@@ -207,6 +211,7 @@ class ProviderModelClient:
         usage = ModelUsage()
         cost_micros = 0
         stop_reason = "stop"
+        provider_request_id = "unknown"
         async for event in self._stream_fn(request, None):
             if event.type == "text_delta":
                 text += event.delta
@@ -216,6 +221,10 @@ class ProviderModelClient:
                 stop_reason = event.stop_reason or "stop"
                 if event.usage is not None:
                     usage, cost_micros = _usage_from(event.usage)
+                # The provider's own request id is the only handle that ties a
+                # bundle's model_response back to the provider's records, so it
+                # is worth carrying when the wire client reports one.
+                provider_request_id = _provider_request_id(event.provider_payload)
         return parse_decision(
             text.strip(),
             observation,
@@ -223,6 +232,7 @@ class ProviderModelClient:
             usage=usage,
             cost_micros=cost_micros,
             stop_reason=stop_reason,
+            provider_request_id=provider_request_id,
         )
 
 
@@ -262,6 +272,24 @@ def _render(observation: Observation, transcript: Sequence[Observation]) -> str:
         lines.append("")
         lines.append(f"You have seen {len(transcript)} observations so far.")
     return "\n".join(lines)
+
+
+def _provider_request_id(provider_payload: Any) -> str:
+    """Extract the provider's request id, falling back to a valid placeholder.
+
+    ``StrictIdentifier`` forbids most punctuation, so a provider id that does
+    not fit the pattern is dropped rather than allowed to fail validation on a
+    path that is only recording provenance.
+    """
+
+    if not isinstance(provider_payload, Mapping):
+        return "unknown"
+    raw = provider_payload.get("id")
+    if not isinstance(raw, str) or not raw:
+        return "unknown"
+    if not _IDENTIFIER.fullmatch(raw):
+        return "unknown"
+    return raw[:128]
 
 
 def _usage_from(usage: Any) -> tuple[ModelUsage, int]:

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -125,24 +125,34 @@ class ProviderModelClient:
         observation: Observation,
         transcript: Sequence[Observation],
     ) -> ModelDecision:
-        from local_operator.model.types import ChatRequest, Message
+        from local_operator.harness.types import ChatRequest, Message, TextContent
 
-        messages = [
-            Message(role="system", content=self._system_prompt),
-            Message(role="user", content=_render(observation, transcript)),
-        ]
-        request = ChatRequest(model=self._model_spec, messages=messages)
+        # The system prompt rides in ``system_blocks`` rather than as a message
+        # so the provider can place a cache breakpoint after this stable block;
+        # every episode step repeats it verbatim.
+        request = ChatRequest(
+            model=self._model_spec,
+            system_blocks=[self._system_prompt],
+            messages=[
+                Message(
+                    role="user",
+                    content=[TextContent(text=_render(observation, transcript))],
+                )
+            ],
+            tool_choice="none",
+        )
         text = ""
         usage = ModelUsage()
         stop_reason = "stop"
         async for event in self._stream_fn(request, None):
-            kind = getattr(event, "kind", None)
-            if kind == "text":
-                text += getattr(event, "text", "") or ""
-            elif kind == "usage":
-                usage = _usage_from(event)
-            elif kind == "done":
-                stop_reason = getattr(event, "stop_reason", None) or "stop"
+            if event.type == "text_delta":
+                text += event.delta
+            elif event.type == "usage":
+                usage = _usage_from(event.usage)
+            elif event.type == "end":
+                stop_reason = event.stop_reason or "stop"
+                if event.usage is not None:
+                    usage = _usage_from(event.usage)
         return parse_decision(
             text.strip(),
             observation,
@@ -190,11 +200,18 @@ def _render(observation: Observation, transcript: Sequence[Observation]) -> str:
     return "\n".join(lines)
 
 
-def _usage_from(event: Any) -> ModelUsage:
+def _usage_from(usage: Any) -> ModelUsage:
+    """Copy provider counts, clamped to the non-negative evidence range.
+
+    ``reasoning_tokens`` is a SUBSET of ``output_tokens`` in the harness's
+    accounting, and the evidence payloads treat it the same way, so it is
+    carried across unchanged rather than added on top.
+    """
+
     return ModelUsage(
-        input_tokens=max(0, int(getattr(event, "input_tokens", 0) or 0)),
-        output_tokens=max(0, int(getattr(event, "output_tokens", 0) or 0)),
-        reasoning_tokens=max(0, int(getattr(event, "reasoning_tokens", 0) or 0)),
-        cache_read_tokens=max(0, int(getattr(event, "cache_read_tokens", 0) or 0)),
-        cache_write_tokens=max(0, int(getattr(event, "cache_write_tokens", 0) or 0)),
+        input_tokens=max(0, int(usage.input_tokens or 0)),
+        output_tokens=max(0, int(usage.output_tokens or 0)),
+        reasoning_tokens=max(0, int(usage.reasoning_tokens or 0)),
+        cache_read_tokens=max(0, int(usage.cache_read_tokens or 0)),
+        cache_write_tokens=max(0, int(usage.cache_write_tokens or 0)),
     )

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -1,0 +1,200 @@
+"""The only runner module allowed to reach into ``local_operator.model``.
+
+``episode.py`` must stay free of provider, config, and session imports so an
+episode cannot inherit the operator's live configuration. That constraint has
+to break somewhere for a real run, and it breaks here, behind
+:class:`~local_operator.evaluation.runner.model.EpisodeModelClient`.
+
+Strict decision parsing also lives here rather than in the runner core. The
+runner treats a malformed decision as a provider failure, so the parsing rules
+and the provider that produced them stay in the same module.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Sequence
+
+from local_operator.evaluation.evidence.models import RouteIdentity
+from local_operator.evaluation.protocol import ActionBatch, Observation
+from local_operator.evaluation.runner.model import ModelDecision, ModelUsage
+
+_SYSTEM_PROMPT = """You are operating a computer to complete one task.
+
+Reply with a single JSON object and nothing else:
+
+  {"actions": [ ... ]}
+
+Each action is one of the protocol's action objects and must carry the
+`observation_id` of the observation you are looking at right now.
+
+Two actions end your turn in a special way:
+
+* `finish` -- you believe the task is complete. The episode is scored.
+* `ask_user` -- you need a human answer. THE EPISODE PAUSES: a person answers
+  your question, and the next observation you see is the state after that
+  answer was delivered. Do not ask a question you can resolve by acting.
+"""
+
+
+class DecisionParseError(ValueError):
+    """The provider returned something that is not a usable action batch."""
+
+
+def parse_decision(
+    payload: str,
+    observation: Observation,
+    *,
+    route: RouteIdentity,
+    usage: ModelUsage | None = None,
+    cost_micros: int = 0,
+    stop_reason: str = "stop",
+    provider_request_id: str = "unknown",
+    tool_call_count: int = 0,
+) -> ModelDecision:
+    """Parse one strict JSON decision and bind it to the current observation.
+
+    Strictness is deliberate: a batch whose actions name a different
+    observation is stale, and executing it would apply a decision made about a
+    screen the environment has already moved past. ``ActionBatch.validate_for``
+    rejects that at the adapter boundary, so the failure is surfaced here where
+    it can be attributed to the provider.
+    """
+
+    try:
+        decoded: Any = json.loads(payload)
+    except json.JSONDecodeError as error:
+        raise DecisionParseError(f"decision is not valid JSON: {error}") from error
+    if not isinstance(decoded, Mapping):
+        raise DecisionParseError("decision must be a JSON object")
+    actions = decoded.get("actions")
+    if not isinstance(actions, list) or not actions:
+        raise DecisionParseError("decision must carry a non-empty actions array")
+    try:
+        batch = ActionBatch.model_validate(
+            {
+                "task_id": observation.task_id,
+                "episode_id": observation.episode_id,
+                "observation_id": observation.observation_id,
+                "observation_sequence": observation.sequence,
+                "actions": actions,
+            },
+            strict=True,
+        )
+    except Exception as error:
+        raise DecisionParseError(f"decision is not a valid action batch: {error}") from error
+    try:
+        batch.validate_for(observation)
+    except Exception as error:
+        raise DecisionParseError(f"decision does not match this observation: {error}") from error
+    return ModelDecision(
+        action_batch=batch,
+        route=route,
+        usage=usage or ModelUsage(),
+        cost_micros=cost_micros,
+        stop_reason=stop_reason,
+        provider_request_id=provider_request_id,
+        tool_call_count=tool_call_count,
+    )
+
+
+class ProviderModelClient:
+    """Drives a real provider through the session stream function.
+
+    The stream function already owns credential resolution, model fallback and
+    retry, so a failure that reaches this class is terminal and is allowed to
+    propagate: the runner records it as a provider error and finalizes the
+    episode unscored on a still-live session.
+    """
+
+    def __init__(
+        self,
+        stream_fn: Any,
+        *,
+        route: RouteIdentity,
+        model_spec: Any,
+        system_prompt: str = _SYSTEM_PROMPT,
+    ) -> None:
+        self._stream_fn = stream_fn
+        self._route = route
+        self._model_spec = model_spec
+        self._system_prompt = system_prompt
+
+    async def decide(
+        self,
+        observation: Observation,
+        transcript: Sequence[Observation],
+    ) -> ModelDecision:
+        from local_operator.model.types import ChatRequest, Message
+
+        messages = [
+            Message(role="system", content=self._system_prompt),
+            Message(role="user", content=_render(observation, transcript)),
+        ]
+        request = ChatRequest(model=self._model_spec, messages=messages)
+        text = ""
+        usage = ModelUsage()
+        stop_reason = "stop"
+        async for event in self._stream_fn(request, None):
+            kind = getattr(event, "kind", None)
+            if kind == "text":
+                text += getattr(event, "text", "") or ""
+            elif kind == "usage":
+                usage = _usage_from(event)
+            elif kind == "done":
+                stop_reason = getattr(event, "stop_reason", None) or "stop"
+        return parse_decision(
+            text.strip(),
+            observation,
+            route=self._route,
+            usage=usage,
+            stop_reason=stop_reason,
+        )
+
+
+def create_provider_model_client(
+    *,
+    auth_store: Any,
+    settings: Mapping[str, Any] | None,
+    route: RouteIdentity,
+    model_spec: Any,
+    session_id: str | None = None,
+) -> ProviderModelClient:
+    """Build a provider-backed client from the harness's own stream function.
+
+    Importing ``configure`` here rather than at module scope keeps the cost off
+    anyone who only imports the runner contracts, and keeps the evaluation
+    package's import-inertness property intact.
+    """
+
+    from local_operator.model.configure import create_stream_fn
+
+    return ProviderModelClient(
+        create_stream_fn(auth_store, settings, session_id=session_id),
+        route=route,
+        model_spec=model_spec,
+    )
+
+
+def _render(observation: Observation, transcript: Sequence[Observation]) -> str:
+    lines = [
+        f"Task: {observation.task_id}",
+        f"Step: {observation.sequence}",
+        f"Observation ID: {observation.observation_id}",
+        "",
+        observation.text or "(no textual state)",
+    ]
+    if len(transcript) > 1:
+        lines.append("")
+        lines.append(f"You have seen {len(transcript)} observations so far.")
+    return "\n".join(lines)
+
+
+def _usage_from(event: Any) -> ModelUsage:
+    return ModelUsage(
+        input_tokens=max(0, int(getattr(event, "input_tokens", 0) or 0)),
+        output_tokens=max(0, int(getattr(event, "output_tokens", 0) or 0)),
+        reasoning_tokens=max(0, int(getattr(event, "reasoning_tokens", 0) or 0)),
+        cache_read_tokens=max(0, int(getattr(event, "cache_read_tokens", 0) or 0)),
+        cache_write_tokens=max(0, int(getattr(event, "cache_write_tokens", 0) or 0)),
+    )

--- a/local_operator/evaluation/runner/responder.py
+++ b/local_operator/evaluation/runner/responder.py
@@ -1,0 +1,44 @@
+"""Who answers when a model asks the user a question mid-episode.
+
+Benchmarks that model a human collaborator let the policy emit an
+``AskUserAction``. The environment cannot answer it, so the runner suspends the
+step loop and asks a responder. Keeping that behind a Protocol means an
+unattended benchmark run, a scripted user simulator, and an interactive
+operator session all drive the same episode code.
+
+``ask`` returns ``None`` to abandon: the question cannot be answered within the
+deadline. The runner treats that as a harness-sourced cancellation rather than
+an error, because an unanswered ask leaves an outstanding exchange open in
+``HostVerifier``, and an episode may not proceed past an ask it never resolved.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class UserResponder(Protocol):
+    """Answers one ask-user prompt raised during an episode.
+
+    ``deadline_ms`` is the budget for this single answer, not for the episode.
+    An implementation that cannot answer inside it must return ``None`` rather
+    than block: the runner is holding an outstanding adapter exchange open for
+    the duration of this call.
+    """
+
+    async def ask(self, prompt: str, deadline_ms: int) -> str | None: ...
+
+
+class NullUserResponder:
+    """Refuses every question immediately.
+
+    This is the default because an unattended evaluation run has nobody to ask,
+    and blocking would stall a batch indefinitely. Refusing immediately turns an
+    ask into a deterministic, promptly-cancelled episode instead of a hang, and
+    the resulting bundle records exactly why it ended.
+    """
+
+    async def ask(self, prompt: str, deadline_ms: int) -> str | None:
+        del prompt, deadline_ms
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.21"
+version = "0.44.22"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -344,6 +344,10 @@ markers = [
     # Applied by LOCATION in tests/e2e/conftest.py, so a module in that package
     # cannot forget it and silently rejoin the unit run.
     "e2e: headless end-to-end tests that drive the assembled TUI application",
+    # Kept IN the default run: these spawn real worker processes and are the
+    # only coverage of the actual subprocess boundary, so they are marked for
+    # selection rather than exclusion.
+    "slow: tests that spawn real subprocesses and take seconds rather than ms",
 ]
 
 # Coverage is measured through pytest-cov (`--cov`), which understands xdist

--- a/tests/unit/evaluation/runner/__init__.py
+++ b/tests/unit/evaluation/runner/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the episode runner."""

--- a/tests/unit/evaluation/runner/conftest.py
+++ b/tests/unit/evaluation/runner/conftest.py
@@ -1,0 +1,390 @@
+"""Shared fixtures for episode-runner tests.
+
+The in-process fake supervisor follows ``test_supervisor.py``'s ``RawSupervisor``
+pattern: it speaks the adapter protocol at the ``_call_raw`` seam, so every
+test drives the REAL ``VerifiedAdapterSession``, the REAL lifecycle
+authorities, and a REAL ``EvidenceWriter`` on ``tmp_path``. Only the subprocess
+boundary is faked, because that is the one thing a unit test cannot afford per
+case; everything the runner is responsible for stays under test.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import uuid
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+import pytest
+
+from local_operator.evaluation.adapters.api import (
+    AckResult,
+    AdapterCapabilities,
+    AdapterMetadata,
+    AdapterSelector,
+    AskUserExchangeResult,
+    CleanupOutcome,
+    CleanupResult,
+    ExecuteResult,
+    ExecutionReceipt,
+    Handshake,
+    ObservationResult,
+    PrepareResult,
+    PythonRuntime,
+    RequirementsResult,
+    ScoreResult,
+    observation_content_id,
+)
+from local_operator.evaluation.evidence.models import RouteIdentity, ScoreArtifact
+from local_operator.evaluation.lifecycle import CleanupAction, CleanupPlan
+from local_operator.evaluation.protocol import ActionBatch, Observation
+from local_operator.evaluation.receipts import (
+    BUDGET_RESOURCES,
+    BudgetAuthorization,
+    CappedAllowance,
+    ComputeRequirement,
+    DependencyPlan,
+    RedactionSet,
+    ResourceAmount,
+    reserve_budget,
+    record_preflight,
+    seal_preflight,
+)
+from local_operator.evaluation.runner.episode import EpisodeConfig, EpisodeSpec
+from local_operator.evaluation.runner.model import ModelDecision, ModelUsage
+
+DIGEST = "0123456789abcdef" * 4
+OTHER_DIGEST = "abcdef0123456789" * 4
+ROUTE = RouteIdentity(provider_id="provider", route_id="route", model_id="model")
+TASK_ID = "task-1"
+
+
+def selector(tmp_path: Path) -> AdapterSelector:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    return AdapterSelector(
+        schema_version="1.0",
+        adapter_id="tiny",
+        distribution="tiny-adapter",
+        version="1.0",
+        entry_point="tiny_adapter:create",
+        package_digest="a" * 64,
+        release_digest="b" * 64,
+        python_executable=str(Path(sys.executable).resolve()),
+        workspace=str(workspace),
+        workspace_digest="c" * 64,
+        route_capability="computer",
+    )
+
+
+def handshake(tmp_path: Path) -> Handshake:
+    return Handshake(
+        selector=selector(tmp_path),
+        metadata=AdapterMetadata(
+            adapter_id="tiny",
+            distribution="tiny-adapter",
+            version="1.0",
+            entry_point="tiny_adapter:create",
+            package_digest="a" * 64,
+            release_digest="b" * 64,
+            schema_version="1.0",
+            capabilities=AdapterCapabilities(routes=("computer",), ask_user=True, scoring=True),
+        ),
+        python=PythonRuntime.current(),
+        workspace_digest="c" * 64,
+        selected_route="computer",
+    )
+
+
+def observation(episode_id: str, sequence: int, *, text: str = "state") -> Observation:
+    provisional = Observation(
+        task_id=TASK_ID,
+        episode_id=episode_id,
+        sequence=sequence,
+        observation_id="provisional",
+        text=f"{text}-{sequence}",
+    )
+    return provisional.model_copy(update={"observation_id": observation_content_id(provisional)})
+
+
+def cleanup_plan(episode_id: str) -> CleanupPlan:
+    return CleanupPlan(
+        episode_id=episode_id,
+        actions=(
+            CleanupAction(
+                action_id="release",
+                kind="release_instance",
+                resource_ref="resource",
+                timeout_ms=1000,
+                max_attempts=2,
+            ),
+        ),
+    )
+
+
+def build_spec(episode_id: str) -> EpisodeSpec:
+    plan = DependencyPlan(
+        release_id="release-1",
+        task_id=TASK_ID,
+        attempt_id=episode_id,
+        requirements=(
+            ComputeRequirement(
+                requirement_id="compute",
+                necessity="required",
+                reportability="optional",
+                cpu_class="standard",
+                memory_class="small",
+                disk_bytes=10_000,
+            ),
+        ),
+    )
+    receipts = (record_preflight(plan, "compute", status="pass", duration_ms=1),)
+    redactions = RedactionSet.from_resolved_values(())
+    preflight = seal_preflight(plan, receipts, redactions)
+    budget = BudgetAuthorization(
+        episode_id=episode_id,
+        allowances=tuple(
+            CappedAllowance(resource=resource, value=1_000_000, reporting="optional")
+            for resource in BUDGET_RESOURCES
+        ),
+    )
+    reservation = reserve_budget(
+        budget,
+        "episode",
+        [ResourceAmount(resource=resource, value=1) for resource in BUDGET_RESOURCES],
+    )
+    return EpisodeSpec(
+        episode_id=episode_id,
+        task_id=TASK_ID,
+        task_digest=DIGEST,
+        input_digest=OTHER_DIGEST,
+        benchmark_id="benchmark",
+        benchmark_release="release-1",
+        environment_digest=DIGEST,
+        environment_release="env-1",
+        config_digest=OTHER_DIGEST,
+        harness_version="0.0.0",
+        harness_git_revision=DIGEST,
+        requested_route=ROUTE,
+        dependency_plan=plan,
+        budget=budget,
+        preflight=preflight,
+        reservations=(reservation,),
+    )
+
+
+def build_config(tmp_path: Path, **overrides: Any) -> EpisodeConfig:
+    evidence = tmp_path / "evidence"
+    artifacts = tmp_path / "artifacts"
+    rescue = tmp_path / "rescue"
+    for path in (evidence, artifacts, rescue):
+        path.mkdir(parents=True, exist_ok=True)
+    defaults: dict[str, Any] = {
+        "evidence_root": evidence,
+        "artifact_root": artifacts,
+        "rescue_root": rescue,
+        "max_steps": 4,
+        "prepare_timeout": 5.0,
+        "reset_timeout": 5.0,
+        "step_timeout": 5.0,
+        "score_timeout": 5.0,
+        "cleanup_timeout": 5.0,
+        "ask_deadline_ms": 1000,
+        "handshake_timeout": 5.0,
+    }
+    defaults.update(overrides)
+    return EpisodeConfig(**defaults)
+
+
+class FakeAdapter:
+    """An in-process adapter that answers the protocol exactly as a worker does.
+
+    Failure injection is per method and per call index so a test can name the
+    precise cutpoint it cares about ("die on the second execute") without
+    reimplementing the protocol for each scenario.
+    """
+
+    def __init__(
+        self,
+        tmp_path: Path,
+        episode_id: str,
+        *,
+        score: ScoreArtifact | None = None,
+        cleanup_status: str = "succeeded",
+        failures: dict[str, BaseException] | None = None,
+        fail_after: dict[str, int] | None = None,
+    ) -> None:
+        self.tmp_path = tmp_path
+        self.episode_id = episode_id
+        self.score = score or ScoreArtifact(status="scored", binary=1)
+        self.cleanup_status = cleanup_status
+        self.failures = failures or {}
+        self.fail_after = fail_after or {}
+        self.calls: list[str] = []
+        self.terminated = False
+        self.sequence = 0
+        self.current = observation(episode_id, 0)
+        self._counts: dict[str, int] = {}
+
+    async def handshake(self, *, timeout: float = 10.0) -> Handshake:
+        del timeout
+        self.calls.append("handshake")
+        self._maybe_fail("handshake")
+        return handshake(self.tmp_path)
+
+    async def terminate(self) -> None:
+        self.terminated = True
+
+    def _maybe_fail(self, method: str) -> None:
+        count = self._counts.get(method, 0)
+        self._counts[method] = count + 1
+        error = self.failures.get(method)
+        if error is None:
+            return
+        if count >= self.fail_after.get(method, 0):
+            raise error
+
+    async def _call_raw(
+        self, method: Any, params: Any, result_type: Any, *, timeout: float
+    ) -> Any:
+        del result_type, timeout
+        self.calls.append(method)
+        self._maybe_fail(method)
+        if method == "inspect_requirements":
+            return RequirementsResult(requirements=())
+        if method == "prepare":
+            return PrepareResult(cleanup_plan=cleanup_plan(self.episode_id))
+        if method == "reset_start":
+            return AckResult()
+        if method == "observe":
+            return ObservationResult(observation=self.current)
+        if method == "execute":
+            self.sequence += 1
+            output = observation(self.episode_id, self.sequence)
+            receipt = ExecutionReceipt(
+                operation_id=params.operation_id,
+                action_batch_id=params.action_batch_id,
+                input_observation_id=self.current.observation_id,
+                output_observation_id=output.observation_id,
+                sequence=output.sequence,
+            )
+            self.current = output
+            return ExecuteResult(observation=output, receipt=receipt)
+        if method == "ask_user_exchange":
+            return AskUserExchangeResult(ask_id=params.ask_id, accepted=True)
+        if method == "score":
+            return ScoreResult(score=self.score)
+        if method == "cleanup":
+            return CleanupResult(
+                outcomes=tuple(
+                    CleanupOutcome(
+                        action_id=action_id,
+                        status=self.cleanup_status,  # pyright: ignore[reportArgumentType]
+                        evidence_code="released",
+                        duration_ms=1,
+                    )
+                    for action_id in params.action_ids
+                )
+            )
+        if method in ("close", "begin_rescue"):
+            return AckResult()
+        raise AssertionError(f"unexpected adapter method {method}")
+
+
+class ScriptedModel:
+    """Emits a fixed sequence of decisions, then finishes."""
+
+    def __init__(self, script: Sequence[str] | None = None, *, error: BaseException | None = None):
+        self.script = list(script or ["finish"])
+        self.error = error
+        self.calls = 0
+
+    async def decide(
+        self, observation_in: Observation, transcript: Sequence[Observation]
+    ) -> ModelDecision:
+        del transcript
+        if self.error is not None:
+            raise self.error
+        kind = self.script[self.calls] if self.calls < len(self.script) else "finish"
+        self.calls += 1
+        return ModelDecision(
+            action_batch=_batch(observation_in, kind),
+            route=ROUTE,
+            usage=ModelUsage(input_tokens=10, output_tokens=5),
+            cost_micros=7,
+        )
+
+
+def _batch(current: Observation, kind: str) -> ActionBatch:
+    if kind == "finish":
+        actions: list[dict[str, Any]] = [
+            {
+                "kind": "finish",
+                "observation_id": current.observation_id,
+                "status": "done",
+                "reason": "task complete",
+            }
+        ]
+    elif kind == "ask":
+        actions = [
+            {
+                "kind": "ask_user",
+                "observation_id": current.observation_id,
+                "request_id": f"ask-{uuid.uuid4().hex[:8]}",
+                "question": "What next?",
+            }
+        ]
+    else:
+        actions = [
+            {
+                "kind": "wait",
+                "observation_id": current.observation_id,
+                "duration_ms": 1,
+            }
+        ]
+    return ActionBatch.model_validate(
+        {
+            "protocol_version": "1.0",
+            "task_id": current.task_id,
+            "episode_id": current.episode_id,
+            "observation_id": current.observation_id,
+            "actions": actions,
+        },
+        strict=True,
+    )
+
+
+class RecordingResponder:
+    def __init__(self, answer: str | None) -> None:
+        self.answer = answer
+        self.prompts: list[str] = []
+
+    async def ask(self, prompt: str, deadline_ms: int) -> str | None:
+        del deadline_ms
+        self.prompts.append(prompt)
+        return self.answer
+
+
+@pytest.fixture
+def episode_id() -> str:
+    # Lineage is process-global per episode ID, so every test needs its own.
+    return f"ep-{uuid.uuid4().hex[:12]}"
+
+
+@pytest.fixture
+def fake_rescue() -> Callable[..., Any]:
+    async def _rescue(descriptor: Any, **kwargs: Any) -> Any:
+        del kwargs
+
+        class _Aggregate:
+            complete = True
+            descriptor_id = descriptor.descriptor_id
+
+        return _Aggregate()
+
+    return _rescue
+
+
+def artifact_digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()

--- a/tests/unit/evaluation/runner/conftest.py
+++ b/tests/unit/evaluation/runner/conftest.py
@@ -299,6 +299,9 @@ class ScriptedModel:
         self.script = list(script or ["finish"])
         self.error = error
         self.calls = 0
+        # Overridable so a test can simulate a provider serving a route other
+        # than the pinned one.
+        self.route = ROUTE
 
     async def decide(
         self, observation: Observation, transcript: Sequence[Observation]
@@ -310,7 +313,7 @@ class ScriptedModel:
         self.calls += 1
         return ModelDecision(
             action_batch=_batch(observation, kind),
-            route=ROUTE,
+            route=self.route,
             usage=ModelUsage(input_tokens=10, output_tokens=5),
             cost_micros=7,
         )

--- a/tests/unit/evaluation/runner/conftest.py
+++ b/tests/unit/evaluation/runner/conftest.py
@@ -14,7 +14,7 @@ import hashlib
 import sys
 import uuid
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Sequence, TypeVar
 
 import pytest
 
@@ -47,12 +47,14 @@ from local_operator.evaluation.receipts import (
     DependencyPlan,
     RedactionSet,
     ResourceAmount,
-    reserve_budget,
     record_preflight,
+    reserve_budget,
     seal_preflight,
 )
 from local_operator.evaluation.runner.episode import EpisodeConfig, EpisodeSpec
 from local_operator.evaluation.runner.model import ModelDecision, ModelUsage
+
+_P = TypeVar("_P")
 
 DIGEST = "0123456789abcdef" * 4
 OTHER_DIGEST = "abcdef0123456789" * 4
@@ -245,9 +247,7 @@ class FakeAdapter:
         if count >= self.fail_after.get(method, 0):
             raise error
 
-    async def _call_raw(
-        self, method: Any, params: Any, result_type: Any, *, timeout: float
-    ) -> Any:
+    async def _call_raw(self, method: Any, params: Any, result_type: Any, *, timeout: float) -> Any:
         del result_type, timeout
         self.calls.append(method)
         self._maybe_fail(method)
@@ -301,7 +301,7 @@ class ScriptedModel:
         self.calls = 0
 
     async def decide(
-        self, observation_in: Observation, transcript: Sequence[Observation]
+        self, observation: Observation, transcript: Sequence[Observation]
     ) -> ModelDecision:
         del transcript
         if self.error is not None:
@@ -309,7 +309,7 @@ class ScriptedModel:
         kind = self.script[self.calls] if self.calls < len(self.script) else "finish"
         self.calls += 1
         return ModelDecision(
-            action_batch=_batch(observation_in, kind),
+            action_batch=_batch(observation, kind),
             route=ROUTE,
             usage=ModelUsage(input_tokens=10, output_tokens=5),
             cost_micros=7,
@@ -388,3 +388,21 @@ def fake_rescue() -> Callable[..., Any]:
 
 def artifact_digest(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
+
+
+def payloads(root: Path, payload_type: type[_P]) -> list[_P]:
+    """Return every event payload of one concrete type from a bundle.
+
+    ``EventRecord.payload`` is a wide union, so reading a field off it directly
+    neither type-checks nor asserts what the test means. Selecting by type does
+    both, and keeps a renamed payload field a compile-time failure rather than
+    an ``AttributeError`` at run time.
+    """
+
+    from local_operator.evaluation.evidence.verify import verify_bundle
+
+    return [
+        event.payload
+        for event in verify_bundle(root).events
+        if isinstance(event.payload, payload_type)
+    ]

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -454,3 +454,43 @@ async def test_scored_zero_is_distinct_from_unscored(tmp_path: Path, episode_id:
     root = outcome.bundle_root
     assert root is not None
     assert verify_bundle(root).valid
+
+
+@pytest.mark.asyncio
+async def test_route_change_is_not_sealed_as_comparable(tmp_path: Path, episode_id: str) -> None:
+    """A silent provider fallback is exactly what comparability exists to catch."""
+
+    from local_operator.evaluation.evidence.models import RouteIdentity
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    model = ScriptedModel(["finish"])
+    model.route = RouteIdentity(
+        provider_id="other-provider", route_id="other-route", model_id="other-model"
+    )
+    runner = _runner(tmp_path, episode_id, adapter=adapter, model=model)
+
+    outcome = await runner.run()
+
+    assert outcome.status == "completed"
+    assert outcome.comparability_label == "route_changed"
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid
+    assert report.outcome is not None
+    assert report.outcome.comparable is False
+
+
+@pytest.mark.asyncio
+async def test_pinned_route_stays_comparable(tmp_path: Path, episode_id: str) -> None:
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = _runner(tmp_path, episode_id, adapter=adapter, model=ScriptedModel())
+
+    outcome = await runner.run()
+
+    assert outcome.comparability_label == "comparable"
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.outcome is not None
+    assert report.outcome.comparable is True

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -1,0 +1,481 @@
+"""Event mapping and terminal coherence for one episode.
+
+Every test here drives the REAL ``VerifiedAdapterSession``, the REAL lifecycle
+authorities and a REAL ``EvidenceWriter``; only the subprocess boundary is
+faked. The standing assertion is that each terminal path leaves a bundle the
+independent verifier accepts, because a runner that writes evidence no verifier
+will take is indistinguishable from one that writes none.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.evaluation.adapters.supervisor import SupervisionError
+from local_operator.evaluation.evidence.models import ScoreArtifact
+from local_operator.evaluation.evidence.verify import verify_bundle
+from local_operator.evaluation.runner.episode import EpisodeRunner
+from tests.unit.evaluation.runner.conftest import (
+    FakeAdapter,
+    RecordingResponder,
+    ScriptedModel,
+    build_config,
+    build_spec,
+    selector,
+)
+
+
+async def _rescue_ok(descriptor: Any, **kwargs: Any) -> Any:
+    del kwargs
+
+    class _Aggregate:
+        complete = True
+        descriptor_id = descriptor.descriptor_id
+
+    return _Aggregate()
+
+
+def _runner(
+    tmp_path: Path,
+    episode_id: str,
+    *,
+    adapter: FakeAdapter,
+    model: ScriptedModel,
+    responder: Any = None,
+    max_steps: int = 4,
+) -> EpisodeRunner:
+    return EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path, max_steps=max_steps),
+        selector=selector(tmp_path),
+        model=model,
+        responder=responder,
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+
+
+def _kinds(root: Path) -> list[str]:
+    return [event.kind for event in verify_bundle(root).events]
+
+
+@pytest.mark.asyncio
+async def test_happy_episode_writes_every_event_in_protocol_order(
+    tmp_path: Path, episode_id: str
+) -> None:
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = _runner(
+        tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "finish"])
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "completed"
+    assert outcome.reportability_label == "reportable"
+    assert outcome.score is not None and outcome.score.status == "scored"
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+    assert _kinds(root) == [
+        # Preflight is event #0 and the commitment precedes all execution.
+        "preflight",
+        "budget_commitment",
+        "lifecycle_transition",
+        "observation",
+        "model_request",
+        "model_response",
+        "usage_cost",
+        "action_batch",
+        "environment_step",
+        "observation",
+        "model_request",
+        "model_response",
+        "usage_cost",
+        "action_batch",
+        "finalization_start",
+        "scoring_start",
+        "scoring_result",
+        "reconciliation",
+        "cleanup",
+        "lifecycle_transition",
+    ]
+    assert adapter.calls[:5] == [
+        "handshake",
+        "inspect_requirements",
+        "prepare",
+        "reset_start",
+        "observe",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_step_event_precedes_its_output_observation(
+    tmp_path: Path, episode_id: str
+) -> None:
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = _runner(
+        tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "finish"])
+    )
+
+    outcome = await runner.run()
+
+    root = outcome.bundle_root
+    assert root is not None
+    kinds = _kinds(root)
+    step = kinds.index("environment_step")
+    # The observation an execution produced must follow the step that declared
+    # it; reversing them leaves the observation unbound to any receipt.
+    assert kinds[step + 1] == "observation"
+
+
+@pytest.mark.asyncio
+async def test_mid_episode_observe_writes_no_duplicate_observation(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """``observe`` is a snapshot check, and a snapshot is not new evidence."""
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = _runner(
+        tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "finish"])
+    )
+
+    outcome = await runner.run()
+
+    root = outcome.bundle_root
+    assert root is not None
+    observations = [
+        event.payload.sequence
+        for event in verify_bundle(root).events
+        if event.kind == "observation"
+    ]
+    # One initial plus exactly one per executed step, with no repeats.
+    assert observations == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_truncation_scores_normally_and_marks_the_last_step(
+    tmp_path: Path, episode_id: str
+) -> None:
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = _runner(
+        tmp_path,
+        episode_id,
+        adapter=adapter,
+        model=ScriptedModel(["step"] * 6),
+        max_steps=2,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "completed"
+    assert outcome.score is not None and outcome.score.status == "scored"
+    root = outcome.bundle_root
+    assert root is not None
+    assert verify_bundle(root).valid
+    steps = [
+        event.payload
+        for event in verify_bundle(root).events
+        if event.kind == "environment_step"
+    ]
+    assert len(steps) == 2
+    assert [step.truncated for step in steps] == [False, True]
+
+
+@pytest.mark.asyncio
+async def test_ask_user_exchange_precedes_the_executed_ask_batch(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """Verify's one-batch-per-observation rule forces this choreography."""
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    responder = RecordingResponder("do the thing")
+    runner = _runner(
+        tmp_path,
+        episode_id,
+        adapter=adapter,
+        model=ScriptedModel(["ask", "finish"]),
+        responder=responder,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "completed"
+    assert responder.prompts == ["What next?"]
+    root = outcome.bundle_root
+    assert root is not None
+    assert verify_bundle(root).valid
+    kinds = _kinds(root)
+    exchange = kinds.index("user_simulator_exchange")
+    assert kinds[exchange + 1] == "action_batch"
+    assert kinds[exchange + 2] == "environment_step"
+    assert "ask_user_exchange" in adapter.calls
+
+
+@pytest.mark.asyncio
+async def test_unanswered_ask_cancels_rather_than_leaving_it_open(
+    tmp_path: Path, episode_id: str
+) -> None:
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = _runner(
+        tmp_path,
+        episode_id,
+        adapter=adapter,
+        model=ScriptedModel(["ask", "finish"]),
+        responder=RecordingResponder(None),
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "cancelled"
+    assert outcome.reportability_label == "cancelled"
+    root = outcome.bundle_root
+    assert root is not None
+    assert verify_bundle(root).valid
+    assert "cancel" in _kinds(root)
+    assert outcome.score is not None and outcome.score.reason == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_provider_failure_finalizes_unscored_on_a_live_session(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """A provider error is not the environment's fault: no rescue, normal cleanup."""
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = _runner(
+        tmp_path,
+        episode_id,
+        adapter=adapter,
+        model=ScriptedModel(error=RuntimeError("provider exhausted retries")),
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "failed"
+    assert outcome.rescue_required is False
+    assert outcome.score is not None
+    assert outcome.score.reason == "infrastructure_failure"
+    root = outcome.bundle_root
+    assert root is not None
+    assert verify_bundle(root).valid
+    errors = [
+        event.payload for event in verify_bundle(root).events if event.kind == "error"
+    ]
+    assert [error.category for error in errors] == ["provider"]
+    # Cleanup ran on the live session rather than being minted as incomplete.
+    assert "cleanup" in adapter.calls
+
+
+@pytest.mark.asyncio
+async def test_adapter_crash_poisons_runs_rescue_and_still_seals(
+    tmp_path: Path, episode_id: str
+) -> None:
+    adapter = FakeAdapter(
+        tmp_path, episode_id, failures={"execute": SupervisionError("worker died")}
+    )
+    runner = _runner(
+        tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "finish"])
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "failed"
+    assert outcome.rescue_required is True
+    assert outcome.rescue_complete is True
+    assert outcome.reportability_label == "cleanup_incomplete"
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+    errors = [event.payload for event in report.events if event.kind == "error"]
+    assert [error.category for error in errors] == ["adapter"]
+    assert adapter.terminated
+
+
+@pytest.mark.asyncio
+async def test_crash_before_any_step_still_reaches_a_terminal(
+    tmp_path: Path, episode_id: str
+) -> None:
+    adapter = FakeAdapter(
+        tmp_path, episode_id, failures={"reset_start": SupervisionError("reset died")}
+    )
+    runner = _runner(tmp_path, episode_id, adapter=adapter, model=ScriptedModel())
+
+    outcome = await runner.run()
+
+    assert outcome.status == "failed"
+    root = outcome.bundle_root
+    assert root is not None
+    assert verify_bundle(root).valid
+    assert outcome.score is not None and outcome.score.reason == "crash"
+
+
+@pytest.mark.asyncio
+async def test_scorer_failure_can_only_abandon_as_ambiguous(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """scoring_start is durable, so a scored intent cannot seal unscored."""
+
+    adapter = FakeAdapter(
+        tmp_path, episode_id, failures={"score": SupervisionError("scorer died")}
+    )
+    runner = _runner(tmp_path, episode_id, adapter=adapter, model=ScriptedModel())
+
+    outcome = await runner.run()
+
+    assert outcome.status == "abandoned"
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.abandonment is not None
+    assert report.abandonment.reason == "ambiguous_finalization"
+    # Rescue runs before abandonment: cloud safety must not wait on a writer.
+    assert outcome.rescue_complete is True
+
+
+@pytest.mark.asyncio
+async def test_incomplete_cleanup_labels_the_run_and_requires_rescue(
+    tmp_path: Path, episode_id: str
+) -> None:
+    adapter = FakeAdapter(tmp_path, episode_id, cleanup_status="failed")
+    runner = _runner(tmp_path, episode_id, adapter=adapter, model=ScriptedModel())
+
+    outcome = await runner.run()
+
+    # The task scored, but a leaked resource still makes the episode failed.
+    assert outcome.status == "failed"
+    assert outcome.rescue_required is True
+    assert outcome.reportability_label == "cleanup_incomplete"
+    root = outcome.bundle_root
+    assert root is not None
+    assert verify_bundle(root).valid
+    cleanups = [
+        event.payload for event in verify_bundle(root).events if event.kind == "cleanup"
+    ]
+    assert [cleanup.rescue_required for cleanup in cleanups] == [True]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_incomplete_outranks_unscored_in_the_label(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """Label precedence: cleanup_incomplete > budget_unreconciled > unscored."""
+
+    adapter = FakeAdapter(
+        tmp_path,
+        episode_id,
+        cleanup_status="failed",
+        failures={"execute": SupervisionError("worker died")},
+    )
+    runner = _runner(
+        tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "finish"])
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.score is not None and outcome.score.status == "unscored"
+    assert outcome.reportability_label == "cleanup_incomplete"
+
+
+@pytest.mark.asyncio
+async def test_unscored_score_artifact_is_never_a_zero_binary(
+    tmp_path: Path, episode_id: str
+) -> None:
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = _runner(
+        tmp_path,
+        episode_id,
+        adapter=adapter,
+        model=ScriptedModel(error=RuntimeError("down")),
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.score is not None
+    assert outcome.score.status == "unscored"
+    assert outcome.score.binary is None
+
+
+@pytest.mark.asyncio
+async def test_failure_before_prepare_has_no_bundle_to_write(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """The manifest needs the cleanup plan prepare returns, so none exists yet."""
+
+    adapter = FakeAdapter(
+        tmp_path, episode_id, failures={"prepare": SupervisionError("prepare died")}
+    )
+    runner = _runner(tmp_path, episode_id, adapter=adapter, model=ScriptedModel())
+
+    outcome = await runner.run()
+
+    assert outcome.status == "failed_pre_bundle"
+    assert outcome.bundle_root is None
+    assert adapter.terminated
+
+
+@pytest.mark.asyncio
+async def test_rescue_descriptor_is_persisted_before_prepare_and_updated_after(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """Stage 1 unblocks prepare; stage 2 lands the real plan before reset_start."""
+
+    from local_operator.evaluation.adapters.supervisor import load_pending_rescue
+
+    seen: list[tuple[str, tuple[str, ...]]] = []
+    adapter = FakeAdapter(tmp_path, episode_id)
+    config = build_config(tmp_path)
+    original = adapter._call_raw
+
+    async def watching(method: Any, params: Any, result_type: Any, **kwargs: Any) -> Any:
+        if method in ("prepare", "reset_start"):
+            pending = load_pending_rescue(config.rescue_root)
+            assert pending is not None, f"{method} ran with no persisted rescue"
+            seen.append(
+                (method, tuple(a.action_id for a in pending.cleanup_plan.actions))
+            )
+        return await original(method, params, result_type, **kwargs)
+
+    adapter._call_raw = watching  # type: ignore[method-assign]
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        config,
+        selector=selector(tmp_path),
+        model=ScriptedModel(),
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "completed"
+    # prepare sees the provisional close-session plan; reset_start, the side
+    # effect boundary, already sees the adapter's real plan.
+    assert seen == [
+        ("prepare", ("close-session",)),
+        ("reset_start", ("release",)),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scored_zero_is_distinct_from_unscored(
+    tmp_path: Path, episode_id: str
+) -> None:
+    adapter = FakeAdapter(
+        tmp_path, episode_id, score=ScoreArtifact(status="scored", binary=0)
+    )
+    runner = _runner(tmp_path, episode_id, adapter=adapter, model=ScriptedModel())
+
+    outcome = await runner.run()
+
+    assert outcome.status == "completed"
+    assert outcome.score is not None
+    assert outcome.score.status == "scored" and outcome.score.binary == 0
+    assert outcome.reportability_label == "reportable"
+    root = outcome.bundle_root
+    assert root is not None
+    assert verify_bundle(root).valid

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -15,7 +15,13 @@ from typing import Any
 import pytest
 
 from local_operator.evaluation.adapters.supervisor import SupervisionError
-from local_operator.evaluation.evidence.models import ScoreArtifact
+from local_operator.evaluation.evidence.models import (
+    CleanupPayload,
+    EnvironmentStepPayload,
+    ErrorPayload,
+    ObservationPayload,
+    ScoreArtifact,
+)
 from local_operator.evaluation.evidence.verify import verify_bundle
 from local_operator.evaluation.runner.episode import EpisodeRunner
 from tests.unit.evaluation.runner.conftest import (
@@ -24,6 +30,7 @@ from tests.unit.evaluation.runner.conftest import (
     ScriptedModel,
     build_config,
     build_spec,
+    payloads,
     selector,
 )
 
@@ -67,9 +74,7 @@ async def test_happy_episode_writes_every_event_in_protocol_order(
     tmp_path: Path, episode_id: str
 ) -> None:
     adapter = FakeAdapter(tmp_path, episode_id)
-    runner = _runner(
-        tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "finish"])
-    )
+    runner = _runner(tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "finish"]))
 
     outcome = await runner.run()
 
@@ -113,13 +118,9 @@ async def test_happy_episode_writes_every_event_in_protocol_order(
 
 
 @pytest.mark.asyncio
-async def test_step_event_precedes_its_output_observation(
-    tmp_path: Path, episode_id: str
-) -> None:
+async def test_step_event_precedes_its_output_observation(tmp_path: Path, episode_id: str) -> None:
     adapter = FakeAdapter(tmp_path, episode_id)
-    runner = _runner(
-        tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "finish"])
-    )
+    runner = _runner(tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "finish"]))
 
     outcome = await runner.run()
 
@@ -139,19 +140,13 @@ async def test_mid_episode_observe_writes_no_duplicate_observation(
     """``observe`` is a snapshot check, and a snapshot is not new evidence."""
 
     adapter = FakeAdapter(tmp_path, episode_id)
-    runner = _runner(
-        tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "finish"])
-    )
+    runner = _runner(tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "finish"]))
 
     outcome = await runner.run()
 
     root = outcome.bundle_root
     assert root is not None
-    observations = [
-        event.payload.sequence
-        for event in verify_bundle(root).events
-        if event.kind == "observation"
-    ]
+    observations = [payload.sequence for payload in payloads(root, ObservationPayload)]
     # One initial plus exactly one per executed step, with no repeats.
     assert observations == [0, 1]
 
@@ -176,11 +171,7 @@ async def test_truncation_scores_normally_and_marks_the_last_step(
     root = outcome.bundle_root
     assert root is not None
     assert verify_bundle(root).valid
-    steps = [
-        event.payload
-        for event in verify_bundle(root).events
-        if event.kind == "environment_step"
-    ]
+    steps = payloads(root, EnvironmentStepPayload)
     assert len(steps) == 2
     assert [step.truncated for step in steps] == [False, True]
 
@@ -262,9 +253,7 @@ async def test_provider_failure_finalizes_unscored_on_a_live_session(
     root = outcome.bundle_root
     assert root is not None
     assert verify_bundle(root).valid
-    errors = [
-        event.payload for event in verify_bundle(root).events if event.kind == "error"
-    ]
+    errors = payloads(root, ErrorPayload)
     assert [error.category for error in errors] == ["provider"]
     # Cleanup ran on the live session rather than being minted as incomplete.
     assert "cleanup" in adapter.calls
@@ -277,9 +266,7 @@ async def test_adapter_crash_poisons_runs_rescue_and_still_seals(
     adapter = FakeAdapter(
         tmp_path, episode_id, failures={"execute": SupervisionError("worker died")}
     )
-    runner = _runner(
-        tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "finish"])
-    )
+    runner = _runner(tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "finish"]))
 
     outcome = await runner.run()
 
@@ -291,7 +278,7 @@ async def test_adapter_crash_poisons_runs_rescue_and_still_seals(
     assert root is not None
     report = verify_bundle(root)
     assert report.valid, [issue.code for issue in report.issues]
-    errors = [event.payload for event in report.events if event.kind == "error"]
+    errors = payloads(root, ErrorPayload)
     assert [error.category for error in errors] == ["adapter"]
     assert adapter.terminated
 
@@ -320,9 +307,7 @@ async def test_scorer_failure_can_only_abandon_as_ambiguous(
 ) -> None:
     """scoring_start is durable, so a scored intent cannot seal unscored."""
 
-    adapter = FakeAdapter(
-        tmp_path, episode_id, failures={"score": SupervisionError("scorer died")}
-    )
+    adapter = FakeAdapter(tmp_path, episode_id, failures={"score": SupervisionError("scorer died")})
     runner = _runner(tmp_path, episode_id, adapter=adapter, model=ScriptedModel())
 
     outcome = await runner.run()
@@ -353,9 +338,7 @@ async def test_incomplete_cleanup_labels_the_run_and_requires_rescue(
     root = outcome.bundle_root
     assert root is not None
     assert verify_bundle(root).valid
-    cleanups = [
-        event.payload for event in verify_bundle(root).events if event.kind == "cleanup"
-    ]
+    cleanups = payloads(root, CleanupPayload)
     assert [cleanup.rescue_required for cleanup in cleanups] == [True]
 
 
@@ -371,9 +354,7 @@ async def test_cleanup_incomplete_outranks_unscored_in_the_label(
         cleanup_status="failed",
         failures={"execute": SupervisionError("worker died")},
     )
-    runner = _runner(
-        tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "finish"])
-    )
+    runner = _runner(tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "finish"]))
 
     outcome = await runner.run()
 
@@ -435,9 +416,7 @@ async def test_rescue_descriptor_is_persisted_before_prepare_and_updated_after(
         if method in ("prepare", "reset_start"):
             pending = load_pending_rescue(config.rescue_root)
             assert pending is not None, f"{method} ran with no persisted rescue"
-            seen.append(
-                (method, tuple(a.action_id for a in pending.cleanup_plan.actions))
-            )
+            seen.append((method, tuple(a.action_id for a in pending.cleanup_plan.actions)))
         return await original(method, params, result_type, **kwargs)
 
     adapter._call_raw = watching  # type: ignore[method-assign]
@@ -462,12 +441,8 @@ async def test_rescue_descriptor_is_persisted_before_prepare_and_updated_after(
 
 
 @pytest.mark.asyncio
-async def test_scored_zero_is_distinct_from_unscored(
-    tmp_path: Path, episode_id: str
-) -> None:
-    adapter = FakeAdapter(
-        tmp_path, episode_id, score=ScoreArtifact(status="scored", binary=0)
-    )
+async def test_scored_zero_is_distinct_from_unscored(tmp_path: Path, episode_id: str) -> None:
+    adapter = FakeAdapter(tmp_path, episode_id, score=ScoreArtifact(status="scored", binary=0))
     runner = _runner(tmp_path, episode_id, adapter=adapter, model=ScriptedModel())
 
     outcome = await runner.run()

--- a/tests/unit/evaluation/runner/test_episode_subprocess.py
+++ b/tests/unit/evaluation/runner/test_episode_subprocess.py
@@ -1,0 +1,489 @@
+"""Real-worker coverage for the episode runner.
+
+Every other runner test drives the protocol in-process. These spawn a genuine
+interpreter running a genuine installed adapter, exactly as production does,
+because the in-process fake cannot exercise process death: the poison, rescue,
+and abandonment paths only mean something if a worker can actually stop
+existing mid-operation.
+
+The fixture construction follows ``adapters/test_launch.py``, which is the
+established way to build a real interpreter and a real distribution here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import csv
+import hashlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
+from typing import Any
+
+import pydantic
+import pytest
+
+from local_operator.evaluation.adapters.api import AdapterSelector
+from local_operator.evaluation.adapters.discovery import workspace_digest
+from local_operator.evaluation.adapters.supervisor import AdapterSupervisor
+from local_operator.evaluation.evidence.verify import verify_bundle
+from local_operator.evaluation.runner.episode import EpisodeRunner
+from tests.unit.evaluation.runner.conftest import (
+    ScriptedModel,
+    build_config,
+    build_spec,
+)
+
+pytestmark = pytest.mark.slow
+
+RELEASE_DIGEST = "b" * 64
+
+# A functioning adapter: it holds one observation, advances it on execute, and
+# grades trivially. Everything it returns has to satisfy the parent's verifier,
+# so the observation identity is recomputed the same way the protocol does.
+_ADAPTER_SOURCE = '''
+from importlib.metadata import distribution
+
+from local_operator.evaluation.adapters.api import (
+    AckResult,
+    AdapterCapabilities,
+    AdapterMetadata,
+    CleanupOutcome,
+    CleanupResult,
+    ExecuteResult,
+    ExecutionReceipt,
+    ObservationResult,
+    PrepareResult,
+    RequirementsResult,
+    ScoreResult,
+    observation_content_id,
+)
+from local_operator.evaluation.adapters.discovery import distribution_digest
+from local_operator.evaluation.evidence.models import ScoreArtifact
+from local_operator.evaluation.lifecycle import CleanupAction, CleanupPlan
+from local_operator.evaluation.protocol import Observation
+
+# The supervisor builds the worker environment from a closed allowlist, so a
+# cutpoint cannot ride in as an env var. The adapter reads it from a file beside
+# its own module instead, which is ordinary adapter-owned input and leaves the
+# production environment policy untouched.
+def _cutpoint():
+    import os
+
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tiny_cutpoint")
+    try:
+        with open(path) as handle:
+            return handle.read().strip()
+    except OSError:
+        return ""
+
+
+def _observation(task_id, episode_id, sequence):
+    provisional = Observation(
+        task_id=task_id,
+        episode_id=episode_id,
+        sequence=sequence,
+        observation_id="provisional",
+        text="state-%%d" %% sequence,
+    )
+    return provisional.model_copy(
+        update={"observation_id": observation_content_id(provisional)}
+    )
+
+
+class TinyAdapter:
+    def __init__(self, metadata):
+        self.metadata = metadata
+        self.task_id = "task-1"
+        self.episode_id = None
+        self.sequence = 0
+        self.current = None
+
+    def _maybe_die(self, name):
+        if _cutpoint() == name:
+            __import__("os").kill(__import__("os").getpid(), 9)
+
+    async def inspect_requirements(self, params):
+        self._maybe_die("inspect_requirements")
+        return RequirementsResult(requirements=())
+
+    async def prepare(self, params):
+        self._maybe_die("prepare")
+        self.episode_id = params.episode_id
+        return PrepareResult(
+            cleanup_plan=CleanupPlan(
+                episode_id=params.episode_id,
+                actions=(
+                    CleanupAction(
+                        action_id="release",
+                        kind="release_instance",
+                        resource_ref="resource",
+                        timeout_ms=1000,
+                        max_attempts=2,
+                    ),
+                ),
+            )
+        )
+
+    async def reset_start(self, params):
+        self._maybe_die("reset_start")
+        self.task_id = params.task_id
+        self.episode_id = params.episode_id
+        self.sequence = 0
+        self.current = _observation(self.task_id, self.episode_id, 0)
+        return AckResult()
+
+    async def observe(self, params):
+        return ObservationResult(observation=self.current)
+
+    async def execute(self, params):
+        self._maybe_die("execute")
+        self.sequence += 1
+        output = _observation(self.task_id, self.episode_id, self.sequence)
+        receipt = ExecutionReceipt(
+            operation_id=params.operation_id,
+            action_batch_id=params.action_batch_id,
+            input_observation_id=self.current.observation_id,
+            output_observation_id=output.observation_id,
+            sequence=output.sequence,
+        )
+        self.current = output
+        return ExecuteResult(observation=output, receipt=receipt)
+
+    async def ask_user_exchange(self, params):
+        raise NotImplementedError
+
+    async def score(self, params):
+        self._maybe_die("score")
+        return ScoreResult(score=ScoreArtifact(status="scored", binary=1))
+
+    async def cleanup(self, params):
+        self._maybe_die("cleanup")
+        return CleanupResult(
+            outcomes=tuple(
+                CleanupOutcome(
+                    action_id=action_id,
+                    status="succeeded",
+                    evidence_code="released",
+                    duration_ms=1,
+                )
+                for action_id in params.action_ids
+            )
+        )
+
+    async def close(self, params):
+        return AckResult()
+
+
+def create():
+    installed = distribution("tiny-runner-adapter")
+    return TinyAdapter(
+        AdapterMetadata(
+            adapter_id="tiny-runner",
+            distribution="tiny-runner-adapter",
+            version="1.0",
+            entry_point="tiny_runner_adapter:create",
+            package_digest=distribution_digest(installed),
+            release_digest="%s",
+            schema_version="1.0",
+            capabilities=AdapterCapabilities(
+                routes=("computer",), ask_user=False, scoring=True
+            ),
+        )
+    )
+''' % RELEASE_DIGEST
+
+
+def _real_interpreter(venv: Path) -> Path:
+    """Copy a working interpreter so its content can be pinned per test run.
+
+    Candidates are tried in turn because not every interpreter can host a
+    ``--copies`` venv: a framework build whose ``libpython`` lives outside the
+    copied tree produces an executable that dies in dyld, and a system Python
+    may refuse to build one without symlinks at all. This mirrors
+    ``adapters/test_launch.py``, which exists for the same reason.
+    """
+
+    candidates = [
+        os.path.realpath(sys.executable),
+        shutil.which("python3") or "",
+        sys.base_prefix + "/bin/python3",
+    ]
+    failures: list[str] = []
+    for base in candidates:
+        if not base or not os.path.exists(base):
+            continue
+        shutil.rmtree(venv, ignore_errors=True)
+        try:
+            subprocess.run(
+                [base, "-m", "venv", "--without-pip", "--copies", str(venv)],
+                check=True,
+                capture_output=True,
+            )
+        except (OSError, subprocess.CalledProcessError) as error:
+            failures.append(f"{base}: venv creation failed ({error})")
+            continue
+        executable = next(
+            (
+                item
+                for item in sorted((venv / "bin").glob("python3.*"))
+                if item.is_file() and not item.is_symlink()
+            ),
+            None,
+        )
+        if executable is None:
+            failures.append(f"{base}: produced no copied executable")
+            continue
+        probe = subprocess.run(
+            [str(executable), "-I", "-c", "print('ok')"], capture_output=True, text=True
+        )
+        if probe.returncode == 0:
+            return executable
+        failures.append(f"{base}: copied interpreter did not run ({probe.stderr[-200:]})")
+    # Failing loudly beats skipping: a host with no usable interpreter gives no
+    # subprocess coverage at all, and a silent skip hides that from CI.
+    raise AssertionError("no usable copied interpreter on this host: " + "; ".join(failures))
+
+
+def _dependency_roots() -> list[str]:
+    roots = [str(Path(__file__).resolve().parents[4])]
+    purelib = sysconfig.get_paths().get("purelib")
+    if purelib:
+        roots.append(purelib)
+    roots.append(str(Path(pydantic.__file__).resolve().parent.parent))
+    seen: list[str] = []
+    for root in roots:
+        if root not in seen and Path(root).is_dir():
+            seen.append(root)
+    return seen
+
+
+def _install_adapter(site: Path) -> str:
+    (site / "_local_operator_repo.pth").write_text("\n".join(_dependency_roots()) + "\n")
+    module = site / "tiny_runner_adapter.py"
+    module.write_text(_ADAPTER_SOURCE)
+    info = site / "tiny_runner_adapter-1.0.dist-info"
+    info.mkdir(exist_ok=True)
+    (info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: tiny-runner-adapter\nVersion: 1.0\n"
+    )
+    (info / "entry_points.txt").write_text(
+        "[local_operator.evaluation_adapters.v1]\n"
+        "tiny-runner = tiny_runner_adapter:create\n"
+    )
+    rows: list[list[str]] = []
+    for path in sorted([module, info / "METADATA", info / "entry_points.txt"]):
+        data = path.read_bytes()
+        digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+        rows.append([str(path.relative_to(site)), f"sha256={digest}", str(len(data))])
+    rows.append([str((info / "RECORD").relative_to(site)), "", ""])
+    target = io.StringIO()
+    csv.writer(target, lineterminator="\n").writerows(rows)
+    (info / "RECORD").write_text(target.getvalue())
+    from importlib.metadata import PathDistribution
+
+    return distribution_digest_of(PathDistribution(info))
+
+
+def distribution_digest_of(distribution: Any) -> str:
+    from local_operator.evaluation.adapters.discovery import distribution_digest
+
+    return distribution_digest(distribution)
+
+
+@pytest.fixture
+def adapter_site(tmp_path: Path) -> Path:
+    """The installed adapter's site-packages, where the cutpoint file lives."""
+
+    executable = _real_interpreter(tmp_path / "venv")
+    site = next(executable.parent.parent.glob("lib/python*/site-packages"))
+    return site
+
+
+@pytest.fixture
+def real_selector(tmp_path: Path, adapter_site: Path) -> AdapterSelector:
+    executable = next(
+        item
+        for item in sorted((tmp_path / "venv" / "bin").glob("python3.*"))
+        if item.is_file() and not item.is_symlink()
+    )
+    site = adapter_site
+    package_digest = _install_adapter(site)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    (workspace / "adapter-release.json").write_text(
+        json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
+    )
+    return AdapterSelector(
+        schema_version="1.0",
+        adapter_id="tiny-runner",
+        distribution="tiny-runner-adapter",
+        version="1.0",
+        entry_point="tiny_runner_adapter:create",
+        package_digest=package_digest,
+        release_digest=RELEASE_DIGEST,
+        python_executable=str(executable.resolve()),
+        workspace=str(workspace),
+        workspace_digest=workspace_digest(str(workspace)),
+        route_capability="computer",
+    )
+
+
+def _arm_cutpoint(site: Path, cutpoint: str | None) -> None:
+    """Tell the installed adapter which operation should kill its process."""
+
+    marker = site / "tiny_cutpoint"
+    if cutpoint is None:
+        marker.unlink(missing_ok=True)
+    else:
+        marker.write_text(cutpoint)
+
+
+@pytest.mark.asyncio
+async def test_real_worker_completes_a_scored_episode(
+    tmp_path: Path,
+    episode_id: str,
+    real_selector: AdapterSelector,
+    adapter_site: Path,
+) -> None:
+    _arm_cutpoint(adapter_site, None)
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path),
+        selector=real_selector,
+        model=ScriptedModel(["step", "step", "finish"]),
+        launch=AdapterSupervisor.launch,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "completed", outcome.diagnostic
+    assert outcome.score is not None and outcome.score.status == "scored"
+    assert outcome.reportability_label == "reportable"
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+    assert report.counters is not None
+    assert report.counters.environment_step_count == 2
+
+
+@pytest.mark.parametrize(
+    "cutpoint",
+    ["prepare", "reset_start", "execute", "score", "cleanup"],
+)
+@pytest.mark.asyncio
+async def test_worker_killed_at_each_cutpoint_stays_coherent(
+    tmp_path: Path,
+    episode_id: str,
+    real_selector: AdapterSelector,
+    adapter_site: Path,
+    cutpoint: str,
+) -> None:
+    """SIGKILL mid-operation must still yield a coherent bundle or abandonment."""
+
+    _arm_cutpoint(adapter_site, cutpoint)
+    rescued: list[Any] = []
+
+    async def recording_rescue(descriptor: Any, **kwargs: Any) -> Any:
+        del kwargs
+        rescued.append(descriptor)
+
+        class _Aggregate:
+            complete = True
+            descriptor_id = descriptor.descriptor_id
+
+        return _Aggregate()
+
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path),
+        selector=real_selector,
+        model=ScriptedModel(["step", "finish"]),
+        launch=AdapterSupervisor.launch,
+        rescue=recording_rescue,
+    )
+
+    outcome = await runner.run()
+
+    # The episode must never claim success when its worker was killed.
+    assert outcome.status in ("failed", "abandoned", "failed_pre_bundle")
+    if cutpoint == "cleanup":
+        # Scoring already happened, so the grade stands; what the kill costs is
+        # the cleanup guarantee, and the run is labelled for exactly that.
+        assert outcome.reportability_label == "cleanup_incomplete"
+        assert outcome.rescue_required is True
+    else:
+        assert outcome.score is None or outcome.score.status == "unscored"
+    if cutpoint == "prepare":
+        # No manifest is possible before prepare returns a cleanup plan.
+        assert outcome.status == "failed_pre_bundle"
+        assert outcome.bundle_root is None
+        return
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    if report.abandonment is not None:
+        # An abandoned bundle is a coherent terminal in its own right.
+        assert report.abandonment.reason in (
+            "ambiguous_finalization",
+            "infrastructure_failure",
+        )
+    else:
+        assert report.valid, [issue.code for issue in report.issues]
+        assert report.outcome is not None
+        # A kill during cleanup happens after grading, so the sealed score is
+        # real; every earlier cutpoint dies before a score can exist.
+        expected = "scored" if cutpoint == "cleanup" else "unscored"
+        assert report.outcome.result.status == expected
+        assert report.outcome.reportable is False
+    # A dead worker leaves resources only the persisted descriptor can reclaim.
+    assert rescued, "a killed worker must trigger rescue"
+
+
+@pytest.mark.asyncio
+async def test_killed_worker_process_group_is_reaped(
+    tmp_path: Path,
+    episode_id: str,
+    real_selector: AdapterSelector,
+    adapter_site: Path,
+) -> None:
+    _arm_cutpoint(adapter_site, "execute")
+    supervisors: list[AdapterSupervisor] = []
+
+    def recording_launch(selector: AdapterSelector) -> AdapterSupervisor:
+        supervisor = AdapterSupervisor.launch(selector)
+        supervisors.append(supervisor)
+        return supervisor
+
+    async def rescue(descriptor: Any, **kwargs: Any) -> Any:
+        del kwargs
+
+        class _Aggregate:
+            complete = True
+            descriptor_id = descriptor.descriptor_id
+
+        return _Aggregate()
+
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path),
+        selector=real_selector,
+        model=ScriptedModel(["step", "finish"]),
+        launch=recording_launch,
+        rescue=rescue,
+    )
+
+    await runner.run()
+
+    assert supervisors
+    supervisor = supervisors[0]
+    assert await asyncio.to_thread(supervisor.process.poll) is not None
+    with pytest.raises(ProcessLookupError):
+        os.killpg(supervisor.pgid, 0)

--- a/tests/unit/evaluation/runner/test_episode_subprocess.py
+++ b/tests/unit/evaluation/runner/test_episode_subprocess.py
@@ -334,6 +334,28 @@ def real_selector(tmp_path: Path, adapter_site: Path) -> AdapterSelector:
     )
 
 
+def _subprocess_config(tmp_path: Path) -> Any:
+    """Config with timeouts sized for a REAL interpreter spawn.
+
+    The in-process default of 5s is ample for a fake adapter but marginal here:
+    a real worker must start CPython and import pydantic and ``local_operator``
+    before it can answer the handshake. Under parallel load that can exceed 5s,
+    and the episode then fails at ``prepare`` -- reporting ``failed_pre_bundle``
+    instead of reaching the cutpoint under test, which turns a genuine
+    assertion into a flake about machine speed rather than about the runner.
+    """
+
+    return build_config(
+        tmp_path,
+        handshake_timeout=60.0,
+        prepare_timeout=60.0,
+        reset_timeout=60.0,
+        step_timeout=60.0,
+        score_timeout=60.0,
+        cleanup_timeout=60.0,
+    )
+
+
 def _arm_cutpoint(site: Path, cutpoint: str | None) -> None:
     """Tell the installed adapter which operation should kill its process."""
 
@@ -354,7 +376,7 @@ async def test_real_worker_completes_a_scored_episode(
     _arm_cutpoint(adapter_site, None)
     runner = EpisodeRunner(
         build_spec(episode_id),
-        build_config(tmp_path),
+        _subprocess_config(tmp_path),
         selector=real_selector,
         model=ScriptedModel(["step", "step", "finish"]),
         launch=AdapterSupervisor.launch,
@@ -402,7 +424,7 @@ async def test_worker_killed_at_each_cutpoint_stays_coherent(
 
     runner = EpisodeRunner(
         build_spec(episode_id),
-        build_config(tmp_path),
+        _subprocess_config(tmp_path),
         selector=real_selector,
         model=ScriptedModel(["step", "finish"]),
         launch=AdapterSupervisor.launch,
@@ -472,7 +494,7 @@ async def test_killed_worker_process_group_is_reaped(
 
     runner = EpisodeRunner(
         build_spec(episode_id),
-        build_config(tmp_path),
+        _subprocess_config(tmp_path),
         selector=real_selector,
         model=ScriptedModel(["step", "finish"]),
         launch=recording_launch,

--- a/tests/unit/evaluation/runner/test_episode_subprocess.py
+++ b/tests/unit/evaluation/runner/test_episode_subprocess.py
@@ -47,7 +47,7 @@ RELEASE_DIGEST = "b" * 64
 # A functioning adapter: it holds one observation, advances it on execute, and
 # grades trivially. Everything it returns has to satisfy the parent's verifier,
 # so the observation identity is recomputed the same way the protocol does.
-_ADAPTER_SOURCE = '''
+_ADAPTER_SOURCE = """
 from importlib.metadata import distribution
 
 from local_operator.evaluation.adapters.api import (
@@ -197,7 +197,7 @@ def create():
             ),
         )
     )
-''' % RELEASE_DIGEST
+""" % RELEASE_DIGEST
 
 
 def _real_interpreter(venv: Path) -> Path:
@@ -274,8 +274,7 @@ def _install_adapter(site: Path) -> str:
         "Metadata-Version: 2.1\nName: tiny-runner-adapter\nVersion: 1.0\n"
     )
     (info / "entry_points.txt").write_text(
-        "[local_operator.evaluation_adapters.v1]\n"
-        "tiny-runner = tiny_runner_adapter:create\n"
+        "[local_operator.evaluation_adapters.v1]\n" "tiny-runner = tiny_runner_adapter:create\n"
     )
     rows: list[list[str]] = []
     for path in sorted([module, info / "METADATA", info / "entry_points.txt"]):

--- a/tests/unit/evaluation/runner/test_isolation.py
+++ b/tests/unit/evaluation/runner/test_isolation.py
@@ -1,0 +1,83 @@
+"""The runner core must not drag the application into an episode.
+
+An evaluation episode has to be reproducible from its pinned inputs. Importing
+providers, config, tools, the TUI, or session code would let a benchmark result
+depend on the operator's own live configuration, and the dependency would be
+invisible -- nothing in a bundle records which settings file was loaded. This
+mirrors the existing startup-isolation assertions in ``test_protocol.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[4]
+
+# provider_client.py is the deliberate exception and imports configure lazily,
+# so it is absent here by construction rather than by luck.
+FORBIDDEN_PREFIXES = (
+    "local_operator.model",
+    "local_operator.providers",
+    "local_operator.config",
+    "local_operator.tools",
+    "local_operator.tui",
+    "local_operator.mobile",
+    "local_operator.session",
+    "textual",
+)
+
+
+def _fresh_import_modules(module: str) -> set[str]:
+    probe = (
+        "import importlib,json,sys;"
+        "importlib.import_module(sys.argv[1]);"
+        "print(json.dumps(sorted(sys.modules)))"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe, module],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr[-3000:]
+    return set(json.loads(completed.stdout.strip().splitlines()[-1]))
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "local_operator.evaluation.runner.episode",
+        "local_operator.evaluation.runner.model",
+        "local_operator.evaluation.runner.responder",
+    ],
+)
+def test_runner_core_does_not_import_the_application(module: str) -> None:
+    imported = _fresh_import_modules(module)
+    leaked = {
+        name
+        for name in imported
+        if any(
+            name == prefix or name.startswith(prefix + ".") for prefix in FORBIDDEN_PREFIXES
+        )
+    }
+    assert not leaked, f"{module} leaked application imports: {sorted(leaked)}"
+
+
+def test_runner_package_import_is_inert() -> None:
+    imported = _fresh_import_modules("local_operator.evaluation.runner")
+    assert not {
+        name for name in imported if name.startswith("local_operator.evaluation.runner.")
+    }
+
+
+def test_provider_client_defers_its_configure_import() -> None:
+    """The one module allowed to reach the app must still not do it eagerly."""
+
+    imported = _fresh_import_modules("local_operator.evaluation.runner.provider_client")
+    assert "local_operator.model.configure" not in imported

--- a/tests/unit/evaluation/runner/test_isolation.py
+++ b/tests/unit/evaluation/runner/test_isolation.py
@@ -62,18 +62,14 @@ def test_runner_core_does_not_import_the_application(module: str) -> None:
     leaked = {
         name
         for name in imported
-        if any(
-            name == prefix or name.startswith(prefix + ".") for prefix in FORBIDDEN_PREFIXES
-        )
+        if any(name == prefix or name.startswith(prefix + ".") for prefix in FORBIDDEN_PREFIXES)
     }
     assert not leaked, f"{module} leaked application imports: {sorted(leaked)}"
 
 
 def test_runner_package_import_is_inert() -> None:
     imported = _fresh_import_modules("local_operator.evaluation.runner")
-    assert not {
-        name for name in imported if name.startswith("local_operator.evaluation.runner.")
-    }
+    assert not {name for name in imported if name.startswith("local_operator.evaluation.runner.")}
 
 
 def test_provider_client_defers_its_configure_import() -> None:

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -29,6 +29,7 @@ from local_operator.evaluation.protocol import (
 from local_operator.evaluation.runner.provider_client import (
     DecisionParseError,
     ProviderModelClient,
+    build_system_prompt,
     parse_decision,
 )
 from local_operator.harness.types import (
@@ -266,6 +267,45 @@ async def test_system_prompt_states_the_schema_the_protocol_enforces() -> None:
     # Derived from the protocol models, so a new action kind cannot drift out.
     for kind in ("click", "type", "key", "scroll", "wait", "finish", "ask_user"):
         assert kind in prompt
+    # A sequence field must read as an array. Told only "value", a model emits
+    # "ctrl+c" for KeyAction.keys, which is a hard non-retryable parse failure.
+    assert "keys: [str, ...]" in prompt
+
+
+def test_prompt_does_not_restate_literals_it_already_derives() -> None:
+    """Hand-written literals drift from the derived block and contradict it."""
+
+    prompt = build_system_prompt()
+
+    # The derived schema line owns the finish literals; the prose below must
+    # explain what the actions MEAN without re-listing their values.
+    assert prompt.count("done|failed|infeasible") == 1
+    assert "must be one of done, failed, or infeasible" not in prompt
+
+
+def test_key_action_array_parses_where_a_joined_string_does_not() -> None:
+    """The distinction the prompt now states is real and load-bearing."""
+
+    current = observation()
+
+    def payload(keys: Any) -> str:
+        return json.dumps(
+            {
+                "actions": [
+                    {
+                        "kind": "key",
+                        "observation_id": current.observation_id,
+                        "keys": keys,
+                    }
+                ]
+            }
+        )
+
+    decision = parse_decision(payload(["ctrl", "c"]), current, route=ROUTE)
+    decision.action_batch.validate_for(current)
+
+    with pytest.raises(DecisionParseError):
+        parse_decision(payload("ctrl+c"), current, route=ROUTE)
 
 
 @pytest.mark.asyncio
@@ -334,6 +374,18 @@ async def test_client_carries_the_provider_request_id() -> None:
     decision = await _client(stream).decide(current, [current])
 
     assert decision.provider_request_id == "chatcmpl-ABC123"
+
+
+@pytest.mark.asyncio
+async def test_an_over_length_provider_id_degrades_rather_than_truncating() -> None:
+    """A truncated id is a valid identifier that matches nothing upstream."""
+
+    current = observation()
+    stream = ScriptedStream(finish_payload(current), provider_payload={"id": "a" * 200})
+
+    decision = await _client(stream).decide(current, [current])
+
+    assert decision.provider_request_id == "unknown"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -99,11 +99,13 @@ class ScriptedStream:
         usage: Usage | None = None,
         stop_reason: str = "stop",
         chunk: int = 7,
+        provider_payload: dict[str, Any] | None = None,
     ) -> None:
         self.text = text
         self.usage = usage
         self.stop_reason = stop_reason
         self.chunk = chunk
+        self.provider_payload = provider_payload
         self.requests: list[Any] = []
 
     def __call__(self, request: Any, signal: Any) -> AsyncIterator[Any]:
@@ -118,7 +120,11 @@ class ScriptedStream:
             yield StreamTextDelta(delta=self.text[start : start + self.chunk])
         if self.usage is not None:
             yield StreamUsageEvent(usage=self.usage)
-        yield StreamEndEvent(stop_reason=self.stop_reason, usage=self.usage)
+        yield StreamEndEvent(
+            stop_reason=self.stop_reason,
+            usage=self.usage,
+            provider_payload=self.provider_payload,
+        )
 
 
 def _client(stream: ScriptedStream) -> ProviderModelClient:
@@ -316,3 +322,27 @@ async def test_client_raises_on_an_unparseable_reply() -> None:
 
     with pytest.raises(DecisionParseError):
         await _client(stream).decide(current, [current])
+
+
+@pytest.mark.asyncio
+async def test_client_carries_the_provider_request_id() -> None:
+    """The only handle tying a bundle's model_response to the provider's records."""
+
+    current = observation()
+    stream = ScriptedStream(finish_payload(current), provider_payload={"id": "chatcmpl-ABC123"})
+
+    decision = await _client(stream).decide(current, [current])
+
+    assert decision.provider_request_id == "chatcmpl-ABC123"
+
+
+@pytest.mark.asyncio
+async def test_an_unusable_provider_id_degrades_instead_of_failing() -> None:
+    """StrictIdentifier forbids spaces; provenance must not break the episode."""
+
+    current = observation()
+    stream = ScriptedStream(finish_payload(current), provider_payload={"id": "not a valid id!"})
+
+    decision = await _client(stream).decide(current, [current])
+
+    assert decision.provider_request_id == "unknown"

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -1,0 +1,318 @@
+"""Offline behavioural coverage for the provider-backed model client.
+
+This module needs no credentials and spends no tokens: it drives the real
+``ProviderModelClient`` against a scripted async stream that yields the same
+event shapes ``local_operator.harness.types`` defines. That is enough to prove
+the thing the runner actually depends on -- a provider reply becomes a
+protocol-valid ``ActionBatch`` -- which is the property that was previously
+asserted nowhere.
+
+Its absence is what let a dead provider path ship: the module type-checked and
+imported cleanly while being incapable of parsing any real reply.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncIterator
+
+import pytest
+
+from local_operator.evaluation.adapters.api import observation_content_id
+from local_operator.evaluation.evidence.models import RouteIdentity
+from local_operator.evaluation.protocol import (
+    ActionBatch,
+    FinishAction,
+    Observation,
+    TypeAction,
+)
+from local_operator.evaluation.runner.provider_client import (
+    DecisionParseError,
+    ProviderModelClient,
+    parse_decision,
+)
+from local_operator.harness.types import (
+    ModelSpec,
+    StreamEndEvent,
+    StreamTextDelta,
+    StreamUsageEvent,
+    Usage,
+)
+
+ROUTE = RouteIdentity(provider_id="provider", route_id="route", model_id="model")
+
+
+def observation(sequence: int = 0) -> Observation:
+    provisional = Observation(
+        task_id="task-1",
+        episode_id="episode-1",
+        sequence=sequence,
+        observation_id="provisional",
+        text="a screen",
+    )
+    return provisional.model_copy(update={"observation_id": observation_content_id(provisional)})
+
+
+def finish_payload(current: Observation) -> str:
+    return json.dumps(
+        {
+            "actions": [
+                {
+                    "kind": "finish",
+                    "observation_id": current.observation_id,
+                    "status": "done",
+                    "reason": "the task is complete",
+                }
+            ]
+        }
+    )
+
+
+def type_payload(current: Observation) -> str:
+    """A non-terminal, frameless action.
+
+    Pointer actions are deliberately excluded here: ``validate_for`` resolves
+    ``frame_id`` against the observation's frames, so covering a click would
+    mean asserting frame plumbing rather than decision parsing.
+    """
+
+    return json.dumps(
+        {
+            "actions": [
+                {
+                    "kind": "type",
+                    "observation_id": current.observation_id,
+                    "text": "hello",
+                }
+            ]
+        }
+    )
+
+
+class ScriptedStream:
+    """Stands in for ``SessionStreamFn`` with a fixed event script."""
+
+    def __init__(
+        self,
+        text: str,
+        *,
+        usage: Usage | None = None,
+        stop_reason: str = "stop",
+        chunk: int = 7,
+    ) -> None:
+        self.text = text
+        self.usage = usage
+        self.stop_reason = stop_reason
+        self.chunk = chunk
+        self.requests: list[Any] = []
+
+    def __call__(self, request: Any, signal: Any) -> AsyncIterator[Any]:
+        self.requests.append(request)
+        return self._events()
+
+    async def _events(self) -> AsyncIterator[Any]:
+        # Delivered in fragments because a provider streams text in pieces; a
+        # client that reads only the first delta would still pass a whole-string
+        # fake and then fail against every real provider.
+        for start in range(0, len(self.text), self.chunk):
+            yield StreamTextDelta(delta=self.text[start : start + self.chunk])
+        if self.usage is not None:
+            yield StreamUsageEvent(usage=self.usage)
+        yield StreamEndEvent(stop_reason=self.stop_reason, usage=self.usage)
+
+
+def _client(stream: ScriptedStream) -> ProviderModelClient:
+    spec = ModelSpec(provider="provider", model_id="model")
+    return ProviderModelClient(stream, route=ROUTE, model_spec=spec)
+
+
+# ---------------------------------------------------------------------------
+# parse_decision
+# ---------------------------------------------------------------------------
+
+
+def test_parse_decision_accepts_a_protocol_correct_finish() -> None:
+    current = observation()
+
+    decision = parse_decision(finish_payload(current), current, route=ROUTE)
+
+    assert isinstance(decision.action_batch, ActionBatch)
+    assert decision.action_batch.protocol_version == "1.0"
+    assert len(decision.action_batch.actions) == 1
+    assert isinstance(decision.action_batch.actions[0], FinishAction)
+    # The batch must survive the same validation the adapter boundary applies.
+    decision.action_batch.validate_for(current)
+
+
+def test_parse_decision_accepts_a_protocol_correct_non_terminal_action() -> None:
+    current = observation()
+
+    decision = parse_decision(type_payload(current), current, route=ROUTE)
+
+    assert isinstance(decision.action_batch.actions[0], TypeAction)
+    decision.action_batch.validate_for(current)
+
+
+def test_parse_decision_binds_the_batch_to_the_current_observation() -> None:
+    current = observation()
+
+    decision = parse_decision(finish_payload(current), current, route=ROUTE)
+
+    batch = decision.action_batch
+    assert batch.task_id == current.task_id
+    assert batch.episode_id == current.episode_id
+    assert batch.observation_id == current.observation_id
+
+
+def test_parse_decision_rejects_a_batch_bound_to_a_stale_observation() -> None:
+    """A decision about a screen the environment has moved past is not usable."""
+
+    stale = observation(0)
+    current = observation(1)
+
+    with pytest.raises(DecisionParseError):
+        parse_decision(finish_payload(stale), current, route=ROUTE)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not json at all",
+        '{"actions": []}',
+        '{"actions": "click"}',
+        '{"no_actions_key": true}',
+        "[]",
+    ],
+)
+def test_parse_decision_rejects_malformed_replies(payload: str) -> None:
+    with pytest.raises(DecisionParseError):
+        parse_decision(payload, observation(), route=ROUTE)
+
+
+def test_parse_decision_rejects_a_wrong_discriminator_key() -> None:
+    """A model emitting ``type`` instead of ``kind`` must fail loudly."""
+
+    current = observation()
+    payload = json.dumps(
+        {
+            "actions": [
+                {
+                    "type": "finish",
+                    "observation_id": current.observation_id,
+                    "status": "done",
+                    "reason": "done",
+                }
+            ]
+        }
+    )
+
+    with pytest.raises(DecisionParseError):
+        parse_decision(payload, current, route=ROUTE)
+
+
+# ---------------------------------------------------------------------------
+# ProviderModelClient
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_client_turns_a_streamed_reply_into_a_valid_action_batch() -> None:
+    current = observation()
+    stream = ScriptedStream(finish_payload(current))
+
+    decision = await _client(stream).decide(current, [current])
+
+    assert isinstance(decision.action_batch, ActionBatch)
+    decision.action_batch.validate_for(current)
+    assert decision.route == ROUTE
+
+
+@pytest.mark.asyncio
+async def test_client_sends_the_system_prompt_as_a_cacheable_block() -> None:
+    current = observation()
+    stream = ScriptedStream(finish_payload(current))
+
+    await _client(stream).decide(current, [current])
+
+    request = stream.requests[0]
+    assert len(request.system_blocks) == 1
+    assert request.messages[0].role == "user"
+    # The episode drives the environment through the protocol, not through
+    # harness tools, so the provider must not be offered any.
+    assert request.tool_choice == "none"
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_states_the_schema_the_protocol_enforces() -> None:
+    """An under-specified prompt is a correctness defect: a parse failure is terminal."""
+
+    current = observation()
+    stream = ScriptedStream(finish_payload(current))
+
+    await _client(stream).decide(current, [current])
+
+    prompt = stream.requests[0].system_blocks[0]
+    # The discriminator key, and every finish literal the protocol accepts.
+    assert '"kind"' in prompt
+    for status in ("done", "failed", "infeasible"):
+        assert status in prompt
+    assert "reason" in prompt
+    # Derived from the protocol models, so a new action kind cannot drift out.
+    for kind in ("click", "type", "key", "scroll", "wait", "finish", "ask_user"):
+        assert kind in prompt
+
+
+@pytest.mark.asyncio
+async def test_client_carries_provider_usage_and_cost_into_the_decision() -> None:
+    """Cost is authoritative provider data; dropping it reports every run as free."""
+
+    current = observation()
+    usage = Usage(
+        input_tokens=1234,
+        output_tokens=56,
+        reasoning_tokens=7,
+        cache_read_tokens=8,
+        cache_write_tokens=9,
+        usd_cost=0.0421,
+    )
+    stream = ScriptedStream(finish_payload(current), usage=usage)
+
+    decision = await _client(stream).decide(current, [current])
+
+    assert decision.usage.input_tokens == 1234
+    assert decision.usage.output_tokens == 56
+    assert decision.usage.reasoning_tokens == 7
+    assert decision.usage.cache_read_tokens == 8
+    assert decision.usage.cache_write_tokens == 9
+    assert decision.cost_micros == 42100
+
+
+@pytest.mark.asyncio
+async def test_unreported_cost_is_zero_rather_than_a_guess() -> None:
+    current = observation()
+    stream = ScriptedStream(finish_payload(current), usage=Usage(input_tokens=5, output_tokens=5))
+
+    decision = await _client(stream).decide(current, [current])
+
+    assert decision.cost_micros == 0
+
+
+@pytest.mark.asyncio
+async def test_client_reports_the_provider_stop_reason() -> None:
+    current = observation()
+    stream = ScriptedStream(finish_payload(current), stop_reason="length")
+
+    decision = await _client(stream).decide(current, [current])
+
+    assert decision.stop_reason == "length"
+
+
+@pytest.mark.asyncio
+async def test_client_raises_on_an_unparseable_reply() -> None:
+    """The runner converts this to a provider failure, so it must surface."""
+
+    current = observation()
+    stream = ScriptedStream("I'm afraid I can't do that.")
+
+    with pytest.raises(DecisionParseError):
+        await _client(stream).decide(current, [current])

--- a/tests/unit/evaluation/runner/test_reconciliation.py
+++ b/tests/unit/evaluation/runner/test_reconciliation.py
@@ -197,6 +197,15 @@ async def test_writer_failure_abandons_after_rescuing_first(
     assert outcome.rescue_complete is True
     assert adapter.terminated
     assert isinstance(outcome.diagnostic, str)
+    # The returned status is not evidence. A bundle whose writer died must
+    # carry its terminal ON DISK, or the "every path leaves a verifiable
+    # bundle or a coherent abandonment" invariant is only a claim.
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.abandonment is not None
+    assert report.abandonment.reason == "infrastructure_failure"
+    assert report.terminal_state == "abandoned"
 
 
 @pytest.mark.asyncio
@@ -225,3 +234,8 @@ async def test_evidence_errors_surface_as_abandonment_not_a_crash(
     # An evidence failure is never reported as a scored or completed episode.
     assert outcome.status in ("abandoned", "failed_pre_bundle")
     assert outcome.score is None
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.abandonment is not None
+    assert report.terminal_state == "abandoned"

--- a/tests/unit/evaluation/runner/test_reconciliation.py
+++ b/tests/unit/evaluation/runner/test_reconciliation.py
@@ -239,3 +239,62 @@ async def test_evidence_errors_surface_as_abandonment_not_a_crash(
     report = verify_bundle(root)
     assert report.abandonment is not None
     assert report.terminal_state == "abandoned"
+
+
+@pytest.mark.parametrize("kind", ["observation", "action_batch"])
+@pytest.mark.asyncio
+async def test_append_failure_after_a_successful_publish_reports_the_disk_truth(
+    tmp_path: Path, episode_id: str, monkeypatch: pytest.MonkeyPatch, kind: str
+) -> None:
+    """An orphaned artifact makes the bundle unabandonable; say so honestly.
+
+    ``observation`` and ``action_batch`` are written publish-then-append, so an
+    append failure after a successful publish leaves an artifact nothing
+    references. ``EvidenceWriter.abandon`` independently re-verifies and refuses
+    on that ``artifact_unreferenced`` error, so NO terminal can be recorded.
+
+    The runner must not answer that by claiming ``abandoned`` over a bundle
+    whose ``terminal_state`` is still ``open`` -- that false report is the exact
+    failure this slice exists to prevent. The returned status has to match what
+    is actually on disk.
+    """
+
+    from local_operator.evaluation.evidence.store import EvidenceWriter
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    original = EvidenceWriter.append
+
+    def poisoned(self: Any, event_kind: Any, payload: Any, **kwargs: Any) -> Any:
+        if event_kind == kind:
+            raise EvidenceError(f"simulated {kind} journal failure")
+        return original(self, event_kind, payload, **kwargs)
+
+    # Patched on the CLASS so the real writer is exercised, not a runner shim.
+    monkeypatch.setattr(EvidenceWriter, "append", poisoned)
+
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path),
+        selector=selector(tmp_path),
+        model=ScriptedModel(["step", "finish"]),
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+
+    outcome = await runner.run()
+
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    if report.abandonment is not None:
+        # If a terminal WAS recordable, it must be coherent and claimed as such.
+        assert outcome.status == "abandoned"
+        assert report.terminal_state == "abandoned"
+    else:
+        # No terminal on disk, so the runner must not claim one.
+        assert outcome.status == "abandonment_failed"
+        assert report.terminal_state == "open"
+        assert outcome.diagnostic is not None
+        assert "abandonment refused" in outcome.diagnostic
+    # Either way the returned status agrees with the bundle on disk.
+    assert (outcome.status == "abandoned") == (report.abandonment is not None)

--- a/tests/unit/evaluation/runner/test_reconciliation.py
+++ b/tests/unit/evaluation/runner/test_reconciliation.py
@@ -14,6 +14,7 @@ from typing import Any
 import pytest
 
 from local_operator.evaluation.adapters.supervisor import SupervisionError
+from local_operator.evaluation.evidence.models import ReconciliationPayload
 from local_operator.evaluation.evidence.store import EvidenceError
 from local_operator.evaluation.evidence.verify import verify_bundle
 from local_operator.evaluation.receipts import (
@@ -29,6 +30,7 @@ from tests.unit.evaluation.runner.conftest import (
     ScriptedModel,
     build_config,
     build_spec,
+    payloads,
     selector,
 )
 
@@ -44,9 +46,7 @@ async def _rescue_ok(descriptor: Any, **kwargs: Any) -> Any:
 
 
 @pytest.mark.asyncio
-async def test_overrun_is_recorded_and_still_scores(
-    tmp_path: Path, episode_id: str
-) -> None:
+async def test_overrun_is_recorded_and_still_scores(tmp_path: Path, episode_id: str) -> None:
     """A tiny allowance is exceeded by real usage; the episode still scores."""
 
     spec = build_spec(episode_id)
@@ -87,9 +87,7 @@ async def test_overrun_is_recorded_and_still_scores(
     assert root is not None
     report = verify_bundle(root)
     assert report.valid
-    reconciliations = [
-        event.payload for event in report.events if event.kind == "reconciliation"
-    ]
+    reconciliations = payloads(root, ReconciliationPayload)
     assert len(reconciliations) == 1
     # Usage was measurable, so the run stays reportable despite the overrun.
     assert reconciliations[0].reportable is True
@@ -119,18 +117,14 @@ async def test_dead_worker_makes_environment_usage_unavailable(
     assert root is not None
     report = verify_bundle(root)
     assert report.valid
-    reconciliations = [
-        event.payload for event in report.events if event.kind == "reconciliation"
-    ]
+    reconciliations = payloads(root, ReconciliationPayload)
     # Required reporting is not demanded by this budget, so the reconciliation
     # still closes; the unavailable entries are what the record preserves.
     assert len(reconciliations) == 1
 
 
 @pytest.mark.asyncio
-async def test_cost_counters_match_the_usage_events(
-    tmp_path: Path, episode_id: str
-) -> None:
+async def test_cost_counters_match_the_usage_events(tmp_path: Path, episode_id: str) -> None:
     adapter = FakeAdapter(tmp_path, episode_id)
     runner = EpisodeRunner(
         build_spec(episode_id),
@@ -153,9 +147,7 @@ async def test_cost_counters_match_the_usage_events(
     assert report.counters.input_tokens == 30
     assert report.counters.output_tokens == 15
     assert report.counters.cost_microusd == 21
-    reconciliations = [
-        event.payload for event in report.events if event.kind == "reconciliation"
-    ]
+    reconciliations = payloads(root, ReconciliationPayload)
     # The sealed outcome's cost must equal the reconciliation's provider cost.
     assert reconciliations[0].provider_cost_microusd == 21
 

--- a/tests/unit/evaluation/runner/test_reconciliation.py
+++ b/tests/unit/evaluation/runner/test_reconciliation.py
@@ -1,0 +1,235 @@
+"""Budget reconciliation, overrun, and the writer-failure terminal.
+
+Overrun is deliberately not a failure: an episode that exceeded its allowance
+still produced a real result, and the overrun belongs in the reconciliation
+record rather than in the score. What DOES change the run's standing is usage
+that could not be measured at all, which is what makes a bundle unreportable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.evaluation.adapters.supervisor import SupervisionError
+from local_operator.evaluation.evidence.store import EvidenceError
+from local_operator.evaluation.evidence.verify import verify_bundle
+from local_operator.evaluation.receipts import (
+    BUDGET_RESOURCES,
+    BudgetAuthorization,
+    CappedAllowance,
+    ResourceAmount,
+    reserve_budget,
+)
+from local_operator.evaluation.runner.episode import EpisodeRunner
+from tests.unit.evaluation.runner.conftest import (
+    FakeAdapter,
+    ScriptedModel,
+    build_config,
+    build_spec,
+    selector,
+)
+
+
+async def _rescue_ok(descriptor: Any, **kwargs: Any) -> Any:
+    del kwargs
+
+    class _Aggregate:
+        complete = True
+        descriptor_id = descriptor.descriptor_id
+
+    return _Aggregate()
+
+
+@pytest.mark.asyncio
+async def test_overrun_is_recorded_and_still_scores(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """A tiny allowance is exceeded by real usage; the episode still scores."""
+
+    spec = build_spec(episode_id)
+    budget = BudgetAuthorization(
+        episode_id=episode_id,
+        allowances=tuple(
+            CappedAllowance(resource=resource, value=1, reporting="optional")
+            for resource in BUDGET_RESOURCES
+        ),
+    )
+    reservation = reserve_budget(
+        budget,
+        "episode",
+        [ResourceAmount(resource=resource, value=1) for resource in BUDGET_RESOURCES],
+    )
+    spec = type(spec)(
+        **{
+            **spec.__dict__,
+            "budget": budget,
+            "reservations": (reservation,),
+        }
+    )
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = EpisodeRunner(
+        spec,
+        build_config(tmp_path),
+        selector=selector(tmp_path),
+        model=ScriptedModel(["step", "finish"]),
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "completed"
+    assert outcome.score is not None and outcome.score.status == "scored"
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid
+    reconciliations = [
+        event.payload for event in report.events if event.kind == "reconciliation"
+    ]
+    assert len(reconciliations) == 1
+    # Usage was measurable, so the run stays reportable despite the overrun.
+    assert reconciliations[0].reportable is True
+
+
+@pytest.mark.asyncio
+async def test_dead_worker_makes_environment_usage_unavailable(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """A poisoned session cannot report environment usage; that is not a guess."""
+
+    adapter = FakeAdapter(
+        tmp_path, episode_id, failures={"execute": SupervisionError("worker died")}
+    )
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path),
+        selector=selector(tmp_path),
+        model=ScriptedModel(["step", "finish"]),
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+
+    outcome = await runner.run()
+
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid
+    reconciliations = [
+        event.payload for event in report.events if event.kind == "reconciliation"
+    ]
+    # Required reporting is not demanded by this budget, so the reconciliation
+    # still closes; the unavailable entries are what the record preserves.
+    assert len(reconciliations) == 1
+
+
+@pytest.mark.asyncio
+async def test_cost_counters_match_the_usage_events(
+    tmp_path: Path, episode_id: str
+) -> None:
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path),
+        selector=selector(tmp_path),
+        model=ScriptedModel(["step", "step", "finish"]),
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+
+    outcome = await runner.run()
+
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid and report.counters is not None
+    # Three decisions at the scripted 10/5 tokens and 7 micros each.
+    assert report.counters.model_request_count == 3
+    assert report.counters.model_response_count == 3
+    assert report.counters.input_tokens == 30
+    assert report.counters.output_tokens == 15
+    assert report.counters.cost_microusd == 21
+    reconciliations = [
+        event.payload for event in report.events if event.kind == "reconciliation"
+    ]
+    # The sealed outcome's cost must equal the reconciliation's provider cost.
+    assert reconciliations[0].provider_cost_microusd == 21
+
+
+@pytest.mark.asyncio
+async def test_writer_failure_abandons_after_rescuing_first(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """Cloud safety needs no writer, so rescue precedes abandonment."""
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    config = build_config(tmp_path)
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        config,
+        selector=selector(tmp_path),
+        model=ScriptedModel(["step", "finish"]),
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+    rescued: list[bool] = []
+
+    async def tracking_rescue(descriptor: Any, **kwargs: Any) -> Any:
+        rescued.append(True)
+        return await _rescue_ok(descriptor, **kwargs)
+
+    runner._rescue = tracking_rescue
+
+    original = runner._append
+
+    def failing(kind: Any, payload: Any) -> None:
+        if kind == "environment_step":
+            raise _poisoned()
+        original(kind, payload)
+
+    def _poisoned() -> BaseException:
+        from local_operator.evaluation.runner.episode import _EvidenceFailure
+
+        return _EvidenceFailure("journal write failed")
+
+    runner._append = failing  # type: ignore[method-assign]
+
+    outcome = await runner.run()
+
+    assert outcome.status == "abandoned"
+    assert rescued == [True]
+    assert outcome.rescue_complete is True
+    assert adapter.terminated
+    assert isinstance(outcome.diagnostic, str)
+
+
+@pytest.mark.asyncio
+async def test_evidence_errors_surface_as_abandonment_not_a_crash(
+    tmp_path: Path, episode_id: str
+) -> None:
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path),
+        selector=selector(tmp_path),
+        model=ScriptedModel(),
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+    original = runner._publish
+
+    def failing(data: bytes, **kwargs: Any) -> Any:
+        raise EvidenceError("artifact store is full")
+
+    runner._publish = failing  # type: ignore[method-assign]
+    del original
+
+    outcome = await runner.run()
+
+    # An evidence failure is never reported as a scored or completed episode.
+    assert outcome.status in ("abandoned", "failed_pre_bundle")
+    assert outcome.score is None


### PR DESCRIPTION
## Summary

This PR adds the fifth slice of Local Operator's benchmark-neutral evaluation platform: the parent **`EpisodeRunner`**. It runs one evaluation episode end to end and leaves behind exactly one bundle the independent verifier accepts. It does not activate a benchmark, OSWorld, provider, CLI, configuration, tool, cloud, or UI path.

The runner composes the four released foundations and adds no new invariants of its own:

- **`protocol` / `adapters.api`** supply the observation and action wire shapes.
- **`adapters.supervisor`** supplies `VerifiedAdapterSession` — parent-owned truth about what the adapter did — plus durable rescue.
- **`receipts` / `lifecycle`** supply preflight, budget, cleanup, and the episode state machine, each a single-use process-local authority.
- **`evidence`** supplies the append-only journal whose verifier is the acceptance test for everything written here.

Five modules under `local_operator/evaluation/runner/`: `episode.py` (the runner and its spec/config/outcome types), `model.py` (`EpisodeModelClient`), `responder.py` (`UserResponder`, `NullUserResponder`), `provider_client.py` (the only module allowed to reach the application), and a docstring-only `__init__.py`.

This is a standard C2 change and is pre-authorized. The PR is the system of record; there is no issue or RFC.

## Not activated

This slice is a foundation, deliberately unreachable from any running code path:

- No CLI command, configuration key, default tool, UI surface, OSWorld integration, or cloud wiring.
- `evaluation/runner/__init__.py` is docstring-only; importing the package starts nothing.
- **Nothing outside the evaluation package imports it.** Verified by search — every reference to `local_operator.evaluation.runner` lives inside the package or its own tests.
- **Startup is unchanged.** Verified by executing the real import: a subprocess that imports `local_operator.cli`, `local_operator.tui.app`, or `local_operator.evaluation` loads **zero** `evaluation.runner` modules.
- `tests/unit/evaluation/runner/test_isolation.py` asserts this permanently: the runner core must not import providers, config, tools, TUI, mobile, session, or textual, and `provider_client` must not import `model.configure` eagerly. An episode has to be reproducible from its pinned inputs, and a transitive import of session configuration is how a benchmark result silently starts depending on the operator's own settings.

## Two-stage rescue persistence

`VerifiedAdapterSession.prepare` refuses to run without a persisted rescue descriptor, but a descriptor **embeds the cleanup plan that only `prepare` can return**. That circularity is resolved in two stages:

1. **Before `prepare`**, persist a *provisional* descriptor carrying the one action the parent can author unaided: `close_session` on the worker identity.
2. **Immediately after `prepare` returns, before `reset_start`**, re-persist the real descriptor with the adapter's returned plan.

This is sound only because `prepare` is declarative and `reset_start` is the side-effect boundary — if `prepare` creates nothing, the provisional plan covers everything that could exist at that instant. The adapter contract is stated at the call site: *prepare must not create environment resources; reset_start does.* The real plan is durable before the first resource exists, so a parent that dies mid-episode leaves every resource reclaimable. Covered by `test_rescue_descriptor_is_persisted_before_prepare_and_updated_after`, which reads the on-disk descriptor at both call boundaries.

## Mandatory `begin_finalization` on every terminal path

`record_final_lifecycle` requires the finalizing marker, so **every** terminal path — including crash and cancel — calls `begin_finalization(intent="unscored")` first. A crash path that skips it has no legal terminal at all and the bundle can only be abandoned. Only an early pre-execution preflight/infrastructure failure bypasses this, and those use `abandon()`.

## ask_user choreography

Forced by the verifier's one-batch-per-observation rule (`verify.py:575-580`): an ask cannot be a batch that is written and then abandoned. So the answer is obtained **first**, and the ask batch is then executed like any other batch — a lone `AskUserAction` is a legal batch, and executing it produces the observation the model sees next:

```
begin_ask → responder → finish_ask(answer) → user_simulator_exchange → execute the ask batch → step + observation
```

An unanswered ask is treated as a harness-sourced cancellation rather than an error, because an outstanding exchange cannot be left open and there is no way to withdraw one. The system prompt tells the model that `ask_user` pauses for a human answer and that it will see the answered observation next turn.

## Three places the design brief contradicted the released code

The architecture pass specified three things the released foundations reject. In each case I followed the code, verified the constraint by execution, and left the explanation at the site — these are exactly the spots a future reader would "simplify" back into a bug.

**1. A crash cannot seal a `failed` lifecycle snapshot.**
- *Design specified:* crash → terminal `failed(crash)` → seal unscored.
- *Released code requires:* `seal()` accepts only a **`completed`** snapshot (`store.py:1359`, "seal requires a completed lifecycle snapshot"), yet `lifecycle.finish_cleanup()` returns `failed` after a crash. Probed directly: sealing a `failed` terminal raises `EvidenceBundleInvalid`.
- *What I did:* failure is carried by `failure_kind` plus an unscored `ScoreArtifact` on a `completed` snapshot — which is precisely what the existing `test_infrastructure_failure_seals_unscored_not_binary_zero` already does.
- *Comment lives at:* `_close_out` in `episode.py`, above `_append_final_lifecycle`.

**2. The scorer version separator cannot be `+`.**
- *Design specified:* `scorer_version = metadata.version + "+" + package_digest[:16]`.
- *Released code requires:* `StrictIdentifier` is `^[A-Za-z0-9][A-Za-z0-9_.:-]*$` — `+` fails validation.
- *What I did:* joined with `-`. The value only has to be exact and stable, not semver.
- *Comment lives at:* `_finalize_scored` in `episode.py`.

**3. `model_request` and `action_batch` must be written *after* the call they describe.**
- *Design specified:* `model_request → model_response → usage_cost`, and `action_batch` then `execute`.
- *Released code requires:* at any terminal the verifier demands every request carry its response and usage (`verify.py:760`) and every non-finish batch carry its step (`verify.py:762-766`). Writing either eagerly leaves a dangling operation when the provider or adapter fails, making the crash bundle **permanently unsealable**.
- *What I did:* call first, then write. The journal still carries the required request→response→usage and batch→step order; only the write point moved. Found by the failure matrix, not by inspection — the eager version passed the happy path and produced an invalid bundle on every failure path.
- *Comment lives at:* `_decide` and `_execute_batch` in `episode.py`.

## Failure taxonomy

| Situation | Terminal |
| --- | --- |
| Adapter RPC / host-verification failure | `ErrorPayload(adapter)` → crash → unscored finalization → cleanup → **rescue** → `failed`, label `cleanup_incomplete` |
| Model provider error (retries exhausted) | `ErrorPayload(provider)` → unscored finalization on the **live** session → normal cleanup, no rescue → `infrastructure_failure` |
| Evidence write failure | **Rescue first** (cloud safety needs no writer), terminate adapter, then `abandon()` → `abandoned` |
| Budget exhaustion / step cap | **Not a failure.** Last `EnvironmentStepPayload.truncated=true`, then score normally; overrun lands in reconciliation |
| Cancellation / unanswered ask | `CancelPayload` → unscored finalization + cleanup → `cancelled` |
| Scorer failure after `begin_finalization(score)` | `scoring_start` is durable and a scored intent cannot seal unscored, so the only legal terminal is `abandon(ambiguous_finalization)`; rescue runs first |

Label precedence is `cleanup_incomplete > budget_unreconciled > unscored`: a leaked resource is a worse claim about a run than an unclosed budget, which matters more than a missing score.

Two bugs the tests caught and this PR fixes: a raw `EvidenceError` escaping to the crash path reported a poisoned writer as an ordinary `failed` episode, and a failed cleanup reported `status="completed"` while the bundle itself said `cleanup_incomplete`.

## Testing evidence

**33/33 runner tests pass.**

- **26 in-process**, driving the *real* `VerifiedAdapterSession`, the *real* lifecycle authorities, and a *real* `EvidenceWriter` on `tmp_path`. Only the subprocess boundary is faked. Every terminal path asserts `verify_bundle().valid` or a coherent `AbandonmentRecord`.
- **7 real-subprocess** (marked `slow`, kept in the default run), spawning a genuine interpreter running a genuine installed adapter distribution and **SIGKILLing it at each cutpoint** — `prepare`, `reset_start`, `execute`, `score`, `cleanup` — asserting poison, rescue, and a coherent bundle or abandonment. A kill during `cleanup` correctly keeps the already-earned score and labels the run `cleanup_incomplete`; every earlier cutpoint dies before a score can exist. The cutpoint arrives through an adapter-owned workspace file rather than an env var, because the supervisor builds the worker environment from a closed allowlist that correctly strips one. These fail loudly rather than skipping when a host cannot build the fixture, so an absent interpreter cannot silently remove all subprocess coverage.

**Whole tree: 10102 passed, 15 skipped.** No regressions; the 354 pre-existing evaluation tests are unaffected.

**All four gates clean over the whole tree, exactly as CI runs them:** `flake8` clean · `black==26.1.0 --check` clean · `isort==5.13.2 --check` clean · `pyright` **0 errors**.

**Packaging:** `uv build` + `uvx twine check` both PASSED, and all five runner modules are present in both the wheel and the sdist.

## Limitation

**`provider_client.py`'s live-provider path is unproven.** It type-checks against the real `local_operator.harness.types` API and its strict JSON decision parsing is unit-covered, but **no test spends tokens against a real provider**, so the actual stream path — `stream_fn` yielding `text_delta` / `usage` / `end` events, and the usage numbers those carry — has never executed end to end. Everything in the testing evidence above uses a scripted in-process model. This is the thinnest part of the change and the reviewer should weigh it as such; the runner core is exercised hard, the provider adapter is not.

## Version

Patch (`0.44.19` → `0.44.20`). This is an inert internal foundation, not a user-facing capability: nothing outside the evaluation package imports it, the package roots stay import-inert, and startup is unchanged.
