### PR TITLE
feat(runtime): run-to-completion residency, viewer-held warmth, and the wake index

### DIFF
--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -337,6 +337,27 @@ class OwnedSessionHandle(SessionHandle):
             return True
         return False
 
+    def next_wake_due_at(self) -> int | None:
+        """Epoch-ms of the earliest armed wake, or ``None`` when none is set.
+
+        The reaper's WARMTH signal (design §6.1 term 2): a runtime whose own
+        ``WakeScheduler`` will fire within ``WARM_WINDOW_S`` stays resident
+        rather than exiting and paying a cold start for a wake seconds away.
+        Read from the live scheduler, not the wake index — the index is a
+        derived file for processes that have no session; this process has
+        the truth in memory. A disposed scheduler reports no wakes so the
+        reaper never waits on a schedule that can no longer fire.
+        """
+        scheduler = getattr(self._session, "wake_scheduler", None)
+        if scheduler is None or getattr(scheduler, "disposed", False):
+            return None
+        try:
+            schedules = scheduler.schedules
+        except Exception:  # noqa: BLE001 — uncertainty must not pin the runtime
+            return None
+        due = [s.next_due_at for s in schedules if isinstance(s.next_due_at, int)]
+        return min(due) if due else None
+
     def _deny_pending_gates(self) -> None:
         """Refuse every parked approval/ask so teardown cannot hang on them.
 

--- a/local_operator/session/runtime/process.py
+++ b/local_operator/session/runtime/process.py
@@ -11,10 +11,16 @@ session its work.
 The child builds a session with the CLI's composition root, wraps it in the
 owned-session handle (approval/ask gates resolved from the phone), registers
 it through the normal record + control socket path, and idles until a signal
-arrives or its work and pending gates drain long enough for self-reaping (see
-:func:`_reaper`). Environment variables are the
+arrives or the residency predicate (:func:`_should_exit`) holds for one
+sustained drain. Environment variables are the
 spawn contract (``LOP_MOBILE_CHILD_CWD``, ``_PROVIDER``, ``_MODEL``) — argv
 would be ps-readable.
+
+**Residency (design §6.1).** The runtime is a unit of WORK, not of state; it
+runs its trajectory to completion and exits when idle, so a closed terminal
+costs nothing and a wake fires in a fresh process later. It stays resident
+while any of three things holds — see :func:`_should_exit` for each term and
+the reasoning behind it.
 
 This was ``mobile/child.py``. Only the phone spawns one today, but nothing in
 it is phone-specific: it is the generic "a session running with no interface
@@ -37,12 +43,25 @@ import time
 logger = logging.getLogger(__name__)
 
 #: Fine polling makes the 3-second drain predictable while remaining cheap for
-#: one event loop. Viewer traffic is deliberately not an input to this loop.
+#: one event loop. Viewer TRAFFIC is not an input to this loop (a chatty
+#: viewer does not reset the drain); viewer PRESENCE is, through term 3 of
+#: the predicate.
 REAP_CHECK_S = 0.25
 
 #: Idle runtimes are disposable once their durable session state is
 #: quiescent. This is a drain for newly arriving work, not a reconnect grace.
 DEFAULT_GRACE_S = 3.0
+
+#: A runtime whose own scheduler will fire a wake within this window stays
+#: resident instead of exiting and paying a ~1.2 s cold start (plus the
+#: supervisor's tick latency) to come back for it. Chosen to exceed
+#: ``MIN_WAKE_INTERVAL_MS`` (60 s, harness.wake) by a margin: a session with
+#: the tightest allowed recurrence then never thrashes exit → spawn → exit
+#: once a minute, because the next fire is always inside the window. Anything
+#: due further out is cheaper to leave to a cold spawn than to hold ~283 MB
+#: for. Not env-tunable on purpose — it pairs with a constant in the wake
+#: layer, and a knob would let the two drift apart.
+WARM_WINDOW_S = 90.0
 
 
 def _grace_seconds() -> float:
@@ -54,11 +73,80 @@ def _grace_seconds() -> float:
     return value if value > 0 else DEFAULT_GRACE_S
 
 
+def _wake_within_window(handle: object, *, now_ms: int | None = None) -> bool:
+    """Term 2 of the predicate: does the runtime's OWN scheduler have a wake
+    due within ``WARM_WINDOW_S``? Read through the handle (an optional
+    capability, probed) so reduced test handles and older hosts that never
+    grew the accessor behave as "no wakes" rather than crash the reaper."""
+    accessor = getattr(handle, "next_wake_due_at", None)
+    if not callable(accessor):
+        return False
+    try:
+        due_at = accessor()
+    except Exception:  # noqa: BLE001 — a broken accessor must not pin the runtime
+        logger.debug("next_wake_due_at failed; treating as no wake", exc_info=True)
+        return False
+    if not isinstance(due_at, int) or isinstance(due_at, bool):
+        return False  # None, or a shape this reaper does not understand
+    now = int(time.time() * 1000) if now_ms is None else now_ms
+    return due_at - now <= WARM_WINDOW_S * 1000
+
+
+def _viewer_attached(runtime: object) -> bool:
+    """Term 3 of the predicate: is an INTERACTIVE viewer connected?
+
+    Only ``ClientKind == "attach"`` counts — a TUI following this session, or
+    the phone's interactive attach while the user has the session open.
+    ``"daemon"`` clients (the mobile daemon's adoption dial, ``lop send``,
+    ``lop stop``, the future supervisor) deliberately do not: the daemon
+    adopts EVERY session on the machine, so if its connection held runtimes
+    warm nothing would ever exit. ``RuntimeServer.attach_clients()`` already
+    computes exactly this count for the attach cap; it is probed rather than
+    required so the reduced handles in tests keep working.
+    """
+    count = getattr(runtime, "attach_clients", None)
+    if not callable(count):
+        return False
+    try:
+        live = count()
+    except Exception:  # noqa: BLE001 — uncertainty here must not pin the runtime
+        logger.debug("attach_clients failed; treating as no viewer", exc_info=True)
+        return False
+    return isinstance(live, int) and live > 0
+
+
 def _should_exit(handle: object, runtime: object) -> bool:
-    """True when the session runtime is quiescent, regardless of viewers."""
-    del runtime  # Viewers observe work; they do not own it.
+    """The residency predicate (design §6.1): exit when ALL three hold.
+
+    1. ``handle.is_busy()`` is False — no turn, compaction, subagents, jobs,
+       queued prompts, or gate parked on a user's answer. Work is
+       authoritative: nothing below can end a turn early.
+    2. No wake is due within :data:`WARM_WINDOW_S` — a runtime about to fire
+       its own wake is cheaper kept than re-spawned (see the constant).
+    3. No interactive viewer is attached — a user looking at the session is
+       about to type, and holding the process warm turns "every message after
+       a 3 s pause costs a cold start" into "the first message of a
+       conversation costs one".
+
+    Reconciling term 3 with the older rule "watchers and replicas observe
+    work; they do not own it": both are still true, and they are about
+    different things. OWNERSHIP of the work is the turn's — a viewer leaving
+    does not abort a turn (term 1 is checked first and alone decides that),
+    and a daemon-class client never holds anything. Term 3 is about
+    READINESS: an attached interactive viewer is the one signal that the
+    next message is imminent, so residency follows it. The phone's SSE
+    watcher count (``phone_watchers``) stays out of the predicate — the
+    daemon's connection is not the user's attention, and the phone's
+    interactive attach dials as ``"attach"`` when it wants warmth.
+    """
     is_busy = getattr(handle, "is_busy", None)
-    return not (is_busy is not None and is_busy())
+    if is_busy is not None and is_busy():
+        return False
+    if _wake_within_window(handle):
+        return False
+    if _viewer_attached(runtime):
+        return False
+    return True
 
 
 async def _clean_exit(handle: object, runtime: object) -> None:
@@ -81,8 +169,12 @@ async def _clean_exit(handle: object, runtime: object) -> None:
 async def _reaper(handle: object, runtime: object, stop: asyncio.Event) -> None:
     """Exit the disposable session runtime after one uninterrupted idle drain.
 
-    Autonomous work and ordinary pending-gate timeouts are authoritative. Any
-    new activity resets the drain; viewer count intentionally does not.
+    The drain is re-checked every ``REAP_CHECK_S`` against the full predicate,
+    so any term flipping back — work arriving, a viewer attaching, a wake
+    entering the warm window — cancels it and the clock restarts from the
+    next fully-idle tick. A wake that fires during the drain starts a turn,
+    which flips ``is_busy()``: that is how "due within the drain" fires once,
+    in-process, with no supervisor involvement.
     """
     grace_s = _grace_seconds()
     while not stop.is_set():
@@ -93,9 +185,14 @@ async def _reaper(handle: object, runtime: object, stop: asyncio.Event) -> None:
         while time.monotonic() < deadline:
             await asyncio.sleep(REAP_CHECK_S)
             if stop.is_set() or not _should_exit(handle, runtime):
-                break  # work arrived (or shutdown began)
+                break  # a predicate term flipped back (or shutdown began)
         else:
-            logger.info("session runtime child: idle for %.1fs; exiting cleanly", grace_s)
+            logger.info(
+                "session runtime: idle for %.1fs (no work, no viewer, no wake within %.0fs); "
+                "exiting cleanly",
+                grace_s,
+                WARM_WINDOW_S,
+            )
             await _clean_exit(handle, runtime)
             stop.set()  # amain's wait() returns; exit code stays 0
             return

--- a/local_operator/session/runtime/process.py
+++ b/local_operator/session/runtime/process.py
@@ -76,8 +76,9 @@ def _grace_seconds() -> float:
 def _wake_within_window(handle: object, *, now_ms: int | None = None) -> bool:
     """Term 2 of the predicate: does the runtime's OWN scheduler have a wake
     due within ``WARM_WINDOW_S``? Read through the handle (an optional
-    capability, probed) so reduced test handles and older hosts that never
-    grew the accessor behave as "no wakes" rather than crash the reaper."""
+    capability, probed) so reduced test handles and older handle
+    implementations that never grew the accessor behave as "no wakes" rather
+    than crash the reaper."""
     accessor = getattr(handle, "next_wake_due_at", None)
     if not callable(accessor):
         return False

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -223,7 +223,7 @@ class ProjectionSink(Protocol):
     The phone renders from a :class:`SessionProjection` snapshot that the
     runtime broadcasts on change; :class:`ProjectionFold` is the production
     implementation. The runtime only ever READS ``projection`` (to serialize
-    a frame) and calls ``set_pending`` (the reduced-host bridge for gate
+    a frame) and calls ``set_pending`` (the reduced-handle bridge for gate
     cards), so that is the whole contract — narrow enough that a test can
     hand in a stub and a future runtime with no phone can hand in nothing.
     """
@@ -247,16 +247,17 @@ class RuntimeServer:
         self._handle = handle
         seed = handle.session_projection_seed
         seed.kind = kind
-        # The projection fold is an OPTIONAL, injected collaborator. Given
-        # one, the runtime uses it as-is (the TUI mirror handle and tests do
-        # this). Given none — the default, and what every headless runtime
-        # does — nothing is built until a client that consumes projection
-        # semantics (the mobile daemon) actually dials, so a runtime that
-        # only ever serves a follower terminal or fires a wake constructs no
-        # fold at all. Welcomes and repaints before that moment serialize the
-        # seed directly: the seed IS the object the host's own fold mutates,
-        # so the bytes on the wire are identical either way. See
-        # ``_ensure_projection_sink``.
+        # The projection fold is an OPTIONAL, injected collaborator. A caller
+        # that already owns a fold may hand it in and the runtime uses it
+        # as-is — only tests do today; every production constructor call
+        # (the TUI at ``tui/app.py``, the owned-session process) passes none.
+        # Given none, nothing is built until a client that consumes
+        # projection semantics (the mobile daemon) actually dials, so a
+        # runtime that only ever serves a follower terminal or fires a wake
+        # constructs no fold at all. Welcomes and repaints before that moment
+        # serialize the seed directly: the seed IS the object the handle's
+        # own fold mutates, so the bytes on the wire are identical either
+        # way. See ``_ensure_projection_sink``.
         self._projection_sink: ProjectionSink | None = projection_sink
         #: How many times this runtime built a fold on its own. Observable
         #: for tests and for the "did a headless runtime pay for a fold?"
@@ -1149,7 +1150,7 @@ class RuntimeServer:
 
     @property
     def fold(self) -> ProjectionFold:
-        """The default fold, built on demand. Hosts that reach for this want
+        """The default fold, built on demand. Handles that reach for this want
         the full :class:`ProjectionFold` surface (subagent details, todos);
         an injected sink that is not one is a programming error here."""
         sink = self._ensure_projection_sink()

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -15,8 +15,9 @@ attached) hosts one of these. It does three things:
    host-provided :class:`SessionHandle`.
 
 This was ``mobile/registrant.py`` and the class was ``Registrant``. Nothing
-about it is phone-specific except the projection fold (which PR 2 makes an
-injected collaborator): the phone daemon, an attach terminal, and — later —
+about it is phone-specific except the projection fold, which is an injected
+:class:`ProjectionSink` collaborator built lazily on the first daemon dial
+when none is supplied: the phone daemon, an attach terminal, and — later —
 wakes and background automations are all VIEWERS of one session runtime.
 ``Registrant`` remains as an alias at the bottom of this module and at the old
 import path, so no call site had to change in the move.
@@ -216,14 +217,51 @@ class SessionHandle(Protocol):
     #   lacking it answers "this session cannot receive peer messages".
 
 
+class ProjectionSink(Protocol):
+    """What the runtime needs from a projection collaborator.
+
+    The phone renders from a :class:`SessionProjection` snapshot that the
+    runtime broadcasts on change; :class:`ProjectionFold` is the production
+    implementation. The runtime only ever READS ``projection`` (to serialize
+    a frame) and calls ``set_pending`` (the reduced-host bridge for gate
+    cards), so that is the whole contract — narrow enough that a test can
+    hand in a stub and a future runtime with no phone can hand in nothing.
+    """
+
+    @property
+    def projection(self) -> SessionProjection: ...
+
+    def set_pending(self, pending: Any) -> None: ...
+
+
 class RuntimeServer:
     """One per interactive process. Construct, ``start()``, ``close()``."""
 
-    def __init__(self, handle: SessionHandle, *, kind: str = "tui") -> None:
+    def __init__(
+        self,
+        handle: SessionHandle,
+        *,
+        kind: str = "tui",
+        projection_sink: ProjectionSink | None = None,
+    ) -> None:
         self._handle = handle
         seed = handle.session_projection_seed
         seed.kind = kind
-        self._fold = ProjectionFold(seed)
+        # The projection fold is an OPTIONAL, injected collaborator. Given
+        # one, the runtime uses it as-is (the TUI mirror handle and tests do
+        # this). Given none — the default, and what every headless runtime
+        # does — nothing is built until a client that consumes projection
+        # semantics (the mobile daemon) actually dials, so a runtime that
+        # only ever serves a follower terminal or fires a wake constructs no
+        # fold at all. Welcomes and repaints before that moment serialize the
+        # seed directly: the seed IS the object the host's own fold mutates,
+        # so the bytes on the wire are identical either way. See
+        # ``_ensure_projection_sink``.
+        self._projection_sink: ProjectionSink | None = projection_sink
+        #: How many times this runtime built a fold on its own. Observable
+        #: for tests and for the "did a headless runtime pay for a fold?"
+        #: question; 0 after a lifetime with no daemon client is the claim.
+        self.projection_sinks_built: int = 0
         self._record = SessionRecord(
             pid=os.getpid(),
             kind=kind,  # type: ignore[arg-type]
@@ -556,6 +594,11 @@ class RuntimeServer:
             wants_frontend=wants_frontend,
         )
         self._clients[id(writer)] = conn
+        if kind == "daemon":
+            # The daemon is the one client that renders projections (attach
+            # clients read the welcome for identity only), so its arrival is
+            # when a lazily-built fold earns its keep.
+            self._ensure_projection_sink()
         await self._push_to(conn)  # the welcome: a full projection, unprompted
         if conn.wants_frontend:
             subscribe_frontend = getattr(self._handle, "subscribe_frontend", None)
@@ -637,8 +680,9 @@ class RuntimeServer:
     def attach_clients(self) -> int:
         """How many attach (follower terminal) connections are live.
 
-        The child reaper's front-end count: an attached TUI is a front end
-        exactly like a phone, so it must hold the child in ACTIVE."""
+        Term 3 of the runtime's residency predicate (``process._should_exit``):
+        an interactive viewer holds the runtime warm; ``daemon`` clients never
+        do. Also the attach-cap count."""
         return sum(1 for c in self._clients.values() if c.kind == "attach")
 
     async def _on_request(self, frame: dict[str, Any], conn: _ClientConn) -> None:
@@ -1037,7 +1081,9 @@ class RuntimeServer:
         """
         from local_operator.mobile.projection import cap_projection_frame
 
-        data, degraded = cap_projection_frame(self._fold.projection)
+        sink = self._projection_sink
+        projection = sink.projection if sink is not None else self._handle.session_projection_seed
+        data, degraded = cap_projection_frame(projection)
         if degraded and not self._frame_cap_warned:
             self._frame_cap_warned = True
             logger.warning(
@@ -1081,9 +1127,35 @@ class RuntimeServer:
 
     # -- host-facing helpers ----------------------------------------------------
 
+    def _ensure_projection_sink(self) -> ProjectionSink:
+        """Return the sink, building the default :class:`ProjectionFold` on
+        first need. Idempotent; the counter records only builds this runtime
+        performed itself, never an injected sink."""
+        sink = self._projection_sink
+        if sink is None:
+            sink = ProjectionFold(self._handle.session_projection_seed)
+            self._projection_sink = sink
+            self.projection_sinks_built += 1
+            logger.info(
+                "session runtime: built projection fold for session %s",
+                self._record.session_id,
+            )
+        return sink
+
+    @property
+    def projection_sink(self) -> ProjectionSink | None:
+        """The sink in use, or ``None`` while no consumer has needed one."""
+        return self._projection_sink
+
     @property
     def fold(self) -> ProjectionFold:
-        return self._fold
+        """The default fold, built on demand. Hosts that reach for this want
+        the full :class:`ProjectionFold` surface (subagent details, todos);
+        an injected sink that is not one is a programming error here."""
+        sink = self._ensure_projection_sink()
+        if not isinstance(sink, ProjectionFold):
+            raise TypeError("an injected projection sink is not a ProjectionFold")
+        return sink
 
     def set_pending(self, pending: Any | None) -> None:
         """Set mobile pending state and canonical gate state for reduced hosts.
@@ -1091,7 +1163,7 @@ class RuntimeServer:
         Production TUI handles publish directly when their real widget mounts;
         this bridge keeps owned/reduced handles on the same contract.
         """
-        self._fold.set_pending(pending)
+        self._ensure_projection_sink().set_pending(pending)
         frontend = getattr(self._handle, "_frontend", None)
         mutate = getattr(frontend, "mutate", None)
         if callable(mutate):

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -8109,16 +8109,26 @@ class Session:
     ) -> None:
         """Best-effort index write. Swallows everything: see
         :meth:`_persist_wake_schedules` for why a failure here must not
-        propagate. Function-local import keeps ``wakes.store`` off this
-        module's import graph in the direction that matters — the store must
-        never import the session, and a top-level import here would make a
-        future cycle silent rather than loud."""
+        propagate.
+
+        The imports are function-local for the reason every other one in
+        this file is: they keep this module's own import cheap and cannot
+        form a top-level cycle if ``wakes.store`` ever grows one. The rule
+        that matters more — the store never imports the session, because the
+        supervisor and the picker read it without a harness — is NOT
+        enforced by this; ``tests/unit/test_import_graph.py`` is what pins
+        that direction."""
         try:
             from local_operator.paths import config_dir
             from local_operator.wakes import store as wake_store
 
             root = config_dir()
-            existing = wake_store.read_entry(root, self._session_id)
+            # An empty list means "remove the entry", and removal needs
+            # nothing from the old file — so skip the read. This is the open
+            # path for every session without wakes (including every subagent
+            # child), and the directory should not be touched twice for a
+            # file that almost never exists.
+            existing = wake_store.read_entry(root, self._session_id) if schedules else None
             wake_store.write_entry(
                 root,
                 self._session_id,

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1892,6 +1892,15 @@ class Session:
         #: is no catch-up pending, so the shim is then a pure passthrough.
         self._resume_catchup_ids: set[str] = set()
         self._load_wake_schedules()
+        # Rebuild this session's wake-index entry from the transcript on EVERY
+        # open. The index (``local_operator.wakes.store``) is a derived file
+        # that a supervisor and the picker read without opening the session;
+        # rewriting it here is what makes it self-healing — a deleted, stale
+        # or corrupt entry is repaired the next time the session is built,
+        # and an empty schedule list removes it. Runs before the catch-up
+        # snapshot only because ``load()`` has already re-armed overdue rows,
+        # so what lands on disk is the post-load truth.
+        self._rebuild_wake_index_entry()
         self._prepare_missed_wake_catchup()
         # The conversation's title is restored from the SAME transcript the
         # history came from, and for the same reason: a resumed session is the
@@ -8068,10 +8077,72 @@ class Session:
         )
 
     async def _persist_wake_schedules(self, schedules: list[WakeSchedule]) -> None:
+        """The ONE writer of schedule state: transcript first, then the
+        derived index, then the install-on-demand hook.
+
+        Order is the contract. The transcript ``wake_schedules`` entry is the
+        source of truth and is the only step allowed to fail this coroutine:
+        the scheduler's ``update()`` awaits it before re-arming, so a failed
+        append means the in-memory schedules never diverge from disk. The
+        index write and the install hook run *after* it and are wrapped so
+        they can never turn a persisted schedule into a raised exception —
+        the index is rebuilt on the next open regardless, and a supervisor
+        that failed to install costs nothing that was not already lost (the
+        live session still fires its own wakes).
+        """
         await self._transcript.append_custom(
             WAKE_SCHEDULES_CUSTOM_TYPE,
             {"schedules": [schedule.model_dump() for schedule in schedules]},
         )
+        self._write_wake_index_entry(schedules, clear=())
+        if schedules:
+            self._ensure_wake_supervisor()
+
+    def _rebuild_wake_index_entry(self) -> None:
+        """Open-time rewrite of the index entry from the scheduler's adopted
+        rows. Clears ``stopped_at``: a stopped session's wakes are dormant
+        only until someone opens it again, and opening is exactly this."""
+        self._write_wake_index_entry(list(self._wake.schedules), clear=("stopped_at",))
+
+    def _write_wake_index_entry(
+        self, schedules: list[WakeSchedule], *, clear: tuple[str, ...]
+    ) -> None:
+        """Best-effort index write. Swallows everything: see
+        :meth:`_persist_wake_schedules` for why a failure here must not
+        propagate. Function-local import keeps ``wakes.store`` off this
+        module's import graph in the direction that matters — the store must
+        never import the session, and a top-level import here would make a
+        future cycle silent rather than loud."""
+        try:
+            from local_operator.paths import config_dir
+            from local_operator.wakes import store as wake_store
+
+            root = config_dir()
+            existing = wake_store.read_entry(root, self._session_id)
+            wake_store.write_entry(
+                root,
+                self._session_id,
+                cwd=self._cwd,
+                schedules=schedules,
+                preserve=existing,
+                clear=clear,
+            )
+        except Exception:  # noqa: BLE001 — the index is derived; the transcript already has it
+            logger.warning("could not update the wake index entry", exc_info=True)
+
+    def _ensure_wake_supervisor(self) -> None:
+        """Install-on-demand chokepoint (design §4.2a). Best-effort; the hook
+        itself promises never to raise, and this guard is belt-and-braces
+        for the same reason the index write has one."""
+        try:
+            from local_operator.paths import config_dir
+            from local_operator.wakes.install import ensure_supervisor_installed
+
+            outcome = ensure_supervisor_installed(config_dir())
+            if not outcome.installed:
+                logger.debug("wake supervisor not installed: %s", outcome.reason)
+        except Exception:  # noqa: BLE001
+            logger.warning("wake supervisor install hook failed", exc_info=True)
 
     # -- subagent roster (resume basis) --------------------------------------
 

--- a/local_operator/wakes/__init__.py
+++ b/local_operator/wakes/__init__.py
@@ -1,0 +1,21 @@
+"""Scheduled wakes outside a live session: the index and its supervisor.
+
+A wake is owned by the session that created it and persisted in that
+session's transcript (``wake_schedules`` custom entry, see
+:mod:`local_operator.harness.wake`). That is the right home for the source of
+truth but the wrong place to *find* wakes from outside: answering "which
+sessions have a wake due?" would mean opening every transcript on the
+machine. This package holds the pieces that make wakes discoverable and
+fireable with no session process running:
+
+- :mod:`.store` — the derived per-session index under
+  ``<config_dir>/wakes/``, rewritten by the session on every schedule change
+  and on every open.
+- :mod:`.install` — the install-on-demand hook for the supervisor that reads
+  that index and engages a runtime when a cold session's wake comes due. A
+  no-op stub until the supervisor lands.
+
+Everything here that the supervisor reads must stay import-light: the
+supervisor is a ~40 MB always-on process whose whole justification is that it
+does NOT carry the harness. See the module docstrings for the exact rule.
+"""

--- a/local_operator/wakes/install.py
+++ b/local_operator/wakes/install.py
@@ -1,0 +1,67 @@
+"""Install-on-demand for the wake supervisor — the chokepoint, not yet the
+installer.
+
+There is exactly one writer of schedule state, ``Session._persist_wake_schedules``,
+so there is exactly one place to ask "does something outside this process
+now need to exist to fire these?" That question is this function. It is
+called after every non-empty persist, idempotently and best-effort: the
+persist has already succeeded by the time it runs, and nothing it does (or
+fails to do) may change that.
+
+**This is a stub.** The supervisor it will install — the ~40 MB always-on
+process that reads :mod:`local_operator.wakes.store` and engages a runtime
+for a cold session whose wake comes due — does not exist yet. The hook lands
+first so that the chokepoint is already wired through the persist path when
+the supervisor arrives, and so the session-side contract (call shape, the
+never-raises rule, where the outcome surfaces) is settled and tested before
+the platform-specific installer is written. The fill-in is scheduled as
+PR 7 of the detached-session series and is shaped after
+``local_operator.mobile.install`` (LaunchAgent on macOS; ``KeepAlive:
+{SuccessfulExit: False}`` so the supervisor can self-retire when the index
+empties).
+
+Until then: every call reports ``installed=False`` with a reason, and a
+session that persists a schedule keeps firing it in-process exactly as it
+does today. Nothing is lost that was not already lost — a wake in a closed
+session did not fire before this stub either.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class InstallOutcome:
+    """What the hook did. ``installed`` is "a supervisor is now in place"
+    (freshly installed OR already present); ``reason`` explains a False."""
+
+    installed: bool
+    reason: str = ""
+
+
+#: The single reason the stub ever reports. A constant so tests and the wake
+#: tool's receipt can match on it rather than on prose.
+NOT_AVAILABLE_REASON = "supervisor not yet available"
+
+
+def ensure_supervisor_installed(config_dir: Path) -> InstallOutcome:
+    """Make sure the wake supervisor is installed for ``config_dir``.
+
+    Contract (binding on the real implementation, not just the stub):
+
+    - **Idempotent.** Called after every persist; an already-installed
+      supervisor is a cheap check, never a reinstall.
+    - **Never raises.** The caller is the wake persist path; an installer
+      failure is logged and reported through the outcome, never propagated.
+      The persist has already succeeded and must stay succeeded.
+    - **Best-effort.** A platform with no installer (Linux without a service
+      manager the hook knows) reports ``installed=False`` and the session
+      carries on firing its own wakes in-process.
+    """
+    del config_dir  # the real installer keys the LaunchAgent label off it
+    return InstallOutcome(installed=False, reason=NOT_AVAILABLE_REASON)

--- a/local_operator/wakes/store.py
+++ b/local_operator/wakes/store.py
@@ -1,0 +1,227 @@
+"""The wake index: one small JSON file per wake-carrying session.
+
+``<config_dir>/wakes/<session_id>.json`` answers, for a process that has no
+session open, the one question a wake trigger needs: *which sessions have
+schedules, and when is the next one due?* Absent file ⇒ no wakes.
+
+**Derived, never authoritative.** The transcript's ``wake_schedules`` custom
+entry (written by ``Session._persist_wake_schedules``) is the source of truth
+for a session's schedules; this file is a projection of it that the session
+rewrites immediately after every transcript append AND on every open (after
+``_load_wake_schedules``). That second rewrite is the self-healing property:
+a deleted, corrupt, or stale index entry is repaired the next time the
+session is built, and an entry for a session whose schedules were emptied is
+removed. Nothing ever reads this file to decide what a session's schedules
+*are* — a reader that finds the file wrong should open the session, not
+patch the file.
+
+**Why it lives outside the session directory.** Two reasons, both about the
+readers. The junk-session reap deletes whole session directories, and an
+index that lived inside one would vanish with the transcript it describes
+(correct) but also be invisible to a scan that does not want to open 4,000
+session directories to find the twelve with wakes (not acceptable for a
+process that ticks every minute). A flat ``wakes/`` directory holds exactly
+one file per session that has something scheduled, so the scan is
+O(sessions-with-wakes), and the directory is empty on the typical machine.
+
+**Why this module must stay import-light.** Its readers are the wake
+supervisor — a ~40 MB always-on process whose whole justification is that it
+does NOT load the harness — and the TUI's session picker at boot, before any
+session exists. Importing ``asyncio``, ``pydantic``, or anything under
+``local_operator.session``/``harness`` here would put those on the
+supervisor's resident set and on the picker's startup path, and it would
+break the cold-boot rule that the picker opens no session. So: stdlib only.
+Schedules are handled as plain dicts (the ``model_dump()`` form the transcript
+already stores); the ``WakeSchedule`` type is imported for annotations only.
+``tests/unit/test_import_graph.py`` pins this in a fresh interpreter.
+
+Every writer here is best-effort *by contract with its caller*: the session
+wraps the call so a failed index write can never break wake persistence — the
+transcript entry is what matters, and the next open rebuilds the index.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
+
+if TYPE_CHECKING:
+    from local_operator.harness.wake import WakeSchedule
+
+logger = logging.getLogger(__name__)
+
+#: Subdirectory of the config dir holding one ``<session_id>.json`` per
+#: wake-carrying session. Flat, not nested under ``sessions/``: see the module
+#: docstring for why the index deliberately does not live with the transcript.
+WAKES_DIRNAME = "wakes"
+
+#: Bumped only on an incompatible change to the entry shape. Readers skip
+#: entries whose schema they do not understand rather than guess, and the
+#: owning session rewrites the entry on its next open — so a schema bump
+#: heals itself the same way a deleted file does.
+INDEX_SCHEMA = 1
+
+
+def wakes_dir(config_dir: Path) -> Path:
+    return Path(config_dir) / WAKES_DIRNAME
+
+
+def entry_path(config_dir: Path, session_id: str) -> Path:
+    return wakes_dir(config_dir) / f"{session_id}.json"
+
+
+def _schedule_dict(schedule: "WakeSchedule | Mapping[str, Any]") -> dict[str, Any]:
+    """Accept either the pydantic model or its already-dumped dict.
+
+    Duck-typed on ``model_dump`` rather than an ``isinstance`` check so this
+    module never imports the model at runtime (see the import-light rule).
+    """
+    if isinstance(schedule, Mapping):
+        return dict(schedule)
+    dump = getattr(schedule, "model_dump", None)
+    if callable(dump):
+        dumped = dump()
+        if isinstance(dumped, Mapping):
+            return dict(dumped)
+    raise TypeError(f"not a wake schedule: {schedule!r}")
+
+
+def next_due_at(entry: Mapping[str, Any]) -> int | None:
+    """Earliest ``next_due_at`` (epoch ms) across an entry's schedules, or
+    ``None`` when the entry carries none. Tolerates malformed rows: a
+    supervisor scanning many entries must not die on one bad file."""
+    earliest: int | None = None
+    for raw in entry.get("schedules") or ():
+        if not isinstance(raw, Mapping):
+            continue
+        due = raw.get("next_due_at")
+        if isinstance(due, bool) or not isinstance(due, int):
+            continue
+        if earliest is None or due < earliest:
+            earliest = due
+    return earliest
+
+
+def read_entry(config_dir: Path, session_id: str) -> dict[str, Any] | None:
+    """One session's entry, or ``None`` when absent or unreadable.
+
+    Unreadable is treated exactly like absent — "no wakes known" — because
+    the transcript is the truth and the next open rewrites the file. A
+    reader that raised on a half-written file would take down a scan over
+    every other session for one bad entry.
+    """
+    path = entry_path(config_dir, session_id)
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError):
+        logger.warning("wake index: unreadable entry %s; treating as absent", path, exc_info=True)
+        return None
+    if not isinstance(data, dict) or data.get("schema") != INDEX_SCHEMA:
+        logger.warning("wake index: skipping entry %s with unknown schema", path)
+        return None
+    return data
+
+
+def read_index(config_dir: Path) -> dict[str, dict[str, Any]]:
+    """Every readable entry keyed by session id. A missing directory is an
+    empty index — the common case on a machine that has never set a wake."""
+    directory = wakes_dir(config_dir)
+    try:
+        names = sorted(os.listdir(directory))
+    except FileNotFoundError:
+        return {}
+    except OSError:
+        logger.warning("wake index: cannot list %s", directory, exc_info=True)
+        return {}
+    index: dict[str, dict[str, Any]] = {}
+    for name in names:
+        if not name.endswith(".json") or name.startswith("."):
+            continue  # staged temp files and stray dotfiles are never entries
+        session_id = name[: -len(".json")]
+        entry = read_entry(config_dir, session_id)
+        if entry is None:
+            continue
+        # The filename is the lookup key; a body whose ``session_id`` disagrees
+        # is a copied or hand-edited file, and the filename wins because that
+        # is what the owning session will overwrite.
+        entry["session_id"] = session_id
+        index[session_id] = entry
+    return index
+
+
+def write_entry(
+    config_dir: Path,
+    session_id: str,
+    *,
+    cwd: str,
+    schedules: "Sequence[WakeSchedule | Mapping[str, Any]]",
+    preserve: Mapping[str, Any] | None = None,
+    clear: tuple[str, ...] = (),
+) -> Path | None:
+    """Write (replace) one session's entry. Returns the path, or ``None``
+    when ``schedules`` is empty — an empty list means *remove* the entry, so
+    "no file" and "no wakes" stay the same statement.
+
+    ``preserve`` is an existing entry whose unknown keys should survive the
+    rewrite (today: ``stopped_at``, which a later change uses to keep a
+    stopped session's wakes dormant). Keys named in ``clear`` are dropped even
+    if present in ``preserve`` — the open-time rewrite clears ``stopped_at``
+    because opening a session is what un-stops it.
+
+    Staged write + ``os.replace`` so a reader never sees a torn file: the
+    supervisor may scan while the session writes, and ``replace`` is atomic
+    on every platform we run on. The temp name starts with ``.`` so the
+    directory scan in :func:`read_index` skips it.
+    """
+    rows = [_schedule_dict(s) for s in schedules]
+    path = entry_path(config_dir, session_id)
+    if not rows:
+        remove_entry(config_dir, session_id)
+        return None
+    entry: dict[str, Any] = {}
+    if preserve:
+        # Unknown keys ride along untouched; the fields below are rewritten
+        # from the caller's (authoritative) values regardless of what the
+        # old file said.
+        entry.update({k: v for k, v in preserve.items() if k not in clear})
+    entry.update(
+        {
+            "schema": INDEX_SCHEMA,
+            "session_id": session_id,
+            "cwd": cwd,
+            "updated_at": int(time.time() * 1000),
+            "schedules": rows,
+        }
+    )
+    directory = path.parent
+    directory.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=f".{session_id}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(entry, handle, separators=(",", ":"), sort_keys=True)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+    return path
+
+
+def remove_entry(config_dir: Path, session_id: str) -> bool:
+    """Delete one session's entry. Idempotent: absent is success."""
+    path = entry_path(config_dir, session_id)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return False
+    return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.27"
+version = "0.44.28"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/session/runtime/test_owned.py
+++ b/tests/unit/session/runtime/test_owned.py
@@ -772,3 +772,38 @@ async def test_attach_seeds_streaming_from_flag_for_mid_turn_subscriber() -> Non
     session.is_streaming = True
     handle.subscribe(lambda: None)
     assert handle._fold.projection.streaming is True
+
+
+# --- next_wake_due_at: the reaper's warmth signal ----------------------------
+
+
+def test_next_wake_due_at_reads_the_live_scheduler() -> None:
+    from types import SimpleNamespace
+
+    from local_operator.harness.wake import WakeSchedule
+
+    loop = asyncio.new_event_loop()
+    try:
+        scheduler = SimpleNamespace(
+            disposed=False,
+            schedules=(
+                WakeSchedule(id="a", message="x", next_due_at=5_000, created_at=0),
+                WakeSchedule(id="b", message="y", next_due_at=2_000, created_at=0),
+            ),
+        )
+        session = SimpleNamespace(
+            session_id="s", wake_scheduler=scheduler, subscribe=lambda h: None
+        )
+        handle = OwnedSessionHandle.__new__(OwnedSessionHandle)
+        handle._session = session  # type: ignore[attr-defined]
+        handle._loop = loop  # type: ignore[attr-defined]
+        assert handle.next_wake_due_at() == 2_000
+        scheduler.schedules = ()
+        assert handle.next_wake_due_at() is None
+        scheduler.schedules = (WakeSchedule(id="a", message="x", next_due_at=5_000, created_at=0),)
+        scheduler.disposed = True
+        assert handle.next_wake_due_at() is None, "a disposed scheduler can no longer fire"
+        handle._session = SimpleNamespace(session_id="s")  # type: ignore[attr-defined]
+        assert handle.next_wake_due_at() is None
+    finally:
+        loop.close()

--- a/tests/unit/session/runtime/test_process_reaper.py
+++ b/tests/unit/session/runtime/test_process_reaper.py
@@ -1,9 +1,10 @@
-"""The child's self-reaper: the truth table, the grace window, and the
-clean-exit ordering."""
+"""The runtime's self-reaper: the three-term residency predicate (design
+§6.1), the grace window, and the clean-exit ordering."""
 
 from __future__ import annotations
 
 import asyncio
+import time
 
 import pytest
 
@@ -26,14 +27,18 @@ class FakeRegistrant:
 
 
 class FakeHandle:
-    def __init__(self, *, busy: bool = False) -> None:
+    def __init__(self, *, busy: bool = False, next_wake_ms: int | None = None) -> None:
         self._busy = busy
+        self._next_wake_ms = next_wake_ms
         self.disposed = False
         self.denied = False
         self.dispose_order: list[str] = []
 
     def is_busy(self) -> bool:
         return self._busy
+
+    def next_wake_due_at(self) -> int | None:
+        return self._next_wake_ms
 
     def _deny_pending_gates(self) -> None:
         self.denied = True
@@ -43,20 +48,83 @@ class FakeHandle:
         self.disposed = True
 
 
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
 @pytest.mark.parametrize(
     "reg",
     [
         FakeRegistrant(supported=False),
         FakeRegistrant(supported=True, watchers=1),
-        FakeRegistrant(supported=True, watchers=5, attaches=3),
+        FakeRegistrant(supported=True, watchers=5),
     ],
 )
-def test_viewer_counts_never_pin_idle_runtime(reg: FakeRegistrant) -> None:
+def test_daemon_and_phone_watchers_never_pin_idle_runtime(reg: FakeRegistrant) -> None:
+    # Term 3 counts INTERACTIVE viewers only. The phone daemon's adoption
+    # connection and its SSE watcher count are daemon-class signals: the
+    # daemon adopts every session on the machine, so if they held runtimes
+    # warm nothing would ever exit.
     assert _should_exit(FakeHandle(), reg) is True
+
+
+@pytest.mark.parametrize("attaches", [1, 3])
+def test_attached_viewer_holds_idle_runtime(attaches: int) -> None:
+    # Term 3: a follower terminal (ClientKind "attach") is the user's
+    # attention, and the next thing they do is type — hold the process warm.
+    assert _should_exit(FakeHandle(), FakeRegistrant(attaches=attaches)) is False
 
 
 def test_active_work_holds() -> None:
     assert _should_exit(FakeHandle(busy=True), FakeRegistrant()) is False
+
+
+def test_wake_inside_warm_window_holds() -> None:
+    # Term 2: a wake due in 60 s (the tightest recurrence the wake layer
+    # allows) is inside WARM_WINDOW_S, so the runtime stays to fire it itself
+    # rather than exiting and cold-starting a minute later.
+    assert child_mod.WARM_WINDOW_S > 60.0
+    handle = FakeHandle(next_wake_ms=_now_ms() + 60_000)
+    assert _should_exit(handle, FakeRegistrant()) is False
+    overdue = FakeHandle(next_wake_ms=_now_ms() - 1_000)
+    assert _should_exit(overdue, FakeRegistrant()) is False
+
+
+def test_wake_beyond_warm_window_does_not_hold() -> None:
+    # A wake an hour out is cheaper to leave to a cold spawn than to hold
+    # ~283 MB for.
+    handle = FakeHandle(next_wake_ms=_now_ms() + 3_600_000)
+    assert _should_exit(handle, FakeRegistrant()) is True
+
+
+def test_warm_window_exceeds_min_wake_interval() -> None:
+    # The constant pairs with MIN_WAKE_INTERVAL_MS: the window must be wider
+    # than the tightest allowed recurrence or a 1-minute wake thrashes
+    # exit → spawn → exit forever.
+    from local_operator.harness.wake import MIN_WAKE_INTERVAL_MS
+
+    assert child_mod.WARM_WINDOW_S * 1000 > MIN_WAKE_INTERVAL_MS
+
+
+def test_predicate_tolerates_reduced_handles_and_runtimes() -> None:
+    # Older hosts and reduced test doubles lack the accessors; each missing
+    # or broken term reads as "does not hold" rather than crashing the reaper
+    # or pinning the process.
+    class Bare:
+        pass
+
+    class Broken:
+        def is_busy(self) -> bool:
+            return False
+
+        def next_wake_due_at(self) -> int:
+            raise RuntimeError("scheduler gone")
+
+        def attach_clients(self) -> int:
+            raise RuntimeError("registry gone")
+
+    assert _should_exit(Bare(), Bare()) is True
+    assert _should_exit(Broken(), Broken()) is True
 
 
 @pytest.mark.asyncio
@@ -97,18 +165,72 @@ async def test_grace_elapses_then_clean_exit(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_viewers_do_not_change_idle_timing(monkeypatch) -> None:
+async def test_phone_watchers_do_not_change_idle_timing(monkeypatch) -> None:
     monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.01)
     monkeypatch.setenv("LOP_SESSION_GRACE_S", "0.08")
     elapsed: list[float] = []
-    for watchers, attaches in ((0, 0), (1, 0), (5, 3)):
-        reg = FakeRegistrant(supported=bool(watchers), watchers=watchers, attaches=attaches)
+    for watchers in (0, 1, 5):
+        reg = FakeRegistrant(supported=bool(watchers), watchers=watchers)
         handle = FakeHandle()
         stop = asyncio.Event()
         started = asyncio.get_running_loop().time()
         await _reaper(handle, reg, stop)
         elapsed.append(asyncio.get_running_loop().time() - started)
     assert max(elapsed) - min(elapsed) < 0.04
+
+
+@pytest.mark.asyncio
+async def test_attached_viewer_holds_then_release_starts_drain(monkeypatch) -> None:
+    """The TUI-closes-while-idle path (design §6.1): the attach count drops
+    to zero, the drain starts THEN, and the runtime exits one grace later."""
+    monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.02)
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "0.15")
+    reg = FakeRegistrant(attaches=1)
+    handle = FakeHandle()
+    stop = asyncio.Event()
+    task = asyncio.ensure_future(_reaper(handle, reg, stop))
+    await asyncio.sleep(0.4)  # well past the grace had the viewer not held it
+    assert not stop.is_set() and not handle.disposed
+    reg._attaches = 0  # the terminal closed
+    deadline = asyncio.get_running_loop().time() + 3
+    while asyncio.get_running_loop().time() < deadline:
+        if stop.is_set():
+            break
+        await asyncio.sleep(0.02)
+    assert stop.is_set() and handle.disposed and reg.closed
+    await task
+
+
+@pytest.mark.asyncio
+async def test_viewer_attaching_mid_drain_cancels_it(monkeypatch) -> None:
+    monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.02)
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "0.15")
+    reg = FakeRegistrant()
+    handle = FakeHandle()
+    stop = asyncio.Event()
+    task = asyncio.ensure_future(_reaper(handle, reg, stop))
+    await asyncio.sleep(0.08)  # inside the drain
+    reg._attaches = 1
+    await asyncio.sleep(0.3)
+    assert not stop.is_set() and not handle.disposed
+    reg._attaches = 0
+    await task
+    assert stop.is_set()
+
+
+@pytest.mark.asyncio
+async def test_wake_in_window_holds_until_it_passes(monkeypatch) -> None:
+    monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.02)
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "0.1")
+    reg = FakeRegistrant()
+    handle = FakeHandle(next_wake_ms=_now_ms() + 30_000)
+    stop = asyncio.Event()
+    task = asyncio.ensure_future(_reaper(handle, reg, stop))
+    await asyncio.sleep(0.3)
+    assert not stop.is_set()
+    handle._next_wake_ms = None  # the wake was cancelled (or retired)
+    await task
+    assert stop.is_set() and handle.disposed
 
 
 @pytest.mark.asyncio
@@ -137,7 +259,8 @@ async def test_busy_session_defers_grace_start(monkeypatch) -> None:
 async def test_new_activity_resets_idle_drain(monkeypatch) -> None:
     monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.02)
     monkeypatch.setenv("LOP_SESSION_GRACE_S", "0.12")
-    reg = FakeRegistrant(watchers=3, attaches=2)
+    # Phone watchers only: an attach client would (correctly) hold forever.
+    reg = FakeRegistrant(supported=True, watchers=3)
     handle = FakeHandle()
     stop = asyncio.Event()
     task = asyncio.ensure_future(_reaper(handle, reg, stop))

--- a/tests/unit/session/runtime/test_server.py
+++ b/tests/unit/session/runtime/test_server.py
@@ -960,3 +960,109 @@ async def test_absent_client_field_means_daemon() -> None:
         wd2.close()
     finally:
         runtime.close()
+
+
+# --- ProjectionSink: injected, lazily built, never for a fold-free runtime ---
+
+
+@pytest.mark.asyncio
+async def test_attach_only_runtime_builds_no_projection_fold() -> None:
+    """A headless runtime serving only follower terminals pays nothing to
+    fold: the welcome serializes the seed directly, and no ProjectionFold is
+    constructed for the whole lifetime of the connection."""
+    handle = FakeHandle()
+    runtime = RuntimeServer(handle, kind="daemon")
+    assert runtime.projection_sink is None
+    runtime.start()
+    writer = None
+    try:
+        record = await _wait_record()
+        reader, writer = await _dial(record, client="attach")
+        # Repaints still flow (the seed is the host's own mutable object).
+        handle._projection.conversation_name = "renamed"
+        runtime._schedule_push()
+        frame = await _until(reader, "projection")
+        assert frame["data"]["conversation_name"] == "renamed"
+        assert frame["data"]["session_id"] == "s1"
+        assert runtime.projection_sink is None
+        assert runtime.projection_sinks_built == 0
+    finally:
+        if writer is not None:
+            writer.close()
+        runtime.close()
+    assert runtime.projection_sinks_built == 0
+
+
+@pytest.mark.asyncio
+async def test_daemon_dial_builds_the_default_fold_once() -> None:
+    """The mobile daemon is the projection consumer; its first dial builds
+    the fold, a redial reuses it, and its frames carry the folded state."""
+    from local_operator.mobile.projection import ProjectionFold
+
+    handle = FakeHandle()
+    runtime = RuntimeServer(handle, kind="daemon")
+    runtime.start()
+    first = second = None
+    try:
+        record = await _wait_record()
+        _, first = await _dial(record)
+        assert isinstance(runtime.projection_sink, ProjectionFold)
+        assert runtime.projection_sinks_built == 1
+        sink = runtime.projection_sink
+        reader, second = await _dial(record)  # daemon redial evicts the first
+        assert runtime.projection_sink is sink
+        assert runtime.projection_sinks_built == 1
+        # A fold mutation reaches the daemon's frame.
+        runtime.set_pending(PendingRequest(request_id="r1", kind="approval", title="write /tmp/x"))
+        frame = await _until(reader, "projection")
+        assert frame["data"]["pending"]["request_id"] == "r1"
+    finally:
+        for w in (first, second):
+            if w is not None:
+                w.close()
+        runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_injected_sink_is_used_as_is() -> None:
+    """A host that already owns a fold hands it in; the runtime builds none
+    of its own and serializes the injected projection."""
+    from local_operator.mobile.projection import ProjectionFold
+
+    handle = FakeHandle()
+    fold = ProjectionFold(handle.session_projection_seed)
+    fold.projection.model_label = "injected/model"
+    runtime = RuntimeServer(handle, kind="tui", projection_sink=fold)
+    assert runtime.projection_sink is fold
+    assert runtime.fold is fold
+    runtime.start()
+    writer = None
+    try:
+        record = await _wait_record()
+        reader, writer = await _dial(record)
+        runtime._schedule_push()
+        frame = await _until(reader, "projection")
+        assert frame["data"]["model_label"] == "injected/model"
+        assert runtime.projection_sinks_built == 0
+    finally:
+        if writer is not None:
+            writer.close()
+        runtime.close()
+
+
+def test_fold_property_rejects_a_foreign_sink() -> None:
+    class Stub:
+        def __init__(self, projection: SessionProjection) -> None:
+            self.projection = projection
+
+        def set_pending(self, pending: Any) -> None:
+            self.projection.pending = pending
+
+    handle = FakeHandle()
+    runtime = RuntimeServer(
+        handle, kind="tui", projection_sink=Stub(handle.session_projection_seed)
+    )
+    runtime.set_pending(None)  # routed to the stub, no fold built
+    assert runtime.projection_sinks_built == 0
+    with pytest.raises(TypeError):
+        _ = runtime.fold

--- a/tests/unit/test_import_graph.py
+++ b/tests/unit/test_import_graph.py
@@ -178,3 +178,36 @@ def test_configure_import_does_not_load_requests(configure_modules: set[str]) ->
         "requests",
         "+2.9 MB / +127 modules per session; only validate_model needs it",
     )
+
+
+# --- The wake index ----------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def wake_store_modules() -> set[str]:
+    """Modules loaded by importing the wake index store."""
+    return _imported_modules("local_operator.wakes.store")
+
+
+def test_wake_store_import_is_stdlib_only(wake_store_modules: set[str]) -> None:
+    # ``local_operator.wakes.store`` is read by two processes that must not
+    # carry the harness: the wake supervisor (a ~40 MB always-on trigger whose
+    # whole justification is that it does NOT load a session) and the TUI's
+    # picker at boot, before any session exists. Every heavy stack pinned on
+    # the CLI path is pinned here too, plus the two that would be the most
+    # natural to reach for from a wake module: asyncio (the live
+    # ``WakeScheduler`` needs it; the store never does) and the session/
+    # engine packages (the store describes schedules; it never runs one).
+    # Measured at this commit: 128 modules total, three of them ours.
+    _assert_absent(wake_store_modules, "asyncio", "the supervisor is a plain loop, no event loop")
+    _assert_absent(wake_store_modules, "pydantic", "WakeSchedule is TYPE_CHECKING-only here")
+    _assert_absent(wake_store_modules, "local_operator.session", "the store never opens a session")
+    _assert_absent(wake_store_modules, "local_operator.harness", "pure-layer types only, lazily")
+    _assert_absent(wake_store_modules, "local_operator.mobile", "no runtime, no daemon")
+    _assert_absent(wake_store_modules, "local_operator.tui", "no front end")
+    _assert_absent(wake_store_modules, "textual", "no front end")
+    _assert_absent(wake_store_modules, "httpx", "no provider layer")
+    _assert_absent(wake_store_modules, "requests", "no provider layer")
+    _assert_absent(wake_store_modules, "tiktoken", "no tokenizer")
+    ours = sorted(m for m in wake_store_modules if m.startswith("local_operator"))
+    assert ours == ["local_operator", "local_operator.wakes", "local_operator.wakes.store"], ours

--- a/tests/unit/wakes/test_install.py
+++ b/tests/unit/wakes/test_install.py
@@ -1,0 +1,23 @@
+"""The install-on-demand chokepoint: a no-op stub with a settled contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from local_operator.wakes.install import (
+    NOT_AVAILABLE_REASON,
+    InstallOutcome,
+    ensure_supervisor_installed,
+)
+
+
+def test_stub_reports_not_installed_and_touches_nothing(tmp_path: Path) -> None:
+    outcome = ensure_supervisor_installed(tmp_path)
+    assert outcome == InstallOutcome(installed=False, reason=NOT_AVAILABLE_REASON)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_stub_is_idempotent(tmp_path: Path) -> None:
+    first = ensure_supervisor_installed(tmp_path)
+    second = ensure_supervisor_installed(tmp_path)
+    assert first == second

--- a/tests/unit/wakes/test_session_index.py
+++ b/tests/unit/wakes/test_session_index.py
@@ -4,6 +4,7 @@ open, self-healing, and never able to break wake persistence."""
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
 import pytest
@@ -38,7 +39,17 @@ def _open(tmp_path: Path, session_id: str = "sess") -> Session:
     )
 
 
-def _schedule(sid: str = "w1", due: int = 1_700_000_060_000) -> WakeSchedule:
+def _schedule(sid: str = "w1", *, due: int | None = None) -> WakeSchedule:
+    # The default due time MUST be future-derived. These tests assert on the
+    # index file surviving between set_wake_schedules and dispose, and a
+    # schedule that is already overdue arms the scheduler's MIN_ARM_MS timer
+    # (~25 ms): when that timer wins the race against dispose()'s awaits, the
+    # pump fires the one-shot, retires it, and persists the now-EMPTY list —
+    # which removes the index file the test is about to read. Nothing here
+    # asserts firing behaviour, so an hour out makes every test in this file
+    # deterministic instead of racing dispose on a loaded host.
+    if due is None:
+        due = int(time.time() * 1000) + 3_600_000
     return WakeSchedule(id=sid, message="check in", next_due_at=due, created_at=1_700_000_000_000)
 
 
@@ -117,8 +128,13 @@ async def test_stopped_at_preserved_on_persist_and_cleared_on_open(
     path.write_text(json.dumps(data), encoding="utf-8")
 
     # A persist from the live session keeps the marker (the stop is not
-    # this session's to undo mid-flight).
-    await session.set_wake_schedules([_schedule("w1"), _schedule("w2", due=1_700_000_120_000)])
+    # this session's to undo mid-flight). The second schedule is also
+    # future-derived — and later than w1's — for the same reason as the
+    # default: an overdue fixture here races dispose the same way, and this
+    # test reads the transcript rows back after a reopen.
+    await session.set_wake_schedules(
+        [_schedule("w1"), _schedule("w2", due=int(time.time() * 1000) + 3_900_000)]
+    )
     entry = wake_store.read_entry(config_dir, "sess")
     assert entry is not None and entry["stopped_at"] == 1_700_000_100_000
     assert [row["id"] for row in entry["schedules"]] == ["w1", "w2"]

--- a/tests/unit/wakes/test_session_index.py
+++ b/tests/unit/wakes/test_session_index.py
@@ -1,0 +1,194 @@
+"""The session as the index's single writer: after every persist, on every
+open, self-healing, and never able to break wake persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from local_operator.harness.types import ModelSpec, StreamEndEvent
+from local_operator.harness.wake import WakeSchedule
+from local_operator.session.session import Session
+from local_operator.session.transcript import Transcript
+from local_operator.wakes import install as wake_install
+from local_operator.wakes import store as wake_store
+from tests.unit.session.test_session import ScriptedStream
+
+MODEL = ModelSpec(provider="test", model_id="m", context_window=100_000)
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path, monkeypatch) -> Path:
+    root = tmp_path / "cfg"
+    root.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(root))
+    return root
+
+
+def _open(tmp_path: Path, session_id: str = "sess") -> Session:
+    return Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[StreamEndEvent(stop_reason="stop")]]),
+        tools=[],
+        transcript=Transcript(tmp_path / session_id),
+        system_blocks_provider=lambda: [],
+        cwd="/work/here",
+    )
+
+
+def _schedule(sid: str = "w1", due: int = 1_700_000_060_000) -> WakeSchedule:
+    return WakeSchedule(id=sid, message="check in", next_due_at=due, created_at=1_700_000_000_000)
+
+
+@pytest.mark.asyncio
+async def test_persist_writes_index_entry_matching_transcript(
+    tmp_path: Path, config_dir: Path
+) -> None:
+    session = _open(tmp_path)
+    try:
+        await session.set_wake_schedules([_schedule()])
+        entry = wake_store.read_entry(config_dir, session.session_id)
+        assert entry is not None
+        assert entry["cwd"] == "/work/here"
+        transcript_rows = session._transcript.latest_custom("wake_schedules")
+        assert transcript_rows is not None
+        # The index is a projection of the transcript entry: same rows, same shape.
+        assert entry["schedules"] == transcript_rows["schedules"]
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_cancelling_last_wake_removes_entry(tmp_path: Path, config_dir: Path) -> None:
+    session = _open(tmp_path)
+    try:
+        await session.set_wake_schedules([_schedule()])
+        assert wake_store.entry_path(config_dir, session.session_id).exists()
+        await session.set_wake_schedules([])
+        assert not wake_store.entry_path(config_dir, session.session_id).exists()
+        assert wake_store.read_index(config_dir) == {}
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_open_rewrites_deleted_entry_from_transcript(
+    tmp_path: Path, config_dir: Path
+) -> None:
+    session = _open(tmp_path)
+    await session.set_wake_schedules([_schedule()])
+    await session.dispose()
+    path = wake_store.entry_path(config_dir, "sess")
+    path.unlink()
+    assert not path.exists()
+
+    reopened = _open(tmp_path)
+    try:
+        assert path.exists(), "open must rebuild the index from the transcript"
+        entry = wake_store.read_entry(config_dir, "sess")
+        assert entry is not None and entry["schedules"][0]["id"] == "w1"
+    finally:
+        await reopened.dispose()
+
+
+@pytest.mark.asyncio
+async def test_open_with_no_schedules_removes_stale_entry(tmp_path: Path, config_dir: Path) -> None:
+    # A stale file for a session whose transcript carries no wakes (e.g. a
+    # hand copy, or a schema that emptied) is removed on open.
+    wake_store.write_entry(config_dir, "sess", cwd="/stale", schedules=[_schedule()])
+    session = _open(tmp_path)
+    try:
+        assert not wake_store.entry_path(config_dir, "sess").exists()
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_stopped_at_preserved_on_persist_and_cleared_on_open(
+    tmp_path: Path, config_dir: Path
+) -> None:
+    session = _open(tmp_path)
+    await session.set_wake_schedules([_schedule()])
+    path = wake_store.entry_path(config_dir, "sess")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["stopped_at"] = 1_700_000_100_000
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    # A persist from the live session keeps the marker (the stop is not
+    # this session's to undo mid-flight).
+    await session.set_wake_schedules([_schedule("w1"), _schedule("w2", due=1_700_000_120_000)])
+    entry = wake_store.read_entry(config_dir, "sess")
+    assert entry is not None and entry["stopped_at"] == 1_700_000_100_000
+    assert [row["id"] for row in entry["schedules"]] == ["w1", "w2"]
+    await session.dispose()
+
+    # Opening the session is what un-stops it.
+    reopened = _open(tmp_path)
+    try:
+        entry = wake_store.read_entry(config_dir, "sess")
+        assert entry is not None and "stopped_at" not in entry
+        assert [row["id"] for row in entry["schedules"]] == ["w1", "w2"]
+    finally:
+        await reopened.dispose()
+
+
+@pytest.mark.asyncio
+async def test_index_failure_never_breaks_wake_persistence(
+    tmp_path: Path, config_dir: Path, monkeypatch, caplog
+) -> None:
+    def boom(*args, **kwargs):  # noqa: ANN001, ANN202
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(wake_store, "write_entry", boom)
+    session = _open(tmp_path)
+    try:
+        with caplog.at_level("WARNING"):
+            await session.set_wake_schedules([_schedule()])
+        # The transcript (source of truth) and the live scheduler both took it.
+        assert session._transcript.latest_custom("wake_schedules") is not None
+        assert [s.id for s in session.wake_scheduler.schedules] == ["w1"]
+        assert any("wake index" in rec.getMessage() for rec in caplog.records)
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_install_hook_called_only_for_non_empty_persist(
+    tmp_path: Path, config_dir: Path, monkeypatch
+) -> None:
+    calls: list[Path] = []
+
+    def fake_install(root: Path) -> wake_install.InstallOutcome:
+        calls.append(root)
+        return wake_install.InstallOutcome(installed=False, reason="stub")
+
+    monkeypatch.setattr(wake_install, "ensure_supervisor_installed", fake_install)
+    session = _open(tmp_path)
+    try:
+        await session.set_wake_schedules([_schedule()])
+        assert calls == [config_dir]
+        await session.set_wake_schedules([])
+        assert calls == [config_dir], "an empty persist must not try to install"
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_install_hook_failure_never_breaks_wake_persistence(
+    tmp_path: Path, config_dir: Path, monkeypatch, caplog
+) -> None:
+    def boom(root: Path) -> wake_install.InstallOutcome:
+        raise RuntimeError("launchctl exploded")
+
+    monkeypatch.setattr(wake_install, "ensure_supervisor_installed", boom)
+    session = _open(tmp_path)
+    try:
+        with caplog.at_level("WARNING"):
+            await session.set_wake_schedules([_schedule()])
+        assert [s.id for s in session.wake_scheduler.schedules] == ["w1"]
+        assert wake_store.read_entry(config_dir, "sess") is not None
+        assert any("install hook failed" in rec.getMessage() for rec in caplog.records)
+    finally:
+        await session.dispose()

--- a/tests/unit/wakes/test_store.py
+++ b/tests/unit/wakes/test_store.py
@@ -1,0 +1,157 @@
+"""The wake index store: one JSON file per wake-carrying session, derived
+from the transcript, absent ⇒ no wakes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from local_operator.harness.wake import WakeSchedule
+from local_operator.wakes import store
+
+
+def _schedule(sid: str = "w1", due: int = 1_700_000_060_000) -> WakeSchedule:
+    return WakeSchedule(id=sid, message="check in", next_due_at=due, created_at=1_700_000_000_000)
+
+
+def test_absent_directory_reads_as_empty_index(tmp_path: Path) -> None:
+    assert store.read_index(tmp_path) == {}
+    assert store.read_entry(tmp_path, "nope") is None
+
+
+def test_write_entry_shape_matches_transcript_dump(tmp_path: Path) -> None:
+    schedule = _schedule()
+    path = store.write_entry(tmp_path, "s1", cwd="/work", schedules=[schedule])
+    assert path == tmp_path / "wakes" / "s1.json"
+    assert path is not None and path.is_file()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["schema"] == store.INDEX_SCHEMA
+    assert data["session_id"] == "s1"
+    assert data["cwd"] == "/work"
+    assert isinstance(data["updated_at"], int)
+    # The row is exactly the transcript's persisted form.
+    assert data["schedules"] == [schedule.model_dump()]
+    # No staged temp file survives.
+    assert [p.name for p in (tmp_path / "wakes").iterdir()] == ["s1.json"]
+
+
+def test_write_accepts_pre_dumped_dicts(tmp_path: Path) -> None:
+    rows = [_schedule().model_dump()]
+    store.write_entry(tmp_path, "s1", cwd="/work", schedules=rows)
+    assert store.read_entry(tmp_path, "s1")["schedules"] == rows  # type: ignore[index]
+
+
+def test_empty_schedules_removes_the_entry(tmp_path: Path) -> None:
+    store.write_entry(tmp_path, "s1", cwd="/work", schedules=[_schedule()])
+    assert store.write_entry(tmp_path, "s1", cwd="/work", schedules=[]) is None
+    assert not (tmp_path / "wakes" / "s1.json").exists()
+    assert store.read_index(tmp_path) == {}
+
+
+def test_remove_entry_is_idempotent(tmp_path: Path) -> None:
+    assert store.remove_entry(tmp_path, "s1") is False
+    store.write_entry(tmp_path, "s1", cwd="/work", schedules=[_schedule()])
+    assert store.remove_entry(tmp_path, "s1") is True
+    assert store.remove_entry(tmp_path, "s1") is False
+
+
+def test_read_index_scans_directory_and_keys_by_filename(tmp_path: Path) -> None:
+    store.write_entry(tmp_path, "s1", cwd="/a", schedules=[_schedule("w1")])
+    store.write_entry(tmp_path, "s2", cwd="/b", schedules=[_schedule("w2")])
+    # Staged temp files, dotfiles and non-json strays are never entries.
+    (tmp_path / "wakes" / ".s3.abc.tmp").write_text("{}", encoding="utf-8")
+    (tmp_path / "wakes" / "README").write_text("x", encoding="utf-8")
+    index = store.read_index(tmp_path)
+    assert sorted(index) == ["s1", "s2"]
+    assert index["s1"]["cwd"] == "/a"
+    assert index["s2"]["schedules"][0]["id"] == "w2"
+
+
+def test_unreadable_or_foreign_schema_entries_are_skipped(tmp_path: Path) -> None:
+    store.write_entry(tmp_path, "good", cwd="/a", schedules=[_schedule()])
+    (tmp_path / "wakes" / "torn.json").write_text('{"schema": 1, "sched', encoding="utf-8")
+    (tmp_path / "wakes" / "future.json").write_text(
+        json.dumps({"schema": 99, "session_id": "future", "schedules": []}), encoding="utf-8"
+    )
+    index = store.read_index(tmp_path)
+    assert sorted(index) == ["good"]
+    assert store.read_entry(tmp_path, "torn") is None
+    assert store.read_entry(tmp_path, "future") is None
+
+
+def test_preserve_keeps_unknown_keys_and_clear_drops_them(tmp_path: Path) -> None:
+    store.write_entry(tmp_path, "s1", cwd="/a", schedules=[_schedule()])
+    path = tmp_path / "wakes" / "s1.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["stopped_at"] = 1_700_000_100_000
+    data["future_key"] = {"nested": True}
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    # A persist-time rewrite preserves what it does not know about.
+    existing = store.read_entry(tmp_path, "s1")
+    store.write_entry(tmp_path, "s1", cwd="/a", schedules=[_schedule("w2")], preserve=existing)
+    after = store.read_entry(tmp_path, "s1")
+    assert after is not None
+    assert after["stopped_at"] == 1_700_000_100_000
+    assert after["future_key"] == {"nested": True}
+    assert after["schedules"][0]["id"] == "w2"
+
+    # The open-time rewrite clears stopped_at and nothing else.
+    existing = store.read_entry(tmp_path, "s1")
+    store.write_entry(
+        tmp_path,
+        "s1",
+        cwd="/a",
+        schedules=[_schedule("w2")],
+        preserve=existing,
+        clear=("stopped_at",),
+    )
+    after = store.read_entry(tmp_path, "s1")
+    assert after is not None
+    assert "stopped_at" not in after
+    assert after["future_key"] == {"nested": True}
+
+
+def test_preserve_cannot_override_authoritative_fields(tmp_path: Path) -> None:
+    stale = {"schema": 0, "session_id": "other", "cwd": "/stale", "schedules": [{"id": "old"}]}
+    store.write_entry(tmp_path, "s1", cwd="/fresh", schedules=[_schedule()], preserve=stale)
+    after = store.read_entry(tmp_path, "s1")
+    assert after is not None
+    assert after["schema"] == store.INDEX_SCHEMA
+    assert after["session_id"] == "s1"
+    assert after["cwd"] == "/fresh"
+    assert after["schedules"][0]["id"] == "w1"
+
+
+def test_next_due_at_is_the_earliest_valid_row() -> None:
+    entry = {
+        "schedules": [
+            {"id": "a", "next_due_at": 300},
+            {"id": "b", "next_due_at": 100},
+            {"id": "c", "next_due_at": "soon"},
+            {"id": "d", "next_due_at": True},
+            "garbage",
+        ]
+    }
+    assert store.next_due_at(entry) == 100
+    assert store.next_due_at({"schedules": []}) is None
+    assert store.next_due_at({}) is None
+
+
+def test_write_is_staged_then_replaced(tmp_path: Path, monkeypatch) -> None:
+    """A failure mid-write leaves the previous entry intact and no temp file."""
+    store.write_entry(tmp_path, "s1", cwd="/a", schedules=[_schedule("w1")])
+    before = (tmp_path / "wakes" / "s1.json").read_bytes()
+
+    def boom(*args, **kwargs):  # noqa: ANN001, ANN202
+        raise OSError("disk full")
+
+    monkeypatch.setattr(store.os, "replace", boom)
+    try:
+        store.write_entry(tmp_path, "s1", cwd="/a", schedules=[_schedule("w2")])
+    except OSError:
+        pass
+    else:  # pragma: no cover - the monkeypatch guarantees the raise
+        raise AssertionError("expected the staged write to raise")
+    assert (tmp_path / "wakes" / "s1.json").read_bytes() == before
+    assert [p.name for p in (tmp_path / "wakes").iterdir()] == ["s1.json"]


### PR DESCRIPTION
## Summary

**PR 2 of the detached-session series** (PR 1 was #526, the runtime package move). This PR changes **runtime residency only**: the on-demand session runtime (`local_operator/session/runtime/process.py`, what the mobile daemon spawns) now runs its trajectory to completion and exits when idle — unless something is about to need it. The TUI still owns its session in-process; that cutover is PR 5.

Three things land, plus one seam:

1. **Run-to-completion with viewer-held warmth (§6.1).** The exit predicate goes from one term to three: exit after a sustained 3 s drain when (a) `handle.is_busy()` is False, (b) no wake is due within `WARM_WINDOW_S = 90 s` from the runtime's own scheduler, and (c) **no interactive viewer is attached** — an `attach`-class client on the control socket. `daemon`-class clients (the mobile daemon's adoption dial, `lop send`, `lop stop`, the future supervisor) deliberately do **not** hold it.
2. **The wake index (§4.3).** A new stdlib-only package `local_operator/wakes/` with `store.py`: one file per wake-carrying session at `<config_dir>/wakes/<session_id>.json`, absent ⇒ no wakes. Derived from the transcript, never authoritative, self-healing.
3. **The install-on-demand hook (§4.2a)** as a no-op stub: `wakes/install.py: ensure_supervisor_installed(config_dir)`, called from the one writer of schedule state. PR 7 fills it in; the chokepoint exists before the thing it installs.
4. **`ProjectionSink` injectable (§3.4).** `RuntimeServer` no longer builds a `ProjectionFold` unconditionally: it takes an optional sink, and with none injected builds the fold lazily on the first **daemon** dial. A headless runtime serving only follower terminals — or, later, firing a wake — constructs no fold.

### What this enables

A runtime that costs nothing when nothing needs it. Under the current daemon path an idle phone-started session already self-reaped after 3 s; now it also stays warm while an interactive viewer is looking (so a conversation never pays a cold start between messages) and while a wake is imminent (so a 1-minute recurring wake never thrashes exit → spawn → exit). The wake index is what a stdlib supervisor (PR 7) and the TUI's picker (PR 8) will read to answer "which cold sessions have wakes, and when?" without opening a single transcript.

## The careful parts

### The predicate's three terms, and reconciling term 3 with "watchers do not own"

`process.py`'s docstring used to say *"Watchers and replicas observe work; they do not own it"* and excluded viewer count from the exit decision entirely. That rule is still true and still enforced — but it is about **ownership** of the work, and term 3 is about **readiness**. The reconciliation is written into `_should_exit`'s docstring:

- Term 1 (`is_busy`) is checked first and alone decides whether a turn continues. A viewer leaving never aborts a turn; a viewer arriving never starts one.
- Term 3 only decides whether an *idle* runtime stays resident. An attached interactive viewer is the one signal that the next message is imminent, so residency follows it. This turns "every message after a 3 s pause costs a ~1.2 s cold start" into "the first message of a conversation costs one".
- The daemon's connection is not the user's attention. The daemon adopts **every** session on the machine; if its dial held runtimes warm, nothing would ever exit. That is why only `ClientKind == "attach"` counts, why `phone_watchers` stays out of the predicate, and why `lop send` (which dials daemon-class precisely so it perturbs no attach accounting) cannot pin a session.

`RuntimeServer.attach_clients()` already computed exactly this count for the attach cap; the predicate reads it through `getattr` so reduced handles keep working.

### Why 90 s

`WARM_WINDOW_S` must exceed `MIN_WAKE_INTERVAL_MS` (60 s) or a session with the tightest allowed recurrence exits after every fire and cold-starts a minute later, forever. It is deliberately **not** env-tunable: it pairs with a constant in the wake layer, and a knob would let the two drift. A unit test pins the relationship.

### The index is derived, and heals

The transcript's `wake_schedules` custom entry stays the source of truth. `Session._persist_wake_schedules` is the **one** writer of schedule state, and its order is the contract:

1. transcript append (the only step allowed to fail the coroutine — the scheduler awaits it before re-arming, so memory never diverges from disk);
2. index write, wrapped so a failure is a log line and nothing more;
3. install hook if the list is non-empty, wrapped the same way.

Every session also **rewrites its entry on open** from what `_load_wake_schedules` adopted, so a deleted/corrupt/stale file is repaired the next time the session is built and an empty schedule list removes it. Unknown keys survive a rewrite (`stopped_at` is preserved on a persist and **cleared on open** — opening a session is what un-stops it; the skip logic itself is PR 7).

### Why the index lives outside the session directory

The junk-session reap deletes whole session directories, and a supervisor ticking every minute must not walk 4,000 of them to find the twelve with wakes. A flat `wakes/` directory holds exactly one file per session with something scheduled, so the scan is O(sessions-with-wakes) and the directory is empty on the typical machine.

### Why `wakes/store.py` is stdlib-only

Its readers are the wake supervisor — a ~40 MB always-on process whose whole justification is that it does **not** load the harness — and the TUI's picker at boot, before any session exists. `WakeSchedule` is a `TYPE_CHECKING` import; rows are handled as the `model_dump()` dicts the transcript already stores. `tests/unit/test_import_graph.py` pins it in a fresh interpreter: no `asyncio`, no `pydantic`, no `local_operator.session`/`harness`/`mobile`/`tui`; measured at 128 modules total, three of them ours.

### The projection seam keeps the daemon's bytes identical

Before a fold exists, welcomes and repaints serialize `handle.session_projection_seed` directly. That is safe because the seed **is** the object the host's own fold mutates (the owned handle and the TUI mirror both fold into the same `SessionProjection`), so the wire bytes are the same either way. The daemon's first dial triggers `_ensure_projection_sink()`; a redial reuses it; `set_pending` and the `fold` property build on demand so the existing reduced-host bridge (`tests/unit/session/test_remote.py`) is unchanged. `projection_sinks_built` is a counter and an INFO log line so "a headless runtime paid for no fold" is observable rather than asserted.

## What this PR does not do

No supervisor, no `/resume` change, no TUI owner-path change, no `PROTOCOL_VERSION` bump (nothing on the wire changed — the auth frame's `client` field already existed), no `engage_runtime` (PR 6), nothing new on `SessionRecord`.

## Testing evidence

Everything below ran against this worktree (`PYTHONPATH` pinned) with an isolated config dir + `HOME` (`LOCAL_OPERATOR_CONFIG_DIR=/tmp/lop-residency-evidence/cfg`), spawning the runtime exactly as the daemon does (`python -m local_operator.session.runtime.process` with the `LOP_MOBILE_CHILD_*` env contract) on the keyless `test` provider. A small client dials the control socket as either `attach` or `daemon` and samples `ps` while holding the connection.

### 1. A daemon-class client does not hold the runtime — exits ≈3 s after idle

```
runtime pid=66081 spawned 21:47:34
[client] record pid=66081 session=e6d62305e467 kind=daemon
[client] welcome op=projection session=e6d62305e467
[client] +  0.5s runtime 66081 00:01 104336 S
[client] EOF from runtime at +3.3s
[client] runtime exited at +3.5s while daemon held
--- 21:47:38 runtime: pid 66081 gone
INFO:...process:session runtime: idle for 3.0s (no work, no viewer, no wake within 90s); exiting cleanly
```

### 2. An attach-class client holds it warm across 65 s idle, then it exits ≈3 s after release

```
runtime pid=64616 spawned 21:46:06
[client] record pid=64616 session=83a7799c8a8c kind=attach
[client] +  0.5s runtime 64616 00:01 105952 S
[client] + 15.1s runtime 64616 00:16  85680 S
[client] + 30.1s runtime 64616 00:31  25216 S
[client] + 45.2s runtime 64616 00:46  25136 S
[client] + 60.3s runtime 64616 01:01  25264 S
[client] released attach at +65.3s; runtime 64616 01:06  25264 S
--- +2s after release: pid 64616 gone     (client's own timestamps; wall clock in the harness was sampled after `wait`)
INFO:...process:session runtime: idle for 3.0s (no work, no viewer, no wake within 90s); exiting cleanly
```

### 3. A 1-hour wake does not hold; a 1-minute recurring wake does, and fires in-process

The schedule is set through `Session.set_wake_schedules` (the same call the wake tool makes) right after the session is built, then the real `process.amain()` serves.

```
=== 1-hour wake, no viewer ===
[runtime] session=6be6085d6727 wake set; next_wake_due_at in 3600s
--- 21:48:36 alive etime=00:02
--- 21:48:40 pid 67060 gone
INFO:...process:session runtime: idle for 3.0s (no work, no viewer, no wake within 90s); exiting cleanly

=== 60 s recurring wake (every 60s), no viewer ===
[runtime] session=1badb5bbd631 wake set; next_wake_due_at in 60s
--- 21:48:56 alive etime=00:05 ...
--- 21:49:51 alive etime=01:00
--- 21:49:56 alive etime=01:05 rss 58880   <- the fire: a turn ran in-process
--- 21:50:11 alive etime=01:20   (SIGTERM sent — a recurring wake would hold forever, as designed)
--- index after the fire:
{"schedules":[{"id":"w1","every_ms":60000,"fired_count":1,"next_due_at":1788313851893,...}],...}
```

`fired_count: 1` with `next_due_at` advanced by 60 s: the wake fired once, in this process, with no supervisor.

### 4. The index: matches the transcript, removed on cancel, rebuilt on open, `stopped_at` semantics

```
$ cat cfg/wakes/6be6085d6727.json
{"cwd":"/tmp/lop-residency-evidence/work","schedules":[{"created_at":1788313715427,"every_ms":null,"fired_count":0,"id":"w1","limit":null,"message":"evidence wake","next_due_at":1788317315427,"until_at":null}],"schema":1,"session_id":"6be6085d6727","updated_at":1788313715427}
transcript wake_schedules entries: 1
index.schedules == transcript.latest.schedules: True

=== delete by hand, reopen (LOP_MOBILE_CHILD_RESUME) ===
removed 'cfg/wakes/6be6085d6727.json'
--- after reopen+exit: 6be6085d6727.json
ids ['w1'] | next_due_at 1788317315427 | has stopped_at: False
--- transcript's next_due_at: 1788317315427

=== inject stopped_at + an unknown key, reopen ===
injected: {'stopped_at': 1788300000000, 'future_key': 'kept'}
after open: has stopped_at: False | future_key: kept | ids ['w1']

=== cancel (persist []) ===
before cancel: ['w1'] | file exists: True
after cancel:  [] | file exists: False
```

`stopped_at` preserved by a **persist** (as opposed to an open) is covered by `tests/unit/wakes/test_session_index.py::test_stopped_at_preserved_on_persist_and_cleared_on_open` — the open-rewrite always runs first in a real process, so the persist case can only be observed after the marker is injected into a live session.

### 5. No fold for an attach-only runtime; exactly one for a daemon dial; the real daemon still gets projections

```
=== attach-only runtime, session a1e46b5f65e2 ===
fold builds logged for a1e46b5f65e2: 0

=== daemon-class dial, session 11d07e7d413e ===
INFO:...server:session runtime: built projection fold for session 11d07e7d413e
```

Then the **real** mobile daemon (`python -m local_operator.mobile.service --port 4199`, `LOP_MOBILE_PASSWORD` set, logged in with the cookie flow) adopting a runtime and streaming it over SSE:

```
login -> 303
runtime pid=72582 session=feeffac59c7c
--- /api/sessions: {'session_id': 'feeffac59c7c', 'model_label': 'test/e2e-model', 'cwd': '/tmp/lop-residency-evidence/work'}
--- SSE /api/sessions/feeffac59c7c/events (5 s window):
projection events received: 1
data: {"session_id": "feeffac59c7c", "pid": 72582, "kind": "daemon", "conversation_name": "", "cwd": "/tmp/lop-residency-evidence/work", "model_label": "test/e2e-model", "model_selector": "test/e2e-model", "effort": "", "effort_ladder": [], "streaming": false, ...
--- runtime log:
INFO:...server:session runtime: built projection fold for session feeffac59c7c
```

The daemon's adoption dial built the fold (one line), and the phone-facing SSE carried a projection frame for that session.

### Unit tests

New: `tests/unit/wakes/{test_store,test_install,test_session_index}.py` (21 tests: shape, staged write, directory scan, skip-on-torn/foreign-schema, preserve/clear, session persist→index, cancel→removed, open-rebuild, stale-removed-on-open, `stopped_at`, index failure never breaks persistence, install hook called only for non-empty, install failure never breaks persistence). `test_process_reaper.py` rewritten for the three terms (attach holds; daemon/phone watchers do not; wake inside/outside the window; the constant vs `MIN_WAKE_INTERVAL_MS`; reduced/broken handles read as "does not hold"; attach → release → drain; attach mid-drain cancels; wake cancelled mid-hold releases). `test_server.py` gains four `ProjectionSink` tests; `test_owned.py` gains `next_wake_due_at`; `test_import_graph.py` gains the store guard.

## Gates

```
.venv/bin/python -m flake8 .                                   → clean
uvx --from black==26.1.0 black --check .                       → 776 files unchanged
uvx isort==5.13.2 --check .                                    → clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .    → 0 errors, 0 warnings
.venv/bin/python -m pytest tests/unit -q                       → 10594 passed, 15 skipped (13:28)
env -u NO_COLOR TERM=xterm-256color pytest tests/unit/tui -q   → 4343 passed, 12 skipped (12:08)
```

## Version

`0.44.27 → 0.44.28` (patch — rebased on #528, which shipped 0.44.27 — `sessions exit when idle`; no user-facing surface changes in this PR, since the TUI still owns its session).

