### PR TITLE
feat(model): stale-while-revalidate catalogue and first-party-free pricing via models.dev

### DIFF
--- a/docs/design/model-catalogue-freshness.md
+++ b/docs/design/model-catalogue-freshness.md
@@ -1,0 +1,592 @@
+# Model catalogue freshness and provider-neutral pricing — design
+
+Status: proposal for one coder PR. Author: architect (lopdev team), 2026-09-01.
+Scope was extended twice mid-design by the manager; the final scope is:
+
+1. A model released today is offered today by `/model` and priced today by
+   the status band, while repeated queries stay at disk speed.
+2. Direct-provider prices stop depending on OpenRouter: a user signed in only
+   to Anthropic gets correct price analytics for `claude-fable-5-1`.
+3. `DiscoveredModel` learns `cache_write_price`.
+
+Everything below cites the working tree at `origin/main` as of today.
+
+---
+
+## 1. The problem as found
+
+### 1.1 One 24h TTL, one synchronous miss path, no user-driven refresh
+
+`catalogue.cached_listing` (`local_operator/model/catalogue.py:316-376`) has
+exactly three behaviours: age < `DEFAULT_TTL_S` (24h, `:64`) → serve from disk;
+otherwise → **synchronous** fetch under a cross-process lease, rewrite, serve;
+fetch failure → serve the stale document. There is no "serve stale AND refresh"
+state, so the only way to get a newer document is to wait for the TTL or delete
+the file.
+
+Every consumer goes through `discovery.available_models` (`discovery.py:1141`)
+→ `_available_models` (`:1190`) → `cached_listing` (`:1268`), and every
+consumer uses the default TTL:
+
+| Caller | Path | Budget | TTL passed |
+|---|---|---|---|
+| `configure._info_from_discovery` (`configure.py:918`) | session boot and, via `refresh_model_info_background`, the TUI cost poll off-loop | `DEFAULT_TIMEOUT_S`=10s blocking / `_REFRESH_TIMEOUT_S`=2s non-blocking (`:1284`) | default |
+| `configure._from_aggregator_catalogue` (`:1140`) | same resolution, leg 2 | `_AGGREGATOR_TIMEOUT_S`=3s within `_remaining_budget` (`:1139`) | default |
+| `controller.live_catalogue` (`controller.py:1049`) | `/model` picker worker, `asyncio.to_thread` per provider (`:1090`) | none beyond discovery's 10s per provider | **`ttl_s` is accepted (`:1050`) but the only caller, `tui/app.py:13655`, never passes it** |
+
+So `/model` paints the static registry, runs `_refresh_catalogue`
+(`app.py:13650`) and gets a 24h-cached answer. There is no `/model refresh`,
+no `r` key, no CLI command (`grep -n "models" local_operator/cli.py` finds
+nothing relevant). Today's incident followed exactly: `anthropic.listing.json`
+was 22h old with 10 models; `/model` did not show `claude-fable-5-1`.
+
+### 1.2 Prices for direct providers come from OpenRouter, and the same TTL
+
+Anthropic's `/v1/models` carries no prices (verified: keys are `id`,
+`display_name`, `created_at`, `max_input_tokens`, `max_tokens`,
+`capabilities`, `type`); OpenAI's and Google's listings carry none either. The
+only price source for a direct-provider id the registry has not been taught is
+`_from_aggregator_catalogue` (`configure.py:1088-1184`): it reads the keyless
+OpenRouter listing (`_AGGREGATOR_CATALOGUE = "openrouter"`, `:975`) and looks
+the id up under a per-provider namespace (`_AGGREGATOR_NAMESPACE`, `:996`).
+Today `openrouter.listing.json` was 6h old and predated OpenRouter's
+`anthropic/claude-fable-5.1` row, so `resolve_model_info("anthropic",
+"claude-fable-5-1")` returned `0.0/0.0` until the doc was force-refreshed.
+
+That leg is also structurally fragile: one third party's public listing,
+keyless *today*, with its own id spellings (`_aggregator_spellings`,
+`:1056`), gates every direct provider's cost display. The operator has ruled
+it out as the price source for direct providers.
+
+### 1.3 The write price is guessed
+
+`DiscoveredModel` (`discovery.py:149-181`) has `cache_read_price` and no write
+price. `_row_from_openai_entry` (`:396-438`) reads `pricing.input_cache_read`
+and ignores `input_cache_write`, which OpenRouter does publish (fable-5.1:
+`input_cache_write` 1.25e-5/token = $12.50/MTok). Both consumers then
+substitute the input price (`configure.py:958-959` and `:1170-1171`, whose
+comment admits the 20% understatement). The legacy `_info_from_listing`
+(`configure.py:610-621`) already reads `input_cache_write` correctly — the
+discovery path regressed it.
+
+### 1.4 The in-process memo is bucketed, not aged
+
+`resolve_model_info` memoises per `(provider, model_id, time // DEFAULT_TTL_S)`
+(`configure.py:1364`). A document refreshed on disk mid-bucket is not seen by
+this process until 00:00 UTC. That is documented and acceptable for *drift*
+(`:1340-1350`), but it means a *new id* must be refetched inside the memoised
+body on its first resolution, or the session runs unpriced all day. This is why
+the "miss" trigger (§3.4) has to live inside `_resolve_model_info_cached`, not
+beside it.
+
+---
+
+## 2. Options evaluated
+
+Costs are stated per session start (SS), boot/paint latency (L), staleness
+bound (S), offline (O), thundering herd (H), code footprint (F).
+
+| # | Option | SS network | L | S | O | H | F | Verdict |
+|---|---|---|---|---|---|---|---|---|
+| 1 | Shorter TTL only (1h) | 1 fetch/provider/hour, **synchronous on the boot path** | up to 10s per provider once an hour; the `_REFRESH_TIMEOUT_S` paint leg would hit its 2s cap hourly | 1h | fine (stale on failure) | lease covers | tiny | **Reject.** Moves the pain onto the path that must be cheap. |
+| 2 | Stale-while-revalidate (soft/hard TTL) | 0 on the calling path; 1 background fetch/provider/soft-TTL | disk speed whenever a document exists | soft TTL for the *next* call; this process's memo bucket still pins (§1.4) | unchanged: hard TTL keeps stale-beats-absent | lease + per-process in-flight set | moderate (catalogue.py only) | **Adopt** for boot/paint paths. |
+| 3 | Explicit refresh: picker passes a short TTL | 0 at boot; 1 fetch/provider/15min *only when the user opens `/model`* | none on boot; picker already paints static rows first and fetches off-loop (`app.py:13636-13648`, `controller.py:1090`) | 15 min for the picker | picker shows "no live list" | lease covers | **one argument** at `app.py:13655` | **Adopt.** Fixes the reported incident by itself. |
+| 4 | Event-driven: refetch on a requested-id miss | 1 fetch per *new id* per document, rate-limited by document age | bounded by the caller's existing budget (`_remaining_budget`) | same day for the id the user actually asked for | fails → registry template, as today | lease covers; a young document is believed, so a typo cannot loop | small (discovery + configure) | **Adopt.** The only option that beats the memo bucket for a brand-new id. |
+| 5 | Per-provider TTLs | fewer fetches for first-party | none | worse for first-party (the ones that matter) | — | — | small but a second knob | **Reject.** With SWR a background fetch per provider per hour is already cheap; distinguishing classes buys nothing measurable and every class needs "today". |
+
+Recommendation: **2 + 3 + 4 together**, one mechanism each, no per-provider
+TTLs, no new user command in this PR.
+
+---
+
+## 3. Recommended design
+
+### 3.1 `catalogue.py`: stale-while-revalidate with soft/hard TTL
+
+Add alongside `DEFAULT_TTL_S` (keep its name and value — it is the memo bucket
+in `configure.py:1364,1424` and the hard TTL):
+
+```python
+#: Age past which a served document is ALSO refreshed in the background. An
+#: hour bounds "released today, offered today" for the next call without
+#: putting a request on the calling path; below it a listing endpoint would be
+#: asked repeatedly for information that changes on the order of days.
+SOFT_TTL_S = 60 * 60
+#: A document younger than this that lacks a requested id is believed: the id
+#: is genuinely unknown, not newly released. Bounds the miss-triggered refetch
+#: (see discovery.available_models(want_id=...)) so a typo cannot refetch on
+#: every resolution.
+MISS_REFETCH_MIN_AGE_S = 10 * 60
+#: Per-process floor between background attempts on one key, so an offline
+#: machine does not spawn a thread every time a stale document is served.
+REVALIDATE_BACKOFF_S = 5 * 60
+```
+
+Introduce a result type and a richer reader; keep `cached_listing` as a thin
+wrapper so its 20+ existing tests and both callers keep working unchanged:
+
+```python
+@dataclasses.dataclass(frozen=True)
+class Listing:
+    payload: dict[str, Any] | None
+    age_s: float            # inf when absent
+    fetched: bool           # a live fetch produced this payload on THIS call
+    refreshing: bool        # a background revalidation was scheduled by this call
+
+def read_listing(key, fetch, *, soft_ttl_s=SOFT_TTL_S, ttl_s=DEFAULT_TTL_S,
+                 cache_dir=None) -> Listing: ...
+
+def cached_listing(key, fetch, *, ttl_s=DEFAULT_TTL_S, cache_dir=None):
+    return read_listing(key, fetch, ttl_s=ttl_s, soft_ttl_s=ttl_s, cache_dir=cache_dir).payload
+```
+
+State machine in `read_listing` (replaces `catalogue.py:343-376`):
+
+1. `age < soft_ttl_s` → serve, no I/O beyond the read.
+2. `soft_ttl_s <= age < ttl_s` → serve **immediately**, then
+   `_schedule_revalidate(key, fetch, cache_dir)`.
+3. `age >= ttl_s` or missing → today's synchronous lease path, unchanged
+   (`:349-376`). The `fetched` flag replaces the `nonlocal fetched` trick in
+   `discovery.py:1229-1246`, which can then be deleted.
+
+`_schedule_revalidate`:
+
+- Per-process dedupe: module-level `_revalidating: set[str]` and
+  `_last_attempt: dict[str, float]` under one `threading.Lock`; return
+  without a thread if the key is in flight or attempted within
+  `REVALIDATE_BACKOFF_S`.
+- Thread body: `lease = _ListingFetchLease(path)`; if `acquire()` is False,
+  **return** (a peer is fetching; unlike the sync path there is nothing to wait
+  for). Else `fetch()` → `_write_cache` → `release()`, any exception logged at
+  debug, `finally` clears the in-flight entry. `daemon=True`, named
+  `catalogue-revalidate:<key>`. A daemon thread killed by process exit leaves
+  a lease that lapses in `_LISTING_LEASE_S` (60s, `:221`) — the existing
+  crash contract, no new state.
+- Plain `threading.Thread`, not the asyncio loop: `catalogue.py` is
+  synchronous and is entered from the CLI, the server, `asyncio.to_thread`
+  workers and `run_in_executor` threads (`configure.py:1478`). The existing
+  precedent for "fire and forget off the calling path" is
+  `refresh_model_info_background` (`configure.py:1431`); this is the same
+  shape one layer down.
+
+`fetch` thunks capture the caller's `client` and credentials
+(`discovery.py:1233-1250`); running one in a thread is safe because
+`fetch_models` opens and closes its own `httpx.Client` when none is passed
+(`discovery.py:862`). The tests' `_StubClient` is passed explicitly and is
+single-threaded; tests that exercise the background path must join the thread
+(§5).
+
+**Conditional GET support (in scope, small).** Add
+`peek_listing(key, cache_dir=None) -> Listing` (read-only, no fetch, no
+sweep). A fetch thunk that wants `If-None-Match` reads the previous payload's
+`etag` through it and, on 304, returns the previous payload unchanged;
+`_write_cache` re-stamps `fetched_at`, which is exactly "validated just now".
+No change to `read_listing`'s signature. Used by the price catalogue (§3.5);
+verified live: models.dev answers `304` with 0 bytes to a matching
+`If-None-Match` (ETag `"2afcb862…"`).
+
+### 3.2 `discovery.py`: statuses, `want_id`, `cache_write_price`
+
+**Statuses.** Extend `ListingStatus` (`:145`) to
+`"ok" | "cached" | "stale" | "static" | "unauthenticated" | "empty"`:
+
+- `"ok"` — fetched live on this call (unchanged).
+- `"cached"` — served from disk, no fetch attempted or needed (age < TTL).
+- `"stale"` (new) — a fetch was attempted and failed; the document on disk is
+  what you got. Today both collapse into `"cached"` (`:1308-1309`), which is
+  why the picker footer cannot tell "fresh enough" from "offline".
+  `tui/app.py:19960` already tests for a status `"unavailable"` that no code
+  emits — that dead branch becomes the `"stale"` branch.
+
+`_available_models` computes them from `Listing.fetched` and from whether the
+thunk raised (`_ListingUnavailable` is still how the thunk reports failure,
+`:186`). The `fetched` nonlocal (`:1229`) goes away.
+
+**`want_id` (option 4).** Add `want_id: str | None = None` to
+`available_models`/`_available_models`. After mapping rows (`:1269`), if
+`want_id` is set, no row's id matches it exactly *or* after the same
+normalisation `_info_from_discovery` applies (`configure._normalised_id`,
+`:868` — move the helper to discovery or import it lazily; it is pure), the
+listing was **not** fetched on this call, and `listing.age_s >=
+MISS_REFETCH_MIN_AGE_S`: call `read_listing(..., ttl_s=0, soft_ttl_s=0)` once
+(sync, under the lease, within the caller's `timeout` — which is the caller's
+remaining budget, see §3.3) and re-map. Status becomes `"ok"` or `"stale"`
+accordingly. One retry, never a loop: the refetched document is 0s old, so a
+second miss for the same id in the same process is believed for ten minutes.
+
+**`cache_write_price`.** Add `cache_write_price: float = 0.0` to
+`DiscoveredModel` after `cache_read_price` (`:180`), and thread it through:
+
+- `_row_from_openai_entry` (`:415-437`): `_per_million(pricing.get("input_cache_write"))`.
+  Ignore `input_cache_write_1h`.
+- `_from_static` (`:945`): `_positive_float(info.cache_writes_price)`.
+- `_merge_one` (`:1006`): live-or-static, same rule as `cache_read_price`.
+- `_rows_from_payload` (`:1129`): `_positive_float(entry.get("cache_write_price"))`.
+- `LISTING_CAPTURE_VERSIONS` (`:118`): `{"anthropic": 2, "openrouter": 2,
+  "radient": 2}` with a docstring line per bump. The stamp is per provider id
+  (`listing_capture_version`, `:125`), so only the two OpenAI-compat
+  aggregators that quote a write price pay the one-time refetch. A version-1
+  document parses to rows with `cache_write_price=0`, which is harmless, but
+  without the bump the fix would be invisible for a day on every install — the
+  same argument as `:110-117`.
+
+**xAI first-party prices (best-effort, optional in this PR).** xAI documents
+`GET /v1/language-models` returning `prompt_text_token_price`,
+`completion_text_token_price`, `cached_prompt_text_token_price` in USD cents
+per 100M tokens (÷ 10 000 → $/MTok). The manager's OAuth credential gets 403
+on it, so it is API-key only. Design: a provider-keyed override table
+`_PROVIDER_TRANSPORTS = {"xai": _fetch_xai}` consulted before
+`_WIRE_TRANSPORTS` in `_build_transports` (`:793-808`); `_fetch_xai` tries the
+priced endpoint and on any non-200 falls back to `_fetch_openai_compat`
+unchanged. Bump `LISTING_CAPTURE_VERSIONS["xai"]`. **Defer to a follow-up PR
+unless the coder has an xAI API key to prove the conversion against a real
+response** — models.dev covers 7/12 xAI models today, and a guessed unit
+factor on a price field is worse than no field.
+
+### 3.3 `configure.py`: resolution legs and budgets
+
+`_resolve_model_info_cached` (`:1241-1311`) becomes:
+
+```
+info = _registry_fallback(...)                                   # unchanged
+if _listing_can_correct(info):
+    info = _info_from_discovery(..., want_id=model_id, timeout=…)  # leg 1: provider listing
+if _needs_enrichment(info):
+    info = _from_price_catalogue(canonical, model_id, info, timeout=_remaining_budget(started))  # leg 2: models.dev (NEW)
+if _needs_enrichment(info) and canonical in AGGREGATOR_PROVIDERS:
+    info = _from_aggregator_catalogue(...)                        # leg 3: only for aggregator ids
+```
+
+Precedence stays "fill the holes" (`_from_aggregator_catalogue` only writes
+where `not (info.input_price or info.output_price)`, `:1159`; same for the
+window `:1172` and `max_tokens` `:1182`). A registry price is a first-hand
+transcription and is not overridden by the catalogue in this PR; a
+`prices_from_catalogue` flag mirroring `limits_from_listing`
+(`configure.py:677-701`) would let the catalogue correct it and is deferred.
+
+`_info_from_discovery` (`:886`): pass `want_id=model_name` through to
+`available_models`; take `cache_writes_price` from `row.cache_write_price`
+when `> 0`, else keep the input-price fallback at `:958-959` (now only for
+listings that genuinely quote no write price).
+
+`_from_aggregator_catalogue` (`:1088`): gate on `provider in
+AGGREGATOR_PROVIDERS` (it is the `openrouter/*` and `radient/*` ids' own
+listing, so leg 1 has normally already priced them; this leg survives only for
+the case where leg 1 was unavailable). Delete `_AGGREGATOR_NAMESPACE` (`:996`)
+and `_aggregator_spellings` (`:1056`) — their only purpose was direct-provider
+lookup. Their spelling rules (`_DOTTED_VERSION_RE`, `:1017`) move to the
+price-catalogue lookup, which needs them for the same reason (`gpt-5.4` vs
+`gpt-5-4`). Existing tests that assert direct providers price via OpenRouter
+(`tests/unit/model/test_configure.py`, the `_from_aggregator_catalogue`
+cases) are re-pointed at `_from_price_catalogue` with the same fixtures
+reshaped to the models.dev projection.
+
+Budgets are unchanged in kind: leg 2 caps at
+`_PRICE_CATALOGUE_TIMEOUT_S = _AGGREGATOR_TIMEOUT_S = 3.0` inside
+`_remaining_budget(started)` — the same "one ceiling for the whole
+resolution" rule documented at `:1028-1050`. Leg 3 shares that remainder. The
+paint path is unaffected: `tui/costs.py:51-61` only ever reads
+`_paint_memo` on-loop and runs the full resolver via
+`refresh_model_info_background` in an executor thread.
+
+The `want_id` miss refetch on leg 1 runs inside the same `timeout` the leg
+already has (10s blocking at boot when the registry cannot describe the model
+— the user is watching a spinner for exactly this; 2s when only correcting a
+complete row, in which case a miss is not possible because the registry row
+*is* the answer).
+
+### 3.4 Freshness triggers, summarised
+
+| Trigger | Where | Mechanism | Bound |
+|---|---|---|---|
+| Any read of a document older than 1h | `read_listing` | background thread, lease, backoff | 0 on the calling path; ≤1 fetch/key/hour/process |
+| `/model` opened | `app.py:13655` → `live_catalogue(ttl_s=PICKER_TTL_S)` | existing sync fetch off-loop, lease | ≤1 fetch/provider/15 min, only when the user asks |
+| Requested id absent from a cached document ≥10 min old | `available_models(want_id=…)` | one sync refetch within the caller's remaining budget, lease | ≤1 refetch per key per 10 min, regardless of how many ids miss |
+| Capture version bump | `_rows_from_payload` (`:1080`) | existing invalidate+re-enter (`:1270-1289`) | once per upgrade |
+
+`PICKER_TTL_S = 15 * 60` lives in `providers/controller.py` beside
+`live_catalogue`: "the user is asking now; fifteen minutes is short enough
+that a release announced during a working session shows on the next open, and
+long enough that scrolling in and out of the picker does not re-list nine
+providers."
+
+### 3.5 Provider-neutral price catalogue: models.dev
+
+New module `local_operator/model/prices.py` (the manager asked for the document
+to go through the same machinery; a separate module keeps the 1,300-line
+`discovery.py` from growing a fourth transport that is not a provider).
+
+**Source.** `https://models.dev/api.json`: public, keyless, 4.44 MB, weak
+ETag, `cache-control: max-age=0, must-revalidate`, honours `If-None-Match`
+with a 304. Provider-keyed; each model carries `cost {input, output,
+cache_read, cache_write}` in $/MTok, `limit {context, output}`, `name`,
+`attachment`, `reasoning`, `tool_call`, `release_date`. Verified today:
+`anthropic.models["claude-fable-5-1"]` → cost 10/50/0.25/12.5, limit
+1,000,000/128,000, `release_date` 2026-09-01. Coverage for our providers
+(priced/total): anthropic 14/14, openai 43/47, xai 7/12, deepseek 3/3, zai
+16/16, google 33/38, mistral 32/34, moonshotai 10/10, alibaba 55/55,
+alibaba-token-plan 26/26, openrouter 349/353. **radient is absent** — its own
+listing quotes prices, so leg 1 covers it.
+
+**Document.** Key `models-dev.listing` → `~/.local-operator/cache/models-dev.listing.json`
+(ends in `.listing`, so `_LEGACY_DOCUMENT_GLOB` cannot match it,
+`catalogue.py:77`). Store a **projection**, not the 4.4 MB body:
+
+```json
+{"capture": 1, "etag": "\"2afcb…\"",
+ "providers": {"anthropic": {"claude-fable-5-1": {"name": …, "cost": {...}, "limit": {...}, "attachment": true, "release_date": "2026-09-01"}}, …}}
+```
+
+Measured: the projection over the 13 provider keys we map is **141 KB** — ~30x
+smaller than the source and a quarter of `openrouter.listing.json`, so the
+25 ms JSON parse the memo exists to avoid (`configure.py:1338`) stays in that
+range. Only providers in `_PRICE_CATALOGUE_KEYS` are kept.
+
+**Key map** (`_PRICE_CATALOGUE_KEYS: dict[str, tuple[str, ...]]`, first match
+wins; the local id is the *canonical* provider after
+`credential_provider_id`, so `xai-oauth`/`openai-device` need no entry):
+
+```
+anthropic → ("anthropic",)      openai → ("openai",)         google → ("google",)
+xai → ("xai",)                  deepseek → ("deepseek",)     mistral → ("mistral",)
+kimi → ("moonshotai", "kimi-for-coding")    zai → ("zai", "zai-coding-plan")
+alibaba → ("alibaba",)          alibaba-token-plan → ("alibaba-token-plan", "alibaba")
+openrouter → ("openrouter",)
+```
+
+**Lookup.** `price_catalogue_row(provider, model_id, *, timeout) ->
+DiscoveredModel | None`: `read_listing("models-dev.listing", fetch,
+...)`, then for each mapped key try the id exactly, then
+`_normalised_id`, then the dotted/dashed spellings that `_aggregator_spellings`
+produces today. Returns a `DiscoveredModel` (so `cache_write_price`, window and
+`max_tokens` ride the same struct the other legs use) with
+`supports_prompt_cache = cache_read > 0`, `supports_images` from
+`attachment`... **no**: `supports_images` is deliberately not taken from a
+second-hand source (`configure.py:1116-1118` states the three-valued
+contract); leave it `None`.
+
+**Fetch thunk.** `httpx.get(URL, headers={"If-None-Match": prev_etag} if
+prev_etag else {}, timeout=timeout)`; 304 → return the previous payload
+(read via `peek_listing`); 200 → project and stamp the new ETag; anything
+else → raise (`read_listing` turns that into stale-beats-absent).
+`want_id` miss semantics apply exactly as in §3.2: a direct-provider id
+absent from a document ≥10 min old triggers one refetch — which for models.dev
+is usually a 0-byte 304 unless the row really did just land.
+
+**Cold start.** The very first resolution on a machine with no document pays
+one 4.4 MB download inside the 3s leg budget. On a slow link that times out
+and the session runs unpriced until the next resolution — so on a cold miss
+that times out, `read_listing` additionally schedules a background fetch with
+the full `DEFAULT_TIMEOUT_S` (the one case where a failed sync fetch is
+followed by a background retry: a timeout on a large body is evidence the
+budget was too small, not that the network is down). Every later start is a
+141 KB read and, hourly, a 304.
+
+### 3.6 Picker: what the user sees
+
+`_populate_model_picker` (`app.py:13622`) is unchanged: static rows paint on
+the keystroke with the footer clause `checking providers…`.
+`_refresh_catalogue` (`:13650`) calls `live_catalogue(ttl_s=PICKER_TTL_S)`.
+`_catalogue_status` (`:19946`) becomes:
+
+- `"cached"` → **silent**. With a 15-minute picker TTL "cached" means "listed
+  within the last quarter hour", which is not something the user needs to
+  read; the existing docstring's "a footer that always says something is a
+  footer nobody reads" applies.
+- `"stale"` → `live list unavailable: anthropic, xai — showing cached`.
+- `"empty"` → `no live list: …` (unchanged).
+
+Nothing new animates; the widget API (`ModelPicker.set_rows`,
+`model_picker.py:312`) is untouched. This footer wording is a user-visible
+string change and needs the designer round with before/after stills of the
+open picker in the `stale` state (use `FakeProviderController.live_catalogue`
+in `tests/unit/tui/test_app_pilot.py:3672` to force statuses, then
+`app.save_screenshot`).
+
+**Deferred:** a `/model refresh` argument (or `r` in the picker, mirroring
+`/usage`'s `force_refresh`, `app.py:15089-15123`) that calls
+`live_catalogue(ttl_s=0)`. Cheap, but it is a new interaction and would add a
+UX round to this PR; the 15-minute TTL already covers the incident.
+
+---
+
+## 4. Concurrency story
+
+- **Cross-process**: `_ListingFetchLease` (`catalogue.py:229`) unchanged and
+  reused by all three fetch paths. Background revalidators that lose the lease
+  simply exit; sync fetchers that lose it keep today's brief wait
+  (`await_peer_briefly`, `:283`).
+- **In-process**: one in-flight set per key for background work; the
+  miss-refetch and the picker's sync fetch both go through the lease, so two
+  threads in one process (the picker worker and a `refresh_model_info_background`
+  executor) resolving the same provider at once produce one request.
+- **Write safety**: `_write_cache` (`:148`) is already mkstemp+rename; the
+  background writer adds nothing new.
+- **Memo**: `_resolve_model_info_cached`'s bucket is unchanged. The new-id
+  case is handled *inside* the memoised body by `want_id`, so the memo caches
+  the fresh answer. `invalidate_model_info_cache` (`:1314`) is untouched.
+
+---
+
+## 5. Test plan
+
+Conventions: `tests/unit/model/test_catalogue.py` uses `tmp_path` cache dirs
+and a `calls` list in the thunk; `test_discovery.py` uses `_StubClient` /
+`_Response` and `cache_dir=tmp_path`; AGENTS.md "Timing" forbids clock waits
+— join threads or wait on the document's existence, never `sleep`.
+
+`test_catalogue.py`
+
+- `test_a_document_between_soft_and_hard_ttl_is_served_and_revalidated_in_the_background`
+  — plant `fetched_at = now - 2h`; `read_listing` returns the old payload
+  with `refreshing=True` and zero sync calls; join `catalogue._revalidation_threads()`
+  (expose a test hook that returns live threads) and assert the file now holds
+  the new payload.
+- `test_a_document_under_the_soft_ttl_schedules_nothing`.
+- `test_a_document_past_the_hard_ttl_still_fetches_synchronously` (guards the
+  offline/cold contract; extends `test_an_expired_cache_refetches`).
+- `test_a_background_revalidation_that_loses_the_lease_exits_without_fetching`
+  — plant an unexpired `.fetching` file.
+- `test_a_failed_background_revalidation_keeps_the_stale_document_and_backs_off`
+  — thunk raises; second `read_listing` within `REVALIDATE_BACKOFF_S` spawns
+  no thread (assert via the hook, not timing).
+- `test_two_reads_in_one_process_spawn_one_revalidation`.
+- `test_cached_listing_is_unchanged_for_existing_callers` — existing tests
+  already prove this; add one asserting `cached_listing` never schedules a
+  thread (its soft TTL equals its hard TTL).
+- `test_peek_listing_reads_without_sweeping_or_fetching`.
+- `test_a_background_thread_runs_off_the_calling_thread` — structural
+  `threading.get_ident()` spy, per AGENTS.md.
+
+`test_discovery.py`
+
+- `test_available_models_reports_stale_when_a_refetch_fails` (split from
+  `test_available_models_reports_cached_when_a_stale_refetch_fails`, `:1236`).
+- `test_a_missing_want_id_refetches_a_document_old_enough_to_be_wrong` — 10
+  models cached 22h ago, stub answers 19 including the id; status `"ok"`, one
+  call, row present.
+- `test_a_missing_want_id_is_believed_when_the_document_is_young` — cached
+  1 min ago, zero calls.
+- `test_a_want_id_that_is_present_makes_no_request`.
+- `test_openrouter_cache_write_price_is_read_and_scaled` (extend
+  `test_openai_compat_parses_a_captured_openrouter_payload`, `:154`, with an
+  `input_cache_write` in the fixture).
+- `test_merge_prefers_a_live_cache_write_price` / `..._keeps_the_static_one_when_live_is_zero`.
+- `test_a_cache_write_price_survives_the_disk_round_trip` (`_rows_from_payload`).
+- `test_an_openrouter_document_from_capture_one_is_refetched_once` (mirrors `:1372`).
+
+`tests/unit/model/test_prices.py` (new)
+
+- Projection: a captured models.dev fixture (trim to two providers) projects to
+  only mapped providers and the five fields; size assertion is structural (no
+  `description` key survives), not numeric.
+- `test_a_matching_etag_returns_the_previous_payload_and_restamps_it` — stub
+  304.
+- Lookup: exact id, normalised id, dotted/dashed spelling, `kimi →
+  moonshotai` then `kimi-for-coding`, unknown provider → `None`.
+- `test_supports_images_is_never_taken_from_the_price_catalogue`.
+
+`tests/unit/model/test_configure.py`
+
+- `test_a_direct_provider_is_priced_from_the_neutral_catalogue_not_openrouter`
+  — `available_models` stub for anthropic returns the row unpriced; models.dev
+  stub prices it; OpenRouter stub asserts **zero** calls.
+- `test_the_write_price_reaches_model_info` — `cache_writes_price == 12.5`,
+  not `10.0`.
+- `test_the_input_price_fallback_survives_a_listing_with_no_write_price`.
+- `test_leg_two_shares_the_resolution_budget` — extend the existing
+  `_remaining_budget` test to the new leg.
+- `test_openrouter_ids_still_fall_back_to_their_own_listing`.
+- Re-point the direct-provider `_from_aggregator_catalogue` tests as in §3.3.
+
+`tests/unit/tui`
+
+- `test_the_picker_asks_for_a_fifteen_minute_listing` — the pilot's
+  `FakeProviderController.live_catalogue(self, *, ttl_s=None)` records
+  `ttl_s`; assert `== PICKER_TTL_S`.
+- `test_model_picker.py`: footer renders `live list unavailable: …` for
+  `stale` and nothing for `cached`.
+
+Real-execution evidence for the PR (per the operator's standing rule): with
+`anthropic.listing.json` and `models-dev.listing.json` deleted, boot `lop`
+on `anthropic/claude-fable-5-1`, show the status band pricing at 10/50, show
+both documents written, `stat` their ages; then age `anthropic.listing.json`
+to 2h by editing `fetched_at`, open `/model`, capture the picker before and
+after the worker lands, and show the document's `fetched_at` advanced with
+the `.fetching` lease gone.
+
+---
+
+## 6. Constants, in one place
+
+| Name | Module | Value | Why |
+|---|---|---|---|
+| `DEFAULT_TTL_S` | catalogue | 24h (unchanged) | hard TTL; memo bucket; sync fetch beyond it keeps offline semantics |
+| `SOFT_TTL_S` | catalogue | 1h | staleness bound for the next call at zero on-path cost |
+| `MISS_REFETCH_MIN_AGE_S` | catalogue | 10 min | a young document that lacks an id is right; bounds typo refetches |
+| `REVALIDATE_BACKOFF_S` | catalogue | 5 min | one background attempt per key per five minutes while offline |
+| `PICKER_TTL_S` | controller | 15 min | the user is asking; sync fetch is already off-loop behind painted rows |
+| `_PRICE_CATALOGUE_TIMEOUT_S` | configure | 3s (= `_AGGREGATOR_TIMEOUT_S`) | same leg-2 budget rule; reachable from the executor thread of the 1 Hz poll |
+| `LISTING_CAPTURE_VERSIONS` | discovery | `anthropic 2, openrouter 2, radient 2` (+`xai 2` if the transport lands) | readers now need `cache_write_price` |
+
+---
+
+## 7. Files to touch
+
+- `local_operator/model/catalogue.py` — `Listing`, `read_listing`,
+  `peek_listing`, `_schedule_revalidate`, constants; `cached_listing` becomes
+  a wrapper. Module docstring §"WHY IT IS CACHED" gains the SWR state.
+- `local_operator/model/discovery.py` — `ListingStatus` + `"stale"`;
+  `want_id`; `cache_write_price` in five places; capture bumps; drop the
+  `fetched` nonlocal. Optional `_fetch_xai`.
+- `local_operator/model/prices.py` — new (§3.5).
+- `local_operator/model/configure.py` — leg order, `_from_price_catalogue`,
+  `want_id` pass-through, write-price plumbing, gate/prune
+  `_from_aggregator_catalogue`, delete `_AGGREGATOR_NAMESPACE` and
+  `_aggregator_spellings` (move spelling helpers to `prices.py`).
+- `local_operator/providers/controller.py` — `PICKER_TTL_S`.
+- `local_operator/tui/app.py` — `:13655` pass the TTL; `_catalogue_status`
+  wording.
+- Tests as in §5. `pyproject.toml` patch bump: this is a fix plus a
+  self-contained enrichment change, not a new surface.
+
+Rough size: ~350 lines of source, ~500 of tests. One coder, one PR.
+
+---
+
+## 8. Deferred (recorded here, not as issues)
+
+- `/model refresh` / `r` key — needs a UX round; not required for the incident.
+- xAI first-party price transport — needs a real API key to validate units.
+- `prices_from_catalogue` registry flag so models.dev can *correct* a
+  transcribed registry price, not only fill a hole.
+- Parallelising `live_catalogue`'s per-provider fetches with `gather` — turns
+  the picker's worst case from a sum of provider timeouts into a max; small,
+  independent, and reviewable on its own.
+- LiteLLM's `model_prices_and_context_window.json` as a second neutral source
+  — per-token floats under litellm-specific ids; worse fit, not needed.
+
+---
+
+## 9. Risks to watch at rollout
+
+1. **Background threads in short-lived CLI processes.** A `lop --model …`
+   that exits in under a second may kill the revalidator mid-write; mkstemp+rename
+   means the document is never half-written, and the lease lapses in 60s. Watch
+   for stranded `*.tmp` files in `~/.local-operator/cache`
+   (`_write_cache`'s `finally` should prevent them; a daemon kill bypasses
+   `finally`). If they appear, add them to the legacy purge glob.
+2. **models.dev availability / shape drift.** It is a GitHub-maintained JSON;
+   a key rename lands as "no prices" (holes stay holes), never as wrong prices.
+   `capture` stamp on the projection lets us force a refetch when the reader
+   changes. Rate: one 304 per machine per hour — negligible.
+3. **The 4.4 MB cold fetch inside a 3 s budget.** Mitigated by the cold-miss
+   background retry (§3.5). Confirm with evidence that a cold boot on a
+   throttled link ends with the document present on the *second* resolution.
+4. **Statuses**: `"stale"` is a new `Literal` member; any exhaustive match on
+   `ListingStatus` (pyright will find them) must learn it.
+5. **Removing the OpenRouter namespace lookup** changes prices for any
+   direct-provider id models.dev lacks but OpenRouter had (openai 4, xai 5,
+   google 5, mistral 2 today). Those rows fall back to the registry template —
+   the honest "cost unavailable", which is the pre-aggregator behaviour and the
+   operator's stated preference over a second coupling.

--- a/docs/design/model-catalogue-freshness.md
+++ b/docs/design/model-catalogue-freshness.md
@@ -418,11 +418,16 @@ the keystroke with the footer clause `checking providers…`.
   within the last quarter hour", which is not something the user needs to
   read; the existing docstring's "a footer that always says something is a
   footer nobody reads" applies.
-- `"stale"` → `live list unavailable: anthropic, xai — showing cached`.
+- `"stale"` → `stale list: anthropic, xai`; when every provider that produced
+  a listing is stale (offline), `stale list: all providers`. The label is
+  budgeted for the 39 cells left beside the access note at 100 columns and
+  parallels `no live list:` (design review round 1, D1/D2).
 - `"empty"` → `no live list: …` (unchanged).
 
-Nothing new animates; the widget API (`ModelPicker.set_rows`,
-`model_picker.py:312`) is untouched. This footer wording is a user-visible
+The widget API (`ModelPicker.set_rows`, `model_picker.py:312`) is untouched;
+`ModelPicker` now keeps its status row (blank) once one has painted in an
+open, so `checking providers…` clearing on settle no longer shrinks the card
+by a row and moves the transcript above it (design review round 1, D3). This footer wording is a user-visible
 string change and needs the designer round with before/after stills of the
 open picker in the `stale` state (use `FakeProviderController.live_catalogue`
 in `tests/unit/tui/test_app_pilot.py:3672` to force statuses, then
@@ -529,8 +534,8 @@ and a `calls` list in the thunk; `test_discovery.py` uses `_StubClient` /
 - `test_the_picker_asks_for_a_fifteen_minute_listing` — the pilot's
   `FakeProviderController.live_catalogue(self, *, ttl_s=None)` records
   `ttl_s`; assert `== PICKER_TTL_S`.
-- `test_model_picker.py`: footer renders `live list unavailable: …` for
-  `stale` and nothing for `cached`.
+- `test_model_picker.py`: footer renders `stale list: …` for `stale` and
+  nothing for `cached`; every-provider-stale collapses to `all providers`.
 
 Real-execution evidence for the PR (per the operator's standing rule): with
 `anthropic.listing.json` and `models-dev.listing.json` deleted, boot `lop`

--- a/docs/design/model-catalogue-freshness.md
+++ b/docs/design/model-catalogue-freshness.md
@@ -162,6 +162,19 @@ State machine in `read_listing` (replaces `catalogue.py:343-376`):
   `catalogue-revalidate:<key>`. A daemon thread killed by process exit leaves
   a lease that lapses in `_LISTING_LEASE_S` (60s, `:221`) — the existing
   crash contract, no new state.
+- *Amended in review round 1 (R1-2, R1-3, R1-5).* The thread runs a separate
+  `revalidate` thunk (defaulting to `fetch`) that carries the provider's full
+  `DEFAULT_TIMEOUT_S`, not the caller's on-path budget: a background refresh
+  that inherited a repaint's 2 s ceiling failed on every slower link, backed
+  off, and left the document to the 24 h sync path. A daemon kill mid-`json.dump`
+  *does* strand `<key>.listing.json.<random>.tmp` (§9 risk 1 confirmed), so
+  `read_listing` also sweeps such files older than five minutes
+  (`purge_stranded_temp_files`; age-gated so a peer's in-flight write is never
+  taken). And a sync reader that loses the lease to *this process's own*
+  thread (call A scheduled it, call B was declared expired by `refetch_if` a
+  moment later) joins that thread for at most `_LISTING_LEASE_WAIT_S` instead
+  of polling the document's mtime — same ceiling, but it returns the instant the
+  refresh lands *or fails*, where the poll spun the whole window on a failure.
 - Plain `threading.Thread`, not the asyncio loop: `catalogue.py` is
   synchronous and is entered from the CLI, the server, `asyncio.to_thread`
   workers and `run_in_executor` threads (`configure.py:1478`). The existing
@@ -213,6 +226,18 @@ MISS_REFETCH_MIN_AGE_S`: call `read_listing(..., ttl_s=0, soft_ttl_s=0)` once
 remaining budget, see §3.3) and re-map. Status becomes `"ok"` or `"stale"`
 accordingly. One retry, never a loop: the refetched document is 0s old, so a
 second miss for the same id in the same process is believed for ten minutes.
+
+*Amended in review round 1 (R1-1).* "Matches" must be wider than the lookup's
+exact/normalised test. Anthropic's `/v1/models` lists dated snapshots only
+(`claude-sonnet-4-5-20250929`) while the API accepts the undated alias, so the
+common configured id `claude-sonnet-4-5` was a miss against a document that
+listed its snapshot — one blocking listing fetch on **every** process start
+older than the miss floor, indefinitely, for a document the refetch could not
+improve. The trigger asks "could a refetch plausibly list this id?", so a row
+counts as present when any of its `ids.id_spellings` (as given, date-stripped,
+dotted) coincides with any of the wanted id's after normalisation, in either
+direction. A genuinely new family id (`claude-fable-5-1` against a
+`claude-sonnet-4-5-*` document) still misses and still refetches.
 
 **`cache_write_price`.** Add `cache_write_price: float = 0.0` to
 `DiscoveredModel` after `cache_read_price` (`:180`), and thread it through:
@@ -575,7 +600,9 @@ Rough size: ~350 lines of source, ~500 of tests. One coder, one PR.
    means the document is never half-written, and the lease lapses in 60s. Watch
    for stranded `*.tmp` files in `~/.local-operator/cache`
    (`_write_cache`'s `finally` should prevent them; a daemon kill bypasses
-   `finally`). If they appear, add them to the legacy purge glob.
+   `finally`). Review round 1 confirmed the daemon-kill path is reachable;
+   `purge_stranded_temp_files` now sweeps `*.listing.json.*.tmp` older than
+   five minutes on every `read_listing`.
 2. **models.dev availability / shape drift.** It is a GitHub-maintained JSON;
    a key rename lands as "no prices" (holes stay holes), never as wrong prices.
    `capture` stamp on the projection lets us force a refetch when the reader

--- a/local_operator/model/catalogue.py
+++ b/local_operator/model/catalogue.py
@@ -440,6 +440,17 @@ def _revalidation_threads() -> list[threading.Thread]:
         return [thread for thread in _threads.values() if thread.is_alive()]
 
 
+def _in_flight_revalidation(path: Path) -> threading.Thread | None:
+    """This process's live background thread for ``path``, if one is running.
+
+    Lets a synchronous reader that lost the lease tell its own thread from a
+    peer process: the former can be joined (bounded), the latter only watched.
+    """
+    with _revalidate_lock:
+        thread = _threads.get(str(path))
+    return thread if thread is not None and thread.is_alive() else None
+
+
 def _schedule_revalidate(
     key: str, fetch: Callable[[], dict[str, Any]], cache_dir: Path | None
 ) -> bool:
@@ -562,6 +573,14 @@ def read_listing(
     before either path starts means one fetch, on the calling thread, with a
     ``fetched``/``failed`` flag that means what it says.
 
+    That closes the race within ONE call; across two it can still happen (call
+    A schedules the refresh, call B is declared expired a moment later and
+    loses the lease to A's thread). B then JOINS that thread for at most
+    ``_LISTING_LEASE_WAIT_S`` and serves the document it left — a bounded wait
+    that ends the instant the refresh lands or fails, rather than the mtime
+    poll a foreign lease holder gets. Rare (two ids, one missing, resolved
+    within seconds of each other) and bounded, so the paint path stays bounded.
+
     A cross-process fetch lease guards the miss path: several lop sessions
     cold-starting together all miss in the same instant, and without the
     lease each fires its own live listing request at the same public
@@ -590,7 +609,22 @@ def read_listing(
     # stale-beats-absent rule. Every failure degrades to fetching.
     lease = _ListingFetchLease(path)
     if not lease.acquire():
-        lease.await_peer_briefly()
+        own = _in_flight_revalidation(path)
+        if own is not None:
+            # The holder is THIS process's background thread (call A served the
+            # soft-window document and scheduled it; call B, moments later, was
+            # declared expired by `refetch_if` for an id the document lacks).
+            # Joining it is strictly better than polling the document's mtime:
+            # the same ceiling, but it returns the instant the thread finishes —
+            # including when its fetch FAILED, where the poll would have spun
+            # the whole window waiting for a rename that is never coming.
+            # Serving disk without waiting was the other option, and it is
+            # wrong here: the caller's memo pins whatever this returns for the
+            # day, so an id the refresh is about to land would stay missing
+            # until midnight — the incident this trigger exists to prevent.
+            own.join(timeout=_LISTING_LEASE_WAIT_S)
+        else:
+            lease.await_peer_briefly()
         payload, age = _read_cache(path)
         if payload is not None:
             return Listing(payload=payload, age_s=age)

--- a/local_operator/model/catalogue.py
+++ b/local_operator/model/catalogue.py
@@ -469,6 +469,7 @@ def read_listing(
     ttl_s: float = DEFAULT_TTL_S,
     cache_dir: Path | None = None,
     refetch_if: Callable[[dict[str, Any], float], bool] | None = None,
+    revalidate: Callable[[], dict[str, Any]] | None = None,
 ) -> Listing:
     """A provider's ``list_models()`` payload, stale-while-revalidate.
 
@@ -479,6 +480,15 @@ def read_listing(
     client's response). ``payload`` is None only when there is no cache AND the
     fetch failed, which is the one case where the caller must keep its static
     fallbacks.
+
+    ``revalidate`` is the thunk the BACKGROUND refresh runs; it defaults to
+    ``fetch``. They differ in budget, not in what they fetch: ``fetch`` runs on
+    the calling path and carries the caller's ceiling (2 s from a repaint), while
+    the background thread is off-path and may take the provider's full default.
+    A background thunk that inherited the on-path budget failed every time on a
+    link slower than that budget, backed off five minutes, and the document only
+    ever advanced through the 24 h synchronous path — the pre-revalidation
+    behaviour, silently restored.
 
     State machine, by document age:
 
@@ -520,7 +530,7 @@ def read_listing(
         if refetch_if is None or not refetch_if(payload, age):
             refreshing = False
             if age >= soft_ttl_s:
-                refreshing = _schedule_revalidate(key, fetch, cache_dir)
+                refreshing = _schedule_revalidate(key, revalidate or fetch, cache_dir)
             return Listing(payload=payload, age_s=age, refreshing=refreshing)
         logger.debug("%s catalogue (%.0fs old) declared expired by its reader", key, age)
 

--- a/local_operator/model/catalogue.py
+++ b/local_operator/model/catalogue.py
@@ -105,6 +105,22 @@ def default_cache_dir() -> Path:
 #: and neither can match a current ``<key>.json`` whose key ends in ``.listing``.
 _LEGACY_DOCUMENT_GLOB = "*.models.json"
 
+#: A temp file :func:`_write_cache` was renaming into place when its process
+#: died. ``mkstemp`` names them ``<key>.json.<random>.tmp`` and every key this
+#: module writes ends in ``.listing``, so the pattern cannot match another
+#: writer's temp file in the shared directory (``update.py`` names its own
+#: ``pypi-local-operator.json.<random>.tmp`` there and owns that cleanup).
+_STRANDED_TEMP_GLOB = "*.listing.json.*.tmp"
+
+#: How old a stranded temp file must be before the sweep takes it. A listing
+#: write is a few milliseconds of ``json.dump`` on a ~190 KB document, so a
+#: temp file that has sat for minutes is not an in-flight write by a peer
+#: process or a sibling thread; it is a corpse. Generous rather than tight,
+#: because deleting a live temp file out from under a writer would turn its
+#: rename into a stranded document, which is the failure this sweep exists to
+#: reclaim, not to cause.
+_STRANDED_TEMP_MIN_AGE_S = 5 * 60
+
 
 def _cache_path(key: str, cache_dir: Path | None) -> Path:
     """The document for ``key``; the key is the WHOLE stem, suffix added once.
@@ -137,6 +153,39 @@ def purge_legacy_documents(cache_dir: Path | None = None) -> None:
     except OSError as exc:  # pragma: no cover - read-only or unreadable cache dir
         # Reclaiming disk is never worth failing a session start over.
         logger.debug("could not purge legacy catalogue documents: %s", exc)
+
+
+def purge_stranded_temp_files(cache_dir: Path | None = None) -> None:
+    """Delete temp files a killed writer never renamed into place.
+
+    :func:`_write_cache` cleans up after itself on every failure it can SEE, but
+    the background revalidation thread is a daemon (:func:`_schedule_revalidate`)
+    and a short ``lop --model ...`` run exits while that thread may still be
+    inside ``json.dump``: the interpreter tears the thread down with no
+    ``finally`` run, and a ~190 KB ``<key>.listing.json.<random>.tmp`` stays
+    beside the document for good. The document itself is never harmed — the
+    rename never happened — but each such exit leaks one file, and a cache with
+    no index has no other way to notice it.
+
+    Age-gated on mtime (:data:`_STRANDED_TEMP_MIN_AGE_S`), because the same
+    name shape is what a peer process or sibling thread is writing RIGHT NOW;
+    an orphan is told from an in-flight write only by how long it has sat.
+    Stateless and idempotent like :func:`purge_legacy_documents`, and every
+    failure is swallowed: a stat that races the writer's own rename must not
+    fail the read that swept.
+    """
+    directory = cache_dir or default_cache_dir()
+    cutoff = time.time() - _STRANDED_TEMP_MIN_AGE_S
+    try:
+        for stranded in directory.glob(_STRANDED_TEMP_GLOB):
+            try:
+                if stranded.stat().st_mtime < cutoff:
+                    stranded.unlink(missing_ok=True)
+            except OSError:
+                # Renamed or removed between the glob and the stat: not ours.
+                continue
+    except OSError as exc:  # pragma: no cover - read-only or unreadable cache dir
+        logger.debug("could not purge stranded catalogue temp files: %s", exc)
 
 
 def _read_cache(path: Path) -> tuple[dict[str, Any] | None, float]:
@@ -524,6 +573,7 @@ def read_listing(
     # which document names went dead, and a dead name has no reader left to
     # notice it. Costs one directory read once the sweep has nothing to match.
     purge_legacy_documents(cache_dir)
+    purge_stranded_temp_files(cache_dir)
     path = _cache_path(key, cache_dir)
     payload, age = _read_cache(path)
     if payload is not None and age < ttl_s:

--- a/local_operator/model/catalogue.py
+++ b/local_operator/model/catalogue.py
@@ -33,11 +33,16 @@ reason the user cannot act on. Model catalogues change on the order of days,
 so the payload is cached on disk with a TTL and a stale entry is preferred to
 no entry:
 
-1. Fresh cache (< TTL)            -> use it, no network.
-2. Stale or missing               -> fetch, rewrite the cache, use it.
-3. Fetch fails but a stale cache exists -> use the stale copy. A window that
+1. Fresh cache (< soft TTL)       -> use it, no network.
+2. Ageing cache (soft <= age < hard TTL) -> use it NOW, and refresh it in a
+   background thread (stale-while-revalidate). The calling path pays nothing;
+   the NEXT call sees the new document. This is what keeps "a model released
+   today is offered today" true without putting a request on a session start
+   or a TUI repaint. See :func:`read_listing` and :func:`_schedule_revalidate`.
+3. Expired or missing (>= hard TTL) -> fetch synchronously, rewrite, use it.
+4. Fetch fails but a stale cache exists -> use the stale copy. A window that
    is a week old is enormously better than pretending a 1M model holds 128k.
-4. Fetch fails with no cache      -> return None; the caller keeps its static
+5. Fetch fails with no cache      -> return None; the caller keeps its static
    fallbacks. A session MUST still start with no network.
 
 The cache holds the RAW payload under a key the caller chooses, so mapping stays
@@ -47,10 +52,12 @@ without either overwriting the other.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import logging
 import os
 import tempfile
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -58,10 +65,32 @@ from typing import Any, Callable
 
 logger = logging.getLogger("local_operator.model.catalogue")
 
-#: How long a cached catalogue is considered fresh. Model listings move on the
-#: order of days; an hour would re-fetch constantly for no new information and
-#: a week would hide a genuinely new model for too long.
+#: The HARD TTL: how old a document may be before a read blocks on a fetch.
+#: Model listings move on the order of days; a week would hide a genuinely new
+#: model for too long, and anything shorter puts a synchronous request on the
+#: boot path more often for no new information. Also the width of the in-process
+#: memo bucket in ``configure._resolve_model_info_cached``, so keep the name.
 DEFAULT_TTL_S = 24 * 60 * 60
+
+#: The SOFT TTL: age past which a served document is ALSO refreshed in the
+#: background. An hour bounds "released today, offered today" for the next call
+#: without putting a request on the calling path; below it a listing endpoint
+#: would be asked repeatedly for information that changes on the order of days.
+#: The incident this exists for: a 22h-old Anthropic document (inside the hard
+#: TTL, so never refetched) hid a model published that morning from ``/model``
+#: and from the cost band for a whole working day.
+SOFT_TTL_S = 60 * 60
+
+#: A document younger than this that lacks a requested id is believed: the id is
+#: genuinely unknown, not newly released. Bounds the miss-triggered refetch
+#: (see ``discovery.available_models(want_id=...)``) so a typo cannot refetch on
+#: every resolution — one refetch per key per ten minutes, however many ids miss.
+MISS_REFETCH_MIN_AGE_S = 10 * 60
+
+#: Per-process floor between background attempts on one key, so an offline
+#: machine does not spawn a thread every time a stale document is served. The
+#: sync miss path is unaffected: it has its own stale-beats-absent rule.
+REVALIDATE_BACKOFF_S = 5 * 60
 
 
 def default_cache_dir() -> Path:
@@ -313,22 +342,166 @@ class _ListingFetchLease:
             pass
 
 
-def cached_listing(
+@dataclasses.dataclass(frozen=True)
+class Listing:
+    """What :func:`read_listing` found, and how.
+
+    ``fetched`` is how a live answer is told from a cached one — the whole
+    difference between discovery's ``"ok"`` and ``"cached"`` statuses. It used
+    to be smuggled out of the fetch thunk through a ``nonlocal`` flag, which
+    could not express "the fetch was attempted and FAILED" (the ``"stale"``
+    status): a thunk that raises never gets to set anything. ``failed`` carries
+    that now. ``refreshing`` says a background revalidation was scheduled by
+    THIS call, which tests use to join it and callers may use to annotate.
+    """
+
+    payload: dict[str, Any] | None
+    #: ``inf`` when there is no usable document.
+    age_s: float
+    #: A live fetch produced ``payload`` on this call.
+    fetched: bool = False
+    #: A live fetch was attempted on this call and raised; ``payload`` is the
+    #: stale document (or ``None`` when there was none to fall back on).
+    failed: bool = False
+    #: A background revalidation thread was started by this call.
+    refreshing: bool = False
+
+
+#: Background revalidations in flight in THIS process, keyed by document PATH
+#: (not by key: two cache directories are two documents). A second read of the
+#: same ageing document must not start a second thread; the cross-process lease
+#: already dedupes between processes but not between the threads of one, and
+#: the TUI resolves the same provider from the picker worker and the 1 Hz cost
+#: poll at once.
+_revalidating: set[str] = set()
+#: ``time.monotonic()`` of the last background attempt per document, for the backoff.
+_last_attempt: dict[str, float] = {}
+#: Live revalidation threads, so tests can join them instead of sleeping.
+_threads: dict[str, threading.Thread] = {}
+_revalidate_lock = threading.Lock()
+
+
+def _revalidation_threads() -> list[threading.Thread]:
+    """The background revalidations currently alive — a TEST hook.
+
+    AGENTS.md forbids waiting on the clock for asynchronous work; a test that
+    wants to see the rewritten document joins these instead.
+    """
+    with _revalidate_lock:
+        return [thread for thread in _threads.values() if thread.is_alive()]
+
+
+def _schedule_revalidate(
+    key: str, fetch: Callable[[], dict[str, Any]], cache_dir: Path | None
+) -> bool:
+    """Refresh ``key`` off the calling path. True when a thread was started.
+
+    Plain ``threading.Thread``, not the asyncio loop: this module is synchronous
+    and is entered from the CLI, the server, ``asyncio.to_thread`` workers and
+    ``run_in_executor`` threads alike, so there is no loop to hand the work to
+    that every caller has. ``refresh_model_info_background`` in ``configure`` is
+    the same shape one layer up. Daemon, so a short-lived ``lop --model ...``
+    process is not held open by a listing fetch: a daemon killed mid-write leaves
+    nothing half-written (``_write_cache`` is mkstemp+rename) and at worst a lease
+    that lapses in ``_LISTING_LEASE_S`` — the existing crash contract.
+
+    Two dedupes. In-process: a key already in flight, or attempted within
+    ``REVALIDATE_BACKOFF_S``, gets no new thread — an offline machine serving a
+    stale document on every repaint must not spawn a thread per repaint.
+    Cross-process: the thread takes the same ``_ListingFetchLease`` as the sync
+    path and, unlike it, simply EXITS when a peer holds it; there is nothing to
+    wait for because the caller already has its answer.
+    """
+    path = _cache_path(key, cache_dir)
+    slot = str(path)
+    now = time.monotonic()
+    with _revalidate_lock:
+        if slot in _revalidating:
+            return False
+        last = _last_attempt.get(slot)
+        if last is not None and now - last < REVALIDATE_BACKOFF_S:
+            return False
+        _revalidating.add(slot)
+        _last_attempt[slot] = now
+
+    def run() -> None:
+        lease = _ListingFetchLease(path)
+        try:
+            if not lease.acquire():
+                return
+            try:
+                fresh = fetch()
+            except Exception as exc:  # noqa: BLE001 - the stale document stays
+                logger.debug("background %s revalidation failed: %s", key, exc)
+                return
+            _write_cache(path, fresh)
+        finally:
+            lease.release()
+            with _revalidate_lock:
+                _revalidating.discard(slot)
+                _threads.pop(slot, None)
+
+    thread = threading.Thread(target=run, name=f"catalogue-revalidate:{key}", daemon=True)
+    with _revalidate_lock:
+        _threads[slot] = thread
+    thread.start()
+    return True
+
+
+def peek_listing(key: str, *, cache_dir: Path | None = None) -> Listing:
+    """The document on disk, read-only: no fetch, no revalidation, no sweep.
+
+    For a fetch thunk that wants to send ``If-None-Match``: it reads the previous
+    payload's stored ETag through this and, on a 304, hands the same payload
+    back so ``_write_cache`` re-stamps ``fetched_at`` — which is exactly
+    "validated just now". Kept separate from :func:`read_listing` so the thunk
+    cannot recurse into the reader that is calling it.
+    """
+    payload, age = _read_cache(_cache_path(key, cache_dir))
+    return Listing(payload=payload, age_s=age)
+
+
+def read_listing(
     key: str,
     fetch: Callable[[], dict[str, Any]],
     *,
+    soft_ttl_s: float = SOFT_TTL_S,
     ttl_s: float = DEFAULT_TTL_S,
     cache_dir: Path | None = None,
-) -> dict[str, Any] | None:
-    """A provider's ``list_models()`` payload, from cache when fresh.
+    refetch_if: Callable[[dict[str, Any], float], bool] | None = None,
+) -> Listing:
+    """A provider's ``list_models()`` payload, stale-while-revalidate.
 
     ``key`` names the document, not the provider: the caller owns the naming, so
     two differently-shaped listings for one provider cannot land on one file.
 
     ``fetch`` returns the payload as a plain dict (``model_dump()`` of the
-    client's response). Returns None only when there is no cache AND the fetch
-    failed, which is the one case where the caller must keep its static
+    client's response). ``payload`` is None only when there is no cache AND the
+    fetch failed, which is the one case where the caller must keep its static
     fallbacks.
+
+    State machine, by document age:
+
+    * ``age < soft_ttl_s`` — served, nothing else happens.
+    * ``soft_ttl_s <= age < ttl_s`` — served IMMEDIATELY, and a background
+      refresh is scheduled (:func:`_schedule_revalidate`). The calling path never
+      waits on the network for a document it already has.
+    * ``age >= ttl_s`` or no document — the synchronous fetch, under the
+      cross-process lease. This is the offline/cold contract and is unchanged.
+
+    ``soft_ttl_s >= ttl_s`` disables the background state entirely, which is
+    how :func:`cached_listing` keeps its original three-state behaviour.
+
+    ``refetch_if(payload, age_s)`` lets the caller declare a document inside
+    the TTL EXPIRED anyway — discovery's "the id I am about to resolve is not
+    in this document and the document is old enough to predate it" rule. It is
+    a predicate here rather than a second call after the fact because the two
+    would race: a document in the soft window has ALREADY had a background
+    refresh scheduled by the time a caller could inspect it, and a synchronous
+    refetch behind that loses the lease to its own process's thread, waits on
+    it, and cannot tell the result apart from a plain cache hit. Deciding
+    before either path starts means one fetch, on the calling thread, with a
+    ``fetched``/``failed`` flag that means what it says.
 
     A cross-process fetch lease guards the miss path: several lop sessions
     cold-starting together all miss in the same instant, and without the
@@ -344,7 +517,12 @@ def cached_listing(
     path = _cache_path(key, cache_dir)
     payload, age = _read_cache(path)
     if payload is not None and age < ttl_s:
-        return payload
+        if refetch_if is None or not refetch_if(payload, age):
+            refreshing = False
+            if age >= soft_ttl_s:
+                refreshing = _schedule_revalidate(key, fetch, cache_dir)
+            return Listing(payload=payload, age_s=age, refreshing=refreshing)
+        logger.debug("%s catalogue (%.0fs old) declared expired by its reader", key, age)
 
     # CROSS-PROCESS FETCH LEASE (see the class docstring): the winner fetches
     # and writes; losers give the winner a brief window, re-read, and serve
@@ -355,7 +533,7 @@ def cached_listing(
         lease.await_peer_briefly()
         payload, age = _read_cache(path)
         if payload is not None:
-            return payload
+            return Listing(payload=payload, age_s=age)
         # No document even after the peer's window: fall through and fetch.
         # The lease is lost or stale; a cold machine must still start.
 
@@ -367,13 +545,30 @@ def cached_listing(
             # Stale beats absent: the numbers are days old at worst, whereas
             # the static fallback is wrong by nearly a factor of six.
             logger.debug("using stale %s catalogue (%.0fs old): %s", key, age, exc)
-            return payload
+            return Listing(payload=payload, age_s=age, failed=True)
         logger.debug("no %s catalogue available: %s", key, exc)
-        return None
+        return Listing(payload=None, age_s=float("inf"), failed=True)
 
     _write_cache(path, fresh)
     lease.release()
-    return fresh
+    return Listing(payload=fresh, age_s=0.0, fetched=True)
+
+
+def cached_listing(
+    key: str,
+    fetch: Callable[[], dict[str, Any]],
+    *,
+    ttl_s: float = DEFAULT_TTL_S,
+    cache_dir: Path | None = None,
+) -> dict[str, Any] | None:
+    """The original three-state reader, kept for callers that want no threads.
+
+    Equivalent to :func:`read_listing` with the soft TTL pinned to the hard one:
+    fresh is served, expired is fetched synchronously, and nothing runs in the
+    background. Callers that want stale-while-revalidate use :func:`read_listing`
+    and read the ``Listing`` flags.
+    """
+    return read_listing(key, fetch, soft_ttl_s=ttl_s, ttl_s=ttl_s, cache_dir=cache_dir).payload
 
 
 def invalidate(key: str, *, cache_dir: Path | None = None) -> None:

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -40,6 +40,7 @@ from local_operator.harness.types import (
 from local_operator.model.catalogue import DEFAULT_TTL_S
 from local_operator.model.defaults import DEFAULT_MODEL_NAMES as _DEFAULT_MODEL_NAMES
 from local_operator.model.effort import default_effort, supported_efforts
+from local_operator.model.ids import normalised_id as _normalised_id
 from local_operator.model.registry import (
     ModelInfo,
     anthropic_default_model_info,
@@ -61,6 +62,7 @@ if TYPE_CHECKING:
     from local_operator.clients.radient import RadientListModelsResponse
     from local_operator.credentials import CredentialManager
     from local_operator.env import EnvConfig
+    from local_operator.model.discovery import DiscoveredModel
     from local_operator.providers.auth_store import AuthStore
     from local_operator.providers.clients import WireClient
     from local_operator.providers.usage import UsageReport
@@ -865,24 +867,6 @@ def _oauth_listing_token(provider: str) -> tuple[str, bool, str | None]:
     return "", False, None
 
 
-def _normalised_id(model_id: str) -> str:
-    """A model id in the one spelling both sides of a match can agree on.
-
-    Discovery NORMALISES ids on ingest — ``_row_from_gemini_entry`` strips
-    Google's ``models/`` resource prefix so the rest of the system sees a bare id
-    — while the user types whatever the provider's own documentation shows, which
-    for Gemini is ``models/gemini-2.5-pro``. An exact-match-only lookup therefore
-    missed the spelling Google itself publishes and handed that session the 128k
-    unknown default. Case is folded for the same reason: an id is a wire
-    identifier, not prose, and no provider ships two models differing only in case.
-    """
-    trimmed = model_id.strip()
-    prefix = "models/"
-    if trimmed.startswith(prefix):
-        trimmed = trimmed[len(prefix) :]
-    return trimmed.casefold()
-
-
 def _info_from_discovery(
     provider: str, model_name: str, fallback: ModelInfo, *, timeout: float | None = None
 ) -> ModelInfo:
@@ -907,6 +891,12 @@ def _info_from_discovery(
     stale-but-correct number, not the frame. That second call is reachable from a
     repaint, where ten seconds is a frozen keyboard rather than a slow start.
 
+    ``model_name`` is passed through as discovery's ``want_id``: a stored
+    document old enough to predate the model is refetched once, inside this
+    same ``timeout``, before the lookup below is allowed to miss. That is what
+    prices a model released this morning on its FIRST resolution rather than
+    after the memo bucket rolls over at midnight.
+
     Imported lazily. The discovery module pulls httpx and the provider registry,
     and this branch is only reached for a model the registry does not describe;
     putting that on the import path would cost every CLI invocation.
@@ -921,6 +911,7 @@ def _info_from_discovery(
             is_oauth=is_oauth,
             account_id=account_id,
             timeout=DEFAULT_TIMEOUT_S if timeout is None else timeout,
+            want_id=model_name,
         )
     except Exception as exc:  # noqa: BLE001 — metadata is never worth a failed start
         logger.debug("%s discovery unavailable for %s: %s", provider, model_name, exc)
@@ -951,11 +942,15 @@ def _info_from_discovery(
         info.output_price = row.output_price
     if row.cache_read_price > 0:
         info.cache_reads_price = row.cache_read_price
-        # A quoted cache-READ price is the only signal some providers give that
-        # prompt caching exists at all; the write price is often absent because the
-        # caching is implicit. Falling back to the input price keeps cost estimates
-        # from reading as free rather than inventing a number.
-        if not info.cache_writes_price:
+        if row.cache_write_price > 0:
+            info.cache_writes_price = row.cache_write_price
+        elif not info.cache_writes_price:
+            # A quoted cache-READ price is the only signal some providers give
+            # that prompt caching exists at all; a listing that quotes no write
+            # price usually caches implicitly. Falling back to the input price
+            # keeps cost estimates from reading as free rather than inventing a
+            # number — it under-states an Anthropic 5m write by 20%, which is
+            # why a quoted write price above takes precedence.
             info.cache_writes_price = info.input_price
     if row.supports_images is not None:
         # The provider's own statement, including a ``false``: ``DiscoveredModel``
@@ -968,53 +963,15 @@ def _info_from_discovery(
     return info
 
 
-#: The catalogue consulted for a direct provider's prices. OpenRouter rather than
-#: Radient because it is the one whose listing is a PUBLIC document — no key, no
-#: account — so this leg works on an install that has only, say, an Anthropic
-#: OAuth login. See :data:`local_operator.model.discovery.PUBLIC_LISTING_PROVIDERS`.
-_AGGREGATOR_CATALOGUE = "openrouter"
-
-#: Seconds this leg may block. Well under ``discovery.DEFAULT_TIMEOUT_S`` (10.0)
-#: because it runs BEHIND the provider's own listing on the same synchronous
-#: call — two default ceilings would be a 20s session start for one unresolvable
-#: model — and because it is reachable from the TUI's 1 Hz poll. Enrichment that
-#: cannot be had in three seconds is worth skipping until the next TTL bucket;
-#: the row degrades to "cost unavailable", which is the honest pre-existing state.
+#: Seconds the price-catalogue leg and the aggregator leg may each block. Well
+#: under ``discovery.DEFAULT_TIMEOUT_S`` (10.0) because they run BEHIND the
+#: provider's own listing on the same synchronous call — two default ceilings
+#: would be a 20s session start for one unresolvable model — and because they
+#: are reachable from the TUI's 1 Hz poll. Enrichment that cannot be had in
+#: three seconds is worth skipping until the next TTL bucket; the row degrades
+#: to "cost unavailable", which is the honest pre-existing state.
 _AGGREGATOR_TIMEOUT_S = 3.0
-
-#: A direct provider's id, mapped to the namespace the same models are published
-#: under in the OpenRouter catalogue. Only providers whose OWN listing quotes no
-#: prices need an entry, which is every direct provider in this tree: Anthropic's
-#: `/v1/models` has no pricing object, OpenAI's `/v1/models` is bare ids, and
-#: Gemini's listing carries token limits only. The aggregators (`openrouter`,
-#: `radient`) are deliberately absent — their own listing IS the priced one.
-#:
-#: Spelled out rather than derived because three of the namespaces are renames
-#: (`x-ai`, `qwen`, `moonshotai`), verified against
-#: `GET https://openrouter.ai/api/v1/models` on 2026-08-10; a derived guess would
-#: silently price a model from whatever else happened to match.
-_AGGREGATOR_NAMESPACE: dict[str, str] = {
-    "anthropic": "anthropic",
-    "openai": "openai",
-    "google": "google",
-    "deepseek": "deepseek",
-    "mistral": "mistralai",
-    "xai": "x-ai",
-    "alibaba": "qwen",
-    "kimi": "moonshotai",
-    # Z.AI's own listing quotes no prices, and GLM is resold on OpenRouter under
-    # the `z-ai/` namespace (verified against GET https://openrouter.ai/api/v1/models
-    # on 2026-08-17). Newer ids not yet carried there fall back to the static rows.
-    "zai": "z-ai",
-}
-
-#: A trailing Anthropic-style release stamp: `claude-opus-4-5-20251101`.
-_DATE_SUFFIX_RE = re.compile(r"-\d{8}$")
-
-#: A version separated by a dash between two digits: the `4-5` of `claude-opus-4-5`.
-#: Anchored on digits BOTH sides so `qwen2.5-coder-1.5b` and `gpt-4o-mini` are left
-#: alone — only a dash that is standing in for a decimal point is rewritten.
-_DOTTED_VERSION_RE = re.compile(r"(?<=\d)-(?=\d)")
+_PRICE_CATALOGUE_TIMEOUT_S = _AGGREGATOR_TIMEOUT_S
 
 #: Seconds a NON-BLOCKING listing refresh may take — the case where the registry
 #: already has a usable answer and is only checking whether the provider has since
@@ -1028,12 +985,13 @@ _REFRESH_TIMEOUT_S = 2.0
 def _remaining_budget(started: float) -> float:
     """What is left of one resolution's total listing budget, in seconds.
 
-    Resolution can consult two listings — the provider's own, then the public
-    aggregator catalogue. Given a ceiling each, they compose into their SUM, so a
-    model neither can describe blocks for both. One deadline across the pair keeps
-    the second leg free in the common case (the first answers in tens of
-    milliseconds) and bounds the pathological one at the single ceiling every
-    caller of this module already budgets for.
+    Resolution can consult up to three listings — the provider's own, the neutral
+    price catalogue, and (for an aggregator's own ids) the aggregator's listing.
+    Given a ceiling each, they compose into their SUM, so a model none can
+    describe blocks for all of them. One deadline across the legs keeps the later
+    ones free in the common case (the first answers in tens of milliseconds) and
+    bounds the pathological one at the single ceiling every caller of this module
+    already budgets for.
 
     Which leg gets STARVED by that is a deliberate priority, not an accident of
     ordering, and inverting it would be a real regression. On a degraded network
@@ -1053,108 +1011,20 @@ def _remaining_budget(started: float) -> float:
     return max(0.01, DEFAULT_TIMEOUT_S - (time.monotonic() - started))
 
 
-def _aggregator_spellings(model_id: str) -> list[str]:
-    """``model_id`` as the aggregator might spell it, most literal first.
+def _fill_from_row(info: ModelInfo, row: "DiscoveredModel") -> ModelInfo:
+    """``info`` with its HOLES filled from a second-hand catalogue row.
 
-    Providers and aggregators disagree about punctuation for the SAME model, and
-    the disagreement is systematic rather than per-model: Anthropic ships
-    `claude-opus-4-5-20251101` while OpenRouter lists `anthropic/claude-opus-4.5`.
-    Trying only the literal id would leave every dated Claude snapshot unpriced,
-    which is precisely the population this fallback exists for.
-
-    Both rewrites are conservative — a date stamp is eight digits at the end, and a
-    dash becomes a dot only between two digits — and every candidate must still be
-    found in the catalogue before it is believed. A miss costs one dict lookup.
-
-    Order is most-literal-first, and the DOTTED-WITH-DATE form comes before either
-    date-stripped one on purpose: OpenRouter publishes dated snapshots under their
-    own dated ids alongside the undated alias (`anthropic/claude-3.5-sonnet-20240620`
-    as well as `anthropic/claude-3.5-sonnet`), so stripping the date first would
-    answer a question about one snapshot with the alias's price. Harmless while
-    snapshots of a family share a rate, wrong the day one does not.
-    """
-    stripped = _DATE_SUFFIX_RE.sub("", model_id)
-    candidates = [model_id]
-    for candidate in (
-        _DOTTED_VERSION_RE.sub(".", model_id),
-        stripped,
-        _DOTTED_VERSION_RE.sub(".", stripped),
-    ):
-        if candidate and candidate not in candidates:
-            candidates.append(candidate)
-    return candidates
-
-
-def _from_aggregator_catalogue(
-    provider: str, model_id: str, info: ModelInfo, *, timeout: float | None = None
-) -> ModelInfo:
-    """Describe a DIRECT provider's model from the public aggregator catalogue.
-
-    The last leg of resolution, reached only when neither the registry nor the
-    provider's own listing could finish the job. It exists because those two
-    sources CANNOT close the gap between them: a direct provider's listing quotes
-    no money at all, and for a model the registry has not been taught about it
-    frequently carries no limits either. That is not a hypothetical —
-    `openai/gpt-5.4` is a shipping model with no registry row, and on a
-    fully-credentialled install it resolved to `input_price=0.0` AND no context
-    window, so the status band read "cost unavailable" and `311.0k/—` for the
-    whole session.
-
-    Structurally this is the same trick the aggregator models already get for free:
-    OpenRouter's listing describes the very same upstream models, and it is fetched
-    with NO credential — ``available_models`` treats it as keyless because it is in
-    :data:`~local_operator.model.discovery.PUBLIC_LISTING_PROVIDERS`, so the request
-    simply goes out without an ``Authorization`` header — and cached on disk for a
-    TTL. So the self-healing property is the point: a row added tomorrow with a 0.0
-    placeholder starts costing correctly instead of silently reading as free until
-    someone notices.
-
-    Every field is taken ONLY where the direct sources left a hole. The provider's
-    own answer is authoritative where it exists and can legitimately differ from
-    what the aggregator's routing exposes — OpenRouter advertises the largest
+    Shared by the price-catalogue and aggregator legs, which have the same
+    contract: every field is taken ONLY where the direct sources left one. The
+    provider's own answer is authoritative where it exists and can legitimately
+    differ from what a catalogue exposes — OpenRouter advertises the largest
     window across its routes, which is the wrong number for a specific upstream
     endpoint. ``supports_images`` is not taken at all: it carries a three-valued
-    contract (see :func:`_info_from_discovery`) in which a stated ``false`` is the
-    PROVIDER's denial, and a second-hand listing has no standing to issue one.
-    ``supports_prompt_cache`` is inferred from a quoted cache-read price, which is
-    the same inference :func:`_info_from_discovery` makes and is only ever
-    widening.
-
-    Never raises and never returns worse data than it was given.
+    contract (see :func:`_info_from_discovery`) in which a stated ``false`` is
+    the PROVIDER's denial, and a second-hand listing has no standing to issue
+    one. ``supports_prompt_cache`` is inferred from a quoted cache-read price,
+    the same inference :func:`_info_from_discovery` makes and only ever widening.
     """
-    namespace = _AGGREGATOR_NAMESPACE.get(provider)
-    if namespace is None:
-        return info
-    try:
-        from local_operator.model.discovery import available_models
-
-        # Two ceilings, whichever is smaller. `_AGGREGATOR_TIMEOUT_S` is this leg's
-        # own cap: it is pure enrichment stacked BEHIND the provider's listing, and
-        # it is reachable from the TUI's 1 Hz poll (`_harvest_subagent_costs` →
-        # `job_cost` → here, for a child on a model not yet in the memo), where a
-        # 10s synchronous stall is input lag rather than a slow start. `timeout` is
-        # what the CALLER has left of the whole resolution's budget, so the two
-        # legs together can never cost more than the single ceiling every caller of
-        # this module already assumes.
-        budget = _AGGREGATOR_TIMEOUT_S if timeout is None else min(_AGGREGATOR_TIMEOUT_S, timeout)
-        rows, _status = available_models(_AGGREGATOR_CATALOGUE, api_key=None, timeout=budget)
-    except Exception as exc:  # noqa: BLE001 — metadata is never worth a failed start
-        logger.debug("aggregator catalogue unavailable for %s/%s: %s", provider, model_id, exc)
-        return info
-
-    # Priced rows only. An unpriced aggregator row is a routing stub that can
-    # answer neither of the two questions this leg is here for, and matching one
-    # would shadow a better-spelled sibling further down the candidate list.
-    priced = {row.id: row for row in rows if row.input_price > 0 or row.output_price > 0}
-    row = None
-    for spelling in _aggregator_spellings(model_id):
-        row = priced.get(f"{namespace}/{spelling}")
-        if row is not None:
-            break
-    if row is None:
-        logger.debug("aggregator catalogue has no priced entry for %s/%s", provider, model_id)
-        return info
-
     info = info.model_copy(deep=True)
     if not (info.input_price or info.output_price):
         info.input_price = row.input_price
@@ -1162,12 +1032,13 @@ def _from_aggregator_catalogue(
         if row.cache_read_price > 0:
             info.cache_reads_price = row.cache_read_price
             info.supports_prompt_cache = True
-            # Same convention as `_info_from_discovery`: `DiscoveredModel` carries
-            # no write price, and the input price is the closest defensible
-            # stand-in. It under-states an Anthropic 5m write by 20% (1.25x base) —
-            # which is why the shipped rows in the registry carry the real number
-            # and this is only the floor for an id nobody has written down yet.
-            if not info.cache_writes_price:
+            if row.cache_write_price > 0:
+                info.cache_writes_price = row.cache_write_price
+            elif not info.cache_writes_price:
+                # A catalogue that quotes a read price and no write price. The
+                # input price is the closest defensible stand-in — it under-states
+                # an Anthropic 5m write by 20% (1.25x base), which is why a quoted
+                # write price above wins and this is only the floor.
                 info.cache_writes_price = info.input_price
     if not _has_real_window(info) and row.context_window > 0:
         # A missing window is not cosmetic and not merely a rendering gap: the
@@ -1182,6 +1053,104 @@ def _from_aggregator_catalogue(
     if not (info.max_tokens and info.max_tokens > 0) and row.max_tokens > 0:
         info.max_tokens = row.max_tokens
     return info
+
+
+def _from_price_catalogue(
+    provider: str, model_id: str, info: ModelInfo, *, timeout: float | None = None
+) -> ModelInfo:
+    """Fill a model's price and limit holes from the neutral models.dev catalogue.
+
+    The second leg of resolution, reached when the registry and the provider's
+    own listing together could not finish the job — which for every DIRECT
+    provider is the normal outcome rather than a failure: none of them quote money
+    in their listing. Until this leg existed the only price source for such an id
+    was the OpenRouter listing looked up under a per-provider namespace, which
+    tied an Anthropic-only user's cost display to one aggregator's document and
+    its id spellings; the day ``claude-fable-5-1`` shipped that document was six
+    hours old and predated the row, so the session ran at $0.00. See
+    :mod:`local_operator.model.prices` for what the catalogue is and why it is
+    trusted for prices and limits but not capabilities.
+
+    Never raises and never returns worse data than it was given. ``timeout`` is
+    what the CALLER has left of the whole resolution's budget, capped at this
+    leg's own ceiling: it is pure enrichment stacked BEHIND the provider's
+    listing and is reachable from the TUI's 1 Hz poll (via
+    ``refresh_model_info_background``'s executor thread), where a 10s stall on
+    a 4.4 MB cold download is input lag rather than a slow start.
+    """
+    try:
+        from local_operator.model.prices import price_catalogue_row
+
+        budget = (
+            _PRICE_CATALOGUE_TIMEOUT_S
+            if timeout is None
+            else min(_PRICE_CATALOGUE_TIMEOUT_S, timeout)
+        )
+        row = price_catalogue_row(provider, model_id, timeout=budget)
+    except Exception as exc:  # noqa: BLE001 — metadata is never worth a failed start
+        logger.debug("price catalogue unavailable for %s/%s: %s", provider, model_id, exc)
+        return info
+    if row is None:
+        logger.debug("price catalogue has no entry for %s/%s", provider, model_id)
+        return info
+    if not (row.input_price > 0 or row.output_price > 0 or row.context_window > 0):
+        # A key with no cost and no limit answers neither question this leg is
+        # here for; models.dev carries such stubs for plan catalogues.
+        return info
+    return _fill_from_row(info, row)
+
+
+def _from_aggregator_catalogue(
+    provider: str, model_id: str, info: ModelInfo, *, timeout: float | None = None
+) -> ModelInfo:
+    """Describe an AGGREGATOR's own model from its public listing, as a last resort.
+
+    Only for ``provider in AGGREGATOR_PROVIDERS`` — the ``openrouter/*`` and
+    ``radient/*`` ids, whose own listing IS the priced one. Leg 1 has normally
+    already priced them from it; this leg survives for the case where leg 1 was
+    unavailable (a credential lookup that raised, a listing behind a login)
+    and the public OpenRouter document can still answer.
+
+    It used to be the price source for DIRECT providers too, through a
+    per-provider namespace map (``anthropic`` → ``anthropic/``, ``xai`` →
+    ``x-ai/``, ...). That coupling is gone: :func:`_from_price_catalogue` is the
+    provider-neutral leg now, and a direct-provider id this function is handed
+    is returned untouched.
+
+    Every field is taken ONLY where the direct sources left a hole
+    (:func:`_fill_from_row`). Never raises and never returns worse data than it
+    was given.
+    """
+    from local_operator.providers.registry import AGGREGATOR_PROVIDERS
+
+    if provider not in AGGREGATOR_PROVIDERS:
+        return info
+    try:
+        from local_operator.model.discovery import (
+            PUBLIC_LISTING_PROVIDERS,
+            available_models,
+        )
+
+        # Radient's listing needs a key; only a PUBLIC listing can be read here
+        # with no credential at all.
+        if provider not in PUBLIC_LISTING_PROVIDERS:
+            return info
+        # Two ceilings, whichever is smaller — see `_from_price_catalogue`.
+        budget = _AGGREGATOR_TIMEOUT_S if timeout is None else min(_AGGREGATOR_TIMEOUT_S, timeout)
+        rows, _status = available_models(provider, api_key=None, timeout=budget, want_id=model_id)
+    except Exception as exc:  # noqa: BLE001 — metadata is never worth a failed start
+        logger.debug("aggregator catalogue unavailable for %s/%s: %s", provider, model_id, exc)
+        return info
+
+    # Priced rows only. An unpriced aggregator row is a routing stub that can
+    # answer neither of the two questions this leg is here for.
+    row = next(
+        (r for r in rows if r.id == model_id and (r.input_price > 0 or r.output_price > 0)), None
+    )
+    if row is None:
+        logger.debug("aggregator catalogue has no priced entry for %s/%s", provider, model_id)
+        return info
+    return _fill_from_row(info, row)
 
 
 def _registry_fallback(provider: str, model_id: str) -> ModelInfo:
@@ -1297,14 +1266,19 @@ def _resolve_model_info_cached(provider: str, model_id: str, _bucket: int) -> Mo
         # source fully described must not pay for a second catalogue read.
         #
         # Budgeted against ONE deadline for the whole resolution, not its own fresh
-        # ceiling. Two independent budgets compose into their SUM, so adding this
+        # ceiling. Two independent budgets compose into their SUM, so adding a
         # leg silently took an unresolvable model's worst case from 10s to 13s —
         # and that model is not the exotic case for the subagent panel, it is the
         # motivating one (a child launched on a `model_spec` override the shipped
         # registry has never heard of). Spending what leg 1 left keeps this leg
         # free for the common case, where leg 1 answers in tens of milliseconds,
-        # while guaranteeing the pair can never cost more than the one ceiling
+        # while guaranteeing the legs can never cost more than the one ceiling
         # callers already budget for.
+        info = _from_price_catalogue(canonical, model_id, info, timeout=_remaining_budget(started))
+    if _needs_enrichment(info):
+        # Leg 3, for an AGGREGATOR's own ids only (the function refuses direct
+        # providers). Normally leg 1 already priced these from the same listing;
+        # this is the fallback for when leg 1 could not run. Same shared deadline.
         info = _from_aggregator_catalogue(
             canonical, model_id, info, timeout=_remaining_budget(started)
         )

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1105,10 +1105,13 @@ def _from_aggregator_catalogue(
 ) -> ModelInfo:
     """Describe an AGGREGATOR's own model from its public listing, as a last resort.
 
-    Only for ``provider in AGGREGATOR_PROVIDERS`` — the ``openrouter/*`` and
-    ``radient/*`` ids, whose own listing IS the priced one. Leg 1 has normally
-    already priced them from it; this leg survives for the case where leg 1 was
-    unavailable (a credential lookup that raised, a listing behind a login)
+    In practice ``openrouter/*`` ids only. The gate is ``AGGREGATOR_PROVIDERS``,
+    but the lookup below needs a listing readable with NO credential, and of the
+    aggregators only OpenRouter's is public (``PUBLIC_LISTING_PROVIDERS``);
+    Radient's needs a key, so a ``radient/*`` id returns ``info`` untouched from
+    this leg and relies on leg 1 having read its listing with the credential.
+    Leg 1 has normally already priced OpenRouter's ids too; this leg survives
+    for the case where leg 1 was unavailable (a credential lookup that raised)
     and the public OpenRouter document can still answer.
 
     It used to be the price source for DIRECT providers too, through a

--- a/local_operator/model/discovery.py
+++ b/local_operator/model/discovery.py
@@ -1429,17 +1429,30 @@ def _lists_id(rows: list[DiscoveredModel], model_id: str) -> bool:
     paid a blocking round trip on boot for a document the refetch could not
     improve — indefinitely, since the refetched document lacked the alias too.
 
-    So a row counts as a hit when any of its :func:`id_spellings` (the id as
-    given, date-stripped, dotted) coincides with any of the wanted id's, after
-    normalisation. That covers both directions — an alias whose snapshot is
-    listed, and a snapshot whose alias is listed (the aggregators' habit) — so
-    neither direction can refetch for a row the provider spells differently.
-    The rewrites are the conservative ones ``prices._lookup`` already trusts.
+    So a row counts as a hit when the wanted id's LITERAL (normalised) is one
+    of the row's :func:`id_spellings` (the id as given, date-stripped, dotted),
+    or the row's literal is one of the wanted id's. That covers both directions
+    — an alias whose snapshot is listed, and a snapshot whose alias is listed
+    (the aggregators' habit) — so neither direction can refetch for a row the
+    provider spells differently. The rewrites are the conservative ones
+    ``prices._lookup`` already trusts.
+
+    The match is literal-against-spellings on purpose, NOT spellings-against-
+    spellings: both sides date-stripped coincide for ANY two snapshots of one
+    family, so a document listing only ``claude-opus-4-5-20251101`` counted
+    ``claude-opus-4-5-20260315`` as present — the day a new snapshot landed,
+    the one trigger built for that case stayed silent, the lookup missed, and
+    the memo pinned the fallback for the rest of the day. A literal never loses
+    its date, so two dated ids match only when they are the same id.
     """
     if any(row.id == model_id for row in rows):
         return True
-    wanted = {normalised_id(spelling) for spelling in id_spellings(model_id)}
-    return any(
-        not wanted.isdisjoint(normalised_id(spelling) for spelling in id_spellings(row.id))
-        for row in rows
-    )
+    wanted_literal = normalised_id(model_id)
+    wanted_spellings = {normalised_id(spelling) for spelling in id_spellings(model_id)}
+    for row in rows:
+        row_literal = normalised_id(row.id)
+        if row_literal in wanted_spellings:
+            return True
+        if any(normalised_id(spelling) == wanted_literal for spelling in id_spellings(row.id)):
+            return True
+    return False

--- a/local_operator/model/discovery.py
+++ b/local_operator/model/discovery.py
@@ -1280,7 +1280,7 @@ def _available_models(
 
     capture = listing_capture_version(definition.id)
 
-    def fetch() -> dict[str, Any]:
+    def fetch_within(ceiling: float) -> dict[str, Any]:
         live = fetch_models(
             definition.id,
             api_key=api_key,
@@ -1288,7 +1288,7 @@ def _available_models(
             account_id=account_id,
             base_url=resolved_base,
             client=client,
-            timeout=timeout,
+            timeout=ceiling,
         )
         if live is None:
             raise _ListingUnavailable(definition.id)
@@ -1296,6 +1296,18 @@ def _available_models(
             "capture": capture,
             "models": [dataclasses.asdict(row) for row in live],
         }
+
+    def fetch() -> dict[str, Any]:
+        # On the calling path: the caller's budget, which from a repaint is 2 s.
+        return fetch_within(timeout)
+
+    def revalidate() -> dict[str, Any]:
+        # Off the calling path, so the caller's budget is the wrong ceiling: a
+        # background refresh that inherited 2 s failed on every link slower
+        # than that, backed off, and left the document to the 24 h sync path.
+        # The provider's full default is what an unhurried listing gets, the
+        # same choice ``prices._price_catalogue_row`` makes for its retry.
+        return fetch_within(DEFAULT_TIMEOUT_S)
 
     storage_id = credential_provider_id(definition.id)
     # Derived ONCE and reused for both the document name and the pruning
@@ -1337,6 +1349,7 @@ def _available_models(
         ttl_s=ttl_s,
         cache_dir=cache_dir,
         refetch_if=lacks_want_id,
+        revalidate=revalidate,
     )
     payload = listing.payload
     live_rows = _rows_from_payload(payload, capture)
@@ -1359,7 +1372,12 @@ def _available_models(
             # model list on every start; online it memoises a session booted at
             # default context, no prompt cache and zero prices.
             listing = read_listing(
-                key, fetch, soft_ttl_s=soft_ttl_s, ttl_s=ttl_s, cache_dir=cache_dir
+                key,
+                fetch,
+                soft_ttl_s=soft_ttl_s,
+                ttl_s=ttl_s,
+                cache_dir=cache_dir,
+                revalidate=revalidate,
             )
             payload = listing.payload
             live_rows = _rows_from_payload(payload, capture)

--- a/local_operator/model/discovery.py
+++ b/local_operator/model/discovery.py
@@ -132,7 +132,12 @@ LYING_MAX_TOKENS = 4096
 #: document parses to rows with a zero write price, which is harmless in itself,
 #: but without the bump the real number would stay invisible for a day on every
 #: install — the same argument as above. Only the two OpenAI-compatible
-#: aggregators quote a write price, so only they pay the one-time refetch.
+#: aggregators quote a write price, so only they pay the one-time refetch — and
+#: it is paid ON the calling path: a version-1 document is invalidated and
+#: refetched synchronously (up to ``DEFAULT_TIMEOUT_S``) by the first resolution
+#: after the upgrade, not in the background. Exactly once per install, which is
+#: acceptable; a bump here is not free for the user whose only provider is
+#: OpenRouter.
 LISTING_CAPTURE_VERSIONS: dict[str, int] = {"anthropic": 2, "openrouter": 2, "radient": 2}
 #: What a transport not named above is stamped with. Version 1 is the original
 #: shape; a transport only earns a bump when its own reader starts needing a

--- a/local_operator/model/discovery.py
+++ b/local_operator/model/discovery.py
@@ -53,7 +53,7 @@ from local_operator.model.catalogue import (
     invalidate,
     read_listing,
 )
-from local_operator.model.ids import normalised_id
+from local_operator.model.ids import id_spellings, normalised_id
 from local_operator.model.registry import ModelInfo, static_models
 from local_operator.providers.registry import (
     PROVIDER_REGISTRY,
@@ -1394,13 +1394,29 @@ def _status_of(listing: Listing, live_rows: list[DiscoveredModel]) -> ListingSta
 
 
 def _lists_id(rows: list[DiscoveredModel], model_id: str) -> bool:
-    """Whether ``model_id`` is in ``rows``, exactly or under the normalised spelling.
+    """Whether ``rows`` already accounts for ``model_id`` under ANY known spelling.
 
-    The same two-step match ``configure._info_from_discovery`` performs, so the
-    miss that triggers a refetch here is the miss that would have cost the
-    caller its answer.
+    This answers "could a refetch plausibly list this id?", not "will the lookup
+    find a row?" — the two differ, and conflating them put a synchronous listing
+    fetch on every process start. Anthropic's ``/v1/models`` lists dated
+    snapshots only (``claude-sonnet-4-5-20250929``) while its API accepts the
+    undated alias, and ``claude-sonnet-4-5`` is a common configured id. Matched
+    exactly or normalised, the alias was a miss against a document that DID
+    list its snapshot, so every process older than ``MISS_REFETCH_MIN_AGE_S``
+    paid a blocking round trip on boot for a document the refetch could not
+    improve — indefinitely, since the refetched document lacked the alias too.
+
+    So a row counts as a hit when any of its :func:`id_spellings` (the id as
+    given, date-stripped, dotted) coincides with any of the wanted id's, after
+    normalisation. That covers both directions — an alias whose snapshot is
+    listed, and a snapshot whose alias is listed (the aggregators' habit) — so
+    neither direction can refetch for a row the provider spells differently.
+    The rewrites are the conservative ones ``prices._lookup`` already trusts.
     """
     if any(row.id == model_id for row in rows):
         return True
-    wanted = normalised_id(model_id)
-    return any(normalised_id(row.id) == wanted for row in rows)
+    wanted = {normalised_id(spelling) for spelling in id_spellings(model_id)}
+    return any(
+        not wanted.isdisjoint(normalised_id(spelling) for spelling in id_spellings(row.id))
+        for row in rows
+    )

--- a/local_operator/model/discovery.py
+++ b/local_operator/model/discovery.py
@@ -25,8 +25,11 @@ of this feature broke in exactly that way:
   :func:`available_models` degrades to the registry instead of propagating.
 
 Results are cached on disk through
-:func:`local_operator.model.catalogue.cached_listing`, so the picker opens at
+:func:`local_operator.model.catalogue.read_listing`, so the picker opens at
 disk speed and a listing outage is invisible for as long as the cache holds.
+An ageing document is served and refreshed in the background, and a requested
+id missing from a document old enough to be wrong triggers one synchronous
+refetch (``want_id``) — together, a model released today is offered today.
 """
 
 from __future__ import annotations
@@ -42,7 +45,15 @@ from typing import Any, Literal
 
 import httpx
 
-from local_operator.model.catalogue import DEFAULT_TTL_S, cached_listing, invalidate
+from local_operator.model.catalogue import (
+    DEFAULT_TTL_S,
+    MISS_REFETCH_MIN_AGE_S,
+    SOFT_TTL_S,
+    Listing,
+    invalidate,
+    read_listing,
+)
+from local_operator.model.ids import normalised_id
 from local_operator.model.registry import ModelInfo, static_models
 from local_operator.providers.registry import (
     PROVIDER_REGISTRY,
@@ -115,7 +126,14 @@ LYING_MAX_TOKENS = 4096
 #: number invalidated every provider's cache on upgrade — including transports
 #: whose payload was already correct — and for an aggregator with no static rows
 #: to fall back on, the replacement answer was an EMPTY model list.
-LISTING_CAPTURE_VERSIONS: dict[str, int] = {"anthropic": 2}
+#:
+#: Version 2 for ``openrouter`` and ``radient`` is ``_row_from_openai_entry``
+#: reading ``pricing.input_cache_write`` into ``cache_write_price``. A version-1
+#: document parses to rows with a zero write price, which is harmless in itself,
+#: but without the bump the real number would stay invisible for a day on every
+#: install — the same argument as above. Only the two OpenAI-compatible
+#: aggregators quote a write price, so only they pay the one-time refetch.
+LISTING_CAPTURE_VERSIONS: dict[str, int] = {"anthropic": 2, "openrouter": 2, "radient": 2}
 #: What a transport not named above is stamped with. Version 1 is the original
 #: shape; a transport only earns a bump when its own reader starts needing a
 #: field its writer did not record.
@@ -139,10 +157,16 @@ def listing_capture_version(provider_id: str) -> int:
 PUBLIC_LISTING_PROVIDERS = frozenset({"openrouter", "radient"})
 
 #: What :func:`available_models` managed to do, for the UI to annotate:
-#: ``ok`` fetched live now, ``cached`` served a stored document, ``static``
-#: registry only, ``unauthenticated`` needs a credential it was not given,
-#: ``empty`` the provider answered and listed nothing.
-ListingStatus = Literal["ok", "cached", "static", "unauthenticated", "empty"]
+#: ``ok`` fetched live now, ``cached`` served a stored document with no fetch
+#: needed (fresh enough, or refreshing in the background), ``stale`` a fetch was
+#: attempted on this call and FAILED so the stored document is what you got,
+#: ``static`` registry only, ``unauthenticated`` needs a credential it was not
+#: given, ``empty`` the provider answered and listed nothing.
+#:
+#: ``cached`` and ``stale`` used to be one value, which is why the picker footer
+#: could not tell "fresh enough" from "offline" — the only case a user hunting
+#: for a model released this morning actually needs to hear about.
+ListingStatus = Literal["ok", "cached", "stale", "static", "unauthenticated", "empty"]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -178,14 +202,19 @@ class DiscoveredModel:
     input_price: float = 0.0
     output_price: float = 0.0
     cache_read_price: float = 0.0
+    #: $/MTok to WRITE a prompt-cache entry. Zero is "not quoted", and the
+    #: consumers then fall back to the input price — which under-states an
+    #: Anthropic 5-minute write by 20% (1.25x base), so a quoted number is
+    #: worth carrying rather than guessing.
+    cache_write_price: float = 0.0
     supports_images: bool | None = None
     supports_prompt_cache: bool = False
 
 
 class _ListingUnavailable(RuntimeError):
-    """Raised inside the ``cached_listing`` thunk when a live listing failed.
+    """Raised inside the ``read_listing`` thunk when a live listing failed.
 
-    ``cached_listing`` chooses between a stale document and ``None`` by catching
+    ``read_listing`` chooses between a stale document and ``None`` by catching
     an exception from the thunk, so a failed transport has to be re-raised rather
     than returned: handing back an empty payload would overwrite a good cache
     with nothing and then serve that for a full day.
@@ -416,6 +445,10 @@ def _row_from_openai_entry(entry: Mapping[str, object]) -> DiscoveredModel | Non
     return DiscoveredModel(
         id=model_id,
         name=_first_str(entry.get("name"), entry.get("display_name")),
+        # OpenRouter also publishes ``input_cache_write_1h`` for the one-hour
+        # Anthropic tier; the five-minute rate is the one every write is billed
+        # at unless a caller asks otherwise, so that is the one carried.
+        cache_write_price=_per_million(pricing.get("input_cache_write")),
         context_window=_first_positive_int(
             entry.get("context_length"),
             entry.get("context_window"),
@@ -962,6 +995,7 @@ def _from_static(model_id: str, info: ModelInfo) -> DiscoveredModel:
         input_price=_positive_float(info.input_price),
         output_price=_positive_float(info.output_price),
         cache_read_price=_positive_float(info.cache_reads_price),
+        cache_write_price=_positive_float(info.cache_writes_price),
         supports_images=_stated_bool(info.supports_images),
         supports_prompt_cache=bool(info.supports_prompt_cache),
     )
@@ -1005,6 +1039,9 @@ def _merge_one(row: DiscoveredModel, info: ModelInfo | None) -> DiscoveredModel:
         output_price=_positive_float(row.output_price) or _positive_float(info.output_price),
         cache_read_price=(
             _positive_float(row.cache_read_price) or _positive_float(info.cache_reads_price)
+        ),
+        cache_write_price=(
+            _positive_float(row.cache_write_price) or _positive_float(info.cache_writes_price)
         ),
         # The provider decides its own capabilities WHEN IT SPEAKS: a stated
         # ``false`` is an answer, and OR-ing it against the registry made it
@@ -1127,6 +1164,7 @@ def _rows_from_payload(
                 input_price=_positive_float(entry.get("input_price")),
                 output_price=_positive_float(entry.get("output_price")),
                 cache_read_price=_positive_float(entry.get("cache_read_price")),
+                cache_write_price=_positive_float(entry.get("cache_write_price")),
                 # ``null`` in the document is the listing's silence, faithfully
                 # stored by ``dataclasses.asdict``. Reading it as False would let
                 # a cache round-trip turn "unstated" into a denial, so the same
@@ -1149,6 +1187,7 @@ def available_models(
     cache_dir: Path | None = None,
     client: httpx.Client | None = None,
     timeout: float = DEFAULT_TIMEOUT_S,
+    want_id: str | None = None,
 ) -> tuple[list[DiscoveredModel], ListingStatus]:
     """Every model a UI should offer for ``provider_id``, plus how it was obtained.
 
@@ -1157,13 +1196,28 @@ def available_models(
     replace registry-only ids. This never raises and never blocks longer than
     ``timeout``; a fresh cache skips the request entirely.
 
+    ``ttl_s`` is the HARD TTL beyond which the call blocks on a fetch. A
+    document older than ``catalogue.SOFT_TTL_S`` but inside it is served as-is
+    and refreshed in the background (stale-while-revalidate), so callers on a
+    boot or paint path pay nothing for freshness; a caller that wants a fresher
+    answer NOW (the model picker) passes a shorter ``ttl_s``.
+
+    ``want_id`` is the id the caller is about to look up. If it is absent from a
+    stored document at least ``catalogue.MISS_REFETCH_MIN_AGE_S`` old, the
+    document is refetched ONCE, synchronously, within ``timeout`` — the one
+    trigger that beats every TTL for a model released this morning, because it
+    fires for exactly the id the user asked for. A young document that lacks the
+    id is believed (a typo must not refetch on every resolution), and the
+    refetched document is zero seconds old, so a second miss is believed too.
+
     Returns:
         ``(models, status)``, where status is ``"ok"`` (fetched live just now),
-        ``"cached"`` (served a stored document because the fetch failed or was
-        skipped as still fresh), ``"static"`` (registry only -- no listing
-        endpoint, or no cache and no successful fetch), ``"unauthenticated"``
-        (the provider needs a credential to list and none was supplied) or
-        ``"empty"`` (the provider answered and listed no models).
+        ``"cached"`` (served a stored document with no fetch needed), ``"stale"``
+        (a fetch was attempted and failed; the stored document is what you got),
+        ``"static"`` (registry only -- no listing endpoint, or no cache and no
+        successful fetch), ``"unauthenticated"`` (the provider needs a credential
+        to list and none was supplied) or ``"empty"`` (the provider answered and
+        listed no models).
     """
     rows = _static_rows(provider_id)
     try:
@@ -1178,6 +1232,7 @@ def available_models(
             cache_dir=cache_dir,
             client=client,
             timeout=timeout,
+            want_id=want_id,
         )
     except Exception as exc:  # noqa: BLE001 - a broken provider is an annotation
         # The layers below already swallow transport failures, so reaching here
@@ -1199,6 +1254,7 @@ def _available_models(
     cache_dir: Path | None,
     client: httpx.Client | None,
     timeout: float,
+    want_id: str | None = None,
 ) -> tuple[list[DiscoveredModel], ListingStatus]:
     definition = get_provider_definition(provider_id)
     transport = _TRANSPORTS.get(definition.id) if definition is not None else None
@@ -1222,16 +1278,9 @@ def _available_models(
         # catalogue is a public page even though inference is not.
         return merge_models(rows, None), "unauthenticated"
 
-    # ``cached_listing`` signals "the fetch failed, serve the stale document" by
-    # catching an exception from the thunk, and reports nothing about which path
-    # it took. This flag is how a live answer is told from a cached one, which is
-    # the whole difference between the "ok" and "cached" statuses.
-    fetched = False
-
     capture = listing_capture_version(definition.id)
 
     def fetch() -> dict[str, Any]:
-        nonlocal fetched
         live = fetch_models(
             definition.id,
             api_key=api_key,
@@ -1243,7 +1292,6 @@ def _available_models(
         )
         if live is None:
             raise _ListingUnavailable(definition.id)
-        fetched = True
         return {
             "capture": capture,
             "models": [dataclasses.asdict(row) for row in live],
@@ -1265,11 +1313,36 @@ def _available_models(
         account_id=account_id,
         host_scoped=bool(is_oauth and definition.oauth_base_url),
     )
-    payload = cached_listing(key, fetch, ttl_s=ttl_s, cache_dir=cache_dir)
+    # The soft TTL never exceeds the hard one: a picker asking for a 15-minute
+    # document wants it fetched NOW, not served-and-refreshed-later.
+    soft_ttl_s = min(SOFT_TTL_S, ttl_s)
+
+    def lacks_want_id(document: Mapping[str, object], age_s: float) -> bool:
+        # The id the caller is about to resolve is not in a document old enough
+        # to predate it: declare the document expired so `read_listing` fetches
+        # ONCE, synchronously, under the lease and inside the caller's budget.
+        # Not a loop: the refetched document is 0s old, so the next miss for the
+        # same id is believed for ten minutes. A young document that lacks the
+        # id is right (a typo), and a document this reader cannot map is handled
+        # by the invalidate-and-re-enter below rather than here.
+        if want_id is None or age_s < MISS_REFETCH_MIN_AGE_S:
+            return False
+        mapped = _rows_from_payload(document, capture)
+        return mapped is not None and not _lists_id(mapped, want_id)
+
+    listing = read_listing(
+        key,
+        fetch,
+        soft_ttl_s=soft_ttl_s,
+        ttl_s=ttl_s,
+        cache_dir=cache_dir,
+        refetch_if=lacks_want_id,
+    )
+    payload = listing.payload
     live_rows = _rows_from_payload(payload, capture)
     if live_rows is None:
         if payload is not None:
-            # A document `cached_listing` could read but this reader cannot use:
+            # A document `read_listing` could read but this reader cannot use:
             # a `models` key that is not an array (a payload-shape change, a
             # truncated write) or a capture older than the transports that will
             # read it. It is written before anything interprets it, so leaving it
@@ -1279,13 +1352,16 @@ def _available_models(
             # Dropping it costs one refetch.
             invalidate(key, cache_dir=cache_dir)
             # RE-ENTER once. Dropping the document without retrying meant the
-            # fetch that was supposed to replace it never ran: `cached_listing`
+            # fetch that was supposed to replace it never ran: `read_listing`
             # had already served this call from a fresh hit, so the thunk was
             # never invoked, and the answer fell through to the registry's static
             # rows — of which an aggregator has NONE. Offline that is an empty
             # model list on every start; online it memoises a session booted at
             # default context, no prompt cache and zero prices.
-            payload = cached_listing(key, fetch, ttl_s=ttl_s, cache_dir=cache_dir)
+            listing = read_listing(
+                key, fetch, soft_ttl_s=soft_ttl_s, ttl_s=ttl_s, cache_dir=cache_dir
+            )
+            payload = listing.payload
             live_rows = _rows_from_payload(payload, capture)
         if live_rows is None:
             # Neither a listing nor a cache: the registry is all there is.
@@ -1305,6 +1381,26 @@ def _available_models(
         live_rows,
         include_static_only=not authoritative_live,
     )
-    if not fetched:
-        return merged, "cached"
-    return merged, ("empty" if not live_rows else "ok")
+    return merged, _status_of(listing, live_rows)
+
+
+def _status_of(listing: Listing, live_rows: list[DiscoveredModel]) -> ListingStatus:
+    """The status a served document earns, from how :func:`read_listing` got it."""
+    if listing.fetched:
+        return "empty" if not live_rows else "ok"
+    if listing.failed:
+        return "stale"
+    return "cached"
+
+
+def _lists_id(rows: list[DiscoveredModel], model_id: str) -> bool:
+    """Whether ``model_id`` is in ``rows``, exactly or under the normalised spelling.
+
+    The same two-step match ``configure._info_from_discovery`` performs, so the
+    miss that triggers a refetch here is the miss that would have cost the
+    caller its answer.
+    """
+    if any(row.id == model_id for row in rows):
+        return True
+    wanted = normalised_id(model_id)
+    return any(normalised_id(row.id) == wanted for row in rows)

--- a/local_operator/model/ids.py
+++ b/local_operator/model/ids.py
@@ -1,0 +1,78 @@
+"""Model-id spelling rules shared by every lookup that matches ids across sources.
+
+WHY A MODULE OF ITS OWN
+-----------------------
+Three modules compare ids that different parties spelled: ``configure`` matches
+what the user typed against a listing, ``discovery`` decides whether a requested
+id is missing from a cached document (the ``want_id`` refetch trigger), and
+``prices`` looks a provider's id up in a third-party price catalogue. They
+cannot share the helpers through any one of themselves: ``configure`` is on the
+CLI import path and must not import ``discovery`` (httpx) at module level, and
+``discovery`` must not import ``configure`` back. Pure string functions with no
+imports are the only thing all three can depend on without a cycle.
+
+Nothing here touches the network, a file, or the registry.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: A trailing Anthropic-style release stamp: `claude-opus-4-5-20251101`.
+_DATE_SUFFIX_RE = re.compile(r"-\d{8}$")
+
+#: A version separated by a dash between two digits: the `4-5` of `claude-opus-4-5`.
+#: Anchored on digits BOTH sides so `qwen2.5-coder-1.5b` and `gpt-4o-mini` are left
+#: alone — only a dash that is standing in for a decimal point is rewritten.
+_DOTTED_VERSION_RE = re.compile(r"(?<=\d)-(?=\d)")
+
+
+def normalised_id(model_id: str) -> str:
+    """A model id in the one spelling both sides of a match can agree on.
+
+    Discovery NORMALISES ids on ingest — ``_row_from_gemini_entry`` strips
+    Google's ``models/`` resource prefix so the rest of the system sees a bare id
+    — while the user types whatever the provider's own documentation shows, which
+    for Gemini is ``models/gemini-2.5-pro``. An exact-match-only lookup therefore
+    missed the spelling Google itself publishes and handed that session the 128k
+    unknown default. Case is folded for the same reason: an id is a wire
+    identifier, not prose, and no provider ships two models differing only in case.
+    """
+    trimmed = model_id.strip()
+    prefix = "models/"
+    if trimmed.startswith(prefix):
+        trimmed = trimmed[len(prefix) :]
+    return trimmed.casefold()
+
+
+def id_spellings(model_id: str) -> list[str]:
+    """``model_id`` as a second-hand catalogue might spell it, most literal first.
+
+    Providers and catalogues disagree about punctuation for the SAME model, and
+    the disagreement is systematic rather than per-model: Anthropic ships
+    `claude-opus-4-5-20251101` while OpenRouter lists `anthropic/claude-opus-4.5`
+    and models.dev keys `openai/gpt-5.4` where the user may type `gpt-5-4`.
+    Trying only the literal id would leave every dated Claude snapshot unpriced,
+    which is precisely the population a price lookup exists for.
+
+    Both rewrites are conservative — a date stamp is eight digits at the end, and a
+    dash becomes a dot only between two digits — and every candidate must still be
+    found in the catalogue before it is believed. A miss costs one dict lookup.
+
+    Order is most-literal-first, and the DOTTED-WITH-DATE form comes before either
+    date-stripped one on purpose: catalogues publish dated snapshots under their
+    own dated ids alongside the undated alias (`anthropic/claude-3.5-sonnet-20240620`
+    as well as `anthropic/claude-3.5-sonnet`), so stripping the date first would
+    answer a question about one snapshot with the alias's price. Harmless while
+    snapshots of a family share a rate, wrong the day one does not.
+    """
+    stripped = _DATE_SUFFIX_RE.sub("", model_id)
+    candidates = [model_id]
+    for candidate in (
+        _DOTTED_VERSION_RE.sub(".", model_id),
+        stripped,
+        _DOTTED_VERSION_RE.sub(".", stripped),
+    ):
+        if candidate and candidate not in candidates:
+            candidates.append(candidate)
+    return candidates

--- a/local_operator/model/prices.py
+++ b/local_operator/model/prices.py
@@ -85,12 +85,18 @@ PRICE_CATALOGUE_CAPTURE = 1
 #: canonical one after ``credential_provider_id``, so the login flavours
 #: (``xai-oauth``, ``openai-device``, ...) need no entry.
 #:
-#: The second keys are subscription/plan catalogues models.dev lists apart from
-#: the pay-per-token one (Kimi's coding plan lists ``k3``, which ``moonshotai``
-#: does not; Z.AI's coding plan likewise). They carry no ``cost`` today, so they
-#: contribute limits only, and only for ids the primary key lacks.
-#: ``alibaba-token-plan`` is a plan of ``alibaba``'s models, so its own key comes
-#: first (plan-specific limits) and the pay-per-token key fills the price.
+#: ``_lookup`` returns the first key's entry for an id OUTRIGHT; it never
+#: merges a second key's fields into it. The second keys are subscription/plan
+#: catalogues models.dev lists apart from the pay-per-token one (Kimi's coding
+#: plan lists ``k3``, which ``moonshotai`` does not; Z.AI's coding plan
+#: likewise), reached only for an id the first key lacks entirely.
+#: ``alibaba-token-plan`` is a plan of ``alibaba``'s models with its own key
+#: first, so an id it lists answers with the plan's numbers alone — which
+#: models.dev quotes as 0/0 on purpose, because the plan bills credits rather
+#: than USD per token. Those zeros are the intended answer ("cost unknown", per
+#: ``_fill_from_row``), NOT a hole for the pay-per-token key to fill: quoting
+#: ``alibaba``'s USD rate for a credit plan would print a cost the user is not
+#: paying. The pay-per-token key is there for a model the plan does not list.
 #:
 #: ``radient`` is deliberately absent: models.dev does not list it, and its own
 #: listing quotes prices, so leg 1 of resolution already covers it.

--- a/local_operator/model/prices.py
+++ b/local_operator/model/prices.py
@@ -1,0 +1,332 @@
+"""Provider-neutral prices and limits from models.dev, cached like a listing.
+
+WHY THIS EXISTS
+---------------
+No direct provider quotes money in its model listing: Anthropic's ``/v1/models``
+carries ``id``, ``display_name``, ``created_at`` and limits, OpenAI's is bare
+ids, Gemini's has token limits only. So for an id the shipped registry has not
+been taught, the ONLY price source used to be the OpenRouter listing, looked up
+under a per-provider namespace. That coupled every direct provider's cost
+display to one aggregator's public document and its id spellings — and on the
+day Anthropic published ``claude-fable-5-1`` the OpenRouter document on disk was
+six hours old and predated the row, so a user signed in only to Anthropic ran
+the whole day at ``$0.00``.
+
+`models.dev <https://models.dev>`_ is a community-maintained, keyless JSON of
+every provider's models with ``cost {input, output, cache_read, cache_write}``
+in $/MTok and ``limit {context, output}``, provider-keyed, updated the day a
+model ships (verified: ``anthropic.models["claude-fable-5-1"]`` carried
+10/50/0.25/12.5 and a 1M/128k limit on its release date). It answers a weak
+ETag and honours ``If-None-Match`` with a 0-byte 304, so keeping it fresh
+hourly costs one header round trip per machine.
+
+WHAT IS STORED
+--------------
+The source is 4.4 MB and 200+ providers. What lands on disk is a PROJECTION:
+only the providers this tree maps (:data:`_PRICE_CATALOGUE_KEYS`) and only the
+five fields a :class:`DiscoveredModel` can carry — measured at ~141 KB, a
+quarter of the OpenRouter listing, so the JSON parse the resolution memo exists
+to avoid stays in the tens of milliseconds. The ETag rides in the document so
+the next fetch can be conditional. The document goes through
+:func:`local_operator.model.catalogue.read_listing` under the key
+``models-dev.listing`` — same directory, same lease, same stale-while-revalidate
+state machine as every provider listing.
+
+WHAT IS NOT TAKEN
+-----------------
+``supports_images`` is left ``None``: it carries a three-valued contract in
+which a stated ``false`` is the PROVIDER's denial, and a second-hand catalogue
+has no standing to issue one. ``supports_prompt_cache`` is inferred from a
+quoted cache-read price, the same inference discovery makes for an
+OpenAI-compatible listing and only ever widening.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from local_operator.model.catalogue import (
+    DEFAULT_TTL_S,
+    MISS_REFETCH_MIN_AGE_S,
+    SOFT_TTL_S,
+    _schedule_revalidate,
+    invalidate,
+    peek_listing,
+    read_listing,
+)
+from local_operator.model.discovery import (
+    DEFAULT_TIMEOUT_S,
+    DiscoveredModel,
+    _positive_float,
+    _positive_int,
+)
+from local_operator.model.ids import id_spellings, normalised_id
+
+logger = logging.getLogger("local_operator.model.prices")
+
+#: The public document. Keyless; see the module docstring for what it carries.
+MODELS_DEV_URL = "https://models.dev/api.json"
+
+#: Document name in the catalogue cache. Ends in ``.listing`` so the legacy
+#: purge glob (``*.models.json``) can never match it.
+PRICE_CATALOGUE_KEY = "models-dev.listing"
+
+#: Stamped into the projection and required when it is read back, for the same
+#: reason ``discovery.LISTING_CAPTURE_VERSIONS`` exists: a reader that starts
+#: needing a field the writer did not record must be able to force one refetch
+#: rather than serve zeros for a day. Version 1 is the five-field projection.
+PRICE_CATALOGUE_CAPTURE = 1
+
+#: A local (canonical) provider id, mapped to the models.dev provider keys that
+#: describe the same models — FIRST MATCH WINS, per model id. The local id is the
+#: canonical one after ``credential_provider_id``, so the login flavours
+#: (``xai-oauth``, ``openai-device``, ...) need no entry.
+#:
+#: The second keys are subscription/plan catalogues models.dev lists apart from
+#: the pay-per-token one (Kimi's coding plan lists ``k3``, which ``moonshotai``
+#: does not; Z.AI's coding plan likewise). They carry no ``cost`` today, so they
+#: contribute limits only, and only for ids the primary key lacks.
+#: ``alibaba-token-plan`` is a plan of ``alibaba``'s models, so its own key comes
+#: first (plan-specific limits) and the pay-per-token key fills the price.
+#:
+#: ``radient`` is deliberately absent: models.dev does not list it, and its own
+#: listing quotes prices, so leg 1 of resolution already covers it.
+_PRICE_CATALOGUE_KEYS: dict[str, tuple[str, ...]] = {
+    "anthropic": ("anthropic",),
+    "openai": ("openai",),
+    "google": ("google",),
+    "xai": ("xai",),
+    "deepseek": ("deepseek",),
+    "mistral": ("mistral",),
+    "kimi": ("moonshotai", "kimi-for-coding"),
+    "zai": ("zai", "zai-coding-plan"),
+    "alibaba": ("alibaba",),
+    "alibaba-token-plan": ("alibaba-token-plan", "alibaba"),
+    "openrouter": ("openrouter",),
+}
+
+#: Every models.dev key the projection keeps, derived from the map above so the
+#: two cannot disagree about what is on disk.
+_PROJECTED_PROVIDERS: frozenset[str] = frozenset(
+    key for keys in _PRICE_CATALOGUE_KEYS.values() for key in keys
+)
+
+
+def project(body: Mapping[str, Any], etag: str | None) -> dict[str, Any]:
+    """The on-disk document for a models.dev body: mapped providers, five fields.
+
+    Pure, so a test can hand it a captured body. Anything that is not the
+    expected shape is skipped rather than raised — a key rename upstream must
+    land as "no prices" (holes stay holes), never as a failed resolution.
+    """
+    providers: dict[str, dict[str, Any]] = {}
+    for provider_key in _PROJECTED_PROVIDERS:
+        provider = body.get(provider_key)
+        if not isinstance(provider, Mapping):
+            continue
+        models = provider.get("models")
+        if not isinstance(models, Mapping):
+            continue
+        projected: dict[str, Any] = {}
+        for model_id, model in models.items():
+            if not isinstance(model_id, str) or not isinstance(model, Mapping):
+                continue
+            cost = model.get("cost")
+            limit = model.get("limit")
+            projected[model_id] = {
+                "name": model.get("name") if isinstance(model.get("name"), str) else "",
+                "cost": dict(cost) if isinstance(cost, Mapping) else {},
+                "limit": dict(limit) if isinstance(limit, Mapping) else {},
+                "attachment": (
+                    model.get("attachment") if isinstance(model.get("attachment"), bool) else None
+                ),
+                "release_date": (
+                    model.get("release_date") if isinstance(model.get("release_date"), str) else ""
+                ),
+            }
+        providers[provider_key] = projected
+    return {"capture": PRICE_CATALOGUE_CAPTURE, "etag": etag, "providers": providers}
+
+
+def _fetch(timeout: float, cache_dir: Path | None) -> dict[str, Any]:
+    """The ``read_listing`` thunk: conditional GET, projected on the way in.
+
+    A 304 hands the previous document back unchanged so ``_write_cache`` re-stamps
+    its ``fetched_at`` — "validated just now" — without re-parsing 4.4 MB. Any
+    other non-200, or a body that is not an object, raises so ``read_listing``
+    applies its stale-beats-absent rule instead of overwriting a good document.
+
+    ``httpx`` is imported here rather than at module level for the same reason
+    ``configure`` imports discovery lazily: this module is reached from the
+    resolution path, and a CLI invocation that resolves a fully described model
+    never needs an HTTP client.
+    """
+    import httpx
+
+    previous = peek_listing(PRICE_CATALOGUE_KEY, cache_dir=cache_dir).payload
+    headers: dict[str, str] = {}
+    etag = previous.get("etag") if previous is not None else None
+    if isinstance(etag, str) and etag:
+        headers["If-None-Match"] = etag
+    response = httpx.get(MODELS_DEV_URL, headers=headers, timeout=timeout, follow_redirects=True)
+    if response.status_code == 304 and previous is not None:
+        logger.debug("models.dev catalogue unchanged (304, etag %s)", etag)
+        return dict(previous)
+    if response.status_code != 200:
+        raise RuntimeError(f"models.dev answered {response.status_code}")
+    body = response.json()
+    if not isinstance(body, Mapping):
+        raise RuntimeError("models.dev body is not an object")
+    document = project(body, response.headers.get("etag"))
+    logger.debug(
+        "models.dev catalogue fetched: %d providers projected, etag %s",
+        len(document["providers"]),
+        document["etag"],
+    )
+    return document
+
+
+def _usable(payload: Mapping[str, Any] | None) -> Mapping[str, Any] | None:
+    """The ``providers`` map of a document this reader can use, else ``None``.
+
+    A capture mismatch is treated as no document, same as discovery's reader:
+    the shape may parse perfectly while a field this version needs is missing.
+    """
+    if payload is None:
+        return None
+    if _positive_int(payload.get("capture")) != PRICE_CATALOGUE_CAPTURE:
+        return None
+    providers = payload.get("providers")
+    return providers if isinstance(providers, Mapping) else None
+
+
+def _row(model_id: str, entry: Mapping[str, Any]) -> DiscoveredModel:
+    """One projected entry as the struct every other resolution leg speaks."""
+    cost = entry.get("cost")
+    cost = cost if isinstance(cost, Mapping) else {}
+    limit = entry.get("limit")
+    limit = limit if isinstance(limit, Mapping) else {}
+    cache_read = _positive_float(cost.get("cache_read"))
+    name = entry.get("name")
+    return DiscoveredModel(
+        id=model_id,
+        name=name if isinstance(name, str) else "",
+        context_window=_positive_int(limit.get("context")),
+        max_tokens=_positive_int(limit.get("output")),
+        input_price=_positive_float(cost.get("input")),
+        output_price=_positive_float(cost.get("output")),
+        cache_read_price=cache_read,
+        cache_write_price=_positive_float(cost.get("cache_write")),
+        # Never from here: a second-hand catalogue cannot issue the provider's
+        # denial that a stated ``False`` means. See the module docstring.
+        supports_images=None,
+        supports_prompt_cache=cache_read > 0,
+    )
+
+
+def _lookup(providers: Mapping[str, Any], provider: str, model_id: str) -> DiscoveredModel | None:
+    """``model_id`` under the first mapped key that lists it, or ``None``.
+
+    Three spellings per key, most literal first: the id as given, the normalised
+    id (``models/`` prefix stripped, case folded, matched against normalised keys)
+    and the dotted/dashed rewrites in :func:`id_spellings`. For ``openrouter``
+    the id already carries its ``vendor/`` namespace, which is how models.dev
+    keys that provider too, so no namespace mapping is needed.
+    """
+    for key in _PRICE_CATALOGUE_KEYS.get(provider, ()):
+        models = providers.get(key)
+        if not isinstance(models, Mapping):
+            continue
+        for spelling in id_spellings(model_id):
+            entry = models.get(spelling)
+            if isinstance(entry, Mapping):
+                return _row(spelling, entry)
+        wanted = normalised_id(model_id)
+        for candidate, entry in models.items():
+            if isinstance(candidate, str) and isinstance(entry, Mapping):
+                if normalised_id(candidate) == wanted:
+                    return _row(candidate, entry)
+    return None
+
+
+def price_catalogue_row(
+    provider: str,
+    model_id: str,
+    *,
+    timeout: float = DEFAULT_TIMEOUT_S,
+    ttl_s: float = DEFAULT_TTL_S,
+    cache_dir: Path | None = None,
+) -> DiscoveredModel | None:
+    """Prices and limits for ``provider/model_id`` from models.dev, or ``None``.
+
+    Never raises. ``timeout`` bounds the ONE request this may make and is the
+    caller's remaining resolution budget (see ``configure._remaining_budget``);
+    a cold machine with no document pays one 4.4 MB download inside it.
+
+    The ``want_id`` rule from discovery applies here too: an id absent from a
+    document at least ``MISS_REFETCH_MIN_AGE_S`` old is refetched once,
+    synchronously — for this document that is usually a 0-byte 304 unless the
+    row really did just land, which is the case this exists for.
+    """
+    if provider not in _PRICE_CATALOGUE_KEYS:
+        return None
+    try:
+        return _price_catalogue_row(provider, model_id, timeout, ttl_s, cache_dir)
+    except Exception as exc:  # noqa: BLE001 — a price is never worth a failed start
+        logger.debug("models.dev catalogue unavailable for %s/%s: %s", provider, model_id, exc)
+        return None
+
+
+def _price_catalogue_row(
+    provider: str, model_id: str, timeout: float, ttl_s: float, cache_dir: Path | None
+) -> DiscoveredModel | None:
+    def fetch() -> dict[str, Any]:
+        return _fetch(timeout, cache_dir)
+
+    def lacks_model(document: Mapping[str, Any], age_s: float) -> bool:
+        # The `want_id` rule: a usable document old enough to predate the id
+        # is refetched once — usually a 0-byte 304 unless the row really did
+        # just land, which is the case this exists for. An unusable document
+        # is handled by the invalidate-and-re-enter below, not here.
+        if age_s < MISS_REFETCH_MIN_AGE_S:
+            return False
+        known = _usable(document)
+        return known is not None and _lookup(known, provider, model_id) is None
+
+    listing = read_listing(
+        PRICE_CATALOGUE_KEY,
+        fetch,
+        soft_ttl_s=min(SOFT_TTL_S, ttl_s),
+        ttl_s=ttl_s,
+        cache_dir=cache_dir,
+        refetch_if=lacks_model,
+    )
+    providers = _usable(listing.payload)
+    if providers is None and listing.payload is not None:
+        # A document from an older capture, or one whose shape this reader does
+        # not recognise: drop it and refetch IN THIS CALL, the same recovery
+        # discovery performs, so the fix is not invisible for a day.
+        invalidate(PRICE_CATALOGUE_KEY, cache_dir=cache_dir)
+        listing = read_listing(
+            PRICE_CATALOGUE_KEY, fetch, soft_ttl_s=0, ttl_s=0, cache_dir=cache_dir
+        )
+        providers = _usable(listing.payload)
+    if providers is None:
+        if listing.failed:
+            # COLD MISS THAT FAILED. The first resolution on a machine with no
+            # document pays a 4.4 MB download inside a 3 s leg budget, and on a
+            # slow link that times out — evidence the budget was too small, not
+            # that the network is down. The one case where a failed sync fetch
+            # is followed by a background retry, with the full default timeout,
+            # so the NEXT resolution finds the document instead of the session
+            # running unpriced all day. Backoff-bounded like every other
+            # revalidation; a genuinely offline machine gets one thread per
+            # five minutes, not one per repaint.
+            _schedule_revalidate(
+                PRICE_CATALOGUE_KEY, lambda: _fetch(DEFAULT_TIMEOUT_S, cache_dir), cache_dir
+            )
+        return None
+    return _lookup(providers, provider, model_id)

--- a/local_operator/model/prices.py
+++ b/local_operator/model/prices.py
@@ -284,7 +284,16 @@ def _price_catalogue_row(
     provider: str, model_id: str, timeout: float, ttl_s: float, cache_dir: Path | None
 ) -> DiscoveredModel | None:
     def fetch() -> dict[str, Any]:
+        # On the calling path: the leg's budget (3 s at most, less when the
+        # provider's own listing spent some of the shared deadline).
         return _fetch(timeout, cache_dir)
+
+    def revalidate() -> dict[str, Any]:
+        # Off the calling path, where the leg budget is the wrong ceiling: a 4.4 MB
+        # download that needs more than 3 s would fail every background attempt
+        # and leave the document to the 24 h sync path. Same full ceiling the
+        # cold-miss retry below already uses.
+        return _fetch(DEFAULT_TIMEOUT_S, cache_dir)
 
     def lacks_model(document: Mapping[str, Any], age_s: float) -> bool:
         # The `want_id` rule: a usable document old enough to predate the id
@@ -303,6 +312,7 @@ def _price_catalogue_row(
         ttl_s=ttl_s,
         cache_dir=cache_dir,
         refetch_if=lacks_model,
+        revalidate=revalidate,
     )
     providers = _usable(listing.payload)
     if providers is None and listing.payload is not None:

--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -2217,8 +2217,9 @@ xai_models: Dict[str, ModelInfo] = {
 #: OpenRouter resells through its own discounted arrangements, and a user
 #: billed by Z.AI directly is charged the direct rate. Quoting the aggregator's
 #: number on the direct route would under-report every session's cost, so the
-#: direct rate is the one carried here and `_AGGREGATOR_NAMESPACE`'s OpenRouter
-#: fallback only ever fills a model this table does not price at all.
+#: direct rate is the one carried here and the models.dev price-catalogue leg
+#: (`configure._from_price_catalogue`) only ever fills a model this table does
+#: not price at all.
 #:
 #: They are carried STATICALLY because Z.AI's `/models` endpoint
 #: returns bare `{id, object, created, owned_by}` rows with no pricing, context

--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -74,6 +74,15 @@ LoginCallbackFactory = Callable[[ProviderDefinition], "LoginCallbacks"]
 #: a request per warm tick the same day.
 EMPTY_OVER_DATA_ACCEPT_MS = 30 * 60_000
 
+#: The listing TTL the ``/model`` picker asks :meth:`live_catalogue` for. The
+#: user is asking NOW, and the fetch already runs off-loop behind rows painted
+#: from the registry, so a short TTL costs nothing visible. Fifteen minutes is
+#: short enough that a release announced during a working session shows on the
+#: next open, and long enough that scrolling in and out of the picker does not
+#: re-list nine providers. Boot and repaint paths keep the default 24h hard TTL
+#: (with an hourly background refresh) because there a request IS visible.
+PICKER_TTL_S = 15 * 60
+
 
 @dataclasses.dataclass(frozen=True)
 class CatalogueEntry:
@@ -1052,8 +1061,11 @@ class ProviderController:
         """The catalogue with each provider's LIVE listing layered over the registry.
 
         Returns ``(entries, statuses)`` where ``statuses`` maps provider id to one
-        of discovery's status strings, so a UI can say "cached" or "login
+        of discovery's status strings, so a UI can say "stale" or "login
         required" instead of implying the catalogue is complete.
+
+        ``ttl_s`` is the hard TTL passed to discovery; the picker passes
+        :data:`PICKER_TTL_S`, and ``None`` keeps discovery's default.
 
         Only providers with a credential are fetched. An unconnected provider still
         contributes its STATIC models — the question "what would I get if I logged

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -13927,11 +13927,20 @@ class OperatorApp(App[None]):
             self.run_worker(self._refresh_catalogue(), thread=False, group="catalogue")
 
     async def _refresh_catalogue(self) -> None:
-        """Worker: replace the picker's rows with the live catalogue."""
+        """Worker: replace the picker's rows with the live catalogue.
+
+        Asks for a FIFTEEN-MINUTE listing rather than discovery's 24h default.
+        The user opening `/model` is the one moment a fresh list is worth a
+        request: the rows are already painted from the registry and the fetch
+        runs off-loop, so the cost is invisible, and a 24h document is exactly
+        how a model published this morning failed to appear here all day.
+        """
         if self._providers is None:
             return
+        from local_operator.providers.controller import PICKER_TTL_S
+
         try:
-            entries, statuses = await self._providers.live_catalogue()
+            entries, statuses = await self._providers.live_catalogue(ttl_s=PICKER_TTL_S)
         except Exception as error:  # noqa: BLE001 — a picker must not take the app down
             rows, note = self._catalogue_rows(self._providers.static_catalogue())
             self._editor().model_picker.set_rows(
@@ -20402,20 +20411,28 @@ def _catalogue_status(statuses: dict[str, str]) -> str:
     Silence when every provider answered, because a footer that always says
     something is a footer nobody reads. The interesting cases are the ones where a
     user hunting for a model released last week would otherwise conclude it does
-    not exist: a cached list, or a provider whose live fetch failed.
+    not exist: a provider whose live fetch FAILED and is showing an old list, or
+    one that listed nothing.
+
+    ``cached`` is silent too. The picker asks for a fifteen-minute listing
+    (``PICKER_TTL_S``), so "cached" means "listed within the last quarter hour",
+    which is not something the user needs to read; it used to be reported when
+    it could also mean "a day old", and it could not be told from a failed
+    refresh at all (both were ``cached``). ``stale`` is the new status for that
+    failure, and it is the one worth a line.
 
     An ``unauthenticated`` provider is deliberately NOT reported here. Its models
     are the ones the picker now hides, and `_catalogue_rows` already counts them
     — two footers counting one fact ("3 provider(s) need a login · 42 hidden")
     reads as two separate problems.
     """
-    cached = sorted(p for p, s in statuses.items() if s == "cached")
-    stale = sorted(p for p, s in statuses.items() if s in ("unavailable", "empty"))
+    stale = sorted(p for p, s in statuses.items() if s == "stale")
+    empty = sorted(p for p, s in statuses.items() if s == "empty")
     bits: list[str] = []
-    if cached:
-        bits.append(f"cached: {', '.join(cached)}")
     if stale:
-        bits.append(f"no live list: {', '.join(stale)}")
+        bits.append(f"live list unavailable: {', '.join(stale)} — showing cached")
+    if empty:
+        bits.append(f"no live list: {', '.join(empty)}")
     return " · ".join(bits)
 
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -288,8 +288,12 @@ PERSIST_HINT = "d in /model saves this for new sessions"
 STALE_LIST_LABEL = "stale list:"
 
 #: Discovery statuses that mean "this provider produced a listing" (live or
-#: stored). The complement — ``static`` and ``unauthenticated`` — never asked
-#: the network, so they are not part of "every provider is stale".
+#: stored). The complement — ``static`` and ``unauthenticated`` — produced no
+#: listing, so they are not part of "every provider is stale". ``static`` is
+#: not only "has no listing endpoint": discovery also reports it for a provider
+#: whose fetch failed with no stored document to fall back on. Excluding that
+#: case only makes the offline collapse fire sooner, which is the right
+#: direction.
 LISTED_STATUSES = frozenset({"ok", "cached", "stale", "empty"})
 
 #: Marks a cost figure RESTORED from a resumed conversation rather than accrued
@@ -20466,8 +20470,9 @@ def _catalogue_status(statuses: dict[str, str]) -> str:
     """
     stale = sorted(p for p, s in statuses.items() if s == "stale")
     empty = sorted(p for p, s in statuses.items() if s == "empty")
-    # ``static`` (no listing endpoint) and ``unauthenticated`` (never asked)
-    # produced no listing, so they do not count toward "every provider".
+    # ``static`` (no listing endpoint, or a failed fetch with nothing stored)
+    # and ``unauthenticated`` produced no listing, so they do not count toward
+    # "every provider".
     listed = sum(1 for s in statuses.values() if s in LISTED_STATUSES)
     bits: list[str] = []
     if len(stale) > 1 and len(stale) == listed:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -278,6 +278,20 @@ if TYPE_CHECKING:  # keeps the provider graph off the TUI's runtime import path
 #: notice), where "press d" alone would name a key that does nothing yet.
 PERSIST_HINT = "d in /model saves this for new sessions"
 
+#: Lead of the `/model` footer clause for a provider whose live refresh FAILED
+#: and whose rows are therefore an older document. One constant because the
+#: clause is composed at two sites (`_catalogue_status` per provider, and the
+#: `live_catalogue` exception path for all of them) and a reader who sees both
+#: across two sessions must meet one vocabulary. Kept short on purpose: the
+#: access note leads the footer and leaves ~39 cells for this clause at 100
+#: columns (see `_catalogue_status`).
+STALE_LIST_LABEL = "stale list:"
+
+#: Discovery statuses that mean "this provider produced a listing" (live or
+#: stored). The complement — ``static`` and ``unauthenticated`` — never asked
+#: the network, so they are not part of "every provider is stale".
+LISTED_STATUSES = frozenset({"ok", "cached", "stale", "empty"})
+
 #: Marks a cost figure RESTORED from a resumed conversation rather than accrued
 #: this session. The restored number is a floor — only the last reported turn's
 #: usage survives in a priceable form — and it lands in the same cell a real
@@ -13943,10 +13957,17 @@ class OperatorApp(App[None]):
             entries, statuses = await self._providers.live_catalogue(ttl_s=PICKER_TTL_S)
         except Exception as error:  # noqa: BLE001 — a picker must not take the app down
             rows, note = self._catalogue_rows(self._providers.static_catalogue())
+            # Same label `_catalogue_status` uses for a failed refresh, so the two
+            # ways a live list can fail read as one vocabulary; the exception took
+            # every provider down together, which is that function's collapsed
+            # spelling, and the reason trails because it is what truncation may
+            # lose without changing the sentence's meaning.
             self._editor().model_picker.set_rows(
                 rows,
                 current=self._current_selector(),
-                status=_status_line(note, f"live model list unavailable: {error}", PERSIST_HINT),
+                status=_status_line(
+                    note, f"{STALE_LIST_LABEL} all providers — {error}", PERSIST_HINT
+                ),
             )
             return
         rows, note = self._catalogue_rows(entries)
@@ -20425,12 +20446,34 @@ def _catalogue_status(statuses: dict[str, str]) -> str:
     are the ones the picker now hides, and `_catalogue_rows` already counts them
     — two footers counting one fact ("3 provider(s) need a login · 42 hidden")
     reads as two separate problems.
+
+    Wording is budgeted, not just chosen. The footer truncates at the picker's
+    width and the access note (``2 hidden — /login <provider>``, 28 cells) leads
+    it, which leaves 39 cells for this clause at a 100-column terminal. The
+    first spelling, ``live list unavailable: anthropic, xai — showing cached``,
+    was 54: the ellipsis ate the trailing ``showing cached``, the only part
+    saying the rows below are still usable, and what survived read as "these
+    providers are down". ``stale list:`` parallels ``no live list:`` so the two
+    failure clauses read as siblings, and it carries the rows-are-usable meaning
+    in the label itself (there IS a list) rather than in a tail that dies first.
+
+    When every provider that produced a listing is stale — the offline case,
+    which fails them all at once — the names are dropped: five names fit no
+    picker width the app renders, and naming only helps when the failure is
+    partial ("anthropic is down, the rest are fine"). A single stale provider
+    is always named, since "all providers" would then be less informative
+    than the name.
     """
     stale = sorted(p for p, s in statuses.items() if s == "stale")
     empty = sorted(p for p, s in statuses.items() if s == "empty")
+    # ``static`` (no listing endpoint) and ``unauthenticated`` (never asked)
+    # produced no listing, so they do not count toward "every provider".
+    listed = sum(1 for s in statuses.values() if s in LISTED_STATUSES)
     bits: list[str] = []
-    if stale:
-        bits.append(f"live list unavailable: {', '.join(stale)} — showing cached")
+    if len(stale) > 1 and len(stale) == listed:
+        bits.append(f"{STALE_LIST_LABEL} all providers")
+    elif stale:
+        bits.append(f"{STALE_LIST_LABEL} {', '.join(stale)}")
     if empty:
         bits.append(f"no live list: {', '.join(empty)}")
     return " · ".join(bits)

--- a/local_operator/tui/widgets/model_picker.py
+++ b/local_operator/tui/widgets/model_picker.py
@@ -66,6 +66,14 @@ PERSIST_HINT_PREFIX = "d in /model"
 MAX_VISIBLE_ROWS = 14
 _SCREEN_HEIGHT_FRACTION = 3
 
+#: The seam the app joins footer clauses with (``_status_line``) and the one the
+#: footer puts between its own count and the status, so the whole line reads as
+#: one run of clauses rather than two kinds of separator.
+_SEAM = " · "
+
+#: Where a footer clause's first value ends — see `_fit_clauses`.
+_FIRST_VALUE_END = re.compile(r", | — ")
+
 #: Below this width the numbers are dropped and the row is just the selector.
 #: Two columns of metadata in 40 cells leaves nothing for the id, which is the
 #: part being chosen.
@@ -309,7 +317,10 @@ class ModelPicker(Static):
         # the app paints `checking providers…` on the keystroke and clears it
         # when the live list lands, and letting the row collapse shrank the card
         # by one line and dropped everything above it while the user was
-        # reading. A blank dim row is less motion than a reflow.
+        # reading. A blank dim row is less motion than a reflow. Set on paint by
+        # `_footer_rows`, which `render_text` reaches as well as `_repaint` —
+        # so a bare `render_text` call (the unit tests do this) holds the row
+        # too; only `close()` releases it.
         self._status_row_held = False
         # A closed picker takes no layout space at all; `visible: hidden` would
         # reserve the rows and leave a hole above the input.
@@ -634,7 +645,7 @@ class ModelPicker(Static):
         """
         total = len(self._matches)
         start, end, _ = self.visible_window()
-        status = [part for part in self._status.split(" · ") if part]
+        status = [part for part in self._status.split(_SEAM) if part]
         persistent = next(
             (part for part in status if part.startswith(PERSIST_HINT_PREFIX)),
             "",
@@ -664,11 +675,11 @@ class ModelPicker(Static):
         # The held row renders as an empty string, which `_pad_to` fills, so the
         # card keeps its height when a status clause comes and goes.
         for text in [
-            *([" · ".join(ordinary)] if ordinary or self._status_row_held else []),
-            *([persistent] if persistent else []),
+            *([_fit_clauses(ordinary, available)] if ordinary or self._status_row_held else []),
+            *([truncate_cells(persistent, available)] if persistent else []),
         ]:
             row = Text(" " * _GUTTER_CELLS, style=dim)
-            row.append(truncate_cells(text, available), style=dim)
+            row.append(text, style=dim)
             rows.append(_pad_to(row, width, dim))
         return rows
 
@@ -683,7 +694,7 @@ class ModelPicker(Static):
         # Catalogue status occupies footer chrome. The persistent-default
         # instruction gets a dedicated second row so wider catalogues cannot
         # crowd it out non-monotonically.
-        persistent = any(part.startswith(PERSIST_HINT_PREFIX) for part in self._status.split(" · "))
+        persistent = any(part.startswith(PERSIST_HINT_PREFIX) for part in self._status.split(_SEAM))
         status_rows = 2 if persistent else (1 if self._status or self._status_row_held else 0)
         return max(
             1,
@@ -768,6 +779,38 @@ class ModelPicker(Static):
         start, end, _ = self.visible_window()
         index = start + y
         return index if start <= index < end else None
+
+
+def _fit_clauses(clauses: list[str], width: int) -> str:
+    """Join footer clauses into ``width`` cells, cutting at a seam before a label.
+
+    Plain ``truncate_cells`` on the joined line is right when the cut lands
+    inside a list of values — ``stale list: anthropic…`` still says which list
+    is stale and names one provider. It is wrong when the cut lands between a
+    label and its first value: the three-clause composite (access note, stale,
+    empty) at 100 columns rendered ``… · no live list:…``, a label with no
+    payload and a dangling colon that reads as a rendering glitch. A trailing
+    clause that cannot keep its label and first value whole is dropped, and
+    so is everything after it; the seam is the cut, not the colon. Whatever
+    survives then takes the plain cell cut, so every line that fitted before
+    this rule renders exactly as it did. The leading clause is never dropped
+    — a footer has to say something.
+
+    "First value" is the text up to the first ``, `` (a provider list) or
+    `` — `` (the reason behind ``stale list: all providers``, the instruction
+    behind ``2 hidden``): the parts that already die first under truncation.
+    Never called with the persistent hint, which has its own row.
+    """
+    kept = list(clauses)
+    while len(kept) > 1 and cell_len(_SEAM.join(kept)) > width:
+        head = _FIRST_VALUE_END.split(kept[-1], maxsplit=1)[0]
+        # A head shorter than its clause is followed by the ellipsis, which
+        # `truncate_cells` charges to the same budget.
+        tail = 0 if head == kept[-1] else cell_len("…")
+        if cell_len(_SEAM.join([*kept[:-1], head])) + tail <= width:
+            break
+        kept.pop()
+    return truncate_cells(_SEAM.join(kept), width)
 
 
 def _pad_to(row: Text, width: int, style: Style) -> Text:

--- a/local_operator/tui/widgets/model_picker.py
+++ b/local_operator/tui/widgets/model_picker.py
@@ -304,6 +304,13 @@ class ModelPicker(Static):
         self._query = ""
         self._open = False
         self._status = ""
+        # Whether this open has painted a status row (anything but the protected
+        # persistent hint). Once it has, the row is kept — blank — until close:
+        # the app paints `checking providers…` on the keystroke and clears it
+        # when the live list lands, and letting the row collapse shrank the card
+        # by one line and dropped everything above it while the user was
+        # reading. A blank dim row is less motion than a reflow.
+        self._status_row_held = False
         # A closed picker takes no layout space at all; `visible: hidden` would
         # reserve the rows and leave a hole above the input.
         self.display = False
@@ -405,6 +412,7 @@ class ModelPicker(Static):
         self._matches = []
         self._selected = 0
         self._window_start = 0
+        self._status_row_held = False
         self._hovered = None
         # A stationary pointer gets no mouse-move after this surface leaves;
         # the style observer updates OSC 22 before `display` hides the node.
@@ -639,9 +647,12 @@ class ModelPicker(Static):
         elif total > end - start:
             bits.append(f"{end - start} of {total}")
         bits.extend(status)
+        ordinary = list(bits)
+        if status:
+            self._status_row_held = True
         if persistent:
             bits.append(persistent)
-        if not bits:
+        if not bits and not self._status_row_held:
             return []
 
         dim = Style(
@@ -650,9 +661,10 @@ class ModelPicker(Static):
         )
         available = max(1, width - _GUTTER_CELLS - _EDGE_MARGIN)
         rows: list[Text] = []
-        ordinary = bits[:-1] if persistent else bits
+        # The held row renders as an empty string, which `_pad_to` fills, so the
+        # card keeps its height when a status clause comes and goes.
         for text in [
-            *([" · ".join(ordinary)] if ordinary else []),
+            *([" · ".join(ordinary)] if ordinary or self._status_row_held else []),
             *([persistent] if persistent else []),
         ]:
             row = Text(" " * _GUTTER_CELLS, style=dim)
@@ -672,7 +684,7 @@ class ModelPicker(Static):
         # instruction gets a dedicated second row so wider catalogues cannot
         # crowd it out non-monotonically.
         persistent = any(part.startswith(PERSIST_HINT_PREFIX) for part in self._status.split(" · "))
-        status_rows = 2 if persistent else (1 if self._status else 0)
+        status_rows = 2 if persistent else (1 if self._status or self._status_row_held else 0)
         return max(
             1,
             min(MAX_VISIBLE_ROWS, screen_height // _SCREEN_HEIGHT_FRACTION) - status_rows,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.31"
+version = "0.44.32"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/model/test_catalogue.py
+++ b/tests/unit/model/test_catalogue.py
@@ -1646,6 +1646,117 @@ def test_the_background_refresh_runs_the_revalidate_thunk_not_the_on_path_one(
     assert listing.fetched is True and ran == ["fetch"]
 
 
+def test_a_sync_reader_that_loses_the_lease_to_its_own_thread_joins_it(
+    tmp_path, _no_backoff_state
+) -> None:
+    """R1-5: call A serves the soft-window document and schedules a refresh; call
+    B, declared expired by its predicate, finds the lease held by A's thread.
+    It must join that thread — returning the moment the refresh lands, with
+    the refreshed document — rather than poll the mtime for the whole window
+    or serve the old document (which the caller's memo would pin for a day)."""
+    import threading
+
+    _plant(tmp_path, "anthropic.listing", _payload(window=1), age_s=2 * 3600)
+    gate = threading.Event()
+    entered = threading.Event()  # set once A's thread HOLDS the lease
+    sync_calls: list[int] = []
+
+    def slow_refresh():
+        entered.set()
+        gate.wait(timeout=5.0)
+        return _payload(window=2)
+
+    def sync_fetch():
+        sync_calls.append(1)
+        return _payload(window=99)
+
+    first = catalogue.read_listing("anthropic.listing", slow_refresh, cache_dir=tmp_path)
+    assert first.refreshing is True
+    thread = catalogue._revalidation_threads()[0]
+    # Not a clock wait: B must start AFTER the thread took the lease, or B
+    # would legitimately win it and fetch on its own.
+    assert entered.wait(timeout=5.0)
+
+    result: list[catalogue.Listing] = []
+
+    def second_call():
+        result.append(
+            catalogue.read_listing(
+                "anthropic.listing",
+                sync_fetch,
+                cache_dir=tmp_path,
+                refetch_if=lambda _payload_, _age: True,
+            )
+        )
+
+    joiner = threading.Thread(target=second_call)
+    joiner.start()
+    # B is parked on A's thread, not fetching on its own and not returning
+    # the stale document: nothing has been served yet.
+    joiner.join(timeout=0.3)
+    assert joiner.is_alive() and result == []
+    gate.set()
+    joiner.join(timeout=5.0)
+    thread.join(timeout=5.0)
+
+    assert sync_calls == [], "B must not fetch behind its own process's refresh"
+    assert result[0].payload == _payload(window=2), "B serves what its own thread wrote"
+    assert result[0].fetched is False and result[0].failed is False
+
+
+def test_a_sync_reader_joining_its_own_failed_thread_returns_at_once(
+    tmp_path, _no_backoff_state
+) -> None:
+    """The case the mtime poll got wrong: a refresh that FAILS never renames a
+    document, so a poller waits out the whole window. Joining returns as soon
+    as the thread does, with the stale document."""
+    import threading
+
+    _plant(tmp_path, "anthropic.listing", _payload(window=1), age_s=2 * 3600)
+    gate = threading.Event()
+    entered = threading.Event()
+
+    def failing_refresh():
+        entered.set()
+        gate.wait(timeout=5.0)
+        raise RuntimeError("offline")
+
+    first = catalogue.read_listing("anthropic.listing", failing_refresh, cache_dir=tmp_path)
+    assert first.refreshing is True
+    assert entered.wait(timeout=5.0)
+
+    result: list[catalogue.Listing] = []
+    sync_calls: list[int] = []
+
+    def sync_fetch():
+        sync_calls.append(1)
+        return _payload(window=99)
+
+    def second_call():
+        result.append(
+            catalogue.read_listing(
+                "anthropic.listing",
+                sync_fetch,
+                cache_dir=tmp_path,
+                refetch_if=lambda _payload_, _age: True,
+            )
+        )
+
+    joiner = threading.Thread(target=second_call)
+    joiner.start()
+    joiner.join(timeout=0.3)
+    assert joiner.is_alive() and result == [], "B is parked on A's thread"
+    released = time.monotonic()
+    gate.set()
+    joiner.join(timeout=5.0)
+    _join_revalidations()
+
+    assert sync_calls == []
+    assert result[0].payload == _payload(window=1)
+    # The join ended when the thread did, not when the 2 s poll window ran out.
+    assert time.monotonic() - released < catalogue._LISTING_LEASE_WAIT_S / 2
+
+
 # -- stranded temp files ------------------------------------------------------
 
 

--- a/tests/unit/model/test_catalogue.py
+++ b/tests/unit/model/test_catalogue.py
@@ -1607,3 +1607,40 @@ def test_a_failed_sync_fetch_reports_failed_with_the_stale_document(tmp_path) ->
     listing = catalogue.read_listing("anthropic.listing", boom, cache_dir=tmp_path)
     assert listing.payload == _payload(window=1)
     assert (listing.fetched, listing.failed) == (False, True)
+
+
+def test_the_background_refresh_runs_the_revalidate_thunk_not_the_on_path_one(
+    tmp_path, _no_backoff_state
+) -> None:
+    """The two thunks differ in BUDGET: `fetch` carries the caller's ceiling (2 s
+    from a repaint), `revalidate` the provider's full default. A background
+    refresh that inherited the on-path budget failed on every link slower than
+    2 s, backed off, and left the document to the 24 h sync path."""
+    _plant(tmp_path, "anthropic.listing", _payload(window=1), age_s=2 * 3600)
+    ran: list[str] = []
+
+    def on_path():
+        ran.append("fetch")
+        return _payload(window=2)
+
+    def off_path():
+        ran.append("revalidate")
+        return _payload(window=3)
+
+    listing = catalogue.read_listing(
+        "anthropic.listing", on_path, cache_dir=tmp_path, revalidate=off_path
+    )
+    assert listing.refreshing is True
+    _join_revalidations()
+    assert ran == ["revalidate"]
+    raw = json.loads((tmp_path / "anthropic.listing.json").read_text(encoding="utf-8"))
+    assert raw["payload"] == _payload(window=3)
+
+    # The SYNC path still runs `fetch`: past the hard TTL the caller's budget
+    # is the right one, because the caller is waiting on it.
+    _plant(tmp_path, "anthropic.listing", _payload(window=1), age_s=25 * 3600)
+    ran.clear()
+    listing = catalogue.read_listing(
+        "anthropic.listing", on_path, cache_dir=tmp_path, revalidate=off_path
+    )
+    assert listing.fetched is True and ran == ["fetch"]

--- a/tests/unit/model/test_catalogue.py
+++ b/tests/unit/model/test_catalogue.py
@@ -1379,3 +1379,231 @@ def test_a_lease_from_a_dead_holder_is_stolen_after_expiry(tmp_path) -> None:
     assert lease._held is True
     lease.release()
     assert not stale.exists(), "release must remove this holder's lease file"
+
+
+# -- stale-while-revalidate --------------------------------------------------
+#
+# The incident these guard: a 22h-old `anthropic.listing.json` — inside the 24h
+# hard TTL, so never refetched — hid a model published that morning from
+# `/model` and from the cost band for a whole working day. `read_listing` now
+# serves a document past the SOFT TTL immediately and refreshes it off the
+# calling path, so the NEXT call sees the new document at zero on-path cost.
+# Threads are JOINED via `catalogue._revalidation_threads()`, never slept on
+# (AGENTS.md "Timing").
+
+
+def _plant(tmp_path, key: str, payload: dict[str, Any], *, age_s: float) -> None:
+    (tmp_path / f"{key}.json").write_text(
+        json.dumps({"fetched_at": time.time() - age_s, "payload": payload}), encoding="utf-8"
+    )
+
+
+def _join_revalidations() -> None:
+    for thread in catalogue._revalidation_threads():
+        thread.join(timeout=5.0)
+
+
+@pytest.fixture
+def _no_backoff_state():
+    """Each test starts with no in-flight or recently-attempted keys."""
+    with catalogue._revalidate_lock:
+        catalogue._revalidating.clear()
+        catalogue._last_attempt.clear()
+        catalogue._threads.clear()
+    yield
+    _join_revalidations()
+
+
+def test_a_document_between_soft_and_hard_ttl_is_served_and_revalidated_in_the_background(
+    tmp_path, _no_backoff_state
+) -> None:
+    _plant(tmp_path, "anthropic.listing", _payload(window=1), age_s=2 * 3600)
+    calls: list[int] = []
+
+    def fetch():
+        calls.append(1)
+        return _payload(window=2)
+
+    listing = catalogue.read_listing("anthropic.listing", fetch, cache_dir=tmp_path)
+
+    # Served the OLD document, synchronously, with no fetch on this path...
+    assert listing.payload == _payload(window=1)
+    assert listing.fetched is False
+    assert listing.refreshing is True
+    assert 2 * 3600 <= listing.age_s < 3 * 3600
+    # ...and the background thread rewrote it.
+    _join_revalidations()
+    assert calls == [1]
+    raw = json.loads((tmp_path / "anthropic.listing.json").read_text(encoding="utf-8"))
+    assert raw["payload"] == _payload(window=2)
+    assert time.time() - raw["fetched_at"] < 60
+    assert not list(tmp_path.glob("*.fetching")), "the background fetch must release its lease"
+
+
+def test_a_document_under_the_soft_ttl_schedules_nothing(tmp_path, _no_backoff_state) -> None:
+    _plant(tmp_path, "anthropic.listing", _payload(), age_s=30 * 60)
+    listing = catalogue.read_listing(
+        "anthropic.listing", lambda: pytest.fail("no fetch expected"), cache_dir=tmp_path
+    )
+    assert listing.refreshing is False
+    assert listing.fetched is False
+    assert catalogue._revalidation_threads() == []
+
+
+def test_a_document_past_the_hard_ttl_still_fetches_synchronously(
+    tmp_path, _no_backoff_state
+) -> None:
+    """The offline/cold contract: beyond the hard TTL the CALLER gets the fresh
+    document, not a promise of one."""
+    _plant(tmp_path, "anthropic.listing", _payload(window=1), age_s=25 * 3600)
+    listing = catalogue.read_listing(
+        "anthropic.listing", lambda: _payload(window=2), cache_dir=tmp_path
+    )
+    assert listing.payload == _payload(window=2)
+    assert listing.fetched is True
+    assert listing.refreshing is False
+    assert catalogue._revalidation_threads() == []
+
+
+def test_a_background_revalidation_that_loses_the_lease_exits_without_fetching(
+    tmp_path, _no_backoff_state
+) -> None:
+    """A peer process is already fetching; unlike the sync path there is nothing
+    to wait for, because the caller already has its answer."""
+    _plant(tmp_path, "anthropic.listing", _payload(window=1), age_s=2 * 3600)
+    (tmp_path / "anthropic.listing.json.fetching").write_text(
+        json.dumps({"holder": "peer:1234", "expires_at": time.time() + 30.0})
+    )
+    calls: list[int] = []
+
+    def fetch():
+        calls.append(1)
+        return _payload(window=2)
+
+    listing = catalogue.read_listing("anthropic.listing", fetch, cache_dir=tmp_path)
+    assert listing.refreshing is True
+    _join_revalidations()
+    assert calls == []
+    raw = json.loads((tmp_path / "anthropic.listing.json").read_text(encoding="utf-8"))
+    assert raw["payload"] == _payload(window=1)
+
+
+def test_a_failed_background_revalidation_keeps_the_stale_document_and_backs_off(
+    tmp_path, _no_backoff_state
+) -> None:
+    _plant(tmp_path, "anthropic.listing", _payload(window=1), age_s=2 * 3600)
+    calls: list[int] = []
+
+    def boom():
+        calls.append(1)
+        raise RuntimeError("offline")
+
+    first = catalogue.read_listing("anthropic.listing", boom, cache_dir=tmp_path)
+    assert first.refreshing is True
+    _join_revalidations()
+    assert calls == [1]
+    raw = json.loads((tmp_path / "anthropic.listing.json").read_text(encoding="utf-8"))
+    assert raw["payload"] == _payload(window=1), "a failed refresh must not touch the document"
+    assert not list(tmp_path.glob("*.fetching"))
+
+    # Within the backoff: served again, no second thread — an offline machine
+    # must not spawn a thread per repaint.
+    second = catalogue.read_listing("anthropic.listing", boom, cache_dir=tmp_path)
+    assert second.payload == _payload(window=1)
+    assert second.refreshing is False
+    assert catalogue._revalidation_threads() == []
+    assert calls == [1]
+
+
+def test_two_reads_in_one_process_spawn_one_revalidation(tmp_path, _no_backoff_state) -> None:
+    _plant(tmp_path, "anthropic.listing", _payload(window=1), age_s=2 * 3600)
+    gate = __import__("threading").Event()
+    calls: list[int] = []
+
+    def slow_fetch():
+        calls.append(1)
+        gate.wait(timeout=5.0)
+        return _payload(window=2)
+
+    try:
+        first = catalogue.read_listing("anthropic.listing", slow_fetch, cache_dir=tmp_path)
+        second = catalogue.read_listing("anthropic.listing", slow_fetch, cache_dir=tmp_path)
+    finally:
+        gate.set()
+    _join_revalidations()
+    assert (first.refreshing, second.refreshing) == (True, False)
+    assert calls == [1]
+
+
+def test_cached_listing_never_schedules_a_thread(tmp_path, _no_backoff_state) -> None:
+    """The compatibility wrapper pins soft TTL to hard TTL: three states, no threads."""
+    _plant(tmp_path, "anthropic.listing", _payload(window=1), age_s=2 * 3600)
+    got = cached_listing(
+        "anthropic.listing", lambda: pytest.fail("no fetch expected"), cache_dir=tmp_path
+    )
+    assert got == _payload(window=1)
+    assert catalogue._revalidation_threads() == []
+
+
+def test_peek_listing_reads_without_sweeping_or_fetching(tmp_path) -> None:
+    orphan = tmp_path / "openrouter.models.json"
+    orphan.write_text("{}", encoding="utf-8")
+    _plant(tmp_path, "models-dev.listing", {"etag": '"abc"'}, age_s=10)
+
+    peeked = catalogue.peek_listing("models-dev.listing", cache_dir=tmp_path)
+    assert peeked.payload == {"etag": '"abc"'}
+    assert 10 <= peeked.age_s < 60
+    assert peeked.fetched is False and peeked.refreshing is False
+    assert orphan.exists(), "peek must not sweep; only read_listing owns the purge"
+    absent = catalogue.peek_listing("nothing.listing", cache_dir=tmp_path)
+    assert absent.payload is None and absent.age_s == float("inf")
+
+
+def test_a_background_thread_runs_off_the_calling_thread(tmp_path, _no_backoff_state) -> None:
+    """Structural, not timed (AGENTS.md): the fetch runs on a thread that is not
+    the caller's, which is the whole point of the soft TTL."""
+    import threading
+
+    _plant(tmp_path, "anthropic.listing", _payload(window=1), age_s=2 * 3600)
+    seen: list[int] = []
+
+    def fetch():
+        seen.append(threading.get_ident())
+        return _payload(window=2)
+
+    catalogue.read_listing("anthropic.listing", fetch, cache_dir=tmp_path)
+    _join_revalidations()
+    assert seen and seen[0] != threading.get_ident()
+
+
+def test_a_readers_predicate_can_expire_a_document_inside_the_ttl(
+    tmp_path, _no_backoff_state
+) -> None:
+    """`refetch_if` is how discovery's `want_id` miss becomes ONE synchronous fetch
+    on the calling thread, rather than a race against the background refresh."""
+    _plant(tmp_path, "anthropic.listing", _payload(window=1), age_s=2 * 3600)
+    asked: list[tuple[dict[str, Any], float]] = []
+
+    def lacks(document, age_s):
+        asked.append((document, age_s))
+        return True
+
+    listing = catalogue.read_listing(
+        "anthropic.listing", lambda: _payload(window=2), cache_dir=tmp_path, refetch_if=lacks
+    )
+    assert listing.fetched is True
+    assert listing.payload == _payload(window=2)
+    assert listing.refreshing is False
+    assert catalogue._revalidation_threads() == []
+    assert asked[0][0] == _payload(window=1) and asked[0][1] >= 2 * 3600
+
+
+def test_a_failed_sync_fetch_reports_failed_with_the_stale_document(tmp_path) -> None:
+    _plant(tmp_path, "anthropic.listing", _payload(window=1), age_s=25 * 3600)
+
+    def boom():
+        raise RuntimeError("offline")
+
+    listing = catalogue.read_listing("anthropic.listing", boom, cache_dir=tmp_path)
+    assert listing.payload == _payload(window=1)
+    assert (listing.fetched, listing.failed) == (False, True)

--- a/tests/unit/model/test_catalogue.py
+++ b/tests/unit/model/test_catalogue.py
@@ -1644,3 +1644,53 @@ def test_the_background_refresh_runs_the_revalidate_thunk_not_the_on_path_one(
         "anthropic.listing", on_path, cache_dir=tmp_path, revalidate=off_path
     )
     assert listing.fetched is True and ran == ["fetch"]
+
+
+# -- stranded temp files ------------------------------------------------------
+
+
+def test_purge_removes_stranded_temp_files_older_than_the_gate_only(tmp_path) -> None:
+    """A daemon revalidation thread killed at interpreter exit mid-`json.dump`
+    leaves `<key>.listing.json.<random>.tmp` that nothing else reclaims. Only
+    OLD ones go: a young one is a peer's in-flight write, and deleting it would
+    strand that peer's rename."""
+    import os
+
+    old = tmp_path / "anthropic.listing.json.abc123.tmp"
+    young = tmp_path / "openrouter.listing.json.def456.tmp"
+    foreign = tmp_path / "pypi-local-operator.json.ghi789.tmp"  # update.py's, not ours
+    document = tmp_path / "anthropic.listing.json"
+    for path in (old, young, foreign, document):
+        path.write_text("{", encoding="utf-8")
+    stale_mtime = time.time() - catalogue._STRANDED_TEMP_MIN_AGE_S - 60
+    os.utime(old, (stale_mtime, stale_mtime))
+    os.utime(foreign, (stale_mtime, stale_mtime))
+
+    catalogue.purge_stranded_temp_files(tmp_path)
+    catalogue.purge_stranded_temp_files(tmp_path)  # idempotent
+
+    assert not old.exists()
+    assert young.exists(), "an in-flight peer write must not be deleted"
+    assert foreign.exists(), "another writer's temp files are its own business"
+    assert document.exists()
+
+
+def test_read_listing_sweeps_stranded_temp_files(tmp_path, _no_backoff_state) -> None:
+    import os
+
+    _plant(tmp_path, "anthropic.listing", _payload(), age_s=10)
+    stranded = tmp_path / "anthropic.listing.json.zzz.tmp"
+    stranded.write_text("{", encoding="utf-8")
+    stale_mtime = time.time() - catalogue._STRANDED_TEMP_MIN_AGE_S - 60
+    os.utime(stranded, (stale_mtime, stale_mtime))
+
+    catalogue.read_listing(
+        "anthropic.listing", lambda: pytest.fail("no fetch expected"), cache_dir=tmp_path
+    )
+    assert not stranded.exists()
+
+
+def test_purge_stranded_is_safe_when_the_cache_dir_does_not_exist(tmp_path) -> None:
+    missing = tmp_path / "never-created"
+    catalogue.purge_stranded_temp_files(missing)  # must not raise
+    assert not missing.exists()

--- a/tests/unit/model/test_discovery.py
+++ b/tests/unit/model/test_discovery.py
@@ -1412,6 +1412,57 @@ def test_a_want_id_that_is_present_makes_no_request(tmp_path) -> None:
     assert client.calls == []
 
 
+@pytest.mark.parametrize(
+    ("listed", "wanted"),
+    [
+        # The R1-1 case: Anthropic's listing carries the dated snapshot only, the
+        # user configures the undated alias its API accepts. Before, this was a
+        # miss on EVERY process start older than the miss floor: a blocking
+        # round trip on boot, forever, for a document the refetch could not fix.
+        ("claude-sonnet-4-5-20250929", "claude-sonnet-4-5"),
+        ("claude-opus-4-5-20251101", "claude-opus-4-5"),
+        ("claude-haiku-4-5-20251001", "claude-haiku-4-5"),
+        # The reverse: an alias-only listing (the aggregators' habit) asked for
+        # a snapshot, and the dotted spelling either way.
+        ("claude-opus-4-5", "claude-opus-4-5-20251101"),
+        ("claude-opus-4.5", "claude-opus-4-5-20251101"),
+        ("gpt-5.4", "gpt-5-4"),
+    ],
+)
+def test_a_want_id_listed_under_another_spelling_makes_no_request(
+    tmp_path, listed: str, wanted: str
+) -> None:
+    # Past the miss floor and inside the soft TTL: the only request possible
+    # is the miss-triggered one, and there must not be one.
+    _plant_anthropic_document(tmp_path, age_s=20 * 60, ids=[listed])
+    client = _StubClient([])
+
+    _models, status = available_models(
+        "anthropic", api_key="sk-ant", client=client, cache_dir=tmp_path, want_id=wanted
+    )
+
+    assert status == "cached"
+    assert client.calls == []
+
+
+def test_a_genuinely_unlisted_id_still_refetches_after_the_alias_widening(tmp_path) -> None:
+    """The widening must not swallow the trigger it sits beside: a NEW family
+    id that no spelling of any listed row matches is still a miss."""
+    _plant_anthropic_document(tmp_path, age_s=20 * 60, ids=["claude-sonnet-4-5-20250929"])
+    fresh = {
+        "data": [{"id": "claude-fable-5-1", "display_name": "Claude Fable 5.1", "type": "model"}],
+        "has_more": False,
+    }
+    client = _StubClient([_Response(200, fresh)])
+
+    _models, status = available_models(
+        "anthropic", api_key="sk-ant", client=client, cache_dir=tmp_path, want_id="claude-fable-5-1"
+    )
+
+    assert status == "ok"
+    assert len(client.calls) == 1
+
+
 def test_a_failed_want_id_refetch_keeps_the_document_and_reports_stale(tmp_path) -> None:
     _plant_anthropic_document(tmp_path, age_s=22 * 3600, ids=["claude-opus-5"])
     client = _StubClient([httpx.ConnectError("offline")])

--- a/tests/unit/model/test_discovery.py
+++ b/tests/unit/model/test_discovery.py
@@ -1445,6 +1445,37 @@ def test_a_want_id_listed_under_another_spelling_makes_no_request(
     assert client.calls == []
 
 
+@pytest.mark.parametrize(
+    ("listed", "wanted"),
+    [
+        # R2-1: a snapshot the document does not list yet, of a family it
+        # does. Matching each side's derived spellings against the OTHER's
+        # derived spellings made every two snapshots of a family coincide, so
+        # the day a new snapshot landed the trigger built for exactly that
+        # case stayed silent and the memo pinned the fallback for the day.
+        ("claude-opus-4-5-20251101", "claude-opus-4-5-20260315"),
+        ("claude-3-5-sonnet-20240620", "claude-3-5-sonnet-20241022"),
+    ],
+)
+def test_an_unlisted_snapshot_of_a_listed_family_still_refetches(
+    tmp_path, listed: str, wanted: str
+) -> None:
+    _plant_anthropic_document(tmp_path, age_s=20 * 60, ids=[listed])
+    fresh = {
+        "data": [{"id": wanted, "display_name": wanted, "type": "model"}],
+        "has_more": False,
+    }
+    client = _StubClient([_Response(200, fresh)])
+
+    models, status = available_models(
+        "anthropic", api_key="sk-ant", client=client, cache_dir=tmp_path, want_id=wanted
+    )
+
+    assert status == "ok"
+    assert len(client.calls) == 1
+    assert wanted in {row.id for row in models}
+
+
 def test_a_genuinely_unlisted_id_still_refetches_after_the_alias_widening(tmp_path) -> None:
     """The widening must not swallow the trigger it sits beside: a NEW family
     id that no spelling of any listed row matches is still a miss."""

--- a/tests/unit/model/test_discovery.py
+++ b/tests/unit/model/test_discovery.py
@@ -1463,6 +1463,41 @@ def test_a_genuinely_unlisted_id_still_refetches_after_the_alias_widening(tmp_pa
     assert len(client.calls) == 1
 
 
+def test_a_background_revalidation_gets_the_full_default_timeout(tmp_path) -> None:
+    """R1-2: the caller's on-path budget (2 s from a repaint) bounds the SYNC
+    fetch only. The background refresh is off-path and must get the provider's
+    full default, or on any link slower than the caller's budget it fails every
+    time and the document only ever advances via the 24 h sync path."""
+    from local_operator.model import catalogue
+
+    with catalogue._revalidate_lock:
+        catalogue._revalidating.clear()
+        catalogue._last_attempt.clear()
+        catalogue._threads.clear()
+    _plant_anthropic_document(tmp_path, age_s=2 * 3600, ids=["claude-opus-5"])
+    client = _StubClient([_Response(200, _ANTHROPIC_BODY)])
+
+    _models, status = available_models(
+        "anthropic", api_key="sk-ant", client=client, cache_dir=tmp_path, timeout=2.0
+    )
+    assert status == "cached"
+    for thread in catalogue._revalidation_threads():
+        thread.join(timeout=5.0)
+
+    assert len(client.calls) == 1
+    _url, _headers, _params, timeout = client.calls[0]
+    assert timeout == discovery.DEFAULT_TIMEOUT_S
+
+    # And the SYNC path keeps the caller's budget: it is the one waiting.
+    _plant_anthropic_document(tmp_path, age_s=25 * 3600, ids=["claude-opus-5"])
+    client = _StubClient([_Response(200, _ANTHROPIC_BODY)])
+    _models, status = available_models(
+        "anthropic", api_key="sk-ant", client=client, cache_dir=tmp_path, timeout=2.0
+    )
+    assert status == "ok"
+    assert client.calls[0][3] == 2.0
+
+
 def test_a_failed_want_id_refetch_keeps_the_document_and_reports_stale(tmp_path) -> None:
     _plant_anthropic_document(tmp_path, age_s=22 * 3600, ids=["claude-opus-5"])
     client = _StubClient([httpx.ConnectError("offline")])

--- a/tests/unit/model/test_discovery.py
+++ b/tests/unit/model/test_discovery.py
@@ -136,6 +136,8 @@ _OPENROUTER_BODY = {
                 "prompt": "0.000003",
                 "completion": "0.000015",
                 "input_cache_read": "0.0000003",
+                "input_cache_write": "0.00000375",
+                "input_cache_write_1h": "0.000006",
             },
             "top_provider": {"context_length": 200_000, "max_completion_tokens": 64_000},
             "architecture": {"input_modalities": ["text", "image"], "modality": "text+image->text"},
@@ -166,10 +168,14 @@ def test_openai_compat_parses_a_captured_openrouter_payload() -> None:
     assert sonnet.input_price == pytest.approx(3.0)
     assert sonnet.output_price == pytest.approx(15.0)
     assert sonnet.cache_read_price == pytest.approx(0.3)
+    # The five-minute write rate, scaled the same way; the `_1h` tier is ignored
+    # because every write is billed at the 5m rate unless a caller asks otherwise.
+    assert sonnet.cache_write_price == pytest.approx(3.75)
     assert sonnet.supports_images is True
     assert sonnet.supports_prompt_cache is True
     assert rows[1].supports_images is False
     assert rows[1].supports_prompt_cache is False
+    assert rows[1].cache_write_price == 0.0
 
 
 def test_openai_compat_reads_the_legacy_modality_string() -> None:
@@ -928,6 +934,82 @@ def test_merge_prefers_live_prices_when_they_are_present() -> None:
     assert merged[0].cache_read_price == pytest.approx(0.3)
 
 
+def test_merge_prefers_a_live_cache_write_price() -> None:
+    static = {"m": _info("m", cache_reads_price=1.5, cache_writes_price=18.75)}
+    live = [DiscoveredModel(id="m", cache_read_price=0.3, cache_write_price=3.75)]
+    merged = merge_models(static, live)
+
+    assert merged[0].cache_write_price == pytest.approx(3.75)
+
+
+def test_merge_keeps_the_static_cache_write_price_when_live_is_zero() -> None:
+    """Same rule as the read price: a zero is "not quoted", never "free"."""
+    static = {"m": _info("m", cache_reads_price=1.5, cache_writes_price=18.75)}
+    merged = merge_models(static, [DiscoveredModel(id="m", cache_read_price=0.3)])
+
+    assert merged[0].cache_write_price == pytest.approx(18.75)
+
+
+def test_a_cache_write_price_survives_the_disk_round_trip(tmp_path) -> None:
+    """The document is `asdict` of the row; the reader must pick the field back up."""
+    body = {
+        "data": [
+            {
+                "id": "anthropic/claude-fable-5.1",
+                "pricing": {
+                    "prompt": "0.00001",
+                    "completion": "0.00005",
+                    "input_cache_read": "0.00000025",
+                    "input_cache_write": "0.0000125",
+                },
+            }
+        ]
+    }
+    client = _StubClient([_Response(200, body)])
+    available_models("openrouter", api_key="k", client=client, cache_dir=tmp_path)
+    models, status = available_models("openrouter", api_key="k", client=client, cache_dir=tmp_path)
+
+    assert status == "cached"
+    assert models[0].cache_write_price == pytest.approx(12.5)
+
+
+def test_an_openrouter_document_from_capture_one_is_refetched_once(tmp_path) -> None:
+    """A version-1 OpenRouter document has no write price; it must not be served for a day.
+
+    Mirrors the Anthropic capture-two guard: the shape is fine and every field
+    maps, so nothing but the stamp can notice the writer left a field at zero.
+    """
+    stale = tmp_path / "openrouter.listing.json"
+    stale.write_text(
+        json.dumps(
+            {
+                "fetched_at": time.time(),
+                "payload": {
+                    "capture": 1,
+                    "models": [{"id": "anthropic/claude-fable-5.1", "input_price": 10.0}],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    body = {
+        "data": [
+            {
+                "id": "anthropic/claude-fable-5.1",
+                "pricing": {"prompt": "0.00001", "input_cache_write": "0.0000125"},
+            }
+        ]
+    }
+    client = _StubClient([_Response(200, body)])
+
+    models, status = available_models("openrouter", api_key="k", client=client, cache_dir=tmp_path)
+
+    assert status == "ok"
+    assert len(client.calls) == 1
+    assert models[0].cache_write_price == pytest.approx(12.5)
+    assert json.loads(stale.read_text())["payload"]["capture"] == 2
+
+
 def test_an_unstated_capability_defers_to_the_registry() -> None:
     """Silence is not a denial. Every lean OpenAI-compatible gateway sends an id
     and nothing else, and reading that as "no images, no caching" would downgrade
@@ -1233,18 +1315,117 @@ def test_available_models_serves_a_fresh_cache_without_a_request(tmp_path) -> No
     assert [row.id for row in second_models] == [row.id for row in first_models]
 
 
-def test_available_models_reports_cached_when_a_stale_refetch_fails(tmp_path) -> None:
+def test_available_models_reports_stale_when_a_refetch_fails(tmp_path) -> None:
     client = _StubClient([_Response(200, _ANTHROPIC_BODY), httpx.ConnectError("offline")])
     available_models("anthropic", api_key="sk-ant", client=client, cache_dir=tmp_path)
     models, status = available_models(
         "anthropic", api_key="sk-ant", client=client, cache_dir=tmp_path, ttl_s=-1
     )
 
-    assert status == "cached"
+    # "stale", not "cached": a fetch was ATTEMPTED and failed, which is the one
+    # thing a user hunting for this morning's model needs the footer to say.
+    # The two were one status before, so the picker could not tell "fresh
+    # enough" from "offline".
+    assert status == "stale"
     # Stale beats absent: the numbers are days old at worst, and losing the
     # window because the network blipped is the regression this guards.
     by_id = {row.id: row for row in models}
     assert by_id["claude-opus-5"].context_window == 1_000_000
+
+
+def _plant_anthropic_document(tmp_path, *, age_s: float, ids: Sequence[str]) -> None:
+    """A capture-2 Anthropic document of the given age, listing exactly ``ids``."""
+    (tmp_path / "anthropic.listing.json").write_text(
+        json.dumps(
+            {
+                "fetched_at": time.time() - age_s,
+                "payload": {
+                    "capture": discovery.listing_capture_version("anthropic"),
+                    "models": [{"id": model_id, "context_window": 1_000_000} for model_id in ids],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_a_missing_want_id_refetches_a_document_old_enough_to_be_wrong(tmp_path) -> None:
+    """The incident: a 22h document (inside the hard TTL) without this morning's model.
+
+    Without this trigger the id the user asked for stays unresolvable until the
+    document expires, and the memo pins the answer for the day. One refetch,
+    inside the caller's budget, for exactly the id being resolved.
+    """
+    _plant_anthropic_document(tmp_path, age_s=22 * 3600, ids=["claude-opus-5"])
+    fresh = {
+        "data": [
+            {"id": "claude-fable-5-1", "display_name": "Claude Fable 5.1", "type": "model"},
+            {"id": "claude-opus-5", "display_name": "Claude Opus 5", "type": "model"},
+        ],
+        "has_more": False,
+    }
+    client = _StubClient([_Response(200, fresh)])
+
+    models, status = available_models(
+        "anthropic",
+        api_key="sk-ant",
+        client=client,
+        cache_dir=tmp_path,
+        want_id="claude-fable-5-1",
+    )
+
+    assert status == "ok"
+    assert len(client.calls) == 1
+    assert "claude-fable-5-1" in {row.id for row in models}
+
+
+def test_a_missing_want_id_is_believed_when_the_document_is_young(tmp_path) -> None:
+    """A typo must not refetch on every resolution: a minute-old miss is a miss."""
+    _plant_anthropic_document(tmp_path, age_s=60, ids=["claude-opus-5"])
+    client = _StubClient([])
+
+    models, status = available_models(
+        "anthropic", api_key="sk-ant", client=client, cache_dir=tmp_path, want_id="claude-typo"
+    )
+
+    assert status == "cached"
+    assert client.calls == []
+
+
+def test_a_want_id_that_is_present_makes_no_request(tmp_path) -> None:
+    # Past the miss floor (so a miss WOULD refetch) but inside the soft TTL, so
+    # the only request this could make is the miss-triggered one.
+    _plant_anthropic_document(tmp_path, age_s=20 * 60, ids=["claude-opus-5"])
+    client = _StubClient([])
+
+    _models, status = available_models(
+        "anthropic",
+        api_key="sk-ant",
+        client=client,
+        cache_dir=tmp_path,
+        # Google's `models/` spelling and case count as present too — the same
+        # normalisation the lookup applies, so a hit there is not a miss here.
+        want_id="models/Claude-Opus-5",
+    )
+
+    assert status == "cached"
+    assert client.calls == []
+
+
+def test_a_failed_want_id_refetch_keeps_the_document_and_reports_stale(tmp_path) -> None:
+    _plant_anthropic_document(tmp_path, age_s=22 * 3600, ids=["claude-opus-5"])
+    client = _StubClient([httpx.ConnectError("offline")])
+
+    models, status = available_models(
+        "anthropic",
+        api_key="sk-ant",
+        client=client,
+        cache_dir=tmp_path,
+        want_id="claude-fable-5-1",
+    )
+
+    assert status == "stale"
+    assert "claude-opus-5" in {row.id for row in models}
 
 
 def test_available_models_reports_static_when_a_cold_fetch_fails(tmp_path) -> None:
@@ -1324,7 +1505,7 @@ def test_available_models_survives_a_broken_cache_layer(tmp_path, monkeypatch) -
     def explode(*args: object, **kwargs: object) -> dict[str, Any]:
         raise OSError("cache is on fire")
 
-    monkeypatch.setattr(discovery, "cached_listing", explode)
+    monkeypatch.setattr(discovery, "read_listing", explode)
     models, status = available_models(
         "anthropic", api_key="sk-ant", client=_StubClient([]), cache_dir=tmp_path
     )
@@ -1415,16 +1596,19 @@ def test_only_the_transport_that_changed_invalidates_its_cache(tmp_path) -> None
     needing a field its writer had not recorded, so only Anthropic's stamp moved.
     """
     assert discovery.listing_capture_version("anthropic") == 2
-    assert discovery.listing_capture_version("openrouter") == discovery.LISTING_CAPTURE_DEFAULT
+    assert discovery.listing_capture_version("openrouter") == 2
+    # Ollama's reader never changed: an OpenAI-compatible document with no
+    # pricing object has nothing new to capture, so its stamp stays at 1.
+    assert discovery.listing_capture_version("ollama") == discovery.LISTING_CAPTURE_DEFAULT
 
-    cached = tmp_path / "openrouter.listing.json"
+    cached = tmp_path / "ollama.listing.json"
     cached.write_text(
         json.dumps(
             {
                 "fetched_at": time.time(),
                 "payload": {
                     "capture": discovery.LISTING_CAPTURE_DEFAULT,
-                    "models": [{"id": "vendor/model", "context_window": 1_000}],
+                    "models": [{"id": "qwen3:8b", "context_window": 1_000}],
                 },
             }
         ),
@@ -1432,11 +1616,11 @@ def test_only_the_transport_that_changed_invalidates_its_cache(tmp_path) -> None
     )
     client = _StubClient([])
 
-    models, status = available_models("openrouter", api_key="k", client=client, cache_dir=tmp_path)
+    models, status = available_models("ollama", api_key=None, client=client, cache_dir=tmp_path)
     # Served from the cache, no fetch, rows intact — the upgrade did not touch it.
     assert status == "cached"
     assert not client.calls
-    assert "vendor/model" in {row.id for row in models}
+    assert "qwen3:8b" in {row.id for row in models}
 
 
 def test_an_unstamped_document_is_the_original_shape_not_a_stale_one(tmp_path) -> None:
@@ -1447,21 +1631,23 @@ def test_an_unstamped_document_is_the_original_shape_not_a_stale_one(tmp_path) -
     per-transport map exists to spare, whose registry has no static rows to answer
     with. Measured before the fix: `static` with 0 models on any failed fetch.
     """
-    cached = tmp_path / "openrouter.listing.json"
+    # Ollama is a transport whose stamp is still version 1, so an unstamped
+    # document is exactly its current shape.
+    cached = tmp_path / "ollama.listing.json"
     cached.write_text(
         json.dumps(
             {
                 "fetched_at": time.time(),
                 # Exactly what the pre-stamp writer produced: no `capture`.
-                "payload": {"models": [{"id": "vendor/model", "context_window": 1_000}]},
+                "payload": {"models": [{"id": "qwen3:8b", "context_window": 1_000}]},
             }
         ),
         encoding="utf-8",
     )
     client = _StubClient([])
 
-    models, status = available_models("openrouter", api_key="k", client=client, cache_dir=tmp_path)
+    models, status = available_models("ollama", api_key=None, client=client, cache_dir=tmp_path)
 
     assert status == "cached"
     assert not client.calls
-    assert "vendor/model" in {row.id for row in models}
+    assert "qwen3:8b" in {row.id for row in models}

--- a/tests/unit/model/test_prices.py
+++ b/tests/unit/model/test_prices.py
@@ -1,0 +1,383 @@
+"""The models.dev price catalogue: provider-neutral prices with no OpenRouter coupling.
+
+The defect this module exists for: Anthropic's ``/v1/models`` quotes no prices,
+so a model the registry had not been taught was priced from the OpenRouter
+listing under a per-provider namespace. The day ``claude-fable-5-1`` shipped,
+that document was six hours old and predated the row, and a user signed in only
+to Anthropic ran the whole day at ``$0.00``. models.dev carried
+``10/50/0.25/12.5`` on release day.
+
+No live network anywhere here: ``httpx.get`` is patched with a canned response,
+and every document lands in ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from local_operator.model import catalogue, prices
+from local_operator.model.prices import (
+    PRICE_CATALOGUE_CAPTURE,
+    PRICE_CATALOGUE_KEY,
+    price_catalogue_row,
+    project,
+)
+
+#: Captured from https://models.dev/api.json on 2026-09-01 (ETag
+#: ``"2afcb862acafd97c7717b83be8fa940b"``), trimmed to the providers and
+#: fields the tests need. ``description``, ``modalities`` and the rest of a real
+#: entry are kept on one row so the projection can be shown to drop them.
+_MODELS_DEV_BODY: dict[str, Any] = {
+    "anthropic": {
+        "id": "anthropic",
+        "name": "Anthropic",
+        "models": {
+            "claude-fable-5-1": {
+                "id": "claude-fable-5-1",
+                "name": "Claude Fable 5.1",
+                "description": "Claude model for demanding reasoning and long-horizon agentic work",
+                "family": "claude-fable",
+                "attachment": True,
+                "reasoning": True,
+                "tool_call": True,
+                "modalities": {"input": ["text", "image", "pdf"], "output": ["text"]},
+                "release_date": "2026-09-01",
+                "limit": {"context": 1_000_000, "output": 128_000},
+                "cost": {"input": 10, "output": 50, "cache_read": 0.25, "cache_write": 12.5},
+            },
+            "claude-opus-4.5": {
+                "id": "claude-opus-4.5",
+                "name": "Claude Opus 4.5",
+                "limit": {"context": 200_000, "output": 64_000},
+                "cost": {"input": 5, "output": 25, "cache_read": 0.5, "cache_write": 6.25},
+            },
+        },
+    },
+    "openai": {
+        "id": "openai",
+        "models": {
+            "gpt-5.4": {
+                "id": "gpt-5.4",
+                "name": "GPT-5.4",
+                "limit": {"context": 400_000, "output": 128_000},
+                "cost": {"input": 2.5, "output": 15, "cache_read": 0.25},
+            }
+        },
+    },
+    "google": {
+        "id": "google",
+        "models": {
+            "gemini-2.5-pro": {
+                "id": "gemini-2.5-pro",
+                "name": "Gemini 2.5 Pro",
+                "limit": {"context": 1_048_576, "output": 65_536},
+                "cost": {"input": 1.25, "output": 10, "cache_read": 0.31},
+            }
+        },
+    },
+    "moonshotai": {
+        "id": "moonshotai",
+        "models": {
+            "kimi-k2.5": {
+                "id": "kimi-k2.5",
+                "name": "Kimi K2.5",
+                "limit": {"context": 262_144, "output": 262_144},
+                "cost": {"input": 0.6, "output": 2.5, "cache_read": 0.1},
+            }
+        },
+    },
+    "kimi-for-coding": {
+        "id": "kimi-for-coding",
+        "models": {
+            "k3": {
+                "id": "k3",
+                "name": "Kimi K3",
+                "limit": {"context": 262_144, "output": 32_768},
+                "cost": {},
+            }
+        },
+    },
+    "openrouter": {
+        "id": "openrouter",
+        "models": {
+            "anthropic/claude-fable-5.1": {
+                "id": "anthropic/claude-fable-5.1",
+                "name": "Anthropic: Claude Fable 5.1",
+                "limit": {"context": 1_000_000, "output": 128_000},
+                "cost": {"input": 10, "output": 50, "cache_read": 0.25, "cache_write": 12.5},
+            }
+        },
+    },
+    # A provider this tree does not map: must not reach disk.
+    "amazon-bedrock": {
+        "id": "amazon-bedrock",
+        "models": {"anthropic.claude-fable-5-1": {"cost": {"input": 10, "output": 50}}},
+    },
+}
+
+_ETAG = '"2afcb862acafd97c7717b83be8fa940b"'
+
+
+class _Canned:
+    """``httpx.get`` stand-in: one response per call, in order, recording headers."""
+
+    def __init__(self, responses: list[httpx.Response]) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, url: str, **kwargs: Any) -> httpx.Response:
+        self.calls.append({"url": url, **kwargs})
+        assert self.responses, f"unexpected request to {url}"
+        return self.responses.pop(0)
+
+
+def _ok(body: Any = None, etag: str = _ETAG) -> httpx.Response:
+    return httpx.Response(
+        200, json=_MODELS_DEV_BODY if body is None else body, headers={"etag": etag}
+    )
+
+
+def _not_modified() -> httpx.Response:
+    return httpx.Response(304, headers={"etag": _ETAG})
+
+
+@pytest.fixture
+def canned():
+    """Patch the transport; yield the recorder so tests can assert on requests."""
+    recorder = _Canned([_ok()])
+    with patch("httpx.get", recorder):
+        yield recorder
+
+
+def _plant(tmp_path, document: dict[str, Any], *, age_s: float = 0.0) -> None:
+    (tmp_path / f"{PRICE_CATALOGUE_KEY}.json").write_text(
+        json.dumps({"fetched_at": time.time() - age_s, "payload": document}), encoding="utf-8"
+    )
+
+
+def _stored(tmp_path) -> dict[str, Any]:
+    return json.loads((tmp_path / f"{PRICE_CATALOGUE_KEY}.json").read_text(encoding="utf-8"))
+
+
+# -- projection ---------------------------------------------------------------
+
+
+def test_the_projection_keeps_only_mapped_providers_and_the_five_fields() -> None:
+    document = project(_MODELS_DEV_BODY, _ETAG)
+
+    assert document["capture"] == PRICE_CATALOGUE_CAPTURE
+    assert document["etag"] == _ETAG
+    assert "amazon-bedrock" not in document["providers"]
+    assert set(document["providers"]) == {
+        "anthropic",
+        "openai",
+        "google",
+        "moonshotai",
+        "kimi-for-coding",
+        "openrouter",
+    }
+    fable = document["providers"]["anthropic"]["claude-fable-5-1"]
+    # Structural, not numeric: the point of the projection is that the bulk of
+    # a real entry never reaches disk.
+    assert set(fable) == {"name", "cost", "limit", "attachment", "release_date"}
+    assert "description" not in json.dumps(document)
+    assert fable["cost"] == {"input": 10, "output": 50, "cache_read": 0.25, "cache_write": 12.5}
+
+
+def test_the_projection_skips_malformed_entries_rather_than_raising() -> None:
+    body = {
+        "anthropic": {"models": {"ok": {"cost": {"input": 1}}, "bad": "not a mapping", 3: {}}},
+        "openai": "not a provider",
+        "google": {"models": ["not", "a", "mapping"]},
+    }
+    document = project(body, None)
+    assert set(document["providers"]) == {"anthropic"}
+    assert set(document["providers"]["anthropic"]) == {"ok"}
+    assert document["etag"] is None
+
+
+# -- the document on disk -----------------------------------------------------
+
+
+def test_a_cold_lookup_fetches_and_writes_the_projection(tmp_path, canned) -> None:
+    row = price_catalogue_row("anthropic", "claude-fable-5-1", cache_dir=tmp_path)
+
+    assert row is not None
+    assert (row.input_price, row.output_price) == (10.0, 50.0)
+    assert (row.cache_read_price, row.cache_write_price) == (0.25, 12.5)
+    assert (row.context_window, row.max_tokens) == (1_000_000, 128_000)
+    assert row.supports_prompt_cache is True
+    assert row.name == "Claude Fable 5.1"
+    # The FIRST fetch carries no validator; there is nothing to validate against.
+    assert "If-None-Match" not in canned.calls[0]["headers"]
+    stored = _stored(tmp_path)["payload"]
+    assert stored["etag"] == _ETAG
+    assert "amazon-bedrock" not in stored["providers"]
+
+
+def test_a_matching_etag_returns_the_previous_payload_and_restamps_it(tmp_path) -> None:
+    """Hourly freshness costs one header round trip, not a 4.4 MB body."""
+    _plant(tmp_path, project(_MODELS_DEV_BODY, _ETAG), age_s=25 * 3600)
+    before = _stored(tmp_path)["fetched_at"]
+    recorder = _Canned([_not_modified()])
+
+    with patch("httpx.get", recorder):
+        row = price_catalogue_row("anthropic", "claude-fable-5-1", cache_dir=tmp_path)
+
+    assert row is not None and row.input_price == 10.0
+    assert recorder.calls[0]["headers"] == {"If-None-Match": _ETAG}
+    stored = _stored(tmp_path)
+    assert stored["payload"]["etag"] == _ETAG
+    assert stored["fetched_at"] > before, "a 304 is 'validated just now'"
+
+
+def test_a_fresh_document_is_served_without_a_request(tmp_path) -> None:
+    _plant(tmp_path, project(_MODELS_DEV_BODY, _ETAG), age_s=60)
+    recorder = _Canned([])
+    with patch("httpx.get", recorder):
+        row = price_catalogue_row("openai", "gpt-5.4", cache_dir=tmp_path)
+    assert row is not None and row.output_price == 15.0
+    assert recorder.calls == []
+
+
+def test_a_failed_fetch_keeps_the_stale_document(tmp_path) -> None:
+    _plant(tmp_path, project(_MODELS_DEV_BODY, _ETAG), age_s=25 * 3600)
+    with patch("httpx.get", side_effect=httpx.ConnectError("offline")):
+        row = price_catalogue_row("anthropic", "claude-fable-5-1", cache_dir=tmp_path)
+    assert row is not None and row.input_price == 10.0
+
+
+def test_a_non_200_never_overwrites_the_document(tmp_path) -> None:
+    _plant(tmp_path, project(_MODELS_DEV_BODY, _ETAG), age_s=25 * 3600)
+    with patch("httpx.get", _Canned([httpx.Response(503, text="down")])):
+        row = price_catalogue_row("anthropic", "claude-fable-5-1", cache_dir=tmp_path)
+    assert row is not None and row.input_price == 10.0
+    assert _stored(tmp_path)["payload"]["providers"]["anthropic"]
+
+
+def test_a_failed_cold_fetch_returns_none_and_schedules_a_background_retry(tmp_path) -> None:
+    """The 4.4 MB cold download timing out inside a 3s leg budget is evidence the
+    budget was too small, not that the network is down: retry off-path with the
+    full timeout so the NEXT resolution finds the document."""
+    with catalogue._revalidate_lock:
+        catalogue._revalidating.clear()
+        catalogue._last_attempt.clear()
+    gate = __import__("threading").Event()
+    recorder = _Canned([_ok()])
+
+    def first_times_out_then_answers(url, **kwargs):
+        if not recorder.calls:
+            recorder.calls.append({"url": url, **kwargs})
+            raise httpx.ReadTimeout("slow link")
+        gate.wait(timeout=5.0)
+        return recorder(url, **kwargs)
+
+    with patch("httpx.get", first_times_out_then_answers):
+        row = price_catalogue_row("anthropic", "claude-fable-5-1", timeout=0.5, cache_dir=tmp_path)
+        assert row is None
+        threads = catalogue._revalidation_threads()
+        assert len(threads) == 1, "one background retry expected"
+        gate.set()
+        for thread in threads:
+            thread.join(timeout=5.0)
+
+    assert recorder.calls[0]["timeout"] == 0.5
+    assert recorder.calls[1]["timeout"] == prices.DEFAULT_TIMEOUT_S
+    assert _stored(tmp_path)["payload"]["providers"]["anthropic"]["claude-fable-5-1"]
+
+
+def test_a_document_from_an_older_capture_is_refetched_in_the_same_call(tmp_path, canned) -> None:
+    _plant(tmp_path, {"capture": 0, "etag": '"old"', "providers": {}}, age_s=60)
+    row = price_catalogue_row("anthropic", "claude-fable-5-1", cache_dir=tmp_path)
+    assert row is not None and row.input_price == 10.0
+    assert _stored(tmp_path)["payload"]["capture"] == PRICE_CATALOGUE_CAPTURE
+
+
+def test_a_missing_id_in_an_old_document_is_refetched_once(tmp_path) -> None:
+    """The `want_id` rule on this document: a release that landed since the last
+    fetch is found on the first resolution, usually via a 0-byte 304 otherwise."""
+    without = json.loads(json.dumps(_MODELS_DEV_BODY))
+    del without["anthropic"]["models"]["claude-fable-5-1"]
+    _plant(tmp_path, project(without, '"before"'), age_s=20 * 60)
+    recorder = _Canned([_ok()])
+
+    with patch("httpx.get", recorder):
+        row = price_catalogue_row("anthropic", "claude-fable-5-1", cache_dir=tmp_path)
+
+    assert row is not None and row.cache_write_price == 12.5
+    assert len(recorder.calls) == 1
+    assert recorder.calls[0]["headers"] == {"If-None-Match": '"before"'}
+
+
+def test_a_missing_id_in_a_young_document_is_believed(tmp_path) -> None:
+    _plant(tmp_path, project(_MODELS_DEV_BODY, _ETAG), age_s=60)
+    recorder = _Canned([])
+    with patch("httpx.get", recorder):
+        assert price_catalogue_row("anthropic", "claude-typo", cache_dir=tmp_path) is None
+    assert recorder.calls == []
+
+
+# -- lookup -------------------------------------------------------------------
+
+
+def _lookup(provider: str, model_id: str, tmp_path):
+    _plant(tmp_path, project(_MODELS_DEV_BODY, _ETAG), age_s=60)
+    with patch("httpx.get", _Canned([])):
+        return price_catalogue_row(provider, model_id, cache_dir=tmp_path)
+
+
+def test_lookup_matches_the_exact_id(tmp_path) -> None:
+    row = _lookup("openai", "gpt-5.4", tmp_path)
+    assert row is not None and row.id == "gpt-5.4"
+
+
+def test_lookup_matches_the_normalised_id(tmp_path) -> None:
+    """Google's own docs spell the id `models/gemini-2.5-pro`; case is folded too."""
+    row = _lookup("google", "models/Gemini-2.5-Pro", tmp_path)
+    assert row is not None and row.id == "gemini-2.5-pro"
+
+
+def test_lookup_matches_a_dotted_version_spelling(tmp_path) -> None:
+    """`claude-opus-4-5-20251101` (Anthropic's spelling) finds `claude-opus-4.5`."""
+    row = _lookup("anthropic", "claude-opus-4-5-20251101", tmp_path)
+    assert row is not None and row.id == "claude-opus-4.5"
+    assert row.input_price == 5.0
+    dashed = _lookup("openai", "gpt-5-4", tmp_path)
+    assert dashed is not None and dashed.id == "gpt-5.4"
+
+
+def test_kimi_tries_moonshotai_then_the_coding_plan(tmp_path) -> None:
+    priced = _lookup("kimi", "kimi-k2.5", tmp_path)
+    assert priced is not None and priced.input_price == 0.6
+    # `k3` is only in the coding-plan catalogue, which quotes limits and no cost.
+    plan_only = _lookup("kimi", "k3", tmp_path)
+    assert plan_only is not None and plan_only.context_window == 262_144
+    assert plan_only.input_price == 0.0
+
+
+def test_openrouter_ids_are_looked_up_under_their_own_namespace(tmp_path) -> None:
+    row = _lookup("openrouter", "anthropic/claude-fable-5.1", tmp_path)
+    assert row is not None and row.cache_write_price == 12.5
+
+
+def test_an_unmapped_provider_returns_none_without_a_request(tmp_path) -> None:
+    recorder = _Canned([])
+    with patch("httpx.get", recorder):
+        assert price_catalogue_row("radient", "some/model", cache_dir=tmp_path) is None
+        assert price_catalogue_row("ollama", "qwen3:8b", cache_dir=tmp_path) is None
+    assert recorder.calls == []
+    assert not (tmp_path / f"{PRICE_CATALOGUE_KEY}.json").exists()
+
+
+def test_supports_images_is_never_taken_from_the_price_catalogue(tmp_path) -> None:
+    """`attachment: true` is projected but NOT read as a capability: a stated
+    `false` is the provider's denial, and a second-hand source cannot issue one."""
+    row = _lookup("anthropic", "claude-fable-5-1", tmp_path)
+    assert row is not None
+    assert row.supports_images is None

--- a/tests/unit/model/test_prices.py
+++ b/tests/unit/model/test_prices.py
@@ -292,6 +292,25 @@ def test_a_failed_cold_fetch_returns_none_and_schedules_a_background_retry(tmp_p
     assert _stored(tmp_path)["payload"]["providers"]["anthropic"]["claude-fable-5-1"]
 
 
+def test_a_background_revalidation_gets_the_full_default_timeout(tmp_path) -> None:
+    """R1-2, this document: the leg budget (3 s at most) bounds only the sync
+    fetch; a soft-window refresh runs off-path with the full default."""
+    with catalogue._revalidate_lock:
+        catalogue._revalidating.clear()
+        catalogue._last_attempt.clear()
+        catalogue._threads.clear()
+    _plant(tmp_path, project(_MODELS_DEV_BODY, _ETAG), age_s=2 * 3600)
+    recorder = _Canned([_ok()])
+    with patch("httpx.get", recorder):
+        row = price_catalogue_row("anthropic", "claude-fable-5-1", timeout=0.5, cache_dir=tmp_path)
+        assert row is not None
+        threads = catalogue._revalidation_threads()
+        assert len(threads) == 1
+        for thread in threads:
+            thread.join(timeout=5.0)
+    assert recorder.calls[0]["timeout"] == prices.DEFAULT_TIMEOUT_S
+
+
 def test_a_document_from_an_older_capture_is_refetched_in_the_same_call(tmp_path, canned) -> None:
     _plant(tmp_path, {"capture": 0, "etag": '"old"', "providers": {}}, age_s=60)
     row = price_catalogue_row("anthropic", "claude-fable-5-1", cache_dir=tmp_path)

--- a/tests/unit/model/test_pricing.py
+++ b/tests/unit/model/test_pricing.py
@@ -18,6 +18,7 @@ import pytest
 from local_operator.harness.types import Usage
 from local_operator.model.configure import (
     _from_aggregator_catalogue,
+    _from_price_catalogue,
     calculate_cost,
     cost_for_usage,
     invalidate_model_info_cache,
@@ -155,6 +156,12 @@ def test_current_generation_claude_is_priced(
 # ---------------------------------------------------------------------------
 # The catalogue fallback (a placeholder self-heals)
 # ---------------------------------------------------------------------------
+#
+# Leg 2 of resolution is the provider-neutral models.dev catalogue
+# (`_from_price_catalogue`), NOT the OpenRouter listing: a user signed in only to
+# Anthropic must get correct prices for a model released this morning without
+# another aggregator's document being fresh. Leg 3 (`_from_aggregator_catalogue`)
+# survives for an aggregator's OWN ids only.
 
 
 def _catalogue(*rows: DiscoveredModel):
@@ -165,8 +172,13 @@ def _catalogue(*rows: DiscoveredModel):
     )
 
 
+def _price_catalogue(row: DiscoveredModel | None):
+    """Patch the models.dev lookup to answer with exactly ``row``."""
+    return patch("local_operator.model.prices.price_catalogue_row", return_value=row)
+
+
 def test_zero_priced_registry_row_falls_back_to_the_catalogue() -> None:
-    """A direct provider's placeholder is healed by the aggregator's price.
+    """A direct provider's placeholder is healed by the neutral catalogue's price.
 
     This is the mechanism that stops the placeholder class of bug recurring: a
     row added tomorrow with `0.0` starts costing correctly instead of silently
@@ -176,31 +188,100 @@ def test_zero_priced_registry_row_falls_back_to_the_catalogue() -> None:
     """
     placeholder = ModelInfo(id="claude-nova-6", name="claude-nova-6", description="")
     row = DiscoveredModel(
-        id="anthropic/claude-nova-6",
+        id="claude-nova-6",
         name="Claude Nova 6",
         input_price=7.0,
         output_price=35.0,
         cache_read_price=0.7,
+        cache_write_price=8.75,
     )
-    with _catalogue(row):
-        healed = _from_aggregator_catalogue("anthropic", "claude-nova-6", placeholder)
+    with _price_catalogue(row):
+        healed = _from_price_catalogue("anthropic", "claude-nova-6", placeholder)
     assert (healed.input_price, healed.output_price) == (7.0, 35.0)
     assert healed.cache_reads_price == 0.7
     assert healed.supports_prompt_cache is True
 
 
-def test_catalogue_fallback_matches_a_dotted_version_spelling() -> None:
-    """`claude-opus-4-5-20251101` finds `anthropic/claude-opus-4.5`.
+def test_the_write_price_reaches_model_info() -> None:
+    """`cache_writes_price` is the catalogue's number, not the input price.
 
-    Providers and aggregators disagree about punctuation systematically, not per
-    model. Without the rewrite every dated Claude snapshot — the spelling
-    Anthropic's own docs use — would stay unpriced.
+    The input-price stand-in under-states an Anthropic 5m write by 20%; both
+    consumers used to substitute it because `DiscoveredModel` had no write price.
     """
-    placeholder = ModelInfo(id="claude-opus-9-5-20991231", name="x", description="")
-    row = DiscoveredModel(id="anthropic/claude-opus-9.5", name="", input_price=4.0)
-    with _catalogue(row):
-        healed = _from_aggregator_catalogue("anthropic", "claude-opus-9-5-20991231", placeholder)
-    assert healed.input_price == 4.0
+    placeholder = ModelInfo(id="claude-fable-5-1", name="x", description="")
+    row = DiscoveredModel(
+        id="claude-fable-5-1",
+        input_price=10.0,
+        output_price=50.0,
+        cache_read_price=0.25,
+        cache_write_price=12.5,
+    )
+    with _price_catalogue(row):
+        healed = _from_price_catalogue("anthropic", "claude-fable-5-1", placeholder)
+    assert healed.cache_writes_price == 12.5, "the input price was substituted for the write"
+
+
+def test_the_input_price_fallback_survives_a_listing_with_no_write_price() -> None:
+    """A catalogue that quotes a read price and no write price still gets the floor."""
+    placeholder = ModelInfo(id="gpt-9", name="x", description="")
+    row = DiscoveredModel(id="gpt-9", input_price=2.0, output_price=8.0, cache_read_price=0.2)
+    with _price_catalogue(row):
+        healed = _from_price_catalogue("openai", "gpt-9", placeholder)
+    assert healed.cache_writes_price == 2.0
+
+
+def test_a_direct_provider_is_priced_from_the_neutral_catalogue_not_openrouter() -> None:
+    """Zero OpenRouter requests on an Anthropic-only install.
+
+    The provider's own listing answers unpriced (as Anthropic's does), models.dev
+    prices it, and the aggregator listing is never consulted for a direct id.
+    """
+    invalidate_model_info_cache()
+    unpriced = DiscoveredModel(id="claude-nova-6", context_window=1_000_000, max_tokens=128_000)
+    priced = DiscoveredModel(
+        id="claude-nova-6",
+        input_price=7.0,
+        output_price=35.0,
+        cache_read_price=0.7,
+        cache_write_price=8.75,
+    )
+    consulted: list[str] = []
+
+    def listing(provider_id, **kwargs):
+        consulted.append(provider_id)
+        return [unpriced], "ok"
+
+    with (
+        patch("local_operator.model.discovery.available_models", side_effect=listing),
+        _price_catalogue(priced),
+    ):
+        info = resolve_model_info("anthropic", "claude-nova-6")
+    invalidate_model_info_cache()
+
+    assert (info.input_price, info.output_price) == (7.0, 35.0)
+    assert info.cache_writes_price == 8.75
+    assert info.context_window == 1_000_000, "the provider's own limit wins over the catalogue"
+    assert consulted == ["anthropic"], f"OpenRouter was consulted for a direct id: {consulted}"
+
+
+def test_openrouter_ids_still_fall_back_to_their_own_listing() -> None:
+    """Leg 3 is for an aggregator's own ids, and nothing else."""
+    placeholder = ModelInfo(id="some/model", name="x", description="")
+    row = DiscoveredModel(id="some/model", input_price=9.0, output_price=27.0)
+    with _catalogue(row) as listing:
+        healed = _from_aggregator_catalogue("openrouter", "some/model", placeholder)
+    assert healed.input_price == 9.0
+    assert listing.call_args.kwargs["want_id"] == "some/model"
+
+
+def test_the_aggregator_leg_refuses_a_direct_provider() -> None:
+    """The namespace map that priced `anthropic/*` from OpenRouter is gone."""
+    placeholder = ModelInfo(id="claude-nova-6", name="x", description="")
+    row = DiscoveredModel(id="anthropic/claude-nova-6", input_price=7.0)
+    with _catalogue(row) as listing:
+        untouched = _from_aggregator_catalogue("anthropic", "claude-nova-6", placeholder)
+    assert untouched.input_price == 0.0
+    listing.assert_not_called()
 
 
 def test_catalogue_fallback_supplies_a_missing_context_window() -> None:
@@ -213,15 +294,15 @@ def test_catalogue_fallback_supplies_a_missing_context_window() -> None:
     """
     bare = ModelInfo(id="gpt-9", name="gpt-9", description="", context_window=-1, max_tokens=-1)
     row = DiscoveredModel(
-        id="openai/gpt-9",
+        id="gpt-9",
         name="",
         input_price=2.0,
         output_price=8.0,
         context_window=400_000,
         max_tokens=64_000,
     )
-    with _catalogue(row):
-        healed = _from_aggregator_catalogue("openai", "gpt-9", bare)
+    with _price_catalogue(row):
+        healed = _from_price_catalogue("openai", "gpt-9", bare)
     assert (healed.context_window, healed.max_tokens) == (400_000, 64_000)
 
 
@@ -240,14 +321,14 @@ def test_catalogue_fallback_never_overrides_a_window_we_already_have() -> None:
         max_tokens=64_000,
     )
     row = DiscoveredModel(
-        id="anthropic/claude-opus-4.5",
+        id="claude-opus-4.5",
         name="",
         input_price=5.0,
         context_window=1_000_000,
         max_tokens=128_000,
     )
-    with _catalogue(row):
-        untouched = _from_aggregator_catalogue("anthropic", "claude-opus-4-5-20251101", described)
+    with _price_catalogue(row):
+        untouched = _from_price_catalogue("anthropic", "claude-opus-4-5-20251101", described)
     assert (untouched.context_window, untouched.max_tokens) == (200_000, 64_000)
     assert untouched.input_price == 5.0, "the price hole was still filled"
 
@@ -255,19 +336,17 @@ def test_catalogue_fallback_never_overrides_a_window_we_already_have() -> None:
 def test_catalogue_fallback_leaves_an_unknown_model_alone() -> None:
     """No match means no price, not a plausible neighbour's price."""
     placeholder = ModelInfo(id="claude-nova-6", name="x", description="")
-    row = DiscoveredModel(id="anthropic/claude-opus-5", name="", input_price=5.0)
-    with _catalogue(row):
-        untouched = _from_aggregator_catalogue("anthropic", "claude-nova-6", placeholder)
+    with _price_catalogue(None):
+        untouched = _from_price_catalogue("anthropic", "claude-nova-6", placeholder)
     assert (untouched.input_price, untouched.output_price) == (0.0, 0.0)
 
 
-def test_catalogue_fallback_skips_the_aggregators_themselves() -> None:
-    """An OpenRouter model is already priced by its own listing; no second leg."""
-    placeholder = ModelInfo(id="some/model", name="x", description="")
-    with _catalogue(DiscoveredModel(id="some/model", name="", input_price=9.0)) as listing:
-        untouched = _from_aggregator_catalogue("openrouter", "some/model", placeholder)
-    assert untouched.input_price == 0.0
-    listing.assert_not_called()
+def test_catalogue_fallback_ignores_a_stub_with_no_cost_and_no_limit() -> None:
+    """A plan-catalogue stub answers neither question this leg is here for."""
+    placeholder = ModelInfo(id="k3", name="x", description="")
+    with _price_catalogue(DiscoveredModel(id="k3", name="Kimi K3")):
+        untouched = _from_price_catalogue("kimi", "k3", placeholder)
+    assert untouched == placeholder
 
 
 def test_a_priced_row_never_reaches_the_aggregator_leg() -> None:
@@ -369,20 +448,25 @@ def test_the_two_listing_legs_share_one_ceiling_rather_than_summing() -> None:
             clock[0] += spent  # leg 1 blocks for nearly the whole ceiling
         return [], "ok"
 
+    def price_leg(provider, model_id, *, timeout, **kwargs):
+        seen.append(timeout)
+        return None
+
     with (
         patch("local_operator.model.discovery.available_models", side_effect=slow),
+        patch("local_operator.model.prices.price_catalogue_row", side_effect=price_leg),
         patch("local_operator.model.configure.time.monotonic", side_effect=lambda: clock[0]),
     ):
         invalidate_model_info_cache()
         resolve_model_info("anthropic", "claude-nova-6")
     invalidate_model_info_cache()
 
-    assert len(seen) == 2, f"expected the provider leg then the aggregator leg, got {seen}"
-    provider_leg, aggregator_leg = seen
+    assert len(seen) == 2, f"expected the provider leg then the price-catalogue leg, got {seen}"
+    provider_leg, price_leg_budget = seen
     assert provider_leg == DEFAULT_TIMEOUT_S, "a blocking resolve must keep the full ceiling"
-    assert aggregator_leg is not None
-    assert spent + aggregator_leg <= DEFAULT_TIMEOUT_S + 0.01, (
-        f"leg 1 spent {spent}s and leg 2 was still granted {aggregator_leg}s, "
+    assert price_leg_budget is not None
+    assert spent + price_leg_budget <= DEFAULT_TIMEOUT_S + 0.01, (
+        f"leg 1 spent {spent}s and leg 2 was still granted {price_leg_budget}s, "
         f"over the {DEFAULT_TIMEOUT_S}s ceiling"
     )
 

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -6804,6 +6804,36 @@ async def _open_model_picker(app, pilot):
     return editor.model_picker
 
 
+class _TtlRecordingController(_AccessController):
+    """Records what listing TTL the picker asks for."""
+
+    def __init__(self) -> None:
+        super().__init__(stored=("openrouter",))
+        self.asked: list[float | None] = []
+
+    async def live_catalogue(self, *, ttl_s=None):
+        self.asked.append(ttl_s)
+        return self.static_catalogue(), {}
+
+
+@pytest.mark.asyncio
+async def test_the_picker_asks_for_a_fifteen_minute_listing() -> None:
+    """The user opening `/model` is the one moment a fresh list is worth a request.
+
+    Discovery's 24h default is what hid a model published that morning from the
+    picker all day; the fetch is off-loop behind painted rows, so a short TTL
+    costs nothing visible.
+    """
+    from local_operator.providers.controller import PICKER_TTL_S
+
+    ctrl = _TtlRecordingController()
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=ctrl)
+    async with app.run_test(size=(90, 24)) as pilot:
+        await pilot.pause()
+        await _open_model_picker(app, pilot)
+    assert ctrl.asked == [PICKER_TTL_S], ctrl.asked
+
+
 @pytest.mark.asyncio
 async def test_the_model_list_offers_what_the_user_can_actually_run() -> None:
     """The list is a set of choices. A row whose only outcome is a login prompt is

--- a/tests/unit/tui/test_model_picker.py
+++ b/tests/unit/tui/test_model_picker.py
@@ -373,9 +373,9 @@ def test_the_status_line_surfaces_what_the_catalogue_does_not_know() -> None:
     """A failed provider is exactly when a user hunting for a model released
     this morning needs telling, rather than concluding it is not real."""
     picker = ModelPicker(lambda row: None)
-    picker.set_rows(_rows(), status="live list unavailable: anthropic — showing cached")
+    picker.set_rows(_rows(), status="stale list: anthropic")
     picker.open("")
-    assert "live list unavailable: anthropic" in picker.render_text(90).plain
+    assert "stale list: anthropic" in picker.render_text(90).plain
 
 
 def test_the_footer_names_stale_providers_and_stays_silent_for_cached_ones() -> None:
@@ -386,14 +386,44 @@ def test_the_footer_names_stale_providers_and_stays_silent_for_cached_ones() -> 
     assert _catalogue_status({"anthropic": "cached", "openrouter": "ok"}) == ""
     assert (
         _catalogue_status({"xai": "stale", "anthropic": "stale", "openrouter": "cached"})
-        == "live list unavailable: anthropic, xai — showing cached"
+        == "stale list: anthropic, xai"
     )
     assert (
         _catalogue_status({"anthropic": "stale", "radient": "empty"})
-        == "live list unavailable: anthropic — showing cached · no live list: radient"
+        == "stale list: anthropic · no live list: radient"
     )
     # Unauthenticated is counted by the access note, not here.
     assert _catalogue_status({"google": "unauthenticated"}) == ""
+
+
+def test_the_stale_clause_fits_beside_the_access_note_at_the_reference_width() -> None:
+    """The access note leads the footer and leaves 39 cells for this clause at
+    100 columns (73-cell picker, 2 gutter, 1 margin, 28-cell note, 3-cell seam).
+    The first spelling was 54 cells and truncation ate the half that said the
+    rows were still usable."""
+    from local_operator.tui.app import _catalogue_status
+
+    clause = _catalogue_status({"anthropic": "stale", "xai": "stale", "openrouter": "ok"})
+    assert cell_len(clause) <= 39, clause
+
+
+def test_every_provider_stale_collapses_to_a_nameless_clause() -> None:
+    """Offline fails every listed provider at once; five names fit no picker
+    width the app renders, and naming only helps when the failure is partial."""
+    from local_operator.tui.app import _catalogue_status
+
+    everyone = {p: "stale" for p in ("anthropic", "google", "mistral", "openai", "xai")}
+    assert _catalogue_status(everyone) == "stale list: all providers"
+    # A provider that never produced a listing is not one of "all providers".
+    assert _catalogue_status({**everyone, "ollama": "static", "zai": "unauthenticated"}) == (
+        "stale list: all providers"
+    )
+    # One stale provider is always named: "all providers" would say less.
+    assert _catalogue_status({"anthropic": "stale"}) == "stale list: anthropic"
+    # Empty is a listing too, so stale + empty is partial and keeps the names.
+    assert _catalogue_status({"anthropic": "stale", "xai": "stale", "radient": "empty"}) == (
+        "stale list: anthropic, xai · no live list: radient"
+    )
 
 
 def test_an_empty_result_says_so_rather_than_rendering_nothing() -> None:
@@ -511,7 +541,7 @@ async def test_large_degraded_catalogue_leads_with_current_family_and_status() -
     picker.set_rows(
         [*bulk, *siblings, current],
         current=current.selector,
-        status="live model list unavailable: provider timeout",
+        status="stale list: all providers — provider timeout",
     )
 
     class _Host(App[None]):
@@ -534,7 +564,7 @@ async def test_large_degraded_catalogue_leads_with_current_family_and_status() -
 
     assert first[0].selector == current.selector
     assert all(row.provider == "anthropic" for row in first)
-    assert "live model list unavailable" in painted, painted
+    assert "stale list: all providers" in painted, painted
 
 
 def test_a_row_shows_the_display_name_beside_the_selector() -> None:
@@ -601,3 +631,25 @@ def test_the_name_never_grows_as_the_window_narrows() -> None:
         row = picker.render_text(width).plain.splitlines()[0]
         painted.append(len(row.partition("(")[2].partition(")")[0]))
     assert painted == sorted(painted, reverse=True), list(zip(widths, painted))
+
+
+def test_the_status_row_is_kept_once_painted_so_the_card_does_not_reflow() -> None:
+    """The app paints `checking providers…` on the keystroke and clears it when
+    the live list lands. Letting the row collapse shrank the card by a line and
+    dropped everything above it while the user was reading; a blank row is less
+    motion than a reflow. A fresh open starts without the row again."""
+    picker = ModelPicker(lambda row: None)
+    picker.set_rows(_rows(), status="checking providers… · d in /model saves this")
+    picker.open("")
+    with_status = picker.render_text(90).plain.split("\n")
+    picker.set_rows(_rows(), status="d in /model saves this")
+    settled = picker.render_text(90).plain.split("\n")
+    assert len(settled) == len(with_status), (with_status, settled)
+    assert settled[-2].strip() == "", settled
+    assert settled[-1].strip() == "d in /model saves this", settled
+    # Never painted a status this open → no held row.
+    picker.close()
+    picker.set_rows(_rows(), status="d in /model saves this")
+    picker.open("")
+    fresh = picker.render_text(90).plain.split("\n")
+    assert len(fresh) == len(settled) - 1, fresh

--- a/tests/unit/tui/test_model_picker.py
+++ b/tests/unit/tui/test_model_picker.py
@@ -370,12 +370,30 @@ def test_an_overflowing_list_says_how_much_it_is_hiding() -> None:
 
 
 def test_the_status_line_surfaces_what_the_catalogue_does_not_know() -> None:
-    """A cached or failed provider is exactly when a user hunting for a model
-    released last week needs telling, rather than concluding it is not real."""
+    """A failed provider is exactly when a user hunting for a model released
+    this morning needs telling, rather than concluding it is not real."""
     picker = ModelPicker(lambda row: None)
-    picker.set_rows(_rows(), status="cached: anthropic")
+    picker.set_rows(_rows(), status="live list unavailable: anthropic — showing cached")
     picker.open("")
-    assert "cached: anthropic" in picker.render_text(90).plain
+    assert "live list unavailable: anthropic" in picker.render_text(90).plain
+
+
+def test_the_footer_names_stale_providers_and_stays_silent_for_cached_ones() -> None:
+    """`stale` is a failed refresh; `cached` is "listed within the picker's
+    fifteen-minute TTL", which is not worth a line nobody would read."""
+    from local_operator.tui.app import _catalogue_status
+
+    assert _catalogue_status({"anthropic": "cached", "openrouter": "ok"}) == ""
+    assert (
+        _catalogue_status({"xai": "stale", "anthropic": "stale", "openrouter": "cached"})
+        == "live list unavailable: anthropic, xai — showing cached"
+    )
+    assert (
+        _catalogue_status({"anthropic": "stale", "radient": "empty"})
+        == "live list unavailable: anthropic — showing cached · no live list: radient"
+    )
+    # Unauthenticated is counted by the access note, not here.
+    assert _catalogue_status({"google": "unauthenticated"}) == ""
 
 
 def test_an_empty_result_says_so_rather_than_rendering_nothing() -> None:

--- a/tests/unit/tui/test_model_picker.py
+++ b/tests/unit/tui/test_model_picker.py
@@ -14,6 +14,7 @@ from textual.app import App, ComposeResult
 
 from local_operator.tui.widgets.command_picker import slash_argument
 from local_operator.tui.widgets.model_picker import (
+    MAX_VISIBLE_ROWS,
     ModelPicker,
     ModelRow,
     format_price_pair,
@@ -378,6 +379,35 @@ def test_the_status_line_surfaces_what_the_catalogue_does_not_know() -> None:
     assert "stale list: anthropic" in picker.render_text(90).plain
 
 
+def test_a_footer_clause_that_cannot_keep_its_first_value_is_dropped_at_the_seam() -> None:
+    """The three-clause composite (access note, stale, empty) at 100 columns
+    used to render ``… · no live list:…`` — a label whose only payload died,
+    leaving a dangling colon that read as a glitch. The cut moves to the seam
+    before that clause. Lines that fitted before, and cuts that land inside a
+    list of names, render exactly as they did."""
+    note = "2 hidden — /login <provider>"
+    picker = ModelPicker(lambda row: None)
+    picker.set_rows(_rows(), status=f"{note} · stale list: anthropic · no live list: radient")
+    picker.open("")
+    # 73-cell picker at a 100-column terminal, as the captured frames were.
+    footer = picker.render_text(73).plain.split("\n")[-1].strip()
+    assert footer == f"{note} · stale list: anthropic", footer
+    assert "no live list" not in footer
+    # Wide enough → every clause, untouched.
+    assert picker.render_text(90).plain.split("\n")[-1].strip() == (
+        f"{note} · stale list: anthropic · no live list: radient"
+    )
+    # A cut inside the provider list keeps the label and first name (the
+    # 60-column frame from design round 1), not the seam rule.
+    picker.set_rows(_rows(), status=f"{note} · stale list: anthropic, xai")
+    assert picker.render_text(56).plain.split("\n")[-1].strip() == (
+        f"{note} · stale list: anthropic…"
+    )
+    # The leading clause is never dropped, however narrow.
+    picker.set_rows(_rows(), status=note)
+    assert picker.render_text(24).plain.split("\n")[-1].strip() == "2 hidden — /login <p…"
+
+
 def test_the_footer_names_stale_providers_and_stays_silent_for_cached_ones() -> None:
     """`stale` is a failed refresh; `cached` is "listed within the picker's
     fifteen-minute TTL", which is not worth a line nobody would read."""
@@ -653,3 +683,54 @@ def test_the_status_row_is_kept_once_painted_so_the_card_does_not_reflow() -> No
     picker.open("")
     fresh = picker.render_text(90).plain.split("\n")
     assert len(fresh) == len(settled) - 1, fresh
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("height", [12, 30, 45])
+async def test_the_held_row_is_paid_for_out_of_the_row_budget_when_mounted(height: int) -> None:
+    """The unmounted test above cannot reach `_row_budget`'s held-row term: with
+    no screen it short-circuits to `MAX_VISIBLE_ROWS`. Mounted, the budget is
+    a third of the screen, and the held blank row must come out of that third —
+    otherwise the card grows a line on settle and pushes the composer, which is
+    the reflow the hold exists to prevent. Pinned at three heights because the
+    cap switches between the screen fraction and `MAX_VISIBLE_ROWS` at 45."""
+    hint = "d in /model saves this"
+    bulk = [
+        ModelRow("openrouter", f"vendor/model-{index}", connected=True, aggregated=True)
+        for index in range(60)
+    ]
+    picker = ModelPicker(lambda row: None)
+    picker.set_rows(bulk, status=f"checking providers… · {hint}")
+
+    class _Host(App[None]):
+        CSS = "ModelPicker { width: 100%; }"
+
+        def compose(self) -> ComposeResult:
+            yield picker
+
+    cap = min(MAX_VISIBLE_ROWS, height // 3)
+    app = _Host()
+    async with app.run_test(size=(100, height)) as pilot:
+        await pilot.pause()
+        picker.open("")
+        await pilot.pause()
+        checking = picker.render_text(100).plain.split("\n")
+        checking_budget = picker._row_budget()
+        heights: list[int] = []
+        budgets: list[int] = []
+        for status in (hint, "", "stale list: anthropic"):
+            picker.set_rows(bulk, status=status)
+            await pilot.pause()
+            heights.append(len(picker.render_text(100).plain.split("\n")))
+            budgets.append(picker._row_budget())
+
+    # The card never changes height across the app's real settle sequence and
+    # never exceeds the screen-fraction cap.
+    assert heights == [len(checking)] * 3, (len(checking), heights)
+    assert len(checking) <= cap, (len(checking), cap)
+    # Two footer rows while the hint is present (`checking…` and hint-only
+    # alike), and once the hint goes the held blank row — or the clause that
+    # replaces it — still costs one: without the hold the empty-status state
+    # would get its row back and the card would grow by a line.
+    assert checking_budget == max(1, cap - 2), (checking_budget, cap)
+    assert budgets == [cap - 2, cap - 1, cap - 1], (cap, budgets)


### PR DESCRIPTION
## Summary

**Incident (2026-09-01):** Anthropic published `claude-fable-5-1` in the morning. With a 22h-old `~/.local-operator/cache/anthropic.listing.json` — inside the 24h TTL, so never refetched — `/model` did not list it, and `resolve_model_info("anthropic", "claude-fable-5-1")` returned `input/output 0.0`, `cache_read/cache_write None`: the only price source for a direct-provider id was the OpenRouter listing looked up under a per-provider namespace, and *that* document was six hours old and predated the row. A user signed in only to Anthropic ran the whole day at `$0.00`.

Two structural causes, both fixed here per `docs/design/model-catalogue-freshness.md` (committed in this PR):

1. **One 24h TTL, one synchronous miss path, no user-driven refresh.** The catalogue reader had three states — fresh/serve, expired/fetch-sync, failed/serve-stale — and nothing between "serve" and "block on the network".
2. **Direct-provider prices came from OpenRouter.** Anthropic's `/v1/models` carries no prices (verified: `id, display_name, created_at, max_input_tokens, max_tokens, capabilities`); OpenAI's and Google's neither. The aggregator leg coupled every direct provider's cost display to one third party's document and its id spellings.

## What changed

**`catalogue.py` — stale-while-revalidate.** `read_listing()` returns a `Listing(payload, age_s, fetched, failed, refreshing)` with a soft/hard TTL state machine: `age < SOFT_TTL_S (1h)` serve; `1h ≤ age < DEFAULT_TTL_S (24h)` serve **immediately** and refresh on a daemon thread (per-process in-flight set + 5-min backoff, the existing cross-process lease; a thread that loses the lease exits); `≥ 24h` or absent → the existing synchronous lease path, unchanged. `cached_listing` stays as a no-thread wrapper (soft TTL pinned to hard). `peek_listing()` reads without sweeping or fetching, for conditional-GET thunks. A `refetch_if(payload, age)` predicate lets a reader declare a document expired *before* either path starts — this is what `want_id` uses, because a second sync call after the background one is scheduled would lose the lease to its own process's thread and could not tell its result from a cache hit.

**`discovery.py`.** New `"stale"` status (a fetch was attempted and failed; before, that collapsed into `"cached"` and the picker footer could not tell "fresh enough" from "offline"). `available_models(want_id=…)`: an id absent from a usable document ≥ `MISS_REFETCH_MIN_AGE_S` (10 min) old triggers **one** synchronous refetch inside the caller's budget — the only trigger that beats every TTL *and* the in-process memo bucket for a brand-new id, and it fires for exactly the id the user asked for. A young document is believed (a typo cannot refetch per resolution), and the refetched document is 0s old so a second miss is believed too. `DiscoveredModel.cache_write_price` from `pricing.input_cache_write`, threaded through `_from_static`/`_merge_one`/`_rows_from_payload`; `LISTING_CAPTURE_VERSIONS` bumped to 2 for `openrouter` and `radient` so the field is not invisible for a day. The `fetched` nonlocal is gone.

**`prices.py` (new) — models.dev.** `https://models.dev/api.json` is keyless, provider-keyed, carries `cost {input, output, cache_read, cache_write}` in $/MTok and `limit {context, output}`, answers a weak ETag and 0-byte 304s. What lands on disk (`models-dev.listing.json`) is a **projection**: only the 13 mapped provider keys and five fields per model — 141,343 bytes measured against the 4.4 MB source. Key map with first-match-wins fallbacks (`kimi → moonshotai, kimi-for-coding`; `zai → zai, zai-coding-plan`; `alibaba-token-plan → alibaba-token-plan, alibaba`; `radient` deliberately absent — its own listing quotes prices). Lookup tries the exact id, the normalised id, and the dotted/dashed spellings. `supports_images` is **never** taken (three-valued contract: a stated `false` is the provider's denial). On a cold miss that times out inside the 3s leg budget, a background retry with the full 10s timeout is scheduled so the *next* resolution finds the document.

**`configure.py` — leg order.** Registry → provider listing (`want_id=model_id`) → **models.dev** → OpenRouter listing **only for `openrouter/*`/`radient/*` ids**. `_AGGREGATOR_NAMESPACE` and `_aggregator_spellings` are deleted; the spelling rules and `_normalised_id` move to a new dependency-free `model/ids.py` (configure is on the CLI import path and must not import discovery; discovery must not import configure back). `_info_from_discovery` and the shared `_fill_from_row` write `ModelInfo.cache_writes_price` from the real number, with the input-price stand-in kept only for listings that genuinely quote no write price (it under-states an Anthropic 5m write by 20%). Budgets unchanged in kind: `_PRICE_CATALOGUE_TIMEOUT_S = _AGGREGATOR_TIMEOUT_S = 3.0` inside `_remaining_budget(started)`; the 1 Hz TUI cost poll still only reads `_paint_memo` on-loop.

**Picker.** `_refresh_catalogue` passes `live_catalogue(ttl_s=PICKER_TTL_S)` (15 min, in `providers/controller.py`; the only caller never passed the accepted argument). `_catalogue_status`: `cached` is now **silent** ("listed within the last quarter hour" is not worth a line); `stale` → `stale list: anthropic, xai`, collapsing to `stale list: all providers` when every listed provider is stale (offline); `empty` unchanged. The dead `"unavailable"` branch that no code emitted becomes the `stale` branch. The footer also keeps its status row (blank) once one has painted, so `checking providers…` clearing on settle no longer reflows the picker — both wording updates came out of design review round 1 (see the remediation comment).

**Version:** `0.44.25 → 0.44.26` (patch: a fix plus a self-contained enrichment; no new surface).

## Testing evidence

Everything below ran from the worktree venv against **temp `cache_dir`s** (the real `~/.local-operator/cache` was read, never written). Commands and outputs verbatim; scripts in `/tmp/lop-cf-evidence/`.

### (a) Reproduction on the pre-change tree

Copied the real `*.listing.json` documents into a temp dir, backdated `fetched_at` to 22h (anthropic) / 6h (others), removed the fable row the way a pre-release capture lacks it, and blocked the network:

```
$ .venv/bin/python /tmp/lop-cf-evidence/repro.py
cache_dir: /var/folders/.../lop-cf-stale-njsb8kg2
available_models(anthropic): status=cached ids=['claude-opus-5', 'claude-sonnet-5', 'claude-fable-5', ...]
claude-fable-5-1 listed: False
resolve_model_info: input=0.0 output=0.0 cache_read=None cache_write=None ctx=1000000
```

### (b) After: correct prices with NO openrouter document present

Temp dir seeded with **only** the 22h-old anthropic document (fable removed). Real network to Anthropic (OAuth) and models.dev:

```
$ .venv/bin/python /tmp/lop-cf-evidence/after.py
cache_dir: /var/folders/.../lop-cf-after-hyzfbepw contents: ['anthropic.listing.json']
local_operator.model.catalogue: anthropic.listing catalogue (79200s old) declared expired by its reader
local_operator.model.prices: models.dev catalogue fetched: 13 providers projected, etag W/"e51cddf3dbca096a2d910c9156f261e2"

(b) resolve_model_info(anthropic, claude-fable-5-1) in 0.66s:
    input=10.0 output=50.0 cache_read=0.25 cache_write=12.5 ctx=1000000 max_tokens=128000 prompt_cache=True
    cache contents: ['anthropic.listing.json', 'models-dev.listing.json']
```

`assert not (cache / "openrouter.listing.json").exists()` held. The `declared expired by its reader` line is the `want_id` miss refetch (e) firing for the anthropic document.

### (c) The models.dev projection and a 304

```
(c) models-dev.listing.json: size=141343 bytes etag=W/"e51cddf3dbca096a2d910c9156f261e2" capture=1
    providers=['alibaba', 'alibaba-token-plan', 'anthropic', 'deepseek', 'google', 'kimi-for-coding',
               'mistral', 'moonshotai', 'openai', 'openrouter', 'xai', 'zai', 'zai-coding-plan']
    anthropic document refetched (want_id miss): fetched_at age = 0.3s, ids include fable: True
local_operator.model.prices: models.dev catalogue unchanged (304, etag W/"e51cddf3dbca096a2d910c9156f261e2")

(c) second fetch with If-None-Match (0.15s): gpt-5.4 -> in=2.5 out=15.0 cache_read=0.25 cache_write=0.0 ctx=1050000
    restamped fetched_at age = 0.0s
```

(Document aged to 25h between the calls to force the conditional GET; the 304 restamps `fetched_at` without re-downloading 4.4 MB.)

### (d) Stale-while-revalidate

Real anthropic document aged to 2h, real OAuth credential (value never printed):

```
$ .venv/bin/python /tmp/lop-cf-evidence/swr.py
credential kind: oauth (value withheld)
(d) available_models on a 2h document: status=cached rows=19 in 0.4 ms (served from disk)
    background threads: ['catalogue-revalidate:anthropic.listing']
    document rewritten: mtime advanced=True, fetched_at age=0.0s, models=11, lease files=[]
    next call: status=cached, refresh scheduled=False
```

### (e) `want_id` miss refetch — see the `declared expired by its reader` line in (b): 22h document lacking the id → one sync refetch → `fetched_at age = 0.3s`, fable present.

### Stale status + footer wording (network down, 25h document)

```
$ .venv/bin/python /tmp/lop-cf-evidence/stale.py
25h document, network down -> status=stale rows=19
footer: 'stale list: anthropic'
```

### (f) The picker

**Real `ProviderController` + real credential store, temp cache dir with the 22h anthropic document (fable removed):**

```
$ .venv/bin/python /tmp/lop-cf-evidence/real_picker.py
live_catalogue(ttl_s=900) in 4.04s; statuses={'openai': 'ok', 'openai-device': 'cached', 'anthropic': 'ok', 'kimi': 'ok', 'zai': 'ok', 'zai-oauth': 'cached', 'openrouter': 'ok', 'alibaba-token-plan': 'ok', 'alibaba-token-plan-oauth': 'cached'}
anthropic rows (19): fable listed = True
fable entry: label='Claude Fable 5.1' ctx=1000000 $-1.0/-1.0
```

(`$-1.0/-1.0` is the picker's pre-existing "unknown" sentinel — picker rows price from the provider listing only, and Anthropic's quotes none; the status band prices through `resolve_model_info`, which is what (b) proves. Pricing picker rows from models.dev is out of scope and noted below.)

**Rendered frames** (real `OperatorApp` via `run_test`, 100×30, `FakeProviderController` forcing `anthropic`/`xai` to the failed-refresh status; SVG → PNG with `rsvg-convert`), before and after typing `/model fable`:

| before (`origin/main`) | after |
| --- | --- |
| `live_catalogue(ttl_s=None)`; footer `cached: openrouter`; the two failed providers are not mentioned | `live_catalogue(ttl_s=900)`; footer `stale list: anthropic, xai`; `cached` silent |
| <img width="700" alt="model-picker-before" src="https://raw.githubusercontent.com/damianvtran/local-operator/pr-catalogue-freshness-assets/shots/model-picker-before.png" /> | <img width="700" alt="model-picker-after-stale" src="https://raw.githubusercontent.com/damianvtran/local-operator/pr-catalogue-freshness-assets/shots/model-picker-after-stale.png" /> |

A third frame with every provider `cached` shows the footer with no catalogue clause at all (the `d in /model saves this…` hint only, in the held status row):

<img width="700" alt="model-picker-after-cached" src="https://raw.githubusercontent.com/damianvtran/local-operator/pr-catalogue-freshness-assets/shots/model-picker-after-cached.png" />

Frames were captured after two `pilot.pause()` settles; the stills live on the `pr-catalogue-freshness-assets` branch (same convention as `pr-tui-ask-assets`).

### Suite and gates

`env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q` → **10496 passed, 15 skipped, 4 errors** in 8:58. The 4 errors are `tests/unit/evaluation/runner/test_episode_subprocess.py::test_worker_cannot_deliver_frames_from_outside_the_root[*]` failing to *create a copied-interpreter venv* under xdist contention (`libpython3.14.dylib no such file`) — a host/interpreter condition in a package this PR does not touch; the same five cases pass serially (`-n0`: `5 passed in 38.26s`). `tests/unit/model` + `tests/unit/providers` re-run three times after the rebase: `1137 passed` ×3.

Gates, whole tree, as CI spells them: `flake8` clean, `black==26.1.0` clean (735 files), `isort==5.13.2` clean, `pyright` 0 errors.

New tests: `test_catalogue.py` (+11, SWR: served-and-revalidated, soft-TTL no-op, hard-TTL sync, lease loss exits, failed refresh backs off, one thread per process, `cached_listing` never threads, `peek_listing`, structural off-thread spy, `refetch_if`, `failed` flag), `test_discovery.py` (+10: stale split, four `want_id` cases, cache-write parse/merge/round-trip, capture-2 refetch), `test_prices.py` (new, 18: projection, ETag/304, stale-beats-absent, non-200 never overwrites, cold-miss background retry, capture recovery, miss refetch, five lookup spellings, unmapped provider, `supports_images` never taken), `test_pricing.py` (re-pointed at `_from_price_catalogue`; +5 incl. zero-OpenRouter-calls for a direct id and write price reaching `ModelInfo`), `test_model_picker.py`/`test_app_pilot.py` (+2: footer wording, picker TTL).

## Deferred (recorded here, not as issues)

- **xAI first-party price transport** (`GET /v1/language-models`, cents per 100M tokens): no API key available to validate the unit factor against a real response; a guessed factor on a price field is worse than no field. models.dev covers 7/12 xAI models.
- **Picker row prices from models.dev**: picker rows still price from the provider listing only (Anthropic → blank). The status band is the incident's surface and is fixed; pricing the picker is a separate change.
- `/model refresh` / `r` key — new interaction, needs a UX round; the 15-min TTL covers the incident.
- `prices_from_catalogue` registry flag so models.dev can *correct* a transcribed registry price rather than only fill a hole.
- Parallelising `live_catalogue`'s per-provider fetches (4.0s above is the serial sum).
- Direct-provider ids that OpenRouter priced but models.dev lacks (openai 4, xai 5, google 5, mistral 2 today) now fall back to the registry template — the honest "cost unavailable", per the operator's preference over a second coupling.

