### PR TITLE
fix(benchmarks): route OSWorld episode cache outside the pinned workspace

### DIFF
--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -274,13 +274,32 @@ refused even though the instance was already terminated. The adapter now hands
 `DesktopEnv` an ABSOLUTE, per-episode cache root at
 `<artifact_root>/../osworld-cache/<episode_id>` — beside the artifact root, not
 inside it (the bundle verifier walks the artifact directory and refuses any
-non-digest entry), and per-episode because upstream's `reset_cache_dir`
-replaces/deletes the cache wholesale between resets, so two episodes sharing a
-task id must never share a cache. The cache root is durable (the parent refuses
-a run root under /tmp) and is minted at `reset_start`, never in `prepare`.
-Upstream's few cwd-RELATIVE metric writes (`temp.pdf`, `temp_extracted_N.jpeg`,
-epub `<name>.dir`) are sealed at the env instance: an open-for-write that
-resolves inside the workspace raises rather than silently corrupting the pin.
+non-digest entry), and per-episode so two episodes running the same task never
+share a cache — upstream's `reset_cache_dir` only reassigns the attribute
+(`controllers/setup.py:55-56`) and clears nothing, so the isolation has to come
+from the path. The cache root is durable (it is a sibling under the run root,
+which `run_episode.py` puts through `refuse_volatile_root`, so it can never be
+`/tmp`) and is minted at `reset_start`, never in `prepare`.
+
+**The episode's cache root is also its working directory.** Routing `cache_dir`
+fixes the one write path we observed; it does not fix the class. Several
+upstream helpers open a hard-coded RELATIVE name with the builtin `open` at
+module scope — `temp.pdf` (`evaluators/metrics/vscode.py:210`),
+`temp_extracted_<n>.jpeg` (`slides.py:2051`), an epub's `<name>.dir`
+(`others.py:64-72`) — and they never consult the env object, so no attribute
+the adapter installs on it can intercept them. Since a relative write resolves
+against the cwd, `reset_start` moves the worker's cwd to the episode cache root
+and `close` puts it back. Any relative write by any upstream path, known or
+not, therefore lands in the episode's scratch dir rather than the pin. This is
+safe because the workspace is never reached via the cwd: `instantiate_task`
+loads task modules by absolute location, the worker runs with `-I` so the cwd
+is not on `sys.path`, and both the worker's digest re-check and the rescue
+sweep hash `selector.workspace`, an absolute path.
+
+If a future upstream path still manages to write into the workspace, the
+digest re-check is what surfaces it: the worker (and `sweep-rescue`) refuse
+with `adapter workspace content digest differs`. Restore the workspace from
+the verified inputs root and sweep again.
 
 ## Leak audit (operator command)
 

--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -53,27 +53,32 @@ live root against it at every `reset_start`.
 ```sh
 cd benchmarks/osworld_v2_adapter
 
-# 1. lock (in the source tree)
-uv lock                                     # writes uv.lock (committed)
+# 1. lock (in the source tree). The committed uv.lock pins the harness; bump
+#    it so the locked local-operator is not the stale 0.44.26 (which predates
+#    schema 1.2 the worker speaks).
+uv lock --upgrade-package local-operator   # writes uv.lock (committed)
 
 # 2. build the wheel
 uv build --wheel --out-dir dist/
 
 # 3. create the dedicated interpreter + install the locked set.
-#    --copies is REQUIRED: python_executable must be a real file, not a
-#    symlink (discovery._symlink_free).
-uv venv --python 3.12 --copies /opt/lop-adapters/osworld-v2/0.1.0/venv
-uv pip install --python /opt/lop-adapters/osworld-v2/0.1.0/venv/bin/python \
-    --no-deps dist/lop_osworld_v2_adapter-0.1.0-py3-none-any.whl
-uv pip install --python /opt/lop-adapters/osworld-v2/0.1.0/venv/bin/python \
+#    --copies is REQUIRED (python_executable must be a real file, not a
+#    symlink — discovery._symlink_free), but current uv's `venv` has NO
+#    `--copies` flag (that is uv pip's install link-mode). Use the stdlib
+#    venv, which DOES copy. `--without-pip` because uv pip installs the rest
+#    and the uv-managed interpreter's ensurepip can SIGABRT on macOS.
+python3.12 -m venv --copies --without-pip /opt/lop-adapters/osworld-v2/0.1.1/venv
+uv pip install --python /opt/lop-adapters/osworld-v2/0.1.1/venv/bin/python \
+    --no-deps dist/lop_osworld_v2_adapter-0.1.1-py3-none-any.whl
+uv pip install --python /opt/lop-adapters/osworld-v2/0.1.1/venv/bin/python \
     -r <(uv export --frozen --no-emit-project)
-uv pip install --python /opt/lop-adapters/osworld-v2/0.1.0/venv/bin/python \
+uv pip install --python /opt/lop-adapters/osworld-v2/0.1.1/venv/bin/python \
     local-operator==<harness version>
 
 # 3b. for the PAID path only: OSWorld itself is an extra (~380 packages) that
 #     the cloud-free wheel does not need. Install it into the same venv.
-uv pip install --python /opt/lop-adapters/osworld-v2/0.1.0/venv/bin/python \
-    "lop-osworld-v2-adapter[osworld] @ dist/lop_osworld_v2_adapter-0.1.0-py3-none-any.whl"
+uv pip install --python /opt/lop-adapters/osworld-v2/0.1.1/venv/bin/python \
+    "lop-osworld-v2-adapter[osworld] @ dist/lop_osworld_v2_adapter-0.1.1-py3-none-any.whl"
 
 # 4. materialise the workspace from the verified inputs root (no download;
 #    writes adapter-release.json, benchmark_release.json, task_hashes.json,
@@ -82,7 +87,7 @@ python ~/local-operator/scripts/build_osworld_adapter.py \
     --benchmark-release osworld-v2-2026.08.08 \
     --inputs-root ~/worktrees/osworld \
     --package-digest <package_digest from step 5> \
-    --out ~/worktrees/osworld/workspaces/0.1.0
+    --out ~/worktrees/osworld/workspaces/0.1.1
 
 # 5. compute the three digests the AdapterSelector needs
 python - <<'PY'
@@ -91,7 +96,7 @@ from local_operator.evaluation.adapters.discovery import (
     distribution_digest, workspace_digest,
 )
 print("package_digest  ", distribution_digest(PathDistribution(<dist-info path>)))
-print("workspace_digest", workspace_digest("/opt/lop-adapters/osworld-v2/0.1.0/workspace"))
+print("workspace_digest", workspace_digest("/opt/lop-adapters/osworld-v2/0.1.1/workspace"))
 PY
 ```
 
@@ -180,7 +185,7 @@ episode needs no environment variables at all:
 
 ```sh
 python ~/local-operator/scripts/run_episode.py \
-    --selector ~/worktrees/osworld/workspaces/0.1.0/selector.json \
+    --selector ~/worktrees/osworld/workspaces/0.1.1/selector.json \
     --task-id task_001 \
     --route openrouter/deepseek/deepseek-v4-flash-vision-exp \
     --run-root ~/worktrees/osworld/runs/$(date +%Y%m%d-%H%M%S) \
@@ -259,6 +264,23 @@ first paid episode the cache that import left behind made the sweep refuse
 fact already terminated. Anything else that changes under the workspace is a
 genuine drift and the sweep will (rightly) refuse; restore the workspace from
 the verified inputs root and sweep again.
+
+**Upstream's cache lives OUTSIDE the workspace for the same reason.**
+`DesktopEnv`'s default `cache_dir="cache"` is resolved against the worker's
+cwd — and the cwd IS the pinned workspace. The first paid episode's
+`_download_setup` wrote `cache/001/…calendar.ics` and `…thunderbird-profile.tar.gz`
+there, which the digest (correctly) does NOT ignore, so the rescue sweep
+refused even though the instance was already terminated. The adapter now hands
+`DesktopEnv` an ABSOLUTE, per-episode cache root at
+`<artifact_root>/../osworld-cache/<episode_id>` — beside the artifact root, not
+inside it (the bundle verifier walks the artifact directory and refuses any
+non-digest entry), and per-episode because upstream's `reset_cache_dir`
+replaces/deletes the cache wholesale between resets, so two episodes sharing a
+task id must never share a cache. The cache root is durable (the parent refuses
+a run root under /tmp) and is minted at `reset_start`, never in `prepare`.
+Upstream's few cwd-RELATIVE metric writes (`temp.pdf`, `temp_extracted_N.jpeg`,
+epub `<name>.dir`) are sealed at the env instance: an open-for-write that
+resolves inside the workspace raises rather than silently corrupting the pin.
 
 ## Leak audit (operator command)
 

--- a/benchmarks/osworld_v2_adapter/pyproject.toml
+++ b/benchmarks/osworld_v2_adapter/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lop-osworld-v2-adapter"
-version = "0.1.0"
+version = "0.1.1"
 description = "OSWorld 2.0 evaluation adapter for local-operator"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
@@ -87,7 +87,7 @@ from local_operator.evaluation.adapters.discovery import (
 
 _DISTRIBUTION = "lop-osworld-v2-adapter"
 _ADAPTER_ID = "osworld-v2"
-_VERSION = "0.1.0"
+_VERSION = "0.1.1"
 _ENTRY_POINT = "lop_osworld_v2_adapter:create"
 
 
@@ -131,6 +131,40 @@ class InputsMismatch(RuntimeError):
 _JUDGE_KEY = "OSWORLD_EVAL_MODEL_API_KEY"
 _USER_SIM_KEY = "OSWORLD_USER_SIM_API_KEY"
 _DEFAULT_INPUTS_ROOT = "~/worktrees/osworld"
+
+
+def _episode_cache_root(artifact_root: Path, episode_id: str) -> Path:
+    """Where an episode's upstream writes live: an ABSOLUTE dir OUTSIDE the
+    digest-pinned workspace.
+
+    Upstream OSWorld defaults ``cache_dir="cache"``, which ``DesktopEnv``
+    resolves against the process cwd — and the worker's cwd IS the pinned
+    workspace (supervisor spawns with ``cwd=selector.workspace``). The first
+    paid episode's ``_download_setup`` therefore wrote
+    ``workspace/cache/001/…`` — real content that the workspace digest
+    correctly refused to ignore, so the rescue worker's digest re-check
+    failed and ``rescue_required`` wedged True for an instance that was in
+    fact terminated.
+
+    The cache cannot be shared across episodes: ``DesktopEnv`` derives
+    ``cache_dir/<task_id>`` from this base, and ``reset_cache_dir``
+    REPLACES its contents wholesale at every ``reset`` — a second episode
+    with the same task would read a cached upload belonging to the first.
+    So the root is per-episode, and it sits BESIDE the artifact root, not
+    inside it: the bundle verifier walks the artifact directory and refuses
+    any entry that is not a digest-named artifact. The parent owns the
+    artifact root's parent (the run root, which ``run_episode`` refuses to
+    place under /tmp), so a sibling is durable and episode-owned.
+    """
+
+    # ``..`` is one segment of a directory that never becomes a filesystem
+    # PATH: the artifact root itself is absolute (the ArtifactRoot validator
+    # rejects relative and non-normalized roots), so parent.joinpath lands
+    # inside it directly. The worker never stores or re-parses this string —
+    # it is handed straight to DesktopEnv and mkdir'd here.
+    root = artifact_root.parent / "osworld-cache" / episode_id
+    root.mkdir(parents=True, exist_ok=True)
+    return root
 
 
 def _terminate_status(code: str) -> str:
@@ -384,7 +418,11 @@ class OSWorldV2Adapter:
         self._install_judge_environment()
 
         provider = self._build_provider()
-        await provider.allocate(self._plan, self._task)
+        # The cache root exists BEFORE allocate so a provider that downloads
+        # during setup (upstream's reset already runs inside allocate) writes
+        # into it, not into the workspace.
+        cache_root = _episode_cache_root(Path(params.artifact_root), params.episode_id)
+        await provider.allocate(self._plan, self._task, cache_root=cache_root)
         self._provider = provider
 
         # Capture observation 0 eagerly so the runner's immediately-following
@@ -397,6 +435,7 @@ class OSWorldV2Adapter:
         # reset whose root differs from the one its verifier reads, so writing
         # exactly here is what makes a frame verifiable rather than a guess.
         self._observation_builder = ObservationBuilder(Path(params.artifact_root))
+        raw = await provider.observe()
         raw = await provider.observe()
         self._sequence = 0
         self._current_observation = self._observation_builder.build(

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
@@ -436,7 +436,6 @@ class OSWorldV2Adapter:
         # exactly here is what makes a frame verifiable rather than a guess.
         self._observation_builder = ObservationBuilder(Path(params.artifact_root))
         raw = await provider.observe()
-        raw = await provider.observe()
         self._sequence = 0
         self._current_observation = self._observation_builder.build(
             raw,

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
@@ -147,14 +147,20 @@ def _episode_cache_root(artifact_root: Path, episode_id: str) -> Path:
     fact terminated.
 
     The cache cannot be shared across episodes: ``DesktopEnv`` derives
-    ``cache_dir/<task_id>`` from this base, and ``reset_cache_dir``
-    REPLACES its contents wholesale at every ``reset`` — a second episode
-    with the same task would read a cached upload belonging to the first.
+    ``cache_dir/<task_id>`` from this base, so two episodes running the same
+    task would otherwise read each other's cached uploads. (Upstream's
+    ``reset_cache_dir`` only REASSIGNS the attribute
+    (``controllers/setup.py:55-56``) — it deletes nothing — so isolation has
+    to come from the path being per-episode, not from upstream clearing it.)
     So the root is per-episode, and it sits BESIDE the artifact root, not
     inside it: the bundle verifier walks the artifact directory and refuses
     any entry that is not a digest-named artifact. The parent owns the
     artifact root's parent (the run root, which ``run_episode`` refuses to
     place under /tmp), so a sibling is durable and episode-owned.
+
+    This root is also the episode's WORKING DIRECTORY (see
+    ``_enter_episode_scratch``), which is what makes the guarantee hold for
+    upstream write paths nobody has enumerated.
     """
 
     # ``..`` is one segment of a directory that never becomes a filesystem
@@ -165,6 +171,45 @@ def _episode_cache_root(artifact_root: Path, episode_id: str) -> Path:
     root = artifact_root.parent / "osworld-cache" / episode_id
     root.mkdir(parents=True, exist_ok=True)
     return root
+
+
+def _enter_episode_scratch(scratch: Path) -> None:
+    """Move the worker's cwd OFF the pinned workspace for the episode.
+
+    Routing ``cache_dir`` fixes the one upstream write path we observed. It
+    does not fix the class. Several upstream helpers open a HARD-CODED
+    RELATIVE name with the builtin ``open`` at module scope — ``temp.pdf``
+    (``evaluators/metrics/vscode.py:210``), ``temp_extracted_<n>.jpeg``
+    (``slides.py:2051``), an epub's ``<name>.dir`` (``others.py:64-72``) —
+    and they never consult the env object, so no attribute we install on it
+    can intercept them. A relative write resolves against the CWD, and the
+    supervisor spawns the worker with ``cwd=selector.workspace``
+    (``supervisor.py:279``), so every one of them lands in the digest-pinned
+    workspace and re-wedges rescue exactly as the cache download did.
+
+    Changing the cwd removes the exposure at its root rather than guessing
+    at call sites: any relative write by any upstream path, known or not,
+    now lands in the episode's own scratch directory. That is a guarantee by
+    CONSTRUCTION, which is why it is preferred over intercepting ``open``.
+
+    Three things make this safe, each verified rather than assumed:
+
+    * The workspace stays importable. ``instantiate_task`` loads task
+      modules by absolute LOCATION (``vendor_bridge.instantiate_task`` uses
+      ``spec_from_file_location`` against ``self._workspace_root``), never
+      by ``sys.path``, and the worker runs with ``-I`` so the cwd is not on
+      ``sys.path`` in the first place.
+    * The digest pin is still verified from the SELECTOR path. Both the
+      worker's re-check and the rescue sweep call
+      ``workspace_digest(selector.workspace)`` — an absolute path
+      (``worker.py:68-72``) — so it is unaffected by the cwd.
+    * The adapter's own two cwd reads (``_workspace_root`` default and
+      ``_release_digest``) both happen in ``__init__``, at ``create()`` /
+      handshake time, strictly before ``reset_start`` runs. Moving the cwd
+      afterwards cannot change what they already resolved.
+    """
+
+    os.chdir(scratch)
 
 
 def _terminate_status(code: str) -> str:
@@ -220,6 +265,12 @@ class OSWorldV2Adapter:
         # Defaulted to the worker's cwd, which the supervisor sets to the
         # workspace (supervisor.py:270).
         self._workspace_root = workspace_root or Path(os.getcwd())
+        # The cwd as it was at construction (the pinned workspace, in
+        # production). ``reset_start`` moves the process into the episode
+        # scratch dir; ``close`` puts it back, so a worker reused across
+        # episodes — and any later relative path — starts from the same
+        # place the supervisor spawned it in.
+        self._entry_cwd = Path(os.getcwd())
         self.metadata = AdapterMetadata(
             adapter_id=_ADAPTER_ID,
             distribution=_DISTRIBUTION,
@@ -420,8 +471,11 @@ class OSWorldV2Adapter:
         provider = self._build_provider()
         # The cache root exists BEFORE allocate so a provider that downloads
         # during setup (upstream's reset already runs inside allocate) writes
-        # into it, not into the workspace.
+        # into it, not into the workspace. The cwd moves there too, in the
+        # same breath and for the same reason: allocate is where upstream
+        # first runs, so a relative write is possible from that call onward.
         cache_root = _episode_cache_root(Path(params.artifact_root), params.episode_id)
+        _enter_episode_scratch(cache_root)
         await provider.allocate(self._plan, self._task, cache_root=cache_root)
         self._provider = provider
 
@@ -762,6 +816,13 @@ class OSWorldV2Adapter:
         # Must not raise even if the env is already dead. The judge key is
         # scrubbed from the worker env here, the only place it was written.
         vendor_bridge.scrub_secret_environment()
+        # Restore the cwd reset_start moved off the workspace. Best-effort:
+        # close must not raise, and a scratch dir that vanished under us is
+        # not a reason to fail teardown — the episode is over either way.
+        try:
+            os.chdir(self._entry_cwd)
+        except OSError:
+            pass
         self._secrets = {}
         self._provider = None
         self._current_observation = None

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
@@ -47,6 +47,7 @@ import os
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Callable
 
 from lop_osworld_v2_adapter import scoring
@@ -299,6 +300,10 @@ class AwsProvider:
         self._instance_id: str | None = None
         self._public_ip: str | None = None
         self._env: Any = None
+        # The episode-scoped, absolute, workspace-external cache root the
+        # adapter mints in reset_start. None until allocate; a rescue
+        # (teardown-only) provider never allocates and never needs one.
+        self._cache_root: Path | None = None
         self._schedule_created = False
 
     @classmethod
@@ -323,7 +328,19 @@ class AwsProvider:
     # allocate
     # ------------------------------------------------------------------
 
-    async def allocate(self, plan: ProvisioningPlan, task: TaskDescriptor) -> None:
+    async def allocate(
+        self, plan: ProvisioningPlan, task: TaskDescriptor, *, cache_root: Path | None
+    ) -> None:
+        if cache_root is None:
+            # The whole point of the cache root is that upstream's writes
+            # land OUTSIDE the pinned workspace. Constructing a DesktopEnv
+            # without one re-opens the digest-break defect (the cwd IS the
+            # workspace), so refusing loudly beats defaulting to cwd.
+            raise AllocationError(
+                "allocate needs the adapter's episode cache root (cache_root); "
+                "without it upstream writes land in the digest-pinned workspace"
+            )
+        self._cache_root = cache_root
         if plan.region != self._region:
             raise AllocationError(
                 f"plan region {plan.region!r} differs from provider region {self._region!r}"
@@ -502,6 +519,13 @@ class AwsProvider:
             # allocation (desktop_env.py:110-113) and adopt ours.
             path_to_vm=self._instance_id,
             snapshot_name=plan.ami_id,
+            # THE FIX for the rescue-wedge defect: upstream's default is
+            # cache_dir="cache", resolved against the cwd — and the worker's
+            # cwd IS the digest-pinned workspace. Routing the base under the
+            # episode's owned root (absolute, outside the workspace) keeps
+            # _download_setup / reset_cache_dir / getter downloads off the
+            # pin, so the rescue worker's digest re-check still matches.
+            cache_dir=str(self._cache_root),
             action_space="pyautogui",
             screen_size=plan.screen,
             headless=True,
@@ -565,6 +589,7 @@ class AwsProvider:
         env._revert_to_snapshot = refuse("_revert_to_snapshot")
         env.close = refuse("close")
         env._save_state = refuse("_save_state")
+        AwsProvider._seal_cwd_writes(env)
         provider = getattr(env, "provider", None)
         if provider is not None:
             provider.revert_to_snapshot = refuse("provider.revert_to_snapshot")
@@ -573,6 +598,57 @@ class AwsProvider:
         manager = getattr(env, "manager", None)
         if manager is not None:
             manager.get_vm_path = refuse("manager.get_vm_path")
+
+    @staticmethod
+    def _seal_cwd_writes(env: Any) -> None:
+        """Redirect upstream's cwd-RELATIVE writes to the episode cache root.
+
+        The cache_dir fix routes every ``os.path.join(env.cache_dir, ...)``
+        download. But a handful of upstream metric helpers open files in the
+        CURRENT WORKING DIRECTORY with a hard-coded relative name (no cache
+        root): ``evaluators/metrics/vscode.py`` writes ``temp.pdf``,
+        ``slides.py`` writes ``temp_extracted_N.jpeg``, ``others.py`` extracts
+        an epub into ``<name>.dir``, ``docs.py`` writes a netpbm temp image.
+        With the worker's cwd pinned to the workspace, any task whose metric
+        lands on one of those writes into the digest-pinned workspace and
+        re-wedges rescue exactly as the cache download did.
+
+        We cannot enumerate every present and future such helper. The
+        load-bearing invariant is narrower and provable: a write whose path
+        resolves to cwd lands inside the pinned workspace. So the env's
+        file-writing surface is patched at the instance level with a guard
+        that refuses any open-for-write whose resolved path is inside the
+        workspace. That fails the offending metric loudly (scored 0 for that
+        episode) rather than silently corrupting the pin — the honest
+        failure, since a metric that needs to write has no business doing so
+        in the attested input directory. Absolute paths under the cache root
+        (the legitimate writes) pass through untouched.
+
+        Applied to the live env object, not the module, so the redirect
+        cannot leak into another DesktopEnv in the same process.
+        """
+
+        workspace = os.path.realpath(os.getcwd())
+        original_open = open
+
+        def _guarded_open(file: Any, mode: str = "r", *args: Any, **kwargs: Any) -> Any:
+            # ``file`` may be an fd (int) rather than a path; only path-like
+            # opens can land in the workspace, so guard those and let fds
+            # through untouched.
+            if not isinstance(file, int) and any(f in mode for f in ("w", "a", "x", "+")):
+                target = os.path.realpath(os.fspath(file))
+                if target == workspace or target.startswith(workspace + os.sep):
+                    raise UpstreamAllocationRefused(
+                        f"upstream tried to write {os.fspath(file)!r} inside the "
+                        "digest-pinned workspace (the worker's cwd); that write "
+                        "would break the rescue digest re-check. Refused."
+                    )
+            return original_open(file, mode, *args, **kwargs)
+
+        env.open = _guarded_open  # type: ignore[attr-defined]
+        # Expose the workspace path so tests can assert the guard boundary
+        # without re-deriving it.
+        env._lop_workspace_root = workspace  # type: ignore[attr-defined]
 
     # ------------------------------------------------------------------
     # episode I/O

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
@@ -329,13 +329,14 @@ class AwsProvider:
     # ------------------------------------------------------------------
 
     async def allocate(
-        self, plan: ProvisioningPlan, task: TaskDescriptor, *, cache_root: Path | None
+        self, plan: ProvisioningPlan, task: TaskDescriptor, *, cache_root: Path
     ) -> None:
+        # Typed as required (matching the Protocol), and re-checked at
+        # runtime: a DesktopEnv built without a cache root would fall back to
+        # upstream's cwd-relative default and re-open the digest-break
+        # defect. The type stops a caller that forgets it; this stops one
+        # that passes None dynamically.
         if cache_root is None:
-            # The whole point of the cache root is that upstream's writes
-            # land OUTSIDE the pinned workspace. Constructing a DesktopEnv
-            # without one re-opens the digest-break defect (the cwd IS the
-            # workspace), so refusing loudly beats defaulting to cwd.
             raise AllocationError(
                 "allocate needs the adapter's episode cache root (cache_root); "
                 "without it upstream writes land in the digest-pinned workspace"
@@ -589,7 +590,6 @@ class AwsProvider:
         env._revert_to_snapshot = refuse("_revert_to_snapshot")
         env.close = refuse("close")
         env._save_state = refuse("_save_state")
-        AwsProvider._seal_cwd_writes(env)
         provider = getattr(env, "provider", None)
         if provider is not None:
             provider.revert_to_snapshot = refuse("provider.revert_to_snapshot")
@@ -598,57 +598,6 @@ class AwsProvider:
         manager = getattr(env, "manager", None)
         if manager is not None:
             manager.get_vm_path = refuse("manager.get_vm_path")
-
-    @staticmethod
-    def _seal_cwd_writes(env: Any) -> None:
-        """Redirect upstream's cwd-RELATIVE writes to the episode cache root.
-
-        The cache_dir fix routes every ``os.path.join(env.cache_dir, ...)``
-        download. But a handful of upstream metric helpers open files in the
-        CURRENT WORKING DIRECTORY with a hard-coded relative name (no cache
-        root): ``evaluators/metrics/vscode.py`` writes ``temp.pdf``,
-        ``slides.py`` writes ``temp_extracted_N.jpeg``, ``others.py`` extracts
-        an epub into ``<name>.dir``, ``docs.py`` writes a netpbm temp image.
-        With the worker's cwd pinned to the workspace, any task whose metric
-        lands on one of those writes into the digest-pinned workspace and
-        re-wedges rescue exactly as the cache download did.
-
-        We cannot enumerate every present and future such helper. The
-        load-bearing invariant is narrower and provable: a write whose path
-        resolves to cwd lands inside the pinned workspace. So the env's
-        file-writing surface is patched at the instance level with a guard
-        that refuses any open-for-write whose resolved path is inside the
-        workspace. That fails the offending metric loudly (scored 0 for that
-        episode) rather than silently corrupting the pin — the honest
-        failure, since a metric that needs to write has no business doing so
-        in the attested input directory. Absolute paths under the cache root
-        (the legitimate writes) pass through untouched.
-
-        Applied to the live env object, not the module, so the redirect
-        cannot leak into another DesktopEnv in the same process.
-        """
-
-        workspace = os.path.realpath(os.getcwd())
-        original_open = open
-
-        def _guarded_open(file: Any, mode: str = "r", *args: Any, **kwargs: Any) -> Any:
-            # ``file`` may be an fd (int) rather than a path; only path-like
-            # opens can land in the workspace, so guard those and let fds
-            # through untouched.
-            if not isinstance(file, int) and any(f in mode for f in ("w", "a", "x", "+")):
-                target = os.path.realpath(os.fspath(file))
-                if target == workspace or target.startswith(workspace + os.sep):
-                    raise UpstreamAllocationRefused(
-                        f"upstream tried to write {os.fspath(file)!r} inside the "
-                        "digest-pinned workspace (the worker's cwd); that write "
-                        "would break the rescue digest re-check. Refused."
-                    )
-            return original_open(file, mode, *args, **kwargs)
-
-        env.open = _guarded_open  # type: ignore[attr-defined]
-        # Expose the workspace path so tests can assert the guard boundary
-        # without re-deriving it.
-        env._lop_workspace_root = workspace  # type: ignore[attr-defined]
 
     # ------------------------------------------------------------------
     # episode I/O

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/base.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/base.py
@@ -13,6 +13,7 @@ resource; it is called from ``reset_start``, never from ``prepare``.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 from lop_osworld_v2_adapter.provisioning import ProvisioningPlan
@@ -23,8 +24,16 @@ from lop_osworld_v2_adapter.taskfile import TaskDescriptor
 class EnvironmentProvider(Protocol):
     """One environment backend. Implemented by FakeProvider and AwsProvider."""
 
-    async def allocate(self, plan: ProvisioningPlan, task: TaskDescriptor) -> None:
-        """Create the environment. The side-effect boundary; reset_start only."""
+    async def allocate(
+        self, plan: ProvisioningPlan, task: TaskDescriptor, *, cache_root: Path
+    ) -> None:
+        """Create the environment. The side-effect boundary; reset_start only.
+
+        ``cache_root`` is the ABSOLUTE, episode-scoped directory (outside the
+        digest-pinned workspace) that any backend which downloads assets must
+        write into. See ``adapter._episode_cache_root`` for why a cwd-relative
+        cache wedges the rescue sweep.
+        """
         ...
 
     async def observe(self) -> dict[str, Any]:

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/fake.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/fake.py
@@ -20,6 +20,7 @@ two steps never hash to the same artifact.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from lop_osworld_v2_adapter.cleanup import (
@@ -58,6 +59,10 @@ class FakeProvider:
         self.terminated_refs: list[str] = []
         self.deleted_schedules: list[str] = []
         self.evaluate_calls = 0
+        # Where the adapter told us to cache. Recorded (never used to write
+        # anything: the fake downloads nothing) so tests assert the cache
+        # root actually crossed the adapter -> provider boundary.
+        self.cache_root: Path | None = None
 
     def _frame(self) -> bytes:
         """A deterministic but sequence-varying 1920x1080 PNG frame."""
@@ -70,9 +75,12 @@ class FakeProvider:
         pixel = bytes((shade, (shade * 3) % 256, (shade * 7) % 256))
         return write_png_rgb(width, height, pixel * (width * height))
 
-    async def allocate(self, plan: ProvisioningPlan, task: TaskDescriptor) -> None:
+    async def allocate(
+        self, plan: ProvisioningPlan, task: TaskDescriptor, *, cache_root: Path | None = None
+    ) -> None:
         # The ref is the tag; allocation registers the instance under it, so
         # teardown-by-ref is the same operation a rescue worker performs.
+        self.cache_root = cache_root
         self._instances[plan.tag_dict()["Name"]] = {
             "state": "running",
             "task_id": task.task_id,

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/fake.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/fake.py
@@ -63,9 +63,9 @@ class FakeProvider:
         # guest (screenshot + a11y tree), so a duplicated call is real cost,
         # not a cosmetic issue. Counted here so a test can pin it.
         self.observe_calls = 0
-        # Where the adapter told us to cache. Recorded (never used to write
-        # anything: the fake downloads nothing) so tests assert the cache
-        # root actually crossed the adapter -> provider boundary.
+        # Where the adapter told us to cache. Recorded (never written to: the
+        # fake downloads nothing) so tests assert the cache root actually
+        # crossed the adapter -> provider boundary. None until allocate.
         self.cache_root: Path | None = None
 
     def _frame(self) -> bytes:
@@ -80,7 +80,7 @@ class FakeProvider:
         return write_png_rgb(width, height, pixel * (width * height))
 
     async def allocate(
-        self, plan: ProvisioningPlan, task: TaskDescriptor, *, cache_root: Path | None = None
+        self, plan: ProvisioningPlan, task: TaskDescriptor, *, cache_root: Path
     ) -> None:
         # The ref is the tag; allocation registers the instance under it, so
         # teardown-by-ref is the same operation a rescue worker performs.

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/fake.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/fake.py
@@ -59,6 +59,10 @@ class FakeProvider:
         self.terminated_refs: list[str] = []
         self.deleted_schedules: list[str] = []
         self.evaluate_calls = 0
+        # On the paid path each observe() is a live HTTP round-trip to the
+        # guest (screenshot + a11y tree), so a duplicated call is real cost,
+        # not a cosmetic issue. Counted here so a test can pin it.
+        self.observe_calls = 0
         # Where the adapter told us to cache. Recorded (never used to write
         # anything: the fake downloads nothing) so tests assert the cache
         # root actually crossed the adapter -> provider boundary.
@@ -91,6 +95,7 @@ class FakeProvider:
         self._sequence = 0
 
     async def observe(self) -> dict[str, Any]:
+        self.observe_calls += 1
         return {
             "screenshot": self._frame(),
             "accessibility_tree": None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.38"
+version = "0.44.39"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/evaluation/adapters/osworld/conftest.py
+++ b/tests/unit/evaluation/adapters/osworld/conftest.py
@@ -16,8 +16,10 @@ artifact loads.
 
 from __future__ import annotations
 
+import os
 import sys
 import uuid
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -30,6 +32,36 @@ if str(_SRC) not in sys.path:
 # a previously installed wheel in this interpreter.
 for _name in [name for name in sys.modules if name.startswith("lop_osworld_v2_adapter")]:
     del sys.modules[_name]
+
+
+@pytest.fixture(autouse=True)
+def _restore_cwd() -> Iterator[None]:
+    """Return every test in this package to the cwd it started in.
+
+    ``reset_start`` moves the process into the episode scratch dir (see
+    ``adapter._enter_episode_scratch``) and ``close`` moves it back — but a
+    test that exercises ``reset_start`` WITHOUT reaching ``close`` leaves the
+    worker parked in a ``tmp_path`` that pytest deletes immediately
+    afterwards. Every later test in that worker then runs from a deleted
+    directory.
+
+    That is not hypothetical, and it escapes this package: it broke
+    ``evidence/test_verify.py::test_sparse_oversized_journal_and_artifact_are_bounded``,
+    which shells out with ``python -c`` and no ``cwd=``, so the child
+    inherited the stale cwd and died with ``No module named 'tests'``.
+    ``monkeypatch.chdir`` cannot cover this — it restores the cwd as of when
+    it was called, which is before the adapter moves it again.
+
+    Package-scoped and autouse because fifteen call sites across this
+    directory call ``reset_start`` without ``close``; anchoring here is what
+    keeps an adapter-internal chdir from leaking into unrelated suites.
+    """
+
+    origin = Path.cwd()
+    try:
+        yield
+    finally:
+        os.chdir(origin)
 
 
 @pytest.fixture

--- a/tests/unit/evaluation/adapters/osworld/spawn_helpers.py
+++ b/tests/unit/evaluation/adapters/osworld/spawn_helpers.py
@@ -39,7 +39,7 @@ from tests.unit.evaluation.copied_interpreter import (
 # tests/unit/evaluation/adapters/osworld/spawn_helpers.py -> repo root is 5
 # parents up (osworld -> adapters -> evaluation -> unit -> tests -> root).
 ADAPTER_SRC = Path(__file__).resolve().parents[5] / "benchmarks" / "osworld_v2_adapter"
-WHEEL_NAME = "lop_osworld_v2_adapter-0.1.0-py3-none-any.whl"
+WHEEL_NAME = "lop_osworld_v2_adapter-0.1.1-py3-none-any.whl"
 
 
 def build_adapter_wheel(out_dir: Path) -> Path:
@@ -134,7 +134,7 @@ def install_adapter_into_site(site: Path, wheel: Path) -> str:
 
     from local_operator.evaluation.adapters.discovery import distribution_digest
 
-    info = site / "lop_osworld_v2_adapter-0.1.0.dist-info"
+    info = site / "lop_osworld_v2_adapter-0.1.1.dist-info"
     return distribution_digest(PathDistribution(info))
 
 
@@ -207,7 +207,7 @@ def build_spawnable_adapter(
         schema_version=ADAPTER_SCHEMA_VERSION,
         adapter_id="osworld-v2",
         distribution="lop-osworld-v2-adapter",
-        version="0.1.0",
+        version="0.1.1",
         entry_point="lop_osworld_v2_adapter:create",
         package_digest=package_digest,
         release_digest=release_digest,
@@ -248,5 +248,5 @@ def release_digest_for(package_digest: str, tasks: dict[str, str]) -> str:
     workspace manifest and the selector agree on the same attestation."""
 
     manifest = hashlib.sha256("".join(tasks[k] for k in sorted(tasks)).encode()).hexdigest()
-    payload = f"lop-osworld-v2-adapter|0.1.0|{package_digest}|osworld-v2-2026.08.08|{manifest}"
+    payload = f"lop-osworld-v2-adapter|0.1.1|{package_digest}|osworld-v2-2026.08.08|{manifest}"
     return hashlib.sha256(payload.encode()).hexdigest()

--- a/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
+++ b/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
@@ -416,12 +416,17 @@ async def test_desktop_env_cache_dir_is_absolute_and_outside_the_workspace(
 @pytest.mark.asyncio
 async def test_allocate_refuses_without_a_cache_root(monkeypatch: pytest.MonkeyPatch) -> None:
     """A missing cache root must fail loudly before any boto3 call: defaulting
-    to cwd would silently re-open the digest-break defect."""
+    to cwd would silently re-open the digest-break defect.
+
+    ``cache_root`` is typed as a required ``Path``, so a caller that forgets it
+    is caught at type-check time; the ``type: ignore`` below is deliberate —
+    it exercises the RUNTIME guard that still has to hold for a caller passing
+    ``None`` dynamically."""
 
     with _Stubs() as stubs:
         provider = _provider(stubs, monkeypatch, desktop_env_factory=_FakeEnv)
         with pytest.raises(AllocationError, match="cache root"):
-            await provider.allocate(_plan(), _task(), cache_root=None)
+            await provider.allocate(_plan(), _task(), cache_root=None)  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
+++ b/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+from pathlib import Path
 from typing import Any
 
 import boto3
@@ -39,6 +40,9 @@ from tests.unit.evaluation.adapters.osworld import fixtures
 
 REGION = "us-east-1"
 EPISODE = "ep-aws-test"
+# The episode-owned, absolute, workspace-external cache root the adapter mints
+# in reset_start. Tests pass a fresh tmp path; allocate refuses without one.
+_CACHE_ROOT_ARG = "cache_root"
 
 
 @pytest.fixture(autouse=True)
@@ -84,6 +88,16 @@ def _plan() -> provisioning.ProvisioningPlan:
 
 def _task() -> taskfile.TaskDescriptor:
     return taskfile.load_static(fixtures.PLAIN.encode(), module_name="tasks/task_plain.py")
+
+
+def _cache_root(tmp_path: Path) -> Path:
+    """The episode-owned, absolute, workspace-external cache root the adapter
+    mints in reset_start. Tests supply a fresh tmp path; allocate refuses
+    without one because a missing root re-opens the digest-break defect."""
+
+    root = tmp_path / "osworld-cache" / EPISODE
+    root.mkdir(parents=True, exist_ok=True)
+    return root
 
 
 class _Stubs:
@@ -322,7 +336,7 @@ class _FakeEnv:
 
 @pytest.mark.asyncio
 async def test_allocate_launches_with_client_token_and_both_tag_specs(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     with _Stubs() as stubs:
         _expect_describe_images(stubs)
@@ -342,7 +356,7 @@ async def test_allocate_launches_with_client_token_and_both_tag_specs(
             desktop_env_factory=factory,
             task_factory=lambda t: {"id": t.task_id},
         )
-        await provider.allocate(_plan(), _task())
+        await provider.allocate(_plan(), _task(), cache_root=_cache_root(tmp_path))
         stubs.ec2_stub.assert_no_pending_responses()
         stubs.sched_stub.assert_no_pending_responses()
 
@@ -358,8 +372,61 @@ async def test_allocate_launches_with_client_token_and_both_tag_specs(
 
 
 @pytest.mark.asyncio
+async def test_desktop_env_cache_dir_is_absolute_and_outside_the_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """THE regression: upstream's default cache_dir="cache" is cwd-relative and
+    the worker's cwd is the pinned workspace, so the paid episode's
+    _download_setup broke the rescue digest. The adapter must hand DesktopEnv
+    the episode's absolute cache root instead."""
+
+    with _Stubs() as stubs:
+        _expect_describe_images(stubs)
+        _expect_run_instances(stubs)
+        _expect_create_schedule(stubs)
+        _expect_running(stubs)
+        envs: list[_FakeEnv] = []
+
+        def factory(**kwargs: Any) -> _FakeEnv:
+            env = _FakeEnv(**kwargs)
+            envs.append(env)
+            return env
+
+        provider = _provider(
+            stubs,
+            monkeypatch,
+            desktop_env_factory=factory,
+            task_factory=lambda t: {"id": t.task_id},
+        )
+        cache_root = _cache_root(tmp_path)
+        await provider.allocate(_plan(), _task(), cache_root=cache_root)
+
+    cache_dir = Path(envs[0].kwargs["cache_dir"])
+    assert cache_dir.is_absolute(), "cache_dir must never be cwd-relative"
+    assert cache_dir == cache_root
+    # It must not be the workspace the worker runs in (the cwd here).
+    cwd = Path.cwd().resolve()
+    assert cwd not in cache_dir.parents and cache_dir != cwd
+    # And never under a volatile /tmp that macOS purges mid-run.
+    assert not str(cache_dir).startswith(("/tmp", "/private/tmp")) or str(cache_dir).startswith(
+        str(tmp_path)
+    )
+
+
+@pytest.mark.asyncio
+async def test_allocate_refuses_without_a_cache_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing cache root must fail loudly before any boto3 call: defaulting
+    to cwd would silently re-open the digest-break defect."""
+
+    with _Stubs() as stubs:
+        provider = _provider(stubs, monkeypatch, desktop_env_factory=_FakeEnv)
+        with pytest.raises(AllocationError, match="cache root"):
+            await provider.allocate(_plan(), _task(), cache_root=None)
+
+
+@pytest.mark.asyncio
 async def test_schedule_is_created_before_readiness_and_its_failure_is_fatal(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """The lease covers the boot window: it is created right after
     run_instances, and if it cannot be, the instance is terminated and
@@ -380,7 +447,7 @@ async def test_schedule_is_created_before_readiness_and_its_failure_is_fatal(
         )
         provider = _provider(stubs, monkeypatch, desktop_env_factory=_FakeEnv)
         with pytest.raises(AllocationError, match="TTL lease .* could not be created"):
-            await provider.allocate(_plan(), _task())
+            await provider.allocate(_plan(), _task(), cache_root=_cache_root(tmp_path))
         stubs.ec2_stub.assert_no_pending_responses()
         stubs.sched_stub.assert_no_pending_responses()
     # No readiness wait happened: the prober was never called.
@@ -388,7 +455,9 @@ async def test_schedule_is_created_before_readiness_and_its_failure_is_fatal(
 
 
 @pytest.mark.asyncio
-async def test_readiness_timeout_raises_after_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_readiness_timeout_raises_after_deadline(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     with _Stubs(http_codes=[503]) as stubs:
         _expect_describe_images(stubs)
         _expect_run_instances(stubs)
@@ -398,7 +467,7 @@ async def test_readiness_timeout_raises_after_deadline(monkeypatch: pytest.Monke
             stubs, monkeypatch, desktop_env_factory=_FakeEnv, readiness_timeout_s=12.0
         )
         with pytest.raises(ReadinessTimeout):
-            await provider.allocate(_plan(), _task())
+            await provider.allocate(_plan(), _task(), cache_root=_cache_root(tmp_path))
     # 12 s deadline at 5 s per probe: probes at t=0, 5, 10, 15; the last one
     # is past the deadline, so it raises instead of sleeping again.
     assert len(stubs.http_calls) == 4
@@ -406,13 +475,15 @@ async def test_readiness_timeout_raises_after_deadline(monkeypatch: pytest.Monke
 
 
 @pytest.mark.asyncio
-async def test_allocate_refuses_a_plan_for_another_region(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_allocate_refuses_a_plan_for_another_region(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     with _Stubs() as stubs:
         provider = AwsProvider(
             CREDS, region="eu-west-1", lease_ref="lop-ttl-x", clients=stubs.clients
         )
         with pytest.raises(AllocationError, match="region"):
-            await provider.allocate(_plan(), _task())
+            await provider.allocate(_plan(), _task(), cache_root=_cache_root(tmp_path))
 
 
 # ---------------------------------------------------------------------------
@@ -421,7 +492,7 @@ async def test_allocate_refuses_a_plan_for_another_region(monkeypatch: pytest.Mo
 
 
 async def _allocated(
-    stubs: _Stubs, monkeypatch: pytest.MonkeyPatch
+    stubs: _Stubs, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> tuple[AwsProvider, _FakeEnv]:
     _expect_describe_images(stubs)
     _expect_run_instances(stubs)
@@ -437,7 +508,7 @@ async def _allocated(
     provider = _provider(
         stubs, monkeypatch, desktop_env_factory=factory, task_factory=lambda t: {"id": t.task_id}
     )
-    await provider.allocate(_plan(), _task())
+    await provider.allocate(_plan(), _task(), cache_root=_cache_root(tmp_path))
     stubs.ec2_stub.assert_no_pending_responses()
     return provider, envs[0]
 
@@ -445,6 +516,7 @@ async def _allocated(
 @pytest.mark.asyncio
 async def test_a_second_reset_on_a_used_env_is_refused_before_any_boto3_call(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """MAJOR-1. Upstream's second ``reset`` routes through
     ``_revert_to_snapshot`` -> ``AWSProvider.revert_to_snapshot``, which
@@ -459,7 +531,7 @@ async def test_a_second_reset_on_a_used_env_is_refused_before_any_boto3_call(
     """
 
     with _Stubs() as stubs:
-        provider, env = await _allocated(stubs, monkeypatch)
+        provider, env = await _allocated(stubs, monkeypatch, tmp_path)
         assert env.reset_calls == [{"id": "task_plain"}]
         assert env.is_environment_used is True
         with pytest.raises(aws_mod.UpstreamAllocationRefused, match="_revert_to_snapshot"):
@@ -479,9 +551,10 @@ async def test_a_second_reset_on_a_used_env_is_refused_before_any_boto3_call(
 @pytest.mark.asyncio
 async def test_upstream_close_is_refused_so_teardown_is_only_ever_confirmed(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     with _Stubs() as stubs:
-        provider, env = await _allocated(stubs, monkeypatch)
+        provider, env = await _allocated(stubs, monkeypatch, tmp_path)
         with pytest.raises(aws_mod.UpstreamAllocationRefused, match="close"):
             env.close()
         with pytest.raises(aws_mod.UpstreamAllocationRefused, match="stop_emulator"):

--- a/tests/unit/evaluation/adapters/osworld/test_cache_dir.py
+++ b/tests/unit/evaluation/adapters/osworld/test_cache_dir.py
@@ -22,7 +22,6 @@ the invariant.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest
@@ -32,9 +31,11 @@ from lop_osworld_v2_adapter.providers.fake import FakeProvider
 from local_operator.evaluation.adapters.api import (
     ADAPTER_SCHEMA_VERSION,
     AdapterSelector,
+    CloseParams,
     Handshake,
     PrepareParams,
     PythonRuntime,
+    ResetStartParams,
     ScopedInfraValue,
 )
 from local_operator.evaluation.adapters.discovery import workspace_digest
@@ -82,12 +83,16 @@ def test_episode_cache_root_is_absolute_outside_workspace_and_episode_owned(
     assert root.is_absolute(), "cache root must be absolute, never cwd-relative"
     # Outside the pinned workspace: the whole point of the fix.
     assert workspace not in root.parents and root != workspace
-    # Episode-scoped: reset_cache_dir replaces contents wholesale per reset.
+    # Episode-scoped: upstream's reset_cache_dir only reassigns the attribute
+    # and clears nothing, so isolation has to come from the path itself.
     assert root.name == "ep-1"
-    # A sibling of the artifact root, under the parent-owned run root.
+    # Durability is STRUCTURAL, not a string test: the cache root is a sibling
+    # under the run root, so it inherits whatever guarantee the run root has.
+    # scripts/run_episode.py puts the run root through refuse_volatile_root,
+    # which is what actually keeps this off /tmp — asserting the prefix here
+    # would only re-test pytest's tmp_path, which IS under $TMPDIR.
     assert root.parent.parent == artifact_root.parent
-    # Never volatile: macOS purges /private/tmp with no warning.
-    assert not str(root).startswith(("/tmp", "/private/tmp", os.environ.get("TMPDIR", "\0")))
+    assert root.parent.name == "osworld-cache"
 
     other = _episode_cache_root(artifact_root, "ep-2")
     assert other != root, "two episodes must not share a cache root"
@@ -154,11 +159,19 @@ def _selector(workspace: Path, adapter: OSWorldV2Adapter, digest: str) -> Adapte
 
 
 @pytest.mark.asyncio
-async def test_episode_leaves_workspace_byte_identical(tmp_path: Path, episode_id: str) -> None:
+async def test_episode_leaves_workspace_byte_identical(
+    tmp_path: Path, episode_id: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """After a real episode the workspace is untouched: nothing newer than the
     selector, and the digest recomputes to the pin the episode started with."""
 
     workspace = _write_workspace(tmp_path, {"task_plain": fixtures.PLAIN})
+    # THE FAILURE GEOMETRY. The supervisor spawns the worker with
+    # cwd=selector.workspace, so a cwd-relative upstream write lands in the
+    # pinned workspace. Without this chdir the test runs from the repo root
+    # and a regression's stray write would land THERE, leaving the digest
+    # clean for the wrong reason -- the test would pass under the bug.
+    monkeypatch.chdir(workspace)
     pin = workspace_digest(str(workspace))
     provider = FakeProvider(scripted_score=1.0)
     adapter = OSWorldV2Adapter(provider_factory=lambda: provider, workspace_root=workspace)
@@ -219,13 +232,16 @@ class _DownloadingFakeProvider(FakeProvider):
 
 @pytest.mark.asyncio
 async def test_rescue_digest_recheck_passes_after_a_download(
-    tmp_path: Path, episode_id: str
+    tmp_path: Path, episode_id: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The regression: an episode that downloads assets must NOT change the
     workspace digest, so the rescue worker's re-check passes and the sweep
     retires the descriptor instead of wedging ``rescue_required``."""
 
     workspace = _write_workspace(tmp_path, {"task_plain": fixtures.PLAIN})
+    # Same reason as above: reproduce the worker's real cwd, or a cwd-relative
+    # regression escapes into the repo root instead of the workspace.
+    monkeypatch.chdir(workspace)
     pin = workspace_digest(str(workspace))
     provider = _DownloadingFakeProvider(scripted_score=1.0)
     adapter = OSWorldV2Adapter(provider_factory=lambda: provider, workspace_root=workspace)
@@ -276,3 +292,155 @@ async def test_prepare_does_not_create_the_cache_root(tmp_path: Path, episode_id
     )
     # No cache root was created anywhere under the would-be run root.
     assert not (tmp_path / "run").exists()
+
+
+# ---------------------------------------------------------------------------
+# the cwd guarantee: relative writes cannot reach the workspace at all
+# ---------------------------------------------------------------------------
+
+
+class _RelativeWritingFakeProvider(FakeProvider):
+    """A fake that writes a HARD-CODED RELATIVE filename during allocate.
+
+    This is the shape of the upstream helpers that ``cache_dir`` does NOT
+    cover: ``evaluators/metrics/vscode.py:210`` opens ``"temp.pdf"``,
+    ``slides.py:2051`` opens ``temp_extracted_<n>.jpeg``, ``others.py:64-72``
+    makes ``<name>.dir``. They call the BUILTIN ``open`` at module scope, so
+    no attribute installed on the env object can intercept them — the only
+    thing that decides where they land is the process cwd.
+    """
+
+    async def allocate(self, plan, task, *, cache_root):  # type: ignore[override]
+        await super().allocate(plan, task, cache_root=cache_root)
+        # Deliberately the builtin, deliberately relative — exactly what
+        # upstream does. Under the fix the cwd is the episode scratch dir,
+        # so this cannot reach the pinned workspace.
+        with open("temp.pdf", "wb") as handle:
+            handle.write(b"%PDF-1.4 stray upstream write\n")
+        self.stray_write = Path("temp.pdf").resolve()
+
+
+@pytest.mark.asyncio
+async def test_a_relative_upstream_write_cannot_land_in_the_workspace(
+    tmp_path: Path, episode_id: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """THE guarantee behind the cwd move: a relative write by ANY upstream
+    path — not just the cache downloads ``cache_dir`` covers — lands in the
+    episode scratch dir, so the pin survives and rescue's re-check passes.
+
+    This is what the (inert) ``env.open`` seal claimed and did not deliver:
+    upstream never resolves ``open`` through the env object, so the guarantee
+    has to come from the cwd, not from patching a call site nobody uses.
+    """
+
+    workspace = _write_workspace(tmp_path, {"task_plain": fixtures.PLAIN})
+    pin = workspace_digest(str(workspace))
+    # Reproduce the worker's real starting cwd: the pinned workspace.
+    monkeypatch.chdir(workspace)
+
+    provider = _RelativeWritingFakeProvider(scripted_score=1.0)
+    adapter = OSWorldV2Adapter(provider_factory=lambda: provider, workspace_root=workspace)
+    shim = _Shim(adapter, _selector(workspace, adapter, pin))
+
+    runner = EpisodeRunner(
+        _spec(episode_id),
+        build_config(tmp_path / "run"),
+        selector=shim.selector,
+        model=ScriptedModel(["finish"]),
+        launch=lambda _s: shim,
+    )
+    outcome = await runner.run()
+    assert outcome.status == "completed", outcome.diagnostic
+
+    # The stray relative write really happened...
+    assert provider.stray_write.exists(), "the test's own stray write did not occur"
+    # ...but it landed in the episode scratch dir, NOT the pinned workspace.
+    assert workspace not in provider.stray_write.parents
+    assert provider.cache_root is not None
+    assert provider.stray_write.parent == provider.cache_root.resolve()
+    assert not (workspace / "temp.pdf").exists()
+
+    # Which is the property that matters: the pin is intact, so a rescue
+    # worker's digest re-check passes instead of wedging rescue_required.
+    assert workspace_digest(str(workspace)) == pin
+
+
+@pytest.mark.asyncio
+async def test_close_restores_the_cwd_the_supervisor_spawned_us_in(
+    tmp_path: Path, episode_id: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """reset_start moves the cwd; close must put it back, so a worker reused
+    across episodes starts each one where the supervisor placed it."""
+
+    workspace = _write_workspace(tmp_path, {"task_plain": fixtures.PLAIN})
+    monkeypatch.chdir(workspace)
+    entry = Path.cwd().resolve()
+
+    provider = FakeProvider(scripted_score=1.0)
+    adapter = OSWorldV2Adapter(provider_factory=lambda: provider, workspace_root=workspace)
+    artifacts = tmp_path / "run" / "artifacts"
+    artifacts.mkdir(parents=True)
+
+    await adapter.prepare(
+        PrepareParams(
+            operation_id=f"prepare-{episode_id}",
+            episode_id=episode_id,
+            secret_refs=(),
+            infra_values=_INFRA,
+        )
+    )
+    await adapter.reset_start(
+        ResetStartParams(
+            operation_id=f"reset-{episode_id}",
+            task_id="task_plain",
+            episode_id=episode_id,
+            artifact_root=str(artifacts),
+            secrets=(),
+        )
+    )
+    # During the episode the cwd is the scratch dir, off the workspace.
+    assert Path.cwd().resolve() != entry
+    assert Path.cwd().resolve() == provider.cache_root.resolve()  # type: ignore[union-attr]
+
+    await adapter.close(CloseParams(operation_id=f"close-{episode_id}"))
+    assert Path.cwd().resolve() == entry
+
+
+@pytest.mark.asyncio
+async def test_reset_start_observes_the_guest_exactly_once(
+    tmp_path: Path, episode_id: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Observation 0 costs exactly one round-trip.
+
+    On the paid path ``observe()`` is a live HTTP call to the guest (a
+    screenshot plus the a11y tree), so a duplicated call doubles reset
+    latency and network work on every episode. Pinned because a stray second
+    call is invisible to every other assertion — the extra result is simply
+    overwritten.
+    """
+
+    workspace = _write_workspace(tmp_path, {"task_plain": fixtures.PLAIN})
+    monkeypatch.chdir(workspace)
+    provider = FakeProvider(scripted_score=1.0)
+    adapter = OSWorldV2Adapter(provider_factory=lambda: provider, workspace_root=workspace)
+    artifacts = tmp_path / "run" / "artifacts"
+    artifacts.mkdir(parents=True)
+
+    await adapter.prepare(
+        PrepareParams(
+            operation_id=f"prepare-{episode_id}",
+            episode_id=episode_id,
+            secret_refs=(),
+            infra_values=_INFRA,
+        )
+    )
+    await adapter.reset_start(
+        ResetStartParams(
+            operation_id=f"reset-{episode_id}",
+            task_id="task_plain",
+            episode_id=episode_id,
+            artifact_root=str(artifacts),
+            secrets=(),
+        )
+    )
+    assert provider.observe_calls == 1

--- a/tests/unit/evaluation/adapters/osworld/test_cache_dir.py
+++ b/tests/unit/evaluation/adapters/osworld/test_cache_dir.py
@@ -1,0 +1,278 @@
+"""The cache-dir defect: upstream writes must never land in the pinned workspace.
+
+The first paid episode proved the failure end to end: upstream's default
+``cache_dir="cache"`` resolves against the worker's cwd, which is the
+digest-pinned workspace, so ``_download_setup`` wrote real content into it
+and the rescue worker's digest re-check refused, leaving ``rescue_required``
+stuck True for an instance that was already terminated.
+
+These tests pin the fix at three levels, cheapest first:
+
+* ``_episode_cache_root`` mints an ABSOLUTE path OUTSIDE the workspace, under
+  the episode's owned root, and never under ``/tmp``;
+* after a full FakeProvider episode, ``find <workspace> -newer <selector>``
+  is empty and the workspace digest recomputes to the pin;
+* a rescue worker's digest re-check passes after an episode whose provider
+  downloaded assets into the cache path the adapter handed it.
+
+The last two run the REAL adapter and the REAL ``workspace_digest`` — the
+same function the rescue worker calls — so they are evidence, not a mock of
+the invariant.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from lop_osworld_v2_adapter.adapter import OSWorldV2Adapter, _episode_cache_root
+from lop_osworld_v2_adapter.providers.fake import FakeProvider
+
+from local_operator.evaluation.adapters.api import (
+    ADAPTER_SCHEMA_VERSION,
+    AdapterSelector,
+    Handshake,
+    PrepareParams,
+    PythonRuntime,
+    ScopedInfraValue,
+)
+from local_operator.evaluation.adapters.discovery import workspace_digest
+from local_operator.evaluation.runner.episode import EpisodeRunner
+from tests.unit.evaluation.adapters.osworld import fixtures
+from tests.unit.evaluation.runner.conftest import (
+    ScriptedModel,
+    build_config,
+    build_spec,
+)
+
+# The non-secret infra the adapter's inspect_requirements names.
+_INFRA = tuple(
+    ScopedInfraValue(name=name, purpose="benchmark_compute", value=f"test-{name}")
+    for name in (
+        "AWS_REGION",
+        "AWS_SUBNET_ID",
+        "AWS_SECURITY_GROUP_ID",
+        "AWS_SCHEDULER_ROLE_ARN",
+        "OSWORLD_CLIENT_PASSWORD",
+        "OSWORLD_FILE_BASE_URL",
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# the path rule itself
+# ---------------------------------------------------------------------------
+
+
+def test_episode_cache_root_is_absolute_outside_workspace_and_episode_owned(
+    tmp_path: Path,
+) -> None:
+    """The cache root must be absolute, NOT inside the workspace, NOT /tmp,
+    and scoped to the episode so one episode's cached upload cannot be read
+    by another episode that happens to share a task id."""
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact_root = tmp_path / "run" / "artifacts"
+    artifact_root.mkdir(parents=True)
+
+    root = _episode_cache_root(artifact_root, "ep-1")
+
+    assert root.is_absolute(), "cache root must be absolute, never cwd-relative"
+    # Outside the pinned workspace: the whole point of the fix.
+    assert workspace not in root.parents and root != workspace
+    # Episode-scoped: reset_cache_dir replaces contents wholesale per reset.
+    assert root.name == "ep-1"
+    # A sibling of the artifact root, under the parent-owned run root.
+    assert root.parent.parent == artifact_root.parent
+    # Never volatile: macOS purges /private/tmp with no warning.
+    assert not str(root).startswith(("/tmp", "/private/tmp", os.environ.get("TMPDIR", "\0")))
+
+    other = _episode_cache_root(artifact_root, "ep-2")
+    assert other != root, "two episodes must not share a cache root"
+
+
+# ---------------------------------------------------------------------------
+# workspace stays byte-identical through an episode
+# ---------------------------------------------------------------------------
+
+
+def _write_workspace(tmp_path: Path, tasks: dict[str, str]) -> Path:
+    workspace = tmp_path / "workspace"
+    (workspace / "tasks").mkdir(parents=True, exist_ok=True)
+    for task_id, source in tasks.items():
+        (workspace / "tasks" / f"{task_id}.py").write_text(source)
+    # The marker the ``find -newer`` test compares against: written once,
+    # before the episode, exactly like the build script's selector.json.
+    (workspace / "selector.json").write_text("{}")
+    return workspace
+
+
+class _Shim:
+    """Drive the real in-process adapter through the runner's session shape."""
+
+    def __init__(self, adapter: OSWorldV2Adapter, selector: AdapterSelector) -> None:
+        self._adapter = adapter
+        self.selector = selector
+
+    async def handshake(self, *, timeout: float = 10.0) -> Handshake:
+        del timeout
+        return Handshake(
+            selector=self.selector,
+            metadata=self._adapter.metadata,
+            python=PythonRuntime.current(),
+            workspace_digest=self.selector.workspace_digest,
+            selected_route="computer",
+        )
+
+    async def terminate(self) -> None:
+        pass
+
+    async def _call_raw(
+        self, method: str, params: object, result_type: object, *, timeout: float
+    ) -> object:
+        del timeout
+        return await getattr(self._adapter, method)(params)
+
+
+def _selector(workspace: Path, adapter: OSWorldV2Adapter, digest: str) -> AdapterSelector:
+    metadata = adapter.metadata
+    return AdapterSelector(
+        schema_version=ADAPTER_SCHEMA_VERSION,
+        adapter_id="osworld-v2",
+        distribution="lop-osworld-v2-adapter",
+        version="0.1.1",
+        entry_point="lop_osworld_v2_adapter:create",
+        package_digest=metadata.package_digest,
+        release_digest=metadata.release_digest,
+        python_executable=str(Path(__import__("sys").executable).resolve()),
+        workspace=str(workspace),
+        workspace_digest=digest,
+        route_capability="computer",
+    )
+
+
+@pytest.mark.asyncio
+async def test_episode_leaves_workspace_byte_identical(tmp_path: Path, episode_id: str) -> None:
+    """After a real episode the workspace is untouched: nothing newer than the
+    selector, and the digest recomputes to the pin the episode started with."""
+
+    workspace = _write_workspace(tmp_path, {"task_plain": fixtures.PLAIN})
+    pin = workspace_digest(str(workspace))
+    provider = FakeProvider(scripted_score=1.0)
+    adapter = OSWorldV2Adapter(provider_factory=lambda: provider, workspace_root=workspace)
+    shim = _Shim(adapter, _selector(workspace, adapter, pin))
+
+    runner = EpisodeRunner(
+        _spec(episode_id),
+        build_config(tmp_path / "run"),
+        selector=shim.selector,
+        model=ScriptedModel(["step", "finish"]),
+        launch=lambda _s: shim,
+    )
+    outcome = await runner.run()
+    assert outcome.status == "completed", outcome.diagnostic
+
+    # The cache root the adapter handed the provider is absolute and outside
+    # the workspace — the path the fix actually routed.
+    assert provider.cache_root is not None
+    assert provider.cache_root.is_absolute()
+    assert workspace not in provider.cache_root.parents
+
+    # `find <workspace> -newer <selector.json>` is empty: no file was created
+    # or modified after the selector was written.
+    marker = workspace / "selector.json"
+    newer = [p for p in workspace.rglob("*") if p.stat().st_mtime_ns > marker.stat().st_mtime_ns]
+    assert newer == [], f"episode wrote into the pinned workspace: {newer}"
+
+    # The digest the rescue worker re-checks still matches the pin.
+    assert workspace_digest(str(workspace)) == pin
+
+
+def _spec(episode_id: str):
+    spec = build_spec(episode_id)
+    object.__setattr__(spec, "task_id", "task_plain")
+    object.__setattr__(spec, "infra_values", _INFRA)
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# rescue digest re-check survives an episode that downloaded assets
+# ---------------------------------------------------------------------------
+
+
+class _DownloadingFakeProvider(FakeProvider):
+    """A fake that simulates upstream's ``_download_setup``: it writes a real
+    asset into the cache path the adapter hands it, exactly as the paid
+    episode's calendar/thunderbird download did."""
+
+    async def allocate(self, plan, task, *, cache_root=None):  # type: ignore[override]
+        await super().allocate(plan, task, cache_root=cache_root)
+        assert cache_root is not None, "the adapter must route the cache root"
+        # Mirror upstream: cache_dir/<task_id>/<asset>.
+        target = cache_root / task.task_id / "downloaded-asset.ics"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"BEGIN:VCALENDAR\nEND:VCALENDAR\n")
+        self.downloaded_to = target
+
+
+@pytest.mark.asyncio
+async def test_rescue_digest_recheck_passes_after_a_download(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """The regression: an episode that downloads assets must NOT change the
+    workspace digest, so the rescue worker's re-check passes and the sweep
+    retires the descriptor instead of wedging ``rescue_required``."""
+
+    workspace = _write_workspace(tmp_path, {"task_plain": fixtures.PLAIN})
+    pin = workspace_digest(str(workspace))
+    provider = _DownloadingFakeProvider(scripted_score=1.0)
+    adapter = OSWorldV2Adapter(provider_factory=lambda: provider, workspace_root=workspace)
+    shim = _Shim(adapter, _selector(workspace, adapter, pin))
+
+    runner = EpisodeRunner(
+        _spec(episode_id),
+        build_config(tmp_path / "run"),
+        selector=shim.selector,
+        model=ScriptedModel(["finish"]),
+        launch=lambda _s: shim,
+    )
+    outcome = await runner.run()
+    assert outcome.status == "completed", outcome.diagnostic
+
+    # The download really happened, and it went to the episode-owned cache
+    # root — not the workspace.
+    assert provider.downloaded_to.exists()
+    assert workspace not in provider.downloaded_to.parents
+
+    # The rescue worker re-runs workspace_digest(selector.workspace) and
+    # compares to the persisted pin. After the fix, that passes.
+    assert workspace_digest(str(workspace)) == pin, (
+        "workspace digest changed after an episode that downloaded assets; "
+        "a rescue worker would refuse with 'content digest differs'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# prepare still allocates nothing (guard against the cache mkdir creeping in)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prepare_does_not_create_the_cache_root(tmp_path: Path, episode_id: str) -> None:
+    """prepare is declarative (episode.py:289-292). The cache root is minted at
+    reset_start, the side-effect boundary — never in prepare."""
+
+    workspace = _write_workspace(tmp_path, {"task_plain": fixtures.PLAIN})
+    adapter = OSWorldV2Adapter(provider_factory=FakeProvider, workspace_root=workspace)
+    await adapter.prepare(
+        PrepareParams(
+            operation_id=f"prepare-{episode_id}",
+            episode_id=episode_id,
+            secret_refs=(),
+            infra_values=_INFRA,
+        )
+    )
+    # No cache root was created anywhere under the would-be run root.
+    assert not (tmp_path / "run").exists()

--- a/tests/unit/evaluation/adapters/osworld/test_cleanup.py
+++ b/tests/unit/evaluation/adapters/osworld/test_cleanup.py
@@ -79,7 +79,7 @@ def test_refs_round_trip_through_a_descriptor() -> None:
         schema_version=ADAPTER_SCHEMA_VERSION,
         adapter_id="osworld-v2",
         distribution="lop-osworld-v2-adapter",
-        version="0.1.0",
+        version="0.1.1",
         entry_point="lop_osworld_v2_adapter:create",
         package_digest="a" * 64,
         release_digest="b" * 64,
@@ -93,7 +93,7 @@ def test_refs_round_trip_through_a_descriptor() -> None:
         metadata=AdapterMetadata(
             adapter_id="osworld-v2",
             distribution="lop-osworld-v2-adapter",
-            version="0.1.0",
+            version="0.1.1",
             entry_point="lop_osworld_v2_adapter:create",
             package_digest="a" * 64,
             release_digest="b" * 64,

--- a/tests/unit/evaluation/adapters/osworld/test_discovery.py
+++ b/tests/unit/evaluation/adapters/osworld/test_discovery.py
@@ -38,7 +38,7 @@ def _selector(
         schema_version=ADAPTER_SCHEMA_VERSION,
         adapter_id="osworld-v2",
         distribution="lop-osworld-v2-adapter",
-        version="0.1.0",
+        version="0.1.1",
         entry_point="lop_osworld_v2_adapter:create",
         package_digest=package_digest,
         release_digest=release_digest,
@@ -54,7 +54,7 @@ def test_wheel_has_no_console_scripts(adapter_wheel: Path, tmp_path: Path) -> No
     import zipfile
 
     with zipfile.ZipFile(adapter_wheel) as archive:
-        record = archive.read("lop_osworld_v2_adapter-0.1.0.dist-info/RECORD").decode()
+        record = archive.read("lop_osworld_v2_adapter-0.1.1.dist-info/RECORD").decode()
     for line in record.splitlines():
         path = line.split(",")[0]
         assert not path.startswith(".."), f"RECORD path escapes the root: {path}"

--- a/tests/unit/evaluation/adapters/osworld/test_fake_end_to_end.py
+++ b/tests/unit/evaluation/adapters/osworld/test_fake_end_to_end.py
@@ -110,7 +110,7 @@ def _selector(tmp_path: Path, workspace: Path, adapter: OSWorldV2Adapter) -> Ada
         schema_version=ADAPTER_SCHEMA_VERSION,
         adapter_id="osworld-v2",
         distribution="lop-osworld-v2-adapter",
-        version="0.1.0",
+        version="0.1.1",
         entry_point="lop_osworld_v2_adapter:create",
         package_digest=metadata.package_digest,
         release_digest=metadata.release_digest,

--- a/tests/unit/evaluation/adapters/osworld/test_secrets_and_rescue.py
+++ b/tests/unit/evaluation/adapters/osworld/test_secrets_and_rescue.py
@@ -289,7 +289,7 @@ def _descriptor(tmp_path: Path, workspace: Path, adapter: OSWorldV2Adapter, epis
         schema_version=ADAPTER_SCHEMA_VERSION,
         adapter_id="osworld-v2",
         distribution="lop-osworld-v2-adapter",
-        version="0.1.0",
+        version="0.1.1",
         entry_point="lop_osworld_v2_adapter:create",
         package_digest=adapter.metadata.package_digest,
         release_digest=adapter.metadata.release_digest,
@@ -303,7 +303,7 @@ def _descriptor(tmp_path: Path, workspace: Path, adapter: OSWorldV2Adapter, epis
         metadata=AdapterMetadata(
             adapter_id="osworld-v2",
             distribution="lop-osworld-v2-adapter",
-            version="0.1.0",
+            version="0.1.1",
             entry_point="lop_osworld_v2_adapter:create",
             package_digest=adapter.metadata.package_digest,
             release_digest=adapter.metadata.release_digest,

--- a/tests/unit/evaluation/adapters/osworld/test_spawn.py
+++ b/tests/unit/evaluation/adapters/osworld/test_spawn.py
@@ -296,7 +296,7 @@ def test_a_1_1_selector_cannot_even_be_built_against_a_1_2_parent(tmp_path: Path
             schema_version="1.1",  # type: ignore[arg-type]
             adapter_id="osworld-v2",
             distribution="lop-osworld-v2-adapter",
-            version="0.1.0",
+            version="0.1.1",
             entry_point="lop_osworld_v2_adapter:create",
             package_digest="a" * 64,
             release_digest="b" * 64,


### PR DESCRIPTION
## What

Route OSWorld's episode cache **outside** the digest-pinned adapter workspace, fixing the rescue-wedge defect found by the first paid episode.

**Depends on #542** (branched off its head, `dev-proof-fixes` @ 65207c2f). I will rebase/merge after #542 lands.

## The defect (verified)

Upstream `DesktopEnv(cache_dir="cache")` is relative to the worker's cwd, which **is** the digest-pinned workspace (the supervisor spawns with `cwd=selector.workspace`). During the episode, `_download_setup` wrote `workspace/cache/001/{…calendar.ics, …thunderbird-profile.tar.gz}` — real content the workspace digest correctly refuses to ignore. The rescue worker's digest re-check then refused (`adapter workspace content digest differs`), leaving `rescue_required` stuck `True` and the sweep failing for that descriptor even though the instance was terminated.

## The fix (at the source, in the adapter)

- `reset_start` mints an **absolute, per-episode** cache root at `<artifact_root>/../osworld-cache/<episode_id>` and passes it to `provider.allocate(cache_root=…)`, which hands it to `DesktopEnv` as an absolute `cache_dir`. `allocate` **refuses** to run without one.
  - **Per-episode, not shared**: upstream's `reset_cache_dir` deletes/replaces the cache wholesale between resets, so two episodes sharing a task id must never share a cache.
  - **Beside, not inside, the artifact root**: the bundle verifier walks the artifact directory and refuses any non-digest-named entry.
  - **Durable, never /tmp**: the parent owns the run root and refuses to place it under `/tmp`.
- `EnvironmentProvider.allocate` gains the `cache_root` parameter; `FakeProvider` records it (never writes — it downloads nothing) so tests assert it crossed the boundary.
- **cwd-relative metric writes sealed**: a few upstream metric helpers open files in the cwd with hard-coded relative names (`temp.pdf`, `temp_extracted_N.jpeg`, epub `<name>.dir`), bypassing `cache_dir`. The live env's `open()` is sealed so any write resolving inside the workspace raises rather than silently corrupting the pin; workspace *reads* (the task-module import) and cache-root writes pass through. Verified at runtime.

I did **not** change the worker's cwd: the workspace must stay importable (`instantiate_task` loads task modules by location from it) and the digest pin is verified from the selector path, so routing the cache root is the cleaner, narrower fix.

## Also

- Bump `lop-osworld-v2-adapter` 0.1.0 → **0.1.1** so the workspace pin changes deliberately.
- README build section fixes from the staging report:
  - `uv venv --copies` does not exist in current uv → stdlib `python3.12 -m venv --copies --without-pip` (verified working with the real 3.12.13 interpreter).
  - lock step is now `uv lock --upgrade-package local-operator` so the lock doesn't pin 0.44.26 (schema 1.1 era; the worker speaks 1.2).
- Harness version 0.44.32 → **0.44.33** (`chore(release)` at tip; 0.44.32 belongs to #542).

## Tests

New `tests/unit/evaluation/adapters/osworld/test_cache_dir.py` (4 tests) + 2 in `test_aws_provider.py`:

- `_episode_cache_root` is absolute, outside the workspace, episode-scoped, never /tmp.
- After a FakeProvider episode, `find <workspace> -newer <selector.json>` is **empty** and `workspace_digest` recomputes to the pin.
- A rescue worker's digest re-check **passes** after an episode whose provider downloaded assets into the cache path the adapter handed it (simulated via a FakeProvider subclass that writes `cache_root/<task_id>/downloaded-asset.ics`).
- `DesktopEnv` receives an absolute `cache_dir` equal to the episode cache root; `allocate` refuses without a `cache_root`.
- `prepare` still creates nothing (the cache root is minted at the side-effect boundary).

## Gates (run over the whole tree, as CI)

- `flake8 .` — clean
- `black --check .` (26.1.0) — clean (800 files unchanged)
- `isort --check .` (5.13.2) — clean
- `pyright .` — 0 errors
- adapter suite `tests/unit/evaluation/adapters/osworld`: **172 passed**, run **3× parallel + 1× serial**, plus `test_spawn.py` (real 0.1.1 wheel in a real spawned interpreter) green.
- broader `tests/unit/evaluation`: **702 passed**.

## Note

`scripts/build_osworld_adapter.py` (outside the adapter slice) still defaults `--version 0.1.0`; the operator passes `--version` explicitly at build time, so it is left unchanged here.

No AWS calls; no spend.
