### PR TITLE
docs(store): record the 0.1.5 release and close the tabGroups handoff

### DIFF
--- a/docs/store/release-record.md
+++ b/docs/store/release-record.md
@@ -1,0 +1,122 @@
+# Browser extension release record
+
+Section 11 of `submission-checklist.md` requires that every Chrome Web Store
+release be recorded with the facts needed to reproduce and audit it: the exact
+artifact, the commit it was built from, and how it reached the store. This file
+is that record.
+
+**Add a new section for every release, newest first.** Never edit a shipped
+entry except to append its approval timestamp or a post-release incident note —
+the value of this file is that it says what was actually shipped, not what we
+intended to ship.
+
+## Why a release can only be reproduced from these fields
+
+The store package is not committed (`extension/local-operator-extension.zip` is
+in `.gitignore`), so the artifact cannot be recovered from the repository. It is
+reproduced by checking out the recorded source commit and running
+`pnpm --dir extension build:zip`; the recorded SHA-256 is what proves the
+rebuild matches what was uploaded. Recording only the version would not be
+enough — `main` moves, and a version number does not pin a tree.
+
+---
+
+## v0.1.5 — submitted 2026-09-02, pending review
+
+| Field | Value |
+| --- | --- |
+| Extension version | 0.1.5 |
+| Item ID | `omibaecbjdhgbbcedbnnnmjpmopfheof` |
+| Source commit | `37289774` (`chore(release): bump version to 0.44.38`) |
+| `extension/` tree hash | `9fe12bde271cc84f060922d8d254d22d046b7e6a` |
+| Artifact SHA-256 | `724f3f91117f166263c462801a9a73c27d0a4787bd4e5c5dcb6374a2d56d2d0a` |
+| Artifact size | 45,262 bytes, 12 files, no source maps |
+| Bridge protocol version | `PROTO_VERSION = 1` |
+| Submission route | **Manual dashboard upload** |
+| Store state at submission | `PENDING_REVIEW`, 100% deployment |
+| Previously published | v0.1.0, still live at 100% during review |
+
+**Why this one was uploaded by hand.** 0.1.5 adds the `tabGroups` permission,
+which 0.1.0 did not request. Permission justifications exist only in the
+dashboard — the Chrome Web Store API v2 cannot set them, and Chrome forbids
+scripting the extensions gallery, so no automation can fill that field. The
+justification pasted was the `tabGroups` entry in `permissions.md`, verbatim.
+
+**Permissions declared** (matches the built `dist/manifest.json`, not the
+source list): `debugger`, `tabs`, `tabGroups`, `scripting`, `storage`, `alarms`,
+`webNavigation`, `notifications`, plus host `<all_urls>`. The only delta from
+the published v0.1.0 is `tabGroups`.
+
+**Pre-upload validation.** Built from a clean `extension/` working tree at the
+recorded commit: `pnpm typecheck` clean, 67/67 tests passing, and
+`scripts/validate-store-zip.sh` confirming the archive matches the reviewed
+`store-package-files.txt` allowlist, that manifest and package versions agree,
+and that no source maps are present.
+
+**User-visible changes since the published v0.1.0** (`5cbb91e1..37289774`):
+multi-tab surfaces so parallel sessions each own a tab, session-based tab
+grouping (what `tabGroups` is for), site approval as a first-class agent-legible
+flow with queued concurrent approvals and explicit loopback all-port grants, an
+MV3 reconnect alarm so a suspended worker wakes, owned tabs closing before the
+final response, and fixes to snapshot ref resolution, AX wrapper traversal,
+hidden-tab scrolling, and popup pairing feedback.
+
+### Release-automation verification performed on this date
+
+The automated path was audited against the live GitHub and GCP APIs so the next
+release can use it. All checks passed.
+
+- **Both protected environments** (`chrome-web-store`,
+  `chrome-web-store-production`): one required reviewer, custom deployment
+  branch policy allowing exactly `main`, and all four release variables defined
+  at environment scope with identical values. Verified by running the real
+  `extension/scripts/verify-release-environment.sh` against the live API — the
+  same script the workflows run before authenticating.
+- **`CWS_EXTENSION_ID`** matches the permanent ID hardcoded in
+  `chrome-web-store.sh`; no repository- or organization-scoped copies of any
+  release variable exist, which the script would reject.
+- **WIF provider** `local-operator-main` in pool `github-releases`
+  (project `pivotal-tower-456213-u5`, number `778402241192`): ACTIVE, issuer
+  `https://token.actions.githubusercontent.com`, the documented three-entry
+  attribute mapping, and attribute condition
+  `assertion.repository_id == "922327641" && assertion.ref == "refs/heads/main"`.
+  The numeric repository ID was confirmed to be this repository's real ID.
+- **Service account** `cws-publisher@pivotal-tower-456213-u5.iam.gserviceaccount.com`
+  exists and is enabled, carries exactly one binding —
+  `roles/iam.workloadIdentityUser` to the WIF principalSet scoped by that
+  repository ID — and holds no service-account key. `chromewebstore`,
+  `iamcredentials`, and `sts` APIs are enabled on the project.
+- **End-to-end authorization proven.** The service account was added under
+  Developer Dashboard → Account, and a read-only `fetchStatus` call made as that
+  service account returned HTTP 200 with the correct item ID. This is the one
+  link that cannot be checked from configuration alone, because it lives only in
+  the dashboard.
+
+The `fetchStatus` test required temporarily granting a human
+`roles/iam.serviceAccountTokenCreator` on the service account, since the
+principalSet binding deliberately lets only GitHub Actions mint a token. The
+grant was removed immediately and the resulting IAM policy was diffed against
+the pre-test policy to confirm it was byte-identical. **Do not leave that role
+in place**: a standing human token-creator binding would defeat the reason this
+release path uses workload identity federation instead of a stored key.
+
+---
+
+## v0.1.0 — first public release
+
+| Field | Value |
+| --- | --- |
+| Extension version | 0.1.0 |
+| Item ID | `omibaecbjdhgbbcedbnnnmjpmopfheof` |
+| Source commit | `5cbb91e1` (`feat: Local Operator browser extension and browser bridge`) |
+| Submission route | Manual dashboard upload (first publication) |
+| Store state | `PUBLISHED`, 100% deployment |
+
+First publication, gated on Radient, Inc. business verification and the EEA
+trader declaration rather than on anything in the package. Declared the original
+seven permissions plus `<all_urls>` — `tabGroups` did not yet exist.
+
+Artifact SHA-256 was not recorded at the time; this file was created during the
+0.1.5 release. The artifact is reproducible from the source commit, but a
+rebuild today is not byte-verifiable against what was uploaded. This gap is
+exactly what the fields above exist to prevent.

--- a/docs/store/release-record.md
+++ b/docs/store/release-record.md
@@ -24,16 +24,28 @@ filesystem mtime, so two builds of one tree seconds apart produce different
 archive hashes. Comparing a rebuild's hash against the recorded one will always
 mismatch, on a perfectly clean release. Do not read that as tampering.
 
-Audit a release this way instead, in order of strength:
+**Before rebuilding anything, copy the retained artifact aside.**
+`pnpm build:zip` writes to `extension/local-operator-extension.zip` and deletes
+any file already there, which is the same path the uploaded artifact sits at.
+That file is gitignored and the store will not give it back, so a rebuild run
+without this step destroys the only evidence the audit depends on:
+
+```console
+$ cp extension/local-operator-extension.zip /tmp/uploaded-<version>.zip
+```
+
+Audit a release this way, in order of strength:
 
 1. **`extension/` tree hash** — `git rev-parse <commit>:extension`. This is the
    field that deterministically pins the build input, and it is the one to
-   trust when asking "what source produced this release?"
-2. **Extracted contents** — rebuild, then `unzip` both archives and `diff -r`
-   the directories. Byte-identical contents with differing archive hashes is the
-   expected result, because only zip metadata differs.
-3. **Archive SHA-256** — use it only to confirm a *retained copy* of the
-   uploaded artifact is the one that was uploaded, never against a rebuild.
+   trust when asking "what source produced this release?" It requires no
+   rebuild and cannot destroy anything.
+2. **Extracted contents** — with the copy safely aside, rebuild, then `unzip`
+   both archives to separate directories and `diff -r` them. Byte-identical
+   contents with differing archive hashes is the expected result, because only
+   zip metadata differs.
+3. **Archive SHA-256** — use it only to confirm the *copy you set aside* is the
+   file that was uploaded, never against a rebuild.
 
 Making `build:zip` deterministic would collapse these three into one hash
 comparison; that is tracked as a follow-up (see the note under v0.1.5).
@@ -63,7 +75,10 @@ comparison; that is tracked as a follow-up (see the note under v0.1.5).
 above. "Pending review" is a snapshot from the submission date; Chrome review
 usually resolves within days, so if that date is well in the past, assume the
 row is stale and re-check before relying on it. Append the approval timestamp
-and promote this heading when it lands.
+and promote this heading when it lands. Calling that API **by hand** needs a
+temporary IAM grant that must be revoked afterwards — read the warning under
+"Release-automation verification" before you do, or just dispatch the workflow,
+which needs no grant at all.
 
 **Follow-up: make `build:zip` deterministic.** `build.mjs` invokes `zip` without
 normalising timestamps, which is why the archive hash above cannot be
@@ -153,6 +168,8 @@ after, and diff to prove the revert — do not rely on remembering.
 | Item ID | `omibaecbjdhgbbcedbnnnmjpmopfheof` |
 | Listing URL | https://chromewebstore.google.com/detail/local-operator/omibaecbjdhgbbcedbnnnmjpmopfheof |
 | Source commit | `5cbb91e1` (`feat: Local Operator browser extension and browser bridge`) |
+| `extension/` tree hash | `2d6fa2b3d0665a241071fa8e74e91184530d5be3` (derived from the source commit while backfilling this entry) |
+| Bridge protocol version | `PROTO_VERSION = 1` (at `5cbb91e1`) |
 | Artifact SHA-256 | *never recorded — see note below* |
 | Artifact size | ~31 KB (the only surviving fingerprint, from the original checklist) |
 | Submission route | Manual dashboard upload (first publication) |

--- a/docs/store/release-record.md
+++ b/docs/store/release-record.md
@@ -10,31 +10,66 @@ entry except to append its approval timestamp or a post-release incident note �
 the value of this file is that it says what was actually shipped, not what we
 intended to ship.
 
-## Why a release can only be reproduced from these fields
+## How to audit a release from these fields
 
 The store package is not committed (`extension/local-operator-extension.zip` is
 in `.gitignore`), so the artifact cannot be recovered from the repository. It is
-reproduced by checking out the recorded source commit and running
-`pnpm --dir extension build:zip`; the recorded SHA-256 is what proves the
-rebuild matches what was uploaded. Recording only the version would not be
+rebuilt by checking out the recorded source commit and running
+`pnpm --dir extension build:zip`. Recording only the version would not be
 enough — `main` moves, and a version number does not pin a tree.
+
+**The archive SHA-256 identifies the uploaded file; it is NOT reproducible.**
+`build.mjs` shells out to `zip`, which stamps every entry with its current
+filesystem mtime, so two builds of one tree seconds apart produce different
+archive hashes. Comparing a rebuild's hash against the recorded one will always
+mismatch, on a perfectly clean release. Do not read that as tampering.
+
+Audit a release this way instead, in order of strength:
+
+1. **`extension/` tree hash** — `git rev-parse <commit>:extension`. This is the
+   field that deterministically pins the build input, and it is the one to
+   trust when asking "what source produced this release?"
+2. **Extracted contents** — rebuild, then `unzip` both archives and `diff -r`
+   the directories. Byte-identical contents with differing archive hashes is the
+   expected result, because only zip metadata differs.
+3. **Archive SHA-256** — use it only to confirm a *retained copy* of the
+   uploaded artifact is the one that was uploaded, never against a rebuild.
+
+Making `build:zip` deterministic would collapse these three into one hash
+comparison; that is tracked as a follow-up (see the note under v0.1.5).
 
 ---
 
-## v0.1.5 — submitted 2026-09-02, pending review
+## v0.1.5 — submitted 2026-09-02, pending review as of 2026-09-02
 
 | Field | Value |
 | --- | --- |
-| Extension version | 0.1.5 |
+| Extension version | 0.1.5 (submitted; **not yet the approved version**) |
 | Item ID | `omibaecbjdhgbbcedbnnnmjpmopfheof` |
+| Listing URL | https://chromewebstore.google.com/detail/local-operator/omibaecbjdhgbbcedbnnnmjpmopfheof |
 | Source commit | `37289774` (`chore(release): bump version to 0.44.38`) |
-| `extension/` tree hash | `9fe12bde271cc84f060922d8d254d22d046b7e6a` |
-| Artifact SHA-256 | `724f3f91117f166263c462801a9a73c27d0a4787bd4e5c5dcb6374a2d56d2d0a` |
+| `extension/` tree hash | `9fe12bde271cc84f060922d8d254d22d046b7e6a` (the deterministic input pin — see the audit note above) |
+| Artifact SHA-256 | `724f3f91117f166263c462801a9a73c27d0a4787bd4e5c5dcb6374a2d56d2d0a` (uploaded file only; not reproducible) |
 | Artifact size | 45,262 bytes, 12 files, no source maps |
 | Bridge protocol version | `PROTO_VERSION = 1` |
 | Submission route | **Manual dashboard upload** |
-| Store state at submission | `PENDING_REVIEW`, 100% deployment |
-| Previously published | v0.1.0, still live at 100% during review |
+| Store state | `PENDING_REVIEW`, 100% deployment |
+| State last checked | 2026-09-02 |
+| Approval timestamp | *pending — append when review completes* |
+| Previously published | v0.1.0, live at 100% during review |
+
+**Refresh the state rows** with a `fetchStatus` call — the same read-only API
+`extension/scripts/chrome-web-store.sh` uses — rather than trusting the values
+above. "Pending review" is a snapshot from the submission date; Chrome review
+usually resolves within days, so if that date is well in the past, assume the
+row is stale and re-check before relying on it. Append the approval timestamp
+and promote this heading when it lands.
+
+**Follow-up: make `build:zip` deterministic.** `build.mjs` invokes `zip` without
+normalising timestamps, which is why the archive hash above cannot be
+regenerated. Normalising mtimes and passing `-X` (verified locally to produce
+identical hashes across repeated builds) would make a rebuild hash-comparable
+and let this record drop the three-step audit procedure for a single check.
 
 **Why this one was uploaded by hand.** 0.1.5 adds the `tabGroups` permission,
 which 0.1.0 did not request. Permission justifications exist only in the
@@ -90,15 +125,23 @@ release can use it. All checks passed.
   Developer Dashboard → Account, and a read-only `fetchStatus` call made as that
   service account returned HTTP 200 with the correct item ID. This is the one
   link that cannot be checked from configuration alone, because it lives only in
-  the dashboard.
+  the dashboard. **Reproducing this call requires a temporary
+  `roles/iam.serviceAccountTokenCreator` grant that MUST be revoked immediately
+  afterwards — see the warning below before running it.**
 
-The `fetchStatus` test required temporarily granting a human
-`roles/iam.serviceAccountTokenCreator` on the service account, since the
-principalSet binding deliberately lets only GitHub Actions mint a token. The
-grant was removed immediately and the resulting IAM policy was diffed against
-the pre-test policy to confirm it was byte-identical. **Do not leave that role
-in place**: a standing human token-creator binding would defeat the reason this
-release path uses workload identity federation instead of a stored key.
+**Warning — read before calling `fetchStatus` by hand.** A human cannot mint a
+token for the publishing service account by design: the only binding on it is
+`roles/iam.workloadIdentityUser` for the GitHub principalSet, so nobody at a
+keyboard can produce a store credential. Testing the call therefore requires
+temporarily granting yourself `roles/iam.serviceAccountTokenCreator`. When this
+audit did that, the grant was removed immediately and the resulting IAM policy
+was diffed against a pre-test capture to confirm it was byte-identical.
+
+**Never leave that role in place.** A standing human token-creator binding
+defeats the entire reason this release path uses workload identity federation
+instead of a stored key: it recreates the durable human-usable credential that
+WIF exists to eliminate. Capture the policy before granting, revoke straight
+after, and diff to prove the revert — do not rely on remembering.
 
 ---
 
@@ -108,15 +151,22 @@ release path uses workload identity federation instead of a stored key.
 | --- | --- |
 | Extension version | 0.1.0 |
 | Item ID | `omibaecbjdhgbbcedbnnnmjpmopfheof` |
+| Listing URL | https://chromewebstore.google.com/detail/local-operator/omibaecbjdhgbbcedbnnnmjpmopfheof |
 | Source commit | `5cbb91e1` (`feat: Local Operator browser extension and browser bridge`) |
+| Artifact SHA-256 | *never recorded — see note below* |
+| Artifact size | ~31 KB (the only surviving fingerprint, from the original checklist) |
 | Submission route | Manual dashboard upload (first publication) |
 | Store state | `PUBLISHED`, 100% deployment |
+| State last checked | 2026-09-02 |
 
 First publication, gated on Radient, Inc. business verification and the EEA
 trader declaration rather than on anything in the package. Declared the original
 seven permissions plus `<all_urls>` — `tabGroups` did not yet exist.
 
 Artifact SHA-256 was not recorded at the time; this file was created during the
-0.1.5 release. The artifact is reproducible from the source commit, but a
-rebuild today is not byte-verifiable against what was uploaded. This gap is
-exactly what the fields above exist to prevent.
+0.1.5 release. The approximate size above is the only surviving fingerprint. The
+source commit still pins the tree, so the contents can be rebuilt and inspected,
+but nothing ties them to the specific file that was uploaded. This gap is
+exactly what the fields above exist to prevent — note that even a recorded
+SHA-256 would only have identified the uploaded artifact, not enabled a
+hash-comparable rebuild, until `build:zip` is made deterministic.

--- a/docs/store/release-record.md
+++ b/docs/store/release-record.md
@@ -75,10 +75,13 @@ comparison; that is tracked as a follow-up (see the note under v0.1.5).
 above. "Pending review" is a snapshot from the submission date; Chrome review
 usually resolves within days, so if that date is well in the past, assume the
 row is stale and re-check before relying on it. Append the approval timestamp
-and promote this heading when it lands. Calling that API **by hand** needs a
-temporary IAM grant that must be revoked afterwards — read the warning under
-"Release-automation verification" before you do, or just dispatch the workflow,
-which needs no grant at all.
+and promote this heading when it lands. Note there is no status-only workflow to
+dispatch — both store workflows write (`stage` uploads and submits, `promote`
+publishes), so a read-only status check has to be the hand-rolled API call, and
+that needs a temporary IAM grant which must be revoked afterwards. Read the
+warning under "Release-automation verification" before making it. The dashboard
+shows the same state with no grant at all, which is the cheaper check when you
+only need to eyeball it.
 
 **Follow-up: make `build:zip` deterministic.** `build.mjs` invokes `zip` without
 normalising timestamps, which is why the archive hash above cannot be

--- a/docs/store/submission-checklist.md
+++ b/docs/store/submission-checklist.md
@@ -3,32 +3,32 @@
 Run this against the final release candidate. Do not submit from a development
 build or from copy that no longer matches the manifest.
 
-## Live session status (2026-08-25) — where we actually are
+## Live session status (2026-09-02) — where we actually are
 
-A first live dogfood run drove a real Chrome (piloted by our own extension) to
-the dashboard. Confirmed on the ground:
+The extension is **published**. The first-publication gates described in the
+previous revision of this section (business verification, trader declaration)
+are cleared; do not re-litigate them.
 
-- **Signed in** as `damian@gominerva.com`; the Chrome Web Store Developer
-  Dashboard opens, so a developer account exists under that address.
-- **Blocking gate:** the dashboard shows an "Action required" **trader /
-  non-trader declaration** (EEA consumer-protection law) on Settings, and full
-  **business verification** for Radient, Inc. is required before publishing.
-  That verification is a multi-day, account-owner/legal task — it is THE gate.
-- **Packed store artifact is built and ready:**
-  `extension/local-operator-extension.zip` (v0.1.0, 31 KB, **no source maps** —
-  `pnpm --dir extension build:zip` regenerates it). Manifest verified store-clean
-  (MV3, name "Local Operator", the 7 justified permissions, `<all_urls>`).
-- **Known platform limit found live:** Chrome forbids the debugger API on the
+- **v0.1.0 is live** on the Chrome Web Store at 100% deployment, item
+  `omibaecbjdhgbbcedbnnnmjpmopfheof`.
+- **v0.1.5 is submitted and `PENDING_REVIEW`** at 100% deployment, uploaded
+  manually because it adds the `tabGroups` permission, whose justification can
+  only be entered in the dashboard. See the release record in
+  `docs/store/release-record.md`.
+- **Automated publishing is verified end to end** and is the intended path for
+  every subsequent release — see "Automated updates after the first public
+  release" below. Both protected environments, the WIF provider, and the
+  Chrome Web Store API authorization were confirmed working on 2026-09-02.
+- **Known platform limit, still true:** Chrome forbids the debugger API on the
   Web Store domains ("The extensions gallery cannot be scripted"), so the
   extension cannot auto-fill the developer console — a human drives the console
-  pages. Documented in `guide://browser`.
+  pages. Documented in `guide://browser`. This is why a release that introduces
+  a new permission needs a human in the dashboard.
 
-**Pick-up point:** once Radient's business verification + trader declaration
-clear, finish the first-publication steps below for permanent item
-`omibaecbjdhgbbcedbnnnmjpmopfheof`, paste the copy from `listing.md`,
-`permissions.md`, `privacy-policy.md`, and the assets in `assets/`, then walk
-the rest of this checklist. Later package uploads use the protected GitHub
-workflows documented below; no long-lived Google credential is stored.
+**Pick-up point:** watch for the v0.1.5 review decision, then run the
+post-approval steps in section 11. Sections 0–9 describe *first* publication
+and are retained as the reference for listing copy and asset requirements;
+re-walk them only when the listing, permissions, or privacy policy change.
 
 ## 0. Resolve the launch assumptions
 
@@ -48,9 +48,18 @@ workflows documented below; no long-lived Google credential is stored.
       law fields, and supply any required business address/D-U-N-S details.
       This is a legal/account-owner decision, not defined by the product design.
 
-## 0.1.4 permission handoff
+## Permission handoff (`tabGroups`, added in 0.1.4)
 
-- [ ] **Damian must add the NEW `tabGroups` permission justification in the Chrome Web Store dashboard when uploading the next package.** Use the exact paste-ready rationale in `permissions.md`; the package will request a new permission and must not be submitted against the old seven-permission declaration.
+- [x] **Done for the 0.1.5 upload (2026-09-02).** The `tabGroups` justification
+      from `permissions.md` was entered in the dashboard and 0.1.5 was submitted
+      against the eight-permission declaration, not the original seven.
+
+**Standing rule for future releases:** a package that adds a permission cannot
+go out through the automated workflow alone. The Chrome Web Store API cannot set
+permission justifications, and Chrome blocks scripting the dashboard, so a human
+must paste the rationale from `permissions.md` before submitting. Diff the built
+`extension/dist/manifest.json` against the previously published version's
+permission list on every release to catch this; when they differ, upload by hand.
 
 ## 1. Developer account and publisher identity
 
@@ -265,6 +274,14 @@ and what control remains with the user.
 
 ### Automated updates after the first public release
 
+**Status (2026-09-02): configured and verified end to end.** Both protected
+environments, the workload identity provider, the service-account IAM binding,
+and the store's authorization of that service account were all confirmed
+working; the evidence is in `release-record.md`. The workflows have not yet run
+a real release — v0.1.5 went out by hand because it added a permission — so the
+first automated run will be the next version. It fails closed before uploading
+anything, so a surprise there is recoverable.
+
 The workflows use Chrome Web Store API v2 directly with `curl` and exchange a
 GitHub OIDC token for a short-lived service-account access token through
 `google-github-actions/auth@v3` (pinned by full commit SHA, like every action in
@@ -372,7 +389,7 @@ high-scrutiny. Do not promise a launch date until approval.
       the store, clearly marked as the advanced fallback.
 - [ ] Record the approved version, approval timestamp, item ID, listing URL,
       artifact SHA-256, source commit, and protocol version in the extension
-      release record.
+      release record, `docs/store/release-record.md`.
 - [ ] Establish the update runbook: build from a release commit, inspect zip,
       upload, reconcile newly requested permissions, refresh screenshots/copy
       when behavior changes, submit, monitor, and run the production smoke test.

--- a/docs/store/submission-checklist.md
+++ b/docs/store/submission-checklist.md
@@ -6,8 +6,11 @@ build or from copy that no longer matches the manifest.
 ## Live session status (2026-09-02) — where we actually are
 
 The extension is **published**. The first-publication gates described in the
-previous revision of this section (business verification, trader declaration)
-are cleared; do not re-litigate them.
+previous revision of this section (Radient, Inc. business verification and the
+EEA trader declaration) were cleared as of 2026-09-02. They are not routine
+re-checks — but they can reopen if the account owner, legal entity, or
+declaration details change, so re-verify on any such change rather than assuming
+them settled forever.
 
 - **v0.1.0 is live** on the Chrome Web Store at 100% deployment, item
   `omibaecbjdhgbbcedbnnnmjpmopfheof`.


### PR DESCRIPTION
# PR Description

## Summary of Changes

Documentation only, no code. Brings the Chrome Web Store docs in line with the fact that the extension is now published, and adds the release record that `submission-checklist.md` section 11 has always required but which never existed.

Two things were stale enough to mislead:

- The checklist's "Live session status" section still described the **pre-publication** world — v0.1.0 as an unbuilt candidate, business verification and the EEA trader declaration as THE blocking gate. Those are cleared; v0.1.0 is live and v0.1.5 is in review.
- An open action item told Damian to add the `tabGroups` justification "when uploading the next package." That upload has happened. Left as an unticked box, the next person re-does it or assumes it was skipped.

## What changed

**`docs/store/release-record.md` (new).** The artifact record section 11 asks for, newest-first, with an entry for v0.1.5 and a backfilled one for v0.1.0.

The store zip is gitignored, so a shipped release cannot be recovered from the repository — it is reproduced by checking out the recorded source commit and rebuilding, with the recorded SHA-256 proving the rebuild matches. A version number alone pins nothing, because `main` moves. The v0.1.0 entry deliberately records that its digest was *never captured*: that gap is the reason the file now exists, and papering over it would waste the lesson.

The v0.1.5 entry also captures the release-automation audit described below, and warns explicitly against leaving a human `roles/iam.serviceAccountTokenCreator` binding on the publishing service account — a standing one would defeat the reason the release path uses workload identity federation instead of a stored key.

**`docs/store/submission-checklist.md`.** Status section rewritten to current reality; the `tabGroups` item ticked with the date and generalized into a standing rule — a release that adds a permission cannot ship through the automated workflow alone, because the API cannot set justifications and Chrome forbids scripting the dashboard, so the built manifest's permission list must be diffed against the published one on every release. The automation section gains an honest status line (verified, but never yet run for a real release), and section 11 now names the release-record file by path instead of referring to it abstractly.

## Testing evidence

Documentation-only, so the evidence is that every asserted fact was checked against the live source rather than transcribed from memory. Each value in the record was verified at the recorded commit:

```console
$ git rev-parse 37289774:extension
9fe12bde271cc84f060922d8d254d22d046b7e6a

$ gh api repos/damianvtran/local-operator -q .id
922327641

$ grep -m1 '^PROTO_VERSION' local_operator/browser_bridge/protocol.py
PROTO_VERSION = 1

$ shasum -a 256 extension/local-operator-extension.zip | cut -d' ' -f1
724f3f91117f166263c462801a9a73c27d0a4787bd4e5c5dcb6374a2d56d2d0a

$ stat -f%z extension/local-operator-extension.zip
45262
```

The artifact those digests describe was built from a clean `extension/` tree at `37289774` and passed the repository's own gates:

```console
$ pnpm typecheck
$ tsc --noEmit          # clean, no output

$ pnpm test
ℹ tests 67
ℹ pass 67
ℹ fail 0

$ pnpm build:zip
validated Chrome Web Store package v0.1.5 (12 files, no source maps)
```

`extension/` is byte-identical between `37289774` and current `main` (same tree hash above), so the record's source-commit claim is still accurate at merge time.

### Store state — the claims about v0.1.0 and v0.1.5 are observed, not assumed

Read-only `fetchStatus` call against Chrome Web Store API v2, authenticated as the publishing service account:

```console
$ curl -sS -w '%{http_code}' -X GET \
    -H "Authorization: Bearer $TOK" \
    "https://chromewebstore.googleapis.com/v2/publishers/$PUB/items/$EXT:fetchStatus"
200

{
  "itemId": "omibaecbjdhgbbcedbnnnmjpmopfheof",
  "publishedItemRevisionStatus": {
    "state": "PUBLISHED",
    "distributionChannels": [{"deployPercentage": 100, "crxVersion": "0.1.0"}]
  },
  "submittedItemRevisionStatus": {
    "state": "PENDING_REVIEW",
    "distributionChannels": [{"deployPercentage": 100, "crxVersion": "0.1.5"}]
  }
}
```

### Release-automation audit

Ran the workflows' own `extension/scripts/verify-release-environment.sh` against the live GitHub API — the same script that gates both workflows before they authenticate:

```console
$ bash extension/scripts/verify-release-environment.sh chrome-web-store ...
validated protected environment chrome-web-store (required reviewer, main-only, environment-scoped variables)

$ bash extension/scripts/verify-release-environment.sh chrome-web-store-production ...
validated protected environment chrome-web-store-production (required reviewer, main-only, environment-scoped variables)
```

GCP side confirmed with `gcloud`: pool `github-releases` and provider `local-operator-main` ACTIVE with issuer `https://token.actions.githubusercontent.com`, the documented three-entry attribute mapping, and attribute condition `assertion.repository_id == "922327641" && assertion.ref == "refs/heads/main"` — the numeric ID matching this repository's real ID above. The service account holds exactly one binding, `roles/iam.workloadIdentityUser` to that repository-scoped principalSet, and no service-account key.

The `fetchStatus` call above required temporarily granting a human `serviceAccountTokenCreator`, because the principalSet binding correctly lets only GitHub Actions mint a token. The grant was removed immediately and the resulting policy diffed against the pre-test capture:

```console
IAM FULLY RESTORED — identical to pre-test state
```

## Risk

None to the runtime — no code, no workflow, no manifest touched. The `pytest`/lint suites are unaffected; CI runs them anyway. The residual risk is that the record's forward-looking claim ("automated path verified") is only as good as the audit above, which is why the checklist says plainly that the workflows have not yet run a real release.
