### PR TITLE
chore(release): bump version to 0.44.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.22"
+version = "0.44.23"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Bumps to 0.44.23. The lazy-load fix (#506) merged carrying the version 0.44.22 it was authored with, but 0.44.22 was already released from a parallel branch mid-review — so this single-line bump is the release commit that lets the fixed build publish under a version that does not exist yet. No other content; the behaviour change is already on main via b7fad18b.