### PR TITLE
fix(evaluation): forward begin_rescue to the adapter so rescue can tear down

### DIFF
--- a/local_operator/evaluation/adapters/api.py
+++ b/local_operator/evaluation/adapters/api.py
@@ -692,6 +692,28 @@ class EvaluationAdapter(Protocol):
     async def close(self, params: CloseParams) -> AckResult: ...
 
 
+@runtime_checkable
+class RescuableAdapter(Protocol):
+    """An adapter that can accept the rescue handoff.
+
+    Deliberately SEPARATE from ``EvaluationAdapter`` rather than a tenth method
+    on it. ``EvaluationAdapter`` is ``runtime_checkable`` and gates every
+    handshake in ``load_selected_adapter``, so adding ``begin_rescue`` there
+    would refuse an otherwise valid adapter at hello -- breaking ordinary
+    episodes for a capability only ever used during teardown, and doing so on
+    an existing installed wheel. Rescue is genuinely optional at load time and
+    mandatory only once a rescue is actually requested, which is exactly the
+    shape of a second protocol the worker checks at that moment.
+
+    ``begin_rescue`` is the only call carrying the descriptor's infra values
+    together with freshly resolved secrets, so it is the sole opportunity a
+    rescue worker (which enters at HANDSHAKEN and never runs prepare or
+    reset_start) has to build a teardown provider.
+    """
+
+    async def begin_rescue(self, params: BeginRescueParams) -> AckResult: ...
+
+
 def observation_content_id(observation: Observation) -> Digest:
     """Identify adapter content while excluding its self-asserted identifier."""
 

--- a/local_operator/evaluation/adapters/worker.py
+++ b/local_operator/evaluation/adapters/worker.py
@@ -15,7 +15,6 @@ from local_operator.evaluation.adapters.api import (
     METHOD_STATES,
     PARAM_MODELS,
     RESULT_MODELS,
-    AckResult,
     AdapterMethod,
     AdapterSelector,
     AdapterState,
@@ -25,6 +24,7 @@ from local_operator.evaluation.adapters.api import (
     Handshake,
     HelloParams,
     PythonRuntime,
+    RescuableAdapter,
     RescueDescriptor,
     canonical_params_digest,
 )
@@ -55,6 +55,17 @@ MAX_REPLAY = 128
 # records are never evicted because losing one would turn a retry into a second
 # side effect; bounded exhaustion poisons before dispatch instead.
 MAX_OPERATION_RECORDS = 4096
+
+
+class AdapterRescueUnsupported(RuntimeError):
+    """The selected adapter cannot accept the rescue handoff.
+
+    Its own type (rather than a bare RuntimeError) so the worker's generic
+    adapter-error path reports it as a normal, replied-to failure instead of
+    a channel-killing protocol error: the parent must receive an answer it can
+    attribute, because a rescue that silently timed out is indistinguishable
+    from a slow one and hides the fact that nothing can be torn down.
+    """
 
 
 @dataclass(frozen=True)
@@ -236,6 +247,24 @@ class Worker:
             return
         except RpcProtocolError:
             raise
+        except AdapterRescueUnsupported:
+            # The ONE adapter-side failure whose reason crosses the wire. The
+            # blanket redaction below exists because adapter exceptions may
+            # carry reprs, paths, or environment values; this message is a
+            # fixed string raised by the worker itself with no adapter-supplied
+            # content, so naming it leaks nothing. It has to be named: a rescue
+            # that cannot start must tell the operator WHY, or a descriptor
+            # that can never be torn down looks like a transient failure.
+            response = self._write_error(
+                request,
+                "invalid_state",
+                "adapter does not implement begin_rescue",
+                digest=digest,
+                operation_id=operation_id,
+            )
+            if rescue_action_id is not None:
+                self._record_rescue_action(rescue_action_id, params, request.method, response)
+            return
         except (AdapterDiscoveryError, Exception):
             # Adapter exceptions may contain reprs, paths, environment values, or
             # tracebacks.  The wire exposes only a closed code and fixed text.
@@ -332,11 +361,40 @@ class Worker:
                 != canonical_digest("adapter-rescue-handshake-v1", self._handshake)
             ):
                 raise RpcProtocolError("rescue pins differ from the exact handshake")
-            # This transition grants cleanup routing only. Adapter code is not
-            # invoked, so it cannot create resources or resolve persisted refs.
+            # The pin checks above are the security boundary and run FIRST:
+            # nothing below may observe a descriptor whose selector/handshake
+            # digests did not match the exact worker this process handshook as.
             self._rescue_descriptor = params.descriptor
             self._rescue_actions.clear()
-            return AckResult()
+            # The adapter MUST see begin_rescue. It is the only call that
+            # carries the descriptor's infra_values plus the freshly resolved
+            # ``params.secrets``, and therefore the only opportunity a rescue
+            # worker has to build a teardown provider -- it never ran prepare
+            # or reset_start, so it holds no credential from any other source.
+            # Storing the descriptor and returning Ack without forwarding left
+            # the adapter's provider None, so every cleanup action took the
+            # "could not look" branch and reported attempted/terminate-
+            # unconfirmed. A sweep then never confirmed teardown and never
+            # discarded the descriptor -- and, far worse, a genuinely leaked
+            # instance was never terminated, because no provider existed to
+            # terminate it. Observed against episode ep-6ea01a117eee.
+            assert self._adapter is not None
+            if not isinstance(self._adapter, RescuableAdapter):
+                # Loud, not silent. An adapter that cannot accept the rescue
+                # handoff cannot tear anything down, and returning a clean Ack
+                # here would let the sweep report an orderly "attempted" for a
+                # resource nobody can release. Checked HERE rather than at
+                # load: rescue is optional for an ordinary episode and
+                # required only once one is actually requested.
+                #
+                # Raised as an ADAPTER error, not RpcProtocolError: a protocol
+                # error tears the channel down without a reply, so the parent
+                # only ever sees an opaque TimeoutError and the operator loses
+                # the reason. This path must name itself all the way out to the
+                # sweep entry, which is the whole point of failing loudly.
+                raise AdapterRescueUnsupported("adapter does not implement begin_rescue")
+            result = await self._adapter.begin_rescue(params)
+            return cast(ProtocolModel, result)
         assert self._adapter is not None
         handler = getattr(self._adapter, method)
         result = await handler(params)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.40"
+version = "0.44.41"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/evaluation/adapters/test_launch.py
+++ b/tests/unit/evaluation/adapters/test_launch.py
@@ -18,6 +18,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -81,6 +82,143 @@ def create():
         )
     )
 """ % RELEASE_DIGEST
+
+
+# A second spawnable distribution whose teardown is only possible with what
+# ``begin_rescue`` delivers. It stands in for the AWS provider without a cloud:
+# ``cleanup`` can confirm a release ONLY when begin_rescue handed it the
+# descriptor's refs AND the freshly resolved secret, mirroring a rescue worker
+# that enters at HANDSHAKEN holding no credential from any other source. If the
+# worker stores the descriptor without forwarding it, ``_provider`` stays None
+# and cleanup reports the honest "could not look" code -- which is exactly the
+# production defect this module now pins.
+_RESCUE_ADAPTER_SOURCE = '''from importlib.metadata import distribution
+
+from local_operator.evaluation.adapters.api import (
+    AckResult,
+    AdapterCapabilities,
+    AdapterMetadata,
+    CleanupOutcome,
+    CleanupResult,
+)
+from local_operator.evaluation.adapters.discovery import distribution_digest
+
+
+class _Provider:
+    """Stands in for a teardown-only cloud client built from delivered secrets."""
+
+    def __init__(self, token):
+        self._token = token
+        self.released = []
+
+    def release(self, ref):
+        self.released.append(ref)
+        return "released-with-" + self._token
+
+
+class RescueSpawnAdapter:
+    def __init__(self, metadata):
+        self.metadata = metadata
+        self._provider = None
+
+    async def begin_rescue(self, params):
+        # The ONLY place a rescue worker can obtain a credential. Build the
+        # teardown client here or teardown is impossible.
+        secrets = {s.name: s.value for s in params.secrets}
+        token = secrets.get("TEARDOWN_TOKEN")
+        if token is not None:
+            self._provider = _Provider(token)
+        return AckResult()
+
+    async def cleanup(self, params):
+        action_id = params.action_ids[0]
+        if self._provider is None:
+            # The honest fallback: cleanup was reached but nothing could look.
+            return CleanupResult(outcomes=(CleanupOutcome(
+                action_id=action_id, status="attempted",
+                evidence_code="terminate-unconfirmed", duration_ms=1),))
+        action = next(a for a in params.cleanup_plan.actions if a.action_id == action_id)
+        code = self._provider.release(action.resource_ref)
+        return CleanupResult(outcomes=(CleanupOutcome(
+            action_id=action_id, status="succeeded",
+            evidence_code=code, duration_ms=1),))
+
+    async def close(self, params): return AckResult()
+
+    async def inspect_requirements(self, params): raise NotImplementedError
+
+    async def prepare(self, params): raise NotImplementedError
+
+    async def reset_start(self, params): raise NotImplementedError
+
+    async def observe(self, params): raise NotImplementedError
+
+    async def execute(self, params): raise NotImplementedError
+
+    async def ask_user_exchange(self, params): raise NotImplementedError
+
+    async def score(self, params): raise NotImplementedError
+
+
+def create():
+    installed = distribution("rescue-e2e-adapter")
+    return RescueSpawnAdapter(
+        AdapterMetadata(
+            adapter_id="rescue-e2e",
+            distribution="rescue-e2e-adapter",
+            version="1.0",
+            entry_point="rescue_e2e_adapter:create",
+            package_digest=distribution_digest(installed),
+            release_digest="{release}",
+            schema_version="1.2",
+            capabilities=AdapterCapabilities(
+                routes=("computer",), ask_user=False, scoring=False
+            ),
+        )
+    )
+'''.replace("{release}", RELEASE_DIGEST)
+
+
+def _install_named_adapter(
+    site: Path, module_name: str, dist_name: str, source: str, adapter_id: str
+) -> str:
+    """Install a single-module distribution with a real hashed RECORD.
+
+    Same shape as ``_install_adapter`` (which predates it and stays as the
+    canonical tiny case); parameterised so a second spawnable adapter does not
+    duplicate the RECORD-writing logic. ``distribution_digest`` verifies these
+    rows, so a hand-written unhashed RECORD would be rejected as an editable
+    install rather than testing the shipped path.
+    """
+
+    module = site / f"{module_name}.py"
+    module.write_text(source)
+    # The dist-info directory is keyed by the DISTRIBUTION name (normalised
+    # with underscores), not the module name: importlib.metadata resolves
+    # ``verify_distribution``'s lookup through it, so naming it after the
+    # module makes the distribution invisible and the handshake fails with
+    # "selected adapter distribution is not installed".
+    info = site / f"{dist_name.replace('-', '_')}-1.0.dist-info"
+    info.mkdir(exist_ok=True)
+    (info / "METADATA").write_text(f"Metadata-Version: 2.1\nName: {dist_name}\nVersion: 1.0\n")
+    # The entry point NAME must equal the selector's adapter_id (not the
+    # distribution name): load_selected_adapter matches on name AND value, and
+    # a mismatch fails as "must expose exactly one exact entry point".
+    (info / "entry_points.txt").write_text(
+        f"[local_operator.evaluation_adapters.v1]\n{adapter_id} = {module_name}:create\n"
+    )
+    rows: list[list[str]] = []
+    for path in sorted([module, info / "METADATA", info / "entry_points.txt"]):
+        data = path.read_bytes()
+        digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+        rows.append([str(path.relative_to(site)), f"sha256={digest}", str(len(data))])
+    rows.append([str((info / "RECORD").relative_to(site)), "", ""])
+    target = io.StringIO()
+    csv.writer(target, lineterminator="\n").writerows(rows)
+    (info / "RECORD").write_text(target.getvalue())
+    from importlib.metadata import PathDistribution
+
+    return distribution_digest(PathDistribution(info))
 
 
 def _install_adapter(site: Path) -> str:
@@ -159,3 +297,154 @@ async def test_supervisor_launch_completes_real_handshake_and_reaps(tmp_path: Pa
     with pytest.raises(ProcessLookupError):
         os.killpg(supervisor.pgid, 0)
     assert await asyncio.to_thread(supervisor.process.poll) is not None
+
+
+def _rescue_selector(tmp_path: Path) -> AdapterSelector:
+    """A real interpreter with the rescue adapter installed and a pinned workspace."""
+
+    executable = copied_interpreter(tmp_path / "venv")
+    site = site_packages_of(executable)
+    package_digest = _install_named_adapter(
+        site,
+        "rescue_e2e_adapter",
+        "rescue-e2e-adapter",
+        _RESCUE_ADAPTER_SOURCE,
+        "rescue-e2e",
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "adapter-release.json").write_text(
+        json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
+    )
+    return AdapterSelector(
+        schema_version="1.2",
+        adapter_id="rescue-e2e",
+        distribution="rescue-e2e-adapter",
+        version="1.0",
+        entry_point="rescue_e2e_adapter:create",
+        package_digest=package_digest,
+        release_digest=RELEASE_DIGEST,
+        python_executable=str(executable.resolve()),
+        workspace=str(workspace),
+        workspace_digest=workspace_digest(str(workspace)),
+        route_capability="computer",
+    )
+
+
+def _rescue_descriptor(selector: AdapterSelector, handshake: Handshake, root: Path) -> Any:
+    from local_operator.evaluation.adapters.api import RescueDescriptor, SecretRef
+    from local_operator.evaluation.lifecycle import CleanupAction, CleanupPlan
+
+    plan = CleanupPlan(
+        episode_id="episode",
+        actions=(
+            CleanupAction(
+                action_id="release-instance",
+                kind="release_instance",
+                resource_ref="lop-ep-episode",
+                timeout_ms=30_000,
+                max_attempts=1,
+            ),
+        ),
+    )
+    return RescueDescriptor(
+        schema_version="1.2",
+        selector=selector,
+        handshake=handshake,
+        episode_id="episode",
+        cleanup_plan=plan,
+        secret_refs=(SecretRef(name="TEARDOWN_TOKEN"),),
+        infra_values=(),
+        artifact_root=str(root),
+    )
+
+
+@pytest.mark.asyncio
+async def test_spawned_rescue_worker_builds_a_provider_and_releases(tmp_path: Path) -> None:
+    """A REAL spawned rescue worker tears down using begin_rescue's secrets.
+
+    This is the regression that a green suite previously missed entirely: every
+    other rescue test called ``adapter.begin_rescue`` in-process, so nothing
+    exercised the worker's dispatch, and the worker answered begin_rescue
+    itself without ever handing it to adapter code. The adapter's provider
+    therefore stayed None in production and every cleanup action reported
+    ``attempted``/``terminate-unconfirmed`` -- a sweep never confirmed teardown,
+    and a genuinely leaked instance would never have been terminated.
+
+    Asserting the evidence code (not merely ``complete``) is what makes this
+    proof: the code can only be produced by a provider that begin_rescue built
+    from the delivered secret, so it cannot pass via the None fallback.
+    """
+
+    from local_operator.evaluation.adapters.api import ResolvedSecret
+    from local_operator.evaluation.adapters.supervisor import run_rescue
+
+    selector = _rescue_selector(tmp_path)
+    supervisor = AdapterSupervisor.launch(selector)
+    try:
+        handshake = await supervisor.handshake(timeout=60)
+    finally:
+        await supervisor.terminate()
+
+    descriptor = _rescue_descriptor(selector, handshake, tmp_path)
+    aggregate = await run_rescue(
+        descriptor,
+        secrets=(ResolvedSecret(name="TEARDOWN_TOKEN", value="tok-4b1e"),),
+    )
+
+    assert aggregate.complete
+    assert [receipt.evidence_code for receipt in aggregate.receipts] == ["released-with-tok-4b1e"]
+    assert [receipt.status for receipt in aggregate.receipts] == ["succeeded"]
+
+
+@pytest.mark.asyncio
+async def test_spawned_rescue_worker_refuses_an_adapter_without_begin_rescue(
+    tmp_path: Path,
+) -> None:
+    """An adapter that cannot accept the handoff fails LOUDLY, never cleanly.
+
+    ``TinyAdapter`` implements the episode methods but not ``begin_rescue``. It
+    can store a descriptor and can never build a provider, so letting the
+    rescue proceed would report an orderly ``attempted`` for a resource nothing
+    is able to release. The worker refuses instead, and the failure surfaces to
+    the sweep as an error rather than as reassuring evidence.
+    """
+
+    from local_operator.evaluation.adapters.rpc import RpcRemoteError
+    from local_operator.evaluation.adapters.supervisor import run_rescue
+
+    executable = copied_interpreter(tmp_path / "venv")
+    site = site_packages_of(executable)
+    package_digest = _install_adapter(site)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "adapter-release.json").write_text(
+        json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
+    )
+    selector = AdapterSelector(
+        schema_version="1.2",
+        adapter_id="tiny-e2e",
+        distribution="tiny-e2e-adapter",
+        version="1.0",
+        entry_point="tiny_e2e_adapter:create",
+        package_digest=package_digest,
+        release_digest=RELEASE_DIGEST,
+        python_executable=str(executable.resolve()),
+        workspace=str(workspace),
+        workspace_digest=workspace_digest(str(workspace)),
+        route_capability="computer",
+    )
+    supervisor = AdapterSupervisor.launch(selector)
+    try:
+        handshake = await supervisor.handshake(timeout=60)
+    finally:
+        await supervisor.terminate()
+
+    descriptor = _rescue_descriptor(selector, handshake, tmp_path)
+    # The reason must survive to the caller. An earlier draft raised
+    # RpcProtocolError here, which killed the channel and surfaced as a bare
+    # TimeoutError -- indistinguishable from a slow worker, and useless to an
+    # operator holding a descriptor nothing can tear down.
+    with pytest.raises(RpcRemoteError) as excinfo:
+        await run_rescue(descriptor)
+    assert "begin_rescue" in str(excinfo.value)

--- a/tests/unit/evaluation/adapters/test_worker.py
+++ b/tests/unit/evaluation/adapters/test_worker.py
@@ -248,6 +248,15 @@ class RescueAdapter:
     def __init__(self, metadata: AdapterMetadata) -> None:
         self.metadata = metadata
         self.cleanup_calls: list[str] = []
+        self.begin_rescue_calls: list[BeginRescueParams] = []
+
+    async def begin_rescue(self, params: BeginRescueParams) -> AckResult:
+        # Recorded so the worker test can assert the handoff actually reached
+        # adapter code. A rescue worker builds its teardown provider here and
+        # nowhere else, so an adapter that is never called can only report
+        # "could not look" for every action.
+        self.begin_rescue_calls.append(params)
+        return AckResult()
 
     async def cleanup(self, params: CleanupParams) -> CleanupResult:
         action_id = params.action_ids[0]


### PR DESCRIPTION
## Summary

A rescue worker could never terminate anything.

`AdapterWorker._dispatch` handled `begin_rescue` entirely itself — validating pins, storing the descriptor, returning `AckResult` — and **never called the adapter**. `params.secrets`, the only credential a rescue worker ever receives, were dropped on the floor (`grep -c secrets worker.py` → `0`). The adapter's provider therefore stayed `None`, and every cleanup action took the honest "could not look" branch, reporting `attempted` / `terminate-unconfirmed`.

The visible symptom was a sweep that never confirmed teardown and never discarded its descriptor. The **serious** consequence is that a genuinely leaked instance would never have been terminated by a sweep, because no provider existed to terminate it. `OSWorldV2Adapter.begin_rescue` — which builds `AwsProvider.for_teardown` from the descriptor's region and the delivered credentials — was dead code in production.

Depends on #543 (branched off `dev-adapter-cache-dir` @ `379cecee`); `0.44.38` sits on top of that PR's `0.44.37`, so please re-sequence at merge time if #543 lands differently.

## How it was found

The reported defect was an instance that had aged out of the EC2 API, with the hypothesis that an empty tag lookup was being mapped to `terminate-unconfirmed`. That hypothesis is **wrong**, and fixing it would have made the sweep pass by coincidence while the provider stayed `None`:

- `AwsProvider._terminate` already returns `EVIDENCE_INSTANCE_ABSENT` for an empty tag query, and `_terminate_status` already maps that to `not_needed`. That path was never broken.
- Read-only AWS confirmed `describe-instances --instance-ids i-0a76923056da31d04` returns **empty without raising** `InvalidInstanceID.NotFound`, so a "positive NotFound evidence" check would not have fired anyway.
- The observed code triple is the exact fingerprint of the `provider is None` branch: `revoke_lease` also reported `schedule-absent` with status `attempted`, where a real provider returning absent yields `not_needed`.

## Change

`local_operator/evaluation/adapters/worker.py`
- The worker keeps doing its own pin validation and descriptor storage **first** — that is the security boundary and is unchanged — then forwards to `self._adapter.begin_rescue(params)` and returns the adapter's result.
- An adapter that cannot accept the handoff fails **loudly** via `AdapterRescueUnsupported`, rather than returning a clean-looking `Ack` for a resource nothing can release.

`local_operator/evaluation/adapters/api.py`
- New `RescuableAdapter` protocol.

### Two design decisions worth review

**1. A separate protocol, not a tenth method on `EvaluationAdapter`.** `EvaluationAdapter` is `runtime_checkable` and gates *every* handshake in `load_selected_adapter`. Adding `begin_rescue` there refused otherwise-valid adapters at `hello` and broke ordinary episodes — caught by the pre-existing `test_supervisor_launch_completes_real_handshake_and_reaps`, which went red. Rescue is optional at load time and mandatory only once a rescue is actually requested, which is the shape of a second protocol checked at that moment.

**2. A named `invalid_state` error, not `RpcProtocolError`.** A protocol error tears the channel down without a reply, so the parent saw only an opaque `TimeoutError` and the operator lost the reason — indistinguishable from a slow worker. The message is a fixed worker-authored string with no adapter-supplied content, so naming it leaks nothing through the blanket redaction that guards every other adapter exception (that redaction is otherwise untouched).

The existing `provider is None` → `attempted` / `terminate-unconfirmed` fallback is deliberately **kept**: it remains correct for genuinely ambiguous cases.

## Evidence: the real stranded descriptor

Run against a **copy** of the real descriptor at `~/worktrees/osworld/runs/proof-20260902-081937/rescue/` (original left intact), with the fixed harness installed into the pinned worker venv, then restored to its shipped bytes (md5 verified).

Tag audit before — `scripts/osworld_tag_audit.py --region us-east-1`:
```
[]
```

Before the fix:
```json
[{"episode_id": "ep-6ea01a117eee", "complete": false,
  "codes": ["session-closed", "terminate-unconfirmed", "schedule-absent"],
  "error": null}]
```
`exit 1`, descriptor retained — forever.

After the fix:
```json
[{"episode_id": "ep-6ea01a117eee", "complete": true,
  "codes": ["session-closed", "instance-absent", "schedule-absent"],
  "error": null}]
```
`exit 0`, descriptor **discarded**.

Tag audit after:
```
[]
```
No AWS writes: `terminate_instances` is reached only when the tag query returns live instances, and it returns zero.

## Tests: closing the blindness that hid this

Every previous rescue test called `adapter.begin_rescue` **directly**, bypassing the RPC layer that never forwarded it — so a fully green suite asserted adapter behaviour production never reached.

Two **real spawned-worker** tests (genuine interpreter, real installed distribution with a hashed RECORD, real supervisor) now cover it in `tests/unit/evaluation/adapters/test_launch.py`:
- `test_spawned_rescue_worker_builds_a_provider_and_releases` — a rescue worker builds a teardown provider from the delivered secret and releases. It asserts the **provider-only evidence code** (`released-with-<token>`), which the `None` fallback cannot produce, so it cannot pass by coincidence.
- `test_spawned_rescue_worker_refuses_an_adapter_without_begin_rescue` — refusal arrives by name, not as a timeout.

**Mutation-proved:** reverting the forwarding line to the original `return AckResult()` reproduces the production defect exactly (`complete=False`) and fails the new test. Restored after.

## Audit for the same blindness elsewhere

`_dispatch` self-handled exactly two methods: `hello` (correct — it *is* worker-level: loads the adapter and builds the handshake) and `begin_rescue` (the defect). Every other method already forwards via `getattr(self._adapter, method)`. No other inert path found.

## Operational note

⚠️ The pinned worker venv at `~/worktrees/osworld/venvs/0.1.0` ships `local_operator` **0.44.31** and **must be rebuilt before any pilot** — the worker is what carries this fix. A harness-side release alone does not reach it.

## Gates

- `flake8` clean; `black==26.1.0 --check` clean (803 files); `isort==5.13.2 --check` clean
- `pyright` — **0 errors, 0 warnings** (adapter wheel confirmed uninstalled)
- `tests/unit/evaluation` — 704 passed
- `tests/unit/evaluation/adapters` — 243 passed, **3× parallel + serial** (no flakiness)
- Full `tests/unit` — 10885 passed, 5 failed

The 5 failures are all in `tests/unit/tui/test_ask_picker.py` and are **pre-existing and unrelated** — reproduced identically on the stashed baseline; this PR touches no TUI code.
