### PR TITLE
fix(anthropic): keep asides on the turn's cache prefix (tool_choice)

### DIFF
--- a/docs/evidence/compaction-advisor/README.md
+++ b/docs/evidence/compaction-advisor/README.md
@@ -10,6 +10,7 @@ arm) live Anthropic `claude-opus-4-8` calls on the configured OAuth credential.
 | `replay-severance.txt` | Counterfactual replay: passes, severance rate, and replay cost for recency vs task-aware preserve at three triggers |
 | `token-benchmark.txt` | Cache-aware token AND dollar accounting, advisor-off vs advisor-on, swept over cadence / floor / trigger / accuracy / cache-hit rate |
 | `cache-integrity.txt` | 15 checks that nothing except a real compaction pass breaks the prompt cache |
+| `aside-tool-choice-measurement.txt` | Live re-measurement of the aside/advisor shape at ~37k tokens: `tool_choice: none` vs `auto` reads the prefix equally well, and the fleet's head-only cache events are better explained by TTL expiry (2026-09-01) |
 
 All four are the verbatim stdout of committed scripts, so they are
 re-derivable without a paid run (only the first needs a credential):

--- a/docs/evidence/compaction-advisor/aside-tool-choice-measurement.txt
+++ b/docs/evidence/compaction-advisor/aside-tool-choice-measurement.txt
@@ -1,0 +1,91 @@
+# Evidence: does an aside's `tool_choice` break the Anthropic message cache?
+
+Captured 2026-09-01 on macOS 25.6.0, live Anthropic `claude-opus-5` and
+`claude-fable-5-1` on the configured OAuth credential, with
+`scripts/measure_aside_tool_choice_cache.py` — a ~37k-token conversation of
+twelve tool-call/tool-result pairs through the real `ChatRequest` /
+`AnthropicClient` path, `effort=low`, `max_tokens=200`.
+
+## What the live measurement says (2026-09-01, claude-opus-5)
+
+```
+1 WARM   (turn, tools, auto)        : cache_read=0 cache_write=36578 input=2 output=200 context=36580 cache_hit=0.0%
+2 ASIDE  pre-fix  (tool_choice none): cache_read=36578 cache_write=674 input=2 output=68 context=37254 cache_hit=98.2%
+3 RE-WARM (turn, tools, auto)       : cache_read=36578 cache_write=0 input=2 output=0 context=36580 cache_hit=100.0%
+4 ASIDE  fixed    (tool_choice auto): cache_read=37252 cache_write=0 input=2 output=67 context=37254 cache_hit=100.0%
+```
+
+Same numbers on `claude-fable-5-1` (`--arms 2`, 2 calls):
+
+```
+1 WARM   (turn, tools, auto)        : cache_read=0 cache_write=36578 input=4 output=200 context=36582 cache_hit=0.0%
+2 ASIDE  pre-fix  (tool_choice none): cache_read=36578 cache_write=674 input=4 output=81 context=37256 cache_hit=98.2%
+```
+
+**The pre-fix arm 2 did NOT re-write the message tail.** It read the whole
+37k-token prefix and wrote only its 674-token appended question — a 98.2% hit,
+byte-identical in outcome to the fixed arm 4. The first run of the same script
+(with a 1s settle between arms) DID show `cache_read=0, cache_write=37252` for
+arm 2, which is the fleet signature — but arm 3 of that run also read 0, so the
+cause was the settle gap, not `tool_choice`: a cache entry "only becomes
+available after the first response begins", and 1s after a warm call was not
+enough for this account. With a 5s settle the `none` arm hits the turn's full
+prefix.
+
+**Conclusion: the live endpoint shows no measurable messages-cache penalty for
+`tool_choice: none` vs `auto`.** Both values read the full conversation
+prefix on this account and both models. The change is kept (see below) but it
+is a hygiene fix with measured cost ~0 and measured benefit ~0 on the paths we
+could exercise, not the 52M-token/day win the shared context predicted.
+
+## The first run (why the 1s settle matters)
+
+```
+1 WARM   (turn, tools, auto)        : cache_read=0 cache_write=36578 input=2 output=0 context=36580 cache_hit=0.0%
+2 ASIDE  pre-fix  (tool_choice none): cache_read=0 cache_write=37252 input=2 output=64 context=37254 cache_hit=0.0%
+3 RE-WARM (turn, tools, auto)       : cache_read=36578 cache_write=0 input=2 output=0 context=36580 cache_hit=100.0%
+4 ASIDE  fixed    (tool_choice auto): cache_read=37252 cache_write=0 input=2 output=67 context=37254 cache_hit=100.0%
+```
+
+Arm 1 wrote the prefix and arm 2 — 1 second later, same body modulo
+`tool_choice` — could not read it, then wrote a superset entry; arm 4, 5+
+seconds later, read that entry in full. Arm 2's `cache_read=0` reproduces the
+fleet signature exactly and had nothing to do with `tool_choice`.
+
+## What the fleet analytics actually show (24h to 2026-09-01T23:20)
+
+254 calls carried the head-only signature (`cache_read` 15k-45k,
+`cache_write` > 100k, output < 2k), 70.7M cache-write tokens, 33.9% of all
+Anthropic cache writes. Cross-checking each against its own session:
+
+- `cache_read` is ≈ the **tools block alone** (209/254), not tools+system —
+  system IS re-read on these events.
+- 219/254 have their next same-session call read ≥ the event's `cache_read`
+  in full: the entry these events write is the one the next turn reads, so
+  they are ordinary prefix-extension writes, not cache churn.
+- 81/254 (24.0M) follow a >60s gap with no same-session anthropic call —
+  the documented 5-minute TTL expiry shape (PR-B's target).
+- The remainder interleave two ~180k and ~350k sub-contexts within one session
+  (parent + subagent lines sharing a `cache_read` plateau ~25k) — each line
+  extends its own prefix and the next call on that line reads it.
+
+So the signature the shared context attributed to `tool_choice` is better
+explained by TTL expiry and per-sub-context prefix extension. The predicted
+"advisor/aside re-writes the tail because tool_choice differs" was **not
+reproducible live** and is **not observable in the fleet data**.
+
+## Why the change is still kept
+
+- The docs' table is unambiguous about the risk direction: any future
+  enforcement of "Tool choice — messages ✘" turns every aside into a full
+  re-write. Byte-identical prefix vs a documented invalidation risk is the
+  strictly safer side of that trade.
+- Sending the value the turn sent is the honest request: nothing about an
+  aside changes the tool surface, so the wire has no business saying it did.
+- The two failure modes the old comment glossed over are now handled: a
+  bare-tool-call aside answer retries once with no tools, and the
+  aside/judge/advisor prompts tell the model to answer in text.
+
+What is NOT claimed: token savings. The 96.1% figure in
+`docs/evidence/compaction-advisor/cache-measurement.txt` remains accurate for
+the shipped shape, and this change does not move it.

--- a/local_operator/compaction/advisor.py
+++ b/local_operator/compaction/advisor.py
@@ -86,10 +86,21 @@ ADVISOR_MAX_CANDIDATES = 40
 #: prefix AHEAD of the messages, so appending one more block diverges the
 #: prefix and the request pays a full cache WRITE — 0% cache hit,
 #: ``cache_write=14590`` against an identical conversation. Carried inside the
-#: appended user turn instead, the same request read 96.1% from cache
-#: (``cache_read=14024``, ``cache_write=568`` for the new turn alone). Since
-#: the whole economic case for this feature is that the read is cached, the
+#: appended user turn instead, the same request read the whole conversation
+#: from cache and wrote only the new turn (``cache_write=568``). Since the
+#: whole economic case for this feature is that the read is cached, the
 #: placement is load-bearing: do not "tidy" this into ``system_blocks``.
+#:
+#: The trailing "text only, no tools" line is the second half of that same
+#: economics. The request carries the working turn's live tool schema (the
+#: front of the cache prefix), and on Anthropic the wire ``tool_choice`` is
+#: the turn's own ``auto`` rather than ``none`` — hygiene against the
+#: documented rule that a differing ``tool_choice`` invalidates the
+#: messages-level cache (measured live, ``none`` currently reads the prefix
+#: just as well; see ``Session.advise_compaction`` and
+#: ``scripts/measure_aside_tool_choice_cache.py``). So the model CAN emit a
+#: tool call here; the caller drops it unread, and this line is what makes
+#: the model not try.
 ADVISOR_SYSTEM_PROMPT = """\
 You are a compaction advisor for a long-running agent session. You are NOT \
 answering the user and you are NOT continuing the work. You read the \
@@ -123,6 +134,8 @@ current unit is young enough that a summary of everything before it loses \
 nothing it still needs.
 - `confidence` is your own 0.0-1.0 estimate. Be honest and low when the \
 conversation does not make the task structure clear.
+- Answer in text only. Do not call any tool: none of the tools above are \
+for you, and a tool call in this answer is discarded unread.
 """
 
 
@@ -201,10 +214,16 @@ def build_advisor_prompt(
     The instructions ride here rather than in a system block because that is
     what the measurement said: a system block goes in front of the cached
     prefix and costs a full cache write (0% hit), while the same text as a
-    trailing user turn leaves the prefix intact (96.1% hit). See
+    trailing user turn leaves the prefix intact and pays only for itself. See
     :data:`ADVISOR_SYSTEM_PROMPT` and ``scripts/measure_advisor_cache.py``.
     Everything this function emits is therefore APPEND-ONLY relative to the
     conversation, which is the property the cache economics rest on.
+
+    The closing line repeats "text, not tools" because the request carries
+    the live tool schema with the turn's own ``tool_choice`` on Anthropic
+    (``scripts/measure_aside_tool_choice_cache.py`` measures why); the
+    instructions block says it once, and the last line the model reads says
+    it again where it decides how to answer.
     """
     candidates = _candidate_messages(messages)
     lines = [f"- {message.id} ({message.role}): {_excerpt(message.text)}" for message in candidates]
@@ -216,7 +235,8 @@ def build_advisor_prompt(
         f"Automatic compaction threshold: {threshold_tokens:,} tokens.\n\n"
         "Candidate anchors, oldest first — `preserve_from` must be one of these ids:\n"
         f"{listing}\n\n"
-        "Answer with the fenced JSON block described in your instructions and nothing else."
+        "Answer with the fenced JSON block described in your instructions and nothing else — "
+        "as text, without calling any tool."
     )
 
 

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -1991,12 +1991,21 @@ class AnthropicClient:
             # ``tool_choice="none"`` — ``Session.complete_aside`` (``/btw`` and
             # the ``/loop`` judge) and ``Session.advise_compaction`` — exist to
             # ride the working turn's cached prefix, and the turn sends
-            # ``{"type": "auto"}``. Measured live (``scripts/
-            # measure_aside_tool_choice_cache.py``): with ``none`` a ~35k-token
-            # aside read only the ~1k head from cache and wrote the other ~34k;
-            # with ``auto`` it read the whole conversation and wrote only its
-            # appended question. Across the fleet that difference was a quarter
-            # of all daily cache-write tokens.
+            # ``{"type": "auto"}``.
+            #
+            # This mapping is hygiene, not a measured saving. Measured live
+            # (``scripts/measure_aside_tool_choice_cache.py``, result in
+            # ``docs/evidence/compaction-advisor/aside-tool-choice-measurement.txt``):
+            # a ~37k-token aside sent with ``none`` read the turn's FULL prefix
+            # and wrote only its appended question, identical to ``auto`` — no
+            # cache break reproduced on either model tried. The fleet's
+            # head-only-hit signature that first pointed here was root-caused
+            # elsewhere: per-account cache isolation when the quota preflight
+            # moved a session between OAuth accounts under a reserve verdict
+            # (PR #537). ``auto`` is kept because it makes the aside body
+            # byte-identical to the turn's request, which is the only shape the
+            # invalidation rule is guaranteed not to bite, and nothing about an
+            # aside changes the tool surface the turn declared.
             #
             # The "reads the turn, calls nothing" contract those callers promise
             # is therefore NOT enforced on the wire for Anthropic. It is

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -1980,9 +1980,42 @@ class AnthropicClient:
                 for tool in request.tools
             ]
             # Safe default: unmapped values fall back to auto (PR-22).
+            #
+            # ``none`` is DELIBERATELY sent as ``auto`` on this wire, and only
+            # here. Anthropic's cache hierarchy is tools -> system -> messages,
+            # and per the prompt-caching docs ("What invalidates the cache")
+            # ``tool_choice`` is rendered into the MESSAGES level: a request
+            # whose ``tool_choice`` differs from the one that wrote the prefix
+            # keeps the tools+system head warm and re-writes every message
+            # block. The callers that send a non-empty tool list with
+            # ``tool_choice="none"`` — ``Session.complete_aside`` (``/btw`` and
+            # the ``/loop`` judge) and ``Session.advise_compaction`` — exist to
+            # ride the working turn's cached prefix, and the turn sends
+            # ``{"type": "auto"}``. Measured live (``scripts/
+            # measure_aside_tool_choice_cache.py``): with ``none`` a ~35k-token
+            # aside read only the ~1k head from cache and wrote the other ~34k;
+            # with ``auto`` it read the whole conversation and wrote only its
+            # appended question. Across the fleet that difference was a quarter
+            # of all daily cache-write tokens.
+            #
+            # The "reads the turn, calls nothing" contract those callers promise
+            # is therefore NOT enforced on the wire for Anthropic. It is
+            # enforced by the callers: both consume only ``StreamTextDelta`` /
+            # ``StreamUsageEvent`` and never execute a ``StreamToolCallDelta``,
+            # so a ``tool_use`` block in the answer is inert (the model is also
+            # told in the appended prompt to answer in text). ``complete_aside``
+            # retries once WITHOUT tools when the answer was a tool call and
+            # nothing else, which is the only way the mapping is observable.
+            #
+            # The no-tools callers (naming, compaction summary, server operator)
+            # send ``tools=[]`` and never reach this branch, so they carry no
+            # ``tool_choice`` key at all, exactly as before. The OpenAI and
+            # Gemini builders keep a literal ``none``: neither documents a
+            # cache penalty for it, and Gemini's mode MUST stay ``NONE`` because
+            # its default with tools present is to allow calls.
             body["tool_choice"] = {
                 "auto": {"type": "auto"},
-                "none": {"type": "none"},
+                "none": {"type": "auto"},
                 "required": {"type": "any"},
             }.get(request.tool_choice, {"type": "auto"})
         effort = _reasoning_effort(request)

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -206,11 +206,16 @@ class SessionProtocol(Protocol):
         the conversation, no events. ``turns`` are appended for this request
         only, which is how a caller supplies the side question itself (and any
         in-flight assistant text it is painting but the context does not carry
-        yet). No tools.
+        yet). No tool is ever executed: the live tool schema rides along only
+        to keep the request on the working turn's cache prefix, and a
+        ``tool_use`` block in the answer is inert.
 
         It is NOT free: the request carries the whole conversation. Nothing is
         recorded, so ``on_usage`` reports the provider's own figures to
-        whatever the host counts spend with.
+        whatever the host counts spend with. It fires once per provider call,
+        and an aside may make two — when the answer was a bare tool call with
+        no text, the implementation retries once without tools — so a host
+        must SUM the callbacks, not keep the last; both calls were billed.
 
         Backs the TUI's ``/btw`` aside overlay. The no-trace guarantee is the
         feature: dismissing the overlay must leave the conversation, and the

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -7328,6 +7328,11 @@ class Session:
         answer that mixes text and a tool call is returned as its text
         without a retry; the text is what was asked for.
 
+        ``on_usage`` fires once per provider call, so a single aside may
+        deliver TWO usage figures when that retry runs — the first call's
+        (bare tool call, discarded) and the retry's. Both were paid for, so
+        hosts must add them rather than keep the last one.
+
         Safe to call mid-turn, and the pairing below is what makes that true —
         see :meth:`_wire_legal_snapshot`.
         """

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -100,6 +100,7 @@ from local_operator.harness.types import (
     SteeringDeliveredEvent,
     StreamEvent,
     StreamTextDelta,
+    StreamToolCallDelta,
     StreamUsageEvent,
     TextContent,
     ToolCall,
@@ -7297,15 +7298,35 @@ class Session:
         change the prefix at position 0 and force the provider to re-process the
         whole conversation at full/cache-write price instead of a cache READ.
         Sending the SAME tool schema the turn sends is what keeps the aside
-        warm against the turn's cached prefix. ``tool_choice="none"`` preserves
-        the "reads the turn, calls nothing" contract on every wire (and the
-        Gemini builder is taught to honour it, since it otherwise ignores
-        ``tool_choice`` and non-empty tools would newly ALLOW a call).
+        warm against the turn's cached prefix. ``tool_choice="none"`` states
+        the "reads the turn, calls nothing" intent, and the OpenAI-compatible
+        and Gemini builders put it on the wire literally (Gemini is taught to
+        honour it, since it otherwise ignores ``tool_choice`` and non-empty
+        tools would newly ALLOW a call).
 
-        Caveat: on Anthropic a ``tool_choice`` that differs from the turn's
-        can still invalidate the growing MESSAGE-tail cache while the
-        tools+system HEAD stays warm — the head is the large, stable win here;
-        the tail delta is bounded by the turn's own tail.
+        On Anthropic the wire says ``auto``, NOT ``none``. The prompt-caching
+        docs list ``tool_choice`` as invalidating the MESSAGES level of that
+        provider's cache hierarchy (tools -> system -> messages), which made a
+        differing value the prime suspect for the fleet's head-only cache
+        events; measured live, ``none`` reads the turn's full prefix just as
+        well (``scripts/measure_aside_tool_choice_cache.py``), so the mapping
+        is hygiene against that documented rule rather than a measured saving.
+        The contract is enforced HERE: the loop below consumes text and
+        usage only, never a ``StreamToolCallDelta``, so a ``tool_use`` block
+        in the answer is inert — nothing runs, nothing joins the history. The
+        appended prompts (``ASIDE_PROMPT``, ``LOOP_JUDGE_PROMPT``) also tell
+        the model to answer in text, so the case is rare to begin with.
+
+        The one way that mapping is observable is an answer that is a tool
+        call and NOTHING else — the model "answered" the question by reaching
+        for ``read``. That would surface as an empty answer on the card, which
+        reads as a provider fault. So when the stream carried a tool call and
+        no text, the request is retried once with ``tools=[]``: the tools block
+        is the front of the prefix, so this retry is a full re-process at
+        write price, but it is bounded to that rare case rather than paid on
+        every aside, and it gives the user an answer instead of a blank. An
+        answer that mixes text and a tool call is returned as its text
+        without a retry; the text is what was asked for.
 
         Safe to call mid-turn, and the pairing below is what makes that true —
         see :meth:`_wire_legal_snapshot`.
@@ -7313,18 +7334,40 @@ class Session:
         blocks = self._system_blocks()
         if inspect.isawaitable(blocks):
             blocks = await blocks
+        messages = self._render_history([*self._wire_legal_snapshot(), *turns])
         request = ChatRequest(
             model=self._model,
             system_blocks=list(blocks),
-            messages=self._render_history([*self._wire_legal_snapshot(), *turns]),
+            messages=messages,
             # Live tools (not []): keep the aside on the SAME cache prefix the
             # working turn builds. See the docstring for why this is a cache
-            # read rather than a full re-process. tool_choice stays "none".
+            # read rather than a full re-process, and why Anthropic puts the
+            # turn's own tool_choice on the wire rather than this "none".
             tools=list(self._context.tools),
             tool_choice="none",
         )
         parts: list[str] = []
+        called_tool = False
         async for event in self._stream_fn(request, None):
+            if isinstance(event, StreamTextDelta):
+                parts.append(event.delta)
+                if on_delta is not None:
+                    on_delta(event.delta)
+            elif isinstance(event, StreamToolCallDelta):
+                # Inert by design (see the docstring): recorded only so an
+                # answer that was NOTHING BUT a call can be retried below.
+                called_tool = True
+            elif isinstance(event, StreamUsageEvent) and on_usage is not None:
+                on_usage(event.usage)
+        if parts or not called_tool:
+            return "".join(parts)
+        # Tool call and no text: the model tried to act instead of answering.
+        # Retry once with no tools at all — off the cache prefix, but bounded
+        # to this case. ``tools=[]`` never reaches the Anthropic mapping, so
+        # the wire genuinely offers nothing to call.
+        logger.debug("aside answered with a bare tool call; retrying without tools")
+        retry = request.model_copy(update={"tools": []})
+        async for event in self._stream_fn(retry, None):
             if isinstance(event, StreamTextDelta):
                 parts.append(event.delta)
                 if on_delta is not None:
@@ -7372,21 +7415,36 @@ class Session:
         expensive one. The knob would invite users to silently destroy the
         economics that justify the call.
 
-        MEASURED, not assumed (``scripts/measure_advisor_cache.py``, live
-        Anthropic): this request shape reads 96.1% of its prompt from cache
-        (``cache_read=14024``, ``cache_write=568`` for the appended turn).
-        Two findings that shape the code:
+        MEASURED, not assumed. Three findings shape the code, and the third
+        corrected the first two:
 
         - The system blocks are passed through UNCHANGED. The advisor's
           instructions ride inside the appended user turn instead, because
           system sits in the cache prefix ahead of the messages: adding one
-          block there measured 0% cache hit and a full ``cache_write=14590``.
-          The request must stay APPEND-ONLY relative to the turn's prefix.
+          block there measured 0% cache hit and a full ``cache_write=14590``
+          (``scripts/measure_advisor_cache.py``). The request must stay
+          APPEND-ONLY relative to the turn's prefix.
         - On Anthropic, ``isolated=True`` measured 100% cache hit as well,
           because that provider keys caching on prefix CONTENT rather than on
           ``prompt_cache_key``. Isolation is still declined, since the key
           does govern the OpenAI-compatible wire and this method has to be
           correct on every provider a session may be running.
+        - The original 96.1%-hit figure came from a ~14k-token toy
+          conversation whose system+tools head WAS most of the prompt, so it
+          could not distinguish a head-only hit from a full one. The shared
+          context therefore blamed ``tool_choice="none"`` for the fleet's
+          head-only cache events; measured live at ~37k tokens
+          (``scripts/measure_aside_tool_choice_cache.py``), a ``none`` aside
+          reads the turn's full prefix exactly as well as an ``auto`` one, so
+          that attribution did not hold — the fleet events are better
+          explained by 5-minute TTL expiry and per-sub-context prefix
+          extension. The wire still sends the turn's own ``auto`` when tools
+          are present, as hygiene against the documented rule that
+          ``tool_choice`` invalidates the messages cache; the "calls nothing"
+          contract is kept by this method reading only text and usage events.
+          See
+          ``docs/evidence/compaction-advisor/aside-tool-choice-measurement.txt``
+          for the numbers.
         """
         blocks = self._system_blocks()
         if inspect.isawaitable(blocks):
@@ -7404,6 +7462,12 @@ class Session:
             isolated=False,
         )
         parts: list[str] = []
+        # Text and usage ONLY. A tool-call delta is dropped on the floor: on
+        # Anthropic the wire says ``auto`` (see the docstring), and this is the
+        # half of the contract that guarantees the advisor never acts. No
+        # bare-tool-call retry here, unlike ``complete_aside``: an unparseable
+        # answer is already a handled outcome (``parse_hint`` returns None and
+        # the size trigger stands), and nobody is looking at a blank card.
         async for event in self._stream_fn(request, None):
             if isinstance(event, StreamTextDelta):
                 parts.append(event.delta)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -992,7 +992,9 @@ LOOP_JUDGE_PROMPT = (
     "  VERDICT: CONTINUE\n"
     "Then, on the next line, one short sentence of reason. Judge strictly: "
     "answer ACHIEVED only if the goal is fully and verifiably met, not merely "
-    "in progress. If unsure, answer CONTINUE."
+    "in progress. If unsure, answer CONTINUE. Answer in text only and do not "
+    "call any tool: this is a verdict on the conversation above, and a tool "
+    "call here is discarded unread."
 )
 
 #: Consecutive-judge-failure breaker for goal mode. There is deliberately NO

--- a/local_operator/tui/widgets/aside_panel.py
+++ b/local_operator/tui/widgets/aside_panel.py
@@ -111,17 +111,20 @@ SQUEEZE_ROWS = PANEL_HEIGHT_MARGIN + CHROME_ROWS + PANEL_PADDING_ROWS + 2
 
 #: The prompt the side question is wrapped in. Three instructions, each earning
 #: its line: OFF THE RECORD so the model does not treat the question as a new
-#: task and start narrating a plan; no tools because none are sent (the request
-#: carries an empty catalogue and ``tool_choice="none"``) and a model that
-#: tried would produce a tool call nobody executes; and answer-from-context
-#: because the whole reason to ask here rather than in the chat is that the
-#: agent already knows.
+#: task and start narrating a plan; TEXT ONLY because the request does carry
+#: the live tool catalogue (it has to, to stay on the working turn's cache
+#: prefix) and on Anthropic even ``tool_choice`` reads ``auto`` on the wire
+#: (see ``Session.complete_aside``), so the prompt is the model-facing half of
+#: "calls nothing" and a call it makes anyway is discarded unread; and
+#: answer-from-context because the whole reason to ask here rather than in the
+#: chat is that the agent already knows.
 ASIDE_PROMPT = """<aside>
 The user has stepped aside to ask you something about this session. This is OFF
 THE RECORD: neither their question nor your answer joins the conversation, and
 no work is being asked for. Answer from the context you already have, briefly
-and directly, in prose. Do not use tools, do not propose a plan, and do not ask
-a follow-up question. If your context does not answer it, say so plainly.
+and directly, in prose. Answer in text only: do not call any tool (a tool call
+here is discarded unread), do not propose a plan, and do not ask a follow-up
+question. If your context does not answer it, say so plainly.
 Question:
 {question}
 </aside>"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.32"
+version = "0.44.33"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/measure_aside_tool_choice_cache.py
+++ b/scripts/measure_aside_tool_choice_cache.py
@@ -4,32 +4,45 @@
 request shape rides the working turn's cached prefix — but it did so on a
 ~14k-token toy conversation whose tools+system HEAD was most of the prompt.
 Fleet analytics on real sessions (average context 184k) then showed a
-different picture: a quarter of all daily cache-WRITE tokens came from side
-requests with the signature ``cache_read ≈ head only, cache_write ≈ the whole
-message tail``. Anthropic's prompt-caching docs explain it ("What invalidates
-the cache"): ``tool_choice`` is rendered into the MESSAGES level of the
-tools -> system -> messages hierarchy, so a request that sends
-``{"type": "none"}`` against a prefix written with ``{"type": "auto"}`` keeps
-the head and re-writes every message block. The toy measurement could not see
-that because its tail was ~10% of the prompt.
+large share of daily cache-WRITE tokens on calls with the signature
+``cache_read ≈ head only, cache_write ≈ the whole message tail``, and
+Anthropic's prompt-caching docs ("What invalidates the cache") offered a
+candidate mechanism: ``tool_choice`` is rendered into the MESSAGES level of
+the tools -> system -> messages hierarchy, so a request that sends
+``{"type": "none"}`` against a prefix written with ``{"type": "auto"}``
+WOULD keep the head and re-write every message block. The toy measurement
+could not have seen that because its tail was ~10% of the prompt.
 
-This script reproduces the effect at a size where it is unambiguous and shows
-the fix closing it. It builds a ~35k-token conversation of tool-result-shaped
-pairs (the thing a real session is made of) and makes four REAL streamed calls,
-printing the provider's own cache counters for each:
+Hypothesis under test: the aside's ``none`` splits the cache at the messages
+level, and sending the turn's own ``auto`` closes the split. The script builds
+a ~35k-token conversation of tool-result-shaped pairs (the thing a real
+session is made of) and makes four REAL streamed calls, printing the
+provider's own cache counters for each:
 
 1. WARM        — a working-turn-shaped request: tools + ``tool_choice=auto``.
                  Writes the prefix.
 2. ASIDE-OLD   — the advisor/aside shape with the PRE-FIX wire body
-                 (``tool_choice: {"type": "none"}``). Expect ``cache_read`` to
-                 be roughly the tools+system head and ``cache_write`` to be the
-                 rest of the conversation.
+                 (``tool_choice: {"type": "none"}``). If the hypothesis holds,
+                 ``cache_read`` is roughly the tools+system head and
+                 ``cache_write`` is the rest of the conversation.
 3. RE-WARM     — re-writes the turn's prefix so (4) is measured against the
                  turn, not against (2)'s ``none`` variant.
 4. ASIDE-FIXED — the same request through the SHIPPED client, which sends the
-                 turn's own ``{"type": "auto"}`` when tools are present. Expect
-                 ``cache_read`` to be the whole conversation and
-                 ``cache_write`` to be only the appended question.
+                 turn's own ``{"type": "auto"}`` when tools are present. If the
+                 hypothesis holds, ``cache_read`` is the whole conversation and
+                 ``cache_write`` is only the appended question.
+
+Result: the hypothesis did NOT hold. Full output, both runs, in
+``docs/evidence/compaction-advisor/aside-tool-choice-measurement.txt``. Arm 2
+(``none``) read the full 36,578-token prefix and wrote only its 674-token
+appended question — identical to arm 4 — on ``claude-opus-5`` and
+``claude-fable-5-1``. Do not expect a cache split from this script on a warm
+account; if arm 2 reads 0, suspect the settle gap first (the script's first
+run did exactly that with a 1s settle, and arm 3 read 0 too — hence
+``SETTLE_SECONDS``). The fleet's head-only signature was later root-caused to
+per-account cache isolation under reserve-verdict account rotation (PR #537).
+The ``none`` -> ``auto`` mapping ships as hygiene (aside body byte-identical
+to the turn's), not as a measured saving.
 
 Deliberately small: four calls of ~35k tokens each, ``max_tokens`` capped and
 the lowest reasoning effort, because the shared OAuth accounts run close to

--- a/scripts/measure_aside_tool_choice_cache.py
+++ b/scripts/measure_aside_tool_choice_cache.py
@@ -1,0 +1,298 @@
+"""Live Anthropic measurement: does an aside's ``tool_choice`` break the cache?
+
+``scripts/measure_advisor_cache.py`` established that the advisor / ``/btw``
+request shape rides the working turn's cached prefix — but it did so on a
+~14k-token toy conversation whose tools+system HEAD was most of the prompt.
+Fleet analytics on real sessions (average context 184k) then showed a
+different picture: a quarter of all daily cache-WRITE tokens came from side
+requests with the signature ``cache_read ≈ head only, cache_write ≈ the whole
+message tail``. Anthropic's prompt-caching docs explain it ("What invalidates
+the cache"): ``tool_choice`` is rendered into the MESSAGES level of the
+tools -> system -> messages hierarchy, so a request that sends
+``{"type": "none"}`` against a prefix written with ``{"type": "auto"}`` keeps
+the head and re-writes every message block. The toy measurement could not see
+that because its tail was ~10% of the prompt.
+
+This script reproduces the effect at a size where it is unambiguous and shows
+the fix closing it. It builds a ~35k-token conversation of tool-result-shaped
+pairs (the thing a real session is made of) and makes four REAL streamed calls,
+printing the provider's own cache counters for each:
+
+1. WARM        — a working-turn-shaped request: tools + ``tool_choice=auto``.
+                 Writes the prefix.
+2. ASIDE-OLD   — the advisor/aside shape with the PRE-FIX wire body
+                 (``tool_choice: {"type": "none"}``). Expect ``cache_read`` to
+                 be roughly the tools+system head and ``cache_write`` to be the
+                 rest of the conversation.
+3. RE-WARM     — re-writes the turn's prefix so (4) is measured against the
+                 turn, not against (2)'s ``none`` variant.
+4. ASIDE-FIXED — the same request through the SHIPPED client, which sends the
+                 turn's own ``{"type": "auto"}`` when tools are present. Expect
+                 ``cache_read`` to be the whole conversation and
+                 ``cache_write`` to be only the appended question.
+
+Deliberately small: four calls of ~35k tokens each, ``max_tokens`` capped and
+the lowest reasoning effort, because the shared OAuth accounts run close to
+their five-hour caps. The request shapes are the real ones (``ChatRequest``
+through ``AnthropicClient``), not hand-built JSON, so what is measured is what
+``Session.complete_aside`` / ``Session.advise_compaction`` send.
+
+Run (needs the configured Anthropic OAuth credential):
+    .venv/bin/python scripts/measure_aside_tool_choice_cache.py
+    .venv/bin/python scripts/measure_aside_tool_choice_cache.py --model claude-fable-5-1 --arms 2
+
+``--arms 2`` stops after the pre-fix arm: two calls instead of four, for
+checking a second model against the same rule without spending the re-warm.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from local_operator.compaction.advisor import ADVISOR_SYSTEM_PROMPT  # noqa: E402
+from local_operator.harness.types import (  # noqa: E402
+    AgentTool,
+    ChatRequest,
+    Message,
+    StreamUsageEvent,
+    TextContent,
+    ToolCall,
+    ToolResult,
+    Usage,
+)
+from local_operator.model.configure import build_model_spec  # noqa: E402
+from local_operator.providers.auth_store import AuthStore, default_db_path  # noqa: E402
+from local_operator.providers.clients import AnthropicClient  # noqa: E402
+
+#: Cheaper than the default TUI model and on the same cache rules; the effect
+#: is a property of the wire, not of the model.
+MODEL_ID = "claude-opus-5"
+
+#: Tool-result pairs in the conversation. Twelve pairs of ~6 KB code-shaped results land
+#: around 35k tokens, which is the smallest size at which a head-only hit and a
+#: full hit are unmistakably different numbers.
+PAIRS = 12
+
+#: Pause between arms. The docs say a cache entry "only becomes available
+#: after the first response begins", and in practice a one-second gap after a
+#: warm call that produced no output was NOT enough: the next arm read 0 and
+#: wrote its own entry, which a later arm then read in full — a result that
+#: looks like the docs being wrong and is really the entry still propagating.
+SETTLE_SECONDS = 5
+
+#: Output cap on every call: this measures the PROMPT side, and every output
+#: token is paid for on accounts that are near their caps.
+MAX_TOKENS = 200
+
+
+async def _noop(*_a: Any, **_k: Any) -> ToolResult:
+    raise AssertionError("tool must not run")
+
+
+def _tools() -> list[AgentTool]:
+    """A realistic core-tool surface, so the tools block is a real chunk of the
+    cache prefix (it sits at position 0 on every wire)."""
+    names = ["bash", "read", "write", "edit", "grep", "glob", "eval", "task", "todo"]
+    return [
+        AgentTool(
+            name=name,
+            description=(
+                f"{name}: {name} tool with the usual parameters. Use it when the task "
+                f"calls for {name}-shaped work and read the result before acting on it."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "target path"},
+                    "content": {"type": "string", "description": "payload"},
+                    "i": {"type": "string", "description": "intent"},
+                },
+            },
+            execute=_noop,
+        )
+        for name in names
+    ]
+
+
+def _fake_tool_output(index: int) -> str:
+    """~6 KB of code-shaped text: what a ``read`` or ``grep`` actually returns.
+
+    Deterministic, so re-runs produce the same prefix and can be compared
+    across days; varied per index, so no two results are the same bytes and
+    the provider cannot collapse them.
+    """
+    lines = []
+    for line in range(40):
+        lines.append(
+            f"{line + 1:4d}| def handler_{index}_{line}(request, *, retries={line % 5}):  "
+            f"# step {index}: validate then dispatch; see ticket LOP-{index * 100 + line}"
+        )
+        lines.append(
+            f"{line + 1:4d}|     return dispatch(request, key='k{index}-{line}', "
+            f"budget={(line * 37 + index) % 1000})"
+        )
+    return "\n".join(lines)
+
+
+def _conversation() -> list[Message]:
+    """A tool-heavy exchange: user asks, assistant calls a tool, tool answers.
+
+    The shape matters as much as the size. Real sessions are mostly tool
+    results, which Anthropic renders as ``tool_result`` blocks inside user
+    messages, and those are exactly the "message blocks" the docs say a
+    ``tool_choice`` change invalidates.
+    """
+    convo: list[Message] = [Message.user("Port the request handlers to the new dispatcher.")]
+    for i in range(PAIRS):
+        call_id = f"call_{i:02d}"
+        convo.append(
+            Message(
+                role="assistant",
+                content=[TextContent(text=f"Reading handler module {i}.")],
+                tool_calls=[
+                    ToolCall(
+                        id=call_id,
+                        name="read",
+                        arguments={"path": f"src/handlers/module_{i}.py"},
+                    )
+                ],
+            )
+        )
+        convo.append(
+            Message.tool_result(
+                ToolResult(
+                    tool_call_id=call_id,
+                    tool_name="read",
+                    content=[TextContent(text=_fake_tool_output(i))],
+                )
+            )
+        )
+    convo.append(Message.assistant("All twelve modules read. Ready to port them."))
+    convo.append(Message.user("Go ahead, but summarise what you will change first, briefly."))
+    return convo
+
+
+SYSTEM = [
+    "You are a helpful coding agent working in a large repository. " * 30,
+    "Environment: macOS, python 3.14, uv-managed venv. " * 20,
+]
+
+#: The advisor's appended turn, as ``build_advisor_prompt`` shapes it: the
+#: instructions ride INSIDE the user turn (a system block would break the
+#: prefix ahead of the messages — measured in ``measure_advisor_cache.py``).
+ADVISOR_QUESTION = (
+    f"{ADVISOR_SYSTEM_PROMPT}\n\n"
+    "A compaction decision is pending for the conversation above.\n\n"
+    "Context size: 480,000 tokens.\nAutomatic compaction threshold: 600,000 tokens.\n\n"
+    "Candidate anchors, oldest first — `preserve_from` must be one of these ids:\n"
+    "- m1 (user): Port the request handlers to the new dispatcher.\n\n"
+    "Answer with the fenced JSON block described in your instructions and nothing else — "
+    "as text, without calling any tool."
+)
+
+
+class PreFixAnthropicClient(AnthropicClient):
+    """The wire body as shipped BEFORE this fix: ``none`` goes out literally.
+
+    Overriding the body builder rather than hand-writing JSON keeps every other
+    byte identical to the fixed client, so the only difference between arms 2
+    and 4 is the ``tool_choice`` value — which is the thing being measured.
+    """
+
+    def _build_body(self, request: ChatRequest, *, oauth: bool = False) -> dict[str, Any]:
+        body = super()._build_body(request, oauth=oauth)
+        if request.tools and request.tool_choice == "none":
+            body["tool_choice"] = {"type": "none"}
+        return body
+
+
+async def _run(
+    client: AnthropicClient, oauth: Any, request: ChatRequest, label: str
+) -> Usage | None:
+    usage = None
+    async for event in client.stream(request, None, oauth_access=oauth):
+        if isinstance(event, StreamUsageEvent):
+            usage = event.usage
+    if usage is None:
+        print(f"{label}: no usage reported")
+        return None
+    total = (
+        (usage.cache_read_tokens or 0) + (usage.cache_write_tokens or 0) + (usage.input_tokens or 0)
+    )
+    rate = (usage.cache_read_tokens or 0) / total * 100 if total else 0.0
+    print(
+        f"{label}: cache_read={usage.cache_read_tokens} "
+        f"cache_write={usage.cache_write_tokens} input={usage.input_tokens} "
+        f"output={usage.output_tokens} context={usage.context_tokens} "
+        f"cache_hit={rate:.1f}%"
+    )
+    return usage
+
+
+async def main(model_id: str = MODEL_ID, arms: int = 4) -> None:
+    base = build_model_spec("anthropic", model_id)
+    # Lowest effort on EVERY arm: effort is rendered into the prompt too, so it
+    # must not differ between the turn and the aside, and the bottom rung
+    # spends the fewest output tokens.
+    efforts = base.reasoning_efforts
+    spec = base.model_copy(update={"reasoning_effort": efforts[0]}) if efforts else base
+    store = AuthStore(default_db_path())
+    oauth = await store.get_oauth_access("anthropic")
+
+    tools = _tools()
+    convo = _conversation()
+    fixed = AnthropicClient()
+    prefix = PreFixAnthropicClient()
+
+    warm = ChatRequest(
+        model=spec,
+        system_blocks=list(SYSTEM),
+        messages=list(convo),
+        tools=tools,
+        tool_choice="auto",
+        max_tokens=MAX_TOKENS,
+    )
+    aside = ChatRequest(
+        model=spec,
+        system_blocks=list(SYSTEM),
+        messages=[*convo, Message.user(ADVISOR_QUESTION)],
+        tools=tools,
+        tool_choice="none",
+        max_tokens=MAX_TOKENS,
+        replayable=True,
+    )
+    assert prefix._build_body(aside, oauth=True)["tool_choice"] == {"type": "none"}
+    assert fixed._build_body(aside, oauth=True)["tool_choice"] == {"type": "auto"}
+
+    print(f"model={spec.model_id} effort={spec.reasoning_effort} pairs={PAIRS}")
+    await _run(fixed, oauth, warm, "1 WARM   (turn, tools, auto)        ")
+    await asyncio.sleep(SETTLE_SECONDS)
+    old = await _run(prefix, oauth, aside, "2 ASIDE  pre-fix  (tool_choice none)")
+    if arms <= 2:
+        return
+    await asyncio.sleep(SETTLE_SECONDS)
+    await _run(fixed, oauth, warm, "3 RE-WARM (turn, tools, auto)       ")
+    await asyncio.sleep(SETTLE_SECONDS)
+    new = await _run(fixed, oauth, aside, "4 ASIDE  fixed    (tool_choice auto)")
+
+    if old and new:
+        print(
+            f"\nRESULT: aside cache_read pre-fix={old.cache_read_tokens} "
+            f"fixed={new.cache_read_tokens}; cache_write pre-fix={old.cache_write_tokens} "
+            f"fixed={new.cache_write_tokens}"
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser.add_argument("--model", default=MODEL_ID)
+    parser.add_argument("--arms", type=int, default=4, choices=(2, 4))
+    args = parser.parse_args()
+    asyncio.run(main(args.model, args.arms))

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -3462,8 +3462,9 @@ async def test_codex_5_6_stream_skips_reasoning_items() -> None:
 # tools block is the FRONT of every provider's cache prefix, so a future
 # refactor that silently dropped `body["tools"]` for a `tool_choice="none"`
 # request would reintroduce the exact prompt-cache regression these tests
-# guard. Each of the three wires must emit the tools AND pin the choice to
-# "none" (the aside reads the turn and calls nothing).
+# guard. Each of the three wires must emit the tools. The OpenAI and Gemini
+# wires pin the choice to "none" (the aside reads the turn and calls nothing);
+# Anthropic deliberately does NOT — see the block below.
 # ---------------------------------------------------------------------------
 
 
@@ -3523,13 +3524,99 @@ def test_anthropic_emits_tools_with_tool_choice_none_and_keeps_cache_control() -
     )
     body = AnthropicClient()._build_body(request)
     assert [t["name"] for t in body["tools"]] == ["bash", "read"]
-    assert body["tool_choice"] == {"type": "none"}
+    # NOT {"type": "none"}: see test_anthropic_tool_choice_none_with_tools_rides_the_turns_auto.
+    assert body["tool_choice"] == {"type": "auto"}
     # The message-tail cache_control placement is unchanged by restoring tools:
     # the tools block sits AHEAD of system+messages in the prefix, so the
     # existing breakpoint policy (last block of the final message, and the
     # prior user turn) must still hold.
     assert "cache_control" in body["messages"][-1]["content"][-1]
     assert "cache_control" in body["messages"][0]["content"][-1]
+
+
+# ---------------------------------------------------------------------------
+# Anthropic tool_choice: "none" with tools present goes out as the turn's
+# "auto".
+#
+# Anthropic renders `tool_choice` into the MESSAGES level of its cache
+# hierarchy (docs, "What invalidates the cache": Tool choice — tools ✓,
+# system ✓, messages ✘). An aside/advisor sending `{"type": "none"}` against a
+# working turn that sent `{"type": "auto"}` therefore kept only the
+# tools+system head warm and re-wrote every message block — measured at a
+# quarter of all daily cache-write tokens across the fleet. The fix is for the
+# aside's body to be byte-identical to the turn's prefix, which means the same
+# `tool_choice`; the "calls nothing" contract is enforced by the callers
+# ignoring tool-call deltas (`Session.complete_aside`,
+# `Session.advise_compaction`). The no-tools callers never reach the branch and
+# must keep carrying no `tool_choice` key at all.
+# ---------------------------------------------------------------------------
+
+
+def _anthropic_request(
+    tool_choice: Literal["auto", "none", "required"], *, tools: list[AgentTool]
+) -> ChatRequest:
+    return ChatRequest(
+        model=_spec(provider="anthropic"),
+        system_blocks=["instructions"],
+        messages=[Message.user("first"), Message.assistant("mid"), Message.user("why?")],
+        tools=tools,
+        tool_choice=tool_choice,
+    )
+
+
+def test_anthropic_tool_choice_none_with_tools_rides_the_turns_auto() -> None:
+    """The aside body must equal the turn body: same tools, same tool_choice."""
+    client = AnthropicClient()
+    turn = client._build_body(_anthropic_request("auto", tools=_aside_tools()))
+    aside = client._build_body(_anthropic_request("none", tools=_aside_tools()))
+    assert aside["tool_choice"] == {"type": "auto"}
+    # Byte-identical prefix, not merely an equal tool_choice: any other key
+    # that differed would break the messages cache just the same.
+    assert aside == turn
+
+
+def test_anthropic_tool_choice_mapping_with_tools() -> None:
+    cases: list[tuple[Literal["auto", "none", "required"], dict[str, str]]] = [
+        ("auto", {"type": "auto"}),
+        ("none", {"type": "auto"}),
+        ("required", {"type": "any"}),
+    ]
+    for choice, expected in cases:
+        body = AnthropicClient()._build_body(_anthropic_request(choice, tools=_aside_tools()))
+        assert body["tool_choice"] == expected, choice
+
+
+def test_anthropic_tool_choice_none_without_tools_sends_no_tool_choice_key() -> None:
+    """Naming, the compaction summary and the server operator send tools=[]
+    with tool_choice="none"; they carry neither key, before and after."""
+    body = AnthropicClient()._build_body(_anthropic_request("none", tools=[]))
+    assert "tools" not in body
+    assert "tool_choice" not in body
+
+
+def test_other_wires_keep_a_literal_none_with_tools() -> None:
+    """The mapping is Anthropic-only. OpenAI-compatible wires document no
+    cache penalty for tool_choice, and Gemini's mode MUST stay NONE because
+    its default with tools present is to allow calls."""
+    openai_request = ChatRequest(
+        model=_spec(provider="openai"),
+        messages=[Message.user("why?")],
+        tools=_aside_tools(),
+        tool_choice="none",
+    )
+    assert OpenAICompatClient("https://x")._build_body(openai_request)["tool_choice"] == "none"
+    assert (
+        OpenAICompatClient("https://x")._build_responses_body(openai_request)["tool_choice"]
+        == "none"
+    )
+    google_request = ChatRequest(
+        model=_spec(provider="google", model_id="gemini-2.5-pro"),
+        messages=[Message.user("why?")],
+        tools=_aside_tools(),
+        tool_choice="none",
+    )
+    body = GoogleClient()._build_body(google_request)
+    assert body["toolConfig"]["functionCallingConfig"]["mode"] == "NONE"
 
 
 def test_google_emits_tools_and_pins_function_calling_to_none() -> None:

--- a/tests/unit/session/test_aside.py
+++ b/tests/unit/session/test_aside.py
@@ -20,6 +20,7 @@ from local_operator.harness.types import (
     StreamEndEvent,
     StreamEvent,
     StreamTextDelta,
+    StreamToolCallDelta,
     StreamUsageEvent,
     TextContent,
     ToolCall,
@@ -33,17 +34,32 @@ MODEL = ModelSpec(provider="test", model_id="m", context_window=100_000)
 
 
 class RecordingStream:
-    """Answers every request with fixed events; keeps the requests."""
+    """Answers every request with fixed events; keeps the requests.
 
-    def __init__(self, events: list[StreamEvent] | None = None) -> None:
+    ``scripted`` answers request N with ``scripted[N]`` instead (the last
+    script repeats), for the tests that need the second request to differ
+    from the first — the bare-tool-call retry.
+    """
+
+    def __init__(
+        self,
+        events: list[StreamEvent] | None = None,
+        *,
+        scripted: list[list[StreamEvent]] | None = None,
+    ) -> None:
         self.events = events if events is not None else [StreamTextDelta(delta="answer.")]
+        self.scripted = scripted
         self.requests: list[ChatRequest] = []
 
     def __call__(self, request: ChatRequest, signal: AbortSignal | None):
         self.requests.append(request)
+        if self.scripted is not None:
+            events = self.scripted[min(len(self.requests) - 1, len(self.scripted) - 1)]
+        else:
+            events = self.events
 
         async def gen():
-            for event in self.events:
+            for event in events:
                 yield event
 
         return gen()
@@ -107,8 +123,10 @@ async def test_complete_aside_sends_the_live_context_and_no_tools(tmp_path) -> N
     The aside sends the SAME live tool schema a working turn sends, not ``[]``:
     the tools block is the front of every provider's cache prefix, so dropping
     it would push the aside off the turn's cached prefix and force a full
-    re-process (the regression this fixes). ``tool_choice="none"`` is what keeps
-    "reads the turn, calls nothing" true even though the tools are present.
+    re-process (the regression this fixes). ``tool_choice="none"`` states the
+    "reads the turn, calls nothing" intent; the OpenAI and Gemini wires carry
+    it literally, and on Anthropic — where it would break the messages cache —
+    the session enforces it by never executing a tool-call delta instead.
     """
     tools = [_tool("bash"), _tool("read")]
     stream = RecordingStream()
@@ -205,6 +223,112 @@ async def test_complete_aside_reports_what_it_spent(tmp_path) -> None:
     await session.complete_aside([Message.user("why?")], on_usage=seen.append)
 
     assert [(u.input_tokens, u.output_tokens) for u in seen] == [(1200, 40)]
+    await session.dispose()
+
+
+#: A model that answered by reaching for a tool. On Anthropic the aside's wire
+#: ``tool_choice`` is the turn's ``auto`` (the messages-level cache is keyed on
+#: it), so this CAN come back; the session is what keeps it inert.
+_BARE_TOOL_CALL: list[StreamEvent] = [
+    StreamToolCallDelta(index=0, id="call_1", name="read"),
+    StreamToolCallDelta(index=0, argument_delta='{"path": "x"}'),
+    StreamUsageEvent(usage=Usage(input_tokens=1000, output_tokens=20)),
+    StreamEndEvent(stop_reason="toolUse"),
+]
+
+
+@pytest.mark.asyncio
+async def test_complete_aside_retries_a_bare_tool_call_without_tools(tmp_path) -> None:
+    """Tool call and no text -> one retry with ``tools=[]``, and its text wins.
+
+    The retry is off the cache prefix by construction (the tools block is the
+    front of it), so it must be BOUNDED to this case: exactly one extra
+    request, never a loop. Both requests' usage is reported, because both were
+    paid for. Nothing executes and nothing joins the history either way.
+    """
+    tools = [_tool("bash"), _tool("read")]
+    stream = RecordingStream(
+        scripted=[
+            _BARE_TOOL_CALL,
+            [
+                StreamTextDelta(delta="because."),
+                StreamUsageEvent(usage=Usage(input_tokens=1100, output_tokens=5)),
+                StreamEndEvent(stop_reason="stop"),
+            ],
+        ]
+    )
+    session = make_session(tmp_path, stream, tools=tools)
+    session._context.messages.append(Message.user("port it"))
+    before = list(session._context.messages)
+    deltas: list[str] = []
+    seen: list[Usage] = []
+
+    answer = await session.complete_aside(
+        [Message.user("why?")], on_delta=deltas.append, on_usage=seen.append
+    )
+
+    assert answer == "because."
+    assert deltas == ["because."]
+    assert len(stream.requests) == 2
+    first, retry = stream.requests
+    assert first.tools == session._context.tools and first.tool_choice == "none"
+    assert retry.tools == [] and retry.tool_choice == "none"
+    # The retry is the same request minus the tools: same history, same system.
+    assert [m.text for m in retry.messages] == [m.text for m in first.messages]
+    assert retry.system_blocks == first.system_blocks
+    assert [u.input_tokens for u in seen] == [1000, 1100]
+    assert session._context.messages == before
+    assert session._transcript.entries() == []
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_complete_aside_retry_is_bounded_to_one(tmp_path) -> None:
+    """A second bare tool call is NOT retried again: the answer is empty and
+    the caller sees it, rather than an unbounded loop off the cache prefix."""
+    stream = RecordingStream(scripted=[_BARE_TOOL_CALL])
+    session = make_session(tmp_path, stream, tools=[_tool("read")])
+
+    answer = await session.complete_aside([Message.user("why?")])
+
+    assert answer == ""
+    assert len(stream.requests) == 2
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_complete_aside_keeps_text_beside_an_inert_tool_call(tmp_path) -> None:
+    """Text plus a tool call is an answer: the text is returned, the call is
+    dropped unread, and there is no retry (the text is what was asked for)."""
+    stream = RecordingStream(
+        [
+            StreamTextDelta(delta="let me check "),
+            StreamToolCallDelta(index=0, id="call_1", name="read"),
+            StreamTextDelta(delta="— it was the sed step."),
+            StreamEndEvent(stop_reason="toolUse"),
+        ]
+    )
+    session = make_session(tmp_path, stream, tools=[_tool("read")])
+
+    answer = await session.complete_aside([Message.user("why?")])
+
+    assert answer == "let me check — it was the sed step."
+    assert len(stream.requests) == 1
+    assert session._transcript.entries() == []
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_complete_aside_empty_text_without_a_tool_call_is_not_retried(tmp_path) -> None:
+    """An empty answer that was NOT a tool call (a refusal, a length stop) is
+    the provider's answer; retrying it would only pay the full prefix twice."""
+    stream = RecordingStream([StreamEndEvent(stop_reason="refusal")])
+    session = make_session(tmp_path, stream, tools=[_tool("read")])
+
+    answer = await session.complete_aside([Message.user("why?")])
+
+    assert answer == ""
+    assert len(stream.requests) == 1
     await session.dispose()
 
 


### PR DESCRIPTION
## Summary of Changes

**Change class: C1 (standard / pre-authorized).**

The compaction advisor (`Session.advise_compaction`) and the `/btw` / `/loop` aside & judge requests (`Session.complete_aside`) send the **live tool schema with `tool_choice="none"`** while the working turn sends `tool_choice=auto`. Anthropic's prompt-caching docs list `tool_choice` as invalidating the **messages** level of the cache hierarchy (tools ✓ / system ✓ / messages ✘), and fleet analytics over 24h (to 2026-09-01T23:20) attributed to that mismatch **33.9% of all Anthropic cache-write tokens: 254 calls / 70.7M tokens with the head-only signature** (`cache_read` 15–45k ≈ tools+system head only, `cache_write` > 100k ≈ context − head, `output < 2k`) — the same window and figures as `docs/evidence/compaction-advisor/aside-tool-choice-measurement.txt`; an earlier rough cut of the same query (~250 events / 52M / 25%) is superseded by those numbers. That attribution was the **hypothesis**; the measurement below did not confirm it, and the signature was later root-caused to per-account cache isolation under reserve-verdict account rotation (#537).

This PR makes the aside's request body byte-identical to the turn's prefix on the Anthropic wire:

- `AnthropicClient._build_body` now emits the turn's own `{"type": "auto"}` whenever `request.tool_choice == "none"` AND tools are present. No-tools callers (naming, compaction summary, server operator) never reach the branch and still carry no `tool_choice` key at all. OpenAI-compatible and Gemini keep a literal `none` (no documented cache penalty there, and Gemini's mode MUST stay `NONE` because its default with tools present is to allow calls).
- The "reads the turn, calls nothing" contract moves to where it is actually enforceable — the callers. Both `complete_aside` and `advise_compaction` already consume only `StreamTextDelta`/`StreamUsageEvent`; a `tool_use` block in the answer is inert. That is now documented at both sites.
- The appended prompts (`ASIDE_PROMPT`, `LOOP_JUDGE_PROMPT`, the advisor's instructions + closing line) now say explicitly to **answer in text and not call a tool**.
- `complete_aside` retries **once** with `tools=[]` when the answer was a bare tool call and no text (the one way the mapping is observable), so the `/btw` card never shows a blank; text-beside-a-call is returned as its text with no retry, and the advisor does not retry at all (an unparseable answer is already a handled outcome there). Justified in the docstring: the retry is off the cache prefix by construction, so it is bounded to that rare case rather than paid on every aside.

## The honest measurement (prediction vs result) ⚠️

**The live endpoint contradicted the predicted mechanism, and the PR keeps the change anyway — as hygiene, not savings.** New sibling script `scripts/measure_aside_tool_choice_cache.py` (real `ChatRequest` through the real `AnthropicClient`, ~37k-token conversation of 12 tool-call/tool-result pairs, `effort=low`, `max_tokens=200`), four arms on `claude-opus-5`:

```
1 WARM   (turn, tools, auto)        : cache_read=0     cache_write=36578 input=2 output=200 context=36580 cache_hit=0.0%
2 ASIDE  pre-fix  (tool_choice none): cache_read=36578 cache_write=674  input=2 output=68  context=37254 cache_hit=98.2%
3 RE-WARM (turn, tools, auto)       : cache_read=36578 cache_write=0    input=2 output=0   context=36580 cache_hit=100.0%
4 ASIDE  fixed    (tool_choice auto): cache_read=37252 cache_write=0    input=2 output=67  context=37254 cache_hit=100.0%
```

Confirmed on `claude-fable-5-1` with the 2-call arm (`--arms 2`): `cache_read=36578, cache_write=674` — identical.

- **Arm 2 (pre-fix `none`) read the FULL turn prefix and wrote only its 674-token appended question** — 98.2% hit, identical in outcome to the fixed arm. No measurable messages-cache penalty for `none` vs `auto` on this account and these models.
- The script's **first run** did show `cache_read=0, cache_write=37252` for arm 2 — the exact fleet signature — but that run's arm 3 also read 0, so the cause was the **1-second settle between arms**, not `tool_choice`: a cache entry "only becomes available after the first response begins" (docs), and 1s was not enough here. The committed script uses a 5s settle (`SETTLE_SECONDS`, documented).
- Re-examining the fleet's 254 head-only events against their own sessions: `cache_read` ≈ the **tools block alone** (209/254), not tools+system; 219/254 have their next same-session call read ≥ that event's `cache_read` (ordinary prefix-extension writes the next turn then hits); 81/254 (24M tokens) follow a >60s gap (the documented 5-min TTL shape — the target of sibling PR #532); the rest interleave two sub-contexts within one session (parent + subagent lines), each extending its own prefix. **The `tool_choice` attribution did not hold up.**

Why keep the change: the docs' invalidation table is unambiguous about the risk direction, so an aside whose `tool_choice` differs from the turn's is one enforcement change away from re-writing every message block on every aside call; and sending the turn's own value is the honest request — nothing about an aside changes the tool surface. The old `96.1%`-hit claims in the `complete_aside`/`advise_compaction` docstrings are corrected (they came from a toy conversation whose head WAS most of the prompt), and `docs/evidence/compaction-advisor/aside-tool-choice-measurement.txt` records the full story, both runs included.

## Related Issue(s)

- Sibling PRs: #532 (1h TTL), #533 (usage-aware account pick) — the other two slices of the same cache/quota investigation, each on its own branch from the same base.

## Impact

- No breaking changes, no dependency updates. `tool_choice` never appears on the wire for no-tools requests, before or after.
- On Anthropic, a tools-carrying aside may now legally emit a `tool_use` block; it is dropped unread by the callers (and the prompts now discourage it), and the bare-tool-call case is retried once without tools.
- Version: `0.44.32 → 0.44.33` (main is at .32 via #527; sibling #533 is at .29 — the merger re-sequences the patch numbers if the merge order changes).

## Testing Details

**Live evidence** — the four usage lines above (plus the fable 2-arm), captured with the provider's own `usage` counters over real streamed OAuth calls through `AuthStore(default_db_path()).get_oauth_access("anthropic")`. Total live spend: 6 calls ≈ 30–37k prompt tokens each, ≤ 200 output tokens. Further live calls were **not** possible: all five preflight accounts read 100% of their 5h window at measurement time (`~/.local-operator/usage_cache.db`), so the fable 4-arm (re-warm + fixed) is the one thing not exercised — arm 4's outcome is implied by arm 2's (identical bodies, and the opus run's arm 4 hit 100%), but not directly shown on that model.

**Unit tests** (`tests/unit/providers/test_clients.py`, `tests/unit/session/test_aside.py`):

- `test_anthropic_tool_choice_none_with_tools_rides_the_turns_auto` — aside body **equal** to turn body (any differing key would break the cache the same way).
- `test_anthropic_tool_choice_mapping_with_tools` — auto→auto, none→auto, required→any with tools present.
- `test_anthropic_tool_choice_none_without_tools_sends_no_tool_choice_key` — no-tools callers unchanged.
- `test_other_wires_keep_a_literal_none_with_tools` — OpenAI compat + responses, Gemini `NONE` unchanged.
- `test_complete_aside_retries_a_bare_tool_call_without_tools` — one retry with `tools=[]`, both usages reported, no trace left; `test_complete_aside_retry_is_bounded_to_one`; `test_complete_aside_keeps_text_beside_an_inert_tool_call`; `test_complete_aside_empty_text_without_a_tool_call_is_not_retried`.
- Existing aside/advisor cache tests updated where they asserted the literal `{"type": "none"}`.

**Gates (whole tree, as CI runs):** flake8 clean · black 26.1.0 clean · isort 5.13.2 clean · pyright 0 errors. `tests/unit` full suite **10568 passed, 15 skipped**; targeted dirs (`tests/unit/providers`, `tests/unit/session`, `tests/unit/model`, `tests/unit/compaction`, `tests/unit/tui`) all green with `-n 4`.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [ ] I have linked all related issues. (none filed; context is the shared cache-quota investigation)

