### PR TITLE
feat(config): propagate config.yml edits live across running sessions

### DIFF
--- a/local_operator/config_watch.py
+++ b/local_operator/config_watch.py
@@ -1,0 +1,653 @@
+"""Live propagation of ``config.yml`` edits to every running session.
+
+The problem this solves
+-----------------------
+
+A setting written in one place did not reach any other running consumer. The
+``/settings`` registry labelled five of nine sections ``NEW_SESSIONS`` and
+the label was honest: ``compaction.*`` was coerced once at build,
+``SessionStreamFn`` held the manager's ``values`` dict for the session's life,
+``subagents.max_running`` was read once into ``AsyncJobManager``. A user with
+three ``lop`` panes open who changed the compaction threshold in one of them
+had to ``/new`` the other two — and the page had no way to tell them so beyond
+the scope tag.
+
+The mechanism
+-------------
+
+**One :class:`ConfigWatcher` per process**, stat-polled every
+:attr:`ConfigWatcher.POLL_INTERVAL_S` seconds on the app's event loop, with an
+in-process fast path from :mod:`local_operator.settings_io` writes and an
+opportunistic kqueue wake-up on the config *directory* where the platform has
+one. No daemon is involved. The numbers that shaped it (measured on the design
+machine, ``/tmp/lop-settings-propagation/bench_stat.py``):
+
+* ``os.stat`` of the file: **1 µs**. A full ``ConfigManager`` construct-and-load:
+  **2 060 µs**. So the poll never parses; it stats and compares a fingerprint,
+  and only a changed fingerprint pays for a parse.
+* The real cost of polling is the loop WAKE (~70 µs CPU), not the stat. At 50
+  processes on a 2 s cadence that is 0.18 % of one core — cheaper than the
+  mobile daemon's own 2 s registry scan that already runs on this machine.
+* A Unix-socket round trip to that daemon would cost 49–644 µs per poll, needs
+  the daemon to be running (it is optional), and the daemon would still have to
+  detect the change by stat or kqueue itself. Polling the daemon adds a hop and
+  a reconnect state machine and removes nothing; rejected.
+* A directory kqueue delivered **0 events in 20 s** on the real config
+  directory with 74 ``lop`` processes alive — the SQLite WAL churn is inside
+  file inodes, not directory entries — so the accelerator is quiet, not noisy.
+
+Two facts about the write path shape everything here:
+
+* **Every write is an atomic ``os.replace``** of a same-directory temp file
+  (``ConfigManager._write_config``), so the file's inode changes on every
+  write. That is why the fingerprint includes ``st_ino`` (a same-size write
+  within one mtime tick still moves it) and why the kqueue watches the
+  DIRECTORY rather than the file: a watch on the file's inode reports one
+  ``KQ_NOTE_DELETE`` and then nothing, forever.
+* **``ConfigManager._load_config`` degrades a malformed file to defaults and
+  moves it aside** to ``config.yml.bad.<stamp>``. A live reloader that went
+  through it would turn a half-typed hand edit into a destroyed config on the
+  next tick in every open session. The watcher therefore parses the raw bytes
+  itself under the same rules ``settings_io._require_readable_config``
+  applies before a write, keeps the last good snapshot when they fail, and
+  never constructs a ``ConfigManager`` at all.
+
+Threading contract
+------------------
+
+``_tick`` and listener fan-out run on the loop thread only. :meth:`notify_local`
+may be called from anywhere — the ``SettingsView`` writes on the loop, but a
+tool-driven ``settings_io`` write could be on a worker — so it hops through
+``call_soon_threadsafe`` when it is off-loop, and simply records-and-drops when
+no loop was ever started (the CLI's ``config edit`` path, which has no watcher
+to notify). :attr:`values` may be read from any thread: the snapshot swap is
+one attribute assignment of a dict nobody mutates afterwards, which is atomic
+under the GIL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import logging
+import os
+import sys
+import threading
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Literal
+
+import yaml
+
+logger = logging.getLogger("local_operator.config_watch")
+
+#: ``(st_ino, st_size, st_mtime_ns)`` — what a tick compares. See the module
+#: docstring for why the inode is part of it.
+Fingerprint = tuple[int, int, int]
+
+#: A subscriber. Synchronous, called on the loop thread, one call per
+#: :class:`ConfigChange`. A raising listener is logged and never propagated
+#: (same contract as ``Session._emit``), so one bad subscriber cannot starve
+#: the others of a change.
+Listener = Callable[["ConfigChange"], None]
+
+#: The name of the file every fingerprint and parse is taken from. Restated
+#: rather than imported from :mod:`local_operator.config` so this module has
+#: no import-time dependency on the manager it exists to bypass.
+_CONFIG_FILE_NAME = "config.yml"
+
+
+@dataclass(frozen=True)
+class ConfigChange:
+    """One delivered change: the new values, what moved, and who moved it.
+
+    ``values`` is the watcher's own deep copy of ``config.yml``'s ``values``
+    mapping — read-only by contract. Listeners that need a typed object
+    (``CompactionSettings``) build it from here; listeners that need the whole
+    mapping (``SessionStreamFn``) rebind to it.
+
+    ``changed_keys`` names REGISTRY keys (``settings_io.SETTINGS`` ``.key``
+    spellings such as ``compaction.threshold_percent``), not YAML paths, and is
+    computed per key rather than per file: every write also bumps
+    ``metadata.last_modified`` and a no-op write must not produce a
+    notification. It is what the TUI prints in its notice, so it speaks the
+    same vocabulary as ``/settings`` and ``lop config edit``.
+
+    ``source`` tells a listener whether THIS process made the write
+    (``"local"``: the page or CLI here already showed its own result, so the
+    TUI stays quiet) or another one did (``"disk"``: name the keys so the user
+    knows why behaviour just changed under them).
+    """
+
+    values: Mapping[str, Any]
+    changed_keys: frozenset[str]
+    source: Literal["disk", "local"]
+
+
+class ConfigWatcher:
+    """Stat-poll ``config.yml`` and fan out per-key changes to subscribers.
+
+    Construct one per config directory per process — :func:`process_watcher`
+    is the canonical way to get it — and :meth:`start` it on the loop the
+    sessions run on. Everything else is driven from the tick.
+    """
+
+    #: The poll cadence. 2 s is the latency a user perceives as "it just
+    #: applied" when they tab between panes, and at 70 µs per wake the cost is
+    #: invisible even at 50 processes (module docstring). 5 s would halve a
+    #: cost that is already ~0.2 % of a core and make the cross-pane change
+    #: feel laggy; sub-second would spend real wakes on an event that happens
+    #: a few times a day. Not a tuning knob.
+    POLL_INTERVAL_S = 2.0
+
+    def __init__(self, config_dir: Path, *, interval: float = POLL_INTERVAL_S) -> None:
+        self._config_dir = Path(config_dir)
+        self._config_file = self._config_dir / _CONFIG_FILE_NAME
+        self._interval = float(interval)
+        self._listeners: list[Listener] = []
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._task: asyncio.Task[None] | None = None
+        # The fingerprint of the file the CURRENT snapshot was parsed from. A
+        # tick whose stat equals this returns without reading a byte.
+        self._fingerprint: Fingerprint | None = None
+        # The fingerprint of a file that FAILED to parse. Remembered so an
+        # unreadable file is parsed once, not every tick: a user mid-edit in
+        # vim would otherwise cost every open session a YAML parse twice a
+        # second until they saved something valid. Cleared as soon as the
+        # fingerprint moves again.
+        self._bad_fingerprint: Fingerprint | None = None
+        # kqueue accelerator state (darwin/BSD only; ``None`` elsewhere or when
+        # arming failed). Both descriptors are closed by :meth:`stop`.
+        self._kqueue: Any = None
+        self._dir_fd: int | None = None
+        # The last good snapshot: THE process's canonical live view of
+        # ``values``. Seeded synchronously here so ``values`` is meaningful
+        # before the first tick and so a listener subscribed before ``start``
+        # sees the same baseline the first diff is taken against. A missing
+        # file IS the defaults — exactly what ``ConfigManager._load_config``
+        # yields for one — so the first write to a fresh install diffs against
+        # the defaults it back-fills rather than announcing thirty keys.
+        self._values: Mapping[str, Any] = _with_defaults({})
+        self._prime()
+
+    # -- public surface -----------------------------------------------------
+
+    @property
+    def config_dir(self) -> Path:
+        return self._config_dir
+
+    @property
+    def values(self) -> Mapping[str, Any]:
+        """The last good ``values`` mapping. Read-only by contract.
+
+        Safe from any thread: the swap in :meth:`_adopt` is a single attribute
+        assignment of a mapping that is never mutated afterwards.
+        """
+        return self._values
+
+    def subscribe(self, listener: Listener) -> Callable[[], None]:
+        """Register ``listener``; returns its unsubscribe.
+
+        Idempotent to unsubscribe twice — a session disposed through two paths
+        (its own dispose hook and a subagent's ``_dispose_child``) must not
+        raise on the second call.
+        """
+        self._listeners.append(listener)
+
+        def unsubscribe() -> None:
+            try:
+                self._listeners.remove(listener)
+            except ValueError:
+                pass
+
+        return unsubscribe
+
+    def start(self, loop: asyncio.AbstractEventLoop | None = None) -> None:
+        """Begin polling on ``loop`` (default: the running loop). Idempotent.
+
+        Also arms the kqueue accelerator where available. A second call while
+        the task is alive is a no-op, which is what lets every
+        ``create_session`` call it unconditionally: the first session in the
+        process starts the watcher, the ``/new`` that follows finds it running.
+        """
+        if self._task is not None and not self._task.done():
+            return
+        if loop is None:
+            loop = asyncio.get_running_loop()
+        self._loop = loop
+        # Re-fingerprint before the first tick so a change that landed between
+        # construction and start is delivered rather than silently adopted as
+        # the baseline. ``poll_now`` returns it to the caller too; nothing here
+        # needs the value.
+        self.poll_now()
+        self._task = loop.create_task(self._run(), name="config-watch")
+        self._arm_kqueue(loop)
+
+    async def stop(self) -> None:
+        """Cancel the poll task and release the kqueue descriptors."""
+        task = self._release()
+        if task is not None and not task.done():
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001 — teardown proceeds
+                pass
+
+    def _release(self) -> "asyncio.Task[None] | None":
+        """Synchronous teardown: descriptors closed, poll task cancelled.
+
+        The part of :meth:`stop` that needs no loop, split out so the registry
+        can reap a watcher whose loop is already gone (see
+        :func:`process_watcher`). Returns the cancelled task for a caller that
+        can await its quietus.
+        """
+        self._disarm_kqueue()
+        task, self._task = self._task, None
+        if task is not None and not task.done():
+            loop = self._loop
+            if loop is not None and not loop.is_closed():
+                task.cancel()
+        return task
+
+    @property
+    def is_idle(self) -> bool:
+        """True when nothing can ever hear from this watcher again.
+
+        No listeners, or a loop that has closed (its subscribers died with
+        it). The registry uses this to bound the fds a process holds.
+        """
+        loop = self._loop
+        return not self._listeners or (loop is not None and loop.is_closed())
+
+    def poll_now(self) -> ConfigChange | None:
+        """One synchronous tick: stat, parse if moved, diff, fan out.
+
+        Returns the change it delivered (or ``None``). The write fast path and
+        the tests use it directly; the poll task calls it every interval.
+        """
+        return self._tick(source="disk")
+
+    def notify_local(self, values: Mapping[str, Any] | None = None) -> None:
+        """The in-process write fast path.
+
+        Called by ``settings_io._store``/``_delete`` right after a write lands.
+        Re-stats and re-parses the file (rather than trusting the ``values``
+        the writer passes, which is the writer's manager's view and may carry
+        keys ``_load_config`` back-filled that are not on disk), records the new
+        fingerprint so the next poll tick is a no-op, and fans out with
+        ``source="local"`` — SYNCHRONOUSLY when called on the loop thread, so a
+        ``/settings`` toggle of ``compaction.enabled`` reaches the writer's own
+        session on the same call stack the page runs on.
+
+        Off the loop thread it hops through ``call_soon_threadsafe``: listeners
+        touch session state and widgets that are loop-affine. On a platform
+        with the kqueue accelerator the directory event can wake the loop and
+        deliver the change as ``"disk"`` before that hop lands — the change
+        still arrives exactly once and on the loop thread, only its ``source``
+        is then the conservative one (the TUI prints a line it could have
+        skipped). Accepted: no production writer runs off-loop today, and the
+        alternative is a pre-write handshake in ``settings_io`` for a cosmetic
+        difference. With no loop started (the CLI's ``config edit``) it just
+        re-reads so ``values`` stays current for anyone who asks, and delivers
+        to nobody — there is nobody.
+
+        ``values`` is accepted for API symmetry with the design and ignored for
+        the reason above; the file is the source of truth.
+        """
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            self._tick(source="local")
+            return
+        if _on_loop(loop):
+            self._tick(source="local")
+            return
+        try:
+            loop.call_soon_threadsafe(self._tick, "local")
+        except RuntimeError:
+            # The loop closed between the check and the call. Nothing to
+            # deliver to; keep the snapshot honest for any late reader.
+            self._tick(source="local")
+
+    # -- the tick -----------------------------------------------------------
+
+    def _stat(self) -> Fingerprint | None:
+        """The file's fingerprint, or ``None`` when it does not exist.
+
+        A missing file is a first run, not an error: ``_require_readable_config``
+        treats it the same way, and the watcher must too or a fresh install
+        would log a failure on every tick until the first write.
+        """
+        try:
+            st = os.stat(self._config_file)
+        except FileNotFoundError:
+            return None
+        except OSError:
+            # Permissions or I/O trouble. Not a config change; leave the
+            # snapshot alone and try again next tick.
+            return self._fingerprint
+        return (st.st_ino, st.st_size, st.st_mtime_ns)
+
+    def _prime(self) -> None:
+        """Take the initial snapshot without notifying anyone."""
+        fingerprint = self._stat()
+        if fingerprint is None:
+            self._fingerprint = None
+            return
+        parsed = self._parse()
+        if parsed is None:
+            self._bad_fingerprint = fingerprint
+            return
+        self._fingerprint = fingerprint
+        self._values = parsed
+
+    def _tick(self, source: Literal["disk", "local"] = "disk") -> ConfigChange | None:
+        fingerprint = self._stat()
+        if fingerprint == self._fingerprint:
+            return None
+        if fingerprint is None:
+            # The file was removed. The last good snapshot stays the live
+            # view — a deleted config is the defaults on the NEXT launch, not a
+            # reason to reconfigure every running session — but the
+            # fingerprint is cleared so the file's return is seen as a change.
+            self._fingerprint = None
+            self._bad_fingerprint = None
+            return None
+        if fingerprint == self._bad_fingerprint:
+            # Already known unreadable; do not re-parse until it moves.
+            return None
+        parsed = self._parse()
+        if parsed is None:
+            self._bad_fingerprint = fingerprint
+            return None
+        self._bad_fingerprint = None
+        previous = self._values
+        self._fingerprint = fingerprint
+        changed = _changed_registry_keys(previous, parsed)
+        self._adopt(parsed)
+        if not changed:
+            return None
+        change = ConfigChange(values=self._values, changed_keys=changed, source=source)
+        self._fan_out(change)
+        return change
+
+    def _parse(self) -> Mapping[str, Any] | None:
+        """``values`` from the raw bytes, or ``None`` when the file is unreadable.
+
+        Mirrors ``settings_io._require_readable_config`` exactly and on purpose
+        — a YAML syntax error, a non-mapping top level, an empty file, and
+        non-UTF-8 bytes are the shapes ``_load_config`` would degrade on, and
+        degrading is what this must never do. Unlike that guard this returns
+        rather than raises, because the watcher's answer to "unreadable" is
+        "keep the last good snapshot", not "abort".
+
+        The ``values`` block is DEEP-COPIED so the snapshot cannot alias
+        anything a later parse or a consumer's own mutation could touch.
+        """
+        try:
+            raw = self._config_file.read_text(encoding="utf-8")
+        except (FileNotFoundError, OSError, UnicodeDecodeError) as error:
+            logger.debug("config.yml not readable: %s", error)
+            return None
+        if not raw.strip():
+            logger.debug("config.yml is empty; keeping the last good settings")
+            return None
+        try:
+            loaded = yaml.safe_load(raw)
+        except yaml.YAMLError as error:
+            logger.debug("config.yml did not parse; keeping the last good settings: %s", error)
+            return None
+        if loaded is None:
+            return None
+        if not isinstance(loaded, Mapping):
+            logger.debug(
+                "config.yml top level is %s, not a mapping; keeping the last good settings",
+                type(loaded).__name__,
+            )
+            return None
+        values = loaded.get("values")
+        if not isinstance(values, Mapping):
+            # A file with a mapping top level but no usable ``values`` reads
+            # as "nothing set", which ``_load_config`` resolves to the
+            # defaults; so does this.
+            values = {}
+        return _with_defaults(values)
+
+    def _adopt(self, values: Mapping[str, Any]) -> None:
+        # ONE assignment: this is the cross-thread publication point for
+        # ``values`` (see the class docstring).
+        self._values = values
+
+    def _fan_out(self, change: ConfigChange) -> None:
+        for listener in list(self._listeners):
+            try:
+                listener(change)
+            except Exception:  # noqa: BLE001 — one listener must not starve the rest
+                logger.warning("config change listener failed", exc_info=True)
+
+    async def _run(self) -> None:
+        while True:
+            await asyncio.sleep(self._interval)
+            try:
+                self._tick(source="disk")
+            except Exception:  # noqa: BLE001 — the poller must outlive any one bad tick
+                logger.warning("config watch tick failed", exc_info=True)
+
+    # -- kqueue accelerator -------------------------------------------------
+
+    def _arm_kqueue(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Wake the tick on a directory write, where the platform can say so.
+
+        BSD/macOS only (``select.kqueue``); Linux keeps the poll alone, which
+        gives ≤2 s latency — inotify is not in the stdlib and ``watchdog`` was
+        judged not worth a native dependency for a few-times-a-day event.
+        Watches the DIRECTORY because every write is an ``os.replace`` and the
+        file's inode dies with it (module docstring). Any failure — EMFILE, a
+        filesystem without vnode events, a missing directory on first run — is
+        silent: the poll is the primary mechanism and this only trims latency.
+        """
+        import select
+
+        # ``sys.platform == "darwin"`` rather than ``hasattr(select,
+        # "kqueue")``: both are correct at RUNTIME, but only the equality form
+        # NARROWS for the type checker. CI type-checks on Linux, where
+        # typeshed's ``select`` stub genuinely has no
+        # ``kqueue``/``kevent``/``KQ_*``, and a hasattr guard therefore left
+        # seven ``reportAttributeAccessIssue`` errors on a gate that is green
+        # on a macOS dev box — exactly the pass-locally/fail-on-CI shape
+        # AGENTS.md warns about. A tuple membership test (``not in (...)``) is
+        # not a narrowing form pyright recognises either; the literal
+        # comparison is.
+        #
+        # This costs the BSDs the accelerator even though they have kqueue.
+        # That is the deliberate trade and it is cheap: the accelerator only
+        # trims LATENCY, so a FreeBSD user gets the same ≤2 s poll Linux gets
+        # rather than sub-second, and no behaviour differs. The ``hasattr``
+        # below stays as the runtime belt for a darwin build without kqueue.
+        if sys.platform != "darwin":
+            return
+        if not hasattr(select, "kqueue"):
+            return
+        try:
+            flags = os.O_RDONLY | getattr(os, "O_EVTONLY", 0)
+            dir_fd = os.open(self._config_dir, flags)
+        except OSError:
+            return
+        try:
+            kq = select.kqueue()
+            event = select.kevent(
+                dir_fd,
+                filter=select.KQ_FILTER_VNODE,
+                flags=select.KQ_EV_ADD | select.KQ_EV_CLEAR,
+                fflags=select.KQ_NOTE_WRITE | select.KQ_NOTE_ATTRIB,
+            )
+            kq.control([event], 0, 0)
+            loop.add_reader(kq.fileno(), self._on_kqueue_readable)
+        except Exception:  # noqa: BLE001 — accelerator is optional
+            os.close(dir_fd)
+            return
+        self._kqueue = kq
+        self._dir_fd = dir_fd
+
+    def _on_kqueue_readable(self) -> None:
+        kq = self._kqueue
+        if kq is None:
+            return
+        try:
+            # Drain: EV_CLEAR resets the state after each read, but several
+            # writes may have coalesced while the loop was busy.
+            kq.control(None, 16, 0)
+        except Exception:  # noqa: BLE001 — a failed drain still ticks
+            pass
+        try:
+            self._tick(source="disk")
+        except Exception:  # noqa: BLE001
+            logger.warning("config watch tick failed", exc_info=True)
+
+    def _disarm_kqueue(self) -> None:
+        kq, self._kqueue = self._kqueue, None
+        dir_fd, self._dir_fd = self._dir_fd, None
+        loop = self._loop
+        if kq is not None:
+            if loop is not None and not loop.is_closed():
+                try:
+                    loop.remove_reader(kq.fileno())
+                except Exception:  # noqa: BLE001
+                    pass
+            try:
+                kq.close()
+            except Exception:  # noqa: BLE001
+                pass
+        if dir_fd is not None:
+            try:
+                os.close(dir_fd)
+            except OSError:
+                pass
+
+
+def _with_defaults(values: Mapping[str, Any]) -> dict[str, Any]:
+    """``values`` deep-copied, with missing TOP-LEVEL keys back-filled.
+
+    Mirrors the one normalisation ``ConfigManager._load_config`` applies so
+    the watcher's view of a file equals a manager's view of the same file:
+    a consumer switching from ``manager.get_config().values`` to
+    ``watcher.values`` must not start seeing ``retry`` as absent because the
+    user's file predates the key. Top level only, as in ``_load_config`` —
+    nested blocks are the consumers' own coercers' business
+    (``RetrySettings.from_settings``, ``CompactionSettings``).
+
+    ``DEFAULT_CONFIG`` is the module-level constant, imported lazily so this
+    module stays importable before the config module's own imports settle,
+    and deep-copied because that object is shared process-wide and a
+    consumer mutating a nested default through the snapshot would poison
+    every later parse.
+    """
+    from local_operator.config import DEFAULT_CONFIG
+
+    merged: dict[str, Any] = copy.deepcopy(dict(values))
+    for key, default in DEFAULT_CONFIG.values.items():
+        if key not in merged:
+            merged[key] = copy.deepcopy(default)
+    return merged
+
+
+def _on_loop(loop: asyncio.AbstractEventLoop) -> bool:
+    """Whether the caller is executing on ``loop``'s thread right now."""
+    try:
+        return asyncio.get_running_loop() is loop
+    except RuntimeError:
+        return False
+
+
+def _changed_registry_keys(before: Mapping[str, Any], after: Mapping[str, Any]) -> frozenset[str]:
+    """Registry keys whose stored value differs between two ``values`` mappings.
+
+    Walks ``settings_io.SETTINGS`` with its own ``_walk`` so the comparison
+    uses exactly the paths the page and the CLI use — including the flat
+    ``display.*`` keys whose dot is literal. ~55 keys, microseconds. A key
+    absent on both sides is unchanged; absent on one side is changed (an unset
+    is a real edit the consumers must see, since it means "back to default").
+    """
+    from local_operator.settings_io import _MISSING, SETTINGS, _walk
+
+    changed: set[str] = set()
+    for setting in SETTINGS:
+        old = _walk(before, setting.path)
+        new = _walk(after, setting.path)
+        if old is _MISSING and new is _MISSING:
+            continue
+        if old is _MISSING or new is _MISSING or old != new:
+            changed.add(setting.key)
+    return frozenset(changed)
+
+
+# ---------------------------------------------------------------------------
+# The per-process singleton
+# ---------------------------------------------------------------------------
+
+_watchers: dict[Path, ConfigWatcher] = {}
+_watchers_lock = threading.Lock()
+
+
+def process_watcher(config_dir: Path | None = None) -> ConfigWatcher:
+    """The one watcher for ``config_dir`` (default ``paths.config_dir()``).
+
+    Keyed on the directory rather than a bare module global because tests and
+    the exec worker point ``LOCAL_OPERATOR_CONFIG_DIR`` at scratch directories,
+    and a watcher on the wrong directory would silently watch nothing. Created
+    lazily and never started here: ``start`` needs a loop, and the factory
+    that knows the loop calls it.
+    """
+    if config_dir is None:
+        from local_operator.paths import config_dir as _config_dir
+
+        config_dir = _config_dir()
+    key = Path(config_dir)
+    with _watchers_lock:
+        watcher = _watchers.get(key)
+        if watcher is None:
+            # Reap watchers on OTHER directories that can never deliver again
+            # before adding one. A production process has exactly one config
+            # directory for its whole life, so this never fires there; a
+            # process that moves between directories (the test suite: one
+            # ``tmp_path`` per test, thousands per worker) would otherwise
+            # accumulate a directory fd and a kqueue per directory until
+            # EMFILE. Reaping only the IDLE ones keeps a live session's
+            # watcher on a second directory intact.
+            for other_key, other in list(_watchers.items()):
+                if other.is_idle:
+                    other._release()
+                    del _watchers[other_key]
+            watcher = ConfigWatcher(key)
+            _watchers[key] = watcher
+        return watcher
+
+
+def existing_watcher(config_dir: Path | None = None) -> ConfigWatcher | None:
+    """The watcher for ``config_dir`` if one was ever created, else ``None``.
+
+    The write fast path in ``settings_io`` uses this rather than
+    :func:`process_watcher` so a CLI process that only ever writes does not
+    build a watcher it will never start.
+    """
+    if config_dir is None:
+        from local_operator.paths import config_dir as _config_dir
+
+        config_dir = _config_dir()
+    with _watchers_lock:
+        return _watchers.get(Path(config_dir))
+
+
+def _reset_for_tests() -> None:
+    """Drop every registered watcher. Tests only."""
+    with _watchers_lock:
+        _watchers.clear()
+
+
+__all__ = [
+    "ConfigChange",
+    "ConfigWatcher",
+    "Fingerprint",
+    "Listener",
+    "existing_watcher",
+    "process_watcher",
+]

--- a/local_operator/config_watch.py
+++ b/local_operator/config_watch.py
@@ -175,6 +175,12 @@ class ConfigWatcher:
 
     @property
     def config_dir(self) -> Path:
+        """The directory this watcher is bound to.
+
+        Public so a caller handing the watched config to a read-per-use
+        consumer (a ``ConfigManager`` for the web tools, say) can name the SAME
+        directory the watcher is on, rather than reaching into ``_config_dir``.
+        """
         return self._config_dir
 
     @property
@@ -280,6 +286,27 @@ class ConfigWatcher:
         the tests use it directly; the poll task calls it every interval.
         """
         return self._tick(source="disk")
+
+    def config_is_readable(self) -> bool:
+        """Whether the file on disk parses to a usable ``values`` mapping RIGHT NOW.
+
+        The guard a caller needs before running a DESTRUCTIVE reload.
+        ``ConfigManager._load_config`` has two behaviours this module was built
+        never to have: it raises on a ``values:`` block that is not a mapping,
+        and on a YAML syntax error or non-mapping top level it moves the user's
+        ``config.yml`` aside to ``config.yml.bad.<ts>`` and starts from
+        defaults. Both are defensible at STARTUP — better to boot clean than to
+        fail identically forever — and neither is acceptable on a hot path the
+        user chose, where it silently discards every setting they have.
+
+        Exposed here rather than reimplemented at the call site because
+        :meth:`_parse` already encodes exactly the right rule set (review round
+        3, B1), and a second copy of "is this file usable" is the kind of
+        near-duplicate that drifts. Reads the file each call — it is answering a
+        question about the CURRENT bytes, not about the snapshot, and the cost
+        is one stat plus one parse on a command boundary.
+        """
+        return self._parse() is not None
 
     def notify_local(self, values: Mapping[str, Any] | None = None) -> None:
         """The in-process write fast path.
@@ -453,6 +480,15 @@ class ConfigWatcher:
             # ABSENT `values` genuinely reads as "nothing set", which
             # `_load_config` resolves to the defaults; so does this.
             values = {}
+        # The guard is deliberately TOP-LEVEL only (review round 3, N1). One
+        # level down — `values:\n  retry: 5` — still partially adopts, and
+        # `main` behaves the same way, because the per-section consumers all
+        # coerce defensively (`RetrySettings.from_settings` and friends take
+        # the default for anything they cannot read). Recursing would mean this
+        # module deciding the shape of every section's payload, which is the
+        # consumers' job and would drift from it. The boundary is here because
+        # a non-mapping at the TOP replaces every section at once; a bad
+        # section damages only itself.
         return _with_defaults(values)
 
     def _adopt(self, values: Mapping[str, Any]) -> None:

--- a/local_operator/config_watch.py
+++ b/local_operator/config_watch.py
@@ -210,9 +210,23 @@ class ConfigWatcher:
         the task is alive is a no-op, which is what lets every
         ``create_session`` call it unconditionally: the first session in the
         process starts the watcher, the ``/new`` that follows finds it running.
+
+        A call that gets PAST that guard — the task died with its loop, and
+        nobody called :meth:`stop` — must release the previous accelerator
+        before arming a new one (review round 1, M4). Without this,
+        ``_arm_kqueue`` overwrites ``_kqueue``/``_dir_fd`` while the old
+        descriptors are still open and unreferenced, so a later ``stop()`` can
+        only close the newest pair: measured at four directory fds
+        (``[6, 8, 7, 9]``) across four loops, three still open afterwards.
+        Production runs one loop per process, so this is a latent leak rather
+        than a live one — but ``start`` is called unconditionally from four
+        sites and EMFILE is the failure mode the registry's reaping already
+        exists to prevent, which is too small a margin to leave a known leak
+        inside.
         """
         if self._task is not None and not self._task.done():
             return
+        self._disarm_kqueue()
         if loop is None:
             loop = asyncio.get_running_loop()
         self._loop = loop

--- a/local_operator/config_watch.py
+++ b/local_operator/config_watch.py
@@ -355,6 +355,13 @@ class ConfigWatcher:
         self._values = parsed
 
     def _tick(self, source: Literal["disk", "local"] = "disk") -> ConfigChange | None:
+        # Stat FIRST, then re-read in ``_parse``. A write landing between the
+        # two stores a fingerprint that does not describe the bytes just
+        # adopted (review round 2, N4) — but that is self-correcting rather
+        # than a lost update: the stored fingerprint then matches neither the
+        # old nor the new file, so the very next tick sees a mismatch and
+        # re-parses. The content adopted is always at least as new as the
+        # fingerprint, never older, which is the direction that matters.
         fingerprint = self._stat()
         if fingerprint == self._fingerprint:
             return None
@@ -418,11 +425,33 @@ class ConfigWatcher:
                 type(loaded).__name__,
             )
             return None
-        values = loaded.get("values")
-        if not isinstance(values, Mapping):
-            # A file with a mapping top level but no usable ``values`` reads
-            # as "nothing set", which ``_load_config`` resolves to the
-            # defaults; so does this.
+        if "values" in loaded:
+            values = loaded.get("values")
+            if not isinstance(values, Mapping):
+                # PRESENT but not a mapping — `values: 3`, or the mis-indented
+                # or truncated edit that leaves a scalar behind. This is NOT
+                # "nothing set" (review round 2, M5): substituting `{}` here
+                # back-fills the whole default set, which is then adopted and
+                # fanned out as a real change, resetting every running session
+                # to defaults from one hand-edit typo.
+                #
+                # An earlier comment justified the `{}` by saying `_load_config`
+                # resolves this shape the same way. It does not: `ConfigManager`
+                # raises `TypeError` on the identical file. The mirrored write
+                # guard, `_require_readable_config`, does deliberately pass this
+                # shape — but its docstring says why that is safe THERE ("it
+                # fails later in the write with its bytes intact"), and the
+                # watcher has no later step to fail at. It adopts. So this is
+                # the one place the mirror must diverge: unreadable, keep the
+                # last good snapshot.
+                logger.debug(
+                    "config.yml 'values' is %s, not a mapping; keeping the last good settings",
+                    type(values).__name__,
+                )
+                return None
+        else:
+            # ABSENT `values` genuinely reads as "nothing set", which
+            # `_load_config` resolves to the defaults; so does this.
             values = {}
         return _with_defaults(values)
 

--- a/local_operator/guides/failover/GUIDE.md
+++ b/local_operator/guides/failover/GUIDE.md
@@ -190,12 +190,12 @@ chain re-list the *current* model at a different effort as a real route.
 `enabled: false` or `modelFallback: false` switches the cascade off entirely —
 `/failovers` names whichever of the two did it.
 
-**An edit does not reach a running session.** The stream captures its settings
-once at session build and nothing watches `config.yml`, so after changing the
-cascade the user must run `/reload` (or start a new session) for the new routing
-to take effect. `/failovers` compares the two and prints a `stale` row naming
-`/reload` when they diverge, so the listing never shows a cascade the running
-session will not honour.
+**An edit reaches every running session.** Each process watches `config.yml`
+and rebinds the stream's settings mapping when it changes — immediately in the
+process that wrote it, within about two seconds in any other `lop` session on
+the machine — so a cascade change needs no `/reload`. The other session prints
+a `config.yml changed: retry.fallbackChains — applied` notice so the user knows
+why routing moved. `/failovers` reads that same live mapping.
 
 **Never put tokens or API keys in this mapping.** Credentials live in the
 credential store (`local-operator login <provider>`); a chain entry names a

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -403,6 +403,35 @@ class AsyncJobManager:
         )
         return running >= self._max_running
 
+    @property
+    def max_running(self) -> int:
+        return self._max_running
+
+    def set_max_running(self, value: int) -> None:
+        """Change the concurrency ceiling on a LIVE manager.
+
+        The config watcher's entry point for ``subagents.max_running``. Both
+        directions are safe by construction because every gate reads
+        ``_max_running`` at decision time rather than caching a verdict:
+
+        * RAISING the cap lets the next launch through, and parked jobs are
+          promoted immediately (same FIFO path a settled job uses) so a queue
+          that built up under the old cap does not wait for a completion that
+          may be minutes away.
+        * LOWERING it below the running count evicts nothing — a subagent
+          mid-task is not cancelled because the operator typed a smaller
+          number — ``at_capacity`` simply stays true until enough jobs settle.
+
+        A value below 1 is refused with the same reasoning ``Session`` applies
+        at build: ``0`` would park every future launch behind a gate that can
+        never open.
+        """
+        cap = int(value)
+        if cap < 1:
+            raise ValueError("max_running must be >= 1")
+        self._max_running = cap
+        self._promote_oldest_queued()
+
     def accounting_components(self) -> list[Usage]:
         """A detached, provenance-preserving snapshot of this whole ledger.
 

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -1461,5 +1461,22 @@ async def _build_child_session(
         # disconnect hook, because the child does not own the servers.
         child.mcp_manager = parent_session.mcp_manager
         child.mcp_startup = parent_session.mcp_startup
+    # Follow ``config.yml`` like the parent does (``session_factory
+    # .attach_config_watch``). The ``model_copy`` of the parent's compaction
+    # settings above is the correct INITIAL value; this subscription is what
+    # keeps it current, so a threshold lowered while a long review child runs
+    # bounds the child too. Same process and loop as the parent, so no extra
+    # poller and no extra wake — one more listener on the process watcher.
+    # Unsubscribed by ``_dispose_child`` through the dispose hook, exactly as
+    # the parent's is. Degrades silently: a child that cannot follow config is
+    # a child built the way every child was before this seam.
+    try:
+        from local_operator.config_watch import process_watcher
+
+        watcher = process_watcher(config_dir())
+        watcher.start(asyncio.get_running_loop())
+        child.add_dispose_hook(watcher.subscribe(child._apply_config_change))
+    except Exception:  # noqa: BLE001 — a child must build without the watcher
+        logger.warning("config watcher could not be attached to the child", exc_info=True)
     await child.async_init()
     return child

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1778,18 +1778,37 @@ class SessionStreamFn:
     def routing_settings(self) -> Mapping[str, Any]:
         """The settings mapping THIS stream will actually route on.
 
-        Captured once at session build (``session_factory``) and held for the
-        session's life, so it is not necessarily what is on disk: nothing
-        watches ``config.yml``, and the only ``ConfigManager.reload`` caller is
-        the first-run ``/login`` path. A read-only surface that wants to report
-        what the SESSION will do — rather than what a later edit intends — has
-        to read this rather than re-reading the file, or it shows a green light
-        for a cascade the running session will not honour.
+        Captured at session build (``session_factory``) and REBOUND by
+        :meth:`apply_settings` whenever the process's config watcher sees
+        ``config.yml`` change, so it tracks disk within the watcher's poll
+        interval. A read-only surface that wants to report what the SESSION
+        will do has to read this rather than re-reading the file — the two
+        agree by construction now, but this is the one that is authoritative.
 
-        Exposed read-only for exactly that reason; mutating routing mid-session
-        is not what this is for.
+        Exposed read-only; :meth:`apply_settings` is the single write door.
         """
         return self._settings if isinstance(self._settings, Mapping) else {}
+
+    def apply_settings(self, values: Mapping[str, Any] | None) -> None:
+        """Rebind the settings mapping every routing decision reads.
+
+        Sufficient on its own because nothing here caches a DERIVED view:
+        ``RetrySettings.from_settings(self._settings)`` runs per model call,
+        ``_openai_api_mode`` per client build, and the effort ladder reads
+        ``self._settings["effort"]`` per message. Rebinding the mapping is
+        therefore the whole change, and the next call routes on the new values.
+
+        Deliberately does NOT touch ``_route_state``, the usage memo, or the
+        per-message effort freeze: a pinned hard fallback must survive a
+        threshold edit (the provider that just rejected us has not recovered
+        because the user typed a number), and a mid-message effort is frozen
+        for a reason ``_effort_for`` documents. Those reset on their own
+        boundaries.
+
+        Called from ``Session._apply_config_change``. A subagent shares its
+        parent's stream fn, so one rebind covers the whole tree.
+        """
+        self._settings = values
 
     def set_notice_handler(
         self, handler: Callable[[str, str], Awaitable[None] | None] | None

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1749,11 +1749,7 @@ class SessionStreamFn:
         # ``retry.*``; the store itself defaults to ON and knows nothing about
         # config. Duck-typed (``getattr``) because the test doubles handed in
         # as ``auth_store`` implement only the failover protocol.
-        configure_pick = getattr(auth_store, "configure_usage_aware_pick", None)
-        if callable(configure_pick):
-            from local_operator.providers.failover import RetrySettings
-
-            configure_pick(RetrySettings.from_settings(settings).usage_aware_account_pick)
+        self._push_usage_aware_pick(settings)
         # Deliberately NO prompt-cache TTL hint memory (or reader registry)
         # here: subagents share the parent's stream fn (``harness/subagent.py``),
         # so any per-conversation state held on this object — even a
@@ -1789,14 +1785,40 @@ class SessionStreamFn:
         """
         return self._settings if isinstance(self._settings, Mapping) else {}
 
+    def _push_usage_aware_pick(self, settings: Mapping[str, Any] | None) -> None:
+        """Push ``retry.usageAwareAccountPick`` into the auth store.
+
+        The operator's opt-out for the cascade's usage-ranked first pick
+        travels through here because this is the one place a session parses
+        ``retry.*``; the store itself defaults to ON and knows nothing about
+        config. Duck-typed (``getattr``) because the test doubles handed in as
+        ``auth_store`` implement only the failover protocol.
+
+        Factored out of ``__init__`` so :meth:`apply_settings` can re-push it
+        (review round 2, B1). This is the ONE ``retry.*`` key that is not read
+        back off the mapping per call — the store copies it into its own state
+        (``AuthStore._usage_aware_pick``) — so a rebind alone moves what
+        ``RetrySettings`` reports while leaving what the cascade actually does
+        unchanged. That gap is what made a live ``— applied`` notice untrue for
+        this key. Constructor and re-push share this method precisely so the
+        two cannot drift apart again.
+        """
+        configure_pick = getattr(self._auth_store, "configure_usage_aware_pick", None)
+        if callable(configure_pick):
+            from local_operator.providers.failover import RetrySettings
+
+            configure_pick(RetrySettings.from_settings(settings).usage_aware_account_pick)
+
     def apply_settings(self, values: Mapping[str, Any] | None) -> None:
         """Rebind the settings mapping every routing decision reads.
 
-        Sufficient on its own because nothing here caches a DERIVED view:
-        ``RetrySettings.from_settings(self._settings)`` runs per model call,
-        ``_openai_api_mode`` per client build, and the effort ladder reads
-        ``self._settings["effort"]`` per message. Rebinding the mapping is
-        therefore the whole change, and the next call routes on the new values.
+        Nearly sufficient on its own, because almost nothing here caches a
+        DERIVED view: ``RetrySettings.from_settings(self._settings)`` runs per
+        model call, ``_openai_api_mode`` per client build, and the effort ladder
+        reads ``self._settings["effort"]`` per message. The one exception is
+        ``retry.usageAwareAccountPick``, which is PUSHED into the auth store
+        rather than pulled from the mapping, so it is re-pushed here — see
+        :meth:`_push_usage_aware_pick`.
 
         Deliberately does NOT touch ``_route_state``, the usage memo, or the
         per-message effort freeze: a pinned hard fallback must survive a
@@ -1809,6 +1831,7 @@ class SessionStreamFn:
         parent's stream fn, so one rebind covers the whole tree.
         """
         self._settings = values
+        self._push_usage_aware_pick(values)
 
     def set_notice_handler(
         self, handler: Callable[[str, str], Awaitable[None] | None] | None

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -397,7 +397,7 @@ class _ForkRequest:
     on_complete: Callable[[str, str], None]
 
 
-def _configured_max_running() -> dict[str, int]:
+def _configured_max_running(values: Mapping[str, Any] | None = None) -> dict[str, int]:
     """``{"max_running": N}`` from config, or ``{}`` to keep the default.
 
     The concurrent-job ceiling governs how many subagents (and backgrounded
@@ -411,16 +411,24 @@ def _configured_max_running() -> dict[str, int]:
     the single source of truth for it. Duplicating the default here is how the
     two would later disagree.
 
+    ``values`` is the ``values`` mapping to read from. Passed by the config
+    watcher's listener (``_apply_config_change``) so the live re-read applies
+    exactly the validation the build applied; ``None`` reads the file through
+    a fresh ``ConfigManager`` as the constructor always has.
+
     Never raises: a malformed config must not stop a session from starting.
     A non-positive value is rejected rather than honoured, because 0 would
     deadlock every launch behind a gate that can never open.
     """
     try:
-        from local_operator.config import ConfigManager
-        from local_operator.paths import config_dir
+        if values is None:
+            from local_operator.config import ConfigManager
+            from local_operator.paths import config_dir
 
-        raw = ConfigManager(config_dir()).get_config_value("subagents", None)
-        if not isinstance(raw, dict):
+            raw = ConfigManager(config_dir()).get_config_value("subagents", None)
+        else:
+            raw = values.get("subagents")
+        if not isinstance(raw, Mapping):
             return {}
         value = raw.get("max_running")
         if value is None:
@@ -2413,12 +2421,12 @@ class Session:
     def routing_settings(self) -> Any:
         """The settings this session's stream will ROUTE on, or ``None``.
 
-        The stream captured its settings mapping at session build and holds it
-        for the session's life, so a surface that re-reads ``config.yml`` is
-        answering a different question than "what will this session do". Kept
-        as a pass-through to the stream (rather than a second copy stored here)
-        so the two can never disagree; ``None`` when the stream predates the
-        accessor, which callers must treat as "cannot say", never as "empty".
+        The mapping the stream holds — captured at build and rebound by the
+        config watcher through :meth:`_apply_config_change` on every change —
+        so it IS what the session will do next. Kept as a pass-through to the
+        stream (rather than a second copy stored here) so the two can never
+        disagree; ``None`` when the stream predates the accessor, which callers
+        must treat as "cannot say", never as "empty".
         """
         return getattr(self._stream_fn, "routing_settings", None)
 
@@ -8950,6 +8958,76 @@ class Session:
         )
 
     # -- lifecycle ----------------------------------------------------------------
+
+    def _apply_config_change(self, change: Any) -> None:
+        """Apply a ``config.yml`` change to this running session.
+
+        The listener the composition root subscribes to the process's
+        :class:`~local_operator.config_watch.ConfigWatcher` (``create_session``
+        for top-level sessions, ``_build_child_session`` for subagents). One
+        listener per session that fans out to the session's own consumers, so
+        the order in which they see a change is deterministic.
+
+        Three groups are live, each for a reason that makes the apply trivial:
+
+        * ``compaction.*`` — re-coerced into a fresh ``CompactionSettings``.
+          All three trigger checks read ``self._compaction_settings`` at check
+          time, so rebinding it IS the change. A compaction pass already in
+          flight keeps the object it captured — a threshold edit does not
+          retarget a summary mid-write — and the next check sees the new one.
+        * ``retry.*``, ``providers.openai.api``, ``effort.*`` — handed to the
+          stream fn's ``apply_settings``, which rebinds the mapping its
+          per-call ``RetrySettings.from_settings`` reads. A subagent shares
+          the parent's stream fn, so the parent's rebind covers the tree;
+          the child still calls it (idempotent) so a child built against a
+          parent whose stream fn has no ``apply_settings`` degrades the same
+          way as its parent.
+        * ``subagents.max_running`` — pushed into the live job manager with
+          the same validation the constructor applied; an unset or invalid
+          value restores the manager's built-in default rather than freezing
+          the last explicit one, so "reset to default" on the page means it.
+
+        Everything else the registry calls LIVE is already read per use
+        (``fork.*``, ``web_*`` knobs, ``subagents.models.*``) and needs no
+        apply here. Everything it calls NEW_SESSIONS is deliberately ignored.
+
+        Guards on ``_disposed`` because the unsubscribe runs as a dispose
+        HOOK, after the session's own teardown, and a tick can land between.
+        Swallows nothing else: the watcher isolates a raising listener and
+        logs it, and a coercion failure here already degrades to defaults.
+        """
+        if self._disposed:
+            return
+        changed = getattr(change, "changed_keys", frozenset())
+        values = getattr(change, "values", None)
+        if not isinstance(values, Mapping):
+            return
+        if any(key.startswith("compaction.") for key in changed):
+            # Same outcome as the factory's ``coerce_compaction_settings`` at
+            # build (dict -> validated, invalid -> defaults, absent -> None,
+            # so the read sites' ``or CompactionSettings()`` applies) but via
+            # the logging coercion: the factory's prints to stderr, which is
+            # the TUI's screen.
+            raw = values.get("compaction")
+            fresh: Any = (
+                _coerce_compaction_settings(dict(raw)) if isinstance(raw, Mapping) else None
+            )
+            self._compaction_settings = fresh
+        if any(
+            key.startswith("retry.") or key.startswith("effort.") or key == "providers.openai.api"
+            for key in changed
+        ):
+            apply_settings = getattr(self._stream_fn, "apply_settings", None)
+            if callable(apply_settings):
+                apply_settings(values)
+        if "subagents.max_running" in changed:
+            from local_operator.harness.jobs import DEFAULT_MAX_RUNNING_JOBS
+
+            cap = _configured_max_running(values).get("max_running", DEFAULT_MAX_RUNNING_JOBS)
+            try:
+                self.jobs.set_max_running(cap)
+            except ValueError:
+                logger.warning("subagents.max_running=%r rejected by the job manager", cap)
 
     def add_dispose_hook(self, hook: Callable[[], Awaitable[None] | None]) -> None:
         """Register teardown that runs after the session's own dispose.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -9013,10 +9013,16 @@ class Session:
                 _coerce_compaction_settings(dict(raw)) if isinstance(raw, Mapping) else None
             )
             self._compaction_settings = fresh
-        if any(
-            key.startswith("retry.") or key.startswith("effort.") or key == "providers.openai.api"
-            for key in changed
-        ):
+        # ``effort.*`` is deliberately NOT in this condition (review round 1,
+        # M1). The stream fn does read ``self._settings["effort"]`` per message
+        # (``configure._effort_for``), but those keys are not in the
+        # ``settings_io`` registry, and the diff walks the registry — so
+        # ``changed`` can never contain one and a ``startswith("effort.")``
+        # clause was unreachable code that read as coverage. An effort edit
+        # therefore does not propagate, exactly as before this PR; registering
+        # those keys is a separate change with its own scope decision, not
+        # something to smuggle in behind a condition nobody could reach.
+        if any(key.startswith("retry.") or key == "providers.openai.api" for key in changed):
             apply_settings = getattr(self._stream_fn, "apply_settings", None)
             if callable(apply_settings):
                 apply_settings(values)

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -9022,7 +9022,16 @@ class Session:
         # therefore does not propagate, exactly as before this PR; registering
         # those keys is a separate change with its own scope decision, not
         # something to smuggle in behind a condition nobody could reach.
-        if any(key.startswith("retry.") or key == "providers.openai.api" for key in changed):
+        #
+        # ``providers.`` covers the whole prefix rather than naming
+        # ``providers.openai.api`` alone (review round 2, M6). Every key under
+        # it is read off the mapping this rebinds — the OpenAI wire surface at
+        # client build, the Anthropic cache TTL at the same point — so naming
+        # one key meant the OTHER moved only as a side effect of a neighbouring
+        # ``retry.*`` edit landing in the same tick, which is both arbitrary
+        # and the thing that made its NEW_LAUNCH label a lie. They are all in
+        # the LIVE ``providers`` section now, so the trigger matches the scope.
+        if any(key.startswith("retry.") or key.startswith("providers.") for key in changed):
             apply_settings = getattr(self._stream_fn, "apply_settings", None)
             if callable(apply_settings):
                 apply_settings(values)

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -41,6 +41,11 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable
 from local_operator.ansi import sanitize_prompt_line
 from local_operator.harness.types import AgentMessage, Message
 
+# Imported as an alias: ``config_dir`` is a parameter/local name in other
+# functions here, and a module-level import of the same spelling would read
+# like one of them.
+from local_operator.paths import config_dir as app_config_dir
+
 # Pure path policy, no engine — see local_operator/resume.py for why it is
 # its own module rather than living here.
 from local_operator.resume import resume_dir
@@ -683,11 +688,6 @@ def load_user_instructions(agent_prompt: str = "") -> str:
     ``utf-8-sig`` strips a BOM that a Windows editor writes; without it the
     ``\ufeff`` survives into the prompt ahead of the first rule.
     """
-    # Imported as an alias: ``config_dir`` is a local parameter name in two
-    # other functions here, and a module-level import of the same spelling
-    # would read like one of them.
-    from local_operator.paths import config_dir as app_config_dir
-
     parts: list[str] = []
     # ``is_file()`` follows symlinks deliberately: pointing the file at a
     # dotfiles checkout is a normal way to version instructions.
@@ -1971,6 +1971,37 @@ def attach_stream_dispose(session: Session, stream_fn: SessionStreamFn) -> None:
     session.add_dispose_hook(stream_fn.close)
 
 
+def attach_config_watch(session: Session, config_dir: Path) -> None:
+    """Subscribe ``session`` to live ``config.yml`` changes; unsubscribe on dispose.
+
+    The config-watch seam (see :mod:`local_operator.config_watch`). Starts the
+    PROCESS's watcher if this is the first session to ask — ``start`` is
+    idempotent, so a ``/new`` in the same process finds it running — and hangs
+    the session's listener on it. The watcher itself is process-scoped and is
+    NOT stopped on dispose: the next session in this process needs it, and the
+    loop closing reaps the task. Only the subscription is per-session, which
+    is why the unsubscriber and not a ``stop`` is the dispose hook.
+
+    Every front end (TUI, headless, exec worker, owned phone session) reaches
+    this through ``create_session``, so they all follow config for free.
+    ``RemoteSession`` followers never get here: the owner applies the change
+    and the follower renders what the owner projects.
+
+    Degrades to "this session does not follow config" on any failure rather
+    than failing the boot: a watcher that cannot start (no loop in an unusual
+    embedding, a config directory that cannot be opened) leaves the session
+    exactly as it was before this seam existed.
+    """
+    try:
+        from local_operator.config_watch import process_watcher
+
+        watcher = process_watcher(config_dir)
+        watcher.start(asyncio.get_running_loop())
+        session.add_dispose_hook(watcher.subscribe(session._apply_config_change))
+    except Exception:  # noqa: BLE001 — boot must not depend on the watcher
+        logger.warning("config watcher could not be attached to the session", exc_info=True)
+
+
 async def create_session(
     args: argparse.Namespace,
     config_manager: ConfigManager,
@@ -2099,6 +2130,12 @@ async def create_session(
     # Stream seam: release the session's shared httpx connection pool on
     # dispose (one leaked pool per turn on the server facade otherwise).
     attach_stream_dispose(session, plan.session_kwargs["stream_fn"])
+    # Config seam: follow ``config.yml`` while the session lives, so an edit in
+    # another pane (or on the page in this one) reaches compaction, retry and
+    # the job cap without a ``/new``. The manager's directory, not
+    # ``paths.config_dir()``: they agree in production, and where a caller
+    # passed a manager on another directory that is the file to follow.
+    attach_config_watch(session, Path(getattr(config_manager, "config_dir", app_config_dir())))
 
     # MCP seam (MCP-20): merge discovered MCP tools in, subscribe to live
     # changes, and fold server teardown into session.dispose. Degrades to

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -246,9 +246,19 @@ SECTIONS: tuple[Section, ...] = (
     # NEW_LAUNCH: they are the session's identity, not a knob it re-reads.
     Section(
         "providers",
-        "Provider wire protocol",
+        # Titled for the WIRE FORMAT, not the word "provider" (design review
+        # round 1, D4): the pane one column to the right is headed `providers`
+        # and lists the user's credentials, so two adjacent things called
+        # "provider" meant two entirely different concepts. This also makes the
+        # header agree with its rows instead of colliding with the pane.
+        #
+        # NOT the designer's other suggestion, "OpenAI API surface": that was
+        # right when this section held one row, but M6 moved the Anthropic
+        # cache-TTL key in beside it, so an OpenAI-specific title would now
+        # mislabel half the section.
+        "Wire protocol",
         Scope.LIVE,
-        "Which API surface a direct provider connection uses.",
+        "How direct provider connections are made: API surface and cache TTL.",
     ),
     # LIVE: every ``retry.*`` key routes through ``RetrySettings.from_settings``
     # PER CALL on the mapping ``SessionStreamFn`` holds, and the config watcher
@@ -302,10 +312,20 @@ SECTIONS: tuple[Section, ...] = (
         Scope.LIVE,
         "Where /fork opens the branched conversation.",
     ),
+    # The GATE comes first, then the knobs it gates (design review round 1,
+    # D3). Whether each tool is offered at all is decided when the tool
+    # inventory is built, so these two flags cannot be LIVE — but reading order
+    # is the hierarchy the user sees, and putting the master switches after
+    # four tuning knobs left someone scanning for "is web search on?" finding
+    # the answer next to the retired-keys graveyard.
+    Section(
+        "web_tools",
+        "Web tools",
+        Scope.NEW_SESSIONS,
+        "Whether the search and fetch tools are offered to the model.",
+    ),
     # LIVE: both tools build their settings from config on EVERY call
-    # (``web_search/tool.py``, ``web_fetch/tool.py``). Whether the tools are
-    # OFFERED at all is decided when the tool inventory is built, so the two
-    # ``enabled`` flags live in ``web_tools`` below rather than here.
+    # (``web_search/tool.py``, ``web_fetch/tool.py``).
     Section(
         "web_search",
         "Web search",
@@ -317,12 +337,6 @@ SECTIONS: tuple[Section, ...] = (
         "Web fetch",
         Scope.LIVE,
         "Limits and rendering for the fetch tool.",
-    ),
-    Section(
-        "web_tools",
-        "Web tools",
-        Scope.NEW_SESSIONS,
-        "Whether the search and fetch tools are offered to the model.",
     ),
     Section(
         "retired",
@@ -423,7 +437,13 @@ SETTINGS: tuple[Setting, ...] = (
     Setting(
         key="providers.anthropic.cache_ttl_1h_min_context_tokens",
         path=("providers", "anthropic", "cache_ttl_1h_min_context_tokens"),
-        section="model",
+        # LIVE, not NEW_LAUNCH (review round 2, M6). `_client_for` reads this
+        # off the same mapping `apply_settings` rebinds, and the session rebinds
+        # on ANY `retry.*` change — so under NEW_LAUNCH the notice told the user
+        # a key needed a `/new` while a neighbouring edit had already moved it.
+        # Applying it live is harmless (it only affects the next client build),
+        # so the honest label is the cheaper of the two fixes.
+        section="providers",
         label="Anthropic 1h cache above (tokens)",
         kind=Kind.INT,
         default=150_000,

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -234,6 +234,22 @@ SECTIONS: tuple[Section, ...] = (
         Scope.NEW_LAUNCH,
         "The provider and model new launches boot on.",
     ),
+    # Split out of ``model`` (review round 1, M3). The design left this key in
+    # ``model`` and proposed documenting the discrepancy, which was defensible
+    # while nothing read the scope aloud — but the config-change notice now
+    # says "takes effect on /new" for every non-LIVE key, and for this one that
+    # is FALSE: ``Session._apply_config_change`` rebinds the stream fn on it and
+    # ``configure._openai_api_mode`` reads the rebound mapping when it builds
+    # the next client. Scope is uniform within a section by construction, so
+    # saying something true here means a section of its own, exactly as ``fork``
+    # and ``web_tools`` are. ``hosting``/``model_name`` genuinely stay
+    # NEW_LAUNCH: they are the session's identity, not a knob it re-reads.
+    Section(
+        "providers",
+        "Provider wire protocol",
+        Scope.LIVE,
+        "Which API surface a direct provider connection uses.",
+    ),
     # LIVE: every ``retry.*`` key routes through ``RetrySettings.from_settings``
     # PER CALL on the mapping ``SessionStreamFn`` holds, and the config watcher
     # rebinds that mapping on every change (``SessionStreamFn.apply_settings``).
@@ -390,10 +406,11 @@ SETTINGS: tuple[Setting, ...] = (
         help="Model id new launches boot on. Written by /model default.",
         empty_unsets=True,
     ),
+    # -- providers ----------------------------------------------------------
     Setting(
         key="providers.openai.api",
         path=("providers", "openai", "api"),
-        section="model",
+        section="providers",
         label="OpenAI API surface",
         kind=Kind.ENUM,
         default="responses",

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -109,7 +109,10 @@ class Scope(enum.Enum):
     split).
     """
 
-    #: Takes effect immediately in this running session.
+    #: Takes effect immediately in every running session on this machine —
+    #: on the same call stack in the process that wrote it, and within
+    #: ``ConfigWatcher.POLL_INTERVAL_S`` for sessions in other processes (see
+    #: :mod:`local_operator.config_watch`).
     LIVE = "live"
     #: Read when a session is built — a ``/new`` or ``/reload`` picks it up.
     NEW_SESSIONS = "new sessions"
@@ -231,10 +234,13 @@ SECTIONS: tuple[Section, ...] = (
         Scope.NEW_LAUNCH,
         "The provider and model new launches boot on.",
     ),
+    # LIVE: every ``retry.*`` key routes through ``RetrySettings.from_settings``
+    # PER CALL on the mapping ``SessionStreamFn`` holds, and the config watcher
+    # rebinds that mapping on every change (``SessionStreamFn.apply_settings``).
     Section(
         "failover",
         "Failover and retry",
-        Scope.NEW_SESSIONS,
+        Scope.LIVE,
         "What happens when a provider call fails or a quota runs out.",
     ),
     Section(
@@ -243,41 +249,64 @@ SECTIONS: tuple[Section, ...] = (
         Scope.LIVE,
         "Theme and the terminal features the TUI is allowed to use.",
     ),
+    # Deliberately NOT live, and split from ``subagents`` for that reason (scope
+    # is uniform within a section by construction). A tool-approval mode that
+    # flipped under a running turn would be a security-relevant surprise; the
+    # per-session ``/approvals`` toggle is the live control, and it WRITES this
+    # default rather than following it.
     Section(
         "session",
         "Session",
         Scope.NEW_SESSIONS,
-        "Approvals, autosave, and how many background jobs may run.",
+        "Approvals and autosave for sessions started from now on.",
     ),
+    # LIVE: ``max_running`` is pushed into the running ``AsyncJobManager`` by
+    # ``Session._apply_config_change`` (raising it lets the next launch through;
+    # lowering it lets running jobs finish — nothing is evicted), and the
+    # ``models.*`` tiers are read at every spawn.
+    Section(
+        "subagents",
+        "Subagents",
+        Scope.LIVE,
+        "Concurrency cap and the model each effort tier runs on.",
+    ),
+    # LIVE: the session re-coerces its ``CompactionSettings`` on every change,
+    # and all three trigger checks read that attribute at check time.
     Section(
         "compaction",
         "Compaction",
-        Scope.NEW_SESSIONS,
+        Scope.LIVE,
         "When the conversation is summarised to reclaim context.",
     ),
-    # LIVE, and stated deliberately: ``/fork`` reads these through the config
-    # manager at the moment it runs, so an edit takes effect on the very next
-    # fork in this same session. Claiming NEW_SESSIONS would be the painted lie
-    # the anti-drift test exists to prevent. A section of its own rather than
-    # folding into "Session" because scope is uniform within a section by
-    # construction and that one is NEW_SESSIONS.
+    # LIVE: ``/fork`` reads these through the config manager at the moment it
+    # runs, so an edit takes effect on the very next fork.
     Section(
         "fork",
         "Fork",
         Scope.LIVE,
         "Where /fork opens the branched conversation.",
     ),
+    # LIVE: both tools build their settings from config on EVERY call
+    # (``web_search/tool.py``, ``web_fetch/tool.py``). Whether the tools are
+    # OFFERED at all is decided when the tool inventory is built, so the two
+    # ``enabled`` flags live in ``web_tools`` below rather than here.
     Section(
         "web_search",
         "Web search",
-        Scope.NEW_SESSIONS,
+        Scope.LIVE,
         "Providers and load balancing for the search tool.",
     ),
     Section(
         "web_fetch",
         "Web fetch",
-        Scope.NEW_SESSIONS,
+        Scope.LIVE,
         "Limits and rendering for the fetch tool.",
+    ),
+    Section(
+        "web_tools",
+        "Web tools",
+        Scope.NEW_SESSIONS,
+        "Whether the search and fetch tools are offered to the model.",
     ),
     Section(
         "retired",
@@ -615,10 +644,11 @@ SETTINGS: tuple[Setting, ...] = (
         help="Write the conversation to disk as it goes.",
         choices=_bool_choices("save automatically", "save on request"),
     ),
+    # -- subagents ----------------------------------------------------------
     Setting(
         key="subagents.max_running",
         path=("subagents", "max_running"),
-        section="session",
+        section="subagents",
         label="Max background jobs",
         kind=Kind.INT,
         default=15,
@@ -629,7 +659,7 @@ SETTINGS: tuple[Setting, ...] = (
     Setting(
         key="subagents.models.lo",
         path=("subagents", "models", "lo"),
-        section="session",
+        section="subagents",
         label="Subagent model: lo",
         kind=Kind.TEXT,
         default="",
@@ -639,7 +669,7 @@ SETTINGS: tuple[Setting, ...] = (
     Setting(
         key="subagents.models.med",
         path=("subagents", "models", "med"),
-        section="session",
+        section="subagents",
         label="Subagent model: med",
         kind=Kind.TEXT,
         default="",
@@ -649,7 +679,7 @@ SETTINGS: tuple[Setting, ...] = (
     Setting(
         key="subagents.models.hi",
         path=("subagents", "models", "hi"),
-        section="session",
+        section="subagents",
         label="Subagent model: hi",
         kind=Kind.TEXT,
         default="",
@@ -775,10 +805,13 @@ SETTINGS: tuple[Setting, ...] = (
         choices=_bool_choices("compact mid-turn", "only between turns"),
     ),
     # -- web search ---------------------------------------------------------
+    # The two ``enabled`` flags sit in ``web_tools`` (NEW_SESSIONS), apart from
+    # the knobs that share their YAML block: they gate whether the tool exists
+    # in the inventory, which is decided once at build.
     Setting(
         key="web_search.enabled",
         path=("web_search", "enabled"),
-        section="web_search",
+        section="web_tools",
         label="Web search",
         kind=Kind.BOOL,
         default=True,
@@ -840,7 +873,7 @@ SETTINGS: tuple[Setting, ...] = (
     Setting(
         key="web_fetch.enabled",
         path=("web_fetch", "enabled"),
-        section="web_fetch",
+        section="web_tools",
         label="Web fetch",
         kind=Kind.BOOL,
         default=True,
@@ -1186,6 +1219,7 @@ def write_setting(manager: "ConfigManager", setting: Setting, value: Any) -> Non
         return
     _store(manager, setting.path, value)
     _invalidate_caches()
+    _notify_watcher(manager)
 
 
 def reset_setting(manager: "ConfigManager", setting: Setting) -> None:
@@ -1202,6 +1236,7 @@ def reset_setting(manager: "ConfigManager", setting: Setting) -> None:
         raise ValueError("this setting is retired and cannot be changed")
     _delete(manager, setting.path)
     _invalidate_caches()
+    _notify_watcher(manager)
 
 
 def _reload_before_write(manager: "ConfigManager") -> None:
@@ -1373,6 +1408,41 @@ def _invalidate_caches() -> None:
 
         settings_reload()
     except Exception:  # pragma: no cover - a cache drop must never fail a write
+        pass
+
+
+def _notify_watcher(manager: "ConfigManager") -> None:
+    """Hand the write to this process's config watcher, if one exists.
+
+    The in-process FAST PATH of :mod:`local_operator.config_watch`: the
+    watcher's poll would deliver this change within its interval anyway, but
+    a user who toggles ``compaction.enabled`` on the page expects their OWN
+    session to honour it on the same keystroke, not two seconds later. The
+    watcher re-reads the file and fans out with ``source="local"`` so the TUI
+    knows not to announce a change the page already showed.
+
+    Sits beside :func:`_invalidate_caches` at the facade level rather than in
+    ``_store``/``_delete`` because a write is one facade call but may be
+    several primitive calls; notifying once per facade call is what keeps a
+    single edit from being announced twice.
+
+    ``existing_watcher`` rather than ``process_watcher``: the CLI's ``config
+    edit`` runs in a process that never started one, and building a watcher
+    there would be work with no subscriber. Keyed on the MANAGER's directory,
+    not ``paths.config_dir()``, so a write through a manager pointed at some
+    other directory (tests, ``--config-dir``) cannot notify the wrong watcher.
+
+    Imported function-locally and guarded for the same reason as
+    ``_invalidate_caches``: a notification must never fail a write that has
+    already landed on disk.
+    """
+    try:
+        from local_operator.config_watch import existing_watcher
+
+        watcher = existing_watcher(getattr(manager, "config_dir", None))
+        if watcher is not None:
+            watcher.notify_local()
+    except Exception:  # pragma: no cover - a notification must never fail a write
         pass
 
 
@@ -1557,6 +1627,7 @@ def write_chains(
     }
     _store(manager, ("retry", "fallbackChains"), stored)
     _invalidate_caches()
+    _notify_watcher(manager)
 
 
 def validate_hop(text: str) -> str | None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5441,10 +5441,73 @@ class OperatorApp(App[None]):
         # `tool_approval_mode`, where believing it and being wrong is a safety
         # problem. Making the promise true is the honest fix; wording around it
         # would leave `/new` quietly serving stale settings.
-        if self._on_config_changed is not None:
-            self._on_config_changed()
+        # GUARDED, because that reload is destructive on a malformed file
+        # (review round 3, B1). In production `_on_config_changed` is
+        # `ConfigManager.reload` → `_load_config`, which RAISES on a non-mapping
+        # `values:` and MOVES the user's config.yml aside on a YAML error. This
+        # PR makes that story likelier, not rarer: the watcher deliberately
+        # holds a broken file in silence, so the user's first hint that they
+        # fat-fingered an edit would be `/new` — the command this feature's own
+        # notice sends them to — either dying or replacing every setting they
+        # have with defaults. Refusing to reload here keeps the module's
+        # never-move-the-user's-file contract intact at the exact moment the
+        # watcher is protecting it.
+        #
+        # The watcher answers the question because it already encodes the rule
+        # set; the `try` covers what remains (a version migration writing to a
+        # read-only dir, a race between the check and the read). Both paths
+        # still build the session — on the last good values, which is what the
+        # watcher has been serving all along — rather than leaving the user
+        # with no new session and an unexplained traceback.
+        self._reload_config_for_new_session(notice)
         notice("starting a new session…")
         self._run_session_transition(self._reload_session())
+
+    def _reload_config_for_new_session(self, notice: NoticeFn) -> None:
+        """Adopt on-disk config for the session `/new` is about to build.
+
+        Two consumers, both of which `/new` must reach for its own notice to be
+        true, and neither of which the other covers:
+
+        * the launch-time ``ConfigManager`` the session factory closed over —
+          `hosting`, `model_name`, `auto_save_conversation`, `web_*.enabled`;
+        * the TUI's own approval gate, which is process state rather than
+          session state and is otherwise written only by
+          ``_load_approvals_default`` at mount (review round 3, Q3). Missing it
+          meant `tool_approval_mode` was the ONE key of the four whose "takes
+          effect on /new" promise was not kept — and the one where believing it
+          and being wrong is a safety problem, in both directions: a tightened
+          `auto → ask` left the new session auto-approving writes with no
+          prompt.
+
+        Refuses the reload outright when the file on disk is not parseable,
+        because `ConfigManager._load_config` would move it aside and continue
+        from defaults (B1). Says so rather than failing silently: a user who
+        just broke their config while trying to change a setting needs to know
+        that is why the change did not take.
+        """
+        if self._on_config_changed is None:
+            return
+        from local_operator.config_watch import process_watcher
+
+        try:
+            if not process_watcher().config_is_readable():
+                notice(
+                    "config.yml is not readable — starting on the last good "
+                    "settings; fix the file and run /new again",
+                    "warning",
+                )
+                return
+            self._on_config_changed()
+        except Exception:  # noqa: BLE001 — a bad config must never break /new
+            logger.warning(
+                "config reload before /new failed; building on the last good values",
+                exc_info=True,
+            )
+            return
+        # Only after a successful reload: the gate must not adopt a value the
+        # factory did not.
+        self._load_approvals_default()
 
     def _cmd_fork(self, arg: str, notice: NoticeFn) -> None:
         """``/fork [message]`` — branch this conversation into a new session.
@@ -12866,12 +12929,23 @@ class OperatorApp(App[None]):
             # also front-loads the answer to "did it take effect?" instead of
             # burying it after up to six key names.
             parts.append(f"applied: {', '.join(live)}")
+        # Verb agreement per clause (design review round 1, D7). Each of these
+        # was only ever exercised with one key, and the multi-key form is the
+        # COMMON one for at least `hosting, model_name` — the pair a user
+        # changes together when they switch models. A sentence whose whole job
+        # is to be trusted about what did and did not happen cannot visibly
+        # disagree with itself.
         if new_sessions:
-            parts.append(f"{', '.join(new_sessions)} takes effect on /new")
+            verb = "takes" if len(new_sessions) == 1 else "take"
+            parts.append(f"{', '.join(new_sessions)} {verb} effect on /new")
         if relaunch:
-            parts.append(f"{', '.join(relaunch)} needs a relaunch")
+            verb = "needs" if len(relaunch) == 1 else "need"
+            parts.append(f"{', '.join(relaunch)} {verb} a relaunch")
         if retired:
-            parts.append(f"{', '.join(retired)} is retired and does nothing")
+            tail = (
+                "is retired and does nothing" if len(retired) == 1 else "are retired and do nothing"
+            )
+            parts.append(f"{', '.join(retired)} {tail}")
         # The approval mode names its VALUE and raises the severity (design
         # review round 1, D2). "changed" is not actionable for a two-valued
         # safety switch: the user in the other pane cannot tell whether

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1930,6 +1930,9 @@ class OperatorApp(App[None]):
         self._session: SessionProtocol | None = None
         self._controller: EventController | None = None
         self._status: StatusLine | None = None
+        #: Unsubscribes this app from the process config watcher (see
+        #: :meth:`_watch_config`). ``None`` until the first session is adopted.
+        self._unsubscribe_config_watch: Callable[[], None] | None = None
         #: The window/tab title writer, or ``None`` when there is no terminal
         #: to title (headless) or the user turned it off. Held by the app,
         #: which owns the terminal, and lent to the band, which owns the state
@@ -2924,6 +2927,10 @@ class OperatorApp(App[None]):
         session.set_ask_handler(self._request_user_choice_on_app_loop)
         self._controller = EventController(session, self)
         self._controller.subscribe()
+        # Beside the event controller because it answers the same question for
+        # a different source: the controller renders what the SESSION says, this
+        # renders what the CONFIG FILE says (a change from another pane).
+        self._watch_config()
         assert self._status is not None
         self._status.update(
             # The EFFECTIVE label: a resumed session that was serving from a
@@ -10493,6 +10500,9 @@ class OperatorApp(App[None]):
             self._status.dispose()
         if self._controller is not None:
             self._controller.dispose()
+        if self._unsubscribe_config_watch is not None:
+            self._unsubscribe_config_watch()
+            self._unsubscribe_config_watch = None
         unsubscribe_frontend = getattr(self, "_unsubscribe_frontend", None)
         if callable(unsubscribe_frontend):
             unsubscribe_frontend()
@@ -12728,6 +12738,110 @@ class OperatorApp(App[None]):
         a dispatch. One implementation means every path renders notices the same.
         """
         self._append_block(NoticeBlock(body, kind))
+
+    def _watch_config(self) -> None:
+        """Subscribe the APP to live ``config.yml`` changes. Idempotent.
+
+        The session's own subscription (``session_factory.attach_config_watch``)
+        applies the values; this one is the USER-FACING half — it tells the
+        user why behaviour just changed under them, and applies the two groups
+        only the TUI owns (``display.*``, ``tui.theme``) when another process
+        wrote them. Registered once per app rather than per session because
+        the app outlives its sessions (``/new``, ``/resume``) and one line per
+        change is the contract; the subscription is dropped on unmount.
+
+        Goes through :func:`process_watcher` rather than the session because a
+        ``RemoteSession`` follower has no watcher of its own, yet its user
+        still edits config and still deserves the notice. ``start`` is
+        idempotent, so calling it here is what makes a follower-only process
+        poll at all.
+        """
+        if self._unsubscribe_config_watch is not None:
+            return
+        try:
+            from local_operator.config_watch import process_watcher
+
+            watcher = process_watcher()
+            watcher.start(asyncio.get_running_loop())
+            self._unsubscribe_config_watch = watcher.subscribe(self._on_config_change)
+        except Exception:  # noqa: BLE001 — a missing notice must not break adoption
+            logger.debug("config watcher unavailable to the TUI", exc_info=True)
+
+    def _on_config_change(self, change: Any) -> None:
+        """React to a ``config.yml`` change, on the app loop.
+
+        Invoked on the loop thread by construction (the watcher ticks on the
+        loop it was started on, and ``notify_local`` hops there), so widgets
+        are touched directly without ``call_from_thread``.
+
+        ``source == "local"`` is silent and applies nothing: the page or the
+        command in THIS process already showed its own result and already
+        repainted (``_persist_theme`` follows ``_apply_theme``;
+        ``settings_io`` already dropped the display cache). Announcing it
+        again would be the line the user just read, twice.
+
+        For a change from another process, ONE notice per change listing the
+        registry keys compactly, with the keys whose section is not LIVE named
+        separately as taking effect on ``/new`` — the honest answer for
+        ``tool_approval_mode``, which the design deliberately keeps
+        build-time. ``changed_keys`` is per registry key, so a write that only
+        bumped ``metadata.last_modified`` never reaches here and produces no
+        line. Then the two TUI-owned groups are applied: the display cache is
+        dropped so the next paint re-reads, and the theme is switched through
+        the same orchestrator ``/theme`` uses. An unknown theme name on disk is
+        reported rather than raised — a config bug should not take down the
+        listener.
+        """
+        if getattr(change, "source", "disk") == "local":
+            return
+        changed = sorted(
+            key
+            for key in getattr(change, "changed_keys", ())
+            # ``/approvals default`` writes this key WITHOUT the facade (it is
+            # older than it) and already prints its own "saved to config.yml"
+            # receipt; the write's own kqueue delivery would read as news. The
+            # source cannot tell the two apart (the write came from this
+            # process either way), so the key is suppressed for the NOTICE
+            # only — it still lands in ``changed`` for any live apply that
+            # needs it — and only when the change carries nothing else, so a
+            # batch that ALSO moved other keys stays honest.
+            if key != "tool_approval_mode" or len(getattr(change, "changed_keys", ())) > 1
+        )
+        if not changed:
+            return
+        from local_operator import settings_io
+
+        scope_of = {section.name: section.scope for section in settings_io.SECTIONS}
+        live: list[str] = []
+        deferred: list[str] = []
+        for key in changed:
+            setting = settings_io.resolve_key(key)
+            scope = scope_of.get(setting.section) if setting is not None else None
+            (live if scope is settings_io.Scope.LIVE else deferred).append(key)
+        parts: list[str] = []
+        if live:
+            parts.append(f"{', '.join(live)} — applied")
+        if deferred:
+            parts.append(f"{', '.join(deferred)} takes effect on /new")
+        self._system_notice("config.yml changed: " + "; ".join(parts))
+
+        if any(key.startswith("display.") for key in changed):
+            try:
+                from local_operator.tui.settings import settings_reload
+
+                settings_reload()
+            except Exception:  # noqa: BLE001 — the cache drop is best-effort
+                logger.debug("display settings cache could not be dropped", exc_info=True)
+        raw_changed = getattr(change, "changed_keys", ())
+        if "tui.theme" in raw_changed:
+            values = getattr(change, "values", {})
+            tui_block = values.get("tui") if isinstance(values, Mapping) else None
+            wanted = tui_block.get("theme") if isinstance(tui_block, Mapping) else None
+            if isinstance(wanted, str) and wanted and wanted != theme_mod.current_theme():
+                try:
+                    self._apply_theme(wanted)
+                except KeyError:
+                    self._system_notice(f"theme: unknown theme {wanted!r} in config.yml", "warning")
 
     def _system_notice(self, body: str, kind: NoticeKind = "info") -> None:
         """A notice about the HARNESS that leaves the empty state intact.
@@ -15703,17 +15817,16 @@ class OperatorApp(App[None]):
         with nothing configured at all, and "you have no cascade, here is the key
         that would create one" is the useful answer for them.
 
-        Reads the SESSION's captured routing settings, not ``config.yml``, for
-        the reason recorded on ``Session.routing_settings``: the stream snapshots
-        its settings at build time and nothing watches the file, so a listing
-        built from disk confirms cascade edits the running session will not
-        honour. That is worst for the user who followed this command's own
-        "ask the agent to change…" hint. The on-disk copy is still read, but
-        only to DETECT that divergence and say so; it never silently replaces
-        what the session will do.
+        Reads the SESSION's routing settings (``Session.routing_settings``),
+        not ``config.yml`` directly: that is the mapping the stream will
+        actually route on. The two agree by construction now that the process
+        config watcher rebinds the stream's mapping on every file change
+        (``SessionStreamFn.apply_settings``), which is why this no longer reads
+        the file to flag drift — the "stale · /reload" row it used to paint
+        described a gap that no longer exists. Falls back to disk only for a
+        host that cannot say what it routes on (an older stream, a test
+        double).
         """
-        from local_operator.config import ConfigManager
-        from local_operator.paths import config_dir
         from local_operator.providers.failover import (
             DEFAULT_CHAIN_KEY,
             RetrySettings,
@@ -15785,37 +15898,26 @@ class OperatorApp(App[None]):
 
         rows: list[tuple[str, str]] = [("primary", primary_detail)]
 
-        # THE SESSION'S snapshot, with the file read only to detect drift.
+        # THE SESSION'S live mapping (kept current by the config watcher).
         session_settings = getattr(session, "routing_settings", None)
-        disk_settings = ConfigManager(config_dir()).get_config().values
         if session_settings is None:
             # A host that cannot say what it routes on (an older stream, a test
             # double). Falling back to disk is the only answer available, and it
             # is the answer this command shipped with.
-            session_settings = disk_settings
-            drifted = False
-        else:
-            # Compare only what routing reads. A `tui.theme` edit is not a
-            # routing change and must not raise a "/reload to apply" flag.
-            drifted = RetrySettings.from_settings(session_settings) != RetrySettings.from_settings(
-                disk_settings
-            )
+            from local_operator.config import ConfigManager
+            from local_operator.paths import config_dir
+
+            session_settings = ConfigManager(config_dir()).get_config().values
         retry = RetrySettings.from_settings(session_settings)
 
         def close(extra: list[tuple[str, str]], hint: str) -> list[tuple[str, str]]:
-            """Finish the tree: drift flag, then the agent affordance.
+            """Finish the tree with the agent affordance.
 
-            Both belong in EVERY state, not just the populated one. The user
+            It belongs in EVERY state, not just the populated one. The user
             staring at "no chain" is the one who most needs to know the agent
-            will write the config for them, and a stale listing is most
-            misleading exactly when it shows a cascade that looks new.
+            will write the config for them.
             """
             out = rows + extra
-            if drifted:
-                # Named on its own row rather than folded into the hint: it is a
-                # fact about this listing's accuracy, and `/reload` is the step
-                # that makes the on-disk cascade the one that actually routes.
-                out.append(("stale", "config.yml changed since this session started · /reload"))
             # The hint is an escape hatch, not a route. With an EMPTY name its
             # text landed at the exact x of every row name while wearing the
             # terminal `└─` glyph, so it read as one more cascade entry. Giving

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5454,11 +5454,21 @@ class OperatorApp(App[None]):
         # watcher is protecting it.
         #
         # The watcher answers the question because it already encodes the rule
-        # set; the `try` covers what remains (a version migration writing to a
-        # read-only dir, a race between the check and the read). Both paths
-        # still build the session — on the last good values, which is what the
-        # watcher has been serving all along — rather than leaving the user
-        # with no new session and an unexplained traceback.
+        # set; the `try` covers the RAISING failures that remain (a version
+        # migration writing to a read-only dir, a `metadata:` block hand-written
+        # without `created_at`). Both paths still build the session — on the
+        # last good values, which is what the watcher has been serving all
+        # along — rather than leaving the user with no new session and an
+        # unexplained traceback.
+        #
+        # The guard NARROWS the destructive window, it does not close it
+        # (review round 4): between the check and `_load_config`'s own read,
+        # another process can land a malformed atomic replace, and the `try`
+        # cannot catch that because the move-aside "succeeds". That window is
+        # ~2ms of `reload()` against `main`'s unconditional exposure, so this
+        # is strictly a shrink; closing it entirely needs a non-destructive
+        # reload on `ConfigManager`, which is a change to that class rather
+        # than to this call site.
         self._reload_config_for_new_session(notice)
         notice("starting a new session…")
         self._run_session_transition(self._reload_session())

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -9692,13 +9692,29 @@ class OperatorApp(App[None]):
         take down a working prompt. Imported at the call site, like that one, so
         the TUI's import cost does not carry the config stack for a command most
         sessions never run.
+
+        Written through the ``settings_io`` FACADE rather than
+        ``manager.set_config_value`` (review round 1, M2). The facade is what
+        marks a write as this process's own: it notifies the config watcher,
+        which fans the change out with ``source="local"``, which is how
+        :meth:`_on_config_change` knows the receipt below has already told the
+        user and stays quiet. Writing underneath it made this process's own
+        write arrive through the poll as ``source="disk"`` — indistinguishable
+        from another pane's edit — so the notice had to special-case the key,
+        and that special case then silenced the genuine cross-process change on
+        the one setting where not knowing is a safety problem. Going through
+        the facade removes the need for the special case rather than tuning it.
         """
         try:
+            from local_operator import settings_io
             from local_operator.config import ConfigManager
             from local_operator.paths import config_dir
 
             manager = ConfigManager(config_dir())
-            manager.set_config_value("tool_approval_mode", mode_word(auto))
+            setting = settings_io.resolve_key("tool_approval_mode")
+            if setting is None:  # pragma: no cover - the key is in the registry
+                raise KeyError("tool_approval_mode is not a registered setting")
+            settings_io.write_setting(manager, setting, mode_word(auto))
             return _home_relative(str(manager.config_file)), ""
         except Exception as error:  # config write failure
             return "", (
@@ -12794,19 +12810,7 @@ class OperatorApp(App[None]):
         """
         if getattr(change, "source", "disk") == "local":
             return
-        changed = sorted(
-            key
-            for key in getattr(change, "changed_keys", ())
-            # ``/approvals default`` writes this key WITHOUT the facade (it is
-            # older than it) and already prints its own "saved to config.yml"
-            # receipt; the write's own kqueue delivery would read as news. The
-            # source cannot tell the two apart (the write came from this
-            # process either way), so the key is suppressed for the NOTICE
-            # only — it still lands in ``changed`` for any live apply that
-            # needs it — and only when the change carries nothing else, so a
-            # batch that ALSO moved other keys stays honest.
-            if key != "tool_approval_mode" or len(getattr(change, "changed_keys", ())) > 1
-        )
+        changed = sorted(getattr(change, "changed_keys", ()))
         if not changed:
             return
         from local_operator import settings_io
@@ -12832,8 +12836,7 @@ class OperatorApp(App[None]):
                 settings_reload()
             except Exception:  # noqa: BLE001 — the cache drop is best-effort
                 logger.debug("display settings cache could not be dropped", exc_info=True)
-        raw_changed = getattr(change, "changed_keys", ())
-        if "tui.theme" in raw_changed:
+        if "tui.theme" in changed:
             values = getattr(change, "values", {})
             tui_block = values.get("tui") if isinstance(values, Mapping) else None
             wanted = tui_block.get("theme") if isinstance(tui_block, Mapping) else None

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5428,6 +5428,21 @@ class OperatorApp(App[None]):
             self._system_notice("new session unavailable: no session-capable launcher", "warning")
             return
         self._session_factory = lambda: self._resume_factory(None)  # type: ignore[misc]
+        # Reload the launch-time config manager BEFORE the rebuild, for the
+        # same load-bearing reason `_leave_setup_state_and_boot` documents: the
+        # factory closes over a manager captured at launch, so without this the
+        # "new" session boots on the values the process started with.
+        #
+        # Design review round 1 (D1) / QA round 2 (Q1) drove the real path and
+        # proved the gap: an out-of-process write to `hosting` followed by
+        # `/new` built with the OLD value. That was survivable while nothing
+        # said otherwise, but the config-change notice now tells the user in so
+        # many words that a NEW_SESSIONS key "takes effect on /new" — including
+        # `tool_approval_mode`, where believing it and being wrong is a safety
+        # problem. Making the promise true is the honest fix; wording around it
+        # would leave `/new` quietly serving stale settings.
+        if self._on_config_changed is not None:
+            self._on_config_changed()
         notice("starting a new session…")
         self._run_session_transition(self._reload_session())
 
@@ -12815,19 +12830,74 @@ class OperatorApp(App[None]):
             return
         from local_operator import settings_io
 
+        # Partitioned by the ACTUAL scope, three ways (design review round 1,
+        # D1). The registry has three scopes and `/settings` renders all three,
+        # but this line used to test one bit — `is LIVE` — and told the user
+        # everything else "takes effect on /new". That was false in two
+        # directions at once: a NEW_LAUNCH key (`hosting`, `model_name`) needs a
+        # relaunch, not a `/new`, and a `retired` key does nothing at all, so
+        # the harness was promising that a key it documents as inert would
+        # start working. The two surfaces contradicting each other is what made
+        # it obvious; a promise the harness cannot keep costs it the credibility
+        # of the live half too.
         scope_of = {section.name: section.scope for section in settings_io.SECTIONS}
         live: list[str] = []
-        deferred: list[str] = []
+        new_sessions: list[str] = []
+        relaunch: list[str] = []
+        retired: list[str] = []
         for key in changed:
             setting = settings_io.resolve_key(key)
-            scope = scope_of.get(setting.section) if setting is not None else None
-            (live if scope is settings_io.Scope.LIVE else deferred).append(key)
+            section = setting.section if setting is not None else None
+            scope = scope_of.get(section) if section is not None else None
+            if section == "retired":
+                retired.append(key)
+            elif scope is settings_io.Scope.LIVE:
+                live.append(key)
+            elif scope is settings_io.Scope.NEW_LAUNCH:
+                relaunch.append(key)
+            else:
+                new_sessions.append(key)
         parts: list[str] = []
         if live:
-            parts.append(f"{', '.join(live)} — applied")
-        if deferred:
-            parts.append(f"{', '.join(deferred)} takes effect on /new")
-        self._system_notice("config.yml changed: " + "; ".join(parts))
+            # "applied:" leads rather than trailing as "— applied" (design
+            # review round 1, D5). The suffix form put the verdict at the end of
+            # an unbounded key list, so in a ~10-column band it wrapped onto its
+            # own line behind a dangling em-dash that read as truncation. This
+            # also front-loads the answer to "did it take effect?" instead of
+            # burying it after up to six key names.
+            parts.append(f"applied: {', '.join(live)}")
+        if new_sessions:
+            parts.append(f"{', '.join(new_sessions)} takes effect on /new")
+        if relaunch:
+            parts.append(f"{', '.join(relaunch)} needs a relaunch")
+        if retired:
+            parts.append(f"{', '.join(retired)} is retired and does nothing")
+        # The approval mode names its VALUE and raises the severity (design
+        # review round 1, D2). "changed" is not actionable for a two-valued
+        # safety switch: the user in the other pane cannot tell whether
+        # approvals were tightened or loosened, and "every tool now runs
+        # without asking" is the fact worth interrupting someone for. The local
+        # receipt for the identical transition is already amber, so leaving the
+        # REMOTE one — where the user did not act and has no other cue — as dim
+        # grey inverted the priority.
+        kind = "info"
+        if "tool_approval_mode" in changed:
+            values = getattr(change, "values", {})
+            mode = str(values.get("tool_approval_mode", "")).strip().lower()
+            if mode == "auto":
+                parts.append("tool approvals now auto — every tool runs without asking")
+                kind = "warning"
+            elif mode == "ask":
+                parts.append("tool approvals now ask — tools prompt before running")
+                kind = "warning"
+            # The running session's gate deliberately does NOT move here: the
+            # key is NEW_SESSIONS and cell A4 of QA round 2 pins that. Only the
+            # cached default is refreshed, so a later bare `/approvals` reports
+            # what a new session would actually boot with instead of the value
+            # this process read at mount.
+            if mode in ("auto", "ask"):
+                self._approvals_default_auto = mode == "auto"
+        self._system_notice("config.yml changed: " + "; ".join(parts), kind)
 
         if any(key.startswith("display.") for key in changed):
             try:

--- a/local_operator/tui/settings.py
+++ b/local_operator/tui/settings.py
@@ -6,9 +6,16 @@ lookup falls back to its default.
 
 This module READS. Writes go through ``local_operator.settings_io``, which the
 ``/settings`` page and ``lop config edit`` both drive, and which calls
-:func:`settings_reload` afterwards — that is still the ONLY invalidator of the
-cache below, so a write that skipped it would leave the running TUI painting
-the old flag and the change would look lost until relaunch.
+:func:`settings_reload` afterwards — so a write that skipped it would leave the
+running TUI painting the old flag and the change would look lost until
+relaunch.
+
+There is now a SECOND invalidator: the TUI's config-watch listener calls
+:func:`settings_reload` when another process changes a ``display.*`` key. That
+distinction matters to :func:`_load`, not just as trivia — the first
+invalidator only ever fires after a write this process just made, so the file
+was well-formed by construction, while the second fires on bytes the user may
+be part-way through hand-editing.
 
 The keys here are LITERAL dotted top-level keys: ``values["display.shimmer"]``,
 not ``values["display"]["shimmer"]``. See ``settings_io`` for why that
@@ -79,14 +86,42 @@ def _defaults() -> dict[str, Any]:
 
 
 def _load() -> dict[str, Any]:
-    """Read ``values`` once; any failure yields pure defaults."""
+    """Read ``values`` once; any failure yields pure defaults.
+
+    Prefers the config WATCHER's already-validated snapshot over constructing a
+    ``ConfigManager`` (review round 4, B3). The manager's constructor runs
+    ``_load_config``, which MOVES a malformed ``config.yml`` aside to
+    ``config.yml.bad.<ts>`` and continues from defaults — and the ``except``
+    below cannot catch that, because from Python's point of view the move-aside
+    succeeded. Destroying the user's settings from a paint path is not a
+    trade-off this module gets to make.
+
+    The exposure is new and specific: this cache used to be invalidated only by
+    ``settings_io._store``, a write THIS process had just performed, so the
+    bytes were well-formed by construction. The config watcher now invalidates
+    it on ANOTHER process's write, which is exactly the case where the file on
+    disk is arbitrary — the user's next hand-edit may be mid-save, truncated or
+    mis-indented, and the watcher deliberately holds such a file in silence.
+
+    ``existing_watcher`` rather than ``process_watcher``, matching
+    ``settings_io._notify_watcher``: a CLI process that never started a watcher
+    must not build one from a paint path, and falls back to the manager — which
+    is safe there precisely because no watcher means no cross-process
+    invalidation to race with.
+    """
     values: dict[str, Any] = {}
     try:
-        from local_operator.config import ConfigManager
+        from local_operator.config_watch import existing_watcher
         from local_operator.paths import config_dir
 
-        manager = ConfigManager(config_dir())
-        values = dict(manager.get_config().values)
+        directory = config_dir()
+        watcher = existing_watcher(directory)
+        if watcher is not None:
+            values = dict(watcher.values)
+        else:
+            from local_operator.config import ConfigManager
+
+            values = dict(ConfigManager(directory).get_config().values)
     except Exception:
         values = {}
     return {key: values.get(key, default) for key, default in _defaults().items()}

--- a/local_operator/tui/widgets/settings_view.py
+++ b/local_operator/tui/widgets/settings_view.py
@@ -2590,8 +2590,24 @@ class SettingsView(Vertical):
             # title, and the half that carries the meaning is the scope. Dropped
             # entirely only when even the bare scope will not fit, which is the
             # one case where a clipped tag would be worse than none.
-            full = f"takes effect: {row.section.scope.value}"
-            short = row.section.scope.value
+            # `retired` is the one section whose SCOPE is not the honest
+            # answer (design review round 2, D8). Its keys are read and do
+            # nothing, so `takes effect: new launch` promises a relaunch will
+            # make them work — while the description one line below says the
+            # opposite, and the config-change notice now says "is retired and
+            # does nothing" about the very same key. Two surfaces describing
+            # one key two different ways is the defect class D1 fixed in the
+            # notice; this is the same thing pointing the other way.
+            #
+            # Special-cased HERE rather than by adding a fourth `Scope` member:
+            # scope answers "when does a change take effect", and "never,
+            # because this key is inert" is a property of the section, not a
+            # new point on that timeline. A fourth member would have to be
+            # handled by every consumer of `Scope` to say one thing about one
+            # section.
+            scope_word = "never" if row.section.name == "retired" else row.section.scope.value
+            full = f"takes effect: {scope_word}"
+            short = scope_word
             # LEFT-aligned on one shared column, not right-aligned against each
             # title. Right-aligning made the tag's position depend on the
             # title's length, so `Model` and `Failover and retry` — two headers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.51"
+version = "0.44.52"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/e2e/test_config_propagation.py
+++ b/tests/e2e/test_config_propagation.py
@@ -1,0 +1,156 @@
+"""End-to-end: an edit made by ANOTHER PROCESS reaches the running TUI.
+
+The unit suites drive the watcher's tick by hand. This is the assembled path:
+the real ``OperatorApp`` over a real ``Session`` in this process, the
+production watcher started by the app on its own loop, and the edit made the
+way a user makes it — ``lop config edit`` running as a separate process
+against the same config directory. Nothing in this process touches the
+watcher after boot; the change has to arrive through the file.
+
+Two things are asserted, both observed in the running process: the session's
+in-memory ``_compaction_settings`` moved to the value the other process wrote,
+and one notice naming the key landed in the transcript.
+
+Timing: waits on an EVENT (a test-only listener on the app's watcher sets a
+signal), never on the 2 s poll cadence — the wait lasts as long as the poll
+takes, and only a genuine hang reaches the deadlock guard. On macOS the kqueue
+accelerator usually delivers it well under the interval; on Linux the poll
+alone does, which is exactly why the CI matrix's Linux leg matters here — it
+proves the mechanism without the accelerator.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from local_operator.config import ConfigManager
+from local_operator.config_watch import process_watcher
+from local_operator.session.session import Session
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.transcript import NoticeBlock
+from tests.e2e.harness import (
+    ScriptedStream,
+    build_session,
+    dispose_quietly,
+    wait_for_adoption,
+)
+from tests.e2e.test_tui_e2e import BOOT_BOUND_S, SCREEN
+from tests.e2e.watchdog import bounded
+from tests.unit.harness.test_comms import ChangeSignal, wait_for
+
+#: Bound on the cross-process round trip: spawn ``lop config edit`` (a full
+#: interpreter start plus the CLI's imports, ~1 s), the watcher's ≤2 s poll,
+#: and the app's paint. Order-of-magnitude headroom for a loaded runner, for
+#: the same reason ``BOOT_BOUND_S`` carries it: this exists to catch a change
+#: that NEVER arrives, not to police latency.
+PROPAGATION_BOUND_S = 60.0
+
+
+@pytest.mark.asyncio
+async def test_a_config_edit_from_another_process_reaches_the_running_session(
+    headless_tui_env: Path,
+) -> None:
+    from local_operator.compaction.thresholds import CompactionSettings
+
+    # A real file to diff against, at the default threshold.
+    ConfigManager(headless_tui_env).set_config_value("hosting", "")
+
+    session = build_session(
+        headless_tui_env / "sessions" / "config-watch",
+        ScriptedStream([]),
+        cwd=headless_tui_env,
+    )
+    # What the factory does for a production session; the harness's
+    # ``build_session`` composes the Session directly and so does not.
+    watcher = process_watcher(headless_tui_env)
+    session._compaction_settings = CompactionSettings()
+    session.add_dispose_hook(watcher.subscribe(session._apply_config_change))
+
+    def threshold() -> float:
+        settings = session._compaction_settings
+        assert isinstance(settings, CompactionSettings)
+        return settings.threshold_percent
+
+    assert threshold() != 0.5
+
+    async def factory() -> Session:
+        return session
+
+    app = OperatorApp(factory)
+    signal = ChangeSignal()
+    unsubscribe = None
+    try:
+        with bounded(BOOT_BOUND_S, "TUI boot"):
+            async with app.run_test(size=SCREEN) as pilot:
+                await wait_for_adoption(app, pilot)
+                # The app started the process watcher on its loop during
+                # adoption. A test-only listener is the event we wait on.
+                assert watcher._task is not None and not watcher._task.done()
+                unsubscribe = watcher.subscribe(signal._fire)
+
+                with bounded(PROPAGATION_BOUND_S, "cross-process config propagation"):
+                    completed = subprocess.run(
+                        [
+                            sys.executable,
+                            "-m",
+                            "local_operator.cli",
+                            "config",
+                            "edit",
+                            "compaction.threshold_percent",
+                            "0.5",
+                        ],
+                        env={
+                            **_inherited_env(),
+                            "LOCAL_OPERATOR_CONFIG_DIR": str(headless_tui_env),
+                        },
+                        capture_output=True,
+                        text=True,
+                        timeout=PROPAGATION_BOUND_S / 2,
+                    )
+                    assert completed.returncode == 0, completed.stderr
+                    assert "Successfully updated compaction.threshold_percent" in completed.stdout
+
+                    await wait_for(
+                        lambda: threshold() == 0.5,
+                        signal=signal,
+                    )
+                    # The notice is appended on the same listener pass as the
+                    # session apply; one pump lets the widget mount.
+                    await pilot.pause()
+                    notices = [block.text() or "" for block in app.query(NoticeBlock)]
+                    assert any(
+                        "config.yml changed: compaction.threshold_percent — applied" in text
+                        for text in notices
+                    ), notices
+    finally:
+        signal.close()
+        if unsubscribe is not None:
+            unsubscribe()
+        await dispose_quietly(session)
+
+
+def _inherited_env() -> dict[str, str]:
+    """The parent's environment, minus anything that would make the child's
+    CLI chatty or reach outside the sandbox. ``PATH``/``HOME`` etc. stay so the
+    interpreter and its site-packages resolve exactly as they do here.
+
+    The repository root is put FIRST on the child's ``PYTHONPATH`` so it
+    imports the same tree this test runs from. In a parallel-agent worktree
+    the shared editable ``.venv`` resolves ``local_operator`` to the main
+    checkout, and the child would then run a ``config edit`` from a different
+    revision than the app under test — a real cross-version mismatch, but not
+    the one this test is about. CI installs the package, where this is a
+    no-op.
+    """
+    import os
+
+    env = dict(os.environ)
+    env.pop("NO_COLOR", None)
+    root = str(Path(__file__).resolve().parents[2])
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = root if not existing else os.pathsep.join((root, existing))
+    return env

--- a/tests/e2e/test_config_propagation.py
+++ b/tests/e2e/test_config_propagation.py
@@ -123,7 +123,7 @@ async def test_a_config_edit_from_another_process_reaches_the_running_session(
                     await pilot.pause()
                     notices = [block.text() or "" for block in app.query(NoticeBlock)]
                     assert any(
-                        "config.yml changed: compaction.threshold_percent — applied" in text
+                        "config.yml changed: applied: compaction.threshold_percent" in text
                         for text in notices
                     ), notices
     finally:

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -1933,5 +1933,25 @@ class TestUsageAwareFirstPick:
         assert store._usage_aware_pick is False
         stream2 = SessionStreamFn(store, {}, "s2")
         assert store._usage_aware_pick is True
+
+        # And it must be RE-pushed when a live config change rebinds the
+        # settings mapping (review round 2 B1, guarded here per round 3 M1).
+        # This is the one ``retry.*`` key the cascade does not re-read off the
+        # mapping — the store copies it into its own state — so a rebind that
+        # only swapped ``_settings`` moved what ``RetrySettings`` reported while
+        # the cascade kept using the stale flag.
+        #
+        # Asserted against the REAL ``SessionStreamFn`` and the REAL store on
+        # purpose: the equivalent probe in ``test_config_live.py`` runs against
+        # a hand-written double whose own ``apply_settings`` re-pushes the flag,
+        # so deleting the production line left that suite green.
+        stream2.apply_settings({"retry": {"usageAwareAccountPick": False}})
+        assert store._usage_aware_pick is False, "apply_settings did not re-push the opt-out"
+        stream2.apply_settings({"retry": {"usageAwareAccountPick": True}})
+        assert store._usage_aware_pick is True, "the re-push is one-way"
+        # ``None`` is "no settings", which restores the store's ON default
+        # rather than freezing the last value.
+        stream2.apply_settings(None)
+        assert store._usage_aware_pick is True
         # Close the streams' http clients without awaiting: no loop is running.
         del stream, stream2

--- a/tests/unit/session/test_config_live.py
+++ b/tests/unit/session/test_config_live.py
@@ -41,6 +41,7 @@ from local_operator.model.configure import (
 from local_operator.providers.failover import RetrySettings
 from local_operator.session.session import Session
 from local_operator.session.transcript import Transcript
+from local_operator.spawn.policy import fork_cmux_placement, fork_mode
 
 MODEL = ModelSpec(provider="test", model_id="m", context_window=100_000)
 
@@ -124,6 +125,32 @@ def _stored(watcher: ConfigWatcher, path: list[str]) -> Any:
     """What a read-per-use consumer sees in the watcher's snapshot (default-aware)."""
     found = settings_io._walk(watcher.values, path)
     return None if found is settings_io._MISSING else found
+
+
+def _search_settings(watcher: ConfigWatcher):
+    """What `execute_web_search` builds per call, from the watcher's directory."""
+    from local_operator.web_search.tool import load_search_settings
+
+    return load_search_settings(ConfigManager(watcher.config_dir))
+
+
+def _fetch_settings(watcher: ConfigWatcher):
+    """What the fetch engine builds per call, from the watcher's directory."""
+    from local_operator.web_fetch.tool import load_fetch_settings
+
+    return load_fetch_settings(ConfigManager(watcher.config_dir))
+
+
+def _spawn_model(session: Session, tier: str, watcher: ConfigWatcher | None = None) -> str:
+    """The subagent ModelSpec the session resolves for an effort tier.
+
+    `_resolve_subagent_model` returns None when config names no model for the
+    tier, which is "inherit the parent" rather than a value — rendered as the
+    empty string so a probe comparing to a `provider/model` string reads a
+    miss as a miss instead of as an exception.
+    """
+    spec = session._resolve_subagent_model("task", tier)
+    return "" if spec is None else f"{spec.provider}/{spec.model_id}"
 
 
 def subscribe(session: Session, watcher: ConfigWatcher) -> None:
@@ -217,29 +244,33 @@ LIVE_KEY_PROBES: dict[str, tuple[Any, Any]] = {
     ),
     # -- subagents ---------------------------------------------------------------
     "subagents.max_running": (3, lambda s, w: s.jobs.max_running),
-    "subagents.models.lo": ("p/lo-model", lambda s, w: _stored(w, ["subagents", "models", "lo"])),
-    "subagents.models.med": (
-        "p/med-model",
-        lambda s, w: _stored(w, ["subagents", "models", "med"]),
-    ),
-    "subagents.models.hi": ("p/hi-model", lambda s, w: _stored(w, ["subagents", "models", "hi"])),
-    # -- read-per-use consumers: the snapshot they are handed ------------------
-    "fork.mode": ("here", lambda s, w: _stored(w, ["fork", "mode"])),
-    "fork.cmux_placement": ("split", lambda s, w: _stored(w, ["fork", "cmux_placement"])),
-    "web_search.strategy": ("ordered", lambda s, w: _stored(w, ["web_search", "strategy"])),
-    "web_search.providers": (["brave"], lambda s, w: _stored(w, ["web_search", "providers"])),
-    "web_search.timeout_seconds": (5.0, lambda s, w: _stored(w, ["web_search", "timeout_seconds"])),
+    "subagents.models.lo": ("openai/lo-model", lambda s, w: _spawn_model(s, "lo")),
+    "subagents.models.med": ("openai/med-model", lambda s, w: _spawn_model(s, "med")),
+    "subagents.models.hi": ("openai/hi-model", lambda s, w: _spawn_model(s, "hi")),
+    # -- read-per-use consumers: observed THROUGH the consumer ------------------
+    # Not through the watcher's snapshot (review round 3, M2). Asserting that a
+    # key reached `watcher.values` is bookkeeping: it cannot tell "this key is
+    # live" from "this key is parsed and nothing reads it", which is exactly the
+    # blind spot that let M3 and round-2's B1 through. These consumers are all
+    # genuinely read-per-use today, and the point of routing the probe through
+    # them is that the guard notices the day one of them starts caching at
+    # construction — the very change the deferred web-tools follow-up proposes.
+    "fork.mode": ("switch", lambda s, w: fork_mode(w.values)),
+    "fork.cmux_placement": ("surface", lambda s, w: fork_cmux_placement(w.values)),
+    "web_search.strategy": ("ordered", lambda s, w: _search_settings(w).strategy),
+    "web_search.providers": (["brave"], lambda s, w: list(_search_settings(w).providers)),
+    "web_search.timeout_seconds": (5.0, lambda s, w: _search_settings(w).timeout_seconds),
     "web_search.searxng_endpoint": (
         "http://searx.local",
-        lambda s, w: _stored(w, ["web_search", "searxng_endpoint"]),
+        lambda s, w: _search_settings(w).searxng_endpoint,
     ),
-    "web_fetch.timeout_seconds": (5.0, lambda s, w: _stored(w, ["web_fetch", "timeout_seconds"])),
-    "web_fetch.max_bytes": (1_000, lambda s, w: _stored(w, ["web_fetch", "max_bytes"])),
-    "web_fetch.max_redirects": (1, lambda s, w: _stored(w, ["web_fetch", "max_redirects"])),
-    "web_fetch.cache_ttl_seconds": (0, lambda s, w: _stored(w, ["web_fetch", "cache_ttl_seconds"])),
-    "web_fetch.allow_private": (True, lambda s, w: _stored(w, ["web_fetch", "allow_private"])),
-    "web_fetch.render_backend": ("plain", lambda s, w: _stored(w, ["web_fetch", "render_backend"])),
-    "web_fetch.enrich": (False, lambda s, w: _stored(w, ["web_fetch", "enrich"])),
+    "web_fetch.timeout_seconds": (5.0, lambda s, w: _fetch_settings(w).timeout_seconds),
+    "web_fetch.max_bytes": (1_048_576, lambda s, w: _fetch_settings(w).max_bytes),
+    "web_fetch.max_redirects": (1, lambda s, w: _fetch_settings(w).max_redirects),
+    "web_fetch.cache_ttl_seconds": (0, lambda s, w: _fetch_settings(w).cache_ttl_seconds),
+    "web_fetch.allow_private": (True, lambda s, w: _fetch_settings(w).allow_private),
+    "web_fetch.render_backend": ("stdlib", lambda s, w: _fetch_settings(w).render_backend),
+    "web_fetch.enrich": (False, lambda s, w: _fetch_settings(w).enrich),
 }
 
 #: LIVE sections whose keys have no session-side apply because the TUI owns
@@ -254,13 +285,20 @@ def _live_sections() -> set[str]:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("key", sorted(LIVE_KEY_PROBES))
-async def test_a_write_from_another_process_reaches_the_running_session(tmp_path, key) -> None:
+async def test_a_write_from_another_process_reaches_the_running_session(
+    tmp_path, key, monkeypatch
+) -> None:
     value, observe = LIVE_KEY_PROBES[key]
     setting = settings_io.resolve_key(key)
     assert setting is not None
     assert value != setting.default, f"{key}: the probe must write a NON-default value"
     config_dir = tmp_path / "config"
     config_dir.mkdir()
+    # Some consumers resolve their own directory through `paths.config_dir()`
+    # rather than taking one (`Session._resolve_subagent_model` builds its own
+    # `ConfigManager`). Pointing the env at the watched directory is what makes
+    # those probes read the file under test instead of the operator's real one.
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
     ConfigManager(config_dir).set_config_value("hosting", "")  # a real file to diff against
 
     stream = RebindableStream(dict(ConfigManager(config_dir).get_config().values))

--- a/tests/unit/session/test_config_live.py
+++ b/tests/unit/session/test_config_live.py
@@ -1,0 +1,459 @@
+"""A running ``Session`` follows ``config.yml``: the registry's LIVE label is true.
+
+The enforcement behind ``settings_io.Scope.LIVE``. For every key in every
+section the registry calls LIVE, a write from a SECOND ``ConfigManager`` (what
+another process's edit looks like) followed by one watcher tick must change
+the subscribed session's typed view — ``_compaction_settings``,
+``routing_settings``, the job cap — or, for the groups that are live because
+they are read per use (``fork.*``, ``subagents.models.*``, ``web_*`` knobs),
+must be readable from the watcher's snapshot the consumer will switch to.
+Then a registry-honesty test closes the loop: every LIVE section has a key
+exercised here, and every key exercised here sits in a LIVE section. A section
+relabelled LIVE without wiring fails by name, and so does one wired without
+being relabelled.
+
+Nothing here waits on the clock: ``poll_now()`` is the tick.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from local_operator import settings_io
+from local_operator.compaction.thresholds import CompactionSettings
+from local_operator.config import ConfigManager
+from local_operator.config_watch import ConfigWatcher, _reset_for_tests, process_watcher
+from local_operator.harness.jobs import DEFAULT_MAX_RUNNING_JOBS
+from local_operator.harness.types import (
+    AbortSignal,
+    ChatRequest,
+    ModelSpec,
+    StreamEndEvent,
+    StreamTextDelta,
+)
+from local_operator.model.configure import SessionStreamFn
+from local_operator.providers.failover import RetrySettings
+from local_operator.session.session import Session
+from local_operator.session.transcript import Transcript
+
+MODEL = ModelSpec(provider="test", model_id="m", context_window=100_000)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+class RebindableStream:
+    """A stream fn exposing the two things ``_apply_config_change`` reads."""
+
+    def __init__(self, settings: dict[str, Any]) -> None:
+        self._settings: Any = settings
+        self.applied: list[Any] = []
+
+    @property
+    def routing_settings(self):
+        return self._settings
+
+    def apply_settings(self, values) -> None:
+        self.applied.append(values)
+        self._settings = values
+
+    def __call__(self, request: ChatRequest, signal: AbortSignal | None):
+        async def gen():
+            yield StreamTextDelta(delta="ok")
+            yield StreamEndEvent(stop_reason="stop")
+
+        return gen()
+
+
+def make_session(tmp_path, stream, **kwargs) -> Session:
+    return Session(
+        model=MODEL,
+        stream_fn=stream,
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["stable"],
+        **kwargs,
+    )
+
+
+def write_from_another_process(config_dir, key: str, value: Any) -> None:
+    """The shape of an edit made elsewhere: a fresh manager, the facade's merge
+    rule, and no in-process notification (``_store`` is below the hook)."""
+    setting = settings_io.resolve_key(key)
+    assert setting is not None, key
+    settings_io._store(ConfigManager(config_dir), setting.path, value)
+
+
+def _stored(watcher: ConfigWatcher, path: list[str]) -> Any:
+    """What a read-per-use consumer sees in the watcher's snapshot (default-aware)."""
+    found = settings_io._walk(watcher.values, path)
+    return None if found is settings_io._MISSING else found
+
+
+def subscribe(session: Session, watcher: ConfigWatcher) -> None:
+    session.add_dispose_hook(watcher.subscribe(session._apply_config_change))
+
+
+def compaction_of(session: Session) -> CompactionSettings:
+    """The session's typed compaction view, asserted present for the checker."""
+    settings = session._compaction_settings
+    assert isinstance(settings, CompactionSettings)
+    return settings
+
+
+# ---------------------------------------------------------------------------
+# What a non-default value for each LIVE key looks like, and how to observe it
+# ---------------------------------------------------------------------------
+
+#: ``key -> (non-default value, observer)``. The observer reads the SESSION's
+#: typed view after one tick and returns what it sees; the test compares that
+#: to the value written. Keys whose consumer reads config per use (no session
+#: attribute to observe) read the watcher's snapshot — the mapping those
+#: consumers are being pointed at.
+LIVE_KEY_PROBES: dict[str, tuple[Any, Any]] = {
+    # -- compaction: the session's typed settings object -----------------------
+    "compaction.enabled": (False, lambda s, w: compaction_of(s).enabled),
+    "compaction.strategy": ("snapcompact", lambda s, w: compaction_of(s).strategy),
+    "compaction.threshold_percent": (0.5, lambda s, w: compaction_of(s).threshold_percent),
+    "compaction.threshold_tokens": (123_456, lambda s, w: compaction_of(s).threshold_tokens),
+    "compaction.keep_recent_tokens": (
+        4_321,
+        lambda s, w: compaction_of(s).keep_recent_tokens,
+    ),
+    "compaction.auto_continue": (False, lambda s, w: compaction_of(s).auto_continue),
+    "compaction.mid_turn_enabled": (False, lambda s, w: compaction_of(s).mid_turn_enabled),
+    # -- failover: what RetrySettings.from_settings reads off the stream --------
+    "retry.enabled": (False, lambda s, w: RetrySettings.from_settings(s.routing_settings).enabled),
+    "retry.maxRetries": (
+        3,
+        lambda s, w: RetrySettings.from_settings(s.routing_settings).max_retries,
+    ),
+    "retry.baseDelayMs": (
+        1_234,
+        lambda s, w: RetrySettings.from_settings(s.routing_settings).base_delay_ms,
+    ),
+    "retry.connectivityMaxRetries": (
+        7,
+        lambda s, w: RetrySettings.from_settings(s.routing_settings).connectivity_max_retries,
+    ),
+    "retry.connectivityBackoffCapMs": (
+        9_999,
+        lambda s, w: RetrySettings.from_settings(s.routing_settings).connectivity_backoff_cap_ms,
+    ),
+    "retry.modelFallback": (
+        False,
+        lambda s, w: RetrySettings.from_settings(s.routing_settings).model_fallback,
+    ),
+    "retry.usageAwareFallback": (
+        True,
+        lambda s, w: RetrySettings.from_settings(s.routing_settings).usage_aware_fallback,
+    ),
+    "retry.usageReservePercent": (
+        25.0,
+        lambda s, w: RetrySettings.from_settings(s.routing_settings).usage_reserve_percent,
+    ),
+    "retry.fallbackChains": (
+        {"default": ["zai/glm-5.3"]},
+        lambda s, w: dict(RetrySettings.from_settings(s.routing_settings).fallback_chains),
+    ),
+    # -- subagents ---------------------------------------------------------------
+    "subagents.max_running": (3, lambda s, w: s.jobs.max_running),
+    "subagents.models.lo": ("p/lo-model", lambda s, w: _stored(w, ["subagents", "models", "lo"])),
+    "subagents.models.med": (
+        "p/med-model",
+        lambda s, w: _stored(w, ["subagents", "models", "med"]),
+    ),
+    "subagents.models.hi": ("p/hi-model", lambda s, w: _stored(w, ["subagents", "models", "hi"])),
+    # -- read-per-use consumers: the snapshot they are handed ------------------
+    "fork.mode": ("here", lambda s, w: _stored(w, ["fork", "mode"])),
+    "fork.cmux_placement": ("split", lambda s, w: _stored(w, ["fork", "cmux_placement"])),
+    "web_search.strategy": ("ordered", lambda s, w: _stored(w, ["web_search", "strategy"])),
+    "web_search.providers": (["brave"], lambda s, w: _stored(w, ["web_search", "providers"])),
+    "web_search.timeout_seconds": (5.0, lambda s, w: _stored(w, ["web_search", "timeout_seconds"])),
+    "web_search.searxng_endpoint": (
+        "http://searx.local",
+        lambda s, w: _stored(w, ["web_search", "searxng_endpoint"]),
+    ),
+    "web_fetch.timeout_seconds": (5.0, lambda s, w: _stored(w, ["web_fetch", "timeout_seconds"])),
+    "web_fetch.max_bytes": (1_000, lambda s, w: _stored(w, ["web_fetch", "max_bytes"])),
+    "web_fetch.max_redirects": (1, lambda s, w: _stored(w, ["web_fetch", "max_redirects"])),
+    "web_fetch.cache_ttl_seconds": (0, lambda s, w: _stored(w, ["web_fetch", "cache_ttl_seconds"])),
+    "web_fetch.allow_private": (True, lambda s, w: _stored(w, ["web_fetch", "allow_private"])),
+    "web_fetch.render_backend": ("plain", lambda s, w: _stored(w, ["web_fetch", "render_backend"])),
+    "web_fetch.enrich": (False, lambda s, w: _stored(w, ["web_fetch", "enrich"])),
+}
+
+#: LIVE sections whose keys have no session-side apply because the TUI owns
+#: them (``appearance``: ``OperatorApp._on_config_change`` applies
+#: ``display.*``/``tui.theme``; covered in the TUI suite).
+TUI_OWNED_LIVE_SECTIONS = {"appearance"}
+
+
+def _live_sections() -> set[str]:
+    return {s.name for s in settings_io.SECTIONS if s.scope is settings_io.Scope.LIVE}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("key", sorted(LIVE_KEY_PROBES))
+async def test_a_write_from_another_process_reaches_the_running_session(tmp_path, key) -> None:
+    value, observe = LIVE_KEY_PROBES[key]
+    setting = settings_io.resolve_key(key)
+    assert setting is not None
+    assert value != setting.default, f"{key}: the probe must write a NON-default value"
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    ConfigManager(config_dir).set_config_value("hosting", "")  # a real file to diff against
+
+    stream = RebindableStream(dict(ConfigManager(config_dir).get_config().values))
+    session = make_session(tmp_path, stream, compaction_settings=CompactionSettings())
+    watcher = ConfigWatcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        before = observe(session, watcher)
+        assert before != value, f"{key}: the session already held the probe value"
+
+        write_from_another_process(config_dir, key, value)
+        change = watcher.poll_now()
+
+        assert change is not None and key in change.changed_keys
+        assert observe(session, watcher) == value
+    finally:
+        await session.dispose()
+
+
+def test_every_live_section_is_exercised_and_every_probe_is_live() -> None:
+    """Registry honesty, both directions, failing BY NAME.
+
+    A section relabelled LIVE needs a probe here (or an entry in the explicit
+    TUI-owned list); a probe here for a key in a non-LIVE section means the
+    code went live and the label did not follow.
+    """
+    live = _live_sections()
+    probed_sections = {
+        cast(settings_io.Setting, settings_io.resolve_key(k)).section for k in LIVE_KEY_PROBES
+    }
+    unprobed = live - probed_sections - TUI_OWNED_LIVE_SECTIONS
+    assert not unprobed, f"LIVE sections with no live-apply probe: {sorted(unprobed)}"
+    mislabelled = {
+        k
+        for k in LIVE_KEY_PROBES
+        if cast(settings_io.Setting, settings_io.resolve_key(k)).section not in live
+    }
+    assert not mislabelled, f"probed as live but not in a LIVE section: {sorted(mislabelled)}"
+    # And every key of every probed LIVE section is probed, not just one per
+    # section: a new key added to a LIVE section must prove it applies.
+    for section in probed_sections:
+        keys = {s.key for s in settings_io.settings_for(section)}
+        missing = keys - set(LIVE_KEY_PROBES)
+        assert not missing, f"{section}: LIVE keys without a probe: {sorted(missing)}"
+
+
+def test_the_deliberately_build_time_keys_stay_new_sessions() -> None:
+    """The design keeps these OUT of live on purpose; a future relabel must be
+    a decision, not a side effect of the section split."""
+    scope_of = {s.name: s.scope for s in settings_io.SECTIONS}
+    for key in ("tool_approval_mode", "auto_save_conversation"):
+        setting = settings_io.resolve_key(key)
+        assert setting is not None
+        assert scope_of[setting.section] is settings_io.Scope.NEW_SESSIONS, key
+    for key in ("web_search.enabled", "web_fetch.enabled"):
+        setting = settings_io.resolve_key(key)
+        assert setting is not None
+        assert setting.section == "web_tools"
+        assert scope_of["web_tools"] is settings_io.Scope.NEW_SESSIONS
+
+
+# ---------------------------------------------------------------------------
+# The three apply paths in detail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compaction_is_recoerced_into_a_fresh_object(tmp_path) -> None:
+    """The read sites hold the attribute, not the object: a pass in flight
+    keeps what it captured, the next check sees the new one."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    ConfigManager(config_dir).set_config_value("hosting", "")
+    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
+    watcher = ConfigWatcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        captured = compaction_of(session)
+        write_from_another_process(config_dir, "compaction.threshold_percent", 0.5)
+        watcher.poll_now()
+        assert compaction_of(session) is not captured
+        assert captured.threshold_percent == CompactionSettings().threshold_percent
+        assert compaction_of(session).threshold_percent == 0.5
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_real_stream_fn_rebinds_and_keeps_its_route_state(tmp_path) -> None:
+    """``SessionStreamFn.apply_settings`` on the production class: the mapping
+    the per-call ``from_settings`` reads moves, and nothing else does — a
+    pinned fallback must survive a threshold edit."""
+
+    class FakeAuth:
+        async def get_oauth_access(self, *args, **kwargs):
+            return None
+
+    stream = SessionStreamFn(cast(Any, FakeAuth()), {"retry": {"maxRetries": 10}}, "session-x")
+    try:
+        route_state = stream._route_state
+        stream.apply_settings({"retry": {"maxRetries": 2}})
+        assert RetrySettings.from_settings(stream.routing_settings).max_retries == 2
+        assert stream._route_state is route_state
+    finally:
+        await stream.close()
+
+
+@pytest.mark.asyncio
+async def test_lowering_max_running_evicts_nothing_and_raising_it_promotes_the_queue(
+    tmp_path,
+) -> None:
+    """Both directions of ``set_max_running`` through the session listener."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    ConfigManager(config_dir).set_config_value("subagents", {"max_running": 1})
+    session = make_session(tmp_path, RebindableStream({}))
+    watcher = ConfigWatcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        session.jobs.set_max_running(1)
+        started: list[str] = []
+
+        async def runner(job_id, signal, on_update):
+            started.append(job_id)
+            return "done"
+
+        first = session.jobs.register("task", "a", runner)
+        assert session.jobs.at_capacity()
+        parked = session.jobs.register("task", "b", runner, queued=True)
+        assert parked in session.jobs.queued_ids()
+
+        # Lower below the running count: nothing is cancelled.
+        write_from_another_process(config_dir, "subagents.max_running", 1)
+        write_from_another_process(config_dir, "subagents.max_running", 2)
+        watcher.poll_now()
+        assert session.jobs.max_running == 2
+        # Raising promoted the parked job without waiting for a completion.
+        assert parked not in session.jobs.queued_ids()
+        assert session.jobs.get(first) is not None
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_unsetting_max_running_restores_the_built_in_default(tmp_path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    ConfigManager(config_dir).set_config_value("subagents", {"max_running": 3})
+    session = make_session(tmp_path, RebindableStream({}))
+    session.jobs.set_max_running(3)
+    watcher = ConfigWatcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        setting = settings_io.resolve_key("subagents.max_running")
+        assert setting is not None
+        settings_io._delete(ConfigManager(config_dir), setting.path)
+        watcher.poll_now()
+        assert session.jobs.max_running == DEFAULT_MAX_RUNNING_JOBS
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_disposed_session_ignores_changes_and_unsubscribes(tmp_path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    ConfigManager(config_dir).set_config_value("hosting", "")
+    stream = RebindableStream({})
+    session = make_session(tmp_path, stream, compaction_settings=CompactionSettings())
+    watcher = ConfigWatcher(config_dir)
+    subscribe(session, watcher)
+    await session.dispose()
+    assert watcher._listeners == []
+    write_from_another_process(config_dir, "retry.maxRetries", 1)
+    watcher.poll_now()
+    assert stream.applied == []
+
+
+@pytest.mark.asyncio
+async def test_the_local_fast_path_applies_on_the_writers_own_call_stack(tmp_path) -> None:
+    """A ``/settings`` toggle in THIS process reaches THIS session before the
+    write facade returns — no poll interval, no loop turn."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    ConfigManager(config_dir).set_config_value("hosting", "")
+    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
+    watcher = process_watcher(config_dir)
+    watcher.start()
+    subscribe(session, watcher)
+    try:
+        setting = settings_io.resolve_key("compaction.enabled")
+        assert setting is not None
+        settings_io.write_setting(ConfigManager(config_dir), setting, False)
+        assert compaction_of(session).enabled is False
+    finally:
+        await session.dispose()
+        await watcher.stop()
+
+
+# ---------------------------------------------------------------------------
+# 8. Subagents follow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_subagent_follows_config_and_does_not_alias_its_parents_seed(
+    tmp_path, monkeypatch
+) -> None:
+    """The ``model_copy`` at build is the child's INITIAL value; the
+    subscription is what keeps it current. Both must hold: the child moves
+    with the file, and the parent's object is not the same object."""
+    from local_operator.harness import subagent as subagent_mod
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    ConfigManager(config_dir).set_config_value("hosting", "")
+
+    parent = make_session(
+        tmp_path,
+        RebindableStream({}),
+        compaction_settings=CompactionSettings(threshold_tokens=250_000),
+    )
+    watcher = process_watcher(config_dir)
+    subscribe(parent, watcher)
+    child = await subagent_mod._build_child_session(
+        label="sub",
+        prompt="do the thing",
+        parent_session=parent,
+        model_spec=None,
+        job_id="job-1",
+    )
+    try:
+        assert compaction_of(child) is not compaction_of(parent)
+        assert compaction_of(child).threshold_tokens == 250_000
+        assert len(watcher._listeners) == 2
+
+        write_from_another_process(config_dir, "compaction.threshold_tokens", 99_000)
+        watcher.poll_now()
+
+        assert compaction_of(child).threshold_tokens == 99_000
+        assert compaction_of(parent).threshold_tokens == 99_000
+        assert compaction_of(child) is not compaction_of(parent)
+    finally:
+        await subagent_mod._dispose_child(child)
+        assert len(watcher._listeners) == 1  # the child unsubscribed itself
+        await parent.dispose()
+        assert watcher._listeners == []
+        await watcher.stop()

--- a/tests/unit/session/test_config_live.py
+++ b/tests/unit/session/test_config_live.py
@@ -33,7 +33,7 @@ from local_operator.harness.types import (
     StreamEndEvent,
     StreamTextDelta,
 )
-from local_operator.model.configure import SessionStreamFn
+from local_operator.model.configure import SessionStreamFn, _openai_api_mode
 from local_operator.providers.failover import RetrySettings
 from local_operator.session.session import Session
 from local_operator.session.transcript import Transcript
@@ -128,6 +128,14 @@ LIVE_KEY_PROBES: dict[str, tuple[Any, Any]] = {
     ),
     "compaction.auto_continue": (False, lambda s, w: compaction_of(s).auto_continue),
     "compaction.mid_turn_enabled": (False, lambda s, w: compaction_of(s).mid_turn_enabled),
+    # -- providers: the wire surface the NEXT client build reads ---------------
+    # Observed through the same function the client builder calls, not through
+    # the raw mapping: what makes this key live is that ``_openai_api_mode``
+    # reads the REBOUND settings, so that is what must move.
+    "providers.openai.api": (
+        "chat_completions",
+        lambda s, w: _openai_api_mode(s.routing_settings),
+    ),
     # -- failover: what RetrySettings.from_settings reads off the stream --------
     "retry.enabled": (False, lambda s, w: RetrySettings.from_settings(s.routing_settings).enabled),
     "retry.maxRetries": (
@@ -252,6 +260,107 @@ def test_every_live_section_is_exercised_and_every_probe_is_live() -> None:
         keys = {s.key for s in settings_io.settings_for(section)}
         missing = keys - set(LIVE_KEY_PROBES)
         assert not missing, f"{section}: LIVE keys without a probe: {sorted(missing)}"
+
+
+#: Non-LIVE keys whose write DOES reach the session, with the reason that is
+#: legitimate. Kept explicit so the guard below fails by name on a new one
+#: rather than being widened silently.
+#:
+#: ``subagents.*`` cannot appear here — it is LIVE. ``web_*.enabled`` cannot
+#: either: the session must NOT react to them (the tool surface is build-time),
+#: which is the whole reason they were split into ``web_tools``.
+_NON_LIVE_KEYS_ALLOWED_TO_APPLY: dict[str, str] = {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "key",
+    sorted(
+        s.key
+        for s in settings_io.SETTINGS
+        if s.section not in _live_sections() and s.kind is not settings_io.Kind.READONLY
+    ),
+)
+async def test_a_non_live_key_does_not_quietly_apply_to_a_running_session(tmp_path, key) -> None:
+    """The direction the other honesty test cannot see (review round 1, M3).
+
+    ``test_every_live_section_is_exercised_and_every_probe_is_live`` walks LIVE
+    sections DOWNWARD: every LIVE section must have a key that provably applies.
+    Nothing walked UPWARD — a key with a real live apply sitting in a NEW_LAUNCH
+    section passed both directions of that test, which is exactly how
+    ``providers.openai.api`` came to be applied live while the notice told the
+    user it "takes effect on /new". A label that overstates is a nuisance; one
+    that UNDERSTATES is the painted lie, because the user acts on it.
+
+    Asserted BEHAVIOURALLY rather than by reading the source: write the key
+    from a second ``ConfigManager``, tick, and require that the session's
+    observable state did not move. That catches a future apply added anywhere
+    in ``_apply_config_change``'s fan-out, not just a string this test knows to
+    grep for.
+    """
+    setting = settings_io.resolve_key(key)
+    assert setting is not None
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    ConfigManager(config_dir).set_config_value("hosting", "")
+
+    stream = RebindableStream(dict(ConfigManager(config_dir).get_config().values))
+    session = make_session(tmp_path, stream, compaction_settings=CompactionSettings())
+    watcher = ConfigWatcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        before = (
+            compaction_of(session).model_dump(),
+            dict(RetrySettings.from_settings(session.routing_settings).__dict__),
+            session.jobs.max_running,
+            len(stream.applied),
+        )
+        # A value that differs from whatever is stored, typed to the setting.
+        # Branched rather than built as a dict literal: a dict evaluates EVERY
+        # value eagerly, so the INT arm ran `int("ask")` for an ENUM key.
+        probe: Any
+        if setting.kind is settings_io.Kind.ENUM:
+            others = [c.value for c in setting.resolved_choices if c.value != setting.default]
+            if not others:
+                pytest.skip(f"{key} has a single choice; nothing to change it to")
+            probe = others[0]
+        elif setting.kind is settings_io.Kind.BOOL:
+            probe = not bool(setting.default)
+        elif setting.kind is settings_io.Kind.INT:
+            probe = int(setting.default or 0) + 7
+        elif setting.kind is settings_io.Kind.FLOAT:
+            probe = float(setting.default or 0) + 3.5
+        elif setting.kind is settings_io.Kind.TEXT:
+            probe = "probe-value"
+        elif setting.kind is settings_io.Kind.LIST:
+            probe = ["probe"]
+        elif setting.kind is settings_io.Kind.CASCADE:
+            probe = {"default": ["probe/model"]}
+        else:
+            pytest.skip(f"{key}: no probe value for {setting.kind}")
+
+        write_from_another_process(config_dir, key, probe)
+        change = watcher.poll_now()
+        assert (
+            change is not None and key in change.changed_keys
+        ), f"{key}: the watcher did not see the write, so this test proved nothing"
+
+        after = (
+            compaction_of(session).model_dump(),
+            dict(RetrySettings.from_settings(session.routing_settings).__dict__),
+            session.jobs.max_running,
+            len(stream.applied),
+        )
+        if key in _NON_LIVE_KEYS_ALLOWED_TO_APPLY:
+            return
+        assert after == before, (
+            f"{key} is in section {setting.section!r} (not LIVE), so the config-change "
+            f"notice tells the user it 'takes effect on /new' — but writing it MOVED the "
+            f"running session. Either give it a LIVE section (as providers.openai.api "
+            f"got) or stop applying it."
+        )
+    finally:
+        await session.dispose()
 
 
 def test_the_deliberately_build_time_keys_stay_new_sessions() -> None:

--- a/tests/unit/session/test_config_live.py
+++ b/tests/unit/session/test_config_live.py
@@ -33,7 +33,11 @@ from local_operator.harness.types import (
     StreamEndEvent,
     StreamTextDelta,
 )
-from local_operator.model.configure import SessionStreamFn, _openai_api_mode
+from local_operator.model.configure import (
+    SessionStreamFn,
+    _anthropic_cache_ttl_1h_min_context_tokens,
+    _openai_api_mode,
+)
 from local_operator.providers.failover import RetrySettings
 from local_operator.session.session import Session
 from local_operator.session.transcript import Transcript
@@ -48,12 +52,31 @@ def _fresh_registry():
     _reset_for_tests()
 
 
+class FakeAuthStore:
+    """Just enough auth store to observe the PUSHED setting.
+
+    ``retry.usageAwareAccountPick`` is the one ``retry.*`` key the cascade does
+    not read back off the settings mapping: the real ``AuthStore`` copies it
+    into ``_usage_aware_pick`` when the stream fn pushes it. A probe that read
+    the mapping instead would pass while the cascade still used the old value,
+    which is precisely the gap review round 2 (B1) found — so the double keeps
+    its own copy, exactly as the real store does.
+    """
+
+    def __init__(self) -> None:
+        self._usage_aware_pick = True  # the real store defaults ON
+
+    def configure_usage_aware_pick(self, enabled: bool) -> None:
+        self._usage_aware_pick = bool(enabled)
+
+
 class RebindableStream:
     """A stream fn exposing the two things ``_apply_config_change`` reads."""
 
     def __init__(self, settings: dict[str, Any]) -> None:
         self._settings: Any = settings
         self.applied: list[Any] = []
+        self.auth_store = FakeAuthStore()
 
     @property
     def routing_settings(self):
@@ -62,6 +85,13 @@ class RebindableStream:
     def apply_settings(self, values) -> None:
         self.applied.append(values)
         self._settings = values
+        # Mirrors the real ``SessionStreamFn.apply_settings``, which re-pushes
+        # this one key rather than relying on the rebind.
+        from local_operator.providers.failover import RetrySettings
+
+        self.auth_store.configure_usage_aware_pick(
+            RetrySettings.from_settings(values).usage_aware_account_pick
+        )
 
     def __call__(self, request: ChatRequest, signal: AbortSignal | None):
         async def gen():
@@ -128,7 +158,11 @@ LIVE_KEY_PROBES: dict[str, tuple[Any, Any]] = {
     ),
     "compaction.auto_continue": (False, lambda s, w: compaction_of(s).auto_continue),
     "compaction.mid_turn_enabled": (False, lambda s, w: compaction_of(s).mid_turn_enabled),
-    # -- providers: the wire surface the NEXT client build reads ---------------
+    # -- providers: read off the rebound mapping at the NEXT client build ------
+    "providers.anthropic.cache_ttl_1h_min_context_tokens": (
+        999_999,
+        lambda s, w: _anthropic_cache_ttl_1h_min_context_tokens(s.routing_settings),
+    ),
     # Observed through the same function the client builder calls, not through
     # the raw mapping: what makes this key live is that ``_openai_api_mode``
     # reads the REBOUND settings, so that is what must move.
@@ -137,6 +171,8 @@ LIVE_KEY_PROBES: dict[str, tuple[Any, Any]] = {
         lambda s, w: _openai_api_mode(s.routing_settings),
     ),
     # -- failover: what RetrySettings.from_settings reads off the stream --------
+    # NOTE the odd one out below: `retry.usageAwareAccountPick` is observed on
+    # the auth STORE, not the mapping, because the store holds its own copy.
     "retry.enabled": (False, lambda s, w: RetrySettings.from_settings(s.routing_settings).enabled),
     "retry.maxRetries": (
         3,
@@ -169,6 +205,15 @@ LIVE_KEY_PROBES: dict[str, tuple[Any, Any]] = {
     "retry.fallbackChains": (
         {"default": ["zai/glm-5.3"]},
         lambda s, w: dict(RetrySettings.from_settings(s.routing_settings).fallback_chains),
+    ),
+    # Observed on the auth STORE, deliberately (review round 2, B1). Every
+    # other `retry.*` key is live because `from_settings` re-reads the mapping
+    # per call; this one is pushed into the store, which then owns the value.
+    # Probing the mapping here would have passed while the cascade kept using
+    # the stale flag — the exact false-green the finding described.
+    "retry.usageAwareAccountPick": (
+        False,
+        lambda s, w: s._stream_fn.auth_store._usage_aware_pick,
     ),
     # -- subagents ---------------------------------------------------------------
     "subagents.max_running": (3, lambda s, w: s.jobs.max_running),
@@ -308,13 +353,29 @@ async def test_a_non_live_key_does_not_quietly_apply_to_a_running_session(tmp_pa
     session = make_session(tmp_path, stream, compaction_settings=CompactionSettings())
     watcher = ConfigWatcher(config_dir)
     subscribe(session, watcher)
-    try:
-        before = (
+
+    def observe() -> tuple[Any, ...]:
+        """Everything a non-LIVE key must NOT move.
+
+        `retry.max_retries` is excluded deliberately: the co-write below moves
+        it on purpose, so including it would make every case fail. The provider
+        readers ARE included — without them the guard could not see M6, whose
+        whole shape is a `providers.*` value riding along on the mapping rebind
+        that a `retry.*` edit triggers. Observed through the same functions the
+        client builder calls, not off the raw mapping.
+        """
+        retry = RetrySettings.from_settings(session.routing_settings)
+        return (
             compaction_of(session).model_dump(),
-            dict(RetrySettings.from_settings(session.routing_settings).__dict__),
+            {k: v for k, v in retry.__dict__.items() if k != "max_retries"},
             session.jobs.max_running,
-            len(stream.applied),
+            _openai_api_mode(session.routing_settings),
+            _anthropic_cache_ttl_1h_min_context_tokens(session.routing_settings),
+            stream.auth_store._usage_aware_pick,
         )
+
+    try:
+        before = observe()
         # A value that differs from whatever is stored, typed to the setting.
         # Branched rather than built as a dict literal: a dict evaluates EVERY
         # value eagerly, so the INT arm ran `int("ask")` for an ENUM key.
@@ -339,18 +400,27 @@ async def test_a_non_live_key_does_not_quietly_apply_to_a_running_session(tmp_pa
         else:
             pytest.skip(f"{key}: no probe value for {setting.kind}")
 
+        # Written TOGETHER with a LIVE `retry.*` key, in one tick (review round
+        # 2, M6). Writing the non-LIVE key alone was the guard's blind spot:
+        # the session rebinds the whole settings mapping when a `retry.*` key
+        # moves, so a non-LIVE key sharing that mapping applies as a side
+        # effect of its neighbour — invisible to a case that only ever changes
+        # one key. The co-write reproduces the real shape (a `/settings` page
+        # or an editor saving several keys at once) and is strictly stronger:
+        # anything the single write caught, this catches too.
         write_from_another_process(config_dir, key, probe)
+        live_probe = 1 + int(RetrySettings.from_settings(session.routing_settings).max_retries)
+        write_from_another_process(config_dir, "retry.maxRetries", live_probe)
         change = watcher.poll_now()
         assert (
             change is not None and key in change.changed_keys
         ), f"{key}: the watcher did not see the write, so this test proved nothing"
-
-        after = (
-            compaction_of(session).model_dump(),
-            dict(RetrySettings.from_settings(session.routing_settings).__dict__),
-            session.jobs.max_running,
-            len(stream.applied),
+        assert "retry.maxRetries" in change.changed_keys, (
+            "the co-written LIVE key did not land in the same tick, so the "
+            "mapping-rebind path this case exists to exercise never fired"
         )
+
+        after = observe()
         if key in _NON_LIVE_KEYS_ALLOWED_TO_APPLY:
             return
         assert after == before, (

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -1034,7 +1034,8 @@ async def test_child_gets_the_parents_mcp_manager_and_catalogue(tmp_path, monkey
     # `disconnect_all` on dispose; the obvious "make the child symmetric with
     # the parent" edit would therefore have the first subagent to finish tear
     # down every server for the rest of the parent's session.
-    assert child._dispose_hooks == []
+    assert not [hook for hook in child._dispose_hooks if getattr(hook, "__name__", "") == "close"]
+    assert len(child._dispose_hooks) == 1  # the config-watch unsubscribe only
     await child.dispose()
     assert manager.disconnected == 0
     await parent.dispose()

--- a/tests/unit/test_config_watch.py
+++ b/tests/unit/test_config_watch.py
@@ -1,0 +1,492 @@
+"""``ConfigWatcher``: the process-wide live view of ``config.yml``.
+
+Every test here is bound by a loop turn or an event, never by the clock (see
+AGENTS.md "Timing, flakes"). The watcher's poll interval is a property of the
+production cadence, not of these tests: they drive ``poll_now()`` directly, and
+the one test that exercises the kqueue accelerator waits on a signal the
+listener sets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator import settings_io
+from local_operator.config import ConfigManager
+from local_operator.config_watch import (
+    ConfigChange,
+    ConfigWatcher,
+    _reset_for_tests,
+    existing_watcher,
+    process_watcher,
+)
+from tests.unit.harness.test_comms import ChangeSignal, wait_for
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+def _write(config_dir: Path, key: str, value: Any) -> None:
+    """A write from ANOTHER process: a fresh manager, no watcher notified."""
+    setting = settings_io.resolve_key(key)
+    assert setting is not None, key
+    manager = ConfigManager(config_dir)
+    settings_io._store(manager, setting.path, value)
+
+
+class Recorder:
+    def __init__(self) -> None:
+        self.changes: list[ConfigChange] = []
+        self.threads: list[int] = []
+
+    def __call__(self, change: ConfigChange) -> None:
+        self.changes.append(change)
+        self.threads.append(threading.get_ident())
+
+
+# ---------------------------------------------------------------------------
+# 1. Fingerprint gate
+# ---------------------------------------------------------------------------
+
+
+def test_the_poll_does_not_parse_when_the_fingerprint_is_unchanged(tmp_path, monkeypatch) -> None:
+    """Two ticks with no write cost ONE parse (at construction), then none.
+
+    Structural, not timed: the property that makes a 2 s poll across fifty
+    processes affordable is that an unchanged file is a stat, never a parse.
+    """
+    ConfigManager(tmp_path).set_config_value("hosting", "x")
+    parses: list[int] = []
+    original = ConfigWatcher._parse
+
+    def spy(self):
+        parses.append(1)
+        return original(self)
+
+    monkeypatch.setattr(ConfigWatcher, "_parse", spy)
+    watcher = ConfigWatcher(tmp_path)
+    assert len(parses) == 1  # the priming parse
+    assert watcher.poll_now() is None
+    assert watcher.poll_now() is None
+    assert len(parses) == 1
+
+
+def test_a_missing_file_is_a_first_run_not_an_error(tmp_path) -> None:
+    """No config.yml yet: the snapshot is the defaults, nothing is logged as
+    bad, and the first write is seen as the change it is."""
+    watcher = ConfigWatcher(tmp_path)
+    recorder = Recorder()
+    watcher.subscribe(recorder)
+    assert watcher.values["retry"]["enabled"] is True  # back-filled defaults
+    assert watcher.poll_now() is None
+    _write(tmp_path, "compaction.threshold_percent", 0.5)
+    change = watcher.poll_now()
+    assert change is not None
+    # Only the key that differs from the defaults, not thirty back-filled ones.
+    assert change.changed_keys == {"compaction.threshold_percent"}
+    assert recorder.changes == [change]
+
+
+# ---------------------------------------------------------------------------
+# 2. Unreadable file keeps the last snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_an_unreadable_file_keeps_the_last_good_snapshot_and_creates_no_bad_file(
+    tmp_path, monkeypatch
+) -> None:
+    """A half-typed hand edit must not degrade a live session NOR be moved
+    aside. ``ConfigManager._load_config`` does both; the watcher must never
+    call it. Then the fix is delivered exactly once."""
+    _write(tmp_path, "compaction.threshold_percent", 0.5)
+    watcher = ConfigWatcher(tmp_path)
+    recorder = Recorder()
+    watcher.subscribe(recorder)
+    assert watcher.values["compaction"]["threshold_percent"] == 0.5
+
+    # The trap: any construction of a manager would move the file aside.
+    monkeypatch.setattr(
+        ConfigManager,
+        "_load_config",
+        lambda self: pytest.fail("the watcher must never load through ConfigManager"),
+    )
+    (tmp_path / "config.yml").write_text("values:\n  compaction: [", encoding="utf-8")
+    assert watcher.poll_now() is None
+    assert recorder.changes == []
+    assert watcher.values["compaction"]["threshold_percent"] == 0.5
+    assert not [p for p in tmp_path.iterdir() if ".bad" in p.name]
+
+    # Not re-parsed while it stays broken: the bad fingerprint is remembered.
+    parses: list[int] = []
+    original = ConfigWatcher._parse
+    monkeypatch.setattr(ConfigWatcher, "_parse", lambda self: (parses.append(1), original(self))[1])
+    assert watcher.poll_now() is None
+    assert parses == []
+
+    monkeypatch.undo()
+    (tmp_path / "config.yml").write_text(
+        "values:\n  compaction:\n    threshold_percent: 0.25\n", encoding="utf-8"
+    )
+    change = watcher.poll_now()
+    assert change is not None and change.changed_keys == {"compaction.threshold_percent"}
+    assert watcher.values["compaction"]["threshold_percent"] == 0.25
+    assert len(recorder.changes) == 1
+
+
+@pytest.mark.parametrize(
+    "content",
+    ["", "   \n", "- a\n- b\n", "just a scalar\n", b"\xff\xfe".decode("latin-1")],
+    ids=["empty", "blank", "list-top-level", "scalar-top-level", "non-utf8-ish"],
+)
+def test_every_shape_the_write_guard_rejects_is_kept_out_of_the_snapshot(
+    tmp_path, content: str
+) -> None:
+    """Same shapes ``settings_io._require_readable_config`` refuses to write
+    over: they must be refused as a live view too, or a session would adopt
+    'defaults' from a file that is mid-edit."""
+    _write(tmp_path, "retry.maxRetries", 3)
+    watcher = ConfigWatcher(tmp_path)
+    (tmp_path / "config.yml").write_bytes(content.encode("latin-1"))
+    assert watcher.poll_now() is None
+    assert watcher.values["retry"]["maxRetries"] == 3
+
+
+def test_a_deleted_file_keeps_the_snapshot_and_sees_its_return(tmp_path) -> None:
+    _write(tmp_path, "retry.maxRetries", 3)
+    watcher = ConfigWatcher(tmp_path)
+    (tmp_path / "config.yml").unlink()
+    assert watcher.poll_now() is None
+    assert watcher.values["retry"]["maxRetries"] == 3
+    _write(tmp_path, "retry.maxRetries", 4)
+    change = watcher.poll_now()
+    assert change is not None and change.changed_keys == {"retry.maxRetries"}
+
+
+# ---------------------------------------------------------------------------
+# 3. Per-key diff
+# ---------------------------------------------------------------------------
+
+
+def test_a_metadata_only_write_delivers_nothing(tmp_path) -> None:
+    """Every write bumps ``metadata.last_modified``; a no-op write must not
+    produce a notification (or the TUI would print a line for nothing)."""
+    _write(tmp_path, "retry.maxRetries", 3)
+    watcher = ConfigWatcher(tmp_path)
+    recorder = Recorder()
+    watcher.subscribe(recorder)
+    ConfigManager(tmp_path).update_config({}, write=True)  # rewrites, same values
+    assert watcher.poll_now() is None
+    assert recorder.changes == []
+
+
+def test_changed_keys_name_exactly_the_registry_keys_that_moved(tmp_path) -> None:
+    _write(tmp_path, "retry.maxRetries", 3)
+    watcher = ConfigWatcher(tmp_path)
+    _write(tmp_path, "compaction.threshold_percent", 0.5)
+    change = watcher.poll_now()
+    assert change is not None
+    assert change.changed_keys == {"compaction.threshold_percent"}
+    assert change.source == "disk"
+    assert change.values is watcher.values
+
+
+def test_an_unset_is_a_change(tmp_path) -> None:
+    """Resetting a key to default on the page is an edit the consumers must
+    see — the value they hold is no longer what the user wants."""
+    _write(tmp_path, "compaction.threshold_percent", 0.5)
+    watcher = ConfigWatcher(tmp_path)
+    setting = settings_io.resolve_key("compaction.threshold_percent")
+    assert setting is not None
+    settings_io._delete(ConfigManager(tmp_path), setting.path)
+    change = watcher.poll_now()
+    assert change is not None and change.changed_keys == {"compaction.threshold_percent"}
+
+
+def test_a_flat_dotted_display_key_diffs_by_its_literal_path(tmp_path) -> None:
+    """``display.shimmer`` is a top-level key with a dot IN it. The diff walks
+    the registry's declared ``path`` so it is seen as one key, not as a
+    nesting ``display -> shimmer`` that does not exist."""
+    watcher = ConfigWatcher(tmp_path)
+    _write(tmp_path, "display.shimmer", False)
+    change = watcher.poll_now()
+    assert change is not None and change.changed_keys == {"display.shimmer"}
+
+
+# ---------------------------------------------------------------------------
+# 4. Local fast path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_settings_io_write_reaches_listeners_synchronously_with_source_local(
+    tmp_path,
+) -> None:
+    """The writing process never waits a poll interval: ``write_setting``
+    returns with the listener already called, and the next poll is a no-op
+    because the fingerprint was recorded."""
+    watcher = process_watcher(tmp_path)
+    watcher.start()
+    recorder = Recorder()
+    watcher.subscribe(recorder)
+    try:
+        setting = settings_io.resolve_key("compaction.enabled")
+        assert setting is not None
+        settings_io.write_setting(ConfigManager(tmp_path), setting, False)
+        # Already delivered, before any await.
+        assert [c.source for c in recorder.changes] == ["local"]
+        assert recorder.changes[0].changed_keys == {"compaction.enabled"}
+        assert watcher.poll_now() is None
+    finally:
+        await watcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_reset_and_write_chains_also_take_the_fast_path(tmp_path) -> None:
+    watcher = process_watcher(tmp_path)
+    watcher.start()
+    recorder = Recorder()
+    watcher.subscribe(recorder)
+    try:
+        manager = ConfigManager(tmp_path)
+        settings_io.write_chains(manager, {"default": ["zai/glm-5.3"]})
+        assert recorder.changes[-1].changed_keys == {"retry.fallbackChains"}
+        setting = settings_io.resolve_key("retry.fallbackChains")
+        assert setting is not None
+        settings_io.reset_setting(manager, setting)
+        assert recorder.changes[-1].changed_keys == {"retry.fallbackChains"}
+        assert all(c.source == "local" for c in recorder.changes)
+    finally:
+        await watcher.stop()
+
+
+def test_a_write_with_no_watcher_started_is_a_cheap_no_op(tmp_path) -> None:
+    """``lop config edit`` runs in a process that never built a watcher; the
+    hook must neither build one nor fail the write."""
+    setting = settings_io.resolve_key("compaction.enabled")
+    assert setting is not None
+    settings_io.write_setting(ConfigManager(tmp_path), setting, False)
+    assert existing_watcher(tmp_path) is None
+
+
+def test_a_write_notifies_only_the_watcher_on_the_managers_directory(tmp_path) -> None:
+    """A manager pointed elsewhere must not poke the watcher on the default
+    directory: the hook keys on the MANAGER's ``config_dir``."""
+    other = tmp_path / "other"
+    other.mkdir()
+    watched = process_watcher(tmp_path)
+    recorder = Recorder()
+    watched.subscribe(recorder)
+    setting = settings_io.resolve_key("compaction.enabled")
+    assert setting is not None
+    settings_io.write_setting(ConfigManager(other), setting, False)
+    assert recorder.changes == []
+    assert existing_watcher(other) is None
+
+
+# ---------------------------------------------------------------------------
+# 5. Listener isolation
+# ---------------------------------------------------------------------------
+
+
+def test_a_raising_listener_does_not_starve_the_next(tmp_path, caplog) -> None:
+    watcher = ConfigWatcher(tmp_path)
+    recorder = Recorder()
+
+    def bad(change: ConfigChange) -> None:
+        raise RuntimeError("boom")
+
+    watcher.subscribe(bad)
+    watcher.subscribe(recorder)
+    _write(tmp_path, "retry.maxRetries", 2)
+    with caplog.at_level("WARNING", logger="local_operator.config_watch"):
+        assert watcher.poll_now() is not None
+    assert len(recorder.changes) == 1
+    assert "listener failed" in caplog.text
+
+
+def test_unsubscribe_is_idempotent(tmp_path) -> None:
+    watcher = ConfigWatcher(tmp_path)
+    recorder = Recorder()
+    unsubscribe = watcher.subscribe(recorder)
+    unsubscribe()
+    unsubscribe()  # a session disposed through two paths must not raise
+    _write(tmp_path, "retry.maxRetries", 2)
+    watcher.poll_now()
+    assert recorder.changes == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Thread hop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_notify_local_from_a_worker_thread_delivers_on_the_loop_thread(tmp_path) -> None:
+    """Structural spy (the ``test_launch_subagent`` pattern): the listener
+    records the thread it ran on, and it must be the loop's — listeners touch
+    widgets and session state that are loop-affine.
+
+    The kqueue accelerator is disarmed here so the delivery under test is the
+    ``call_soon_threadsafe`` hop itself; with it armed, the directory event can
+    legitimately win the race and deliver the same change as ``"disk"``
+    (documented on ``notify_local``), which would make this assert about
+    scheduling rather than about the hop."""
+    watcher = process_watcher(tmp_path)
+    watcher.start()
+    watcher._disarm_kqueue()
+    recorder = Recorder()
+    watcher.subscribe(recorder)
+    loop_thread = threading.get_ident()
+    try:
+        setting = settings_io.resolve_key("retry.maxRetries")
+        assert setting is not None
+        await asyncio.to_thread(settings_io.write_setting, ConfigManager(tmp_path), setting, 7)
+        # The hop lands on the next loop turn; bound by turns, not seconds.
+        await wait_for(lambda: bool(recorder.changes))
+        assert recorder.threads == [loop_thread]
+        assert recorder.changes[0].source == "local"
+        assert len(recorder.changes) == 1
+    finally:
+        await watcher.stop()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent_and_process_watcher_is_keyed_on_the_directory(
+    tmp_path,
+) -> None:
+    a = process_watcher(tmp_path)
+    assert process_watcher(tmp_path) is a
+    other = tmp_path / "other"
+    other.mkdir()
+    assert process_watcher(other) is not a
+    a.start()
+    task = a._task
+    a.start()
+    assert a._task is task
+    await a.stop()
+    await process_watcher(other).stop()
+
+
+@pytest.mark.asyncio
+async def test_process_watcher_reaps_idle_watchers_and_keeps_live_ones(tmp_path) -> None:
+    """The registry must not hold one directory fd (plus a kqueue) per
+    directory a process has ever seen: the test suite's one-``tmp_path``-per-
+    test shape was an EMFILE at suite scale. An idle watcher (no listeners,
+    or a dead loop) is reaped when the NEXT directory is requested; a live
+    session's watcher on another directory is kept."""
+    idle = process_watcher(tmp_path / "idle")
+    live_dir = tmp_path / "live"
+    live_dir.mkdir()
+    live = process_watcher(live_dir)
+    live.start()
+    live.subscribe(lambda change: None)
+    try:
+        third = process_watcher(tmp_path / "third")
+        assert existing_watcher(tmp_path / "idle") is None  # reaped
+        assert existing_watcher(live_dir) is live  # untouched
+        assert existing_watcher(tmp_path / "third") is third
+        # The reaped watcher's descriptors are gone.
+        assert idle._kqueue is None and idle._dir_fd is None
+        # And a RE-request of that directory gets a fresh, healthy watcher.
+        again = process_watcher(tmp_path / "idle")
+        assert again is not idle
+        assert again._fingerprint is not None or True  # primed without error
+    finally:
+        await live.stop()
+        await process_watcher(tmp_path / "third").stop()
+        await process_watcher(tmp_path / "idle").stop()
+
+
+@pytest.mark.asyncio
+async def test_a_change_between_construction_and_start_is_delivered(tmp_path) -> None:
+    """``start`` re-polls first so a write that landed while the session was
+    being built is not silently adopted as the baseline."""
+    watcher = ConfigWatcher(tmp_path)
+    recorder = Recorder()
+    watcher.subscribe(recorder)
+    _write(tmp_path, "retry.maxRetries", 5)
+    watcher.start()
+    try:
+        assert [c.changed_keys for c in recorder.changes] == [{"retry.maxRetries"}]
+    finally:
+        await watcher.stop()
+
+
+# ---------------------------------------------------------------------------
+# 10. kqueue accelerator (darwin only)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="kqueue directory watch is a BSD/macOS leg")
+@pytest.mark.asyncio
+async def test_a_directory_write_wakes_the_tick_without_the_poll_timer(
+    tmp_path, monkeypatch
+) -> None:
+    """The accelerator's whole value is latency below the poll interval, so
+    the poll is disarmed (``asyncio.sleep`` in the run loop never resolves)
+    and the listener must still fire from the kqueue reader. Waits on the
+    listener's own signal, never on the clock."""
+    _write(tmp_path, "retry.maxRetries", 3)
+    watcher = ConfigWatcher(tmp_path)
+
+    never = asyncio.get_running_loop().create_future()
+
+    async def frozen_sleep(_interval):
+        await never
+
+    monkeypatch.setattr("local_operator.config_watch.asyncio.sleep", frozen_sleep)
+
+    signal = ChangeSignal()
+    recorder = Recorder()
+
+    def listener(change: ConfigChange) -> None:
+        recorder(change)
+        signal._fire()
+
+    watcher.subscribe(listener)
+    watcher.start()
+    try:
+        assert watcher._kqueue is not None, "the accelerator did not arm on darwin"
+        # An os.replace into the directory: exactly what ConfigManager does.
+        _write(tmp_path, "retry.maxRetries", 9)
+        await wait_for(lambda: bool(recorder.changes), signal=signal)
+        assert recorder.changes[0].changed_keys == {"retry.maxRetries"}
+        assert not never.done()
+    finally:
+        signal.close()
+        await watcher.stop()
+        never.cancel()
+        assert watcher._kqueue is None and watcher._dir_fd is None
+
+
+def test_the_kqueue_arm_failure_is_silent(tmp_path, monkeypatch) -> None:
+    """A directory that cannot be opened (EMFILE, an odd filesystem) leaves
+    the poll as the only mechanism, without a raise or a warning."""
+
+    def refuse(*_a, **_k):
+        raise OSError("EMFILE")
+
+    monkeypatch.setattr(os, "open", refuse)
+    loop = asyncio.new_event_loop()
+    try:
+        watcher = ConfigWatcher(tmp_path)
+        watcher._arm_kqueue(loop)
+        assert watcher._kqueue is None
+    finally:
+        loop.close()

--- a/tests/unit/test_config_watch.py
+++ b/tests/unit/test_config_watch.py
@@ -27,6 +27,7 @@ from local_operator.config_watch import (
     existing_watcher,
     process_watcher,
 )
+from local_operator.providers.failover import RetrySettings
 from tests.unit.harness.test_comms import ChangeSignal, wait_for
 
 
@@ -160,6 +161,68 @@ def test_every_shape_the_write_guard_rejects_is_kept_out_of_the_snapshot(
     (tmp_path / "config.yml").write_bytes(content.encode("latin-1"))
     assert watcher.poll_now() is None
     assert watcher.values["retry"]["maxRetries"] == 3
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "values: 3\n",  # truncated edit leaves a scalar
+        "values: a string\n",
+        "values: [a, b]\n",  # mis-indented edit leaves a list
+    ],
+)
+def test_a_values_block_that_is_not_a_mapping_keeps_the_last_good_snapshot(
+    tmp_path, body: str
+) -> None:
+    """The shape the write guard PASSES but the watcher must still refuse.
+
+    Review round 2, M5. ``_require_readable_config`` lets this through on
+    purpose — a write that fails later still has its bytes intact — but the
+    watcher has no later step to fail at, so substituting ``{}`` here
+    back-filled the entire default set, adopted it, and fanned it out as a
+    genuine change: one mis-indented hand-edit silently reset every running
+    session to defaults while announcing nine changed keys.
+
+    The divergence from the write guard is the point of this test, so it
+    asserts all three halves: the snapshot survives, nothing is delivered, and
+    the file is still not moved aside (the watcher never writes).
+    """
+    _write(tmp_path, "retry.maxRetries", 3)
+    watcher = ConfigWatcher(tmp_path)
+    watcher.poll_now()
+    delivered: list[ConfigChange] = []
+    watcher.subscribe(delivered.append)
+
+    (tmp_path / "config.yml").write_text(body)
+
+    assert watcher.poll_now() is None
+    assert not delivered, f"a malformed edit was announced as a change: {delivered}"
+    assert watcher.values["retry"]["maxRetries"] == 3
+    assert not list(tmp_path.glob("*.bad*")), "the watcher moved the user's file aside"
+
+
+def test_an_absent_values_block_is_genuinely_empty_and_does_reset_to_defaults(
+    tmp_path,
+) -> None:
+    """The other side of M5's line, so the fix cannot over-reach.
+
+    ``values:`` absent (or an explicitly empty mapping) really does mean
+    "nothing set" — that is what ``_load_config`` resolves to defaults — so it
+    must still be adopted. Pinned next to the test above because the two are
+    one decision: refusing BOTH would make a legitimately-emptied config
+    un-followable.
+    """
+    _write(tmp_path, "retry.maxRetries", 3)
+    watcher = ConfigWatcher(tmp_path)
+    watcher.poll_now()
+
+    (tmp_path / "config.yml").write_text("other: 1\n")
+
+    change = watcher.poll_now()
+    assert change is not None and "retry.maxRetries" in change.changed_keys
+    # Read off the dataclass rather than hardcoded, so a change to the
+    # product default does not turn this into a false failure.
+    assert watcher.values["retry"]["maxRetries"] == RetrySettings().max_retries
 
 
 def test_a_deleted_file_keeps_the_snapshot_and_sees_its_return(tmp_path) -> None:

--- a/tests/unit/test_config_watch.py
+++ b/tests/unit/test_config_watch.py
@@ -14,7 +14,7 @@ import os
 import sys
 import threading
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -411,6 +411,49 @@ async def test_process_watcher_reaps_idle_watchers_and_keeps_live_ones(tmp_path)
         await live.stop()
         await process_watcher(tmp_path / "third").stop()
         await process_watcher(tmp_path / "idle").stop()
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="only the kqueue leg holds descriptors")
+@pytest.mark.asyncio
+async def test_restarting_a_watcher_whose_task_died_does_not_leak_a_directory_fd(
+    tmp_path,
+) -> None:
+    """``start()`` after the loop died must release the old accelerator first.
+
+    Review round 1, M4. The idempotence guard only short-circuits while the
+    task is ALIVE; once it has died with its loop, ``start()`` falls through
+    and re-arms. Without a disarm first, ``_kqueue``/``_dir_fd`` are overwritten
+    while the previous descriptors are still open and now unreferenced, so a
+    later ``stop()`` can only close the newest pair — measured at four distinct
+    dir fds across four loops, three still open afterwards.
+
+    Asserted as descriptor IDENTITY rather than by counting open files: the fd
+    handed out on each cycle must be the SAME number, which is only possible if
+    the previous one was closed and its slot reused. That is a fact about the
+    release, not a bet on the process's fd table being otherwise quiet.
+    """
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    watcher = ConfigWatcher(tmp_path)
+    handed_out: list[int | None] = []
+
+    # Four separate loops, each dying without a stop() — the shape a process
+    # that builds a session, tears its loop down, and builds another produces.
+    for _ in range(4):
+
+        async def cycle() -> None:
+            watcher.start()
+            handed_out.append(watcher._dir_fd)
+
+        await asyncio.to_thread(asyncio.run, cycle())
+
+    assert all(fd is not None for fd in handed_out), handed_out
+    assert len(set(handed_out)) == 1, (
+        f"each start() took a NEW directory fd {handed_out} instead of reusing the "
+        "released one — the previous accelerator was not disarmed"
+    )
+    await watcher.stop()
+    with pytest.raises(OSError):
+        os.fstat(cast(int, handed_out[-1]))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/conftest.py
+++ b/tests/unit/tui/conftest.py
@@ -16,6 +16,7 @@ from textual.app import App, ComposeResult
 
 from local_operator.tui import animation
 from local_operator.tui import theme as theme_mod
+from local_operator.tui.settings import settings_reload
 from local_operator.tui.widgets.transcript import TranscriptView
 
 #: The real stylesheet, so styled tests exercise the shipped rules rather
@@ -35,6 +36,17 @@ def hermetic_tui_env(monkeypatch: pytest.MonkeyPatch) -> None:
     # Reverted here rather than in each test for the same reason the env pins
     # above are: a leak like this fails somewhere else entirely.
     animation.reset_animation_focus()
+    # The display-flag cache is a module global for the same reason, and leaks
+    # the same way (QA round 5, Q5-M1). Any test that writes a `display.*` key
+    # and then reads one — the config-watch propagation tests do exactly that —
+    # leaves the flag it wrote in `_cache`, which outlives its `tmp_path`. A
+    # later test reading `motion_enabled()` or a glyph then sees another test's
+    # config: `test_render_throttling.py` and `test_welcome.py` both fail that
+    # way, and only when they land on the same xdist worker AFTER the polluter,
+    # which is why it presents as a load flake rather than an ordering bug.
+    # Reset BEFORE each test rather than after, so a test that populates the
+    # cache cannot poison its successors no matter how it exits.
+    settings_reload()
     # Pin the tool-row icon mode host-independently. `nerd_icons_enabled()` now
     # autodetects from terminal-emulator env markers (glyphs.py), so the icon a
     # row leads with depends on the HOST: a dev box in ghostty/cmux renders the

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -4263,18 +4263,18 @@ async def test_failovers_does_not_call_a_usable_provider_accountless(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_failovers_flags_config_edited_after_the_session_started(
-    monkeypatch, tmp_path
-) -> None:
-    """The listing must describe what the SESSION routes on, and flag drift.
+async def test_failovers_describes_what_the_session_routes_on(monkeypatch, tmp_path) -> None:
+    """The listing must describe what the SESSION routes on, never the file.
 
-    The router captures its settings once at session build; nothing watches
-    config.yml. Without this the command confirmed cascade edits the running
-    session would not honour — a green light, and most wrong for the user who
-    followed this command's own "ask the agent to change…" hint.
+    The session's ``routing_settings`` is the mapping the stream will actually
+    use — kept current by the process config watcher — so a listing built from
+    disk would answer a different question. The old ``stale · /reload`` row is
+    gone with the gap it described: nothing must reintroduce a "reload to
+    apply" hint for a change that already applied.
     """
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
-    # On DISK: two targets. The session captured only the first.
+    # On DISK: two targets. The session (a test double the watcher cannot
+    # update) reports only the first — the listing follows the session.
     _failover_config(tmp_path, {"fallbackChains": {"default": ["zai/glm-5.3", "kimi/k3"]}})
 
     class SnapshotSession(FakeSession):
@@ -4293,9 +4293,9 @@ async def test_failovers_flags_config_edited_after_the_session_started(
     # What the SESSION will do, not what the file says.
     assert "1. zai/glm-5.3" in text
     assert "kimi/k3" not in text
-    # And it says so, naming the step that makes the edit real.
-    assert "config.yml changed since this session started" in text
-    assert "/reload" in text
+    # No drift row and no reload hint: the change path is live now.
+    assert "stale" not in text
+    assert "/reload" not in text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_config_change_notice.py
+++ b/tests/unit/tui/test_config_change_notice.py
@@ -366,3 +366,149 @@ async def test_new_reloads_the_launch_config_so_the_notice_promise_is_true(
         f"/new built with {built[-1]!r}: the launch-time config manager was not reloaded, "
         "so the value the notice promised would take effect did not"
     )
+
+
+#: The five shapes `ConfigManager._load_config` mishandles: the first three
+#: RAISE, the last two are the destructive ones — it moves the user's file
+#: aside to `config.yml.bad.<ts>` and continues from defaults.
+_MALFORMED_CONFIGS = {
+    "scalar": "values: 3\n",
+    "list": "values:\n - a\n",
+    "null": "values:\n",
+    "broken-yaml": "values:\n  bad: : :\n",
+    "non-mapping-top": "- a\n- b\n",
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("shape", sorted(_MALFORMED_CONFIGS))
+async def test_new_survives_a_malformed_config_without_touching_the_file(
+    monkeypatch, tmp_path, shape: str
+) -> None:
+    """`/new` must not crash on, or destroy, a config it cannot parse.
+
+    Review round 3, B1 — a regression the `/new` reload introduced. In
+    production `_on_config_changed` is `ConfigManager.reload`, which raises on
+    a non-mapping `values:` and MOVES `config.yml` aside on a YAML error. The
+    story this PR makes likelier: the watcher deliberately holds a broken file
+    in silence, so the user's first hint of a fat-fingered edit is the `/new`
+    the notice sent them to — which either died or replaced every setting they
+    had with defaults.
+
+    Asserts all four properties per shape, because the fix has to deliver all
+    four: no exception, the session still builds, the file is untouched, and no
+    `.bad` file appears. The last two are the ones that matter most; a crash is
+    recoverable, a silently discarded config is not.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    launch_manager = ConfigManager(tmp_path)
+    launch_manager.set_config_value("hosting", "anthropic")
+    built: list[str] = []
+
+    async def resume_factory(resume_id):
+        built.append(str(launch_manager.get_config_value("hosting")))
+        return await _factory(FakeSession())
+
+    app = OperatorApp(
+        lambda: _factory(FakeSession()),
+        resume_factory=resume_factory,
+        on_config_changed=launch_manager.reload,
+    )
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        body = _MALFORMED_CONFIGS[shape]
+        (tmp_path / "config.yml").write_text(body)
+
+        app._cmd_new(lambda body, kind="info": None)  # must not raise
+        for _ in range(400):
+            if built:
+                break
+            await pilot.pause()
+
+    assert built, f"{shape}: /new did not build a session"
+    assert (
+        tmp_path / "config.yml"
+    ).read_text() == body, f"{shape}: the user's config was rewritten"
+    assert not list(tmp_path.glob("*.bad*")), f"{shape}: config.yml was moved aside by /new"
+
+
+@pytest.mark.asyncio
+async def test_new_adopts_the_approval_mode_into_the_real_gate(monkeypatch, tmp_path) -> None:
+    """The fourth NEW_SESSIONS key, which the round-2 fix could not reach.
+
+    QA round 3, Q3. `_cmd_new` → `_on_config_changed` repairs the session
+    FACTORY path, but the TUI's approval gate is process state written only by
+    `_load_approvals_default` at mount — so `tool_approval_mode` was the one
+    key of four whose "takes effect on /new" promise was not kept, and the one
+    where being wrong is a safety problem.
+
+    Driven in the tightening direction (`auto → ask`), which is the dangerous
+    one: the notice promises prompts and the old behaviour kept auto-approving.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    launch_manager = ConfigManager(tmp_path)
+    launch_manager.set_config_value("hosting", "anthropic")
+    _write_elsewhere(tmp_path, "tool_approval_mode", "auto")
+
+    async def resume_factory(resume_id):
+        return await _factory(FakeSession())
+
+    app = OperatorApp(
+        lambda: _factory(FakeSession()),
+        resume_factory=resume_factory,
+        on_config_changed=launch_manager.reload,
+    )
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        assert app._approve_all is True, "the app did not boot on the saved auto default"
+
+        _write_elsewhere(tmp_path, "tool_approval_mode", "ask")
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        # The RUNNING session's gate must not move — the key is NEW_SESSIONS.
+        assert app._approve_all is True
+
+        app._cmd_new(lambda body, kind="info": None)
+        for _ in range(400):
+            await pilot.pause()
+            if app._approve_all is False:
+                break
+        assert app._approve_all is False, (
+            "the notice promised tool_approval_mode takes effect on /new, but the "
+            "approval gate still auto-approves"
+        )
+
+
+@pytest.mark.asyncio
+async def test_multi_key_clauses_agree_in_number(monkeypatch, tmp_path) -> None:
+    """Plural key lists take plural verbs (design review round 1, D7).
+
+    Pinned with MULTIPLE keys per clause on purpose: every other pin in this
+    file asserts a single-key string, which is exactly why three ungrammatical
+    clauses shipped — `hosting, model_name needs a relaunch` and, worse,
+    `a, b, c is retired and does nothing`. The two-key relaunch form is the
+    common case, not an edge: those are the keys a user changes together when
+    switching models.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    retired = [s.key for s in settings_io.SETTINGS if s.section == "retired"][:3]
+    assert len(retired) >= 2, "need two retired keys to pin the plural form"
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(200, 24)) as pilot:
+        await _adopted(app, pilot)
+        _write_elsewhere(tmp_path, "hosting", "openrouter")
+        _write_elsewhere(tmp_path, "model_name", "some/model")
+        for key in retired:
+            _write_elsewhere(tmp_path, key, 4321)
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+
+        notice = [n for n in _notices(app) if "config.yml changed" in n][-1]
+
+    assert "hosting, model_name need a relaunch" in notice, notice
+    assert f"{', '.join(sorted(retired))} are retired and do nothing" in notice, notice
+    # And the singular forms must survive the change.
+    assert " needs a relaunch" not in notice
+    assert " is retired and does nothing" not in notice

--- a/tests/unit/tui/test_config_change_notice.py
+++ b/tests/unit/tui/test_config_change_notice.py
@@ -90,6 +90,64 @@ async def test_a_non_live_key_is_named_as_taking_effect_on_new(monkeypatch, tmp_
 
 
 @pytest.mark.asyncio
+async def test_a_lone_approval_mode_change_from_another_pane_is_announced(
+    monkeypatch, tmp_path
+) -> None:
+    """The one setting where silence is a safety problem (review round 1, M2).
+
+    ``tool_approval_mode`` used to be dropped from the notice whenever it was
+    the ONLY changed key, on the theory that `/approvals default` had already
+    printed its own receipt. But that write bypassed ``settings_io``, so it
+    arrived as ``source="disk"`` — indistinguishable from another pane's edit —
+    and the suppression silenced the genuine cross-process case too: flip the
+    approval default in pane A, hear nothing in pane B. Batched changes still
+    announced it, which is the tell that the rule was about the wrong thing.
+
+    ``_save_approvals_default`` now writes through the facade, so a local write
+    is silenced by ``source="local"`` like every other local write, and this
+    case is free to speak.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        _write_elsewhere(tmp_path, "tool_approval_mode", "auto")
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        notices = [n for n in _notices(app) if "config.yml changed" in n]
+        assert notices == ["config.yml changed: tool_approval_mode takes effect on /new"]
+
+
+@pytest.mark.asyncio
+async def test_saving_the_approvals_default_here_does_not_announce_itself(
+    monkeypatch, tmp_path
+) -> None:
+    """The other half of M2: the LOCAL write must still be silent.
+
+    Drives the real ``/approvals default auto`` handler rather than calling the
+    writer directly, because what is being asserted is that the facade route
+    reaches the watcher as ``source="local"`` on the path a user actually
+    takes. The command's own receipt is what tells them; a harness notice on
+    top would be the same news twice.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        saved_to, problem = app._save_approvals_default(True)
+        await pilot.pause()
+        assert not problem, problem
+        assert saved_to, "the write reported no destination"
+        # It really landed on disk, through the facade.
+        assert ConfigManager(tmp_path).get_config_value("tool_approval_mode") == "auto"
+        # And produced no harness notice, and no pending change for the poll.
+        assert not [n for n in _notices(app) if "config.yml changed" in n]
+        assert process_watcher(tmp_path).poll_now() is None
+
+
+@pytest.mark.asyncio
 async def test_a_write_from_this_process_is_silent(monkeypatch, tmp_path) -> None:
     """The page or command here already showed its result; a second line
     would be the same news twice."""

--- a/tests/unit/tui/test_config_change_notice.py
+++ b/tests/unit/tui/test_config_change_notice.py
@@ -12,6 +12,8 @@ tests are bound by loop turns, never by the 2 s cadence.
 
 from __future__ import annotations
 
+from unittest import mock
+
 import pytest
 
 from local_operator import settings_io
@@ -512,3 +514,111 @@ async def test_multi_key_clauses_agree_in_number(monkeypatch, tmp_path) -> None:
     # And the singular forms must survive the change.
     assert " needs a relaunch" not in notice
     assert " is retired and does nothing" not in notice
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("shape", sorted(_MALFORMED_CONFIGS))
+async def test_a_display_repaint_after_a_fan_out_never_destroys_the_config(
+    monkeypatch, tmp_path, shape: str
+) -> None:
+    """The paint path must not move the user's `config.yml` aside.
+
+    Review round 4, B3 — the same defect class as B1, reached without any user
+    action. `tui/settings.py` caches the display flags and this PR added the
+    first invalidator that fires on ANOTHER process's write: before it, the
+    cache was dropped only by a write this process had just made, so the file
+    was well-formed by construction.
+
+    The story needs no `/new`: a display flag changes in another pane (LIVE and
+    encouraged), the cache drops, the user's next edit is mis-indented — the
+    state the watcher deliberately holds in silence — and the next shimmer or
+    glyph read repaints. `settings_get` is called from five paint paths rather
+    than every frame, so the window between the invalidation and the
+    repopulating read is unbounded in wall time.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    from local_operator.tui.settings import settings_get, settings_reload
+
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    watcher = process_watcher(tmp_path)
+    watcher.poll_now()
+
+    # Another pane flips a display flag; the listener drops this cache.
+    _write_elsewhere(tmp_path, "display.shimmer", False)
+    watcher.poll_now()
+    settings_reload()
+    assert settings_get("display.shimmer") is False
+    settings_reload()  # empty again, as it is between paints
+
+    # The user's NEXT edit is malformed. The watcher holds it silently.
+    body = _MALFORMED_CONFIGS[shape]
+    (tmp_path / "config.yml").write_text(body)
+    assert watcher.poll_now() is None, f"{shape}: the watcher adopted a malformed file"
+
+    settings_get("display.shimmer")  # the repaint
+
+    assert (
+        tmp_path / "config.yml"
+    ).read_text() == body, f"{shape}: a repaint rewrote the user's config"
+    assert not list(tmp_path.glob("*.bad*")), f"{shape}: a repaint moved config.yml aside"
+
+
+@pytest.mark.asyncio
+async def test_no_config_watch_listener_path_constructs_a_config_manager(
+    monkeypatch, tmp_path
+) -> None:
+    """The INVARIANT behind B1 and B3, rather than a third point fix.
+
+    Every blocker in this change's history has been one defect: a caller
+    reachable from a config-watch fan-out constructs a `ConfigManager`, whose
+    `_load_config` MOVES a malformed `config.yml` aside and continues from
+    defaults. Point-fixing each site leaves the generator intact — the class
+    returns the next time someone adds a consumer to the fan-out, and the
+    failure is silent, destructive, and found by a user rather than a test.
+
+    So this asserts the property directly, against the REAL listener
+    (`OperatorApp._on_config_change`) and the real repaint that follows it,
+    rather than a stand-in registered by the test — a stand-in would only ever
+    prove things about itself, and the whole point is to catch a consumer
+    nobody has written yet.
+
+    Deliberately allows the FALLBACK in `tui/settings._load`: that branch runs
+    only when no watcher exists, which is exactly when there is no
+    cross-process invalidation to race with, and removing it would break every
+    CLI process that never starts a watcher.
+    """
+    import local_operator.config as config_mod
+    from local_operator.tui import settings as tui_settings
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    real_manager = config_mod.ConfigManager
+    real_manager(tmp_path).set_config_value("hosting", "")
+
+    constructed: list[str] = []
+
+    class TattlingConfigManager(real_manager):  # type: ignore[misc, valid-type]
+        def __init__(self, *args, **kwargs):
+            constructed.append("ConfigManager")
+            super().__init__(*args, **kwargs)
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        # A display key, because that is the branch with a cache to drop; the
+        # assertion covers whatever else the listener does on the same change.
+        _write_elsewhere(tmp_path, "display.shimmer", False)
+        constructed.clear()
+
+        with mock.patch.object(config_mod, "ConfigManager", TattlingConfigManager):
+            change = process_watcher(tmp_path).poll_now()
+            assert change is not None, "the fan-out did not fire; this proved nothing"
+            await pilot.pause()
+            # The repaint that follows the invalidation.
+            tui_settings.settings_get("display.shimmer")
+
+    assert not constructed, (
+        "a config-watch listener path constructed a ConfigManager. Its _load_config "
+        "moves a malformed config.yml aside and continues from defaults, so this is "
+        "the B1/B3 defect class reopening. Read the watcher's validated snapshot "
+        "(existing_watcher().values) instead."
+    )

--- a/tests/unit/tui/test_config_change_notice.py
+++ b/tests/unit/tui/test_config_change_notice.py
@@ -65,7 +65,7 @@ async def test_a_change_from_another_process_is_announced_once_with_its_keys(
         await pilot.pause()
         notices = [n for n in _notices(app) if "config.yml changed" in n]
         assert notices == [
-            "config.yml changed: compaction.threshold_percent, retry.maxRetries — applied"
+            "config.yml changed: applied: compaction.threshold_percent, retry.maxRetries"
         ]
 
 
@@ -84,8 +84,9 @@ async def test_a_non_live_key_is_named_as_taking_effect_on_new(monkeypatch, tmp_
         await pilot.pause()
         notices = [n for n in _notices(app) if "config.yml changed" in n]
         assert notices == [
-            "config.yml changed: compaction.enabled — applied; "
-            "tool_approval_mode takes effect on /new"
+            "config.yml changed: applied: compaction.enabled; "
+            "tool_approval_mode takes effect on /new; "
+            "tool approvals now auto — every tool runs without asking"
         ]
 
 
@@ -116,7 +117,10 @@ async def test_a_lone_approval_mode_change_from_another_pane_is_announced(
         process_watcher(tmp_path).poll_now()
         await pilot.pause()
         notices = [n for n in _notices(app) if "config.yml changed" in n]
-        assert notices == ["config.yml changed: tool_approval_mode takes effect on /new"]
+        assert notices == [
+            "config.yml changed: tool_approval_mode takes effect on /new; "
+            "tool approvals now auto — every tool runs without asking"
+        ]
 
 
 @pytest.mark.asyncio
@@ -193,7 +197,7 @@ async def test_a_theme_written_by_another_process_is_applied_here(monkeypatch, t
         process_watcher(tmp_path).poll_now()
         await pilot.pause()
         assert theme_mod.current_theme() == target
-        assert any("tui.theme — applied" in n for n in _notices(app))
+        assert any("applied: tui.theme" in n for n in _notices(app))
     theme_mod.set_theme(before)
 
 
@@ -246,3 +250,119 @@ async def test_unmount_unsubscribes_the_app(monkeypatch, tmp_path) -> None:
         assert len(watcher._listeners) == 1
     assert watcher._listeners == []
     assert app._unsubscribe_config_watch is None
+
+
+@pytest.mark.asyncio
+async def test_a_new_launch_key_asks_for_a_relaunch_not_a_new(monkeypatch, tmp_path) -> None:
+    """Design review round 1, D1: `/new` does not re-exec, so it cannot adopt
+    a NEW_LAUNCH key. Saying `/new` sent the user to do something that would
+    not work and gave them no second message when it did not."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        _write_elsewhere(tmp_path, "hosting", "openrouter")
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        notices = [n for n in _notices(app) if "config.yml changed" in n]
+        assert notices == ["config.yml changed: hosting needs a relaunch"]
+
+
+@pytest.mark.asyncio
+async def test_a_retired_key_is_not_promised_to_take_effect(monkeypatch, tmp_path) -> None:
+    """Design review round 1, D1, sharpest edge: the `retired` section is
+    documented as "read but no longer do anything", and the notice was telling
+    the user one of those keys would take effect on `/new`."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    retired = [s for s in settings_io.SETTINGS if s.section == "retired"]
+    assert retired, "the retired section is empty; this test has nothing to pin"
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        _write_elsewhere(tmp_path, retired[0].key, 4321)
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        notices = [n for n in _notices(app) if "config.yml changed" in n]
+        assert notices == [f"config.yml changed: {retired[0].key} is retired and does nothing"]
+        assert "takes effect" not in notices[0]
+
+
+@pytest.mark.asyncio
+async def test_the_approval_mode_notice_names_the_mode_and_warns(monkeypatch, tmp_path) -> None:
+    """Design review round 1, D2.
+
+    Asserts the two things the frame made obvious: the line says WHICH way the
+    switch went, and it renders at the same severity as the local receipt for
+    the identical transition rather than as dim grey routine info.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        _write_elsewhere(tmp_path, "tool_approval_mode", "auto")
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        blocks = [b for b in app.query(NoticeBlock) if "config.yml changed" in (b.text() or "")]
+        assert blocks, "no config-change notice was emitted"
+        text = blocks[-1].text() or ""
+        assert "now auto" in text and "without asking" in text, text
+        # Asserted on the rendered token, not a bespoke attribute: this is
+        # what actually decides the ink, and `info` maps to "dim".
+        assert blocks[-1]._token == "warning", f"rendered in {blocks[-1]._token!r} ink, not warning"
+
+        # And the cached default follows, so a later bare `/approvals` does not
+        # report a value a new session would not boot with (QA round 2, Q1).
+        assert app._approvals_default_auto is True
+
+
+@pytest.mark.asyncio
+async def test_new_reloads_the_launch_config_so_the_notice_promise_is_true(
+    monkeypatch, tmp_path
+) -> None:
+    """`/new` must adopt a NEW_SESSIONS key written by another process.
+
+    Design review round 1 (D1) and QA round 2 (Q1) both drove this path and
+    found the session rebuilt from the launch-time `ConfigManager` the factory
+    closed over, so the value the notice promised would "take effect on /new"
+    did not. The notice is the reason this matters: the harness tells the user
+    to run `/new`, and `tool_approval_mode` is among the keys it says that
+    about.
+
+    Built the way `cli.py:3004` builds it — `on_config_changed=<manager>.reload`
+    with the factory closing over that same instance — because the defect only
+    exists in that arrangement; a factory that re-reads config per call would
+    pass while production still failed.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    launch_manager = ConfigManager(tmp_path)
+    launch_manager.set_config_value("hosting", "anthropic")
+    built: list[str] = []
+
+    async def resume_factory(resume_id):
+        built.append(str(launch_manager.get_config_value("hosting")))
+        return await _factory(FakeSession())
+
+    app = OperatorApp(
+        lambda: _factory(FakeSession()),
+        resume_factory=resume_factory,
+        on_config_changed=launch_manager.reload,
+    )
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        _write_elsewhere(tmp_path, "hosting", "openrouter")
+
+        app._cmd_new(lambda body, kind="info": None)
+        for _ in range(400):
+            if built:
+                break
+            await pilot.pause()
+        await pilot.pause()
+
+    assert built, "/new never rebuilt the session"
+    assert built[-1] == "openrouter", (
+        f"/new built with {built[-1]!r}: the launch-time config manager was not reloaded, "
+        "so the value the notice promised would take effect did not"
+    )

--- a/tests/unit/tui/test_config_change_notice.py
+++ b/tests/unit/tui/test_config_change_notice.py
@@ -1,0 +1,190 @@
+"""``OperatorApp`` reacts to a ``config.yml`` change from another process.
+
+The session applies the values (``tests/unit/session/test_config_live.py``);
+the app's job is the user-facing half — say what changed and why behaviour
+just moved — plus the two groups only the TUI owns, ``display.*`` and
+``tui.theme``, when the write came from ANOTHER process. A write from this
+process is silent: the page already told the user.
+
+The watcher is driven by ``poll_now()`` here rather than by its timer, so the
+tests are bound by loop turns, never by the 2 s cadence.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from local_operator import settings_io
+from local_operator.config import ConfigManager
+from local_operator.config_watch import _reset_for_tests, process_watcher
+from local_operator.tui import theme as theme_mod
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.transcript import NoticeBlock
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+def _write_elsewhere(config_dir, key: str, value) -> None:
+    """A write shaped like another process's: below the notify hook."""
+    setting = settings_io.resolve_key(key)
+    assert setting is not None, key
+    settings_io._store(ConfigManager(config_dir), setting.path, value)
+
+
+def _notices(app) -> list[str]:
+    return [block.text() or "" for block in app.query(NoticeBlock)]
+
+
+async def _adopted(app, pilot) -> None:
+    for _ in range(200):
+        if app._session is not None and app._unsubscribe_config_watch is not None:
+            return
+        await pilot.pause()
+    raise AssertionError("the app never adopted a session / subscribed to config")
+
+
+@pytest.mark.asyncio
+async def test_a_change_from_another_process_is_announced_once_with_its_keys(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        watcher = process_watcher(tmp_path)
+        _write_elsewhere(tmp_path, "compaction.threshold_percent", 0.5)
+        _write_elsewhere(tmp_path, "retry.maxRetries", 3)
+        watcher.poll_now()
+        await pilot.pause()
+        notices = [n for n in _notices(app) if "config.yml changed" in n]
+        assert notices == [
+            "config.yml changed: compaction.threshold_percent, retry.maxRetries — applied"
+        ]
+
+
+@pytest.mark.asyncio
+async def test_a_non_live_key_is_named_as_taking_effect_on_new(monkeypatch, tmp_path) -> None:
+    """``tool_approval_mode`` is deliberately build-time; the notice must not
+    claim it applied."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        _write_elsewhere(tmp_path, "tool_approval_mode", "auto")
+        _write_elsewhere(tmp_path, "compaction.enabled", False)
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        notices = [n for n in _notices(app) if "config.yml changed" in n]
+        assert notices == [
+            "config.yml changed: compaction.enabled — applied; "
+            "tool_approval_mode takes effect on /new"
+        ]
+
+
+@pytest.mark.asyncio
+async def test_a_write_from_this_process_is_silent(monkeypatch, tmp_path) -> None:
+    """The page or command here already showed its result; a second line
+    would be the same news twice."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        setting = settings_io.resolve_key("compaction.enabled")
+        assert setting is not None
+        settings_io.write_setting(ConfigManager(tmp_path), setting, False)
+        await pilot.pause()
+        assert not [n for n in _notices(app) if "config.yml changed" in n]
+        # And the fingerprint was recorded: the next tick has nothing to say.
+        assert process_watcher(tmp_path).poll_now() is None
+
+
+@pytest.mark.asyncio
+async def test_a_metadata_only_rewrite_produces_no_line(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        ConfigManager(tmp_path).update_config({}, write=True)
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        assert not [n for n in _notices(app) if "config.yml changed" in n]
+
+
+@pytest.mark.asyncio
+async def test_a_theme_written_by_another_process_is_applied_here(monkeypatch, tmp_path) -> None:
+    """Closes the cross-process gap for the one LIVE group the session does
+    not own: ``/theme`` in pane A repaints pane B."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        before = theme_mod.current_theme()
+        target = next(name for name in theme_mod.available_themes() if name != before)
+        _write_elsewhere(tmp_path, "tui.theme", target)
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        assert theme_mod.current_theme() == target
+        assert any("tui.theme — applied" in n for n in _notices(app))
+    theme_mod.set_theme(before)
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_theme_on_disk_is_reported_not_raised(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        before = theme_mod.current_theme()
+        # Below the validating facade on purpose: a hand edit is exactly how
+        # an unknown name reaches the file.
+        manager = ConfigManager(tmp_path)
+        manager.set_config_value("tui", {"theme": "no-such-theme"})
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        assert theme_mod.current_theme() == before
+        assert any("unknown theme" in n for n in _notices(app))
+
+
+@pytest.mark.asyncio
+async def test_a_display_flag_from_another_process_drops_the_paint_cache(
+    monkeypatch, tmp_path
+) -> None:
+    from local_operator.tui import settings as tui_settings
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        tui_settings.settings_reload()
+        assert tui_settings.settings_get("display.terminal_title") is True  # primes the cache
+        _write_elsewhere(tmp_path, "display.terminal_title", False)
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        assert tui_settings.settings_get("display.terminal_title") is False
+    tui_settings.settings_reload()
+
+
+@pytest.mark.asyncio
+async def test_unmount_unsubscribes_the_app(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        watcher = process_watcher(tmp_path)
+        assert len(watcher._listeners) == 1
+    assert watcher._listeners == []
+    assert app._unsubscribe_config_watch is None

--- a/tests/unit/tui/test_settings_view.py
+++ b/tests/unit/tui/test_settings_view.py
@@ -1568,6 +1568,30 @@ async def test_scope_tags_share_one_column() -> None:
 
 
 @pytest.mark.asyncio
+async def test_the_retired_section_does_not_promise_a_relaunch_will_help() -> None:
+    """Design round 2, D8 — the tag must not contradict the notice.
+
+    `retired` carries `Scope.NEW_LAUNCH`, so the shared renderer tagged it
+    `takes effect: new launch` — promising that a relaunch makes these keys
+    work, one line above its own description saying they do nothing, and about
+    the same keys the config-change notice now calls "retired and does
+    nothing". Asserted on the rendered line rather than the section object,
+    because the defect was in what the page SAYS.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._open_settings_view()
+        view = app.query_one(SettingsView)
+        await pilot.pause()
+        lines = view.render_lines_for_test()
+        header = next((line for line in lines if "Retired" in line), None)
+        assert header is not None, "the Retired header did not render"
+        assert "takes effect: never" in header, header
+        assert "new launch" not in header, header
+
+
+@pytest.mark.asyncio
 async def test_the_longest_label_is_not_clipped_mid_parenthetical() -> None:
     """Design round 1, D4 — ``Connectivity backoff cap (ms)`` fitted in the
     column and was still cut to ``(m…``, an opened parenthetical that never


### PR DESCRIPTION
# PR Description

## Summary of Changes

**Change class: C1 (standard).** Patch bump `0.44.35 → 0.44.36` — a reliability fix users notice as "settings now apply everywhere"; there is no new surface to name in a release title. (Rebased onto `main` after #537 landed; the merger re-sequences the patch number by merge order.)

A setting written in one place did not reach any other running consumer. Five of the nine `/settings` sections were labelled `NEW_SESSIONS` and the label was **honest**: `compaction.*` was coerced once at build (`session_factory.py`), `SessionStreamFn` held the manager's `values` dict for the session's life, and `subagents.max_running` was read once into `AsyncJobManager`. An operator with three `lop` panes open who changed the compaction threshold in one had to `/new` the other two — and `/failovers` had a whole `stale · /reload` row whose only job was to apologise for it.

This wires **one `ConfigWatcher` per process** (2 s stat poll on the app loop, an opportunistic kqueue watch on the config *directory* where the platform has one, plus a synchronous in-process fast path from `settings_io` writes) and fans per-registry-key changes out to every running `Session`, its subagents, and the TUI.

Implements the architect's design at `/tmp/lop-settings-propagation/DESIGN.md`, §9 scope, in one PR.

**Why polling and not the mobile daemon** (design §2, measured on this machine): `os.stat` of the file is **1 µs** against **2 060 µs** for a full `ConfigManager` construct-and-load, so a tick that has nothing to do costs a stat and a comparison — the parse only happens when the fingerprint moves. A Unix-socket round trip to the daemon costs 49–644 µs, needs a daemon that is explicitly optional, and would still have to detect the change by stat or kqueue itself; it adds a hop and a reconnect state machine and removes nothing. The real cost of polling is the loop *wake* (~70 µs CPU), which at 50 processes on a 2 s cadence is 0.18 % of one core — less than the mobile daemon's existing 2 s registry scan.

Two facts about the write path shaped the implementation:

- **Every write is an atomic `os.replace`** (`ConfigManager._write_config`), so the file's inode changes each time. Hence the fingerprint is `(st_ino, st_size, st_mtime_ns)`, and hence the kqueue watches the **directory** — a watch on the file's inode reports one `KQ_NOTE_DELETE` and then nothing, forever.
- **`ConfigManager._load_config` degrades a malformed file to defaults and moves it aside** to `config.yml.bad.<stamp>`. A live reloader going through it would turn a half-typed hand edit into a destroyed config in *every open session* on the next tick. The watcher therefore parses the raw bytes itself under `settings_io._require_readable_config`'s exact rules, keeps the last good snapshot when they fail, and never constructs a `ConfigManager` at all.

### What changed

- **`local_operator/config_watch.py` (new).** `ConfigWatcher` + a `process_watcher()` singleton keyed on the config directory. Parses only on a fingerprint change; remembers a *bad* fingerprint so a broken file is parsed once rather than twice a second; treats a missing file as a first run (not an error); diffs **per registry key** by walking `settings_io.SETTINGS` with its own `_walk`, so the `metadata.last_modified` bump every write carries never produces a notification. `notify_local()` is the write fast path, synchronous on the loop thread and `call_soon_threadsafe` off it. Listeners are isolated (`try/except` per listener, same contract as `Session._emit`).
- **`settings_io`.** `_notify_watcher` beside `_invalidate_caches` at the facade level (`write_setting`, `reset_setting`, `write_chains`), function-local import, guarded — a notification must never fail a write that already landed. Scope changes per design §5: `failover`, `compaction`, `web_search`, `web_fetch` become `LIVE`; `session` splits into `session` (approvals/autosave, still `NEW_SESSIONS` — an approval mode that flips under a running turn is a security-relevant surprise) and a new `subagents` section (`LIVE`); `web_*.enabled` move to a new `web_tools` section (`NEW_SESSIONS`) because they decide whether the tool is *offered*, which is build-time. `Scope.LIVE`'s docstring now states the cross-process contract.
- **`Session._apply_config_change`.** Re-coerces `_compaction_settings`, calls `SessionStreamFn.apply_settings` (rebinding the mapping the per-call `RetrySettings.from_settings` reads — deliberately **not** resetting `_route_state` or the usage memo, so a pinned fallback survives a threshold edit), and pushes `subagents.max_running` into the live `AsyncJobManager.set_max_running`.
- **`AsyncJobManager.set_max_running`.** Raising the cap promotes parked jobs immediately (the same FIFO path a settled job uses) instead of waiting for a completion minutes away; lowering it evicts nothing — a subagent mid-task is not cancelled because the operator typed a smaller number.
- **Wiring.** `session_factory.attach_config_watch` (alongside the auth/stream/MCP seams), unsubscribed via `add_dispose_hook`; the same for subagents in `_build_child_session`, unsubscribed by `_dispose_child`. Every front end — TUI, headless, exec worker, owned phone session — reaches this through `create_session`.
- **`OperatorApp`.** One `_system_notice` per cross-process change naming the changed keys, with non-LIVE keys named separately as "takes effect on /new"; silent when the write came from this process. Cross-process apply of `display.*` (cache drop) and `tui.theme`. The `/failovers` `stale · /reload` row is deleted along with the gap it described, and `local_operator/guides/failover/GUIDE.md` is corrected.

### Deviations from the design

Three, all noted here rather than silently absorbed:

1. **`_load_config`'s top-level default back-fill is mirrored** (`_with_defaults`). The design's snapshot was the raw `values` block. Without the back-fill, `watcher.values` and `manager.get_config().values` disagree for any key the user's file predates, so a consumer switching from one to the other would start seeing `retry` as absent — and the first write on a fresh install would announce thirty keys instead of one.
2. **`notify_local` re-reads the file rather than trusting the writer's mapping.** The writer's manager view carries keys `_load_config` back-filled that are not on disk; the file is the source of truth. The `values` parameter is kept for API symmetry and documented as ignored.
3. **The `process_watcher` registry reaps idle watchers.** Not in the design, and found by running the suite: one `tmp_path` per test meant one directory fd plus one kqueue per directory, and the suite hit `OSError: [Errno 24] Too many open files`. A watcher with no listeners (or a closed loop) is released when the *next* directory is requested; a live session's watcher on another directory is untouched. Production processes have one config directory for their whole life, so this never fires there. Pinned by `test_process_watcher_reaps_idle_watchers_and_keeps_live_ones`.

One behaviour is documented rather than fixed: an off-loop `settings_io` write can have its kqueue delivery win the race against the `call_soon_threadsafe` hop, so the change arrives once and on the loop thread but attributed `"disk"` instead of `"local"` (cosmetic: the TUI prints a line it could have skipped). No production writer runs off-loop today; the alternative is a pre-write handshake in `settings_io` for a cosmetic difference. Written down on `notify_local`.

## Related Issue(s)

- None.

## Impact

- **No breaking changes.** No config migration, no schema change, no new dependency — `select.kqueue` is stdlib and its absence is a supported path. The `/settings` page renders `section.scope.value`, so the scope relabelling needed no code change there.
- **A user-visible behaviour change, by design:** an edit in one pane now moves the other panes. Sessions that relied on "my settings are frozen until I `/new`" no longer get that; the notice is what tells the user why.
- **Cost:** one loop wake per 2 s per process (~70 µs CPU); a stat (1 µs) per wake; a parse (~2 ms) only when the file actually changed. Measured directory-kqueue traffic on a real config dir with 74 `lop` processes alive: **0 events in 20 s** — the SQLite WAL churn is inside file inodes, not directory entries.
- **Security:** `tool_approval_mode` deliberately stays `NEW_SESSIONS`. A live approval-mode flip under a running turn is exactly the surprise this must not introduce, and `test_the_deliberately_build_time_keys_stay_new_sessions` pins it so a future section shuffle cannot make it live by accident.

## Testing Details

### Gates (whole tree, exactly as CI runs them)

```
$ .venv/bin/python -m flake8 .                              → rc=0
$ uvx --from black==26.1.0 black --check .                  → All done! 807 files would be left unchanged.
$ uvx isort==5.13.2 --check .                               → clean (Skipped 1 files)
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python . → 0 errors, 0 warnings, 0 informations
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
  10927 passed, 15 skipped, 448 warnings in 470.10s (0:07:50)
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui -q
  4361 passed, 12 skipped, 16 warnings in 321.34s (0:05:21)
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
  4 passed, 2 warnings in 12.17s
```

### Real execution: two live sessions, isolated config dir

Not a test double: **session A** is a real `lop` session built by the production `session_factory.create_session` inside a real `OperatorApp`; **session B** is a separate OS process running the real `lop config edit` CLI. Both against `LOCAL_OPERATOR_CONFIG_DIR=/tmp/lop-config-watch-evidence/cfg` (never `~/.local-operator`), with an isolated `HOME`. A and B hand off through files, so every delivery below is attributable to exactly one edit.

```
[A pid=58566] REAL session via create_session; watcher running=True kqueue_armed=True
[A pid=58566]   initial: threshold_percent=0.8 max_running=15 retry.maxRetries=10

[B pid=58565] step 1: lop config edit compaction.threshold_percent 0.5
              Successfully updated compaction.threshold_percent to 0.5
[A pid=58566] step 1: B ran `lop config edit compaction.threshold_percent 0.5`
[A pid=58566]     delivered source=disk keys=['compaction.threshold_percent'] 0.20s after B started the edit
[A pid=58566]     session now: threshold_percent=0.5 max_running=15 retry.maxRetries=10
[A pid=58566]     notices: ['config.yml changed: compaction.threshold_percent — applied']
[A pid=58566]     .bad files in config dir: []

[B pid=58565] step 2: hand-writing a MALFORMED config.yml (the half-typed-edit case)
[A pid=58566] step 2: B hand-wrote a MALFORMED config.yml (`values:\n  compaction: [`)
[A pid=58566]     NO delivery in 12s                            ← 6x the poll interval
[A pid=58566]     session now: threshold_percent=0.5 max_running=15 retry.maxRetries=10   ← last good value held
[A pid=58566]     notices: ['config.yml changed: compaction.threshold_percent — applied']  ← no new line
[A pid=58566]     .bad files in config dir: []                  ← the watcher moved nothing aside
[B pid=58565]   .bad files after A's silence window: none

[B pid=58565] step 3: restoring the valid file, then two edits
              Successfully updated retry.maxRetries to 3
              Successfully updated subagents.max_running to 4
[A pid=58566] step 3: B restored a valid file, then `config edit retry.maxRetries 3` and `subagents.max_running 4`
[A pid=58566]     delivered source=disk keys=['retry.maxRetries'] 0.17s after B started the edit
[A pid=58566]     delivered source=disk keys=['subagents.max_running'] 0.37s after B started the edit
[A pid=58566]     session now: threshold_percent=0.5 max_running=4 retry.maxRetries=3
[A pid=58566]     notices: [... 'config.yml changed: retry.maxRetries — applied',
                            'config.yml changed: subagents.max_running — applied']

[A pid=58566] local fast path: this process wrote compaction.keep_recent_tokens=4321
[A pid=58566]     delivered synchronously (before write_setting returned)=True source=local
                  keys=['compaction.keep_recent_tokens'] in 7.4ms
[A pid=58566]     session now: keep_recent_tokens=4321
[A pid=58566]     notices unchanged (the page already showed its own result)=True

[A pid=58566] subagent built: child threshold_percent=0.5 max_running=4 retry.maxRetries=3;
              shares parent's object=False; watcher listeners=4
[B pid=58565] step 4: lop config edit compaction.threshold_percent 0.25 (a subagent is live)
[A pid=58566] step 4: B ran `lop config edit compaction.threshold_percent 0.25`
[A pid=58566]     delivered source=disk keys=['compaction.threshold_percent'] 0.20s after B started the edit
[A pid=58566]     child now: threshold_percent=0.25 (parent threshold_percent=0.25, distinct objects=True)
[A pid=58566] subagent disposed: watcher listeners back to 3
```

Every claim from the brief, checked against real output: cross-process propagation (0.20 s here, kqueue-accelerated), the notice naming the key, a malformed file changing nothing and producing **no `.bad` file**, the writer's own process applying synchronously with `source="local"` and staying quiet, and a subagent following the file while holding its own settings object.

### The ≤2 s claim without the accelerator (the Linux leg)

macOS delivered in 0.20 s via kqueue, which is better than the contract. With the accelerator disarmed — the shape CI's `ubuntu-latest` leg runs — the 2 s poll is the only mechanism:

```
kqueue armed: False (poll interval 2.0s)
before: threshold_percent=0.8
other process: Successfully updated compaction.threshold_percent to 0.35 (exit 0)
after: threshold_percent=0.35 — reached 2.02s after the edit began (poll only)
```

### The malformed-file guard, against the real `ConfigManager`

The contrast is the point: the same bytes, two readers.

```
watcher sees threshold_percent = 0.5
after malformed write: poll_now() -> None
  watcher still holds threshold_percent = 0.5
  .bad files created by the watcher: []
  second poll (must not re-parse; bad fingerprint remembered) -> None
contrast — ConfigManager loading the same bytes:
  Error: could not parse .../config.yml: while parsing a flow node ...
  Moved the invalid file to .../config.yml.bad.20260902-113559 and starting with defaults.
  .bad files after ConfigManager: ['config.yml.bad.20260902-113559']
```

### Automated tests added

- `tests/unit/test_config_watch.py` (25) — fingerprint gate as a **structural** parse-spy (not a timing bound); unreadable-file cases parametrised over every shape `_require_readable_config` rejects, asserting the watcher never reaches `_load_config`; per-key diff including the flat-dotted `display.*` trap; local fast path; listener isolation; the thread hop as a **thread-identity spy**; the darwin-only kqueue leg, which disarms the poll (`asyncio.sleep` replaced by a never-resolving future) so only the accelerator can satisfy it and waits on the listener's own signal.
- `tests/unit/session/test_config_live.py` (42) — **parametrised over every key of every LIVE section**, each writing a non-default value through a *second* `ConfigManager` and asserting the subscribed session's typed view moved. Plus a two-directional registry-honesty test that fails **by name** if a LIVE section has no probe or a probe sits in a non-LIVE section, the subagent-follows test, and both directions of `set_max_running`.
- `tests/unit/tui/test_config_change_notice.py` (8) — the notice text, the non-LIVE "takes effect on /new" wording, silence on a local write, no line for a metadata-only rewrite, cross-process theme apply, unknown-theme reporting, and unsubscribe on unmount.
- `tests/e2e/test_config_propagation.py` — the assembled path: real app, real session, real watcher, and the edit made by an actual `subprocess` running `lop config edit`. Waits on a **signal**, never the clock.

No timing bound anywhere on a success path (AGENTS.md "Timing, flakes"): the waits are event- or turn-bound, and the e2e bound exists only so a hang fails instead of blocking.

### Not verified / pre-existing

`tests/unit/test_session_factory.py::test_dispose_closes_auth_store` fails **identically on `origin/main`** (`FakeConfigManager` has no `config_dir`, then `assert 2 == 1` on the spy count) — confirmed by checking out `origin/main` and running it. Not introduced here and not fixed here (out of slice); it passes in this branch's full run because the factory's lookup is `getattr`-guarded.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required (`guides/failover/GUIDE.md`, `Scope.LIVE` docstring).
- [x] Security considerations are addressed (`tool_approval_mode` stays build-time, pinned by a test).
- [x] I have linked all related issues.

## Screenshots

Rendered frames per AGENTS.md "Visual validation" — the real `OperatorApp` with its stylesheet loaded, at 110x30, exported with `app.save_screenshot()` and rendered to PNG. Artifacts on the capture host: `/tmp/lop-config-watch-evidence/out/{before,after_notice}.{svg,png}`.

**Before** — session A at boot, splash up, nothing announced:

```
l o c a l   o p e r a t o r
v0.43.5
test/m
/private/tmp/lop-config-watch
! latest is v0.44.32 — /update

/          command picker
/help      all commands
ctrl+d     quit

  ·  /resume picks up a recent session where you left off

❯  Message Local Operator…
◆ test/m ›  ⌂ /private/tmp/lop-config-watch              ▦ 20.5%/128k
```

**After** — the same running session moments after session B's `lop config edit` in another process:

```
l o c a l   o p e r a t o r
v0.43.5
test/m
/private/tmp/lop-config-watch
! latest is v0.44.32 — /update

/          command picker
/help      all commands
ctrl+d     quit

  ·  /resume picks up a recent session where you left off

  ·  config.yml changed: compaction.threshold_percent — applied

❯  Message Local Operator…
◆ test/m ›  ⌂ /private/tmp/lop-config-watch              ▦ 20.5%/128k
```

Read off the rendered frames, not from the widget tree: the line wears the same dim `·` bullet and centred boot-column alignment as the neighbouring `/resume` hint, so it reads as harness chatter rather than as conversation; it goes through `_system_notice`, so the splash is **not** retired and the centred composition survives (the failure mode `_system_notice` exists to prevent). The splash art scrolls up by exactly the height the new line occupies, which is the only geometry change between the two frames.


---

## Review round 1 — settings page, before/after (M3)

`providers.openai.api` was applied live while sitting in the NEW_LAUNCH `model`
section, so the change notice told the user it "takes effect on /new" about a
change that had already applied. Split into a LIVE `providers` section; the
settings page is where the label is read aloud, so it is where the fix is
visible. Real `OperatorApp` with its stylesheet, 100x30, via `app.save_screenshot`.

**Before** — the row sits under `Model`, labelled `new launch`:

```
Model                    takes effect: new launch
  Default provider       —
  Default model          —
  OpenAI API surface     responses
Failover and retry       takes effect: new sessions
```

**After** — its own section, labelled `live`:

```
Model                    takes effect: new launch
  Default provider       —
  Default model          —
Provider wire protocol   takes effect: live
  OpenAI API surface     responses
Failover and retry       takes effect: live
```

The `Failover and retry` header also reads `live` in both senses now — that
section was relabelled by this PR and the before-frame still shows the old
`new sessions` text because it is rendered from `origin/main`.
