### PR TITLE
fix(tui): never decide the subagent landing from a stale layout

### DIFF
--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -2604,8 +2604,32 @@ class SubagentView(Vertical):
                 self._landing_snap_pending = False
             return
         offset = body.scroll_offset.y
+        blocks = body.blocks()
+        # Nothing may be decided from a layout the offset has outrun. The
+        # container republishes ``virtual_size`` (and so ``max_scroll_y``, and
+        # so the followed offset) before every child's ``virtual_region`` has
+        # been reassigned, so there is a window where the offset addresses a
+        # row that no block claims yet. Searching in that window matches
+        # nothing, falls through to ``target == offset``, and spends the
+        # one-shot on a landing it never actually inspected.
+        #
+        # Observed on CI four times with identical numbers — ``offset=28,
+        # owner_top=25, max=28`` — and reproduced locally under xdist with the
+        # trace ``snap-post 28 28 37 following=True pending=False``: the
+        # deciding call saw the FINAL extent (37) and still found no owner,
+        # because the notice's region had not been republished yet.
+        #
+        # Returning WITHOUT clearing the flag is the point: the one-shot
+        # survives to the next refresh, which is what a one-shot is for. The
+        # user-visible alternative is issue #407 itself — a narrow page
+        # opening on a hanging-indented red continuation line instead of the
+        # notice's first row.
+        if not any(
+            block.virtual_region.y <= offset < block.virtual_region.bottom for block in blocks
+        ):
+            return
         target = offset
-        for block in body.blocks():
+        for block in blocks:
             top = block.virtual_region.y
             bottom = block.virtual_region.bottom
             if top < offset < bottom:

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -2605,13 +2605,34 @@ class SubagentView(Vertical):
             return
         offset = body.scroll_offset.y
         blocks = body.blocks()
-        # Nothing may be decided from a layout the offset has outrun. The
-        # container republishes ``virtual_size`` (and so ``max_scroll_y``, and
-        # so the followed offset) before every child's ``virtual_region`` has
-        # been reassigned, so there is a window where the offset addresses a
-        # row that no block claims yet. Searching in that window matches
-        # nothing, falls through to ``target == offset``, and spends the
-        # one-shot on a landing it never actually inspected.
+        # Only decide when a block actually OWNS the current offset.
+        #
+        # The container republishes ``virtual_size`` (and so ``max_scroll_y``,
+        # and so the followed offset) before every child's ``virtual_region``
+        # has been reassigned, so there is a window where the offset addresses
+        # a row no block claims yet. Searching in that window matches nothing,
+        # falls through to ``target == offset``, and spends the one-shot on a
+        # landing it never actually inspected.
+        #
+        # An unowned offset does NOT prove the layout is stale, and this test
+        # is deliberately not written as if it did: the gap margin
+        # (``.gap-above``) and the list's own vertical padding are real rows
+        # that no block's region covers, so unowned offsets exist at steady
+        # state too (measured: sets like ``[6, 8]`` in every configuration
+        # tried). The condition being tested is narrower and is the one that
+        # matters here — "is there a block whose head I could snap to?" With
+        # no owner there is nothing to snap to, so there is no decision to
+        # make and no reason to retire the guard.
+        #
+        # The cost of that is a one-shot which may never be spent on a
+        # completed child that sends no further refresh. That is deliberate
+        # and safe rather than merely tolerable: a surviving one-shot can only
+        # ever snap to the head of the block that owns the CURRENT offset, so
+        # firing it late is a no-op or a correction upward inside the block
+        # the reader is already looking at — never a jump somewhere else.
+        # Verified against the alternative during review: a reader parked
+        # mid-block and then repainted is yanked in MORE configurations
+        # without this guard than with it.
         #
         # Observed on CI four times with identical numbers — ``offset=28,
         # owner_top=25, max=28`` — and reproduced locally under xdist with the

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -2619,14 +2619,28 @@ class SubagentView(Vertical):
         if target != offset:
             with body._tail_anchor.programmatic_scroll():
                 body.scroll_to(y=target, animate=False, immediate=True)
-            # A snap that pulled back from the tail is a landing, not a
-            # follow. Leaving following armed lets `_size_updated` on the
-            # next extent change `_scroll_to_tail` onto the wrap fragment
-            # this just left (review round 1, F1). Released AFTER the
-            # programmatic context: ``note_user_scroll`` is a no-op while
-            # that depth is non-zero.
-            if target < body.max_scroll_y:
-                body._tail_anchor.release()
+        # Release whenever the landing is NOT the tail — including the case
+        # where no scroll was needed because the offset already sat on a head.
+        #
+        # This release used to live inside the ``target != offset`` branch, so
+        # a snap that found the offset already on a head spent the one-shot
+        # while leaving sticky-follow armed. That is not a rare path: this
+        # method runs several times during an open (measured: three on the
+        # narrow fixture, the first two returning early against a body that is
+        # still short), and any growth after the deciding call then sends
+        # ``_size_updated`` -> ``_scroll_to_tail`` to the new tail. On a short
+        # viewport that tail is three rows inside the wrapping notice — issue
+        # #407 exactly, reached after the guard had declared the landing done.
+        #
+        # Measured as ``offset=28, owner_top=25, max=28`` on CI (four
+        # identical failures) and reproduced locally at 1-in-8 under load.
+        # Keyed on the POSITION rather than on whether a scroll happened,
+        # because the invariant the anchor encodes is "the viewport is not at
+        # the end", and that is equally true in both branches. Released AFTER
+        # the programmatic context above: ``note_user_scroll`` is a no-op
+        # while that depth is non-zero.
+        if target < body.max_scroll_y:
+            body._tail_anchor.release()
         self._landing_snap_pending = False
 
     def _empty_state(self) -> str:

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -4044,12 +4044,12 @@ async def test_the_landing_survives_the_next_extent_change(tmp_path) -> None:
         landed, landed_top = _landing_owner_top(view)
         if landed_top != landed:
             # The landing itself did not come out on a row head. That is the
-            # SIBLING test's subject, and there is a known residual race in
-            # the snap that can still produce it under heavy parallel load
-            # (issue filed; the deciding call can read block regions that lag
-            # the container's republished extent). Failing here too would
-            # report one defect twice and make this test's own subject —
-            # whether a settled landing SURVIVES growth — unreachable.
+            # SIBLING test's subject — it asserts exactly this and fails with
+            # the offending offsets — so failing here too would report one
+            # defect twice while making this test's own subject (whether a
+            # SETTLED landing survives growth) unreachable. Skipping keeps the
+            # two subjects separate: if the landing regresses, the sibling
+            # goes red and names it; this one simply has nothing to say.
             pytest.skip(
                 f"landing did not settle on a row head (offset={landed}, "
                 f"owner_top={landed_top}); that is the sibling test's subject"

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -1047,6 +1047,48 @@ async def _wait_history(pilot: Any, view: SubagentView) -> None:
     await pilot.pause()
 
 
+async def _wait_landing_settled(
+    pilot: Any, view: SubagentView, *, cycles: int = 4, limit: int = 200
+) -> None:
+    """Block until the initial landing has been DECIDED, then settled.
+
+    The landing is the end of a deferred chain, not a state that exists when
+    the history worker returns: ``_settle_initial_landing`` re-arms the
+    one-shot inside a ``call_after_refresh``, ``_reconcile_current_body``
+    schedules ``_schedule_landing_snap`` through another, and that schedules
+    ``_snap_landing_to_row_head`` through a third. Until the last of those
+    runs, the body is wherever sticky-tail following left it — which on a
+    short viewport is the raw tail, three rows into the wrapping notice.
+
+    A fixed pause budget is a bet that the chain drains inside it. The bet
+    holds on an idle box (the snap lands before the first pause here) and
+    loses on a contended CI runner, where it failed four times with the
+    identical signature ``offset=28, owner_top=25, max=28`` — offset equal to
+    ``max_scroll_y``, i.e. the untouched tail, the snap never having run.
+    That reproduces exactly by forcing the state the numbers describe
+    (``_tail_anchor.acquire()`` then ``_scroll_to_tail()``).
+
+    So wait on the two observables the assertions actually depend on: the
+    one-shot being spent (``_landing_snap_pending`` false, which is set false
+    on every path out of the snap, including the ones that decide no snap is
+    needed) and the geometry then holding still, since the snap can be
+    followed by a further layout pass. The ceiling is a deadlock guard, not a
+    timing assumption: a slow machine costs nothing and a landing that never
+    settles still fails with what it was waiting for.
+    """
+    for _ in range(limit):
+        await pilot.pause()
+        if not view._landing_snap_pending and not view._initial_tail_pending:
+            break
+    else:
+        raise AssertionError(
+            "the landing snap never resolved "
+            f"(snap_pending={view._landing_snap_pending}, "
+            f"tail_pending={view._initial_tail_pending})"
+        )
+    await _wait_geometry_settled(pilot, view._body, cycles=cycles, limit=limit)
+
+
 async def _wait_geometry_settled(
     pilot: Any, body: Any, *, cycles: int = 4, limit: int = 200
 ) -> None:
@@ -3897,8 +3939,7 @@ async def test_a_narrow_viewport_opens_on_a_row_head_not_a_wrap_fragment(
     async with app.run_test(size=(62, 24)) as pilot:
         view = await _open(pilot, app, job)
         await _wait_history(pilot, view)
-        for _ in range(12):
-            await pilot.pause()
+        await _wait_landing_settled(pilot, view)
         offset, owner_top = _landing_owner_top(view)
         assert owner_top is not None, (
             f"no block owns the landing offset {offset}; "
@@ -3921,4 +3962,94 @@ async def test_a_narrow_viewport_opens_on_a_row_head_not_a_wrap_fragment(
         assert notice.virtual_region.y == offset, (
             f"landed on {type(view._body.blocks()[0]).__name__} at {offset}, "
             f"not the wrapping notice at {notice.virtual_region.y}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_landing_survives_the_next_extent_change(tmp_path) -> None:
+    """A row that arrives after the landing must not drag it back onto a wrap.
+
+    The snap pulls the offset back to a row head, which leaves the viewport
+    ABOVE the tail — so sticky-tail following has to be released, or the very
+    next extent change calls ``_scroll_to_tail`` and puts the fragment straight
+    back. ``_snap_landing_to_row_head`` does release it, and the comment there
+    names this exact regression (F1, review round 1), but nothing exercised it:
+    removing the ``_tail_anchor.release()`` call leaves the whole file green on
+    ``main``, because the sibling test above asserts the landing and then stops
+    looking.
+
+    This is that missing half. It opens the same 62x24 page, waits for the same
+    landing, then appends one live row — the ordinary thing a running child
+    does — and requires the first visible line to still be a row head.
+
+    Mutation: delete the ``release()`` call and this fails with the offset
+    three rows inside the notice, which is the shape issue #407 reported.
+    """
+    transcript = Transcript(tmp_path / "child")
+    for index in range(20):
+        await transcript.append_message(
+            Message.assistant(f"durable {index}: applying the review fixes to the widget.")
+        )
+    events: list[dict[str, Any]] = []
+    for index in range(2):
+        events.extend(_text(f"m{index}", f"Step {index}: applying the review fixes to the widget."))
+    events.append(_call("c1", "edit", path="local_operator/tui/widgets/subagent_view.py"))
+    events.append(
+        _result(
+            "c1",
+            "edit",
+            "Invalid arguments: argument 'edits' does not match type array",
+            is_error=True,
+        )
+    )
+    events.append(_long_error_notice())
+    job = _job_with(events, status="running")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(62, 24)) as pilot:
+        view = await _open(pilot, app, job)
+        await _wait_history(pilot, view)
+        await _wait_landing_settled(pilot, view)
+
+        landed, landed_top = _landing_owner_top(view)
+        assert landed_top == landed, (
+            "precondition: the page did not land on a row head, so this test "
+            f"cannot say anything about what happens next (offset={landed}, "
+            f"owner_top={landed_top})"
+        )
+        # Following must be off after a snap that pulled back from the tail.
+        # Asserted as the STATE, not inferred from the offset, so a failure
+        # here names the cause rather than its symptom.
+        assert not view._body._tail_anchor.following, (
+            "the landing snap left sticky-tail following armed; the next "
+            "extent change will scroll back onto the wrap fragment"
+        )
+
+        # One more live row: the ordinary growth a running child produces,
+        # published the way the jobs coalescer publishes it rather than by
+        # poking the view, so this exercises the real repaint path.
+        from local_operator.session.frontend_state import FrontendSessionState, JobState
+
+        job.trajectory.extend(_text("m9", "Step 9: still working through the widget rewrite."))
+        app._apply_frontend_state(
+            FrontendSessionState(
+                session_id="sess",
+                epoch="owner",
+                jobs=[JobState.from_job(job)],
+            )
+        )
+        await _wait_geometry_settled(pilot, view._body)
+
+        offset, owner_top = _landing_owner_top(view)
+        assert owner_top is not None, (
+            f"no block owns the offset {offset} after growth; "
+            f"starts={[b.virtual_region.y for b in view._body.blocks()[:12]]}"
+        )
+        assert owner_top == offset, (
+            f"growth dragged the viewport {offset - owner_top} rows into a block "
+            f"(offset={offset}, owner_top={owner_top}, max={view._body.max_scroll_y})"
         )

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -1069,12 +1069,18 @@ async def _wait_landing_settled(
     (``_tail_anchor.acquire()`` then ``_scroll_to_tail()``).
 
     So wait on the two observables the assertions actually depend on: the
-    one-shot being spent (``_landing_snap_pending`` false, which is set false
-    on every path out of the snap, including the ones that decide no snap is
-    needed) and the geometry then holding still, since the snap can be
-    followed by a further layout pass. The ceiling is a deadlock guard, not a
-    timing assumption: a slow machine costs nothing and a landing that never
-    settles still fails with what it was waiting for.
+    one-shot being spent (``_landing_snap_pending`` false) and the geometry
+    then holding still, since the snap can be followed by a further layout
+    pass.
+
+    ``_snap_landing_to_row_head`` does NOT clear the flag on every path out
+    of it — it returns with the one-shot still armed when the body is not yet
+    mounted or laid out, and when the history page is still pending. Those
+    are exactly the states this helper must keep waiting through, so the
+    flag's meaning here is "the landing has been decided", not "the snap
+    function has run". The ceiling is therefore a deadlock guard rather than
+    a timing assumption: a slow machine costs nothing, and a landing that
+    never resolves fails naming both flags instead of hanging.
     """
     for _ in range(limit):
         await pilot.pause()

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -1082,17 +1082,37 @@ async def _wait_landing_settled(
     a timing assumption: a slow machine costs nothing, and a landing that
     never resolves fails naming both flags instead of hanging.
     """
+    body = view._body
+    stable = 0
+    last: tuple[int, float] | None = None
     for _ in range(limit):
         await pilot.pause()
-        if not view._landing_snap_pending and not view._initial_tail_pending:
-            break
-    else:
-        raise AssertionError(
-            "the landing snap never resolved "
-            f"(snap_pending={view._landing_snap_pending}, "
-            f"tail_pending={view._initial_tail_pending})"
-        )
-    await _wait_geometry_settled(pilot, view._body, cycles=cycles, limit=limit)
+        current = (body.virtual_size.height, body.scroll_y)
+        decided = not view._landing_snap_pending and not view._initial_tail_pending
+        # BOTH, and on the same frame. The flag alone is not enough: the snap
+        # is called several times (measured: three on this fixture, the first
+        # two returning early while the body is still short), and the call
+        # that runs against a still-growing layout can find the current offset
+        # already sitting on a head, take ``target == offset``, and clear the
+        # one-shot without scrolling or releasing the anchor. A later pass
+        # then grows the extent, sticky-follow moves to the new tail, and the
+        # landing is a wrap fragment again with the flag long since spent —
+        # observed here as the precondition failing at ``offset=28,
+        # owner_top=25``, the same numbers CI reported.
+        #
+        # Requiring the extent to have held still for ``cycles`` frames while
+        # the flag is clear is what makes "decided" mean decided against the
+        # FINAL layout rather than against whichever one the one-shot met.
+        stable = stable + 1 if decided and current == last else 0
+        last = current
+        if stable >= cycles:
+            return
+    raise AssertionError(
+        "the landing never settled: "
+        f"snap_pending={view._landing_snap_pending}, "
+        f"tail_pending={view._initial_tail_pending}, "
+        f"virtual_height={body.virtual_size.height}, scroll_y={body.scroll_y}"
+    )
 
 
 async def _wait_geometry_settled(

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -4042,14 +4042,24 @@ async def test_the_landing_survives_the_next_extent_change(tmp_path) -> None:
         await _wait_landing_settled(pilot, view)
 
         landed, landed_top = _landing_owner_top(view)
-        assert landed_top == landed, (
-            "precondition: the page did not land on a row head, so this test "
-            f"cannot say anything about what happens next (offset={landed}, "
-            f"owner_top={landed_top})"
-        )
-        # Following must be off after a snap that pulled back from the tail.
+        if landed_top != landed:
+            # The landing itself did not come out on a row head. That is the
+            # SIBLING test's subject, and there is a known residual race in
+            # the snap that can still produce it under heavy parallel load
+            # (issue filed; the deciding call can read block regions that lag
+            # the container's republished extent). Failing here too would
+            # report one defect twice and make this test's own subject —
+            # whether a settled landing SURVIVES growth — unreachable.
+            pytest.skip(
+                f"landing did not settle on a row head (offset={landed}, "
+                f"owner_top={landed_top}); that is the sibling test's subject"
+            )
+        # Following must be off after a snap that has landed above the tail.
         # Asserted as the STATE, not inferred from the offset, so a failure
-        # here names the cause rather than its symptom.
+        # here names the cause rather than its symptom. This is the assertion
+        # that kills the F1 mutant, and it does not depend on the timing
+        # above: once the landing IS on a head short of the tail, the anchor
+        # must be released or the growth below will drag it back.
         assert not view._body._tail_anchor.following, (
             "the landing snap left sticky-tail following armed; the next "
             "extent change will scroll back onto the wrap fragment"


### PR DESCRIPTION
# PR Description

## Summary of Changes

The last flake on `main` turned out to be a **real product bug**, not a flaky test. The test was reporting it honestly all along.

`test_a_narrow_viewport_opens_on_a_row_head_not_a_wrap_fragment` failed on CI **four times with the identical signature**:

```
landing sits 3 rows into a block (offset=28, owner_top=25, max=28)
```

Identical numbers across four runs is not a race between two outcomes — it is one deterministic bad state reached by timing.

### Root cause (the real one)

Textual republishes a container's `virtual_size` — and therefore `max_scroll_y`, and therefore the sticky-followed offset — **before every child's `virtual_region` has been reassigned**. That leaves a window where the offset addresses a row no block claims yet.

`_snap_landing_to_row_head` searched for the owning block in that window, matched nothing, fell through to `target == offset`, and **spent its one-shot on a landing it had never actually inspected**. The next layout published the real regions, and the offset was three rows inside the wrapping notice with the guard already retired.

Captured under xdist:

```
snap-post 28 28 37 following=True pending=False
```

The deciding call saw the **final** extent (37) and still found no owner. That is exactly CI's numbers.

The fix refuses to decide when no block owns the offset, returning **without clearing the flag** — the one-shot survives to the next refresh, which is what a one-shot is for.

### Second product bug, found on the way

`_snap_landing_to_row_head` releases sticky-tail following after landing above the tail (F1, issue #407). The release sat **inside** the `target != offset` branch, so a snap that found the offset already on a head spent the one-shot while leaving following armed — and the next extent change dragged it back onto the fragment. Now keyed on the position, since the invariant is "the viewport is not at the end".

### Test changes

- `_wait_landing_settled` replaces `for _ in range(12): await pilot.pause()` — the snap is the end of a three-hop deferred chain, so a fixed budget was a bet. The file already had `_wait_geometry_settled` documenting this exact reasoning.
- `test_the_landing_survives_the_next_extent_change` is new: it closes a gap where **removing the anchor release left the whole file green on `main`**.

## Testing Evidence

### Failure rate, measured under matched load

| tree | result |
|---|---|
| `main`, 20 loaded runs | **2 failures** |
| branch, 20 loaded runs | **0 failures** |
| branch, 14 loaded xdist runs (load avg 158) | **0 failures, 0 skips** |
| branch with the layout guard reverted, 12 runs | **1 failure** — same signature |

The last row is the proof the guard is load-bearing rather than incidental.

### Mutation testing — every guard still fails

```
snap made a no-op (#407 reintroduced)
  → FAILED ... landing sits 3 rows into a block (offset=28, owner_top=25, max=28)

anchor release removed (F1 reintroduced)
  → FAILED ... the landing snap left sticky-tail following armed;
               the next extent change will scroll back onto the wrap fragment

stale-layout guard removed
  → 1/12 loaded runs fail with the original CI signature
```

The first is the critical one: the **fixed** test still fails when the defect is reintroduced, so the de-flake did not paper over anything.

### Suites

```
test_subagent_view.py    124 passed (serial, repeated)
full TUI suite           4184 passed, 12 skipped
three lint gates         flake8 / isort / black clean repo-wide
```

## Known residual

`test_the_landing_survives_the_next_extent_change` skips itself if the landing has not settled on a row head, rather than failing — that condition is the sibling test's subject, and failing both would report one defect twice. Across the final 14 loaded runs it skipped **0 times**. The F1 assertion it exists for still kills its mutant with the skip in place, verified.

## Related

- Issue #407 is the user-visible defect: a narrow subagent page opening on a hanging-indented red continuation line instead of the notice's first row.
- Applies the AGENTS.md guidance from #507 ("wait on the event, never on the clock"; "prove the test can still fail").
- #513 fixed four suites of this class; this was the last one on the CI census — and the only one that turned out to be a product bug.
