### PR TITLE
chore(release): bump version to 0.44.38

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.37"
+version = "0.44.38"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
# PR Description

## Summary of Changes

Bumps `local-operator` to the next unused patch version, **0.44.38**, so the two commits sitting unreleased on `main` can publish in a new immutable release.

`v0.44.37` was tagged against `c60cf8c2`, and **#546 merged roughly six minutes afterwards** as `43fca010`. `main` therefore carries two commits that no release includes, while `pyproject.toml` still reads `0.44.37` — a version already on PyPI and immutable. This branch changes only that one line.

## What this release will carry

Exactly two commits in `v0.44.37..origin/main`:

- **`43fca010` — `docs(readme): document cross-session communication (#546)`** — the README now documents peer-to-peer messaging between running `lop` sessions: a new section with a screenshot (`static/tui-peer-message.png`), a table-of-contents entry, a top-nav link, and a "Why Local Operator" bullet. Users discovering the feature no longer have to find it in the tool list.
- **`5e96e659` — `fix(model): drop the cached model listing when a credential changes (#535)`** — re-authing a provider now actually clears its cached model catalogue. Previously `lop login <provider>` wrote the credential row and left the listing fetched under the *old* credential in place, so the one action a user takes when a model is missing was a no-op, and a newly logged-in account inherited the previous account's model list until the TTL lapsed. Both login paths and both logout paths now invalidate every scoped document for that credential identity.

## Version rationale

**Patch**, per the "choose the bump by materiality, not commit type" rule in `AGENTS.md`. The content is documentation plus one bug fix. There is no new surface or subsystem a user would notice and adopt — nothing here can be named as a step-function capability in a release title, which is the stated test for a minor.

## Testing evidence

Release/version checks — `0.44.38` confirmed free everywhere before pushing:

```console
$ .venv/bin/python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])"
0.44.38

$ git diff --name-only origin/main...HEAD
pyproject.toml

$ git diff --check origin/main...HEAD
# no output; rc=0

$ curl -s https://pypi.org/pypi/local-operator/json | <version check>
latest: 0.44.37
0.44.36 PRESENT
0.44.37 PRESENT
0.44.38 FREE

$ git ls-remote --tags origin v0.44.38
# no output; no remote tag exists
```

No `v0.44.38` tag, GitHub Release, or PyPI artifact exists.

## Quality gates

Run over the whole tree with `.venv/bin/python`, exactly as CI does:

```console
$ .venv/bin/python -m flake8 .
rc=0

$ uvx --from black==26.1.0 black --check .
All done! ✨ 🍰 ✨
808 files would be left unchanged.
rc=0

$ uvx isort==5.13.2 --check .
Skipped 1 files
rc=0

$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations
rc=0
```

**The unit suite was deliberately skipped locally and left to CI.** The diff touches no `.py` file — it is a single version string in `pyproject.toml` — and a full local run costs ~15 minutes on this host, which is currently contended by sibling worktrees. CI runs the same suite against this head; the gate is not being waived, only relocated to the runner that will report it on this PR.
