### PR TITLE
fix(session): keep a busy-steer peer message as its own row

### DIFF
--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -1116,10 +1116,25 @@ class FrontendStateStore:
         try:
             for message in session.queued_steering():
                 content = list(getattr(message, "content", ()) or ())
+                text = str(getattr(message, "text", "") or "")
+                if not text:
+                    # Not everything on the steering queue is a plain user
+                    # Message: a busy-path wake and a busy-path peer steer
+                    # queue their CustomMessage, which carries no ``text``
+                    # property or ``content`` blocks — only ``details``.
+                    # Without this a follower saw those entries as
+                    # ``{"text": ""}`` and a renderer would paint a blank
+                    # queued row. ``body`` is the raw human-facing text a
+                    # peer row keeps for the UIs, preferred over ``text``
+                    # (the model-facing provenance envelope); a wake only has
+                    # ``text``, which IS its human-facing message.
+                    details = getattr(message, "details", None)
+                    if isinstance(details, dict):
+                        text = str(details.get("body") or details.get("text") or "")
                 queued.append(
                     {
                         "id": str(getattr(message, "id", "") or ""),
-                        "text": str(getattr(message, "text", "") or ""),
+                        "text": text,
                         "image_count": sum(
                             1 for block in content if block.__class__.__name__ == "ImageContent"
                         ),

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -3953,8 +3953,9 @@ class Session:
           session stays idle — non-interrupting by design.
         - ``mailbox`` + ``wake`` while idle: drive a turn now via the prompt
           pipeline (which persists the row once — do NOT also append).
-        - ``steer`` while busy: inject mid-turn through the existing steer
-          path (which persists its own steering row — do NOT also append).
+        - ``steer`` while busy: put the peer row ITSELF on the steering queue
+          so it is injected mid-turn (the drain persists what it takes — do
+          NOT also append).
         - ``steer`` while idle: nothing to steer into, so degrade to a driven
           turn exactly like mailbox+wake idle (dropping it would violate the
           guarantee that the message MUST appear in history).
@@ -3985,9 +3986,26 @@ class Session:
         busy = self._is_streaming
         if mode == "steer":
             if busy:
-                # steer() persists its own transcript row when the queue
-                # drains; appending here too would double-write.
-                self.steer(str(message.details["body"]), message_id=message.id)
+                # Queue the peer CustomMessage ITSELF, not a plain user Message
+                # built from its body (what ``steer()`` would mint). Both reach
+                # the model — ``_default_convert_to_llm`` renders this custom
+                # type as a user turn exactly as ``build_llm_history`` does on
+                # replay — but only the CustomMessage keeps the provenance:
+                # ``_drain_steering`` persists whatever it takes, so a plain
+                # Message left a bare user row in the transcript (no sender,
+                # no ``<peer-session-message>`` envelope, so the model read it
+                # as the user's own words and a resume repainted it as one),
+                # and the drain announces every plain user Message with a
+                # ``MessageStartEvent`` that the TUI paints as a UserBlock
+                # under the PeerMessageBlock the receipt below already painted
+                # — the message showed twice. Same shape as the busy wake and
+                # busy resume-catchup paths, which queue their CustomMessage.
+                # The drain persists the row; appending here too would
+                # double-write. Deliberately NOT counted as courtesy: a
+                # ``now=True`` send is an explicit mid-turn steer, so it must
+                # stay urgent for ``_has_urgent_steering`` like a typed steer.
+                self._steering_queue.put_nowait(message)
+                self.refresh_frontend_state()
                 await self._emit_peer_receipt(message, sender)
                 self._peer_arrival.mark()
                 return "delivered mid-turn (steered)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.26"
+version = "0.44.27"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/session/test_frontend_state.py
+++ b/tests/unit/session/test_frontend_state.py
@@ -770,3 +770,56 @@ def test_checkpoint_strips_trajectories_and_live_events() -> None:
     assert payload["state"]["jobs"][0]["trajectory"] == []
     # The in-memory state a live follower reads keeps its trajectory.
     assert len(store.state.jobs[0].trajectory) == 50
+
+
+def test_queued_custom_steers_project_their_human_text() -> None:
+    """The queued-steering snapshot reads ``text``/``content``, which only a
+    plain user Message has. A busy-path peer steer and a busy-path wake queue
+    their CustomMessage instead, and those used to project as ``{"text": ""}``
+    — a blank row for any follower that renders the queue. A peer row keeps
+    its raw text in ``details["body"]`` (``details["text"]`` is the
+    model-facing envelope); a wake's human text is its ``details["text"]``."""
+    from local_operator.harness.types import CustomMessage
+    from local_operator.harness.wake import WAKE_PROMPT_MESSAGE_TYPE
+    from local_operator.session.peer import PEER_MESSAGE_MESSAGE_TYPE
+
+    peer = CustomMessage(
+        custom_type=PEER_MESSAGE_MESSAGE_TYPE,
+        attribution="user",
+        details={
+            "text": "<peer-session-message from_pid=3>\nredirect now\n</peer-session-message>",
+            "body": "redirect now",
+            "sender": {"pid": 3},
+        },
+    )
+    wake = CustomMessage(
+        custom_type=WAKE_PROMPT_MESSAGE_TYPE,
+        attribution="user",
+        details={"wake_id": "w1", "occurrence": 1, "text": "wake: check the build"},
+    )
+    typed = Message.user("plain steer")
+    session = SimpleNamespace(
+        jobs=SimpleNamespace(list=lambda: []),
+        _subagent_comms=None,
+        model=_spec(),
+        effective_model=_spec(),
+        session_id="s1",
+        cwd="/repo",
+        queued_steering=lambda: [peer, wake, typed],
+        conversation_name="Canonical state",
+        goal="",
+        active_agent="",
+        active_team_name="",
+        wake_scheduler=None,
+        mcp_manager=None,
+        mcp_startup=None,
+    )
+    store = FrontendStateStore(_state(jobs=[]))
+    state = store.refresh_from_session(session)
+    assert [entry["text"] for entry in state.queued_steering] == [
+        "redirect now",
+        "wake: check the build",
+        "plain steer",
+    ]
+    assert [entry["id"] for entry in state.queued_steering] == [peer.id, wake.id, typed.id]
+    assert all(entry["image_count"] == 0 for entry in state.queued_steering)

--- a/tests/unit/session/test_session_peer.py
+++ b/tests/unit/session/test_session_peer.py
@@ -12,7 +12,12 @@ from typing import Any
 
 import pytest
 
-from local_operator.harness.types import Message, StreamEndEvent, StreamTextDelta
+from local_operator.harness.types import (
+    CustomMessage,
+    Message,
+    StreamEndEvent,
+    StreamTextDelta,
+)
 from local_operator.session.peer import PEER_MESSAGE_MESSAGE_TYPE
 from local_operator.session.transcript import Transcript
 from tests.unit.session.test_session import ScriptedStream, make_session, wait_for
@@ -229,20 +234,69 @@ async def test_steer_while_busy_routes_through_the_steer_queue(tmp_path):
         ]
     )
     session = make_session(tmp_path, stream, tools=[tool])
+    events: list[Any] = []
+    session.subscribe(events.append)
 
     prompt_task = asyncio.ensure_future(session.prompt("long task"))
     await wait_for(lambda: tool_started.is_set())
 
     detail = await session.receive_peer_message("redirect now", mode="steer", sender={"pid": 3})
     assert "steer" in detail
-    # It went onto the steering queue, not a direct transcript append.
-    assert not session._steering_queue.empty()
+    # It went onto the steering queue, not a direct transcript append — and
+    # the queued item is the peer row ITSELF, not a plain user Message minted
+    # from its body. A plain Message is what produced the double paint: the
+    # drain announced it as a user MessageStartEvent under the PeerMessageBlock
+    # the receipt had already painted, and persisted a bare user row that lost
+    # the sender and the provenance envelope.
+    queued = session.queued_steering()
+    assert len(queued) == 1
+    assert isinstance(queued[0], CustomMessage)
+    assert queued[0].custom_type == PEER_MESSAGE_MESSAGE_TYPE
+    assert queued[0].details["body"] == "redirect now"
+    # Nothing persisted yet: the drain owns the write.
+    assert _peer_rows(session) == []
+    # An explicit `now=True` send is a real steer, not a courtesy wake, so it
+    # must count as urgent (it may interrupt a running tool like a typed one).
+    assert session._has_urgent_steering()
 
     release_tool.set()
     await prompt_task
 
-    # The steered text reached the follow-up model call.
-    assert any("redirect now" in m.text for m in stream.requests[1].messages)
+    # Persisted exactly once, as the peer CustomMessage with its provenance —
+    # not as a plain user row.
+    rows = _peer_rows(session)
+    assert len(rows) == 1
+    assert rows[0].payload["details"]["body"] == "redirect now"
+    assert rows[0].payload["details"]["sender"]["pid"] == 3
+    plain_user_rows = [
+        e
+        for e in session._transcript.entries()
+        if e.type == "message"
+        and e.payload.get("kind") != "custom"
+        and e.payload.get("role") == "user"
+        and "redirect now" in str(e.payload.get("content"))
+    ]
+    assert plain_user_rows == []
+
+    # The model saw the ENVELOPE (sender provenance), not the bare body.
+    follow_up = [m.text for m in stream.requests[1].messages]
+    assert any("<peer-session-message" in t and "redirect now" in t for t in follow_up)
+
+    # The front end got exactly one receipt for it — the peer delivery — and
+    # NO user-role MessageStartEvent (that is the second, spurious UserBlock).
+    receipts = [e for e in events if getattr(e, "type", None) == "peer_message_delivered"]
+    assert len(receipts) == 1
+    assert receipts[0].message_id == queued[0].id
+    user_starts = [
+        e
+        for e in events
+        if getattr(e, "type", None) == "message_start"
+        and getattr(e.message, "role", None) == "user"
+        and "redirect now" in getattr(e.message, "text", "")
+    ]
+    assert user_starts == []
+    # The steer drain still reported that it delivered the message.
+    assert any(getattr(e, "type", None) == "steering_delivered" for e in events)
     await session.dispose()
 
 

--- a/tests/unit/tui/test_peer_message.py
+++ b/tests/unit/tui/test_peer_message.py
@@ -119,6 +119,102 @@ async def test_resume_replays_peer_message_without_double_paint() -> None:
 
 
 @pytest.mark.asyncio
+async def test_busy_steer_paints_one_peer_block_and_no_user_block(tmp_path) -> None:
+    """A `send now=True` landing mid-turn paints ONE PeerMessageBlock, and
+    nothing else for the same message.
+
+    Regression: the busy-steer path used to queue a plain user Message built
+    from the peer body, so the steering drain announced it with a user
+    ``MessageStartEvent`` — which the app, finding no echo it registered,
+    painted as a second copy in a ``UserBlock`` right under the
+    ``PeerMessageBlock`` the live receipt had already put up. A REAL Session
+    in the REAL app is the only host that exercises both hops (the receipt
+    and the drain's announcement), so the FakeSession is no use here.
+    """
+    import asyncio
+
+    from local_operator.harness.types import (
+        AgentTool,
+        StreamEndEvent,
+        StreamTextDelta,
+        StreamToolCallDelta,
+        TextContent,
+        ToolResult,
+    )
+    from local_operator.session.session import Session
+    from local_operator.session.transcript import Transcript
+    from local_operator.tui.widgets.transcript import UserBlock
+    from tests.unit.session.test_session import MODEL, ScriptedStream
+
+    tool_started = asyncio.Event()
+    release_tool = asyncio.Event()
+
+    async def blocking_execute(tool_call_id, args, signal, on_update, context):
+        tool_started.set()
+        await release_tool.wait()
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="block", content=[TextContent(text="done")]
+        )
+
+    tool = AgentTool(
+        name="block", parameters={"type": "object", "properties": {}}, execute=blocking_execute
+    )
+    stream = ScriptedStream(
+        [
+            [
+                StreamToolCallDelta(index=0, id="c1", name="block", argument_delta="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamTextDelta(delta="ack"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    session = Session(
+        model=MODEL,
+        stream_fn=stream,
+        tools=[tool],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: [],
+    )
+
+    async def factory():
+        return session
+
+    app = OperatorApp(factory)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _settle_for_session(pilot, app)
+        # The gate would otherwise park the scripted tool call on a prompt the
+        # test never answers (see AGENTS.md on the capture scripts).
+        app._set_approve_all(True)
+        prompt_task = asyncio.ensure_future(session.prompt("long task"))
+        for _ in range(200):
+            await pilot.pause()
+            if tool_started.is_set():
+                break
+        assert tool_started.is_set(), "the scripted tool never started"
+
+        await session.receive_peer_message(
+            "redirect now", mode="steer", sender={"pid": 3, "conversation_name": "peer"}
+        )
+        await _settle_for_peer_block(pilot, app)
+        release_tool.set()
+        await prompt_task
+        # Let the drain's events cross into the app before counting; the
+        # spurious UserBlock (if any) is painted from that announcement.
+        for _ in range(20):
+            await pilot.pause()
+
+        peers = _peer_blocks(app)
+        assert len(peers) == 1
+        assert peers[0].text() == "redirect now"
+        user_bodies = [
+            b.text() for b in app.query_one(TranscriptView).blocks() if isinstance(b, UserBlock)
+        ]
+        # Only the prompt that opened the turn is a user row.
+        assert user_bodies == ["long task"], user_bodies
+    await session.dispose()
+
+
+@pytest.mark.asyncio
 async def test_live_receipt_suppresses_its_replay() -> None:
     session = FakeSession()
     session._history = [


### PR DESCRIPTION
## Summary of Changes

A peer message sent with `now=True` (the `send` tool / `lop send` steer mode) that lands while the receiving session is **busy** no longer shows twice in the TUI. Before, the transcript painted the proper `PeerMessageBlock` (`↔ peer message from "<name>" (pid N, model)`) and then a second copy of the same text as a plain `UserBlock` directly under it. Now only the `PeerMessageBlock` appears.

Bug fix; patch bump `0.44.26 → 0.44.27` (rebased onto #526, which released 0.44.26).

## Diagnosis

`Session.receive_peer_message`, `mode == "steer"` while `_is_streaming`:

```python
self.steer(str(message.details["body"]), message_id=message.id)
await self._emit_peer_receipt(message, sender)
```

`steer()` mints a **plain user `Message`** from the body and queues it. When `_drain_steering` takes it at the next tool boundary it does two things, both wrong for a peer message:

1. **Persists that plain user row.** The peer `CustomMessage` — with `sender`, `body`, and the `<peer-session-message …>` envelope in `details["text"]` — was never written on this path, so the transcript lost provenance, the model read the bare body as the user's own words, and a `/resume` repainted it as a user prompt.
2. **Announces it with a user `MessageStartEvent`** (`isinstance(message, Message) and message.role == "user"`). `tui/events.py` turns that into `UserMessageStart`; `app.on_user_message_start` finds no echo it registered for that id and paints a `UserBlock`. The `PeerMessageDeliveredEvent` fired by `_emit_peer_receipt` had already painted the `PeerMessageBlock`. Two copies.

Every other branch (mailbox record-only, mailbox+wake, idle steer) persists/delivers the `CustomMessage` itself, and both `Transcript.build_llm_history` and `Session._default_convert_to_llm` already render `PEER_MESSAGE_MESSAGE_TYPE` as a user turn carrying the envelope.

## The Fix

Queue the peer `CustomMessage` itself on the busy-steer branch — the same shape the busy wake path (`_steering_queue.put_nowait(wake_message)`) and the busy resume-catchup path already use:

```python
self._steering_queue.put_nowait(message)
self.refresh_frontend_state()
await self._emit_peer_receipt(message, sender)
```

- `_drain_steering` persists whatever it takes, so the row lands **once**, as the peer `CustomMessage` with its provenance.
- Drained messages go to `AgentLoop._drain_pending` → `context.messages`, and the next provider call runs `config.convert_to_llm` (= `_default_convert_to_llm`), whose allow-list renders the custom type as a user turn of `details["text"]` — confirmed by the test asserting `<peer-session-message` appears in the follow-up request, not just the body.
- The drain only announces `MessageStartEvent` for plain user `Message`s, so no second `UserBlock`. `SteeringDeliveredEvent` still fires.
- **Not** counted as courtesy: a `now=True` send is an explicit mid-turn steer, so `_has_urgent_steering()` stays `True` for it, like a typed steer (asserted).
- `refresh_frontend_state()` is still called, matching what `steer()` did.
- **Follower projection** (review R1-2): the `queued_steering` snapshot in `session/frontend_state.py` read `text`/`content`, which only a plain user `Message` has, so a queued peer `CustomMessage` — and a busy-path wake, pre-existing — projected as `{"text": ""}`. It now falls back to `details["body"]` (peer raw text) then `details["text"]` (wake message) for custom entries.

## Impact

- No breaking changes, no dependency updates.
- Transcript rows written by the busy-steer path change from a plain `user` message to a `peer_message` custom row — i.e. the same shape every other peer delivery path already writes and every reader (`build_llm_history`, TUI replay, mobile projection, `hub peek`) already handles.

## Testing Details

**Visual reproduction** (real `Session` with a scripted model that calls a tool blocking until released, hosted in the real `OperatorApp`; `receive_peer_message(mode="steer")` lands while the tool blocks; frame saved after the turn completes so the drain has run). Script: a `run_test` + `save_screenshot` capture per AGENTS.md "Visual validation", rendered with `rsvg-convert`.

**Before** — `PeerMessageBlock=1 UserBlock=2`; the peer text is painted a second time as a user row:

![before](https://raw.githubusercontent.com/damianvtran/local-operator/pr-peer-steer-dup-assets/before.png)

**After** — `PeerMessageBlock=1 UserBlock=1` (the only user row is the prompt that opened the turn):

![after](https://raw.githubusercontent.com/damianvtran/local-operator/pr-peer-steer-dup-assets/after.png)

Block sequence, before → after:

```
before: UserBlock, ToolCard, AssistantBlock, PeerMessageBlock, UserBlock, AssistantBlock
after:  UserBlock, ToolCard, AssistantBlock, PeerMessageBlock, AssistantBlock
```

**Not done:** a live two-process reproduction (two real `lop` sessions, one `send`ing into the other with `now=True`). The wire hop (`lop send` → registrant → `tui_handle.receive_peer_message` → `Session.receive_peer_message`) is unchanged by this PR; the repro above enters at `Session.receive_peer_message` with the same arguments the handle passes, which is the seam where the defect lived.

**The tests fail on the pre-fix tree** (session change stashed, tests kept):

```
tests/unit/session/test_session_peer.py::test_steer_while_busy_routes_through_the_steer_queue
>       assert isinstance(queued[0], CustomMessage)
E       AssertionError: assert False

tests/unit/tui/test_peer_message.py::test_busy_steer_paints_one_peer_block_and_no_user_block
E       AssertionError: ['long task', 'redirect now']
E       assert ['long task', 'redirect now'] == ['long task']
```

and pass with it:

```
tests/unit/session/test_session_peer.py   9 passed
tests/unit/tui/test_peer_message.py      10 passed
```

`test_steer_while_busy_routes_through_the_steer_queue` now asserts: the queued item is the `CustomMessage` with `custom_type == PEER_MESSAGE_MESSAGE_TYPE`; nothing is persisted until the drain; `_has_urgent_steering()` is `True`; exactly one persisted `peer_message` row with `sender.pid`, and no plain user row containing the text; the follow-up model request contains `<peer-session-message` with the body; exactly one `peer_message_delivered` event carrying the queued message id; **zero** user-role `message_start` events for the text; `steering_delivered` still fires.

`test_queued_custom_steers_project_their_human_text` (new, `tests/unit/session/test_frontend_state.py`) queues a peer CustomMessage, a wake CustomMessage and a plain steer and asserts the projected texts are `redirect now` / `wake: check the build` / `plain steer`; it fails on the pre-fix snapshot code with `['', '', 'plain steer']`.

`test_busy_steer_paints_one_peer_block_and_no_user_block` (new) drives a real `Session` in the real `OperatorApp` through the same busy-steer delivery and asserts one `PeerMessageBlock` with the body and that the only `UserBlock` is the opening prompt.

**Suite and gates**, run over the whole tree exactly as CI does:

| gate | result |
|---|---|
| `pytest tests/unit` (`env -u NO_COLOR TERM=xterm-256color`) | **10551 passed**, 15 skipped (pre-rebase head); post-rebase run: 10541 passed, 19 failed — all 19 in `tests/unit/session/runtime/test_server.py` (`runtime never published a live record`, a 5 s registry-scan deadline) on a host at load average 56–78 from sibling suites; the file passes 75/75 re-run in isolation and is untouched by this PR |
| `flake8 .` | clean |
| `black --check .` (26.1.0) | 769 files unchanged |
| `isort --check .` (5.13.2) | clean |
| `pyright .` | 0 errors, 0 warnings |

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required (docstring + inline rationale on the changed branch).
- [x] Security considerations are addressed (no new code execution surface).
- [x] I have linked all related issues (none filed).
