### PR TITLE
fix(tui): render the aside answer as markdown

### DIFF
--- a/local_operator/tui/widgets/aside_panel.py
+++ b/local_operator/tui/widgets/aside_panel.py
@@ -45,12 +45,15 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 from rich.cells import cell_len
+from rich.console import Console
+from rich.markdown import Markdown
 from rich.style import Style
 from rich.text import Text
 from textual.widgets import Static
 
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets import overlay
+from local_operator.tui.widgets.assistant import flatten
 from local_operator.tui.widgets.tool_card import truncate_cells
 
 #: The card takes the COMPOSER's width and the composer's left and right
@@ -135,8 +138,11 @@ Question:
 #: (``UserBlock.RULE`` / ``SPINE_INDENT``), not the composer's ``❯``, which
 #: marks a row being typed. An aside question is sent the moment Enter lands,
 #: so the card uses the same spine at the same column — and a forked exchange
-#: then renders in the transcript exactly as it looked on the card, which is
-#: what "keep this" ought to look like. The card is already told apart from the
+#: then renders in the transcript as it looked on the card, which is what
+#: "keep this" ought to look like. The ANSWER holds up its half of that by
+#: rendering as markdown here too (:meth:`AsidePanel._markdown_rows`); it used
+#: to arrive as literal ``**bold**``, so identical words changed shape the
+#: moment ``^f`` moved them. The card is already told apart from the
 #: transcript by the two things the design system reserves for that (the
 #: ``$lo-overlay`` elevation step and the title row); a third differentiator
 #: spelled in a glyph that already means something else would be a second
@@ -227,6 +233,12 @@ class AsidePanel(Static):
         #: grows as the composer wraps without resizing this card, so Textual
         #: emits no resize event for it and the app has to ask.
         self._layout_shown: tuple[int, int, int] | None = None
+        #: Rendered answer rows, keyed by the three things they depend on:
+        #: ``(text, width, theme epoch)``. See :meth:`_markdown_rows` for why
+        #: it is here and :meth:`_body` for why it cannot grow.
+        self._answer_cache: dict[tuple[str, int, int], list[Text]] = {}
+        #: Keys :meth:`_markdown_rows` reached during the paint in progress.
+        self._used_answers: set[tuple[str, int, int]] = set()
         self.display = False
 
     # -- state ---------------------------------------------------------------
@@ -250,16 +262,25 @@ class AsidePanel(Static):
         self._turns = []
         self._notice = ""
         self._scroll_back = 0
+        self._answer_cache.clear()
         self._generation += 1
         self.display = True
         self._repaint()
 
     def close(self) -> None:
-        """Hide the card and discard the exchange — that is what dismiss means."""
+        """Hide the card and discard the exchange — that is what dismiss means.
+
+        The rendered-answer cache is discarded WITH it. A dismissed exchange
+        that lives on in a cache is the trace this surface promises not to
+        leave, and the paint-scoped prune cannot reach it: ``_repaint`` returns
+        early on a hidden card, so nothing would run to drop it.
+        """
         self._generation += 1
         self._turns = []
         self._notice = ""
         self._scroll_back = 0
+        self._answer_cache.clear()
+        self._used_answers.clear()
         self.display = False
 
     def ask(self, question: str) -> int:
@@ -363,8 +384,13 @@ class AsidePanel(Static):
         self._repaint()
 
     def _max_scroll_back(self) -> int:
-        """How many whole turns are droppable off the head at this size."""
-        return max(0, len(self._turn_groups()) - 1)
+        """How many whole turns are droppable off the head at this size.
+
+        Counted off ``_turns`` rather than off built groups: the grouping is one
+        group per turn, so building them to take their length rendered the whole
+        exchange on every wheel event to learn a number the list already had.
+        """
+        return max(0, len(self._turns) - 1)
 
     # -- geometry -------------------------------------------------------------
     def _screen_size(self) -> tuple[int, int]:
@@ -425,28 +451,47 @@ class AsidePanel(Static):
         self._repaint()
 
     # -- rendering ------------------------------------------------------------
-    def _turn_groups(self) -> list[list[Text]]:
-        """The exchange as one row group per turn, newest last.
+    def _turn_group(
+        self, index: int, width: int, fg: Style, dim: Style, danger: Style
+    ) -> list[Text]:
+        """One turn as a row group: its question, then its answer.
 
         Grouped rather than flattened because the card sheds whole TURNS when
         it overflows (see :meth:`_body`) — cutting by row left the top of the
         card showing a mid-sentence continuation at the answer indent with no
         question above it, which reads as the start of a new answer.
+
+        One turn at a time, and not the whole exchange, because rendering is
+        what :meth:`_body` is trying to avoid spending on turns it then drops.
+        The leading blank separates this turn from the one above it, so the
+        oldest turn does not get one.
         """
-        width = self._content_width()
-        fg = Style(color=theme_mod.semantic_color("fg"))
-        dim = Style(color=theme_mod.semantic_color("dim"))
-        danger = Style(color=theme_mod.semantic_color("danger"))
-        groups: list[list[Text]] = []
-        for index, turn in enumerate(self._turns):
-            rows: list[Text] = [] if index == 0 else [Text()]
-            rows.extend(self._question_rows(turn.question, width, dim, fg))
-            rows.extend(self._answer_rows(turn, width, fg, dim, danger))
-            groups.append(rows)
-        return groups
+        turn = self._turns[index]
+        rows: list[Text] = [] if index == 0 else [Text()]
+        rows.extend(self._question_rows(turn.question, width, dim, fg))
+        rows.extend(self._answer_rows(turn, width, dim, danger))
+        return rows
 
     def _body(self) -> AsideBody:
-        """The visible rows: the tail of the exchange, cut on turn boundaries.
+        """The visible rows, and the paint-scoped bound on the answer cache.
+
+        The cache is rebuilt to exactly what THIS paint reached. Keying on the
+        text means a streaming answer mints a fresh key per delta, so a cache
+        that only ever inserted would hold every prefix of every answer for as
+        long as the card is open; dropping whatever the paint did not touch
+        bounds it without a policy. What it bounds it AT is what
+        :meth:`_visible_rows` renders — the turns on the card, plus at most the
+        one turn it had to build to find out did not fit.
+        """
+        self._used_answers = set()
+        body = self._visible_rows()
+        self._answer_cache = {
+            key: rows for key, rows in self._answer_cache.items() if key in self._used_answers
+        }
+        return body
+
+    def _visible_rows(self) -> AsideBody:
+        """The tail of the exchange, cut on turn boundaries.
 
         Tail-anchored rather than paged, and that is the difference between
         this card and the usage card. A quota table is a reference document the
@@ -454,34 +499,55 @@ class AsidePanel(Static):
         always the newest turn. ``_scroll_back`` lets the WHEEL walk back
         through the earlier ones without taking ↑/↓ from the composer, which is
         holding focus so the user can keep talking.
+
+        Turns are built LAZILY, newest first, and the walk stops as soon as one
+        does not fit. The cut used to read the lengths of a fully-built
+        exchange, which looked necessary — the budget is spent backwards, so
+        the sizes have to come from somewhere — but every group above the cut
+        was rendered and then thrown away. Measured at a 120x40 card over
+        realistic answers, a cold paint cost 9.7 ms at 10 turns and 117 ms at
+        120 while painting ONE question, against 1.1/8.7 ms for the same card
+        before the answer was markdown at all. The turn count is uncapped and
+        the card repaints on every streamed delta, so that is a stall the user
+        feels while typing. Only a group's own length gates the walk, so a
+        group nobody will see never has to exist.
         """
         width = self._content_width()
+        fg = Style(color=theme_mod.semantic_color("fg"))
         dim = Style(color=theme_mod.semantic_color("dim"))
-        if not self._turns:
+        danger = Style(color=theme_mod.semantic_color("danger"))
+        count = len(self._turns)
+        if not count:
             return AsideBody(
                 [Text(truncate_cells("Ask anything about this session.", width), style=dim)]
             )
 
-        groups = self._turn_groups()
         budget = self._fit()[2]
         # Walk back from the newest turn, taking whole turns while they fit.
         # One row of the budget is held back for the marker whenever anything
         # is dropped, so the reader is told what is above rather than shown a
         # conversation that begins nowhere.
-        end = len(groups) - min(self._scroll_back, max(0, len(groups) - 1))
+        end = count - min(self._scroll_back, max(0, count - 1))
         first = end - 1
-        total = len(groups[first])
-        while first > 0 and total + len(groups[first - 1]) <= budget - 1:
+        window = [self._turn_group(first, width, fg, dim, danger)]
+        total = len(window[0])
+        while first > 0:
+            # Built to be measured. It is kept only if it fits, which is the
+            # one turn's worth of render this cut cannot do without.
+            above = self._turn_group(first - 1, width, fg, dim, danger)
+            if total + len(above) > budget - 1:
+                break
             first -= 1
-            total += len(groups[first])
-        window = [list(group) for group in groups[first:end]]
+            total += len(above)
+            window.append(above)
+        window.reverse()
         # The blank row that separates turns belongs BETWEEN them. On the first
         # visible group it is a blank leading the card, which reads as the
         # exchange having started and then said nothing.
         if window and window[0] and not window[0][0].plain:
             window[0] = window[0][1:]
         lines = [row for group in window for row in group]
-        hidden = first + (len(groups) - end)
+        hidden = first + (count - end)
         if hidden == 0:
             return AsideBody(lines[-budget:] if len(lines) > budget else lines)
         noun = "question" if hidden == 1 else "questions"
@@ -518,9 +584,7 @@ class AsidePanel(Static):
         rows.extend(Text(f"{ANSWER_INDENT}{line}", style=text_style) for line in wrapped[1:])
         return rows
 
-    def _answer_rows(
-        self, turn: AsideTurn, width: int, fg: Style, dim: Style, danger: Style
-    ) -> list[Text]:
+    def _answer_rows(self, turn: AsideTurn, width: int, dim: Style, danger: Style) -> list[Text]:
         body = max(1, width - len(ANSWER_INDENT))
         if turn.state == "error" and not turn.answer.strip():
             return self._error_rows(turn.error or "the aside failed", body, danger)
@@ -528,7 +592,10 @@ class AsidePanel(Static):
         if not text:
             waiting = "thinking…" if turn.state == "running" else "no answer"
             return [Text(f"{ANSWER_INDENT}{waiting}", style=dim)]
-        rows = [Text(f"{ANSWER_INDENT}{line}", style=fg) for line in _wrap(text, body)]
+        # Copied because the renderer hands back its CACHED list, and the
+        # status rows below are appended per state — mutating it in place would
+        # leave a stale "…" welded onto the answer the next paint reads back.
+        rows = list(self._markdown_rows(text, body))
         if turn.state == "running":
             rows.append(Text(f"{ANSWER_INDENT}…", style=dim))
         elif turn.state == "cancelled":
@@ -536,6 +603,84 @@ class AsidePanel(Static):
         elif turn.state == "error":
             rows.extend(self._error_rows(turn.error, body, danger))
         return rows
+
+    def _markdown_rows(self, text: str, body: int) -> list[Text]:
+        """The answer as MARKDOWN rows, indented onto the card's text column.
+
+        The answer is model prose, and every other surface that shows model
+        prose renders it (``AssistantBlock`` at
+        :meth:`AssistantBlock._flat_rows`). Rendered here through the SAME
+        :func:`flatten` rather than a second renderer, so a code span, a bullet
+        and a heading are the one shape everywhere — and so ``^f``, which hands
+        this exact string to an ``AssistantBlock``, cannot change how the words
+        look on their way into the chat.
+
+        The QUESTION deliberately stays plain (see :meth:`_question_rows`).
+
+        Width is the body column, not the card: :func:`flatten` bakes the width
+        in AND pads every row out to it, so rendering at ``_content_width()``
+        and then adding ``ANSWER_INDENT`` would push each row two cells past
+        the card's own edge.
+
+        The pad is KEPT. It is what makes a fenced code block a rectangle: rich
+        paints the block's fill onto the pad, so cropping it leaves a ragged
+        dark band with the card's ``$lo-overlay`` showing through the notch at
+        the end of every short line. On prose rows the pad carries no
+        background, so against the card fill it is invisible — the cost is
+        trailing spaces on a copied row, which
+        ``TranscriptBlock.get_selection`` already drops for the transcript's
+        own padded rows.
+
+        CACHED, because ``_repaint`` runs on every streamed delta and repaints
+        the whole card: the streaming turn is one render, but the settled turns
+        beside it would be re-rendered from text that cannot have changed.
+        Measured at a 120-column card over a 636-character answer in 106
+        deltas, the median repaint went 0.21 ms plain to 0.75 ms markdown; with
+        the cache the settled turns are dictionary hits and only the live
+        answer renders.
+
+        The cache is a warm-path optimisation and NOT the bound on this cost.
+        It cannot be: width is in the key, so a resize misses every key at
+        once. What bounds the work is :meth:`_visible_rows` rendering only the
+        turns the card shows — read its note for the measurements, which is
+        where a paint that rendered 120 answers to show one question was
+        costing 117 ms.
+
+        Keyed on ``(text, width, theme epoch)`` — the three inputs
+        :func:`flatten` bakes in. Width because it is folded into the rows
+        (``sync_layout``/``on_resize`` repaint, and a stale key would paint the
+        old fold at the new width); the theme epoch for the reason
+        ``AssistantBlock`` drops its frozen renderable on one (TUI-016), the
+        ramp the code spans were coloured from having moved.
+        """
+        key = (text, body, theme_mod.get_theme_epoch())
+        self._used_answers.add(key)
+        cached = self._answer_cache.get(key)
+        if cached is not None:
+            return cached
+        indent = Text(ANSWER_INDENT)
+        rows: list[Text] = []
+        for line in flatten(Markdown(text), body, self._flat_console()).split("\n"):
+            row = indent.copy()
+            row.append_text(line)
+            rows.append(row)
+        self._answer_cache[key] = rows
+        return rows
+
+    def _flat_console(self) -> Console | None:
+        """The app's console, or ``None`` when the card is detached.
+
+        Same bargain ``AssistantBlock._flat_console`` makes, for the same
+        reason: the app's console carries the brand markdown theme and the
+        terminal's encoding, so the card's code spans match the transcript's.
+        A card built before mount, or held directly by a test, has no app —
+        :func:`flatten` then falls back to a private console carrying the same
+        theme, so the rows are the same either way.
+        """
+        try:
+            return self.app.console
+        except Exception:
+            return None
 
     @staticmethod
     def _error_rows(message: str, body: int, danger: Style) -> list[Text]:
@@ -712,9 +857,15 @@ def _wrap(text: str, width: int) -> list[str]:
     """Wrap prose to ``width``, preserving the blank lines between paragraphs.
 
     ``textwrap`` on the whole string would collapse the paragraph breaks a
-    model uses for structure, which is most of the shape a plain-text answer
-    has. Lists survive for the same reason: each source line is wrapped on its
-    own, so a ``- item`` keeps its own row.
+    writer uses for structure, which is most of the shape text carries when
+    nothing is interpreting it. Lists survive for the same reason: each source
+    line is wrapped on its own, so a ``- item`` keeps its own row.
+
+    This is the VERBATIM path, and the two callers left on it are the ones
+    whose text must not be reinterpreted: the user's own question (an asterisk
+    they typed is an asterisk they meant) and an error message (a provider's
+    stack trace is not markup). The ANSWER is model prose and renders as
+    markdown — see :meth:`AsidePanel._markdown_rows`.
     """
     out: list[str] = []
     for line in text.splitlines():

--- a/tests/unit/tui/test_aside.py
+++ b/tests/unit/tui/test_aside.py
@@ -25,7 +25,7 @@ import pytest
 
 from local_operator.harness.types import Message, Usage
 from local_operator.tui.app import RESIZE_REFIT_DELAY_S, OperatorApp
-from local_operator.tui.widgets.aside_panel import AsidePanel, AsideTurn
+from local_operator.tui.widgets.aside_panel import QUESTION_MARK, AsidePanel, AsideTurn
 from local_operator.tui.widgets.editor import (
     ASIDE_PLACEHOLDER,
     DEFAULT_PLACEHOLDER,
@@ -669,11 +669,15 @@ def test_a_long_exchange_cuts_on_a_turn_boundary_and_counts_questions() -> None:
     continuation at the answer indent with no question above it, which reads
     as the start of a new answer. And counted in questions, because a user
     remembers asking three things and never counted the rows they wrapped to.
+
+    The answer is a LIST because the answer renders as markdown: twelve
+    repetitions of a bare word are one paragraph to a markdown parser, which
+    folds to a single row and leaves nothing to overflow.
     """
     panel = AsidePanel()
     panel.display = True
     panel._turns = [
-        AsideTurn(question=f"question {index}?", answer="line\n" * 12, state="done")
+        AsideTurn(question=f"question {index}?", answer="- line\n" * 12, state="done")
         for index in range(6)
     ]
     rendered = panel.render_lines_for_test()
@@ -688,11 +692,15 @@ def test_the_wheel_walks_back_through_earlier_questions() -> None:
 
     The wheel and not ↑/↓: those belong to the focused composer's prompt
     history, and the aside's premise is that the user keeps typing there.
+
+    A LIST for the reason
+    ``test_a_long_exchange_cuts_on_a_turn_boundary_and_counts_questions``
+    records: the answer is markdown, so a tall turn has to be tall AS markdown.
     """
     panel = AsidePanel()
     panel.display = True
     panel._turns = [
-        AsideTurn(question=f"question {index}?", answer="line\n" * 12, state="done")
+        AsideTurn(question=f"question {index}?", answer="- line\n" * 12, state="done")
         for index in range(6)
     ]
     assert "question 5?" in "\n".join(panel.render_lines_for_test())
@@ -718,3 +726,267 @@ def test_a_fork_refusal_is_stated_on_the_card_not_in_the_transcript() -> None:
     # And it clears the moment the user does the thing it asked for.
     panel.ask("why?")
     assert not any("nothing to fork" in line for line in panel.render_lines_for_test())
+
+
+# -- the answer is markdown, the question is not ---------------------------
+def test_the_answer_renders_as_markdown_not_as_its_own_source() -> None:
+    """Model prose on the card is prose, the same as everywhere else it shows.
+
+    The card used to wrap the answer as plain text, so the markdown a model
+    writes reached the user as literal source — backticks around `code`,
+    asterisks around **bold**, a `-` where the transcript draws a bullet. The
+    same string handed to an `AssistantBlock` by `^f` rendered properly, so
+    identical words changed shape the moment the user kept them.
+    """
+    panel = AsidePanel()
+    panel.display = True
+    panel._turns = [
+        AsideTurn(
+            question="how does it work?",
+            answer=(
+                "Call `run_turn()`, which is **not** re-entrant:\n"
+                "\n"
+                "- drains deltas\n"
+                "- flushes cards\n"
+            ),
+            state="done",
+        )
+    ]
+    body = "\n".join(panel.render_lines_for_test())
+
+    # The markup is gone...
+    assert "`run_turn()`" not in body
+    assert "**not**" not in body
+    assert "- drains deltas" not in body
+    # ...and what it MEANT is on the card.
+    assert "run_turn()" in body
+    assert "not" in body
+    assert "•" in body, "a list item renders as a bullet, as it does in the transcript"
+    assert "drains deltas" in body
+
+
+def test_the_question_is_never_markdown_rendered() -> None:
+    """The question is the user's own typed input echoed back.
+
+    `_question_rows` mirrors `UserBlock`'s spine deliberately, and running the
+    user's keystrokes through a markdown parser would eat the asterisks and
+    underscores out of a question that is ABOUT them — "what does **kwargs
+    mean" is a question this surface exists to be asked.
+    """
+    panel = AsidePanel()
+    panel.display = True
+    panel._turns = [
+        AsideTurn(question="what does **kwargs mean in `f(**kwargs)`?", answer="a.", state="done")
+    ]
+    body = "\n".join(panel.render_lines_for_test())
+
+    assert "**kwargs" in body
+    assert "`f(**kwargs)`" in body
+
+
+def test_an_error_is_shown_verbatim_rather_than_parsed() -> None:
+    """A provider's failure text is a diagnostic, not markup to interpret."""
+    panel = AsidePanel()
+    panel.display = True
+    generation = panel.ask("why?")
+    panel.fail_answer(generation, "no handler for `__call__` in **provider**")
+    body = "\n".join(panel.render_lines_for_test())
+
+    assert "`__call__`" in body
+    assert "**provider**" in body
+
+
+def test_the_rendered_rows_are_the_rows_the_card_is_pinned_to() -> None:
+    """Markdown changes how many rows an answer occupies, and the card is
+    sized to its CONTENT — so the count has to be the real, final one.
+
+    `_repaint` pins `styles.height` to the painted rows plus the gutter. A
+    renderer that returned rows the card did not paint (or vice versa) would
+    clip its own last line or reserve a row of empty overlay over the chat.
+    """
+    panel = AsidePanel()
+    panel.display = True
+    panel._turns = [
+        AsideTurn(
+            question="q?",
+            answer="intro:\n\n- one\n- two\n\nand a `tail`.\n",
+            state="done",
+        )
+    ]
+    rows = panel._compose_rows()
+
+    assert len(rows) == len(panel.render_lines_for_test())
+    # Every row is one painted line: a row carrying an embedded newline would
+    # make the height pin disagree with what lands on screen.
+    assert not any("\n" in row.plain for row in rows)
+
+
+def test_a_half_arrived_fence_never_swallows_the_prose_before_it() -> None:
+    """A dangling ``` or ** is a normal intermediate state while streaming.
+
+    The parser reads an unclosed fence as a code block running to the end of
+    the text, which restyles the tail — the transcript's own `AssistantBlock`
+    does exactly the same mid-stream. What must NOT happen is text going
+    missing: the sentence the user has already read stays on the card through
+    every intermediate state.
+    """
+    panel = AsidePanel()
+    panel.display = True
+    generation = panel.ask("how do I re-enter?")
+    answer = "Stop it first:\n\n```python\nloop.stop()\n```\n\nThen **re-enter** it.\n"
+
+    seen = ""
+    for index in range(0, len(answer), 4):
+        seen += answer[index : index + 4]
+        panel.append_answer(generation, answer[index : index + 4])
+        body = "\n".join(panel.render_lines_for_test())
+        if "Stop it first" in seen:
+            assert "Stop it first" in body, f"prose vanished at {seen!r}"
+
+    panel.settle_answer(generation, answer)
+    body = "\n".join(panel.render_lines_for_test())
+    assert "loop.stop()" in body
+    assert "Then re-enter it." in body
+    assert "```" not in body
+
+
+def test_a_settled_answer_is_not_re_rendered_on_every_delta() -> None:
+    """`_repaint` runs per streamed delta and repaints the WHOLE card.
+
+    Without a cache the turns ABOVE the streaming one are re-rendered from
+    text that cannot have changed, and the cost is linear in the exchange's
+    length: measured at a 120-column card, 0.75 ms per repaint with nothing
+    above it against 17.6 ms at 21 turns, past the 30 ms bar
+    `test_tui_responsiveness` holds the loop to. The cache is keyed on
+    `(text, width, theme epoch)` — the three inputs `flatten` bakes in.
+    """
+    panel = AsidePanel()
+    panel.display = True
+    panel._turns = [
+        AsideTurn(question=f"q{index}?", answer=f"answer `{index}`", state="done")
+        for index in range(4)
+    ]
+    panel.render_lines_for_test()
+    settled = dict(panel._answer_cache)
+    assert settled, "settled answers are cached"
+
+    # A delta on a NEW turn reuses every settled render rather than redoing it.
+    panel._turns.append(AsideTurn(question="q4?", answer="streaming"))
+    panel.render_lines_for_test()
+    assert all(panel._answer_cache.get(key) is rows for key, rows in settled.items())
+
+
+def test_the_cache_cannot_grow_without_bound_while_an_answer_streams() -> None:
+    """Keyed on the TEXT, so every delta mints a fresh key.
+
+    An insert-only cache would hold every prefix of every answer for as long
+    as the card is open. The paint drops whatever it did not touch, which
+    bounds it at the visible turns without needing a size policy.
+    """
+    panel = AsidePanel()
+    panel.display = True
+    panel._turns = [AsideTurn(question="q?")]
+    answer = "a sentence that arrives a few characters at a time, as they do.\n"
+
+    sizes = []
+    for index in range(0, len(answer), 4):
+        panel._turns[-1].answer += answer[index : index + 4]
+        panel.render_lines_for_test()
+        sizes.append(len(panel._answer_cache))
+
+    assert max(sizes) == 1, f"one live answer, one entry — saw {max(sizes)}"
+
+
+def test_dismissing_the_aside_drops_the_rendered_answers_too() -> None:
+    """ "No trace" covers the render cache, not just the turns.
+
+    `close()` has to clear it explicitly: `_repaint` returns early on a hidden
+    card, so the paint-scoped prune never runs to drop it.
+    """
+    panel = AsidePanel()
+    panel.display = True
+    panel._turns = [AsideTurn(question="q?", answer="an answer with `code`", state="done")]
+    panel.render_lines_for_test()
+    assert panel._answer_cache
+
+    panel.close()
+    assert panel._answer_cache == {}
+
+
+@pytest.mark.asyncio
+async def test_a_resize_refolds_the_answer_rather_than_reusing_the_old_width() -> None:
+    """`flatten` bakes the width in, so the cache key carries it.
+
+    A cache keyed on the text alone would paint the old fold at the new width
+    — rows either overflowing the card's column or stopping short of it — and
+    nothing about the card would say why. Driven through the real app because
+    the width comes from the composer's column, which only a laid-out screen
+    has.
+    """
+    session = AsideSession(
+        answer=(
+            "A sentence long enough to fold differently at sixty columns than at "
+            "a hundred and twenty, with `code` in it."
+        ),
+    )
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        panel = await _open_with_question(pilot, app, "how wide is this?")
+        wide = [key[1] for key in panel._answer_cache]
+        assert wide, "the settled answer is cached at the width it was folded at"
+
+        await pilot.resize_terminal(60, 24)
+        deadline = time.monotonic() + 5.0
+        while True:
+            await pilot.pause()
+            narrow = [key[1] for key in panel._answer_cache]
+            if narrow and narrow != wide:
+                break
+            assert time.monotonic() < deadline, f"the answer never refolded: {narrow} == {wide}"
+            await asyncio.sleep(RESIZE_REFIT_DELAY_S)
+
+        # And the rows it painted fit the card it was refolded for.
+        assert max(narrow) < max(wide)
+        rows = panel.render_lines_for_test()
+        assert max(len(row) for row in rows) <= panel.panel_width()
+
+
+def test_a_paint_renders_only_the_turns_the_card_can_show() -> None:
+    """The card sheds whole turns, so it must not RENDER what it sheds.
+
+    `_body` cuts the exchange to a budget of a couple of turns. The cut used to
+    read the lengths of a fully-built exchange, so every turn above it was
+    markdown-rendered and then discarded. Rendering is the expensive half —
+    measured at a 120x40 card over realistic answers, a cold paint cost 9.7 ms
+    at 10 turns and 117 ms at 120, against the 50 ms bar
+    `tests/unit/test_tui_responsiveness.py` calls a dropped frame (`STALL_MS`
+    records from 30 ms). The turn count is uncapped and the card paints on
+    every streamed delta, so the cost grew with an exchange the user could not
+    even see. `_visible_rows` now builds turns lazily, newest first, and stops
+    when one does not fit.
+
+    The warm cache does not make this test redundant, because the cache is not
+    what bounds the cost: the width is in the key, so a resize drag misses
+    every key at once and re-renders whatever the paint walks.
+
+    Pinned as a ratio rather than a millisecond count so the test says what is
+    wrong (work proportional to the whole exchange) rather than how fast this
+    machine is. The `+ 1` is the single turn the cut has to build in order to
+    measure it and find it does not fit — the one render the walk genuinely
+    cannot avoid. Anything above that is a turn rendered for nobody.
+    """
+    panel = AsidePanel()
+    panel.display = True
+    panel._turns = [
+        AsideTurn(question=f"question {index}?", answer=f"answer `{index}` here", state="done")
+        for index in range(50)
+    ]
+    rendered = panel.render_lines_for_test()
+    painted_questions = [row for row in rendered if row.startswith(QUESTION_MARK)]
+
+    assert len(panel._answer_cache) <= len(painted_questions) + 1, (
+        f"the paint rendered {len(panel._answer_cache)} answers to show "
+        f"{len(painted_questions)} — every turn above the cut is markdown-rendered "
+        "and then discarded by `_body`"
+    )


### PR DESCRIPTION
## Summary

The `/btw` aside card wrapped the model's answer as **plain text**, so markdown reached the user as literal source — `` `code` `` kept its backticks, `**bold**` kept its asterisks, a `- item` never became a bullet. It was the one surface showing assistant prose that did not render it.

`^F` made the divergence visible in one keystroke: fork hands the **same answer string** to an `AssistantBlock` (`app.py:15832`), where it renders properly. Identical words changed shape the moment the user kept them — while the module docstring already claimed a forked exchange "renders in the transcript exactly as it looked on the card". That claim is now true in both directions.

Patch bump territory: one widget, no config, no API surface.

## Before / after

Same input, same width (160×34), same seeded conversation behind the card. The only difference is this branch.

**Before — literal markdown on the card:**

<!-- SCREENSHOT 1: drag ~/Desktop/aside-before.png here -->

**After — rendered:**

<!-- SCREENSHOT 2: drag ~/Desktop/aside-after.png here -->

The rows a user actually reads, from `render_lines_for_test()`:

| | before | after |
|---|---|---|
| code span | `` `dashboard-credit-surface-enabled` `` | `dashboard-credit-surface-enabled`, code style |
| list item | `- the **balance widget** showing…` | ` • the balance widget showing…` |
| emphasis | `*fails closed*` | *fails closed* |

> Note on the frames: bold and code spans show slightly wide letter-spacing in the SVG export. That is Textual's SVG exporter mis-advancing bold font metrics, **not** this change — an untouched transcript `AssistantBlock` rendering the same markdown exports identically. Verified with a control capture before including these.

## The change

`_markdown_rows()` renders the answer through the **existing** `flatten(Markdown(...), width, console)` in `assistant.py` rather than a second renderer, so a code span, a bullet and a heading are one shape everywhere. Width is `_content_width() - len(ANSWER_INDENT)`: `flatten` bakes width in *and* pads each row to it, so rendering at the full card width and then indenting would push every row two cells past the card's own edge.

**The trailing pad is kept, deliberately.** Rich paints a fenced block's fill onto the pad, so cropping it leaves a ragged notch with `$lo-overlay` showing through at the end of every short line. On prose rows the pad carries no background and is invisible against the card fill. `TranscriptBlock.get_selection` already drops trailing pad on copy.

**The question and the error rows stay verbatim.** A question is the user's own keystrokes echoed back — "what does `**kwargs` mean" is a question this surface exists to be asked — and a provider's stack trace is not markup.

## The performance defect this went through two rounds for

The first implementation cached rendered rows on `(text, width, theme epoch)` and looked fine. **QA found the cache was masking a 15–27× repaint regression**: `_turn_groups()` rendered *every* turn before `_body()` cut down to the ones the card can show, and since width is in every cache key, one resize drag re-rendered the whole exchange.

Cold repaint median, 120×40, distinct realistic answers:

| turns | painted questions | answers rendered | first attempt | **this PR** | base `37289774` |
|---|---|---|---|---|---|
| 10 | 1 | 10 → **2** | 9.73 ms | **2.12 ms** | 1.07 ms |
| 40 | 1 | 40 → **2** | 37.54 ms | **2.10 ms** | 2.95 ms |
| 80 | 1 | 80 → **2** | 78.24 ms | **2.04 ms** | 5.94 ms |
| 120 | 1 | 120 → **2** | 117.51 ms | **1.99 ms** | 8.72 ms |

`STALL_MS = 30.0` in `test_tui_responsiveness.py` starts recording at 30 ms, and `_repaint` runs on **every streamed delta** — so at 80+ turns the first attempt was a stall felt while typing.

`_visible_rows()` now builds turns lazily, newest first, stopping at the first that does not fit. The result is **flat in turn count**, and below base HEAD from 40 turns up because base re-wrapped every turn as plain text on every paint. `_max_scroll_back()` was also calling `_turn_groups()` — a second full render per wheel event to read a length `len(self._turns)` already had.

*Rejected:* estimating a turn's height without building its rows. A markdown answer's row count is whatever `flatten` decides; a second estimator is the fold implemented twice and free to disagree with the one that paints, turning a wrong estimate into a silently wrong cut. That is a correctness risk traded for the single render the lazy walk already costs.

The guard is a test, not a benchmark: `test_a_paint_renders_only_the_turns_the_card_can_show` asserts a **ratio** (renders vs. visible turns), so it names the wrong thing rather than the machine's speed — per the timing-bounds section of `AGENTS.md`. Restoring the pre-fix module makes it fail with `the paint rendered 50 answers to show 5`.

## Testing evidence

**Gates — run over the whole tree, exactly as CI does, on the final commit:**

```
.venv/bin/python -m flake8 .                                    rc=0
uvx --from black==26.1.0 black --check .                        808 files unchanged
uvx isort==5.13.2 --check .                                     rc=0
.venv/bin/python -m pyright --pythonpath .venv/bin/python .     0 errors, 0 warnings
env -u NO_COLOR TERM=xterm-256color pytest tests/unit/tui -q    4428 passed, 12 skipped (387s)
```

**Mutation proof — reverting `_answer_rows` to the plain-wrap version fails 6 of 9 new tests:** `renders_as_markdown_not_as_its_own_source`, `half_arrived_fence`, `not_re_rendered_on_every_delta`, `cache_cannot_grow_without_bound`, `dismissing_drops_rendered_answers`, `resize_refolds`. The other three (`question_is_never_markdown_rendered`, `error_shown_verbatim`, `rendered_rows_are_the_rows_pinned_to`) pass against old code by design — they guard what must *not* change.

**Row-for-row equivalence of the new cut:** both implementations run in one process and diffed — **552 scenarios, 0 differences** in rows and `hidden_turns`. 6 sizes (120×40 → 30×10) × 4 answer shapes (short, card-overflowing, mixed `running`/`cancelled`/`error`, empty) × 8 turn counts × 5 scroll positions. That covers the turn-boundary cut, the `↑ N earlier questions · scroll` marker, scroll-back, and the pinned-question oversized-turn case.

**Independent QA against the running TUI** (not the diff) — all four acceptance criteria pass: rich rendering of heading/bold/italic/code/bullets/numbers/fences; the question verbatim (`what does **kwargs mean and why \`backticks\`?` renders with its asterisks); `^F` fork parity word-for-word with the transcript block; and `styles.height − painted rows == gutter` at every intermediate stream state across 120×40, 80×24, 60×30 and 40×20.

**Tried to break the rendering, no overflow found.** Asserted with `cell_len(row) > panel._content_width()`, never by eye: tables, 200-char identifiers, bare URLs, fence-only with and without a language tag, blockquotes, nested lists, `---` rules, CJK, emoji with ZWJ and skin-tone modifiers, backslash escapes, tabs, embedded ANSI escapes, and NUL/BEL control bytes — at 20/24/26/30/40/50/60/80/120 columns. A direct `flatten` sweep found table overflow only at widths 1–3, unreachable since `PANEL_MIN_WIDTH = 24` floors the content column at 22.

**Also verified:** resize during streaming invalidates the cache (widths went `{114} → {74}`, no stale fold); cached `Text` objects are never mutated in place across `running`/`cancelled`/`error`/`done` repaints; one-character deltas mid-fence never lose already-arrived prose; the cache stays at 2–3 entries at 30 turns, is cleared by `close()`, and a `dark`→`light` switch bumps the theme epoch and prunes the stale entry.

**Partial markdown while streaming:** an unclosed fence *does* restyle the tail as code, but never swallows it — and `AssistantBlock` behaves identically on the same input, so the card matches the transcript rather than introducing a divergence.

**Two existing fixtures changed** from `"line\n" * 12` to `"- line\n" * 12`, which deserves scrutiny since changing a fixture to make a test pass is how a regression hides. Twelve bare repetitions are **one paragraph** to a markdown parser, folding to a single row — so the tall-turn tests no longer had a tall turn. Measured: base + old text gave group sizes `[13,14,14,14,14,14]` against a 16-row budget with the marker present and `rendered[3] == "▌ question 5?"`; the old text under the new renderer collapses to `[2,3,3,3,3,3]` with no marker. The new fixture restores `[14,15,15,15,15,15]`, marker present, same assertions at the same strength.

## Known and deliberately not addressed

- **Raw HTML is swallowed** (`<div>raw html</div>` renders empty; `Use the <aside> block` loses the tag). Real, but **exact parity** with the transcript's `AssistantBlock` — a consequence of rendering markdown at all, not of this change. Worth a separate issue covering both surfaces.
- **Prose shed at very small cards** (40×20, two turns): identical on base HEAD. That is `_body()`'s tail-cut, unrelated to markdown.
- `test_tui_responsiveness.py` has **no aside-card site**, so nothing outside `test_aside.py` would have caught the stall above. Worth adding, outside this slice.

## Review notes

Two findings from review, both applied: `_answer_rows` had a dead `fg` parameter once markdown supplied its own colours, and `close()` cleared `_answer_cache` but not `_used_answers`, leaving a dismissed answer's text inside a stale key tuple — which a strict reading of the card's "leaves no trace" promise covers.

No new dependency. No import cycle (`assistant.py` holds no reference to `aside_panel`; `subagent_view.py` and `widgets/__init__.py` already import from `assistant`, so it is the established shared render layer). No images or screenshots added to the repo — the frames above are attached to this description only.
