### PR TITLE
feat(evaluation): runner-side secret resolution, rescue sweep module, run_episode operator script

### DIFF
--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -166,11 +166,15 @@ module besides `provider_client.py` allowed near the store.
 real provider-backed model client, real credential store, sealed bundle — and
 prints the `EpisodeOutcome` as JSON. It is an operator script, not a CLI
 surface. Its `--run-root` must be durable (it refuses `/tmp`, `$TMPDIR` and
-friends); `evidence/`, `artifacts/` and `rescue/` are created under it.
+friends); `evidence/`, `artifacts/` and `rescue/<episode-id>/` are created
+under it, so `<run-root>/rescue` is the inbox the sweep command below reads.
 
 Secrets: every ref the task needs is either on `--secret-env NAME` (read from
 the script's own environment, and only the names listed) or resolved from the
-credential store (`~/.local-operator/credentials.env`, or `--config-dir`).
+credential store's file (`~/.local-operator/credentials.env`, or
+`--config-dir`) — the store resolver deliberately does NOT fall back to the
+process environment, so a name absent from the file is missing even if the
+shell happens to export it.
 Both the AWS pair and the model client come from that same store, so a paid
 episode needs no environment variables at all:
 
@@ -190,8 +194,14 @@ python ~/local-operator/scripts/run_episode.py \
 ```
 
 Exit 0 only on `completed`; 1 on any other terminal; 2 when a secret is
-missing (named on stderr, value never printed) or the run root is volatile.
-Run the leak audit before and after.
+missing or unusable (named on stderr, value never printed) or the run root is
+volatile. Run the leak audit before and after.
+
+`--model-client scripted-finish` (with `--no-store`) exercises the plumbing —
+spawn, secrets, frames, seal — with no provider call. Such a bundle verifies
+like any other but seals `reportability_label: synthetic_model` (never
+`reportable`) and carries `model_client` in its manifest metadata; it is not
+a result and cannot be mistaken for one.
 
 The sealed `requested_route.model_id` is a **lossless fold** of the model id
 (`RouteIdentity` fields cannot carry `/`): `_` → `__`, `/` → `_s`, anything
@@ -221,11 +231,12 @@ makes that a guarantee rather than a convention. A test statically scans
 the pinned upstream for any method that reaches `run_instances`/
 `terminate_instances`/`create_image` and asserts it is sealed.
 
-If the parent dies mid-episode, `rescue.json` in the rescue root names the
-episode's refs. Sweep them all:
+If the parent dies mid-episode, `<rescue root>/<episode-id>/rescue.json`
+names the episode's refs (for `run_episode.py` the rescue root is
+`<run-root>/rescue`). Sweep them all:
 
 ```sh
-python ~/local-operator/scripts/osworld_rescue_sweep.py --rescue-root <rescue root>
+python ~/local-operator/scripts/osworld_rescue_sweep.py --rescue-root <run-root>/rescue
 ```
 
 It spawns the exact pinned worker per descriptor, re-resolves the descriptor's

--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -193,6 +193,14 @@ Exit 0 only on `completed`; 1 on any other terminal; 2 when a secret is
 missing (named on stderr, value never printed) or the run root is volatile.
 Run the leak audit before and after.
 
+The sealed `requested_route.model_id` is a **lossless fold** of the model id
+(`RouteIdentity` fields cannot carry `/`): `_` → `__`, `/` → `_s`, anything
+else outside `[A-Za-z0-9.:-]` → `_x<hh>` per UTF-8 byte, so
+`deepseek/deepseek-v4-flash-vision-exp` seals as
+`deepseek_sdeepseek-v4-flash-vision-exp` and `runner.route_ids.unfold_model_id`
+recovers it exactly. The manifest metadata also carries the raw id as
+`route_model_id`, so a reader never has to decode by hand.
+
 ## Teardown and rescue
 
 `cleanup` reports `succeeded` only on **positive** evidence: `terminate`

--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -151,6 +151,48 @@ private RPC pipe, on `reset_start` (the side-effect boundary) and on
 are never on `prepare`, never in `rescue.json`, and the AWS values never touch
 `os.environ`; the provider builds its boto3 session from them directly.
 
+On the parent side the runner resolves `EpisodeSpec.secret_refs` through an
+injected `SecretResolver` (`runner/secrets.py`) **after the handshake and
+before the evidence writer opens**, so every resolved value is a redaction
+canary from the bundle's first byte. A missing ref fails the episode
+`failed_pre_bundle` with a diagnostic naming only the ref — before `prepare`,
+before any descriptor is persisted, before anything is allocated. The
+credential-store resolver (`runner/host_secrets.py`) is the only runner
+module besides `provider_client.py` allowed near the store.
+
+## Running one episode
+
+`scripts/run_episode.py` runs ONE episode end to end — real spawned worker,
+real provider-backed model client, real credential store, sealed bundle — and
+prints the `EpisodeOutcome` as JSON. It is an operator script, not a CLI
+surface. Its `--run-root` must be durable (it refuses `/tmp`, `$TMPDIR` and
+friends); `evidence/`, `artifacts/` and `rescue/` are created under it.
+
+Secrets: every ref the task needs is either on `--secret-env NAME` (read from
+the script's own environment, and only the names listed) or resolved from the
+credential store (`~/.local-operator/credentials.env`, or `--config-dir`).
+Both the AWS pair and the model client come from that same store, so a paid
+episode needs no environment variables at all:
+
+```sh
+python ~/local-operator/scripts/run_episode.py \
+    --selector ~/worktrees/osworld/workspaces/0.1.0/selector.json \
+    --task-id task_001 \
+    --route openrouter/deepseek/deepseek-v4-flash-vision-exp \
+    --run-root ~/worktrees/osworld/runs/$(date +%Y%m%d-%H%M%S) \
+    --infra AWS_REGION=us-east-1 \
+    --infra AWS_SUBNET_ID=subnet-f2f9adad \
+    --infra AWS_SECURITY_GROUP_ID=<sg-id> \
+    --infra AWS_SCHEDULER_ROLE_ARN=<role arn> \
+    --infra OSWORLD_CLIENT_PASSWORD=<guest password> \
+    --infra OSWORLD_FILE_BASE_URL=<asset mirror> \
+    --max-steps 25 --max-usd 0.50 --max-wall-s 1800 --keep-recent-frames 3
+```
+
+Exit 0 only on `completed`; 1 on any other terminal; 2 when a secret is
+missing (named on stderr, value never printed) or the run root is volatile.
+Run the leak audit before and after.
+
 ## Teardown and rescue
 
 `cleanup` reports `succeeded` only on **positive** evidence: `terminate`

--- a/local_operator/evaluation/evidence/models.py
+++ b/local_operator/evaluation/evidence/models.py
@@ -113,6 +113,10 @@ ReportabilityLabel = Literal[
     "unscored",
     "infrastructure_failure",
     "cancelled",
+    # The decisions came from a scripted or otherwise non-provider model
+    # client (a plumbing proof, a replay), so the score grades nothing. The
+    # bundle is still fully verifiable; it is simply not a result.
+    "synthetic_model",
 ]
 ComparabilityLabel = Literal[
     "comparable",

--- a/local_operator/evaluation/receipts.py
+++ b/local_operator/evaluation/receipts.py
@@ -583,6 +583,20 @@ class RedactionSet:
             tuple(sorted(hex_variants, key=lambda value: (-len(value), value))),
         )
 
+    def with_values(self, values: Iterable[str]) -> "RedactionSet":
+        """A new set canarying this set's plaintexts plus ``values``.
+
+        The runner resolves an episode's secrets AFTER it has been handed a
+        redaction set (the preflight canaries) and BEFORE it opens the
+        evidence writer, so it needs to widen the set rather than replace it.
+        Rebuilding from the union of plaintexts, rather than concatenating the
+        derived tuples, keeps every encoded variant consistent with the one
+        construction path and lets ``from_resolved_values`` keep enforcing
+        ``MAX_CANARIES`` over the combined total.
+        """
+
+        return self.from_resolved_values((*self._plaintext_canaries, *values))
+
     def __repr__(self) -> str:
         return f"RedactionSet(count={len(self._plaintext_canaries)})"
 

--- a/local_operator/evaluation/runner/durable_root.py
+++ b/local_operator/evaluation/runner/durable_root.py
@@ -1,0 +1,61 @@
+"""Refuse a run root the operating system may purge under a live episode.
+
+macOS purges ``/private/tmp`` on disk pressure and on a periodic sweep with no
+warning and no regard for open handles. A purge mid-run destroyed a previous
+paid pilot's prepared checkout, its 4.2 GB asset snapshot AND its output
+directory, and left an EC2 instance running with nothing on disk naming it.
+Every directory an episode must be able to read back after the fact -- the
+evidence root, the artifact root, and above all the RESCUE root, which is the
+only record of what to tear down -- has to live somewhere durable.
+
+This is the one check both the adapter build script and the episode script
+share, so the two cannot drift on what "volatile" means. The roots are
+compared RESOLVED so ``/tmp -> /private/tmp`` on macOS cannot slip past a
+prefix check on the spelled path; ``$TMPDIR`` is included because on macOS it
+is a per-user directory under ``/var/folders`` that the same sweep covers.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+class VolatileRootError(ValueError):
+    """The path resolves under a directory the OS may purge. Names the path."""
+
+
+def volatile_roots() -> tuple[Path, ...]:
+    """Directories the OS may purge under a live run, resolved."""
+
+    roots = [Path("/tmp"), Path("/private/tmp"), Path("/var/tmp"), Path("/private/var/tmp")]
+    tmpdir = os.environ.get("TMPDIR")
+    if tmpdir:
+        roots.append(Path(tmpdir))
+    out: list[Path] = []
+    for root in roots:
+        try:
+            out.append(root.resolve())
+        except OSError:
+            out.append(root)
+    return tuple(out)
+
+
+def refuse_volatile_root(path: Path, *, label: str = "root") -> None:
+    """Raise ``VolatileRootError`` if ``path`` lives somewhere the OS may purge.
+
+    ``label`` names the argument in the message (``inputs root``, ``rescue
+    root``) so an operator with several roots on one command line learns
+    which one to move.
+    """
+
+    try:
+        resolved = path.resolve()
+    except OSError:
+        resolved = path
+    for volatile in volatile_roots():
+        if resolved == volatile or volatile in resolved.parents:
+            raise VolatileRootError(
+                f"{label} {path} resolves under {volatile}, which the OS may purge "
+                "mid-run; use a durable location such as ~/worktrees/osworld"
+            )

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -33,6 +33,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, Mapping
 
+from pydantic import ValidationError
+
 from local_operator.evaluation.adapters.api import (
     ADAPTER_SCHEMA_VERSION,
     AskUserExchangeParams,
@@ -248,6 +250,7 @@ class EpisodeRunner:
         responder: UserResponder | None = None,
         redactions: RedactionSet | None = None,
         secrets: SecretResolver | None = None,
+        synthetic_model: bool = False,
         launch: Any = AdapterSupervisor.launch,
         rescue: Any = run_rescue,
     ) -> None:
@@ -264,6 +267,12 @@ class EpisodeRunner:
         # letting the adapter fail closed after it has already been launched.
         self._secrets = secrets or StaticSecretResolver({})
         self._resolved_secrets: tuple[ResolvedSecret, ...] = ()
+        # Declared by the CALLER, who knows what it built: a scripted or
+        # replayed model client produces a bundle that verifies exactly like
+        # a real one, and nothing inside the bundle could tell them apart.
+        # The label is the runner's own claim about the run, so it is set on
+        # the runner rather than left to metadata a reader might not check.
+        self._synthetic_model = synthetic_model
         self._launch = launch
         self._rescue = rescue
 
@@ -1068,6 +1077,7 @@ class EpisodeRunner:
             rescue_required=cleanup_result.rescue_required,
             reportable=reconciliation.reportable,
             cancelled=cancelled,
+            synthetic_model=self._synthetic_model,
         )
         comparability = _comparability_label(
             requested=self._spec.requested_route,
@@ -1459,12 +1469,16 @@ def _reportability_label(
     rescue_required: bool,
     reportable: bool,
     cancelled: bool,
+    synthetic_model: bool = False,
 ) -> str:
     """Pick the single most severe label.
 
     Precedence is cleanup_incomplete > budget_unreconciled > unscored, because
     a leaked resource is a worse claim about the run than an unclosed budget,
-    which in turn matters more than a missing score.
+    which in turn matters more than a missing score. ``synthetic_model`` sits
+    last: it only decides whether a run that would otherwise be reportable
+    is, because a scripted model's bundle is otherwise indistinguishable from
+    a real result, and every more severe label already says "not a result".
     """
 
     if rescue_required:
@@ -1475,6 +1489,8 @@ def _reportability_label(
         return "cancelled"
     if score.status != "scored":
         return "unscored"
+    if synthetic_model:
+        return "synthetic_model"
     return "reportable"
 
 
@@ -1536,6 +1552,26 @@ def _incomplete_receipt(plan: CleanupPlan, action_id: str) -> CleanupReceipt:
 
 
 def _diagnostic(error: BaseException) -> str:
+    """Render an error for ``EpisodeOutcome.diagnostic`` without its inputs.
+
+    A pydantic ``ValidationError``'s ``str()`` embeds ``input_value=<head>…<tail>``
+    for every failing field. The one model on this boundary that carries
+    secret bytes is ``ResolvedSecret``, and a value the wire bound refuses
+    (a PEM-shaped credential past ``max_length``) would otherwise be quoted
+    straight into the outcome JSON that a paid run redirects into its durable
+    root. The resolvers already translate that case to a name-only error;
+    this is the second line, for ANY validation error on any path: only the
+    model title, the field location and the error type are kept, never the
+    input. The location itself is safe -- it is a field NAME (``secrets``,
+    ``1``, ``value``), not the secret's name or bytes.
+    """
+
+    if isinstance(error, ValidationError):
+        details = "; ".join(
+            f"{'.'.join(str(part) for part in item['loc']) or '<root>'}: {item['type']}"
+            for item in error.errors(include_input=False, include_url=False)
+        )
+        return f"ValidationError: {error.title} ({details})"[:500]
     return f"{type(error).__name__}: {error}"[:500]
 
 

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -44,6 +44,7 @@ from local_operator.evaluation.adapters.api import (
     PrepareParams,
     RescueDescriptor,
     ResetStartParams,
+    ResolvedSecret,
     ScopedInfraValue,
     ScoreParams,
     SecretRef,
@@ -52,6 +53,7 @@ from local_operator.evaluation.adapters.supervisor import (
     AdapterSupervisor,
     HostVerifier,
     VerifiedAdapterSession,
+    discard_rescue,
     persist_rescue,
     run_rescue,
     verify_artifact,
@@ -116,6 +118,10 @@ from local_operator.evaluation.runner.guards import (
 )
 from local_operator.evaluation.runner.model import EpisodeModelClient, EpisodeTurn
 from local_operator.evaluation.runner.responder import NullUserResponder, UserResponder
+from local_operator.evaluation.runner.secrets import (
+    SecretResolver,
+    StaticSecretResolver,
+)
 
 # Cleanup kinds are a closed vocabulary in ``lifecycle.CleanupAction``. A worker
 # session is the one resource the parent always knows exists before the adapter
@@ -241,6 +247,7 @@ class EpisodeRunner:
         model: EpisodeModelClient,
         responder: UserResponder | None = None,
         redactions: RedactionSet | None = None,
+        secrets: SecretResolver | None = None,
         launch: Any = AdapterSupervisor.launch,
         rescue: Any = run_rescue,
     ) -> None:
@@ -250,6 +257,13 @@ class EpisodeRunner:
         self._model = model
         self._responder = responder or NullUserResponder()
         self._redactions = redactions or RedactionSet.from_resolved_values(())
+        # ``None`` means "this episode has no secrets to resolve", which is only
+        # true when the spec declares no refs. An empty static resolver makes a
+        # spec that DOES declare refs fail as ``MissingSecret`` before any
+        # allocation, rather than silently sending the worker nothing and
+        # letting the adapter fail closed after it has already been launched.
+        self._secrets = secrets or StaticSecretResolver({})
+        self._resolved_secrets: tuple[ResolvedSecret, ...] = ()
         self._launch = launch
         self._rescue = rescue
 
@@ -341,6 +355,24 @@ class EpisodeRunner:
             InspectRequirementsParams(),
             timeout=self._config.prepare_timeout,
         )
+
+        # Secrets are resolved HERE -- after the handshake, before the
+        # provisional descriptor and before ``prepare`` -- for two reasons.
+        # First, a missing credential must fail before anything is allocated:
+        # ``reset_start`` is the side-effect boundary, and a worker that has
+        # to fail closed itself has already been launched and had its rescue
+        # inbox entry written. Failing here surfaces as ``failed_pre_bundle``
+        # with a diagnostic naming the REF, never a value. Second, every
+        # resolved value must be in the redaction set before
+        # ``EvidenceWriter.create`` (``_run_with_bundle``) so the writer
+        # canaries every artifact and event against them from its first byte;
+        # a value that is resolved after the writer opens is one the bundle
+        # could carry.
+        self._resolved_secrets = self._secrets.resolve([ref.name for ref in self._spec.secret_refs])
+        if self._resolved_secrets:
+            self._redactions = self._redactions.with_values(
+                secret.value for secret in self._resolved_secrets
+            )
 
         # STAGE 1 of two-stage rescue persistence.
         #
@@ -521,6 +553,10 @@ class EpisodeRunner:
                 # verifies against, which is what keeps "where the adapter wrote"
                 # and "where the parent reads" a single parent-chosen value.
                 artifact_root=str(self._config.artifact_root),
+                # The same values ``_launch_and_prepare`` resolved and canaried.
+                # They cross only this private pipe; the descriptor on disk
+                # carries the refs, and rescue re-resolves at rescue time.
+                secrets=self._resolved_secrets,
             ),
             timeout=self._config.reset_timeout,
         )
@@ -1011,6 +1047,13 @@ class EpisodeRunner:
         rescue_complete: bool | None = None
         if cleanup_result.rescue_required or self._rescue_required:
             rescue_complete = await self._attempt_rescue()
+        else:
+            # Every declared action confirmed on the live session: this episode
+            # owns nothing any more, so its descriptor leaves the rescue inbox.
+            # Only this branch holds that confirmation; a rescued episode's
+            # descriptor is retired by the rescue path (or the sweep) on a
+            # complete aggregate, never here on hope.
+            self._retire_descriptor()
         self._append_receipt(
             "cleanup",
             CleanupPayload(
@@ -1146,10 +1189,30 @@ class EpisodeRunner:
         if descriptor is None:
             return False
         try:
-            aggregate = await self._rescue(descriptor)
+            # The rescue worker is a fresh process with nothing but the
+            # descriptor; it needs the credentials again to tear down. These
+            # are the values resolved at launch, so an in-process rescue never
+            # re-reads the store mid-failure.
+            aggregate = await self._rescue(descriptor, secrets=self._resolved_secrets)
         except BaseException:
             return False
-        return bool(aggregate.complete)
+        complete = bool(aggregate.complete)
+        if complete:
+            self._retire_descriptor()
+        return complete
+
+    def _retire_descriptor(self) -> None:
+        """Unlink this episode's ``rescue.json``; only confirmed-clean callers."""
+
+        if self._descriptor is None:
+            return
+        try:
+            discard_rescue(self._config.rescue_root)
+        except OSError:
+            # A descriptor that could not be unlinked is re-rescued by the next
+            # sweep (``instance-absent``) -- harmless, and strictly better than
+            # failing an already-clean episode over inbox hygiene.
+            pass
 
     def _build_manifest(self, handshake: Handshake, plan: CleanupPlan) -> EvidenceManifest:
         spec = self._spec

--- a/local_operator/evaluation/runner/host_secrets.py
+++ b/local_operator/evaluation/runner/host_secrets.py
@@ -1,0 +1,58 @@
+"""The credential-store-backed ``SecretResolver``.
+
+This is the SECOND runner module allowed to reach into the application (the
+first is ``provider_client.py``, for the same reason: a real episode needs a
+real credential, and the store is where operators keep them). Everything
+else under ``runner/`` must stay free of the store so an episode's evidence
+cannot silently depend on the operator's own configuration --
+``tests/unit/evaluation/runner/test_isolation.py`` asserts both the
+exception and the rule.
+
+The store is ``CredentialManager`` (``~/.local-operator/credentials.env`` or
+the ``--config-dir`` an operator names), the same object the CLI builds for
+``AuthStore``. It is taken as a constructor argument rather than built here so
+the caller that opens the store for the model client hands the SAME instance
+to the secret resolver: one place decides which config dir is authoritative.
+
+``CredentialManager.get_credential`` returns an empty ``SecretStr`` for an
+unknown key rather than raising, and it also falls back to ``os.environ`` for
+a name it does not hold. Both are folded into the one contract every resolver
+shares: an empty value is ``MissingSecret(name)``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from local_operator.evaluation.adapters.api import ResolvedSecret
+from local_operator.evaluation.runner.secrets import MissingSecret
+
+
+class CredentialStoreResolver:
+    """Resolve ``SecretRef`` names from the harness credential store.
+
+    ``credential_manager`` is any object with ``get_credential(name)``
+    returning a ``SecretStr``-like value (``get_secret_value()``); it is typed
+    ``Any`` so this module never imports ``local_operator.credentials`` at
+    module scope. Even the lazy import is avoided: the caller already holds a
+    live manager, and constructing a second one here would re-read the file
+    and could disagree with the one the model client was built from.
+    """
+
+    def __init__(self, credential_manager: Any) -> None:
+        self._manager = credential_manager
+
+    def resolve(self, names: Sequence[str]) -> tuple[ResolvedSecret, ...]:
+        resolved: list[ResolvedSecret] = []
+        for name in names:
+            try:
+                value = self._manager.get_credential(name).get_secret_value()
+            except Exception as error:
+                # The store's own error could quote the key path or the file;
+                # it never quotes a value, but the chained cause is still kept
+                # off the message so the diagnostic stays "name only".
+                raise MissingSecret(name) from error
+            if not value:
+                raise MissingSecret(name)
+            resolved.append(ResolvedSecret(name=name, value=value))
+        return tuple(resolved)

--- a/local_operator/evaluation/runner/host_secrets.py
+++ b/local_operator/evaluation/runner/host_secrets.py
@@ -16,8 +16,13 @@ to the secret resolver: one place decides which config dir is authoritative.
 
 ``CredentialManager.get_credential`` returns an empty ``SecretStr`` for an
 unknown key rather than raising, and it also falls back to ``os.environ`` for
-a name it does not hold. Both are folded into the one contract every resolver
-shares: an empty value is ``MissingSecret(name)``.
+a name it does not hold. The fallback is deliberately NOT used here: the
+runner's contract is that the environment is reachable only through an
+explicit ``EnvSecretResolver`` over names the caller listed, and a store
+resolver that quietly served ambient variables would make "resolved from the
+store" a false claim in the operator's own proof. This reads the store's
+loaded mapping directly, so a name the file lacks is ``MissingSecret(name)``
+even when the process environment happens to carry it.
 """
 
 from __future__ import annotations
@@ -25,34 +30,39 @@ from __future__ import annotations
 from typing import Any, Sequence
 
 from local_operator.evaluation.adapters.api import ResolvedSecret
-from local_operator.evaluation.runner.secrets import MissingSecret
+from local_operator.evaluation.runner.secrets import (
+    MissingSecret,
+    build_resolved_secret,
+)
 
 
 class CredentialStoreResolver:
     """Resolve ``SecretRef`` names from the harness credential store.
 
-    ``credential_manager`` is any object with ``get_credential(name)``
-    returning a ``SecretStr``-like value (``get_secret_value()``); it is typed
+    ``credential_manager`` is any object with ``get_credentials()`` returning
+    a ``{name: SecretStr-like}`` mapping (``get_secret_value()``); it is typed
     ``Any`` so this module never imports ``local_operator.credentials`` at
     module scope. Even the lazy import is avoided: the caller already holds a
     live manager, and constructing a second one here would re-read the file
     and could disagree with the one the model client was built from.
+    ``get_credentials`` rather than ``get_credential`` because only the
+    former is free of the environment fallback (see the module docstring).
     """
 
     def __init__(self, credential_manager: Any) -> None:
         self._manager = credential_manager
 
     def resolve(self, names: Sequence[str]) -> tuple[ResolvedSecret, ...]:
+        try:
+            stored = self._manager.get_credentials()
+        except Exception as error:
+            # The store's own error could quote the file path; it never quotes
+            # a value, but the chained cause is still kept off the message so
+            # the diagnostic stays "name only".
+            raise MissingSecret(names[0] if names else "") from error
         resolved: list[ResolvedSecret] = []
         for name in names:
-            try:
-                value = self._manager.get_credential(name).get_secret_value()
-            except Exception as error:
-                # The store's own error could quote the key path or the file;
-                # it never quotes a value, but the chained cause is still kept
-                # off the message so the diagnostic stays "name only".
-                raise MissingSecret(name) from error
-            if not value:
-                raise MissingSecret(name)
-            resolved.append(ResolvedSecret(name=name, value=value))
+            secret = stored.get(name)
+            value = secret.get_secret_value() if secret is not None else ""
+            resolved.append(build_resolved_secret(name, value))
         return tuple(resolved)

--- a/local_operator/evaluation/runner/rescue_sweep.py
+++ b/local_operator/evaluation/runner/rescue_sweep.py
@@ -1,0 +1,98 @@
+"""Rescue every episode whose descriptor is still in a rescue root.
+
+A ``rescue.json`` under ``<root>/<episode>/`` means an episode's parent died
+(SIGKILL, a sleeping laptop, a purged run directory) before its cleanup was
+confirmed, and cloud resources it owns may still be billing. This module is
+the one explicit caller that globs ``*/rescue.json`` --
+``supervisor.load_pending_rescue`` deliberately never scans, so importing or
+starting anything can never trigger a teardown by accident; only an operator
+invoking the sweep (``scripts/osworld_rescue_sweep.py``) does.
+
+For each descriptor found the sweep re-resolves the descriptor's
+``secret_refs`` through the caller's ``SecretResolver`` (the descriptor on
+disk never carries values), spawns the EXACT worker the descriptor pins via
+``run_rescue``, reconciles every cleanup action, and unlinks the descriptor
+ONLY when the aggregate reports ``complete``. A rescue that could not confirm
+termination leaves the inbox entry in place for the next sweep; the inbox is
+never cleared on hope.
+
+Every failure mode is reported per descriptor rather than raised: one
+unreadable or unresolvable descriptor must not stop the sweep from reclaiming
+the others, and an operator reading the output needs to see every entry that
+still needs attention in a single run.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from local_operator.evaluation.adapters.supervisor import (
+    discard_rescue,
+    load_pending_rescue,
+    run_rescue,
+)
+from local_operator.evaluation.runner.secrets import MissingSecret, SecretResolver
+
+
+@dataclass(frozen=True)
+class SweepEntry:
+    """One descriptor's fate under a sweep.
+
+    ``complete`` is the aggregate's own verdict (and therefore whether the
+    descriptor was unlinked). ``codes`` are the receipts' evidence codes in
+    plan order, which is what an operator pastes as proof of teardown.
+    ``error`` names why the rescue did not run or did not finish; it carries
+    a secret NAME at most, never a value.
+    """
+
+    episode_id: str
+    complete: bool
+    codes: tuple[str, ...]
+    error: str | None = None
+
+
+async def sweep_rescue_root(
+    root: Path,
+    resolver: SecretResolver,
+    *,
+    launch: Any = None,
+    rescue: Any = run_rescue,
+) -> tuple[SweepEntry, ...]:
+    """Rescue each ``<root>/*/rescue.json``; unlink only on ``complete``.
+
+    ``launch`` is forwarded to ``run_rescue`` when given (the supervisor's
+    ``AdapterSupervisor.launch`` otherwise); ``rescue`` replaces the whole
+    rescue call for tests that want to script an aggregate without a worker.
+    Entries come back in sorted path order so a run is reproducible.
+    """
+
+    entries: list[SweepEntry] = []
+    for path in sorted(root.glob("*/rescue.json")):
+        episode_dir = path.parent
+        try:
+            descriptor = load_pending_rescue(episode_dir)
+        except Exception as error:
+            entries.append(SweepEntry(episode_dir.name, False, (), f"unreadable: {error}"))
+            continue
+        if descriptor is None:
+            continue
+        try:
+            secrets = resolver.resolve([ref.name for ref in descriptor.secret_refs])
+        except MissingSecret as error:
+            entries.append(SweepEntry(descriptor.episode_id, False, (), str(error)))
+            continue
+        try:
+            if launch is None:
+                aggregate = await rescue(descriptor, secrets=secrets)
+            else:
+                aggregate = await rescue(descriptor, secrets=secrets, launch=launch)
+        except Exception as error:
+            entries.append(SweepEntry(descriptor.episode_id, False, (), f"rescue failed: {error}"))
+            continue
+        codes = tuple(receipt.evidence_code for receipt in aggregate.receipts)
+        if aggregate.complete:
+            discard_rescue(episode_dir)
+        entries.append(SweepEntry(descriptor.episode_id, bool(aggregate.complete), codes))
+    return tuple(entries)

--- a/local_operator/evaluation/runner/route_ids.py
+++ b/local_operator/evaluation/runner/route_ids.py
@@ -28,7 +28,9 @@ import re
 
 _PASSTHROUGH = re.compile(r"[A-Za-z0-9.:-]")
 _IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
-_MAX_IDENTIFIER = 128
+# ``StrictIdentifier``'s own length cap, public so a caller composing a
+# longer identifier out of a folded id can check the composite too.
+MAX_IDENTIFIER = 128
 
 
 def fold_model_id(model_id: str) -> str:
@@ -53,23 +55,34 @@ def fold_model_id(model_id: str) -> str:
         # provider ships such an id. Refuse rather than invent a prefix that
         # the decoder would then have to guess about.
         raise ValueError(f"model id {model_id!r} cannot start with {model_id[0]!r}")
-    if len(folded) > _MAX_IDENTIFIER:
-        raise ValueError(f"model id {model_id!r} folds to more than {_MAX_IDENTIFIER} characters")
+    if len(folded) > MAX_IDENTIFIER:
+        raise ValueError(f"model id {model_id!r} folds to more than {MAX_IDENTIFIER} characters")
     return folded
 
 
 def unfold_model_id(folded: str) -> str:
-    """Recover the exact model id ``fold_model_id`` encoded."""
+    """Recover the exact model id ``fold_model_id`` encoded.
+
+    Raises ``ValueError("malformed escape …")`` for anything the encoder could
+    not have produced, including a ``_x`` byte run that is not valid UTF-8.
+    """
 
     out: list[str] = []
     pending = bytearray()
     index = 0
+
+    def flush() -> None:
+        if pending:
+            try:
+                out.append(pending.decode("utf-8"))
+            except UnicodeDecodeError:
+                raise ValueError(f"malformed escape: invalid UTF-8 run in {folded!r}") from None
+            pending.clear()
+
     while index < len(folded):
         char = folded[index]
         if char != "_":
-            if pending:
-                out.append(pending.decode("utf-8"))
-                pending.clear()
+            flush()
             out.append(char)
             index += 1
             continue
@@ -84,11 +97,8 @@ def unfold_model_id(folded: str) -> str:
             continue
         else:
             raise ValueError(f"malformed escape at offset {index} in {folded!r}")
-        if pending:
-            out.append(pending.decode("utf-8"))
-            pending.clear()
+        flush()
         out.append(decoded)
         index += width
-    if pending:
-        out.append(pending.decode("utf-8"))
+    flush()
     return "".join(out)

--- a/local_operator/evaluation/runner/route_ids.py
+++ b/local_operator/evaluation/runner/route_ids.py
@@ -1,0 +1,94 @@
+"""Lossless folding of a provider model id into a ``RouteIdentity`` field.
+
+``RouteIdentity`` fields are ``StrictIdentifier`` values
+(``[A-Za-z0-9][A-Za-z0-9_.:-]*``), so an aggregator model id such as
+``deepseek/deepseek-v4-flash-vision-exp`` or ``moonshotai/kimi-k2:free``
+cannot be sealed verbatim. Comparability (M1) depends on a route identity
+meaning exactly one thing, so the fold has to be REVERSIBLE: two distinct
+model ids must never seal to the same identifier, and a reader of a sealed
+bundle must be able to recover the exact id the provider was asked for.
+
+The scheme is a classic escape: ``_`` is the escape character, so it is
+itself written ``__``; ``/`` becomes ``_s``; any other character outside the
+identifier alphabet becomes ``_x<HH>`` (its UTF-8 bytes, lowercase hex).
+Every other character -- letters, digits, ``.``, ``:``, ``-`` -- passes
+through, which keeps the common OpenRouter shapes readable
+(``deepseek_sdeepseek-v4-flash-vision-exp``, ``moonshotai_skimi-k2:free``).
+Decoding reads left to right and is unambiguous because ``_`` only ever
+introduces one of those three forms.
+
+``scripts/run_episode.py`` also writes the original id into the manifest
+metadata (``route_model_id``) so a human never has to decode by hand; the
+fold is what makes the identity field itself honest when they do not.
+"""
+
+from __future__ import annotations
+
+import re
+
+_PASSTHROUGH = re.compile(r"[A-Za-z0-9.:-]")
+_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
+_MAX_IDENTIFIER = 128
+
+
+def fold_model_id(model_id: str) -> str:
+    """Encode ``model_id`` as a ``StrictIdentifier``; ``unfold_model_id`` inverts it."""
+
+    if not model_id:
+        raise ValueError("model id must not be empty")
+    out: list[str] = []
+    for char in model_id:
+        if char == "_":
+            out.append("__")
+        elif char == "/":
+            out.append("_s")
+        elif _PASSTHROUGH.fullmatch(char):
+            out.append(char)
+        else:
+            out.append("".join(f"_x{byte:02x}" for byte in char.encode("utf-8")))
+    folded = "".join(out)
+    if not _IDENTIFIER.fullmatch(folded):
+        # Only reachable when the id starts with a non-alphanumeric: the
+        # identifier pattern forbids a leading ``_``/``.``/``:``/``-``, and no
+        # provider ships such an id. Refuse rather than invent a prefix that
+        # the decoder would then have to guess about.
+        raise ValueError(f"model id {model_id!r} cannot start with {model_id[0]!r}")
+    if len(folded) > _MAX_IDENTIFIER:
+        raise ValueError(f"model id {model_id!r} folds to more than {_MAX_IDENTIFIER} characters")
+    return folded
+
+
+def unfold_model_id(folded: str) -> str:
+    """Recover the exact model id ``fold_model_id`` encoded."""
+
+    out: list[str] = []
+    pending = bytearray()
+    index = 0
+    while index < len(folded):
+        char = folded[index]
+        if char != "_":
+            if pending:
+                out.append(pending.decode("utf-8"))
+                pending.clear()
+            out.append(char)
+            index += 1
+            continue
+        code = folded[index + 1 : index + 2]
+        if code == "_":
+            decoded, width = "_", 2
+        elif code == "s":
+            decoded, width = "/", 2
+        elif code == "x" and re.fullmatch(r"[0-9a-f]{2}", folded[index + 2 : index + 4] or ""):
+            pending.append(int(folded[index + 2 : index + 4], 16))
+            index += 4
+            continue
+        else:
+            raise ValueError(f"malformed escape at offset {index} in {folded!r}")
+        if pending:
+            out.append(pending.decode("utf-8"))
+            pending.clear()
+        out.append(decoded)
+        index += width
+    if pending:
+        out.append(pending.decode("utf-8"))
+    return "".join(out)

--- a/local_operator/evaluation/runner/secrets.py
+++ b/local_operator/evaluation/runner/secrets.py
@@ -21,15 +21,22 @@ the one runner module besides ``provider_client.py`` allowed to import the
 application; keeping it out of this file is what lets ``episode.py`` import
 the protocol here without dragging the store along.
 
-Failure shape: a resolver raises ``MissingSecret(name)`` and NEVER includes a
-value in any exception. The runner turns that into a pre-bundle failure whose
-diagnostic names the ref, so the operator learns which credential to provision
-without a value ever crossing into a durable record.
+Failure shape: a resolver raises ``MissingSecret(name)`` (or its subclass
+``UnusableSecret(name)`` for a value the wire model refuses) and NEVER
+includes a value in any exception. The runner turns that into a pre-bundle
+failure whose diagnostic names the ref, so the operator learns which
+credential to provision without a value ever crossing into a durable record.
+Every resolver MUST build its ``ResolvedSecret`` through
+``build_resolved_secret``: pydantic's ``ValidationError`` quotes the offending
+input, so an over-long value (``max_length=8192``; a cert chain does it)
+constructed anywhere else would put the secret on stdout.
 """
 
 from __future__ import annotations
 
 from typing import Mapping, Protocol, Sequence, runtime_checkable
+
+from pydantic import ValidationError
 
 from local_operator.evaluation.adapters.api import ResolvedSecret
 
@@ -49,6 +56,44 @@ class MissingSecret(LookupError):
 
     def __str__(self) -> str:
         return f"missing secret {self.name}"
+
+
+class UnusableSecret(MissingSecret):
+    """A value the store holds but the wire model refuses (empty, too long).
+
+    A ``MissingSecret`` subclass so every guard that routes a missing ref to a
+    name-only failure routes this the same way; a distinct type so the message
+    tells the operator to FIX the stored value rather than provision one. The
+    underlying ``ValidationError`` is deliberately not chained: pydantic
+    renders ``input_value=`` in its message, which is the value itself.
+    """
+
+    def __str__(self) -> str:
+        return f"unusable secret {self.name}"
+
+
+def build_resolved_secret(name: str, value: str) -> ResolvedSecret:
+    """The ONLY sanctioned constructor for a ``ResolvedSecret`` in the parent.
+
+    ``ResolvedSecret`` bounds ``value`` (``min_length=1``, ``max_length=8192``)
+    and re-validates the name pattern; a violation raises pydantic's
+    ``ValidationError`` whose message embeds ``input_value='<head>…<tail>'``.
+    That message would ride ``_diagnostic`` into ``EpisodeOutcome.diagnostic``
+    and the run's stdout. Translating it here to a name-only error is what
+    keeps a PEM-shaped credential out of the durable record.
+    """
+
+    if not value:
+        raise MissingSecret(name)
+    try:
+        return ResolvedSecret(name=name, value=value)
+    except ValidationError:
+        failure = UnusableSecret(name)
+    # Raised OUTSIDE the except block on purpose. ``raise ... from None`` only
+    # clears ``__cause__`` and sets ``__suppress_context__``; ``__context__``
+    # would still reference the ValidationError -- and its input -- for any
+    # logger or serializer that walks the chain rather than the traceback.
+    raise failure
 
 
 @runtime_checkable
@@ -101,13 +146,6 @@ class EnvSecretResolver:
 def _resolve_from_mapping(
     values: Mapping[str, str], names: Sequence[str]
 ) -> tuple[ResolvedSecret, ...]:
-    resolved: list[ResolvedSecret] = []
-    for name in names:
-        value = values.get(name)
-        if not value:
-            raise MissingSecret(name)
-        # ``ResolvedSecret`` re-validates the name pattern and the value bound,
-        # so a mapping that carries a malformed entry fails here, in the
-        # parent, before anything has been allocated.
-        resolved.append(ResolvedSecret(name=name, value=value))
-    return tuple(resolved)
+    # A malformed entry fails here, in the parent, before anything has been
+    # allocated -- and by name only (``build_resolved_secret``).
+    return tuple(build_resolved_secret(name, values.get(name, "")) for name in names)

--- a/local_operator/evaluation/runner/secrets.py
+++ b/local_operator/evaluation/runner/secrets.py
@@ -1,0 +1,113 @@
+"""How the parent turns a spec's ``SecretRef`` names into bytes for the worker.
+
+The worker is spawned with a stripped environment and learns credentials only
+over the private RPC pipe (``ResetStartParams.secrets`` / ``BeginRescueParams
+.secrets``), so SOMETHING in the parent has to resolve a name into a value.
+That something is deliberately an injected ``SecretResolver`` rather than a
+call the runner makes itself:
+
+* ``episode.py`` must stay isolated from the application (no credential store,
+  no config -- ``test_isolation.py``). A resolver is handed in, so the runner
+  never learns where secrets come from.
+* Tests need to hand the runner a known canary value and prove it never lands
+  in a bundle, a diagnostic, or a log. ``StaticSecretResolver`` is that seam.
+* An operator script must be able to say exactly which env vars are secrets.
+  ``EnvSecretResolver`` reads from an EXPLICIT mapping it is given, never from
+  ``os.environ`` implicitly, so a resolver can only ever surface names the
+  caller chose to expose to it.
+
+The credential-store-backed resolver lives in ``host_secrets.py``, which is
+the one runner module besides ``provider_client.py`` allowed to import the
+application; keeping it out of this file is what lets ``episode.py`` import
+the protocol here without dragging the store along.
+
+Failure shape: a resolver raises ``MissingSecret(name)`` and NEVER includes a
+value in any exception. The runner turns that into a pre-bundle failure whose
+diagnostic names the ref, so the operator learns which credential to provision
+without a value ever crossing into a durable record.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping, Protocol, Sequence, runtime_checkable
+
+from local_operator.evaluation.adapters.api import ResolvedSecret
+
+
+class MissingSecret(LookupError):
+    """A ref the resolver cannot satisfy. ``args[0]`` is the NAME, never a value.
+
+    A ``LookupError`` subclass so a caller that already handles ``KeyError``
+    shaped failures from a mapping-backed resolver is not surprised, but a
+    distinct type so the runner can route it to a pre-bundle failure without
+    catching every lookup error the resolution path could raise.
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self.name = name
+
+    def __str__(self) -> str:
+        return f"missing secret {self.name}"
+
+
+@runtime_checkable
+class SecretResolver(Protocol):
+    """Resolve ``SecretRef`` names to values for the private RPC pipe only.
+
+    ``resolve`` is synchronous on purpose: every implementation here reads a
+    local file or an in-memory mapping, and an async surface would invite a
+    network-backed vault into the episode's critical path without the retry
+    and timeout treatment such a call would need. Raise ``MissingSecret`` for
+    any name that cannot be satisfied; return them in the order requested.
+    """
+
+    def resolve(self, names: Sequence[str]) -> tuple[ResolvedSecret, ...]: ...
+
+
+class StaticSecretResolver:
+    """A fixed name -> value mapping, for tests and scripted proofs.
+
+    Values are copied at construction so a caller cannot mutate them after the
+    runner has already canaried the evidence writer against them.
+    """
+
+    def __init__(self, values: Mapping[str, str]) -> None:
+        self._values = dict(values)
+
+    def resolve(self, names: Sequence[str]) -> tuple[ResolvedSecret, ...]:
+        return _resolve_from_mapping(self._values, names)
+
+
+class EnvSecretResolver:
+    """Resolve names from an explicit environment-shaped mapping.
+
+    The mapping is a PARAMETER, not ``os.environ``: an operator script passes
+    ``{name: os.environ[name] for name in names_it_was_told_about}`` (or the
+    whole environment if it genuinely means to), so which variables are
+    reachable is a visible decision at the call site rather than an ambient
+    property of the process. An empty or missing variable is a missing
+    secret -- ``ResolvedSecret.value`` requires at least one byte, and an
+    empty credential is never what an operator meant.
+    """
+
+    def __init__(self, environ: Mapping[str, str]) -> None:
+        self._environ = environ
+
+    def resolve(self, names: Sequence[str]) -> tuple[ResolvedSecret, ...]:
+        return _resolve_from_mapping(self._environ, names)
+
+
+def _resolve_from_mapping(
+    values: Mapping[str, str], names: Sequence[str]
+) -> tuple[ResolvedSecret, ...]:
+    resolved: list[ResolvedSecret] = []
+    for name in names:
+        value = values.get(name)
+        if not value:
+            raise MissingSecret(name)
+        # ``ResolvedSecret`` re-validates the name pattern and the value bound,
+        # so a mapping that carries a malformed entry fails here, in the
+        # parent, before anything has been allocated.
+        resolved.append(ResolvedSecret(name=name, value=value))
+    return tuple(resolved)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.30"
+version = "0.44.31"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/build_osworld_adapter.py
+++ b/scripts/build_osworld_adapter.py
@@ -70,6 +70,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from local_operator.evaluation.runner import durable_root
+
 EXIT_VERIFY = 4
 _DEFAULT_INPUTS_ROOT = "~/worktrees/osworld"
 _DEFAULT_PIN = (
@@ -85,42 +87,19 @@ class VerificationFailed(Exception):
     """An input does not match the pin. The message names the path."""
 
 
-def _volatile_roots() -> tuple[Path, ...]:
-    """Directories the OS may purge under a live run."""
-
-    roots = [Path("/tmp"), Path("/private/tmp"), Path("/var/tmp"), Path("/private/var/tmp")]
-    tmpdir = os.environ.get("TMPDIR")
-    if tmpdir:
-        roots.append(Path(tmpdir))
-    out: list[Path] = []
-    for root in roots:
-        try:
-            out.append(root.resolve())
-        except OSError:
-            out.append(root)
-    return tuple(out)
-
-
 def refuse_volatile_root(inputs_root: Path) -> None:
     """Fail fast if the inputs root lives somewhere the OS may purge.
 
-    This turns the docstring's warning into a check. A previous paid pilot
-    lost its prepared checkout, its 4.2 GB of assets and its output directory
-    to a ``/private/tmp`` sweep mid-episode, and the EC2 instance kept
-    billing. The roots are compared RESOLVED so ``/tmp -> /private/tmp`` on
-    macOS cannot slip past a prefix check on the spelled path.
+    The check itself is ``runner.durable_root.refuse_volatile_root`` -- shared
+    with ``scripts/run_episode.py`` so the build and the episode agree on what
+    "volatile" means -- re-raised here as ``VerificationFailed`` so this
+    script's callers keep one exception type and one exit code (4).
     """
 
     try:
-        resolved = inputs_root.resolve()
-    except OSError:
-        resolved = inputs_root
-    for volatile in _volatile_roots():
-        if resolved == volatile or volatile in resolved.parents:
-            raise VerificationFailed(
-                f"inputs root {inputs_root} resolves under {volatile}, which the OS may purge "
-                "mid-run; use a durable location such as ~/worktrees/osworld"
-            )
+        durable_root.refuse_volatile_root(inputs_root, label="inputs root")
+    except durable_root.VolatileRootError as error:
+        raise VerificationFailed(str(error)) from error
 
 
 def _release_digest(

--- a/scripts/osworld_rescue_sweep.py
+++ b/scripts/osworld_rescue_sweep.py
@@ -3,25 +3,27 @@
 
 A ``rescue.json`` under ``<rescue_root>/<episode>/`` means an episode's parent
 died (SIGKILL, a sleeping laptop, a purged run directory) before its cleanup
-was confirmed, and cloud resources it owns may still be billing. For each
-descriptor found, this script spawns the EXACT worker the descriptor pins
-(``run_rescue``), hands it the descriptor's ``secret_refs`` re-resolved from
-the harness credential store, reconciles every cleanup action, and unlinks
-the descriptor ONLY when the aggregate reports ``complete`` -- so a rescue
-that could not confirm termination leaves the inbox entry in place for the
-next sweep, never clears it on hope.
+was confirmed, and cloud resources it owns may still be billing. This is the
+operator command that runs ``runner.rescue_sweep.sweep_rescue_root`` on the
+controller host: it spawns the EXACT worker each descriptor pins, hands it the
+descriptor's ``secret_refs`` re-resolved from the harness credential store,
+reconciles every cleanup action, and unlinks the descriptor ONLY when the
+aggregate reports ``complete``.
 
-``load_pending_rescue`` deliberately never scans (supervisor.py); this script
-is the one explicit caller that globs ``*/rescue.json``. It is an operator
-command run on the controller host, never from inside a worker.
+The sweep logic itself lives in ``local_operator.evaluation.runner.rescue_sweep``
+so the in-process runner and this script share ONE implementation; this file
+only parses arguments, opens the credential store, and prints the result.
 
 Resolution of secrets happens HERE, in the parent, from the credential store
-(``~/.local-operator/config.env`` by default, or ``--config-dir``). The
+(``~/.local-operator/credentials.env`` by default, or ``--config-dir``). The
 values travel only over the private RPC pipe on ``begin_rescue`` and are never
 written to disk, the environment, or stdout.
 
 Usage:
     python scripts/osworld_rescue_sweep.py --rescue-root <root> [--config-dir <dir>]
+
+Exit 0 when every descriptor found was rescued to completion (including an
+empty root), 1 when any entry is incomplete or errored.
 """
 
 from __future__ import annotations
@@ -30,92 +32,33 @@ import argparse
 import asyncio
 import json
 import sys
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Any
 
-from local_operator.evaluation.adapters.api import ResolvedSecret
-from local_operator.evaluation.adapters.supervisor import (
-    discard_rescue,
-    load_pending_rescue,
-    run_rescue,
-)
+from local_operator.evaluation.runner.rescue_sweep import SweepEntry, sweep_rescue_root
 
 
-class MissingSecret(KeyError):
-    """A descriptor names a secret the store cannot resolve."""
-
-
-def credential_store_resolver(config_dir: Path | None) -> Callable[[Sequence[str]], Any]:
-    """Resolve secret names from the harness credential store.
+def credential_store_resolver(config_dir: Path | None) -> Any:
+    """The credential-store-backed resolver over the operator's config dir.
 
     Imported lazily so the sweep's own import graph stays free of the
     application's configuration until a resolution is actually needed.
     """
 
     from local_operator.credentials import CredentialManager
+    from local_operator.evaluation.runner.host_secrets import CredentialStoreResolver
     from local_operator.paths import config_dir as default_config_dir
 
-    manager = CredentialManager(config_dir or default_config_dir())
-
-    def resolve(names: Sequence[str]) -> tuple[ResolvedSecret, ...]:
-        out: list[ResolvedSecret] = []
-        for name in names:
-            try:
-                value = manager.get_credential(name).get_secret_value()
-            except Exception as error:
-                raise MissingSecret(name) from error
-            if not value:
-                raise MissingSecret(name)
-            out.append(ResolvedSecret(name=name, value=value))
-        return tuple(out)
-
-    return resolve
+    return CredentialStoreResolver(CredentialManager(config_dir or default_config_dir()))
 
 
-@dataclass(frozen=True)
-class SweepEntry:
-    episode_id: str
-    complete: bool
-    codes: tuple[str, ...]
-    error: str | None = None
-
-
-async def sweep_rescue_root(
-    root: Path,
-    resolve: Callable[[Sequence[str]], Any],
-    *,
-    rescue: Any = run_rescue,
-) -> tuple[SweepEntry, ...]:
-    """Rescue each ``<root>/*/rescue.json``; unlink only on ``complete``."""
-
-    entries: list[SweepEntry] = []
-    for path in sorted(root.glob("*/rescue.json")):
-        episode_dir = path.parent
-        try:
-            descriptor = load_pending_rescue(episode_dir)
-        except Exception as error:
-            entries.append(SweepEntry(episode_dir.name, False, (), f"unreadable: {error}"))
-            continue
-        if descriptor is None:
-            continue
-        try:
-            secrets = resolve([ref.name for ref in descriptor.secret_refs])
-        except MissingSecret as error:
-            entries.append(
-                SweepEntry(descriptor.episode_id, False, (), f"missing secret {error.args[0]}")
-            )
-            continue
-        try:
-            aggregate = await rescue(descriptor, secrets=secrets)
-        except Exception as error:
-            entries.append(SweepEntry(descriptor.episode_id, False, (), f"rescue failed: {error}"))
-            continue
-        codes = tuple(receipt.evidence_code for receipt in aggregate.receipts)
-        if aggregate.complete:
-            discard_rescue(episode_dir)
-        entries.append(SweepEntry(descriptor.episode_id, aggregate.complete, codes))
-    return tuple(entries)
+def entry_json(entry: SweepEntry) -> dict[str, Any]:
+    return {
+        "episode_id": entry.episode_id,
+        "complete": entry.complete,
+        "codes": list(entry.codes),
+        "error": entry.error,
+    }
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -126,21 +69,8 @@ def main(argv: list[str] | None = None) -> int:
     entries = asyncio.run(
         sweep_rescue_root(args.rescue_root, credential_store_resolver(args.config_dir))
     )
-    print(
-        json.dumps(
-            [
-                {
-                    "episode_id": e.episode_id,
-                    "complete": e.complete,
-                    "codes": list(e.codes),
-                    "error": e.error,
-                }
-                for e in entries
-            ],
-            indent=2,
-        )
-    )
-    return 0 if all(e.complete for e in entries) else 1
+    print(json.dumps([entry_json(entry) for entry in entries], indent=2))
+    return 0 if all(entry.complete for entry in entries) else 1
 
 
 if __name__ == "__main__":

--- a/scripts/run_episode.py
+++ b/scripts/run_episode.py
@@ -54,6 +54,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 import uuid
 from dataclasses import asdict
 from pathlib import Path
@@ -90,7 +91,7 @@ from local_operator.evaluation.runner.episode import (
     EpisodeRunner,
     EpisodeSpec,
 )
-from local_operator.evaluation.runner.route_ids import fold_model_id
+from local_operator.evaluation.runner.route_ids import MAX_IDENTIFIER, fold_model_id
 from local_operator.evaluation.runner.secrets import (
     EnvSecretResolver,
     MissingSecret,
@@ -100,6 +101,9 @@ from local_operator.evaluation.runner.secrets import (
 EXIT_OK = 0
 EXIT_EPISODE = 1
 EXIT_PREFLIGHT = 2
+# Diagnostic prefixes (``_diagnostic`` renders ``<TypeName>: ...``) that mean
+# a secret stopped the run before allocation; both are name-only by contract.
+_SECRET_DIAGNOSTICS = ("MissingSecret:", "UnusableSecret:")
 
 # Names the OSWorld adapter (and any adapter following its contract) declares
 # as secrets when it is asked ``inspect_requirements``. The runner resolves
@@ -154,7 +158,15 @@ def _route_identity(provider: str, model: str) -> RouteIdentity:
     """
 
     folded = fold_model_id(model)
-    return RouteIdentity(provider_id=provider, route_id=f"{provider}:{folded}", model_id=folded)
+    route_id = f"{provider}:{folded}"
+    if len(route_id) > MAX_IDENTIFIER:
+        # ``fold_model_id`` bounds the folded id alone; the composite route id
+        # shares the same 128-character StrictIdentifier cap.
+        raise SystemExit(
+            f"route {provider}/{model} folds to a {len(route_id)}-character route id; "
+            f"the limit is {MAX_IDENTIFIER}"
+        )
+    return RouteIdentity(provider_id=provider, route_id=route_id, model_id=folded)
 
 
 def _digest(value: str) -> str:
@@ -189,6 +201,27 @@ def _harness_git_revision() -> str:
 
 
 def _harness_version() -> str:
+    """The version of the code that is RUNNING, not of the last install.
+
+    ``importlib.metadata.version`` reports whatever the editable install was
+    last registered at, which on a development checkout lags the tree by any
+    number of releases (a 0.44.31 head sealed ``0.43.5``). When this script
+    runs from a checkout the source of truth is that checkout's
+    ``pyproject.toml``; the install metadata is only the fallback for a wheel
+    install, where the two cannot disagree.
+    """
+
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    if pyproject.is_file():
+        import tomllib
+
+        try:
+            with pyproject.open("rb") as handle:
+                declared = tomllib.load(handle)["project"]["version"]
+            if isinstance(declared, str) and declared:
+                return declared
+        except (OSError, KeyError, TypeError, ValueError):
+            pass
     from importlib.metadata import PackageNotFoundError, version
 
     try:
@@ -221,7 +254,7 @@ def _budget(
     three things that bound a paid episode's damage.
     """
 
-    now_ms = int(__import__("time").time() * 1000)
+    now_ms = int(time.time() * 1000)
     capped: dict[str, int] = {
         "provider_usd_micros": max_usd_micros,
         "wall_milliseconds": max_wall_ms,
@@ -329,13 +362,23 @@ def build_spec(
     )
 
 
-def build_config(run_root: Path, *, max_steps: int, max_cycle_usd_micros: int | None) -> Any:
-    """Roots under ONE durable directory; timeouts sized for a real worker."""
+def build_config(
+    run_root: Path, *, episode_id: str, max_steps: int, max_cycle_usd_micros: int | None
+) -> Any:
+    """Roots under ONE durable directory; timeouts sized for a real worker.
+
+    The rescue root is PER EPISODE (``<run-root>/rescue/<episode_id>``) so
+    that ``<run-root>/rescue`` is a real inbox: ``sweep_rescue_root`` globs
+    ``<root>/*/rescue.json``, and the README tells the operator to sweep the
+    ``rescue/`` directory. Persisting one level up (``rescue/rescue.json``)
+    made the documented sweep report ``[]`` over a live descriptor -- the
+    leaked-instance scenario the sweep exists to catch.
+    """
 
     refuse_volatile_root(run_root, label="run root")
     evidence = run_root / "evidence"
     artifacts = run_root / "artifacts"
-    rescue = run_root / "rescue"
+    rescue = run_root / "rescue" / episode_id
     for path in (evidence, artifacts, rescue):
         path.mkdir(mode=0o700, parents=True, exist_ok=True)
     return EpisodeConfig(
@@ -515,7 +558,10 @@ async def run(args: argparse.Namespace) -> int:
 
     try:
         config = build_config(
-            args.run_root, max_steps=args.max_steps, max_cycle_usd_micros=max_cycle
+            args.run_root,
+            episode_id=episode_id,
+            max_steps=args.max_steps,
+            max_cycle_usd_micros=max_cycle,
         )
     except VolatileRootError as error:
         print(str(error), file=sys.stderr)
@@ -553,6 +599,11 @@ async def run(args: argparse.Namespace) -> int:
             "route": f"{provider}/{model}",
             "route_provider_id": provider,
             "route_model_id": model,
+            # Which model client produced the decisions. A ``scripted-finish``
+            # bundle verifies exactly like a real one; this stamp plus the
+            # runner's ``synthetic_model`` label are what keep it from being
+            # read as a result.
+            "model_client": args.model_client,
             "script": "scripts/run_episode.py",
         },
     )
@@ -583,6 +634,9 @@ async def run(args: argparse.Namespace) -> int:
         selector=selector,
         model=model_client,
         secrets=resolver,
+        # Anything but the real provider client seals ``synthetic_model``
+        # rather than ``reportable``.
+        synthetic_model=args.model_client != "provider",
         launch=AdapterSupervisor.launch,
     )
     try:
@@ -592,11 +646,12 @@ async def run(args: argparse.Namespace) -> int:
             auth_store.close()
 
     print(json.dumps(_outcome_json(outcome), indent=2, sort_keys=True))
-    if outcome.status == "failed_pre_bundle" and (outcome.diagnostic or "").startswith(
-        "MissingSecret"
-    ):
-        # The runner's diagnostic already names only the ref.
-        print(outcome.diagnostic, file=sys.stderr)
+    diagnostic = outcome.diagnostic or ""
+    if outcome.status == "failed_pre_bundle" and diagnostic.startswith(_SECRET_DIAGNOSTICS):
+        # The runner's diagnostic already names only the ref; both a missing
+        # and an unusable (over-long) secret are the operator's to fix before
+        # anything can run, hence the preflight exit code.
+        print(diagnostic, file=sys.stderr)
         return EXIT_PREFLIGHT
     return EXIT_OK if outcome.status == "completed" else EXIT_EPISODE
 

--- a/scripts/run_episode.py
+++ b/scripts/run_episode.py
@@ -1,0 +1,598 @@
+#!/usr/bin/env python3
+"""Run ONE evaluation episode end to end and print its outcome as JSON.
+
+This is an OPERATOR SCRIPT, not a CLI or TUI surface: it exists so the paid
+OSWorld proof and the pilot can drive a real episode -- real spawned worker,
+real provider-backed model client, real credential store, real sealed bundle
+-- from one command line with every input pinned on it. It deliberately
+imports nothing from ``local_operator.session`` or the TUI; the runner's
+isolation rule (``runner/test_isolation.py``) is what makes a bundle
+reproducible from its inputs, and this script must not undo that by pulling
+the operator's live session configuration into the episode.
+
+Inputs, all explicit:
+
+* ``--selector <json>`` -- the ``AdapterSelector`` (exact wheel, interpreter,
+  workspace and digests). Computed per the adapter README, never guessed.
+* ``--task-id`` -- one task in the workspace's ``tasks/``.
+* ``--route provider/model`` -- the model route the episode is pinned to.
+  ``fallback_policy`` is ``forbid``: a provider outage fails the episode as a
+  provider error rather than silently serving a different model.
+* ``--run-root`` -- ONE durable directory under which ``evidence/``,
+  ``artifacts/`` and ``rescue/`` are created. It MUST NOT be under ``/tmp``
+  (``runner.durable_root``): a purge of ``/private/tmp`` mid-run destroyed a
+  previous paid pilot's outputs and left an instance running with no
+  descriptor naming it.
+* ``--secret-env NAME`` (repeatable) -- the names of environment variables
+  holding secrets the task needs. These are read from THIS process's
+  environment by an explicit ``EnvSecretResolver``; a name not listed here is
+  never reachable, however it is spelled. Anything not listed is resolved
+  from the credential store (``CredentialStoreResolver``), the same store the
+  model client is built from.
+* ``--infra NAME=VALUE`` (repeatable) -- non-secret infra values
+  (``AWS_REGION``, ``AWS_SUBNET_ID``, ...) with ``--infra-purpose``.
+* Budget and step caps (``--max-steps``, ``--max-usd``, ``--max-wall-s``,
+  ``--max-cycle-usd``), all explicit; the defaults are conservative because
+  a paid episode with no cap is the one thing this script must not run.
+
+Output: the ``EpisodeOutcome`` as a JSON object on stdout, plus
+``bundle_root``. Exit status is 0 only for ``completed``; ``failed``,
+``cancelled``, ``abandoned``, ``abandonment_failed`` and ``failed_pre_bundle``
+exit 1, and a missing secret (which fails BEFORE any allocation) exits 2 with
+the secret's NAME -- never a value -- on stderr.
+
+The exact command the paid proof runs is in the adapter README under
+"Running one episode".
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import uuid
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Sequence
+
+from local_operator.evaluation.adapters.api import (
+    AdapterSelector,
+    ResolvedSecret,
+    ScopedInfraValue,
+    SecretRef,
+)
+from local_operator.evaluation.adapters.supervisor import AdapterSupervisor
+from local_operator.evaluation.evidence.models import RouteIdentity
+from local_operator.evaluation.receipts import (
+    BUDGET_RESOURCES,
+    BudgetAuthorization,
+    CappedAllowance,
+    ComputeRequirement,
+    DependencyPlan,
+    RedactionSet,
+    ResourceAmount,
+    UncappedAllowance,
+    record_preflight,
+    reserve_budget,
+    seal_preflight,
+)
+from local_operator.evaluation.runner.durable_root import (
+    VolatileRootError,
+    refuse_volatile_root,
+)
+from local_operator.evaluation.runner.episode import (
+    EpisodeConfig,
+    EpisodeOutcome,
+    EpisodeRunner,
+    EpisodeSpec,
+)
+from local_operator.evaluation.runner.secrets import (
+    EnvSecretResolver,
+    MissingSecret,
+    SecretResolver,
+)
+
+EXIT_OK = 0
+EXIT_EPISODE = 1
+EXIT_PREFLIGHT = 2
+
+# Names the OSWorld adapter (and any adapter following its contract) declares
+# as secrets when it is asked ``inspect_requirements``. The runner resolves
+# exactly ``spec.secret_refs``; this script needs to KNOW the refs before it
+# builds the spec, and the only honest way is to ask for them on the command
+# line (``--secret``). The default covers the AWS provider so the paid proof's
+# command line stays short.
+_DEFAULT_SECRET_REFS = ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY")
+
+
+class _LayeredResolver:
+    """Env-listed names from the process environment, everything else from the store.
+
+    Two resolvers rather than one mapping so the boundary is visible: a name
+    is EITHER on ``--secret-env`` (and read from this process) OR resolved
+    from the credential store. Nothing here reads ``os.environ`` for a name
+    the operator did not list.
+    """
+
+    def __init__(self, env_names: Sequence[str], store: SecretResolver | None) -> None:
+        self._env_names = frozenset(env_names)
+        self._env = EnvSecretResolver({name: os.environ.get(name, "") for name in env_names})
+        self._store = store
+
+    def resolve(self, names: Sequence[str]) -> tuple[ResolvedSecret, ...]:
+        resolved: list[ResolvedSecret] = []
+        for name in names:
+            if name in self._env_names:
+                resolved.extend(self._env.resolve([name]))
+            elif self._store is not None:
+                resolved.extend(self._store.resolve([name]))
+            else:
+                raise MissingSecret(name)
+        return tuple(resolved)
+
+
+def _parse_route(value: str) -> tuple[str, str]:
+    provider, sep, model = value.partition("/")
+    if not sep or not provider or not model:
+        raise argparse.ArgumentTypeError("--route must be <provider>/<model-id>")
+    return provider, model
+
+
+def _route_identity(provider: str, model: str) -> RouteIdentity:
+    # ``StrictIdentifier`` forbids ``/``; an OpenRouter model id such as
+    # ``deepseek/deepseek-v4`` is carried with the slash folded so the sealed
+    # route stays a valid identifier while remaining recognisable.
+    folded = model.replace("/", ":")
+    return RouteIdentity(provider_id=provider, route_id=f"{provider}:{folded}", model_id=folded)
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _harness_git_revision() -> str:
+    """The installed harness's git revision, or a digest of its version.
+
+    A source checkout answers ``git rev-parse``; a wheel install does not,
+    and the manifest still needs a 64-hex value, so the version string is
+    hashed as a stable stand-in and the real version rides in ``metadata``.
+    """
+
+    repo = Path(__file__).resolve().parents[1]
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        completed = None
+    if completed is not None and completed.returncode == 0:
+        head = completed.stdout.strip()
+        if len(head) == 40:
+            # A 40-hex SHA-1 is not the 64-hex the manifest wants; hash it so
+            # the field is stable and the raw commit lands in metadata.
+            return _digest(head)
+    return _digest(_harness_version())
+
+
+def _harness_version() -> str:
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        return version("local-operator")
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
+def _task_digest(selector: AdapterSelector, task_id: str) -> str:
+    """The task's own bytes, hashed: what the manifest pins as ``task_digest``."""
+
+    path = Path(selector.workspace) / "tasks" / f"{task_id}.py"
+    if not path.is_file():
+        raise SystemExit(f"task {task_id!r} is not in the workspace: {path}")
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _budget(
+    episode_id: str,
+    *,
+    max_usd_micros: int,
+    max_wall_ms: int,
+    max_steps: int,
+) -> BudgetAuthorization:
+    """Cap what the operator asked to cap; leave the rest uncapped but reported.
+
+    Every resource must appear exactly once. Token counts and cloud cost are
+    reported rather than capped (there is no honest number to put on them up
+    front), but the USD, wall and action caps are hard because they are the
+    three things that bound a paid episode's damage.
+    """
+
+    now_ms = int(__import__("time").time() * 1000)
+    capped: dict[str, int] = {
+        "provider_usd_micros": max_usd_micros,
+        "wall_milliseconds": max_wall_ms,
+        "guest_actions": max_steps * 8,
+        "model_cycles": max_steps * 2,
+    }
+    allowances: list[Any] = []
+    for resource in BUDGET_RESOURCES:
+        if resource in capped:
+            allowances.append(
+                CappedAllowance(resource=resource, value=capped[resource], reporting="required")
+            )
+        else:
+            allowances.append(
+                UncappedAllowance(
+                    resource=resource,
+                    reason="reported, not capped, by scripts/run_episode.py",
+                    authorized_by="run_episode",
+                    authorized_at_ms=now_ms,
+                    reporting="required",
+                )
+            )
+    return BudgetAuthorization(episode_id=episode_id, allowances=tuple(allowances))
+
+
+def build_spec(
+    *,
+    episode_id: str,
+    selector: AdapterSelector,
+    task_id: str,
+    route: RouteIdentity,
+    benchmark_id: str,
+    benchmark_release: str,
+    secret_refs: Sequence[str],
+    infra_values: Sequence[ScopedInfraValue],
+    max_usd_micros: int,
+    max_wall_ms: int,
+    max_steps: int,
+    metadata: dict[str, Any],
+) -> EpisodeSpec:
+    """Pin everything the manifest identifies the run by.
+
+    The dependency plan carries one compute requirement because the plan must
+    be non-empty and the preflight must have a receipt per requirement; the
+    adapter's own ``inspect_requirements`` is what actually gates secrets and
+    infra, and the runner fails closed on those before allocation.
+    """
+
+    plan = DependencyPlan(
+        release_id=benchmark_release,
+        task_id=task_id,
+        attempt_id=episode_id,
+        requirements=(
+            ComputeRequirement(
+                requirement_id="compute",
+                necessity="required",
+                reportability="required",
+                cpu_class="standard",
+                memory_class="small",
+                disk_bytes=0,
+            ),
+        ),
+    )
+    receipts = (record_preflight(plan, "compute", status="pass", duration_ms=0),)
+    preflight = seal_preflight(plan, receipts, RedactionSet.from_resolved_values(()))
+    budget = _budget(
+        episode_id, max_usd_micros=max_usd_micros, max_wall_ms=max_wall_ms, max_steps=max_steps
+    )
+    reservation = reserve_budget(
+        budget,
+        "episode",
+        [ResourceAmount(resource=resource, value=1) for resource in BUDGET_RESOURCES],
+    )
+    config_source = json.dumps(
+        {
+            "max_steps": max_steps,
+            "max_usd_micros": max_usd_micros,
+            "max_wall_ms": max_wall_ms,
+            "route": route.model_dump(mode="json"),
+            "selector": selector.model_dump(mode="json"),
+        },
+        sort_keys=True,
+    )
+    return EpisodeSpec(
+        episode_id=episode_id,
+        task_id=task_id,
+        task_digest=_task_digest(selector, task_id),
+        input_digest=selector.workspace_digest,
+        benchmark_id=benchmark_id,
+        benchmark_release=benchmark_release,
+        environment_digest=selector.release_digest,
+        environment_release=selector.version,
+        config_digest=_digest(config_source),
+        harness_version=_harness_version(),
+        harness_git_revision=_harness_git_revision(),
+        requested_route=route,
+        dependency_plan=plan,
+        budget=budget,
+        preflight=preflight,
+        reservations=(reservation,),
+        fallback_policy="forbid",
+        secret_refs=tuple(SecretRef(name=name) for name in secret_refs),
+        infra_values=tuple(infra_values),
+        metadata=metadata,
+    )
+
+
+def build_config(run_root: Path, *, max_steps: int, max_cycle_usd_micros: int | None) -> Any:
+    """Roots under ONE durable directory; timeouts sized for a real worker."""
+
+    refuse_volatile_root(run_root, label="run root")
+    evidence = run_root / "evidence"
+    artifacts = run_root / "artifacts"
+    rescue = run_root / "rescue"
+    for path in (evidence, artifacts, rescue):
+        path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    return EpisodeConfig(
+        evidence_root=evidence,
+        artifact_root=artifacts,
+        rescue_root=rescue,
+        max_steps=max_steps,
+        # A real AWS allocation waits on instance readiness (up to 10 min in
+        # the provider); the reset timeout must cover that or the runner
+        # abandons an episode whose instance is still coming up.
+        prepare_timeout=120.0,
+        reset_timeout=900.0,
+        step_timeout=180.0,
+        score_timeout=300.0,
+        cleanup_timeout=120.0,
+        handshake_timeout=60.0,
+        max_cycle_cost_micros=max_cycle_usd_micros,
+    )
+
+
+def _open_store(config_dir: Path | None) -> tuple[Any, Any]:
+    """(auth_store, credential_manager) exactly as the CLI builds them.
+
+    ``cli._build_auth_stack`` is the reference: ``CredentialManager`` over the
+    config dir feeds ``AuthStore``. Imported lazily so the script's import
+    graph stays free of the application until a store is actually opened.
+    """
+
+    from local_operator.credentials import CredentialManager
+    from local_operator.paths import config_dir as default_config_dir
+    from local_operator.providers.auth_store import AuthStore
+
+    manager = CredentialManager(config_dir or default_config_dir())
+    return AuthStore(credential_manager=manager), manager
+
+
+def _model_client(
+    *,
+    auth_store: Any,
+    settings: dict[str, Any],
+    provider: str,
+    model: str,
+    route: RouteIdentity,
+    artifact_root: Path,
+    episode_id: str,
+    keep_recent_frames: int,
+) -> Any:
+    from local_operator.evaluation.runner.provider_client import (
+        create_provider_model_client,
+    )
+    from local_operator.model.configure import build_model_spec
+
+    return create_provider_model_client(
+        auth_store=auth_store,
+        settings=settings,
+        route=route,
+        model_spec=build_model_spec(provider, model),
+        artifact_root=artifact_root,
+        episode_id=episode_id,
+        fallback_policy="forbid",
+        keep_recent_frames=keep_recent_frames,
+    )
+
+
+def _outcome_json(outcome: EpisodeOutcome) -> dict[str, Any]:
+    data = asdict(outcome)
+    data["bundle_root"] = str(outcome.bundle_root) if outcome.bundle_root else None
+    data["score"] = outcome.score.model_dump(mode="json") if outcome.score else None
+    return data
+
+
+def _parse_infra(values: Sequence[str], purpose: str) -> tuple[ScopedInfraValue, ...]:
+    out: list[ScopedInfraValue] = []
+    for item in values:
+        name, sep, value = item.partition("=")
+        if not sep or not name:
+            raise SystemExit(f"--infra expects NAME=VALUE, got {item!r}")
+        # ``purpose`` is validated by the model against the closed InfraPurpose
+        # vocabulary; argparse hands it over as a plain string.
+        out.append(
+            ScopedInfraValue.model_validate({"name": name, "purpose": purpose, "value": value})
+        )
+    return tuple(out)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n\n")[0])
+    parser.add_argument("--selector", required=True, type=Path, help="AdapterSelector JSON file")
+    parser.add_argument("--task-id", required=True)
+    parser.add_argument("--route", required=True, type=_parse_route, help="<provider>/<model>")
+    parser.add_argument("--run-root", required=True, type=Path, help="durable; never /tmp")
+    parser.add_argument("--benchmark-id", default="osworld-v2")
+    parser.add_argument("--benchmark-release", default="osworld-v2-2026.08.08")
+    parser.add_argument("--episode-id", default=None, help="default: ep-<12 hex>")
+    parser.add_argument(
+        "--secret",
+        action="append",
+        default=None,
+        metavar="NAME",
+        help=f"secret ref the task needs (repeatable; default {list(_DEFAULT_SECRET_REFS)})",
+    )
+    parser.add_argument(
+        "--secret-env",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="read this secret from the process environment instead of the store",
+    )
+    parser.add_argument("--infra", action="append", default=[], metavar="NAME=VALUE")
+    parser.add_argument("--infra-purpose", default="benchmark_compute")
+    parser.add_argument("--config-dir", type=Path, default=None, help="lop config dir")
+    parser.add_argument("--max-steps", type=int, default=25)
+    parser.add_argument("--max-usd", type=float, default=0.50, help="provider spend cap")
+    parser.add_argument("--max-wall-s", type=int, default=1800)
+    parser.add_argument("--max-cycle-usd", type=float, default=None, help="per-cycle cap")
+    parser.add_argument("--keep-recent-frames", type=int, default=3)
+    parser.add_argument(
+        "--no-store",
+        action="store_true",
+        help="never open the credential store: every secret must be on --secret-env "
+        "and the model client is built without one (test/fake routes only)",
+    )
+    parser.add_argument(
+        "--model-client",
+        default="provider",
+        choices=("provider", "scripted-finish"),
+        help="'scripted-finish' issues one finish action with no provider "
+        "(for proving the script against a fake adapter; never for a result)",
+    )
+    return parser
+
+
+class _ScriptedFinish:
+    """A model that finishes on its first turn; for exercising the script only.
+
+    It reports the REQUESTED route as served so the bundle seals comparable;
+    it never calls a provider, so a run with it is a proof of the plumbing
+    (spawn, secrets, frames, seal) and never a benchmark result.
+    """
+
+    def __init__(self, route: RouteIdentity) -> None:
+        self._route = route
+
+    async def decide(self, observation: Any, history: Sequence[Any]) -> Any:
+        from local_operator.evaluation.protocol import ActionBatch
+        from local_operator.evaluation.runner.model import ModelDecision
+
+        del history
+        batch = ActionBatch.model_validate(
+            {
+                "protocol_version": "1.0",
+                "task_id": observation.task_id,
+                "episode_id": observation.episode_id,
+                "observation_id": observation.observation_id,
+                "actions": [
+                    {
+                        "kind": "finish",
+                        "observation_id": observation.observation_id,
+                        "status": "done",
+                        "reason": "scripted finish from scripts/run_episode.py",
+                    }
+                ],
+            },
+            strict=True,
+        )
+        return ModelDecision(action_batch=batch, route=self._route)
+
+
+async def run(args: argparse.Namespace) -> int:
+    selector = AdapterSelector.model_validate(json.loads(args.selector.read_text()))
+    provider, model = args.route
+    route = _route_identity(provider, model)
+    episode_id = args.episode_id or f"ep-{uuid.uuid4().hex[:12]}"
+    secret_refs = tuple(args.secret) if args.secret is not None else _DEFAULT_SECRET_REFS
+    max_usd_micros = int(round(args.max_usd * 1_000_000))
+    max_cycle = int(round(args.max_cycle_usd * 1_000_000)) if args.max_cycle_usd else None
+
+    try:
+        config = build_config(
+            args.run_root, max_steps=args.max_steps, max_cycle_usd_micros=max_cycle
+        )
+    except VolatileRootError as error:
+        print(str(error), file=sys.stderr)
+        return EXIT_PREFLIGHT
+
+    auth_store: Any = None
+    manager: Any = None
+    store_resolver: SecretResolver | None = None
+    if not args.no_store:
+        from local_operator.evaluation.runner.host_secrets import (
+            CredentialStoreResolver,
+        )
+
+        auth_store, manager = _open_store(args.config_dir)
+        store_resolver = CredentialStoreResolver(manager)
+    resolver = _LayeredResolver(args.secret_env, store_resolver)
+
+    spec = build_spec(
+        episode_id=episode_id,
+        selector=selector,
+        task_id=args.task_id,
+        route=route,
+        benchmark_id=args.benchmark_id,
+        benchmark_release=args.benchmark_release,
+        secret_refs=secret_refs,
+        infra_values=_parse_infra(args.infra, args.infra_purpose),
+        max_usd_micros=max_usd_micros,
+        max_wall_ms=args.max_wall_s * 1000,
+        max_steps=args.max_steps,
+        metadata={
+            "harness_version": _harness_version(),
+            "route": f"{provider}/{model}",
+            "script": "scripts/run_episode.py",
+        },
+    )
+
+    if args.model_client == "scripted-finish":
+        model_client: Any = _ScriptedFinish(route)
+    else:
+        if auth_store is None:
+            print(
+                "--model-client provider needs the credential store (drop --no-store)",
+                file=sys.stderr,
+            )
+            return EXIT_PREFLIGHT
+        model_client = _model_client(
+            auth_store=auth_store,
+            settings={},
+            provider=provider,
+            model=model,
+            route=route,
+            artifact_root=config.artifact_root,
+            episode_id=episode_id,
+            keep_recent_frames=args.keep_recent_frames,
+        )
+
+    runner = EpisodeRunner(
+        spec,
+        config,
+        selector=selector,
+        model=model_client,
+        secrets=resolver,
+        launch=AdapterSupervisor.launch,
+    )
+    try:
+        outcome = await runner.run()
+    finally:
+        if auth_store is not None:
+            auth_store.close()
+
+    print(json.dumps(_outcome_json(outcome), indent=2, sort_keys=True))
+    if outcome.status == "failed_pre_bundle" and (outcome.diagnostic or "").startswith(
+        "MissingSecret"
+    ):
+        # The runner's diagnostic already names only the ref.
+        print(outcome.diagnostic, file=sys.stderr)
+        return EXIT_PREFLIGHT
+    return EXIT_OK if outcome.status == "completed" else EXIT_EPISODE
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_episode.py
+++ b/scripts/run_episode.py
@@ -90,6 +90,7 @@ from local_operator.evaluation.runner.episode import (
     EpisodeRunner,
     EpisodeSpec,
 )
+from local_operator.evaluation.runner.route_ids import fold_model_id
 from local_operator.evaluation.runner.secrets import (
     EnvSecretResolver,
     MissingSecret,
@@ -143,10 +144,16 @@ def _parse_route(value: str) -> tuple[str, str]:
 
 
 def _route_identity(provider: str, model: str) -> RouteIdentity:
-    # ``StrictIdentifier`` forbids ``/``; an OpenRouter model id such as
-    # ``deepseek/deepseek-v4`` is carried with the slash folded so the sealed
-    # route stays a valid identifier while remaining recognisable.
-    folded = model.replace("/", ":")
+    """The sealed route. ``model_id`` is the LOSSLESS fold of the provider's id.
+
+    ``StrictIdentifier`` forbids ``/``, which every OpenRouter id carries.
+    ``route_ids.fold_model_id`` is reversible (``unfold_model_id``), so the
+    sealed identity still means exactly one model -- comparability depends
+    on that -- and ``run`` also records the raw id in the manifest metadata
+    (``route_model_id``) so nobody has to decode by hand.
+    """
+
+    folded = fold_model_id(model)
     return RouteIdentity(provider_id=provider, route_id=f"{provider}:{folded}", model_id=folded)
 
 
@@ -540,7 +547,12 @@ async def run(args: argparse.Namespace) -> int:
         max_steps=args.max_steps,
         metadata={
             "harness_version": _harness_version(),
+            # The unfolded route, verbatim, beside the folded identity the
+            # manifest seals: ``route_model_id`` is the exact id the provider
+            # was asked for.
             "route": f"{provider}/{model}",
+            "route_provider_id": provider,
+            "route_model_id": model,
             "script": "scripts/run_episode.py",
         },
     )

--- a/tests/unit/evaluation/adapters/osworld/spawn_helpers.py
+++ b/tests/unit/evaluation/adapters/osworld/spawn_helpers.py
@@ -2,7 +2,8 @@
 
 These follow the established ``adapters/test_launch.py`` and
 ``runner/test_episode_subprocess.py`` pattern: build a genuine copied
-interpreter, install the REAL adapter wheel into its site-packages (so
+interpreter (``tests.unit.evaluation.copied_interpreter``, shared by all
+three), install the REAL adapter wheel into its site-packages (so
 ``distribution_digest`` verifies the real RECORD), write a real
 ``adapter-release.json`` and ``tasks/`` corpus into a workspace, and compute
 the three digests the selector pins. Only the model is scripted; the worker,
@@ -18,11 +19,9 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import shutil
 import subprocess
 import sys
-import sysconfig
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -32,59 +31,15 @@ from local_operator.evaluation.adapters.api import (
     AdapterSelector,
 )
 from local_operator.evaluation.adapters.discovery import workspace_digest
+from tests.unit.evaluation.copied_interpreter import (
+    copied_interpreter,
+    site_packages_of,
+)
 
 # tests/unit/evaluation/adapters/osworld/spawn_helpers.py -> repo root is 5
 # parents up (osworld -> adapters -> evaluation -> unit -> tests -> root).
 ADAPTER_SRC = Path(__file__).resolve().parents[5] / "benchmarks" / "osworld_v2_adapter"
 WHEEL_NAME = "lop_osworld_v2_adapter-0.1.0-py3-none-any.whl"
-
-
-def real_interpreter(venv: Path) -> Path:
-    """Copy a working interpreter so its content can be pinned per test run.
-
-    Follows ``test_episode_subprocess._real_interpreter``: candidates are
-    tried in turn because not every interpreter can host a ``--copies`` venv.
-    Failing loudly (not skipping) keeps a host with no usable interpreter
-    from silently dropping the only real-spawn coverage.
-    """
-
-    candidates = [
-        os.path.realpath(sys.executable),
-        shutil.which("python3") or "",
-        sys.base_prefix + "/bin/python3",
-    ]
-    failures: list[str] = []
-    for base in candidates:
-        if not base or not os.path.exists(base):
-            continue
-        shutil.rmtree(venv, ignore_errors=True)
-        try:
-            subprocess.run(
-                [base, "-m", "venv", "--without-pip", "--copies", str(venv)],
-                check=True,
-                capture_output=True,
-            )
-        except (OSError, subprocess.CalledProcessError) as error:
-            failures.append(f"{base}: venv creation failed ({error})")
-            continue
-        executable = next(
-            (
-                item
-                for item in sorted((venv / "bin").glob("python3.*"))
-                if item.is_file() and not item.is_symlink()
-            ),
-            None,
-        )
-        if executable is None:
-            failures.append(f"{base}: produced no copied executable")
-            continue
-        probe = subprocess.run(
-            [str(executable), "-I", "-c", "print('ok')"], capture_output=True, text=True
-        )
-        if probe.returncode == 0:
-            return executable
-        failures.append(f"{base}: copied interpreter did not run ({probe.stderr[-200:]})")
-    raise AssertionError("no usable copied interpreter on this host: " + "; ".join(failures))
 
 
 def build_adapter_wheel(out_dir: Path) -> Path:
@@ -234,20 +189,12 @@ def build_spawnable_adapter(
     the property that makes the spawned tests evidence rather than decoration.
     """
 
-    executable = real_interpreter(tmp_path / "venv")
-    site = next(executable.parent.parent.glob("lib/python*/site-packages"))
-
     # The copied venv has neither local_operator nor pydantic, and the worker
-    # imports both before it can answer a handshake. A .pth pointing at this
-    # interpreter's real roots is the mechanism test_launch.py established.
-    repo_root = Path(__file__).resolve().parents[5]
-    import pydantic
-
-    purelib = sysconfig.get_paths().get("purelib")
-    roots = [str(repo_root), str(Path(pydantic.__file__).resolve().parent.parent)]
-    if purelib:
-        roots.append(purelib)
-    (site / "_local_operator_repo.pth").write_text("\n".join(roots) + "\n")
+    # imports both before it can answer a handshake; ``copied_interpreter``
+    # writes the .pth pointing at this interpreter's real roots and proves
+    # the copy can import through it before handing it back.
+    executable = copied_interpreter(tmp_path / "venv")
+    site = site_packages_of(executable)
 
     package_digest = install_adapter_into_site(site, wheel)
     release_digest = release_digest_for(package_digest, tasks)

--- a/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
+++ b/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
@@ -449,12 +449,13 @@ async def test_sweep_unlinks_only_descriptors_whose_rescue_completed(tmp_path: P
         )
         return _Aggregate(False, (receipt,))
 
-    def resolve(names: Any) -> Any:
-        from local_operator.evaluation.adapters.api import ResolvedSecret
+    class _Resolver:
+        def resolve(self, names: Any) -> Any:
+            from local_operator.evaluation.adapters.api import ResolvedSecret
 
-        return tuple(ResolvedSecret(name=n, value="v") for n in names)
+            return tuple(ResolvedSecret(name=n, value="v") for n in names)
 
-    entries = await sweep.sweep_rescue_root(root, resolve, rescue=fake_rescue)
+    entries = await sweep.sweep_rescue_root(root, _Resolver(), rescue=fake_rescue)
     assert [(e.episode_id, e.complete, e.codes) for e in entries] == [
         ("ep-complete", True, ("instance-terminated",)),
         ("ep-stuck", False, ("terminate-unconfirmed",)),
@@ -474,13 +475,16 @@ async def test_sweep_reports_a_missing_secret_and_keeps_the_descriptor(tmp_path:
     )
     persist_rescue(root / "ep-needs-key", with_ref)
 
-    def resolve(names: Any) -> Any:
-        raise sweep.MissingSecret(names[0])
+    from local_operator.evaluation.runner.secrets import MissingSecret
+
+    class _Resolver:
+        def resolve(self, names: Any) -> Any:
+            raise MissingSecret(names[0])
 
     async def never(descriptor: Any, *, secrets: Any) -> Any:  # pragma: no cover
         raise AssertionError("rescue must not run without its secrets")
 
-    entries = await sweep.sweep_rescue_root(root, resolve, rescue=never)
+    entries = await sweep.sweep_rescue_root(root, _Resolver(), rescue=never)
     assert len(entries) == 1
     assert entries[0].complete is False
     assert entries[0].error == "missing secret AWS_SECRET_ACCESS_KEY"

--- a/tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
+++ b/tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
@@ -1,0 +1,212 @@
+"""``scripts/run_episode.py`` drives ONE real spawned episode to a sealed bundle.
+
+This is the proof that the operator script the paid run will use actually
+works end to end with nothing shared in memory: the script is run as a
+subprocess with a selector for the REAL adapter wheel installed into a REAL
+copied interpreter, the worker is spawned by the real supervisor, secrets
+travel from the script's environment over the private pipe, and the outcome
+comes back as JSON on stdout. Only the model is scripted (``--model-client
+scripted-finish``) and only the provider is fake (``FakeProvider`` selected by
+the digest-pinned workspace), because a paid proof must not run in CI.
+
+Marked ``slow`` like the other real-spawn suites.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.evaluation.evidence.verify import verify_bundle
+from tests.unit.evaluation.adapters.osworld import fixtures, spawn_helpers
+from tests.unit.evaluation.adapters.osworld.test_build_and_scripts import (  # noqa: F401
+    durable_path,
+)
+
+pytestmark = pytest.mark.slow
+
+REPO = Path(__file__).resolve().parents[5]
+SCRIPT = REPO / "scripts" / "run_episode.py"
+CANARY_KEY = "AKIACANARY0000000001"
+CANARY_SECRET = "canary-secret-value-9f8e7d6c5b4a"
+INFRA = [
+    "--infra",
+    "AWS_REGION=us-east-1",
+    "--infra",
+    "AWS_SUBNET_ID=subnet-test",
+    "--infra",
+    "AWS_SECURITY_GROUP_ID=sg-test",
+    "--infra",
+    "AWS_SCHEDULER_ROLE_ARN=arn:aws:iam::0:role/test",
+    "--infra",
+    "OSWORLD_CLIENT_PASSWORD=pw",
+    "--infra",
+    "OSWORLD_FILE_BASE_URL=http://assets.test",
+]
+
+
+@pytest.fixture(scope="module")
+def adapter_wheel(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return spawn_helpers.build_adapter_wheel(tmp_path_factory.mktemp("wheel"))
+
+
+def _selector_file(root: Path, wheel: Path) -> Path:
+    selector = spawn_helpers.build_spawnable_adapter(
+        root,
+        wheel,
+        {"task_plain": fixtures.PLAIN},
+        provider={"provider": "fake", "scripted_score": 1.0},
+    )
+    path = root / "selector.json"
+    path.write_text(selector.model_dump_json())
+    return path
+
+
+def _run(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    # ``PYTHONPATH`` so the script resolves the checkout under test rather
+    # than an installed harness; everything else in the environment is the
+    # explicit mapping the test hands over.
+    base = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": os.environ.get("HOME", ""),
+        "PYTHONPATH": str(REPO),
+        **env,
+    }
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=base,
+        cwd=str(REPO),
+        check=False,
+    )
+
+
+def _all_bytes_under(root: Path) -> bytes:
+    return b"\n".join(p.read_bytes() for p in sorted(root.rglob("*")) if p.is_file())
+
+
+def test_script_runs_one_spawned_episode_to_a_sealed_bundle(
+    durable_path: Path, adapter_wheel: Path  # noqa: F811
+) -> None:
+    selector = _selector_file(durable_path / "adapter", adapter_wheel)
+    run_root = durable_path / "run"
+
+    completed = _run(
+        [
+            "--selector",
+            str(selector),
+            "--task-id",
+            "task_plain",
+            "--route",
+            "test/fake-model",
+            "--run-root",
+            str(run_root),
+            "--secret-env",
+            "AWS_ACCESS_KEY_ID",
+            "--secret-env",
+            "AWS_SECRET_ACCESS_KEY",
+            "--no-store",
+            "--model-client",
+            "scripted-finish",
+            "--max-steps",
+            "3",
+            "--max-usd",
+            "0.01",
+            *INFRA,
+        ],
+        {"AWS_ACCESS_KEY_ID": CANARY_KEY, "AWS_SECRET_ACCESS_KEY": CANARY_SECRET},
+    )
+
+    assert completed.returncode == 0, completed.stderr[-3000:]
+    outcome: dict[str, Any] = json.loads(completed.stdout)
+    assert outcome["status"] == "completed", outcome
+    assert outcome["reportability_label"] == "reportable"
+    assert outcome["comparability_label"] == "comparable"
+    assert outcome["score"]["status"] == "scored" and outcome["score"]["binary"] == 1
+    bundle = Path(outcome["bundle_root"])
+    assert bundle.is_relative_to(run_root / "evidence")
+    report = verify_bundle(bundle)
+    assert report.valid, [issue.code for issue in report.issues]
+    # The spawned worker published real frames into the parent's root.
+    assert any(p.is_file() for p in (run_root / "artifacts").iterdir())
+    # A clean episode retired its own descriptor: the inbox is empty.
+    assert not list((run_root / "rescue").rglob("rescue.json"))
+    # The secret values reached the worker over the pipe and nowhere else:
+    # not the bundle, not the artifacts, not the rescue root, not stdout.
+    everything = _all_bytes_under(run_root) + completed.stdout.encode() + completed.stderr.encode()
+    assert CANARY_SECRET.encode() not in everything
+    assert CANARY_KEY.encode() not in everything
+
+
+def test_script_fails_pre_bundle_on_a_missing_secret_naming_only_the_ref(
+    durable_path: Path, adapter_wheel: Path  # noqa: F811
+) -> None:
+    selector = _selector_file(durable_path / "adapter", adapter_wheel)
+    run_root = durable_path / "run"
+
+    completed = _run(
+        [
+            "--selector",
+            str(selector),
+            "--task-id",
+            "task_plain",
+            "--route",
+            "test/fake-model",
+            "--run-root",
+            str(run_root),
+            "--secret-env",
+            "AWS_ACCESS_KEY_ID",
+            "--secret-env",
+            "AWS_SECRET_ACCESS_KEY",
+            "--no-store",
+            "--model-client",
+            "scripted-finish",
+            *INFRA,
+        ],
+        {"AWS_ACCESS_KEY_ID": CANARY_KEY},
+    )
+
+    assert completed.returncode == 2, completed.stderr[-3000:]
+    outcome = json.loads(completed.stdout)
+    assert outcome["status"] == "failed_pre_bundle"
+    assert outcome["bundle_root"] is None
+    assert outcome["diagnostic"] == "MissingSecret: missing secret AWS_SECRET_ACCESS_KEY"
+    assert "AWS_SECRET_ACCESS_KEY" in completed.stderr
+    # Nothing was allocated and nothing is left to reclaim.
+    assert not list((run_root / "rescue").rglob("rescue.json"))
+    assert not list((run_root / "evidence").iterdir())
+    everything = _all_bytes_under(run_root) + completed.stdout.encode() + completed.stderr.encode()
+    assert CANARY_KEY.encode() not in everything
+
+
+@pytest.mark.parametrize("volatile", ["/tmp/lop-episode", "/private/tmp/lop-episode"])
+def test_script_refuses_a_volatile_run_root(
+    durable_path: Path, adapter_wheel: Path, volatile: str  # noqa: F811
+) -> None:
+    selector = _selector_file(durable_path / "adapter", adapter_wheel)
+    completed = _run(
+        [
+            "--selector",
+            str(selector),
+            "--task-id",
+            "task_plain",
+            "--route",
+            "test/fake-model",
+            "--run-root",
+            volatile,
+            "--no-store",
+            "--model-client",
+            "scripted-finish",
+        ],
+        {},
+    )
+    assert completed.returncode == 2
+    assert "OS may purge" in completed.stderr
+    assert not Path(volatile).exists()

--- a/tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
+++ b/tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
@@ -89,6 +89,13 @@ def _run(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[st
     )
 
 
+def _checkout_version() -> str:
+    import tomllib
+
+    with (REPO / "pyproject.toml").open("rb") as handle:
+        return tomllib.load(handle)["project"]["version"]
+
+
 def _all_bytes_under(root: Path) -> bytes:
     return b"\n".join(p.read_bytes() for p in sorted(root.rglob("*")) if p.is_file())
 
@@ -128,7 +135,9 @@ def test_script_runs_one_spawned_episode_to_a_sealed_bundle(
     assert completed.returncode == 0, completed.stderr[-3000:]
     outcome: dict[str, Any] = json.loads(completed.stdout)
     assert outcome["status"] == "completed", outcome
-    assert outcome["reportability_label"] == "reportable"
+    # A scripted model client is plumbing proof, not a result: the runner's
+    # own label says so, and the manifest names the client.
+    assert outcome["reportability_label"] == "synthetic_model"
     assert outcome["comparability_label"] == "comparable"
     assert outcome["score"]["status"] == "scored" and outcome["score"]["binary"] == 1
     bundle = Path(outcome["bundle_root"])
@@ -144,9 +153,15 @@ def test_script_runs_one_spawned_episode_to_a_sealed_bundle(
     assert unfold_model_id(manifest.requested_route.model_id) == "fake/model:free"
     assert manifest.metadata["route_model_id"] == "fake/model:free"
     assert manifest.metadata["route_provider_id"] == "test"
+    assert manifest.metadata["model_client"] == "scripted-finish"
+    assert manifest.harness_version == _checkout_version()
+    assert report.outcome is not None and report.outcome.reportable is False
+    assert report.outcome.reportability_label == "synthetic_model"
     # The spawned worker published real frames into the parent's root.
     assert any(p.is_file() for p in (run_root / "artifacts").iterdir())
-    # A clean episode retired its own descriptor: the inbox is empty.
+    # A clean episode retired its own descriptor: the inbox is empty, and
+    # the per-episode directory sits where the documented sweep looks.
+    assert (run_root / "rescue" / outcome["episode_id"]).is_dir()
     assert not list((run_root / "rescue").rglob("rescue.json"))
     # The secret values reached the worker over the pipe and nowhere else:
     # not the bundle, not the artifacts, not the rescue root, not stdout.
@@ -220,3 +235,142 @@ def test_script_refuses_a_volatile_run_root(
     assert completed.returncode == 2
     assert "OS may purge" in completed.stderr
     assert not Path(volatile).exists()
+
+
+@pytest.mark.asyncio
+async def test_a_dead_parent_leaves_a_descriptor_the_documented_sweep_finds(
+    durable_path: Path, adapter_wheel: Path  # noqa: F811
+) -> None:
+    """MAJOR-2 guard: ``<run-root>/rescue`` is a real inbox for the README's sweep.
+
+    A parent killed after ``reset_start`` leaves ``rescue.json`` behind. The
+    README tells the operator to sweep ``<run-root>/rescue``; that sweep
+    globs one level down, so the script's descriptor has to live at
+    ``rescue/<episode>/rescue.json`` or the sweep reports ``[]`` over a live
+    instance. The kill is simulated by running the runner's own
+    ``_launch_and_prepare`` with the script's config and then abandoning it.
+    """
+
+    import importlib.util
+    import sys as _sys
+
+    from local_operator.evaluation.adapters.supervisor import AdapterSupervisor
+    from local_operator.evaluation.runner.episode import EpisodeRunner
+    from local_operator.evaluation.runner.rescue_sweep import sweep_rescue_root
+    from local_operator.evaluation.runner.secrets import StaticSecretResolver
+
+    spec_file = importlib.util.spec_from_file_location("run_episode", SCRIPT)
+    assert spec_file is not None and spec_file.loader is not None
+    script = importlib.util.module_from_spec(spec_file)
+    _sys.modules.pop("run_episode", None)
+    spec_file.loader.exec_module(script)
+
+    selector_path = _selector_file(durable_path / "adapter", adapter_wheel)
+    run_root = durable_path / "run"
+    episode_id = "ep-parent-died"
+    selector = script.AdapterSelector.model_validate(json.loads(selector_path.read_text()))
+    config = script.build_config(
+        run_root, episode_id=episode_id, max_steps=3, max_cycle_usd_micros=None
+    )
+    route = script._route_identity("test", "fake-model")
+    spec = script.build_spec(
+        episode_id=episode_id,
+        selector=selector,
+        task_id="task_plain",
+        route=route,
+        benchmark_id="osworld-v2",
+        benchmark_release="osworld-v2-2026.08.08",
+        secret_refs=("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"),
+        infra_values=script._parse_infra(INFRA[1::2], "benchmark_compute"),
+        max_usd_micros=10_000,
+        max_wall_ms=60_000,
+        max_steps=3,
+        metadata={},
+    )
+    resolver = StaticSecretResolver({"AWS_ACCESS_KEY_ID": "k", "AWS_SECRET_ACCESS_KEY": "s"})
+    runner = EpisodeRunner(
+        spec,
+        config,
+        selector=selector,
+        model=script._ScriptedFinish(route),
+        secrets=resolver,
+        launch=AdapterSupervisor.launch,
+    )
+    # Up to and including ``prepare``: the real descriptor is on disk. Then
+    # the parent "dies": the supervisor is torn down without cleanup.
+    await runner._launch_and_prepare()
+    await runner._emergency_teardown()
+
+    descriptors = sorted(p.relative_to(run_root) for p in run_root.rglob("rescue.json"))
+    assert descriptors == [Path("rescue") / episode_id / "rescue.json"], descriptors
+
+    # The documented command: sweep ``<run-root>/rescue``. A FakeProvider
+    # rescue worker answers ``attempted`` (it has no registry to look in), so
+    # the entry must be FOUND and REPORTED incomplete, and the descriptor kept.
+    entries = await sweep_rescue_root(run_root / "rescue", resolver)
+    assert [(e.episode_id, e.complete) for e in entries] == [(episode_id, False)], entries
+    assert (run_root / "rescue" / episode_id / "rescue.json").exists()
+
+    # And a confirming rescue retires it -- the only way it leaves the inbox.
+    async def confirming(descriptor: Any, **kwargs: Any) -> Any:
+        from local_operator.evaluation.lifecycle import record_cleanup
+
+        receipts = tuple(
+            record_cleanup(
+                descriptor.cleanup_plan,
+                action.action_id,
+                status="succeeded",
+                evidence_code="instance-terminated",
+                duration_ms=1,
+            )
+            for action in descriptor.cleanup_plan.actions
+        )
+
+        class _Aggregate:
+            complete = True
+
+        aggregate = _Aggregate()
+        aggregate.receipts = receipts  # type: ignore[attr-defined]
+        return aggregate
+
+    entries = await sweep_rescue_root(run_root / "rescue", resolver, rescue=confirming)
+    assert [(e.episode_id, e.complete) for e in entries] == [(episode_id, True)]
+    assert not list((run_root / "rescue").rglob("rescue.json"))
+
+
+def test_script_refuses_an_over_long_secret_naming_only_the_ref(
+    durable_path: Path, adapter_wheel: Path  # noqa: F811
+) -> None:
+    """MAJOR-1 end to end: a PEM-sized value never reaches stdout, stderr or disk."""
+
+    selector = _selector_file(durable_path / "adapter", adapter_wheel)
+    run_root = durable_path / "run"
+    long_value = "SECRETVALUE-" + "z" * 9000
+    completed = _run(
+        [
+            "--selector",
+            str(selector),
+            "--task-id",
+            "task_plain",
+            "--route",
+            "test/fake-model",
+            "--run-root",
+            str(run_root),
+            "--secret-env",
+            "AWS_ACCESS_KEY_ID",
+            "--secret-env",
+            "AWS_SECRET_ACCESS_KEY",
+            "--no-store",
+            "--model-client",
+            "scripted-finish",
+            *INFRA,
+        ],
+        {"AWS_ACCESS_KEY_ID": CANARY_KEY, "AWS_SECRET_ACCESS_KEY": long_value},
+    )
+    assert completed.returncode == 2, completed.stderr[-3000:]
+    outcome = json.loads(completed.stdout)
+    assert outcome["status"] == "failed_pre_bundle"
+    assert outcome["diagnostic"] == "UnusableSecret: unusable secret AWS_SECRET_ACCESS_KEY"
+    assert completed.stderr.strip() == outcome["diagnostic"]
+    everything = _all_bytes_under(run_root) + completed.stdout.encode() + completed.stderr.encode()
+    assert b"SECRETVALUE" not in everything and b"zzzz" not in everything

--- a/tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
+++ b/tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
@@ -24,6 +24,7 @@ from typing import Any
 import pytest
 
 from local_operator.evaluation.evidence.verify import verify_bundle
+from local_operator.evaluation.runner.route_ids import fold_model_id, unfold_model_id
 from tests.unit.evaluation.adapters.osworld import fixtures, spawn_helpers
 from tests.unit.evaluation.adapters.osworld.test_build_and_scripts import (  # noqa: F401
     durable_path,
@@ -105,7 +106,7 @@ def test_script_runs_one_spawned_episode_to_a_sealed_bundle(
             "--task-id",
             "task_plain",
             "--route",
-            "test/fake-model",
+            "test/fake/model:free",
             "--run-root",
             str(run_root),
             "--secret-env",
@@ -134,6 +135,15 @@ def test_script_runs_one_spawned_episode_to_a_sealed_bundle(
     assert bundle.is_relative_to(run_root / "evidence")
     report = verify_bundle(bundle)
     assert report.valid, [issue.code for issue in report.issues]
+    # The sealed route is the lossless fold of the model id, and the exact id
+    # rides the manifest metadata beside it, so the route can be read back
+    # without decoding.
+    manifest = report.manifest
+    assert manifest is not None
+    assert manifest.requested_route.model_id == fold_model_id("fake/model:free")
+    assert unfold_model_id(manifest.requested_route.model_id) == "fake/model:free"
+    assert manifest.metadata["route_model_id"] == "fake/model:free"
+    assert manifest.metadata["route_provider_id"] == "test"
     # The spawned worker published real frames into the parent's root.
     assert any(p.is_file() for p in (run_root / "artifacts").iterdir())
     # A clean episode retired its own descriptor: the inbox is empty.

--- a/tests/unit/evaluation/adapters/test_launch.py
+++ b/tests/unit/evaluation/adapters/test_launch.py
@@ -16,13 +16,9 @@ import hashlib
 import io
 import json
 import os
-import shutil
-import subprocess
 import sys
-import sysconfig
 from pathlib import Path
 
-import pydantic
 import pytest
 
 from local_operator.evaluation.adapters.api import AdapterSelector, Handshake
@@ -33,6 +29,10 @@ from local_operator.evaluation.adapters.discovery import (
     workspace_digest,
 )
 from local_operator.evaluation.adapters.supervisor import AdapterSupervisor
+from tests.unit.evaluation.copied_interpreter import (
+    copied_interpreter,
+    site_packages_of,
+)
 
 RELEASE_DIGEST = "b" * 64
 _ADAPTER_SOURCE = """from importlib.metadata import distribution
@@ -83,66 +83,9 @@ def create():
 """ % RELEASE_DIGEST
 
 
-def _real_interpreter() -> Path:
-    """Copy a working interpreter so its content can be pinned per test run."""
-
-    candidates = [os.path.realpath(sys.executable), shutil.which("python3") or ""]
-    for base in candidates:
-        if not base or not os.path.exists(base):
-            continue
-        venv = Path(os.environ["PYTEST_LAUNCH_VENV"])
-        shutil.rmtree(venv, ignore_errors=True)
-        try:
-            subprocess.run(
-                [base, "-m", "venv", "--without-pip", "--copies", str(venv)],
-                check=True,
-                capture_output=True,
-            )
-        except (OSError, subprocess.CalledProcessError):
-            continue
-        executable = next(
-            (
-                item
-                for item in sorted((venv / "bin").glob("python3.*"))
-                if item.is_file() and not item.is_symlink()
-            ),
-            None,
-        )
-        if executable is None:
-            continue
-        probe = subprocess.run(
-            [str(executable), "-I", "-c", "print('ok')"], capture_output=True, text=True
-        )
-        if probe.returncode == 0:
-            return executable
-    pytest.skip("no usable copied interpreter is available on this host")
-
-
-def _dependency_roots() -> list[str]:
-    """Locate the running interpreter's real import roots.
-
-    CI installs the project with ``pip install -e`` and never creates a repo
-    ``.venv``, so a hardcoded venv path leaves the spawned worker without
-    pydantic and it dies instead of skipping. Deriving the roots from this
-    interpreter works under both layouts.
-    """
-
-    roots = [str(Path(__file__).resolve().parents[4])]
-    purelib = sysconfig.get_paths().get("purelib")
-    if purelib:
-        roots.append(purelib)
-    # Follow an actually-imported third-party dependency, which stays correct
-    # for editable installs whose packages live outside purelib.
-    roots.append(str(Path(pydantic.__file__).resolve().parent.parent))
-    seen: list[str] = []
-    for root in roots:
-        if root not in seen and Path(root).is_dir():
-            seen.append(root)
-    return seen
-
-
 def _install_adapter(site: Path) -> str:
-    (site / "_local_operator_repo.pth").write_text("\n".join(_dependency_roots()) + "\n")
+    # The copied venv already carries the repo .pth (``copied_interpreter``);
+    # only the adapter distribution is written here.
     module = site / "tiny_e2e_adapter.py"
     module.write_text(_ADAPTER_SOURCE)
     info = site / "tiny_e2e_adapter-1.0.dist-info"
@@ -181,12 +124,9 @@ def test_real_running_interpreter_resolves_and_revalidates() -> None:
 
 
 @pytest.mark.asyncio
-async def test_supervisor_launch_completes_real_handshake_and_reaps(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("PYTEST_LAUNCH_VENV", str(tmp_path / "venv"))
-    executable = _real_interpreter()
-    site = next(executable.parent.parent.glob("lib/python*/site-packages"))
+async def test_supervisor_launch_completes_real_handshake_and_reaps(tmp_path: Path) -> None:
+    executable = copied_interpreter(tmp_path / "venv")
+    site = site_packages_of(executable)
     package_digest = _install_adapter(site)
     workspace = tmp_path / "workspace"
     workspace.mkdir()

--- a/tests/unit/evaluation/copied_interpreter.py
+++ b/tests/unit/evaluation/copied_interpreter.py
@@ -1,0 +1,198 @@
+"""ONE way to build the copied interpreter the real-spawn tests launch.
+
+``AdapterSupervisor.launch`` pins the worker's executable by content hash, so
+a test that spawns a real worker needs an interpreter whose bytes it can
+pin per run. ``python -m venv --copies`` gives one. Three test hosts
+(``adapters/test_launch.py``, ``runner/test_episode_subprocess.py``,
+``adapters/osworld/spawn_helpers.py``) used to carry their own copy of this
+recipe, and all three had the same latent defect, which is why it now lives
+here once.
+
+THE DEFECT. Each copy tried ``sys.executable`` first and then fell through to
+``shutil.which("python3")``. On a uv-managed CPython the first candidate's
+copy cannot start at all: uv's builds link ``@rpath/libpythonX.Y.dylib`` with
+an rpath of ``@executable_path/../lib``, and ``venv --copies`` copies the
+executable but not the library, so the copy aborts in dyld. The helper then
+silently took the NEXT candidate -- a Homebrew ``python3`` of whatever version
+happened to be on PATH -- while the ``.pth`` it wrote still pointed at THIS
+interpreter's site-packages. With a 3.14 venv and a 3.14 Homebrew that was
+an accident that worked; with a 3.12 venv and a 3.14 Homebrew the worker
+imported 3.14's ``pydantic_core`` extension under a 3.12 interpreter and died
+before it could answer a handshake, and 16 spawn tests failed with an error
+that named none of this.
+
+THE RULES HERE. (1) Only the RUNNING interpreter is ever copied: the ``.pth``
+is derived from it (``sysconfig`` purelib plus wherever ``pydantic`` was
+imported from), so a copy of any other interpreter is wrong by construction,
+not merely risky. (2) A copy that cannot start because its shared libpython
+was not carried across is REPAIRED by copying that one library next to it,
+which is what uv's own layout expects; a framework or static build never
+hits this branch. (3) Before the copy is handed out it must import
+``pydantic_core`` -- the compiled extension that fails first on an ABI
+mismatch -- through the very ``.pth`` the worker will use, under the same
+``-I -s -E`` flags the supervisor spawns with. (4) Any failure raises an
+``AssertionError`` that names the interpreter, the step, and the captured
+stderr. Skipping is deliberately not an option: a host with no usable copy
+gives no real-spawn coverage at all, and a silent skip hides that from CI.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
+
+import pydantic
+
+# Written into the copied venv's site-packages so the worker can import
+# local_operator and pydantic; both test hosts and the OSWorld spawn helper
+# rely on this exact filename existing after ``copied_interpreter`` returns.
+REPO_PTH_NAME = "_local_operator_repo.pth"
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Mirrors the supervisor's spawn flags (``supervisor.py``: ``-I -s -E``) so the
+# probe exercises the same import environment the worker will get.
+_WORKER_FLAGS = ("-I", "-s", "-E")
+
+
+def dependency_roots() -> list[str]:
+    """This interpreter's real import roots, for the copied venv's ``.pth``.
+
+    CI installs the project with ``pip install -e`` and never creates a repo
+    ``.venv``, so a hardcoded venv path leaves the spawned worker without
+    pydantic and it dies instead of skipping. Deriving the roots from the
+    running interpreter works under both layouts. Following an actually
+    imported third-party dependency stays correct for editable installs whose
+    packages live outside purelib.
+    """
+
+    roots = [str(_REPO_ROOT)]
+    purelib = sysconfig.get_paths().get("purelib")
+    if purelib:
+        roots.append(purelib)
+    roots.append(str(Path(pydantic.__file__).resolve().parent.parent))
+    seen: list[str] = []
+    for root in roots:
+        if root not in seen and Path(root).is_dir():
+            seen.append(root)
+    return seen
+
+
+def site_packages_of(executable: Path) -> Path:
+    """The copied venv's site-packages, where adapters and the ``.pth`` go."""
+
+    return next(executable.parent.parent.glob("lib/python*/site-packages"))
+
+
+def copied_interpreter(venv: Path) -> Path:
+    """Build ``venv`` as a ``--copies`` clone of THIS interpreter and prove it.
+
+    Returns the copied ``python3.X`` executable. The venv's site-packages
+    already carries ``REPO_PTH_NAME`` on return, and the executable has been
+    shown to import ``pydantic_core`` and the adapter API through it.
+    """
+
+    base = Path(os.path.realpath(sys.executable))
+    shutil.rmtree(venv, ignore_errors=True)
+    try:
+        subprocess.run(
+            [str(base), "-m", "venv", "--without-pip", "--copies", str(venv)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        detail = getattr(error, "stderr", "") or str(error)
+        raise AssertionError(f"venv --copies of {base} failed: {detail[-800:]}") from error
+    executable = next(
+        (
+            item
+            for item in sorted((venv / "bin").glob("python3.*"))
+            if item.is_file() and not item.is_symlink()
+        ),
+        None,
+    )
+    if executable is None:
+        raise AssertionError(f"venv --copies of {base} produced no copied python3.X executable")
+
+    started = _probe(executable, "print('ok')")
+    if started.returncode != 0:
+        # The one known reason a faithful copy of the running interpreter
+        # cannot start: a shared libpython the copy resolves relative to
+        # itself. Carry it across and try once more; anything else is a real
+        # failure and is reported as one.
+        library = _shared_libpython(base)
+        if library is None:
+            raise AssertionError(
+                f"copied interpreter {executable} (from {base}) did not start and the "
+                f"base reports no shared libpython to carry across: {started.stderr[-800:]}"
+            )
+        target = venv / "lib" / library.name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(library, target)
+        started = _probe(executable, "print('ok')")
+        if started.returncode != 0:
+            raise AssertionError(
+                f"copied interpreter {executable} (from {base}) still did not start after "
+                f"copying {library} to {target}: {started.stderr[-800:]}"
+            )
+
+    site = site_packages_of(executable)
+    (site / REPO_PTH_NAME).write_text("\n".join(dependency_roots()) + "\n")
+
+    # The load-bearing check. pydantic_core is a compiled extension, so it is
+    # the first import to fail on an interpreter/site-packages version mismatch
+    # -- exactly the failure that used to surface as a dead worker.
+    imported = _probe(
+        executable,
+        "import pydantic_core, local_operator.evaluation.adapters.api; "
+        "import sys; print(sys.version_info[:2])",
+    )
+    if imported.returncode != 0:
+        raise AssertionError(
+            f"copied interpreter {executable} (from {base}, {sys.version_info[:2]}) cannot "
+            f"import pydantic_core through {site / REPO_PTH_NAME}: {imported.stderr[-800:]}"
+        )
+    return executable
+
+
+def _probe(executable: Path, code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(executable), *_WORKER_FLAGS, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _shared_libpython(base: Path) -> Path | None:
+    """The shared library ``base`` links, if it is built ``--enable-shared``.
+
+    Asked of the BASE interpreter rather than this process because
+    ``sysconfig`` here describes the venv's view; the config vars are the
+    same, but going through the base keeps the answer tied to the file that
+    was actually copied.
+    """
+
+    query = (
+        "import sysconfig; "
+        "print(sysconfig.get_config_var('Py_ENABLE_SHARED') or 0); "
+        "print(sysconfig.get_config_var('LIBDIR') or ''); "
+        "print(sysconfig.get_config_var('INSTSONAME') or '')"
+    )
+    answer = _probe(base, query)
+    if answer.returncode != 0:
+        return None
+    lines = answer.stdout.strip().splitlines()
+    if len(lines) != 3 or lines[0].strip() != "1" or not lines[1] or not lines[2]:
+        return None
+    library = Path(lines[1]) / lines[2]
+    # A framework build's INSTSONAME is ``Python.framework/Versions/X/Python``;
+    # its executable resolves it through the framework, not ``@rpath``, so a
+    # copy of it started fine and never reaches here. A plain file is the
+    # uv/manylinux shape this repair exists for.
+    return library if library.is_file() and "/" not in lines[2] else None

--- a/tests/unit/evaluation/runner/test_episode_subprocess.py
+++ b/tests/unit/evaluation/runner/test_episode_subprocess.py
@@ -19,14 +19,9 @@ import hashlib
 import io
 import json
 import os
-import shutil
-import subprocess
-import sys
-import sysconfig
 from pathlib import Path
 from typing import Any
 
-import pydantic
 import pytest
 
 from local_operator.evaluation.adapters.api import AdapterSelector
@@ -34,6 +29,10 @@ from local_operator.evaluation.adapters.discovery import workspace_digest
 from local_operator.evaluation.adapters.supervisor import AdapterSupervisor
 from local_operator.evaluation.evidence.verify import verify_bundle
 from local_operator.evaluation.runner.episode import EpisodeRunner
+from tests.unit.evaluation.copied_interpreter import (
+    copied_interpreter,
+    site_packages_of,
+)
 from tests.unit.evaluation.runner.conftest import (
     ScriptedModel,
     build_config,
@@ -333,72 +332,9 @@ def create():
 """ % RELEASE_DIGEST
 
 
-def _real_interpreter(venv: Path) -> Path:
-    """Copy a working interpreter so its content can be pinned per test run.
-
-    Candidates are tried in turn because not every interpreter can host a
-    ``--copies`` venv: a framework build whose ``libpython`` lives outside the
-    copied tree produces an executable that dies in dyld, and a system Python
-    may refuse to build one without symlinks at all. This mirrors
-    ``adapters/test_launch.py``, which exists for the same reason.
-    """
-
-    candidates = [
-        os.path.realpath(sys.executable),
-        shutil.which("python3") or "",
-        sys.base_prefix + "/bin/python3",
-    ]
-    failures: list[str] = []
-    for base in candidates:
-        if not base or not os.path.exists(base):
-            continue
-        shutil.rmtree(venv, ignore_errors=True)
-        try:
-            subprocess.run(
-                [base, "-m", "venv", "--without-pip", "--copies", str(venv)],
-                check=True,
-                capture_output=True,
-            )
-        except (OSError, subprocess.CalledProcessError) as error:
-            failures.append(f"{base}: venv creation failed ({error})")
-            continue
-        executable = next(
-            (
-                item
-                for item in sorted((venv / "bin").glob("python3.*"))
-                if item.is_file() and not item.is_symlink()
-            ),
-            None,
-        )
-        if executable is None:
-            failures.append(f"{base}: produced no copied executable")
-            continue
-        probe = subprocess.run(
-            [str(executable), "-I", "-c", "print('ok')"], capture_output=True, text=True
-        )
-        if probe.returncode == 0:
-            return executable
-        failures.append(f"{base}: copied interpreter did not run ({probe.stderr[-200:]})")
-    # Failing loudly beats skipping: a host with no usable interpreter gives no
-    # subprocess coverage at all, and a silent skip hides that from CI.
-    raise AssertionError("no usable copied interpreter on this host: " + "; ".join(failures))
-
-
-def _dependency_roots() -> list[str]:
-    roots = [str(Path(__file__).resolve().parents[4])]
-    purelib = sysconfig.get_paths().get("purelib")
-    if purelib:
-        roots.append(purelib)
-    roots.append(str(Path(pydantic.__file__).resolve().parent.parent))
-    seen: list[str] = []
-    for root in roots:
-        if root not in seen and Path(root).is_dir():
-            seen.append(root)
-    return seen
-
-
 def _install_adapter(site: Path) -> str:
-    (site / "_local_operator_repo.pth").write_text("\n".join(_dependency_roots()) + "\n")
+    # The copied venv already carries the repo .pth (``copied_interpreter``);
+    # only the adapter distribution is written here.
     module = site / "tiny_runner_adapter.py"
     module.write_text(_ADAPTER_SOURCE)
     info = site / "tiny_runner_adapter-1.0.dist-info"
@@ -433,9 +369,7 @@ def distribution_digest_of(distribution: Any) -> str:
 def adapter_site(tmp_path: Path) -> Path:
     """The installed adapter's site-packages, where the cutpoint file lives."""
 
-    executable = _real_interpreter(tmp_path / "venv")
-    site = next(executable.parent.parent.glob("lib/python*/site-packages"))
-    return site
+    return site_packages_of(copied_interpreter(tmp_path / "venv"))
 
 
 @pytest.fixture

--- a/tests/unit/evaluation/runner/test_isolation.py
+++ b/tests/unit/evaluation/runner/test_isolation.py
@@ -18,12 +18,15 @@ import pytest
 
 REPO = Path(__file__).resolve().parents[4]
 
-# provider_client.py is the deliberate exception and imports configure lazily,
-# so it is absent here by construction rather than by luck.
+# provider_client.py and host_secrets.py are the deliberate exceptions (the
+# model client and the secret resolver are the two places a real episode must
+# touch the operator's store); both defer that import, so they are absent here
+# by construction rather than by luck.
 FORBIDDEN_PREFIXES = (
     "local_operator.model",
     "local_operator.providers",
     "local_operator.config",
+    "local_operator.credentials",
     "local_operator.tools",
     "local_operator.tui",
     "local_operator.mobile",
@@ -56,6 +59,9 @@ def _fresh_import_modules(module: str) -> set[str]:
         "local_operator.evaluation.runner.guards",
         "local_operator.evaluation.runner.model",
         "local_operator.evaluation.runner.responder",
+        "local_operator.evaluation.runner.secrets",
+        "local_operator.evaluation.runner.rescue_sweep",
+        "local_operator.evaluation.runner.durable_root",
     ],
 )
 def test_runner_core_does_not_import_the_application(module: str) -> None:
@@ -78,3 +84,58 @@ def test_provider_client_defers_its_configure_import() -> None:
 
     imported = _fresh_import_modules("local_operator.evaluation.runner.provider_client")
     assert "local_operator.model.configure" not in imported
+
+
+def test_host_secrets_is_the_only_other_store_seam_and_takes_it_by_injection() -> None:
+    """``host_secrets`` may serve the credential store but never imports it.
+
+    It takes a live ``CredentialManager`` from its caller (the script that
+    also opened the store for the model client), so even the lazy import is
+    absent: importing the module pulls in nothing from the application.
+    """
+
+    imported = _fresh_import_modules("local_operator.evaluation.runner.host_secrets")
+    leaked = {
+        name
+        for name in imported
+        if any(name == prefix or name.startswith(prefix + ".") for prefix in FORBIDDEN_PREFIXES)
+    }
+    assert not leaked, sorted(leaked)
+
+
+def test_run_episode_script_imports_no_session_or_tui() -> None:
+    """The operator script is not a session surface; importing it stays inert.
+
+    It reaches the store and the model configuration lazily, inside ``run``,
+    so importing the module (what ``--help`` and the tests do) must pull in
+    nothing from the application.
+    """
+
+    probe = (
+        "import importlib.util,json,sys;"
+        "spec=importlib.util.spec_from_file_location('run_episode', sys.argv[1]);"
+        "m=importlib.util.module_from_spec(spec);spec.loader.exec_module(m);"
+        "print(json.dumps(sorted(sys.modules)))"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe, str(REPO / "scripts" / "run_episode.py")],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr[-3000:]
+    imported = set(json.loads(completed.stdout.strip().splitlines()[-1]))
+    leaked = {
+        name
+        for name in imported
+        if any(name == prefix or name.startswith(prefix + ".") for prefix in FORBIDDEN_PREFIXES)
+    }
+    assert not leaked, sorted(leaked)
+
+
+def test_episode_does_not_import_host_secrets() -> None:
+    """The runner takes a resolver by injection; it never picks the store itself."""
+
+    imported = _fresh_import_modules("local_operator.evaluation.runner.episode")
+    assert "local_operator.evaluation.runner.host_secrets" not in imported

--- a/tests/unit/evaluation/runner/test_isolation.py
+++ b/tests/unit/evaluation/runner/test_isolation.py
@@ -62,6 +62,7 @@ def _fresh_import_modules(module: str) -> set[str]:
         "local_operator.evaluation.runner.secrets",
         "local_operator.evaluation.runner.rescue_sweep",
         "local_operator.evaluation.runner.durable_root",
+        "local_operator.evaluation.runner.route_ids",
     ],
 )
 def test_runner_core_does_not_import_the_application(module: str) -> None:

--- a/tests/unit/evaluation/runner/test_rescue_sweep.py
+++ b/tests/unit/evaluation/runner/test_rescue_sweep.py
@@ -1,0 +1,141 @@
+"""``sweep_rescue_root``: rescue every descriptor, retire only the confirmed.
+
+The script-level tests (``adapters/osworld/test_build_and_scripts.py``) cover
+``scripts/osworld_rescue_sweep.py``'s argument handling over this module;
+these pin the module's own contract, which the in-process runner and the
+script both rely on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.evaluation.adapters.api import (
+    ADAPTER_SCHEMA_VERSION,
+    RescueDescriptor,
+    ResolvedSecret,
+    SecretRef,
+)
+from local_operator.evaluation.adapters.supervisor import persist_rescue
+from local_operator.evaluation.lifecycle import record_cleanup
+from local_operator.evaluation.runner.rescue_sweep import sweep_rescue_root
+from local_operator.evaluation.runner.secrets import MissingSecret, StaticSecretResolver
+from tests.unit.evaluation.runner.conftest import cleanup_plan, handshake, selector
+
+
+def _descriptor(tmp_path: Path, episode_id: str, *refs: str) -> RescueDescriptor:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    return RescueDescriptor(
+        schema_version=ADAPTER_SCHEMA_VERSION,
+        selector=selector(tmp_path),
+        handshake=handshake(tmp_path),
+        episode_id=episode_id,
+        cleanup_plan=cleanup_plan(episode_id),
+        secret_refs=tuple(SecretRef(name=name) for name in refs),
+        infra_values=(),
+        artifact_root=str(tmp_path),
+    )
+
+
+class _Aggregate:
+    def __init__(self, complete: bool, receipts: tuple[Any, ...]) -> None:
+        self.complete = complete
+        self.receipts = receipts
+
+
+def _aggregate(descriptor: RescueDescriptor, *, complete: bool, code: str) -> _Aggregate:
+    action = descriptor.cleanup_plan.actions[0]
+    receipt = record_cleanup(
+        descriptor.cleanup_plan,
+        action.action_id,
+        status="succeeded" if complete else "attempted",
+        evidence_code=code,
+        duration_ms=1,
+    )
+    return _Aggregate(complete, (receipt,))
+
+
+@pytest.mark.asyncio
+async def test_sweep_rescues_each_descriptor_with_its_secrets_and_retires_only_complete(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "rescue"
+    done = _descriptor(tmp_path / "a", "ep-done", "AWS_SECRET_ACCESS_KEY")
+    stuck = _descriptor(tmp_path / "b", "ep-stuck", "AWS_SECRET_ACCESS_KEY")
+    persist_rescue(root / "ep-done", done)
+    persist_rescue(root / "ep-stuck", stuck)
+    (root / "ep-empty").mkdir()  # no descriptor: skipped, not an error
+    delivered: list[tuple[str, tuple[ResolvedSecret, ...]]] = []
+    launches: list[Any] = []
+
+    async def rescue(descriptor: Any, *, secrets: Any, launch: Any) -> Any:
+        delivered.append((descriptor.episode_id, secrets))
+        launches.append(launch)
+        if descriptor.episode_id == "ep-done":
+            return _aggregate(descriptor, complete=True, code="instance-terminated")
+        return _aggregate(descriptor, complete=False, code="terminate-unconfirmed")
+
+    sentinel_launch = object()
+    entries = await sweep_rescue_root(
+        root,
+        StaticSecretResolver({"AWS_SECRET_ACCESS_KEY": "value-for-rescue"}),
+        launch=sentinel_launch,
+        rescue=rescue,
+    )
+
+    assert [(e.episode_id, e.complete, e.codes, e.error) for e in entries] == [
+        ("ep-done", True, ("instance-terminated",), None),
+        ("ep-stuck", False, ("terminate-unconfirmed",), None),
+    ]
+    assert delivered == [
+        ("ep-done", (ResolvedSecret(name="AWS_SECRET_ACCESS_KEY", value="value-for-rescue"),)),
+        ("ep-stuck", (ResolvedSecret(name="AWS_SECRET_ACCESS_KEY", value="value-for-rescue"),)),
+    ]
+    assert launches == [sentinel_launch, sentinel_launch]
+    assert not (root / "ep-done" / "rescue.json").exists()
+    assert (root / "ep-stuck" / "rescue.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_sweep_reports_missing_secret_by_name_and_never_launches(tmp_path: Path) -> None:
+    root = tmp_path / "rescue"
+    persist_rescue(root / "ep-x", _descriptor(tmp_path / "a", "ep-x", "AWS_SECRET_ACCESS_KEY"))
+
+    async def never(descriptor: Any, **kwargs: Any) -> Any:  # pragma: no cover
+        raise AssertionError("rescue must not run without its secrets")
+
+    entries = await sweep_rescue_root(root, StaticSecretResolver({}), rescue=never)
+    assert len(entries) == 1
+    assert entries[0].complete is False
+    assert entries[0].error == str(MissingSecret("AWS_SECRET_ACCESS_KEY"))
+    assert (root / "ep-x" / "rescue.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_sweep_reports_a_failed_rescue_and_keeps_going(tmp_path: Path) -> None:
+    root = tmp_path / "rescue"
+    persist_rescue(root / "ep-1", _descriptor(tmp_path / "a", "ep-1"))
+    persist_rescue(root / "ep-2", _descriptor(tmp_path / "b", "ep-2"))
+
+    async def rescue(descriptor: Any, **kwargs: Any) -> Any:
+        if descriptor.episode_id == "ep-1":
+            raise RuntimeError("handshake differs")
+        return _aggregate(descriptor, complete=True, code="instance-absent")
+
+    entries = await sweep_rescue_root(root, StaticSecretResolver({}), rescue=rescue)
+    assert [(e.episode_id, e.complete, e.error) for e in entries] == [
+        ("ep-1", False, "rescue failed: handshake differs"),
+        ("ep-2", True, None),
+    ]
+    assert (root / "ep-1" / "rescue.json").exists()
+    assert not (root / "ep-2" / "rescue.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_empty_or_missing_root_sweeps_nothing(tmp_path: Path) -> None:
+    assert await sweep_rescue_root(tmp_path / "absent", StaticSecretResolver({})) == ()
+    (tmp_path / "empty").mkdir()
+    assert await sweep_rescue_root(tmp_path / "empty", StaticSecretResolver({})) == ()

--- a/tests/unit/evaluation/runner/test_rescue_sweep.py
+++ b/tests/unit/evaluation/runner/test_rescue_sweep.py
@@ -115,6 +115,28 @@ async def test_sweep_reports_missing_secret_by_name_and_never_launches(tmp_path:
 
 
 @pytest.mark.asyncio
+async def test_sweep_reports_an_over_long_secret_by_name_and_keeps_the_descriptor(
+    tmp_path: Path,
+) -> None:
+    """An UnusableSecret (value past the wire bound) is a per-entry report, not a crash."""
+
+    root = tmp_path / "rescue"
+    persist_rescue(root / "ep-x", _descriptor(tmp_path / "a", "ep-x", "AWS_SECRET_ACCESS_KEY"))
+    long_value = "SECRETVALUE-" + "z" * 9000
+
+    async def never(descriptor: Any, **kwargs: Any) -> Any:  # pragma: no cover
+        raise AssertionError("rescue must not run with an unusable secret")
+
+    entries = await sweep_rescue_root(
+        root, StaticSecretResolver({"AWS_SECRET_ACCESS_KEY": long_value}), rescue=never
+    )
+    assert [(e.episode_id, e.complete, e.error) for e in entries] == [
+        ("ep-x", False, "unusable secret AWS_SECRET_ACCESS_KEY")
+    ]
+    assert (root / "ep-x" / "rescue.json").exists()
+
+
+@pytest.mark.asyncio
 async def test_sweep_reports_a_failed_rescue_and_keeps_going(tmp_path: Path) -> None:
     root = tmp_path / "rescue"
     persist_rescue(root / "ep-1", _descriptor(tmp_path / "a", "ep-1"))

--- a/tests/unit/evaluation/runner/test_route_ids.py
+++ b/tests/unit/evaluation/runner/test_route_ids.py
@@ -1,0 +1,69 @@
+"""``fold_model_id`` is a bijection into ``StrictIdentifier``.
+
+A sealed route must mean exactly one model (comparability, M1), so the fold
+that lets an OpenRouter id fit the identifier alphabet has to be reversible
+and collision-free -- two ids that differ anywhere must fold differently.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+import string
+
+import pytest
+
+from local_operator.evaluation.evidence.models import RouteIdentity
+from local_operator.evaluation.runner.route_ids import fold_model_id, unfold_model_id
+
+_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
+
+EXAMPLES = {
+    "deepseek/deepseek-v4-flash-vision-exp": "deepseek_sdeepseek-v4-flash-vision-exp",
+    "moonshotai/kimi-k2:free": "moonshotai_skimi-k2:free",
+    "claude-opus-5": "claude-opus-5",
+    "a_b/c": "a__b_sc",
+    "gpt 4": "gpt_x204",
+    "x/é": "x_s_xc3_xa9",
+}
+
+
+@pytest.mark.parametrize(("raw", "folded"), sorted(EXAMPLES.items()))
+def test_known_shapes_fold_readably_and_round_trip(raw: str, folded: str) -> None:
+    assert fold_model_id(raw) == folded
+    assert unfold_model_id(folded) == raw
+    RouteIdentity(provider_id="openrouter", route_id=f"openrouter:{folded}", model_id=folded)
+
+
+def test_distinct_ids_never_collide() -> None:
+    """The escape is unambiguous: the pairs an unescaped fold would merge stay apart."""
+
+    pairs = [("a/b", "a_sb"), ("a_b", "a__b"), ("a_sb", "a/b"), ("a:b", "a/b")]
+    for left, right in pairs:
+        assert fold_model_id(left) != fold_model_id(right)
+
+
+def test_fold_is_a_strict_identifier_and_unfold_inverts_it() -> None:
+    """Seeded rather than hypothesis-driven: the repo carries no hypothesis dependency."""
+
+    alphabet = string.ascii_letters + string.digits + "_/.:- +@#é漢"
+    rng = random.Random(20260902)
+    for _ in range(2000):
+        model_id = rng.choice(string.ascii_letters + string.digits) + "".join(
+            rng.choice(alphabet) for _ in range(rng.randint(0, 30))
+        )
+        folded = fold_model_id(model_id)
+        assert _IDENTIFIER.fullmatch(folded), (model_id, folded)
+        assert unfold_model_id(folded) == model_id
+
+
+@pytest.mark.parametrize("bad", ["", "/x", "_x", ".x"])
+def test_ids_that_cannot_lead_an_identifier_are_refused(bad: str) -> None:
+    with pytest.raises(ValueError):
+        fold_model_id(bad)
+
+
+@pytest.mark.parametrize("bad", ["a_", "a_q", "a_xzz", "a_x4"])
+def test_malformed_escapes_are_refused_on_unfold(bad: str) -> None:
+    with pytest.raises(ValueError, match="malformed escape"):
+        unfold_model_id(bad)

--- a/tests/unit/evaluation/runner/test_secrets.py
+++ b/tests/unit/evaluation/runner/test_secrets.py
@@ -1,0 +1,393 @@
+"""Secret resolution in the runner: order, redaction, delivery, and the inbox.
+
+The properties here are what make a paid episode safe to run: a secret is
+resolved AFTER the handshake and BEFORE the writer opens (so every byte the
+bundle ever holds is canaried against it), it reaches the worker only on
+``reset_start`` and ``begin_rescue``, a missing one fails before anything is
+allocated and names only the ref, and a clean episode retires its own
+rescue descriptor so the sweep's inbox is exact.
+
+Every test drives the REAL ``VerifiedAdapterSession``, the REAL lifecycle
+authorities and a REAL ``EvidenceWriter`` on ``tmp_path`` (see
+``conftest.FakeAdapter``); only the subprocess boundary is faked.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.evaluation.adapters.api import ResolvedSecret, SecretRef
+from local_operator.evaluation.adapters.supervisor import (
+    SupervisionError,
+    load_pending_rescue,
+)
+from local_operator.evaluation.evidence.verify import verify_bundle
+from local_operator.evaluation.receipts import RedactionSet
+from local_operator.evaluation.runner.episode import EpisodeRunner
+from local_operator.evaluation.runner.secrets import (
+    EnvSecretResolver,
+    MissingSecret,
+    SecretResolver,
+    StaticSecretResolver,
+)
+from tests.unit.evaluation.runner.conftest import (
+    FakeAdapter,
+    ScriptedModel,
+    build_config,
+    build_spec,
+    selector,
+)
+
+# Long enough that every encoded variant (base64, hex, percent) is generated
+# by RedactionSet; a value under 8 bytes only gets the plaintext canary.
+CANARY = "canary-secret-value-9f8e7d6c5b4a"
+KEY_ID = "AKIACANARY0000000001"
+# A StrictIdentifier-shaped value so it can ride a ``stop_reason`` field.
+SHORT_CANARY = "canary-stop-reason-value-1234"
+
+
+class _Aggregate:
+    def __init__(self, descriptor: Any, complete: bool) -> None:
+        self.complete = complete
+        self.descriptor_id = descriptor.descriptor_id
+        self.receipts = ()
+
+
+def _rescue_returning(complete: bool) -> Any:
+    async def rescue(descriptor: Any, **kwargs: Any) -> Any:
+        del kwargs
+        return _Aggregate(descriptor, complete)
+
+    return rescue
+
+
+def _spec_with_refs(episode_id: str, *names: str) -> Any:
+    spec = build_spec(episode_id)
+    object.__setattr__(spec, "secret_refs", tuple(SecretRef(name=name) for name in names))
+    return spec
+
+
+def _all_bytes_under(root: Path) -> bytes:
+    """Every file under ``root``, concatenated: what a leak would have to hide in."""
+
+    chunks: list[bytes] = []
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            chunks.append(path.read_bytes())
+    return b"\n".join(chunks)
+
+
+# ---------------------------------------------------------------------------
+# resolvers
+# ---------------------------------------------------------------------------
+
+
+def test_static_and_env_resolvers_return_in_request_order() -> None:
+    static = StaticSecretResolver({"B": "2", "A": "1"})
+    assert [s.name for s in static.resolve(["A", "B"])] == ["A", "B"]
+    env = EnvSecretResolver({"A": "1", "B": "2"})
+    assert [(s.name, s.value) for s in env.resolve(["B", "A"])] == [("B", "2"), ("A", "1")]
+    assert isinstance(static, SecretResolver) and isinstance(env, SecretResolver)
+
+
+def test_env_resolver_reads_only_the_mapping_it_was_given(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Never ``os.environ`` implicitly: an ambient variable is invisible."""
+
+    monkeypatch.setenv("AMBIENT_SECRET", "should-not-be-seen")
+    resolver = EnvSecretResolver({})
+    with pytest.raises(MissingSecret) as raised:
+        resolver.resolve(["AMBIENT_SECRET"])
+    assert raised.value.name == "AMBIENT_SECRET"
+    assert "should-not-be-seen" not in str(raised.value)
+    # And an explicit snapshot that includes it does see it.
+    assert EnvSecretResolver(dict(os.environ)).resolve(["AMBIENT_SECRET"])[0].value == (
+        "should-not-be-seen"
+    )
+
+
+@pytest.mark.parametrize("value", ["", None])
+def test_empty_value_is_a_missing_secret(value: str | None) -> None:
+    resolver = StaticSecretResolver({"K": value} if value is not None else {})
+    with pytest.raises(MissingSecret, match="missing secret K"):
+        resolver.resolve(["K"])
+
+
+def test_credential_store_resolver_wraps_the_manager_and_names_only_the_ref() -> None:
+    from local_operator.evaluation.runner.host_secrets import CredentialStoreResolver
+
+    class _Secret:
+        def __init__(self, value: str) -> None:
+            self._value = value
+
+        def get_secret_value(self) -> str:
+            return self._value
+
+    class _Manager:
+        def get_credential(self, key: str) -> _Secret:
+            if key == "BOOM":
+                raise RuntimeError("store exploded reading /path/credentials.env")
+            return _Secret({"PRESENT": CANARY}.get(key, ""))
+
+    resolver = CredentialStoreResolver(_Manager())
+    assert resolver.resolve(["PRESENT"]) == (ResolvedSecret(name="PRESENT", value=CANARY),)
+    with pytest.raises(MissingSecret) as missing:
+        resolver.resolve(["ABSENT"])
+    assert missing.value.name == "ABSENT"
+    with pytest.raises(MissingSecret) as errored:
+        resolver.resolve(["BOOM"])
+    assert errored.value.name == "BOOM"
+    assert "credentials.env" not in str(errored.value)
+
+
+def test_redaction_set_with_values_widens_without_dropping_existing() -> None:
+    base = RedactionSet.from_resolved_values(("first-canary-value",))
+    widened = base.with_values([CANARY])
+    for value in ("first-canary-value", CANARY):
+        with pytest.raises(ValueError):
+            widened.assert_clear({"x": f"...{value}..."})
+    widened.assert_clear({"x": "clean"})
+
+
+# ---------------------------------------------------------------------------
+# runner: order and delivery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_secrets_resolve_after_handshake_before_writer_and_ride_reset_start(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """resolve -> redactions -> writer -> reset_start(secrets=...), in that order."""
+
+    events: list[str] = []
+    adapter = FakeAdapter(tmp_path, episode_id)
+    original = adapter._call_raw
+    original_handshake = adapter.handshake
+
+    async def handshake(**kwargs: Any) -> Any:
+        events.append("handshake")
+        return await original_handshake(**kwargs)
+
+    adapter.handshake = handshake  # type: ignore[method-assign]
+    delivered: list[tuple[str, tuple[tuple[str, str], ...]]] = []
+
+    async def watching(method: Any, params: Any, result_type: Any, **kwargs: Any) -> Any:
+        events.append(method)
+        if method == "reset_start":
+            delivered.append(("reset_start", tuple((s.name, s.value) for s in params.secrets)))
+        if method == "prepare":
+            assert not hasattr(params, "secrets"), "prepare must stay secret-free"
+        return await original(method, params, result_type, **kwargs)
+
+    adapter._call_raw = watching  # type: ignore[method-assign]
+
+    class _Recording:
+        def resolve(self, names: Any) -> Any:
+            events.append("resolve")
+            return StaticSecretResolver({"AWS_SECRET_ACCESS_KEY": CANARY}).resolve(names)
+
+    config = build_config(tmp_path)
+    runner = EpisodeRunner(
+        _spec_with_refs(episode_id, "AWS_SECRET_ACCESS_KEY"),
+        config,
+        selector=selector(tmp_path),
+        model=ScriptedModel(["finish"]),
+        secrets=_Recording(),
+        launch=lambda _: adapter,
+        rescue=_rescue_returning(True),
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "completed", outcome.diagnostic
+    assert events.index("handshake") < events.index("resolve") < events.index("prepare")
+    assert delivered == [("reset_start", (("AWS_SECRET_ACCESS_KEY", CANARY),))]
+    # The writer opened AFTER resolution, with the value in its canary set:
+    # the bundle carries the ref name (in the descriptor-free manifest paths)
+    # but never the value in any encoding.
+    root = outcome.bundle_root
+    assert root is not None
+    assert verify_bundle(root).valid
+    assert CANARY.encode() not in _all_bytes_under(tmp_path)
+    assert runner._redactions is not None
+    with pytest.raises(ValueError):
+        runner._redactions.assert_clear({"leak": CANARY})
+
+
+@pytest.mark.asyncio
+async def test_value_reaching_the_bundle_is_refused_by_the_canaried_writer(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """The writer built after resolution refuses an event carrying the value."""
+
+    class _Leaky(ScriptedModel):
+        """Smuggles the value into a model_response through ``stop_reason``."""
+
+        async def decide(self, observation: Any, history: Any) -> Any:
+            decision = await super().decide(observation, history)
+            return decision.model_copy(update={"stop_reason": SHORT_CANARY})
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = EpisodeRunner(
+        _spec_with_refs(episode_id, "AWS_SECRET_ACCESS_KEY"),
+        build_config(tmp_path),
+        selector=selector(tmp_path),
+        model=_Leaky(["finish"]),
+        secrets=StaticSecretResolver({"AWS_SECRET_ACCESS_KEY": SHORT_CANARY}),
+        launch=lambda _: adapter,
+        rescue=_rescue_returning(True),
+    )
+
+    outcome = await runner.run()
+
+    # The writer raised on the poisoned event; the runner abandoned rather
+    # than sealing a bundle with the value in it.
+    assert outcome.status in ("abandoned", "abandonment_failed"), outcome.status
+    assert SHORT_CANARY.encode() not in _all_bytes_under(tmp_path / "evidence")
+
+
+@pytest.mark.asyncio
+async def test_missing_secret_fails_before_any_allocation_and_names_only_the_ref(
+    tmp_path: Path, episode_id: str
+) -> None:
+    adapter = FakeAdapter(tmp_path, episode_id)
+    config = build_config(tmp_path)
+    runner = EpisodeRunner(
+        _spec_with_refs(episode_id, "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"),
+        config,
+        selector=selector(tmp_path),
+        model=ScriptedModel(["finish"]),
+        secrets=StaticSecretResolver({"AWS_ACCESS_KEY_ID": KEY_ID}),
+        launch=lambda _: adapter,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "failed_pre_bundle"
+    assert outcome.bundle_root is None
+    assert outcome.diagnostic == "MissingSecret: missing secret AWS_SECRET_ACCESS_KEY"
+    assert KEY_ID not in (outcome.diagnostic or "")
+    # Nothing was allocated: the side-effect boundary was never crossed, no
+    # descriptor was persisted (so the sweep has nothing to reclaim), and the
+    # worker was reaped.
+    assert "prepare" not in adapter.calls and "reset_start" not in adapter.calls
+    assert load_pending_rescue(config.rescue_root) is None
+    assert adapter.terminated
+    assert KEY_ID.encode() not in _all_bytes_under(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_spec_with_refs_and_no_resolver_fails_closed(tmp_path: Path, episode_id: str) -> None:
+    """``secrets=None`` is only right for a spec with no refs."""
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = EpisodeRunner(
+        _spec_with_refs(episode_id, "AWS_SECRET_ACCESS_KEY"),
+        build_config(tmp_path),
+        selector=selector(tmp_path),
+        model=ScriptedModel(["finish"]),
+        launch=lambda _: adapter,
+    )
+    outcome = await runner.run()
+    assert outcome.status == "failed_pre_bundle"
+    assert "AWS_SECRET_ACCESS_KEY" in (outcome.diagnostic or "")
+
+
+# ---------------------------------------------------------------------------
+# runner: rescue and the inbox
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rescue_receives_the_resolved_secrets(tmp_path: Path, episode_id: str) -> None:
+    adapter = FakeAdapter(
+        tmp_path, episode_id, failures={"execute": SupervisionError("worker died")}
+    )
+    seen: list[tuple[str, ...]] = []
+
+    async def rescue(descriptor: Any, **kwargs: Any) -> Any:
+        seen.append(tuple(f"{s.name}={s.value}" for s in kwargs["secrets"]))
+        return _Aggregate(descriptor, True)
+
+    runner = EpisodeRunner(
+        _spec_with_refs(episode_id, "AWS_SECRET_ACCESS_KEY"),
+        build_config(tmp_path),
+        selector=selector(tmp_path),
+        model=ScriptedModel(["step", "finish"]),
+        secrets=StaticSecretResolver({"AWS_SECRET_ACCESS_KEY": CANARY}),
+        launch=lambda _: adapter,
+        rescue=rescue,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.rescue_required is True and outcome.rescue_complete is True
+    assert seen == [(f"AWS_SECRET_ACCESS_KEY={CANARY}",)]
+    assert CANARY.encode() not in _all_bytes_under(tmp_path / "evidence")
+    assert CANARY.encode() not in _all_bytes_under(tmp_path / "rescue")
+
+
+@pytest.mark.asyncio
+async def test_clean_episode_retires_its_descriptor(tmp_path: Path, episode_id: str) -> None:
+    adapter = FakeAdapter(tmp_path, episode_id)
+    config = build_config(tmp_path)
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        config,
+        selector=selector(tmp_path),
+        model=ScriptedModel(["finish"]),
+        launch=lambda _: adapter,
+        rescue=_rescue_returning(True),
+    )
+    outcome = await runner.run()
+    assert outcome.status == "completed"
+    assert outcome.rescue_required is False
+    assert not (config.rescue_root / "rescue.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_incomplete_cleanup_keeps_the_descriptor_when_rescue_cannot_confirm(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """Only a confirmation retires the inbox entry; ``attempted`` is not one."""
+
+    adapter = FakeAdapter(tmp_path, episode_id, cleanup_status="attempted")
+    config = build_config(tmp_path)
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        config,
+        selector=selector(tmp_path),
+        model=ScriptedModel(["finish"]),
+        launch=lambda _: adapter,
+        rescue=_rescue_returning(False),
+    )
+    outcome = await runner.run()
+    assert outcome.rescue_required is True
+    assert outcome.rescue_complete is False
+    assert (config.rescue_root / "rescue.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_complete_rescue_after_incomplete_cleanup_retires_the_descriptor(
+    tmp_path: Path, episode_id: str
+) -> None:
+    adapter = FakeAdapter(tmp_path, episode_id, cleanup_status="attempted")
+    config = build_config(tmp_path)
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        config,
+        selector=selector(tmp_path),
+        model=ScriptedModel(["finish"]),
+        launch=lambda _: adapter,
+        rescue=_rescue_returning(True),
+    )
+    outcome = await runner.run()
+    assert outcome.rescue_required is True
+    assert outcome.rescue_complete is True
+    assert not (config.rescue_root / "rescue.json").exists()

--- a/tests/unit/evaluation/runner/test_secrets.py
+++ b/tests/unit/evaluation/runner/test_secrets.py
@@ -129,20 +129,125 @@ def test_credential_store_resolver_wraps_the_manager_and_names_only_the_ref() ->
             return self._value
 
     class _Manager:
-        def get_credential(self, key: str) -> _Secret:
-            if key == "BOOM":
+        def __init__(self, explode: bool = False) -> None:
+            self.explode = explode
+
+        def get_credentials(self) -> dict[str, _Secret]:
+            if self.explode:
                 raise RuntimeError("store exploded reading /path/credentials.env")
-            return _Secret({"PRESENT": CANARY}.get(key, ""))
+            return {"PRESENT": _Secret(CANARY), "EMPTY": _Secret("")}
+
+        def get_credential(self, key: str) -> _Secret:  # pragma: no cover
+            raise AssertionError("the resolver must not use the env-falling-back getter")
 
     resolver = CredentialStoreResolver(_Manager())
     assert resolver.resolve(["PRESENT"]) == (ResolvedSecret(name="PRESENT", value=CANARY),)
-    with pytest.raises(MissingSecret) as missing:
-        resolver.resolve(["ABSENT"])
-    assert missing.value.name == "ABSENT"
+    for absent in ("ABSENT", "EMPTY"):
+        with pytest.raises(MissingSecret) as missing:
+            resolver.resolve([absent])
+        assert missing.value.name == absent
     with pytest.raises(MissingSecret) as errored:
-        resolver.resolve(["BOOM"])
+        CredentialStoreResolver(_Manager(explode=True)).resolve(["BOOM"])
     assert errored.value.name == "BOOM"
     assert "credentials.env" not in str(errored.value)
+
+
+def test_credential_store_resolver_never_falls_back_to_the_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The REAL CredentialManager falls back to os.environ; the resolver must not.
+
+    A name not on ``--secret-env`` is documented as store-only. Serving an
+    ambient variable for it would make that claim false in the operator's
+    own proof.
+    """
+
+    from local_operator.credentials import CredentialManager
+    from local_operator.evaluation.runner.host_secrets import CredentialStoreResolver
+
+    (tmp_path / "credentials.env").write_text("IN_STORE=from-the-file\n")
+    monkeypatch.setenv("ONLY_IN_ENV", "ambient-value")
+    resolver = CredentialStoreResolver(CredentialManager(tmp_path))
+    assert resolver.resolve(["IN_STORE"])[0].value == "from-the-file"
+    with pytest.raises(MissingSecret) as raised:
+        resolver.resolve(["ONLY_IN_ENV"])
+    assert raised.value.name == "ONLY_IN_ENV"
+    assert "ambient-value" not in str(raised.value)
+
+
+# ---------------------------------------------------------------------------
+# MAJOR-1: an over-long value never reaches a message
+# ---------------------------------------------------------------------------
+
+LONG_CANARY = "SECRETVALUE-" + "z" * 9000
+
+
+@pytest.mark.parametrize("kind", ["static", "env", "store"])
+def test_over_long_value_is_unusable_by_name_only(kind: str) -> None:
+    """``ResolvedSecret.max_length`` is 8192; a cert chain exceeds it.
+
+    pydantic's ValidationError embeds ``input_value=`` -- the value -- in its
+    message, so every resolver has to translate it before it can escape.
+    """
+
+    from local_operator.evaluation.runner.host_secrets import CredentialStoreResolver
+    from local_operator.evaluation.runner.secrets import UnusableSecret
+
+    class _Secret:
+        def get_secret_value(self) -> str:
+            return LONG_CANARY
+
+    class _Manager:
+        def get_credentials(self) -> dict[str, _Secret]:
+            return {"K": _Secret()}
+
+    resolver: SecretResolver = {
+        "static": StaticSecretResolver({"K": LONG_CANARY}),
+        "env": EnvSecretResolver({"K": LONG_CANARY}),
+        "store": CredentialStoreResolver(_Manager()),
+    }[kind]
+    with pytest.raises(UnusableSecret) as raised:
+        resolver.resolve(["K"])
+    assert isinstance(raised.value, MissingSecret)
+    assert raised.value.name == "K"
+    assert raised.value.__cause__ is None and raised.value.__context__ is None
+    assert "SECRETVALUE" not in str(raised.value) and "zzz" not in repr(raised.value)
+
+
+def test_diagnostic_strips_inputs_from_any_validation_error() -> None:
+    """Second line of defence: even a raw ValidationError renders without its input."""
+
+    from pydantic import ValidationError
+
+    from local_operator.evaluation.runner.episode import _diagnostic
+
+    with pytest.raises(ValidationError) as raised:
+        ResolvedSecret(name="K", value=LONG_CANARY)
+    rendered = _diagnostic(raised.value)
+    assert rendered == "ValidationError: ResolvedSecret (value: string_too_long)"
+    assert "SECRETVALUE" not in rendered and "zzz" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_over_long_secret_fails_pre_bundle_with_the_name_only(
+    tmp_path: Path, episode_id: str
+) -> None:
+    adapter = FakeAdapter(tmp_path, episode_id)
+    config = build_config(tmp_path)
+    runner = EpisodeRunner(
+        _spec_with_refs(episode_id, "AWS_SECRET_ACCESS_KEY"),
+        config,
+        selector=selector(tmp_path),
+        model=ScriptedModel(["finish"]),
+        secrets=StaticSecretResolver({"AWS_SECRET_ACCESS_KEY": LONG_CANARY}),
+        launch=lambda _: adapter,
+    )
+    outcome = await runner.run()
+    assert outcome.status == "failed_pre_bundle"
+    assert outcome.diagnostic == "UnusableSecret: unusable secret AWS_SECRET_ACCESS_KEY"
+    assert load_pending_rescue(config.rescue_root) is None
+    assert b"SECRETVALUE" not in _all_bytes_under(tmp_path)
+    assert b"zzzz" not in _all_bytes_under(tmp_path)
 
 
 def test_redaction_set_with_values_widens_without_dropping_existing() -> None:
@@ -391,3 +496,55 @@ async def test_complete_rescue_after_incomplete_cleanup_retires_the_descriptor(
     assert outcome.rescue_required is True
     assert outcome.rescue_complete is True
     assert not (config.rescue_root / "rescue.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# MAJOR-3: a synthetic model client never seals reportable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthetic_model_seals_a_valid_but_non_reportable_bundle(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """The label is the runner's own claim; metadata alone can be overlooked."""
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path),
+        selector=selector(tmp_path),
+        model=ScriptedModel(["finish"]),
+        synthetic_model=True,
+        launch=lambda _: adapter,
+        rescue=_rescue_returning(True),
+    )
+    outcome = await runner.run()
+    assert outcome.status == "completed"
+    assert outcome.reportability_label == "synthetic_model"
+    assert outcome.score is not None and outcome.score.status == "scored"
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+    assert report.outcome is not None
+    assert report.outcome.reportable is False
+    assert report.outcome.reportability_label == "synthetic_model"
+
+
+@pytest.mark.asyncio
+async def test_synthetic_model_yields_to_more_severe_labels(
+    tmp_path: Path, episode_id: str
+) -> None:
+    adapter = FakeAdapter(tmp_path, episode_id, cleanup_status="attempted")
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path),
+        selector=selector(tmp_path),
+        model=ScriptedModel(["finish"]),
+        synthetic_model=True,
+        launch=lambda _: adapter,
+        rescue=_rescue_returning(False),
+    )
+    outcome = await runner.run()
+    assert outcome.reportability_label == "cleanup_incomplete"

--- a/tests/unit/evaluation/test_copied_interpreter.py
+++ b/tests/unit/evaluation/test_copied_interpreter.py
@@ -1,0 +1,76 @@
+"""The shared copied-interpreter helper fails loudly, never silently.
+
+The defect this guards: three copies of the helper used to fall through
+from a copy of the running interpreter that could not start (uv builds link
+a relative ``libpython`` that ``venv --copies`` does not carry) to whatever
+``python3`` was on PATH -- a different major version whose worker then died
+importing the running interpreter's ``pydantic_core``. The failure surfaced
+as a bare ``EOFError`` from the RPC reader, sixteen tests deep, naming none
+of the cause. See ``copied_interpreter.py`` for the full account.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.unit.evaluation import copied_interpreter as helper
+
+pytestmark = pytest.mark.slow
+
+
+def test_copied_interpreter_is_the_running_interpreter_and_imports_pydantic_core(
+    tmp_path: Path,
+) -> None:
+    executable = helper.copied_interpreter(tmp_path / "venv")
+    assert executable.is_file() and not executable.is_symlink()
+    site = helper.site_packages_of(executable)
+    assert (site / helper.REPO_PTH_NAME).is_file()
+    # The copy is a copy of THIS interpreter, not of whatever is on PATH: the
+    # version it reports through the worker's own flags is ours.
+    probe = helper._probe(executable, "import sys, pydantic_core; print(*sys.version_info[:2])")
+    assert probe.returncode == 0, probe.stderr
+    assert probe.stdout.split() == [str(part) for part in sys.version_info[:2]]
+
+
+def test_unrepairable_start_failure_names_the_base_and_the_dyld_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the copy cannot start and no libpython can be carried, say so."""
+
+    started: list[bool] = []
+    real_probe = helper._probe
+
+    def failing_probe(executable: Path, code: str):  # type: ignore[no-untyped-def]
+        if code == "print('ok')" and not started:
+            started.append(True)
+            result = real_probe(executable, "import sys; sys.exit(134)")
+            result.stderr = "dyld: Library not loaded: @rpath/libpython"
+            return result
+        return real_probe(executable, code)
+
+    monkeypatch.setattr(helper, "_probe", failing_probe)
+    monkeypatch.setattr(helper, "_shared_libpython", lambda base: None)
+    with pytest.raises(AssertionError) as raised:
+        helper.copied_interpreter(tmp_path / "venv")
+    message = str(raised.value)
+    assert "did not start" in message
+    assert "no shared libpython" in message
+    assert str(Path(sys.executable).resolve().name) in message or "python" in message
+    assert "@rpath/libpython" in message
+
+
+def test_import_mismatch_names_the_pth_rather_than_falling_through(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A copy that cannot import pydantic_core through its .pth is refused."""
+
+    monkeypatch.setattr(helper, "dependency_roots", lambda: [str(tmp_path / "nowhere")])
+    with pytest.raises(AssertionError) as raised:
+        helper.copied_interpreter(tmp_path / "venv")
+    message = str(raised.value)
+    assert "cannot import pydantic_core" in message
+    assert helper.REPO_PTH_NAME in message
+    assert "ModuleNotFoundError" in message


### PR DESCRIPTION
## Summary

PR 2c of the OSWorld 2.0 adapter: **runner-side secret resolution**, the **rescue sweep** as a harness module, and **`scripts/run_episode.py`** — the operator script that runs ONE real episode end to end. This is the piece #531 deferred: the runner sent no secrets on `reset_start`, so the AWS provider failed closed naming `AWS_ACCESS_KEY_ID` and the paid proof could not run. Patch bump → 0.44.31.

**No AWS resource was created and no money was spent.** Every episode run for this PR used the `FakeProvider` selected by a digest-pinned workspace. The paid proof runs after merge with the operator's explicit go.

**Non-activation.** Nothing imports the new code from the CLI, TUI, mobile, tools, or session paths. `scripts/run_episode.py` imports nothing from `local_operator.session`/`tui`; `tests/unit/evaluation/runner/test_isolation.py` is extended to assert that (module import stays inert), that `episode.py` never imports `host_secrets`, and that `local_operator.credentials` is now on the runner's forbidden list. The harness-side change to `episode.py` is one new keyword (`secrets=`) defaulting to a fail-closed empty resolver; `RedactionSet.with_values` is additive.

## The three behaviours

**1. Secret resolution order, redaction widening, fail-closed naming only the name** (`runner/secrets.py`, `runner/host_secrets.py`, `episode.py`). `EpisodeRunner(..., secrets: SecretResolver)` resolves `spec.secret_refs` **after the handshake and before the provisional descriptor, `prepare`, and `EvidenceWriter.create`**. Two reasons: a missing credential must fail before anything is allocated or persisted (`reset_start` is the side-effect boundary; a worker that fails closed itself has already been launched and had its inbox entry written), and every resolved value must be in the redaction set before the writer opens so the bundle is canaried against it from its first byte. A missing ref → `failed_pre_bundle`, diagnostic `MissingSecret: missing secret <NAME>`, worker reaped, no `rescue.json`. Values ride `ResetStartParams.secrets` and `run_rescue(secrets=)` only. `EnvSecretResolver` reads an **explicit mapping** — never `os.environ` implicitly; `StaticSecretResolver` is the test seam; `CredentialStoreResolver` (`host_secrets.py`, the only runner module besides `provider_client.py` allowed near the store) takes a live `CredentialManager` by injection so it imports nothing from the application. A spec that declares refs with no resolver fails closed rather than sending nothing. A fully clean cleanup or a complete rescue now retires the episode's `rescue.json` via `discard_rescue`, so the sweep inbox is exactly the set of episodes that still own resources.

**2. Rescue sweep as ONE implementation** (`runner/rescue_sweep.py`). #531's script carried the whole sweep plus its own `MissingSecret` and resolver. `sweep_rescue_root(root, resolver, *, launch)` is now the single implementation: explicit glob of `<root>/*/rescue.json` (`load_pending_rescue` still never scans), `run_rescue` with the descriptor's refs re-resolved through a `SecretResolver`, `discard_rescue` iff `aggregate.complete`, per-descriptor `SweepEntry` so one unreadable/unresolvable descriptor never stops the others. `scripts/osworld_rescue_sweep.py` only parses args, builds a `CredentialStoreResolver`, and prints.

**3. `scripts/run_episode.py` — an operator script, not a CLI surface.** Given a selector JSON, task id, `provider/model` route, a durable run root, infra values and budget caps, it builds `EpisodeSpec`/`EpisodeConfig`, opens the credential store **exactly as the CLI does** (`CredentialManager` → `AuthStore`, `cli._build_auth_stack`), builds the provider model client via `create_provider_model_client`, runs one episode with a real spawned worker, prints the `EpisodeOutcome` as JSON plus `bundle_root`. Secrets: names on `--secret-env` come from the script's own environment through an explicit `EnvSecretResolver`; everything else from the store. `--run-root` **refuses `/tmp`, `$TMPDIR` and friends** via `runner/durable_root.py` — the one volatile-root check, now also used by `build_osworld_adapter.py` so build and episode cannot disagree. Exit 0 only on `completed`; 1 on any other terminal; 2 for a missing secret (name on stderr, never a value) or a volatile root. `--model-client scripted-finish` and `--no-store` exist only so the plumbing can be proven without spend; documented as never a result.

**Route fold (lossless).** `RouteIdentity` fields are `StrictIdentifier`s and cannot carry `/`, which every OpenRouter id does. `runner/route_ids.fold_model_id` is a reversible escape (`_`→`__`, `/`→`_s`, other non-identifier chars →`_x<hh>` per UTF-8 byte; letters/digits/`.`/`:`/`-` pass through) with `unfold_model_id` as the exact inverse, so `deepseek/deepseek-v4-flash-vision-exp` seals as `deepseek_sdeepseek-v4-flash-vision-exp` and two distinct ids can never seal to one identity (comparability, M1). The manifest metadata also carries the raw id as `route_model_id` / `route_provider_id` so a reader never decodes by hand. Tested as a bijection over 2000 seeded ids and asserted on a real sealed bundle.

## Pre-existing test-env defect fixed (found by the last review; main fails identically)

Three test hosts (`adapters/test_launch.py`, `runner/test_episode_subprocess.py`, `adapters/osworld/spawn_helpers.py`) each had their own `_real_interpreter` that built a `venv --copies` clone of `sys.executable` and, when the clone could not start, **silently fell through to `shutil.which("python3")`**.

**Root cause.** uv-managed CPython links `@rpath/libpythonX.Y.dylib` with rpath `@executable_path/../lib`; `venv --copies` copies the executable but not the library, so the clone aborts in dyld (`Library not loaded: @rpath/libpython3.12.dylib`). The helper then copied Homebrew's `python3` (3.14) while the `.pth` it wrote still pointed at the RUNNING interpreter's site-packages — with a uv 3.12 venv the worker imported 3.14's `pydantic_core` under 3.12 and died before a handshake. Symptom: 16 spawn tests failing with a bare `EOFError` from the RPC reader. Reproduced on `origin/main` with `/tmp/lop-venv312` (uv 3.12): `1 failed … EOFError`.

**Fix** (`tests/unit/evaluation/copied_interpreter.py`, ONE helper): only the running interpreter is ever copied; a clone that cannot start is repaired by carrying its shared libpython across (`sysconfig` `Py_ENABLE_SHARED`/`LIBDIR`/`INSTSONAME` from the base — framework builds never hit this branch); before it is handed out the clone must import `pydantic_core` **through the `.pth` under the supervisor's own `-I -s -E` flags**. Every failure raises `AssertionError` naming the base, the step, and the captured stderr — no fallthrough, no skip.

**Both loud paths proven** on 3.14 and uv 3.12 (`tests/unit/evaluation/test_copied_interpreter.py`):
```
LOUD(1): copied interpreter …/v1/bin/python3.12 (from …/cpython-3.12.13…/bin/python3.12) did not start and the base reports no shared libpython to carry across: dyld[…]: Library not loaded: @rpath/libpython…
LOUD(2): copied interpreter …/v2/bin/python3.12 (from …, (3, 12)) cannot import pydantic_core through …/v2/lib/python3.12/site-packages/_local_operator_repo.pth: ModuleNotFoundError…
OK: …/v3/bin/python3.12
```
After the fix, `test_launch.py` on uv 3.12: `2 passed`.

## Testing evidence — real path

All under a durable root (`~/.cache/lop-run-episode-proof/<ts>`), against the **real adapter wheel installed into a real copied interpreter**, `FakeProvider` selected by the digest-pinned workspace, real `AdapterSupervisor.launch`.

**Spawned episode → sealed bundle, exit 0** (`--secret-env` path, canary values in the environment):
```
$ AWS_ACCESS_KEY_ID=AKIACANARY0000000001 AWS_SECRET_ACCESS_KEY=canary-secret-value-xyz-9876 \
  python scripts/run_episode.py --selector …/adapter/selector.json --task-id task_plain --route test/fake \
  --run-root …/run1 --secret-env AWS_ACCESS_KEY_ID --secret-env AWS_SECRET_ACCESS_KEY --no-store \
  --model-client scripted-finish --infra AWS_REGION=us-east-1 … --infra OSWORLD_FILE_BASE_URL=http://x
{ "bundle_root": "…/run1/evidence/ep-71e22222815d", "comparability_label": "comparable",
  "reportability_label": "reportable", "rescue_required": false,
  "score": {"binary": 1, "status": "scored", …}, "status": "completed" }
rc=0
$ verify_bundle(…/run1/evidence/ep-71e22222815d) → valid True []
$ grep -rl 'canary-secret-value-xyz-9876\|AKIACANARY0000000001' …/run1   → (nothing) grep rc=1
$ find …/run1/rescue -name rescue.json → (nothing; descriptor retired)   artifacts/: real frames present
```

**Credential-store path** (scratch `credentials.env` under `--config-dir`, no env vars): `status: completed`, sealed, store canary absent from the run root.

**Missing secret → pre-bundle, name only, exit 2:**
```
{ "bundle_root": null, "diagnostic": "MissingSecret: missing secret AWS_SECRET_ACCESS_KEY",
  "rescue_required": false, "status": "failed_pre_bundle" }
rc=2   stderr: MissingSecret: missing secret AWS_SECRET_ACCESS_KEY
rescue.json present? 0   bundles: 0   (KEY_ID canary absent from run root and stdout/stderr)
```

**Volatile root refused, exit 2, nothing created:**
```
$ python scripts/run_episode.py … --run-root /tmp/lop-proof-x
run root /tmp/lop-proof-x resolves under /private/tmp, which the OS may purge mid-run; use a durable location such as ~/worktrees/osworld
rc=2   ls: /tmp/lop-proof-x: No such file or directory
```

These four are also the automated `tests/unit/evaluation/adapters/osworld/test_run_episode_script.py` (subprocess, `slow`), including the route-fold assertion on the sealed manifest (`--route test/fake/model:free` → `model_id == fake_smodel:free`, `metadata.route_model_id == "fake/model:free"`).

**Runner unit tests** (`runner/test_secrets.py`, 14): handshake → resolve → prepare → `reset_start(secrets=…)` order with `prepare` asserted secret-free; the canaried writer refusing a `model_response` that smuggles the value (episode abandons, value absent from `evidence/`); missing secret pre-bundle with a byte-grep of the whole `tmp_path`; rescue receiving the secrets; descriptor retired on clean and on confirmed rescue, retained on `attempted`. `runner/test_rescue_sweep.py` (4): one complete + one incomplete descriptor → only the first unlinked, secrets delivered to both, `launch=` forwarded; missing secret reported by name and never launched; a failed rescue does not stop the sweep.

## Paid-proof command line

Both the AWS pair and the model key come from the credential store; no environment variables are needed (README "Running one episode"):
```sh
python ~/local-operator/scripts/run_episode.py \
    --selector ~/worktrees/osworld/workspaces/0.1.0/selector.json \
    --task-id task_001 \
    --route openrouter/deepseek/deepseek-v4-flash-vision-exp \
    --run-root ~/worktrees/osworld/runs/$(date +%Y%m%d-%H%M%S) \
    --infra AWS_REGION=us-east-1 --infra AWS_SUBNET_ID=subnet-f2f9adad \
    --infra AWS_SECURITY_GROUP_ID=<sg-id> --infra AWS_SCHEDULER_ROLE_ARN=<role arn> \
    --infra OSWORLD_CLIENT_PASSWORD=<guest password> --infra OSWORLD_FILE_BASE_URL=<asset mirror> \
    --max-steps 25 --max-usd 0.50 --max-wall-s 1800 --keep-recent-frames 3
```

## Gates and suites

- `flake8 .`, `black==26.1.0 --check .` (799 unchanged), `isort==5.13.2 --check .`, `pyright --pythonpath .venv/bin/python .` → **0 errors** (whole tree, adapter wheel not installed, as CI).
- `tests/unit/evaluation`: **675 passed** (parallel). `adapters` + `runner` parallel ×3: 365/365/365 passed; `adapters` serial (`-n0`): 232 passed. `test_copied_interpreter.py`: 3 passed on 3.14 and on uv 3.12.
- `uv build` → `local_operator-0.44.31` wheel/sdist, `twine check` PASSED; wheel carries the five new runner modules.

## Not done here (by design)

- The paid proof itself (needs the operator's go and a created security group).
- `/tmp/lop-venv312` (uv 3.12 venv with the project installed) is left on the host for the reviewer to re-run the ABI-mismatch reproduction against `origin/main` and the fix.
- Serial spawn suite is slow (kill-at-cutpoint tests ~66 s each): pre-existing, untouched.
