### PR TITLE
docs(guides): steer agents to the send tool in peer-messaging

### DIFF
--- a/local_operator/guides/peer-messaging/GUIDE.md
+++ b/local_operator/guides/peer-messaging/GUIDE.md
@@ -1,6 +1,6 @@
 ---
 name: peer-messaging
-description: Message another local lop session — the in-session `send` tool for agents, `lop send` for humans — and list running sessions with `lop sessions`. No cmux needed.
+description: Message another local lop session — agents use the `send` tool (never a shelled `lop send`), humans use `lop send` — and list sessions with `lop sessions`. No cmux needed.
 ---
 
 # Peer messaging between lop sessions
@@ -15,22 +15,32 @@ Two entry points, one wire:
 
 - **The `send` tool** — the way an AGENT messages a peer from inside its own
   session (below). Wake defaults ON, so an idle peer responds right away.
-- **`lop send`** — the shell command for HUMANS (further below). Mailbox by
-  default; `--wake` opts in to waking.
+- **`lop send`** — the shell command for HUMANS at a terminal (further below).
+  Mailbox by default; `--wake` opts in to waking.
 
 They share the same target resolution and delivery semantics; the only
 difference is the default and who runs them.
+
+> **Agents: use the `send` tool. Never `bash` a `lop send`.** Three reasons,
+> and they are why the rule is worth remembering rather than looking up. The
+> tool call is its own **auditable card** — a delivery buried in a shell trace
+> is hard to review and easy to miss in an approval prompt. The tool **wakes by
+> default**, where the CLI's mailbox default leaves an idle peer sitting on the
+> note until something else wakes it. And the tool prompts at the **write
+> tier**, like every other capability that can start autonomous work in another
+> process. The shell command below is documented for the human at a terminal,
+> not as an agent recipe.
 
 **Trust boundary is the account.** The discovery record is mode `0600` under a
 `0700` directory, so anything that can read a session's control key is already
 the owning user. Delivery is loopback only. There is no cross-account path; the
 same-account boundary is the whole authorization story.
 
-## The `send` tool — agent-facing, in-session
+## The `send` tool — the agent entry point
 
-An agent messages a peer with the `send` tool, not by shelling out to `lop
-send`: the tool call is its own auditable card, and its defaults are tuned for
-agent-to-agent hand-offs.
+This is how an agent messages a peer. It runs inside the session process, so it
+resolves the target, names the delivery in its own card, and returns the
+receive side's own detail string.
 
 Parameters:
 
@@ -39,17 +49,58 @@ Parameters:
 - `pid` — exact pid (unambiguous; the disambiguation error lists these).
 - `session` — exact session id.
 - `message` — the body; it lands in the peer's transcript as an inbound
-  cross-session card.
+  cross-session card. Required, and non-empty.
 - `wake` (default **true**) — mailbox mode: wake an idle peer so it responds
   right away. `wake=False` is the quiet drop: the peer reads it on its next
-  turn and stays idle (the TUI card shows this mode as `quiet`).
-- `now` — steer the peer mid-turn instead of using the mailbox; opens a turn
-  if the peer is idle.
+  turn and stays idle (the TUI card shows this mode as `quiet`). Ignored when
+  `now=True`.
+- `now` (default **false**) — steer the peer mid-turn instead of using the
+  mailbox; opens a turn if the peer is idle.
 
-**Agent sends wake idle targets by default.** A peer parked on a scheduled
-wake or an idle turn answers the moment the message lands — there is no
-"it will notice next time it wakes" gap. Pass `wake=False` deliberately for a
-non-urgent hand-off the peer may fold into whatever it does next.
+Addressing precedence is `pid`, then `session`, then the `target` substring —
+supply one. `pid` is the form to reach for when a substring could match more
+than one session.
+
+### Worked examples
+
+A non-urgent hand-off the peer folds into whatever it does next — it stays
+idle and reads this on its next turn:
+
+```
+send(target="peer-send design", message="gates are green, ready for review", wake=False)
+→ delivered to the mailbox (will be read on the next turn)
+```
+
+Something the peer should act on now. This is the default, so `wake` needs no
+spelling out:
+
+```
+send(target="release cutter", message="the deploy finished; verify prod")
+→ delivered and woke the session
+```
+
+The same, addressed unambiguously by pid — the form the disambiguation error
+hands you:
+
+```
+send(pid=64190, message="the deploy finished; verify prod")
+→ delivered and woke the session
+```
+
+Redirect a peer that is actively working, before it goes further down a wrong
+path:
+
+```
+send(target="ingest refactor", message="hold off — the schema changed", now=True)
+→ delivered mid-turn (steered)
+```
+
+**Sends wake idle targets by default.** A peer parked on a scheduled wake or
+an idle turn answers the moment the message lands — there is no "it will
+notice next time it wakes" gap. Pass `wake=False` deliberately when the note
+is not urgent.
+
+### What the result tells you
 
 The result echoes the receive side's own detail string, so the sender knows
 exactly how the peer took it:
@@ -60,8 +111,16 @@ exactly how the peer took it:
 - `delivered mid-turn (steered)` — `now=True` while the peer was working.
 - `delivered (opened a turn)` — `now=True` while the peer was idle.
 
-A session cannot send to itself (the tool refuses), and an ambiguous `target`
-returns the candidate list asking for a `pid`.
+Refusals are answers too, and each names its own fix:
+
+- An ambiguous `target` returns the candidate list — `2 sessions match; retry
+  with pid=<n>:` followed by one `pid=<n>` line per session.
+- No match returns `no live session matches '<target>'`.
+- A session cannot send to itself; the tool refuses before it dials.
+- A body over the 256 KB cap is rejected with the measured size, not truncated.
+- If the ack is lost after the peer committed the message, the tool says the
+  message **may or may not** have arrived rather than claiming failure — check
+  with the peer instead of resending, or it lands twice.
 
 ## `lop sessions` — what is running and what it costs
 
@@ -70,13 +129,15 @@ lop sessions
 lop sessions --json
 ```
 
-Columns:
+The table prints `STATE PID KIND CONVERSATION MODEL RSS FOOTPRINT UPTIME
+HB_AGE`:
 
 - `STATE` — `live` (pid alive and heartbeating), `wedged` (pid alive but its
   owner has not heartbeat within the timeout, so it will not service the socket
   promptly), or `stale` (dead; the record is reaped on the next scan).
-- `PID` `KIND` `CONVERSATION` `MODEL` `CWD` — session identity. `KIND` is `tui`
+- `PID` `KIND` `CONVERSATION` `MODEL` — session identity. `KIND` is `tui`
   (interactive), `daemon` (daemon-owned), or `exec` (headless one-shot).
+  `CONVERSATION` falls back to the session id when the session has no name yet.
 - `RSS` — resident set size. Always available; the baseline number.
 - `FOOTPRINT` — the *true* memory cost. On macOS RSS under-reports because
   memory is compressed and swapped, so this column shows the phys footprint
@@ -87,14 +148,29 @@ Columns:
 - `HB_AGE` — how long since its last heartbeat. A large `HB_AGE` on a `live`
   row is an early sign of a session going wedged.
 
-`--json` emits the same fields as a list of objects (bytes, not human sizes)
-for scripting.
+**The table does not show a session's `cwd`.** `cwd` and `session_id` are
+`--json`-only fields — which matters because `target` matches against the cwd
+basename, so `--json` is where you look to see what a substring will match:
 
-## `lop send` — the shell command (humans)
+```
+lop sessions --json
+```
 
-The same wire, driven from a terminal. Mailbox by default — a human sending
-from a shell usually wants the non-interrupting drop; `--wake` opts in to
-waking an idle session.
+It emits one object per session with `state`, `pid`, `kind`,
+`conversation_name`, `session_id`, `model_label`, `cwd`, `rss_bytes`,
+`footprint_bytes`, `uptime_s` and `heartbeat_age_s` (bytes and seconds, not
+human-formatted sizes) for scripting.
+
+## `lop send` — the HUMAN entry point
+
+The same wire, driven from a terminal by a person. Mailbox by default — a human
+sending from a shell usually wants the non-interrupting drop; `--wake` opts in
+to waking an idle session.
+
+**This section is not an agent recipe.** An agent inside a session uses the
+`send` tool above; shelling out to this command buries the delivery in a shell
+trace and takes the mailbox default, which leaves an idle peer sitting on the
+message.
 
 ```
 lop send "<target>" "your message"
@@ -137,6 +213,20 @@ sessions, `lop send` prints the candidates and exits non-zero asking you to
 disambiguate with `--pid`. If the only match is `wedged`, it says so rather
 than hanging on a dial.
 
+**With `--pid` or `--session`, pipe the body — do not pass it as an argument.**
+`send` declares `target` and `message` as two optional positionals, so a single
+positional alongside `--pid`/`--session` binds to `target`, leaving `message`
+empty; the command then looks for a body on stdin, finds a terminal, and exits
+1 with `no message given`. Nothing is delivered. So:
+
+```
+echo "the deploy finished; verify prod" | lop send --pid 12345 --wake   # works
+lop send --pid 12345 --wake "the deploy finished; verify prod"          # exits 1
+```
+
+The positional form (`lop send "<target>" "message"`) is unaffected — both
+positionals are filled, so it is the form to prefer at a terminal.
+
 ### What the human sees
 
 The delivered message appears in the target's transcript marked
@@ -154,7 +244,11 @@ process and looks itself up by pid. Both name the same sender.
 lop send "peer-send design" "gates are green, ready for review"
 
 # Wake an idle session to act now
-lop send --pid 12345 --wake "the deploy finished; verify prod"
+lop send "release cutter" --wake "the deploy finished; verify prod"
+
+# Wake an idle session addressed by exact pid — body on stdin, per the
+# grammar note above
+echo "the deploy finished; verify prod" | lop send --pid 12345 --wake
 
 # Redirect a session mid-turn
 lop send "ingest refactor" --now "hold off — the schema changed"

--- a/local_operator/guides/peer-messaging/GUIDE.md
+++ b/local_operator/guides/peer-messaging/GUIDE.md
@@ -213,19 +213,31 @@ sessions, `lop send` prints the candidates and exits non-zero asking you to
 disambiguate with `--pid`. If the only match is `wedged`, it says so rather
 than hanging on a dial.
 
-**With `--pid` or `--session`, pipe the body — do not pass it as an argument.**
-`send` declares `target` and `message` as two optional positionals, so a single
-positional alongside `--pid`/`--session` binds to `target`, leaving `message`
-empty; the command then looks for a body on stdin, finds a terminal, and exits
-1 with `no message given`. Nothing is delivered. So:
+**With `--pid` or `--session`, pipe the body — a lone positional is read as the
+target, not the message.** `send` declares `target` and `message` as two
+optional positionals, so a *single* positional alongside `--pid`/`--session`
+binds to `target`, leaving `message` empty; the command then looks for a body
+on stdin, finds a terminal, and exits 1 with `no message given`. Nothing is
+delivered. Piping the body is the clean form:
 
 ```
 echo "the deploy finished; verify prod" | lop send --pid 12345 --wake   # works
+echo "gates are green" | lop send --session 7c44b23dc86f                # works
 lop send --pid 12345 --wake "the deploy finished; verify prod"          # exits 1
 ```
 
-The positional form (`lop send "<target>" "message"`) is unaffected — both
-positionals are filled, so it is the form to prefer at a terminal.
+A *second* positional does fill `message`, so a placeholder target delivers —
+the selector wins, because the resolver checks `--pid`/`--session` before it
+ever looks at `target`:
+
+```
+lop send ignored "the deploy finished; verify prod" --pid 12345         # works
+```
+
+That works, but it reads as though it addresses `ignored`; prefer the piped
+form. The plain positional form (`lop send "<target>" "message"`) is unaffected
+— both positionals are filled, so it stays the form to reach for at a
+terminal.
 
 ### What the human sees
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.39"
+version = "0.44.40"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

`guide://peer-messaging` was steering agents the wrong way. The `lop send` shell command had **more space and more worked examples** than the `send` tool, so an agent reading the guide came away with shell recipes freshest in mind — directly undercutting the system prompt's own rule at `prompts_md/system.md:162` ("use the `send` tool for peer messaging — never shell out to `lop send`") and the rationale already written down at `tools/builtin.py:4621`: a shelled send buries the delivery in an opaque shell trace, and the CLI's mailbox default leaves an idle peer sitting on the note.

This rebalances the guide so the tool leads and carries the worked examples, and fixes two factual defects that were verified broken against real running sessions.

Docs-only: **no `.py` behaviour changed**. The guide is packaged data, so it ships in the wheel and is re-verified through the real discovery/resolver path below.

## What changed

- **The `send` tool now leads and dominates.** It carries four worked examples (quiet drop, wake-by-default, address-by-pid, mid-turn steer), each showing the call *and* the detail string it returns, plus a new "What the result tells you" section covering the refusals (ambiguous target, no match, self-send, oversize body, and the lost-ack case that must not be retried blindly).
- **An unmissable agent rule** in a blockquote near the top: *use the `send` tool; never `bash` a `lop send`*, with the three reasons stated briefly — auditable card, wake-on by default, write-tier approval — so the rule survives summarization instead of being a bare prohibition.
- **`lop send` is marked the HUMAN entry point.** The section stays (it is a real product surface people use from a terminal) but says plainly that it is not an agent recipe.
- Parameter list reconciled with the real `SendParams`: `message` is required and non-empty, `wake` is ignored when `now=True`, `now` defaults to false, and the `pid` → `session` → `target` addressing precedence is stated.

## Defect 1 — a `CWD` column that does not exist

**Before** (line ~78): listed `PID KIND CONVERSATION MODEL CWD` as the table's identity columns.

**After:** the guide states the real header and says where `cwd` actually lives. Measured against a live table (`cli.py:1265-1268`):

```
STATE       PID KIND    CONVERSATION             MODEL                         RSS FOOTPRINT   UPTIME  HB_AGE
live      68985 tui     781b501cbcc6             test/e2e                    53.5M    143.0M      13s     13s
```

No `CWD`. `cwd` and `session_id` are `--json`-only — confirmed by the actual key set:

```
['conversation_name', 'cwd', 'footprint_bytes', 'heartbeat_age_s', 'kind',
 'model_label', 'pid', 'rss_bytes', 'session_id', 'state', 'uptime_s']
```

This is not a cosmetic fix: `target` matches against the **cwd basename**, so `--json` is exactly where a reader must look to predict what a substring will match. The guide now says so.

## Defect 2 — a documented example that delivers nothing

**Before** (line ~157), presented as *the* "wake an idle session" example:

```
lop send --pid 12345 --wake "the deploy finished; verify prod"
```

Run verbatim against a live session it exits **1** and delivers nothing:

```
$ lop send --pid 69005 --wake 'the deploy finished; verify prod'
no message given (pass it as an argument or pipe it on stdin)
rc=1
```

**Root cause** (a real CLI grammar defect, `cli.py:438-446`): `send` declares `target` and `message` as two `nargs="?"` positionals. With `--pid` supplied the single positional binds to **`target`**, `message` stays `None`, the body falls through to the stdin branch, finds a terminal, and exits. It is broader than the guide's one line — `lop send --pid N "body"` and `lop send --session ID "body"` fail the same way.

**Fixing the parser is out of scope for this docs change.** Instead the example is replaced with a form I ran and watched deliver, keeping the "wake an idle session by exact pid" case represented:

```
$ echo 'the deploy finished; verify prod' | lop send --pid 69005 --wake
→ 7c44b23dc86f (pid 69005): delivered and woke the session
rc=0
```

and the constraint itself is now documented under "Choosing a target", with the working and failing forms side by side, so the next reader does not rediscover it the hard way.

## Testing evidence

**Isolation first.** The operator has ~16 live sessions doing real work on this host. Every session used here was **spawned by me** under `LOCAL_OPERATOR_CONFIG_DIR=/tmp/lop-gs/cfg` with `--hosting test` (no network, no real model), so the discovery records, `lop sessions` and `lop send` could only ever see and reach my own. **Nothing was delivered to, woken, or steered in any session I did not start.** All three receivers were stopped afterwards; the operator's 13 live sessions were untouched.

**Every command in the rewritten guide, run verbatim**, against receivers whose cwd basenames match the example targets:

| Command | Result | rc |
|---|---|---|
| `lop sessions` | table printed | 0 |
| `lop sessions --json` | 11 keys incl. `cwd`, `session_id` | 0 |
| `lop send "peer-send design" "gates are green, ready for review"` | `delivered to the mailbox (will be read on the next turn)` | 0 |
| `lop send "release cutter" --wake "the deploy finished; verify prod"` | `delivered and woke the session` | 0 |
| `lop send "ingest refactor" --now "hold off — the schema changed"` | `delivered (opened a turn)` | 0 |
| `lop send "peer-send design" < note.txt` | `delivered to the mailbox …` | 0 |
| `git log -1 --stat \| lop send "release cutter"` | `delivered to the mailbox …` | 0 |
| `echo "…" \| lop send --pid N --wake` (the fix) | `delivered and woke the session` | 0 |
| `lop send --pid N --wake "…"` (documented as broken) | `no message given` | 1 |

**Delivery confirmed at the RECEIVER, not just the sender's ack** — reading each receiver's own `transcript.jsonl` for `custom_type: "peer_message"` rows:

```
=== 781b501cbcc6 — 2 peer_message rows
    gates are green, ready for review
    note from a file
=== 7c44b23dc86f — 3 peer_message rows
    the deploy finished; verify prod
    commit 37289774…            (the piped git-log body)
    the deploy finished; verify prod   (the --pid stdin fix)
=== 915843efc78c — 1 peer_message rows
    hold off — the schema changed
```

The TUI card was checked in the receivers' pty output too: `↔ peer message from (pid …)`, matching `transcript.py:1715`.

**The `send` tool itself was exercised** (`execute_send` in-process against the same isolated receivers), which is what backs the rewritten examples rather than just the CLI:

```
default (wake ON)   -> delivered and woke the session
wake=False quiet    -> delivered to the mailbox (will be read on the next turn)
now=True steer      -> delivered (opened a turn)
by session id       -> delivered and woke the session
ambiguous substring -> 2 sessions match; retry with pid=<n>:  pid=64190 … pid=64209 …
no match            -> no live session matches 'zzz-nothing'
```

**All four delivery detail strings verified against both branches.** The fourth (`delivered mid-turn (steered)`) only fires when the peer is genuinely streaming, which the `test` provider never holds long enough to hit from outside — so a real `Session` was parked mid-turn on a stalled stream and the real receive half driven directly:

```
peer _is_streaming = True
now=True  while BUSY -> delivered mid-turn (steered)
wake=True while BUSY -> delivered to the mailbox (will be read on the next turn)
peer _is_streaming = False
now=True  while IDLE -> delivered (opened a turn)
```

All four match the literals at `session/session.py:3996,4002,4010,4039`. The 256 KB cap claim was checked too: 300 KB → `message is too large (300001 bytes); cap is 262144 bytes`; 200 KB delivers.

**Guide integrity.** Front matter parses, fences balanced (18), and it still resolves through the real runtime path:

```
resolved chars: 12088
agent rule present: True
stale CWD column claim gone: True
worked tool examples present: 4
```

The catalog test caught a real regression mid-work: my first rewritten `description:` was 201 chars against the ≤180 prompt-size cap in `test_packaged_catalog_is_small_and_descriptions_are_prompt_sized`. Tightened to 171 and green.

## Consistency sweep

Grepped for other places telling an agent to shell out for peer messaging:

- `prompts_md/system.md:162` already carries the correct rule and **agrees** with this rewrite — left alone as instructed.
- `docs/design/peer-send.md` is a historical design document — **not touched**.
- `README.md` is human-facing prose, and all four of its `lop send` examples use the positional form, which I verified works. No agent-facing contradiction, so left alone.

No other agent-facing instruction contradicts the rule.

## Gates

| Gate | Result |
|---|---|
| `flake8 .` | clean (rc=0) |
| `black --check .` (26.1.0) | 808 files unchanged |
| `isort --check .` (5.13.2) | clean (rc=0) |
| `pyright` (whole tree) | **0 errors, 0 warnings, 0 informations** |
| `tests/unit/guides`, `tests/unit/skills` | 219 passed |
| peer-messaging suites (`test_send_tool`, `test_peer_send`, `test_peer_client`, `test_cli_send`, `test_session_peer`) | 56 passed |

No `.py` file changed (the diff is the guide plus the version bump), so per AGENTS.md I ran the targeted subsets above rather than the ~15-minute full suite on this contended host, and CI covers the rest.

Version bumped one patch above `origin/main` (0.44.38) → **0.44.39**; confirmed 404 on PyPI and not an existing tag at branch time.

## Not addressed (deliberately)

- **The `lop send` positional-grammar defect itself.** `--pid`/`--session` with an inline body binds to `target` and exits 1. Out of scope for a docs change, so it is documented rather than fixed; the parser fix wants its own PR (likely making `message` the only positional when an explicit selector is present, which is a user-visible CLI change deserving its own review).
