### PR TITLE
fix(evaluation): frame-id contract and corrective re-prompt; bytecode-proof workspace digest (proof episode fixes)

### DIFF
--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -243,6 +243,23 @@ It spawns the exact pinned worker per descriptor, re-resolves the descriptor's
 secret refs from the credential store, reconciles every action, and unlinks
 the descriptor **only** when the aggregate is complete.
 
+The sweep takes no `--region`, unlike the audit below: each descriptor
+already carries the episode's `AWS_REGION` in its `infra_values`, and the
+worker reconciles in that region. Passing one would only invite a mismatch
+between where the operator thinks the instance is and where the descriptor
+says it is.
+
+The sweep re-hashes the pinned workspace before it will spawn the worker, so
+the workspace must still match the selector's `workspace_digest`. Bytecode
+caches never count: `__pycache__/` and `*.pyc` are excluded from the digest
+by rule, and the worker is launched with `-B` so it writes none — upstream's
+`instantiate_task` imports the task module from the workspace, and in the
+first paid episode the cache that import left behind made the sweep refuse
+("adapter workspace content digest differs") for an instance that was in
+fact already terminated. Anything else that changes under the workspace is a
+genuine drift and the sweep will (rightly) refuse; restore the workspace from
+the verified inputs root and sweep again.
+
 ## Leak audit (operator command)
 
 Every instance and volume this adapter creates carries `lop:adapter=osworld-v2`

--- a/local_operator/compaction/pruning.py
+++ b/local_operator/compaction/pruning.py
@@ -491,9 +491,21 @@ def shed_stale_frames(messages: Sequence[Message], *, limit: int) -> tuple[list[
     TURNS, not on the presence of an image, because by the time a caller
     sheds, the oldest turns have already been pruned to notices and are the
     stalest thing in the tail. "Oldest first" means those, never the recent
-    frames a screen-driving surface actually acts on. A removed observation's
-    assistant reply goes with it: a reply that answers an observation no
-    longer visible is a decision made about a screen the model cannot see.
+    frames a screen-driving surface actually acts on. A turn is its
+    observation plus EVERYTHING up to the next observation: the reply, and
+    any rejected-reply / correction pair that preceded the accepted reply. All
+    of it goes with the observation, because a reply that answers an
+    observation no longer visible is a decision made about a screen the model
+    cannot see.
+
+    The same rule covers a tail whose FRONT is not an observation. The
+    compaction cut point may legally land on an assistant reply or on a
+    correction message, leaving the end of a turn whose observation is
+    already behind the marker; those orphans are shed first. Stopping on them
+    instead (the earlier behaviour) stalled the shed for the rest of the
+    episode: every pass found a non-observation at the front, removed
+    nothing, and the client refused the request as unrecoverable with a dozen
+    sheddable turns still in the prefix.
 
     Never removes the current observation (the last message — without it the
     request has no question), and stops short of a compaction marker in the
@@ -509,16 +521,15 @@ def shed_stale_frames(messages: Sequence[Message], *, limit: int) -> tuple[list[
             head = index + 1
     tail = list(messages[head:])
     while tail and count_stale_observations(tail) > limit:
-        observation, assistant = tail[0], (tail[1] if len(tail) > 1 else None)
-        if not _is_stale_observation(observation):
+        # Everything before the NEXT stale observation is the oldest turn (or
+        # the orphaned end of one); never the last message, which is the
+        # current observation and the request's only question.
+        end = 1
+        while end < len(tail) and not _is_stale_observation(tail[end]):
+            end += 1
+        if end >= len(tail):
             break
-        # Keeping the assistant while shedding its observation would leave a
-        # decision the model can no longer see the screen for; shed the pair
-        # but never the last message (the current observation).
-        removable = 2 if (assistant is not None and assistant.role == "assistant") else 1
-        if removable >= len(tail):
-            break
-        del tail[:removable]
+        del tail[:end]
     if head == 0 and len(tail) == len(messages):
         return list(messages), 0
     return [*messages[:head], *tail], len(messages) - head - len(tail)

--- a/local_operator/evaluation/adapters/discovery.py
+++ b/local_operator/evaluation/adapters/discovery.py
@@ -193,10 +193,14 @@ def workspace_digest(path: str) -> str:
                 raise AdapterDiscoveryError("adapter workspace contains a symlink")
             if stat.S_ISDIR(info.st_mode):
                 continue
-            if _is_bytecode_cache(candidate.relative_to(root)):
-                continue
+            # The unsafe-file check precedes the bytecode exclusion: the cache
+            # rule forgives a bytecode FILE, not any entry named like one, so a
+            # fifo or hardlink named ``x.pyc`` under ``__pycache__`` is refused
+            # like any other.
             if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
                 raise AdapterDiscoveryError("adapter workspace contains an unsafe file")
+            if _is_bytecode_cache(candidate.relative_to(root)):
+                continue
             if len(entries) >= MAX_WORKSPACE_FILES:
                 raise AdapterDiscoveryError("adapter workspace file count exceeds limit")
             total_bytes += info.st_size

--- a/local_operator/evaluation/adapters/discovery.py
+++ b/local_operator/evaluation/adapters/discovery.py
@@ -31,6 +31,20 @@ MAX_WORKSPACE_FILES = 100_000
 MAX_WORKSPACE_BYTES = 4 * 1024 * 1024 * 1024
 RELEASE_MANIFEST = "adapter-release.json"
 
+#: Bytecode caches are never verified content. The finder refuses to load any
+#: ``.pyc`` (RECORD-covered or not), the worker is spawned with ``-B`` so it
+#: writes none, and the workspace digest skips them by RULE rather than by
+#: hoping nothing writes one: in the first paid episode, upstream OSWorld's
+#: ``instantiate_task`` imported ``tasks/task_001.py`` inside the pinned
+#: workspace and CPython dropped ``tasks/__pycache__/task_001.cpython-312.pyc``
+#: there. The rescue worker then re-hashed the workspace, found the cache,
+#: refused with "adapter workspace content digest differs", and the sweep
+#: exited 1 forever for an instance that was in fact already terminated. A
+#: cache file that no loader here will ever execute cannot be allowed to
+#: invalidate a pin.
+BYTECODE_CACHE_DIRECTORY = "__pycache__"
+BYTECODE_SUFFIXES: tuple[str, ...] = tuple(importlib.machinery.BYTECODE_SUFFIXES)
+
 
 class AdapterDiscoveryError(RuntimeError):
     """A closed discovery failure safe to report across the RPC boundary."""
@@ -154,6 +168,12 @@ def workspace_digest(path: str) -> str:
     handshake, but it is not re-verified immediately before spawn the way the
     executable identity is. That asymmetry is a known, deliberate gap for a
     later round to close or accept explicitly.
+
+    ``__pycache__`` directories and bytecode files are excluded by rule (see
+    ``BYTECODE_CACHE_DIRECTORY``): they are a side effect of importing, not
+    content, and no loader in this subsystem will ever execute one. A symlink
+    or an unsafe file INSIDE a cache directory is still fatal -- the exclusion
+    is of bytecode from the manifest, not of the directory from inspection.
     """
 
     root = Path(path)
@@ -172,6 +192,8 @@ def workspace_digest(path: str) -> str:
             if stat.S_ISLNK(info.st_mode):
                 raise AdapterDiscoveryError("adapter workspace contains a symlink")
             if stat.S_ISDIR(info.st_mode):
+                continue
+            if _is_bytecode_cache(candidate.relative_to(root)):
                 continue
             if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
                 raise AdapterDiscoveryError("adapter workspace contains an unsafe file")
@@ -194,6 +216,19 @@ def workspace_digest(path: str) -> str:
             )
     entries.sort(key=lambda entry: entry["path"])
     return canonical_digest("adapter-workspace-manifest-v1", entries)
+
+
+def _is_bytecode_cache(relative: Path) -> bool:
+    """Whether a workspace-relative path is a bytecode artifact to skip.
+
+    Both spellings are matched: the standard ``__pycache__/<stem>.<tag>.pyc``
+    and a legacy ``<stem>.pyc`` beside its source, because CPython writes the
+    former and ``compileall -b`` writes the latter, and neither is content.
+    """
+
+    if BYTECODE_CACHE_DIRECTORY in relative.parts[:-1]:
+        return True
+    return any(relative.name.endswith(suffix) for suffix in BYTECODE_SUFFIXES)
 
 
 def verify_release_manifest(selector: AdapterSelector) -> None:
@@ -224,12 +259,17 @@ def worker_argv(selector: AdapterSelector) -> tuple[str, ...]:
     if workspace_digest(selector.workspace) != selector.workspace_digest:
         raise AdapterDiscoveryError("adapter workspace content digest differs")
     # Isolation flags prevent user site, PYTHON* variables, and current-directory
-    # imports from changing which exact wheel the worker verifies.
+    # imports from changing which exact wheel the worker verifies. ``-B`` keeps
+    # the worker from writing bytecode: its cwd IS the pinned workspace, and an
+    # adapter that imports a task module from it (upstream OSWorld does) would
+    # otherwise leave a ``__pycache__`` behind that the digest must then ignore
+    # by rule -- see ``BYTECODE_CACHE_DIRECTORY``. Belt and braces.
     return (
         selector.python_executable,
         "-I",
         "-s",
         "-E",
+        "-B",
         "-m",
         "local_operator.evaluation.adapters.worker",
     )

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -257,11 +257,14 @@ class AdapterSupervisor:
         }
         env = minimal_environment(environment or os.environ, protocol_fds=protocol_fds)
         env[LAUNCH_IDENTITY_ENV] = json.dumps(resolved.__dict__, sort_keys=True)
+        # Same flags the worker gets (``discovery.worker_argv``): the leader
+        # runs in the workspace too and must leave no bytecode there either.
         argv = (
             selector.python_executable,
             "-I",
             "-s",
             "-E",
+            "-B",
             "-m",
             "local_operator.evaluation.adapters.supervisor",
             "--supervise",

--- a/local_operator/evaluation/adapters/worker.py
+++ b/local_operator/evaluation/adapters/worker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, cast
@@ -408,6 +409,10 @@ def _descriptor(name: str) -> int:
 
 
 def main() -> int:
+    # The launcher passes ``-B``; this is the in-process guarantee of the same
+    # thing, so a worker started any other way (a test harness, a debugger)
+    # still never writes bytecode into the verified workspace it runs in.
+    sys.dont_write_bytecode = True
     request_fd = _descriptor(REQUEST_FD_ENV)
     response_fd = _descriptor(RESPONSE_FD_ENV)
     # stdout belongs to diagnostics, never framing.  Redirect it before metadata

--- a/local_operator/evaluation/evidence/models.py
+++ b/local_operator/evaluation/evidence/models.py
@@ -96,6 +96,11 @@ UnscoredReason = Literal[
     "crash",
     "ambiguous_finalization",
     "scorer_failure",
+    # The model never produced a usable decision within the runner's retry
+    # bound. Neither infrastructure (the provider answered every call) nor a
+    # crash (nothing broke): the agent under test could not act, which is a
+    # fact about the agent that must not be filed under the harness.
+    "model_failure",
 ]
 AbandonmentReason = Literal[
     "preflight_failure",
@@ -265,6 +270,7 @@ class LifecycleTransitionPayload(ProtocolModel):
             "scorer",
             "cleanup",
             "cancelled",
+            "model",
         ]
         | None
     ) = None
@@ -520,7 +526,13 @@ class CleanupPayload(ProtocolModel):
 
 class ErrorPayload(ProtocolModel):
     error_id: StrictIdentifier
-    category: Literal["adapter", "environment", "provider", "infrastructure", "scorer", "internal"]
+    # ``model`` is the agent under test itself: a billed reply that failed
+    # strict decision parsing (retryable while the runner re-prompts, terminal
+    # once its bound is spent). It is kept apart from ``provider`` so a model
+    # that cannot follow the action contract is never reported as an outage.
+    category: Literal[
+        "adapter", "environment", "provider", "infrastructure", "scorer", "internal", "model"
+    ]
     diagnostic_code: StrictIdentifier
     detail_artifact: EvidenceArtifactRef | None = None
     retryable: bool

--- a/local_operator/evaluation/lifecycle.py
+++ b/local_operator/evaluation/lifecycle.py
@@ -465,6 +465,7 @@ class EpisodeLifecycle(AuthorityModel):
             "ambiguous_finalization",
             "cleanup",
             "unreportable",
+            "model",
         ]
         | None
     ) = None

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -188,6 +188,14 @@ class EpisodeConfig:
     the episode is still scored on the state it reached. ``None`` means
     :func:`default_guards`; an empty tuple disables them.
     ``max_cycle_cost_micros`` feeds the default cost-rate guard's absolute cap.
+    ``max_decision_retries`` is how many corrective re-prompts one observation
+    may take after a billed reply fails strict parsing (a ``frame_id`` the
+    observation does not carry, malformed JSON) before the episode ends as a
+    model failure. The default is 2 -- one re-prompt is the minimum for a
+    single defect, a second covers a reply that fixes it and introduces
+    another; beyond that the model is not converging and every further call
+    is money spent on a batch that can never execute. ``0`` restores the old
+    one-strike behaviour.
     The frame policy (``keep_recent_frames``) is deliberately NOT here: the
     model client owns its context and is built before the runner
     (``create_provider_model_client(keep_recent_frames=...)``), so a copy on
@@ -207,6 +215,7 @@ class EpisodeConfig:
     handshake_timeout: float = 30.0
     max_cycle_cost_micros: int | None = None
     guards: tuple[EpisodeGuard, ...] | None = None
+    max_decision_retries: int = 2
 
 
 @dataclass(frozen=True)
@@ -630,13 +639,46 @@ class EpisodeRunner:
                 return
 
     async def _decide(self, observation: Observation) -> Any:
-        """Ask the model, writing request/response/usage in that exact order.
+        """Ask the model until it returns a usable batch, within the retry bound.
+
+        A :class:`DecisionRejected` is a BILLED call whose reply failed strict
+        parsing (the first paid episode's ``frame_id "1"`` against a published
+        ``"screen"``). It is the model's error, not the provider's, and it is
+        recoverable: the client has already folded the rejection into its
+        context, so calling ``decide`` again for the same observation is a
+        corrective re-prompt. Each attempt -- rejected or not -- writes its own
+        request/response/usage triple and counts as a model cycle, because
+        each was a real provider call; a rejected one additionally writes a
+        retryable ``error`` event naming the defect, so a reader can see the
+        correction happen rather than infer it from an extra triple.
+
+        The bound is ``config.max_decision_retries`` corrective re-prompts.
+        Spending it means the model is not converging, and the episode ends
+        as a MODEL failure (``_ModelFailure``) rather than burning the budget
+        on replies that can never execute.
+        """
+
+        rejections = 0
+        while True:
+            try:
+                return await self._decide_once(observation)
+            except _DecisionRejection as rejection:
+                rejections += 1
+                if rejections > self._config.max_decision_retries:
+                    raise _ModelFailure(
+                        f"model produced no usable decision after {rejections} attempt(s): "
+                        f"{rejection.diagnostic}"
+                    ) from rejection
+
+    async def _decide_once(self, observation: Observation) -> Any:
+        """One model call, writing request/response/usage in that exact order.
 
         The verifier binds a response to its request and a usage record to that
         response, so all three must be written even when the provider reports
         nothing -- a missing usage record leaves an unclosed operation and the
         bundle cannot reach a terminal.
         """
+        from local_operator.evaluation.runner.model import DecisionRejected
 
         request_id = f"req-{self._model_cycles}-{uuid.uuid4().hex[:12]}"
         message_count = len(self._turns)
@@ -646,10 +688,18 @@ class EpisodeRunner:
         # by a provider failure, and the verifier requires every request to
         # carry its response and usage before any terminal (verify.py:760) --
         # so recording it eagerly would make the failure path unsealable.
+        rejected: DecisionRejected | None = None
         try:
             decision = await self._model.decide(observation, tuple(self._turns))
         except _EvidenceFailure:
             raise
+        except DecisionRejected as error:
+            # A billed call with an unusable reply. Its evidence is written
+            # below exactly like an accepted decision's -- the bundle's
+            # counters must stay a pure sum of what was actually spent -- and
+            # the rejection is then raised for ``_decide`` to bound.
+            rejected = error
+            decision = error
         except BaseException as error:
             from local_operator.evaluation.runner.provider_client import (
                 ContextUnrecoverableError,
@@ -694,6 +744,10 @@ class EpisodeRunner:
                     summary_artifact=summary_artifact,
                 ),
             )
+        # A rejected reply may carry no served route (a scripted client need
+        # not know one); the requested route is the honest stand-in because
+        # nothing served was accepted.
+        served_route = decision.route or self._spec.requested_route
         self._append(
             "model_request",
             ModelRequestPayload(
@@ -715,7 +769,7 @@ class EpisodeRunner:
                 request_id=request_id,
                 provider_request_id=decision.provider_request_id,
                 requested_route=self._spec.requested_route,
-                served_route=decision.route,
+                served_route=served_route,
                 stop_reason=decision.stop_reason,
                 output_tokens=decision.usage.output_tokens,
                 reasoning_tokens=decision.usage.reasoning_tokens,
@@ -741,9 +795,9 @@ class EpisodeRunner:
         self._recent_costs.append(decision.cost_micros)
         self._served_routes.add(
             (
-                decision.route.provider_id,
-                decision.route.route_id,
-                decision.route.model_id,
+                served_route.provider_id,
+                served_route.route_id,
+                served_route.model_id,
             )
         )
         self._provider_cost_micros += decision.cost_micros
@@ -757,6 +811,22 @@ class EpisodeRunner:
             self._usage_totals[name] = self._usage_totals.get(name, 0) + getattr(
                 decision.usage, name
             )
+        if rejected is not None:
+            # The diagnostic is what the model will be shown; it is published
+            # as an artifact rather than squeezed into the identifier-shaped
+            # ``diagnostic_code`` so the exact correction is auditable.
+            detail = self._publish(rejected.diagnostic.encode("utf-8"), media_type="text/plain")
+            self._append(
+                "error",
+                ErrorPayload(
+                    error_id=f"err-{uuid.uuid4().hex[:12]}",
+                    category="model",
+                    diagnostic_code="decision-rejected",
+                    detail_artifact=detail,
+                    retryable=True,
+                ),
+            )
+            raise _DecisionRejection(rejected.diagnostic) from rejected
         return decision
 
     def _append_batch(
@@ -990,8 +1060,20 @@ class EpisodeRunner:
         skips it has no terminal at all and the bundle can only be abandoned.
         """
 
-        provider_failure = isinstance(error, _ProviderFailure)
-        category: Literal["adapter", "provider"] = "provider" if provider_failure else "adapter"
+        # Three failure classes, each with its own category, unscored reason
+        # and lifecycle failure kind, because they answer different questions
+        # for whoever reads the bundle: ``provider`` is an outage on the way to
+        # the model, ``model`` is the agent under test failing to act, and
+        # ``adapter`` (crash) is the harness or environment breaking.
+        category: Literal["adapter", "provider", "model"]
+        reason: Literal["crash", "infrastructure_failure", "model_failure"]
+        failure_kind: Literal["crash", "infrastructure", "model"]
+        if isinstance(error, _ProviderFailure):
+            category, reason, failure_kind = "provider", "infrastructure_failure", "infrastructure"
+        elif isinstance(error, _ModelFailure):
+            category, reason, failure_kind = "model", "model_failure", "model"
+        else:
+            category, reason, failure_kind = "adapter", "crash", "crash"
         self._append(
             "error",
             ErrorPayload(
@@ -1001,14 +1083,11 @@ class EpisodeRunner:
                 retryable=False,
             ),
         )
-        reason: Literal["crash", "infrastructure_failure"] = (
-            "infrastructure_failure" if provider_failure else "crash"
-        )
         self._begin_finalization(FinalizationIntent(kind="unscored"), None)
         score = ScoreArtifact(status="unscored", reason=reason)
         return await self._close_out(
             score,
-            failure_kind="crash" if not provider_failure else "infrastructure",
+            failure_kind=failure_kind,
             cancelled=False,
             diagnostic=_diagnostic(error),
         )
@@ -1461,6 +1540,29 @@ class EpisodeRunner:
 
 class _ProviderFailure(Exception):
     """A terminal model-provider error after the client exhausted its retries."""
+
+
+class _DecisionRejection(Exception):
+    """One billed reply failed parsing; its evidence is already written.
+
+    Raised by ``_decide_once`` AFTER the attempt's triple and its retryable
+    ``error`` event are in the journal, so ``_decide`` can count it against
+    the retry bound without touching evidence itself.
+    """
+
+    def __init__(self, diagnostic: str) -> None:
+        super().__init__(diagnostic)
+        self.diagnostic = diagnostic
+
+
+class _ModelFailure(Exception):
+    """The model spent its corrective re-prompts without a usable decision.
+
+    Distinct from ``_ProviderFailure`` because every call was answered and
+    billed: the provider worked, the agent under test did not. The bundle
+    seals ``category="model"`` / ``reason="model_failure"`` so a run that
+    ended this way is never counted as an infrastructure outage.
+    """
 
 
 def _reportability_label(

--- a/local_operator/evaluation/runner/model.py
+++ b/local_operator/evaluation/runner/model.py
@@ -101,6 +101,60 @@ class EpisodeTurn(ProtocolModel):
     ask_answer: str | None = None
 
 
+class DecisionRejected(Exception):
+    """The provider answered, and was billed, but the reply is not a usable batch.
+
+    This is the MODEL's error, not the provider's: the request went through,
+    tokens were spent, and what came back failed strict decision parsing (not
+    JSON, wrong shape, a stale observation id, a ``frame_id`` the observation
+    does not carry, a coordinate outside the frame). It is raised INSTEAD of a
+    :class:`ModelDecision` so the runner can still record the attempt honestly
+    -- every field a decision would have carried for the bundle's
+    request/response/usage triple is here -- and then ask again.
+
+    The first paid OSWorld episode ended on exactly this: the model named
+    ``frame_id "1"`` where the adapter had published ``"screen"``, the reply
+    was classified as a provider failure, and the episode was sealed unscored
+    after a single call. A rejected reply is recoverable in a way a dead
+    provider is not, which is why it has its own type and its own path.
+
+    ``diagnostic`` is the parse error, phrased so it can be shown back to the
+    model verbatim. An implementation that raises this is expected to have
+    folded the rejection into its own context first (the bad reply, then the
+    diagnostic as the next user turn) so that the runner's re-call of
+    :meth:`EpisodeModelClient.decide` for the same observation is a corrective
+    re-prompt rather than a blind replay.
+    """
+
+    def __init__(
+        self,
+        diagnostic: str,
+        *,
+        route: RouteIdentity | None = None,
+        usage: ModelUsage | None = None,
+        cost_micros: int = 0,
+        stop_reason: str = "stop",
+        provider_request_id: str = "unknown",
+        tool_call_count: int = 0,
+        prompt_cache_key: str | None = None,
+        context_tokens: int | None = None,
+        compaction: CompactionRecord | None = None,
+    ) -> None:
+        super().__init__(diagnostic)
+        self.diagnostic = diagnostic
+        # The served route matters even for a rejected reply: a fallback that
+        # answered badly still moved the run off its pinned route.
+        self.route = route
+        self.usage = usage or ModelUsage()
+        self.cost_micros = cost_micros
+        self.stop_reason = stop_reason
+        self.provider_request_id = provider_request_id
+        self.tool_call_count = tool_call_count
+        self.prompt_cache_key = prompt_cache_key
+        self.context_tokens = context_tokens
+        self.compaction = compaction
+
+
 @runtime_checkable
 class EpisodeModelClient(Protocol):
     """Chooses the next action batch for an episode.
@@ -111,10 +165,19 @@ class EpisodeModelClient(Protocol):
     on prompt construction. The current ``observation`` is the last entry's
     observation too (its ``batch`` is still ``None``).
 
-    Raising is the contract for an unrecoverable provider failure: the runner
-    treats it as ``ErrorPayload(category="provider")`` and finalizes the
-    episode unscored on a still-live session. Internal retries therefore belong
-    inside the implementation, below this boundary.
+    Two failure contracts, deliberately distinct:
+
+    * Raising :class:`DecisionRejected` means the call was billed but the
+      reply was unusable. The runner records the attempt (request, response,
+      usage, and a retryable ``error`` event) and calls ``decide`` AGAIN with
+      the same observation and history, up to ``EpisodeConfig.max_decision_retries``
+      times; only when that bound is spent does the episode end, as a MODEL
+      failure. The implementation owns making the re-call corrective.
+    * Raising anything else is the contract for an unrecoverable provider
+      failure: the runner treats it as ``ErrorPayload(category="provider")``
+      and finalizes the episode unscored on a still-live session. Internal
+      retries for transport faults therefore belong inside the implementation,
+      below this boundary.
     """
 
     async def decide(

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -5,9 +5,11 @@ episode cannot inherit the operator's live configuration. That constraint has
 to break somewhere for a real run, and it breaks here, behind
 :class:`~local_operator.evaluation.runner.model.EpisodeModelClient`.
 
-Strict decision parsing also lives here rather than in the runner core. The
-runner treats a malformed decision as a provider failure, so the parsing rules
-and the provider that produced them stay in the same module.
+Strict decision parsing also lives here rather than in the runner core. A
+malformed decision is surfaced as :class:`DecisionRejected` -- a billed call
+whose reply is unusable -- which the runner records and retries with the
+rejection fed back, so the parsing rules and the feedback that corrects them
+stay in the same module.
 
 **Context management** also lives here, on the central compaction engine
 (``local_operator.compaction``) rather than a second implementation. The
@@ -33,6 +35,7 @@ from local_operator.evaluation.evidence.models import RouteIdentity
 from local_operator.evaluation.protocol import ActionBatch, ComputerAction, Observation
 from local_operator.evaluation.runner.model import (
     CompactionRecord,
+    DecisionRejected,
     EpisodeTurn,
     ModelDecision,
     ModelUsage,
@@ -55,6 +58,12 @@ DEFAULT_KEEP_RECENT_FRAMES = 3
 #: batched into rebuilds instead of done per turn.
 DEFAULT_REBUILD_EVERY_FRAMES = 8
 
+#: Longest slice of a rejected reply replayed into the context as the model's
+#: own words before the correction. The reply has to be there -- the model
+#: must see WHAT it said to fix it -- but a runaway reply (a provider's
+#: max-token wall of prose) must not cost the whole window on the retry.
+MAX_REJECTED_REPLY_CHARS = 4_000
+
 #: Rendered in place of an observation's text when it is byte-identical to the
 #: previous turn's. The adapter owns observation text and the runner never
 #: second-guesses it; this is the one append-only-safe dedup, because it only
@@ -72,11 +81,12 @@ _IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]*")
 def _action_schema_lines() -> list[str]:
     """Describe every action kind by reading the protocol models themselves.
 
-    A parse failure is TERMINAL for an episode -- there is no retry and no
-    repair -- so a prompt that under-specifies the wire shape is a correctness
-    defect, not prompt polish. Deriving the text from ``ComputerAction`` means a
-    new action kind or a changed literal cannot silently drift out of the
-    instructions the model is given.
+    A parse failure costs a billed corrective re-prompt at best and the
+    episode at worst (``EpisodeConfig.max_decision_retries``), so a prompt
+    that under-specifies the wire shape is a correctness defect, not prompt
+    polish. Deriving the text from ``ComputerAction`` means a new action kind
+    or a changed literal cannot silently drift out of the instructions the
+    model is given.
     """
 
     lines: list[str] = []
@@ -133,6 +143,17 @@ it, and "[screenshot omitted ...]" marks an older screenshot that a newer one
 has replaced. A message starting <previous-context-summary> summarises turns
 that are no longer shown.
 
+Every observation lists its frames on a "Frames:" line as "<frame_id>
+(<width>x<height>)", one per attached screenshot, in order. Any action that
+takes a "frame_id" MUST use one of the ids named on the CURRENT observation's
+"Frames:" line, exactly as written, and its x/y must lie inside that frame's
+width and height (0-based). Never invent a frame id or number the frames
+yourself.
+
+If a reply of yours is rejected, the next user message starts "Your previous
+reply was rejected:" and names the defect. Reply again for the SAME
+observation with a corrected batch; nothing was executed.
+
 Reply with a single JSON object and nothing else, with no prose and no code
 fence:
 
@@ -185,7 +206,7 @@ def parse_decision(
     observation is stale, and executing it would apply a decision made about a
     screen the environment has already moved past. ``ActionBatch.validate_for``
     rejects that at the adapter boundary, so the failure is surfaced here where
-    it can be attributed to the provider.
+    it can be attributed to the model and fed back to it.
     """
 
     try:
@@ -332,6 +353,7 @@ class _ContextBuilder:
             # part of the observation that followed it -- "the state after
             # that answer was delivered", as the system prompt promises.
             lines.append(f"Answer from the user: {previous.ask_answer}")
+        lines.append(f"Frames: {_frames_line(observation)}")
         lines.extend(["", rendered_text])
         content: list[Any] = [TextContent(text="\n".join(lines))]
         for frame in observation.frames:
@@ -347,6 +369,32 @@ class _ContextBuilder:
                 )
             )
         return Message(role="user", content=content)
+
+    def append_rejection(self, reply: str, diagnostic: str) -> None:
+        """Fold a rejected reply into the history so the next call corrects it.
+
+        Appended, never substituted: the bad reply goes in as the assistant's
+        own words and the diagnostic as the user turn that follows, which is
+        the only append-only way to tell the model what was wrong. The next
+        ``decide`` for the same observation then sends
+        ``user(observation) / assistant(bad) / user(rejection)`` and, once it
+        answers well, the runner's close of the turn appends that good batch
+        after the rejection -- a conversation that reads exactly as it
+        happened. The rendered/closed cursors are indices into the TURN
+        history, not into ``_messages``, so the extra pair does not disturb
+        them.
+        """
+        from local_operator.harness.types import Message, TextContent
+
+        shown = reply
+        if len(shown) > MAX_REJECTED_REPLY_CHARS:
+            shown = shown[:MAX_REJECTED_REPLY_CHARS] + "\n[... reply truncated]"
+        # A provider refuses an empty assistant message; a reply that was all
+        # whitespace is replayed as a marker so the pair stays well-formed.
+        self._messages.append(
+            Message(role="assistant", content=[TextContent(text=shown or "(empty reply)")])
+        )
+        self._messages.append(Message(role="user", content=[TextContent(text=diagnostic)]))
 
     def frames_in_history(self) -> int:
         from local_operator.compaction.pruning import count_frame_messages
@@ -457,18 +505,38 @@ class ProviderModelClient:
         if extra_usage is not None:
             usage = _add_usage(usage, extra_usage)
             cost_micros += extra_cost
-        return parse_decision(
-            text.strip(),
-            observation,
-            route=self._route,
-            usage=usage,
-            cost_micros=cost_micros,
-            stop_reason=stop_reason,
-            provider_request_id=provider_request_id,
-            prompt_cache_key=self._prompt_cache_key,
-            context_tokens=_estimate_context(messages),
-            compaction=compaction,
-        )
+        try:
+            return parse_decision(
+                text.strip(),
+                observation,
+                route=self._route,
+                usage=usage,
+                cost_micros=cost_micros,
+                stop_reason=stop_reason,
+                provider_request_id=provider_request_id,
+                prompt_cache_key=self._prompt_cache_key,
+                context_tokens=_estimate_context(messages),
+                compaction=compaction,
+            )
+        except DecisionParseError as error:
+            # The call happened and was billed; only the reply is unusable.
+            # Fold the rejection into the history NOW, before the runner
+            # decides whether to re-call, so a re-call for the same observation
+            # is corrective by construction. The billing provenance rides on
+            # the exception so the runner can write this attempt's triple.
+            diagnostic = _rejection_prompt(str(error), observation)
+            self._context.append_rejection(text, diagnostic)
+            raise DecisionRejected(
+                diagnostic,
+                route=self._route,
+                usage=usage,
+                cost_micros=cost_micros,
+                stop_reason=stop_reason,
+                provider_request_id=provider_request_id,
+                prompt_cache_key=self._prompt_cache_key,
+                context_tokens=_estimate_context(messages),
+                compaction=compaction,
+            ) from error
 
     async def _maybe_compact(self) -> tuple[CompactionRecord | None, ModelUsage | None, int]:
         """Run one compaction pass when the frame budget or the token threshold says so.
@@ -744,6 +812,44 @@ class ProviderModelClient:
                 # is worth carrying when the wire client reports one.
                 provider_request_id = _provider_request_id(event.provider_payload)
         return text, usage, cost_micros, stop_reason, provider_request_id, context_tokens
+
+
+def _frames_line(observation: Observation) -> str:
+    """``id (WxH)`` for every frame, or ``none`` when the observation has none.
+
+    This line is the frame-id CONTRACT made visible. The protocol lets an
+    adapter name its frames however it likes (OSWorld publishes ``screen``;
+    the test adapters publish ``frame-<n>``), and ``ActionBatch.validate_for``
+    refuses any id the observation does not carry -- so a model that was never
+    told the ids can only guess. The first paid episode guessed ``"1"``. The
+    geometry is the model-visible size because that is the coordinate space
+    the model's x/y are validated against.
+    """
+
+    if not observation.frames:
+        return "none"
+    return ", ".join(
+        f"{frame.frame_id} ({frame.geometry.model_visible.width}x"
+        f"{frame.geometry.model_visible.height})"
+        for frame in observation.frames
+    )
+
+
+def _rejection_prompt(reason: str, observation: Observation) -> str:
+    """The user turn that asks for a corrected reply.
+
+    Restates the observation id and the frame ids because those are the two
+    facts a rejected reply most often got wrong, and because the correction
+    is the LAST message in the request: a model reads it more reliably than
+    the same facts several messages up.
+    """
+
+    return (
+        f"Your previous reply was rejected: {reason}\n"
+        "Nothing was executed. Reply again for this same observation "
+        f"(Observation ID: {observation.observation_id}; Frames: "
+        f"{_frames_line(observation)}) with a corrected JSON batch and nothing else."
+    )
 
 
 def create_provider_model_client(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.35"
+version = "0.44.36"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/compaction/test_pass.py
+++ b/tests/unit/compaction/test_pass.py
@@ -431,6 +431,54 @@ def test_shed_stale_frames_stops_at_a_compaction_marker_and_at_a_frameless_prefi
         shed_stale_frames(messages, limit=-1)
 
 
+def test_shed_stale_frames_sheds_a_whole_turn_and_an_orphaned_turn_end() -> None:
+    """A turn is its observation plus everything up to the next observation.
+
+    Two shapes the pair-wise shed got wrong. (1) A turn whose accepted reply
+    was preceded by a rejected reply and a correction (the runner's
+    corrective re-prompt) is FOUR messages; shedding only the first two left
+    the rejection pair orphaned at the front, where it is not an observation,
+    and the shed stopped for good. (2) The compaction cut point may land on a
+    reply or a correction, so the tail can START with the end of a turn whose
+    observation is behind the marker; the shed must clear those orphans
+    rather than refuse. Either way it stalled the client's shed and the
+    request was refused as unrecoverable with sheddable turns still present.
+    """
+    from local_operator.compaction.pruning import shed_stale_frames
+
+    corrected = [
+        _frame_turn("t0"),
+        Message.assistant("bad0"),
+        Message.user("Your previous reply was rejected: ..."),
+        Message.assistant("a0"),
+        _frame_turn("t1"),
+        Message.assistant("a1"),
+        _frame_turn("t2"),
+    ]
+    # limit counts the current observation too (as the sibling tests show).
+    out, removed = shed_stale_frames(corrected, limit=2)
+    assert removed == 4
+    assert [_texts(m)[0] for m in out] == ["t1", "a1", "t2"]
+    assert out[0] is corrected[4] and out[-1] is corrected[-1]
+
+    orphaned_front = [
+        Message.assistant("a-behind-marker"),
+        Message.user("Your previous reply was rejected: ..."),
+        Message.assistant("a-corrected"),
+        _frame_turn("t1"),
+        Message.assistant("a1"),
+        _frame_turn("t2"),
+    ]
+    out, removed = shed_stale_frames(orphaned_front, limit=0)
+    assert removed == 5
+    assert [_texts(m)[0] for m in out] == ["t2"]
+
+    # limit already satisfied: identity out, nothing removed.
+    out, removed = shed_stale_frames(orphaned_front, limit=2)
+    assert removed == 0
+    assert all(a is b for a, b in zip(out, orphaned_front))
+
+
 def test_shed_stale_frames_treats_pruned_notices_as_stale_turns() -> None:
     """The shed operates on TURNS, not on the presence of an image: by the
     time a caller sheds, ``run_compaction_pass`` has already pruned the oldest

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -975,7 +975,46 @@ def test_workspace_content_mutation_changes_digest(tmp_path: Path) -> None:
 def test_exact_record_digest_and_worker_flags(tmp_path: Path) -> None:
     distribution = fake_distribution(tmp_path, [])
     selector = selected(tmp_path, distribution_digest(distribution))
-    assert worker_argv(selector)[1:5] == ("-I", "-s", "-E", "-m")
+    # ``-B`` is load-bearing: the worker's cwd is the pinned workspace, and a
+    # bytecode cache written there by an adapter import is what broke the
+    # first paid episode's rescue (workspace digest drift).
+    assert worker_argv(selector)[1:6] == ("-I", "-s", "-E", "-B", "-m")
+
+
+def test_workspace_digest_ignores_bytecode_caches_by_rule(tmp_path: Path) -> None:
+    """The exact drift from bundle ep-6ea01a117eee: upstream imported
+    ``tasks/task_001.py`` inside the pinned workspace and CPython wrote
+    ``tasks/__pycache__/task_001.cpython-312.pyc``; the rescue worker then
+    refused with "adapter workspace content digest differs". Bytecode is
+    never verified content, so a cache -- standard or legacy-beside-source,
+    planted by any tool -- must leave the digest exactly where it was."""
+
+    base = selected(tmp_path, "a" * 64)
+    workspace = Path(base.workspace)
+    tasks = workspace / "tasks"
+    tasks.mkdir()
+    (tasks / "task_001.py").write_text("MARK = 'source'\n")
+    before = workspace_digest(str(workspace))
+
+    cache = tasks / "__pycache__"
+    cache.mkdir()
+    (cache / "task_001.cpython-312.pyc").write_bytes(b"\x00" * 64)
+    assert workspace_digest(str(workspace)) == before
+
+    (tasks / "task_001.pyc").write_bytes(b"\x00" * 64)
+    assert workspace_digest(str(workspace)) == before
+
+    # The whole cache directory is excluded (nothing imports from it), but it
+    # is still INSPECTED: a symlink planted inside one is refused like any
+    # other. Real content outside the cache still moves the digest.
+    (cache / "stray.py").write_text("x = 1\n")
+    assert workspace_digest(str(workspace)) == before
+    (cache / "task_002.cpython-312.pyc").symlink_to(tasks / "task_001.py")
+    with pytest.raises(AdapterDiscoveryError, match="symlink"):
+        workspace_digest(str(workspace))
+    (cache / "task_002.cpython-312.pyc").unlink()
+    (tasks / "task_002.py").write_text("MARK = 'more'\n")
+    assert workspace_digest(str(workspace)) != before
 
 
 def test_verify_uses_only_selected_distribution(

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -1009,6 +1009,12 @@ def test_workspace_digest_ignores_bytecode_caches_by_rule(tmp_path: Path) -> Non
     # other. Real content outside the cache still moves the digest.
     (cache / "stray.py").write_text("x = 1\n")
     assert workspace_digest(str(workspace)) == before
+    # The exclusion forgives a bytecode FILE, never an entry merely named like
+    # one: a fifo named ``*.pyc`` inside the cache is still unsafe.
+    os.mkfifo(cache / "task_004.cpython-312.pyc")
+    with pytest.raises(AdapterDiscoveryError, match="unsafe"):
+        workspace_digest(str(workspace))
+    os.unlink(cache / "task_004.cpython-312.pyc")
     (cache / "task_002.cpython-312.pyc").symlink_to(tasks / "task_001.py")
     with pytest.raises(AdapterDiscoveryError, match="symlink"):
         workspace_digest(str(workspace))

--- a/tests/unit/evaluation/copied_interpreter.py
+++ b/tests/unit/evaluation/copied_interpreter.py
@@ -54,9 +54,9 @@ REPO_PTH_NAME = "_local_operator_repo.pth"
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 
-# Mirrors the supervisor's spawn flags (``supervisor.py``: ``-I -s -E``) so the
-# probe exercises the same import environment the worker will get.
-_WORKER_FLAGS = ("-I", "-s", "-E")
+# Mirrors the supervisor's spawn flags (``supervisor.py``: ``-I -s -E -B``) so
+# the probe exercises the same import environment the worker will get.
+_WORKER_FLAGS = ("-I", "-s", "-E", "-B")
 
 
 def dependency_roots() -> list[str]:

--- a/tests/unit/evaluation/runner/conftest.py
+++ b/tests/unit/evaluation/runner/conftest.py
@@ -54,6 +54,7 @@ from local_operator.evaluation.receipts import (
 from local_operator.evaluation.runner.episode import EpisodeConfig, EpisodeSpec
 from local_operator.evaluation.runner.model import (
     CompactionRecord,
+    DecisionRejected,
     EpisodeTurn,
     ModelDecision,
     ModelUsage,
@@ -333,6 +334,19 @@ class ScriptedModel:
         if self.error is not None:
             raise self.error
         kind = self.script[self.calls] if self.calls < len(self.script) else "finish"
+        if kind == "reject":
+            # A billed call whose reply failed parsing -- what the provider
+            # client raises for the first paid episode's ``frame_id "1"``.
+            # Counted as a call so the script advances to the corrected reply.
+            self.calls += 1
+            raise DecisionRejected(
+                "Your previous reply was rejected: action references unknown frame_id '1'",
+                route=self.route,
+                usage=ModelUsage(input_tokens=10, output_tokens=5),
+                cost_micros=7,
+                provider_request_id=f"rejected-{self.calls}",
+                prompt_cache_key="lop-eval-test",
+            )
         compaction = None
         if self.calls in self.compact_on:
             compaction = CompactionRecord(

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -735,3 +735,129 @@ async def test_context_unrecoverable_seals_as_a_harness_error_not_a_provider_one
     assert len(errors) == 1
     assert errors[0].category == "adapter"
     assert errors[0].diagnostic_code == "contextunrecoverableerror"
+
+
+# ---------------------------------------------------------------------------
+# Rejected decisions: one bad reply is re-prompted, not fatal; the retry is
+# in the evidence; the bound ends the episode as a MODEL failure.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_one_rejected_decision_is_re_prompted_and_the_corrected_batch_proceeds(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """Bundle ep-6ea01a117eee ended on its first decision (``frame_id '1'``
+    against ``screen``) as a provider failure with $0 spent. A rejected reply
+    is now recorded as a billed attempt with a retryable ``model`` error, the
+    model is asked again for the SAME observation, and the corrected batch
+    runs the episode to a scored, reportable seal."""
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    model = ScriptedModel(["reject", "step", "finish"])
+    runner = _runner(tmp_path, episode_id, adapter=adapter, model=model)
+
+    outcome = await runner.run()
+
+    assert outcome.status == "completed", outcome.diagnostic
+    assert outcome.score is not None and outcome.score.status == "scored"
+    assert outcome.reportability_label == "reportable"
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+    # Three billed calls, three triples: the rejected attempt is not hidden.
+    assert report.counters is not None
+    assert report.counters.model_request_count == 3
+    assert report.counters.model_response_count == 3
+    assert model.calls == 3
+    # The re-prompt was for the same observation: identical history both times.
+    assert model.histories[0] == model.histories[1]
+    errors = payloads(root, ErrorPayload)
+    assert [(e.category, e.diagnostic_code, e.retryable) for e in errors] == [
+        ("model", "decision-rejected", True)
+    ]
+    assert errors[0].detail_artifact is not None
+    # Journal order: the rejected attempt's triple, THEN its error, then the
+    # corrected attempt's triple.
+    kinds = _kinds(root)
+    first_request = kinds.index("model_request")
+    assert kinds[first_request : first_request + 7] == [
+        "model_request",
+        "model_response",
+        "usage_cost",
+        "error",
+        "model_request",
+        "model_response",
+        "usage_cost",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_exhausted_decision_retries_seal_as_a_model_failure(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """After ``max_decision_retries`` corrective re-prompts the model still
+    has not produced a usable batch. That is the agent's failure, so the
+    bundle says ``model`` / ``model_failure`` -- not ``provider`` (nothing was
+    down) and not ``crash`` (nothing broke) -- and every billed attempt is in
+    the evidence."""
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    model = ScriptedModel(["reject", "reject", "reject", "step", "finish"])
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path, max_decision_retries=2),
+        selector=selector(tmp_path),
+        model=model,
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "failed"
+    assert outcome.rescue_required is False
+    assert outcome.score is not None
+    assert outcome.score.status == "unscored"
+    assert outcome.score.reason == "model_failure"
+    assert outcome.reportability_label == "unscored"
+    assert outcome.diagnostic is not None and "3 attempt(s)" in outcome.diagnostic
+    # Exactly the bound plus one: no fourth call.
+    assert model.calls == 3
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+    assert report.counters is not None
+    assert report.counters.model_request_count == 3
+    errors = payloads(root, ErrorPayload)
+    assert [(e.category, e.retryable) for e in errors] == [
+        ("model", True),
+        ("model", True),
+        ("model", True),
+        ("model", False),
+    ]
+    assert errors[-1].diagnostic_code == "modelfailure"
+    # Cleanup ran on the live session: the environment was never at fault.
+    assert "cleanup" in adapter.calls
+
+
+@pytest.mark.asyncio
+async def test_zero_decision_retries_restores_one_strike(tmp_path: Path, episode_id: str) -> None:
+    adapter = FakeAdapter(tmp_path, episode_id)
+    model = ScriptedModel(["reject", "finish"])
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path, max_decision_retries=0),
+        selector=selector(tmp_path),
+        model=model,
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "failed"
+    assert outcome.score is not None and outcome.score.reason == "model_failure"
+    assert model.calls == 1

--- a/tests/unit/evaluation/runner/test_episode_subprocess.py
+++ b/tests/unit/evaluation/runner/test_episode_subprocess.py
@@ -157,11 +157,17 @@ def _maybe_import_workspace_task():
     marker = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tiny_workspace_import")
     if not os.path.exists(marker):
         return
-    path = os.path.join(os.getcwd(), "tasks", "task_001.py")
-    spec = importlib.util.spec_from_file_location("osworld_task_task_001", path)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    assert module.MARK == "source"
+    for relative, expected in (
+        (("tasks", "task_001.py"), "source"),
+        (("tasks", "pkg", "mod.py"), "nested"),
+    ):
+        path = os.path.join(os.getcwd(), *relative)
+        spec = importlib.util.spec_from_file_location(
+            "osworld_task_" + relative[-1].replace(".py", ""), path
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        assert module.MARK == expected
 
 
 # Build the frame list for one observation, publishing real bytes into the root
@@ -406,10 +412,13 @@ def real_selector(tmp_path: Path, adapter_site: Path) -> AdapterSelector:
     (workspace / "adapter-release.json").write_text(
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
-    # A task module in the pinned workspace, as the OSWorld layout has, so a
-    # test can make the worker import from the verified tree.
+    # Task modules in the pinned workspace, as the OSWorld layout has, so a
+    # test can make the worker import from the verified tree. The nested
+    # module proves ``-B`` covers subdirectory caches, not only the top level.
     (workspace / "tasks").mkdir(exist_ok=True)
     (workspace / "tasks" / "task_001.py").write_text("MARK = 'source'\n")
+    (workspace / "tasks" / "pkg").mkdir(exist_ok=True)
+    (workspace / "tasks" / "pkg" / "mod.py").write_text("MARK = 'nested'\n")
     return AdapterSelector(
         schema_version="1.2",
         adapter_id="tiny-runner",

--- a/tests/unit/evaluation/runner/test_episode_subprocess.py
+++ b/tests/unit/evaluation/runner/test_episode_subprocess.py
@@ -145,6 +145,25 @@ def _frame_mode():
         return ""
 
 
+# Whether reset_start should import a task module from the WORKSPACE (the
+# worker's cwd), the way upstream OSWorld's ``instantiate_task`` does. Armed
+# through a file beside the module like the cutpoint. This is the import that
+# left ``tasks/__pycache__/task_001.cpython-312.pyc`` in the first paid
+# episode's pinned workspace and broke its rescue.
+def _maybe_import_workspace_task():
+    import importlib.util
+    import os
+
+    marker = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tiny_workspace_import")
+    if not os.path.exists(marker):
+        return
+    path = os.path.join(os.getcwd(), "tasks", "task_001.py")
+    spec = importlib.util.spec_from_file_location("osworld_task_task_001", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.MARK == "source"
+
+
 # Build the frame list for one observation, publishing real bytes into the root
 # the PARENT supplied on reset_start. The dishonest modes each break exactly one
 # clause of the parent's verification so the refusals cannot pass for each other.
@@ -260,6 +279,7 @@ class TinyAdapter:
 
     async def reset_start(self, params):
         self._maybe_die("reset_start")
+        _maybe_import_workspace_task()
         self.task_id = params.task_id
         self.episode_id = params.episode_id
         self.artifact_root = params.artifact_root
@@ -386,6 +406,10 @@ def real_selector(tmp_path: Path, adapter_site: Path) -> AdapterSelector:
     (workspace / "adapter-release.json").write_text(
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
+    # A task module in the pinned workspace, as the OSWorld layout has, so a
+    # test can make the worker import from the verified tree.
+    (workspace / "tasks").mkdir(exist_ok=True)
+    (workspace / "tasks" / "task_001.py").write_text("MARK = 'source'\n")
     return AdapterSelector(
         schema_version="1.2",
         adapter_id="tiny-runner",
@@ -448,6 +472,14 @@ async def _accepting_rescue(descriptor: Any, **kwargs: Any) -> Any:
         descriptor_id = descriptor.descriptor_id
 
     return _Aggregate()
+
+
+def _arm_workspace_import(site: Path, enabled: bool) -> None:
+    marker = site / "tiny_workspace_import"
+    if enabled:
+        marker.write_text("1")
+    else:
+        marker.unlink(missing_ok=True)
 
 
 def _arm_frames(site: Path, mode: str | None) -> None:
@@ -760,3 +792,40 @@ async def test_worker_cannot_deliver_frames_from_outside_the_root(
         assert report.valid, [issue.code for issue in report.issues]
         assert report.outcome is not None
         assert report.outcome.reportable is False
+
+
+@pytest.mark.asyncio
+async def test_worker_importing_from_the_workspace_leaves_no_bytecode_behind(
+    tmp_path: Path,
+    episode_id: str,
+    real_selector: AdapterSelector,
+    adapter_site: Path,
+) -> None:
+    """The workspace-digest drift from bundle ep-6ea01a117eee, reproduced with
+    a real worker: the adapter imports ``tasks/task_001.py`` from the pinned
+    workspace during ``reset_start``. The worker runs with ``-B`` (and sets
+    ``sys.dont_write_bytecode``), so no ``__pycache__`` may appear under the
+    workspace, and the workspace still hashes to the selector's pin afterwards
+    -- which is what a later rescue re-checks."""
+
+    _arm_cutpoint(adapter_site, None)
+    _arm_workspace_import(adapter_site, True)
+    try:
+        runner = EpisodeRunner(
+            build_spec(episode_id),
+            _subprocess_config(tmp_path),
+            selector=real_selector,
+            model=ScriptedModel(["step", "finish"]),
+            launch=AdapterSupervisor.launch,
+        )
+
+        outcome = await runner.run()
+    finally:
+        _arm_workspace_import(adapter_site, False)
+
+    assert outcome.status == "completed", outcome.diagnostic
+    workspace = Path(real_selector.workspace)
+    caches = [path for path in workspace.rglob("*") if path.name == "__pycache__"]
+    assert caches == [], caches
+    assert not list(workspace.rglob("*.pyc"))
+    assert workspace_digest(str(workspace)) == real_selector.workspace_digest

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -29,7 +29,7 @@ from local_operator.evaluation.protocol import (
     Observation,
     TypeAction,
 )
-from local_operator.evaluation.runner.model import EpisodeTurn
+from local_operator.evaluation.runner.model import DecisionRejected, EpisodeTurn
 from local_operator.evaluation.runner.provider_client import (
     DecisionParseError,
     ProviderModelClient,
@@ -370,13 +370,177 @@ async def test_client_reports_the_provider_stop_reason() -> None:
 
 @pytest.mark.asyncio
 async def test_client_raises_on_an_unparseable_reply() -> None:
-    """The runner converts this to a provider failure, so it must surface."""
+    """An unusable reply is a billed MODEL error, surfaced as ``DecisionRejected``
+    with the call's provenance so the runner can record the attempt and
+    re-prompt -- never a provider failure, and never silently swallowed."""
 
     current = observation()
-    stream = ScriptedStream("I'm afraid I can't do that.")
+    stream = ScriptedStream(
+        "I'm afraid I can't do that.",
+        usage=Usage(input_tokens=11, output_tokens=7, usd_cost=0.002),
+        provider_payload={"id": "chatcmpl-REJ"},
+    )
 
-    with pytest.raises(DecisionParseError):
+    with pytest.raises(DecisionRejected) as info:
         await _client(stream).decide(current, _turns(current))
+
+    rejected = info.value
+    assert isinstance(rejected.__cause__, DecisionParseError)
+    assert rejected.usage.input_tokens == 11 and rejected.usage.output_tokens == 7
+    assert rejected.cost_micros == 2000
+    assert rejected.provider_request_id == "chatcmpl-REJ"
+    assert rejected.route == ROUTE
+    assert rejected.diagnostic.startswith("Your previous reply was rejected:")
+
+
+# ---------------------------------------------------------------------------
+# Frame-id contract: the model is told which frame ids exist, and a wrong one
+# is fed back rather than ending the episode (the first paid OSWorld episode).
+# ---------------------------------------------------------------------------
+
+
+def _click_payload(current: Observation, frame_id: str, x: int = 0, y: int = 0) -> str:
+    return json.dumps(
+        {
+            "actions": [
+                {
+                    "kind": "click",
+                    "observation_id": current.observation_id,
+                    "frame_id": frame_id,
+                    "x": x,
+                    "y": y,
+                }
+            ]
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_rendered_observation_names_its_frame_ids_and_geometry(tmp_path: Path) -> None:
+    """The adapter chooses the frame ids (OSWorld: ``screen``; here: ``frame-N``)
+    and ``validate_for`` refuses any other, so the rendered text MUST list them.
+    The first paid episode's model was never told and guessed ``"1"``."""
+
+    stream = RecordingStream(_wait_reply)
+    client = _client(stream, tmp_path)
+    current = _framed_observation(tmp_path, 4)
+
+    await client.decide(current, _turns(current))
+
+    text = stream.requests[0].messages[0].content[0].text
+    assert "Frames: frame-4 (1x1)" in text
+    # The system prompt states the constraint the observation line serves.
+    prompt = stream.requests[0].system_blocks[0]
+    assert '"Frames:"' in prompt
+    assert "MUST use one of the ids named on the CURRENT observation" in prompt
+
+
+@pytest.mark.asyncio
+async def test_frameless_observation_renders_no_frames_rather_than_nothing() -> None:
+    current = observation()
+    stream = ScriptedStream(finish_payload(current))
+
+    await _client(stream).decide(current, _turns(current))
+
+    assert "Frames: none" in stream.requests[0].messages[0].content[0].text
+
+
+@pytest.mark.asyncio
+async def test_unknown_frame_id_is_fed_back_and_the_corrected_reply_proceeds(
+    tmp_path: Path,
+) -> None:
+    """The exact defect from bundle ep-6ea01a117eee: ``frame_id "1"`` against a
+    published ``frame-0``. The first call raises ``DecisionRejected``; the
+    client has ALREADY appended the bad reply and a correction naming the
+    valid ids, so the runner's re-call for the same observation is corrective
+    and the corrected click parses."""
+
+    current = _framed_observation(tmp_path, 0)
+    replies = iter([_click_payload(current, "1"), _click_payload(current, "frame-0")])
+    stream = RecordingStream(lambda _message: next(replies))
+    client = _client(stream, tmp_path)
+    history = _turns(current)
+
+    with pytest.raises(DecisionRejected) as info:
+        await client.decide(current, history)
+    assert "unknown frame_id '1'" in info.value.diagnostic
+
+    decision = await client.decide(current, history)
+
+    assert decision.action_batch.actions[0].frame_id == "frame-0"  # type: ignore[union-attr]
+    # The retry request is the original observation, the model's own bad
+    # reply, then the correction -- appended, never rewritten.
+    retry = stream.requests[1]
+    assert _shape(retry) == [
+        ("user", ("text", "image")),
+        ("assistant", ("text",)),
+        ("user", ("text",)),
+    ]
+    assert retry.messages[0] is stream.requests[0].messages[0]
+    assert json.loads(retry.messages[1].content[0].text)["actions"][0]["frame_id"] == "1"
+    correction = retry.messages[2].content[0].text
+    assert correction.startswith("Your previous reply was rejected:")
+    assert "Frames: frame-0 (1x1)" in correction
+    assert current.observation_id in correction
+
+
+@pytest.mark.asyncio
+async def test_a_corrected_turn_closes_after_the_correction_in_the_next_request(
+    tmp_path: Path,
+) -> None:
+    """Once the runner closes the corrected turn, the accepted batch is
+    replayed AFTER the rejection pair, so the conversation reads as it
+    happened and the sent prefix is still reused by identity."""
+
+    first = _framed_observation(tmp_path, 0)
+    second = _framed_observation(tmp_path, 1)
+    replies = iter(
+        [
+            _click_payload(first, "nope"),
+            _click_payload(first, "frame-0"),
+            _click_payload(second, "frame-1"),
+        ]
+    )
+    stream = RecordingStream(lambda _message: next(replies))
+    client = _client(stream, tmp_path)
+
+    history = [EpisodeTurn(observation=first)]
+    with pytest.raises(DecisionRejected):
+        await client.decide(first, tuple(history))
+    decision = await client.decide(first, tuple(history))
+    history[-1] = history[-1].model_copy(update={"batch": decision.action_batch})
+    history.append(EpisodeTurn(observation=second))
+    await client.decide(second, tuple(history))
+
+    third = stream.requests[2]
+    assert _shape(third) == [
+        ("user", ("text", "image")),
+        ("assistant", ("text",)),
+        ("user", ("text",)),
+        ("assistant", ("text",)),
+        ("user", ("text", "image")),
+    ]
+    assert json.loads(third.messages[3].content[0].text)["actions"][0]["frame_id"] == "frame-0"
+    assert all(a is b for a, b in zip(stream.requests[1].messages, third.messages))
+
+
+@pytest.mark.asyncio
+async def test_a_runaway_rejected_reply_is_replayed_truncated(tmp_path: Path) -> None:
+    from local_operator.evaluation.runner.provider_client import (
+        MAX_REJECTED_REPLY_CHARS,
+    )
+
+    current = _framed_observation(tmp_path, 0)
+    stream = RecordingStream("x" * (MAX_REJECTED_REPLY_CHARS * 3))
+    client = _client(stream, tmp_path)
+
+    with pytest.raises(DecisionRejected):
+        await client.decide(current, _turns(current))
+
+    block = client._context.messages[1].content[0]
+    assert isinstance(block, TextContent)
+    assert len(block.text) < MAX_REJECTED_REPLY_CHARS + 64
+    assert block.text.endswith("[... reply truncated]")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two defects found by the **first real paid OSWorld episode** — run root `~/worktrees/osworld/runs/proof-20260902-081937`, bundle `evidence/ep-6ea01a117eee` — fixed at the source, each proven by mutation. Patch bump → 0.44.32.

**No AWS call and no spend in this PR.** Every test here uses the in-process fake adapter or a real spawned worker with the fake provider.

**The AWS side of that episode WORKED.** The instance launched, the TTL schedule was created and later deleted, the instance was terminated, and the post-episode tag audit printed `[]`. The bundle's `cleanup` event carries three receipts (close-session, release-instance, revoke-ttl-lease) and its `rescue.json` is still in the inbox only because of defect 2 below — the rescue re-check refused, not the teardown.

## Reproduction (from the bundle, read-only)

`outcome.json`:
```
"status": "failed", "reportability_label": "cleanup_incomplete", "rescue_required": true, "rescue_complete": false,
"score": {"status": "unscored", "reason": "infrastructure_failure"},
"diagnostic": "_ProviderFailure: DecisionParseError: decision does not match this observation: action references unknown frame_id '1'"
```
`events.jsonl`: `observation` (sequence 0, one 1920x1080 PNG frame, instruction text) → `error {category: "provider", diagnostic_code: "providerfailure", retryable: false}` → finalization → cleanup. **Zero `model_request` events**: the one billed call was never recorded, and the episode ended on its first decision.

The rescue worker's refusal: `adapter workspace content digest differs`, because `~/worktrees/osworld/workspaces/0.1.0/workspace/tasks/__pycache__/task_001.cpython-312.pyc` now exists — written by upstream `instantiate_task` importing the task module from the pinned workspace during `reset_start`. That file is still there.

## Defect 1 — the model was never told which frame ids exist (runner, general)

The adapter publishes its frame as `frame_id="screen"`; the model answered `frame_id "1"`; `ActionBatch.validate_for` rejected it; the runner filed the `DecisionParseError` as `_ProviderFailure`. Nothing in the prompt or the rendered observation listed the ids.

- **Rendered observation** now carries `Frames: screen (1920x1080)` (or `Frames: none`) — every frame's id and model-visible geometry, in order. Any adapter naming works; nothing special-cases `screen`.
- **System prompt** states that `frame_id` MUST be one of the ids on the current observation's `Frames:` line and what a rejection message looks like.
- **A rejected reply is a MODEL error and is re-prompted.** `DecisionRejected` (new, `runner/model.py`) is raised by the client instead of a decision when a billed reply fails strict parsing; it carries the call's full billing provenance. The client has already appended the bad reply and a correction (naming the observation id and the frame ids) to its append-only history, so the runner's re-call for the same observation is corrective by construction. `EpisodeRunner._decide` retries up to `EpisodeConfig.max_decision_retries` (default 2; `0` = old one-strike). **Every attempt writes its own `model_request`/`model_response`/`usage_cost` triple** and counts as a model cycle; a rejected attempt also writes a retryable `error` (`category="model"`, `diagnostic_code="decision-rejected"`, the shown diagnostic as its detail artifact).
- **Exhausting the bound** seals as `_ModelFailure`: `category="model"`, `reason="model_failure"`, `failure_kind="model"` — new literals on `ErrorPayload`, `UnscoredReason` and the lifecycle payloads, distinct from `provider` (nothing was down) and `crash` (nothing broke).
- **Shed regression this exposed** (`compaction/pruning.py`): `shed_stale_frames` removed observation/reply *pairs* and stopped when the tail's front was not an observation. A corrected turn is four messages and the compaction cut can land on a reply or a correction, so the tail could start with an orphaned turn end; the shed then removed nothing for the rest of the episode and the client refused as unrecoverable with sheddable turns still present (the existing 48-turn drive failed at turn 24 once the `Frames:` line nudged the cut). A turn is now its observation plus everything up to the next observation; an orphaned front is shed first; the current observation is still never removed.

## Defect 2 — bytecode cache invalidated the workspace pin (boundary)

- Worker (`discovery.worker_argv`) and supervisor leader (`AdapterSupervisor.launch`) are spawned with **`-B`**; `worker.main` sets `sys.dont_write_bytecode` as the in-process guarantee. The copied-interpreter probe mirrors the flag set.
- `workspace_digest` **excludes `__pycache__/` and every `BYTECODE_SUFFIXES` file by rule** (`_is_bytecode_cache`). Bytecode is never verified content — the finder already refuses to load any `.pyc`, RECORD-covered or not — so a cache from any tool can never invalidate a pin. The cache directory is still inspected: a symlink inside one is refused like any other.
- `release_digest` / `package_digest` have no such exposure: one JSON file, and RECORD rows respectively (a `.pyc` would have to be an explicit row the wheel declared).
- README: the sweep section now says why the sweep takes no `--region` (each descriptor carries the episode's `AWS_REGION`; the audit has no descriptor) and what the digest re-check does and does not count. PROOF_PLAN and README agree.

**Effect on the stranded descriptor — and a second drift source found while checking.** Re-hashing the real workspace with this branch gives `b6b4f0f4…`, NOT the pin (`89a78cdf…`). The `__pycache__` is now ignored, but the same episode also wrote `workspace/cache/001/{…_calendar.ics, …_thunderbird-profile.tar.gz}` (mtime 08:21:38): upstream `DesktopEnv(cache_dir="cache")` is a **relative** path resolved against the worker's cwd, which is the pinned workspace, and the setup controller downloads task assets there. Verified by copying the workspace under a durable path and removing only `cache/`: the digest is `89a78cdf…` again, with or without the `.pyc`. Those files are real content, not bytecode, and the digest must NOT learn to ignore arbitrary directories — the fix is adapter-side: pass an absolute `cache_dir` outside the workspace to `DesktopEnv` (e.g. under the artifact root). **Reviewer's caveat (round 1), accepted:** upstream `desktop_env.py:367` calls `setup_controller.reset_cache_dir(self.cache_dir)`, which DELETES the cache directory between resets, so the absolute path must be **per-episode**, not a shared global cache, unless cross-episode asset reuse is explicitly wanted and the deletion is understood. That means a new adapter wheel and workspace rebuild. **Not in this PR** (the slice is the runner and the boundary). For the stranded descriptor the README's new sweep text already gives the path: restore the workspace from the verified inputs root (delete `cache/` and `tasks/__pycache__`), then sweep. Not run here (no AWS calls).

## Tests and mutation proof

All gates run over the whole tree as CI does: `flake8` clean, `black==26.1.0` 799 unchanged, `isort==5.13.2` clean, `pyright` 0 errors (adapter wheel not installed in the venv).

Suites: `tests/unit/evaluation/runner + evidence + protocol + lifecycle + compaction` → **638 passed**; `tests/unit/evaluation/adapters` → **235 passed ×3 in parallel** (35 s each) and **235 passed serial** (`-n0`, 86 s); the rest of `tests/unit` (minus tui) → 5541 passed.

| Mutation | Failing tests |
|---|---|
| drop the `Frames:` line from the renderer | `test_rendered_observation_names_its_frame_ids_and_geometry`, `test_frameless_observation_renders_no_frames_rather_than_nothing` |
| don't fold the rejection into the context | `test_unknown_frame_id_is_fed_back_and_the_corrected_reply_proceeds`, `test_a_corrected_turn_closes_after_the_correction_in_the_next_request`, `test_a_runaway_rejected_reply_is_replayed_truncated` |
| runner never retries (`rejections >= 1`) | `test_one_rejected_decision_is_re_prompted_and_the_corrected_batch_proceeds` (`'failed' == 'completed'`) |
| file `_ModelFailure` as provider | `test_exhausted_decision_retries_seal_as_a_model_failure`, `test_zero_decision_retries_restores_one_strike` |
| old `shed_stale_frames` (pairs) | `test_shed_stale_frames_sheds_a_whole_turn_and_an_orphaned_turn_end`, `test_shed_actually_sheds_and_a_mid_size_window_runs_to_the_end` |
| remove `-B` from both argv AND `dont_write_bytecode` | `test_worker_importing_from_the_workspace_leaves_no_bytecode_behind` (real spawn: `tasks/__pycache__` appeared) |
| remove only one of the two | still passes — the belt-and-braces point |
| digest walk includes bytecode | `test_workspace_digest_ignores_bytecode_caches_by_rule` |

New runner test `test_one_rejected_decision_is_re_prompted…` asserts the journal order `model_request, model_response, usage_cost, error, model_request, model_response, usage_cost` and that the model saw the identical history both times; `test_exhausted_decision_retries…` asserts exactly `max_decision_retries + 1` calls and four `model` errors (three retryable, one terminal).

`uv build` → `local_operator-0.44.32-py3-none-any.whl` + sdist; `twine check` PASSED on both.

## Not addressed (deliberately)

- **Adapter writes OSWorld's asset cache into the pinned workspace** (`DesktopEnv(cache_dir="cache")`, relative to cwd). This is the second, non-bytecode drift source above; the fix is an adapter wheel change (per-episode absolute `cache_dir` outside the workspace — upstream `reset_cache_dir` deletes it between resets) and a workspace rebuild. Without it the next paid episode's rescue re-check will drift again on any task with downloadable assets.
- The stranded `rescue.json` for `ep-6ea01a117eee` is not swept here (that is an AWS call); the workspace must first be restored (drop `cache/` and `tasks/__pycache__`).
- `max_decision_retries` is not exposed on `scripts/run_episode.py`'s CLI; the default (2) applies to the next paid run.
