### PR TITLE
feat(tui): invoke skills by name with a `$skill` composer prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ current session's cost live).
 
 ### Keys worth knowing
 
+- `$<skill>` — run a named skill on the rest of the line
+  (`$research the payments rewrite`); `$` alone opens the picker.
 - **Type while the agent works** — your message is delivered at the next
   step as steering, no need to wait.
 - `esc` — stop the agent without ending the session.
@@ -338,6 +340,13 @@ Drop a `SKILL.md` (with optional reference files) into
 only the skills relevant to the current turn are surfaced, and their bodies
 load on demand via `skill://<name>` reads, so your context isn't taxed by
 knowledge you aren't using. `/skills` lists what's loaded.
+
+You can also invoke one **by name** instead of leaving the choice to the
+router: type `$` in the composer to pick from your skills, then write the
+request — `$research compare these two API designs` loads that skill and
+sends it with your message. A skill marked `hide: true` is excluded from
+automatic routing and is reachable this way only, which makes `$` the home
+for "never pick this on your own, but run it when I say so".
 
 ### 🔗 MCP servers
 

--- a/local_operator/skills/invoke.py
+++ b/local_operator/skills/invoke.py
@@ -25,9 +25,17 @@ it to the model together with the request. Three properties are deliberate:
 The recognition rule is narrow on purpose, because ``$`` is also money and
 also shell. A token is an invocation only when it is the FIRST token of the
 buffer, and only when what follows the ``$`` matches a DISCOVERED SKILL NAME.
-``$100 for the redesign`` matches no skill and is plain prose; so is ``$PATH``
-and a stray ``$`` alone. That is what keeps this from needing an escape rule:
-the vocabulary decides, so nothing that is not a skill name is ever captured.
+``$100 for the redesign`` matches no skill and is plain prose; so is a stray
+``$`` alone. That is what keeps this from needing an escape rule: the
+vocabulary decides, so nothing that is not a skill name is ever captured.
+
+The converse is worth stating plainly: matching is case-insensitive and the
+vocabulary is user-controlled, so a skill actually NAMED ``path`` or ``editor``
+would make ``$PATH is unset`` or ``$EDITOR is vim`` invoke it. Nothing here can
+tell those apart from a deliberate invocation — the name is the whole grammar —
+and the transcript row shows what was typed either way, so the user can see it
+happened. Naming a skill after a common environment variable is the thing to
+avoid.
 """
 
 from __future__ import annotations
@@ -38,13 +46,21 @@ from typing import NamedTuple
 
 from local_operator.skills.discovery import Skill
 
-#: A leading ``$name`` token. ``name`` uses the skill-name character set
-#: (letters, digits, hyphen, underscore, dot) so ``$research,`` and ``$research.``
-#: end the token at the punctuation rather than swallowing it — a sentence that
-#: opens with an invocation still reads as a sentence. Anchored at the start:
+#: A leading ``$name`` token. ``name`` uses the skill-name character set:
+#: letters, digits, hyphen, underscore and dot, because real skill names
+#: contain all of them. The consequence is that ``.`` and ``-`` do NOT end the
+#: token — ``$research.`` parses the name ``research.``, misses the vocabulary
+#: and is sent as prose, which is the safe direction but not a sentence that
+#: invokes. ``$research,`` DOES work, since ``,`` is outside the class.
+#: Anchored at the start:
 #: an invocation is a prefix, never something found mid-draft. A ``$`` followed
 #: by nothing usable does not match at all.
 _INVOCATION_RE = re.compile(r"^\$([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+#: The opening tag of a rendered payload, capturing the typed line stored in
+#: its ``invocation`` attribute. Anchored to the tag rather than searched
+#: loosely so ordinary prose quoting the words cannot be mistaken for one.
+_INVOCATION_TAG_RE = re.compile(r'<skill name="[^"]*" invocation="([^"]*)">')
 
 
 class SkillInvocation(NamedTuple):
@@ -60,6 +76,11 @@ class SkillInvocation(NamedTuple):
     #: The raw token as typed (``"$research"``), for echoing a row that shows
     #: what the user actually wrote rather than a reconstruction of it.
     token: str
+    #: The whole line the user typed, stripped. Carried into the rendered
+    #: payload so a RESUMED session can recover it (see :func:`typed_line_of`);
+    #: without it the persisted message — which is the payload — replays as the
+    #: user's row and the skill body becomes the conversation's title.
+    typed: str = ""
 
 
 def parse_invocation(text: str, skills: Mapping[str, Skill]) -> SkillInvocation | None:
@@ -94,37 +115,12 @@ def parse_invocation(text: str, skills: Mapping[str, Skill]) -> SkillInvocation 
     if skill is None:
         return None
     request = stripped[match.end() :].strip()
-    return SkillInvocation(skill=skill, request=request, token=match.group(0))
-
-
-def invocation_name(text: str) -> str | None:
-    """The ``$``-token name being typed, or ``None`` — the picker's question.
-
-    Unlike :func:`parse_invocation` this does NOT check the token against the
-    vocabulary, because a user three characters into ``$res`` has not typed a
-    valid name yet and still wants the list. It answers "is the caret in a
-    ``$`` token", and returns ``""`` for a bare ``$`` so the picker opens on
-    the full set the moment the sigil is typed.
-
-    The token must still be the first thing in the buffer and must not have
-    been terminated by whitespace: once the user types a space they are writing
-    the REQUEST, and a skill list there is stale advice — the same phase rule
-    :func:`local_operator.tui.widgets.command_picker.slash_context` applies to
-    the command word.
-    """
-    stripped = text.lstrip()
-    if not stripped.startswith("$"):
-        return None
-    token = stripped[1:]
-    # A terminated token is no longer being typed. Checked before the pattern
-    # so `$research ` (trailing space) closes the list even though its name is
-    # perfectly valid.
-    if token != token.split(" ")[0] or "\n" in token:
-        return None
-    if not token:
-        return ""
-    match = _INVOCATION_RE.match(stripped)
-    return match.group(1) if match else None
+    return SkillInvocation(
+        skill=skill,
+        request=request,
+        token=match.group(0),
+        typed=stripped.strip(),
+    )
 
 
 def render_invocation(invocation: SkillInvocation, body: str) -> str:
@@ -138,13 +134,72 @@ def render_invocation(invocation: SkillInvocation, body: str) -> str:
     A bare ``$name`` with no request is not given a fake one. The skill body is
     the instruction in that case, and inventing "follow this skill" text around
     it would put words in the user's mouth that the skill may contradict.
+
+    The opening tag carries the typed line in an ``invocation`` attribute. That
+    is not decoration for the model: the payload is what gets PERSISTED, so a
+    resumed session replays this string as the user's row, and without the
+    typed line recorded here that row (and the conversation title derived from
+    it) becomes the whole skill body. :func:`typed_line_of` reads it back, and
+    keeping it inside the payload means there is no parallel store that can
+    disagree with the message it describes.
     """
     header = (
         f"The user invoked the `{invocation.skill.name}` skill directly. Follow it for "
         "this request. Its reference files, if any, are listed at the end of the body "
         "and are read with `skill://<name>/<path>`."
     )
-    parts = [header, f'<skill name="{invocation.skill.name}">', body, "</skill>"]
+    typed = _escape_attr(invocation.typed)
+    parts = [
+        header,
+        f'<skill name="{invocation.skill.name}" invocation="{typed}">',
+        body,
+        "</skill>",
+    ]
     if invocation.request:
         parts.append(invocation.request)
     return "\n".join(parts)
+
+
+def _escape_attr(value: str) -> str:
+    """Escape a typed line for an XML-ish attribute, reversibly.
+
+    Deliberately minimal and paired with :func:`_unescape_attr`: only the two
+    characters that could end the attribute or the tag. A newline becomes a
+    literal ``&#10;`` so a multi-line draft cannot break the single-line tag
+    the replay scanner matches.
+    """
+    return (
+        value.replace("&", "&amp;")
+        .replace('"', "&quot;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\n", "&#10;")
+    )
+
+
+def _unescape_attr(value: str) -> str:
+    """Inverse of :func:`_escape_attr`; ``&amp;`` last so it cannot double-undo."""
+    return (
+        value.replace("&#10;", "\n")
+        .replace("&gt;", ">")
+        .replace("&lt;", "<")
+        .replace("&quot;", '"')
+        .replace("&amp;", "&")
+    )
+
+
+def typed_line_of(text: str) -> str | None:
+    """The ``$skill`` line a rendered payload was built from, or ``None``.
+
+    The read side of the ``invocation`` attribute. Used by transcript REPLAY:
+    a persisted user message is the payload, and painting it verbatim would
+    show a resumed conversation the whole SKILL.md body as the user's row and
+    title the thread after it. Recovering the line here keeps replay showing
+    what the live session showed — the same live/replay parity the loop-prompt
+    skip in ``OperatorApp._replay_history`` exists to maintain.
+
+    ``None`` for any text that is not one of these payloads, which is every
+    ordinary message, so the caller falls through to painting it verbatim.
+    """
+    match = _INVOCATION_TAG_RE.search(text)
+    return _unescape_attr(match.group(1)) if match else None

--- a/local_operator/skills/invoke.py
+++ b/local_operator/skills/invoke.py
@@ -1,0 +1,150 @@
+"""Manual skill invocation: the ``$name`` composer prefix.
+
+Semantic routing (:mod:`local_operator.skills.index`) decides which skills a
+turn *probably* needs. This module is the other half: the user saying which
+skill they want, by name, with no embedder in the loop.
+
+``$research fix the login bug`` loads the ``research`` SKILL.md body and hands
+it to the model together with the request. Three properties are deliberate:
+
+- **Deterministic.** The body is injected as context, not suggested as a
+  ``read skill://`` the model may skip. "Manual invocation" that the model can
+  decline is not invocation, it is a hint.
+- **Hidden skills are reachable.** A skill with ``hide: true`` /
+  ``disable-model-invocation`` is excluded from semantic routing on purpose,
+  and until now was reachable only if the agent happened to read its URL.
+  Naming it explicitly is exactly the "never auto-select, let me fire it"
+  case that flag describes, so :func:`parse_invocation` does not filter on
+  ``hide``.
+- **The frozen block is untouched.** Selection is frozen per session for
+  prompt-cache warmth and re-opens only on compaction
+  (``session_factory._render_knowledge_block``). Injecting at the MESSAGE
+  level rides the volatile tail that changes every turn anyway, so a manual
+  invocation costs nothing in cache warmth on the turns around it.
+
+The recognition rule is narrow on purpose, because ``$`` is also money and
+also shell. A token is an invocation only when it is the FIRST token of the
+buffer, and only when what follows the ``$`` matches a DISCOVERED SKILL NAME.
+``$100 for the redesign`` matches no skill and is plain prose; so is ``$PATH``
+and a stray ``$`` alone. That is what keeps this from needing an escape rule:
+the vocabulary decides, so nothing that is not a skill name is ever captured.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import NamedTuple
+
+from local_operator.skills.discovery import Skill
+
+#: A leading ``$name`` token. ``name`` uses the skill-name character set
+#: (letters, digits, hyphen, underscore, dot) so ``$research,`` and ``$research.``
+#: end the token at the punctuation rather than swallowing it — a sentence that
+#: opens with an invocation still reads as a sentence. Anchored at the start:
+#: an invocation is a prefix, never something found mid-draft. A ``$`` followed
+#: by nothing usable does not match at all.
+_INVOCATION_RE = re.compile(r"^\$([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+
+class SkillInvocation(NamedTuple):
+    """A resolved ``$name`` prefix and the request that followed it.
+
+    ``request`` is the buffer with the token removed and stripped; it is
+    legitimately ``""`` when the user typed only ``$name``, which means "run
+    this skill, the skill itself says on what".
+    """
+
+    skill: Skill
+    request: str
+    #: The raw token as typed (``"$research"``), for echoing a row that shows
+    #: what the user actually wrote rather than a reconstruction of it.
+    token: str
+
+
+def parse_invocation(text: str, skills: Mapping[str, Skill]) -> SkillInvocation | None:
+    """Resolve a leading ``$name`` against the discovered vocabulary.
+
+    Returns ``None`` — meaning "this is ordinary prose, send it unchanged" —
+    when the text does not start with ``$``, when the token is not a known
+    skill name, or when the name is followed immediately by a word character
+    the pattern would have to swallow. Never raises: an unparseable draft is
+    always just a draft.
+
+    Matching is case-insensitive because skill names are lower-case by
+    convention while a sentence-start ``$Research`` is a natural thing to type,
+    and the ``skills`` mapping is keyed by the discovered name.
+    """
+    stripped = text.lstrip()
+    match = _INVOCATION_RE.match(stripped)
+    if match is None:
+        return None
+    name = match.group(1)
+    skill = skills.get(name)
+    if skill is None:
+        # Case-insensitive second pass. Done as an explicit scan rather than by
+        # lower-casing the mapping up front so the ORIGINAL discovery name is
+        # what gets resolved and echoed — the skill is `research`, even when
+        # the user typed `$Research`.
+        lowered = name.lower()
+        skill = next(
+            (candidate for key, candidate in skills.items() if key.lower() == lowered),
+            None,
+        )
+    if skill is None:
+        return None
+    request = stripped[match.end() :].strip()
+    return SkillInvocation(skill=skill, request=request, token=match.group(0))
+
+
+def invocation_name(text: str) -> str | None:
+    """The ``$``-token name being typed, or ``None`` — the picker's question.
+
+    Unlike :func:`parse_invocation` this does NOT check the token against the
+    vocabulary, because a user three characters into ``$res`` has not typed a
+    valid name yet and still wants the list. It answers "is the caret in a
+    ``$`` token", and returns ``""`` for a bare ``$`` so the picker opens on
+    the full set the moment the sigil is typed.
+
+    The token must still be the first thing in the buffer and must not have
+    been terminated by whitespace: once the user types a space they are writing
+    the REQUEST, and a skill list there is stale advice — the same phase rule
+    :func:`local_operator.tui.widgets.command_picker.slash_context` applies to
+    the command word.
+    """
+    stripped = text.lstrip()
+    if not stripped.startswith("$"):
+        return None
+    token = stripped[1:]
+    # A terminated token is no longer being typed. Checked before the pattern
+    # so `$research ` (trailing space) closes the list even though its name is
+    # perfectly valid.
+    if token != token.split(" ")[0] or "\n" in token:
+        return None
+    if not token:
+        return ""
+    match = _INVOCATION_RE.match(stripped)
+    return match.group(1) if match else None
+
+
+def render_invocation(invocation: SkillInvocation, body: str) -> str:
+    """Build the message text that carries an invoked skill to the model.
+
+    The body is delivered inside a tagged block with an imperative, mirroring
+    :func:`local_operator.skills.index.render_block`'s voice: a bare paste of
+    SKILL.md reads to the model as reference material it may consult, and the
+    whole point of a manual invocation is that the user has already decided.
+
+    A bare ``$name`` with no request is not given a fake one. The skill body is
+    the instruction in that case, and inventing "follow this skill" text around
+    it would put words in the user's mouth that the skill may contradict.
+    """
+    header = (
+        f"The user invoked the `{invocation.skill.name}` skill directly. Follow it for "
+        "this request. Its reference files, if any, are listed at the end of the body "
+        "and are read with `skill://<name>/<path>`."
+    )
+    parts = [header, f'<skill name="{invocation.skill.name}">', body, "</skill>"]
+    if invocation.request:
+        parts.append(invocation.request)
+    return "\n".join(parts)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -34,7 +34,16 @@ from collections.abc import Mapping, Sequence
 from contextlib import nullcontext
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, NamedTuple, Protocol, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    NamedTuple,
+    Protocol,
+    TypeGuard,
+    cast,
+)
 
 from rich.console import Group
 from rich.padding import Padding
@@ -860,6 +869,48 @@ def _parse_loop_verdict(text: str) -> tuple[bool | None, str]:
 #: is how an agent burns a budget unattended.
 DEFAULT_LOOP_ITERATIONS = 3
 MAX_LOOP_ITERATIONS = 25
+
+
+def _skill_body_has_content(body: str | None) -> TypeGuard[str]:
+    """Whether a resolved SKILL.md carries anything beyond its frontmatter.
+
+    ``resolve_skill_url`` returns the file verbatim, so a stub whose YAML block
+    is the entire file comes back as a NON-EMPTY string with zero instruction
+    in it. A plain truthiness check therefore called that a successful load and
+    sent the model a `<skill>` block containing only `name:` and
+    `description:` — which is the silent no-op this exists to catch.
+    """
+    if not body or not body.strip():
+        return False
+    text = body.lstrip()
+    if text.startswith("---"):
+        # Drop the leading YAML block, if it is terminated. An UNterminated one
+        # is malformed rather than empty, so it falls through and counts as
+        # content: the user should see the skill fire and read the odd result,
+        # not be told their skill is empty when it is broken.
+        rest = text[3:]
+        end = rest.find("\n---")
+        if end != -1:
+            text = rest[end + 4 :]
+    return bool(text.strip())
+
+
+def _typed_line_of(text: str) -> str | None:
+    """The ``$skill`` line behind a persisted payload, or ``None``.
+
+    A thin lazy-import wrapper over
+    :func:`local_operator.skills.invoke.typed_line_of`, matching the contract
+    the rest of this module keeps with the skills subsystem: it is imported at
+    the point of use and every failure degrades to "not an invocation", so a
+    broken or absent skills package can never stop a transcript replaying.
+    """
+    try:
+        from local_operator.skills.invoke import typed_line_of
+
+        return typed_line_of(text)
+    except Exception:  # noqa: BLE001 — replay must never fail on this
+        return None
+
 
 #: The prompt each loop iteration submits. Deliberately references the
 #: standing goal (carried in the system prompt) rather than restating it, so
@@ -1943,6 +1994,18 @@ class OperatorApp(App[None]):
         self._compaction_owns_working_block: bool = False
         #: A prompt typed DURING a pass, sent when the pass ends.
         self._prompt_held_for_compaction: str = ""
+        #: What the USER typed for that held prompt, when it differs from the
+        #: string above — a ``$skill`` invocation holds the expanded SKILL.md
+        #: body to SEND while the composer must get the short line back.
+        #: ``""`` means "they are the same string", which is every other
+        #: prompt, so the sentinel above keeps its load-bearing emptiness
+        #: (round 13's mutation tests) instead of widening to a tuple.
+        #:
+        #: The two consumers genuinely want opposite halves: `on_compaction_
+        #: ended` SENDS the held prompt (the payload), while the `/reload`
+        #: teardown HANDS IT BACK to the composer (the typed line). One field
+        #: could not serve both without one of them being wrong.
+        self._typed_held_for_compaction: str = ""
         #: Its attachments, held in parallel. Separate so the line above keeps
         #: `""` as its sentinel — that field's emptiness is load-bearing and
         #: mutation-tested (round 13), and widening it to a tuple would move
@@ -3653,6 +3716,16 @@ class OperatorApp(App[None]):
                     # live/replay divergence review round 2 pinned.
                     if text in (LOOP_PROMPT, _CONTINUATION_PROMPT):
                         continue
+                    # A `$skill` invocation persists as its EXPANDED payload,
+                    # because that is what the model was sent. Replaying it
+                    # verbatim showed a resumed conversation the whole SKILL.md
+                    # body as the user's row — and, since the picker titles a
+                    # session from its first user turn, named every such thread
+                    # "The user invoked the `research` skill…". The typed line
+                    # rides the payload's own opening tag, so replay repaints
+                    # exactly what the live session painted. Same live/replay
+                    # parity rule as the two prompts skipped above.
+                    text = _typed_line_of(text) or text
                     # The images ride the persisted message as base64 content
                     # blocks — the same bytes the model saw — so a resumed
                     # prompt replays WITH its pictures, not just the receipt
@@ -4438,8 +4511,13 @@ class OperatorApp(App[None]):
         # hold took it.
         self._compacting = False
         held, self._prompt_held_for_compaction = self._prompt_held_for_compaction, ""
+        typed, self._typed_held_for_compaction = self._typed_held_for_compaction, ""
         held_images, self._images_held_for_compaction = self._images_held_for_compaction, {}
         if held:
+            # The TYPED line goes back, not the payload: handing a user the
+            # expanded body of a `$skill` they invoked would make them delete a
+            # whole SKILL.md by hand to recover the one line they wrote.
+            held = typed or held
             editor = self._editor()
             # Never clobber something typed since: the draft in the box is
             # newer than the prompt we are handing back.
@@ -10373,6 +10451,9 @@ class OperatorApp(App[None]):
             # minutes and then sent the words without the screenshot would be
             # worse than not queueing at all.
             self._prompt_held_for_compaction = sent
+            # Only when they differ, so the common path leaves this empty and
+            # the hand-back below falls through to the held prompt itself.
+            self._typed_held_for_compaction = text if sent != text else ""
             # From the MESSAGE, not from the widget: the composer clears itself
             # synchronously after posting and Textual delivers on a later tick,
             # so re-reading it here saw an empty map and queued the prompt
@@ -16650,9 +16731,25 @@ class OperatorApp(App[None]):
         # `ctrl+c` leads the pair: copying is the gesture a user reaches for far
         # more often than pasting an image, and the two-line entry reads better
         # above a one-line neighbour than wedged under it.
+        # `$skill` is documented for the SAME reason as the two key rows above:
+        # it is a composer grammar, not a slash command, so the table cannot
+        # carry it — and unlike `/`, nothing else advertises it. A user who
+        # never types `$` on a hunch never discovers that naming a skill is
+        # possible at all, which makes `/help` the only durable surface for it
+        # ("the surface still there an hour in", the ctrl+c note above).
+        #
+        # Named with a placeholder rather than bare `$`, because the gesture is
+        # the NAME: a lone sigil reads as a shell prompt. MEASURED against the
+        # 74-cell ceiling the block documents at length above: `name_width` is
+        # 16 on the current registry and the description is 47, composing to
+        # 63 — inside the bound with headroom, and pinned by the same test.
+        skill_note = Text()
+        skill_note.append("$<skill>".ljust(name_width), style=muted)
+        skill_note.append("runs a named skill on the rest of the line", style=dim)
         lines.append(copy_note)
         lines.append(copy_note_more)
         lines.append(paste_note)
+        lines.append(skill_note)
         # `cmd+v` gets its own row because the claim is CONDITIONAL and a
         # conditional claim needs the words to qualify it. The chord reaches
         # the app only where the terminal implements the kitty keyboard
@@ -16853,7 +16950,17 @@ class OperatorApp(App[None]):
             if invocation is None:
                 return None
             body = resolve_skill_url(f"skill://{invocation.skill.name}", skills)
-            if not body:
+            if not _skill_body_has_content(body):
+                # NOT a silent fall-through. Returning None here sends the raw
+                # `$research fix it` line as prose while the row on screen
+                # still reads like an invocation, so the user believes the
+                # skill fired and the model never saw it. An empty SKILL.md is
+                # the realistic cause (a stub someone has not written yet).
+                self._notice(
+                    f"skill `{invocation.skill.name}` has an empty body — sending your "
+                    "message as written",
+                    "warning",
+                )
                 return None
             return render_invocation(invocation, body)
         except Exception as exc:
@@ -16861,7 +16968,19 @@ class OperatorApp(App[None]):
             return None
 
     def _skills_block(self) -> RichBlock | None:
-        """Graceful introspection of the skills stream (exception-safe)."""
+        """Graceful introspection of the skills stream (exception-safe).
+
+        Lists HIDDEN skills too, tagged. Before manual invocation existed,
+        filtering them was right: `hide` means "never route to this", so a
+        hidden skill was something only the agent could reach by URL and
+        listing it advertised a capability the user could not use. `$name`
+        inverts that — a hidden skill is now reachable ONLY by being typed, so
+        the command that exists to list skills was concealing exactly the
+        entries its reader most needs to see.
+
+        The header names the gesture for the same reason: a bare list of names
+        does not tell the reader they are typeable.
+        """
         try:
             from pathlib import Path
 
@@ -16869,14 +16988,16 @@ class OperatorApp(App[None]):
             from local_operator.skills.discovery import discover_skills
 
             skills, _warnings = discover_skills(default_skill_roots(Path(os.getcwd())))
-            visible = [skill for skill in skills if not skill.hide]
-            if not visible:
+            if not skills:
                 return None
-            return RichBlock(
-                _tree_listing(
-                    [(skill.name, skill.description) for skill in visible], "loaded skills"
+            rows = [
+                (
+                    skill.name,
+                    f"{skill.description} (hidden)" if skill.hide else skill.description,
                 )
-            )
+                for skill in skills
+            ]
+            return RichBlock(_tree_listing(rows, "loaded skills · type $<name> to run one"))
         except Exception:
             return None
 
@@ -19283,7 +19404,20 @@ class OperatorApp(App[None]):
             # round 2, D5).
             self._replace_stop_notice(RECALL_DECLINE_NOTICE, "note")
             return
-        text = message.text
+        # The row's text, NOT ``message.text``. For every ordinary steer the
+        # two are the same string, but a ``$skill`` invocation deliberately
+        # sends the expanded SKILL.md body while the row keeps the short line
+        # the user typed (``_submit_prompt``'s ``sent``). A recall hands the
+        # composer back what the USER wrote — recalling their own words is the
+        # whole gesture, and loading the payload instead dumped a whole skill
+        # body into the composer for them to delete by hand.
+        text = user_block.text()
+        # ``message.text`` is still what left the QUEUE, so history and the
+        # echo registry are keyed on their own strings below: the submit
+        # recorded the typed line in history and registered the echo under the
+        # SENT text, and taking the wrong one for either leaves a stale entry
+        # that swallows the resend.
+        sent_text = message.text
         # The steer recorded itself in prompt history on submit; the recall
         # UNSENT it, so Up-arrow must not offer the line the composer already
         # holds as a past prompt.
@@ -19329,7 +19463,7 @@ class OperatorApp(App[None]):
         # By the message's OWN id, which is the key the steer registered under:
         # `message` is the object `steer_message` queued, so this takes exactly
         # this steer's entry and never a sibling with the same words.
-        self._consume_user_echo(text, message_id=message.id)
+        self._consume_user_echo(sent_text, message_id=message.id)
         for held in self._queued_steer_notices:
             if held is notice:
                 self._queued_steer_notices.remove(held)
@@ -19550,9 +19684,22 @@ class OperatorApp(App[None]):
         # A prompt typed DURING the pass was held rather than sent into a
         # history being rewritten; now the history is settled, it goes.
         held, self._prompt_held_for_compaction = self._prompt_held_for_compaction, ""
+        # Kept, not dropped: the markers are resolved against the TYPED text
+        # below. Cleared after that so a later `/reload` cannot hand back a
+        # line whose prompt already went.
+        typed, self._typed_held_for_compaction = self._typed_held_for_compaction, ""
         held_images, self._images_held_for_compaction = self._images_held_for_compaction, {}
         if held or held_images:
-            self._start_turn(held, resolve_markers(held, held_images))
+            # `resolve_markers` orders images by WHERE the citation sits, so it
+            # must read the text the user actually wrote. Run against the
+            # expanded payload, a `[Image #N]` appearing anywhere in the
+            # SKILL.md body (a skill about screenshots is the obvious case)
+            # shifts the citation positions and the model silently receives the
+            # attachments in the wrong order — verified: a draft citing #2 then
+            # #1 sent `[BBB, AAA]` on the normal path and `[AAA, BBB]` here.
+            # The PAYLOAD is still what gets sent; only the marker walk uses
+            # the typed line.
+            self._start_turn(held, resolve_markers(typed or held, held_images))
 
     def on_effective_model_changed(self, message: EffectiveModelChanged) -> None:
         """Repaint the model segment with the model actually serving requests.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -162,6 +162,7 @@ from local_operator.tui.widgets.editor import (
     ModelQueryOpened,
     RefreshArgumentChoices,
     ShellModeChanged,
+    SkillQueryOpened,
     StopRequested,
     resolve_markers,
 )
@@ -236,6 +237,7 @@ if TYPE_CHECKING:  # keeps the provider graph off the TUI's runtime import path
     from local_operator.multiplexer import SessionBroadcast
     from local_operator.providers.controller import CatalogueEntry
     from local_operator.providers.oauth.callback_server import LoginCallbacks
+    from local_operator.skills.discovery import Skill
 
 
 #: ONE sentence for ONE instruction, carried verbatim by every surface that
@@ -2055,6 +2057,11 @@ class OperatorApp(App[None]):
         #: entries keep the historical by-text behaviour, limit included. Both
         #: in-tree sessions take the keyword, so no shipping path relies on it.
         self._pending_user_echoes: list[_PendingUserEcho] = []
+        #: Discovered skills by name, for the ``$skill`` composer prefix.
+        #: ``None`` until the first submit or picker sync asks; see
+        #: :meth:`_discovered_skills` for why one discovery per session is the
+        #: right lifetime rather than a per-keystroke filesystem walk.
+        self._skills_by_name: dict[str, Skill] | None = None
         #: Wake receipts painted LIVE this session, as ``(wake_id, occurrence)``
         #: keys. ``on_wake_delivered`` records each; the history replay skips a
         #: persisted ``wake_prompt`` whose key is already here — otherwise a
@@ -7386,7 +7393,13 @@ class OperatorApp(App[None]):
             # the markers THAT text still cites, not the whole slash line's.
             self._run_slash_command(text, message.attachments)
             return
-        self._submit_prompt(text, images, message.attachments)
+        # `$skill` is the manual counterpart to semantic routing: the user
+        # naming the skill instead of an embedder guessing it. Resolved HERE,
+        # next to the slash dispatch, because both are prefix grammars the
+        # composer owns — but it is NOT a command: it produces a prompt, so it
+        # falls through to the ordinary submit with an expanded payload rather
+        # than dispatching anything of its own.
+        self._submit_prompt(text, images, message.attachments, sent=self._expand_invocation(text))
 
     def on_inline_command_requested(self, message: InlineCommandRequested) -> None:
         """Run a slash command spliced out of the MIDDLE of a draft.
@@ -10232,8 +10245,27 @@ class OperatorApp(App[None]):
         text: str,
         images: list[ImageContent] | None = None,
         attachments: Mapping[int, Attachment] | None = None,
+        *,
+        sent: str | None = None,
     ) -> None:
+        """Paint one user prompt and dispatch it.
+
+        ``sent`` splits what the transcript SHOWS from what the model RECEIVES,
+        for the one case where they legitimately differ: a ``$skill`` manual
+        invocation, whose row must stay the short line the user typed while the
+        model gets that line with the SKILL.md body prepended. ``None`` — every
+        other caller — means the two are the same string, which is the property
+        the echo registry depends on everywhere else.
+
+        Everything DOWNSTREAM of the row takes ``sent``: the steer queue, the
+        compaction hold, and the turn itself, because those are the paths whose
+        payload the session announces back and whose echo entries are matched
+        against it. Conversation NAMING deliberately keeps the display text —
+        titling a thread from an injected skill body would name it after the
+        skill's prose instead of the user's request.
+        """
         images = images or []
+        sent = text if sent is None else sent
         user_block = UserBlock(text, len(images))
         self._append_block(user_block)
         # The pictures themselves, under the prompt that cites them. The
@@ -10260,7 +10292,7 @@ class OperatorApp(App[None]):
             # contents by identity to know which transcript blocks the user
             # took back (`_recall_queued_steers`), so the app and the queue
             # must share one Message rather than each building their own.
-            steer_message = Message.user(text, images)
+            steer_message = Message.user(sent, images)
             session.steer_message(steer_message)
             # "boundary" is engine vocabulary the UI never defines, and this is
             # the line answering "did my text just get thrown away?" — so it says
@@ -10302,7 +10334,7 @@ class OperatorApp(App[None]):
             # No such implementation exists in tree, and unlike the prompt path
             # there is no signature to probe — a re-minting host would have to
             # be caught by its own tests (round 1, F2).
-            self._register_user_echo(text, message_id=steer_message.id)
+            self._register_user_echo(sent, message_id=steer_message.id)
             # Held with the notice so Esc can lift the whole steer — the queued
             # row, the user row and its image blocks — back out of the
             # transcript and into the composer (:meth:`_recall_queued_steers`).
@@ -10340,7 +10372,7 @@ class OperatorApp(App[None]):
             # The attachments are part of the same prompt: a pass that ran for
             # minutes and then sent the words without the screenshot would be
             # worse than not queueing at all.
-            self._prompt_held_for_compaction = text
+            self._prompt_held_for_compaction = sent
             # From the MESSAGE, not from the widget: the composer clears itself
             # synchronously after posting and Textual delivers on a later tick,
             # so re-reading it here saw an empty map and queued the prompt
@@ -10349,7 +10381,7 @@ class OperatorApp(App[None]):
             self._append_block(NoticeBlock("queued — sends when compaction finishes", "note"))
             self._maybe_name_conversation(text)
             return
-        self._start_turn(text, images)
+        self._start_turn(sent, images)
         # AFTER the turn is dispatched, and then concurrently with it: the
         # title is decoration, so it must never sit in front of the user's
         # first reply — but it must also not wait for the whole turn, which is
@@ -15625,6 +15657,41 @@ class OperatorApp(App[None]):
         self._notice(f"forked {len(pairs)} aside {plural} into the chat")
 
     # -- argument lists -------------------------------------------------------
+    def on_skill_query_opened(self, message: SkillQueryOpened) -> None:
+        """The buffer just entered a ``$`` token — offer the skill vocabulary.
+
+        The ``$`` twin of :meth:`on_argument_query_opened`, and it answers on
+        the message for the same reason: every route into the list arrives at
+        one place with one set of rows.
+
+        HIDDEN skills are offered here. They are excluded from semantic
+        routing by ``hide``/``disable-model-invocation``, but manual invocation
+        is precisely the deliberate act that flag leaves open, and a name the
+        user can type but cannot see is a worse secret than a listed one.
+
+        An empty vocabulary sets a notice rather than leaving a bare list: a
+        machine with no skills installed is a real answer, and the row says so
+        instead of showing an empty box the user cannot account for.
+        """
+        message.stop()
+        picker = self._editor().picker
+        skills = self._discovered_skills()
+        if not skills:
+            picker.set_choices([])
+            picker.set_notice("no skills found — see `/skills`")
+            return
+        picker.set_notice("")
+        picker.set_choices(
+            [
+                ArgumentChoice(
+                    skill.name,
+                    skill.description,
+                    detail="hidden" if skill.hide else "",
+                )
+                for skill in sorted(skills.values(), key=lambda item: item.name.lower())
+            ]
+        )
+
     def on_argument_query_opened(self, message: ArgumentQueryOpened) -> None:
         """The buffer just entered ``/<command> …`` — fill that command's list.
 
@@ -16729,6 +16796,69 @@ class OperatorApp(App[None]):
         lines.append(notify_note)
         lines.append(notify_note_more)
         return RichBlock(Group(*lines))
+
+    def _discovered_skills(self) -> dict[str, Skill]:
+        """Discovered skills by name, computed once per session.
+
+        Cached because it is read on EVERY submit to decide whether a leading
+        ``$`` is an invocation, and discovery walks the filesystem. The cache
+        matches the lifetime the rest of the skills subsystem already assumes:
+        discovery and the semantic index are built at session creation, so a
+        skill added mid-session is not visible to routing either and telling
+        the user to restart is one consistent rule rather than two.
+
+        Hidden skills are KEPT (unlike :meth:`_skills_block`, which lists what
+        routing can select). ``hide`` suppresses automatic selection; naming a
+        skill by hand is the deliberate case that flag exists to leave open.
+
+        Never raises: a broken skills tree degrades to "no invocations", which
+        sends the user's ``$foo`` through as the prose it is indistinguishable
+        from at that point.
+        """
+        if self._skills_by_name is None:
+            try:
+                from pathlib import Path
+
+                from local_operator.skills.api import default_skill_roots
+                from local_operator.skills.discovery import discover_skills
+
+                skills, _warnings = discover_skills(default_skill_roots(Path(os.getcwd())))
+                self._skills_by_name = {skill.name: skill for skill in skills}
+            except Exception:
+                self._skills_by_name = {}
+        return self._skills_by_name
+
+    def _expand_invocation(self, text: str) -> str | None:
+        """Expand a leading ``$skill`` into skill body + request, or ``None``.
+
+        ``None`` means "not an invocation, send the text unchanged" — the
+        answer for ordinary prose, for ``$100``, and for any ``$word`` that is
+        not a discovered skill name. The body is read through the SAME
+        ``skill://`` resolver the ``read`` tool uses, so a manual invocation
+        and an agent-initiated read return byte-identical content, reference
+        listing included.
+
+        A body that cannot be read is not a silent failure: the notice says so
+        and the raw text goes through untouched, because swallowing the user's
+        request would be the worse half of the trade.
+        """
+        skills = self._discovered_skills()
+        if not skills:
+            return None
+        try:
+            from local_operator.skills.invoke import parse_invocation, render_invocation
+            from local_operator.skills.protocol import resolve_skill_url
+
+            invocation = parse_invocation(text, skills)
+            if invocation is None:
+                return None
+            body = resolve_skill_url(f"skill://{invocation.skill.name}", skills)
+            if not body:
+                return None
+            return render_invocation(invocation, body)
+        except Exception as exc:
+            self._notice(f"could not load skill: {exc}", "warning")
+            return None
 
     def _skills_block(self) -> RichBlock | None:
         """Graceful introspection of the skills stream (exception-safe)."""

--- a/local_operator/tui/widgets/command_picker.py
+++ b/local_operator/tui/widgets/command_picker.py
@@ -157,6 +157,12 @@ class PickerMode(Enum):
 
     COMMAND = "command"
     ARGUMENT = "argument"
+    #: The ``$skill`` manual-invocation list. A third mode rather than a reuse
+    #: of ``COMMAND`` because the two complete differently: a command word is
+    #: inline and caret-anchored, while a ``$`` token is only ever the FIRST
+    #: token of the buffer, and Enter on a skill row must not run anything —
+    #: an invocation produces a PROMPT the user still has to write.
+    SKILL = "skill"
 
 
 #: One rendered row: its display name and the thing it stands for. A UNION
@@ -442,10 +448,42 @@ def slash_argument(
     return None if context is None else context.value
 
 
+def skill_token(text: str, cursor: int | None = None) -> SlashContext | None:
+    """The ``$skill`` token being typed at the start of the buffer, or ``None``.
+
+    The ``$`` counterpart to :func:`slash_context`, and deliberately STRICTER
+    than it in two ways.
+
+    It is **not inline**. A ``/`` opens a command anywhere a boundary allows,
+    because a user who has typed a message may still want to route it. A ``$``
+    is only an invocation as the buffer's FIRST token: mid-draft, ``$`` is
+    overwhelmingly money or a shell variable, and there is no second syntax to
+    disambiguate them. Restricting the position is what removes the need for an
+    escape rule — ``a $5 coffee`` cannot be a token by construction.
+
+    It is **word-phase only**, like :func:`slash_context`: the terminating
+    space means the user has moved on to the request, where a skill list is
+    stale advice.
+
+    ``query`` is ``""`` for a bare ``$``, which opens the list on the full set.
+    The caret must be INSIDE the token; moving it out into the request closes
+    the list, which is what makes the picker phase a property of the parse.
+    """
+    if not text.startswith("$"):
+        return None
+    cursor = len(text) if cursor is None else cursor
+    end = 1
+    while end < len(text) and not text[end].isspace():
+        end += 1
+    if cursor > end:
+        return None
+    return SlashContext(0, text[1:end], end)
+
+
 class CompletionMode(Enum):
     """Which slot :func:`completion_for` is completing.
 
-    The three completion sites in ``Editor`` differ only in which span they
+    The four completion sites in ``Editor`` differ only in which span they
     rewrite and whether a trailing space follows the inserted name, and that
     difference is exactly what this enum names.
     """
@@ -458,6 +496,10 @@ class CompletionMode(Enum):
     #: A NAME+message argument — ``/team fro`` → ``/team frontend-guild ``, the
     #: space opening the message tail (``Editor._complete_name_argument``).
     NAME_ARGUMENT = "name_argument"
+    #: A ``$skill`` invocation — ``$res`` → ``$research ``. Takes the trailing
+    #: space for the same reason ``NAME_ARGUMENT`` does: the space closes the
+    #: list and opens the request tail the user is about to type.
+    SKILL = "skill"
 
 
 def completion_for(
@@ -490,6 +532,16 @@ def completion_for(
     Returns ``None`` when the caret is not in the slot ``mode`` names — the
     parse the caller would otherwise have had to repeat.
     """
+    if mode is CompletionMode.SKILL:
+        token = skill_token(text, caret)
+        if token is None:
+            return None
+        # Same trailing-space contract as the command word: it terminates the
+        # token, closes the list, and opens the request. The suffix beyond the
+        # token is preserved because a user can complete a `$skill` typed in
+        # front of a request they already wrote.
+        completed = f"${row_name} {text[token.end :].lstrip()}"
+        return completed, len(row_name) + 2
     if mode is CompletionMode.COMMAND:
         context = slash_context(text, caret, known)
         if context is None:
@@ -795,7 +847,13 @@ class CommandPicker(Static):
         the first report a no-op — and is where a browse should start anyway.
         """
         self._choices = list(choices)
-        if self._mode is PickerMode.ARGUMENT:
+        # SKILL rides the same fill path as ARGUMENT: both are app-pushed
+        # ``ArgumentChoice`` sets that land one message-loop tick after the
+        # keystroke that opened the list, so both need the immediate re-derive
+        # below or the picker sits closed on the empty set it opened with until
+        # the user types another character. Gating this on ARGUMENT alone is
+        # exactly why a bare ``$`` painted nothing.
+        if self._mode in (PickerMode.ARGUMENT, PickerMode.SKILL):
             matches = argument_suggestions(self._query, self._choices)
             seeding = highlight is not None and not self._query and not self._chosen_by_hand
             if seeding:
@@ -805,7 +863,11 @@ class CommandPicker(Static):
                 # again one message later.
                 self._suppress_report = True
             try:
-                self._apply(PickerMode.ARGUMENT, self._query, matches)
+                # The CURRENT mode, not a hard-coded ARGUMENT: re-applying the
+                # wrong one here would be read as a mode CHANGE by `_apply` and
+                # would reset the highlight, the window and the Esc latch on
+                # every fill.
+                self._apply(self._mode, self._query, matches)
             finally:
                 self._suppress_report = False
             if seeding:
@@ -984,6 +1046,27 @@ class CommandPicker(Static):
             return
         matches = command_suggestions(context.query, self._commands)
         self._apply(PickerMode.COMMAND, context.query, matches)
+
+    def sync_skills(self, text: str, cursor: int | None = None) -> None:
+        """Re-derive the ``$skill`` suggestions from the editor's ``text``.
+
+        The third sibling of :meth:`sync` and :meth:`sync_argument`, and it
+        closes the same way they do: leaving the token forgets the dismissal,
+        so the next ``$`` opens a fresh list rather than inheriting an Esc.
+
+        Rows are :class:`ArgumentChoice` and go through
+        :func:`argument_suggestions`, so a skill name is ranked by the very
+        scorer that ranks commands and providers — ``$cr`` finds
+        ``code-review`` by the rule the user already learned from ``/lgt``
+        finding ``logout``.
+        """
+        token = skill_token(text, cursor)
+        if token is None:
+            self._dismissed_query = None
+            self._mode = PickerMode.SKILL
+            self._close()
+            return
+        self._apply(PickerMode.SKILL, token.query, argument_suggestions(token.query, self._choices))
 
     def sync_argument(self, query: str) -> None:
         """Re-derive the ARGUMENT suggestions for the current command.

--- a/local_operator/tui/widgets/command_picker.py
+++ b/local_operator/tui/widgets/command_picker.py
@@ -468,16 +468,25 @@ def skill_token(text: str, cursor: int | None = None) -> SlashContext | None:
     ``query`` is ``""`` for a bare ``$``, which opens the list on the full set.
     The caret must be INSIDE the token; moving it out into the request closes
     the list, which is what makes the picker phase a property of the parse.
+
+    LEADING WHITESPACE is skipped, matching both :func:`slash_context` (which
+    opens on ``  /he``) and the submit-side parser in
+    :mod:`local_operator.skills.invoke`, which ``lstrip``s. Requiring column 0
+    made the two disagree: ``  $research fix`` offered no list while still
+    expanding on Enter, so the invocation fired with no UI cue that it would.
+    Only spaces and tabs are skipped \u2014 a ``$`` after a NEWLINE is on a second
+    line and is not the buffer's first token.
     """
-    if not text.startswith("$"):
+    indent = len(text) - len(text.lstrip(" \t"))
+    if not text.startswith("$", indent):
         return None
     cursor = len(text) if cursor is None else cursor
-    end = 1
+    end = indent + 1
     while end < len(text) and not text[end].isspace():
         end += 1
     if cursor > end:
         return None
-    return SlashContext(0, text[1:end], end)
+    return SlashContext(indent, text[indent + 1 : end], end)
 
 
 class CompletionMode(Enum):
@@ -540,8 +549,12 @@ def completion_for(
         # token, closes the list, and opens the request. The suffix beyond the
         # token is preserved because a user can complete a `$skill` typed in
         # front of a request they already wrote.
-        completed = f"${row_name} {text[token.end :].lstrip()}"
-        return completed, len(row_name) + 2
+        # `token.start` is the `$`, which is not column 0 when the draft is
+        # indented; the leading run is preserved rather than normalised away so
+        # completing never silently reformats what the user typed.
+        lead = text[: token.start]
+        completed = f"{lead}${row_name} {text[token.end :].lstrip()}"
+        return completed, token.start + len(row_name) + 2
     if mode is CompletionMode.COMMAND:
         context = slash_context(text, caret, known)
         if context is None:

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -145,6 +145,7 @@ from local_operator.tui.widgets.command_picker import (
     PickerMode,
     completion_for,
     ghost_for,
+    skill_token,
     slash_argument,
     slash_argument_context,
     slash_context,
@@ -812,6 +813,19 @@ class ArgumentQueryOpened(Message):
         self.command = command
 
 
+class SkillQueryOpened(Message):
+    """Posted when the buffer enters a ``$skill`` token, so the app fills rows.
+
+    Carries nothing: there is exactly one skill vocabulary per session, unlike
+    the per-command argument sets :class:`ArgumentQueryOpened` has to name.
+
+    Transition-only, for the same economy: discovery walks the filesystem, so
+    it happens once per token rather than once per keystroke. Leaving the token
+    re-arms it (``Editor._skill_choices_requested``), which is what lets the
+    app re-answer with a fresh set on the next ``$``.
+    """
+
+
 class RefreshArgumentChoices(Message):
     """Posted when the rows an open argument list should offer have changed
     UNDER the same command word — which :class:`ArgumentQueryOpened` can never
@@ -1151,6 +1165,12 @@ class Editor(TextArea):
         #: The first argument SLOT of a two-level command (``/mcp login``)
         #: whose choice set depends on it; ``None`` for one-level commands.
         self._argument_subcommand: str | None = None
+        #: True while a :class:`SkillQueryOpened` has been posted for the token
+        #: the caret is in. The transition latch for the skill list, mirroring
+        #: ``_argument_command``'s role for argument lists; cleared on leaving
+        #: the token so the next ``$`` asks again. Assigned here because
+        #: ``_sync_picker`` reads it during ``super().__init__()``.
+        self._skill_choices_requested: bool = False
         # Command words (primaries AND aliases) whose argument opens the value
         # list, and the subset of those the bare command cannot stand without.
         # DERIVED from the registry in :meth:`set_commands` rather than listed
@@ -2069,7 +2089,17 @@ class Editor(TextArea):
                     # afterwards would measure the completed word (always one
                     # exact match) and submit unconditionally.
                     unambiguous = self._picker_choice_is_unambiguous(name)
-                    if self._picker.mode is PickerMode.ARGUMENT:
+                    if self._picker.mode is PickerMode.SKILL:
+                        # NEITHER key ever submits here, ambiguous or not. A
+                        # completed `$skill ` is not a runnable thing the way
+                        # `/logout anthropic` is — it is the opening of a
+                        # prompt the user is still writing, so Enter fills the
+                        # name and waits, exactly as it does for a NAME+message
+                        # command. Submitting on the one-match case would send
+                        # a bare invocation the moment the name resolved,
+                        # discarding the request the user was about to type.
+                        self._complete_skill(name)
+                    elif self._picker.mode is PickerMode.ARGUMENT:
                         self._resolve_argument(name, key, unambiguous)
                     elif unambiguous:
                         self._apply_command(name)
@@ -4672,6 +4702,12 @@ class Editor(TextArea):
         inside one phase does not re-open an Esc-dismissed list.
         """
         cursor = self._caret_offset()
+        # Checked FIRST and short-circuiting: a `$` token is anchored at offset
+        # 0, so it cannot overlap a slash construct, and answering it here
+        # keeps the three phases mutually exclusive without the slash parsers
+        # having to know the sigil exists.
+        if skill_token(self.text, cursor) is not None:
+            return "skill"
         if (
             slash_argument(self.text, self._argument_commands, cursor, self._command_names)
             is not None
@@ -4713,6 +4749,22 @@ class Editor(TextArea):
         the caret sits, not just what the buffer contains.
         """
         cursor = self._caret_offset()
+        # The `$skill` list is derived before either slash list for the reason
+        # given in `_picker_phase`: the token owns offset 0 exclusively, so
+        # there is no arbitration to do and the slash parsers stay unaware of
+        # it. The rows themselves are pushed by the app (SkillQueryOpened),
+        # exactly as an argument list's are.
+        if skill_token(self.text, cursor) is not None:
+            if not self._skill_choices_requested:
+                self._skill_choices_requested = True
+                self.post_message(SkillQueryOpened())
+            self._picker.sync_skills(self.text, cursor)
+            self._picker_phase_at_last_sync = self._picker_phase()
+            self._sync_ghost()
+            return
+        # Left the token: the next `$` asks for rows again, so a skill added
+        # between two invocations is not invisible for the rest of the session.
+        self._skill_choices_requested = False
         list_argument = slash_argument(
             self.text, self._argument_commands, cursor, self._command_names
         )
@@ -5131,6 +5183,8 @@ class Editor(TextArea):
         """
         if not self._picker.is_open():
             return None
+        if self._picker.mode is PickerMode.SKILL:
+            return CompletionMode.SKILL
         if self._picker.mode is not PickerMode.ARGUMENT:
             return CompletionMode.COMMAND
         if self._is_name_argument_command(self._argument_command):
@@ -5383,6 +5437,21 @@ class Editor(TextArea):
             self._complete_argument(name)
             return
         self._run_argument(name)
+
+    def _complete_skill(self, name: str) -> None:
+        """Put ``$name `` in the buffer, leaving the caret in the request.
+
+        The trailing space is deliberate and is what the picker's close depends
+        on: it terminates the token, so the list drops away on the same
+        keystroke that chose from it and the caret lands where the request is
+        typed. Same contract as :meth:`_complete_name_argument`, minus the
+        inline reassembly — a ``$`` token is anchored at the buffer start, so
+        there is never a preceding draft to move it in front of.
+        """
+        completed = self._completion_for(CompletionMode.SKILL, name)
+        if completed is None:
+            return
+        self._set_text_and_caret(*completed)
 
     def _complete_argument(self, name: str) -> None:
         """Put ``name`` in the argument slot without acting on it.

--- a/tests/unit/skills/test_invoke.py
+++ b/tests/unit/skills/test_invoke.py
@@ -8,9 +8,9 @@ import pytest
 
 from local_operator.skills.discovery import Skill
 from local_operator.skills.invoke import (
-    invocation_name,
     parse_invocation,
     render_invocation,
+    typed_line_of,
 )
 
 
@@ -117,31 +117,45 @@ class TestNotAnInvocation:
         assert parse_invocation("$research go", {}) is None
 
 
-class TestInvocationName:
-    """The picker's question: is the caret in a `$` token, and what is typed."""
+class TestTypedLineRoundTrip:
+    """The payload carries the typed line, so REPLAY can repaint the row.
 
-    def test_bare_sigil_opens_the_full_list(self):
-        assert invocation_name("$") == ""
+    A persisted user message IS the payload. Without this, resuming a session
+    showed the whole SKILL.md body as the user's row and titled the thread
+    after it (the picker names a session from its first user turn).
+    """
 
-    def test_partial_name_is_the_query(self):
-        assert invocation_name("$res") == "res"
+    def test_round_trips_the_typed_line(self, skills):
+        invocation = _resolved("$research fix the login bug", skills)
+        rendered = render_invocation(invocation, "body")
+        assert typed_line_of(rendered) == "$research fix the login bug"
 
-    def test_unknown_name_still_queries(self):
-        """Three characters in, nothing is valid yet — the list must stay up."""
-        assert invocation_name("$zzz") == "zzz"
+    def test_returns_none_for_ordinary_text(self):
+        assert typed_line_of("just a normal message") is None
+        assert typed_line_of("") is None
 
-    def test_space_terminates_the_token(self):
-        assert invocation_name("$research go") is None
+    @pytest.mark.parametrize(
+        "draft",
+        [
+            '$research handle "quoted" input',
+            "$research compare <a> & <b>",
+            "$research line one\nline two",
+            '$research 100% & <tags> "all" at once',
+        ],
+    )
+    def test_escaping_survives_hostile_drafts(self, skills, draft):
+        """The attribute must not be breakable by what the user types."""
+        invocation = _resolved(draft, skills)
+        rendered = render_invocation(invocation, "body")
+        assert typed_line_of(rendered) == draft
 
-    def test_trailing_space_closes_the_list(self):
-        assert invocation_name("$research ") is None
-
-    def test_newline_terminates(self):
-        assert invocation_name("$research\nmore") is None
-
-    @pytest.mark.parametrize("text", ["", "hello", "/team", "a $research"])
-    def test_non_tokens(self, text):
-        assert invocation_name(text) is None
+    def test_body_that_looks_like_the_tag_does_not_confuse_it(self, skills):
+        """A skill DOCUMENTING this feature must not hijack the read-back."""
+        invocation = _resolved("$research go", skills)
+        rendered = render_invocation(
+            invocation, 'Write <skill name="x" invocation="$fake other"> to invoke.'
+        )
+        assert typed_line_of(rendered) == "$research go"
 
 
 class TestRenderInvocation:

--- a/tests/unit/skills/test_invoke.py
+++ b/tests/unit/skills/test_invoke.py
@@ -1,0 +1,164 @@
+"""Manual ``$name`` skill invocation: parsing, the money guard, rendering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from local_operator.skills.discovery import Skill
+from local_operator.skills.invoke import (
+    invocation_name,
+    parse_invocation,
+    render_invocation,
+)
+
+
+def _resolved(text: str, skills: dict[str, Skill]):
+    """Parse and assert a match, so a regression fails HERE and stays typed.
+
+    ``parse_invocation`` is deliberately ``Optional`` — "this is prose" is half
+    its job — so the positive-path tests would otherwise each need their own
+    ``assert is not None`` before touching a field.
+    """
+    result = parse_invocation(text, skills)
+    assert result is not None, f"expected {text!r} to resolve to a skill"
+    return result
+
+
+def _skill(name: str, *, hide: bool = False) -> Skill:
+    return Skill(
+        name=name,
+        description=f"The {name} skill.",
+        file_path=Path(f"/skills/{name}/SKILL.md"),
+        base_dir=Path(f"/skills/{name}"),
+        source="/skills",
+        hide=hide,
+    )
+
+
+@pytest.fixture
+def skills() -> dict[str, Skill]:
+    return {
+        "research": _skill("research"),
+        "code-review": _skill("code-review"),
+        "secret_audit": _skill("secret_audit", hide=True),
+    }
+
+
+class TestParseInvocation:
+    def test_bare_name_resolves_with_empty_request(self, skills):
+        result = parse_invocation("$research", skills)
+        assert result is not None
+        assert result.skill.name == "research"
+        assert result.request == ""
+        assert result.token == "$research"
+
+    def test_name_and_request_splits_on_the_token(self, skills):
+        result = parse_invocation("$research fix the login bug", skills)
+        assert result is not None
+        assert result.skill.name == "research"
+        assert result.request == "fix the login bug"
+
+    def test_hyphenated_and_underscored_names_resolve(self, skills):
+        assert _resolved("$code-review this MR", skills).skill.name == "code-review"
+        assert _resolved("$secret_audit", skills).skill.name == "secret_audit"
+
+    def test_hidden_skills_are_invocable(self, skills):
+        """`hide` suppresses semantic ROUTING; naming it is the explicit case."""
+        result = parse_invocation("$secret_audit check the repo", skills)
+        assert result is not None
+        assert result.skill.hide is True
+
+    def test_case_insensitive_but_resolves_the_discovery_name(self, skills):
+        result = parse_invocation("$Research look into this", skills)
+        assert result is not None
+        assert result.skill.name == "research"
+        assert result.request == "look into this"
+
+    def test_leading_whitespace_is_tolerated(self, skills):
+        assert _resolved("  $research go", skills).skill.name == "research"
+
+
+class TestNotAnInvocation:
+    """The vocabulary is the guard: anything that is not a skill name is prose."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "$100 for the redesign",
+            "$5/unit at scale",
+            "$PATH is not set",
+            "$",
+            "$ research",
+            "$unknown-skill do the thing",
+            "please run $research later",
+            "cost is $research",
+            "",
+            "   ",
+            "just a normal message",
+            "/research",
+        ],
+    )
+    def test_returns_none(self, skills, text):
+        assert parse_invocation(text, skills) is None
+
+    def test_money_amount_never_matches_even_with_numeric_skill(self, skills):
+        """A numeric-named skill still cannot capture a currency amount."""
+        assert parse_invocation("$100 for the redesign", skills) is None
+
+    def test_trailing_punctuation_ends_the_token(self, skills):
+        result = parse_invocation("$research, then report", skills)
+        assert result is not None
+        assert result.skill.name == "research"
+        assert result.request == ", then report"
+
+    def test_empty_vocabulary_matches_nothing(self):
+        assert parse_invocation("$research go", {}) is None
+
+
+class TestInvocationName:
+    """The picker's question: is the caret in a `$` token, and what is typed."""
+
+    def test_bare_sigil_opens_the_full_list(self):
+        assert invocation_name("$") == ""
+
+    def test_partial_name_is_the_query(self):
+        assert invocation_name("$res") == "res"
+
+    def test_unknown_name_still_queries(self):
+        """Three characters in, nothing is valid yet — the list must stay up."""
+        assert invocation_name("$zzz") == "zzz"
+
+    def test_space_terminates_the_token(self):
+        assert invocation_name("$research go") is None
+
+    def test_trailing_space_closes_the_list(self):
+        assert invocation_name("$research ") is None
+
+    def test_newline_terminates(self):
+        assert invocation_name("$research\nmore") is None
+
+    @pytest.mark.parametrize("text", ["", "hello", "/team", "a $research"])
+    def test_non_tokens(self, text):
+        assert invocation_name(text) is None
+
+
+class TestRenderInvocation:
+    def test_body_and_request_both_reach_the_model(self, skills):
+        invocation = _resolved("$research fix the login bug", skills)
+        rendered = render_invocation(invocation, "# Research\nDo it well.")
+        assert "Do it well." in rendered
+        assert "fix the login bug" in rendered
+        assert 'name="research"' in rendered
+        assert "</skill>" in rendered
+
+    def test_bare_invocation_carries_no_invented_request(self, skills):
+        invocation = _resolved("$research", skills)
+        rendered = render_invocation(invocation, "# Research\nDo it well.")
+        assert rendered.rstrip().endswith("</skill>")
+
+    def test_names_the_skill_in_the_imperative(self, skills):
+        invocation = _resolved("$code-review this MR", skills)
+        rendered = render_invocation(invocation, "body")
+        assert "`code-review`" in rendered

--- a/tests/unit/tui/test_skill_invocation.py
+++ b/tests/unit/tui/test_skill_invocation.py
@@ -7,7 +7,10 @@ the request) and what the TRANSCRIPT shows (the short line the user typed).
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
@@ -214,6 +217,227 @@ async def test_enter_on_a_skill_row_completes_without_submitting(skill_root) -> 
         await pilot.pause()
         assert editor.text == "$research "
         assert session.prompts == []
+
+
+class TestHandBackPathsReturnTheTypedLine:
+    """Every path that hands a held prompt BACK must return what was typed.
+
+    The `sent` split means an invocation's queued/held payload is the expanded
+    SKILL.md body. Three paths consume those strings, and they do not all want
+    the same half: the ones that SEND want the payload, the ones that hand the
+    text back to the composer want the user's line. Getting it backwards makes
+    the user delete a whole skill body by hand to recover one sentence, which
+    is what these pin.
+    """
+
+    @pytest.mark.asyncio
+    async def test_esc_recall_of_a_queued_steer_restores_the_typed_line(self, skill_root) -> None:
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one(Editor)
+            # Mid-turn, so the submit takes the STEER branch.
+            session.streaming = True
+            await _submit(app, pilot, "$research fix the login bug")
+            for _ in range(60):
+                await pilot.pause()
+                if app._held_steer_blocks:
+                    break
+            # The QUEUE carries the payload...
+            queued = app._held_steer_blocks[0][0]
+            assert "Read primary sources." in queued.text
+            # ...and the recall gives back the line.
+            app._recall_queued_steers()
+            await pilot.pause()
+            assert editor.text == "$research fix the login bug"
+            assert "Read primary sources." not in editor.text
+
+    @pytest.mark.asyncio
+    async def test_compaction_hold_keeps_both_halves(self, skill_root) -> None:
+        """The hold sends the body; the hand-back returns the line."""
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            app._compacting = True
+            await _submit(app, pilot, "$research fix the login bug")
+            await pilot.pause()
+            assert "Read primary sources." in app._prompt_held_for_compaction
+            assert app._typed_held_for_compaction == "$research fix the login bug"
+
+    @pytest.mark.asyncio
+    async def test_reload_during_a_hold_hands_back_the_typed_line(self, skill_root) -> None:
+        """The `/reload` teardown returns the draft, so it must return the LINE.
+
+        Driven through the real teardown rather than the two fields, because
+        the defect was which of them that code path read.
+        """
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one(Editor)
+            app._compacting = True
+            await _submit(app, pilot, "$research fix the login bug")
+            await pilot.pause()
+            assert not editor.text
+            await app._reload_session()
+            await pilot.pause()
+            assert editor.text == "$research fix the login bug"
+            assert "Read primary sources." not in editor.text
+
+    @pytest.mark.asyncio
+    async def test_ordinary_prompt_holds_no_separate_typed_line(self, skill_root) -> None:
+        """`""` stays the sentinel for "the two strings are the same"."""
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            app._compacting = True
+            await _submit(app, pilot, "just a normal message")
+            await pilot.pause()
+            assert app._prompt_held_for_compaction == "just a normal message"
+            assert app._typed_held_for_compaction == ""
+
+    @pytest.mark.asyncio
+    async def test_ordinary_steer_recall_is_unchanged(self, skill_root) -> None:
+        """The non-invocation path must behave exactly as it did before."""
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one(Editor)
+            session.streaming = True
+            await _submit(app, pilot, "please also check the logs")
+            for _ in range(60):
+                await pilot.pause()
+                if app._held_steer_blocks:
+                    break
+            app._recall_queued_steers()
+            await pilot.pause()
+            assert editor.text == "please also check the logs"
+
+
+class TestReviewRegressions:
+    """Defects found in independent review of the first commit."""
+
+    @pytest.mark.asyncio
+    async def test_compaction_resume_orders_images_by_the_typed_citations(self, skill_root) -> None:
+        """`resolve_markers` must read the TYPED line, not the payload.
+
+        Images are ordered by WHERE the citation sits. A `[Image #N]` anywhere
+        in the SKILL.md body (a skill about screenshots is the obvious case)
+        shifts those positions, so resolving against the expanded payload sent
+        the model the attachments in the wrong order — silently.
+
+        Driven through the real `on_compaction_ended` call site, not through
+        `resolve_markers` directly: the defect was WHICH STRING that call site
+        passed, so a test that calls the helper itself cannot catch it.
+        """
+        from local_operator.tui.events import CompactionEnded
+        from local_operator.tui.widgets.editor import Attachment
+
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            # A skill whose BODY cites an image, which is what shifts the order.
+            app._skills_by_name = None
+            app._compacting = True
+            editor = app.query_one(Editor)
+            editor.focus()
+            await pilot.pause()
+            # Hold a prompt the way a mid-compaction submit does, with the
+            # payload and the typed line diverging exactly as they do live.
+            typed = "$research compare [Image #2] against [Image #1]"
+            app._prompt_held_for_compaction = (
+                'lead\n<skill name="research" invocation="x">See [Image #1].</skill>\n' + typed
+            )
+            app._typed_held_for_compaction = typed
+            app._images_held_for_compaction = {
+                1: Attachment(cast(Any, "AAA"), "[Image #1]"),
+                2: Attachment(cast(Any, "BBB"), "[Image #2]"),
+            }
+            app.on_compaction_ended(CompactionEnded("manual", True, "snapcompact", 10, 5))
+            for _ in range(200):
+                await pilot.pause()
+                if session.prompts:
+                    break
+            # Cited #2 first, so #2's image must be sent first.
+            assert session.prompt_images[0] == ["BBB", "AAA"]
+
+    @pytest.mark.asyncio
+    async def test_replay_repaints_the_typed_line_not_the_body(self, skill_root) -> None:
+        """A resumed session must show what the live session showed.
+
+        Driven through `_replay_history`, the real call site: the defect was
+        that replay painted the persisted payload verbatim.
+        """
+        from local_operator.skills.api import default_skill_roots
+        from local_operator.skills.discovery import discover_skills
+        from local_operator.skills.invoke import parse_invocation, render_invocation
+
+        skills, _ = discover_skills(default_skill_roots(Path(os.getcwd())))
+        invocation = parse_invocation("$research fix the login bug", {s.name: s for s in skills})
+        assert invocation is not None
+        payload = render_invocation(invocation, "Read primary sources.")
+
+        session = FakeSession()
+        # `history` is a read-only property backed by `_history` on the fake.
+        session._history = [SimpleNamespace(role="user", text=payload, content=[])]
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            app._project_settled_rows(list(session._history))
+            await pilot.pause()
+            shown = _transcript_text(app)
+            assert "$research fix the login bug" in shown
+            assert "Read primary sources." not in shown
+
+    @pytest.mark.asyncio
+    async def test_empty_skill_body_warns_instead_of_silently_sending_prose(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The user must not believe a skill fired when it did not."""
+        root = tmp_path / "skills"
+        (root / "stub").mkdir(parents=True)
+        (root / "stub" / "SKILL.md").write_text("---\nname: stub\ndescription: A stub.\n---\n")
+        monkeypatch.setenv("LOCAL_OPERATOR_SKILL_EXTRA_ROOTS", str(root))
+        monkeypatch.chdir(tmp_path)
+
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await _submit(app, pilot, "$stub do the thing")
+            await _await_prompt(pilot, session)
+            await pilot.pause()
+            # Sent as written, and SAID SO.
+            assert session.prompts == ["$stub do the thing"]
+            assert "empty body" in _transcript_text(app)
+
+    @pytest.mark.asyncio
+    async def test_indented_draft_offers_the_list_it_will_act_on(self, skill_root) -> None:
+        """The picker and the submit parser must agree about leading spaces."""
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one(Editor)
+            editor.focus()
+            await pilot.pause()
+            editor.load_text("  $resea")
+            editor.move_cursor(editor._end_of_buffer())
+            await pilot.pause()
+            for _ in range(50):
+                await pilot.pause()
+                if editor.picker.is_open():
+                    break
+            assert editor.picker.is_open(), "indented draft expanded but offered no list"
+            await pilot.press("enter")
+            await pilot.pause()
+            assert editor.text == "  $research "
 
 
 class TestSkillTokenParser:

--- a/tests/unit/tui/test_skill_invocation.py
+++ b/tests/unit/tui/test_skill_invocation.py
@@ -1,0 +1,250 @@
+"""The ``$skill`` composer prefix: expansion at submit, and the picker.
+
+Two properties carry the feature and are asserted separately here, because
+they can regress independently: what the MODEL receives (the skill body plus
+the request) and what the TRANSCRIPT shows (the short line the user typed).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.command_picker import (
+    CompletionMode,
+    PickerMode,
+    completion_for,
+    skill_token,
+)
+from local_operator.tui.widgets.editor import Editor
+from local_operator.tui.widgets.transcript import TranscriptView
+
+from .test_app_pilot import FakeSession, _factory, _transcript_text
+
+
+@pytest.fixture
+def skill_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A skills root wired in as the ONLY root, via the documented env var."""
+    root = tmp_path / "skills"
+    for name, description, body, hide in [
+        ("research", "Investigate a question.", "Read primary sources.", False),
+        ("code-review", "Review a merge request.", "Check the diff.", False),
+        ("secret-audit", "Audit credentials.", "Scan for secrets.", True),
+    ]:
+        skill_dir = root / name
+        skill_dir.mkdir(parents=True)
+        front = f"---\nname: {name}\ndescription: {description}\n"
+        if hide:
+            front += "hide: true\n"
+        front += "---\n\n"
+        (skill_dir / "SKILL.md").write_text(front + body)
+    monkeypatch.setenv("LOCAL_OPERATOR_SKILL_EXTRA_ROOTS", str(root))
+    # cwd walk-up must not pick up a real project root on the dev machine.
+    monkeypatch.chdir(tmp_path)
+    return root
+
+
+async def _submit(app: OperatorApp, pilot, text: str) -> None:
+    """Load a draft the way the suite does and send it.
+
+    ``move_cursor(_end_of_buffer())`` is not decoration: ``load_text`` leaves
+    the caret at offset 0, and every picker parse in this codebase is
+    caret-anchored, so without it the caret sits INSIDE the ``$`` token and
+    Enter completes the row instead of submitting — the same reason the
+    existing pilot tests move the caret after loading a ``/`` draft.
+    """
+    editor = app.query_one(Editor)
+    editor.focus()
+    await pilot.pause()
+    editor.load_text(text)
+    editor.move_cursor(editor._end_of_buffer())
+    await pilot.pause()
+    await pilot.press("enter")
+
+
+async def _await_prompt(pilot, session: FakeSession) -> None:
+    for _ in range(200):
+        await pilot.pause()
+        if session.prompts:
+            return
+
+
+@pytest.mark.asyncio
+async def test_invocation_sends_body_and_request(skill_root) -> None:
+    """The model gets the SKILL.md body and the request; one prompt, not two."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _submit(app, pilot, "$research fix the login bug")
+        await _await_prompt(pilot, session)
+    assert len(session.prompts) == 1
+    sent = session.prompts[0]
+    assert "Read primary sources." in sent
+    assert "fix the login bug" in sent
+    assert "`research`" in sent
+
+
+@pytest.mark.asyncio
+async def test_transcript_shows_what_was_typed_not_the_body(skill_root) -> None:
+    """The row is the user's line; the injected body never lands in the ledger."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _submit(app, pilot, "$research fix the login bug")
+        await _await_prompt(pilot, session)
+        await pilot.pause()
+        shown = _transcript_text(app)
+        assert "$research fix the login bug" in shown
+        assert "Read primary sources." not in shown
+        assert len(app.query_one(TranscriptView).blocks()) == 1
+
+
+@pytest.mark.asyncio
+async def test_bare_invocation_sends_the_skill_alone(skill_root) -> None:
+    """`$research` + Enter completes the row; a second Enter sends it bare.
+
+    Two keystrokes, deliberately, and the same shape ``/team <name>`` has: the
+    first Enter acts on the open list (the name is a ROW, and acting on the
+    highlighted row is what Enter means while a list is up), the second submits
+    the buffer. Sending on the first would make the list unusable for its main
+    purpose \u2014 choosing a skill and then typing the request.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _submit(app, pilot, "$research")
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        assert editor.text == "$research "
+        assert session.prompts == []
+        await pilot.press("enter")
+        await _await_prompt(pilot, session)
+    assert "Read primary sources." in session.prompts[0]
+
+
+@pytest.mark.asyncio
+async def test_hidden_skill_is_invocable_by_name(skill_root) -> None:
+    """`hide` blocks semantic routing, not a user naming it outright."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _submit(app, pilot, "$secret-audit check the repo")
+        await _await_prompt(pilot, session)
+    assert "Scan for secrets." in session.prompts[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    ["$100 for the redesign", "$unknown do the thing", "just a normal message"],
+)
+async def test_non_invocations_are_sent_verbatim(skill_root, text) -> None:
+    """The money guard: an unmatched `$` token is prose and is not rewritten."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _submit(app, pilot, text)
+        await _await_prompt(pilot, session)
+    assert session.prompts == [text]
+
+
+@pytest.mark.asyncio
+async def test_picker_opens_on_the_sigil_and_lists_skills(skill_root) -> None:
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await pilot.press("dollar_sign")
+        for _ in range(50):
+            await pilot.pause()
+            if editor.picker.is_open():
+                break
+        assert editor.picker.mode is PickerMode.SKILL
+        names = [name for name, _ in editor.picker._matches]
+        assert "research" in names
+        # Hidden skills are offered: a name you can type but cannot see is a
+        # worse secret than a listed one.
+        assert "secret-audit" in names
+
+
+@pytest.mark.asyncio
+async def test_picker_closes_once_the_request_starts(skill_root) -> None:
+    """Word phase only — the terminating space hands over to the request."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        editor.load_text("$research ")
+        editor.move_cursor(editor._end_of_buffer())
+        await pilot.pause()
+        assert not editor.picker.is_open()
+
+
+@pytest.mark.asyncio
+async def test_enter_on_a_skill_row_completes_without_submitting(skill_root) -> None:
+    """A completed `$skill ` opens a prompt; it is not itself a runnable thing."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        editor.load_text("$resea")
+        editor.move_cursor(editor._end_of_buffer())
+        await pilot.pause()
+        for _ in range(50):
+            await pilot.pause()
+            if editor.picker.is_open():
+                break
+        await pilot.press("enter")
+        await pilot.pause()
+        assert editor.text == "$research "
+        assert session.prompts == []
+
+
+class TestSkillTokenParser:
+    """The pure parse, independent of any app."""
+
+    def test_bare_sigil_is_an_empty_query(self):
+        token = skill_token("$")
+        assert token is not None and token.query == ""
+
+    def test_partial_name(self):
+        token = skill_token("$res")
+        assert token is not None and token.query == "res"
+
+    def test_space_closes_the_token(self):
+        assert skill_token("$research go") is None
+
+    def test_only_at_the_buffer_start(self):
+        """Mid-draft `$` is money or a shell variable, never an invocation."""
+        assert skill_token("a $research") is None
+        assert skill_token("costs $5") is None
+
+    def test_caret_outside_the_token_closes_it(self):
+        assert skill_token("$research go", 11) is None
+
+    def test_completion_adds_the_terminating_space(self):
+        assert completion_for("$res", 4, CompletionMode.SKILL, "research", ()) == (
+            "$research ",
+            10,
+        )
+
+    def test_completion_preserves_a_following_request(self):
+        result = completion_for("$res fix bug", 4, CompletionMode.SKILL, "research", ())
+        assert result is not None
+        assert result[0] == "$research fix bug"


### PR DESCRIPTION
# PR Description

## Summary of Changes

Adds **manual skill invocation** to the TUI composer. Semantic routing decides which skills a turn *probably* needs; there was no way to say which one it *definitely* needs.

`$research fix the login bug` loads that skill's `SKILL.md` and sends it with the request. Typing `$` opens a picker of skill names and descriptions; Tab or Enter completes to `$research ` and waits for the request.

`$` follows the convention Codex established for the same gesture, and the composer grammar had it free — only `/` (slash commands) and `!` (bang-mode shell) were claimed.

Three properties carry the feature:

- **Deterministic.** The body is injected into the message, not suggested as a `read skill://` the model may skip. Manual invocation the model can decline is a hint, not an invocation.
- **Hidden skills become reachable.** `hide` / `disable-model-invocation` excludes a skill from routing on purpose; until now that also made it reachable only if the agent happened to read its URL. Naming it is exactly the "never auto-select, let me fire it deliberately" case the flag describes.
- **The frozen block is untouched.** Selection is frozen per session for prompt-cache warmth and re-opens only on compaction. Injecting at the *message* level rides the volatile tail that changes every turn anyway, so an invocation costs nothing in cache warmth on the turns around it.

The recognition rule is narrow because `$` is also money: a token is an invocation only as the buffer's **first** token **and** only when it matches a **discovered skill name**. `$100 for the redesign` matches nothing and is sent verbatim, as is any unknown `$word`. The vocabulary is the guard, which removes the need for an escape rule.

### Commits

1. **`feat(tui): invoke skills by name with a $skill composer prefix`** — the feature.
2. **`fix(tui): carry the typed line through every path that hands text back`** — fixes for six defects found in independent review of the first commit (detailed under *Impact*).

## Related Issue(s)

- Related: none — this came from a direct feature request.

## Impact

**No breaking changes. No dependency updates.**

`_submit_prompt` gains an optional `sent` parameter that splits what the transcript **shows** from what the model **receives**. `sent=None` (every pre-existing caller) means the two are the same string, which is the property the echo registry depends on everywhere else.

The riskiest part of this change was threading that split correctly, and the first commit got it wrong in four places — every path that *hands text back* rather than *sends*. All are fixed in the second commit, each pinned by a test driven through the real call site:

| Defect | Symptom |
|---|---|
| Esc-recall of a queued steer | You typed 26 chars, pressed the "give me my words back" key, and got 305 chars of skill body to delete by hand |
| `/reload` during a compaction hold | Same data loss, different key |
| Compaction resume | `resolve_markers` orders images by citation *position*, so a `[Image #N]` in a skill body **silently sent the model the wrong screenshot** |
| Transcript replay | A resumed session showed the whole `SKILL.md` as the user's row — and since the session picker titles a conversation from its first user turn, named every skill-invoked thread *"The user invoked the `research` skill…"* |

Replay parity is restored by carrying the typed line in the payload's own opening tag (`invocation="…"`, escaped). Storing it *inside* the message rather than beside it means there is no parallel record that can disagree with the message it describes — the same live/replay parity rule as the loop-prompt skip directly above it.

Also fixed from review: an empty `SKILL.md` sent the raw line as prose with no signal (the user believes the skill fired); an indented `  $research` expanded but offered no picker; and `invocation_name` was dead code duplicating the grammar `skill_token` implements.

**One shared-code fix worth a reviewer's eye:** `CommandPicker.set_choices` re-derived rows only in `ARGUMENT` mode, so an app-pushed set landed a tick after the keystroke and a bare `$` painted nothing. It now re-applies for both app-filled modes and uses the **current** mode rather than a hardcoded `ARGUMENT` — passing the wrong one reads as a mode change and would reset the highlight, window and Esc latch on every fill. This is a latent trap for the existing argument lists, not just the new one. Verified not to regress `/theme`'s live-preview seeding (highlight lands on the current theme's row, not row 0), `/model`, `/login`, `/team` or `/mcp`.

**One deliberate behaviour change to flag:** `/skills` now lists hidden skills, tagged. That filter was right when `hide` meant the user could not reach them either; now a hidden skill is reachable *only* by being typed, so the command that lists skills was concealing exactly the entries its reader most needs.

**Scope is the TUI composer only** — `lop exec` and other prompt entry points do not recognise `$`.

## Testing Details

**Full suite: 10,318 passed, 15 skipped, 0 failures.** All four gates green (`flake8`, `black --check`, `isort --check`, `pyright` — 0 errors).

**57 new tests** across `tests/unit/skills/test_invoke.py` (parser) and `tests/unit/tui/test_skill_invocation.py` (integration).

Scenarios validated:

- **Money guard** — `$100 for the redesign`, `$5/unit`, `$PATH`, `${HOME}/bin`, `$`, `$ research`, `$researchfoo`, `prefix $research`, and any unknown `$word` are all sent verbatim.
- **Positive path** — bare `$research`, case-insensitivity resolving to the original discovery name, hyphen/dot/underscore names, multi-line drafts, indented drafts, and prefix-of-a-real-skill (`$res` resolves `res`, not `research`).
- **Transcript vs payload** — the row shows the typed line; the body never enters the ledger.
- **Every hand-back path** — Esc-recall, `/reload` during a hold, compaction resume image ordering, and replay.
- **Hostile drafts round-trip** through the `invocation` attribute (quotes, `<`/`>`, `&`, newlines), including a skill body that *documents this feature* and so contains a fake tag.
- **Empty/frontmatter-only `SKILL.md`** warns instead of silently sending prose.
- **Picker interactions** — Escape then re-open, arrow keys, backspacing out, non-first-position `$`, bang mode, and the empty-vocabulary notice.

**Mutation-verified:** reverting any one of the six fixes fails exactly one test. This mattered — two of my first regression tests asserted the helpers rather than the call sites and passed with the fix reverted; they were rewritten to drive the real paths.

**Exercised the real path, not just the suite:** drove the actual `OperatorApp` against a real skill on disk with keystrokes. Typing `$` offered it, Tab completed to `$demo-brief `, the sentinel body and the request both reached the session, the transcript row held neither, a `hide: true` skill rendered with its tag, and a replayed session repainted the typed line.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.

### Notes for the reviewer

Two decisions that are defensible either way, flagged rather than buried:

1. **Bare `$research` takes two Enters** — the first completes the highlighted row, the second sends. This matches `/team <name>`; sending on the first would make the picker unusable for its main purpose (choose a skill, then type the request).
2. **Docs** — `/help` gains a `$<skill>` row (a composer grammar cannot appear in the slash table, and nothing else advertises it; measured at 62 cells against that block's documented 74-cell ceiling), `/skills` names the gesture in its header, and README covers it in both the skills section and the keys list.
