### PR TITLE
feat(anthropic): 1h prompt-cache TTL for large contexts

### DIFF
--- a/local_operator/analytics/model.py
+++ b/local_operator/analytics/model.py
@@ -190,6 +190,15 @@ class CallSnapshot:
     # a future caller that priced off-thread itself). The normal recording path
     # leaves this False so the store prices from the model + token counts.
     priced: bool = False
+    # The 1-hour-TTL slice of ``cache_write_tokens`` (Anthropic
+    # ``cache_creation.ephemeral_1h_input_tokens``), a SUBSET of it. Kept as
+    # its own column rather than folded in because it is priced at 2x base
+    # where a 5m write is 1.25x, and the point of the large-context 1h TTL is
+    # a trade that has to stay measurable after the fact. 0 on every other
+    # provider and on pre-1h Anthropic responses. NOTE: ``price_snapshot``
+    # still prices ALL writes at the 5m rate; splitting the rate is a
+    # follow-up, and this column is what makes it possible.
+    cache_write_1h_tokens: int = 0
     # Provider-reported dollar cost for this call (OpenRouter ``usage.cost``,
     # any compat provider that precomputes billing). Copied off ``Usage.usd_cost``
     # at record time so ``price_snapshot`` can prefer it over the registry table

--- a/local_operator/analytics/store.py
+++ b/local_operator/analytics/store.py
@@ -115,7 +115,12 @@ CREATE TABLE IF NOT EXISTS calls (
   -- priceable. Integer so the aggregate SUM is exact; see CallSnapshot.
   cost_micro INTEGER NOT NULL DEFAULT 0,
   cost_known INTEGER NOT NULL DEFAULT 0,
-  {_COMPONENT_COLUMNS}
+  {_COMPONENT_COLUMNS},
+  -- The slice of cache_write_tokens written with the 1-hour TTL (Anthropic
+  -- ``cache_creation.ephemeral_1h_input_tokens``); the 5m slice is the
+  -- remainder. Priced at 2x base rather than 1.25x, so the two must be
+  -- separable to judge whether the large-context 1h TTL pays for itself.
+  cache_write_1h_tokens INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_calls_ts ON calls(ts_ms);
 CREATE INDEX IF NOT EXISTS idx_calls_session ON calls(session_id);
@@ -207,6 +212,7 @@ _CALL_COLUMNS = (
     "cost_micro",
     "cost_known",
     *(f"c_{key}" for key in COMPONENT_KEYS),
+    "cache_write_1h_tokens",
 )
 
 #: Columns added AFTER the first shipped schema. A database created by an older
@@ -232,6 +238,9 @@ _MIGRATION_COLUMNS: tuple[tuple[str, str], ...] = (
     # rollup tables). After this ALTER they read ``c_images=0`` rather than
     # being re-apportioned — we cannot honestly unbake a historical estimate.
     ("c_images", "INTEGER NOT NULL DEFAULT 0"),
+    # Rows recorded before the Anthropic 1h TTL shipped were all 5m writes, so
+    # 0 here is the truth for them, not a placeholder.
+    ("cache_write_1h_tokens", "INTEGER NOT NULL DEFAULT 0"),
 )
 
 #: The names in ``_MIGRATION_COLUMNS`` as a set, for the "is this column optional
@@ -339,6 +348,7 @@ def _row_values(snapshot: CallSnapshot, cost_micro: int, cost_known: bool) -> tu
         int(cost_micro),
         1 if cost_known else 0,
         *(components[key] for key in COMPONENT_KEYS),
+        snapshot.cache_write_1h_tokens,
     )
 
 

--- a/local_operator/analytics/store.py
+++ b/local_operator/analytics/store.py
@@ -120,6 +120,13 @@ CREATE TABLE IF NOT EXISTS calls (
   -- ``cache_creation.ephemeral_1h_input_tokens``); the 5m slice is the
   -- remainder. Priced at 2x base rather than 1.25x, so the two must be
   -- separable to judge whether the large-context 1h TTL pays for itself.
+  -- SCOPE: a RAW-LEDGER diagnostic, deliberately NOT in the usage_daily /
+  -- usage_monthly rollups or the report projection — the rollup tables have
+  -- no ALTER migration path (CREATE TABLE IF NOT EXISTS cannot add a column
+  -- to an existing one, unlike calls' _MIGRATION_COLUMNS), so threading it
+  -- there is a schema change of its own (follow-up tracked on the feature
+  -- PR). Answers the trade question within the 90-day ledger window
+  -- (DEFAULT_RETENTION_DAYS); beyond that, price the split when it ships.
   cache_write_1h_tokens INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_calls_ts ON calls(ts_ms);

--- a/local_operator/config.py
+++ b/local_operator/config.py
@@ -156,7 +156,22 @@ DEFAULT_CONFIG = Config(
             # Direct OpenAI GPT-5 calls use the public Responses API by default.
             # Set `providers.openai.api` to `chat_completions` for an explicit
             # compatibility opt-out; other OpenAI-shaped providers never read it.
-            "providers": {"openai": {"api": "responses"}},
+            #
+            # `providers.anthropic.cache_ttl_1h_min_context_tokens`: once a
+            # session's context reaches this many tokens, Anthropic requests
+            # carry the 1-hour prompt-cache TTL instead of the default 5 minutes.
+            # A 1h write costs 2× base (vs 1.25× for 5m), but a large context
+            # that idles past 5 minutes — waiting on subagents, a wake, or the
+            # user — otherwise rewrites the WHOLE prefix on its next call.
+            # Measured over 24h on this harness's own traffic: 276 TTL-expiry
+            # rewrites of >150k contexts cost 89.5M write tokens (~112M
+            # base-equivalent), while the incremental writes on those contexts
+            # were only 14.7M (~11M base-equivalent extra at 2×). 150k is the
+            # size above which the rewrite dominates; 0 disables the feature.
+            "providers": {
+                "openai": {"api": "responses"},
+                "anthropic": {"cache_ttl_1h_min_context_tokens": 150_000},
+            },
             # One ordered cascade for every text-model call. Entries may be
             # "provider/model" strings or {provider, model, effort} mappings;
             # usage-aware switching is opt-in because it spends one lightweight

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -132,6 +132,8 @@ def _merge_accounting_component(
     total.output_tokens += component.output_tokens
     total.cache_read_tokens += component.cache_read_tokens
     total.cache_write_tokens += component.cache_write_tokens
+    total.cache_write_5m_tokens += component.cache_write_5m_tokens
+    total.cache_write_1h_tokens += component.cache_write_1h_tokens
     total.reasoning_tokens += component.reasoning_tokens
     if component.context_tokens is not None:
         total.context_tokens = component.context_tokens

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -492,6 +492,16 @@ class AgentLoop:
         # every request under it so the session's frozen auto-effort cannot
         # raise the retry back to the rung that produced nothing.
         effort_ceiling: str | None = None
+        # The provider-reported context size of the latest call in THIS run
+        # (``Usage.context_tokens``), stamped onto the next request as its
+        # prompt-cache TTL hint. Run-local on purpose: the host's
+        # ``get_context_tokens_hint`` is the cross-turn seed (last turn's
+        # final call, or a resumed transcript's), and a long tool loop can
+        # grow past the TTL threshold dozens of calls before the host's figure
+        # is next refreshed — a subagent is ONE turn for its whole life and
+        # would otherwise never carry a hint at all. Once a call in this run
+        # has reported, its count beats the seed (review F9).
+        run_context_tokens: int | None = None
 
         yield AgentStartEvent(generation=generation)
 
@@ -529,7 +539,15 @@ class AgentLoop:
 
                     assistant, stop_reason, stream_error = None, "stop", None
                     async for event in self._model_turn(
-                        context, config, signal, effort_ceiling=effort_ceiling
+                        context,
+                        config,
+                        signal,
+                        effort_ceiling=effort_ceiling,
+                        context_tokens_hint=(
+                            run_context_tokens
+                            if run_context_tokens is not None
+                            else self._host_context_tokens_hint(config)
+                        ),
                     ):
                         if isinstance(event, _ModelTurnResult):
                             assistant, stop_reason, stream_error = (
@@ -541,6 +559,11 @@ class AgentLoop:
                             yield event
                     if assistant is None:
                         raise RuntimeError("model turn produced no assistant message")
+                    if assistant.usage is not None and assistant.usage.context_tokens:
+                        # Only a REPORTED count advances the hint: a wire that
+                        # omits it must not blank a figure the previous call
+                        # (or the host's seed) supplied.
+                        run_context_tokens = int(assistant.usage.context_tokens)
                     context.messages.append(assistant)
                     new_messages.append(assistant)
 
@@ -804,18 +827,35 @@ class AgentLoop:
 
     # (``_abortable_stream`` is a module-level helper; see below the class.)
 
+    @staticmethod
+    def _host_context_tokens_hint(config: LoopConfig) -> int | None:
+        """The host's cross-turn context-size seed, or ``None`` when it has
+        none — a zero is treated as "nothing reported" because a provider
+        never reports an empty context, so 0 here can only be an unset
+        default, not a deliberate suppression (that is ``ChatRequest``'s
+        explicit ``0``, which only the session's own direct calls set)."""
+        reader = config.get_context_tokens_hint
+        if reader is None:
+            return None
+        hint = reader()
+        return int(hint) if hint else None
+
     async def _model_turn(
         self,
         context: LoopContext,
         config: LoopConfig,
         signal: AbortSignal | None,
         effort_ceiling: str | None = None,
+        context_tokens_hint: int | None = None,
     ) -> AsyncIterator[AgentEvent | _ModelTurnResult]:
         """One provider call: build the request, stream it, assemble the
         assistant message, emitting message_start/update/end events.
 
         The model is resolved HERE, per call, not once per run — see
-        :meth:`_current_model`.
+        :meth:`_current_model`. ``context_tokens_hint`` is stamped onto the
+        request by THIS loop, the owner of the conversation the call belongs
+        to — never remembered on the shared stream fn, where a subagent's
+        registration would overwrite the parent's (review F8).
         """
         shaped = list(context.messages)
         if config.transform_context is not None:
@@ -868,6 +908,7 @@ class AgentLoop:
                 messages=list(converted),
                 tools=list(context.tools),
                 effort_ceiling=effort_ceiling,
+                context_tokens_hint=context_tokens_hint,
             )
             stream = _abortable_stream(config.stream_fn(request, signal), signal)
             async for event in stream:

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -895,6 +895,12 @@ def _accumulate_usage(job: Any, usage: "Usage | None") -> None:
     total.output_tokens += usage.output_tokens
     total.cache_read_tokens += usage.cache_read_tokens
     total.cache_write_tokens += usage.cache_write_tokens
+    # The TTL split of the write count folds exactly where the write count
+    # does (they are subsets of it; see ``Usage.cache_write_1h_tokens``), so
+    # the job aggregate can price the two rates apart the moment a reader
+    # needs to.
+    total.cache_write_5m_tokens += usage.cache_write_5m_tokens
+    total.cache_write_1h_tokens += usage.cache_write_1h_tokens
     # Child failover can mix provider receipts and table-priced calls. Preserve
     # every original call so the TUI can price each one independently instead of
     # treating one receipt as authoritative for the aggregate token buckets.

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -224,6 +224,18 @@ class Usage(BaseModel):
     output_tokens: int = 0
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
+    # The TTL split of ``cache_write_tokens`` when the provider reports one
+    # (Anthropic's ``usage.cache_creation.ephemeral_5m_input_tokens`` /
+    # ``ephemeral_1h_input_tokens``). SUBSETS of ``cache_write_tokens``, never
+    # added on top — the docs state ``cache_creation_input_tokens`` equals their
+    # sum, and every existing consumer of ``cache_write_tokens`` stays correct.
+    # They exist because the two TTLs are priced differently (1.25× vs 2× base):
+    # once the Anthropic client starts writing 1h entries on large contexts,
+    # analytics needs to tell the two apart to know whether the trade paid off.
+    # Both stay 0 on providers without a TTL split, and on an Anthropic response
+    # that omits the ``cache_creation`` object (older API versions).
+    cache_write_5m_tokens: int = 0
+    cache_write_1h_tokens: int = 0
     context_tokens: int | None = None  # provider-reported full context size if given
     # The reasoning/thinking slice of ``output_tokens`` when the provider
     # breaks it out (OpenAI ``output_tokens_details.reasoning_tokens``). Kept
@@ -1530,6 +1542,18 @@ class ChatRequest(BaseModel):
     # caches. Session hosts populate it once from their session id; keeping it
     # on the request lets retries and fallback clones preserve the same value.
     prompt_cache_key: str | None = None
+    #: The provider-reported size of this session's context on its LAST call
+    #: (``Usage.context_tokens``), when the host knows it. A HINT, not wire
+    #: content: the Anthropic client reads it to decide whether the request is
+    #: large enough for the 1-hour prompt-cache TTL (see
+    #: ``AnthropicClient._cache_ttl_for``). The client cannot measure this
+    #: itself without a tokenizer, and the provider's own count from the
+    #: previous turn is the most accurate figure anyone has. ``None`` on a
+    #: session's first call and on paths that never saw a usage event (a fork's
+    #: first request, one-shot errands); the client then falls back to a byte
+    #: estimate of the serialized body. Set by ``SessionStreamFn.__call__``
+    #: from the last usage it recorded; retries and fallback clones keep it.
+    context_tokens_hint: int | None = None
     #: This call's output has NOT been shown to anyone yet, so a failed attempt
     #: may be discarded and retried whole.
     #:

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1446,18 +1446,22 @@ class LoopConfig(BaseModel):
     has_pending_fork: Callable[[], bool] | None = Field(default=None, exclude=True)
 
     # The provider-reported context size (``Usage.context_tokens``) of this
-    # conversation's LAST call, re-read immediately before every provider call
-    # and stamped onto the request as ``ChatRequest.context_tokens_hint``.
-    # Per-CONVERSATION memory, not per-stream-fn: subagents share the parent's
-    # stream fn (one httpx pool, one failover cascade), so a hint remembered
-    # on the stream fn itself would let a child's tiny first request inherit
-    # the parent's 300k count and pay 2x write rates on a fresh ~10k prefix —
-    # and let the parent's post-child request go out at 5m on its large
-    # context, the exact expiry this hint exists to dodge. The loop asks the
-    # HOST (which owns the conversation), exactly as it does for the model and
-    # the system blocks. ``None`` (no callback, or nothing reported yet) means
-    # no hint and the client's own byte estimate decides. Read in
-    # ``SessionStreamFn.__call__``; see ``ChatRequest.context_tokens_hint``.
+    # conversation's last call BEFORE this run — the cross-turn seed. The loop
+    # reads it for the run's first request and stamps it as
+    # ``ChatRequest.context_tokens_hint``; from the second request on, the
+    # count the previous call of the SAME run reported wins, because a long
+    # tool loop grows past the TTL threshold long before the host's figure is
+    # next refreshed. Per-CONVERSATION, stamped per REQUEST by the loop that
+    # owns the call — never remembered on the stream fn: subagents share the
+    # parent's stream fn (one httpx pool, one failover cascade), so a hint
+    # held there is last-writer-wins between the parent and every child, and
+    # a child's construction would silently downgrade the parent's next
+    # request to 5m on its large context (the exact expiry this hint exists
+    # to dodge) while the child's tiny first request inherits the parent's
+    # 300k count and pays 2x write rates on a fresh ~10k prefix. The loop asks
+    # the HOST (which owns the conversation), exactly as it does for the
+    # model and the system blocks. ``None`` (no callback, or nothing reported
+    # yet) means no hint and the client's own byte estimate decides.
     get_context_tokens_hint: Callable[[], int | None] | None = Field(default=None, exclude=True)
 
     interrupt_mode: Literal["immediate", "wait"] = "wait"
@@ -1566,12 +1570,15 @@ class ChatRequest(BaseModel):
     #: previous turn is the most accurate figure anyone has. ``None`` on a
     #: session's first call and on paths that never saw a usage event (a fork's
     #: first request, one-shot errands); the client then falls back to a byte
-    #: estimate of the serialized body. Stamped by ``SessionStreamFn.__call__``
-    #: from the conversation owner's registered reader (see
-    #: ``SessionStreamFn.set_context_tokens_hint`` — the memory is
-    #: per-conversation precisely because subagents share one stream fn);
-    #: retries and fallback clones keep it, and a caller's EXPLICIT value —
-    #: including ``0``, which suppresses the hint — always wins.
+    #: estimate of the serialized body. Stamped by the OWNER of the
+    #: conversation the call belongs to — the harness loop for turn calls
+    #: (``LoopConfig.get_context_tokens_hint`` seeds it, then the run's own
+    #: usage events advance it) and the session for its direct calls (asides,
+    #: the compaction advisor) — never by the shared stream fn, which merely
+    #: passes through what the request carries: subagents share one stream
+    #: fn, so any memory held there is last-writer-wins across conversations.
+    #: Retries and fallback clones keep it, and an EXPLICIT ``0`` suppresses
+    #: the hint (a one-shot prompt that is a fresh write-once prefix).
     context_tokens_hint: int | None = None
     #: This call's output has NOT been shown to anyone yet, so a failed attempt
     #: may be discarded and retried whole.

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1445,6 +1445,21 @@ class LoopConfig(BaseModel):
     # steering alone.
     has_pending_fork: Callable[[], bool] | None = Field(default=None, exclude=True)
 
+    # The provider-reported context size (``Usage.context_tokens``) of this
+    # conversation's LAST call, re-read immediately before every provider call
+    # and stamped onto the request as ``ChatRequest.context_tokens_hint``.
+    # Per-CONVERSATION memory, not per-stream-fn: subagents share the parent's
+    # stream fn (one httpx pool, one failover cascade), so a hint remembered
+    # on the stream fn itself would let a child's tiny first request inherit
+    # the parent's 300k count and pay 2x write rates on a fresh ~10k prefix —
+    # and let the parent's post-child request go out at 5m on its large
+    # context, the exact expiry this hint exists to dodge. The loop asks the
+    # HOST (which owns the conversation), exactly as it does for the model and
+    # the system blocks. ``None`` (no callback, or nothing reported yet) means
+    # no hint and the client's own byte estimate decides. Read in
+    # ``SessionStreamFn.__call__``; see ``ChatRequest.context_tokens_hint``.
+    get_context_tokens_hint: Callable[[], int | None] | None = Field(default=None, exclude=True)
+
     interrupt_mode: Literal["immediate", "wait"] = "wait"
     # Epoch-ms deadline for the whole run, if any.
     deadline: float | None = None
@@ -1551,8 +1566,12 @@ class ChatRequest(BaseModel):
     #: previous turn is the most accurate figure anyone has. ``None`` on a
     #: session's first call and on paths that never saw a usage event (a fork's
     #: first request, one-shot errands); the client then falls back to a byte
-    #: estimate of the serialized body. Set by ``SessionStreamFn.__call__``
-    #: from the last usage it recorded; retries and fallback clones keep it.
+    #: estimate of the serialized body. Stamped by ``SessionStreamFn.__call__``
+    #: from the conversation owner's registered reader (see
+    #: ``SessionStreamFn.set_context_tokens_hint`` — the memory is
+    #: per-conversation precisely because subagents share one stream fn);
+    #: retries and fallback clones keep it, and a caller's EXPLICIT value —
+    #: including ``0``, which suppresses the hint — always wins.
     context_tokens_hint: int | None = None
     #: This call's output has NOT been shown to anyone yet, so a failed attempt
     #: may be discarded and retried whole.

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1566,6 +1566,34 @@ def _openai_api_mode(settings: Mapping[str, Any] | None) -> str:
     return "chat_completions" if configured == "chat_completions" else "responses"
 
 
+#: Default for ``providers.anthropic.cache_ttl_1h_min_context_tokens`` when the
+#: settings mapping lacks the key (an old config file, a test passing ``{}``).
+#: Mirrors ``DEFAULT_CONFIG`` in ``config.py`` rather than importing it: the
+#: ``config`` module is the CLI's, and ``_openai_api_mode`` above already takes
+#: the same restate-the-default stance for the sibling key.
+ANTHROPIC_CACHE_TTL_1H_MIN_CONTEXT_TOKENS = 150_000
+
+
+def _anthropic_cache_ttl_1h_min_context_tokens(settings: Mapping[str, Any] | None) -> int:
+    """Resolve the context size above which Anthropic requests use the 1h TTL.
+
+    Same shape as ``_openai_api_mode``: a missing ``providers`` block (old
+    config files) or a malformed value falls back to the default rather than
+    silently disabling the feature, because the failure mode of "disabled" is
+    a bill that quietly grew rather than an error anyone sees. Only an explicit
+    non-negative integer is honoured; ``0`` is the documented off switch.
+    """
+    providers = settings.get("providers") if isinstance(settings, Mapping) else None
+    anthropic = providers.get("anthropic") if isinstance(providers, Mapping) else None
+    configured = (
+        anthropic.get("cache_ttl_1h_min_context_tokens") if isinstance(anthropic, Mapping) else None
+    )
+    # ``bool`` is an ``int`` subclass; ``true`` in YAML must not read as 1 token.
+    if isinstance(configured, int) and not isinstance(configured, bool) and configured >= 0:
+        return configured
+    return ANTHROPIC_CACHE_TTL_1H_MIN_CONTEXT_TOKENS
+
+
 # ---------------------------------------------------------------------------
 # stream_fn factory
 # ---------------------------------------------------------------------------
@@ -1699,6 +1727,16 @@ class SessionStreamFn:
         # until first use, and stays None whenever the cache cannot open (a
         # permanent live-fetch miss, never an error). See ``_usage_cache_store``.
         self._usage_cache: "UsageCacheStore | None" = None
+        # The provider-reported context size of the last NON-isolated call this
+        # stream fn forwarded, carried onto the next request as
+        # ``ChatRequest.context_tokens_hint``. Only the Anthropic client reads it
+        # (to pick the prompt-cache TTL); it is remembered here rather than read
+        # off ``Session._last_usage`` because every provider call — turns, tool
+        # loops, asides, compaction summaries — funnels through ``__call__``
+        # and ``_record_stream`` already sees each final ``Usage``. Isolated
+        # (naming) calls are excluded: their tiny prefix is not the session's
+        # context and would drag the hint below the threshold mid-turn.
+        self._last_context_tokens: int | None = None
 
     def _client_for(self, spec: ModelSpec) -> WireClient:
         from local_operator.providers.clients import client_for_spec
@@ -1707,6 +1745,9 @@ class SessionStreamFn:
             spec,
             http_client=self._http,
             openai_api=_openai_api_mode(self._settings),
+            anthropic_cache_ttl_1h_min_context_tokens=_anthropic_cache_ttl_1h_min_context_tokens(
+                self._settings
+            ),
         )
 
     @property
@@ -3345,6 +3386,12 @@ class SessionStreamFn:
             # alone and is unaffected either way.
             request = request.model_copy(update={"prompt_cache_key": self._cache_lineage_id})
 
+        if request.context_tokens_hint is None and self._last_context_tokens:
+            # The provider's own count from the previous call is the most
+            # accurate size anyone has for this request (the client only has a
+            # byte estimate). A hint the caller set deliberately is kept.
+            request = request.model_copy(update={"context_tokens_hint": self._last_context_tokens})
+
         await self.preflight_usage(request.model)
         async for event in self._record_stream(
             request,
@@ -3407,6 +3454,12 @@ class SessionStreamFn:
             # input tokens) is recorded too — best-effort and never raising.
             if component_chars is not None and final_usage is not None:
                 self._record_usage(request, component_chars, final_usage, ok)
+            if final_usage is not None and not request.isolated and final_usage.context_tokens:
+                # Feeds the next request's ``context_tokens_hint``; see the
+                # attribute's note in ``__init__`` for why isolated calls are
+                # left out. Failed streams still report input usage on some
+                # wires, and that count is as honest as a successful one.
+                self._last_context_tokens = int(final_usage.context_tokens)
 
     def _record_usage(
         self,
@@ -3472,6 +3525,7 @@ class SessionStreamFn:
                     output_tokens=int(usage.output_tokens),
                     cache_read_tokens=int(usage.cache_read_tokens),
                     cache_write_tokens=int(usage.cache_write_tokens),
+                    cache_write_1h_tokens=int(getattr(usage, "cache_write_1h_tokens", 0)),
                     reasoning_tokens=int(getattr(usage, "reasoning_tokens", 0)),
                     context_tokens=int(context_tokens or 0),
                     component_chars=component_chars,

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1727,16 +1727,13 @@ class SessionStreamFn:
         # until first use, and stays None whenever the cache cannot open (a
         # permanent live-fetch miss, never an error). See ``_usage_cache_store``.
         self._usage_cache: "UsageCacheStore | None" = None
-        # Registered by the conversation owner (see
-        # ``set_context_tokens_hint``); reads back the last provider-reported
-        # context size for THIS conversation. Kept as a REGISTRAR rather than
-        # memory on this object because subagents share the parent's stream fn
-        # (see ``harness/subagent.py``), so anything stored here is shared by
-        # every child too and would contaminate their first requests — the
-        # parent's 300k count would send a fresh ~10k child prefix out at 2x
-        # write rates. The value's home is the session, which knows which
-        # calls belong to its conversation.
-        self._context_tokens_hint_reader: Callable[[], int | None] | None = None
+        # Deliberately NO prompt-cache TTL hint memory (or reader registry)
+        # here: subagents share the parent's stream fn (``harness/subagent.py``),
+        # so any per-conversation state held on this object — even a
+        # registered reader — is last-writer-wins between the parent and every
+        # child. ``ChatRequest.context_tokens_hint`` is stamped by the call's
+        # OWNER (the harness loop, or the session for its direct calls) and
+        # ``__call__`` only passes it through.
 
     def _client_for(self, spec: ModelSpec) -> WireClient:
         from local_operator.providers.clients import client_for_spec
@@ -1749,21 +1746,6 @@ class SessionStreamFn:
                 self._settings
             ),
         )
-
-    def set_context_tokens_hint(self, reader: Callable[[], int | None] | None) -> None:
-        """Register the per-CONVERSATION context-size hint reader.
-
-        The reader returns the provider-reported context size of the
-        conversation's last call, and ``__call__`` stamps it onto the next
-        request as ``ChatRequest.context_tokens_hint`` (read by the Anthropic
-        client to pick the prompt-cache TTL). The session — the owner of the
-        conversation — registers it, mirroring how it already passes its
-        per-session state into the loop as callables. Because the memory lives
-        with the caller and only the READER is held here, a subagent sharing
-        this stream fn cannot see (or poison) the parent's hint and vice
-        versa; see the attribute note in ``__init__``.
-        """
-        self._context_tokens_hint_reader = reader
 
     @property
     def routing_settings(self) -> Mapping[str, Any]:
@@ -3323,12 +3305,12 @@ class SessionStreamFn:
             # * the session's prompt cache key, which identifies a request
             #   PREFIX. The naming call's prefix is a different system block, so
             #   sharing the key buys no hit and dirties the turn's cache entry.
-            # * the per-conversation context hint, whose reader belongs to the
-            #   session's conversation — a naming call is not part of it, and
-            #   stamping the session's large count onto a tiny one-shot prompt
-            #   would send it out at the 1h write rate for no replay benefit.
-            #   The branch order gives it for free: the hint is stamped after
-            #   this early return, never inside it.
+            #
+            # The prompt-cache TTL hint needs no guard here: it rides the
+            # request itself (``ChatRequest.context_tokens_hint``), stamped by
+            # the conversation's owner, and an errand's request is built
+            # without one — the client's byte estimate of its tiny body
+            # decides, so it never goes out at the 1h write rate.
             async for event in self._record_stream(
                 request,
                 stream_with_failover(
@@ -3406,18 +3388,6 @@ class SessionStreamFn:
             # cache on prefix CONTENT, so a fork hits there on byte-identity
             # alone and is unaffected either way.
             request = request.model_copy(update={"prompt_cache_key": self._cache_lineage_id})
-
-        hint = (
-            self._context_tokens_hint_reader()
-            if self._context_tokens_hint_reader is not None
-            else None
-        )
-        if request.context_tokens_hint is None and hint:
-            # The provider's own count of THIS conversation's previous call is
-            # the most accurate size anyone has for this request (the client
-            # alone only has a byte estimate). A hint the caller set
-            # deliberately — including an explicit 0 to suppress one — is kept.
-            request = request.model_copy(update={"context_tokens_hint": hint})
 
         await self.preflight_usage(request.model)
         async for event in self._record_stream(

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1727,16 +1727,16 @@ class SessionStreamFn:
         # until first use, and stays None whenever the cache cannot open (a
         # permanent live-fetch miss, never an error). See ``_usage_cache_store``.
         self._usage_cache: "UsageCacheStore | None" = None
-        # The provider-reported context size of the last NON-isolated call this
-        # stream fn forwarded, carried onto the next request as
-        # ``ChatRequest.context_tokens_hint``. Only the Anthropic client reads it
-        # (to pick the prompt-cache TTL); it is remembered here rather than read
-        # off ``Session._last_usage`` because every provider call — turns, tool
-        # loops, asides, compaction summaries — funnels through ``__call__``
-        # and ``_record_stream`` already sees each final ``Usage``. Isolated
-        # (naming) calls are excluded: their tiny prefix is not the session's
-        # context and would drag the hint below the threshold mid-turn.
-        self._last_context_tokens: int | None = None
+        # Registered by the conversation owner (see
+        # ``set_context_tokens_hint``); reads back the last provider-reported
+        # context size for THIS conversation. Kept as a REGISTRAR rather than
+        # memory on this object because subagents share the parent's stream fn
+        # (see ``harness/subagent.py``), so anything stored here is shared by
+        # every child too and would contaminate their first requests — the
+        # parent's 300k count would send a fresh ~10k child prefix out at 2x
+        # write rates. The value's home is the session, which knows which
+        # calls belong to its conversation.
+        self._context_tokens_hint_reader: Callable[[], int | None] | None = None
 
     def _client_for(self, spec: ModelSpec) -> WireClient:
         from local_operator.providers.clients import client_for_spec
@@ -1749,6 +1749,21 @@ class SessionStreamFn:
                 self._settings
             ),
         )
+
+    def set_context_tokens_hint(self, reader: Callable[[], int | None] | None) -> None:
+        """Register the per-CONVERSATION context-size hint reader.
+
+        The reader returns the provider-reported context size of the
+        conversation's last call, and ``__call__`` stamps it onto the next
+        request as ``ChatRequest.context_tokens_hint`` (read by the Anthropic
+        client to pick the prompt-cache TTL). The session — the owner of the
+        conversation — registers it, mirroring how it already passes its
+        per-session state into the loop as callables. Because the memory lives
+        with the caller and only the READER is held here, a subagent sharing
+        this stream fn cannot see (or poison) the parent's hint and vice
+        versa; see the attribute note in ``__init__``.
+        """
+        self._context_tokens_hint_reader = reader
 
     @property
     def routing_settings(self) -> Mapping[str, Any]:
@@ -3308,6 +3323,12 @@ class SessionStreamFn:
             # * the session's prompt cache key, which identifies a request
             #   PREFIX. The naming call's prefix is a different system block, so
             #   sharing the key buys no hit and dirties the turn's cache entry.
+            # * the per-conversation context hint, whose reader belongs to the
+            #   session's conversation — a naming call is not part of it, and
+            #   stamping the session's large count onto a tiny one-shot prompt
+            #   would send it out at the 1h write rate for no replay benefit.
+            #   The branch order gives it for free: the hint is stamped after
+            #   this early return, never inside it.
             async for event in self._record_stream(
                 request,
                 stream_with_failover(
@@ -3386,11 +3407,17 @@ class SessionStreamFn:
             # alone and is unaffected either way.
             request = request.model_copy(update={"prompt_cache_key": self._cache_lineage_id})
 
-        if request.context_tokens_hint is None and self._last_context_tokens:
-            # The provider's own count from the previous call is the most
-            # accurate size anyone has for this request (the client only has a
-            # byte estimate). A hint the caller set deliberately is kept.
-            request = request.model_copy(update={"context_tokens_hint": self._last_context_tokens})
+        hint = (
+            self._context_tokens_hint_reader()
+            if self._context_tokens_hint_reader is not None
+            else None
+        )
+        if request.context_tokens_hint is None and hint:
+            # The provider's own count of THIS conversation's previous call is
+            # the most accurate size anyone has for this request (the client
+            # alone only has a byte estimate). A hint the caller set
+            # deliberately — including an explicit 0 to suppress one — is kept.
+            request = request.model_copy(update={"context_tokens_hint": hint})
 
         await self.preflight_usage(request.model)
         async for event in self._record_stream(
@@ -3454,12 +3481,6 @@ class SessionStreamFn:
             # input tokens) is recorded too — best-effort and never raising.
             if component_chars is not None and final_usage is not None:
                 self._record_usage(request, component_chars, final_usage, ok)
-            if final_usage is not None and not request.isolated and final_usage.context_tokens:
-                # Feeds the next request's ``context_tokens_hint``; see the
-                # attribute's note in ``__init__`` for why isolated calls are
-                # left out. Failed streams still report input usage on some
-                # wires, and that count is as honest as a successful one.
-                self._last_context_tokens = int(final_usage.context_tokens)
 
     def _record_usage(
         self,

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -1821,6 +1821,58 @@ class AnthropicClient:
     #: only has to land on the right side of a 150k threshold, not be exact.
     _BYTES_PER_TOKEN_ESTIMATE = 4
 
+    #: Token FLOOR counted per image in the byte-based context estimate in
+    #: ``_cache_ttl_for``. The serialized body carries images as base64 in
+    #: ``source.data``, so a naive ``len(json) / 4`` turns one ~1 MB screenshot
+    #: into ~330k "tokens". Anthropic bills an image by its PIXEL AREA
+    #: (``width × height / 750``, capped at ~1.15 megapixels), so a worst-case
+    #: image is ~1.6k tokens no matter how many bytes its base64 spelling
+    #: takes. A floor rather than a parse: media_type/size metadata is not
+    #: reliably present on every path that builds an ``ImageContent``, and
+    #: the estimate only has to land on the right side of the threshold.
+    _IMAGE_TOKENS_ESTIMATE = 1_600
+
+    @staticmethod
+    def _estimate_context_tokens(body: dict[str, Any]) -> int:
+        """Size the request for ``_cache_ttl_for``'s threshold comparison.
+
+        Counts the serialized body's characters EXCEPT base64 image payloads,
+        each of which contributes ``_IMAGE_TOKENS_ESTIMATE`` instead: bytes of
+        base64 say nothing about the tokens a provider bills (see that
+        constant), and leaving them in makes any first call, fork or resume
+        carrying a screenshot flip to the 1h TTL on a ~1.6k-token image.
+        Images are located by walking the body's shape — any dict with a
+        ``source`` whose ``type`` is ``base64`` and whose ``data`` is a string
+        — rather than by key position, because tool results nest them one
+        level deeper than plain message content.
+        """
+        images = 0
+
+        def _swap_out_images(value: Any) -> Any:
+            nonlocal images
+            if isinstance(value, dict):
+                source = value.get("source")
+                if (
+                    isinstance(source, dict)
+                    and source.get("type") == "base64"
+                    and isinstance(source.get("data"), str)
+                ):
+                    images += 1
+                    # The key stays so the shape (and key order) matches what
+                    # gets serialized; only the counted payload shrinks.
+                    return {**value, "source": {**source, "data": ""}}
+                return {k: _swap_out_images(v) for k, v in value.items()}
+            if isinstance(value, list):
+                return [_swap_out_images(item) for item in value]
+            return value
+
+        # ``default=str`` guards against any non-JSON-native value a caller
+        # slipped into the body; ``separators`` matches what httpx sends.
+        serialized = json.dumps(_swap_out_images(body), default=str, separators=(",", ":"))
+        return len(serialized) // AnthropicClient._BYTES_PER_TOKEN_ESTIMATE + (
+            images * AnthropicClient._IMAGE_TOKENS_ESTIMATE
+        )
+
     @staticmethod
     def _cache_control(ttl: str | None) -> dict[str, Any]:
         """One ``cache_control`` marker. ``ttl`` is ``"1h"`` or None (5m).
@@ -1869,23 +1921,21 @@ class AnthropicClient:
            the session's previous call, stamped by ``SessionStreamFn``. It is
            exact for the prefix this request replays, and off only by the
            one new turn appended since.
-        2. A byte estimate of the serialized body (``len(json) / 4``) when no
-           hint exists: a session's first call, a fork's first request, a
-           one-shot errand with no usage history. The estimate is coarse —
-           base64 images and JSON punctuation skew it — but it only has to
-           land on the right side of a 150k threshold, and the hint replaces
-           it from the second call on. Without the fallback a resumed 400k
-           session would send its first (and most expensive) request at 5m.
+        2. A byte estimate of the serialized body when no hint exists: a
+           session's first call, a fork's first request, a one-shot errand
+           with no usage history. The estimate (``_estimate_context_tokens``)
+           excludes base64 image payloads — Anthropic bills an image by pixel
+           area, not bytes — but is otherwise coarse; it only has to land on
+           the right side of a 150k threshold, and the hint replaces it from
+           the second call on. Without the fallback a resumed 400k session
+           would send its first (and most expensive) request at 5m.
         """
         threshold = self._cache_ttl_1h_min_context_tokens
         if threshold <= 0:
             return None
         size = request.context_tokens_hint
         if size is None:
-            # ``default=str`` guards against any non-JSON-native value a caller
-            # slipped into the body; ``separators`` matches what httpx sends.
-            serialized = json.dumps(body, default=str, separators=(",", ":"))
-            size = len(serialized) // self._BYTES_PER_TOKEN_ESTIMATE
+            size = self._estimate_context_tokens(body)
         return "1h" if size >= threshold else None
 
     @classmethod

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -1733,6 +1733,9 @@ class AnthropicClient:
     the volatile tail stays un-cached). Content arrives as
     ``content_block_start/delta/stop`` events for ``text`` and ``tool_use``
     blocks; tool arguments stream via ``input_json_delta``.
+
+    Large contexts switch every marker to the 1-hour cache TTL; see
+    ``_cache_ttl_for`` for the economics and the wire constraint.
     """
 
     def __init__(
@@ -1741,10 +1744,16 @@ class AnthropicClient:
         *,
         http_client: httpx.AsyncClient | None = None,
         timeout: float = 600.0,
+        cache_ttl_1h_min_context_tokens: int = 0,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._owns_client = http_client is None
         self._http = http_client or httpx.AsyncClient(timeout=_stream_timeout(timeout))
+        # Context size (tokens) from which requests carry the 1h TTL; 0 keeps
+        # every request on the default 5m. Defaults OFF at the constructor so a
+        # bare ``AnthropicClient()`` (tests, scripts) sends the exact body it
+        # always did; ``client_for_spec`` passes the configured threshold.
+        self._cache_ttl_1h_min_context_tokens = max(0, int(cache_ttl_1h_min_context_tokens))
 
     async def aclose(self) -> None:
         if self._owns_client:
@@ -1807,8 +1816,82 @@ class AnthropicClient:
     #: told they are a CLI.
     CLAUDE_CODE_IDENTITY = "You are Claude Code, Anthropic's official CLI for Claude."
 
+    #: Rough bytes-per-token for the byte-based context estimate in
+    #: ``_cache_ttl_for``. English prose and JSON both sit near 4; the estimate
+    #: only has to land on the right side of a 150k threshold, not be exact.
+    _BYTES_PER_TOKEN_ESTIMATE = 4
+
+    @staticmethod
+    def _cache_control(ttl: str | None) -> dict[str, Any]:
+        """One ``cache_control`` marker. ``ttl`` is ``"1h"`` or None (5m).
+
+        The 5m marker deliberately omits the ``ttl`` key rather than spelling
+        ``"5m"``: it is the exact shape every prior request sent, so a client
+        below the threshold (or with the feature off) produces a byte-identical
+        body to the one before this feature existed, and nothing about the
+        default path has to be re-validated.
+        """
+        marker: dict[str, Any] = {"type": "ephemeral"}
+        if ttl:
+            marker["ttl"] = ttl
+        return marker
+
+    def _cache_ttl_for(self, request: ChatRequest, body: dict[str, Any]) -> str | None:
+        """Pick the prompt-cache TTL for this request: ``"1h"`` or None (5m).
+
+        WHY: a 5m entry expires while a large session waits on a subagent, a
+        scheduled wake, or the user, and its next call then rewrites the whole
+        prefix at 1.25× base. Measured over 24h of this harness's own traffic:
+        276 such rewrites of >150k contexts cost 89.5M write tokens (~112M
+        base-equivalent), while ALL incremental writes on those contexts were
+        14.7M tokens — which at the 1h rate (2× base instead of 1.25×) cost
+        ~11M base-equivalent extra. Above the threshold the 1h TTL is a
+        ~10:1 win; below it, small prefixes are cheap to rewrite and the 2×
+        write rate on every turn would cost more than the expiries it avoids.
+
+        CONSTRAINT (Anthropic, "Mixing different TTLs"): a 1h marker must
+        appear BEFORE every 5m marker in the request, so a body cannot carry
+        5m markers on the system blocks and 1h markers on the messages. The
+        result of this method is therefore applied to EVERY marker in the
+        request — system blocks and message breakpoints alike — never to a
+        subset.
+
+        The decision is one-directional in practice and needs no hysteresis:
+        context only grows within a turn, and once it crosses the threshold
+        the 1h markers stay until compaction shrinks it. Dropping back to 5m
+        markers after compaction is fine — the compacted prefix is new
+        content that has to be written either way, and a smaller context is
+        exactly the case where the cheaper write rate wins again.
+
+        Two size sources, in preference order:
+
+        1. ``request.context_tokens_hint`` — the provider's OWN count from
+           the session's previous call, stamped by ``SessionStreamFn``. It is
+           exact for the prefix this request replays, and off only by the
+           one new turn appended since.
+        2. A byte estimate of the serialized body (``len(json) / 4``) when no
+           hint exists: a session's first call, a fork's first request, a
+           one-shot errand with no usage history. The estimate is coarse —
+           base64 images and JSON punctuation skew it — but it only has to
+           land on the right side of a 150k threshold, and the hint replaces
+           it from the second call on. Without the fallback a resumed 400k
+           session would send its first (and most expensive) request at 5m.
+        """
+        threshold = self._cache_ttl_1h_min_context_tokens
+        if threshold <= 0:
+            return None
+        size = request.context_tokens_hint
+        if size is None:
+            # ``default=str`` guards against any non-JSON-native value a caller
+            # slipped into the body; ``separators`` matches what httpx sends.
+            serialized = json.dumps(body, default=str, separators=(",", ":"))
+            size = len(serialized) // self._BYTES_PER_TOKEN_ESTIMATE
+        return "1h" if size >= threshold else None
+
     @classmethod
-    def _system_blocks(cls, blocks: Sequence[str]) -> list[dict[str, Any]]:
+    def _system_blocks(
+        cls, blocks: Sequence[str], *, ttl: str | None = None
+    ) -> list[dict[str, Any]]:
         """System blocks → Anthropic ``system`` array with cache breakpoints.
 
         The harness sends [instructions, tool inventory, skills, env/date];
@@ -1819,13 +1902,16 @@ class AnthropicClient:
         at ``MAX_CACHE_BREAKPOINTS`` — Anthropic rejects requests carrying
         more than 4 ``cache_control`` markers, so surplus stable blocks keep
         the cache prefix intact without adding markers.
+
+        ``ttl`` is the request-wide TTL from ``_cache_ttl_for``; every marker
+        placed here carries it, because a 1h marker may not follow a 5m one.
         """
         rendered: list[dict[str, Any]] = []
         stable_count = min(cls.MAX_CACHE_BREAKPOINTS, max(0, len(blocks) - 2))
         for index, block in enumerate(blocks):
             entry: dict[str, Any] = {"type": "text", "text": block}
             if index < stable_count:
-                entry["cache_control"] = {"type": "ephemeral"}
+                entry["cache_control"] = cls._cache_control(ttl)
             rendered.append(entry)
         return rendered
 
@@ -1862,7 +1948,7 @@ class AnthropicClient:
         return blocks
 
     def _message_cache_breakpoints(
-        self, messages: list[dict[str, Any]], body: dict[str, Any]
+        self, messages: list[dict[str, Any]], body: dict[str, Any], *, ttl: str | None = None
     ) -> None:
         """Place cache_control on the conversation, not just the system head.
 
@@ -1877,6 +1963,10 @@ class AnthropicClient:
         first; when the sum would exceed the cap the LOWEST-value system
         breakpoint (the last stable block) is dropped in favour of the
         message markers, which cover far more tokens.
+
+        ``ttl`` must be the SAME value the system markers were rendered with:
+        Anthropic rejects a 1h marker that follows a 5m one, and the message
+        markers always follow the system ones.
         """
         system = body.get("system") or []
         system_markers = [i for i, entry in enumerate(system) if "cache_control" in entry]
@@ -1902,7 +1992,7 @@ class AnthropicClient:
             system[index].pop("cache_control", None)
         for block in message_targets:
             if isinstance(block, dict):
-                block["cache_control"] = {"type": "ephemeral"}
+                block["cache_control"] = self._cache_control(ttl)
 
     def _build_body(self, request: ChatRequest, *, oauth: bool = False) -> dict[str, Any]:
         messages: list[dict[str, Any]] = []
@@ -1960,16 +2050,12 @@ class AnthropicClient:
         blocks = list(request.system_blocks)
         if oauth:
             blocks.insert(0, self.CLAUDE_CODE_IDENTITY)
+        # Rendered marker-free first: the TTL every marker will carry is
+        # decided once messages, tools and system text are ALL in the body, so
+        # the byte-estimate fallback sees everything the provider will count.
+        # See ``_cache_ttl_for`` for why one value applies to every marker.
         if blocks:
-            body["system"] = self._system_blocks(blocks)
-        # System-only breakpoints stop the cached prefix before the first
-        # message: the entire growing conversation would be re-processed at
-        # full price on every request. Mark the last content block of the
-        # final message and the second-to-last user turn so the previous
-        # prefix stays warm across turns, within MAX_CACHE_BREAKPOINTS by
-        # dropping the lowest-value system breakpoint.
-        self._message_cache_breakpoints(messages, body)
-
+            body["system"] = [{"type": "text", "text": block} for block in blocks]
         if request.tools:
             body["tools"] = [
                 {
@@ -1979,6 +2065,17 @@ class AnthropicClient:
                 }
                 for tool in request.tools
             ]
+        ttl = self._cache_ttl_for(request, body)
+        if blocks:
+            body["system"] = self._system_blocks(blocks, ttl=ttl)
+        # System-only breakpoints stop the cached prefix before the first
+        # message: the entire growing conversation would be re-processed at
+        # full price on every request. Mark the last content block of the
+        # final message and the second-to-last user turn so the previous
+        # prefix stays warm across turns, within MAX_CACHE_BREAKPOINTS by
+        # dropping the lowest-value system breakpoint.
+        self._message_cache_breakpoints(messages, body, ttl=ttl)
+        if request.tools:
             # Safe default: unmapped values fall back to auto (PR-22).
             body["tool_choice"] = {
                 "auto": {"type": "auto"},
@@ -2055,6 +2152,19 @@ class AnthropicClient:
                     usage.input_tokens = int(raw_usage.get("input_tokens", usage.input_tokens))
                     usage.cache_read_tokens = int(raw_usage.get("cache_read_input_tokens", 0))
                     usage.cache_write_tokens = int(raw_usage.get("cache_creation_input_tokens", 0))
+                    # The per-TTL split of the write count. Anthropic documents
+                    # ``cache_creation_input_tokens`` as the SUM of these two,
+                    # and the two are priced differently (1.25× vs 2× base), so
+                    # analytics needs them apart to judge the 1h trade. The
+                    # object is absent on older API versions; both then stay 0.
+                    creation = raw_usage.get("cache_creation") or {}
+                    if isinstance(creation, dict):
+                        usage.cache_write_5m_tokens = int(
+                            creation.get("ephemeral_5m_input_tokens", 0) or 0
+                        )
+                        usage.cache_write_1h_tokens = int(
+                            creation.get("ephemeral_1h_input_tokens", 0) or 0
+                        )
                     # Anthropic reports input_tokens EXCLUDING cached blocks
                     # (OpenAI includes them), so the context actually read is
                     # the sum of the three. The compaction trigger and the TUI
@@ -2434,11 +2544,18 @@ def client_for_spec(
     *,
     http_client: httpx.AsyncClient | None = None,
     openai_api: str = "responses",
+    anthropic_cache_ttl_1h_min_context_tokens: int = 0,
 ) -> WireClient:
     """Build the wire client for a ``ModelSpec`` via the provider registry.
 
     Unknown providers raise :class:`ValueError` — the legacy fallback to the
     local ollama endpoint silently served the wrong wire shape.
+
+    ``anthropic_cache_ttl_1h_min_context_tokens`` is the configured
+    ``providers.anthropic.cache_ttl_1h_min_context_tokens`` (see
+    ``AnthropicClient._cache_ttl_for``); it only reaches the Anthropic wire.
+    Like ``openai_api`` it is a per-provider setting resolved by the caller
+    (``SessionStreamFn._client_for``) so this function stays settings-free.
     """
     from local_operator.providers.registry import get_provider_definition
 
@@ -2450,7 +2567,11 @@ def client_for_spec(
         return MockClient()
     if wire == "anthropic":
         base = spec.base_url or (definition.base_url if definition else None) or ANTHROPIC_API_URL
-        return AnthropicClient(base_url=base, http_client=http_client)
+        return AnthropicClient(
+            base_url=base,
+            http_client=http_client,
+            cache_ttl_1h_min_context_tokens=anthropic_cache_ttl_1h_min_context_tokens,
+        )
     if wire == "google":
         base = spec.base_url or GOOGLE_API_URL
         return GoogleClient(base_url=base, http_client=http_client)

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -1691,6 +1691,11 @@ def _aggregate_usage(usages: list[Usage]) -> Usage:
         output_tokens=sum(u.output_tokens for u in usages),
         cache_read_tokens=sum(u.cache_read_tokens for u in usages),
         cache_write_tokens=sum(u.cache_write_tokens for u in usages),
+        # Same contract as ``cache_write_tokens`` above: the TTL split folds
+        # wherever the write count does, or the frontend's split would read
+        # as the first call's value only (see ``Usage.cache_write_1h_tokens``).
+        cache_write_5m_tokens=sum(u.cache_write_5m_tokens for u in usages),
+        cache_write_1h_tokens=sum(u.cache_write_1h_tokens for u in usages),
         reasoning_tokens=sum(u.reasoning_tokens for u in usages),
         context_tokens=last_context,
         cost_components=components,

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1392,6 +1392,14 @@ class Session:
             # is actually serving requests, the session persists that fact and
             # emits the event a front end repaints its model display from.
             route_bridge(self._on_route_settled)
+        hint_bridge = getattr(self._stream_fn, "set_context_tokens_hint", None)
+        if callable(hint_bridge):
+            # The stream fn is SHARED with subagents, so its TTL hint memory
+            # must live here — the conversation owner — or a child's first
+            # request would inherit this session's large count (and this
+            # session's next request the child's small one). See
+            # ``SessionStreamFn.set_context_tokens_hint``.
+            hint_bridge(lambda: self._context_tokens_hint if self._context_tokens_hint else None)
         self._tools = list(tools)
         self._transcript = transcript
         self._session_id = session_id or transcript.directory.name
@@ -1624,6 +1632,18 @@ class Session:
         # ``Transcript.usages_since_compaction`` and ``_last_reported_usage``).
         self._last_usage: Usage | None = _last_reported_usage(
             [_parsed_usage(payload) for payload in transcript.usages_since_compaction()]
+        )
+        # The per-conversation prompt-cache TTL hint (see
+        # ``SessionStreamFn.set_context_tokens_hint``): the provider-reported
+        # context size of THIS session's last turn call, excluding isolated
+        # errands (their tiny prefix is not this conversation) and one-shots
+        # that do not carry the conversation (their prompt is a different,
+        # write-once prefix — see ``_one_shot_complete``). Seeded from the
+        # transcript's last usage so a RESUMED large session starts on its
+        # real size instead of re-deriving it through the client's byte
+        # estimate. ``None`` until the first provider call reports one.
+        self._context_tokens_hint: int | None = (
+            self._last_usage.context_tokens if self._last_usage is not None else None
         )
         self._last_activity_ms: int = 0  # epoch ms; drives idle-flush pruning
         self._generation = 0  # monotonic turn counter for agent_start/end
@@ -4691,6 +4711,12 @@ class Session:
                 # waiting for another user message. The loop keeps the turn-start
                 # snapshot as a fallback if this host resolver ever fails.
                 get_system_blocks=self._system_blocks,
+                # Per-conversation TTL hint memory: the loop re-reads it before
+                # every provider call and the stream fn stamps it onto the
+                # request. Lives here — not on the shared stream fn — so a
+                # subagent's calls cannot contaminate this session's hint; see
+                # ``SessionStreamFn.set_context_tokens_hint``.
+                get_context_tokens_hint=lambda: self._context_tokens_hint,
                 convert_to_llm=self._render_history,
                 stream_fn=self._stream_fn,
                 get_steering_messages=self._drain_steering,
@@ -4781,6 +4807,21 @@ class Session:
                 if isinstance(message, Message) and message.usage is not None:
                     self._last_usage = message.usage
                     break
+            # The TTL hint rides the same per-conversation memory: a hint the
+            # provider never reported (some wires omit it) clears the stale
+            # one rather than keeping a pre-compaction figure alive forever.
+            hint = next(
+                (
+                    int(message.usage.context_tokens)
+                    for message in reversed(new_messages)
+                    if isinstance(message, Message)
+                    and message.usage is not None
+                    and message.usage.context_tokens
+                ),
+                None,
+            )
+            if hint is not None:
+                self._context_tokens_hint = hint
             self._last_activity_ms = int(time.time() * 1000)
             # The run just completed provider round-trips; the idle flush
             # measures provider-cache age from this stamp, not turn
@@ -7247,6 +7288,15 @@ class Session:
             tools=[],
             tool_choice="none",
             replayable=True,
+            # ``0`` is a DELIBERATE hint, not a missing one: this prompt is a
+            # fresh write-once system+transcript prefix, not the turn's cached
+            # prefix, so a 1h entry (2x write rate) buys nothing — it is never
+            # replayed except a stall retry. Inheriting the session's large
+            # pre-compaction count here would send a transcript-sized prompt
+            # out at the 1h rate for several dollars of pure overpayment per
+            # compaction. ``SessionStreamFn.__call__`` keeps a set hint, and
+            # the Anthropic client treats 0 as below any threshold.
+            context_tokens_hint=0,
         )
         parts: list[str] = []
         async for event in self._stream_fn(request, None):

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1392,14 +1392,13 @@ class Session:
             # is actually serving requests, the session persists that fact and
             # emits the event a front end repaints its model display from.
             route_bridge(self._on_route_settled)
-        hint_bridge = getattr(self._stream_fn, "set_context_tokens_hint", None)
-        if callable(hint_bridge):
-            # The stream fn is SHARED with subagents, so its TTL hint memory
-            # must live here — the conversation owner — or a child's first
-            # request would inherit this session's large count (and this
-            # session's next request the child's small one). See
-            # ``SessionStreamFn.set_context_tokens_hint``.
-            hint_bridge(lambda: self._context_tokens_hint if self._context_tokens_hint else None)
+        # Deliberately NO bridge for the prompt-cache TTL hint, unlike the two
+        # above: the stream fn is SHARED with subagents, so a registered reader
+        # is last-writer-wins — constructing a child overwrote the parent's
+        # reader for good and downgraded every later parent request to 5m
+        # (review F8). The hint rides each request instead, stamped by its
+        # owner: the loop reads ``get_context_tokens_hint`` for turn calls and
+        # the session's direct calls stamp ``_context_tokens_hint`` themselves.
         self._tools = list(tools)
         self._transcript = transcript
         self._session_id = session_id or transcript.directory.name
@@ -1634,13 +1633,17 @@ class Session:
             [_parsed_usage(payload) for payload in transcript.usages_since_compaction()]
         )
         # The per-conversation prompt-cache TTL hint (see
-        # ``SessionStreamFn.set_context_tokens_hint``): the provider-reported
-        # context size of THIS session's last turn call, excluding isolated
-        # errands (their tiny prefix is not this conversation) and one-shots
-        # that do not carry the conversation (their prompt is a different,
-        # write-once prefix — see ``_one_shot_complete``). Seeded from the
-        # transcript's last usage so a RESUMED large session starts on its
-        # real size instead of re-deriving it through the client's byte
+        # ``ChatRequest.context_tokens_hint``): the provider-reported context
+        # size of THIS session's last turn call, excluding isolated errands
+        # (their tiny prefix is not this conversation) and one-shots that do
+        # not carry the conversation (their prompt is a different, write-once
+        # prefix — see ``_one_shot_complete``). Moves in lockstep with
+        # ``_last_usage`` (see ``_note_usage``) so a hint is never staler than
+        # the compaction trigger's figure, and is stamped per request by the
+        # call's owner: the loop seeds its run from it and then prefers its
+        # own in-run counts; asides and the advisor stamp it directly. Seeded
+        # from the transcript's last usage so a RESUMED large session starts on
+        # its real size instead of re-deriving it through the client's byte
         # estimate. ``None`` until the first provider call reports one.
         self._context_tokens_hint: int | None = (
             self._last_usage.context_tokens if self._last_usage is not None else None
@@ -4236,6 +4239,27 @@ class Session:
 
     # -- context accounting ---------------------------------------------------
 
+    def _note_usage(self, messages: Sequence[AgentMessage]) -> None:
+        """Adopt the newest provider usage in ``messages`` as this
+        conversation's latest reading — ONE place for both the compaction
+        trigger's figure (``_last_usage``) and the prompt-cache TTL hint.
+
+        Both the post-run scan and the mid-turn boundary hook go through
+        here, so the hint can never lag the usage the way it did when only
+        the turn boundary moved it (review F9): the hint is what the next
+        request of THIS turn (an aside, the advisor) and the NEXT turn's
+        first call are stamped with. The hint only ADVANCES on a reported
+        count — a wire that omits ``context_tokens`` keeps the previous
+        figure rather than blanking it and sending a large context out at
+        the 5m TTL by the byte estimate.
+        """
+        for message in reversed(messages):
+            if isinstance(message, Message) and message.usage is not None:
+                self._last_usage = message.usage
+                if message.usage.context_tokens:
+                    self._context_tokens_hint = int(message.usage.context_tokens)
+                return
+
     def restored_usage(self) -> Usage | None:
         """The provider's own last reading for THIS conversation, or ``None``.
 
@@ -4711,11 +4735,11 @@ class Session:
                 # waiting for another user message. The loop keeps the turn-start
                 # snapshot as a fallback if this host resolver ever fails.
                 get_system_blocks=self._system_blocks,
-                # Per-conversation TTL hint memory: the loop re-reads it before
-                # every provider call and the stream fn stamps it onto the
-                # request. Lives here — not on the shared stream fn — so a
-                # subagent's calls cannot contaminate this session's hint; see
-                # ``SessionStreamFn.set_context_tokens_hint``.
+                # Cross-turn seed for the prompt-cache TTL hint: the loop stamps
+                # it on the run's first request and then prefers the counts its
+                # own calls report. Lives here — not on the shared stream fn —
+                # so a subagent's calls cannot contaminate this session's hint;
+                # see ``LoopConfig.get_context_tokens_hint``.
                 get_context_tokens_hint=lambda: self._context_tokens_hint,
                 convert_to_llm=self._render_history,
                 stream_fn=self._stream_fn,
@@ -4802,26 +4826,9 @@ class Session:
                 if is_todo_end and self._job_id is not None and self._subagent_comms is not None:
                     self._subagent_comms.notify_detail_persisted(self._job_id)
 
-            # Track the latest provider usage for compaction trigger math.
-            for message in reversed(new_messages):
-                if isinstance(message, Message) and message.usage is not None:
-                    self._last_usage = message.usage
-                    break
-            # The TTL hint rides the same per-conversation memory: a hint the
-            # provider never reported (some wires omit it) clears the stale
-            # one rather than keeping a pre-compaction figure alive forever.
-            hint = next(
-                (
-                    int(message.usage.context_tokens)
-                    for message in reversed(new_messages)
-                    if isinstance(message, Message)
-                    and message.usage is not None
-                    and message.usage.context_tokens
-                ),
-                None,
-            )
-            if hint is not None:
-                self._context_tokens_hint = hint
+            # Track the latest provider usage for compaction trigger math (and
+            # the TTL hint that rides with it).
+            self._note_usage(new_messages)
             self._last_activity_ms = int(time.time() * 1000)
             # The run just completed provider round-trips; the idle flush
             # measures provider-cache age from this stamp, not turn
@@ -5663,6 +5670,14 @@ class Session:
         # was looking at when they typed the command, rather than a rewritten
         # head they never saw.
         await self._drain_pending_fork()
+        # The post-run usage scan has not happened yet — the boundary
+        # snapshot carries the assistant message that just finished, whose
+        # usage is the provider's ground truth for the trigger math below AND
+        # for the prompt-cache TTL hint a mid-turn aside or advisor call is
+        # stamped with. Unconditional, ahead of the compaction gate: the hint
+        # must track the conversation's size even for a host that switched
+        # mid-turn compaction off.
+        self._note_usage(messages)
         try:
             from local_operator.compaction.api import CompactionSettings
         except ImportError:
@@ -5673,13 +5688,6 @@ class Session:
         # (on), same posture as _resolve_strategy's capability probes.
         if not settings.enabled or not getattr(settings, "mid_turn_enabled", True):
             return None
-        # The post-run usage scan has not happened yet — the boundary
-        # snapshot carries the assistant message that just finished, whose
-        # usage is the provider's ground truth for the trigger math.
-        for message in reversed(messages):
-            if isinstance(message, Message) and message.usage is not None:
-                self._last_usage = message.usage
-                break
         # Cheap pre-gate: when the provider just reported its context size and
         # that figure already fails the trigger, skip the full plan — the
         # plan renders the whole history to prove the same thing, and this
@@ -7294,8 +7302,9 @@ class Session:
             # replayed except a stall retry. Inheriting the session's large
             # pre-compaction count here would send a transcript-sized prompt
             # out at the 1h rate for several dollars of pure overpayment per
-            # compaction. ``SessionStreamFn.__call__`` keeps a set hint, and
-            # the Anthropic client treats 0 as below any threshold.
+            # compaction. The stream fn passes the request's hint through
+            # untouched, and the Anthropic client treats 0 as below any
+            # threshold.
             context_tokens_hint=0,
         )
         parts: list[str] = []
@@ -7372,6 +7381,10 @@ class Session:
             # read rather than a full re-process. tool_choice stays "none".
             tools=list(self._context.tools),
             tool_choice="none",
+            # Same prefix as the turn, so the same TTL: the session stamps its
+            # own hint here because the shared stream fn holds none (a child
+            # would overwrite it — see ``ChatRequest.context_tokens_hint``).
+            context_tokens_hint=self._context_tokens_hint,
         )
         parts: list[str] = []
         async for event in self._stream_fn(request, None):
@@ -7452,6 +7465,9 @@ class Session:
             tool_choice="none",
             replayable=True,
             isolated=False,
+            # Append-only on the turn's prefix, so it shares the turn's TTL;
+            # stamped here for the reason ``complete_aside`` gives.
+            context_tokens_hint=self._context_tokens_hint,
         )
         parts: list[str] = []
         async for event in self._stream_fn(request, None):

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -374,6 +374,20 @@ SETTINGS: tuple[Setting, ...] = (
             Choice("chat_completions", "chat_completions", "explicit compatibility opt-out"),
         ),
     ),
+    Setting(
+        key="providers.anthropic.cache_ttl_1h_min_context_tokens",
+        path=("providers", "anthropic", "cache_ttl_1h_min_context_tokens"),
+        section="model",
+        label="Anthropic 1h cache above (tokens)",
+        kind=Kind.INT,
+        default=150_000,
+        help=(
+            "Context size from which Anthropic requests use the 1-hour prompt-cache "
+            "TTL (2x write cost, survives idle gaps over 5 minutes). 0 disables."
+        ),
+        minimum=0,
+        maximum=10_000_000,
+    ),
     # -- failover -----------------------------------------------------------
     Setting(
         key="retry.enabled",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.32"
+version = "0.44.33"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/analytics/test_store.py
+++ b/tests/unit/analytics/test_store.py
@@ -740,3 +740,46 @@ def test_wal_is_enabled_despite_a_busy_journal_transition(tmp_path, monkeypatch)
     assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
     conn.close()
     assert busied["n"] == 2  # and the retry was genuinely exercised, not skipped
+
+
+def test_cache_write_1h_tokens_is_recorded_and_migrated(tmp_path):
+    """The 1h slice of a cache write lands in its own ledger column, and a
+    database from before the column existed gains it on open (old rows read
+    0, which is the truth: every pre-1h write was a 5m write)."""
+    import sqlite3
+
+    db = tmp_path / "pre1h.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript(f"""
+        CREATE TABLE calls (
+          id INTEGER PRIMARY KEY AUTOINCREMENT, ts_ms INTEGER, session_id TEXT,
+          provider TEXT, model_id TEXT, ok INTEGER, input_tokens INTEGER,
+          output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER,
+          reasoning_tokens INTEGER, context_tokens INTEGER,
+          cost_micro INTEGER NOT NULL DEFAULT 0, cost_known INTEGER NOT NULL DEFAULT 0,
+          {_PRE_IMAGES_COMPONENT_COLUMNS}, c_images INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE session_names (
+          session_id TEXT PRIMARY KEY, name TEXT, updated_at_ms INTEGER
+        );
+        """)
+    conn.execute(
+        "INSERT INTO calls (ts_ms, session_id, provider, model_id, ok, input_tokens, "
+        "output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, "
+        "context_tokens) VALUES (1, 'old', 'anthropic', 'claude', 1, 1, 1, 0, 500, 0, 501)"
+    )
+    conn.commit()
+    conn.close()
+
+    store = AnalyticsStore(db)
+    import dataclasses
+
+    snap = dataclasses.replace(_snap(cache_write=300), cache_write_1h_tokens=120)
+    assert store.record_batch([snap]) == 1
+    conn = store._connect()
+    assert conn is not None
+    rows = conn.execute(
+        "SELECT session_id, cache_write_tokens, cache_write_1h_tokens FROM calls ORDER BY id"
+    ).fetchall()
+    assert rows == [("old", 500, 0), ("s1", 300, 120)]
+    store.close()

--- a/tests/unit/harness/test_jobs.py
+++ b/tests/unit/harness/test_jobs.py
@@ -164,6 +164,42 @@ def test_accumulate_usage_leaves_reported_dollar_none_when_unreported() -> None:
     assert len(job.usage.cost_components) == 2
 
 
+def test_accumulate_usage_folds_cache_write_ttl_split() -> None:
+    """The 5m/1h cache-write split folds wherever ``cache_write_tokens`` does
+    (review F4) — otherwise the job aggregate's split reads as the FIRST
+    child call's value only, and a per-rate price split silently
+    mis-reports from its first reader."""
+    from local_operator.harness.subagent import _accumulate_usage
+
+    class _Job:
+        def __init__(self, usage=None) -> None:
+            self.usage = usage
+
+    job = _Job()
+    _accumulate_usage(
+        job,
+        Usage(
+            input_tokens=1,
+            cache_write_tokens=1_000,
+            cache_write_5m_tokens=1_000,
+            cache_write_1h_tokens=0,
+        ),
+    )
+    _accumulate_usage(
+        job,
+        Usage(
+            input_tokens=1,
+            cache_write_tokens=3_000,
+            cache_write_5m_tokens=0,
+            cache_write_1h_tokens=3_000,
+        ),
+    )
+    assert job.usage is not None
+    assert job.usage.cache_write_tokens == 4_000
+    assert job.usage.cache_write_5m_tokens == 1_000
+    assert job.usage.cache_write_1h_tokens == 3_000
+
+
 def _task_row(
     job_id: str,
     *,

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -39,12 +39,14 @@ from local_operator.harness.types import (
     StreamEvent,
     StreamTextDelta,
     StreamToolCallDelta,
+    StreamUsageEvent,
     TextContent,
     ToolCallComposeEvent,
     ToolContext,
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
     ToolResult,
+    Usage,
 )
 from local_operator.providers.failover import ProviderError
 
@@ -1385,6 +1387,76 @@ class TestTheModelIsReadAtEveryCall:
             pass
 
         assert self._labels(stream) == ["test/m", "test/m"]
+
+
+class TestTheContextHintIsStampedPerRequestByTheLoop:
+    """``ChatRequest.context_tokens_hint`` is stamped by the LOOP, per call.
+
+    The hint picks the Anthropic prompt-cache TTL, and the loop is the owner
+    of the conversation its calls belong to. Two contracts (review F8/F9):
+    the host's ``get_context_tokens_hint`` is only the cross-turn SEED, and
+    once a call in this run reports ``Usage.context_tokens`` that count wins
+    for the rest of the run — a subagent is one turn for its whole life, and
+    a tool loop crosses the threshold long before the host's figure moves.
+    """
+
+    @staticmethod
+    def _three_call_stream(reported: list[int | None]) -> ScriptedStream:
+        def turn(context: int | None, more: bool) -> list[StreamEvent]:
+            events: list[StreamEvent] = []
+            if more:
+                events.append(tool_call_delta(0, id="c", name="echo", args="{}"))
+            if context is not None:
+                events.append(StreamUsageEvent(usage=Usage(input_tokens=1, context_tokens=context)))
+            events.append(StreamEndEvent(stop_reason="toolUse" if more else "stop"))
+            return events
+
+        return ScriptedStream(
+            [turn(reported[0], True), turn(reported[1], True), turn(reported[2], False)]
+        )
+
+    @staticmethod
+    def _hints(stream: ScriptedStream) -> list[int | None]:
+        return [r.context_tokens_hint for r in stream.requests]
+
+    async def _run(self, stream: ScriptedStream, **kwargs: Any) -> None:
+        executed: list[str] = []
+        context = LoopContext(system_blocks=["sys"], tools=[echo_tool(executed)])
+        async for _ in AgentLoop().run(
+            [Message.user("go")], context, make_config(stream, **kwargs), None
+        ):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_the_seed_covers_the_first_call_and_in_run_counts_take_over(self):
+        """Call 1 carries the host's seed; call N+1 carries what call N reported."""
+        stream = self._three_call_stream([160_000, 170_000, 180_000])
+
+        await self._run(stream, get_context_tokens_hint=lambda: 140_000)
+
+        assert self._hints(stream) == [140_000, 160_000, 170_000]
+
+    @pytest.mark.asyncio
+    async def test_without_a_seed_the_first_call_is_unstamped(self):
+        """No host callback (a subagent's first request, a bare embedder): the
+        client's own estimate decides call 1, and the run still learns its
+        size from call 1's report — the case the turn-boundary-only update
+        never covered."""
+        stream = self._three_call_stream([160_000, 170_000, 180_000])
+
+        await self._run(stream)
+
+        assert self._hints(stream) == [None, 160_000, 170_000]
+
+    @pytest.mark.asyncio
+    async def test_a_call_that_reports_no_count_keeps_the_last_one(self):
+        """A wire that omits ``context_tokens`` must not blank the hint —
+        that would send a large context out at 5m by the byte estimate."""
+        stream = self._three_call_stream([160_000, None, 180_000])
+
+        await self._run(stream, get_context_tokens_hint=lambda: None)
+
+        assert self._hints(stream) == [None, 160_000, 160_000]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -3213,169 +3213,213 @@ def test_anthropic_cache_ttl_threshold_setting_reads_like_openai_api() -> None:
         )
 
 
-@pytest.mark.asyncio
-async def test_session_stream_feeds_last_context_into_anthropic_ttl(tmp_path) -> None:
-    """The provider's reported context on call N picks the TTL on call N+1.
+def _anthropic_sse(context_tokens: int, *, tool_call: bool = False) -> bytes:
+    """One mocked Anthropic stream whose usage adds up to ``context_tokens``
+    (the client derives ``Usage.context_tokens`` as input + cache read +
+    cache write). ``tool_call`` ends the message in a ``tool_use`` for the
+    ``echo`` tool so the harness loop makes a second call in the SAME turn."""
+    head = (
+        b'data: {"type":"message_start","message":{"usage":{"input_tokens":5,'
+        b'"cache_read_input_tokens":' + str(context_tokens - 5).encode() + b","
+        b'"cache_creation_input_tokens":0}}}\n\n'
+    )
+    if tool_call:
+        return (
+            head + b'data: {"type":"content_block_start","index":0,"content_block":'
+            b'{"type":"tool_use","id":"tu_1","name":"echo"}}\n\n'
+            b'data: {"type":"content_block_delta","index":0,"delta":'
+            b'{"type":"input_json_delta","partial_json":"{\\"text\\":\\"x\\"}"}}\n\n'
+            b'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},'
+            b'"usage":{"output_tokens":1}}\n\n'
+        )
+    return (
+        head + b'data: {"type":"content_block_start","index":0,"content_block":'
+        b'{"type":"text","text":""}}\n\n'
+        b'data: {"type":"content_block_delta","index":0,"delta":'
+        b'{"type":"text_delta","text":"ok"}}\n\n'
+        b'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},'
+        b'"usage":{"output_tokens":1}}\n\n'
+    )
 
-    Mirrors how the session drives the hint now that the memory is
-    per-conversation (review F1): the caller registers a READER on the stream
-    fn and updates the value behind it from each final usage — exactly what
-    ``Session.__init__``/the turn boundary do. Call 1 has no hint and a tiny
-    body, so the byte estimate keeps it at 5m even though the threshold is
-    low. The mocked response reports a 200k context; call 2 (same small
-    body) then goes out with ``ttl: 1h`` on every marker. An isolated call
-    in between neither reads nor moves the hint: its response reports a
-    SMALL context (5k) and call 3 still goes 1h — so dropping the
-    reader/guard would have to fail the test, not just leave it green.
-    """
-    bodies: list[dict[str, Any]] = []
-    hint: dict[str, int | None] = {"value": None}
 
-    def handler(request: httpx.Request) -> httpx.Response:
-        body = json.loads(request.content)
-        bodies.append(body)
-        isolated = body.get("metadata", {}).get("isolation") is not None
-        # Deliberately DIFFERENT counts: 200k for the turn, 5k for the
-        # isolated errand. A mock that reports the same figure for every
-        # call cannot prove the isolated one was excluded.
-        context = 5_000 if isolated else 200_000
-        return httpx.Response(
-            200,
-            content=(
-                b'data: {"type":"message_start","message":{"usage":{"input_tokens":5,'
-                b'"cache_read_input_tokens":199995,"cache_creation_input_tokens":0,'
-                b'"context_tokens":' + str(context).encode() + b"}}}\n\n"
-                b'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},'
-                b'"usage":{"output_tokens":1}}\n\n'
-            ),
-            headers={"content-type": "text/event-stream"},
+def _cache_markers(body: dict[str, Any]) -> list[dict[str, Any]]:
+    found = [e["cache_control"] for e in body["system"] if "cache_control" in e]
+    for message in body["messages"]:
+        found.extend(b["cache_control"] for b in message["content"] if "cache_control" in b)
+    return found
+
+
+def _echo_tool():
+    from local_operator.harness.types import AgentTool, TextContent, ToolResult
+
+    async def execute(tool_call_id, args, signal, on_update, context):
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="echo", content=[TextContent(text="ok")]
         )
 
+    return AgentTool(
+        name="echo",
+        parameters={"type": "object", "properties": {"text": {"type": "string"}}},
+        execute=execute,
+    )
+
+
+def _anthropic_session(tmp_path, name: str, stream, *, blocks: list[str]):
+    """A real ``Session`` on the real stream fn — the integration under test
+    is the harness loop stamping the hint per request, so nothing here may
+    touch the hint by hand."""
+    from local_operator.session.session import Session
+    from local_operator.session.transcript import Transcript
+
+    return Session(
+        model=build_model_spec("anthropic", "claude-opus-4-8"),
+        stream_fn=stream,
+        tools=[_echo_tool()],
+        transcript=Transcript(tmp_path / name),
+        system_blocks_provider=lambda: blocks,
+    )
+
+
+def _ttl_stream(tmp_path, handler):
     store = AuthStore(tmp_path / "auth.db")
     store.upsert_credential("anthropic", {"key": "sk-ant", "source": "login"})
     settings = {"providers": {"anthropic": {"cache_ttl_1h_min_context_tokens": 150_000}}}
     stream = create_stream_fn(store, settings, session_id="session-ttl")
-    # The conversation owner (Session) registers the hint reader and moves the
-    # value behind it as usages land — the per-conversation design from F1.
-    stream.set_context_tokens_hint(lambda: hint["value"])
-    await stream._http.aclose()
     stream._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
-    spec = build_model_spec("anthropic", "claude-opus-4-8")
-    request = ChatRequest(
-        model=spec,
-        system_blocks=["instructions", "inventory", "skills", "env"],
-        messages=[Message.user("first"), Message.assistant("mid"), Message.user("second")],
+    return store, stream
+
+
+@pytest.mark.asyncio
+async def test_session_stream_feeds_last_context_into_anthropic_ttl(tmp_path) -> None:
+    """The provider's reported context on call N picks the TTL on call N+1 —
+    INSIDE the same turn, not only at the turn boundary (review F9).
+
+    A real ``Session`` drives a real stream fn; nothing sets the hint by
+    hand. Turn 1, call 1 has no hint and a tiny body, so the byte estimate
+    keeps it at 5m even though the threshold is low; the mock answers with
+    a tool call and a 200k context. Call 2 — same turn, after the tool ran
+    — goes out with ``ttl: 1h`` on every marker: a subagent is one turn for
+    its whole life and a long tool loop crosses the threshold mid-run, so a
+    hint advanced only at the turn edge would never reach either. An
+    isolated errand (``complete_once``) between the turns neither reads nor
+    moves the hint: its own body decides (5m) and its SMALL report (5k)
+    does not enter the conversation, so turn 2's first call still goes 1h
+    on the session's own 200k. Dropping the isolation guard would have to
+    fail this test, not leave it green.
+    """
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        bodies.append(body)
+        # The errand is the one request without the turn's tool schema (it
+        # carries no tools and no history). Deliberately DIFFERENT counts:
+        # 200k for the turn, 5k for the errand — a mock that reports the same
+        # figure for every call cannot prove the errand was excluded.
+        errand = not body.get("tools")
+        content = (
+            _anthropic_sse(5_000) if errand else _anthropic_sse(200_000, tool_call=len(bodies) == 1)
+        )
+        return httpx.Response(200, content=content, headers={"content-type": "text/event-stream"})
+
+    store, stream = _ttl_stream(tmp_path, handler)
+    session = _anthropic_session(
+        tmp_path, "sess", stream, blocks=["instructions", "inventory", "skills", "env"]
     )
     try:
-        await _collect_stream(stream(request, None))
-        # The turn reported 200k: move the hint the way the session does.
-        hint["value"] = 200_000
-        await _collect_stream(stream(request.model_copy(update={"isolated": True}), None))
-        await _collect_stream(stream(request, None))
+        await session.prompt("first")
+        await session.complete_once("name it", "title?")
+        await session.prompt("second")
     finally:
+        await session.dispose()
         await stream.close()
         store.close()
 
-    def markers(body: dict[str, Any]) -> list[dict[str, Any]]:
-        found = [e["cache_control"] for e in body["system"] if "cache_control" in e]
-        for message in body["messages"]:
-            found.extend(b["cache_control"] for b in message["content"] if "cache_control" in b)
-        return found
-
-    assert len(bodies) == 3
-    assert markers(bodies[0]) and all(m == {"type": "ephemeral"} for m in markers(bodies[0]))
-    # Isolated: runs while the hint says 200k, but the isolated branch skips
-    # the stamping entirely, so the small body stays 5m by the estimate.
-    assert all(m == {"type": "ephemeral"} for m in markers(bodies[1]))
-    # The turn call after it still carries the conversation's own 200k hint
-    # (the isolated 5k report never entered it) and goes 1h on every marker.
-    assert markers(bodies[2]) and all(
-        m == {"type": "ephemeral", "ttl": "1h"} for m in markers(bodies[2])
+    assert len(bodies) == 4
+    # Turn 1 / call 1: no hint yet, tiny body → 5m by the estimate.
+    assert _cache_markers(bodies[0]) and all(
+        m == {"type": "ephemeral"} for m in _cache_markers(bodies[0])
     )
+    # Turn 1 / call 2 (after the tool ran): call 1 reported 200k → 1h NOW.
+    assert bodies[1]["messages"][-1]["content"][0]["type"] == "tool_result"
+    assert _cache_markers(bodies[1]) and all(
+        m == {"type": "ephemeral", "ttl": "1h"} for m in _cache_markers(bodies[1])
+    )
+    # Isolated errand: the session's hint says 200k, but its request carries
+    # none and its small body stays 5m by the estimate.
+    assert not bodies[2].get("tools")
+    assert [b["text"] for m in bodies[2]["messages"] for b in m["content"]] == ["title?"]
+    assert all(m == {"type": "ephemeral"} for m in _cache_markers(bodies[2]))
+    # Turn 2 / call 1: the conversation's own 200k (the errand's 5k never
+    # entered it) → 1h on every marker.
+    assert _cache_markers(bodies[3]) and all(
+        m == {"type": "ephemeral", "ttl": "1h"} for m in _cache_markers(bodies[3])
+    )
+    assert session._context_tokens_hint == 200_000
 
 
 @pytest.mark.asyncio
 async def test_session_stream_hint_is_per_conversation_not_per_stream_fn(
     tmp_path,
 ) -> None:
-    """A parent and a subagent share ONE stream fn but not ONE hint (F1).
+    """A parent and a subagent share ONE stream fn but not ONE hint (F1/F8).
 
     Subagents are built with ``stream_fn=parent_session._stream_fn``, so any
-    memory held on the stream fn is shared by every child. This test drives
-    the two conversations the way the harness does — parent hint 300k,
-    child hint ``None`` — through the SAME stream fn, and asserts both sides
-    of the contamination the shared-scalar design would cause: the child's
-    first request stays 5m (no hint → its own small body decides) while the
-    parent's next request goes 1h on its own large hint. It also proves the
-    child cannot poison the parent: the child's 10k report changes nothing
-    the parent reads.
+    memory — or registered reader — on the stream fn is last-writer-wins
+    between the two conversations. Two real ``Session`` objects drive the
+    same stream fn here exactly as the harness does, with NO manual hint
+    handling anywhere: the parent works up a 300k context, a child is then
+    constructed on the same stream fn and runs its own turn (10k), and the
+    parent works again. Both directions of the contamination are asserted:
+    the child's first request stays 5m on its own small body, and the
+    parent's post-child request goes 1h on its own large hint — the round-2
+    reproduction was exactly that request dropping to 5m because the child's
+    construction had overwritten the parent's reader for good.
     """
     bodies: list[dict[str, Any]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
-        bodies.append(json.loads(request.content))
-        return httpx.Response(
-            200,
-            content=(
-                b'data: {"type":"message_start","message":{"usage":{"input_tokens":5,'
-                b'"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}\n\n'
-                b'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},'
-                b'"usage":{"output_tokens":1}}\n\n'
-            ),
-            headers={"content-type": "text/event-stream"},
-        )
+        body = json.loads(request.content)
+        bodies.append(body)
+        is_child = body["system"][0]["text"] == "child instructions"
+        content = _anthropic_sse(10_000 if is_child else 300_000)
+        return httpx.Response(200, content=content, headers={"content-type": "text/event-stream"})
 
-    store = AuthStore(tmp_path / "auth.db")
-    store.upsert_credential("anthropic", {"key": "sk-ant", "source": "login"})
-    settings = {"providers": {"anthropic": {"cache_ttl_1h_min_context_tokens": 150_000}}}
-    stream = create_stream_fn(store, settings, session_id="session-parent")
-    await stream._http.aclose()
-    stream._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
-    # Two conversations, one pipe — the parent's registered reader and the
-    # child's, exactly as Session.__init__ builds them (the child registers
-    # its own on the same stream fn object).
-    parent_hint: dict[str, int | None] = {"value": 300_000}
-    child_hint: dict[str, int | None] = {"value": None}
-    stream.set_context_tokens_hint(lambda: parent_hint["value"])
-    spec = build_model_spec("anthropic", "claude-opus-4-8")
-    parent_request = ChatRequest(
-        model=spec,
-        system_blocks=["instructions", "inventory", "skills", "env"],
-        messages=[Message.user("parent turn")],
+    store, stream = _ttl_stream(tmp_path, handler)
+    parent = _anthropic_session(
+        tmp_path, "parent", stream, blocks=["instructions", "inventory", "skills", "env"]
     )
-    child_request = ChatRequest(
-        model=spec,
-        system_blocks=["child instructions"],
-        messages=[Message.user("child errand")],
-    )
+    child = None
     try:
-        # Parent works while the child runs — same stream fn, interleaved.
-        await _collect_stream(stream(parent_request, None))
-        stream.set_context_tokens_hint(lambda: child_hint["value"])
-        await _collect_stream(stream(child_request, None))
-        stream.set_context_tokens_hint(lambda: parent_hint["value"])
-        await _collect_stream(stream(parent_request, None))
+        await parent.prompt("parent turn")
+        # The child is constructed AFTER the parent has a hint, the way a
+        # ``task`` call builds it mid-conversation, and runs on the same pipe.
+        child = _anthropic_session(tmp_path, "child", stream, blocks=["child instructions"])
+        await child.prompt("child errand")
+        await parent.prompt("parent again")
     finally:
+        if child is not None:
+            await child.dispose()
+        await parent.dispose()
         await stream.close()
         store.close()
 
-    def markers(body: dict[str, Any]) -> list[dict[str, Any]]:
-        found = [e["cache_control"] for e in body["system"] if "cache_control" in e]
-        for message in body["messages"]:
-            found.extend(b["cache_control"] for b in message["content"] if "cache_control" in b)
-        return found
-
     assert len(bodies) == 3
-    # Parent: 300k hint → 1h on every marker.
-    assert markers(bodies[0]) and all(
-        m == {"type": "ephemeral", "ttl": "1h"} for m in markers(bodies[0])
+    # Parent, first call: no hint, small body → 5m; the mock then reports 300k.
+    assert _cache_markers(bodies[0]) and all(
+        m == {"type": "ephemeral"} for m in _cache_markers(bodies[0])
     )
+    assert parent._context_tokens_hint == 300_000
     # Child (same stream fn, NO hint of its own): its small body decides and
-    # stays 5m — this is the (a) contamination the shared scalar caused.
-    assert all(m == {"type": "ephemeral"} for m in markers(bodies[1]))
-    # Parent again after the child: still 1h on its own hint, proving the
-    # child's call did not overwrite anything the parent reads — the (b)
-    # contamination (parent downgraded to 5m at the exact resume moment).
-    assert markers(bodies[2]) and all(
-        m == {"type": "ephemeral", "ttl": "1h"} for m in markers(bodies[2])
+    # stays 5m — contamination (a), the parent's 300k on a fresh ~10k prefix.
+    assert bodies[1]["system"][0]["text"] == "child instructions"
+    assert all(m == {"type": "ephemeral"} for m in _cache_markers(bodies[1]))
+    assert child is not None and child._context_tokens_hint == 10_000
+    # Parent again after the child: 1h on its OWN 300k, proving the child's
+    # construction and its 10k report changed nothing the parent reads —
+    # contamination (b), the parent downgraded to 5m at the resume moment.
+    assert bodies[2]["system"][0]["text"] == "instructions"
+    assert _cache_markers(bodies[2]) and all(
+        m == {"type": "ephemeral", "ttl": "1h"} for m in _cache_markers(bodies[2])
     )
+    assert parent._context_tokens_hint == 300_000

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -3185,3 +3185,88 @@ async def test_preflight_reuses_stale_row_when_a_peer_holds_the_lease(tmp_path) 
         await stream_a.close()
         await stream_b.close()
         store.close()
+
+
+# ---------------------------------------------------------------------------
+# Anthropic 1h prompt-cache TTL: settings → client, last usage → next request
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_cache_ttl_threshold_setting_reads_like_openai_api() -> None:
+    """Same resolution rules as ``_openai_api_mode``: missing/malformed → the
+    default, an explicit non-negative int (including the 0 off switch) wins."""
+    from local_operator.model.configure import ANTHROPIC_CACHE_TTL_1H_MIN_CONTEXT_TOKENS
+    from local_operator.model.configure import (
+        _anthropic_cache_ttl_1h_min_context_tokens as read,
+    )
+
+    assert read(None) == ANTHROPIC_CACHE_TTL_1H_MIN_CONTEXT_TOKENS
+    assert read({}) == ANTHROPIC_CACHE_TTL_1H_MIN_CONTEXT_TOKENS
+    assert read({"providers": {"openai": {"api": "responses"}}}) == (
+        ANTHROPIC_CACHE_TTL_1H_MIN_CONTEXT_TOKENS
+    )
+    assert read({"providers": {"anthropic": {"cache_ttl_1h_min_context_tokens": 0}}}) == 0
+    assert read({"providers": {"anthropic": {"cache_ttl_1h_min_context_tokens": 42}}}) == 42
+    for bad in ("150000", -1, True, None, 1.5):
+        assert read({"providers": {"anthropic": {"cache_ttl_1h_min_context_tokens": bad}}}) == (
+            ANTHROPIC_CACHE_TTL_1H_MIN_CONTEXT_TOKENS
+        )
+
+
+@pytest.mark.asyncio
+async def test_session_stream_feeds_last_context_into_anthropic_ttl(tmp_path) -> None:
+    """The provider's reported context on call N picks the TTL on call N+1.
+
+    Call 1 has no hint and a tiny body, so the byte estimate keeps it at 5m
+    even though the threshold is low. The mocked response reports a 200k
+    context; call 2 (same small body) then goes out with ``ttl: 1h`` on every
+    marker. An isolated call in between must neither read nor move the hint.
+    """
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            content=(
+                b'data: {"type":"message_start","message":{"usage":{"input_tokens":5,'
+                b'"cache_read_input_tokens":199995,"cache_creation_input_tokens":0}}}\n\n'
+                b'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},'
+                b'"usage":{"output_tokens":1}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", {"key": "sk-ant", "source": "login"})
+    settings = {"providers": {"anthropic": {"cache_ttl_1h_min_context_tokens": 150_000}}}
+    stream = create_stream_fn(store, settings, session_id="session-ttl")
+    await stream._http.aclose()
+    stream._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    spec = build_model_spec("anthropic", "claude-opus-4-8")
+    request = ChatRequest(
+        model=spec,
+        system_blocks=["instructions", "inventory", "skills", "env"],
+        messages=[Message.user("first"), Message.assistant("mid"), Message.user("second")],
+    )
+    try:
+        await _collect_stream(stream(request, None))
+        await _collect_stream(stream(request.model_copy(update={"isolated": True}), None))
+        await _collect_stream(stream(request, None))
+    finally:
+        await stream.close()
+        store.close()
+
+    def markers(body: dict[str, Any]) -> list[dict[str, Any]]:
+        found = [e["cache_control"] for e in body["system"] if "cache_control" in e]
+        for message in body["messages"]:
+            found.extend(b["cache_control"] for b in message["content"] if "cache_control" in b)
+        return found
+
+    assert len(bodies) == 3
+    assert markers(bodies[0]) and all(m == {"type": "ephemeral"} for m in markers(bodies[0]))
+    # Isolated: no hint stamped, so the small body stays 5m by the estimate.
+    assert all(m == {"type": "ephemeral"} for m in markers(bodies[1]))
+    assert markers(bodies[2]) and all(
+        m == {"type": "ephemeral", "ttl": "1h"} for m in markers(bodies[2])
+    )

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -3217,20 +3217,34 @@ def test_anthropic_cache_ttl_threshold_setting_reads_like_openai_api() -> None:
 async def test_session_stream_feeds_last_context_into_anthropic_ttl(tmp_path) -> None:
     """The provider's reported context on call N picks the TTL on call N+1.
 
-    Call 1 has no hint and a tiny body, so the byte estimate keeps it at 5m
-    even though the threshold is low. The mocked response reports a 200k
-    context; call 2 (same small body) then goes out with ``ttl: 1h`` on every
-    marker. An isolated call in between must neither read nor move the hint.
+    Mirrors how the session drives the hint now that the memory is
+    per-conversation (review F1): the caller registers a READER on the stream
+    fn and updates the value behind it from each final usage — exactly what
+    ``Session.__init__``/the turn boundary do. Call 1 has no hint and a tiny
+    body, so the byte estimate keeps it at 5m even though the threshold is
+    low. The mocked response reports a 200k context; call 2 (same small
+    body) then goes out with ``ttl: 1h`` on every marker. An isolated call
+    in between neither reads nor moves the hint: its response reports a
+    SMALL context (5k) and call 3 still goes 1h — so dropping the
+    reader/guard would have to fail the test, not just leave it green.
     """
     bodies: list[dict[str, Any]] = []
+    hint: dict[str, int | None] = {"value": None}
 
     def handler(request: httpx.Request) -> httpx.Response:
-        bodies.append(json.loads(request.content))
+        body = json.loads(request.content)
+        bodies.append(body)
+        isolated = body.get("metadata", {}).get("isolation") is not None
+        # Deliberately DIFFERENT counts: 200k for the turn, 5k for the
+        # isolated errand. A mock that reports the same figure for every
+        # call cannot prove the isolated one was excluded.
+        context = 5_000 if isolated else 200_000
         return httpx.Response(
             200,
             content=(
                 b'data: {"type":"message_start","message":{"usage":{"input_tokens":5,'
-                b'"cache_read_input_tokens":199995,"cache_creation_input_tokens":0}}}\n\n'
+                b'"cache_read_input_tokens":199995,"cache_creation_input_tokens":0,'
+                b'"context_tokens":' + str(context).encode() + b"}}}\n\n"
                 b'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},'
                 b'"usage":{"output_tokens":1}}\n\n'
             ),
@@ -3241,6 +3255,9 @@ async def test_session_stream_feeds_last_context_into_anthropic_ttl(tmp_path) ->
     store.upsert_credential("anthropic", {"key": "sk-ant", "source": "login"})
     settings = {"providers": {"anthropic": {"cache_ttl_1h_min_context_tokens": 150_000}}}
     stream = create_stream_fn(store, settings, session_id="session-ttl")
+    # The conversation owner (Session) registers the hint reader and moves the
+    # value behind it as usages land — the per-conversation design from F1.
+    stream.set_context_tokens_hint(lambda: hint["value"])
     await stream._http.aclose()
     stream._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     spec = build_model_spec("anthropic", "claude-opus-4-8")
@@ -3251,6 +3268,8 @@ async def test_session_stream_feeds_last_context_into_anthropic_ttl(tmp_path) ->
     )
     try:
         await _collect_stream(stream(request, None))
+        # The turn reported 200k: move the hint the way the session does.
+        hint["value"] = 200_000
         await _collect_stream(stream(request.model_copy(update={"isolated": True}), None))
         await _collect_stream(stream(request, None))
     finally:
@@ -3265,8 +3284,98 @@ async def test_session_stream_feeds_last_context_into_anthropic_ttl(tmp_path) ->
 
     assert len(bodies) == 3
     assert markers(bodies[0]) and all(m == {"type": "ephemeral"} for m in markers(bodies[0]))
-    # Isolated: no hint stamped, so the small body stays 5m by the estimate.
+    # Isolated: runs while the hint says 200k, but the isolated branch skips
+    # the stamping entirely, so the small body stays 5m by the estimate.
     assert all(m == {"type": "ephemeral"} for m in markers(bodies[1]))
+    # The turn call after it still carries the conversation's own 200k hint
+    # (the isolated 5k report never entered it) and goes 1h on every marker.
+    assert markers(bodies[2]) and all(
+        m == {"type": "ephemeral", "ttl": "1h"} for m in markers(bodies[2])
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_stream_hint_is_per_conversation_not_per_stream_fn(
+    tmp_path,
+) -> None:
+    """A parent and a subagent share ONE stream fn but not ONE hint (F1).
+
+    Subagents are built with ``stream_fn=parent_session._stream_fn``, so any
+    memory held on the stream fn is shared by every child. This test drives
+    the two conversations the way the harness does — parent hint 300k,
+    child hint ``None`` — through the SAME stream fn, and asserts both sides
+    of the contamination the shared-scalar design would cause: the child's
+    first request stays 5m (no hint → its own small body decides) while the
+    parent's next request goes 1h on its own large hint. It also proves the
+    child cannot poison the parent: the child's 10k report changes nothing
+    the parent reads.
+    """
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            content=(
+                b'data: {"type":"message_start","message":{"usage":{"input_tokens":5,'
+                b'"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}\n\n'
+                b'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},'
+                b'"usage":{"output_tokens":1}}\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", {"key": "sk-ant", "source": "login"})
+    settings = {"providers": {"anthropic": {"cache_ttl_1h_min_context_tokens": 150_000}}}
+    stream = create_stream_fn(store, settings, session_id="session-parent")
+    await stream._http.aclose()
+    stream._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    # Two conversations, one pipe — the parent's registered reader and the
+    # child's, exactly as Session.__init__ builds them (the child registers
+    # its own on the same stream fn object).
+    parent_hint: dict[str, int | None] = {"value": 300_000}
+    child_hint: dict[str, int | None] = {"value": None}
+    stream.set_context_tokens_hint(lambda: parent_hint["value"])
+    spec = build_model_spec("anthropic", "claude-opus-4-8")
+    parent_request = ChatRequest(
+        model=spec,
+        system_blocks=["instructions", "inventory", "skills", "env"],
+        messages=[Message.user("parent turn")],
+    )
+    child_request = ChatRequest(
+        model=spec,
+        system_blocks=["child instructions"],
+        messages=[Message.user("child errand")],
+    )
+    try:
+        # Parent works while the child runs — same stream fn, interleaved.
+        await _collect_stream(stream(parent_request, None))
+        stream.set_context_tokens_hint(lambda: child_hint["value"])
+        await _collect_stream(stream(child_request, None))
+        stream.set_context_tokens_hint(lambda: parent_hint["value"])
+        await _collect_stream(stream(parent_request, None))
+    finally:
+        await stream.close()
+        store.close()
+
+    def markers(body: dict[str, Any]) -> list[dict[str, Any]]:
+        found = [e["cache_control"] for e in body["system"] if "cache_control" in e]
+        for message in body["messages"]:
+            found.extend(b["cache_control"] for b in message["content"] if "cache_control" in b)
+        return found
+
+    assert len(bodies) == 3
+    # Parent: 300k hint → 1h on every marker.
+    assert markers(bodies[0]) and all(
+        m == {"type": "ephemeral", "ttl": "1h"} for m in markers(bodies[0])
+    )
+    # Child (same stream fn, NO hint of its own): its small body decides and
+    # stays 5m — this is the (a) contamination the shared scalar caused.
+    assert all(m == {"type": "ephemeral"} for m in markers(bodies[1]))
+    # Parent again after the child: still 1h on its own hint, proving the
+    # child's call did not overwrite anything the parent reads — the (b)
+    # contamination (parent downgraded to 5m at the exact resume moment).
     assert markers(bodies[2]) and all(
         m == {"type": "ephemeral", "ttl": "1h"} for m in markers(bodies[2])
     )

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -3566,3 +3566,206 @@ def test_google_function_calling_mode_maps_auto_and_required() -> None:
             )
         )
         assert body["toolConfig"]["functionCallingConfig"]["mode"] == mode
+
+
+# ---------------------------------------------------------------------------
+# Anthropic 1-hour prompt-cache TTL for large contexts
+# ---------------------------------------------------------------------------
+
+
+def _every_cache_control(body: dict[str, Any]) -> list[dict[str, Any]]:
+    """Every ``cache_control`` marker in a body, system blocks and messages.
+
+    The wire constraint is request-wide (a 1h marker may not follow a 5m one),
+    so the assertions below inspect EVERY marker rather than sampling one.
+    """
+    markers = [e["cache_control"] for e in body.get("system", []) if "cache_control" in e]
+    for message in body["messages"]:
+        content = message.get("content")
+        if isinstance(content, list):
+            markers.extend(b["cache_control"] for b in content if "cache_control" in b)
+    return markers
+
+
+def _large_context_request() -> ChatRequest:
+    return ChatRequest(
+        model=_spec(provider="anthropic"),
+        system_blocks=["instructions", "inventory", "skills", "env"],
+        messages=[Message.user("first"), Message.assistant("mid"), Message.user("second")],
+    )
+
+
+def test_anthropic_ttl_off_sends_no_ttl_keys() -> None:
+    """Threshold 0 (and the constructor default) keeps the historical body:
+    markers exist, none carries a ``ttl`` — even with a huge hint."""
+    request = _large_context_request().model_copy(update={"context_tokens_hint": 900_000})
+    for client in (AnthropicClient(), AnthropicClient(cache_ttl_1h_min_context_tokens=0)):
+        body = client._build_body(request)
+        markers = _every_cache_control(body)
+        assert markers, "the breakpoint policy itself must be untouched"
+        assert all(m == {"type": "ephemeral"} for m in markers)
+        assert "ttl" not in json.dumps(body)
+
+
+def test_anthropic_ttl_hint_above_threshold_marks_every_breakpoint_1h() -> None:
+    """Above the threshold EVERY marker carries ``ttl: 1h`` and none is 5m —
+    Anthropic rejects a 1h entry that follows a shorter one."""
+    client = AnthropicClient(cache_ttl_1h_min_context_tokens=150_000)
+    request = _large_context_request().model_copy(update={"context_tokens_hint": 150_000})
+    body = client._build_body(request, oauth=True)
+    markers = _every_cache_control(body)
+    assert len(markers) >= 3  # system head + last message + previous user turn
+    assert all(m == {"type": "ephemeral", "ttl": "1h"} for m in markers)
+
+
+def test_anthropic_ttl_hint_below_threshold_stays_5m() -> None:
+    client = AnthropicClient(cache_ttl_1h_min_context_tokens=150_000)
+    request = _large_context_request().model_copy(update={"context_tokens_hint": 149_999})
+    markers = _every_cache_control(client._build_body(request))
+    assert markers and all(m == {"type": "ephemeral"} for m in markers)
+
+
+def test_anthropic_ttl_without_hint_falls_back_to_byte_estimate() -> None:
+    """No hint (first call, fork) → ``len(json)/4`` decides. A 2 KB body reads
+    as ~500 tokens; the same body with a 4k-token threshold stays 5m and with
+    a 100-token threshold goes 1h, so the estimate is what flipped it."""
+    request = ChatRequest(
+        model=_spec(provider="anthropic"),
+        system_blocks=["x" * 1_000, "inventory", "skills", "env"],
+        messages=[Message.user("a" * 1_000), Message.assistant("mid"), Message.user("second")],
+    )
+    assert request.context_tokens_hint is None
+    small_threshold = AnthropicClient(cache_ttl_1h_min_context_tokens=100)
+    assert all(
+        m == {"type": "ephemeral", "ttl": "1h"}
+        for m in _every_cache_control(small_threshold._build_body(request))
+    )
+    big_threshold = AnthropicClient(cache_ttl_1h_min_context_tokens=4_000)
+    assert all(
+        m == {"type": "ephemeral"} for m in _every_cache_control(big_threshold._build_body(request))
+    )
+
+
+def test_anthropic_ttl_estimate_counts_tools_too() -> None:
+    """Tools sit at position 0 of the cached prefix, so the byte estimate has
+    to include them: a tool-heavy first request must not be undercounted."""
+    tools = [
+        AgentTool(
+            name=f"tool{i}",
+            description="d" * 400,
+            parameters={"type": "object", "properties": {}},
+            execute=_aside_execute,
+        )
+        for i in range(10)
+    ]
+    slim = ChatRequest(
+        model=_spec(provider="anthropic"),
+        system_blocks=["instructions", "inventory", "skills", "env"],
+        messages=[Message.user("first"), Message.assistant("mid"), Message.user("second")],
+    )
+    heavy = slim.model_copy(update={"tools": tools})
+    client = AnthropicClient(cache_ttl_1h_min_context_tokens=800)
+    assert all(m == {"type": "ephemeral"} for m in _every_cache_control(client._build_body(slim)))
+    assert all(
+        m == {"type": "ephemeral", "ttl": "1h"}
+        for m in _every_cache_control(client._build_body(heavy))
+    )
+
+
+def test_anthropic_ttl_keeps_the_breakpoint_budget() -> None:
+    """The TTL rides on the existing markers; it must not add any. Nine system
+    blocks + two message targets still fit MAX_CACHE_BREAKPOINTS."""
+    client = AnthropicClient(cache_ttl_1h_min_context_tokens=1)
+    request = ChatRequest(
+        model=_spec(provider="anthropic"),
+        system_blocks=[f"block-{i}" for i in range(9)],
+        messages=[Message.user("first"), Message.assistant("mid"), Message.user("second")],
+        context_tokens_hint=500_000,
+    )
+    markers = _every_cache_control(client._build_body(request, oauth=True))
+    assert len(markers) == AnthropicClient.MAX_CACHE_BREAKPOINTS
+    assert all(m["ttl"] == "1h" for m in markers)
+    rendered = AnthropicClient._system_blocks([f"b{i}" for i in range(9)], ttl="1h")
+    assert sum("cache_control" in b for b in rendered) == AnthropicClient.MAX_CACHE_BREAKPOINTS
+
+
+def test_client_for_spec_passes_anthropic_ttl_threshold() -> None:
+    client = client_for_spec(
+        _spec(provider="anthropic", model_id="claude-opus-4-8"),
+        anthropic_cache_ttl_1h_min_context_tokens=123_456,
+    )
+    assert isinstance(client, AnthropicClient)
+    assert client._cache_ttl_1h_min_context_tokens == 123_456
+
+
+async def test_anthropic_usage_parses_cache_creation_ttl_split() -> None:
+    """``usage.cache_creation`` splits the write count by TTL; both slices land
+    on the Usage event and the sum still equals ``cache_write_tokens``."""
+    body = _sse(
+        [
+            {
+                "type": "message_start",
+                "message": {
+                    "usage": {
+                        "input_tokens": 10,
+                        "cache_read_input_tokens": 1_800,
+                        "cache_creation_input_tokens": 248,
+                        "cache_creation": {
+                            "ephemeral_5m_input_tokens": 148,
+                            "ephemeral_1h_input_tokens": 100,
+                        },
+                    }
+                },
+            },
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text"}},
+            {"type": "content_block_delta", "index": 0, "delta": {"text": "ok"}},
+            {"type": "message_delta", "delta": {"stop_reason": "end_turn"}},
+        ]
+    )
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200, content=body, headers={"content-type": "text/event-stream"}
+        )
+    )
+    client = AnthropicClient(http_client=httpx.AsyncClient(transport=transport))
+    events = await _collect(
+        client.stream(
+            ChatRequest(model=_spec(provider="anthropic"), messages=[Message.user("hi")]), "sk-ant"
+        )
+    )
+    usage = [e for e in events if isinstance(e, StreamEndEvent)][-1].usage
+    assert usage is not None
+    assert usage.cache_write_tokens == 248
+    assert usage.cache_write_5m_tokens == 148
+    assert usage.cache_write_1h_tokens == 100
+    assert usage.cache_write_5m_tokens + usage.cache_write_1h_tokens == usage.cache_write_tokens
+    assert usage.context_tokens == 10 + 1_800 + 248
+
+
+async def test_anthropic_usage_without_cache_creation_object_leaves_split_zero() -> None:
+    """Older API versions omit the object; the split must read 0, not raise."""
+    body = _sse(
+        [
+            {
+                "type": "message_start",
+                "message": {"usage": {"input_tokens": 5, "cache_creation_input_tokens": 40}},
+            },
+            {"type": "message_delta", "delta": {"stop_reason": "end_turn"}},
+        ]
+    )
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200, content=body, headers={"content-type": "text/event-stream"}
+        )
+    )
+    client = AnthropicClient(http_client=httpx.AsyncClient(transport=transport))
+    events = await _collect(
+        client.stream(
+            ChatRequest(model=_spec(provider="anthropic"), messages=[Message.user("hi")]), "sk-ant"
+        )
+    )
+    usage = [e for e in events if isinstance(e, StreamEndEvent)][-1].usage
+    assert usage is not None
+    assert usage.cache_write_tokens == 40
+    assert usage.cache_write_5m_tokens == 0
+    assert usage.cache_write_1h_tokens == 0

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -3646,6 +3646,57 @@ def test_anthropic_ttl_without_hint_falls_back_to_byte_estimate() -> None:
     )
 
 
+def test_anthropic_ttl_estimate_excludes_base64_image_payloads() -> None:
+    """The fallback byte estimate must not count base64 image data (F3).
+
+    Anthropic bills an image by pixel area (~≤1.6k tokens), not by the bytes
+    its base64 spelling takes in the serialized body. A naive ``len(json)/4``
+    turns one ~1 MB screenshot into ~330k \"tokens\" and flips an image-bearing
+    first/fork request to 1h on a prompt that is really tiny. The estimate
+    swaps each image payload for a flat per-image allowance instead, wherever
+    the image sits (message content or tool-result content)."""
+    image = ImageContent(data="a" * 1_400_000, mime_type="image/png")  # ~1 MB decoded
+    with_image = ChatRequest(
+        model=_spec(provider="anthropic"),
+        system_blocks=["instructions", "inventory", "skills", "env"],
+        messages=[Message.user("first"), Message.assistant("mid"), Message.user("second")],
+    ).model_copy(
+        update={"messages": [Message(role="user", content=[TextContent(text="look"), image])]}
+    )
+    without_image = with_image.model_copy(update={"messages": [Message.user("look")]})
+    two_images = with_image.model_copy(
+        update={
+            "messages": [Message(role="user", content=[TextContent(text="look"), image, image])]
+        }
+    )
+    # Sanity: the payload is what dominates the serialized bytes — dropping it
+    # must shrink the body by two orders of magnitude, or the test proves
+    # nothing about the estimate.
+    client = AnthropicClient()
+    with_bytes = len(json.dumps(client._build_body(with_image), default=str))
+    without_bytes = len(json.dumps(client._build_body(without_image), default=str))
+    assert with_bytes > 100 * without_bytes
+
+    # Threshold the naive estimate would blow past (1.4M base64 chars / 4 ≈
+    # 350k \"tokens\") but the real prompt (~1.6k for the image + a tiny body)
+    # cannot reach: the request stays 5m.
+    stayed_5m = AnthropicClient(cache_ttl_1h_min_context_tokens=50_000)
+    markers = _every_cache_control(stayed_5m._build_body(with_image))
+    assert markers and all(m == {"type": "ephemeral"} for m in markers)
+    # The allowance itself is counted, not just dropped: two images (2 x 1.6k
+    # + body ≈ 3.3k) clear a 3k bar while the single-image body (≈1.7k) does
+    # not — the estimate stays order-correct in image count.
+    low_bar = AnthropicClient(cache_ttl_1h_min_context_tokens=3_300)
+    assert all(
+        m == {"type": "ephemeral"} for m in _every_cache_control(low_bar._build_body(with_image))
+    )
+    tipped = AnthropicClient(cache_ttl_1h_min_context_tokens=3_000)
+    assert all(
+        m == {"type": "ephemeral", "ttl": "1h"}
+        for m in _every_cache_control(tipped._build_body(two_images))
+    )
+
+
 def test_anthropic_ttl_estimate_counts_tools_too() -> None:
     """Tools sit at position 0 of the cached prefix, so the byte estimate has
     to include them: a tool-heavy first request must not be undercounted."""

--- a/tests/unit/session/test_aside.py
+++ b/tests/unit/session/test_aside.py
@@ -209,6 +209,28 @@ async def test_complete_aside_reports_what_it_spent(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_complete_aside_carries_the_conversations_context_hint(tmp_path) -> None:
+    """An aside rides the turn's cached prefix, so it must carry the turn's
+    ``context_tokens_hint`` — stamped by the SESSION, because the shared
+    stream fn holds no per-conversation memory (review F8). The hint here is
+    the one the turn's last call reported, not a figure set by hand."""
+    stream = RecordingStream(
+        [
+            StreamUsageEvent(usage=Usage(input_tokens=200_000, context_tokens=200_000)),
+            StreamEndEvent(stop_reason="stop"),
+        ]
+    )
+    session = make_session(tmp_path, stream)
+    await session.prompt("work")
+    assert stream.requests[0].context_tokens_hint is None  # nothing reported yet
+
+    await session.complete_aside([Message.user("why?")])
+
+    assert stream.requests[1].context_tokens_hint == 200_000
+    await session.dispose()
+
+
+@pytest.mark.asyncio
 async def test_adopt_aside_writes_to_both_the_context_and_the_transcript(tmp_path) -> None:
     """Forking is the door out, so it has to land where a resume will find it."""
     session = make_session(tmp_path, RecordingStream())

--- a/tests/unit/session/test_frontend_state.py
+++ b/tests/unit/session/test_frontend_state.py
@@ -196,6 +196,35 @@ def test_usage_join_and_turn_end_does_not_double_count_mixed_calls() -> None:
     ]
 
 
+def test_usage_join_folds_cache_write_ttl_split() -> None:
+    """The frontend's turn-end usage join folds the 5m/1h cache-write split
+    wherever it folds ``cache_write_tokens`` (review F4) — the split prices
+    differently (1.25x vs 2x base), so a join that dropped it would read as
+    zero from its first reader."""
+    from local_operator.session.frontend_state import _aggregate_usage
+
+    aggregate = _aggregate_usage(
+        [
+            Usage(
+                input_tokens=1,
+                cache_write_tokens=1_000,
+                cache_write_5m_tokens=1_000,
+                context_tokens=200_000,
+            ),
+            Usage(
+                input_tokens=1,
+                cache_write_tokens=3_000,
+                cache_write_1h_tokens=3_000,
+                context_tokens=210_000,
+            ),
+        ]
+    )
+    assert aggregate.cache_write_tokens == 4_000
+    assert aggregate.cache_write_5m_tokens == 1_000
+    assert aggregate.cache_write_1h_tokens == 3_000
+    assert aggregate.context_tokens == 210_000
+
+
 def test_subagent_progress_defers_job_publication_to_the_coalescer(monkeypatch) -> None:
     """A raw progress edge neither rescans nor publishes canonical state itself.
 

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -32,6 +32,7 @@ from local_operator.harness.types import (
     StreamEvent,
     StreamTextDelta,
     StreamToolCallDelta,
+    StreamUsageEvent,
     TextContent,
     ToolCall,
     ToolResult,
@@ -2641,6 +2642,67 @@ async def test_mid_turn_compaction_disabled_by_setting(tmp_path, monkeypatch):
     assert "mid-turn" not in reasons
     compactions = [e for e in session._transcript.entries() if e.type == "compaction"]
     assert len(compactions) <= 1
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_context_hint_advances_at_every_boundary_even_with_mid_turn_compaction_off(
+    tmp_path,
+):
+    """The prompt-cache TTL hint moves with ``_last_usage`` at the tool-loop
+    boundary, and that update is NOT gated on mid-turn compaction (review
+    F9): with ``mid_turn_enabled=False`` a session's asides and advisor
+    calls during a long tool run would otherwise be stamped with the
+    previous TURN's count. The boundary hook fires AFTER a tool batch lands,
+    so the tool that runs after call 1 still sees no hint, the one after
+    call 2 sees call 1's 200k, and every request the loop builds is stamped
+    from the previous call of the same run.
+    """
+    seen_by_tool: list[int | None] = []
+
+    def call(context_tokens: int, *, more: bool) -> list[StreamEvent]:
+        events: list[StreamEvent] = []
+        if more:
+            events.append(StreamToolCallDelta(index=0, id="c", name="peek", argument_delta="{}"))
+        events.append(
+            StreamUsageEvent(
+                usage=Usage(input_tokens=context_tokens, context_tokens=context_tokens)
+            )
+        )
+        events.append(StreamEndEvent(stop_reason="toolUse" if more else "stop"))
+        return events
+
+    stream = ScriptedStream(
+        [call(200_000, more=True), call(210_000, more=True), call(220_000, more=False)]
+    )
+    holder: dict[str, Session] = {}
+
+    async def peek(tool_call_id, args, signal, on_update, context):
+        seen_by_tool.append(holder["session"]._context_tokens_hint)
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="peek", content=[TextContent(text="ok")]
+        )
+
+    tool = AgentTool(name="peek", parameters={"type": "object"}, execute=peek)
+    session = make_session(
+        tmp_path,
+        stream,
+        tools=[tool],
+        compaction_settings=CompactionSettings(mid_turn_enabled=False),
+    )
+    holder["session"] = session
+    assert session._context_tokens_hint is None
+
+    await session.prompt("go")
+
+    # The boundary hook advanced the session's hint after call 1 even though
+    # its compaction half was switched off (the second tool run saw 200k)...
+    assert seen_by_tool == [None, 200_000]
+    # ...the loop stamped each request from the previous call of THIS run, and
+    # the post-run scan left the session on the final count as the next
+    # turn's seed.
+    assert [r.context_tokens_hint for r in stream.requests] == [None, 200_000, 210_000]
+    assert session._context_tokens_hint == 220_000
     await session.dispose()
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -59,7 +59,10 @@ def test_config_manager_initialization(temp_config_dir):
     assert config_manager.get_config_value("conversation_length") == DEFAULT_CONFIG.get_value(
         "conversation_length"
     )
-    assert config_manager.get_config_value("providers") == {"openai": {"api": "responses"}}
+    assert config_manager.get_config_value("providers") == {
+        "openai": {"api": "responses"},
+        "anthropic": {"cache_ttl_1h_min_context_tokens": 150_000},
+    }
 
 
 def test_config_managers_do_not_share_nested_defaults(temp_config_dir):
@@ -194,7 +197,10 @@ def test_config_manager_load_partial_values(temp_config_dir):
         "detail_length"
     )
     assert config_manager.get_config_value("model_name") == DEFAULT_CONFIG.get_value("model_name")
-    assert config_manager.get_config_value("providers") == {"openai": {"api": "responses"}}
+    assert config_manager.get_config_value("providers") == {
+        "openai": {"api": "responses"},
+        "anthropic": {"cache_ttl_1h_min_context_tokens": 150_000},
+    }
 
 
 def test_config_manager_update_config(temp_config_dir):

--- a/tests/unit/test_settings_io.py
+++ b/tests/unit/test_settings_io.py
@@ -38,6 +38,7 @@ def _consumer_defaults() -> dict[str, object]:
     """
     from local_operator.compaction.thresholds import CompactionSettings
     from local_operator.harness.jobs import DEFAULT_MAX_RUNNING_JOBS
+    from local_operator.model.configure import ANTHROPIC_CACHE_TTL_1H_MIN_CONTEXT_TOKENS
     from local_operator.providers.failover import (
         CONNECTIVITY_BACKOFF_CAP_MS,
         CONNECTIVITY_MAX_RETRIES,
@@ -71,6 +72,12 @@ def _consumer_defaults() -> dict[str, object]:
         "retry.fallbackChains": dict(retry.fallback_chains),
         "subagents.max_running": DEFAULT_MAX_RUNNING_JOBS,
         "providers.openai.api": DEFAULT_CONFIG.values["providers"]["openai"]["api"],
+        # The client-side constant is the real consumer (``_anthropic_cache_ttl_
+        # 1h_min_context_tokens`` restates it for a settings mapping without the
+        # key); the config default is checked against the same constant below.
+        "providers.anthropic.cache_ttl_1h_min_context_tokens": (
+            ANTHROPIC_CACHE_TTL_1H_MIN_CONTEXT_TOKENS
+        ),
         # The fork keys have REAL single-value consumers — the constants
         # ``/fork`` itself reads — so they are mapped here rather than
         # allow-listed. An allow-list entry would buy a green test while leaving

--- a/tests/unit/tui/test_settings_view.py
+++ b/tests/unit/tui/test_settings_view.py
@@ -4096,9 +4096,15 @@ async def test_click_selects_a_row_without_arming_a_text_selection() -> None:
         before = view._selected
 
         body = view._body
-        # A row several lines down in the body, resolved to a settable row.
+        # Aim at the first selectable row that is NOT the cursor's, looked up
+        # from the painted rows rather than a fixed body line: the list is one
+        # line per row and grows whenever a setting is added, so a hard-coded
+        # offset silently lands on a section header (which `on_click` rightly
+        # ignores) and the assertion below reads as a product regression.
+        target = next(i for i, row in enumerate(view._rows) if row.selectable and i != before)
         x = body.region.x + 6
-        y = body.region.y + 5
+        y = body.region.y + target - body.scroll_offset.y
+        assert body.region.contains(x, y), "target row is not on screen"
         await pilot._post_mouse_events(
             [events.MouseDown, events.MouseUp, events.Click], offset=(x, y), button=1
         )


### PR DESCRIPTION
## Summary of Changes

**Feature (C1 standard / pre-authorized):** on the Anthropic wire, once a session's context is large, every prompt-cache marker carries the 1-hour TTL (`cache_control: {type: ephemeral, ttl: "1h"}`) instead of the default 5 minutes.

Why: a 5m entry expires while a 150k–500k session idles 6–25 minutes waiting on subagents, wakes or the user, and its next call rewrites the WHOLE prefix at 1.25× base. A 1h write costs 2× base but survives the gap. Measured over 24h on this harness's own traffic (`~/.local-operator/analytics.db`): **276 TTL-expiry rewrites of >150k contexts = 89.5M write tokens ≈ 112M base-equivalent avoided**, versus **14.7M incremental writes on those contexts ≈ 11M base-equivalent extra at 2×** — roughly a 10:1 trade.

- **Threshold setting** `providers.anthropic.cache_ttl_1h_min_context_tokens` (default `150000`; `0` disables). Read in `SessionStreamFn._client_for` via `_anthropic_cache_ttl_1h_min_context_tokens` — the same path/shape as `_openai_api_mode` for `providers.openai.api` — and passed through `client_for_spec(anthropic_cache_ttl_1h_min_context_tokens=…)` to `AnthropicClient`. Registered in `settings_io` so `/settings` can edit it. Bare `AnthropicClient()` defaults to OFF, so scripts/tests send the historical body.
- **One TTL per request.** Anthropic's "Mixing different TTLs" rule: a 1h entry must appear before any 5m entry, so `_cache_ttl_for` decides once and BOTH `_system_blocks` and `_message_cache_breakpoints` render every marker with it. The marker count and `MAX_CACHE_BREAKPOINTS=4` budget are unchanged — the TTL rides on the existing markers.
- **Context size**: new optional `ChatRequest.context_tokens_hint`, stamped per request by the OWNER of the call — never remembered on the shared `SessionStreamFn`, which only passes it through. The harness loop seeds a run from `LoopConfig.get_context_tokens_hint` (the session's last provider-reported `Usage.context_tokens`, also seeded from the transcript on resume) and, once a call in the run reports a count, prefers that for every later request of the same run — so call N+1 of a tool loop goes 1h as soon as call N crosses the threshold, and a subagent (one turn for its whole life) learns its own size (review F8/F9). `Session.complete_aside`/`advise_compaction` stamp the session's own hint; the compaction summary errand pins `context_tokens_hint=0` because its write-once prompt gains nothing from 1h markers (review F2); the isolated naming errand carries none. When absent (first call, fork's first request) the client falls back to a byte estimate of the serialized body (`len(json) // 4`, with base64 image payloads excluded and a 1.6k-token floor per image), computed after system, tools and messages are in the body. Because nothing per-conversation lives on the stream fn, subagents sharing the parent's stream fn can neither inherit nor poison the parent's hint (review F1/F8). No hysteresis: the threshold flips one way as context grows; dropping back to 5m after compaction is fine (the compacted prefix is new content either way) — documented in the method docstring.
- **Usage split**: `Usage.cache_write_5m_tokens` / `cache_write_1h_tokens` parsed from `usage.cache_creation.ephemeral_{5m,1h}_input_tokens` (subsets of `cache_write_tokens`, per the docs' "sum" statement); folded in `harness/jobs.py`; recorded to a new migrated `calls.cache_write_1h_tokens` ledger column (`_MIGRATION_COLUMNS`, old rows read 0 which is true for them).
- Version `0.44.27 → 0.44.30` (patch: small self-contained feature). **Three sibling PRs were assigned 0.44.28/29/30 up front; the merger re-sequences if the merge order differs.**

**Follow-up (not in this PR):** `price_snapshot` / `cost_for_usage` still price ALL cache writes at the 5m rate (1.25×); the new column is what makes a split rate possible. Likewise, `cache_write_1h_tokens` is a **90-day raw-ledger diagnostic** (the `calls` table), deliberately not threaded into `usage_daily`/`usage_monthly` or the read projection: the rollup tables have no ALTER-migration path (unlike `calls`' `_MIGRATION_COLUMNS`), so adding a measure there is a schema change of its own — tracked as a follow-up (review F5); within the ledger window the trade is answerable via raw SQL on the column.

## Related Issue(s)

- Related: prompt-cache cost analysis (sibling PRs: advisor/aside `tool_choice` cache split, usage-aware account selection).

## Impact

- No breaking changes, no dependency updates.
- Requests below the threshold (and with the feature off) are byte-identical to before: the 5m marker still omits the `ttl` key.
- Analytics DB gains one column via the existing idempotent `ALTER TABLE` migration path.
- Cost: +2× vs 1.25× on incremental writes for contexts ≥150k; −1.25× × prefix on every avoided expiry rewrite.

## Testing Details

### Live verification against api.anthropic.com (OAuth credential from the shared store, `claude-haiku-4-5`, no extra `anthropic-beta` header needed — only `oauth-2025-04-20` was sent)

**1. 1h TTL accepted on OAuth (HTTP 200) and reported as a 1h write:**
```
status 200
beta header sent: oauth-2025-04-20
usage: {"input_tokens": 10, "cache_creation_input_tokens": 6623, "cache_read_input_tokens": 0,
        "cache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 6623}, "output_tokens": 5}
```
(A first attempt with a ~700-token system block returned 200 with all-zero cache counters — below haiku's 4096-token cache minimum, not a TTL problem.)

**2. Timed pair: same prefix 370 s later — 1h READ vs 5m REWRITE** (`/tmp/lop-1h-probe/evidence.py`, both arms same size, same account):
```
[22:50:40] 1h WRITE:            cache_creation_input_tokens=6627  cache_read=0   cache_creation={5m:0, 1h:6627}
[22:50:41] 5m WRITE (control):  cache_creation_input_tokens=6627  cache_read=0   cache_creation={5m:6627, 1h:0}
sleeping 370s
[22:56:52] 1h READ after 370s:  cache_creation_input_tokens=0     cache_read=6627  cache_creation={5m:0, 1h:0}
[22:56:53] 5m after 370s:       cache_creation_input_tokens=6627  cache_read=0     cache_creation={5m:6627, 1h:0}
```
The 1h entry served a full-prefix read after 6 min 12 s; the 5m entry had expired and was rewritten in full.

(A first run of this pair 429'd on the reads — `"This request would exceed your account's rate limit"` — because the sticky account pick landed on a row at 100% of its 5h window; rerun pinned to the credential at 9%.)

**3. Real client path** (`client_for_spec(..., anthropic_cache_ttl_1h_min_context_tokens=150_000)` + `AnthropicClient.stream` with `context_tokens_hint=200_000`):
```
markers on wire: [{'type': 'ephemeral', 'ttl': '1h'}, {'type': 'ephemeral', 'ttl': '1h'}, {'type': 'ephemeral', 'ttl': '1h'}]
HTTP OK; parsed Usage: {"input_tokens": 3, "cache_read_tokens": 0, "cache_write_tokens": 7174,
  "cache_write_5m_tokens": 0, "cache_write_1h_tokens": 7174, "context_tokens": 7177, "output_tokens": 5}
```
Total live traffic: 7 calls of ≤ ~7k tokens (probe ×2, pair ×4 + 2 that 429'd, client path ×1).

### Unit tests (new)
- `tests/unit/providers/test_clients.py`: threshold off → no `ttl` anywhere; hint ≥ threshold → every marker `ttl: 1h`, none 5m; hint below → 5m; no hint → byte estimate decides (and includes tools); breakpoint budget unchanged at 4; `client_for_spec` passes the threshold; `cache_creation` split parsed; missing `cache_creation` object → 0/0.
- `tests/unit/model/test_configure.py`: settings reader (missing/malformed/bool/negative → default, `0` honoured); two end-to-end tests driving REAL `Session` objects through a real `SessionStreamFn` on a mocked Anthropic wire with no manual hint handling anywhere — (a) turn 1 call 1 (no hint) 5m, the provider reports 200k with a tool call, call 2 of the SAME turn goes 1h on every marker, an isolated `complete_once` errand between turns (reporting 5k) carries no hint and stays 5m, turn 2 call 1 goes 1h on the session's own 200k; (b) a parent `Session` works up 300k, a child `Session` is then constructed on the SAME stream fn and runs its turn (5m on its own 10k body), and the parent's post-child request goes 1h on its own 300k — both contamination directions, review F1/F8.
- `tests/unit/harness/test_loop.py` (added): loop-level contract — the host seed covers call 1 and in-run counts take over (`[140k, 160k, 170k]`), no seed → call 1 unstamped and the run still learns from call 1, a call that omits `context_tokens` keeps the last count — review F9.
- `tests/unit/session/test_aside.py` (added): an aside carries the hint the turn's last call reported. `tests/unit/session/test_session.py` (added): with `mid_turn_enabled=False` the boundary hook still advances the session's hint after every call and each loop request is stamped from the previous call of the run — review F9.
- `tests/unit/providers/test_clients.py` (added): the byte estimate excludes base64 image payloads — a 1.4M-char image no longer flips a small body to 1h, and the 1.6k-per-image floor is still counted (single image stays 5m under a 3.3k bar, two images tip a 3k bar) — review F3.
- `tests/unit/harness/test_jobs.py`, `tests/unit/session/test_frontend_state.py` (added): the subagent job accumulator and the frontend turn-end join fold `cache_write_5m_tokens`/`cache_write_1h_tokens` wherever `cache_write_tokens` folds — review F4.
- `tests/unit/analytics/test_store.py`: new column recorded and migrated onto a pre-1h DB (old rows read 0).
- `tests/unit/test_config.py`, `tests/unit/test_settings_io.py`: default pinned to the consumer constant.

### Gates (whole tree, as CI)
```
.venv/bin/python -m flake8 .                                   → clean
uvx --from black==26.1.0 black --check .                       → 769 files would be left unchanged
uvx isort==5.13.2 --check .                                    → clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .    → 0 errors, 0 warnings
pytest tests/unit/providers tests/unit/model tests/unit/session tests/unit/harness tests/unit/analytics tests/unit/test_config.py tests/unit/test_settings_io.py -n 4 → 2349 passed
```

(Remediation round 4: re-run at head `f37019c8` (rebased onto `47bc768f`, version 0.44.33) — all four gates clean (`black` → 802 files would be left unchanged); `env -u NO_COLOR TERM=xterm-256color pytest tests/unit/tui -n 4 → 4353 passed, 12 skipped` (the suite CI's `test (3.12)` was failing in; F11's `test_click_selects_a_row_without_arming_a_text_selection` reproduced red on `bf6be177` and passes with the fix); `pytest tests/unit/providers tests/unit/model tests/unit/session tests/unit/harness tests/unit/analytics tests/unit/compaction -n 4 → 2514 passed` (the round-1 `test_live_progress_never_schedules_the_roster_writer` flake appeared once in three runs and passed in the other two and serially).)

(Remediation round 2: re-run at head `aaad706d` — all four gates clean; `pytest tests/unit/providers tests/unit/model tests/unit/session tests/unit/harness tests/unit/analytics -n 4 → 2228 passed` (+5 tests over round 2's 2223); `tests/unit/test_fork.py tests/unit/compaction → 274 passed`. Negative check: reverting only the loop's `context_tokens_hint=` stamp fails all six new/rewritten hint tests.)

(Remediation round 1: re-run at head `67d02901` — one transient failure of `test_live_progress_never_schedules_the_roster_writer` appeared once under `-n 4` and never reproduced in 10 subsequent runs including serial `-n0`; it also passes on the round-1 head `2cf0d11e`, so it is not introduced by this change.)

### Not validated
- A live ≥150k-token request (accounts are near their 5h caps; the threshold path is exercised via the hint on a 7k body, which produces the identical wire shape).
- The end-to-end `lop` TUI session; the plumbing is covered by the real-`Session`-through-real-`SessionStreamFn` tests above.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required (setting documented in `config.py` default and `settings_io` help).
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.



