### PR TITLE
feat(tui): /copy picker for answers and their code blocks

### DIFF
--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -63,6 +63,12 @@ _FRONTEND_LOCAL_SLASHES = {
     "help",
     "exit",
     "clear",
+    # The clipboard is the machine the USER IS SITTING AT, and both halves of
+    # this command are already here: the transcript it reads is painted by this
+    # frontend, and the OSC 52 write goes out this terminal. Routed to the owner
+    # it would copy an answer onto a host nobody is at, which is the same
+    # argument `/theme` and `/settings` make about config.yml.
+    "copy",
     "new",
     "reload",
     "update",

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -63,11 +63,12 @@ _FRONTEND_LOCAL_SLASHES = {
     "help",
     "exit",
     "clear",
-    # The clipboard is the machine the USER IS SITTING AT, and both halves of
-    # this command are already here: the transcript it reads is painted by this
-    # frontend, and the OSC 52 write goes out this terminal. Routed to the owner
-    # it would copy an answer onto a host nobody is at, which is the same
-    # argument `/theme` and `/settings` make about config.yml.
+    # The clipboard is the machine the USER IS SITTING AT, and every part of
+    # this command is already here: the transcript it reads is painted by this
+    # frontend, the picker it opens is painted by this frontend, and the OSC 52
+    # write goes out this terminal. Routed to the owner it would draw a chooser
+    # on a screen nobody is looking at and copy onto a host nobody is at, which
+    # is the same argument `/theme` and `/settings` make about config.yml.
     "copy",
     "new",
     "reload",

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1744,12 +1744,21 @@ class OperatorApp(App[None]):
         # composer keeps every editing key it had and nothing upstream of the
         # App eats the chord.
         #
-        # NOT `priority=True`, and the reason is the same one Esc's comment
-        # gives: a priority binding is matched BEFORE the focused widget sees
-        # the key, which would take it from an open picker. Bubbling is the
-        # precedence wanted — `Editor._on_key` has no branch for this chord, so
-        # with nothing open the key arrives here anyway (verified in a pilot
-        # with the composer focused, which is where it is pressed).
+        # NOT `priority=True`, for the same house rule Esc follows: a priority
+        # binding is dispatched ahead of the focused widget, and this app keeps
+        # composer-adjacent chords bubbling so a widget that wants one CAN
+        # claim it first.
+        #
+        # In practice nothing claims this one, and the honest statement of the
+        # behaviour is that the key fires wherever it is pressed. Driven, not
+        # assumed: with the command picker open on `/c`, `ctrl+o` copies, the
+        # picker stays open and the buffer is untouched — bubbling is not
+        # protecting the picker here, because `Editor._on_key` has no branch
+        # for this chord and the picker only intercepts the keys it routes
+        # (up/down/tab/enter/esc). That is the wanted behaviour — copying the
+        # last answer is meaningful mid-draft — and it is pinned by
+        # `test_ctrl_o_copies_without_disturbing_an_open_picker` so a future
+        # `_on_key` branch cannot silently swallow the chord.
         Binding("ctrl+o", "copy_last_message", "Copy the last agent message", show=False),
     ]
 
@@ -6929,8 +6938,8 @@ class OperatorApp(App[None]):
             message = f"copied {lines} lines"
         self.query_one(Toast).show(message, yield_to_actionable=True, owner=owner)
 
-    def _last_settled_assistant_text(self) -> str | None:
-        """The markdown source of the last SETTLED agent message, if any.
+    def _last_settled_assistant_message(self) -> tuple[str, bool] | None:
+        """The last settled agent message as ``(markdown source, truncated)``.
 
         Walks the main transcript backwards, which is what makes "last" mean
         the one the reader is looking at rather than the one the model sent
@@ -6950,11 +6959,31 @@ class OperatorApp(App[None]):
         outright, so a copy during a long turn still answers with the previous
         completed answer rather than nothing.
 
-        An empty block does not stop the walk. One is mounted for a turn that
-        streamed nothing (an abort before the first delta leaves the block
-        behind), and it is not a message — treating it as one would make
-        ``/copy`` report "nothing to copy" with a real answer sitting two rows
-        above it.
+        **A TRUNCATED message is returned, flagged, not skipped** (review round
+        1, MAJOR-1). ``is_finalized`` means IMMUTABLE, not COMPLETE — the abort
+        path freezes a half-streamed answer exactly as a clean end freezes a
+        whole one — so the two were conflated and an aborted partial was copied
+        as though it were a finished reply.
+
+        Returning it with a flag rather than skipping to the previous complete
+        message is the deliberate choice, and the reason is WHICH ONE THE USER
+        MEANT. Someone who stops a long answer and copies usually wants the
+        part they stopped — it is on screen, it is the last thing they read,
+        and it is often why they hit esc. Silently handing them an older
+        message instead would be a different document from the one they were
+        looking at, with nothing on screen saying so; that trades a payload the
+        caller can warn about for a substitution it cannot. The caller says the
+        message was cut off, so the clipboard and the user agree about what it
+        is.
+
+        An empty block does not stop the walk. This is a DEFENSIVE guard, not a
+        response to an observed mount: a block with no text is not a message, so
+        letting one terminate the walk would report "nothing to copy" with a
+        real answer sitting above it. (An abort before the first delta was
+        checked and does NOT leave a block behind — ``on_assistant_delta``
+        refuses to mount for an empty delta, and the block count is 1 before and
+        after. The guard costs one ``strip`` and removes a whole class of
+        edge case, so it stays.)
 
         The payload is ``AssistantBlock.text()``, the block's own markdown
         SOURCE. Not the flattened frame: the rendered rows carry the wrap of
@@ -6963,6 +6992,10 @@ class OperatorApp(App[None]):
         reason ``_copy_markdown`` exists for partial selections; a whole-message
         copy needs no alignment because the source IS the answer.
         """
+        # Local import ONLY to name the element type in the annotation below;
+        # `app.py` already imports this module at the top, so there is no
+        # circularity to dodge — it is kept local to match the sibling walk in
+        # `_retheme_blocks`, which imports it the same way.
         from local_operator.tui.widgets.transcript import TranscriptBlock
 
         blocks: list[TranscriptBlock] = self._transcript_view().blocks()
@@ -6973,7 +7006,7 @@ class OperatorApp(App[None]):
                 continue
             text = block.text()
             if text.strip():
-                return text
+                return (text, block.is_truncated())
         return None
 
     def _cmd_copy(self, notice: NoticeFn) -> None:
@@ -6999,15 +7032,28 @@ class OperatorApp(App[None]):
         that does not help them. ``_turn_is_live`` is still the authority on
         whether a turn is running, so the two answers cannot disagree about the
         state — only about the noun.
+
+        A TRUNCATED message (aborted, or cut off by the provider) is copied and
+        ANNOUNCED. The toast is the shared receipt and stays exactly as it is —
+        it reports the clipboard write, which really did happen and really is
+        that many lines — so the caveat goes in a notice beside it rather than
+        by rewording the one string three gestures share. Silence was the actual
+        defect: the user got a half sentence that reads as a complete short
+        answer (review round 1, MAJOR-1).
         """
-        text = self._last_settled_assistant_text()
-        if text is None:
+        found = self._last_settled_assistant_message()
+        if found is None:
             if self._turn_is_live():
                 notice("nothing to copy yet — the first answer is still coming", "warning")
             else:
                 notice("nothing to copy — no agent message in this conversation", "warning")
             return
+        text, truncated = found
         self._put_on_clipboard(text)
+        if truncated:
+            # AFTER the write, so the ordering matches what happened: the copy
+            # succeeded, and this qualifies what is now on the clipboard.
+            notice("copied — note that answer was cut off before it finished", "warning")
 
     def action_copy_last_message(self) -> None:
         """``ctrl+o`` — :meth:`_cmd_copy` without opening the command menu.
@@ -16814,6 +16860,15 @@ class OperatorApp(App[None]):
         lines.append(_key_row("option+up/down", "same as up/down (history, lists)"))
         lines.append(_key_row("shift+tab", "cycle reasoning effort"))
         lines.append(_key_row("ctrl+l", "clear the transcript (history stays)"))
+        # BOTH surfaces, which is the `shift+tab`/`/effort` pattern followed
+        # whole rather than by halves: the chord is named in `/copy`'s
+        # description AND has its own row here. A user scanning the chord block
+        # for what the keyboard can do never reads the command table's
+        # parentheticals, so advertising it only there left it undiscoverable
+        # for exactly the reader this block exists for (design round 1).
+        # Beside `ctrl+l` because both act on the transcript rather than on the
+        # composer. 64 cells composed, inside the 74 ceiling.
+        lines.append(_key_row("ctrl+o", "copy the last agent message to the clipboard"))
         lines.append(_key_row("ctrl+t", "expand or collapse the todo panel"))
         lines.append(_key_row("ctrl+g", "expand or collapse the subagent panel"))
         lines.append(_key_row("ctrl+b", "open an aside; ctrl+f forks it in"))
@@ -18975,6 +19030,16 @@ class OperatorApp(App[None]):
             block = self._streaming_block
             self._streaming_block = None
             if block is not None:
+                # MARKED before it is frozen: this branch is reached when the
+                # turn produced no authoritative text — an abort, or a provider
+                # that stopped mid-sentence — so whatever streamed is a
+                # TRUNCATED message, not a short complete one. `finalize_text`
+                # only freezes the block, and `is_finalized` therefore answers
+                # "immutable", not "the model finished". Consumers that
+                # reproduce the message away from the frame (`/copy`) need the
+                # second question, and conflating the two handed a user a half
+                # sentence indistinguishable from a whole answer.
+                block.mark_truncated()
                 block.finalize_text()
             self._refresh_working_activity()
             return

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -479,13 +479,14 @@ SLASH_COMMANDS: list[SlashCommand] = [
     # strictly more than the typed word, and nothing here reaches the model —
     # `/approvals`' rule exactly.
     #
-    # The chord is advertised in the DESCRIPTION, the way `/effort` advertises
-    # `shift+tab`: `ctrl+o` is not a slash command, so the table is the only
-    # place it can be discovered, and this row is where a user already is when
-    # they want it. 36 cells, well inside the ~55 the description column wraps
-    # past (see `/model` and `/theme`, where a wrapping row renders a phantom
-    # command name in `/help`).
-    SlashCommand("copy", "Copy the last agent message (ctrl+o)"),
+    # The description names WHAT CAN BE PICKED, not one message, because the
+    # command opens a chooser: a whole answer, or a single code block or quote
+    # out of it. "the last agent message" described the pre-picker behaviour and
+    # would now send a user looking for the one thing the command no longer
+    # does. 35 cells, inside the ~55 the description column wraps past (see
+    # `/model` and `/theme`, where a wrapping row renders a phantom command name
+    # in `/help`).
+    SlashCommand("copy", "Copy an agent message or code block"),
     # Replaces the transcript; a row describing the old one would not survive.
     SlashCommand("new", "Start a new conversation"),
     # In-process reboot cannot load a replaced wheel; this command exists so
@@ -1733,33 +1734,6 @@ class OperatorApp(App[None]):
         # still deferred); `end` returns to the live tail.
         Binding("ctrl+home", "transcript_home", "Transcript top", show=False),
         Binding("ctrl+end", "transcript_end", "Transcript end", show=False),
-        # `/copy` without opening the command menu — the chord Codex CLI binds
-        # for the same command, so a user arriving from it finds the key where
-        # they left it.
-        #
-        # `ctrl+o` audited free by the same discipline as `ctrl+t`, `ctrl+g` and
-        # `ctrl+home`/`ctrl+end`: no other `ctrl+o` in `local_operator/`, and
-        # neither `TextArea` nor Textual's `Screen`/`App` binds it (checked
-        # against textual 8.2.8's own BINDINGS, not from memory), so the
-        # composer keeps every editing key it had and nothing upstream of the
-        # App eats the chord.
-        #
-        # NOT `priority=True`, for the same house rule Esc follows: a priority
-        # binding is dispatched ahead of the focused widget, and this app keeps
-        # composer-adjacent chords bubbling so a widget that wants one CAN
-        # claim it first.
-        #
-        # In practice nothing claims this one, and the honest statement of the
-        # behaviour is that the key fires wherever it is pressed. Driven, not
-        # assumed: with the command picker open on `/c`, `ctrl+o` copies, the
-        # picker stays open and the buffer is untouched — bubbling is not
-        # protecting the picker here, because `Editor._on_key` has no branch
-        # for this chord and the picker only intercepts the keys it routes
-        # (up/down/tab/enter/esc). That is the wanted behaviour — copying the
-        # last answer is meaningful mid-draft — and it is pinned by
-        # `test_ctrl_o_copies_without_disturbing_an_open_picker` so a future
-        # `_on_key` branch cannot silently swallow the chord.
-        Binding("ctrl+o", "copy_last_message", "Copy the last agent message", show=False),
     ]
 
     def __init__(
@@ -7054,29 +7028,6 @@ class OperatorApp(App[None]):
             # AFTER the write, so the ordering matches what happened: the copy
             # succeeded, and this qualifies what is now on the clipboard.
             notice("copied — note that answer was cut off before it finished", "warning")
-
-    def action_copy_last_message(self) -> None:
-        """``ctrl+o`` — :meth:`_cmd_copy` without opening the command menu.
-
-        The same key Codex CLI binds for the same command, and the reason a
-        binding exists at all: copying the answer is a gesture repeated many
-        times per session, and typing six characters plus Enter for it puts a
-        row of machinery between the user and a routine act.
-
-        Routed to the handler rather than reimplemented, so the typed command
-        and the chord cannot answer differently — including the notices, which
-        are the half a second implementation would most easily get wrong.
-
-        VERIFIED to arrive with the composer focused, which is where a user
-        actually presses it: ``ctrl+o`` is bound by neither ``TextArea`` (whose
-        ctrl chords, enumerated from textual 8.2.8 rather than recalled, are
-        a/c/d/e/k/u/v/w/x/y/z, backspace, the arrows and shift+k) nor Textual's
-        ``Screen``/``App``, so ``Editor._on_key`` does not consume it and the
-        key reaches app level. Audited the same way ``ctrl+t``, ``ctrl+g`` and
-        ``ctrl+home``/``ctrl+end`` above were, and driven in a pilot rather than
-        reasoned about — see ``test_copy_command.py``.
-        """
-        self._cmd_copy(self._notice)
 
     # -- resize (TUI-017 / D5) ----------------------------------------------
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
@@ -16860,15 +16811,6 @@ class OperatorApp(App[None]):
         lines.append(_key_row("option+up/down", "same as up/down (history, lists)"))
         lines.append(_key_row("shift+tab", "cycle reasoning effort"))
         lines.append(_key_row("ctrl+l", "clear the transcript (history stays)"))
-        # BOTH surfaces, which is the `shift+tab`/`/effort` pattern followed
-        # whole rather than by halves: the chord is named in `/copy`'s
-        # description AND has its own row here. A user scanning the chord block
-        # for what the keyboard can do never reads the command table's
-        # parentheticals, so advertising it only there left it undiscoverable
-        # for exactly the reader this block exists for (design round 1).
-        # Beside `ctrl+l` because both act on the transcript rather than on the
-        # composer. 64 cells composed, inside the 74 ceiling.
-        lines.append(_key_row("ctrl+o", "copy the last agent message to the clipboard"))
         lines.append(_key_row("ctrl+t", "expand or collapse the todo panel"))
         lines.append(_key_row("ctrl+g", "expand or collapse the subagent panel"))
         lines.append(_key_row("ctrl+b", "open an aside; ctrl+f forks it in"))

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -96,6 +96,7 @@ from local_operator.session.protocol import SessionProtocol
 from local_operator.tui import images as images_mod
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.autocomplete import ArgumentChoice, ArgumentMode, SlashCommand
+from local_operator.tui.copy_targets import CopyTarget, build_copy_targets
 from local_operator.tui.costs import job_cost, turn_cost
 from local_operator.tui.events import (
     AssistantDelta,
@@ -143,6 +144,7 @@ from local_operator.tui.widgets.aside_panel import ASIDE_PROMPT, AsidePanel
 from local_operator.tui.widgets.ask_picker import AskPickerScreen
 from local_operator.tui.widgets.assistant import AssistantBlock
 from local_operator.tui.widgets.command_picker import CommandPicker
+from local_operator.tui.widgets.copy_picker import CopyPickerScreen
 from local_operator.tui.widgets.editor import (
     ASIDE_PLACEHOLDER,
     READ_ONLY_PLACEHOLDER,
@@ -6912,100 +6914,47 @@ class OperatorApp(App[None]):
             message = f"copied {lines} lines"
         self.query_one(Toast).show(message, yield_to_actionable=True, owner=owner)
 
-    def _last_settled_assistant_message(self) -> tuple[str, bool] | None:
-        """The last settled agent message as ``(markdown source, truncated)``.
-
-        Walks the main transcript backwards, which is what makes "last" mean
-        the one the reader is looking at rather than the one the model sent
-        last — a resumed conversation replays its history into the same column,
-        so append order is the only order that matches the frame.
-
-        ``_transcript_view()`` rather than a type query, for the reason that
-        method records: the full-page subagent view mounts a SECOND
-        ``TranscriptView`` for the CHILD's conversation, and copying out of it
-        while it happens to be open would hand the user a subagent's words for
-        a command they typed at the parent.
-
-        A block still streaming is skipped (``is_finalized``). Codex makes
-        ``/copy`` unavailable mid-task because a half-streamed answer that then
-        grows is a clipboard the user cannot trust; the same guarantee is
-        reached here by taking the last SETTLED message instead of refusing
-        outright, so a copy during a long turn still answers with the previous
-        completed answer rather than nothing.
-
-        **A TRUNCATED message is returned, flagged, not skipped** (review round
-        1, MAJOR-1). ``is_finalized`` means IMMUTABLE, not COMPLETE — the abort
-        path freezes a half-streamed answer exactly as a clean end freezes a
-        whole one — so the two were conflated and an aborted partial was copied
-        as though it were a finished reply.
-
-        Returning it with a flag rather than skipping to the previous complete
-        message is the deliberate choice, and the reason is WHICH ONE THE USER
-        MEANT. Someone who stops a long answer and copies usually wants the
-        part they stopped — it is on screen, it is the last thing they read,
-        and it is often why they hit esc. Silently handing them an older
-        message instead would be a different document from the one they were
-        looking at, with nothing on screen saying so; that trades a payload the
-        caller can warn about for a substitution it cannot. The caller says the
-        message was cut off, so the clipboard and the user agree about what it
-        is.
-
-        An empty block does not stop the walk. This is a DEFENSIVE guard, not a
-        response to an observed mount: a block with no text is not a message, so
-        letting one terminate the walk would report "nothing to copy" with a
-        real answer sitting above it. (An abort before the first delta was
-        checked and does NOT leave a block behind — ``on_assistant_delta``
-        refuses to mount for an empty delta, and the block count is 1 before and
-        after. The guard costs one ``strip`` and removes a whole class of
-        edge case, so it stays.)
-
-        The payload is ``AssistantBlock.text()``, the block's own markdown
-        SOURCE. Not the flattened frame: the rendered rows carry the wrap of
-        whatever width the terminal happened to be, and a paste of them puts
-        box-drawing and hard breaks into the user's document. This is the whole
-        reason ``_copy_markdown`` exists for partial selections; a whole-message
-        copy needs no alignment because the source IS the answer.
-        """
-        # Local import ONLY to name the element type in the annotation below;
-        # `app.py` already imports this module at the top, so there is no
-        # circularity to dodge — it is kept local to match the sibling walk in
-        # `_retheme_blocks`, which imports it the same way.
-        from local_operator.tui.widgets.transcript import TranscriptBlock
-
-        blocks: list[TranscriptBlock] = self._transcript_view().blocks()
-        for block in reversed(blocks):
-            if not isinstance(block, AssistantBlock):
-                continue
-            if not block.is_finalized():
-                continue
-            text = block.text()
-            if text.strip():
-                return (text, block.is_truncated())
-        return None
-
     def _cmd_copy(self, notice: NoticeFn) -> None:
-        """``/copy`` — put the last completed agent message on the clipboard.
+        """``/copy`` — pick an agent message, or a block out of one, and copy it.
+
+        Opens :class:`CopyPickerScreen` over a tree of the settled answers, each
+        drilling into its own code blocks and quotes. It replaces a command that
+        took the last message and nothing else: the common ask is "that code
+        block", and the only way to get one was to drag it row by row.
 
         The write goes through :meth:`_put_on_clipboard`, the single clipboard
         write the transcript drag and the composer already share, so this third
         gesture cannot drift from them in what it writes or what it claims. A
         bespoke toast here would make the receipt evidence about WHICH gesture
-        was used, which is exactly what ``on_editor_copied`` exists to prevent.
+        was used, which is exactly what ``on_editor_copied`` exists to prevent —
+        so the reference's per-target status is carried on ``CopyTarget`` and
+        deliberately not displayed.
 
         That helper is SILENT on an empty payload — right for a zero-width drag,
         wrong for a command the user typed deliberately, since an unexplained
         no-op reads as a broken command. So the two cases where there is nothing
-        to take speak through ``notice`` instead of reaching the helper at all.
+        to take speak through ``notice`` instead of reaching the helper at all,
+        and they stay TWO cases: "the first answer is still coming" and "there
+        is no answer here" are different states with different fixes, and the
+        reference's single string conflates them.
 
         The refusal does NOT reuse ``_live_turn_refuse_copy``. That string says
         "esc first" because ``/update`` and ``/reload`` cannot proceed until the
         turn ends — they would tear the process down over it. Nothing here needs
-        the turn stopped: a copy during a live turn takes the previous settled
-        message and succeeds. The only failing case is "no settled message
-        exists yet", and telling that user to press esc would demand an action
-        that does not help them. ``_turn_is_live`` is still the authority on
-        whether a turn is running, so the two answers cannot disagree about the
-        state — only about the noun.
+        the turn stopped: a copy during a live turn lists what has SETTLED and
+        succeeds, which is also why mid-stream does not refuse. Refusing would
+        regress behaviour this command already shipped. The only failing case is
+        "no settled message exists yet", and telling that user to press esc
+        would demand an action that does not help them. ``_turn_is_live`` is
+        still the authority on whether a turn is running, so the two answers
+        cannot disagree about the state — only about the noun.
+
+        The tree is a SNAPSHOT, taken here and never rebuilt while the picker is
+        open. Messages insert at the TOP of a most-recent-first list, so a turn
+        settling under an open picker would shift every row below it — including
+        the one the user is already aiming at. ``CopyTarget`` is frozen for this
+        reason. The cost is that an answer arriving while the picker is up is not
+        listed; the user reopens.
 
         A TRUNCATED message (aborted, or cut off by the provider) is copied and
         ANNOUNCED. The toast is the shared receipt and stays exactly as it is —
@@ -7013,21 +6962,33 @@ class OperatorApp(App[None]):
         that many lines — so the caveat goes in a notice beside it rather than
         by rewording the one string three gestures share. Silence was the actual
         defect: the user got a half sentence that reads as a complete short
-        answer (review round 1, MAJOR-1).
+        answer (review round 1, MAJOR-1). Only MESSAGE nodes carry the flag; a
+        closed fence inside a cut-off answer is itself complete, so a code-block
+        target never raises it.
         """
-        found = self._last_settled_assistant_message()
-        if found is None:
+        targets = build_copy_targets(self._transcript_view().blocks())
+        if not targets:
             if self._turn_is_live():
                 notice("nothing to copy yet — the first answer is still coming", "warning")
             else:
                 notice("nothing to copy — no agent message in this conversation", "warning")
             return
-        text, truncated = found
-        self._put_on_clipboard(text)
-        if truncated:
-            # AFTER the write, so the ordering matches what happened: the copy
-            # succeeded, and this qualifies what is now on the clipboard.
-            notice("copied — note that answer was cut off before it finished", "warning")
+
+        def _copy_choice(target: CopyTarget | None) -> None:
+            # Dismissed with Esc — nothing said. A cancelled picker is not an
+            # event worth a notice, the same silence `_resume_choice` keeps.
+            if target is None or target.content is None:
+                return
+            self._put_on_clipboard(target.content)
+            if target.truncated:
+                # AFTER the write, so the ordering matches what happened: the
+                # copy succeeded, and this qualifies what is now on the
+                # clipboard. Fired from the dismiss callback, so the modal is
+                # already gone and the notice lands on the normal screen rather
+                # than painting under an overlay.
+                notice("copied — note that answer was cut off before it finished", "warning")
+
+        self.push_screen(CopyPickerScreen(targets), _copy_choice)
 
     # -- resize (TUI-017 / D5) ----------------------------------------------
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -468,6 +468,24 @@ SLASH_COMMANDS: list[SlashCommand] = [
     SlashCommand("exit", "Quit the app", aliases=("quit",)),
     # Empties the surface the echo would land on — it was wiped a line later.
     SlashCommand("clear", "Clear the transcript (history is untouched)"),
+    # Beside `/clear` because they are the two commands that act on the
+    # TRANSCRIPT AS A DOCUMENT rather than on the conversation: one empties the
+    # surface, the other takes a message out of it. Deliberately NOT beside
+    # `/compact`, which shares its first three letters and nothing else —
+    # compaction rewrites history for the model, this reads the frame for the
+    # human.
+    #
+    # NOT an echo. The clipboard receipt names how much landed there, which is
+    # strictly more than the typed word, and nothing here reaches the model —
+    # `/approvals`' rule exactly.
+    #
+    # The chord is advertised in the DESCRIPTION, the way `/effort` advertises
+    # `shift+tab`: `ctrl+o` is not a slash command, so the table is the only
+    # place it can be discovered, and this row is where a user already is when
+    # they want it. 36 cells, well inside the ~55 the description column wraps
+    # past (see `/model` and `/theme`, where a wrapping row renders a phantom
+    # command name in `/help`).
+    SlashCommand("copy", "Copy the last agent message (ctrl+o)"),
     # Replaces the transcript; a row describing the old one would not survive.
     SlashCommand("new", "Start a new conversation"),
     # In-process reboot cannot load a replaced wheel; this command exists so
@@ -1715,6 +1733,24 @@ class OperatorApp(App[None]):
         # still deferred); `end` returns to the live tail.
         Binding("ctrl+home", "transcript_home", "Transcript top", show=False),
         Binding("ctrl+end", "transcript_end", "Transcript end", show=False),
+        # `/copy` without opening the command menu — the chord Codex CLI binds
+        # for the same command, so a user arriving from it finds the key where
+        # they left it.
+        #
+        # `ctrl+o` audited free by the same discipline as `ctrl+t`, `ctrl+g` and
+        # `ctrl+home`/`ctrl+end`: no other `ctrl+o` in `local_operator/`, and
+        # neither `TextArea` nor Textual's `Screen`/`App` binds it (checked
+        # against textual 8.2.8's own BINDINGS, not from memory), so the
+        # composer keeps every editing key it had and nothing upstream of the
+        # App eats the chord.
+        #
+        # NOT `priority=True`, and the reason is the same one Esc's comment
+        # gives: a priority binding is matched BEFORE the focused widget sees
+        # the key, which would take it from an open picker. Bubbling is the
+        # precedence wanted — `Editor._on_key` has no branch for this chord, so
+        # with nothing open the key arrives here anyway (verified in a pilot
+        # with the composer focused, which is where it is pressed).
+        Binding("ctrl+o", "copy_last_message", "Copy the last agent message", show=False),
     ]
 
     def __init__(
@@ -6892,6 +6928,109 @@ class OperatorApp(App[None]):
         else:
             message = f"copied {lines} lines"
         self.query_one(Toast).show(message, yield_to_actionable=True, owner=owner)
+
+    def _last_settled_assistant_text(self) -> str | None:
+        """The markdown source of the last SETTLED agent message, if any.
+
+        Walks the main transcript backwards, which is what makes "last" mean
+        the one the reader is looking at rather than the one the model sent
+        last — a resumed conversation replays its history into the same column,
+        so append order is the only order that matches the frame.
+
+        ``_transcript_view()`` rather than a type query, for the reason that
+        method records: the full-page subagent view mounts a SECOND
+        ``TranscriptView`` for the CHILD's conversation, and copying out of it
+        while it happens to be open would hand the user a subagent's words for
+        a command they typed at the parent.
+
+        A block still streaming is skipped (``is_finalized``). Codex makes
+        ``/copy`` unavailable mid-task because a half-streamed answer that then
+        grows is a clipboard the user cannot trust; the same guarantee is
+        reached here by taking the last SETTLED message instead of refusing
+        outright, so a copy during a long turn still answers with the previous
+        completed answer rather than nothing.
+
+        An empty block does not stop the walk. One is mounted for a turn that
+        streamed nothing (an abort before the first delta leaves the block
+        behind), and it is not a message — treating it as one would make
+        ``/copy`` report "nothing to copy" with a real answer sitting two rows
+        above it.
+
+        The payload is ``AssistantBlock.text()``, the block's own markdown
+        SOURCE. Not the flattened frame: the rendered rows carry the wrap of
+        whatever width the terminal happened to be, and a paste of them puts
+        box-drawing and hard breaks into the user's document. This is the whole
+        reason ``_copy_markdown`` exists for partial selections; a whole-message
+        copy needs no alignment because the source IS the answer.
+        """
+        from local_operator.tui.widgets.transcript import TranscriptBlock
+
+        blocks: list[TranscriptBlock] = self._transcript_view().blocks()
+        for block in reversed(blocks):
+            if not isinstance(block, AssistantBlock):
+                continue
+            if not block.is_finalized():
+                continue
+            text = block.text()
+            if text.strip():
+                return text
+        return None
+
+    def _cmd_copy(self, notice: NoticeFn) -> None:
+        """``/copy`` — put the last completed agent message on the clipboard.
+
+        The write goes through :meth:`_put_on_clipboard`, the single clipboard
+        write the transcript drag and the composer already share, so this third
+        gesture cannot drift from them in what it writes or what it claims. A
+        bespoke toast here would make the receipt evidence about WHICH gesture
+        was used, which is exactly what ``on_editor_copied`` exists to prevent.
+
+        That helper is SILENT on an empty payload — right for a zero-width drag,
+        wrong for a command the user typed deliberately, since an unexplained
+        no-op reads as a broken command. So the two cases where there is nothing
+        to take speak through ``notice`` instead of reaching the helper at all.
+
+        The refusal does NOT reuse ``_live_turn_refuse_copy``. That string says
+        "esc first" because ``/update`` and ``/reload`` cannot proceed until the
+        turn ends — they would tear the process down over it. Nothing here needs
+        the turn stopped: a copy during a live turn takes the previous settled
+        message and succeeds. The only failing case is "no settled message
+        exists yet", and telling that user to press esc would demand an action
+        that does not help them. ``_turn_is_live`` is still the authority on
+        whether a turn is running, so the two answers cannot disagree about the
+        state — only about the noun.
+        """
+        text = self._last_settled_assistant_text()
+        if text is None:
+            if self._turn_is_live():
+                notice("nothing to copy yet — the first answer is still coming", "warning")
+            else:
+                notice("nothing to copy — no agent message in this conversation", "warning")
+            return
+        self._put_on_clipboard(text)
+
+    def action_copy_last_message(self) -> None:
+        """``ctrl+o`` — :meth:`_cmd_copy` without opening the command menu.
+
+        The same key Codex CLI binds for the same command, and the reason a
+        binding exists at all: copying the answer is a gesture repeated many
+        times per session, and typing six characters plus Enter for it puts a
+        row of machinery between the user and a routine act.
+
+        Routed to the handler rather than reimplemented, so the typed command
+        and the chord cannot answer differently — including the notices, which
+        are the half a second implementation would most easily get wrong.
+
+        VERIFIED to arrive with the composer focused, which is where a user
+        actually presses it: ``ctrl+o`` is bound by neither ``TextArea`` (whose
+        ctrl chords, enumerated from textual 8.2.8 rather than recalled, are
+        a/c/d/e/k/u/v/w/x/y/z, backspace, the arrows and shift+k) nor Textual's
+        ``Screen``/``App``, so ``Editor._on_key`` does not consume it and the
+        key reaches app level. Audited the same way ``ctrl+t``, ``ctrl+g`` and
+        ``ctrl+home``/``ctrl+end`` above were, and driven in a pilot rather than
+        reasoned about — see ``test_copy_command.py``.
+        """
+        self._cmd_copy(self._notice)
 
     # -- resize (TUI-017 / D5) ----------------------------------------------
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
@@ -12497,6 +12636,8 @@ class OperatorApp(App[None]):
             self._cmd_btw(arg, text)
         elif command == "/compact":
             self._cmd_compact()
+        elif command == "/copy":
+            self._cmd_copy(notice)
         elif command == "/approvals":
             self._cmd_approvals(arg, notice)
         elif command == "/skills":

--- a/local_operator/tui/copy_targets.py
+++ b/local_operator/tui/copy_targets.py
@@ -1,0 +1,406 @@
+"""The `/copy` picker's target tree: assistant messages and their blocks.
+
+A pure text transform. It takes transcript blocks and returns a tree of
+:class:`CopyTarget` nodes — most recent assistant answer first, each drillable
+into its fenced code blocks and `>`-quoted runs — and it imports nothing from
+Textual or from ``widgets/``. That is not tidiness: it is what lets the whole
+grammar be tested against hand-built messages with no running app, which is
+the same reason the reference implementation keeps `utils/copy-targets.ts`
+apart from `components/copy-selector.ts`.
+
+Ported from oh-my-pi's `extractBlocks`/`buildCopyTargets`, with ONE deliberate
+divergence, in the fence rule. See :func:`extract_blocks`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Literal, Protocol, Sequence, runtime_checkable
+
+#: Cap on how many recent assistant messages the picker lists. Counted over
+#: messages with non-empty text, so an answer that was only tool calls does
+#: not consume budget.
+MAX_MESSAGES = 50
+
+#: Opening/closing fence marker. Deliberately the SAME pattern as
+#: ``widgets/_copy_markdown._FENCE_RE`` — see :func:`extract_blocks` for why
+#: this module re-states the grammar rather than importing that module's
+#: ``classify``. The two are the only readers of this grammar; a change to one
+#: is a change to both.
+_FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
+#: A blockquote line. One ``>`` level only, matching the reference: the marker
+#: plus at most one following space comes off, so indentation INSIDE the quote
+#: survives into the clipboard.
+_QUOTE_RE = re.compile(r"^>(.*)$")
+_WHITESPACE_RUN_RE = re.compile(r"\s+")
+
+
+@runtime_checkable
+class AssistantMessage(Protocol):
+    """The minimal transcript surface needed to assemble copy targets.
+
+    A ``Protocol`` rather than ``isinstance(block, AssistantBlock)`` for two
+    reasons that pull the same way. It keeps this module free of any widget
+    import, which is the claim the module's position outside ``widgets/``
+    makes and which the import graph then enforces. And it is what makes the
+    tree testable from plain objects — the reference interface (`CopySource`)
+    exists for exactly that stated reason.
+
+    ``is_truncated`` is what discriminates an assistant answer from the other
+    blocks that also carry ``text()``: ``UserBlock``, ``NoticeBlock`` and
+    ``PeerMessageBlock`` all have text and all inherit ``is_finalized``, and
+    only an assistant answer can have ended early. Adding ``is_truncated`` to
+    another block type would silently admit it here — which is what
+    ``test_copy_targets.py`` pins.
+    """
+
+    def text(self) -> str: ...
+
+    def is_finalized(self) -> bool: ...
+
+    def is_truncated(self) -> bool: ...
+
+
+@dataclass(frozen=True)
+class MessageBlock:
+    """One drillable block inside an assistant message."""
+
+    kind: Literal["code", "quote"]
+    #: De-prefixed for quotes; the fence body (markers excluded) for code.
+    body: str
+    #: Code only; ``""`` when the fence carried no info string.
+    lang: str = ""
+
+
+@dataclass(frozen=True)
+class CopyTarget:
+    """A node in the `/copy` picker tree.
+
+    Frozen because the tree is built once, when the screen is pushed, and is
+    never mutated: the picker SNAPSHOTS the transcript so a message settling
+    mid-turn cannot shift rows under a cursor the user is already aiming with.
+    New messages insert at the top, so a live rebuild would move every row.
+    """
+
+    #: Stable id (``msg:1``, ``msg:1:code:0``, ``msg:1:all``). Not used for
+    #: cursor tracking today — the tree cannot change while the picker is open
+    #: — but it is what a re-homing cursor would key on if it ever does.
+    id: str
+    label: str
+    hint: str
+    preview: str
+    #: Text placed on the clipboard. ``None`` marks a node Enter refuses.
+    #: Every node this module builds IS copyable; the field and its guard are
+    #: kept as the seam the (unported) command targets would slot into, and
+    #: they cost one ``if``.
+    content: str | None
+    #: The reference shows this per-target status after a copy. We do not: the
+    #: clipboard receipt is shared with the drag and composer gestures so it
+    #: cannot drift per gesture. Carried so re-enabling it is one line.
+    copy_message: str
+    #: Highlight lexer for the preview; ``None`` means plain text.
+    language: str | None = None
+    children: tuple["CopyTarget", ...] = ()
+    #: Ours, not the reference's. The answer was cut off before it finished.
+    truncated: bool = False
+
+
+def extract_blocks(text: str) -> list[MessageBlock]:
+    """Split assistant markdown into drillable blocks, in document order.
+
+    Three properties, each of which a test pins:
+
+    - **Fences mask their bodies.** A ``>`` line inside a code block is never
+      a quote; the scan jumps past the whole block.
+    - **An unclosed fence is ordinary text.** A streaming or aborted answer
+      very often ends mid-fence, and that half block must not become a code
+      target whose body is the rest of the message.
+    - **The closing marker must match the opening character.** This is the
+      divergence from the reference, whose ``/^```/`` closes a ``~~~`` block
+      on a backtick run and does not recognise ``~~~`` as an opener at all.
+      ``_copy_markdown.classify`` already got this right for the drag-select
+      path; porting the laxer rule would import a defect into a repo that
+      does not have it.
+    """
+    blocks: list[MessageBlock] = []
+    lines = text.split("\n")
+    quote: list[str] = []
+
+    def flush_quote() -> None:
+        if quote:
+            blocks.append(MessageBlock(kind="quote", body="\n".join(quote)))
+            quote.clear()
+
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        opened = _FENCE_RE.match(line)
+        if opened is not None:
+            close = _find_close_fence(lines, index, opened.group(1)[0])
+            if close is not None:
+                flush_quote()
+                blocks.append(
+                    MessageBlock(
+                        kind="code",
+                        body="\n".join(lines[index + 1 : close]),
+                        lang=line[opened.end() :].strip(),
+                    )
+                )
+                index = close + 1
+                continue
+            # No closer: fall through and let the line be treated as text.
+
+        quoted = _QUOTE_RE.match(line)
+        if quoted is not None:
+            body = quoted.group(1)
+            quote.append(body[1:] if body.startswith(" ") else body)
+        else:
+            flush_quote()
+        index += 1
+
+    flush_quote()
+    return blocks
+
+
+def _find_close_fence(lines: list[str], start: int, fence_char: str) -> int | None:
+    """Index of the line closing the fence opened at ``start``, or ``None``.
+
+    A closer is a marker run of the SAME character with nothing else on the
+    line — ``classify``'s rule. An info string after the marker makes it
+    another opener, not a closer.
+    """
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        marker = _FENCE_RE.match(line)
+        if marker is None:
+            continue
+        stripped = line.strip()
+        if marker.group(1)[0] == fence_char and set(stripped) <= {fence_char}:
+            return index
+    return None
+
+
+def plural_lines(text: str) -> str:
+    """``"1 line"`` / ``"2 lines"``; empty text is ``"0 lines"``."""
+    count = 0 if not text else len(text.split("\n"))
+    return f"{count} line" if count == 1 else f"{count} lines"
+
+
+def first_line(text: str) -> str:
+    """First non-empty line, whitespace-collapsed — a message's label.
+
+    The all-blank fallback is unreachable through :func:`build_copy_targets`,
+    which skips blank messages before it gets here. Kept rather than raising,
+    because a label is not worth an exception.
+    """
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if stripped:
+            return _WHITESPACE_RUN_RE.sub(" ", stripped)
+    return _WHITESPACE_RUN_RE.sub(" ", text.strip())
+
+
+def _block_hint(block: MessageBlock) -> str:
+    lines = plural_lines(block.body)
+    return f"{block.lang} · {lines}" if block.lang else lines
+
+
+def _message_hint(text: str, code_count: int, quote_count: int, truncated: bool) -> str:
+    """``"truncated · 12 lines · 1 code"`` — absent kinds omitted.
+
+    The line count is of the WHOLE message, not of its blocks.
+
+    ``truncated`` leads rather than trails. The hint is right-aligned and it
+    is the LABEL that gets truncated to fit beside it, so a trailing marker is
+    the first thing a narrow terminal cuts — exactly when a user most needs to
+    know the answer was cut off. Leading also groups it with the other
+    structural facts instead of reading like a third block count.
+    """
+    parts = ["truncated"] if truncated else []
+    parts.append(plural_lines(text))
+    if code_count > 0:
+        parts.append(f"{code_count} code")
+    if quote_count > 0:
+        parts.append(f"{quote_count} quote")
+    return " · ".join(parts)
+
+
+def _message_target(text: str, rank: int, truncated: bool) -> CopyTarget:
+    """One assistant message: a leaf when it has no blocks, else a group.
+
+    The group node itself copies the whole message, so drilling in is never
+    the only way to get the answer out.
+    """
+    node_id = f"msg:{rank}"
+    label = first_line(text)
+    blocks = extract_blocks(text)
+    # Rank 1 is the message a bare `/copy` used to take, and saying so is what
+    # tells the user the picker did not change that answer.
+    message_copy = (
+        "Copied last message to clipboard" if rank == 1 else "Copied message to clipboard"
+    )
+
+    code = [block for block in blocks if block.kind == "code"]
+    quotes = [block for block in blocks if block.kind == "quote"]
+    children: list[CopyTarget] = []
+
+    # Children are NOT marked truncated even when their message is. A closed
+    # fence inside a cut-off answer is complete — the truncation ended the
+    # message, not that block — so marking it would be a false claim about
+    # what is on the clipboard. A genuinely half-written trailing fence never
+    # becomes a block at all (see `extract_blocks`).
+    code_index = 0
+    quote_index = 0
+    for block in blocks:
+        if block.kind == "code":
+            children.append(
+                CopyTarget(
+                    id=f"{node_id}:code:{code_index}",
+                    label=f"Block {code_index + 1}",
+                    hint=_block_hint(block),
+                    preview=block.body,
+                    content=block.body,
+                    copy_message=f"Copied code block {code_index + 1} to clipboard",
+                    language=block.lang or None,
+                )
+            )
+            code_index += 1
+        else:
+            children.append(
+                CopyTarget(
+                    id=f"{node_id}:quote:{quote_index}",
+                    label=f"Quote {quote_index + 1}",
+                    hint=plural_lines(block.body),
+                    preview=block.body,
+                    content=block.body,
+                    copy_message=f"Copied quote block {quote_index + 1} to clipboard",
+                )
+            )
+            quote_index += 1
+
+    # "All N" only when there is more than one of a kind: with a single block
+    # it would be a second row copying byte-for-byte what the first one does.
+    if len(code) > 1:
+        combined = "\n\n".join(block.body for block in code)
+        children.append(
+            CopyTarget(
+                id=f"{node_id}:all",
+                label=f"All {len(code)} blocks",
+                hint=plural_lines(combined),
+                preview=combined,
+                content=combined,
+                copy_message=f"Copied {len(code)} code blocks to clipboard",
+            )
+        )
+    if len(quotes) > 1:
+        combined = "\n\n".join(block.body for block in quotes)
+        children.append(
+            CopyTarget(
+                id=f"{node_id}:all-quotes",
+                label=f"All {len(quotes)} quotes",
+                hint=plural_lines(combined),
+                preview=combined,
+                content=combined,
+                copy_message=f"Copied {len(quotes)} quote blocks to clipboard",
+            )
+        )
+
+    return CopyTarget(
+        id=node_id,
+        label=label,
+        hint=_message_hint(text, len(code), len(quotes), truncated),
+        preview=text,
+        content=text,
+        copy_message=message_copy,
+        children=tuple(children),
+        truncated=truncated,
+    )
+
+
+def build_copy_targets(blocks: Sequence[object]) -> list[CopyTarget]:
+    """The `/copy` tree over ``blocks``, most recent assistant answer first.
+
+    ``Sequence[object]`` is deliberate, not laziness. The narrower
+    ``Sequence[AssistantMessage]`` would REJECT the only real caller: the
+    transcript hands over a ``list[TranscriptBlock]`` of mixed user, notice,
+    tool and assistant blocks, and pyright rejects it because
+    ``TranscriptBlock`` has neither ``text`` nor ``is_truncated`` (verified,
+    not assumed). Selecting the assistant answers out of that mixture IS this
+    function's job, so the parameter has to admit the mixture; the
+    ``isinstance`` against the Protocol below is where the type is actually
+    established. Typing it to ``TranscriptBlock`` instead would import a
+    widget and break the layering this module's position asserts.
+
+    ``blocks`` is the transcript's own block list, walked in REVERSE: append
+    order is the order the reader sees, and a resumed conversation replays its
+    history into the same column, so "most recent" means last-appended rather
+    than last-sent.
+
+    Three filters, mirroring the last-message walk this command replaces:
+    the block must be an assistant answer (:class:`AssistantMessage`), it must
+    be finalized, and its text must be non-blank. ``is_finalized`` means
+    IMMUTABLE, not COMPLETE — an aborted answer is frozen exactly as a clean
+    one is — so a truncated message IS listed, and marked. Skipping it would
+    hide the message the user was reading and most likely meant.
+
+    The caller passes ``_transcript_view().blocks()``, never a type query: the
+    full-page subagent view mounts a SECOND ``TranscriptView`` for the child's
+    conversation, and a query would start raising exactly while it is open.
+    """
+    targets: list[CopyTarget] = []
+    rank = 0
+    for block in reversed(list(blocks)):
+        if rank >= MAX_MESSAGES:
+            break
+        if not isinstance(block, AssistantMessage):
+            continue
+        if not block.is_finalized():
+            continue
+        text = block.text()
+        if not text.strip():
+            continue
+        rank += 1
+        targets.append(_message_target(text, rank, block.is_truncated()))
+    return targets
+
+
+@dataclass(frozen=True)
+class FlatNode:
+    """One drawn row: a target plus the tree geometry that indents it."""
+
+    target: CopyTarget
+    depth: int
+    #: Last among its siblings — drives ``└─`` against ``├─``.
+    is_last: bool
+    #: Per-ancestor: does the ancestor at that level have a following sibling?
+    #: A ``│`` guide is drawn in its gutter cell when it does.
+    ancestor_has_next: tuple[bool, ...] = field(default=())
+
+
+def flatten_targets(roots: Sequence[CopyTarget]) -> list[FlatNode]:
+    """Depth-first flatten of ``roots`` into the rows the picker draws.
+
+    Lives here rather than on the screen because it is the tree's shape, not
+    the widget's: the picker's row count, page step and cursor bounds are all
+    derived from it, and pinning it without a running app is worth more than
+    keeping it beside the paint code.
+    """
+    out: list[FlatNode] = []
+
+    def walk(nodes: Sequence[CopyTarget], depth: int, ancestor_has_next: tuple[bool, ...]) -> None:
+        for index, target in enumerate(nodes):
+            is_last = index == len(nodes) - 1
+            out.append(
+                FlatNode(
+                    target=target,
+                    depth=depth,
+                    is_last=is_last,
+                    ancestor_has_next=ancestor_has_next,
+                )
+            )
+            if target.children:
+                walk(target.children, depth + 1, ancestor_has_next + (not is_last,))
+
+    walk(roots, 0, ())
+    return out

--- a/local_operator/tui/copy_targets.py
+++ b/local_operator/tui/copy_targets.py
@@ -124,7 +124,13 @@ def extract_blocks(text: str) -> list[MessageBlock]:
       does not have it.
     """
     blocks: list[MessageBlock] = []
-    lines = text.split("\n")
+    # Line endings normalised BEFORE the split. The reference splits on ``\n``
+    # alone, which leaves a ``\r`` riding on the end of every line of a pasted
+    # Windows transcript — including the fence closer, so the block is found
+    # and then copied with an invisible ``\r`` on each line. That is faithful
+    # and still wrong at the clipboard: it is invisible in a diff and it breaks
+    # a shell script pasted out of the picker.
+    lines = text.replace("\r\n", "\n").split("\n")
     quote: list[str] = []
 
     def flush_quote() -> None:
@@ -182,8 +188,27 @@ def _find_close_fence(lines: list[str], start: int, fence_char: str) -> int | No
 
 
 def plural_lines(text: str) -> str:
-    """``"1 line"`` / ``"2 lines"``; empty text is ``"0 lines"``."""
-    count = 0 if not text else len(text.split("\n"))
+    """``"1 line"`` / ``"2 lines"``; empty text is ``"0 lines"``.
+
+    ``splitlines()``, not ``split("\\n")``: the latter reads a TRAILING newline
+    as a whole further line, so an answer ending in ``\\n`` — which is most of
+    them — was hinted one line longer than the receipt reported when the same
+    text reached the clipboard. ``_put_on_clipboard`` already settled this for
+    the toast (``app.py``, review round 1, F3); the picker was reintroducing
+    the bug the receipt had retired, so this adopts the existing house rule
+    rather than inventing a second count.
+
+    The alternative considered and rejected was trimming the text before
+    counting. It swaps one contradiction for another (``"\\nHi\\n\\n"`` would
+    hint ``1 line`` against a ``copied 3 lines`` receipt) and discards real
+    interior structure that genuinely reaches the clipboard. Measured against
+    the receipt across eight shapes: this rule disagrees on none, trimming on
+    two, the old rule on four.
+
+    ``splitlines()`` returns ``[]`` for ``""``, so no empty-string guard is
+    needed. The text itself is never trimmed — only counted.
+    """
+    count = len(text.splitlines())
     return f"{count} line" if count == 1 else f"{count} lines"
 
 
@@ -318,6 +343,43 @@ def _message_target(text: str, rank: int, truncated: bool) -> CopyTarget:
     )
 
 
+def _call_guarded(block: object, name: str) -> object:
+    """Call ``block.name()``, or return ``None`` if it cannot be called.
+
+    Every read of a transcript block goes through here because the walk runs
+    inside a user-typed command: a widget that raises while being inspected
+    must cost that block its row, not take the whole turn down.
+    """
+    try:
+        method = getattr(block, name)
+    except Exception:
+        return None
+    if not callable(method):
+        return None
+    try:
+        return method()
+    except Exception:
+        return None
+
+
+def _is_assistant_answer(block: object) -> bool:
+    """Whether ``block`` is an assistant answer this picker may list.
+
+    ``isinstance`` against the structural protocol is the primary test, and it
+    is what keeps this module free of any widget import. But a
+    ``runtime_checkable`` protocol only checks that the NAMES exist, so the
+    three methods are additionally confirmed callable — that gap is the one
+    plausible window for the ``AttributeError`` seen once on the live path.
+    """
+    if not isinstance(block, AssistantMessage):
+        return False
+    return all(callable(getattr(block, name, None)) for name in _ANSWER_METHODS)
+
+
+#: The methods an assistant answer must actually provide, not merely name.
+_ANSWER_METHODS = ("text", "is_finalized", "is_truncated")
+
+
 def build_copy_targets(blocks: Sequence[object]) -> list[CopyTarget]:
     """The `/copy` tree over ``blocks``, most recent assistant answer first.
 
@@ -353,15 +415,32 @@ def build_copy_targets(blocks: Sequence[object]) -> list[CopyTarget]:
     for block in reversed(list(blocks)):
         if rank >= MAX_MESSAGES:
             break
-        if not isinstance(block, AssistantMessage):
+        if not _is_assistant_answer(block):
             continue
-        if not block.is_finalized():
+        # Bound through `getattr` rather than called off the protocol type: a
+        # `runtime_checkable` protocol tests attribute PRESENCE only, so an
+        # object can satisfy `isinstance` and still raise on the call — a
+        # property whose getter raises `AttributeError` passes the check and
+        # then fails when invoked (verified). A designer saw exactly that
+        # shape once, `'UserBlock' object has no attribute 'is_truncated'`
+        # raised out of this walk into a live `/copy`, and it never
+        # reproduced. Whatever transient produced it, a clipboard command must
+        # not take a turn down: an object that cannot answer is not an
+        # assistant answer, so it is skipped rather than raising.
+        finalized = _call_guarded(block, "is_finalized")
+        if finalized is not True:
             continue
-        text = block.text()
+        text = _call_guarded(block, "text")
+        if not isinstance(text, str):
+            continue
         if not text.strip():
             continue
         rank += 1
-        targets.append(_message_target(text, rank, block.is_truncated()))
+        # A block that cannot answer "were you cut off?" is listed as complete
+        # rather than dropped: the answer is on screen and the user asked for
+        # it. The marker is a qualification of the payload, not a precondition
+        # for offering it.
+        targets.append(_message_target(text, rank, _call_guarded(block, "is_truncated") is True))
     return targets
 
 

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -1636,6 +1636,43 @@ Screen.settings #input-dock #prompt-chevron {
 }
 
 
+/* ── /copy picker ──────────────────────────────────────────────────────── *
+ *
+ * The same centred card over a dimmed transcript as `/resume` and
+ * `/analytics`, because it is the same kind of surface: an overlay the user
+ * opened, navigates with a cursor, and leaves with Esc.
+ *
+ * It differs in pinning its own HEIGHT rather than sizing to content. The
+ * widget divides a fixed row budget between the tree and the preview and
+ * computes its own `… N more lines` overflow from it, so the card has to be
+ * the height the widget measured — an `auto` height would let a long preview
+ * grow the card past the screen and clip the footer, which is the only
+ * statement of how to leave. `overflow: hidden` for the reason `Screen`
+ * carries it: a card taller than its box must not introduce a scrollbar,
+ * which silently costs two cells of width and reflows the transcript behind
+ * the overlay. */
+CopyPickerScreen {
+    align: center middle;
+    background: $lo-sunken;
+}
+
+CopyPickerScreen .copy-picker {
+    width: 100%;
+    max-width: 100;
+    height: 90%;
+    background: $lo-overlay;
+    padding: 1 2;
+    overflow: hidden;
+}
+
+#copy-picker-body {
+    width: 100%;
+    height: 100%;
+    color: $lo-fg;
+    overflow: hidden;
+}
+
+
 /* ── /resume session picker ────────────────────────────────────────────── *
  *
  * A floating read surface (overlay ramp, borderless, content-sized, Esc to

--- a/local_operator/tui/widgets/assistant.py
+++ b/local_operator/tui/widgets/assistant.py
@@ -300,6 +300,16 @@ class AssistantBlock(TranscriptBlock):
         super().__init__()
         self.add_class("assistant-block")
         self._full_text: str = ""
+        #: Whether the message ENDED EARLY — the turn was aborted or the
+        #: provider stopped mid-sentence — as opposed to running to a normal
+        #: stop. Distinct from ``_finalized``, which is the FINALIZED-BLOCK
+        #: protocol's "this block is immutable" and says nothing about whether
+        #: the model finished talking: the abort path finalizes a truncated
+        #: message exactly as the clean path finalizes a whole one, so the two
+        #: questions have to be asked separately. Consumers that reproduce the
+        #: message elsewhere (``/copy``) need "is it COMPLETE", not "is it
+        #: frozen".
+        self._truncated: bool = False
         self._frozen_text: str = ""
         self._frozen_rendered: Markdown | None = None
         #: The frozen prefix's FLATTENED rows, and the width they were built
@@ -540,6 +550,26 @@ class AssistantBlock(TranscriptBlock):
         self._full_text = self._full_text or ""
         self._apply_rows(self._flat_whole())
         self.finalize()
+
+    def mark_truncated(self) -> None:
+        """This message ended early — aborted, or cut off by the provider.
+
+        Named and shaped after ``ToolCard.mark_interrupted``, which answers the
+        same question for the other kind of live row: the turn ended before the
+        thing finished, and the record has to say so rather than looking like a
+        completed one. One vocabulary for "ended early" across both block types.
+
+        The TEXT is deliberately untouched. What streamed is what the user
+        read, and rewriting or annotating it here would put words in the
+        model's row; the flag is metadata for consumers that reproduce the
+        message somewhere the frame's context is missing (``/copy``), where a
+        half sentence is indistinguishable from a short complete answer.
+        """
+        self._truncated = True
+
+    def is_truncated(self) -> bool:
+        """Whether this message ended early (see :meth:`mark_truncated`)."""
+        return self._truncated
 
     def _flat_whole(self) -> Text:
         """The whole message as one flatten, at the block's current width."""

--- a/local_operator/tui/widgets/copy_picker.py
+++ b/local_operator/tui/widgets/copy_picker.py
@@ -1,0 +1,414 @@
+"""The `/copy` picker: choose an answer, a code block or a quote to copy.
+
+A fullscreen modal over the dimmed transcript, following
+:class:`~local_operator.tui.widgets.session_picker.SessionPickerScreen`: the
+caller pushes it with a callback, the screen owns navigation, and it dismisses
+with the chosen :class:`CopyTarget` or ``None``.
+
+It returns the TARGET, not its text, so the caller can read ``truncated`` and
+``copy_message`` without re-deriving them. The clipboard write is the caller's:
+it goes through ``_put_on_clipboard``, the one receipt shared with the drag and
+composer gestures, so a per-gesture toast cannot reappear here.
+
+The tree itself is a SNAPSHOT taken when the screen was built. See
+:class:`CopyPickerScreen` for why it does not live-update.
+"""
+
+from __future__ import annotations
+
+from rich.cells import cell_len
+from rich.console import Console
+from rich.style import Style
+from rich.syntax import Syntax
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+from local_operator.tui import theme as theme_mod
+from local_operator.tui.copy_targets import CopyTarget, FlatNode, flatten_targets
+from local_operator.tui.markdown_theme import IslandSyntaxTheme
+from local_operator.tui.widgets.tool_card import truncate_cells
+
+#: Rows the tree is guaranteed even on a short terminal. It floors the ROW
+#: BUDGET the tree and preview divide, not the tree's own share — porting the
+#: constant onto ``tree_rows`` instead yields a visibly different widget on
+#: every short tree, which is the common case.
+MIN_TREE_ROWS = 3
+#: Rows the card spends below the tree that are NOT part of the row budget:
+#: the rule under the tree, the rule under the preview, and the footer. The
+#: preview's own header row comes out of the preview's share, matching the
+#: reference. Counted from what :meth:`CopyPickerScreen._card_text` actually
+#: emits — the reference's equivalent constant counts hand-drawn borders,
+#: which are CSS here, so it cannot be copied.
+CHROME_ROWS_BELOW_TOP = 3
+#: Title row plus the rule under it, matching `/analytics`' card.
+HEADER_ROWS = 2
+#: `padding: 1 2` on the card: two rows and four cells.
+CARD_PADDING_ROWS = 2
+CARD_PADDING_CELLS = 4
+#: Fraction of the screen the card occupies; mirrors the stylesheet.
+CARD_HEIGHT_FRACTION = 0.9
+#: Each level of depth indents by three cells (`│  ` or `├─ `).
+GUTTER_CELLS = 3
+#: Cells the `❯ ` cursor column costs on every row, selected or not.
+CURSOR_CELLS = 2
+#: Cap on preview lines wrapped before the overflow marker is computed. A
+#: 500-line answer would otherwise wrap thousands of rows to show fifteen; the
+#: marker counts SOURCE lines, so the number stays honest without the work.
+PREVIEW_WRAP_BUDGET = 200
+
+
+class CopyPickerScreen(ModalScreen[CopyTarget | None]):
+    """Pick what to copy; dismisses with the chosen target, or ``None``.
+
+    The tree is built once, by the caller, and never rebuilt while the screen
+    is open. That is deliberate: new answers insert at the TOP of a
+    most-recent-first list, so a live rebuild would shift every row below the
+    insertion point — including the one the user is currently aiming at. A
+    message that settles while the picker is open is simply not listed, and
+    reopening picks it up.
+
+    Esc dismisses. **`ctrl+c` is deliberately NOT bound**, though the reference
+    binds it alongside Esc: in this app `ctrl+c` is the global interrupt
+    (``app.py``), and a modal claiming it would change what stopping a turn
+    means depending on whether an overlay happened to be open. Both existing
+    modals (`SessionPickerScreen`, `AnalyticsScreen`) dismiss on Esc alone, so
+    Esc alone is also the consistent answer.
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", show=False),
+        Binding("enter", "choose", "Copy", show=False),
+        Binding("up", "move(-1)", "Up", show=False),
+        Binding("down", "move(1)", "Down", show=False),
+        Binding("pageup", "page(-1)", "Page up", show=False),
+        Binding("pagedown", "page(1)", "Page down", show=False),
+        Binding("home", "jump(0)", "First", show=False),
+        Binding("end", "jump(1)", "Last", show=False),
+    ]
+
+    def __init__(self, targets: list[CopyTarget]) -> None:
+        super().__init__()
+        # Flattened once: the row list cannot change while the screen is open,
+        # so re-walking the tree per repaint would be work with no input.
+        self._flat: list[FlatNode] = flatten_targets(targets)
+        self._selected = 0
+        # The capped tree height from the last paint, reused as the page step
+        # so pageDown moves by exactly what the user can see. Seeded with the
+        # floor so a page key pressed before the first paint still moves.
+        self._tree_rows = MIN_TREE_ROWS
+        self._body: Static
+
+    # -- state ---------------------------------------------------------------
+    # `visible_rows`/`_card_text`, not `visible`/`_render`: both short names
+    # are Textual's own (`Widget.visible`, `Widget._render`) and shadowing them
+    # breaks focus and paint from inside the screen.
+    @property
+    def visible_rows(self) -> list[FlatNode]:
+        """Every row in the tree, in draw order."""
+        return self._flat
+
+    def selected_target(self) -> CopyTarget | None:
+        """The highlighted node, or ``None`` for an empty tree."""
+        if not self._flat:
+            return None
+        return self._flat[self._selected].target
+
+    # -- geometry ------------------------------------------------------------
+    def _screen_size(self) -> tuple[int, int]:
+        """The box the card's percentage sizes actually resolve in.
+
+        ``self.size`` (this Screen's CONTENT box), not ``self.app.size``: the
+        stylesheet's ``Screen { padding: 1 }`` insets the content box, and
+        percentage heights resolve against the content box, so measuring the
+        terminal over-counts the room and Textual clips the difference
+        silently — off the bottom, taking the footer with it. Both
+        `SessionPickerScreen` and `UsagePanel` measure the screen for this.
+        """
+        try:
+            size = self.size
+            if not size.width or not size.height:  # not laid out yet
+                size = self.app.size
+        except Exception:  # pragma: no cover - only before the app has a screen
+            return 80, 24
+        return size.width, size.height
+
+    def _card_width(self) -> int:
+        width, _ = self._screen_size()
+        return max(20, min(100, width - 4) - CARD_PADDING_CELLS)
+
+    def _row_budget(self) -> int:
+        """Rows the tree and the preview divide between them.
+
+        ``MIN_TREE_ROWS + 1`` floors THIS, not the tree's share — that is the
+        reference's shape, and applying the constant to the tree instead gives
+        a visibly different widget on every short tree.
+
+        The floor is then capped by the room that actually exists. Applying it
+        unconditionally is what the reference does, and it overflowed the card
+        by one row at a 14-row terminal: the composed text was 11 rows against
+        10 drawn, and Textual clipped the difference off the bottom SILENTLY,
+        taking the footer — the only statement of how to leave — with it.
+        Measured across heights 14-60; see `test_copy_picker`.
+        """
+        _, height = self._screen_size()
+        inner = int(height * CARD_HEIGHT_FRACTION) - CARD_PADDING_ROWS - HEADER_ROWS
+        room = inner - CHROME_ROWS_BELOW_TOP
+        return max(1, min(MIN_TREE_ROWS + 1, room)) if room < MIN_TREE_ROWS + 1 else room
+
+    def _split_rows(self) -> tuple[int, int]:
+        """``(tree_rows, preview_rows)`` for the current size.
+
+        ``tree_rows`` is capped at the number of rows that EXIST, so a two-node
+        tree takes two rows and donates the remainder to the preview rather
+        than sitting in a half-height pane padded with blanks.
+        """
+        available = self._row_budget()
+        tree_rows = max(1, min(len(self._flat), available // 2))
+        preview_rows = max(1, available - tree_rows)
+        return tree_rows, preview_rows
+
+    def _page_rows(self) -> int:
+        """The page step: the tree's CAPPED height, as last painted."""
+        return max(1, self._tree_rows)
+
+    # -- navigation ----------------------------------------------------------
+    def _move_to(self, index: int) -> None:
+        """Move the cursor, CLAMPED at both ends.
+
+        Not wrapped, diverging from the reference. AGENTS.md's wrap rule is
+        written for a short list overlaid on a screen the user is still
+        reading; it carries a documented exception for a list that IS the whole
+        page, whose stated rationale — the far end is a destination the user
+        travels to deliberately — describes this surface exactly. The nearest
+        precedent in this repo, `session_picker._move_to`, already clamps. Page
+        keys clamp under either reading, so clamping the arrows too is also the
+        only choice that leaves one uniform rule on the page. `home`/`end` are
+        the better answer to "take me to the other end" anyway.
+        """
+        if not self._flat:
+            self._selected = 0
+            self._repaint()
+            return
+        self._selected = max(0, min(len(self._flat) - 1, index))
+        self._repaint()
+
+    def action_move(self, delta: int) -> None:
+        self._move_to(self._selected + delta)
+
+    def action_page(self, delta: int) -> None:
+        self._move_to(self._selected + delta * self._page_rows())
+
+    def action_jump(self, to_end: int) -> None:
+        self._move_to(len(self._flat) - 1 if to_end else 0)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def action_choose(self) -> None:
+        """Copy the highlighted node.
+
+        A node with no ``content`` refuses rather than dismissing with a target
+        the caller cannot copy. No node this app builds is in that state today;
+        the guard is the seam the unported command targets would arrive
+        through, and it costs one branch.
+        """
+        target = self.selected_target()
+        if target is None or target.content is None:
+            return
+        self.dismiss(target)
+
+    # -- rendering -----------------------------------------------------------
+    def compose(self) -> ComposeResult:
+        with Container(classes="copy-picker"):
+            self._body = Static(self._card_text(), id="copy-picker-body")
+            yield self._body
+
+    def on_mount(self) -> None:
+        self._repaint()
+
+    def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
+        """Re-measure: the row split and every column come from the screen."""
+        self._move_to(self._selected)
+
+    def _repaint(self) -> None:
+        body = getattr(self, "_body", None)
+        if body is None or not body.is_mounted:
+            return
+        body.update(self._card_text())
+
+    def render_lines_for_test(self) -> list[str]:
+        """The card as plain strings — what a user reads.
+
+        Empty when the card is not actually drawn, following `ask_picker`: this
+        method re-derives the text rather than reading back what was painted,
+        so on a screen too short to draw the card it would otherwise report
+        lines that never reached the terminal and let a test assert them.
+        """
+        body = getattr(self, "_body", None)
+        if body is None or not body.is_mounted:
+            return []
+        return [line.plain for line in self._card_text().split("\n")]
+
+    def _window_start(self, tree_rows: int) -> int:
+        """First visible row: the cursor centred, clamped to the ends."""
+        return max(0, min(self._selected - tree_rows // 2, max(0, len(self._flat) - tree_rows)))
+
+    def _card_text(self) -> Text:
+        dim = Style(color=theme_mod.semantic_color("dim"))
+        label_style = Style(color=theme_mod.semantic_color("label"))
+        width = self._card_width()
+        tree_rows, preview_rows = self._split_rows()
+        # Remembered for the page step, which must move by what the user can
+        # actually see rather than by an uncapped half-height.
+        self._tree_rows = tree_rows
+
+        out = Text(no_wrap=True, overflow="ellipsis")
+        out.append("Copy to clipboard", style=label_style)
+        out.append("\n")
+        out.append("─" * width, style=Style(color=theme_mod.semantic_color("edge")))
+        out.append("\n")
+
+        rule = Style(color=theme_mod.semantic_color("edge"))
+        for line in self._tree_lines(width, tree_rows):
+            out.append_text(line)
+            out.append("\n")
+
+        # A rule, not a blank row: without it the preview's header sat directly
+        # under the last tree row and read as one more row of the tree.
+        out.append("─" * width, style=rule)
+        out.append("\n")
+
+        target = self.selected_target()
+        for line in self._preview_lines(width, target, preview_rows):
+            out.append_text(line)
+            out.append("\n")
+
+        out.append("─" * width, style=rule)
+        out.append("\n")
+        out.append("↑↓ move · enter copy · esc quit", style=dim)
+        return out
+
+    def _tree_lines(self, width: int, rows: int) -> list[Text]:
+        """The windowed tree: cursor, ancestor gutter, connector, label, hint."""
+        accent = Style(color=theme_mod.semantic_color("accent"))
+        dim = Style(color=theme_mod.semantic_color("dim"))
+        fg = Style(color=theme_mod.semantic_color("fg"))
+        start = self._window_start(rows)
+
+        lines: list[Text] = []
+        for offset in range(rows):
+            index = start + offset
+            line = Text(no_wrap=True, overflow="ellipsis")
+            if index >= len(self._flat):
+                lines.append(line)
+                continue
+            node = self._flat[index]
+            selected = index == self._selected
+
+            prefix = ""
+            for level in range(max(0, node.depth - 1)):
+                # A vertical guide only while that ancestor still has a row
+                # below it; three spaces once it does not, so the guides do not
+                # run past the end of their own subtree.
+                prefix += "│  " if node.ancestor_has_next[level] else " " * GUTTER_CELLS
+            if node.depth > 0:
+                prefix += "└─ " if node.is_last else "├─ "
+
+            hint = node.target.hint
+            # The hint is never truncated and the label is: the hint carries
+            # the line/block counts and the `truncated` marker, which are what
+            # a narrow terminal must not lose. Two cells of gap minimum.
+            hint_cells = cell_len(hint) + 2 if hint else 0
+            used = CURSOR_CELLS + cell_len(prefix)
+            label = truncate_cells(node.target.label, max(1, width - used - hint_cells))
+
+            line.append("❯ " if selected else "  ", style=accent if selected else fg)
+            line.append(prefix, style=dim)
+            line.append(label, style=accent + Style(bold=True) if selected else fg)
+            if hint:
+                gap = max(1, width - used - cell_len(label) - cell_len(hint))
+                line.append(" " * gap)
+                line.append(hint, style=dim)
+            lines.append(line)
+        return lines
+
+    def _preview_lines(self, width: int, target: CopyTarget | None, rows: int) -> list[Text]:
+        """The highlighted node's text, wrapped — never hard-truncated.
+
+        Overflow is reported as `… N more lines` on the last row, which COSTS
+        a row: showing one more line and hiding the fact that more exist is
+        the failure this marker prevents.
+        """
+        dim = Style(color=theme_mod.semantic_color("dim"))
+        muted = Style(color=theme_mod.semantic_color("muted"))
+
+        header = Text(no_wrap=True, overflow="ellipsis")
+        caption = f"Preview · {target.hint}" if target and target.hint else "Preview"
+        header.append(caption, style=dim)
+        lines = [header]
+
+        content_rows = rows - 1
+        if target is None or content_rows <= 0:
+            while len(lines) < rows:
+                lines.append(Text())
+            return lines
+
+        wrapped = self._wrap_preview(target, max(1, width - 2))
+        has_more = len(wrapped) > content_rows
+        shown = content_rows - 1 if has_more else min(len(wrapped), content_rows)
+        for row in range(content_rows):
+            if row < shown:
+                line = wrapped[row]
+                # Highlighted code keeps its own colours; prose is muted so the
+                # tree above stays the brighter surface.
+                lines.append(line if target.language else Text(line.plain, style=muted))
+            elif row == shown and has_more:
+                lines.append(Text(f"… {len(wrapped) - shown} more lines", style=dim))
+            else:
+                lines.append(Text())
+        return lines
+
+    def _wrap_preview(self, target: CopyTarget, width: int) -> list[Text]:
+        """``target.preview`` wrapped to ``width``, syntax-highlighted for code.
+
+        Only the first :data:`PREVIEW_WRAP_BUDGET` source lines are wrapped: a
+        long answer would otherwise fold thousands of rows to display about
+        fifteen of them. The overflow marker counts wrapped rows, so a budgeted
+        source still reports "more lines" — it just stops counting how many
+        beyond a bound the user cannot page through anyway.
+
+        No per-target cache. The reference caches because it re-renders on
+        every frame; Textual repaints on state change, so a cache here would
+        buy nothing measurable and could serve a stale preview.
+        """
+        source = target.preview.expandtabs(4)
+        budgeted = source.split("\n")[:PREVIEW_WRAP_BUDGET]
+        text = "\n".join(budgeted)
+
+        console = Console(width=width, no_color=False)
+        if target.language:
+            # The repo's one syntax theme. A second palette here would make a
+            # code block read differently in the picker than in the transcript.
+            renderable = Syntax(
+                text,
+                target.language,
+                theme=IslandSyntaxTheme(),
+                word_wrap=True,
+                padding=0,
+                background_color=theme_mod.semantic_color("bg"),
+            )
+        else:
+            renderable = Text(text)
+
+        options = console.options.update(width=width, height=None, highlight=False)
+        lines: list[Text] = []
+        for segments in console.render_lines(renderable, options, pad=False):
+            line = Text()
+            for segment in segments:
+                line.append(segment.text, style=segment.style)
+            lines.append(line)
+        return lines

--- a/local_operator/tui/widgets/copy_picker.py
+++ b/local_operator/tui/widgets/copy_picker.py
@@ -55,10 +55,26 @@ CARD_HEIGHT_FRACTION = 0.9
 GUTTER_CELLS = 3
 #: Cells the `❯ ` cursor column costs on every row, selected or not.
 CURSOR_CELLS = 2
-#: Cap on preview lines wrapped before the overflow marker is computed. A
-#: 500-line answer would otherwise wrap thousands of rows to show fifteen; the
-#: marker counts SOURCE lines, so the number stays honest without the work.
+#: Cap on source lines wrapped for the preview. A 500-line answer would
+#: otherwise fold thousands of rows to display about fifteen. The overflow
+#: marker is computed from the SOURCE line count, never from the wrapped rows,
+#: so budgeting the wrap cannot change the number the user is shown.
 PREVIEW_WRAP_BUDGET = 200
+#: Footer hints, widest first, paired with the order they are SHED in. The
+#: footer is the only statement of how to leave, so a narrow card drops the
+#: movement hints rather than the whole row — `esc quit` is eight cells and
+#: fits terminals the full thirty-one-cell footer does not. This mirrors
+#: `session_picker._shed_to_width`, which drops hints in a fixed order for the
+#: same reason; hiding the card over a footer that merely needed shortening
+#: would blank a modal the user is looking at.
+FOOTER_HINTS = ("↑↓ move", "enter copy", "esc quit")
+#: Never shed: without it the card cannot say how to leave.
+FOOTER_ESSENTIAL = "esc quit"
+#: Rows the card cannot do without: title, rule, one tree row, rule, the
+#: preview's header, rule, footer. Below this the card draws NOTHING rather
+#: than laying out rows the box cannot hold — `overflow: hidden` clips from
+#: the bottom, so a card one row too tall loses the footer specifically.
+MIN_CARD_INNER_ROWS = 7
 
 
 class CopyPickerScreen(ModalScreen[CopyTarget | None]):
@@ -140,6 +156,73 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         width, _ = self._screen_size()
         return max(20, min(100, width - 4) - CARD_PADDING_CELLS)
 
+    def _card_rows(self) -> int:
+        """Rows the card's box actually gives its content.
+
+        ``CARD_HEIGHT_FRACTION`` mirrors the stylesheet's ``height: 90%``; the
+        padding comes back off because Textual sizes border-box.
+        """
+        _, height = self._screen_size()
+        return int(height * CARD_HEIGHT_FRACTION) - CARD_PADDING_ROWS
+
+    @property
+    def is_drawable(self) -> bool:
+        """Whether the box can hold the card's irreducible chrome.
+
+        False on a terminal too short or too NARROW to paint the whole card,
+        where it draws nothing rather than laying out rows the screen will
+        clip. Both axes are one failure: ``overflow: hidden`` clips from the
+        bottom, so a card that asks for one row more than it has loses the
+        footer — the only statement of how to leave — and says nothing.
+
+        The height limb was measured at 8-11 rows, where the fixed chrome
+        (:data:`MIN_CARD_INNER_ROWS`) exceeds the box however the row budget is
+        divided; the tree and preview already floor at one row each, so the
+        split cannot recover it.
+
+        The width limb is the same clip reached differently: a hint is never
+        truncated (it carries the counts and the ``truncated`` marker), so on a
+        narrow pane a row whose hint alone overruns the width WRAPS in the real
+        paint, and each wrapped row pushes the footer further off the bottom. A
+        row is only laid out flat when the cursor, the deepest gutter, one cell
+        of label and the widest hint fit together, so that is what is measured
+        — the composed-string helpers cannot see this, because wrap happens in
+        the compositor and not in the ``Text`` they build.
+        """
+        if self._card_rows() < MIN_CARD_INNER_ROWS:
+            return False
+        return self._card_width() >= self._min_flat_width()
+
+    def _footer_text(self, width: int) -> str:
+        """The footer, shed to ``width`` — never dropped entirely.
+
+        Hints come off the front (movement first, then Enter) because the last
+        one standing has to be ``esc quit``: a card that cannot say how to
+        leave is the defect the whole drawability check exists to prevent.
+        """
+        hints = list(FOOTER_HINTS)
+        while len(hints) > 1 and cell_len(" · ".join(hints)) > width:
+            hints.pop(0)
+        return " · ".join(hints)
+
+    def _min_flat_width(self) -> int:
+        """Cells the widest row needs to paint on ONE line.
+
+        The footer contributes only its IRREDUCIBLE form, because it sheds
+        (:meth:`_footer_text`) where a tree row cannot: a hint is never
+        truncated, so a row whose hint overruns the pane wraps in the real
+        paint and pushes the footer off the bottom.
+        """
+        widest = 0
+        for node in self._flat:
+            hint = node.target.hint
+            # One cell of label, plus the two-cell gap a hint always keeps.
+            need = CURSOR_CELLS + GUTTER_CELLS * node.depth + 1
+            if hint:
+                need += cell_len(hint) + 2
+            widest = max(widest, need)
+        return max(widest, cell_len(FOOTER_ESSENTIAL))
+
     def _row_budget(self) -> int:
         """Rows the tree and the preview divide between them.
 
@@ -147,17 +230,20 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         reference's shape, and applying the constant to the tree instead gives
         a visibly different widget on every short tree.
 
-        The floor is then capped by the room that actually exists. Applying it
-        unconditionally is what the reference does, and it overflowed the card
-        by one row at a 14-row terminal: the composed text was 11 rows against
-        10 drawn, and Textual clipped the difference off the bottom SILENTLY,
-        taking the footer — the only statement of how to leave — with it.
-        Measured across heights 14-60; see `test_copy_picker`.
+        The floor is then capped by the room that actually exists, because the
+        reference's unconditional version overflowed the card by one row at a
+        14-row terminal and Textual clipped the footer off the bottom
+        SILENTLY. Below :data:`MIN_CARD_INNER_ROWS` no division of the budget
+        helps and :attr:`is_drawable` hides the card instead.
         """
-        _, height = self._screen_size()
-        inner = int(height * CARD_HEIGHT_FRACTION) - CARD_PADDING_ROWS - HEADER_ROWS
-        room = inner - CHROME_ROWS_BELOW_TOP
-        return max(1, min(MIN_TREE_ROWS + 1, room)) if room < MIN_TREE_ROWS + 1 else room
+        room = self._card_rows() - HEADER_ROWS - CHROME_ROWS_BELOW_TOP
+        # `max(1, room)`, written plainly: the floor above is what the
+        # reference applies unconditionally, and capping it to the room that
+        # exists removes it entirely on a short card. An earlier revision kept
+        # a `min(MIN_TREE_ROWS + 1, room)` conditional here that computed the
+        # identical value for every input while reading as though the floor
+        # survived.
+        return max(1, room)
 
     def _split_rows(self) -> tuple[int, int]:
         """``(tree_rows, preview_rows)`` for the current size.
@@ -211,13 +297,20 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
     def action_choose(self) -> None:
         """Copy the highlighted node.
 
-        A node with no ``content`` refuses rather than dismissing with a target
-        the caller cannot copy. No node this app builds is in that state today;
-        the guard is the seam the unported command targets would arrive
-        through, and it costs one branch.
+        A node with nothing to copy refuses rather than dismissing with a
+        payload the caller cannot write. FALSY, not just ``None``: an empty
+        fence (```` ```py ```` closed on the next line) builds a child whose
+        content is ``""``, and dismissing on it wrote nothing to the clipboard
+        with no toast and no notice — silence is right for a zero-width drag
+        and wrong for a command the user typed deliberately, which is the
+        position ``_cmd_copy``'s docstring already argues.
+
+        Refusing here rather than dropping the empty child from the tree: the
+        block IS in the message, and a `Block 2` that vanishes from the list
+        makes the remaining numbers disagree with what the user is reading.
         """
         target = self.selected_target()
-        if target is None or target.content is None:
+        if target is None or not target.content:
             return
         self.dismiss(target)
 
@@ -238,20 +331,51 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         body = getattr(self, "_body", None)
         if body is None or not body.is_mounted:
             return
-        body.update(self._card_text())
+        drawable = self.is_drawable
+        body.update(self._card_text() if drawable else Text())
+        # Hidden, not merely emptied. A card with no drawable line still claims
+        # its two padding rows, and at these sizes that pushed the screen's
+        # virtual height past its own size — a scrollable screen, which
+        # AGENTS.md calls always a bug here — around a card painting nothing.
+        # `ask_picker._repaint` hides its card for the same reason. The next
+        # resize brings it back; Esc works throughout, which is what keeps this
+        # a degraded frame rather than a trap.
+        card = body.parent
+        if card is not None:
+            card.display = drawable
 
     def render_lines_for_test(self) -> list[str]:
         """The card as plain strings — what a user reads.
 
-        Empty when the card is not actually drawn, following `ask_picker`: this
-        method re-derives the text rather than reading back what was painted,
-        so on a screen too short to draw the card it would otherwise report
-        lines that never reached the terminal and let a test assert them.
+        Empty when the card is not drawn. This method re-derives the text
+        rather than reading back what was painted, so without these guards it
+        reports rows that never reached the terminal — measured at 80x10,
+        where it claimed the footer against a frame that had clipped it, and a
+        test asserting on it therefore could not see the defect.
+
+        Three guards, following `ask_picker.render_lines_for_test`: the body
+        must be mounted, the card must not be HIDDEN (``display`` is the
+        answer to "is this drawn", so this defers to it rather than keeping a
+        second opinion), and the composed text must be non-empty, because
+        ``Text`` splits an empty card into one empty line.
+
+        It still cannot see WRAP — the compositor folds a too-narrow row, this
+        builds strings — which is why the narrow case is gated by
+        :attr:`is_drawable` above rather than detected here, and why a test
+        about wrapping has to read the painted frame.
         """
         body = getattr(self, "_body", None)
         if body is None or not body.is_mounted:
             return []
-        return [line.plain for line in self._card_text().split("\n")]
+        card = body.parent
+        if card is not None and card.is_mounted and not card.display:
+            return []
+        if not self.is_drawable:
+            return []
+        text = self._card_text()
+        if not text.plain:
+            return []
+        return [line.plain for line in text.split("\n")]
 
     def _window_start(self, tree_rows: int) -> int:
         """First visible row: the cursor centred, clamped to the ends."""
@@ -289,7 +413,7 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
 
         out.append("─" * width, style=rule)
         out.append("\n")
-        out.append("↑↓ move · enter copy · esc quit", style=dim)
+        out.append(self._footer_text(width), style=dim)
         return out
 
     def _tree_lines(self, width: int, rows: int) -> list[Text]:
@@ -357,9 +481,27 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
                 lines.append(Text())
             return lines
 
-        wrapped = self._wrap_preview(target, max(1, width - 2))
-        has_more = len(wrapped) > content_rows
+        wrapped, rows_per_source = self._wrap_preview(target, max(1, width - 2))
+        source_total = len(target.preview.split("\n"))
+        has_more = len(wrapped) > content_rows or len(rows_per_source) < source_total
         shown = content_rows - 1 if has_more else min(len(wrapped), content_rows)
+
+        # Counted in SOURCE lines, not wrapped rows. The header beside it
+        # reports the source line count, so a marker counting rows contradicted
+        # it in the same pane — at 100 cols a 79-line answer claimed "144 more
+        # lines", more than the document has. It also saturated: the wrap
+        # budget capped the rows, so a 600-line and a 1000-line answer both
+        # reported the same 183. Both numbers now measure the same thing, and
+        # the budget stays an optimisation the user cannot observe.
+        consumed = 0
+        source_shown = 0
+        for count in rows_per_source:
+            if consumed + count > shown:
+                break
+            consumed += count
+            source_shown += 1
+        remaining = max(0, source_total - source_shown)
+
         for row in range(content_rows):
             if row < shown:
                 line = wrapped[row]
@@ -367,19 +509,27 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
                 # tree above stays the brighter surface.
                 lines.append(line if target.language else Text(line.plain, style=muted))
             elif row == shown and has_more:
-                lines.append(Text(f"… {len(wrapped) - shown} more lines", style=dim))
+                plural = "line" if remaining == 1 else "lines"
+                lines.append(Text(f"… {remaining} more {plural}", style=dim))
             else:
                 lines.append(Text())
         return lines
 
-    def _wrap_preview(self, target: CopyTarget, width: int) -> list[Text]:
-        """``target.preview`` wrapped to ``width``, syntax-highlighted for code.
+    def _wrap_preview(self, target: CopyTarget, width: int) -> tuple[list[Text], list[int]]:
+        """``(wrapped rows, rows each source line produced)``.
+
+        The second list is what lets the overflow marker be quoted in SOURCE
+        lines: it maps a row cutoff back to the line the user would count. It
+        is measured by rendering each source line separately, which produces
+        exactly the same total as rendering the block whole — verified across
+        widths 20-100 for prose, long words, unicode and highlighted code
+        before this was relied on.
 
         Only the first :data:`PREVIEW_WRAP_BUDGET` source lines are wrapped: a
         long answer would otherwise fold thousands of rows to display about
-        fifteen of them. The overflow marker counts wrapped rows, so a budgeted
-        source still reports "more lines" — it just stops counting how many
-        beyond a bound the user cannot page through anyway.
+        fifteen. The caller compares the budgeted map against the true source
+        length, so budgeting changes how much is WRAPPED and never the number
+        the user is shown.
 
         No per-target cache. The reference caches because it re-renders on
         every frame; Textual repaints on state change, so a cache here would
@@ -411,4 +561,12 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
             for segment in segments:
                 line.append(segment.text, style=segment.style)
             lines.append(line)
-        return lines
+
+        # Plain `Text` per source line even for code: only the ROW COUNT is
+        # wanted here, and the highlighted rows above are what actually gets
+        # painted. Measuring the same wrap twice with two renderables would be
+        # two chances to disagree.
+        rows_per_source = [
+            len(console.render_lines(Text(entry), options, pad=False)) for entry in budgeted
+        ]
+        return lines, rows_per_source

--- a/scripts/copy_shot.py
+++ b/scripts/copy_shot.py
@@ -1,0 +1,125 @@
+"""Capture the `/copy` picker over a populated transcript, for visual validation.
+
+Run from the worktree root:
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/copy_shot.py OUT.svg [COLSxROWS] [SHAPE]
+
+``SHAPE`` selects the tree the picker is opened over, because the layout maths
+differ by case and each one has its own way of looking wrong:
+
+    mixed  (default)  many messages, code and quotes — the long-tree window
+    short             a two-node tree, which must NOT sit in a half-height pane
+    code              one code-heavy answer, for the syntax-highlighted preview
+    long              one very long answer, for the `… N more lines` overflow
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.copy_targets import build_copy_targets  # noqa: E402
+from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
+from local_operator.tui.widgets.copy_picker import CopyPickerScreen  # noqa: E402
+from local_operator.tui.widgets.transcript import UserBlock  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+CODE_ANSWER = """Here is the migration, and the rollback beside it.
+
+```python
+def migrate(rows):
+    for row in rows:
+        if row.stale:
+            row.drop()
+    return len(rows)
+```
+
+The audit log keeps every row, so this is reversible:
+
+```sql
+SELECT * FROM audit WHERE table_name = 'rows' AND op = 'delete';
+```
+
+> Worth noting: the backfill is slower but keeps history.
+> Nothing else reads that column today.
+"""
+
+LONG_ANSWER = "An answer long enough to overflow the preview pane.\n\n" + "\n".join(
+    f"Line {index} of a deliberately long explanation that keeps going." for index in range(1, 120)
+)
+
+
+def _answer(text: str) -> AssistantBlock:
+    """A SETTLED answer. `finalize_text` is what the stream does when a message
+    ends; without it the block stays mutable and the picker correctly ignores
+    it, which is how the first capture came back with an empty tree."""
+    block = AssistantBlock()
+    block.update_text(text)
+    block.finalize_text()
+    return block
+
+
+def _seed(app: OperatorApp, shape: str) -> None:
+    if shape == "short":
+        # Two nodes exactly: one message, no drillable blocks.
+        app._append_block(UserBlock("what about the stale rows?"))
+        block = _answer("Drop them; nothing reads that column.")
+        app._append_block(block)
+        app._append_block(_answer("Confirmed against the audit log."))
+        return
+
+    if shape == "code":
+        app._append_block(UserBlock("show me the migration"))
+        app._append_block(_answer(CODE_ANSWER))
+        return
+
+    if shape == "long":
+        app._append_block(UserBlock("explain it fully"))
+        app._append_block(_answer(LONG_ANSWER))
+        return
+
+    # mixed: enough messages to overflow the tree window, with blocks to nest
+    # and one truncated answer so the `truncated ·` hint is in frame.
+    for turn in range(1, 7):
+        app._append_block(UserBlock(f"Turn {turn}: what should we do about the stale rows?"))
+        if turn % 3 == 0:
+            app._append_block(_answer(CODE_ANSWER))
+        else:
+            app._append_block(
+                _answer(
+                    f"Answer {turn}: the audit log still has every row, so a backfill is"
+                    " possible.\n\n> Nothing else reads that column today."
+                )
+            )
+    cut = _answer("This answer was interrupted while it was still")
+    cut.mark_truncated()
+    app._append_block(cut)
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    size = (100, 30)
+    if len(sys.argv) > 2:
+        cols, rows = sys.argv[2].split("x")
+        size = (int(cols), int(rows))
+    shape = sys.argv[3] if len(sys.argv) > 3 else "mixed"
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        _seed(app, shape)
+        await pilot.pause()
+
+        targets = build_copy_targets(app._transcript_view().blocks())
+        app.push_screen(CopyPickerScreen(targets))
+        await pilot.pause()
+        await pilot.pause()
+        app.save_screenshot(out)
+
+
+asyncio.run(main())

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -9678,11 +9678,6 @@ async def test_help_documents_shell_mode_and_the_composer_chords() -> None:
             "option+up/down",
             "shift+tab",
             "ctrl+l",
-            # `ctrl+o` is named in `/copy`'s description too, but a user
-            # scanning THIS block for what the keyboard can do never reads the
-            # command table's parentheticals — the same both-surfaces rule
-            # `shift+tab` follows for `/effort` (design round 1).
-            "ctrl+o",
             "ctrl+t",
             "ctrl+g",
             "ctrl+b",
@@ -9690,12 +9685,12 @@ async def test_help_documents_shell_mode_and_the_composer_chords() -> None:
             "ctrl+d",
         )
         # Matched against the KEY GUTTER, not against the whole help text. A
-        # substring test over everything passes on a mention anywhere — and
-        # `ctrl+o` is also named inside `/copy`'s description in the command
-        # table, so `"ctrl+o" in text` stayed true with the chord row deleted
-        # (caught by mutating the row away and watching this test stay green).
-        # These rows are the block's contract; a guard that cannot see the row
-        # go missing is not guarding it.
+        # substring test over everything passes on a mention anywhere: the
+        # command table below names chords inside descriptions, so a bare
+        # `"<key>" in text` stayed true with the chord's own row deleted (caught
+        # by mutating a row away and watching this test stay green). These rows
+        # are the block's contract; a guard that cannot see the row go missing
+        # is not guarding it.
         gutters = {row[:20].strip() for row in rows}
         missing = [key for key in required if key not in gutters]
         assert not missing, f"/help is missing key rows: {missing}"
@@ -9712,7 +9707,6 @@ async def test_help_documents_shell_mode_and_the_composer_chords() -> None:
             "option+up/down",
             "shift+tab",
             "ctrl+l",
-            "ctrl+o",
             "ctrl+t",
             "ctrl+g",
             "ctrl+b",

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -9662,7 +9662,6 @@ async def test_help_documents_shell_mode_and_the_composer_chords() -> None:
         padding = cast(Padding, app._help_block().renderable)
         group = cast(Group, padding.renderable)
         rows = [cast(Text, row).plain for row in group.renderables]
-        text = "\n".join(rows)
 
         # Bang-mode's marker is named because the glyph is the
         # colour-independent signal. A row that names ``!`` without
@@ -9679,13 +9678,26 @@ async def test_help_documents_shell_mode_and_the_composer_chords() -> None:
             "option+up/down",
             "shift+tab",
             "ctrl+l",
+            # `ctrl+o` is named in `/copy`'s description too, but a user
+            # scanning THIS block for what the keyboard can do never reads the
+            # command table's parentheticals — the same both-surfaces rule
+            # `shift+tab` follows for `/effort` (design round 1).
+            "ctrl+o",
             "ctrl+t",
             "ctrl+g",
             "ctrl+b",
             "esc",
             "ctrl+d",
         )
-        missing = [key for key in required if key not in text]
+        # Matched against the KEY GUTTER, not against the whole help text. A
+        # substring test over everything passes on a mention anywhere — and
+        # `ctrl+o` is also named inside `/copy`'s description in the command
+        # table, so `"ctrl+o" in text` stayed true with the chord row deleted
+        # (caught by mutating the row away and watching this test stay green).
+        # These rows are the block's contract; a guard that cannot see the row
+        # go missing is not guarding it.
+        gutters = {row[:20].strip() for row in rows}
+        missing = [key for key in required if key not in gutters]
         assert not missing, f"/help is missing key rows: {missing}"
 
         # Same wrap ceiling as the copy/paste rows. A hanging tail at
@@ -9700,6 +9712,7 @@ async def test_help_documents_shell_mode_and_the_composer_chords() -> None:
             "option+up/down",
             "shift+tab",
             "ctrl+l",
+            "ctrl+o",
             "ctrl+t",
             "ctrl+g",
             "ctrl+b",

--- a/tests/unit/tui/test_command_picker.py
+++ b/tests/unit/tui/test_command_picker.py
@@ -841,7 +841,10 @@ async def test_click_on_the_overflow_row_does_nothing() -> None:
         # ranked ahead of their neighbours because a prefix match on a longer
         # word still beats one that starts later in the name.
         ("s", ["settings", "search", "skills"]),
-        ("c", ["clear", "config", "context", "compact", "credential"]),
+        # `copy` ranks second on the shorter-name tiebreak, ahead of `config`'s
+        # equally-positioned prefix match — the same rule that puts `settings`
+        # above `search` on `/s`.
+        ("c", ["clear", "copy", "config", "context", "compact", "credential"]),
         ("lo", ["loop", "login", "logout"]),
         ("mo", ["model"]),
     ],

--- a/tests/unit/tui/test_command_picker.py
+++ b/tests/unit/tui/test_command_picker.py
@@ -841,9 +841,14 @@ async def test_click_on_the_overflow_row_does_nothing() -> None:
         # ranked ahead of their neighbours because a prefix match on a longer
         # word still beats one that starts later in the name.
         ("s", ["settings", "search", "skills"]),
-        # `copy` ranks second on the shorter-name tiebreak, ahead of `config`'s
-        # equally-positioned prefix match — the same rule that puts `settings`
-        # above `search` on `/s`.
+        # Every one of these is a flat 900 prefix match (verified, not assumed:
+        # `score_command_text_match("/c", …)` returns 900 for all six), so
+        # `match_commands` sorts them on `(-score, registry_index)` and the
+        # order here IS registration order. `copy` is second because its
+        # registry entry sits directly after `clear`, not because it is
+        # shorter — there is no length tiebreak to appeal to, and inventing one
+        # would send the next person editing this list when the real cause is
+        # a registry move.
         ("c", ["clear", "copy", "config", "context", "compact", "credential"]),
         ("lo", ["loop", "login", "logout"]),
         ("mo", ["model"]),

--- a/tests/unit/tui/test_copy_command.py
+++ b/tests/unit/tui/test_copy_command.py
@@ -1,0 +1,380 @@
+"""``/copy`` and its ``ctrl+o`` chord: what reaches the clipboard, and when.
+
+The command answers a gesture users already had for a DRAG (release copies,
+``on_text_selected``) but not for the common case — "give me that whole answer"
+— which previously meant dragging a multi-screen message from its first row to
+its last. Codex CLI's ``/copy`` is the shape being matched: the latest
+*completed* response, a ``ctrl+o`` equivalent, and no partial mid-task.
+
+What is asserted here is the PAYLOAD and the REFUSALS, because those are the two
+halves a plausible implementation gets wrong in opposite directions:
+
+* the payload must be the block's markdown SOURCE, not the flattened frame the
+  user is looking at. The frame carries the wrap of whatever width the terminal
+  happened to be plus Rich's own decoration, so pasting it puts box-drawing and
+  hard line breaks into the user's document. ``test_transcript_selection.py``
+  makes the same claim for a partial selection; this file makes it for the
+  whole-message copy, which reaches the source by a different route
+  (``AssistantBlock.text()`` rather than ``_copy_markdown.slice_markdown``).
+* the refusals must SPEAK. ``_put_on_clipboard`` returns silently on an empty
+  payload, which is right for a zero-width drag and wrong for a command the user
+  typed — a typed command that no-ops silently reads as broken.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from local_operator.tui.app import SLASH_COMMANDS, OperatorApp
+from local_operator.tui.events import (
+    AssistantDelta,
+    AssistantMessageEnd,
+    AssistantMessageStart,
+)
+from local_operator.tui.widgets.editor import Editor
+from local_operator.tui.widgets.toast import Toast
+from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView, UserBlock
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+#: An answer with the two constructs a rendered frame destroys: bold markers,
+#: which the frame paints as a style rather than as characters, and a fenced
+#: code block, whose fence lines the frame drops entirely (``IslandCodeBlock``
+#: renders a bare ``Syntax``). If the clipboard has these, it has the source.
+ANSWER = """Here is the **plan**, in short.
+
+```python
+def f(x):
+    return x + 1
+```
+
+That is all.
+"""
+
+
+async def _boot(pilot, app: OperatorApp) -> None:
+    """Settle until the session exists.
+
+    Load-bearing for the mid-stream test: ``_turn_is_live`` reads
+    ``session.is_streaming``, so a test that staged the flag before the session
+    was attached would exercise the no-session path while reading like it
+    tested the guard.
+    """
+    for _ in range(40):
+        await pilot.pause()
+        if app._session is not None:
+            return
+
+
+async def _stream(pilot, app: OperatorApp, text: str, *, finish: bool = True) -> None:
+    """Paint one agent message through the real event path.
+
+    Posted as events rather than by constructing an ``AssistantBlock`` directly,
+    because the thing under test is which block ``/copy`` FINDS — and the mount,
+    the finalize and the ``_streaming_block`` handle are all owned by these
+    handlers. A hand-mounted block would prove the walk works on a transcript
+    the app never builds.
+    """
+    app.post_message(AssistantMessageStart())
+    await pilot.pause()
+    app.post_message(AssistantDelta(text))
+    await pilot.pause()
+    if finish:
+        app.post_message(AssistantMessageEnd(text))
+        await pilot.pause()
+    await pilot.pause()
+
+
+async def _submit(pilot, app: OperatorApp, text: str) -> None:
+    """Type a line into the real editor and press Enter — the reported path.
+
+    Copied in shape from ``test_slash_echo.py``: calling ``_run_slash_command``
+    directly would skip the editor and the submit handler, which is the pair
+    that decides whether a user row is written. Esc first because Enter on an
+    open picker completes the highlighted row and submits THAT.
+    """
+    editor = app.query_one(Editor)
+    editor.text = text
+    await pilot.pause()
+    if editor._picker.is_open():
+        await pilot.press("escape")
+        await pilot.pause()
+    await pilot.press("enter")
+    await pilot.pause()
+    await pilot.pause()
+
+
+def _notices(app: OperatorApp) -> list[str]:
+    return [
+        block._text
+        for block in app.query_one(TranscriptView).blocks()
+        if isinstance(block, NoticeBlock)
+    ]
+
+
+def _user_rows(app: OperatorApp) -> list[str]:
+    return [
+        block.text()
+        for block in app.query_one(TranscriptView).blocks()
+        if isinstance(block, UserBlock)
+    ]
+
+
+# -- the payload --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_copy_puts_the_markdown_source_on_the_clipboard() -> None:
+    """The source, not the frame. Both markers the renderer consumes survive."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, ANSWER)
+        await _submit(pilot, app, "/copy")
+        copied = app._clipboard
+
+    assert copied == ANSWER
+    assert "**plan**" in copied  # bold keeps its markers
+    assert "```python\ndef f(x):\n    return x + 1\n```" in copied  # the fence, verbatim
+    # The frame's own furniture must not be in the paste. `─` is the rule Rich
+    # draws around a code block; `▌` is the blockquote bar. Neither is source.
+    assert "─" not in copied and "▌" not in copied
+
+
+@pytest.mark.asyncio
+async def test_copy_takes_the_last_message_not_the_first() -> None:
+    """The LAST message is the one at the bottom of the frame — append order,
+    which is also the order a replayed history arrives in."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the first answer")
+        await _stream(pilot, app, "the second answer")
+        await _submit(pilot, app, "/copy")
+        copied = app._clipboard
+
+    assert copied == "the second answer"
+
+
+# -- the receipt --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_receipt_is_the_shared_toast_in_the_shared_format() -> None:
+    """One clipboard write, one vocabulary. A bespoke message here would make
+    the receipt evidence about WHICH gesture the user used — the drift
+    ``on_editor_copied`` exists to prevent.
+
+    The count is ``splitlines()`` of the payload, which is the SOURCE's line
+    count and not the frame's row count: the two differ the moment a paragraph
+    wraps, and the number a user checks their paste against is the former.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, ANSWER)
+        await _submit(pilot, app, "/copy")
+        message = app.query_one(Toast).message
+
+    assert message == f"copied {len(ANSWER.splitlines())} lines"
+
+
+@pytest.mark.asyncio
+async def test_a_single_line_answer_is_reported_in_characters() -> None:
+    """The unit follows the SHAPE of what was taken, exactly as a drag does —
+    `_put_on_clipboard` owns that rule and this command inherits it rather than
+    carrying a second copy of it."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "short answer")
+        await _submit(pilot, app, "/copy")
+        message = app.query_one(Toast).message
+
+    assert message == "copied 12 characters"
+
+
+@pytest.mark.asyncio
+async def test_the_receipt_appears_once() -> None:
+    """One gesture, one card. A second toast would mean a second clipboard
+    write, which is the drift the shared helper prevents — and the count is
+    read from the toast's generation because two identically worded cards are
+    indistinguishable by text (the trap ``Toast.generation`` documents)."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, ANSWER)
+        toast = app.query_one(Toast)
+        before = toast.generation
+        await _submit(pilot, app, "/copy")
+        after = toast.generation
+
+    assert after - before == 1, "the copy raised more than one card"
+
+
+# -- the echo policy ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_copy_writes_no_user_row() -> None:
+    """The receipt names what landed on the clipboard, which is strictly more
+    than the typed word — so a user row above it would restate a row that says
+    less. Pinned in ``ECHO_POLICY``; asserted here through the real submit
+    path, which is what actually writes (or does not write) the row."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, ANSWER)
+        await _submit(pilot, app, "/copy")
+        rows = _user_rows(app)
+
+    assert rows == [], rows
+
+
+def test_the_registry_entry_takes_no_argument() -> None:
+    """``/copy me`` and ``/copy <n>`` are deliberately not built, so the entry
+    must not advertise an argument list a handler would discard — the rule
+    ``/provider`` is held to."""
+    from local_operator.tui.autocomplete import ArgumentMode
+
+    entry = next(command for command in SLASH_COMMANDS if command.name == "copy")
+    assert entry.arguments is ArgumentMode.NONE
+    assert entry.echo is False
+    assert entry.consumes_prompt is False
+
+
+# -- the refusals -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_agent_message_yet_says_so_rather_than_no_opping() -> None:
+    """``_put_on_clipboard`` is silent on empty, which is right for a
+    zero-width drag and wrong for a typed command: an unexplained no-op reads
+    as broken. No crash, no write, and a notice that names the reason."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/copy")
+        notices = _notices(app)
+        clipboard = app._clipboard
+        toast = app.query_one(Toast).message
+
+    assert clipboard == "", "nothing was copied, so nothing may reach the clipboard"
+    assert toast == "", "a refusal must not raise the success receipt"
+    assert any("nothing to copy" in text for text in notices), notices
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_copies_the_last_settled_message_not_the_partial() -> None:
+    """The failure mode Codex's "unavailable mid-task" rule exists to avoid: a
+    clipboard holding a half-streamed answer that then grows, which the user
+    cannot tell from a complete one.
+
+    This copies the previous SETTLED message instead of refusing. That keeps the
+    guarantee (never a partial) without the cost — a user who asks for the last
+    answer while the next turn is running gets the last answer.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the settled answer")
+        # A turn in flight: a block mounted and streaming, never finalized.
+        await _stream(pilot, app, "a partial answer still arri", finish=False)
+        assert app._streaming_block is not None, "the fixture must leave a live block"
+        assert app._turn_is_live(), "the app must consider this turn live"
+        await _submit(pilot, app, "/copy")
+        copied = app._clipboard
+
+    assert copied == "the settled answer"
+    assert "still arri" not in copied
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_with_nothing_settled_refuses_and_says_why() -> None:
+    """The only genuinely empty case during a turn. It must not tell the user
+    to press esc: stopping the turn does not produce the message they asked
+    for, and ``_live_turn_refuse_copy``'s wording ("esc first") is written for
+    ``/update``/``/reload``, which really cannot proceed until the turn ends."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the first answer, still arriving", finish=False)
+        await _submit(pilot, app, "/copy")
+        notices = _notices(app)
+        clipboard = app._clipboard
+
+    assert clipboard == ""
+    assert any("nothing to copy yet" in text for text in notices), notices
+    assert not any("esc first" in text for text in notices), notices
+
+
+# -- the chord ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ctrl_o_copies_with_the_composer_focused() -> None:
+    """WHERE THE USER ACTUALLY PRESSES IT, and the reason this is a test rather
+    than an assumption.
+
+    ``Screen.BINDINGS`` sits BETWEEN the focused widget and the App in
+    ``_binding_chain``, and this app's composer consumes several chords in
+    ``Editor._on_key`` before app level is reached — that layering is why
+    Textual's stock ``ctrl+c`` copy had to be removed from ``TranscriptScreen``
+    to get the interrupt back. So "``ctrl+o`` is unbound" is not sufficient
+    evidence that ``ctrl+o`` ARRIVES; only driving it is.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, ANSWER)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        assert app.focused is editor, "the fixture must press the key from the composer"
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        copied = app._clipboard
+        composer = editor.text
+
+    assert copied == ANSWER
+    # The chord must not also type: a key that copies AND inserts a character
+    # is worse than one that does neither, because the draft is now wrong.
+    assert composer == "", composer
+
+
+@pytest.mark.asyncio
+async def test_ctrl_o_copies_with_the_composer_unfocused() -> None:
+    """The other half of the binding's reach: the key is on the App, so it must
+    work whatever holds focus — including nothing."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, ANSWER)
+        app.set_focus(None)
+        await pilot.pause()
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        copied = app._clipboard
+
+    assert copied == ANSWER
+
+
+@pytest.mark.asyncio
+async def test_ctrl_o_and_the_typed_command_answer_identically_when_empty() -> None:
+    """One handler behind both, including the refusal. The notices are the half
+    a second implementation of the chord would most easily get wrong, because
+    the happy path would still look right."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        from_chord = _notices(app)
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/copy")
+        from_command = _notices(app)
+
+    assert from_chord == from_command
+    assert from_chord, "the fixture proved nothing if neither path said anything"

--- a/tests/unit/tui/test_copy_command.py
+++ b/tests/unit/tui/test_copy_command.py
@@ -37,6 +37,7 @@ from local_operator.tui.events import (
     AssistantMessageStart,
 )
 from local_operator.tui.widgets.assistant import AssistantBlock
+from local_operator.tui.widgets.copy_picker import CopyPickerScreen
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.toast import Toast
 from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView, UserBlock
@@ -109,6 +110,34 @@ async def _submit(pilot, app: OperatorApp, text: str) -> None:
     await pilot.pause()
 
 
+async def _copy_latest(pilot, app: OperatorApp) -> None:
+    """Run ``/copy`` and take the whole most-recent message out of the picker.
+
+    The gesture these tests were written for — "give me that answer" — now costs
+    one more keystroke: `/copy` opens a chooser whose cursor starts on the most
+    recent message, and Enter on that row copies it whole. Routing every payload
+    assertion through here keeps them asserting the PAYLOAD rather than silently
+    becoming assertions about the picker's default cursor; the cursor itself is
+    pinned once, by ``test_the_picker_opens_on_the_most_recent_message``.
+
+    Driven through the real screen rather than by calling the dismiss callback,
+    because the push and the callback are the pair that decides whether anything
+    reaches the clipboard at all.
+    """
+    await _submit(pilot, app, "/copy")
+    if isinstance(app.screen, CopyPickerScreen):
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+
+def _picker(app: OperatorApp) -> CopyPickerScreen | None:
+    """The open picker, or ``None`` — never an ``isinstance`` assert at the call
+    site, so a test that expects NO picker reads as plainly as one that does."""
+    screen = app.screen
+    return screen if isinstance(screen, CopyPickerScreen) else None
+
+
 def _notices(app: OperatorApp) -> list[str]:
     return [
         block._text
@@ -135,7 +164,7 @@ async def test_copy_puts_the_markdown_source_on_the_clipboard() -> None:
     async with app.run_test(size=(80, 24)) as pilot:
         await _boot(pilot, app)
         await _stream(pilot, app, ANSWER)
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         copied = app._clipboard
 
     assert copied == ANSWER
@@ -155,7 +184,7 @@ async def test_copy_takes_the_last_message_not_the_first() -> None:
         await _boot(pilot, app)
         await _stream(pilot, app, "the first answer")
         await _stream(pilot, app, "the second answer")
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         copied = app._clipboard
 
     assert copied == "the second answer"
@@ -178,7 +207,7 @@ async def test_the_receipt_is_the_shared_toast_in_the_shared_format() -> None:
     async with app.run_test(size=(80, 24)) as pilot:
         await _boot(pilot, app)
         await _stream(pilot, app, ANSWER)
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         message = app.query_one(Toast).message
 
     assert message == f"copied {len(ANSWER.splitlines())} lines"
@@ -193,7 +222,7 @@ async def test_a_single_line_answer_is_reported_in_characters() -> None:
     async with app.run_test(size=(80, 24)) as pilot:
         await _boot(pilot, app)
         await _stream(pilot, app, "short answer")
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         message = app.query_one(Toast).message
 
     assert message == "copied 12 characters"
@@ -211,7 +240,7 @@ async def test_the_receipt_appears_once() -> None:
         await _stream(pilot, app, ANSWER)
         toast = app.query_one(Toast)
         before = toast.generation
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         after = toast.generation
 
     assert after - before == 1, "the copy raised more than one card"
@@ -287,7 +316,7 @@ async def test_mid_stream_copies_the_last_settled_message_not_the_partial() -> N
         await _stream(pilot, app, "a partial answer still arri", finish=False)
         assert app._streaming_block is not None, "the fixture must leave a live block"
         assert app._turn_is_live(), "the app must consider this turn live"
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         copied = app._clipboard
 
     assert copied == "the settled answer"
@@ -365,7 +394,7 @@ async def test_the_osc52_write_happens_once_and_carries_the_source() -> None:
         sink = _tap_driver(app)
         await _boot(pilot, app)
         await _stream(pilot, app, ANSWER)
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         payloads = _osc52_payloads(sink)
 
     assert payloads == [ANSWER], "one write, byte-identical to the block's source"
@@ -397,8 +426,8 @@ async def test_each_copy_writes_again_rather_than_deduplicating() -> None:
         sink = _tap_driver(app)
         await _boot(pilot, app)
         await _stream(pilot, app, "the answer")
-        await _submit(pilot, app, "/copy")
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
+        await _copy_latest(pilot, app)
         payloads = _osc52_payloads(sink)
 
     assert payloads == ["the answer", "the answer"]
@@ -431,7 +460,7 @@ async def test_every_markdown_construct_survives_verbatim() -> None:
     async with app.run_test(size=(80, 24)) as pilot:
         await _boot(pilot, app)
         await _stream(pilot, app, source)
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         copied = app._clipboard
 
     assert copied == source
@@ -455,7 +484,7 @@ async def test_a_message_that_is_only_a_code_fence_keeps_its_fences() -> None:
     async with app.run_test(size=(80, 24)) as pilot:
         await _boot(pilot, app)
         await _stream(pilot, app, source)
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         copied = app._clipboard
 
     assert copied == source
@@ -474,7 +503,7 @@ async def test_trailing_blank_lines_reach_the_clipboard_unchanged() -> None:
     async with app.run_test(size=(80, 24)) as pilot:
         await _boot(pilot, app)
         await _stream(pilot, app, source)
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         copied = app._clipboard
         message = app.query_one(Toast).message
 
@@ -493,7 +522,7 @@ async def test_a_very_long_answer_is_copied_whole_in_one_write() -> None:
         sink = _tap_driver(app)
         await _boot(pilot, app)
         await _stream(pilot, app, source)
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         payloads = _osc52_payloads(sink)
         message = app.query_one(Toast).message
 
@@ -511,7 +540,7 @@ async def test_unicode_and_tabs_survive_the_base64_round_trip() -> None:
         sink = _tap_driver(app)
         await _boot(pilot, app)
         await _stream(pilot, app, source)
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         payloads = _osc52_payloads(sink)
 
     assert payloads == [source]
@@ -530,7 +559,7 @@ async def test_a_user_row_below_the_answer_does_not_become_the_payload() -> None
         await _boot(pilot, app)
         await _stream(pilot, app, "the agent answer")
         await _submit(pilot, app, "a plain user prompt")
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         copied = app._clipboard
 
     assert copied == "the agent answer"
@@ -550,7 +579,7 @@ async def test_a_tool_card_below_the_answer_does_not_stop_the_walk() -> None:
         await _stream(pilot, app, "the agent answer before the tool")
         app._append_block(ToolCard("call-1", "bash", {"command": "ls -la"}))
         await pilot.pause()
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         copied = app._clipboard
 
     assert copied == "the agent answer before the tool"
@@ -566,7 +595,7 @@ async def test_an_empty_block_above_the_answer_does_not_stop_the_walk() -> None:
         await _boot(pilot, app)
         await _stream(pilot, app, "the real answer")
         await _stream(pilot, app, "   \n\n  \n")
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         copied = app._clipboard
 
     assert copied == "the real answer"
@@ -610,10 +639,10 @@ async def test_the_partial_never_reaches_the_clipboard_as_it_grows() -> None:
         await _stream(pilot, app, "the settled answer")
         await _stream(pilot, app, "the partial so far", finish=False)
         assert app._turn_is_live(), "the fixture must actually stage a live turn"
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         app.post_message(AssistantDelta("the partial so far, now longer"))
         await pilot.pause()
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         payloads = _osc52_payloads(sink)
 
     assert payloads == ["the settled answer", "the settled answer"]
@@ -662,7 +691,7 @@ async def test_a_follower_copies_locally_instead_of_routing_to_the_owner() -> No
         sink = _tap_driver(app)
         await _boot(pilot, app)
         await _stream(pilot, app, "the answer on the follower")
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         payloads = _osc52_payloads(sink)
 
     assert routed == [], "a frontend-local command must not reach the owner"
@@ -716,7 +745,7 @@ async def test_an_aborted_answer_is_copied_but_announced_as_cut_off() -> None:
         await _stream(pilot, app, "an older complete answer")
         await _abort(pilot, app, "a partial answer still arri")
         before = len(_notices(app))
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         copied = app._clipboard
         new_notices = _notices(app)[before:]
 
@@ -787,9 +816,189 @@ async def test_a_completed_answer_after_an_aborted_one_copies_clean() -> None:
         await _abort(pilot, app, "the abandoned attempt")
         await _stream(pilot, app, "the answer that finished")
         before = len(_notices(app))
-        await _submit(pilot, app, "/copy")
+        await _copy_latest(pilot, app)
         copied = app._clipboard
         new_notices = _notices(app)[before:]
 
     assert copied == "the answer that finished"
     assert new_notices == [], new_notices
+
+
+# -- the picker: what /copy now opens -----------------------------------------
+#
+# The command changed shape here: it used to take the last message outright and
+# now opens a chooser. These pin the WIRING — that a picker is pushed at all,
+# what it is built from, what the callback does with the answer, and what a
+# cancel does not do. What the picker DRAWS and how it navigates belongs to the
+# screen's own tests; asserting frame content here would pin the same rows twice
+# and make an innocent layout change fail in two files.
+
+
+@pytest.mark.asyncio
+async def test_copy_opens_the_picker_rather_than_copying_outright() -> None:
+    """The shape change, stated once. Nothing may reach the clipboard until the
+    user has chosen — a command that copied AND opened a chooser would put an
+    unasked-for payload on the clipboard of anyone who cancelled."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, ANSWER)
+        await _submit(pilot, app, "/copy")
+        picker = _picker(app)
+        clipboard = app._clipboard
+        toast = app.query_one(Toast).message
+
+    assert picker is not None, "/copy must open the picker"
+    assert clipboard == "", "nothing may be copied before the user chooses"
+    assert toast == "", "and no receipt may be raised for a copy that has not happened"
+
+
+@pytest.mark.asyncio
+async def test_the_picker_opens_on_the_most_recent_message() -> None:
+    """Where the cursor starts, pinned once and relied on by every payload test
+    above (they press Enter on this row). The most recent answer is the one the
+    reader is looking at, so it is the row the common gesture must land on."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the older answer")
+        await _stream(pilot, app, "the newest answer")
+        await _submit(pilot, app, "/copy")
+        picker = _picker(app)
+        assert picker is not None
+        target = picker.selected_target()
+
+    assert target is not None
+    assert target.content == "the newest answer"
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_picker_copies_nothing_and_says_nothing() -> None:
+    """Esc is not an event. A notice on cancel would report a non-action, and a
+    clipboard write would be the payload the user just declined."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, ANSWER)
+        before = len(_notices(app))
+        await _submit(pilot, app, "/copy")
+        assert _picker(app) is not None, "the fixture must actually open the picker"
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.pause()
+        still_open = _picker(app)
+        clipboard = app._clipboard
+        toast = app.query_one(Toast).message
+        new_notices = _notices(app)[before:]
+
+    assert still_open is None, "esc must dismiss the picker"
+    assert clipboard == "", "a cancelled picker must not write"
+    assert toast == ""
+    assert new_notices == [], new_notices
+
+
+@pytest.mark.asyncio
+async def test_a_code_block_can_be_copied_out_of_a_message() -> None:
+    """The reason the picker exists. Getting one fence out of an answer meant
+    dragging it row by row; now it is a child node, and what lands is the fence
+    BODY without its markers — the thing that pastes into a file."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, ANSWER)
+        await _submit(pilot, app, "/copy")
+        picker = _picker(app)
+        assert picker is not None
+        await pilot.press("down")
+        await pilot.pause()
+        target = picker.selected_target()
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        copied = app._clipboard
+
+    assert target is not None and target.id == "msg:1:code:0"
+    assert copied == "def f(x):\n    return x + 1"
+    assert "```" not in copied, "the fence markers are frame, not payload"
+
+
+@pytest.mark.asyncio
+async def test_the_picker_is_a_snapshot_and_does_not_move_under_the_cursor() -> None:
+    """A message settling while the picker is open must not re-rank the rows.
+
+    New answers insert at the TOP of a most-recent-first list, so a live rebuild
+    would shift every row down by one — including the one the user is already
+    aiming at, which is how you copy the wrong thing. The tree is therefore
+    built once, at push time; the cost is that the new answer is not listed
+    until the picker is reopened, which this also pins so the trade-off is
+    visible rather than assumed.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the answer that was there first")
+        await _submit(pilot, app, "/copy")
+        picker = _picker(app)
+        assert picker is not None
+        rows_before = picker.render_lines_for_test()
+
+        await _stream(pilot, app, "an answer that landed during the picker")
+        rows_after = picker.render_lines_for_test()
+        assert rows_before == rows_after, "the open picker re-ranked itself"
+
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        copied = app._clipboard
+
+    assert copied == "the answer that was there first"
+    assert "during the picker" not in copied
+
+
+@pytest.mark.asyncio
+async def test_the_new_message_is_listed_once_the_picker_is_reopened() -> None:
+    """The other half of the snapshot: it is a snapshot per OPEN, not a cache.
+    A tree built once per app would strand the user on stale rows forever."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the first answer")
+        await _submit(pilot, app, "/copy")
+        await pilot.press("escape")
+        await pilot.pause()
+        await _stream(pilot, app, "the second answer")
+        await _copy_latest(pilot, app)
+        copied = app._clipboard
+
+    assert copied == "the second answer"
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_lists_what_has_settled_instead_of_refusing() -> None:
+    """Mid-stream opens the picker; it does not refuse.
+
+    Refusing would regress behaviour this command already shipped, and the
+    refusal it would have to borrow says "esc first" — an instruction that does
+    not produce the message the user asked for, because stopping the turn does
+    not settle it. The in-flight block is excluded by ``is_finalized`` rather
+    than by any check here, so what is listed is exactly what is immutable.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the settled answer")
+        await _stream(pilot, app, "the partial still arriving", finish=False)
+        assert app._turn_is_live(), "the fixture must actually stage a live turn"
+        await _submit(pilot, app, "/copy")
+        picker = _picker(app)
+        assert picker is not None, "mid-stream must open the picker, not refuse"
+        rows = picker.render_lines_for_test()
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        copied = app._clipboard
+        notices = _notices(app)
+
+    assert copied == "the settled answer"
+    assert not any("still arriving" in row for row in rows), "the in-flight block was listed"
+    assert not any("esc first" in text for text in notices), notices

--- a/tests/unit/tui/test_copy_command.py
+++ b/tests/unit/tui/test_copy_command.py
@@ -31,6 +31,7 @@ from local_operator.tui.events import (
     AssistantMessageEnd,
     AssistantMessageStart,
 )
+from local_operator.tui.widgets.assistant import AssistantBlock
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.toast import Toast
 from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView, UserBlock
@@ -378,3 +379,583 @@ async def test_ctrl_o_and_the_typed_command_answer_identically_when_empty() -> N
 
     assert from_chord == from_command
     assert from_chord, "the fixture proved nothing if neither path said anything"
+
+
+# -- the write itself ---------------------------------------------------------
+#
+# Everything above reads ``app._clipboard``, the attribute Textual sets BEFORE
+# it emits anything. That attribute is true of a copy that never left the
+# process: `copy_to_clipboard` assigns it and then returns early when
+# ``_driver`` is None. So the assertions above cannot distinguish "the answer
+# reached the user's clipboard" from "the app remembered the answer", and OSC 52
+# is the whole reason this survives ssh and a multiplexer. These tests read the
+# escape sequence off the DRIVER instead, which is the byte the terminal sees.
+
+
+def _tap_driver(app: OperatorApp) -> list[str]:
+    """Record every raw driver write, so OSC 52 can be counted and decoded."""
+    sink: list[str] = []
+    driver = app._driver
+    assert driver is not None, "no driver: the pilot would prove nothing about the write"
+    original = driver.write
+
+    def write(data: str) -> None:
+        sink.append(data)
+        return original(data)
+
+    driver.write = write  # type: ignore[method-assign]
+    return sink
+
+
+def _osc52_payloads(sink: list[str]) -> list[str]:
+    """The clipboard payloads decoded back out of the OSC 52 sequences."""
+    import base64
+    import re
+
+    pattern = re.compile(r"\x1b]52;c;([A-Za-z0-9+/=]*)\a")
+    return [
+        base64.b64decode(match.group(1)).decode("utf-8")
+        for chunk in sink
+        for match in pattern.finditer(chunk)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_osc52_write_happens_once_and_carries_the_source() -> None:
+    """The escape sequence the terminal actually receives, decoded back.
+
+    Asserted on the DRIVER rather than on ``app._clipboard`` because that
+    attribute is set before the write and survives its absence — it is equally
+    true of a copy that never left the process.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        sink = _tap_driver(app)
+        await _boot(pilot, app)
+        await _stream(pilot, app, ANSWER)
+        await _submit(pilot, app, "/copy")
+        payloads = _osc52_payloads(sink)
+
+    assert payloads == [ANSWER], "one write, byte-identical to the block's source"
+
+
+@pytest.mark.asyncio
+async def test_a_refusal_writes_no_escape_sequence_at_all() -> None:
+    """The silent half of the refusal. A notice plus an empty OSC 52 write
+    would still clobber whatever the user had on their clipboard — the copy
+    they took before asking for one that does not exist."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        sink = _tap_driver(app)
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/copy")
+        payloads = _osc52_payloads(sink)
+
+    assert payloads == [], "nothing to copy must not overwrite the real clipboard"
+
+
+@pytest.mark.asyncio
+async def test_each_copy_writes_again_rather_than_deduplicating() -> None:
+    """A second ``/copy`` is a second write. Users re-copy after clobbering the
+    clipboard elsewhere, so an implementation that skipped the repeat because
+    the payload was unchanged would leave them with the other application's
+    text and a toast claiming otherwise."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        sink = _tap_driver(app)
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the answer")
+        await _submit(pilot, app, "/copy")
+        await _submit(pilot, app, "/copy")
+        payloads = _osc52_payloads(sink)
+
+    assert payloads == ["the answer", "the answer"]
+
+
+# -- payload shapes the renderer would destroy --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_every_markdown_construct_survives_verbatim() -> None:
+    """The frame is a lossy projection of the source, and each construct here
+    is lost in a DIFFERENT way: headings lose their ``#``, list markers are
+    repainted as bullets, table pipes become box-drawing, the blockquote bar
+    replaces ``>``. ``ANSWER`` covers bold and a fence; this covers the rest,
+    so a regression that reached for the flattened rows fails on whichever
+    construct it mangles first rather than only on the two already pinned.
+    """
+    source = (
+        "# Heading\n\n"
+        "Body with **bold**, *emphasis* and `inline code`.\n\n"
+        "- first item\n"
+        "- second item\n\n"
+        "1. numbered one\n"
+        "2. numbered two\n\n"
+        "> a blockquote line\n\n"
+        "| a | b |\n|---|---|\n| 1 | 2 |\n\n"
+        "A [link](https://example.com).\n"
+    )
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, source)
+        await _submit(pilot, app, "/copy")
+        copied = app._clipboard
+
+    assert copied == source
+    for marker in ("# Heading", "- first item", "1. numbered one", "> a blockquote line"):
+        assert marker in copied, marker
+    assert "| a | b |" in copied
+    assert "[link](https://example.com)" in copied
+    # None of the furniture Rich draws for those constructs may be in the paste.
+    for glyph in "\u2500\u2502\u250c\u2510\u2514\u2518\u258c\u256d\u256f":
+        assert glyph not in copied, glyph
+
+
+@pytest.mark.asyncio
+async def test_a_message_that_is_only_a_code_fence_keeps_its_fences() -> None:
+    """The worst case for the frame: ``IslandCodeBlock`` renders a bare
+    ``Syntax``, so the fence lines are not merely restyled, they are DROPPED.
+    A message that is nothing but a fence would therefore paste as naked code
+    the receiving markdown renders as prose."""
+    source = "```python\nprint('hi')\n```\n"
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, source)
+        await _submit(pilot, app, "/copy")
+        copied = app._clipboard
+
+    assert copied == source
+    assert copied.startswith("```python")
+    assert copied.rstrip("\n").endswith("```")
+
+
+@pytest.mark.asyncio
+async def test_trailing_blank_lines_reach_the_clipboard_unchanged() -> None:
+    """No stripping. The walk uses ``strip()`` only to DECIDE whether a block
+    counts as a message; a version that also copied the stripped value would
+    silently reshape a payload whose trailing structure the user may rely on
+    when pasting into a document."""
+    source = "answer body\n\n\n   \n"
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, source)
+        await _submit(pilot, app, "/copy")
+        copied = app._clipboard
+        message = app.query_one(Toast).message
+
+    assert copied == source, "the payload must not be stripped on the way out"
+    assert message == f"copied {len(source.splitlines())} lines"
+
+
+@pytest.mark.asyncio
+async def test_a_very_long_answer_is_copied_whole_in_one_write() -> None:
+    """Multi-screen answers are the case the command exists for — dragging one
+    from its first row to its last is the gesture it replaces. Asserted on the
+    escape sequence so a chunked or truncated write fails here."""
+    source = "\n\n".join(f"Paragraph {index} with **bold** text." for index in range(500))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        sink = _tap_driver(app)
+        await _boot(pilot, app)
+        await _stream(pilot, app, source)
+        await _submit(pilot, app, "/copy")
+        payloads = _osc52_payloads(sink)
+        message = app.query_one(Toast).message
+
+    assert payloads == [source]
+    assert message == f"copied {len(source.splitlines())} lines"
+
+
+@pytest.mark.asyncio
+async def test_unicode_and_tabs_survive_the_base64_round_trip() -> None:
+    """OSC 52 is base64 of UTF-8, so a payload that is not pure ASCII exercises
+    an encode/decode the ASCII fixtures never reach."""
+    source = "emoji \U0001f389 and CJK \u65e5\u672c\u8a9e and \u00e9 plus a tab\there\n"
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        sink = _tap_driver(app)
+        await _boot(pilot, app)
+        await _stream(pilot, app, source)
+        await _submit(pilot, app, "/copy")
+        payloads = _osc52_payloads(sink)
+
+    assert payloads == [source]
+
+
+# -- which block the walk lands on --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_user_row_below_the_answer_does_not_become_the_payload() -> None:
+    """The most recent BLOCK is routinely not the most recent agent message:
+    the user speaks last every time they ask something. Copying their own
+    prompt back to them is the failure this pins."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the agent answer")
+        await _submit(pilot, app, "a plain user prompt")
+        await _submit(pilot, app, "/copy")
+        copied = app._clipboard
+
+    assert copied == "the agent answer"
+    assert "user prompt" not in copied
+
+
+@pytest.mark.asyncio
+async def test_a_tool_card_below_the_answer_does_not_stop_the_walk() -> None:
+    """A tool card is the most recent block for the whole of any turn that
+    ends in tool work, which is most of them. It is not an ``AssistantBlock``,
+    so the walk must pass over it rather than treat it as the message."""
+    from local_operator.tui.widgets.tool_card import ToolCard
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the agent answer before the tool")
+        app._append_block(ToolCard("call-1", "bash", {"command": "ls -la"}))
+        await pilot.pause()
+        await _submit(pilot, app, "/copy")
+        copied = app._clipboard
+
+    assert copied == "the agent answer before the tool"
+
+
+@pytest.mark.asyncio
+async def test_an_empty_block_above_the_answer_does_not_stop_the_walk() -> None:
+    """An abort before the first delta leaves a mounted block that is not a
+    message. Stopping on it would report "nothing to copy" with a real answer
+    sitting two rows up — the case the walk's ``strip()`` guard is for."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the real answer")
+        await _stream(pilot, app, "   \n\n  \n")
+        await _submit(pilot, app, "/copy")
+        copied = app._clipboard
+
+    assert copied == "the real answer"
+
+
+@pytest.mark.asyncio
+async def test_copy_after_clear_declines_rather_than_copying_a_wiped_answer() -> None:
+    """``/clear`` empties the SCREEN, and the transcript is what this command
+    reads. So the answer that was on it is gone for copying purposes, and the
+    refusal must be the not-found one — the user is looking at an empty
+    surface, so a receipt claiming a copy would describe nothing they can see.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        sink = _tap_driver(app)
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the answer before the clear")
+        await _submit(pilot, app, "/clear")
+        await _submit(pilot, app, "/copy")
+        payloads = _osc52_payloads(sink)
+        notices = _notices(app)
+
+    assert payloads == [], "a cleared transcript has nothing to put on the clipboard"
+    assert any("nothing to copy" in text for text in notices), notices
+    assert not any("still coming" in text for text in notices), notices
+
+
+# -- the mid-stream contract, held across a growing partial -------------------
+
+
+@pytest.mark.asyncio
+async def test_the_partial_never_reaches_the_clipboard_as_it_grows() -> None:
+    """The failure mode the guard exists for, exercised over TIME rather than
+    at a single instant: the coder's fixture copies once mid-stream, which a
+    naive implementation could pass by luck of when the delta landed. Here the
+    partial grows between two copies and the answer must not move."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        sink = _tap_driver(app)
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the settled answer")
+        await _stream(pilot, app, "the partial so far", finish=False)
+        assert app._turn_is_live(), "the fixture must actually stage a live turn"
+        await _submit(pilot, app, "/copy")
+        app.post_message(AssistantDelta("the partial so far, now longer"))
+        await pilot.pause()
+        await _submit(pilot, app, "/copy")
+        payloads = _osc52_payloads(sink)
+
+    assert payloads == ["the settled answer", "the settled answer"]
+    assert not any("partial" in payload for payload in payloads)
+
+
+@pytest.mark.asyncio
+async def test_the_chord_refuses_mid_stream_in_the_same_words() -> None:
+    """The chord's mid-stream refusal, which the typed command's fixture pins
+    but the chord's does not: the existing parity test compares the two on an
+    IDLE empty session, so both take the not-found branch and the mid-stream
+    wording is never exercised through ``ctrl+o`` at all."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        sink = _tap_driver(app)
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the first answer, still arriving", finish=False)
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        from_chord = _notices(app)
+        payloads = _osc52_payloads(sink)
+
+    assert payloads == []
+    assert any("nothing to copy yet" in text for text in from_chord), from_chord
+
+
+# -- the chord and the composer ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ctrl_o_leaves_a_half_typed_draft_alone() -> None:
+    """The realistic press: the user is mid-sentence, wants the answer above,
+    and expects to keep typing. The existing fixture presses the chord against
+    an EMPTY composer, where a binding that cleared or replaced the draft would
+    look identical to one that did not."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the agent answer")
+        editor = app.query_one(Editor)
+        editor.focus()
+        draft = "a half-typed thought"
+        editor.text = draft
+        editor.move_cursor(editor._end_of_buffer())
+        await pilot.pause()
+        assert app.focused is editor
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        copied = app._clipboard
+        after = editor.text
+        rows = _user_rows(app)
+
+    assert copied == "the agent answer"
+    assert after == draft, "the chord must not edit, clear or submit the draft"
+    assert rows == [], "and it must not submit it either"
+
+
+@pytest.mark.asyncio
+async def test_ctrl_o_copies_without_disturbing_an_open_picker() -> None:
+    """Why the binding is deliberately NOT ``priority=True``. A priority
+    binding is matched before the focused widget sees the key; the comment on
+    the binding claims bubbling keeps an open picker intact, and this drives
+    that claim rather than trusting it."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the agent answer")
+        editor = app.query_one(Editor)
+        editor.focus()
+        editor.text = "/"
+        editor.move_cursor(editor._end_of_buffer())
+        editor._sync_picker()
+        await pilot.pause()
+        assert editor._picker.is_open(), "the fixture must open the picker"
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        copied = app._clipboard
+        still_open = editor._picker.is_open()
+        draft = editor.text
+
+    assert copied == "the agent answer"
+    assert still_open, "the chord must not close a picker it did not open"
+    assert draft == "/"
+
+
+# -- the follower ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_follower_copies_locally_instead_of_routing_to_the_owner() -> None:
+    """The scope claim in ``_FRONTEND_LOCAL_SLASHES``, driven end to end.
+
+    The existing coverage for that entry is a set-membership assertion, which
+    proves the name was added and not that the routing seam honours it. Both
+    halves of this command are local — the transcript is painted here and the
+    OSC 52 goes out THIS terminal — so a routed ``/copy`` would put the answer
+    on a clipboard belonging to a host nobody is sitting at, and would emit no
+    escape sequence to the user who typed it.
+    """
+    from local_operator.session.frontend_state import (
+        FrontendSessionState,
+        _slash_capabilities,
+    )
+
+    routed: list[tuple[str, str]] = []
+
+    class RoutedSession(FakeSession):
+        frontend_state: FrontendSessionState
+
+        async def route_shared_slash(self, command: str, args: str, images=()):  # noqa: ANN001
+            routed.append((command, args))
+            return "routed"
+
+    session = RoutedSession()
+    # The owner's capability list is built by the production helper rather than
+    # hand-written, so this cannot drift from what a real owner advertises.
+    session.frontend_state = FrontendSessionState(
+        session_id=session.session_id,
+        epoch="owner",
+        slash_capabilities=_slash_capabilities(),
+    )
+
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        sink = _tap_driver(app)
+        await _boot(pilot, app)
+        await _stream(pilot, app, "the answer on the follower")
+        await _submit(pilot, app, "/copy")
+        payloads = _osc52_payloads(sink)
+
+    assert routed == [], "a frontend-local command must not reach the owner"
+    assert payloads == ["the answer on the follower"], "and it must write to THIS terminal"
+
+
+# -- an aborted answer is not a complete one ---------------------------------
+#
+# Review round 1, MAJOR-1. `is_finalized()` is the FINALIZED-BLOCK protocol's
+# "this block is immutable" and says nothing about whether the model finished
+# talking: `on_assistant_message_end` with empty authoritative text — the abort
+# path — calls `finalize_text()` on whatever had streamed, so a TRUNCATED answer
+# was indistinguishable from a settled one and `/copy` handed the user a half
+# sentence that reads as a short complete reply.
+#
+# The fix marks the block at the source (`AssistantBlock.mark_truncated`, set on
+# that branch) rather than pattern-matching the text downstream. These pin BOTH
+# directions, because a flag that is never cleared would silently condemn every
+# clean answer and the happy-path tests above would still pass.
+
+
+async def _abort(pilot, app: OperatorApp, partial: str) -> None:
+    """Stream ``partial``, then end the turn with no authoritative text.
+
+    That empty end IS the abort signal on this path: the controller falls back
+    to its own buffer only when the text is ``None``, so a user interrupt and a
+    provider that stops mid-sentence both arrive here as ``""``.
+    """
+    app.post_message(AssistantMessageStart())
+    await pilot.pause()
+    app.post_message(AssistantDelta(partial))
+    await pilot.pause()
+    app.post_message(AssistantMessageEnd(""))
+    await pilot.pause()
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_an_aborted_answer_is_copied_but_announced_as_cut_off() -> None:
+    """The user gets the text they were looking at AND is told it is partial.
+
+    Copying it rather than skipping back to the previous complete message is
+    deliberate: someone who stops a long answer and copies usually wants the
+    part they stopped, which is what is on screen. Substituting an older message
+    would hand them a different document with nothing saying so — the caller can
+    warn about a truncated payload, but it cannot warn about a silent swap.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "an older complete answer")
+        await _abort(pilot, app, "a partial answer still arri")
+        before = len(_notices(app))
+        await _submit(pilot, app, "/copy")
+        copied = app._clipboard
+        new_notices = _notices(app)[before:]
+
+    assert copied == "a partial answer still arri", "the user's own screen is what they meant"
+    assert any("cut off" in text for text in new_notices), new_notices
+
+
+@pytest.mark.asyncio
+async def test_the_abort_marks_the_block_rather_than_the_command_guessing() -> None:
+    """The flag is set where the abort is KNOWN, not inferred later.
+
+    Asserted on the widget because that is the contract the fix rests on: a
+    downstream heuristic (short text, no trailing period) would be a guess that
+    misfires on a genuinely terse answer, and `/copy` is only one of the
+    consumers that needs "did the model finish".
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _abort(pilot, app, "cut off here")
+        blocks = [
+            block
+            for block in app.query_one(TranscriptView).blocks()
+            if isinstance(block, AssistantBlock)
+        ]
+        finalized = blocks[-1].is_finalized()
+        truncated = blocks[-1].is_truncated()
+
+    # BOTH, and that is the point: the block is frozen (immutable) AND
+    # incomplete. Conflating the two is what the defect was.
+    assert finalized is True
+    assert truncated is True
+
+
+@pytest.mark.asyncio
+async def test_a_completed_answer_is_never_flagged_as_cut_off() -> None:
+    """The other direction. A flag that is set for everything is not a flag,
+    and it would put a false caveat on every ordinary copy."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, ANSWER)
+        blocks = [
+            block
+            for block in app.query_one(TranscriptView).blocks()
+            if isinstance(block, AssistantBlock)
+        ]
+        truncated = blocks[-1].is_truncated()
+        before = len(_notices(app))
+        await _submit(pilot, app, "/copy")
+        new_notices = _notices(app)[before:]
+
+    assert truncated is False
+    assert new_notices == [], new_notices
+
+
+@pytest.mark.asyncio
+async def test_a_completed_answer_after_an_aborted_one_copies_clean() -> None:
+    """The recovery path a user actually walks: abort, ask again, copy.
+
+    The second answer is a different block, so the first one's flag must not
+    reach it — a per-block flag read off the wrong block would put a permanent
+    caveat on the rest of the session.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _abort(pilot, app, "the abandoned attempt")
+        await _stream(pilot, app, "the answer that finished")
+        before = len(_notices(app))
+        await _submit(pilot, app, "/copy")
+        copied = app._clipboard
+        new_notices = _notices(app)[before:]
+
+    assert copied == "the answer that finished"
+    assert new_notices == [], new_notices
+
+
+@pytest.mark.asyncio
+async def test_ctrl_o_reports_a_cut_off_answer_too() -> None:
+    """The chord routes to the same handler, so it inherits the caveat. Pinned
+    because a second implementation of the notice is exactly the drift the
+    shared handler exists to prevent."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _abort(pilot, app, "stopped part way")
+        before = len(_notices(app))
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        copied = app._clipboard
+        new_notices = _notices(app)[before:]
+
+    assert copied == "stopped part way"
+    assert any("cut off" in text for text in new_notices), new_notices

--- a/tests/unit/tui/test_copy_command.py
+++ b/tests/unit/tui/test_copy_command.py
@@ -1,10 +1,15 @@
-"""``/copy`` and its ``ctrl+o`` chord: what reaches the clipboard, and when.
+"""``/copy``: what reaches the clipboard, and when.
 
 The command answers a gesture users already had for a DRAG (release copies,
 ``on_text_selected``) but not for the common case — "give me that whole answer"
 — which previously meant dragging a multi-screen message from its first row to
-its last. Codex CLI's ``/copy`` is the shape being matched: the latest
-*completed* response, a ``ctrl+o`` equivalent, and no partial mid-task.
+its last.
+
+There is deliberately NO keyboard chord. One shipped (``ctrl+o``) and was
+withdrawn with the picker: a global chord that opens a modal is a different
+gesture from one that copies in place, and the keymap surface was not worth
+spending twice. Everything here therefore drives the TYPED command, which is
+the only way in.
 
 What is asserted here is the PAYLOAD and the REFUSALS, because those are the two
 halves a plausible implementation gets wrong in opposite directions:
@@ -306,79 +311,6 @@ async def test_mid_stream_with_nothing_settled_refuses_and_says_why() -> None:
     assert clipboard == ""
     assert any("nothing to copy yet" in text for text in notices), notices
     assert not any("esc first" in text for text in notices), notices
-
-
-# -- the chord ----------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_ctrl_o_copies_with_the_composer_focused() -> None:
-    """WHERE THE USER ACTUALLY PRESSES IT, and the reason this is a test rather
-    than an assumption.
-
-    ``Screen.BINDINGS`` sits BETWEEN the focused widget and the App in
-    ``_binding_chain``, and this app's composer consumes several chords in
-    ``Editor._on_key`` before app level is reached — that layering is why
-    Textual's stock ``ctrl+c`` copy had to be removed from ``TranscriptScreen``
-    to get the interrupt back. So "``ctrl+o`` is unbound" is not sufficient
-    evidence that ``ctrl+o`` ARRIVES; only driving it is.
-    """
-    app = OperatorApp(lambda: _factory(FakeSession()))
-    async with app.run_test(size=(80, 24)) as pilot:
-        await _boot(pilot, app)
-        await _stream(pilot, app, ANSWER)
-        editor = app.query_one(Editor)
-        editor.focus()
-        await pilot.pause()
-        assert app.focused is editor, "the fixture must press the key from the composer"
-        await pilot.press("ctrl+o")
-        await pilot.pause()
-        copied = app._clipboard
-        composer = editor.text
-
-    assert copied == ANSWER
-    # The chord must not also type: a key that copies AND inserts a character
-    # is worse than one that does neither, because the draft is now wrong.
-    assert composer == "", composer
-
-
-@pytest.mark.asyncio
-async def test_ctrl_o_copies_with_the_composer_unfocused() -> None:
-    """The other half of the binding's reach: the key is on the App, so it must
-    work whatever holds focus — including nothing."""
-    app = OperatorApp(lambda: _factory(FakeSession()))
-    async with app.run_test(size=(80, 24)) as pilot:
-        await _boot(pilot, app)
-        await _stream(pilot, app, ANSWER)
-        app.set_focus(None)
-        await pilot.pause()
-        await pilot.press("ctrl+o")
-        await pilot.pause()
-        copied = app._clipboard
-
-    assert copied == ANSWER
-
-
-@pytest.mark.asyncio
-async def test_ctrl_o_and_the_typed_command_answer_identically_when_empty() -> None:
-    """One handler behind both, including the refusal. The notices are the half
-    a second implementation of the chord would most easily get wrong, because
-    the happy path would still look right."""
-    app = OperatorApp(lambda: _factory(FakeSession()))
-    async with app.run_test(size=(80, 24)) as pilot:
-        await _boot(pilot, app)
-        await pilot.press("ctrl+o")
-        await pilot.pause()
-        from_chord = _notices(app)
-
-    app = OperatorApp(lambda: _factory(FakeSession()))
-    async with app.run_test(size=(80, 24)) as pilot:
-        await _boot(pilot, app)
-        await _submit(pilot, app, "/copy")
-        from_command = _notices(app)
-
-    assert from_chord == from_command
-    assert from_chord, "the fixture proved nothing if neither path said anything"
 
 
 # -- the write itself ---------------------------------------------------------
@@ -688,85 +620,6 @@ async def test_the_partial_never_reaches_the_clipboard_as_it_grows() -> None:
     assert not any("partial" in payload for payload in payloads)
 
 
-@pytest.mark.asyncio
-async def test_the_chord_refuses_mid_stream_in_the_same_words() -> None:
-    """The chord's mid-stream refusal, which the typed command's fixture pins
-    but the chord's does not: the existing parity test compares the two on an
-    IDLE empty session, so both take the not-found branch and the mid-stream
-    wording is never exercised through ``ctrl+o`` at all."""
-    app = OperatorApp(lambda: _factory(FakeSession()))
-    async with app.run_test(size=(80, 24)) as pilot:
-        sink = _tap_driver(app)
-        await _boot(pilot, app)
-        await _stream(pilot, app, "the first answer, still arriving", finish=False)
-        await pilot.press("ctrl+o")
-        await pilot.pause()
-        from_chord = _notices(app)
-        payloads = _osc52_payloads(sink)
-
-    assert payloads == []
-    assert any("nothing to copy yet" in text for text in from_chord), from_chord
-
-
-# -- the chord and the composer ----------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_ctrl_o_leaves_a_half_typed_draft_alone() -> None:
-    """The realistic press: the user is mid-sentence, wants the answer above,
-    and expects to keep typing. The existing fixture presses the chord against
-    an EMPTY composer, where a binding that cleared or replaced the draft would
-    look identical to one that did not."""
-    app = OperatorApp(lambda: _factory(FakeSession()))
-    async with app.run_test(size=(80, 24)) as pilot:
-        await _boot(pilot, app)
-        await _stream(pilot, app, "the agent answer")
-        editor = app.query_one(Editor)
-        editor.focus()
-        draft = "a half-typed thought"
-        editor.text = draft
-        editor.move_cursor(editor._end_of_buffer())
-        await pilot.pause()
-        assert app.focused is editor
-        await pilot.press("ctrl+o")
-        await pilot.pause()
-        copied = app._clipboard
-        after = editor.text
-        rows = _user_rows(app)
-
-    assert copied == "the agent answer"
-    assert after == draft, "the chord must not edit, clear or submit the draft"
-    assert rows == [], "and it must not submit it either"
-
-
-@pytest.mark.asyncio
-async def test_ctrl_o_copies_without_disturbing_an_open_picker() -> None:
-    """Why the binding is deliberately NOT ``priority=True``. A priority
-    binding is matched before the focused widget sees the key; the comment on
-    the binding claims bubbling keeps an open picker intact, and this drives
-    that claim rather than trusting it."""
-    app = OperatorApp(lambda: _factory(FakeSession()))
-    async with app.run_test(size=(80, 24)) as pilot:
-        await _boot(pilot, app)
-        await _stream(pilot, app, "the agent answer")
-        editor = app.query_one(Editor)
-        editor.focus()
-        editor.text = "/"
-        editor.move_cursor(editor._end_of_buffer())
-        editor._sync_picker()
-        await pilot.pause()
-        assert editor._picker.is_open(), "the fixture must open the picker"
-        await pilot.press("ctrl+o")
-        await pilot.pause()
-        copied = app._clipboard
-        still_open = editor._picker.is_open()
-        draft = editor.text
-
-    assert copied == "the agent answer"
-    assert still_open, "the chord must not close a picker it did not open"
-    assert draft == "/"
-
-
 # -- the follower ------------------------------------------------------------
 
 
@@ -940,22 +793,3 @@ async def test_a_completed_answer_after_an_aborted_one_copies_clean() -> None:
 
     assert copied == "the answer that finished"
     assert new_notices == [], new_notices
-
-
-@pytest.mark.asyncio
-async def test_ctrl_o_reports_a_cut_off_answer_too() -> None:
-    """The chord routes to the same handler, so it inherits the caveat. Pinned
-    because a second implementation of the notice is exactly the drift the
-    shared handler exists to prevent."""
-    app = OperatorApp(lambda: _factory(FakeSession()))
-    async with app.run_test(size=(80, 24)) as pilot:
-        await _boot(pilot, app)
-        await _abort(pilot, app, "stopped part way")
-        before = len(_notices(app))
-        await pilot.press("ctrl+o")
-        await pilot.pause()
-        copied = app._clipboard
-        new_notices = _notices(app)[before:]
-
-    assert copied == "stopped part way"
-    assert any("cut off" in text for text in new_notices), new_notices

--- a/tests/unit/tui/test_copy_picker.py
+++ b/tests/unit/tui/test_copy_picker.py
@@ -1,0 +1,388 @@
+"""The `/copy` picker screen: layout maths, navigation, and the target it hands back.
+
+The layout tests are the load-bearing ones. The row split is where a literal
+port of the reference's prose (rather than its source) produces a visibly
+different widget on every short tree, and the budget floor is where the card
+overflowed its box by one row at a 14-row terminal — clipped silently, off the
+bottom, taking the footer with it.
+
+Geometry is asserted against the REAL app and the real stylesheet: the
+lightweight hosts elsewhere in this suite declare no `CSS_PATH`, so a card
+sized by percentage rules would not be sized at all under one.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.binding import Binding
+
+from local_operator.tui.copy_targets import (
+    CopyTarget,
+    build_copy_targets,
+    flatten_targets,
+)
+from local_operator.tui.widgets.assistant import AssistantBlock
+from local_operator.tui.widgets.copy_picker import (
+    CARD_PADDING_ROWS,
+    MIN_TREE_ROWS,
+    CopyPickerScreen,
+)
+
+CODE_ANSWER = "Here it is.\n\n```python\ndef f():\n    return 1\n```\n\n> and a quote"
+
+
+def _answer(text: str, truncated: bool = False) -> AssistantBlock:
+    """A SETTLED answer, which is the only kind the picker lists."""
+    block = AssistantBlock()
+    block.update_text(text)
+    block.finalize_text()
+    if truncated:
+        block.mark_truncated()
+    return block
+
+
+def _targets(*texts: str) -> list[CopyTarget]:
+    return build_copy_targets([_answer(text) for text in texts])
+
+
+async def _open(app, targets: list[CopyTarget], pilot) -> CopyPickerScreen:
+    screen = CopyPickerScreen(targets)
+    app.push_screen(screen)
+    await pilot.pause()
+    await pilot.pause()
+    return screen
+
+
+def _real_app():
+    from local_operator.tui.app import OperatorApp
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    return OperatorApp(lambda: _factory(FakeSession()))
+
+
+# --- layout -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_short_tree_takes_only_the_rows_it_has() -> None:
+    """`tree_rows` is capped at the number of rows that EXIST, so a two-node
+    tree donates the rest to the preview instead of sitting in a half-height
+    pane padded with blanks. This is the case the reference's own source gets
+    right and its prose description does not."""
+    app = _real_app()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets("one", "two"), pilot)
+        tree_rows, preview_rows = screen._split_rows()
+        assert tree_rows == 2
+        # The whole remaining budget, not a half share.
+        assert preview_rows == screen._row_budget() - 2
+
+
+@pytest.mark.asyncio
+async def test_a_long_tree_splits_the_budget_in_half() -> None:
+    app = _real_app()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets(*[f"answer {i}" for i in range(40)]), pilot)
+        available = screen._row_budget()
+        tree_rows, preview_rows = screen._split_rows()
+        assert tree_rows == available // 2
+        assert preview_rows == available - tree_rows
+
+
+@pytest.mark.asyncio
+async def test_the_minimum_floors_the_budget_not_the_tree_share() -> None:
+    """`MIN_TREE_ROWS` floors `available`, which is what makes a two-node tree
+    on a short terminal take two rows rather than three."""
+    app = _real_app()
+    async with app.run_test(size=(100, 14)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets("only one"), pilot)
+        assert screen._row_budget() >= MIN_TREE_ROWS + 1 or screen._row_budget() >= 1
+        assert screen._split_rows()[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_the_card_never_overflows_its_box_at_any_height() -> None:
+    """The failure this pins: at 14 rows the composed card was 11 rows against
+    10 drawn, and Textual clipped the difference off the bottom SILENTLY —
+    taking the footer, the only statement of how to leave, with it. A
+    scrollbar appearing is the other half of the same bug: it costs two cells
+    of width and reflows the transcript behind the overlay."""
+    for height in (14, 16, 18, 20, 24, 30, 40, 60):
+        app = _real_app()
+        async with app.run_test(size=(100, height)) as pilot:
+            await pilot.pause()
+            targets = _targets(*[CODE_ANSWER for _ in range(20)])
+            screen = await _open(app, targets, pilot)
+            drawn = screen.query_one(".copy-picker").region.height
+            composed = len(screen.render_lines_for_test()) + CARD_PADDING_ROWS
+            assert composed <= drawn, (height, composed, drawn)
+            assert app.screen.virtual_size.height <= app.screen.size.height, height
+            assert not app.screen.show_vertical_scrollbar, height
+
+
+@pytest.mark.asyncio
+async def test_the_footer_is_always_the_last_drawn_row() -> None:
+    """It is the only statement of how to leave the screen."""
+    for height in (14, 20, 30, 50):
+        app = _real_app()
+        async with app.run_test(size=(100, height)) as pilot:
+            await pilot.pause()
+            screen = await _open(app, _targets(CODE_ANSWER), pilot)
+            assert screen.render_lines_for_test()[-1] == "↑↓ move · enter copy · esc quit"
+
+
+@pytest.mark.asyncio
+async def test_render_lines_are_empty_before_the_card_is_drawn() -> None:
+    """This method re-derives the text rather than reading back what was
+    painted, so an undrawn card must report nothing — otherwise a test can
+    assert a line that never reached the terminal."""
+    screen = CopyPickerScreen(_targets("unmounted"))
+    assert screen.render_lines_for_test() == []
+
+
+# --- the tree ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_tree_draws_labels_hints_and_nesting() -> None:
+    app = _real_app()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets(CODE_ANSWER), pilot)
+        lines = screen.render_lines_for_test()
+        assert any("❯ Here it is." in line and "1 code · 1 quote" in line for line in lines)
+        assert any("├─ Block 1" in line and "python · 2 lines" in line for line in lines)
+        assert any("└─ Quote 1" in line for line in lines)
+
+
+@pytest.mark.asyncio
+async def test_a_truncated_answer_is_marked_in_the_tree_and_the_preview() -> None:
+    app = _real_app()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        targets = build_copy_targets([_answer("cut off here", truncated=True)])
+        screen = await _open(app, targets, pilot)
+        lines = screen.render_lines_for_test()
+        assert any("truncated · 1 line" in line for line in lines)
+        assert any(line.startswith("Preview · truncated") for line in lines)
+
+
+@pytest.mark.asyncio
+async def test_the_hint_survives_a_narrow_terminal_and_the_label_gives_way() -> None:
+    """The hint carries the line counts and the `truncated` marker; the label
+    is the column that can afford to lose cells."""
+    app = _real_app()
+    async with app.run_test(size=(52, 20)) as pilot:
+        await pilot.pause()
+        long_label = "An extremely long first line that cannot possibly fit in this width"
+        targets = build_copy_targets([_answer(long_label, truncated=True)])
+        screen = await _open(app, targets, pilot)
+        row = next(line for line in screen.render_lines_for_test() if "❯" in line)
+        assert "truncated · 1 line" in row
+        assert "…" in row
+
+
+@pytest.mark.asyncio
+async def test_the_window_follows_the_cursor_past_the_visible_rows() -> None:
+    """A cursor that leaves the window would move the selection to a row the
+    user cannot see."""
+    app = _real_app()
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets(*[f"answer {i}" for i in range(40)]), pilot)
+        for _ in range(20):
+            await pilot.press("down")
+        await pilot.pause()
+        tree_rows, _ = screen._split_rows()
+        start = screen._window_start(tree_rows)
+        assert start <= screen._selected < start + tree_rows
+        assert any("answer 19" in line for line in screen.render_lines_for_test())
+
+
+# --- navigation -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_arrows_clamp_at_both_ends_rather_than_wrapping() -> None:
+    """A deliberate divergence from the reference, which wraps. AGENTS.md's
+    wrap rule carries an exception for a list that IS the whole page, and the
+    nearest precedent here (`session_picker._move_to`) already clamps. Page
+    keys clamp under either reading, so clamping the arrows too keeps ONE
+    uniform rule on the page."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets("one", "two", "three"), pilot)
+        await pilot.press("up")
+        assert screen._selected == 0
+        for _ in range(10):
+            await pilot.press("down")
+        assert screen._selected == len(screen.visible_rows) - 1
+        await pilot.press("down")
+        assert screen._selected == len(screen.visible_rows) - 1
+
+
+@pytest.mark.asyncio
+async def test_the_page_keys_clamp_and_step_by_the_visible_tree() -> None:
+    """By the CAPPED tree height, so a page moves by what the user can see."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets(*[f"answer {i}" for i in range(40)]), pilot)
+        step = screen._page_rows()
+        assert step == screen._split_rows()[0]
+        await pilot.press("pagedown")
+        assert screen._selected == step
+        await pilot.press("pageup")
+        assert screen._selected == 0
+        await pilot.press("pageup")
+        assert screen._selected == 0
+
+
+@pytest.mark.asyncio
+async def test_home_and_end_reach_the_ends_the_arrows_no_longer_wrap_to() -> None:
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets(*[f"answer {i}" for i in range(30)]), pilot)
+        await pilot.press("end")
+        assert screen._selected == len(screen.visible_rows) - 1
+        await pilot.press("home")
+        assert screen._selected == 0
+
+
+@pytest.mark.asyncio
+async def test_the_cursor_can_reach_every_row_including_nested_children() -> None:
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        targets = _targets(CODE_ANSWER)
+        screen = await _open(app, targets, pilot)
+        seen = []
+        for _ in range(len(flatten_targets(targets))):
+            target = screen.selected_target()
+            assert target is not None
+            seen.append(target.id)
+            await pilot.press("down")
+        assert seen == [node.target.id for node in flatten_targets(targets)]
+
+
+# --- the answer it hands back -----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enter_dismisses_with_the_highlighted_target() -> None:
+    """The whole point of the two-way surface. It returns the TARGET, not its
+    text, so the caller can read `truncated` without re-deriving it."""
+    chosen: list[CopyTarget | None] = []
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        screen = CopyPickerScreen(_targets(CODE_ANSWER))
+        app.push_screen(screen, chosen.append)
+        await pilot.pause()
+        await pilot.press("down")  # onto Block 1
+        await pilot.press("enter")
+        await pilot.pause()
+    assert len(chosen) == 1
+    assert chosen[0] is not None
+    assert chosen[0].id == "msg:1:code:0"
+    assert chosen[0].content == "def f():\n    return 1"
+
+
+@pytest.mark.asyncio
+async def test_esc_dismisses_with_nothing() -> None:
+    chosen: list[CopyTarget | None] = []
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.push_screen(CopyPickerScreen(_targets("an answer")), chosen.append)
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+    assert chosen == [None]
+
+
+@pytest.mark.asyncio
+async def test_ctrl_c_is_not_bound_by_the_modal() -> None:
+    """The reference binds `ctrl+c` beside Esc. Here it is the GLOBAL
+    interrupt, and a modal claiming it would change what stopping a turn means
+    depending on whether an overlay happened to be open. Both existing modals
+    dismiss on Esc alone."""
+    keys = {
+        binding.key if isinstance(binding, Binding) else binding[0]
+        for binding in CopyPickerScreen.BINDINGS
+    }
+    assert "ctrl+c" not in keys
+    assert "escape" in keys
+
+
+@pytest.mark.asyncio
+async def test_a_truncated_target_carries_its_flag_to_the_caller() -> None:
+    """The caller warns that the copied answer was cut off; it must not have
+    to re-derive that from the text."""
+    chosen: list[CopyTarget | None] = []
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        targets = build_copy_targets([_answer("half an answer", truncated=True)])
+        app.push_screen(CopyPickerScreen(targets), chosen.append)
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+    assert chosen[0] is not None and chosen[0].truncated is True
+
+
+# --- the preview ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_preview_tracks_the_cursor() -> None:
+    app = _real_app()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets(CODE_ANSWER), pilot)
+        await pilot.press("down")  # Block 1
+        await pilot.pause()
+        lines = screen.render_lines_for_test()
+        assert any(line.startswith("Preview · python · 2 lines") for line in lines)
+        assert any("def f():" in line for line in lines)
+
+
+@pytest.mark.asyncio
+async def test_a_long_preview_reports_how_much_it_is_not_showing() -> None:
+    """Wrapped, never hard-truncated, and the marker COSTS a row: showing one
+    more line while hiding that more exist is the failure it prevents."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        body = "\n".join(f"line {index}" for index in range(200))
+        screen = await _open(app, _targets(body), pilot)
+        lines = screen.render_lines_for_test()
+        marker = [line for line in lines if line.startswith("… ") and "more lines" in line]
+        assert len(marker) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_short_preview_shows_no_overflow_marker() -> None:
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets("one line only"), pilot)
+        assert not any("more lines" in line for line in screen.render_lines_for_test())
+
+
+@pytest.mark.asyncio
+async def test_the_preview_wraps_rather_than_truncating() -> None:
+    """A hard-truncated preview would hide the end of every long line, which
+    is exactly where a user checks whether they picked the right block."""
+    app = _real_app()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        sentence = "word " * 60
+        screen = await _open(app, _targets(sentence.strip()), pilot)
+        lines = screen.render_lines_for_test()
+        assert sum(1 for line in lines if line.startswith("word ")) > 1

--- a/tests/unit/tui/test_copy_picker.py
+++ b/tests/unit/tui/test_copy_picker.py
@@ -103,24 +103,104 @@ async def test_the_minimum_floors_the_budget_not_the_tree_share() -> None:
         assert screen._split_rows()[0] == 1
 
 
+def _painted(app) -> str:
+    """What the COMPOSITOR actually put on screen.
+
+    The only way to see WRAP: `render_lines_for_test` composes strings and a
+    row that wraps in the real paint still reports as one line there. NBSP is
+    normalised because the footer's spacing paints as `\\u00a0`.
+    """
+    return "\n".join(
+        "".join(segment.text for segment in strip)
+        for strip in app.screen._compositor.render_strips()
+    ).replace("\u00a0", " ")
+
+
 @pytest.mark.asyncio
 async def test_the_card_never_overflows_its_box_at_any_height() -> None:
     """The failure this pins: at 14 rows the composed card was 11 rows against
     10 drawn, and Textual clipped the difference off the bottom SILENTLY —
     taking the footer, the only statement of how to leave, with it. A
     scrollbar appearing is the other half of the same bug: it costs two cells
-    of width and reflows the transcript behind the overlay."""
-    for height in (14, 16, 18, 20, 24, 30, 40, 60):
+    of width and reflows the transcript behind the overlay.
+
+    The sweep starts at 6, not 14. An earlier revision of this test swept
+    14-60 and was written to prevent exactly this defect, but the band where
+    the card actually clipped its footer (8-11) sat below its floor, so it
+    passed throughout — a guard whose range excluded the failure it named.
+    """
+    for height in (6, 8, 10, 11, 12, 14, 16, 18, 20, 24, 30, 40, 60):
         app = _real_app()
         async with app.run_test(size=(100, height)) as pilot:
             await pilot.pause()
             targets = _targets(*[CODE_ANSWER for _ in range(20)])
             screen = await _open(app, targets, pilot)
-            drawn = screen.query_one(".copy-picker").region.height
-            composed = len(screen.render_lines_for_test()) + CARD_PADDING_ROWS
-            assert composed <= drawn, (height, composed, drawn)
+            card = screen.query_one(".copy-picker")
+            lines = screen.render_lines_for_test()
+            # A hidden card is the correct answer below the chrome floor, and
+            # it claims no padding either — that is the point of hiding rather
+            # than emptying it.
+            composed = len(lines) + CARD_PADDING_ROWS if lines else 0
+            assert composed <= card.region.height, (height, composed, card.region.height)
             assert app.screen.virtual_size.height <= app.screen.size.height, height
             assert not app.screen.show_vertical_scrollbar, height
+
+
+@pytest.mark.asyncio
+async def test_the_footer_is_painted_or_the_card_is_not_drawn_at_all() -> None:
+    """Asserted against the PAINTED frame, across both axes.
+
+    `render_lines_for_test` cannot see this: it builds strings, and a row too
+    wide for the pane wraps in the compositor. At 36 columns the helper
+    reported the footer while the frame had pushed it off the card, so a test
+    reading the helper could not catch it.
+
+    The contract is two-sided — either the footer is on screen, or the card
+    drew nothing. A half-card with no way out advertised is the defect; an
+    absent card on a terminal that cannot hold one is a degraded frame, and
+    Esc still leaves it.
+    """
+    for width, height in (
+        (100, 8),
+        (100, 10),
+        (100, 11),
+        (100, 12),
+        (100, 30),
+        (32, 24),
+        (36, 24),
+        (38, 24),
+        (40, 24),
+        (60, 24),
+        (80, 14),
+    ):
+        app = _real_app()
+        async with app.run_test(size=(width, height)) as pilot:
+            await pilot.pause()
+            screen = await _open(app, _targets(CODE_ANSWER), pilot)
+            frame = _painted(app)
+            card = screen.query_one(".copy-picker")
+            if card.display:
+                assert "esc quit" in frame, (width, height, frame)
+            else:
+                assert "Copy to clipboard" not in frame, (width, height, frame)
+            assert screen.render_lines_for_test() == [] or card.display
+
+
+@pytest.mark.asyncio
+async def test_esc_still_leaves_a_card_too_small_to_draw() -> None:
+    """Hiding the card must not strand the user: the screen is still a modal
+    over their conversation, and Esc is the only way off it."""
+    chosen: list[CopyTarget | None] = []
+    app = _real_app()
+    async with app.run_test(size=(100, 9)) as pilot:
+        await pilot.pause()
+        screen = CopyPickerScreen(_targets(CODE_ANSWER))
+        app.push_screen(screen, chosen.append)
+        await pilot.pause()
+        assert not screen.is_drawable
+        await pilot.press("escape")
+        await pilot.pause()
+    assert chosen == [None]
 
 
 @pytest.mark.asyncio
@@ -132,6 +212,48 @@ async def test_the_footer_is_always_the_last_drawn_row() -> None:
             await pilot.pause()
             screen = await _open(app, _targets(CODE_ANSWER), pilot)
             assert screen.render_lines_for_test()[-1] == "↑↓ move · enter copy · esc quit"
+
+
+@pytest.mark.asyncio
+async def test_the_test_helper_reports_nothing_when_the_card_is_hidden() -> None:
+    """The helper's own docstring promises it will not report lines that never
+    reached the terminal. It only checked `is_mounted`, so at 80x10 the body
+    was mounted with `display=True` and it happily reported the footer against
+    a frame that had clipped it — a comment asserting a guarantee the code did
+    not implement, and the guard that would have caught the clipping."""
+    app = _real_app()
+    async with app.run_test(size=(80, 10)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets(CODE_ANSWER), pilot)
+        assert not screen.is_drawable
+        assert screen.render_lines_for_test() == []
+        assert "esc quit" not in _painted(app)
+
+
+@pytest.mark.asyncio
+async def test_enter_on_an_empty_block_refuses_rather_than_copying_nothing() -> None:
+    """An empty fence builds a child whose content is `""`. The guard tested
+    `content is None`, so Enter dismissed the picker and wrote nothing — no
+    toast, no notice. `_cmd_copy`'s docstring argues that silence is right for
+    a zero-width drag and wrong for a command typed deliberately."""
+    chosen: list[CopyTarget | None] = []
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        screen = CopyPickerScreen(_targets("Here:\n\n```py\n```\n"))
+        app.push_screen(screen, chosen.append)
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.pause()
+        target = screen.selected_target()
+        assert target is not None and target.content == ""
+        await pilot.press("enter")
+        await pilot.pause()
+        # Still open: the refusal is visible as the picker not going away.
+        assert chosen == []
+        await pilot.press("escape")
+        await pilot.pause()
+    assert chosen == [None]
 
 
 @pytest.mark.asyncio
@@ -364,6 +486,50 @@ async def test_a_long_preview_reports_how_much_it_is_not_showing() -> None:
         lines = screen.render_lines_for_test()
         marker = [line for line in lines if line.startswith("… ") and "more lines" in line]
         assert len(marker) == 1
+
+
+@pytest.mark.asyncio
+async def test_the_overflow_marker_agrees_with_the_header_at_every_width() -> None:
+    """Both numbers must measure the same thing. The marker counted WRAPPED
+    ROWS while the header counts SOURCE LINES, so at 100 columns a 79-line
+    answer claimed `… 144 more lines` — more than the document contains — and
+    the contradiction was visible in one pane."""
+    body = "\n".join(f"line {index} of an answer long enough to wrap here" for index in range(79))
+    checked = 0
+    for width in (60, 70, 100):
+        app = _real_app()
+        async with app.run_test(size=(width, 30)) as pilot:
+            await pilot.pause()
+            screen = await _open(app, _targets(body), pilot)
+            lines = screen.render_lines_for_test()
+            header = next(line for line in lines if line.startswith("Preview · "))
+            total = int(header.split("·")[1].strip().split()[0])
+            marker = next(line for line in lines if "more lines" in line)
+            claimed = int(marker.strip().split()[1])
+            shown = sum(1 for line in lines if line.startswith("line "))
+            # Exactly the lines not on screen — not merely a smaller number.
+            assert claimed == total - shown, (width, claimed, total, shown)
+            checked += 1
+    assert checked == 3
+
+
+@pytest.mark.asyncio
+async def test_the_overflow_marker_does_not_saturate_on_a_budgeted_answer() -> None:
+    """`PREVIEW_WRAP_BUDGET` caps the WRAP, not the count. While the marker
+    counted wrapped rows the budget capped it too, so a 600-line and a
+    1000-line answer both reported the same 183 — a precise-looking constant,
+    which is worse than no number."""
+    claims = []
+    for length in (600, 1000):
+        app = _real_app()
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            body = "\n".join(f"line {index}" for index in range(length))
+            screen = await _open(app, _targets(body), pilot)
+            marker = next(line for line in screen.render_lines_for_test() if "more lines" in line)
+            claims.append(int(marker.strip().split()[1]))
+    assert claims[0] != claims[1], claims
+    assert claims[1] - claims[0] == 400, claims
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_copy_picker_qa.py
+++ b/tests/unit/tui/test_copy_picker_qa.py
@@ -1,0 +1,654 @@
+"""Independent QA probes of the `/copy` picker: parity, payload, and refusals.
+
+Written against the RUNNING app rather than against the helpers, because the
+questions this file asks are ones only the assembled system answers: whether a
+fence grammar edge reaches the clipboard intact, whether the truncation caveat
+fires for the node the user actually chose, and whether a chord that was
+removed is really gone from the key map rather than merely from the help text.
+
+It sits beside `test_copy_command.py` (payload and refusals) and
+`test_copy_picker.py` (layout and navigation) and deliberately does not repeat
+them. What is here is the ground those two leave uncovered:
+
+* **Reference parity on CONTENT.** The port's own tests assert our behaviour;
+  these assert the reference's semantics for the same input — user messages
+  never listed, most-recent-first ordering, the 50-message cap exercised past
+  its edge, and the `All N` rows appearing only above one block of a kind.
+* **The grammar's hostile inputs.** Adjacent fences, an info string carrying
+  spaces, `~~~`, an unclosed fence, a `>` inside a fence, CRLF, tabs. Each is a
+  case where a plausible parser produces a *plausible* wrong answer rather than
+  an exception, so only the payload distinguishes them.
+* **The truncation contract on CHILDREN.** The caveat is a claim about what is
+  on the clipboard. A complete fence inside a cut-off answer is complete, so
+  copying it must stay silent; the message node above it must not.
+
+Payload assertions read the DRIVER, not ``app._clipboard``: Textual assigns
+that attribute before it checks for a driver, so it cannot tell "the escape
+sequence went out" from "the app remembered a string".
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+
+import pytest
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.copy_targets import MAX_MESSAGES, build_copy_targets
+from local_operator.tui.events import (
+    AssistantDelta,
+    AssistantMessageEnd,
+    AssistantMessageStart,
+)
+from local_operator.tui.widgets.assistant import AssistantBlock
+from local_operator.tui.widgets.copy_picker import CopyPickerScreen
+from local_operator.tui.widgets.editor import Editor
+from local_operator.tui.widgets.toast import Toast
+from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+# -- harness ------------------------------------------------------------------
+# Shaped after `test_copy_command.py`'s helpers rather than importing them: that
+# module's `_copy_latest` folds "open the picker" and "take the default row"
+# into one call, and every probe here needs to steer between those two steps.
+
+_OSC52_RE = re.compile(r"\x1b\]52;c;([^\x07\x1b]*)(?:\x07|\x1b\\)")
+
+
+async def _boot(pilot, app: OperatorApp) -> None:
+    """Settle until the session exists, so `_turn_is_live` reads the real flag."""
+    for _ in range(40):
+        await pilot.pause()
+        if app._session is not None:
+            return
+
+
+async def _stream(pilot, app: OperatorApp, text: str, *, finish: bool = True) -> None:
+    """Paint one agent message through the real event path."""
+    app.post_message(AssistantMessageStart())
+    await pilot.pause()
+    app.post_message(AssistantDelta(text))
+    await pilot.pause()
+    if finish:
+        app.post_message(AssistantMessageEnd(text))
+        await pilot.pause()
+    await pilot.pause()
+
+
+async def _submit(pilot, app: OperatorApp, text: str) -> None:
+    """Type a line into the real editor and press Enter."""
+    editor = app.query_one(Editor)
+    editor.text = text
+    await pilot.pause()
+    if editor._picker.is_open():
+        await pilot.press("escape")
+        await pilot.pause()
+    await pilot.press("enter")
+    await pilot.pause()
+    await pilot.pause()
+
+
+def _picker(app: OperatorApp) -> CopyPickerScreen | None:
+    screen = app.screen
+    return screen if isinstance(screen, CopyPickerScreen) else None
+
+
+def _tap_driver(app: OperatorApp) -> list[str]:
+    """Record every raw driver write, so OSC 52 can be counted and decoded."""
+    sink: list[str] = []
+    driver = app._driver
+    assert driver is not None, "no driver: the pilot would prove nothing about the write"
+    original = driver.write
+
+    def write(data: str) -> None:
+        sink.append(data)
+        original(data)
+
+    driver.write = write  # type: ignore[method-assign]
+    return sink
+
+
+def _osc52_payloads(sink: list[str]) -> list[str]:
+    """Every OSC 52 payload written, decoded back to the source text."""
+    return [
+        base64.b64decode(match.group(1)).decode("utf-8")
+        for chunk in sink
+        for match in _OSC52_RE.finditer(chunk)
+    ]
+
+
+def _notices(app: OperatorApp) -> list[str]:
+    return [
+        block._text
+        for block in app.query_one(TranscriptView).blocks()
+        if isinstance(block, NoticeBlock)
+    ]
+
+
+def _rows(screen: CopyPickerScreen) -> list[str]:
+    """Every row's `id`, in draw order — the tree's shape as a flat list."""
+    return [node.target.id for node in screen.visible_rows]
+
+
+def _labels(screen: CopyPickerScreen) -> list[str]:
+    return [node.target.label for node in screen.visible_rows]
+
+
+def _answer(text: str, truncated: bool = False) -> AssistantBlock:
+    block = AssistantBlock()
+    block.update_text(text)
+    block.finalize_text()
+    if truncated:
+        block.mark_truncated()
+    return block
+
+
+async def _copy_row(pilot, app: OperatorApp, steps: int) -> str | None:
+    """Open the picker, move down `steps` rows, press Enter; return the row id."""
+    await _submit(pilot, app, "/copy")
+    picker = _picker(app)
+    if picker is None:
+        return None
+    for _ in range(steps):
+        await pilot.press("down")
+        await pilot.pause()
+    target = picker.selected_target()
+    await pilot.press("enter")
+    await pilot.pause()
+    await pilot.pause()
+    return target.id if target else None
+
+
+# -- reference parity on content ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_user_message_is_never_a_row_even_between_two_answers() -> None:
+    """The reference skips every non-assistant message outright
+    (`if (msg.role !== "assistant") continue`), and a user turn sitting between
+    two answers is where a walk that merely takes "the last N blocks" would
+    leak one in. Asserted on the ROWS, not on the clipboard: a leaked user row
+    the user never selects is still a leak."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "first answer")
+        await _submit(pilot, app, "a question only the user asked")
+        await _stream(pilot, app, "second answer")
+        await _submit(pilot, app, "/copy")
+        picker = _picker(app)
+        assert picker is not None
+        labels = _labels(picker)
+        ids = _rows(picker)
+        await pilot.press("escape")
+        await pilot.pause()
+
+    assert labels == ["second answer", "first answer"], labels
+    assert ids == ["msg:1", "msg:2"], ids
+    assert not any("question" in label for label in labels), labels
+
+
+def test_the_cap_counts_from_the_most_recent_end_not_the_oldest() -> None:
+    """Sixty answers, fifty rows — and the fifty must be the fifty NEWEST. A
+    walk that capped from the front would list the same COUNT while listing the
+    wrong messages, which no length assertion can catch."""
+    targets = build_copy_targets([_answer(f"answer {index}") for index in range(60)])
+
+    assert len(targets) == MAX_MESSAGES
+    assert targets[0].label == "answer 59"
+    assert targets[-1].label == "answer 10"
+    assert [t.label for t in targets] == [f"answer {i}" for i in range(59, 9, -1)]
+
+
+def test_the_all_rows_appear_only_above_more_than_one_block_of_that_kind() -> None:
+    """`All N` is a convenience over several blocks; above one it would be a
+    second row copying byte-for-byte what the row above copies. The two kinds
+    are counted INDEPENDENTLY, so a message with two fences and one quote gets
+    `All 2 blocks` and no `All N quotes`."""
+    one_code_two_quotes = build_copy_targets([_answer("```py\na\n```\n\n> q1\n\ntext\n\n> q2\n")])[
+        0
+    ]
+    two_code_one_quote = build_copy_targets([_answer("```py\na\n```\n\n```js\nb\n```\n\n> q1\n")])[
+        0
+    ]
+
+    assert [c.label for c in one_code_two_quotes.children] == [
+        "Block 1",
+        "Quote 1",
+        "Quote 2",
+        "All 2 quotes",
+    ]
+    assert [c.label for c in two_code_one_quote.children] == [
+        "Block 1",
+        "Block 2",
+        "Quote 1",
+        "All 2 blocks",
+    ]
+
+
+def test_the_all_blocks_row_joins_bodies_with_one_blank_line() -> None:
+    """The documented separator is `"\\n\\n"` — the reference's
+    `.join("\\n\\n")`. A single newline would weld the last line of one block
+    onto the first of the next when the payload is pasted into a file."""
+    target = build_copy_targets([_answer("```py\na\nb\n```\n\n```js\nc\n```\n")])[0]
+    combined = next(c for c in target.children if c.label == "All 2 blocks")
+
+    assert combined.content == "a\nb\n\nc"
+
+
+# -- the grammar's hostile inputs ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name, message, expected",
+    [
+        # Two fences with no prose between them are two blocks, not one block
+        # whose body swallowed the middle markers.
+        ("adjacent", "```py\na\n```\n```js\nb\n```\n", [("code", "a"), ("code", "b")]),
+        # The info string is everything after the marker, trimmed — a language
+        # plus attributes stays one string rather than being split on space.
+        ("info string", "```python title=x.py\nbody\n```\n", [("code", "body")]),
+        # `~~~` is a fence here, which the reference does not recognise at all.
+        ("tilde", "~~~\nbody\n~~~\n", [("code", "body")]),
+        # No closer: ordinary text, so a streaming or cut-off answer's half
+        # block never becomes a copyable "block" with a body it never had.
+        ("unclosed", "before\n```py\nhalf written\n", []),
+        # Fences mask their bodies: this `>` is code, not a quote.
+        ("quote in fence", "```\n> not a quote\n```\n", [("code", "> not a quote")]),
+        # A quote run ends where the fence begins; both survive, in order.
+        ("quote then fence", "> q\n```py\nc\n```\n", [("quote", "q"), ("code", "c")]),
+        # `>` plus at most ONE space comes off, so a bare `>foo` de-prefixes.
+        ("no space after gt", ">tight\n", [("quote", "tight")]),
+        # Only one optional space: further indentation is the quote's own.
+        ("quote keeps indent", ">     deep\n", [("quote", "    deep")]),
+        # A message that is nothing but a fence still yields its body.
+        ("only a fence", "```py\nbody\n```", [("code", "body")]),
+        # Tabs are payload, not layout: they must reach the clipboard as tabs.
+        ("tabs", "```py\n\tif x:\n\t\treturn\n```\n", [("code", "\tif x:\n\t\treturn")]),
+    ],
+)
+def test_the_block_grammar_holds_on_its_edges(
+    name: str, message: str, expected: list[tuple[str, str]]
+) -> None:
+    """Each of these produces a PLAUSIBLE wrong answer under a plausible wrong
+    parser — a swallowed separator, a language split on its first space, a half
+    block presented as whole — so the body is what distinguishes them, not an
+    exception. Asserted through `build_copy_targets` rather than
+    `extract_blocks` so the child `content` (what is actually copied) is what
+    is checked, not an intermediate."""
+    target = build_copy_targets([_answer(message)])[0]
+    got = [
+        ("code" if child.id.split(":")[2] == "code" else "quote", child.content)
+        for child in target.children
+        if not child.id.endswith(("all", "all-quotes"))
+    ]
+
+    assert got == expected, f"{name}: {got}"
+
+
+def test_twenty_code_blocks_all_become_rows_and_the_all_row_counts_them() -> None:
+    """A long answer is where an off-by-one in the child walk hides: the labels
+    are 1-based while the ids are 0-based, and only a message with many blocks
+    makes the two disagree visibly."""
+    message = "\n".join(f"```py\nblock {index}\n```\n" for index in range(20))
+    target = build_copy_targets([_answer(message)])[0]
+    blocks = [c for c in target.children if ":code:" in c.id]
+    combined = next(c for c in target.children if c.id.endswith(":all"))
+
+    assert len(blocks) == 20
+    assert blocks[0].id == "msg:1:code:0" and blocks[0].label == "Block 1"
+    assert blocks[-1].id == "msg:1:code:19" and blocks[-1].label == "Block 20"
+    assert combined.label == "All 20 blocks"
+    assert combined.content == "\n\n".join(f"block {index}" for index in range(20))
+
+
+def test_the_info_string_reaches_the_language_whole_rather_than_first_word() -> None:
+    """The reference takes the info string as ONE trimmed string
+    (`open[1].trim()`), and so must we: a fence tagged
+    ```` ```python title=x.py ```` carries an attribute, not a second field.
+
+    Pinned because splitting it on the first space is the natural-looking
+    "fix" for the preview lexer — Pygments cannot resolve `python title=x.py`
+    — and it would silently change the LANGUAGE our tree reports away from the
+    reference's. The lexer's own tolerance is checked below rather than
+    papered over here: an unresolvable name renders plain, it does not raise.
+    """
+    plain = build_copy_targets([_answer("```python\nx = 1\n```\n")])[0]
+    attributed = build_copy_targets([_answer("```python title=x.py\nx = 1\n```\n")])[0]
+    bare = build_copy_targets([_answer("```\nx = 1\n```\n")])[0]
+
+    assert plain.children[0].language == "python"
+    assert attributed.children[0].language == "python title=x.py"
+    assert attributed.children[0].hint.startswith("python title=x.py · ")
+    # An empty info string is no language at all, so the preview stays plain.
+    assert bare.children[0].language is None
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_info_string_still_renders_a_preview() -> None:
+    """Because the info string is carried whole, the preview lexer is
+    regularly handed something Pygments cannot resolve. That must degrade to a
+    plain preview, not raise inside a repaint — a modal that throws while
+    painting takes the app down with the user's answer still uncopied."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "Here:\n\n```python title=x.py extra\nx = 1\n```\n")
+        await _submit(pilot, app, "/copy")
+        picker = _picker(app)
+        assert picker is not None
+        await pilot.press("down")
+        await pilot.pause()
+        drawn = picker.render_lines_for_test()
+        await pilot.press("escape")
+        await pilot.pause()
+
+    assert any("x = 1" in line for line in drawn), drawn
+
+
+def test_a_crlf_answer_does_not_carry_a_stray_return_into_the_payload() -> None:
+    """A pasted-in Windows transcript reaches the block as `\\r\\n`. The split
+    is on `\\n`, so a `\\r` rides on the end of every line — including the
+    fence CLOSER, which is why the block is found at all.
+
+    Marked `xfail(strict=True)` rather than deleted or relaxed, following the
+    precedent at `test_transcript_selection.py:4966`: the assertion IS the
+    acceptance check for the defect, so it must start passing the moment the
+    defect is fixed and fail loudly if someone "fixes" it by changing what is
+    expected instead. A trailing `\\r` is invisible in a diff and breaks a
+    shell script pasted out of the picker."""
+    target = build_copy_targets([_answer("Intro\r\n```py\r\nx = 1\r\n```\r\n")])[0]
+    block = target.children[0]
+
+    assert block.content == "x = 1", repr(block.content)
+
+
+# -- payload correctness, off the driver --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_quote_child_reaches_the_clipboard_de_prefixed() -> None:
+    """The `>` markers are the transcript's syntax, not the user's text. This
+    goes through OSC 52 rather than `app._clipboard` because that attribute is
+    assigned before the driver check and cannot prove a write went out."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "Quoting:\n\n> first line\n> second line\n")
+        sink = _tap_driver(app)
+        chosen = await _copy_row(pilot, app, 1)
+        payloads = _osc52_payloads(sink)
+
+    assert chosen == "msg:1:quote:0"
+    assert payloads == ["first line\nsecond line"], payloads
+    assert ">" not in payloads[0]
+
+
+@pytest.mark.asyncio
+async def test_the_message_node_copies_markdown_source_not_the_painted_frame() -> None:
+    """The frame carries box-drawing, a left bar (`\\u258c`) and the wrap of
+    whatever width the terminal happened to be. The clipboard must carry the
+    SOURCE: fences intact, `**bold**` as characters."""
+    answer = "A **bold** claim.\n\n```python\ndef f():\n    return 1\n```\n"
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, answer)
+        sink = _tap_driver(app)
+        chosen = await _copy_row(pilot, app, 0)
+        payloads = _osc52_payloads(sink)
+
+    assert chosen == "msg:1"
+    assert len(payloads) == 1, payloads
+    copied = payloads[0]
+    assert "**bold**" in copied, "the source's emphasis markers, not a style"
+    assert "```python" in copied, "the fence lines are source"
+    assert "\u258c" not in copied and "─" not in copied, "no frame decoration"
+
+
+@pytest.mark.asyncio
+async def test_exactly_one_escape_goes_out_per_copy_and_decodes_byte_identical() -> None:
+    """One gesture, one write. A second escape would double-write the clipboard
+    on terminals that treat OSC 52 as an append, and a payload that does not
+    decode byte-identical means the base64 round trip lost something."""
+    body = "unicode → ok\n\ttabbed\ntrailing spaces   "
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, f"Here:\n\n```txt\n{body}\n```\n")
+        sink = _tap_driver(app)
+        chosen = await _copy_row(pilot, app, 1)
+        payloads = _osc52_payloads(sink)
+
+    assert chosen == "msg:1:code:0"
+    assert len(payloads) == 1, f"expected one escape, got {len(payloads)}"
+    assert payloads[0] == body, repr(payloads[0])
+
+
+# -- the truncation contract --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_copying_a_complete_block_inside_a_cut_off_answer_stays_silent() -> None:
+    """The caveat is a claim about what is on the CLIPBOARD. A closed fence
+    inside an aborted answer is itself complete — the abort ended the message,
+    not that block — so raising the caveat there would be a false warning, and
+    a false warning on the common case is how a true one stops being read.
+
+    The same run asserts the message node above it DOES warn, so the test
+    cannot pass by the notice never firing at all."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _boot(pilot, app)
+        app.post_message(AssistantMessageStart())
+        await pilot.pause()
+        app.post_message(AssistantDelta("Partial:\n\n```py\nx = 1\n```\n\nand then it st"))
+        await pilot.pause()
+        app.post_message(AssistantMessageEnd(""))
+        await pilot.pause()
+        await pilot.pause()
+
+        picker_rows = None
+        before_child = len(_notices(app))
+        child_id = await _copy_row(pilot, app, 1)
+        after_child = _notices(app)[before_child:]
+
+        before_message = len(_notices(app))
+        message_id = await _copy_row(pilot, app, 0)
+        after_message = _notices(app)[before_message:]
+
+        picker_rows = message_id
+
+    assert child_id == "msg:1:code:0", child_id
+    assert after_child == [], f"a complete block must not raise the caveat: {after_child}"
+    assert picker_rows == "msg:1"
+    assert any("cut off" in notice for notice in after_message), after_message
+
+
+@pytest.mark.asyncio
+async def test_a_cut_off_answer_is_listed_and_marked_in_its_hint() -> None:
+    """Listed, because it is the message the user was reading and most likely
+    means; marked, because it is not the whole answer. `truncated` LEADS the
+    hint — the hint is right-aligned and the label is what gives way, so a
+    trailing marker is the first thing a narrow terminal cuts."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _boot(pilot, app)
+        app.post_message(AssistantMessageStart())
+        await pilot.pause()
+        app.post_message(AssistantDelta("half a sen"))
+        await pilot.pause()
+        app.post_message(AssistantMessageEnd(""))
+        await pilot.pause()
+        await pilot.pause()
+        await _submit(pilot, app, "/copy")
+        picker = _picker(app)
+        assert picker is not None
+        target = picker.selected_target()
+        drawn = picker.render_lines_for_test()
+        await pilot.press("escape")
+        await pilot.pause()
+
+    assert target is not None and target.truncated
+    assert target.hint.startswith("truncated · "), target.hint
+    assert any("truncated" in line for line in drawn), drawn
+
+
+# -- the preview's overflow claim ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_overflow_marker_counts_the_lines_that_actually_exist() -> None:
+    """The marker is the preview's one quantitative claim, and the only signal
+    that the pane is not the whole answer. It has to scale with the answer: a
+    600-line message and a 1000-line message reporting the identical number
+    tells the user their answer is a fixed size, which is worse than no number
+    at all because it looks precise.
+
+    The wrap budget is the right optimisation — folding thousands of rows to
+    show fifteen is real work avoided — but the design that introduced it says
+    the marker "counts SOURCE lines, so the number stays honest without the
+    work" (`copy_picker.py`, `PREVIEW_WRAP_BUDGET`). It counts wrapped rows
+    instead, so the honesty the budget was allowed on the strength of is the
+    part that went missing.
+
+    Two sizes in one test, because a single size cannot distinguish "off by a
+    constant" from "saturated": the failure is that the two numbers are EQUAL.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "\n".join(f"line {index}" for index in range(600)))
+        await _submit(pilot, app, "/copy")
+        picker = _picker(app)
+        assert picker is not None
+        drawn = picker.render_lines_for_test()
+        shown = sum(1 for line in drawn if line.strip().startswith("line "))
+        marker = next(line for line in drawn if "more lines" in line)
+        claimed = int(marker.strip().split()[1])
+        await pilot.press("escape")
+        await pilot.pause()
+
+    assert (
+        claimed == 600 - shown
+    ), f"preview claims {claimed} more lines; {600 - shown} are actually unshown"
+
+
+# -- navigation and refusals --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enter_on_a_group_node_copies_the_whole_message() -> None:
+    """Drilling in must never be the only way to get the answer out: the group
+    row itself is copyable, and what it copies is the WHOLE message including
+    the blocks its children expose separately."""
+    answer = "Intro line.\n\n```py\nx = 1\n```\n\n> a quote\n"
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, answer)
+        await _submit(pilot, app, "/copy")
+        picker = _picker(app)
+        assert picker is not None
+        group = picker.selected_target()
+        assert group is not None
+        assert group.children, "the fixture must be a GROUP node"
+        sink = _tap_driver(app)
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        payloads = _osc52_payloads(sink)
+
+    assert len(payloads) == 1, payloads
+    assert payloads[0].strip() == answer.strip()
+
+
+@pytest.mark.asyncio
+async def test_esc_writes_no_escape_sequence_and_leaves_the_draft_alone() -> None:
+    """A cancelled picker is not an event. Asserted on the DRIVER — the
+    clipboard attribute cannot tell "nothing was written" from "the app
+    remembered nothing" — and on the composer, because a modal that eats or
+    edits the draft behind it is the failure Esc is supposed to avoid."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "an answer")
+        await _submit(pilot, app, "/copy")
+        assert _picker(app) is not None
+        sink = _tap_driver(app)
+        before = len(_notices(app))
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.pause()
+        payloads = _osc52_payloads(sink)
+        new_notices = _notices(app)[before:]
+        toast = app.query_one(Toast).message
+        still_open = _picker(app)
+
+    assert still_open is None
+    assert payloads == [], payloads
+    assert new_notices == [], new_notices
+    assert toast == ""
+
+
+@pytest.mark.asyncio
+async def test_ctrl_o_does_nothing_now_that_the_chord_is_gone() -> None:
+    """The chord was withdrawn with the picker. "Gone" has to mean gone from
+    the KEY MAP, not merely from the help text: a stale binding would still
+    copy, or still crash on a handler that no longer exists. The draft is
+    checked too, because an unbound control key that reaches the editor as text
+    is its own regression."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await _boot(pilot, app)
+        await _stream(pilot, app, "an answer worth copying")
+        editor = app.query_one(Editor)
+        editor.text = "a draft the user is still writing"
+        editor.focus()
+        await pilot.pause()
+        sink = _tap_driver(app)
+        await pilot.press("ctrl+o")
+        await pilot.pause()
+        await pilot.pause()
+        payloads = _osc52_payloads(sink)
+        draft = editor.text
+        toast = app.query_one(Toast).message
+        screen_now = app.screen
+
+    assert payloads == [], f"ctrl+o still wrote to the clipboard: {payloads}"
+    assert draft == "a draft the user is still writing", repr(draft)
+    assert toast == ""
+    assert not isinstance(screen_now, CopyPickerScreen), "ctrl+o must not open the picker"
+
+
+@pytest.mark.asyncio
+async def test_the_two_empty_cases_keep_their_distinct_wording() -> None:
+    """Two states the reference's single string conflates: nothing has ever
+    been said, versus the first answer is still arriving. Asserted in ONE test
+    so the pair cannot silently converge on the same wording — two separate
+    tests would both still pass if someone flattened them into one message."""
+    fresh = OperatorApp(lambda: _factory(FakeSession()))
+    async with fresh.run_test(size=(100, 40)) as pilot:
+        await _boot(pilot, fresh)
+        before = len(_notices(fresh))
+        await _submit(pilot, fresh, "/copy")
+        empty_conversation = _notices(fresh)[before:]
+        assert _picker(fresh) is None, "an empty tree must not open an overlay"
+
+    live = OperatorApp(lambda: _factory(FakeSession()))
+    async with live.run_test(size=(100, 40)) as pilot:
+        await _boot(pilot, live)
+        live._session.streaming = True  # type: ignore[union-attr]
+        live.post_message(AssistantMessageStart())
+        await pilot.pause()
+        live.post_message(AssistantDelta("still writ"))
+        await pilot.pause()
+        before = len(_notices(live))
+        await _submit(pilot, live, "/copy")
+        mid_first_answer = _notices(live)[before:]
+        assert _picker(live) is None
+
+    assert empty_conversation == ["nothing to copy — no agent message in this conversation"]
+    assert mid_first_answer == ["nothing to copy yet — the first answer is still coming"]
+    assert empty_conversation != mid_first_answer, "the two states must stay distinguishable"

--- a/tests/unit/tui/test_copy_targets.py
+++ b/tests/unit/tui/test_copy_targets.py
@@ -333,3 +333,67 @@ def test_every_target_is_copyable_today() -> None:
     Enter guard is written against the type, so this pins what it guards."""
     targets = build_copy_targets([_Assistant("a\n```\nb\n```\n\n```\nc\n```\n\n> q")])
     assert all(node.target.content is not None for node in flatten_targets(targets))
+
+
+# --- robustness of the walk -------------------------------------------------
+
+
+def test_a_crlf_answer_is_normalised_before_the_split() -> None:
+    """A pasted Windows transcript arrives as `\r\n`. Splitting on `\n` alone
+    leaves a `\r` on every line — invisible in a diff, and it breaks a shell
+    script pasted out of the picker."""
+    targets = build_copy_targets([_Assistant("Intro\r\n```py\r\nx = 1\r\n```\r\n")])
+    assert targets[0].children[0].content == "x = 1"
+    assert "\r" not in targets[0].children[0].content
+
+
+def test_line_counts_agree_with_the_clipboard_receipt() -> None:
+    """`splitlines()`, not `split("\n")`: the latter reads a trailing newline
+    as a whole further line, so an answer ending in `\n` — most of them — was
+    hinted one line longer than `_put_on_clipboard` reported for the same
+    text. That receipt already settled this (app.py, review round 1, F3)."""
+    shapes = (
+        "Here is the answer.\n",
+        "\nHi\n\n",
+        "answer body\n\n\n   \n",
+        "a\nb\n",
+        "x\n\n\n",
+    )
+    for text in shapes:
+        hint = plural_lines(text)
+        assert int(hint.split()[0]) == len(text.splitlines()), (text, hint)
+
+
+def test_a_block_that_raises_while_inspected_costs_only_its_own_row() -> None:
+    """A `runtime_checkable` protocol tests attribute PRESENCE, not that the
+    call works: a property whose getter raises satisfies `isinstance` and then
+    raises when invoked. A designer saw that shape once as
+    `'UserBlock' object has no attribute 'is_truncated'` raised out of this
+    walk into a live `/copy`. Whatever the transient was, a clipboard command
+    must not take the turn down with it."""
+
+    class _Raises:
+        def text(self) -> str:
+            return "should never be listed"
+
+        def is_finalized(self) -> bool:
+            return True
+
+        @property
+        def is_truncated(self):  # type: ignore[no-untyped-def]
+            raise AttributeError("half-built widget")
+
+    targets = build_copy_targets([_Assistant("a real answer"), _Raises()])
+    assert [target.label for target in targets] == ["a real answer"]
+
+
+def test_a_block_whose_methods_are_not_callable_is_skipped() -> None:
+    """The other half of the same gap: the names exist, so `isinstance`
+    passes, but they are attributes rather than methods."""
+
+    class _NotCallable:
+        text = "not a method"
+        is_finalized = True
+        is_truncated = False
+
+    assert build_copy_targets([_NotCallable()]) == []

--- a/tests/unit/tui/test_copy_targets.py
+++ b/tests/unit/tui/test_copy_targets.py
@@ -1,0 +1,335 @@
+"""The `/copy` picker's target tree, pinned without an app.
+
+The tree is a pure text transform, so these tests build messages as strings
+and assert the nodes directly: a broken fence rule names the construct that
+broke rather than surfacing three calls away as a wrong clipboard.
+
+The fence tests are the ones to keep. They are where this port deliberately
+does NOT follow oh-my-pi, whose closing rule is a bare ``/^```/``.
+"""
+
+from __future__ import annotations
+
+from local_operator.tui.copy_targets import (
+    MAX_MESSAGES,
+    CopyTarget,
+    build_copy_targets,
+    extract_blocks,
+    first_line,
+    flatten_targets,
+    plural_lines,
+)
+
+
+class _Assistant:
+    """A settled assistant answer — the minimal shape the tree admits."""
+
+    def __init__(self, text: str, finalized: bool = True, truncated: bool = False) -> None:
+        self._text = text
+        self._finalized = finalized
+        self._truncated = truncated
+
+    def text(self) -> str:
+        return self._text
+
+    def is_finalized(self) -> bool:
+        return self._finalized
+
+    def is_truncated(self) -> bool:
+        return self._truncated
+
+
+class _NotAnAnswer:
+    """A user/notice-shaped block: text and finalized, but never truncated."""
+
+    def __init__(self, text: str = "what about the stale rows?") -> None:
+        self._text = text
+
+    def text(self) -> str:
+        return self._text
+
+    def is_finalized(self) -> bool:
+        return True
+
+
+def _by_id(targets: list[CopyTarget], node_id: str) -> CopyTarget:
+    return next(node.target for node in flatten_targets(targets) if node.target.id == node_id)
+
+
+# --- block extraction -------------------------------------------------------
+
+
+def test_a_fence_masks_its_body_so_an_inner_quote_is_not_a_quote() -> None:
+    """The `>` inside a code block is code, and copying it as a quote would
+    hand the user a fragment of a program with its first character eaten."""
+    blocks = extract_blocks("```sh\n> redirected output\n```\n> a real quote")
+    assert [(block.kind, block.body) for block in blocks] == [
+        ("code", "> redirected output"),
+        ("quote", "a real quote"),
+    ]
+
+
+def test_an_unclosed_fence_is_ordinary_text() -> None:
+    """A truncated or still-streaming answer very often ends mid-fence. If the
+    opener alone made a block, its body would be the whole rest of the
+    message — a code target that is not code."""
+    assert extract_blocks("intro\n```python\ndef f():\n    pass") == []
+
+
+def test_a_tilde_fence_is_not_closed_by_backticks() -> None:
+    """The divergence from oh-my-pi, whose `CLOSE_FENCE_RE = /^```/` closes any
+    fence on any backtick run and does not open on `~~~` at all. Matching the
+    fence character is what `_copy_markdown.classify` already does for the
+    drag-select path; the two are the only readers of this grammar and they
+    must agree, or the same message copies differently by route."""
+    blocks = extract_blocks("~~~\ninside\n```\nstill inside\n~~~\nafter")
+    assert [(block.kind, block.body) for block in blocks] == [("code", "inside\n```\nstill inside")]
+
+
+def test_a_backtick_fence_is_not_closed_by_tildes() -> None:
+    """The same rule in the other direction."""
+    blocks = extract_blocks("```\ninside\n~~~\nstill inside\n```")
+    assert [block.body for block in blocks] == ["inside\n~~~\nstill inside"]
+
+
+def test_a_marker_carrying_an_info_string_opens_and_never_closes() -> None:
+    """`classify` requires a closer to be marker characters alone. Treating
+    ```` ```python ```` as a closer would end the block at the next fence that
+    happens to name a language and split one block into two wrong ones."""
+    blocks = extract_blocks("```\nfirst\n```python\nsecond\n```")
+    assert [block.body for block in blocks] == ["first\n```python\nsecond"]
+
+
+def test_the_info_string_becomes_the_language_and_is_stripped() -> None:
+    blocks = extract_blocks("```  python  \nx = 1\n```")
+    assert blocks[0].lang == "python"
+    assert blocks[0].body == "x = 1"
+
+
+def test_a_fence_with_no_info_string_has_no_language() -> None:
+    """Which is what leaves the preview plain rather than guessing a lexer."""
+    assert extract_blocks("```\nx = 1\n```")[0].lang == ""
+
+
+def test_a_quote_keeps_its_inner_indentation() -> None:
+    """The marker plus ONE optional space comes off. Stripping all leading
+    whitespace would flatten a quoted code sample or list."""
+    blocks = extract_blocks("> outer\n>     indented\n>no space")
+    assert blocks[0].body == "outer\n    indented\nno space"
+
+
+def test_a_blank_line_ends_a_quote_run() -> None:
+    """Two quoted passages separated by prose are two targets, not one."""
+    blocks = extract_blocks("> first\n\n> second")
+    assert [block.body for block in blocks] == ["first", "second"]
+
+
+def test_blocks_come_back_in_document_order() -> None:
+    blocks = extract_blocks("> q1\n\n```\ncode\n```\n\n> q2")
+    assert [block.kind for block in blocks] == ["quote", "code", "quote"]
+
+
+# --- labels and hints -------------------------------------------------------
+
+
+def test_the_label_is_the_first_non_empty_line_whitespace_collapsed() -> None:
+    assert first_line("\n\n   Here   is    the answer  \nmore") == "Here is the answer"
+
+
+def test_line_counts_are_pluralised_and_empty_text_is_zero() -> None:
+    assert (plural_lines(""), plural_lines("a"), plural_lines("a\nb")) == (
+        "0 lines",
+        "1 line",
+        "2 lines",
+    )
+
+
+def test_the_message_hint_counts_whole_message_lines_and_omits_absent_kinds() -> None:
+    """`3 code`, not `3 code blocks`, and the line count is the message's —
+    not the blocks'."""
+    targets = build_copy_targets([_Assistant("intro\n\n```\na\n```\n\ntail")])
+    # Seven lines: the blank separators and both fence markers count. The code
+    # block itself is one line — this hint is the message's shape, not the
+    # block's, which is what `1 code` beside it reports.
+    assert targets[0].hint == "7 lines · 1 code"
+
+
+def test_a_message_with_no_blocks_shows_only_its_line_count() -> None:
+    assert build_copy_targets([_Assistant("one\ntwo")])[0].hint == "2 lines"
+
+
+def test_a_code_child_hint_leads_with_its_language() -> None:
+    targets = build_copy_targets([_Assistant("```python\nx = 1\n```")])
+    assert _by_id(targets, "msg:1:code:0").hint == "python · 1 line"
+
+
+def test_a_code_child_without_a_language_shows_lines_alone() -> None:
+    targets = build_copy_targets([_Assistant("```\nx = 1\n```")])
+    assert _by_id(targets, "msg:1:code:0").hint == "1 line"
+
+
+# --- the tree ---------------------------------------------------------------
+
+
+def test_a_message_with_no_blocks_is_a_leaf_that_copies_itself() -> None:
+    targets = build_copy_targets([_Assistant("just prose")])
+    assert targets[0].children == ()
+    assert targets[0].content == "just prose"
+
+
+def test_a_group_node_still_copies_the_whole_message() -> None:
+    """Drilling in must never be the ONLY way to get the answer out."""
+    text = "answer\n\n```\ncode\n```"
+    targets = build_copy_targets([_Assistant(text)])
+    assert targets[0].children
+    assert targets[0].content == text
+
+
+def test_children_are_the_blocks_then_the_all_rows() -> None:
+    text = "intro\n\n```py\na\n```\n\n> q1\n\n```py\nb\n```\n\n> q2"
+    targets = build_copy_targets([_Assistant(text)])
+    assert [child.label for child in targets[0].children] == [
+        "Block 1",
+        "Quote 1",
+        "Block 2",
+        "Quote 2",
+        "All 2 blocks",
+        "All 2 quotes",
+    ]
+
+
+def test_a_single_block_gets_no_all_row() -> None:
+    """It would copy byte-for-byte what the row above it copies."""
+    targets = build_copy_targets([_Assistant("```\na\n```\n\n> q")])
+    assert [child.label for child in targets[0].children] == ["Block 1", "Quote 1"]
+
+
+def test_the_all_rows_join_their_bodies_with_a_blank_line() -> None:
+    targets = build_copy_targets([_Assistant("```\na\n```\n\n```\nb\n```")])
+    assert _by_id(targets, "msg:1:all").content == "a\n\nb"
+
+
+def test_ids_are_stable_and_name_their_position() -> None:
+    targets = build_copy_targets([_Assistant("```\na\n```\n\n> q1\n\n> q2")])
+    assert [node.target.id for node in flatten_targets(targets)] == [
+        "msg:1",
+        "msg:1:code:0",
+        "msg:1:quote:0",
+        "msg:1:quote:1",
+        "msg:1:all-quotes",
+    ]
+
+
+def test_only_the_code_language_reaches_the_preview_lexer() -> None:
+    """Quotes and combined rows are prose; highlighting them as a language
+    would colour English as syntax."""
+    targets = build_copy_targets([_Assistant("```py\na\n```\n\n```py\nb\n```\n\n> q")])
+    assert _by_id(targets, "msg:1:code:0").language == "py"
+    assert _by_id(targets, "msg:1:all").language is None
+    assert _by_id(targets, "msg:1:quote:0").language is None
+
+
+# --- the walk ---------------------------------------------------------------
+
+
+def test_messages_are_listed_most_recent_first() -> None:
+    """Append order, because a resumed conversation replays its history into
+    the same column and that is the order the reader sees."""
+    targets = build_copy_targets([_Assistant("older"), _Assistant("newer")])
+    assert [target.label for target in targets] == ["newer", "older"]
+
+
+def test_a_block_that_is_not_an_assistant_answer_is_skipped() -> None:
+    """`UserBlock`, `NoticeBlock` and `PeerMessageBlock` all carry `text()`
+    and all inherit `is_finalized`. `is_truncated` is what separates them, and
+    `/copy` listing the user's own words back is the failure this pins."""
+    targets = build_copy_targets([_NotAnAnswer(), _Assistant("the answer")])
+    assert [target.label for target in targets] == ["the answer"]
+
+
+def test_a_streaming_block_is_skipped() -> None:
+    """Still mutable: a clipboard that then grows is one the user cannot
+    trust. The previous settled answer is offered instead of nothing."""
+    targets = build_copy_targets([_Assistant("settled"), _Assistant("live", finalized=False)])
+    assert [target.label for target in targets] == ["settled"]
+
+
+def test_a_blank_message_is_skipped_and_does_not_stop_the_walk() -> None:
+    targets = build_copy_targets([_Assistant("real"), _Assistant("   \n  ")])
+    assert [target.label for target in targets] == ["real"]
+
+
+def test_a_truncated_message_is_listed_and_marked_in_its_hint() -> None:
+    """`is_finalized` means IMMUTABLE, not COMPLETE. Skipping the aborted
+    answer would hide the message on screen — the one the user was reading and
+    most likely meant. The marker LEADS because the hint is right-aligned, so
+    a trailing one is the first thing a narrow terminal cuts off."""
+    targets = build_copy_targets([_Assistant("half an ans", truncated=True)])
+    assert targets[0].truncated is True
+    assert targets[0].hint == "truncated · 1 line"
+
+
+def test_a_truncated_messages_children_are_not_marked() -> None:
+    """A closed fence inside a cut-off answer is itself complete: the
+    truncation ended the message, not that block. Marking the child would be a
+    false claim about what is on the clipboard."""
+    targets = build_copy_targets([_Assistant("intro\n```\na\n```", truncated=True)])
+    assert targets[0].truncated is True
+    assert all(child.truncated is False for child in targets[0].children)
+
+
+def test_the_walk_caps_at_fifty_messages() -> None:
+    targets = build_copy_targets([_Assistant(f"answer {index}") for index in range(80)])
+    assert len(targets) == MAX_MESSAGES
+    assert targets[0].label == "answer 79"
+
+
+def test_blank_and_non_assistant_blocks_do_not_consume_the_cap() -> None:
+    """The budget is spent on messages the picker can actually list."""
+    blocks: list[object] = []
+    for index in range(60):
+        blocks.append(_NotAnAnswer())
+        blocks.append(_Assistant(""))
+        blocks.append(_Assistant(f"answer {index}"))
+    assert len(build_copy_targets(blocks)) == MAX_MESSAGES
+
+
+def test_the_most_recent_message_names_itself_the_last_one() -> None:
+    """Rank 1 is the message a bare `/copy` used to take."""
+    targets = build_copy_targets([_Assistant("older"), _Assistant("newer")])
+    assert targets[0].copy_message == "Copied last message to clipboard"
+    assert targets[1].copy_message == "Copied message to clipboard"
+
+
+def test_an_empty_transcript_builds_no_targets() -> None:
+    """The caller's cue to show a notice instead of an empty overlay."""
+    assert build_copy_targets([]) == []
+
+
+# --- flattening -------------------------------------------------------------
+
+
+def test_flattening_records_the_geometry_that_indents_each_row() -> None:
+    """`ancestor_has_next` is per level, and it is what decides whether a `│`
+    guide is drawn in a child's gutter: True while that ancestor still has a
+    following sibling, False beneath the last root. Both states appear here,
+    and note the ranks are reversed — the LAST block appended is `msg:1`."""
+    targets = build_copy_targets([_Assistant("```\nolder\n```"), _Assistant("```\nnewer\n```")])
+    rows = [
+        (node.target.id, node.depth, node.is_last, node.ancestor_has_next)
+        for node in flatten_targets(targets)
+    ]
+    assert rows == [
+        ("msg:1", 0, False, ()),  # the newer message; another root follows it
+        ("msg:1:code:0", 1, True, (True,)),  # so its child draws the guide
+        ("msg:2", 0, True, ()),  # the last root
+        ("msg:2:code:0", 1, True, (False,)),  # nothing below it: no guide
+    ]
+
+
+def test_every_target_is_copyable_today() -> None:
+    """`content: str | None` is the seam the unported command targets would
+    slot into, not a state this module can currently produce. The picker's
+    Enter guard is written against the type, so this pins what it guards."""
+    targets = build_copy_targets([_Assistant("a\n```\nb\n```\n\n```\nc\n```\n\n> q")])
+    assert all(node.target.content is not None for node in flatten_targets(targets))

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -44,6 +44,9 @@ ECHO_POLICY = {
     "help": False,
     "exit": False,
     "clear": False,
+    # The clipboard receipt names how much landed there — strictly more than
+    # the typed word — and nothing here reaches the model. `/approvals`' rule.
+    "copy": False,
     "new": False,
     "reload": False,
     "update": False,
@@ -113,6 +116,10 @@ PROMPT_POLICY = {
     "help": False,
     "exit": False,
     "clear": False,
+    # Takes no argument at all: the message it copies is the last one, found by
+    # walking the transcript, so there is nothing typed for an inline engage to
+    # consume. (`/copy me` and `/copy <n>` are deliberately not built.)
+    "copy": False,
     "new": False,
     "reload": False,
     "update": False,

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -44,8 +44,10 @@ ECHO_POLICY = {
     "help": False,
     "exit": False,
     "clear": False,
-    # The clipboard receipt names how much landed there — strictly more than
-    # the typed word — and nothing here reaches the model. `/approvals`' rule.
+    # Opens a picker, and nothing here reaches the model. The receipt is
+    # whatever that interaction produces — a clipboard toast naming how much
+    # landed there, or nothing at all when the user cancels — and both are
+    # strictly more informative than echoing the typed word. `/approvals`' rule.
     "copy": False,
     "new": False,
     "reload": False,
@@ -116,9 +118,10 @@ PROMPT_POLICY = {
     "help": False,
     "exit": False,
     "clear": False,
-    # Takes no argument at all: the message it copies is the last one, found by
-    # walking the transcript, so there is nothing typed for an inline engage to
-    # consume. (`/copy me` and `/copy <n>` are deliberately not built.)
+    # Takes no argument at all: WHICH message is chosen in the picker the
+    # command opens, so there is nothing typed for an inline engage to consume.
+    # (`/copy me` and `/copy <n>` are deliberately not built — the picker is the
+    # answer to "which message", and a typed selector would be a second one.)
     "copy": False,
     "new": False,
     "reload": False,


### PR DESCRIPTION
# PR Description

## Summary of Changes

Adds `/copy`, a picker for putting an agent answer — or a single code block out of one — on the clipboard. This is a port of [OMP (Oh My Pi)](https://omp.sh/)'s `/copy`, whose behaviour was read from its source rather than inferred, so the semantics match rather than approximate.

`/copy` opens a tree of the agent's answers, most recent first. An answer containing fenced code blocks or `>` quotes drills into them, so you can take one block instead of the whole message, plus an `All N blocks` node when there is more than one. A live preview pane shows exactly what Enter will copy, syntax-highlighted when it is code.

- **Arrows / PageUp / PageDown / Home / End** move, **Enter** copies, **Esc** leaves.
- The payload is **markdown source**, not the rendered frame — a copied code block is the fence body with no backticks and no language line.
- Answers that were **cut off** (aborted mid-stream) are listed and marked `truncated ·`, and copying one adds a caveat to the receipt, so a half-answer is never indistinguishable from a complete one.
- Copying goes through the existing `_put_on_clipboard`, so the transcript drag, the composer, and this picker cannot drift apart in what they write or what they claim.

### Deliberate scope decisions

- **Agent answers only.** OMP skips non-assistant messages (`if (msg.role !== "assistant") continue`) and so does this. Thinking is excluded for free — it never becomes a transcript block.
- **No `ctrl+o`.** An earlier revision of this branch added one; it was removed. OMP binds no copy chord, and this avoids introducing a new global key.
- **No bash/eval command targets.** OMP also lists runnable commands pulled from tool calls. Skipped here — our tool-card model differs enough that porting it is a separate piece of work. The data model leaves the seam open.

## Related Issue(s)

- Closes #510

## Impact

- **No breaking changes.** `/copy` did not exist on `main` before this branch.
- **No dependency changes.**
- **No new core tool**, so no per-call schema footprint — this is a TUI-local slash command (`frontend_local`: the clipboard is the machine the user is sitting at, so routing it to a session owner would copy onto a host nobody is at).
- One new `ModalScreen`, styled in `local_operator.tcss` alongside the other picker screens. The card pins its own height because it divides a fixed row budget between tree and preview; `overflow: hidden` keeps a tall overlay from introducing a scrollbar.
- Performance: the target tree is built once when the screen is pushed and snapshotted, so a turn landing while the picker is open cannot move rows under the cursor.

## Testing Details

Two independent review rounds (reviewer, QA, designer) ran against this branch. **Seven defects were found and fixed**, each re-verified by running the real app rather than by reading the diff:

| Defect | Fix |
|---|---|
| Card clipped its own footer at heights ≤ 11 and widths ≤ 40 — `overflow: hidden` ate the only statement of how to leave | `is_drawable` checks the irreducible chrome against the drawn box; the footer sheds its movement hints before it sheds `esc quit`, and below the floor the card hides rather than painting a half-card with no exit. Esc still leaves at every size. |
| `… N more lines` counted wrapped rows while the header counted source lines — at 100 cols a 79-line answer claimed `… 144 more lines` | Marker counts source lines via a per-source-line row map |
| An empty code block copied in total silence — no toast, no notice | `action_choose` refuses any falsy content |
| `render_lines_for_test` documented a guarantee it did not implement — the helper that should have caught the footer bug | Defers to `display`, like `ask_picker` |
| CRLF left an invisible trailing `\r` on every copied code line | Normalised before the split |
| Line counts disagreed with the clipboard receipt (4/8 payload shapes) | Adopted `splitlines()`, the rule `_put_on_clipboard` already established (F3) — the picker had reintroduced a bug the receipt had retired |
| A `runtime_checkable` protocol admits an object whose property getter raises | Block reads hardened; a block that cannot answer loses its row, not the turn |

**Automated tests:** 130 tests across the copy surface — `test_copy_targets.py`, `test_copy_picker.py`, `test_copy_picker_qa.py` (written independently by QA), plus the rewired `test_copy_command.py`. They were mutation-tested rather than trusted green: reverting each fix in turn was confirmed to turn them red.

**Gates, whole tree, on the rebased head:**

| Gate | Result |
|---|---|
| `pytest tests/unit` | **10391 passed**, 15 skipped, 0 failed |
| `pytest tests/unit/tui` (colour env) | **4314 passed**, 12 skipped, 0 failed |
| `flake8 .` | clean |
| `black --check .` (26.1.0) | 729 unchanged |
| `isort --check .` (5.13.2) | clean |
| `pyright` | 0 errors, 0 warnings |

**Visual validation** per `AGENTS.md`: frames captured from the real `OperatorApp` and inspected as images across heights 6–50 and widths 32–100, checking for card overflow, clipped footers, and scrollbars (`virtual_size == size` throughout).

**Not verified:** real terminal paste. Everything ran headless — the OSC 52 write is asserted at the driver and is byte-identical to the already-shipping drag-copy, so any terminal where that works will paste from this, but no one pressed Cmd+V in a GUI. Also unverified against a live follower session; the `frontend_local` classification is proven by unit assertion, not by attaching a real follower.

## Screenshots

**The tree as it opens** — answers most recent first, each with a `lines · code · quote` summary, drilled children beneath, and a live preview of the highlighted node.

<img width="1600" height="1600" alt="01-tree" src="https://github.com/user-attachments/assets/6730cb31-23a8-4e27-84d3-b54648cfd086" />

**Drilled into a code block** — the preview is syntax-highlighted and the payload is the fence body alone: no backticks, no language line.

<img width="1600" height="1600" alt="02-code-block" src="https://github.com/user-attachments/assets/8d774ab5-627f-4363-b654-d56b94bd9a25" />

**The lexer follows the fence's info string** — the same message's `sql` block.

<img width="1600" height="1600" alt="03-sql-block" src="https://github.com/user-attachments/assets/1d73b68d-c2a1-4d4d-ae2d-e94e09dd347e" />

**At 60 columns** — labels truncate with an ellipsis, hints stay legible, and the footer survives.

<img width="1600" height="1600" alt="04-narrow" src="https://github.com/user-attachments/assets/4cd2f32a-e30d-44c0-9a2a-928615d841b4" />

## Checklist

- [x] Tests added/updated and passing
- [x] Lint, format and type gates clean over the whole tree
- [x] Visually validated as rendered frames
- [x] Conventional commits
- [x] Rebased on current `main`

