### PR TITLE
feat(evaluation): carry the parent-chosen artifact root to out-of-process adapters

### DIFF
--- a/local_operator/evaluation/adapters/api.py
+++ b/local_operator/evaluation/adapters/api.py
@@ -12,9 +12,9 @@ import platform
 import sys
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Literal, Protocol, TypeAlias, runtime_checkable
+from typing import Annotated, Any, Literal, Protocol, TypeAlias, runtime_checkable
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import AfterValidator, Field, field_validator, model_validator
 
 from local_operator.evaluation.evidence.models import ScoreArtifact, canonical_digest
 from local_operator.evaluation.lifecycle import CleanupPlan
@@ -26,7 +26,17 @@ from local_operator.evaluation.receipts import (
     StrictIdentifier,
 )
 
-ADAPTER_SCHEMA_VERSION = "1.0"
+# 1.1 adds the parent-chosen ``artifact_root`` to ``ResetStartParams``. It is a
+# REQUIRED field on a model whose config is ``extra="forbid"`` and ``strict``,
+# so the change is wire-breaking in both directions: a 1.0 worker rejects the
+# new key as an unknown extra, and a 1.1 worker cannot serve a parent that omits
+# it. This boundary deliberately pins exact versions rather than accepting
+# ranges (see ``AdapterSelector``), so the bump is what locks a 1.0 adapter out
+# instead of letting it fail later as an opaque invalid_request.
+ADAPTER_SCHEMA_VERSION = "1.1"
+# One alias for the three models that pin the version, so a future bump cannot
+# move the constant while leaving a model silently accepting the older literal.
+SchemaVersion: TypeAlias = Literal["1.1"]
 ADAPTER_ENTRY_POINT_GROUP = "local_operator.evaluation_adapters.v1"
 MAX_RESCUE_REFS = 256
 MAX_REQUIREMENTS = 256
@@ -110,7 +120,7 @@ def canonical_params_digest(method: AdapterMethod, params: ProtocolModel) -> Dig
 class AdapterSelector(ProtocolModel):
     """Exact wheel and interpreter selection; ranges and fallback are absent."""
 
-    schema_version: Literal["1.0"]
+    schema_version: SchemaVersion
     adapter_id: StrictIdentifier
     distribution: StrictIdentifier
     version: StrictIdentifier
@@ -154,7 +164,7 @@ class AdapterMetadata(ProtocolModel):
     entry_point: StrictIdentifier
     package_digest: Digest
     release_digest: Digest
-    schema_version: Literal["1.0"]
+    schema_version: SchemaVersion
     capabilities: AdapterCapabilities
 
 
@@ -248,28 +258,42 @@ class ScopedInfraValue(ProtocolModel):
     value: str = Field(min_length=1, max_length=4096)
 
 
+def _normalized_absolute_root(value: str) -> str:
+    # Normalized AND absolute, not merely absolute: the parent opens this
+    # directory with O_DIRECTORY and then resolves artifact names against that
+    # descriptor, so a path containing ".." would let the root itself denote a
+    # different directory than the one the parent believes it authorized.
+    if not os.path.isabs(value) or os.path.normpath(value) != value:
+        raise ValueError("artifact root must be normalized and absolute")
+    return value
+
+
+# The single definition of a parent-authorized artifact directory. Both the
+# rescue descriptor and the live episode's reset carry one, and they must agree
+# on what makes a root acceptable -- a second, slightly different validator is
+# exactly how a confinement boundary develops a gap.
+ArtifactRoot: TypeAlias = Annotated[
+    str,
+    Field(min_length=1, max_length=4096),
+    AfterValidator(_normalized_absolute_root),
+]
+
+
 class RescueDescriptor(ProtocolModel):
-    schema_version: Literal["1.0"]
+    schema_version: SchemaVersion
     selector: AdapterSelector
     handshake: Handshake
     episode_id: StrictIdentifier
     cleanup_plan: CleanupPlan
     secret_refs: tuple[SecretRef, ...] = Field(max_length=MAX_RESCUE_REFS)
     infra_values: tuple[ScopedInfraValue, ...] = Field(max_length=MAX_RESCUE_REFS)
-    artifact_root: str = Field(min_length=1, max_length=4096)
+    artifact_root: ArtifactRoot
     descriptor_id: Digest = ZERO_DIGEST
 
     @field_validator("secret_refs", "infra_values", mode="before")
     @classmethod
     def _freeze_refs(cls, value: Any) -> Any:
         return tuple(value) if isinstance(value, list) else value
-
-    @field_validator("artifact_root")
-    @classmethod
-    def _absolute_artifact_root(cls, value: str) -> str:
-        if not os.path.isabs(value) or os.path.normpath(value) != value:
-            raise ValueError("artifact root must be normalized and absolute")
-        return value
 
     @model_validator(mode="after")
     def _content_bind(self) -> "RescueDescriptor":
@@ -364,8 +388,38 @@ class PrepareResult(ProtocolModel):
 
 
 class ResetStartParams(OperationParams):
+    """Begin the episode, and tell the worker where its frame bytes may go.
+
+    WHY ``reset_start`` AND NOT ``prepare``. The worker's environment is built
+    from a closed allowlist (``supervisor._ENV_ALLOW`` is locale and temp only),
+    so a genuinely out-of-process adapter has no ambient way to learn the
+    directory the parent will read frames from. The path therefore has to arrive
+    as validated RPC input, and this is the call it belongs on:
+
+    * ``prepare`` is contractually ALLOCATION-FREE -- it creates nothing, so it
+      produces no observation and has no bytes to publish. Handing it a writable
+      root would invite exactly the allocation the two-stage rescue persistence
+      depends on it not doing, and would widen the window in which a resource
+      exists that no persisted descriptor names.
+    * ``reset_start`` is the side-effect boundary AND the first call that yields
+      an observation: the parent calls ``observe`` immediately after it, and
+      every later ``observe``/``execute`` runs in ``RUNNING``, which only
+      ``reset_start`` can enter. So it is the single point that precedes every
+      frame-producing call while still being the first one that needs the root.
+    * ``RescueDescriptor`` keeps its own copy because rescue runs in a NEW
+      process against a persisted file, with no live session to have been told.
+
+    Confinement is not established by this field. The parent treats the root as
+    the only directory it will ever open, and resolves each artifact by its
+    content digest relative to that directory descriptor with ``O_NOFOLLOW``
+    (``supervisor.verify_artifact``); the worker names bytes by digest and never
+    supplies a path. Sending the root is what makes the worker able to write
+    where the parent already looks -- it grants no new read authority.
+    """
+
     task_id: StrictIdentifier
     episode_id: StrictIdentifier
+    artifact_root: ArtifactRoot
 
 
 class ObserveParams(ProtocolModel):

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -627,6 +627,15 @@ class VerifiedAdapterSession:
             self.verifier.episode_id,
         ):
             raise SupervisionError("reset belongs to another task or episode")
+        # The root announced to the worker and the root the verifier reads from
+        # are the same authorization, so they are checked against each other
+        # rather than trusted to have been populated consistently. A caller that
+        # points the adapter at one directory while verifying another would get
+        # silent "artifact path is unsafe" failures at the first frame; worse, a
+        # root that merely resolves to the verifier's would make the mismatch
+        # depend on symlink state at call time.
+        if params.artifact_root != str(self.verifier.artifact_root):
+            raise SupervisionError("reset artifact root differs from the verified root")
         self._ensure_usable()
         ack = await self._mutating_call(
             "reset_start",

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -794,7 +794,23 @@ def verify_artifact(root: Path, reference: ArtifactRef) -> bytes:
     """Read one content-addressed artifact without following attacker links."""
 
     name = reference.sha256
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    # O_NONBLOCK is a LIVENESS guard, not a performance hint. The S_ISREG check
+    # below sits BEHIND this open, so without it a worker that publishes a FIFO
+    # under an honest-looking digest name blocks the caller inside the kernel
+    # until a writer appears -- which never happens. That wedges the parent
+    # permanently: verify_artifact runs synchronously on the event-loop thread
+    # (episode._record_observation, HostVerifier._validate_observation_content)
+    # and AFTER the mutating call's wait_for has already closed, so no timeout,
+    # poison, rescue, or process-group teardown can fire. On a regular file
+    # O_NONBLOCK is a POSIX no-op -- same S_ISREG, size, and bytes -- so the
+    # FIFO simply returns immediately and falls into the existing
+    # "artifact is not a matching regular file" refusal.
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
     root_fd = os.open(root, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
     try:
         fd = os.open(name, flags, dir_fd=root_fd)

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Any, Literal, Mapping
 
 from local_operator.evaluation.adapters.api import (
+    ADAPTER_SCHEMA_VERSION,
     AskUserExchangeParams,
     CleanupParams,
     CloseParams,
@@ -357,7 +358,10 @@ class EpisodeRunner:
 
     def _persist_descriptor(self, handshake: Handshake, plan: CleanupPlan) -> None:
         descriptor = RescueDescriptor(
-            schema_version="1.0",
+            # Tracked from the constant rather than restated: a literal here
+            # silently disagrees with the models on the next protocol bump, and
+            # the failure surfaces as an unrelated pre-bundle validation error.
+            schema_version=ADAPTER_SCHEMA_VERSION,
             selector=self._selector,
             handshake=handshake,
             episode_id=self._spec.episode_id,
@@ -472,11 +476,22 @@ class EpisodeRunner:
 
     async def _reset_and_observe(self) -> None:
         session = self._require_session()
+        # The parent owns this directory, so the parent creates it. An adapter
+        # told to publish into a missing root would otherwise have to create it
+        # itself, which hands the worker a say in the mode and ownership of the
+        # one directory the parent later opens and reads.
+        self._config.artifact_root.mkdir(mode=0o700, parents=True, exist_ok=True)
         result = await session.reset_start(
             ResetStartParams(
                 operation_id=f"reset-{self._spec.episode_id}",
                 task_id=self._spec.task_id,
                 episode_id=self._spec.episode_id,
+                # The worker is spawned with a stripped environment, so this RPC
+                # field is its ONLY way to learn where published frame bytes are
+                # read from. It is the same directory ``_record_observation``
+                # verifies against, which is what keeps "where the adapter wrote"
+                # and "where the parent reads" a single parent-chosen value.
+                artifact_root=str(self._config.artifact_root),
             ),
             timeout=self._config.reset_timeout,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.23"
+version = "0.44.24"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/evaluation/adapters/test_api.py
+++ b/tests/unit/evaluation/adapters/test_api.py
@@ -27,7 +27,7 @@ def selector(tmp_path: Path) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return AdapterSelector(
-        schema_version="1.0",
+        schema_version="1.1",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.2.3",
@@ -49,7 +49,7 @@ def metadata() -> AdapterMetadata:
         entry_point="tiny_adapter:create",
         package_digest=DIGEST,
         release_digest="b" * 64,
-        schema_version="1.0",
+        schema_version="1.1",
         capabilities=AdapterCapabilities(routes=("computer",), ask_user=True, scoring=True),
     )
 
@@ -133,7 +133,7 @@ def test_scoped_infra_has_no_provider_or_model_purpose() -> None:
 def test_rescue_descriptor_is_content_bound_and_has_refs_not_secrets(tmp_path: Path) -> None:
     selected = selector(tmp_path)
     descriptor = RescueDescriptor(
-        schema_version="1.0",
+        schema_version="1.1",
         selector=selected,
         handshake=handshake(tmp_path),
         episode_id="episode",

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -101,7 +101,7 @@ def selected(tmp_path: Path, digest: str) -> AdapterSelector:
         shutil.copy2(Path(sys.executable).resolve(), executable)
         executable.chmod(0o755)
     return AdapterSelector(
-        schema_version="1.0",
+        schema_version="1.1",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.0",

--- a/tests/unit/evaluation/adapters/test_launch.py
+++ b/tests/unit/evaluation/adapters/test_launch.py
@@ -74,7 +74,7 @@ def create():
             entry_point="tiny_e2e_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="%s",
-            schema_version="1.0",
+            schema_version="1.1",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=False
             ),
@@ -194,7 +194,7 @@ async def test_supervisor_launch_completes_real_handshake_and_reaps(
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     selector = AdapterSelector(
-        schema_version="1.0",
+        schema_version="1.1",
         adapter_id="tiny-e2e",
         distribution="tiny-e2e-adapter",
         version="1.0",

--- a/tests/unit/evaluation/adapters/test_supervisor.py
+++ b/tests/unit/evaluation/adapters/test_supervisor.py
@@ -56,7 +56,7 @@ def selector(tmp_path: Path) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return AdapterSelector(
-        schema_version="1.0",
+        schema_version="1.1",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.0",
@@ -78,7 +78,7 @@ def metadata() -> AdapterMetadata:
         entry_point="tiny_adapter:create",
         package_digest="a" * 64,
         release_digest="b" * 64,
-        schema_version="1.0",
+        schema_version="1.1",
         capabilities=AdapterCapabilities(routes=("computer",), ask_user=False, scoring=True),
     )
 
@@ -110,7 +110,7 @@ def plan() -> CleanupPlan:
 
 def descriptor(tmp_path: Path) -> RescueDescriptor:
     return RescueDescriptor(
-        schema_version="1.0",
+        schema_version="1.1",
         selector=selector(tmp_path),
         handshake=handshake(tmp_path),
         episode_id="episode",
@@ -306,7 +306,12 @@ def test_invalid_prepare_response_poisons_and_blocks_reset(tmp_path: Path) -> No
             await session.prepare(params, timeout=1)
         with pytest.raises(SupervisionError, match="poisoned"):
             await session.reset_start(
-                ResetStartParams(operation_id="reset", task_id="task", episode_id="episode"),
+                ResetStartParams(
+                    operation_id="reset",
+                    task_id="task",
+                    episode_id="episode",
+                    artifact_root=str(tmp_path),
+                ),
                 timeout=1,
             )
 

--- a/tests/unit/evaluation/adapters/test_worker.py
+++ b/tests/unit/evaluation/adapters/test_worker.py
@@ -270,7 +270,7 @@ def rescue_selector(tmp_path: Path) -> AdapterSelector:
     release_digest = "b" * 64
     (workspace / "adapter-release.json").write_text(f'{{"release_digest":"{release_digest}"}}')
     return AdapterSelector(
-        schema_version="1.0",
+        schema_version="1.1",
         adapter_id="rescue",
         distribution="rescue-adapter",
         version="1.0",
@@ -292,7 +292,7 @@ def rescue_metadata() -> AdapterMetadata:
         entry_point="rescue_adapter:create",
         package_digest="a" * 64,
         release_digest="b" * 64,
-        schema_version="1.0",
+        schema_version="1.1",
         capabilities=AdapterCapabilities(routes=("computer",), ask_user=False, scoring=False),
     )
 
@@ -339,7 +339,7 @@ async def test_real_worker_rescue_invokes_each_cleanup_once_and_blocks_normal_fl
             ),
         )
         descriptor = RescueDescriptor(
-            schema_version="1.0",
+            schema_version="1.1",
             selector=selected,
             handshake=handshake,
             episode_id="episode",
@@ -461,7 +461,7 @@ def test_rescue_cleanup_rejects_forged_episode_and_action_without_losing_pin(
         selected_route="computer",
     )
     descriptor = RescueDescriptor(
-        schema_version="1.0",
+        schema_version="1.1",
         selector=selected,
         handshake=pinned_handshake,
         episode_id="episode",

--- a/tests/unit/evaluation/runner/conftest.py
+++ b/tests/unit/evaluation/runner/conftest.py
@@ -66,7 +66,7 @@ def selector(tmp_path: Path) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return AdapterSelector(
-        schema_version="1.0",
+        schema_version="1.1",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.0",
@@ -90,7 +90,7 @@ def handshake(tmp_path: Path) -> Handshake:
             entry_point="tiny_adapter:create",
             package_digest="a" * 64,
             release_digest="b" * 64,
-            schema_version="1.0",
+            schema_version="1.1",
             capabilities=AdapterCapabilities(routes=("computer",), ask_user=True, scoring=True),
         ),
         python=PythonRuntime.current(),

--- a/tests/unit/evaluation/runner/test_episode_subprocess.py
+++ b/tests/unit/evaluation/runner/test_episode_subprocess.py
@@ -730,9 +730,7 @@ async def test_real_worker_publishes_a_frame_the_parent_verifies_and_bundles(
     assert observations, "no observation events were recorded"
     assert all(event["payload"]["artifacts"] for event in observations)
     assert {
-        artifact["sha256"]
-        for event in observations
-        for artifact in event["payload"]["artifacts"]
+        artifact["sha256"] for event in observations for artifact in event["payload"]["artifacts"]
     } == {hashlib.sha256(payload).hexdigest()}
     assert all(
         artifact["media_type"] == "image/png" and artifact["byte_count"] == len(payload)

--- a/tests/unit/evaluation/runner/test_episode_subprocess.py
+++ b/tests/unit/evaluation/runner/test_episode_subprocess.py
@@ -67,7 +67,55 @@ from local_operator.evaluation.adapters.api import (
 from local_operator.evaluation.adapters.discovery import distribution_digest
 from local_operator.evaluation.evidence.models import ScoreArtifact
 from local_operator.evaluation.lifecycle import CleanupAction, CleanupPlan
-from local_operator.evaluation.protocol import Observation
+from local_operator.evaluation.protocol import (
+    ArtifactRef,
+    FrameGeometry,
+    FrameRef,
+    FrameSize,
+    Observation,
+)
+
+
+# A genuinely valid 1x1 PNG, constructed rather than pasted so its CRCs are
+# right: the parent runs the real media validator over these bytes, and a
+# hand-mangled blob would be refused for the wrong reason.
+def _png_bytes():
+    import struct
+    import zlib
+
+    def chunk(kind, payload):
+        return (
+            struct.pack(">I", len(payload))
+            + kind
+            + payload
+            + struct.pack(">I", zlib.crc32(kind + payload) & 0xFFFFFFFF)
+        )
+
+    return (
+        b"\\x89PNG\\r\\n\\x1a\\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(b"\\x00\\x00\\x00\\x00"))
+        + chunk(b"IEND", b"")
+    )
+
+
+# Write frame bytes into the PARENT-SUPPLIED root, named by digest.
+#
+# This is the point of the artifact_root field: this process's environment was
+# stripped by the supervisor, so `root` arrived on ResetStartParams and is the
+# only way the worker knows where the parent will look. Content addressing is
+# the adapter's half of confinement -- it publishes under a name it cannot
+# choose, so it cannot aim the parent at anything but these bytes. `name` exists
+# only so the escape tests can publish under a WRONG name.
+def _publish(root, payload, name=None):
+    import hashlib
+    import os
+
+    digest = hashlib.sha256(payload).hexdigest()
+    path = os.path.join(root, name or digest)
+    with open(path, "wb") as handle:
+        handle.write(payload)
+    return digest
 
 # The supervisor builds the worker environment from a closed allowlist, so a
 # cutpoint cannot ride in as an env var. The adapter reads it from a file beside
@@ -84,13 +132,83 @@ def _cutpoint():
         return ""
 
 
-def _observation(task_id, episode_id, sequence):
+# Which frame behaviour this run exercises, read the same adapter-owned way as
+# the cutpoint. "" means the original no-frame adapter, so every pre-existing
+# test in this module keeps its exact previous behaviour.
+def _frame_mode():
+    import os
+
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tiny_frame_mode")
+    try:
+        with open(path) as handle:
+            return handle.read().strip()
+    except OSError:
+        return ""
+
+
+# Build the frame list for one observation, publishing real bytes into the root
+# the PARENT supplied on reset_start. The dishonest modes each break exactly one
+# clause of the parent's verification so the refusals cannot pass for each other.
+def _frames(root, sequence):
+    import hashlib
+    import os
+
+    mode = _frame_mode()
+    if not mode or root is None:
+        return ()
+    payload = _png_bytes()
+    digest = hashlib.sha256(payload).hexdigest()
+    byte_count = len(payload)
+    if mode == "honest":
+        _publish(root, payload)
+    elif mode == "outside_root":
+        # Publish into a sibling directory and name it by its true digest. The
+        # parent only ever opens `root`, so the bytes are simply not there.
+        outside = os.path.join(os.path.dirname(root), "outside")
+        os.makedirs(outside, exist_ok=True)
+        _publish(outside, payload)
+    elif mode == "symlink_escape":
+        # Real bytes outside the root, with an in-root symlink pointing at them.
+        # Only O_NOFOLLOW distinguishes this from the honest case.
+        outside = os.path.join(os.path.dirname(root), "outside")
+        os.makedirs(outside, exist_ok=True)
+        target = os.path.join(outside, digest)
+        with open(target, "wb") as handle:
+            handle.write(payload)
+        link = os.path.join(root, digest)
+        if not os.path.lexists(link):
+            os.symlink(target, link)
+    elif mode == "digest_mismatch":
+        # Different bytes of the SAME length under the honest digest's name.
+        # Length-changing tampering would be caught by the size check first,
+        # leaving the digest comparison itself unexercised.
+        tampered = payload[:-1] + bytes([payload[-1] ^ 0xFF])
+        _publish(root, tampered, name=digest)
+    elif mode == "byte_count_mismatch":
+        _publish(root, payload)
+        byte_count = byte_count + 1
+    return (
+        FrameRef(
+            frame_id="frame-%%d" %% sequence,
+            artifact=ArtifactRef(
+                sha256=digest, media_type="image/png", byte_count=byte_count
+            ),
+            geometry=FrameGeometry(
+                native=FrameSize(width=1, height=1),
+                model_visible=FrameSize(width=1, height=1),
+            ),
+        ),
+    )
+
+
+def _observation(task_id, episode_id, sequence, root=None):
     provisional = Observation(
         task_id=task_id,
         episode_id=episode_id,
         sequence=sequence,
         observation_id="provisional",
         text="state-%%d" %% sequence,
+        frames=_frames(root, sequence),
     )
     return provisional.model_copy(
         update={"observation_id": observation_content_id(provisional)}
@@ -104,6 +222,9 @@ class TinyAdapter:
         self.episode_id = None
         self.sequence = 0
         self.current = None
+        # Learned ONLY from reset_start; the stripped environment offers no
+        # other route to it, which is exactly what this fixture proves.
+        self.artifact_root = None
 
     def _maybe_die(self, name):
         if _cutpoint() == name:
@@ -135,8 +256,11 @@ class TinyAdapter:
         self._maybe_die("reset_start")
         self.task_id = params.task_id
         self.episode_id = params.episode_id
+        self.artifact_root = params.artifact_root
         self.sequence = 0
-        self.current = _observation(self.task_id, self.episode_id, 0)
+        self.current = _observation(
+            self.task_id, self.episode_id, 0, self.artifact_root
+        )
         return AckResult()
 
     async def observe(self, params):
@@ -145,7 +269,9 @@ class TinyAdapter:
     async def execute(self, params):
         self._maybe_die("execute")
         self.sequence += 1
-        output = _observation(self.task_id, self.episode_id, self.sequence)
+        output = _observation(
+            self.task_id, self.episode_id, self.sequence, self.artifact_root
+        )
         receipt = ExecutionReceipt(
             operation_id=params.operation_id,
             action_batch_id=params.action_batch_id,
@@ -366,6 +492,39 @@ def _arm_cutpoint(site: Path, cutpoint: str | None) -> None:
         marker.write_text(cutpoint)
 
 
+async def _accepting_rescue(descriptor: Any, **kwargs: Any) -> Any:
+    """Stand in for a real rescue so a refusal is not misread as a leak.
+
+    A refused frame poisons the session, which legitimately demands rescue. The
+    tests using this are about confinement, not about reclamation, so rescue is
+    reported complete and the assertions stay on the refusal itself.
+    """
+
+    del kwargs
+
+    class _Aggregate:
+        complete = True
+        descriptor_id = descriptor.descriptor_id
+
+    return _Aggregate()
+
+
+def _arm_frames(site: Path, mode: str | None) -> None:
+    """Tell the installed adapter how to publish observation frames.
+
+    Armed through a file beside the adapter module for the same reason the
+    cutpoint is: the worker's environment is built from a closed allowlist, so a
+    test cannot hand it a mode any other way without weakening the policy under
+    test. ``None`` restores the frameless adapter the other tests here expect.
+    """
+
+    marker = site / "tiny_frame_mode"
+    if mode is None:
+        marker.unlink(missing_ok=True)
+    else:
+        marker.write_text(mode)
+
+
 @pytest.mark.asyncio
 async def test_real_worker_completes_a_scored_episode(
     tmp_path: Path,
@@ -508,3 +667,146 @@ async def test_killed_worker_process_group_is_reaped(
     assert await asyncio.to_thread(supervisor.process.poll) is not None
     with pytest.raises(ProcessLookupError):
         os.killpg(supervisor.pgid, 0)
+
+
+@pytest.mark.asyncio
+async def test_real_worker_publishes_a_frame_the_parent_verifies_and_bundles(
+    tmp_path: Path,
+    episode_id: str,
+    real_selector: AdapterSelector,
+    adapter_site: Path,
+) -> None:
+    """A genuinely spawned adapter delivers observation frames end to end.
+
+    This is the regression guard for the gap that ``artifact_root`` on
+    ``ResetStartParams`` closes. The worker is a real process whose environment
+    was built from the supervisor's closed allowlist, so the ONLY way it can
+    know where to write frame bytes is the field the parent sent it. Before that
+    field existed an out-of-process adapter could not publish a frame at all,
+    and the in-process fakes hid it because they shared the parent's memory.
+
+    The assertion chain is deliberately the full one: the parent read the bytes
+    (``verify_artifact``), accepted them (digest, size, media), copied them into
+    the bundle, and the sealed bundle still verifies. A test that stopped at
+    "the episode completed" would pass against an adapter that published no
+    frames whatsoever, which is precisely the broken state.
+    """
+
+    _arm_cutpoint(adapter_site, None)
+    _arm_frames(adapter_site, "honest")
+    config = _subprocess_config(tmp_path)
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        config,
+        selector=real_selector,
+        model=ScriptedModel(["step", "finish"]),
+        launch=AdapterSupervisor.launch,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "completed", outcome.diagnostic
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+
+    # The worker really wrote into the parent-chosen directory, and the bytes
+    # there are the exact PNG the parent then admitted into the bundle.
+    published = [item for item in config.artifact_root.iterdir() if item.is_file()]
+    assert published, "the spawned worker published nothing into the parent's root"
+    payload = published[0].read_bytes()
+    assert payload.startswith(b"\x89PNG\r\n\x1a\n")
+    assert published[0].name == hashlib.sha256(payload).hexdigest()
+
+    # Every observation carried a frame, and the frame's bytes are in the
+    # bundle: an episode that silently dropped frames would fail here.
+    events = [
+        json.loads(line)
+        for line in (root / "events.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    observations = [item for item in events if item.get("kind") == "observation"]
+    assert observations, "no observation events were recorded"
+    assert all(event["payload"]["artifacts"] for event in observations)
+    assert {
+        artifact["sha256"]
+        for event in observations
+        for artifact in event["payload"]["artifacts"]
+    } == {hashlib.sha256(payload).hexdigest()}
+    assert all(
+        artifact["media_type"] == "image/png" and artifact["byte_count"] == len(payload)
+        for event in observations
+        for artifact in event["payload"]["artifacts"]
+    )
+    # The bundle stores artifacts content-addressed, so the frame's digest being
+    # present is proof the parent ingested these exact bytes rather than
+    # recording a reference to something it never read.
+    assert (root / "artifacts" / hashlib.sha256(payload).hexdigest()).read_bytes() == payload
+
+
+@pytest.mark.parametrize(
+    ("mode", "refusal"),
+    [
+        # Bytes exist, but only outside the one directory the parent opens.
+        ("outside_root", "artifact path is unsafe or unavailable"),
+        # An in-root name that resolves outside it; O_NOFOLLOW is the guard.
+        ("symlink_escape", "artifact path is unsafe or unavailable"),
+        # In-root bytes of the declared length whose content is not the digest.
+        ("digest_mismatch", "artifact digest differs"),
+        # In-root bytes of the right content but a lied-about length.
+        ("byte_count_mismatch", "artifact is not a matching regular file"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_worker_cannot_deliver_frames_from_outside_the_root(
+    tmp_path: Path,
+    episode_id: str,
+    real_selector: AdapterSelector,
+    adapter_site: Path,
+    mode: str,
+    refusal: str,
+) -> None:
+    """Being told the root grants no authority to read outside it, or to lie.
+
+    Sending the worker a writable path is only safe because the parent keeps
+    resolving artifacts by content, inside that one directory descriptor, with
+    ``O_NOFOLLOW``. Each mode here breaks a different clause of that check, so a
+    weakened ``verify_artifact`` cannot be masked by another clause still
+    holding -- verified by reintroducing the weakness: dropping ``O_NOFOLLOW``
+    let ``symlink_escape`` reach ``completed``, and removing the digest
+    comparison turned ``digest_mismatch`` red.
+
+    The episode must not report success, and it must never seal a bundle that
+    claims frames it could not verify.
+    """
+
+    _arm_cutpoint(adapter_site, None)
+    _arm_frames(adapter_site, mode)
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        _subprocess_config(tmp_path),
+        selector=real_selector,
+        model=ScriptedModel(["step", "finish"]),
+        launch=AdapterSupervisor.launch,
+        rescue=_accepting_rescue,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status != "completed"
+    # Pinning the exact refusal keeps each mode honest about WHICH clause caught
+    # it. Without this, length-changing tampering is rejected by the size check
+    # and the digest comparison goes untested while the suite stays green.
+    assert outcome.diagnostic is not None and refusal in outcome.diagnostic
+    assert outcome.score is None or outcome.score.status == "unscored"
+    root = outcome.bundle_root
+    if root is None:
+        return
+    report = verify_bundle(root)
+    # Whatever terminal it reached must be coherent: a refused frame may not
+    # leave a bundle that both verifies and reports a reportable success.
+    if report.abandonment is None:
+        assert report.valid, [issue.code for issue in report.issues]
+        assert report.outcome is not None
+        assert report.outcome.reportable is False

--- a/tests/unit/evaluation/runner/test_episode_subprocess.py
+++ b/tests/unit/evaluation/runner/test_episode_subprocess.py
@@ -191,7 +191,7 @@ def create():
             entry_point="tiny_runner_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="%s",
-            schema_version="1.0",
+            schema_version="1.1",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=True
             ),
@@ -320,7 +320,7 @@ def real_selector(tmp_path: Path, adapter_site: Path) -> AdapterSelector:
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     return AdapterSelector(
-        schema_version="1.0",
+        schema_version="1.1",
         adapter_id="tiny-runner",
         distribution="tiny-runner-adapter",
         version="1.0",

--- a/tests/unit/evaluation/runner/test_episode_subprocess.py
+++ b/tests/unit/evaluation/runner/test_episode_subprocess.py
@@ -187,6 +187,13 @@ def _frames(root, sequence):
     elif mode == "byte_count_mismatch":
         _publish(root, payload)
         byte_count = byte_count + 1
+    elif mode == "fifo":
+        # A FIFO under an honest-looking digest name. Nothing ever writes to it,
+        # so a parent that opens it without O_NONBLOCK blocks in the kernel
+        # forever -- the liveness attack, not a content one.
+        path = os.path.join(root, digest)
+        if not os.path.lexists(path):
+            os.mkfifo(path)
     return (
         FrameRef(
             frame_id="frame-%%d" %% sequence,
@@ -754,6 +761,10 @@ async def test_real_worker_publishes_a_frame_the_parent_verifies_and_bundles(
         ("digest_mismatch", "artifact digest differs"),
         # In-root bytes of the right content but a lied-about length.
         ("byte_count_mismatch", "artifact is not a matching regular file"),
+        # A FIFO nobody writes to: the LIVENESS case. The S_ISREG check sits
+        # behind the open, so only O_NONBLOCK stops this wedging the parent
+        # forever -- and it is refused by that same existing clause.
+        ("fifo", "artifact is not a matching regular file"),
     ],
 )
 @pytest.mark.asyncio
@@ -774,6 +785,13 @@ async def test_worker_cannot_deliver_frames_from_outside_the_root(
     holding -- verified by reintroducing the weakness: dropping ``O_NOFOLLOW``
     let ``symlink_escape`` reach ``completed``, and removing the digest
     comparison turned ``digest_mismatch`` red.
+
+    ``fifo`` is the odd one out and belongs here anyway: it attacks LIVENESS
+    rather than content. The refusal it lands on is shared with
+    ``byte_count_mismatch``, so the assertion that matters is that the episode
+    TERMINATES at all -- without ``O_NONBLOCK`` the open never returns, and
+    because ``verify_artifact`` runs on the event-loop thread after the mutating
+    call's ``wait_for`` has closed, nothing upstream can time it out.
 
     The episode must not report success, and it must never seal a bundle that
     claims frames it could not verify.


### PR DESCRIPTION
## Summary

The parent reads adapter-produced observation frames with `verify_artifact(self._config.artifact_root, frame.artifact)` (`runner/episode.py`), but **`artifact_root` existed only on `RescueDescriptor`** — `PrepareParams` and `ResetStartParams` did not carry it. The spawned worker's environment is deliberately built from a closed allowlist (`supervisor._ENV_ALLOW` is locale and temp only), so a genuinely out-of-process adapter had **no way to learn where to write frame bytes**.

The consequence was that only in-process and rescue paths could deliver observation frames the parent could read. This was found while building the first real adapter (OSWorld), whose end-to-end sealed-bundle proof had to run **in-process** because of it.

This PR closes that gap and fixes a liveness hazard the gap was hiding. It does not activate a benchmark, OSWorld, provider, CLI, configuration, tool, cloud, or UI path.

## The design

**`artifact_root` is carried on `ResetStartParams` only — not on `PrepareParams`.** The path must be one the parent chooses and the worker is told, arriving as a validated RPC field rather than through the environment, and `reset_start` is the correct carrier:

- **`prepare` is contractually allocation-free.** It creates nothing and therefore produces no observation and has no bytes to publish. Handing it a writable root would invite exactly the allocation the two-stage rescue persistence depends on it not doing, widening the window in which a resource exists that no persisted descriptor names.
- **`reset_start` is both the side-effect boundary and the first call that yields an observation.** The parent calls `observe` immediately after it, and every later `observe`/`execute` runs in `RUNNING`, which only `reset_start` can enter. So it is the single point that precedes every frame-producing call while still being the first one that needs the root.
- **`RescueDescriptor` keeps its own copy** because rescue runs in a *new* process against a persisted file, with no live session to have been told.

**One shared validator, not two.** `RescueDescriptor`'s bespoke `artifact_root` field validator was extracted into a single `ArtifactRoot` annotated type (absolute *and* normalized, `min_length=1`, `max_length=4096`) now used by both models. A second, slightly-different definition of what makes a root acceptable is exactly how a confinement boundary develops a gap. Normalization is load-bearing rather than cosmetic: the parent opens this directory with `O_DIRECTORY` and resolves artifact names against that descriptor, so a root containing `..` could denote a different directory than the one the parent authorized.

**The parent creates the directory it names.** `_reset_and_observe` now does `mkdir(mode=0o700, parents=True, exist_ok=True)` before the call. An adapter told to publish into a missing root would otherwise have to create it itself, which hands the worker a say in the mode and ownership of the one directory the parent later opens and reads.

**Write-location and read-location cannot drift.** `VerifiedAdapterSession.reset_start` refuses a reset whose `artifact_root` differs from the one its `HostVerifier` reads from, alongside the existing task/episode check. Pointing the adapter at one directory while verifying another would otherwise produce silent `artifact path is unsafe` failures at the first frame — and worse, a root that merely *resolves* to the verifier's would make the mismatch depend on symlink state at call time.

**`verify_artifact` is not weakened.** The parent still resolves every artifact by content digest, inside that one directory descriptor, with `O_NOFOLLOW`, checking digest, byte count, and media. Sending the worker the root is what makes it able to write where the parent already looks; it grants no new read authority.

## Schema version 1.0 → 1.1

Adding a **required** field to a model whose config is `extra="forbid"` and `strict=True` is wire-breaking in **both** directions: a 1.0 worker rejects the new key as an unknown extra, and a 1.1 worker cannot serve a parent that omits it. This boundary deliberately pins exact versions rather than accepting ranges (see `AdapterSelector`), so the bump is what locks a 1.0 adapter out cleanly instead of letting it fail later as an opaque `invalid_request`.

The three models that pin the version (`AdapterSelector`, `AdapterMetadata`, `RescueDescriptor`) now share one `SchemaVersion` alias, so a future bump cannot move the constant while leaving a model silently accepting the older literal. The runner likewise now tracks `ADAPTER_SCHEMA_VERSION` instead of restating `"1.0"` when minting rescue descriptors — that hardcoded literal was found by this bump, where it surfaced as an unrelated `failed_pre_bundle` validation error.

Audited: no stranded `"1.0"` remains on the adapter schema.

## BLOCKER found in review: a worker could wedge the parent forever with a FIFO

This is a **liveness** hazard, not a content one, and it is called out here rather than buried because its failure mode is a permanent hang of the parent process.

`verify_artifact` opened the artifact with `O_RDONLY | O_CLOEXEC | O_NOFOLLOW` — **without `O_NONBLOCK`**. An adapter could `mkfifo(root/<honest-looking-digest>)`; opening a FIFO with no writer blocks in the kernel indefinitely, and the `S_ISREG` check that would have refused it **sits behind that blocking open**.

Nothing upstream could recover. `verify_artifact` is called synchronously from `_record_observation` (`runner/episode.py`) and `_validate_observation_content` (`supervisor.py`) **on the event-loop thread**, and **after** `_mutating_call`'s `wait_for` has already closed — so an outer `wait_for` never fires. No timeout, no poison, no rescue, no process-tree teardown.

**This PR is what made it reachable.** `verify_artifact` is untouched by this change, but before it a spawned worker had no way to learn the root at all. The gap closed here and this hazard are the same door, so it is fixed here rather than deferred.

**The fix is one flag:** `getattr(os, "O_NONBLOCK", 0)` added to the open flags. Verified behaviour-preserving on regular files, where POSIX makes it a no-op — measured as the same `S_ISREG`, the same size (69), and the same bytes with and without it. The FIFO open now returns immediately and falls into the **existing** `"artifact is not a matching regular file"` refusal, so no new error path was needed.

## Testing evidence

**A real spawned worker delivers a verified frame end to end.** `test_real_worker_publishes_a_frame_the_parent_verifies_and_bundles` launches a genuine interpreter running a genuine installed distribution through `AdapterSupervisor`, with the environment built from the production closed allowlist. The adapter publishes a **real 69-byte PNG** (constructed with correct CRCs, since the parent runs the real media validator over it) into the **parent-supplied root**, named by its own digest. Asserted: the bytes landed in the parent's directory under their true digest; the parent read and accepted them; both observation events carry the frame as `image/png`/69 bytes; the bundle stores those exact bytes content-addressed; and `verify_bundle().valid`.

The frame mode is armed through a file beside the adapter module — the same adapter-owned mechanism the existing cutpoint uses, because an env var cannot survive the allowlist. Default mode is empty, so every pre-existing test in that module keeps its exact previous behaviour.

**Proven to bite.** Denying the adapter the field fails the test with *"the spawned worker published nothing into the parent's root"* — the precise pre-PR state.

**Five confinement cases, each pinned to the exact refusal it should reach**, so a weakened check cannot be masked by another clause still holding:

| case | refusal |
| --- | --- |
| bytes published outside the root | `artifact path is unsafe or unavailable` |
| in-root symlink to bytes outside it | `artifact path is unsafe or unavailable` |
| same-length digest tampering | `artifact digest differs` |
| lied-about byte count | `artifact is not a matching regular file` |
| FIFO nobody writes to | `artifact is not a matching regular file` |

Pinning the message caught a real defect in my own test: length-*changing* tampering was being rejected by the size check first, leaving the digest comparison entirely unexercised while the suite stayed green. It is now same-length tampering and genuinely reaches the digest clause.

**All proven load-bearing by mutation.** Dropping `O_NOFOLLOW` let the symlink escape reach `completed`; removing the digest comparison turned the digest case red; removing `O_NONBLOCK` made the FIFO case **hang until killed at 120s** rather than fail an assertion — which is the hazard itself, and why that probe was run under a hard timeout.

The `fifo` case is the odd one out and its docstring says so plainly: it attacks liveness rather than content and shares its refusal with `byte_count_mismatch`, so what it actually asserts is that the episode *terminates at all*.

**Suite:** `tests/unit/evaluation` **419 passed**, against a 413 baseline captured on `origin/main` before any change — the six new tests, no regressions.

**Gates**, whole tree, exactly as CI spells them: `flake8` clean, `black==26.1.0` clean (722 files), `isort==5.13.2` clean, `pyright` 0 errors. `uv build` + `uvx twine check` both PASSED on the sdist and the wheel.

## Known consistency point

`exist_ok=True` on the parent `mkdir` does **not** re-apply the mode, so a pre-existing `0o777` root stays `0o777`. This matches `persist_rescue`'s existing behaviour, so it is consistent with the boundary rather than a regression, and is left alone deliberately.

## Not activated

- No CLI command, configuration key, default tool, UI surface, OSWorld integration, or cloud wiring.
- **Nothing outside the evaluation package imports it.** Verified by search: no reference to `local_operator.evaluation` exists in `local_operator/` outside `local_operator/evaluation/` itself.
- The evaluation subsystem still has no production caller, which is why this is a **patch** despite the `ADAPTER_SCHEMA_VERSION` change — no released adapter can be stranded by it.

## Follow-on

The OSWorld adapter branch depends on this landing first: it needs `schema_version="1.1"` and to read the root from `reset_start`. That branch is untouched here.
