### PR TITLE
fix(tui): word motion on the encoding a default Ghostty sends

### DIFF
--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -913,12 +913,48 @@ class Editor(TextArea):
     #:
     #: This half only covers terminals that encode option+arrow as a CSI
     #: sequence with modifier 3 (``\x1b[1;3D``), which Textual's parser resolves
-    #: to the ``alt+left`` key name. The other two encodings are handled
-    #: elsewhere: ``\x1bb``/``\x1bf`` (readline meta) already parse to
-    #: ``ctrl+left``/``ctrl+right`` and hit the inherited bindings, and the
-    #: ``Esc``-prefixed form arrives as two separate events and is coalesced in
-    #: :meth:`_on_key`. All three are pinned in
-    #: ``tests/unit/tui/test_word_caret.py``.
+    #: to the ``alt+left`` key name. The other encodings are handled elsewhere:
+    #: the ``Esc``-prefixed form arrives as two separate events and is coalesced
+    #: in :meth:`_on_key`, and the readline meta form is bound below. All four
+    #: are pinned in ``tests/unit/tui/test_word_caret.py``.
+    #:
+    #: ``alt+b``/``alt+f`` are the readline word-motion chords, and they are
+    #: bound because a terminal may REWRITE the arrow away before this app ever
+    #: sees a key. Ghostty ships exactly that as a factory default (verified
+    #: with ``ghostty +show-config --default``, which ignores user config, on
+    #: 1.3.1)::
+    #:
+    #:     keybind = alt+arrow_left=esc:b
+    #:     keybind = alt+arrow_right=esc:f
+    #:
+    #: so ``⌥←`` is turned into meta-b upstream and the fact that it was an
+    #: arrow is destroyed. What reaches Textual then depends on the keyboard
+    #: protocol, and ONLY the legacy row was covered before:
+    #:
+    #: ==================  ================  ==============  =============
+    #: terminal state      bytes             Textual key     bound by
+    #: ==================  ================  ==============  =============
+    #: legacy encoding     ``\x1bb``         ``ctrl+left``   ``TextArea``
+    #: kitty protocol      ``\x1b[98;3u``    ``alt+b``       this table
+    #: ==================  ================  ==============  =============
+    #:
+    #: Textual negotiates the kitty protocol, so the second row is the one a
+    #: default Ghostty actually lands on; the first is why the bug hides so
+    #: well, since the same corrupted bytes happen to decode to a bound key
+    #: once the protocol is off. Nothing about the chord differs to the user —
+    #: only the protocol state — which is why this looked like it worked in a
+    #: plain terminal and failed under a multiplexer speaking kitty.
+    #:
+    #: This is NOT multiplexer-specific: a multiplexer that re-encodes
+    #: faithfully still forwards ``alt+b``, because ``alt+b`` is genuinely what
+    #: the terminal handed it. The same keys are also what iTerm2 and
+    #: Terminal.app send with "Use Option as Meta" enabled, so binding them is
+    #: correct on its own terms rather than a workaround for one terminal.
+    #:
+    #: There is no shift variant to add: Ghostty has no ``alt+shift+arrow``
+    #: default, so ``⌥⇧←`` survives intact as ``\x1b[1;4D``. That asymmetry —
+    #: selection-by-word working while movement-by-word did not — is the
+    #: signature of this bug (see #518).
     #:
     #: ``show=False`` to match every other binding in this app — the footer is
     #: not a key reference here (see ``OperatorApp.BINDINGS``).
@@ -1002,6 +1038,8 @@ class Editor(TextArea):
         Binding("alt+right", "cursor_word_right", "Cursor word right", show=False),
         Binding("alt+shift+left", "cursor_word_left(True)", "Select word left", show=False),
         Binding("alt+shift+right", "cursor_word_right(True)", "Select word right", show=False),
+        Binding("alt+b", "cursor_word_left", "Cursor word left", show=False),
+        Binding("alt+f", "cursor_word_right", "Cursor word right", show=False),
         Binding("ctrl+v,super+v", "system_paste", "Paste from the system clipboard", show=False),
     ]
 

--- a/tests/unit/tui/test_word_caret.py
+++ b/tests/unit/tui/test_word_caret.py
@@ -20,12 +20,27 @@ bytes            parses to                  terminals
 ``\\x1b\\x1b[D``   ``escape`` THEN ``left``   iTerm2 "Esc+", Terminal.app "Esc+",
                                             and any terminal once
                                             ``TEXTUAL_DISABLE_KITTY_KEY`` is set
+``\\x1b[98;3u``   ``alt+b``                  Ghostty on its DEFAULT settings,
+                                            once the kitty keyboard protocol
+                                            is negotiated
 ===============  =========================  =====================================
 
-The third row is the defect this change fixes: the composer used to run its
+The third row is the defect #370/#375 fixed: the composer used to run its
 escape action (post ``StopRequested`` — abort the agent's turn) and then move
 the caret one character, so ⌥← to fix a typo killed the running turn. The
 regression guard is ``stop_requested`` staying empty on those rows.
+
+The fourth row is issue #518, and it is not a terminal preference like the
+others — it is Ghostty's factory default. Ghostty ships
+``keybind = alt+arrow_left=esc:b``, rewriting ⌥← into readline's meta-b and
+DESTROYING the fact that it was an arrow before any application sees the key.
+Under the legacy encoding that damage is invisible here, because the resulting
+``\\x1bb`` happens to parse to ``ctrl+left``, which ``TextArea`` binds (row 2).
+Textual negotiates the kitty protocol, though, and the same chord then arrives
+as ``\\x1b[98;3u`` → ``alt+b``, which nothing bound — so word motion silently
+did nothing on a stock Ghostty. Note ⌥⇧← was unaffected (Ghostty has no
+``alt+shift+arrow`` default to corrupt), which is why selection-by-word worked
+while movement-by-word did not.
 """
 
 from __future__ import annotations
@@ -129,8 +144,9 @@ def _watch_stops(app: OperatorApp) -> list[StopRequested]:
         ("\x1b[1;3D", DELTA_START, "Ghostty / kitty / WezTerm / iTerm2 CSI mode"),
         ("\x1bb", DELTA_START, "iTerm2 default preset / Terminal.app Option-as-Meta"),
         ("\x1b\x1b[D", DELTA_START, "iTerm2 Esc+ / Terminal.app Esc+"),
+        ("\x1b[98;3u", DELTA_START, "Ghostty default esc:b under the kitty protocol"),
     ],
-    ids=["csi-modifier-3", "readline-meta", "escape-prefixed"],
+    ids=["csi-modifier-3", "readline-meta", "escape-prefixed", "kitty-csi-u-meta"],
 )
 @pytest.mark.asyncio
 async def test_option_left_moves_one_word_on_every_encoding(
@@ -160,8 +176,9 @@ async def test_option_left_moves_one_word_on_every_encoding(
         ("\x1b[1;3C", "Ghostty / kitty / WezTerm / iTerm2 CSI mode"),
         ("\x1bf", "iTerm2 default preset / Terminal.app Option-as-Meta"),
         ("\x1b\x1b[C", "iTerm2 Esc+ / Terminal.app Esc+"),
+        ("\x1b[102;3u", "Ghostty default esc:f under the kitty protocol"),
     ],
-    ids=["csi-modifier-3", "readline-meta", "escape-prefixed"],
+    ids=["csi-modifier-3", "readline-meta", "escape-prefixed", "kitty-csi-u-meta"],
 )
 @pytest.mark.asyncio
 async def test_option_right_moves_one_word_on_every_encoding(raw: str, terminals: str) -> None:


### PR DESCRIPTION
## Summary of Changes

Word-wise caret movement now works on the encoding a **default Ghostty** sends.

#375 covered three encodings of `option+arrow`. There is a fourth, and it is the one a stock Ghostty install produces — so `⌥←` did nothing in the composer for anyone who had not overridden their terminal's defaults.

## Diagnosis

Ghostty ships these as **factory defaults**, verified with `ghostty +show-config --default` (which ignores user config entirely, so this is not a local misconfiguration) on Ghostty 1.3.1:

```
keybind = alt+arrow_left=esc:b
keybind = alt+arrow_right=esc:f
```

Ghostty rewrites `⌥←` into readline's meta-b **before any application sees a key**, discarding the fact that it was ever an arrow. What then reaches Textual depends on the keyboard protocol, and only one row was covered before this change:

| terminal state | bytes on the wire | Textual key | bound before? |
|---|---|---|---|
| legacy encoding | `\x1bb` | `ctrl+left` | ✅ yes (inherited from `TextArea`) |
| **kitty protocol** | **`\x1b[98;3u`** | **`alt+b`** | ❌ **no** |
| `⌥→`, kitty protocol | `\x1b[102;3u` | `alt+f` | ❌ no |

Textual negotiates the kitty keyboard protocol, so **the unbound row is the one a default Ghostty actually lands on.**

The legacy row is why this hid so well. The same corrupted bytes happen to decode to `ctrl+left` — a key `TextArea` already binds — once the protocol is off. So word motion worked in a plain terminal and silently did nothing under a multiplexer that speaks kitty, with nothing about the chord differing from the user's point of view.

Captured from a real keyboard (macOS 15, Ghostty 1.3.1, `macos-option-as-alt = true`), same physical key, two protocol states:

```
legacy mode:  ⌥←  ->  b'\x1bb'        -> ctrl+left  -> moves
kitty mode:   ⌥←  ->  b'\x1b[98;3u'   -> alt+b      -> nothing
```

This is **not** a multiplexer bug. A multiplexer that re-encodes faithfully still forwards `alt+b`, because `alt+b` is genuinely what the terminal handed it — the arrow was destroyed one layer upstream. Confirmed by injecting a true `alt+left` into the same pane, which arrives correctly as `\x1b[1;3D`.

## The Fix

Two additive bindings, the same shape as #375:

```python
Binding("alt+b", "cursor_word_left", "Cursor word left", show=False),
Binding("alt+f", "cursor_word_right", "Cursor word right", show=False),
```

`alt+b`/`alt+f` are the readline word-motion chords and are also what iTerm2 and Terminal.app send with "Use Option as Meta" enabled, so binding them is correct on its own terms rather than a workaround for one terminal. For reference, omp binds exactly these alongside the arrow forms.

No collision: both keys were unbound, and both are absent from `ESCAPE_CHORD_KEYS` and `VERTICAL_CHORD_KEYS`, so the escape-coalescing path from #375 is untouched (asserted before editing).

No shift variant exists to add — Ghostty has no `alt+shift+arrow` default, so `⌥⇧←` survives intact as `\x1b[1;4D`. That asymmetry (selection-by-word working while movement-by-word did not) is the signature of this bug.

## Validation

**Exercised the real path**, not just the suite: drove the real `OperatorApp` with the literal wire bytes through the real `XTermParser` and the real driver injection.

```
word LEFT from end of line:
  '\x1b[1;3D'    CSI mod-3 (arrow preserved)       col 22 -> 17  stopped_turn=False text_intact=True
  '\x1bb'        legacy meta-b                     col 22 -> 17  stopped_turn=False text_intact=True
  '\x1b\x1b[D'   Esc-prefixed                      col 22 -> 17  stopped_turn=False text_intact=True
  '\x1b[98;3u'   kitty CSI-u  <-- GHOSTTY DEFAULT  col 22 -> 17  stopped_turn=False text_intact=True

word RIGHT from start of line:
  '\x1b[1;3C'    CSI mod-3 (arrow preserved)       col  0 ->  5  stopped_turn=False text_intact=True
  '\x1bf'        legacy meta-f                     col  0 ->  5  stopped_turn=False text_intact=True
  '\x1b\x1b[C'   Esc-prefixed                      col  0 ->  5  stopped_turn=False text_intact=True
  '\x1b[102;3u'  kitty CSI-u  <-- GHOSTTY DEFAULT  col  0 ->  5  stopped_turn=False text_intact=True
```

All four encodings land on the same column, no turn is stopped, no text is mutated.

**The new tests fail without the fix.** Removing just the two bindings turns both new cases red, so they are genuine regression guards rather than decoration:

```
FAILED test_option_left_moves_one_word_on_every_encoding[kitty-csi-u-meta]
FAILED test_option_right_moves_one_word_on_every_encoding[kitty-csi-u-meta]
```

**Regression guards re-checked** (the escape-coalescing path is the risky neighbour here):

```
lone Esc still stops the turn              stops=1  text=''
plain 'b' still types                      stops=0  text='b'
plain 'f' still types                      stops=0  text='f'
alt+b types nothing (kitty)                stops=0  text='hello world'
alt+f types nothing (kitty)                stops=0  text='hello world'
Esc then 'b' -> stop AND type b            stops=1  text='b'
```

**Suite and gates**, run over the whole tree exactly as CI does:

- `pytest tests/unit/tui` — **4186 passed**, 12 skipped
- `flake8 .` — clean
- `black --check .` — 722 files unchanged
- `isort --check .` — clean
- `pyright .` — 0 errors, 0 warnings

## Terminal-side workaround

Worth documenting either way, since it fixes every application at once rather than app-by-app:

```
keybind = alt+arrow_left=csi:1;3D
keybind = alt+arrow_right=csi:1;3C
```

This has to be a per-chord keybind: Ghostty has no setting governing the encoding (checked all 634 config keys). `macos-option-as-alt` only decides whether Option counts as Alt, not what bytes the resulting chord produces.

Fixes #518
