### PR TITLE
fix(preflight): keep a session on its sticky account under a reserve verdict

### DIFF
--- a/local_operator/guides/failover/GUIDE.md
+++ b/local_operator/guides/failover/GUIDE.md
@@ -35,7 +35,9 @@ first, then a per-session hash of the session id so concurrent sessions start on
 different accounts rather than stampeding one, then round-robin for callers with
 no session. An account that just failed on a provider-side fault is *demoted*
 (sorted last), never removed — a 500 is not the account's fault, so it stays
-available as a last resort.
+available as a last resort. A demotion never applies to the account a session
+is already sticky to: it steers *new* picks, and a session's warm prompt cache
+lives on its current account (see "Quota reserve" below).
 
 When a request fails on quota, `_recover_quota_blocked` (in
 `providers/failover.py`) probes the *other* accounts' own usage before the chain
@@ -62,10 +64,22 @@ rather than on quota forecasts. Turn it on to spend one lightweight quota
 request per user-message boundary in exchange for routing that leaves a
 provider before it fails.
 
-`usageReservePercent` (default 10) holds back a slice of quota. Two rules that
-are easy to get backwards:
+`usageReservePercent` (default 10) is the headroom below which an account
+counts as **low**. Three rules that are easy to get backwards:
 
-- Reserve quota can select a **lower-effort route on the same provider** without
+- **Low is a preference for new picks, never an eviction.** The provider's
+  prompt cache is per account, so a session already transacting on a low
+  account **stays there** — it is told once (`quota low (N% remaining) —
+  staying on this account to keep the prompt cache warm; new sessions will
+  prefer other accounts`) and keeps spending that account down to zero. Moving
+  it would rewrite its whole conversation prefix at cache-write price on an
+  account that has never seen it; on a multi-account host that rewrite was
+  measured at ~38% of all cache writes. The low account is demoted for
+  *other* sessions' first picks (and for a session that only just landed on
+  it with nothing cached), and the reactive 429 path keeps the same promise
+  (`rotate_sibling`: "sticky preserved"). Only a **depleted** verdict (0%
+  remaining) moves a running session, because then the rewrite is unavoidable.
+- Low quota can select a **lower-effort route on the same provider** without
   blocking the account. Dropping from high to low effort on the model the user
   chose is cheaper than leaving for another vendor, so the reserve buys a
   cheaper route before it buys a different provider.

--- a/local_operator/guides/failover/GUIDE.md
+++ b/local_operator/guides/failover/GUIDE.md
@@ -37,7 +37,11 @@ no session. An account that just failed on a provider-side fault is *demoted*
 (sorted last), never removed — a 500 is not the account's fault, so it stays
 available as a last resort. A demotion never applies to the account a session
 is already sticky to: it steers *new* picks, and a session's warm prompt cache
-lives on its current account (see "Quota reserve" below).
+lives on its current account (see "Quota reserve" below). Because the marks
+are process-wide, this also means *another* session's 500 on account A no
+longer moves a session that is sticky to A — only that session's **own** 500
+does, since `rotate_sibling` clears its sticky for a server fault before the
+mark is consulted.
 
 When a request fails on quota, `_recover_quota_blocked` (in
 `providers/failover.py`) probes the *other* accounts' own usage before the chain
@@ -70,15 +74,20 @@ counts as **low**. Three rules that are easy to get backwards:
 - **Low is a preference for new picks, never an eviction.** The provider's
   prompt cache is per account, so a session already transacting on a low
   account **stays there** — it is told once (`quota low (N% remaining) —
-  staying on this account to keep the prompt cache warm; new sessions will
-  prefer other accounts`) and keeps spending that account down to zero. Moving
-  it would rewrite its whole conversation prefix at cache-write price on an
+  staying on this account to keep the prompt cache warm`) and keeps spending
+  that account down to zero, at its current effort (a same-provider
+  lower-effort hop would invalidate the cached conversation too). Moving it
+  would rewrite its whole conversation prefix at cache-write price on an
   account that has never seen it; on a multi-account host that rewrite was
-  measured at ~38% of all cache writes. The low account is demoted for
-  *other* sessions' first picks (and for a session that only just landed on
-  it with nothing cached), and the reactive 429 path keeps the same promise
-  (`rotate_sibling`: "sticky preserved"). Only a **depleted** verdict (0%
-  remaining) moves a running session, because then the rewrite is unavoidable.
+  measured at ~38% of all cache writes. The reactive 429 path keeps the same
+  promise (`rotate_sibling`: "sticky preserved"). Only a **depleted** verdict
+  (0% remaining) moves a running session, because then the rewrite is
+  unavoidable. A *new* session that lands on the low account with nothing
+  cached still moves off it: its own boundary walk demotes the row and
+  re-picks. That is per session, not a standing preference — the demotion
+  written by the walk is short-lived, and the stay branch writes none — so
+  new sessions do not yet *avoid* a low account up front; that needs the
+  usage-ranked first pick (`retry.usageAwareAccountPick`), a separate change.
 - Low quota can select a **lower-effort route on the same provider** without
   blocking the account. Dropping from high to low effort on the model the user
   chose is cheaper than leaving for another vendor, so the reserve buys a

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1665,15 +1665,6 @@ class SessionStreamFn:
         self._primary_selector: str | None = None
         self._usage_checked_selector: str | None = None
         self._usage_checked_at = 0.0
-        # The credential this session was sticky to when the CURRENT boundary
-        # walk began — i.e. the account whose prompt cache holds this
-        # conversation. Captured by ``preflight_usage`` ahead of its first
-        # resolve, because every resolve in the walk re-pins the session, so
-        # the store's live sticky stops answering "where is my cache warm?"
-        # after the first hop. Read by ``_apply_account_health`` to decide
-        # whether a reserve verdict is about a warm account (stay) or a fresh
-        # pick (move on).
-        self._boundary_sticky_id: int | None = None
         # Quota is re-probed at EVERY user-message boundary, but the user only
         # needs to hear about a CHANGE in quota standing — not the same "quota
         # low"/"quota exhausted" line echoed on every message they send while
@@ -2455,7 +2446,17 @@ class SessionStreamFn:
         # ``_apply_account_health``); against any other row it is a fresh pick
         # the walk may still move. ``None`` on a session's very first boundary
         # — nothing is warm anywhere, so every row is a fresh pick.
-        self._boundary_sticky_id = self._auth_store.session_credential_id(
+        #
+        # A LOCAL, threaded through ``_apply_account_health`` like the memos
+        # above, never an attribute: this stream fn is shared by a parent and
+        # its child sessions (``harness/subagent.py`` hands the child the
+        # parent's stream fn), and a mid-turn ``/model`` probe can re-enter
+        # here while a walk is suspended at an ``await``. A second entrant
+        # would re-read the store sticky — by then the first walk's fresh pick,
+        # since every resolve re-pins — and an attribute would hand that pick
+        # back to the first walk as "warm", settling it on a reserve account it
+        # meant to move off.
+        boundary_sticky_id = self._auth_store.session_credential_id(
             model.provider, self._session_id
         )
         while True:
@@ -2494,6 +2495,7 @@ class SessionStreamFn:
                             attempted_ids,
                             quota_cache,
                             usage_memo,
+                            boundary_sticky_id,
                         ):
                             continue
                         return
@@ -2646,6 +2648,7 @@ class SessionStreamFn:
                             attempted_ids,
                             quota_cache,
                             usage_memo,
+                            boundary_sticky_id,
                         ):
                             continue
                         return
@@ -2667,7 +2670,7 @@ class SessionStreamFn:
                         # rotation, which spammed the transcript on every
                         # boundary. Rotate silently.
                         continue
-                    if access.credential_id != self._boundary_sticky_id:
+                    if access.credential_id != boundary_sticky_id:
                         # Reserve on a FRESH pick: steer new picks elsewhere.
                         # Same rule and reasoning as the account-scope path in
                         # ``_apply_account_health``.
@@ -2682,8 +2685,7 @@ class SessionStreamFn:
                         selector,
                         f"model:{health.state}",
                         f"{model.provider} {condition}{remaining} for {model.model_id} "
-                        "— staying on this account to keep the prompt cache warm; "
-                        "new sessions will prefer other accounts",
+                        "— staying on this account to keep the prompt cache warm",
                         "info",
                     )
                     await self._route_state.clear_settled("primary model still has quota")
@@ -2744,6 +2746,7 @@ class SessionStreamFn:
                 attempted_ids,
                 quota_cache,
                 usage_memo,
+                boundary_sticky_id,
             ):
                 continue
             return
@@ -2760,6 +2763,7 @@ class SessionStreamFn:
         attempted_ids: set[int],
         quota_cache: dict[str, str] | None = None,
         usage_memo: "dict[str, UsageReport | None] | None" = None,
+        boundary_sticky_id: int | None = None,
     ) -> bool:
         """Act on a low/depleted account-scope verdict.
 
@@ -2772,6 +2776,11 @@ class SessionStreamFn:
         ``usage_memo`` is the same walk's per-account report memo, threaded
         for the same reason one level down: the fallback chain may list this
         walk's own provider, whose accounts have already been read.
+        ``boundary_sticky_id`` is the credential the session was sticky to
+        when the walk BEGAN — the account its prompt cache is warm on — and
+        is walk-local for the reason ``preflight_usage`` gives where it reads
+        it; the default ``None`` (nothing warm) is only for callers outside a
+        walk.
 
         The binding windows that produced ``health`` can be scoped to a model
         tier while the shared windows still hold quota (Anthropic's
@@ -2846,14 +2855,14 @@ class SessionStreamFn:
         # preserved"), applied to the preflight.
         #
         # "Already transacting on" is the sticky captured BEFORE this
-        # boundary's walk started (``_boundary_sticky_id``): the walk's own
+        # boundary's walk started (``boundary_sticky_id``): the walk's own
         # resolves re-pin the session as they go, so a row the walk only just
         # landed on is a FRESH pick with nothing cached, and demoting it to
         # keep walking (below) is still right. Both callers of this method
         # arrive with a row the walk resolved — the boundary probe and a
         # blocked-row recovery — so the fresh-pick branch is reachable from
         # both.
-        on_warm_account = access.credential_id == self._boundary_sticky_id
+        on_warm_account = access.credential_id == boundary_sticky_id
         if not siblings and health.state == "reserve":
             # Last account on this provider, still holding spendable quota.
             # Crossing the reserve threshold used to hop to the next chain
@@ -2866,6 +2875,7 @@ class SessionStreamFn:
                 fallback,
                 f"{model.provider} {condition}{remaining} — continuing until "
                 f"{model.provider} quota is exhausted",
+                keep_effort=False,
             )
             return False
 
@@ -2930,6 +2940,7 @@ class SessionStreamFn:
                     attempted_ids,
                     quota_cache,
                     usage_memo,
+                    boundary_sticky_id,
                 )
 
         if not siblings and fallback is None:
@@ -2980,11 +2991,16 @@ class SessionStreamFn:
             # lone-account rule because that one must also hold when nothing
             # is cached yet. This is the branch the rotation below used to
             # take for every low account, warm or not.
+            #
+            # ``keep_effort``: the whole point of staying is the warm cache,
+            # and a same-provider effort hop would spend part of it — see
+            # ``_settle_on_reserve_account``.
             await self._settle_on_reserve_account(
                 model,
                 fallback,
                 f"{model.provider} {condition}{remaining} — staying on this account to "
-                "keep the prompt cache warm; new sessions will prefer other accounts",
+                "keep the prompt cache warm",
+                keep_effort=True,
             )
             return False
 
@@ -3049,21 +3065,37 @@ class SessionStreamFn:
         )
         return False
 
-    async def _settle_on_reserve_account(self, model: ModelSpec, fallback: Any, text: str) -> None:
+    async def _settle_on_reserve_account(
+        self, model: ModelSpec, fallback: Any, text: str, *, keep_effort: bool
+    ) -> None:
         """Keep serving on an account that is low but still holds quota.
 
         Shared by the two account-scope reasons to stay — the LAST account on
         the provider, and the account this session's prompt cache is warm on
-        — so they cannot drift apart. A same-provider lower-effort hop is
-        still taken first when the chain offers one: it reduces token spend
-        without abandoning remaining quota or the account's warm cache.
-        Otherwise one ``account:reserve`` line per transition (the
-        ``account:`` scope token keeps it distinct from the model-tier branch
-        that shares this selector), and the route settles on the primary.
+        — so they cannot drift apart. One ``account:reserve`` line per
+        transition (the ``account:`` scope token keeps it distinct from the
+        model-tier branch that shares this selector), and the route settles on
+        the primary. The two stays alias on that token on purpose: both mean
+        "low, still serving here", and a session that crosses from one to the
+        other (a sibling blocked or unblocked while this account stays low)
+        is not owed a second line for the same standing.
+
+        ``keep_effort`` decides whether a same-provider lower-effort hop the
+        chain offers is taken first. On the LAST account it is (``False``):
+        nothing else can serve, so trading a one-off cache rewrite for a
+        lower per-request spend on every request until the window resets
+        is the better side of the bargain. On the WARM account it is not
+        (``True``): the session is staying precisely to keep its cache, and
+        Anthropic invalidates cached message prefixes when the thinking
+        parameters change (system and tools stay cached; the conversation
+        does not) — the same reason the auto-effort is frozen per tool loop
+        (``_message_effort``). A hop here would rewrite the very prefix the
+        stay exists to protect, and a healthy sibling is available, so the
+        spend argument is weaker too.
         """
         from local_operator.providers.failover import parse_selector
 
-        if fallback is not None:
+        if fallback is not None and not keep_effort:
             fallback_provider, _model_id = parse_selector(fallback.selector)
             if fallback_provider == model.provider:
                 await self._route_state.activate(fallback, text, quota=True)
@@ -3087,8 +3119,8 @@ class SessionStreamFn:
         since ``attempted_ids`` already holds it, the walk would end there
         with the session left on the reserve account it meant to leave.
         Releasing is safe precisely because this row is NOT the boundary's
-        original sticky (``_boundary_sticky_id``): nothing of this
-        conversation is cached on it yet.
+        original sticky (the walk-local ``boundary_sticky_id``): nothing of
+        this conversation is cached on it yet.
         """
         self._auth_store.deprioritize_credential(model.provider, credential_id)
         self._auth_store.release_session_credential(model.provider, self._session_id)

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1665,6 +1665,15 @@ class SessionStreamFn:
         self._primary_selector: str | None = None
         self._usage_checked_selector: str | None = None
         self._usage_checked_at = 0.0
+        # The credential this session was sticky to when the CURRENT boundary
+        # walk began — i.e. the account whose prompt cache holds this
+        # conversation. Captured by ``preflight_usage`` ahead of its first
+        # resolve, because every resolve in the walk re-pins the session, so
+        # the store's live sticky stops answering "where is my cache warm?"
+        # after the first hop. Read by ``_apply_account_health`` to decide
+        # whether a reserve verdict is about a warm account (stay) or a fresh
+        # pick (move on).
+        self._boundary_sticky_id: int | None = None
         # Quota is re-probed at EVERY user-message boundary, but the user only
         # needs to hear about a CHANGE in quota standing — not the same "quota
         # low"/"quota exhausted" line echoed on every message they send while
@@ -2438,6 +2447,17 @@ class SessionStreamFn:
         # walk and discarded with it, so the next boundary still re-probes
         # live and can notice recovery.
         usage_memo: dict[str, UsageReport | None] = {}
+        # The credential this session is ALREADY transacting on, read before
+        # the walk resolves anything: every resolve below re-pins the session
+        # to whatever row it lands on, so after the first iteration the store's
+        # sticky no longer says where the conversation's prompt cache lives.
+        # A reserve verdict against THIS row keeps the session on it (see
+        # ``_apply_account_health``); against any other row it is a fresh pick
+        # the walk may still move. ``None`` on a session's very first boundary
+        # — nothing is warm anywhere, so every row is a fresh pick.
+        self._boundary_sticky_id = self._auth_store.session_credential_id(
+            model.provider, self._session_id
+        )
         while True:
             try:
                 access = await self._auth_store.get_oauth_access(
@@ -2630,6 +2650,8 @@ class SessionStreamFn:
                             continue
                         return
                 if siblings:
+                    # Only reserve or depleted reach here: healthy and unknown
+                    # returned above.
                     if health.state == "depleted":
                         self._write_quota_block(
                             self._auth_store,
@@ -2638,16 +2660,34 @@ class SessionStreamFn:
                             health,
                             max(60_000, health.reset_after_ms or self.DEFAULT_USAGE_BLOCK_MS),
                         )
-                    else:
-                        self._auth_store.deprioritize_credential(
-                            model.provider, access.credential_id
-                        )
-                    # Rotating to another same-provider account is an internal
-                    # implementation detail — the user's request is still being
-                    # served on this provider, just on a different login. It
-                    # used to emit a notice per rotation, which spammed the
-                    # transcript on every boundary. Rotate silently.
-                    continue
+                        # Rotating to another same-provider account is an
+                        # internal implementation detail — the user's request
+                        # is still being served on this provider, just on a
+                        # different login. It used to emit a notice per
+                        # rotation, which spammed the transcript on every
+                        # boundary. Rotate silently.
+                        continue
+                    if access.credential_id != self._boundary_sticky_id:
+                        # Reserve on a FRESH pick: steer new picks elsewhere.
+                        # Same rule and reasoning as the account-scope path in
+                        # ``_apply_account_health``.
+                        self._demote_fresh_pick(model, access.credential_id)
+                        continue
+                    # Reserve on the account this session is already
+                    # transacting on: stay. Moving would rewrite the
+                    # conversation's prompt cache on a sibling that has never
+                    # seen it; the reserve verdict is a preference for new
+                    # picks. See ``_apply_account_health`` for the numbers.
+                    await self._announce_quota_change(
+                        selector,
+                        f"model:{health.state}",
+                        f"{model.provider} {condition}{remaining} for {model.model_id} "
+                        "— staying on this account to keep the prompt cache warm; "
+                        "new sessions will prefer other accounts",
+                        "info",
+                    )
+                    await self._route_state.clear_settled("primary model still has quota")
+                    return
                 if health.state == "reserve":
                     # Last account, still holding this model's quota. Same
                     # rule as the account-scope path: reserve is not a
@@ -2744,7 +2784,11 @@ class SessionStreamFn:
         any shared headroom — including remaining under the reserve
         threshold — is always allowed to spend it down to zero before
         a provider fallback is even considered. Reserve is a preference
-        between siblings of the same provider, not a hop to the next one.
+        between siblings of the same provider, not a hop to the next one —
+        and, since the provider's prompt cache is per account, a preference
+        for NEW picks only: a session already transacting on a reserve
+        account stays there (see the ``on_warm_account`` branch), and only a
+        depleted verdict moves it.
         """
         from local_operator.providers.failover import parse_selector
 
@@ -2783,35 +2827,46 @@ class SessionStreamFn:
             quota_cache=quota_cache,
             usage_memo=usage_memo,
         )
+        # A reserve verdict is a preference for NEW picks, never a reason to
+        # move a session that is already transacting on the account. The
+        # provider's prompt cache is per account: a conversation carrying a
+        # 150-500k-token warm prefix that is re-resolved onto a sibling
+        # rewrites the whole prefix at cache-write price on an account that
+        # has never seen it, and buys nothing for it — the reserve account
+        # still HAS quota. Measured on a five-account host: 374 such moves in
+        # 30 hours, ~102M cache-write tokens, roughly 38% of every Anthropic
+        # cache write, most of them a few seconds after a full cache hit in
+        # the same conversation; with three accounts above 90% the demotion
+        # expired and re-fired at every boundary, ping-ponging the session
+        # between cold caches. So the session under verdict stays put (the
+        # store exempts its sticky row from the demotion too, see
+        # ``AuthStore._usable_key_rows``) and only a DEPLETED verdict may move
+        # it, because at 0% the rewrite is unavoidable. This is the promise
+        # the reactive 429 path already keeps (``rotate_sibling``: "sticky
+        # preserved"), applied to the preflight.
+        #
+        # "Already transacting on" is the sticky captured BEFORE this
+        # boundary's walk started (``_boundary_sticky_id``): the walk's own
+        # resolves re-pin the session as they go, so a row the walk only just
+        # landed on is a FRESH pick with nothing cached, and demoting it to
+        # keep walking (below) is still right. Both callers of this method
+        # arrive with a row the walk resolved — the boundary probe and a
+        # blocked-row recovery — so the fresh-pick branch is reachable from
+        # both.
+        on_warm_account = access.credential_id == self._boundary_sticky_id
         if not siblings and health.state == "reserve":
             # Last account on this provider, still holding spendable quota.
             # Crossing the reserve threshold used to hop to the next chain
             # entry (Kimi at 10% remaining → Qwen maxed → Grok) while this
             # account could still serve. Reserve is a preference BETWEEN
             # siblings of the same provider, not a licence to leave the
-            # provider; spend it to zero, then fail over. A same-provider
-            # lower-effort hop is still allowed — it reduces token spend
-            # without abandoning remaining quota.
-            if fallback is not None:
-                fallback_provider, _model_id = parse_selector(fallback.selector)
-                if fallback_provider == model.provider:
-                    await self._route_state.activate(
-                        fallback,
-                        f"{model.provider} {condition}{remaining}",
-                        quota=True,
-                    )
-                    return False
-            # ``account:`` scope token: this is the account-scope path, and its
-            # condition must dedup separately from the model-tier branch that
-            # shares this selector.
-            await self._announce_quota_change(
-                selector,
-                f"account:{health.state}",
+            # provider; spend it to zero, then fail over.
+            await self._settle_on_reserve_account(
+                model,
+                fallback,
                 f"{model.provider} {condition}{remaining} — continuing until "
                 f"{model.provider} quota is exhausted",
-                "info",
             )
-            await self._route_state.clear_settled("primary model still has quota")
             return False
 
         if not siblings and health.state == "depleted":
@@ -2917,6 +2972,22 @@ class SessionStreamFn:
             self._route_state.clear()
             return False
 
+        if health.state == "reserve" and on_warm_account:
+            # Reserve on the account this session is already transacting on,
+            # with a sibling available: stay anyway. Placed AFTER the
+            # tier-spent guard because that verdict is the more specific one
+            # (the binding cap does not even gate this model), and after the
+            # lone-account rule because that one must also hold when nothing
+            # is cached yet. This is the branch the rotation below used to
+            # take for every low account, warm or not.
+            await self._settle_on_reserve_account(
+                model,
+                fallback,
+                f"{model.provider} {condition}{remaining} — staying on this account to "
+                "keep the prompt cache warm; new sessions will prefer other accounts",
+            )
+            return False
+
         # How the account is taken out of the running depends on WHAT the
         # verdict was, and conflating the two is the incident this split
         # comes from. "Depleted" is a fact about the provider: it will 429
@@ -2938,6 +3009,11 @@ class SessionStreamFn:
         # the moment it is the only thing left. The mark is short-lived on
         # purpose; the preflight re-checks and re-applies it while the
         # preference still holds.
+        #
+        # A reserve verdict on the session's warm account never reaches this
+        # point (it settled above); a reserve verdict here is about a FRESH
+        # pick, so demoting it steers new picks — and this walk's next
+        # resolve — elsewhere.
         if health.state == "depleted":
 
             def take_out_of_rotation(credential_id: int) -> None:
@@ -2952,10 +3028,7 @@ class SessionStreamFn:
         else:
 
             def take_out_of_rotation(credential_id: int) -> None:
-                # Keyed by ``model.provider``, not ``storage``: demotions
-                # are consulted by ``_resolve`` under the provider name the
-                # request resolves with.
-                self._auth_store.deprioritize_credential(model.provider, credential_id)
+                self._demote_fresh_pick(model, credential_id)
 
         if siblings:
             take_out_of_rotation(access.credential_id)
@@ -2975,6 +3048,50 @@ class SessionStreamFn:
             quota=True,
         )
         return False
+
+    async def _settle_on_reserve_account(self, model: ModelSpec, fallback: Any, text: str) -> None:
+        """Keep serving on an account that is low but still holds quota.
+
+        Shared by the two account-scope reasons to stay — the LAST account on
+        the provider, and the account this session's prompt cache is warm on
+        — so they cannot drift apart. A same-provider lower-effort hop is
+        still taken first when the chain offers one: it reduces token spend
+        without abandoning remaining quota or the account's warm cache.
+        Otherwise one ``account:reserve`` line per transition (the
+        ``account:`` scope token keeps it distinct from the model-tier branch
+        that shares this selector), and the route settles on the primary.
+        """
+        from local_operator.providers.failover import parse_selector
+
+        if fallback is not None:
+            fallback_provider, _model_id = parse_selector(fallback.selector)
+            if fallback_provider == model.provider:
+                await self._route_state.activate(fallback, text, quota=True)
+                return
+        await self._announce_quota_change(
+            f"{model.provider}/{model.model_id}", "account:reserve", text, "info"
+        )
+        await self._route_state.clear_settled("primary model still has quota")
+
+    def _demote_fresh_pick(self, model: ModelSpec, credential_id: int) -> None:
+        """Deprioritize a reserve row the walk only just resolved onto.
+
+        Keyed by ``model.provider``, not ``storage``: demotions are consulted
+        by ``_resolve`` under the provider name the request resolves with.
+
+        The pin is released in the same breath, and it has to be: the resolve
+        that found this row pinned the session to it, and the store keeps a
+        demoted STICKY row in service on purpose (the warm-cache rule in
+        ``AuthStore._usable_key_rows``). Demoting without releasing would hand
+        the walk's next resolve the very row it is trying to move off — and
+        since ``attempted_ids`` already holds it, the walk would end there
+        with the session left on the reserve account it meant to leave.
+        Releasing is safe precisely because this row is NOT the boundary's
+        original sticky (``_boundary_sticky_id``): nothing of this
+        conversation is cached on it yet.
+        """
+        self._auth_store.deprioritize_credential(model.provider, credential_id)
+        self._auth_store.release_session_credential(model.provider, self._session_id)
 
     async def _recover_blocked_accounts(
         self,

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -838,13 +838,14 @@ class AuthStore:
         demoted = self._active_demotions(provider)
         if not demoted:
             return ordered
-        preferred = [r for r in ordered if r.id not in demoted]
         # Every row demoted means the pool has been walked once, so the marks
         # describe an outage rather than any one account: they are stale and the
         # rows are equally good again. Only THIS tier's rows are cleared -- the
         # cascade calls this once per credential tier with a different subset,
         # so popping the whole provider would let a one-row tier wipe the marks
-        # belonging to rows it never saw.
+        # belonging to rows it never saw. Judged on the RAW mark set, before the
+        # sticky exemption below, so "the whole tier is demoted" keeps meaning
+        # exactly that and the stale-marks rule is unchanged by stickiness.
         #
         # This branch is NOT the cascade's safety net, and exactly one pass
         # reaches it. On :meth:`_resolve`'s FIRST pass ``_usable_key_rows`` has
@@ -861,7 +862,7 @@ class AuthStore:
         # demoted lone row resolvable at all is the ``ignore_demotions`` pass in
         # :meth:`_resolve`; do not reason about cascade-wide all-demoted
         # behaviour from here.
-        if not preferred:
+        if all(r.id in demoted for r in ordered):
             # Not under ``read_only``: clearing the marks is a routing DECISION,
             # and an isolated request running beside a user's turn must not be
             # able to move that turn's account. It still gets the same order --
@@ -870,7 +871,14 @@ class AuthStore:
             if not read_only:
                 self.clear_deprioritized(provider, [r.id for r in ordered])
             return ordered
-        return preferred + [r for r in ordered if r.id in demoted]
+        # The session's sticky row is exempt from the sort-last: see
+        # ``_usable_key_rows`` for why a demotion is a preference for NEW picks
+        # and never a reason to move a session off the account it is
+        # transacting on. ``_base_selection_order`` already put it first, and
+        # the partition is stable, so exempting it keeps it there.
+        movable = demoted - {self.session_credential_id(provider, session_id)}
+        preferred = [r for r in ordered if r.id not in movable]
+        return preferred + [r for r in ordered if r.id in movable]
 
     def _base_selection_order(
         self, rows: list[StoredCredential], provider: str, session_id: str | None
@@ -881,7 +889,7 @@ class AuthStore:
         its only caller.
         """
         if session_id:
-            sticky_id = self._sticky.get((provider, session_id))
+            sticky_id = self.session_credential_id(provider, session_id)
             sticky = next((r for r in rows if r.id == sticky_id), None)
             if sticky is not None:
                 rest = [r for r in rows if r.id != sticky.id]
@@ -902,6 +910,33 @@ class AuthStore:
             self._sticky.pop((provider, session_id), None)
         else:
             self._sticky[(provider, session_id)] = credential_id
+
+    def session_credential_id(self, provider: str, session_id: str | None) -> int | None:
+        """The credential ``session_id`` is sticky to for ``provider``, if any.
+
+        The read half of :meth:`pin_session_credential`. The quota preflight
+        captures this BEFORE its boundary walk resolves anything, because the
+        walk's own resolve pins the session to whatever row it lands on — so
+        "is the account under verdict the one this session is transacting
+        on?" can only be answered from a reading taken ahead of the walk. Same
+        storage-id normalisation as the write, so an alias and its base agree.
+        """
+        if not session_id:
+            return None
+        return self._sticky.get((self._storage_id(provider), session_id))
+
+    def release_session_credential(self, provider: str, session_id: str | None) -> None:
+        """Forget a session's sticky selection so its next resolve picks afresh.
+
+        The public clear beside :meth:`pin_session_credential`. Needed by the
+        quota preflight when it demotes a row the session was only just pinned
+        to by the walk's own resolve (a fresh pick, nothing cached on it yet):
+        the cascade keeps a demoted STICKY row in service on purpose (see
+        ``_usable_key_rows``), so without dropping the pin the re-resolve would
+        hand back the very row the walk is trying to move off. A no-op without
+        a session id, like the write it mirrors.
+        """
+        self._set_sticky(provider, session_id, None)
 
     def pin_session_credential(
         self, provider: str, session_id: str | None, credential_id: int
@@ -926,6 +961,7 @@ class AuthStore:
         *,
         ignore_demotions: bool = False,
         model_id: str = "",
+        session_id: str | None = None,
     ) -> list[StoredCredential]:
         # ``model_id`` scopes the block filter: an account blocked only for a
         # model family (a spent scoped weekly cap) still serves every other
@@ -967,7 +1003,33 @@ class AuthStore:
         # the net has already fired -- that is what suppressed this filter.
         demoted = set() if ignore_demotions else self._active_demotions(provider)
         if demoted:
-            remaining = [r for r in rows if r.id not in demoted]
+            # The session's STICKY row survives the drop (a BLOCKED sticky does
+            # not: the block filter above ran first and blocks are verdicts
+            # that the account cannot serve). A demotion is a preference about
+            # where NEW picks go; it is never a reason to move a session that
+            # is already transacting on the account. The provider's prompt
+            # cache is per account, so moving a live conversation rewrites its
+            # whole prefix (150-500k tokens at cache-write price) to buy
+            # nothing — the sibling has never seen it. Measured on this host:
+            # 374 such moves in 30h, 102M cache-write tokens, ~38% of every
+            # Anthropic cache write, most of them 2-70s after a full cache hit
+            # in the same conversation. The marks are process-wide, so this
+            # exemption is also what keeps ANOTHER session's demotion of this
+            # account from evicting a sibling session mid-conversation on it.
+            # A session whose OWN request 529'd still moves: ``rotate_sibling``
+            # clears that session's sticky for a server fault before the mark
+            # is consulted, so the exemption finds nothing to keep. The
+            # reactive quota path already keeps the warm-account promise
+            # (``rotate_sibling``: "sticky preserved" on a usage 429); this is
+            # the same rule applied to the preference marks.
+            #
+            # The exemption is keyed on stickiness alone, not on whether the
+            # session has actually sent a request yet — the store cannot tell.
+            # A caller that demotes a row the session was pinned to by a
+            # resolve moments ago (a fresh pick) and wants the next resolve to
+            # move must release the pin first (``release_session_credential``).
+            sticky_id = self.session_credential_id(provider, session_id)
+            remaining = [r for r in rows if r.id not in demoted or r.id == sticky_id]
             if remaining:
                 return remaining
             # Every row in THIS tier is demoted: yield the tier so the cascade
@@ -1229,6 +1291,7 @@ class AuthStore:
             source=None,
             ignore_demotions=ignore_demotions,
             model_id=model_id,
+            session_id=session_id,
         )
         for row in self._selection_order(oauth_rows, provider, session_id, read_only=read_only):
             try:
@@ -1256,6 +1319,7 @@ class AuthStore:
             source="login",
             ignore_demotions=ignore_demotions,
             model_id=model_id,
+            session_id=session_id,
         )
         for row in self._selection_order(login_rows, provider, session_id, read_only=read_only):
             key = row.data.get("key")
@@ -1282,6 +1346,7 @@ class AuthStore:
                 source=None,
                 ignore_demotions=ignore_demotions,
                 model_id=model_id,
+                session_id=session_id,
             )
             if row.data.get("source") != "login"
         ]

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -1003,6 +1003,21 @@ class AuthStore:
         # the net has already fired -- that is what suppressed this filter.
         demoted = set() if ignore_demotions else self._active_demotions(provider)
         if demoted:
+            # Every row in THIS tier is demoted: yield the tier so the cascade
+            # moves on to whatever comes next -- another tier, the env var, or
+            # the resolver -- and, if nothing else serves, the second pass at
+            # the end of :meth:`_resolve` clears the marks together and
+            # re-resolves (the sticky then wins as usual). Judged on the RAW
+            # rows, BEFORE the sticky exemption below, and it has to be: run
+            # after it, an all-demoted tier with a sticky inside came back as
+            # the one sticky row, ``_selection_order`` read that one-row tier
+            # as "all demoted" and cleared only the sticky's mark -- an
+            # outage's marks then decayed asymmetrically and every other
+            # session's fresh pick skewed onto the sticky's account for the
+            # rest of the TTL. The stale-marks rule is about the tier, and
+            # stickiness must not change what "the whole tier" means.
+            if all(r.id in demoted for r in rows):
+                return []
             # The session's STICKY row survives the drop (a BLOCKED sticky does
             # not: the block filter above ran first and blocks are verdicts
             # that the account cannot serve). A demotion is a preference about
@@ -1029,13 +1044,7 @@ class AuthStore:
             # resolve moments ago (a fresh pick) and wants the next resolve to
             # move must release the pin first (``release_session_credential``).
             sticky_id = self.session_credential_id(provider, session_id)
-            remaining = [r for r in rows if r.id not in demoted or r.id == sticky_id]
-            if remaining:
-                return remaining
-            # Every row in THIS tier is demoted: yield the tier so the cascade
-            # moves on to whatever comes next -- another tier, the env var, or
-            # the resolver.
-            return []
+            return [r for r in rows if r.id not in demoted or r.id == sticky_id]
         return rows
 
     # -- the cascade ---------------------------------------------------------

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -456,7 +456,7 @@ SETTINGS: tuple[Setting, ...] = (
         label="Usage reserve (%)",
         kind=Kind.FLOAT,
         default=10.0,
-        help="Quota headroom kept in reserve before usage-aware fallback moves on.",
+        help="Headroom below which new sessions avoid an account; running ones stay.",
         minimum=0.0,
         maximum=100.0,
     ),

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -456,7 +456,7 @@ SETTINGS: tuple[Setting, ...] = (
         label="Usage reserve (%)",
         kind=Kind.FLOAT,
         default=10.0,
-        help="Headroom below which new sessions avoid an account; running ones stay.",
+        help="Headroom below which an account counts as low; a running session stays on it.",
         minimum=0.0,
         maximum=100.0,
     ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.32"
+version = "0.44.35"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -832,6 +832,251 @@ async def test_usage_preflight_demotes_rather_than_blocks_a_reserve_account(tmp_
 
 
 @pytest.mark.asyncio
+async def test_reserve_on_the_sticky_account_keeps_the_session_there(tmp_path) -> None:
+    """A reserve verdict is a preference for NEW picks, never an eviction.
+
+    The measured defect: a session sticky to account A (its whole conversation
+    cached there) hit a boundary where A read 8% remaining and B was healthy.
+    The preflight demoted A process-wide, the cascade dropped A from the tier,
+    the session was re-pinned to B and its 150-500k-token prefix was rewritten
+    on B at cache-write price — then, 120s later with B also low, back again.
+    Now the session stays on A with one info line, and only a FRESH session
+    prefers B."""
+    store = AuthStore(tmp_path / "auth.db")
+    warm = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    cold = store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    stream = create_stream_fn(
+        store,
+        {"retry": {"usageAwareFallback": True, "usageReservePercent": 10}},
+        session_id="session-a",
+    )
+    notices: list[str] = []
+    stream.set_notice_handler(lambda text, kind: notices.append(f"{kind}:{text}"))
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+    # The session has been transacting on A: that is where its cache is warm.
+    store.pin_session_credential("anthropic", "session-a", warm.id)
+
+    async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        return _anthropic_usage(92.0 if access_token == "oauth-a" else 40.0)
+
+    async def boundary() -> None:
+        stream.begin_message()
+        stream._usage_checked_at = 0.0
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await boundary()
+            await stream.preflight_usage(model)
+
+            selected = await store.get_oauth_access("anthropic", "session-a")
+            assert selected is not None and selected.credential_id == warm.id
+            assert not store.is_blocked(warm.id, "anthropic")
+            # Not demoted either: the mark is for a fresh pick the walk is
+            # moving off, and this walk moved off nothing.
+            assert store._active_demotions("anthropic") == set()
+            assert stream._route_state.active is None
+            assert notices == [
+                "info:anthropic quota low (8% remaining) — staying on this account to keep "
+                "the prompt cache warm; new sessions will prefer other accounts"
+            ]
+
+            # Steady state is silent, and the session still does not move.
+            await boundary()
+            await stream.preflight_usage(model)
+            selected = await store.get_oauth_access("anthropic", "session-a")
+            assert selected is not None and selected.credential_id == warm.id
+            assert len(notices) == 1
+
+        # A session with nothing cached anywhere still prefers the healthy
+        # account: that is what the reserve threshold is FOR.
+        fresh = create_stream_fn(
+            store,
+            {"retry": {"usageAwareFallback": True, "usageReservePercent": 10}},
+            session_id=_session_hashing_to_first_row(2),
+        )
+        try:
+            with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+                await fresh.preflight_usage(model)
+            picked = await store.get_oauth_access("anthropic", fresh._session_id)
+            assert picked is not None and picked.credential_id == cold.id
+        finally:
+            await fresh.close()
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_depleted_on_the_sticky_account_still_moves_the_session(tmp_path) -> None:
+    """The one verdict that may move a warm session: at 0% the rewrite is
+    unavoidable, so the block is written and the session re-pins to a sibling."""
+    store = AuthStore(tmp_path / "auth.db")
+    warm = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    cold = store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    stream = create_stream_fn(
+        store,
+        {"retry": {"usageAwareFallback": True, "usageReservePercent": 10}},
+        session_id="session-a",
+    )
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+    store.pin_session_credential("anthropic", "session-a", warm.id)
+
+    async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        return _anthropic_usage(100.0 if access_token == "oauth-a" else 40.0)
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(model)
+
+        assert store.is_blocked(warm.id, "anthropic")
+        selected = await store.get_oauth_access("anthropic", "session-a")
+        assert selected is not None and selected.credential_id == cold.id
+        assert store.session_credential_id("anthropic", "session-a") == cold.id
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_reserve_on_a_fresh_pick_moves_on_and_the_walk_terminates(tmp_path) -> None:
+    """A row the walk only just landed on holds nothing cached, so reserve on it
+    still steers the walk to a sibling — and the walk must END there.
+
+    The trap: the store keeps a demoted STICKY row in service, and the walk's
+    own resolve pinned the session to this fresh pick. Demoting without
+    releasing the pin would re-resolve the same row, find it in
+    ``attempted_ids``, and return with the session parked on the account it
+    meant to leave. Three accounts, the first two in reserve, so the walk has
+    to move twice; every probe is counted so a re-probe of the same account
+    would show up as a fourth fetch."""
+    store = AuthStore(tmp_path / "auth.db")
+    first = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    second = store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    third = store.upsert_credential("anthropic", _oauth("oauth-c", "account-c"))
+    session = _session_hashing_to_first_row(3)
+    stream = create_stream_fn(
+        store,
+        {"retry": {"usageAwareFallback": True, "usageReservePercent": 10}},
+        session_id=session,
+    )
+    notices: list[str] = []
+    stream.set_notice_handler(lambda text, kind: notices.append(f"{kind}:{text}"))
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+    probed: list[str] = []
+
+    async def usage_for_access(_client, _provider, *, access_token="", **_kwargs):
+        probed.append(access_token)
+        return _anthropic_usage({"oauth-a": 95.0, "oauth-b": 93.0}.get(access_token, 20.0))
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(model)
+
+        assert probed == ["oauth-a", "oauth-b", "oauth-c"]
+        selected = await store.get_oauth_access("anthropic", session)
+        assert selected is not None and selected.credential_id == third.id
+        assert store._active_demotions("anthropic") == {first.id, second.id}
+        assert not store.is_blocked(first.id, "anthropic")
+        assert not store.is_blocked(second.id, "anthropic")
+        # Silent: fresh-pick rotation is the internal detail it always was.
+        assert notices == []
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_reserve_on_the_sticky_account_is_silent_after_the_walk_settles(
+    tmp_path,
+) -> None:
+    """The stay decision is taken against the sticky captured BEFORE the walk,
+    so a session whose warm account is reached only after the walk moves off a
+    fresh reserve pick is still recognised as warm there — and not demoted.
+
+    Shape: sticky on C (warm). The walk starts on C (sticky first), finds it
+    in reserve, and must settle immediately, never touching A or B."""
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    warm = store.upsert_credential("anthropic", _oauth("oauth-c", "account-c"))
+    stream = create_stream_fn(
+        store,
+        {"retry": {"usageAwareFallback": True, "usageReservePercent": 10}},
+        session_id="session-a",
+    )
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+    store.pin_session_credential("anthropic", "session-a", warm.id)
+    probed: list[str] = []
+
+    async def usage_for_access(_client, _provider, *, access_token="", **_kwargs):
+        probed.append(access_token)
+        return _anthropic_usage(94.0 if access_token == "oauth-c" else 20.0)
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(model)
+
+        assert probed == ["oauth-c"]
+        selected = await store.get_oauth_access("anthropic", "session-a")
+        assert selected is not None and selected.credential_id == warm.id
+        assert store._active_demotions("anthropic") == set()
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_model_tier_reserve_on_the_sticky_account_keeps_the_session_there(
+    tmp_path,
+) -> None:
+    """The model-tier branch (a scoped weekly cap in reserve) keeps the same
+    promise as the account-scope one: warm account stays, fresh pick moves."""
+    store = AuthStore(tmp_path / "auth.db")
+    warm = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    cold = store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    stream = create_stream_fn(
+        store,
+        {"retry": {"usageAwareFallback": True, "usageReservePercent": 10}},
+        session_id="session-a",
+    )
+    notices: list[str] = []
+    stream.set_notice_handler(lambda text, kind: notices.append(f"{kind}:{text}"))
+    model = ModelSpec(provider="anthropic", model_id="claude-fable-5")
+    store.pin_session_credential("anthropic", "session-a", warm.id)
+
+    async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        return _anthropic_fable_usage(95.0 if access_token == "oauth-a" else 20.0)
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(model)
+
+        selected = await store.get_oauth_access("anthropic", "session-a")
+        assert selected is not None and selected.credential_id == warm.id
+        assert store._active_demotions("anthropic") == set()
+        assert not store.is_blocked(warm.id, "anthropic")
+        assert len(notices) == 1 and "staying on this account" in notices[0]
+        assert "for claude-fable-5" in notices[0]
+
+        # And a session that is NOT warm on A moves to B (silently).
+        fresh = create_stream_fn(
+            store,
+            {"retry": {"usageAwareFallback": True, "usageReservePercent": 10}},
+            session_id=_session_hashing_to_first_row(2),
+        )
+        try:
+            with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+                await fresh.preflight_usage(model)
+            picked = await store.get_oauth_access("anthropic", fresh._session_id)
+            assert picked is not None and picked.credential_id == cold.id
+        finally:
+            await fresh.close()
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
 async def test_reserve_account_still_serves_after_the_healthy_sibling_depletes(tmp_path) -> None:
     """The incident this change fixes, replayed end to end.
 
@@ -1219,8 +1464,9 @@ async def test_distinct_quota_conditions_on_one_selector_do_not_alias(tmp_path) 
       exhausted" line.
     - Phase 2 (``model-reserve``): the Opus weekly tier cap that gates this exact
       model is in reserve while the shared pool is healthy → a MODEL-scope reserve
-      verdict and the ``model:reserve`` "for <model> — continuing until anthropic
-      quota is exhausted" line.
+      verdict and the ``model:reserve`` "for <model> — staying on this account to
+      keep the prompt cache warm" line (the session is already sticky to this
+      account from phase 1, so a reserve verdict keeps it there).
 
     Under the fix both are announced once (tokens ``tier-spent:reserve`` and
     ``model:reserve`` are distinct). Under the bug — a token that encoded only
@@ -1231,9 +1477,10 @@ async def test_distinct_quota_conditions_on_one_selector_do_not_alias(tmp_path) 
     point. See ``test_state_only_quota_token_would_alias_distinct_scopes`` for the
     companion that pins the bug direction by forcing a state-only token.
 
-    Two same-provider accounts are configured so the walk rotates siblings
-    silently before the last account lands on the scoped reserve announce (the
-    model-tier branch), and so the account-scope tier-spent branch is reachable."""
+    Two same-provider accounts are configured so a sibling exists (the shape
+    under which phase 2 takes the model-tier stay-on-sticky branch rather than
+    the lone-account one), and so the account-scope tier-spent branch is
+    reachable."""
     store = AuthStore(tmp_path / "auth.db")
     store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
     store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
@@ -1263,7 +1510,7 @@ async def test_distinct_quota_conditions_on_one_selector_do_not_alias(tmp_path) 
         stream._usage_checked_at = 0.0
 
     tier_spent_line = "continuing until shared windows are exhausted"
-    model_reserve_line = "for claude-opus-5 — continuing until anthropic quota is exhausted"
+    model_reserve_line = "for claude-opus-5 — staying on this account to keep the prompt cache warm"
     try:
         with patch("local_operator.providers.usage.fetch_usage", side_effect=report_for_phase):
             # 1) The account-scope (tier-spent) reserve condition announces once
@@ -1341,7 +1588,7 @@ async def test_state_only_quota_token_would_alias_distinct_scopes(tmp_path) -> N
         stream._usage_checked_at = 0.0
 
     tier_spent_line = "continuing until shared windows are exhausted"
-    model_reserve_line = "for claude-opus-5 — continuing until anthropic quota is exhausted"
+    model_reserve_line = "for claude-opus-5 — staying on this account to keep the prompt cache warm"
     try:
         with patch("local_operator.providers.usage.fetch_usage", side_effect=report_for_phase):
             phase["value"] = "tier-spent"

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -877,7 +877,7 @@ async def test_reserve_on_the_sticky_account_keeps_the_session_there(tmp_path) -
             assert stream._route_state.active is None
             assert notices == [
                 "info:anthropic quota low (8% remaining) — staying on this account to keep "
-                "the prompt cache warm; new sessions will prefer other accounts"
+                "the prompt cache warm"
             ]
 
             # Steady state is silent, and the session still does not move.
@@ -1020,6 +1020,129 @@ async def test_reserve_on_the_sticky_account_is_silent_after_the_walk_settles(
         selected = await store.get_oauth_access("anthropic", "session-a")
         assert selected is not None and selected.credential_id == warm.id
         assert store._active_demotions("anthropic") == set()
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_walks_on_one_stream_fn_each_keep_their_own_boundary_sticky(
+    tmp_path,
+) -> None:
+    """Review F2: the boundary sticky is walk-local, not stream-fn state.
+
+    A child session runs on its PARENT's stream fn (``harness/subagent.py``),
+    so two boundary walks can interleave on one instance. Shape: no sticky
+    yet; the parent's walk hash-picks A (reserve) and its resolve pins the
+    session to A, then suspends in the usage fetch. The child's walk enters
+    meanwhile, reads the store sticky — now A, the parent's fresh pick — and
+    judges A warm. Held on the instance, that reading leaked into the parent's
+    walk when it resumed: A compared equal to "its" boundary sticky, so the
+    parent settled on a reserve account it had every reason to leave. Kept
+    per walk, the parent still sees ``None`` (nothing was warm when it began),
+    demotes the fresh pick and moves to B."""
+    store = AuthStore(tmp_path / "auth.db")
+    low = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    healthy = store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    session = _session_hashing_to_first_row(2)
+    stream = create_stream_fn(
+        store,
+        {"retry": {"usageAwareFallback": True, "usageReservePercent": 10}},
+        session_id=session,
+    )
+    parent_model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+    child_model = ModelSpec(provider="anthropic", model_id="claude-sonnet-5")
+    parent_suspended = asyncio.Event()
+    child_done = asyncio.Event()
+    probed: list[str] = []
+
+    async def usage_for_access(_client, _provider, *, access_token="", **_kwargs):
+        probed.append(access_token)
+        if len(probed) == 1:
+            # The parent's first probe: park it until the child's whole walk
+            # has run, so the child's reading of the sticky is the one the
+            # parent would have inherited from a shared attribute.
+            parent_suspended.set()
+            await child_done.wait()
+        return _anthropic_usage(95.0 if access_token == "oauth-a" else 20.0)
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            parent = asyncio.create_task(stream.preflight_usage(parent_model))
+            await parent_suspended.wait()
+            # The parent's resolve has pinned the session to its fresh pick.
+            assert store.session_credential_id("anthropic", session) == low.id
+
+            # The child opens its own boundary on the shared stream fn.
+            stream.begin_message()
+            await stream.preflight_usage(child_model)
+            child_done.set()
+            await parent
+
+        # The parent judged A against ITS boundary reading (None): a fresh
+        # pick in reserve, so it was demoted and the walk moved on to B.
+        selected = await store.get_oauth_access("anthropic", session)
+        assert selected is not None and selected.credential_id == healthy.id
+        assert store._active_demotions("anthropic") == {low.id}
+        assert not store.is_blocked(low.id, "anthropic")
+        assert probed == ["oauth-a", "oauth-a", "oauth-b"]
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_a_warm_stay_keeps_the_current_effort(tmp_path) -> None:
+    """Review F4: staying on the warm account must not take the same-provider
+    lower-effort hop the chain offers. Anthropic drops the cached message
+    prefix when the thinking parameters change, so the hop would rewrite the
+    very conversation the stay exists to keep warm — the last-account branch
+    still takes it (``test_usage_reserve_can_reduce_effort_without_blocking_account``),
+    because there nothing else can serve and the per-request saving wins."""
+    store = AuthStore(tmp_path / "auth.db")
+    warm = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {
+                    "default": [
+                        {"provider": "anthropic", "model": "claude-opus-5", "effort": "low"}
+                    ]
+                },
+            }
+        },
+        session_id="session-a",
+    )
+    notices: list[str] = []
+    stream.set_notice_handler(lambda text, kind: notices.append(f"{kind}:{text}"))
+    model = ModelSpec(
+        provider="anthropic",
+        model_id="claude-opus-5",
+        reasoning=True,
+        reasoning_effort="high",
+    )
+    store.pin_session_credential("anthropic", "session-a", warm.id)
+
+    async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        return _anthropic_usage(95.0 if access_token == "oauth-a" else 20.0)
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(model)
+
+        selected = await store.get_oauth_access("anthropic", "session-a")
+        assert selected is not None and selected.credential_id == warm.id
+        # No effort route activated: the request goes out at the effort the
+        # conversation is cached under.
+        assert stream._route_state.active is None
+        assert notices == [
+            "info:anthropic quota low (5% remaining) — staying on this account to keep "
+            "the prompt cache warm"
+        ]
     finally:
         await stream.close()
         store.close()

--- a/tests/unit/model/test_effort_classifier.py
+++ b/tests/unit/model/test_effort_classifier.py
@@ -339,6 +339,9 @@ async def test_a_mid_turn_switch_still_quota_checks_the_new_provider(monkeypatch
         def is_blocked(self, *args, **kwargs):
             return False
 
+        def session_credential_id(self, provider, session_id):
+            return None
+
     stream._auth_store = cast(Any, WatchedAuth())
     first = ModelSpec(provider="pa", model_id="m")
     second = ModelSpec(provider="pb", model_id="m")
@@ -499,6 +502,9 @@ async def test_a_stale_call_cannot_spend_the_new_models_quota_check() -> None:
         def is_blocked(self, *args, **kwargs):
             return False
 
+        def session_credential_id(self, provider, session_id):
+            return None
+
     stream = SessionStreamFn(cast(Any, FakeAuth()), {"retry": {"usageAwareFallback": True}}, "s")
     # Observe the CREDENTIAL LOOKUP the check body performs, never the flags the
     # gate itself reads: a probe computed from that state passes even when the
@@ -516,6 +522,9 @@ async def test_a_stale_call_cannot_spend_the_new_models_quota_check() -> None:
 
         def is_blocked(self, *args, **kwargs):
             return False
+
+        def session_credential_id(self, provider, session_id):
+            return None
 
     stream._auth_store = cast(Any, WatchedAuth())
     first = ModelSpec(provider="pa", model_id="m")

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -1466,6 +1466,36 @@ class TestADemotionNeverMovesASessionOffItsStickyAccount:
         assert [r.id for r in order] == [a.id, b.id]
         assert store._active_demotions("anthropic") == set()
 
+    async def test_an_all_demoted_tier_clears_both_marks_through_resolve(
+        self, tmp_path: Any
+    ) -> None:
+        """Review F3: the same rule seen from ``_resolve``, where the tier
+        filter runs first. Sticky on A, A and B both demoted (an outage, not a
+        verdict about either account). The exemption used to hand the cascade
+        ``[A]`` alone, ``_selection_order`` read that one-row tier as "all
+        demoted" and cleared only A's mark — B stayed demoted, and every other
+        session's fresh pick then skewed onto A for the rest of the TTL. The
+        all-demoted judgement runs on the RAW rows so both marks clear
+        together, exactly as they did before the exemption existed, and the
+        sticky session still lands on A."""
+        store, a, b = self._pool(tmp_path)
+        store.pin_session_credential("anthropic", "s1", a.id)
+        store.deprioritize_credential("anthropic", a.id)
+        store.deprioritize_credential("anthropic", b.id)
+
+        access = await store.get_oauth_access("anthropic", "s1")
+        assert access is not None and access.credential_id == a.id
+        assert store._active_demotions("anthropic") == set()
+
+        # With the marks gone, a non-sticky session spreads by hash again
+        # rather than being funnelled onto the sticky's account.
+        picks = set()
+        for session in ("s2", "s3", "s4", "s5", "s6", "s7"):
+            other = await store.get_oauth_access("anthropic", session, read_only=True)
+            assert other is not None
+            picks.add(other.credential_id)
+        assert picks == {a.id, b.id}
+
     def test_the_sticky_sorts_first_even_while_demoted(self, tmp_path: Any) -> None:
         """The ordering half agrees with the tier-filter half: a demoted sticky
         is not sorted last either, or the two would disagree on the second

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -1324,3 +1324,176 @@ class TestLoginFlavourAliases:
         assert row.provider == "xai"
         assert await store.get_api_key("xai") == "flavour-write"
         assert await store.get_api_key("xai-oauth") == "flavour-write"
+
+
+class TestADemotionNeverMovesASessionOffItsStickyAccount:
+    """A demotion is a preference for NEW picks, never an eviction.
+
+    The provider's prompt cache is per account. Before this, a reserve
+    demotion written by the quota preflight — process-wide and shared by every
+    session in the process — dropped the demoted row from its tier, so a
+    session sticky to it fell to the hash pick and was re-pinned to a sibling
+    whose cache had never seen its conversation: the whole prefix rewritten at
+    cache-write price, and with several accounts low, again at the next
+    boundary once the 120s mark expired. Measured on a five-account host at
+    ~38% of all Anthropic cache writes over 30 hours. The reactive 429 path
+    already kept the sticky (``rotate_sibling``: "sticky preserved"); this
+    class pins the same rule for the preference marks.
+    """
+
+    @staticmethod
+    def _pool(tmp_path: Any) -> tuple[AuthStore, Any, Any]:
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        a = store.upsert_credential(
+            "anthropic",
+            {"type": "oauth", "access": "tok-a", "refresh": "r", "email": "a@example.com"},
+        )
+        b = store.upsert_credential(
+            "anthropic",
+            {"type": "oauth", "access": "tok-b", "refresh": "r", "email": "b@example.com"},
+        )
+        return store, a, b
+
+    async def test_sticky_survives_its_own_demotion_when_a_sibling_is_available(
+        self, tmp_path: Any
+    ) -> None:
+        """(a) The regression: sticky on A, A demoted, B healthy → still A."""
+        store, a, b = self._pool(tmp_path)
+        store.pin_session_credential("anthropic", "s1", a.id)
+
+        store.deprioritize_credential("anthropic", a.id)
+
+        access = await store.get_oauth_access("anthropic", "s1")
+        assert access is not None and access.credential_id == a.id
+        # The mark is untouched: it still steers OTHER picks (below).
+        assert store._active_demotions("anthropic") == {a.id}
+
+    async def test_a_session_without_a_sticky_still_skips_the_demoted_row(
+        self, tmp_path: Any
+    ) -> None:
+        """(b) Unchanged: a fresh session's hash pick never lands on a demoted row."""
+        store, a, b = self._pool(tmp_path)
+        store.deprioritize_credential("anthropic", a.id)
+
+        # Every session id, whatever its hash, avoids A while B is usable.
+        for session in ("s1", "s2", "s3", "session-abc", "another"):
+            access = await store.get_oauth_access("anthropic", session)
+            assert access is not None and access.credential_id == b.id, session
+
+    async def test_a_blocked_sticky_still_moves(self, tmp_path: Any) -> None:
+        """(c) Unchanged: a BLOCK is a verdict that the account cannot serve, and
+        the block filter runs ahead of the sticky exemption."""
+        store, a, b = self._pool(tmp_path)
+        store.pin_session_credential("anthropic", "s1", a.id)
+
+        store.block_credential(a.id, "anthropic", block_ms=60_000)
+
+        access = await store.get_oauth_access("anthropic", "s1")
+        assert access is not None and access.credential_id == b.id
+
+    async def test_a_blocked_and_demoted_sticky_still_moves(self, tmp_path: Any) -> None:
+        """Both marks at once (the depleted-then-demoted shape) still moves."""
+        store, a, b = self._pool(tmp_path)
+        store.pin_session_credential("anthropic", "s1", a.id)
+        store.deprioritize_credential("anthropic", a.id)
+        store.block_credential(a.id, "anthropic", block_ms=60_000)
+
+        access = await store.get_oauth_access("anthropic", "s1")
+        assert access is not None and access.credential_id == b.id
+
+    async def test_the_usage_limit_path_still_preserves_the_sticky(self, tmp_path: Any) -> None:
+        """(d) The reactive promise this change extends is itself unchanged."""
+        from local_operator.providers.failover import ProviderError
+
+        store, a, b = self._pool(tmp_path)
+        store.pin_session_credential("anthropic", "s1", a.id)
+
+        usage_limit = ProviderError(429, "rate limit reached", retryable=True)
+        assert store.rotate_sibling("anthropic", "s1", usage_limit, api_key="tok-a") is True
+
+        assert store.session_credential_id("anthropic", "s1") == a.id
+        # Blocked for the backoff, so the request in hand goes to B; the pin
+        # brings the session back to A once the block lapses.
+        assert store.is_blocked(a.id, "anthropic")
+
+    async def test_the_exemption_is_per_session(self, tmp_path: Any) -> None:
+        """Another session's warm account is not this session's: a demotion
+        written by (or for) one session still steers every OTHER session."""
+        store, a, b = self._pool(tmp_path)
+        store.pin_session_credential("anthropic", "warm", a.id)
+        store.deprioritize_credential("anthropic", a.id)
+
+        warm = await store.get_oauth_access("anthropic", "warm")
+        cold = await store.get_oauth_access("anthropic", "cold")
+        assert warm is not None and warm.credential_id == a.id
+        assert cold is not None and cold.credential_id == b.id
+
+    async def test_releasing_the_pin_lets_the_demotion_take_effect(self, tmp_path: Any) -> None:
+        """The escape hatch the preflight uses for a FRESH pick: a row the walk
+        only just pinned holds nothing cached, so release + demote moves on."""
+        store, a, b = self._pool(tmp_path)
+        store.pin_session_credential("anthropic", "s1", a.id)
+        store.deprioritize_credential("anthropic", a.id)
+        store.release_session_credential("anthropic", "s1")
+
+        access = await store.get_oauth_access("anthropic", "s1")
+        assert access is not None and access.credential_id == b.id
+        # ...and the session is now pinned to the account that served.
+        assert store.session_credential_id("anthropic", "s1") == b.id
+
+    async def test_a_read_only_resolve_also_stays_on_the_demoted_sticky(
+        self, tmp_path: Any
+    ) -> None:
+        """An isolated request beside the turn lands on the SAME credential the
+        turn is transacting on — the point of ``read_only`` reading stickiness."""
+        store, a, b = self._pool(tmp_path)
+        store.pin_session_credential("anthropic", "s1", a.id)
+        store.deprioritize_credential("anthropic", a.id)
+
+        access = await store.get_oauth_access("anthropic", "s1", read_only=True)
+        assert access is not None and access.credential_id == a.id
+        assert store._active_demotions("anthropic") == {a.id}
+
+    def test_the_all_demoted_stale_marks_rule_ignores_the_exemption(self, tmp_path: Any) -> None:
+        """ "Every row in the tier is demoted" is judged on the raw marks, so the
+        stale-marks clear in ``_selection_order`` fires exactly as before."""
+        store, a, b = self._pool(tmp_path)
+        store.pin_session_credential("anthropic", "s1", a.id)
+        store.deprioritize_credential("anthropic", a.id)
+        store.deprioritize_credential("anthropic", b.id)
+
+        order = store._selection_order(store.list_credentials("anthropic"), "anthropic", "s1")
+        assert [r.id for r in order] == [a.id, b.id]
+        assert store._active_demotions("anthropic") == set()
+
+    def test_the_sticky_sorts_first_even_while_demoted(self, tmp_path: Any) -> None:
+        """The ordering half agrees with the tier-filter half: a demoted sticky
+        is not sorted last either, or the two would disagree on the second
+        (``ignore_demotions``) pass."""
+        store, a, b = self._pool(tmp_path)
+        store.pin_session_credential("anthropic", "s1", a.id)
+        store.deprioritize_credential("anthropic", a.id)
+
+        order = store._selection_order(store.list_credentials("anthropic"), "anthropic", "s1")
+        assert [r.id for r in order] == [a.id, b.id]
+        # A session with no sticky still sees A last.
+        order = store._selection_order(store.list_credentials("anthropic"), "anthropic", "s2")
+        assert order[-1].id == a.id
+
+    async def test_a_server_fault_on_the_sticky_still_moves_the_session(
+        self, tmp_path: Any
+    ) -> None:
+        """The exemption must not undo 529 rotation: ``rotate_sibling`` clears
+        the session's sticky for a server fault before the mark is consulted,
+        so the demoted row has no pin to hide behind and the next attempt
+        moves to the sibling as it always did."""
+        from local_operator.providers.failover import ProviderError
+
+        store, a, b = self._pool(tmp_path)
+        store.pin_session_credential("anthropic", "s1", a.id)
+
+        overloaded = ProviderError(529, "overloaded_error: Overloaded", retryable=True)
+        assert store.rotate_sibling("anthropic", "s1", overloaded, api_key="tok-a") is True
+
+        access = await store.get_oauth_access("anthropic", "s1")
+        assert access is not None and access.credential_id == b.id


### PR DESCRIPTION
## Summary of Changes

**Change class: C1 (standard / pre-authorized).** Bug fix / reliability; patch bump `0.44.32 → 0.44.35` (rebased onto #527's 0.44.32 / tag `v0.44.32`; sequenced after #532 → 0.44.33 and #534 → 0.44.34 — the merger re-sequences the patch numbers by merge order).

Anthropic's prompt cache is isolated per organization/workspace, i.e. per OAuth account. This machine load-balances ~16 sessions plus subagents across 5 accounts. When the quota preflight found a session's **current** account in reserve (≤ `usageReservePercent` remaining, default 10 %) with an unblocked sibling, it called `deprioritize_credential` (process-wide, 120 s TTL), `_usable_key_rows` dropped the demoted row from its tier, `_base_selection_order` could no longer find the sticky, fell to the crc32 hash, and `_resolve` re-pinned the session onto a sibling whose cache had never seen the conversation. The only part of the prefix that hit was the shared tools+system head (~22–40 k tokens, warm on every account); the conversation (150–500 k tokens) was rewritten at cache-write price. With three of five accounts above 90 % of the 5 h window, the mark expired and re-fired at every message boundary — ping-pong between cold caches.

The reactive 429 path already got this right (`rotate_sibling`: "Sticky preserved: same account stays first after backoff"). The preflight's reserve path contradicted it.

**Principle implemented: a reserve verdict is a preference for NEW picks, never a reason to move a session already transacting on an account. Only a depleted verdict (0 %) may move a session, because there the rewrite is unavoidable.** On this PR alone a *new* session that lands on a low account still moves off it through its own boundary walk (demote fresh pick + release pin + re-pick); an up-front *avoidance* of low accounts at first pick is #533's usage-ranked first resolve, not this change.

### `AuthStore` (`providers/auth_store.py`)

- `_usable_key_rows` keeps a demoted row when it is the session's sticky (`session_id` is now threaded from `_resolve`). A **blocked** sticky still drops — the block filter runs first and blocks are verdicts that the account cannot serve.
- `_selection_order` exempts the sticky from the sort-last for the same reason. `_usable_key_rows` judges "every row in this tier is demoted" on the **raw** rows before applying the exemption (review F3): an all-demoted tier still yields empty, so `_resolve`'s second pass clears the tier's marks together and the sticky wins the re-resolve — instead of the exemption handing `_selection_order` a one-row tier and clearing only the sticky's mark. The `read_only` gate is unchanged.
- Two public seams beside `pin_session_credential`: `session_credential_id(provider, session_id)` (read) and `release_session_credential(provider, session_id)` (clear). Both storage-id normalised like the write.
- A session whose OWN request 529'd still rotates: `rotate_sibling` clears that session's sticky for a server fault before the mark is consulted, so the exemption has nothing to keep (asserted).

### Preflight (`model/configure.py`)

- `preflight_usage` captures `boundary_sticky_id` **before** its first resolve — every resolve in the walk re-pins the session, so the store's live sticky stops saying "where is my cache warm" after the first hop. It is a walk-local threaded through `_apply_account_health` like `attempted_ids` (review F2): the stream fn is shared by parent and child sessions and re-entered by a mid-turn `/model` probe, so an instance attribute could be overwritten by a second walk while the first is suspended.
- `_apply_account_health`: reserve on the boundary sticky with a sibling available → **stay**: one deduped `account:reserve` info line (`anthropic quota low (8% remaining) — staying on this account to keep the prompt cache warm`), route settled on the primary, no demotion, no block, **and no same-provider effort hop** (review F4: Anthropic invalidates the cached message prefix when thinking parameters change, which would rewrite the very conversation the stay protects). Shares `_settle_on_reserve_account(keep_effort=...)` with the existing last-account rule so the two cannot drift; the last-account branch still takes the effort hop, because there nothing else can serve and the per-request saving outweighs one rewrite. The two stays alias on the `account:reserve` token on purpose (both mean "low, still serving here").
- Reserve on a row the walk only just resolved onto (a **fresh pick**, nothing cached) still demotes — via `_demote_fresh_pick`, which also releases the pin. Without the release the store would keep serving the demoted sticky, `attempted_ids` would already hold it, and the walk would end parked on the account it meant to leave. This branch is reachable from both callers (the boundary probe and the blocked-row recovery), so it is not dead.
- Depleted stays as it was: block written, session moves.
- Same split on the model-tier branch (scoped weekly cap in reserve).
- The `usageReservePercent` help text and the failover guide now describe the reserve as a new-pick preference and a low-quota notice, not an eviction.

## Related Issue(s)

- Related: usage-skew / "All 5 OAuth credentials unusable" investigation. Sibling PRs: #534 (advisor/aside `tool_choice` cache split — ruled the compaction advisor out live), #533 (usage-aware least-loaded first pick), #532 (1h cache TTL on large contexts).

## Impact

- No breaking changes, no dependency updates.
- `AuthStore._usable_key_rows` gains a keyword-only `session_id=None`; the three cascade call sites pass it. Two new public methods; nothing removed.
- Behaviour change for users with several accounts on one provider and `usageAwareFallback: true` (NOT the shipped default): a running session no longer hops accounts when its account crosses the reserve threshold. It hops on depletion, as before. New sessions still prefer healthier accounts.
- Cost: one dict read per boundary (`session_credential_id`). No provider calls added.

## Testing Details

### Gates (whole tree, as CI)

```
.venv/bin/python -m flake8 .                                  → clean (rc 0)
uvx --from black==26.1.0 black --check .                       → 799 files would be left unchanged
uvx isort==5.13.2 --check .                                    → clean (rc 0)
.venv/bin/python -m pyright --pythonpath .venv/bin/python .    → 0 errors, 0 warnings, 0 informations
```

### Unit tests

`tests/unit/providers tests/unit/model tests/unit/session -n 4` (at 6727102f, rebased onto 47bc768f): **1864 passed, 1 failed** — `test_catalogue.py::test_the_gemini_wire_reaches_the_spec_through_a_real_transport[gemini-2.5-pro]`, which is **pre-existing on main** and reproduced 3/3 on the untouched base tree (`git stash` of the whole change) with the same command. Mechanism, bisected: `test_clients.py::test_google_sends_no_effort_key` calls the real `build_model_spec("google", "gemini-2.5-pro")` and warms the process-wide `_resolve_model_info_cached` lru; when worksteal puts the gemini wire test on the same worker the memo hit skips discovery and its `http.calls` assertion fires. Passes with `--dist load` (2/2), standalone (6/6), and `tests/unit/model` alone (3/3). Not touched here — out of slice.

`tests/unit` (full): 3 fails on the first run were the 2 `WatchedAuth` fakes in `test_effort_classifier.py` needing the new `session_credential_id` seam (fixed) + the gemini flake above; the 3 `test_episode_subprocess.py` errors ("no usable copied interpreter") are a host-environment issue with `venv --copies` on this uv Python and pass on re-run (13/13, and `tests/unit/evaluation` 512/512).

New tests, all **red on the pre-fix tree** (sources stashed, tests kept — 11 failures, each the defect assertion `credential_id == 2` where 1 was expected, or the missing seam):

- `test_auth_store.py::TestADemotionNeverMovesASessionOffItsStickyAccount` (11): (a) sticky + demoted + sibling → still sticky, mark untouched; (b) no sticky + demoted → every session hash skips the demoted row; (c) blocked sticky → moves; blocked+demoted → moves; (d) `rotate_sibling` usage-limit still preserves sticky; exemption is per session (a "cold" session still moves); `release_session_credential` lets the demotion take effect; `read_only` resolve stays on the demoted sticky without clearing; all-demoted stale-marks rule ignores the exemption; sticky sorts first while demoted; a 529 on the sticky still rotates.
- `test_configure.py` (5): reserve on sticky → no demotion, no block, exactly one notice, silent on the next boundary, session stays on A while a fresh session picks B; depleted on sticky → block + move + re-pin; reserve on fresh picks across 3 accounts → probes A, B, C exactly once each, lands on C, walk terminates, silent; sticky on C found in reserve first → settles immediately (`probed == ["oauth-c"]`); model-tier reserve on sticky → stays with the `for claude-fable-5 … staying on this account` line, fresh session moves.
- **Round-1 remediation tests** (all three red at the pre-fix head 8a9e366f with the new tests copied in — `1 == 2` for the parent's account, `FallbackTarget(... effort='low') is None`, `{2} == set()` — green at 6727102f): `test_configure.py::test_concurrent_walks_on_one_stream_fn_each_keep_their_own_boundary_sticky` (F2: parent walk parked in its first usage fetch after pinning fresh pick A; child boundary runs a whole walk on the same stream fn; parent resumes and still demotes A and moves to B — `probed == [a, a, b]`), `test_configure.py::test_a_warm_stay_keeps_the_current_effort` (F4: effort chain entry offered, warm stay leaves `_route_state.active is None`), `test_auth_store.py::…::test_an_all_demoted_tier_clears_both_marks_through_resolve` (F3: the reviewer's reproduction — sticky A, A+B demoted, resolve → A and `_active_demotions == set()`, then six non-sticky read-only picks spread over both rows).
- `test_distinct_quota_conditions_on_one_selector_do_not_alias` / its bracket companion: the phase-2 expected line updated to the new stay-on-sticky text (the session is sticky to that account from phase 1). Still asserts both scoped tokens announce once and a state-only token would alias.

### Reproduction (unit-level harness, `preflight_usage` driven end to end)

Two OAuth rows, session sticky on A, A at 8 % remaining, B at 60 %:

**Before (base, pre-fix tree):**
```
sticky before preflight : A
resolved after preflight: B
demoted ids             : ['A']
blocked                 : A=False B=False
notices                 : (none)
verdict                 : MOVED (cache cold on B)
fresh session picks     : B
```

**After (this PR):**
```
sticky before preflight : A
resolved after preflight: A
demoted ids             : []
blocked                 : A=False B=False
notices                 : ['[info] anthropic quota low (8% remaining) — staying on this account to keep the prompt cache warm']
verdict                 : STAYED on A
fresh session picks     : B
```

### Live proof of the premise (per-account cache isolation)

Three requests on `claude-haiku-4-5-20251001` through the machine's real shared OAuth store, over the exact wire body the harness builds (`AnthropicClient._build_body`/`_headers`, so `cache_control` markers ride along), ~5.8 k-token unique body; `message_start.usage` read straight off the SSE:

```
{"label": "1: first call on X (writes X's cache)",          "account": "<acct X>", "input": 3, "cache_creation": 5787, "cache_read": 0}
{"label": "2: same conversation on Y (never seen it)",     "account": "<acct Y>", "input": 3, "cache_creation": 5787, "cache_read": 0}
{"label": "3: same conversation again on X (full read)",   "account": "<acct X>", "input": 3, "cache_creation": 0,    "cache_read": 5787}

step 2 on Y: rewrote 5787 tokens, read 0 -> CONFIRMED: the cache is per account
step 3 on X: read 5787 of the 5787 written in step 1 -> CONFIRMED: the write lives on X
```

The harness's own `AnthropicClient.stream` path reports the same numbers for this body (`input=3 cache_read=5787 cache_write=0` on a fourth call to X); the proof reads `message_start` directly only so the three usage dicts are the provider's own words.

### Analytics evidence (`~/.local-operator/analytics.db`, read-only)

Head-only-hit events over the last 30 h — `cache_read` in the shared-head band (10–60 k), conversation rewritten (`cache_write` > 60 k), context ≥ 100 k:

```sql
WITH w AS (SELECT * FROM calls WHERE provider='anthropic' AND ts_ms >= (strftime('%s','now') - 30*3600)*1000),
moved AS (SELECT * FROM w WHERE cache_read_tokens BETWEEN 10000 AND 60000 AND cache_write_tokens > 60000 AND context_tokens >= 100000)
SELECT 'all anthropic calls', COUNT(*), SUM(cache_write_tokens) FROM w
UNION ALL SELECT 'head-only-hit events', COUNT(*), SUM(cache_write_tokens) FROM moved
UNION ALL SELECT 'share of cache writes (%)', NULL, ROUND(100.0*(SELECT SUM(cache_write_tokens) FROM moved)/(SELECT SUM(cache_write_tokens) FROM w),1)
UNION ALL SELECT 'distinct sessions affected', COUNT(DISTINCT session_id), NULL FROM moved;
```
```
all anthropic calls         42406  269751307
head-only-hit events          374  102005294
share of cache writes (%)            37.8
distinct sessions affected     22
```
(The brief's "368 / ~100M / ~half" was taken a few hours earlier; the window has since drifted to 374 / 102M / 37.8 % of Anthropic cache writes.)

Gap to the previous call in the same session, for those events — 313 of 374 are under five minutes, so not 5-minute TTL expiry:
```
< 5 min (not TTL expiry)  313   82616698
>= 5 min                   58   17979484
first call                  3    1409112
```

Session `1079f51b0059` (local time), the cited 20:31 pair — a full hit, then 2 s later a head-only hit with the conversation rewritten, then 6 s later again:
```
20:31:18  ctx=301892  cr=301557  cw=333     gap=9s
20:31:20  ctx=302657  cr= 26932  cw=275721  gap=2s   ← moved
20:31:24  ctx=303410  cr=301890  cw=1518    gap=3s   ← reads the NEW entry in full
20:31:37  ctx=303784  cr=303408  cw=374     gap=12s
20:31:44  ctx=311648  cr= 25939  cw=285707  gap=6s   ← moved again
```

Child session `a2384d9fbb88` (subagent `pr2-residency`; its analytics rows are recorded under the parent `0a08dc6d7624`, since a child shares the parent's `SessionStreamFn`), from its transcript (UTC), every big cache write in the window:
```
02:42:53  +567s  ctx=229597 cr=22521 cw=207074
02:43:01    +7s  ctx=229841 cr=22521 cw=207318
02:50:20    +6s  ctx=230924 cr=22521 cw=208401
02:51:55   +71s  ctx=237283 cr=22521 cw=214758
```
`cr=22521` is exactly the tools+system head; four rewrites of a ~210 k conversation within 9 minutes, three of them 6–71 s after the previous call.

### Not done

- No live multi-session soak with the fix installed (the runtime is pinned to `main`; the fix is validated at the `preflight_usage` seam and through the real `AuthStore` cascade). After merge + `lop-update`, the same analytics query should show the head-only-hit share collapsing.
- The gemini test-ordering flake noted above is an adjacent finding, deliberately left alone.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass (modulo the pre-existing gemini ordering flake, documented above).
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.

