### PR TITLE
fix(cli): bind `lop send` positionals against the selector flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ lop sessions
 lop send "release cutter" "gates are green, ready for review"
 lop send "release cutter" --wake "the deploy finished; verify prod"
 lop send "ingest refactor" --now "hold off, the schema changed"
+lop send --pid 12345 "gates are green, ready for review"   # address by exact pid
 git log -1 --stat | lop send "release cutter"      # body from stdin
 ```
 
@@ -438,8 +439,12 @@ is matched case-insensitively against the conversation name, then the session
 id, then the cwd basename. Only `live` sessions are eligible. When a substring
 matches several of them, `lop send` prints the candidates and exits non-zero
 asking you to disambiguate with `--pid` rather than delivering to the wrong
-session. A target that has gone `wedged` says so immediately instead of hanging
-on the dial.
+session. Address a session exactly one way: a `--pid`/`--session` selector
+already names the recipient, so a single positional beside one is the message,
+and a positional target passed *together* with a selector names two different
+sessions and is refused as an ambiguous recipient rather than silently
+delivering to the selector. A target that has gone `wedged` says so immediately
+instead of hanging on the dial.
 
 **Every delivery leaves a receipt.** A delivered message appears in the target's
 transcript as an inbound card reading `↔ peer message from "<conversation>"

--- a/README.md
+++ b/README.md
@@ -439,12 +439,16 @@ is matched case-insensitively against the conversation name, then the session
 id, then the cwd basename. Only `live` sessions are eligible. When a substring
 matches several of them, `lop send` prints the candidates and exits non-zero
 asking you to disambiguate with `--pid` rather than delivering to the wrong
-session. Address a session exactly one way: a `--pid`/`--session` selector
-already names the recipient, so a single positional beside one is the message,
-and a positional target passed *together* with a selector names two different
-sessions and is refused as an ambiguous recipient rather than silently
-delivering to the selector. A target that has gone `wedged` says so immediately
-instead of hanging on the dial.
+session — replacing the target with a `--pid`, not adding one to it. Address a
+session exactly one way: a `--pid`/`--session` selector already names the
+recipient, so a single positional beside one is the message, and a positional
+target passed *together* with a selector names two different sessions and is
+refused as an ambiguous recipient rather than silently delivering to the
+selector. The same rule applies to the body: with a selector, a typed positional
+*and* a piped stdin are two candidate messages and are refused rather than one
+silently winning, so a piped payload can never be discarded without you being
+told. A target that has gone `wedged` says so immediately instead of hanging on
+the dial.
 
 **Every delivery leaves a receipt.** A delivered message appears in the target's
 transcript as an inbound card reading `↔ peer message from "<conversation>"

--- a/docs/design/peer-send.md
+++ b/docs/design/peer-send.md
@@ -587,6 +587,67 @@ the body from stdin when `message` is omitted (`lop send mytarget < note.txt`),
 which is the ergonomic path for an agent piping a longer note. `--pid`/`--session`
 override the positional `target`.
 
+#### Revision: argument grammar
+
+**The "`--pid`/`--session` override the positional `target`" rule above shipped
+and was wrong.** It is recorded here rather than deleted because the sentence
+reads as obviously correct and is how this defect gets re-derived.
+
+Two optional positionals plus a selector flag is not a grammar argparse can
+resolve. argparse fills `target` first, always, so `lop send --pid N "hello"`
+bound `"hello"` to `target`, left `message` empty, and exited 1 with `no message
+given (pass it as an argument or pipe it on stdin)` — an error that is not
+merely unhelpful but **false**, since the user did pass it as an argument. That
+was the exact invocation this guide documented. Worse, the "override" behaviour
+made `lop send other-name "body" --pid N` deliver to pid N, exit 0, and read as
+though it addressed `other-name`: a wrong-recipient hazard, and with
+`--wake`/`--now` it had already interrupted the wrong session by the time the
+success line printed.
+
+The rule now:
+
+1. `--pid` and `--session` are mutually exclusive (an argparse
+   `add_mutually_exclusive_group`, which produces a better error than a
+   hand-written check).
+2. With a selector present: two positionals → **refused** as an ambiguous
+   recipient (exit 1, nothing resolved and nothing dialled); one positional →
+   it is the **message**; none → body from stdin.
+3. With no selector: first positional is the target, second is the message —
+   unchanged.
+4. A typed body argument wins over piped stdin.
+
+The rebinding lives in `cli._bind_send_positionals`, a pure namespace-in /
+tuple-out function, for the same reason `resolve_peer_target` is a core:
+argparse is the wrong place to express a rule that depends on which flags are
+present. The *conflict* half also lives in `mobile/peer_send.resolve_peer_target`
+so the `send` tool inherits it — a conflict rule that existed only in `cli.py`
+would falsify that module's claim to be the single source of truth.
+
+**Two alternatives look obviously right and are both wrong. Do not re-adopt
+them without re-running these probes.**
+
+- **`message` as `nargs="*"`, joined into a body.** A single `nargs="*"`
+  positional **cannot** absorb words that appear after an optional flag.
+  Measured: `["peer", "--wake", "act on this now"]` → `SystemExit(2)`,
+  `error: unrecognized arguments: act on this now`. That breaks
+  `lop send "<target>" --wake "…"` and `--now "…"`, three documented forms that
+  work today. Disqualifying on its own.
+- **`message` as `argparse.REMAINDER`.** Measured:
+  `["peer", "--wake", "act on this now"]` → `message=['--wake', 'act on this
+  now']`. `--wake` is swallowed **into the body**: the command parses, exits 0,
+  delivers — and the delivery mode silently degrades from wake to mailbox with
+  the flag text pasted into the message. A currently-working invocation starts
+  quietly doing the wrong thing, which is worse than the bug being fixed.
+
+`-m/--message` was also considered and rejected as the primary fix: it leaves
+the natural form (`lop send --pid N "hello"`) broken unless the user learns a
+second flag, and it fights every send-style Unix command (`mail`, `write`,
+`wall`, `notify-send`, `gh pr comment -b`) where the body is a positional.
+
+A dash-leading body beside a selector needs `--`
+(`lop send --pid N -- "--dashy"`). That is argparse's standard behaviour and
+deliberately not special-cased; a bespoke escape would be a second grammar.
+
 Dispatch in `main()` beside the others (`cli.py:2099`): `elif args.subcommand ==
 "send": return send_command(args)`.
 

--- a/docs/design/peer-send.md
+++ b/docs/design/peer-send.md
@@ -614,7 +614,56 @@ The rule now:
    it is the **message**; none → body from stdin.
 3. With no selector: first positional is the target, second is the message —
    unchanged.
-4. A typed body argument wins over piped stdin.
+4. With a selector, a typed positional **and** a piped stdin body are
+   **refused** as an ambiguous body. See below.
+5. An empty or whitespace positional target is **absence**, matching the shared
+   core's `(target or "").strip()`; an explicitly-passed but blank `--session`
+   is an error rather than a silent fall-back to substring matching.
+
+#### The stdin seam (review round 1, BLOCKER-1)
+
+The first cut of this rule read stdin *after* binding, and it lost payloads.
+`git log --stat | lop send alpha --pid 10` — the form the CLI's own ambiguity
+guidance leads a user to type — bound `alpha` to `message`, never looked at
+stdin, and delivered the literal string `alpha` at **exit 0** with a success
+line. That is strictly worse than the defect this revision fixes: the original
+was loud (exit 1, nothing sent), this was silent and destroyed the piped data.
+
+The cause is ordering. Rule 4 as originally drafted said stdin is read "only
+when no message positional survives rebinding", but the binder made one survive
+*before* it could know whether stdin held anything, so the rule could never
+fire. **The binder therefore takes the piped body as an INPUT** — a
+`stdin_body` parameter, keeping it pure and testable — rather than having the
+caller apply stdin as a fallback afterwards.
+
+Given both, the choice was to pick a winner or to refuse. **Refuse.** Two
+candidate bodies is the same "the command names two things" shape as two
+candidate recipients, and it gets the same answer for the same reason: whichever
+body loses is discarded silently, and a silently discarded payload is exactly
+the bug class this whole revision exists to remove. A loud error costs a retype.
+This deliberately supersedes proposal §8 case 10, which specified that the typed
+argument wins.
+
+**`isatty()` is not the discriminator.** It returns False for an empty redirect
+(`</dev/null`) exactly as it does for a pipe carrying data, so keying off it
+would turn every `lop send --pid N "hi" </dev/null` into an ambiguity error.
+Only actual bytes count as a piped body. stdin is also read only when at most
+one positional was typed, so `slow-producer | lop send NAME "body"` does not
+block on output that cannot change the outcome.
+
+#### The recovery seam (review round 1, BLOCKER-2)
+
+The ambiguity refusal made the *pre-existing* disambiguation guidance a dead
+end. `N sessions match; disambiguate with --pid:` invited the user to re-run
+with the flag appended — producing `NAME BODY --pid N`, the exact form now
+refused. The tool surface was worse, because its reader is a model making the
+minimal edit to its previous call: keep `target`, add `pid`.
+
+Both surfaces now say **replace**, not add: the CLI prints `replace the target
+with one of these:` plus a worked `lop send --pid N <body>` example, and the
+tool says `drop \`target\` and retry with pid=<n> instead (passing both is
+refused)`. Any refusal that a recovery path can walk a user into has to state
+the form that works, not merely the address that failed.
 
 The rebinding lives in `cli._bind_send_positionals`, a pure namespace-in /
 tuple-out function, for the same reason `resolve_peer_target` is a core:

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -38,6 +38,7 @@ import functools
 import math
 import os
 import platform
+import shlex
 import subprocess
 import sys
 import time
@@ -440,7 +441,7 @@ def build_cli_parser() -> argparse.ArgumentParser:
         nargs="?",
         help=(
             "conversation-name / session-id / cwd substring (case-insensitive). "
-            "Omit when addressing with --pid/--session."
+            "Omit when addressing with --pid/--session; passing both is refused."
         ),
     )
     send_parser.add_argument(
@@ -448,7 +449,8 @@ def build_cli_parser() -> argparse.ArgumentParser:
         nargs="?",
         help=(
             "message text; omit to read the body from stdin. With --pid/--session "
-            "a single positional IS the message."
+            "a single positional IS the message, and typing one while also piping "
+            "a body is refused."
         ),
     )
     # Mutually exclusive because they name DIFFERENT recipients: argparse rejects
@@ -1130,8 +1132,9 @@ def _peer_sender_identity() -> "dict[str, Any]":
 
 def _bind_send_positionals(
     args: argparse.Namespace,
+    stdin_body: "str | None" = None,
 ) -> "tuple[str | None, str | None, str]":
-    """Map ``lop send``'s parsed positionals onto ``(target, message, error)``.
+    """Map ``lop send``'s positionals and stdin onto ``(target, message, error)``.
 
     ``lop send`` accepts the recipient EITHER as a positional substring or as a
     ``--pid``/``--session`` selector, so argparse alone cannot decide what a
@@ -1140,43 +1143,96 @@ def _bind_send_positionals(
     "no message given" — the exact form guides/peer-messaging documented.
 
     A selector fully determines the recipient, so with one present a lone
-    positional has exactly one possible meaning: the body. With BOTH a
+    positional normally has exactly one possible meaning: the body. With BOTH a
     positional and a selector the command names two different recipients; the
     resolver would silently prefer the selector and deliver somewhere the
     command does not appear to name, so we refuse instead of guessing.
 
-    Kept as a pure function (namespace in, tuple out) for the same reason
-    ``resolve_peer_target`` is a core rather than parser logic: the rule is
-    testable without a parser, a socket, or a registry. Expressing it in
+    ``stdin_body`` is the piped body (``None`` when stdin is a tty or held no
+    bytes) and it is an INPUT to the binding, not a fallback applied afterwards.
+    It has to be: with a selector and one positional there are two readings —
+    the positional is the body (discarding the pipe), or the positional is a
+    target that conflicts with the selector (making the pipe the body). Deciding
+    without knowing whether a pipe carried data is what made
+    ``git log | lop send alpha --pid 10`` deliver the literal string ``alpha``
+    and silently drop the commit log, at exit 0. Two candidate bodies is the
+    same "the command names two things" shape as two candidate recipients, so it
+    gets the same answer: refuse, rather than discard one of them silently. A
+    loud error costs a retype; a silent winner costs the payload.
+
+    Note that stdin being a pipe is NOT the discriminator — ``isatty()`` is
+    False for an empty redirect (``</dev/null``) just as it is for a pipe
+    carrying data, so keying off it would break ``lop send --pid N "hi"
+    </dev/null``. Only actual bytes count as a piped body.
+
+    Blank-vs-absent follows the shared core exactly (``peer_send.py``): a target
+    that is empty or whitespace is ABSENCE, not a competing address, so
+    ``lop send '' BODY --pid 123`` delivers. A blank ``--session`` is instead an
+    error — the user explicitly asked to address by session id and supplied
+    nothing, and falling back to substring matching there would silently switch
+    grammars (``--session '' hello`` would start treating ``hello`` as a target).
+    ``--pid`` cannot be blank; argparse's ``type=int`` rejects it first.
+
+    Kept as a pure function (namespace + stdin in, tuple out) for the same
+    reason ``resolve_peer_target`` is a core rather than parser logic: the rule
+    is testable without a parser, a socket, or a registry. Expressing it in
     argparse itself was tried and rejected — ``nargs="*"`` cannot absorb words
     that follow an optional flag (``lop send peer --wake "act now"`` becomes
     "unrecognized arguments"), and ``argparse.REMAINDER`` swallows ``--wake``
     INTO the body, silently downgrading the delivery mode. See
     ``docs/design/peer-send.md`` §4.3.
     """
-    target, message = args.target, args.message
-    selector = (
-        f"--pid {args.pid}"
-        if args.pid is not None
-        else f"--session {args.session}" if args.session else ""
-    )
-    if not selector:
-        # No selector: today's grammar exactly — first positional is the target,
-        # second is the body.
-        return target, message, ""
+    # Blank/whitespace is absence, matching the core's `(target or "").strip()`.
+    # An explicitly typed '' is not an address, so it must not read as one.
+    target = args.target if (args.target or "").strip() else None
+    message = args.message
+    piped = stdin_body if (stdin_body or "").strip() else None
+
+    if args.session is not None and not args.session.strip():
+        return None, None, "empty --session (pass a session id, or drop the flag)"
+
+    if args.pid is not None:
+        selector, by = f"--pid {args.pid}", "pid"
+    elif args.session:
+        selector, by = f"--session {args.session}", "session id"
+    else:
+        # No selector: the historical grammar exactly — first positional is the
+        # target, second is the body, stdin fills an absent body.
+        return args.target, (message if message is not None else piped), ""
+
     if target is not None and message is not None:
-        by = "pid" if args.pid is not None else "session id"
         return (
             None,
             None,
             (
                 f"ambiguous recipient: {target!r} and {selector} name different "
-                f'sessions. Drop one — `lop send {selector} "{message}"` to address '
-                f'by {by}, or `lop send {target!r} "{message}"` to address by name'
+                f"sessions. Drop one — `lop send {selector} {shlex.quote(message)}` "
+                f"to address by {by}, or `lop send {shlex.quote(target)} "
+                f"{shlex.quote(message)}` to address by name"
             ),
         )
-    # One positional (or none) alongside a selector: it is the body.
-    return None, target, ""
+    # The sole surviving positional is the body, whichever slot argparse used:
+    # a blank target is absence, so `lop send '' BODY --pid N` leaves BODY in
+    # the `message` slot with nothing addressing anyone.
+    typed = message if message is not None else target
+    if typed is not None and piped is not None:
+        # Two candidate bodies: the positional and the pipe. Refusing rather
+        # than picking is the same answer two candidate RECIPIENTS get, and for
+        # the same reason — silently discarding one of them is how
+        # `git log | lop send alpha --pid 10` delivered the string 'alpha'.
+        return (
+            None,
+            None,
+            (
+                f"ambiguous body: {typed!r} and the piped input both look like the "
+                f"message. Drop one — `lop send {selector}` to send the piped input, "
+                f"or `lop send {selector} {shlex.quote(typed)}` with nothing piped "
+                f"to send {typed!r}"
+            ),
+        )
+    # One positional (or none) alongside a selector: it is the body. With no
+    # positional the piped input is, which is how the documented pipe form works.
+    return None, (typed if typed is not None else piped), ""
 
 
 def _resolve_peer_target(
@@ -1221,22 +1277,51 @@ def send_command(args: argparse.Namespace) -> int:
 
     The positionals are rebound BEFORE anything is resolved or dialled, because
     an ambiguous recipient must cost nothing: the refusal has to happen while
-    the command is still inert."""
+    the command is still inert. stdin is read up front for the same reason —
+    the binder cannot tell a lone positional's meaning without knowing whether a
+    pipe also carried a body, and reading it later meant the positional won and
+    the piped payload was discarded silently."""
     import asyncio
 
     from local_operator.mobile.peer_client import send_peer_message
     from local_operator.mobile.peer_send import candidate_lines, validate_peer_body
 
-    target, message, bind_error = _bind_send_positionals(args)
+    # stdin can only change the binding when at most ONE positional was typed:
+    # with both slots filled the outcome is already decided (a conflict when a
+    # selector is present, the typed body otherwise), so stdin is irrelevant.
+    # Restricting the read matters beyond efficiency — `slow | lop send NAME
+    # "body"` must not block waiting for a producer whose output is not used,
+    # and a tty read would block waiting for the user to type.
+    #
+    # Only real bytes count as a piped body: `isatty()` is False for an empty
+    # redirect (`</dev/null`) exactly as it is for a pipe carrying data, so it
+    # cannot distinguish "piped a body" from "stdin merely is not a terminal".
+    stdin_body = None
+    if args.message is None and not sys.stdin.isatty():
+        stdin_body = sys.stdin.read()
+
+    target, message, bind_error = _bind_send_positionals(args, stdin_body)
     if bind_error:
         _peer_red(bind_error)
         return 1
 
     record, candidates, error = _resolve_peer_target(args, target)
     if candidates:
-        print(f"{len(candidates)} sessions match; disambiguate with --pid:", file=sys.stderr)
+        # "REPLACE the target with", not "add --pid": appending the flag to the
+        # command the user just typed produces `NAME BODY --pid N`, which the
+        # ambiguity guard now refuses. The instruction has to describe the form
+        # that actually works, or it walks the user into a second error.
+        print(
+            f"{len(candidates)} sessions match; replace the target with one of these:",
+            file=sys.stderr,
+        )
         for line in candidate_lines(candidates, indent="  ", prefix="--pid"):
             print(line, file=sys.stderr)
+        if message is not None:
+            print(
+                f"  e.g. `lop send --pid {candidates[0].pid} {shlex.quote(message)}`",
+                file=sys.stderr,
+            )
         return 1
     if error or record is None:
         _peer_red(error or "no target resolved")
@@ -1261,15 +1346,12 @@ def send_command(args: argparse.Namespace) -> int:
         _peer_red("that target is this session; use the composer to message yourself")
         return 1
 
-    # Body: positional wins; otherwise read stdin (piped note).
-
-    if message is not None:
-        text = message
-    elif not sys.stdin.isatty():
-        text = sys.stdin.read()
-    else:
+    # The binder already resolved the body from the positionals and stdin
+    # together; nothing survives here means neither supplied one.
+    if message is None:
         _peer_red("no message given (pass it as an argument or pipe it on stdin)")
         return 1
+    text = message
     body_error = validate_peer_body(text)
     if body_error:
         _peer_red(body_error)

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1296,9 +1296,19 @@ def send_command(args: argparse.Namespace) -> int:
     # Only real bytes count as a piped body: `isatty()` is False for an empty
     # redirect (`</dev/null`) exactly as it is for a pipe carrying data, so it
     # cannot distinguish "piped a body" from "stdin merely is not a terminal".
+    # Decoded leniently off the BINARY stream rather than through `sys.stdin`'s
+    # strict UTF-8 text wrapper. Reading before resolution widened this from a
+    # delivery-path concern to every path: a `some-binary-producer | lop send …`
+    # (a gzip or an image piped by mistake) would raise UnicodeDecodeError out
+    # of send_command as a traceback, even when the target does not resolve and
+    # the bytes are never used. An uncaught traceback is never an acceptable
+    # user-visible failure here — the same U1 rule the delivery except-clause
+    # below follows. `errors="replace"` degrades a binary paste into the
+    # existing, well-worded `validate_peer_body` refusal instead of a new error.
     stdin_body = None
     if args.message is None and not sys.stdin.isatty():
-        stdin_body = sys.stdin.read()
+        raw = sys.stdin.buffer.read() if hasattr(sys.stdin, "buffer") else sys.stdin.read()
+        stdin_body = raw.decode("utf-8", "replace") if isinstance(raw, bytes) else raw
 
     target, message, bind_error = _bind_send_positionals(args, stdin_body)
     if bind_error:
@@ -1317,11 +1327,21 @@ def send_command(args: argparse.Namespace) -> int:
         )
         for line in candidate_lines(candidates, indent="  ", prefix="--pid"):
             print(line, file=sys.stderr)
-        if message is not None:
-            print(
-                f"  e.g. `lop send --pid {candidates[0].pid} {shlex.quote(message)}`",
-                file=sys.stderr,
-            )
+        # The worked example must not echo the body back. For a PIPED body the
+        # right recovery is to re-pipe, not to paste — printing it would dump up
+        # to the whole 256 KB cap onto stderr and tell the user to retype what
+        # they piped. A long typed body is elided for the same reason: the line
+        # exists to show the SHAPE of the working command, not to reproduce the
+        # message the user still has one line up.
+        if stdin_body is not None:
+            example = "<your piped input> | lop send --pid " + str(candidates[0].pid)
+        elif message is not None:
+            body = message if len(message) <= 60 else message[:57] + "..."
+            example = f"lop send --pid {candidates[0].pid} {shlex.quote(body)}"
+        else:
+            example = ""
+        if example:
+            print(f"  e.g. `{example}`", file=sys.stderr)
         return 1
     if error or record is None:
         _peer_red(error or "no target resolved")

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1303,8 +1303,18 @@ def send_command(args: argparse.Namespace) -> int:
     # of send_command as a traceback, even when the target does not resolve and
     # the bytes are never used. An uncaught traceback is never an acceptable
     # user-visible failure here — the same U1 rule the delivery except-clause
-    # below follows. `errors="replace"` degrades a binary paste into the
-    # existing, well-worded `validate_peer_body` refusal instead of a new error.
+    # below follows.
+    #
+    # `errors="replace"` DELIVERS undecodable input as U+FFFD replacement
+    # characters; it does not refuse it. `validate_peer_body` rejects only an
+    # empty or over-cap body, and mojibake is neither, so mis-piping a gzip
+    # sends the peer a screenful of "�" at rc=0. That is deliberate: this is a
+    # text-messaging command, the sender sees the recipient in the success line,
+    # and no payload is lost or misdirected. Refusing on undecodable bytes
+    # instead would mean inventing a new error class here and deciding what
+    # fraction of replacements is "too much" — a guess, on a path where the
+    # user can simply look at what they piped. The prior behaviour on this path
+    # was a crash, so degraded text is strictly better.
     stdin_body = None
     if args.message is None and not sys.stdin.isatty():
         raw = sys.stdin.buffer.read() if hasattr(sys.stdin, "buffer") else sys.stdin.read()
@@ -1336,8 +1346,16 @@ def send_command(args: argparse.Namespace) -> int:
         if stdin_body is not None:
             example = "<your piped input> | lop send --pid " + str(candidates[0].pid)
         elif message is not None:
-            body = message if len(message) <= 60 else message[:57] + "..."
-            example = f"lop send --pid {candidates[0].pid} {shlex.quote(body)}"
+            # A short body is reproduced verbatim so the line pastes and works,
+            # which is what BLOCKER-2 asked for. A long one becomes a
+            # PLACEHOLDER rather than a truncation: pasting `…LLL...` would
+            # silently deliver a 60-character stub ending in an ellipsis, which
+            # is the copy-paste trap the piped branch above already avoids.
+            example = (
+                f"lop send --pid {candidates[0].pid} {shlex.quote(message)}"
+                if len(message) <= 60
+                else f"lop send --pid {candidates[0].pid} '<your message>'"
+            )
         else:
             example = ""
         if example:

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -438,15 +438,26 @@ def build_cli_parser() -> argparse.ArgumentParser:
     send_parser.add_argument(
         "target",
         nargs="?",
-        help="conversation-name / session-id / cwd substring (case-insensitive)",
+        help=(
+            "conversation-name / session-id / cwd substring (case-insensitive). "
+            "Omit when addressing with --pid/--session."
+        ),
     )
     send_parser.add_argument(
         "message",
         nargs="?",
-        help="message text; omit to read the body from stdin",
+        help=(
+            "message text; omit to read the body from stdin. With --pid/--session "
+            "a single positional IS the message."
+        ),
     )
-    send_parser.add_argument("--pid", type=int, help="target by exact pid")
-    send_parser.add_argument("--session", dest="session", help="target by exact session id")
+    # Mutually exclusive because they name DIFFERENT recipients: argparse rejects
+    # the pair natively ("argument --session: not allowed with argument --pid"),
+    # which is a better error than anything hand-written here, and it removes a
+    # whole branch from _bind_send_positionals below.
+    send_selector = send_parser.add_mutually_exclusive_group()
+    send_selector.add_argument("--pid", type=int, help="target by exact pid")
+    send_selector.add_argument("--session", dest="session", help="target by exact session id")
     send_parser.add_argument(
         "--now",
         "--steer",
@@ -1117,8 +1128,60 @@ def _peer_sender_identity() -> "dict[str, Any]":
     return peer_sender_identity(os.getppid())
 
 
+def _bind_send_positionals(
+    args: argparse.Namespace,
+) -> "tuple[str | None, str | None, str]":
+    """Map ``lop send``'s parsed positionals onto ``(target, message, error)``.
+
+    ``lop send`` accepts the recipient EITHER as a positional substring or as a
+    ``--pid``/``--session`` selector, so argparse alone cannot decide what a
+    single positional means: it always fills ``target`` first, which made
+    ``lop send --pid N "hello"`` bind "hello" to the TARGET and then fail with
+    "no message given" — the exact form guides/peer-messaging documented.
+
+    A selector fully determines the recipient, so with one present a lone
+    positional has exactly one possible meaning: the body. With BOTH a
+    positional and a selector the command names two different recipients; the
+    resolver would silently prefer the selector and deliver somewhere the
+    command does not appear to name, so we refuse instead of guessing.
+
+    Kept as a pure function (namespace in, tuple out) for the same reason
+    ``resolve_peer_target`` is a core rather than parser logic: the rule is
+    testable without a parser, a socket, or a registry. Expressing it in
+    argparse itself was tried and rejected — ``nargs="*"`` cannot absorb words
+    that follow an optional flag (``lop send peer --wake "act now"`` becomes
+    "unrecognized arguments"), and ``argparse.REMAINDER`` swallows ``--wake``
+    INTO the body, silently downgrading the delivery mode. See
+    ``docs/design/peer-send.md`` §4.3.
+    """
+    target, message = args.target, args.message
+    selector = (
+        f"--pid {args.pid}"
+        if args.pid is not None
+        else f"--session {args.session}" if args.session else ""
+    )
+    if not selector:
+        # No selector: today's grammar exactly — first positional is the target,
+        # second is the body.
+        return target, message, ""
+    if target is not None and message is not None:
+        by = "pid" if args.pid is not None else "session id"
+        return (
+            None,
+            None,
+            (
+                f"ambiguous recipient: {target!r} and {selector} name different "
+                f'sessions. Drop one — `lop send {selector} "{message}"` to address '
+                f'by {by}, or `lop send {target!r} "{message}"` to address by name'
+            ),
+        )
+    # One positional (or none) alongside a selector: it is the body.
+    return None, target, ""
+
+
 def _resolve_peer_target(
     args: argparse.Namespace,
+    target: "str | None",
 ) -> "tuple[Any | None, list[Any], str]":
     """Resolve a ``lop send`` target to one live SessionRecord.
 
@@ -1127,13 +1190,20 @@ def _resolve_peer_target(
     mapped onto the core's keyword arguments. The resolution rules themselves —
     pid, then session id, then case-insensitive substring; only ``live`` records;
     candidates returned on ambiguity — live in the core so the in-session
-    ``send`` tool resolves targets identically."""
+    ``send`` tool resolves targets identically.
+
+    ``target`` is passed explicitly rather than read off the namespace because
+    ``_bind_send_positionals`` has already decided whether the positional was a
+    target or the message body; ``args.target`` is the RAW parse and using it
+    here would re-introduce the binding bug one layer down. It is required
+    rather than defaulted for that reason: a caller that forgets it should fail
+    loudly, not silently resolve as though no target was given."""
     from local_operator.mobile.peer_send import resolve_peer_target
 
     # The flag grammar is passed in so the CLI's user-visible error keeps saying
     # `--pid` / `--session`, exactly as it did before the extraction.
     return resolve_peer_target(
-        target=args.target,
+        target=target,
         pid=args.pid,
         session=args.session,
         pid_hint="--pid",
@@ -1147,13 +1217,22 @@ def send_command(args: argparse.Namespace) -> int:
     Delivery mode maps from the flags: ``--now``/``--steer`` => steer (inject
     mid-turn), otherwise mailbox; ``--wake`` drives a turn if the mailbox
     target is idle. The body comes from the positional argument or, when
-    omitted, stdin (the ergonomic path for piping a longer note)."""
+    omitted, stdin (the ergonomic path for piping a longer note).
+
+    The positionals are rebound BEFORE anything is resolved or dialled, because
+    an ambiguous recipient must cost nothing: the refusal has to happen while
+    the command is still inert."""
     import asyncio
 
     from local_operator.mobile.peer_client import send_peer_message
     from local_operator.mobile.peer_send import candidate_lines, validate_peer_body
 
-    record, candidates, error = _resolve_peer_target(args)
+    target, message, bind_error = _bind_send_positionals(args)
+    if bind_error:
+        _peer_red(bind_error)
+        return 1
+
+    record, candidates, error = _resolve_peer_target(args, target)
     if candidates:
         print(f"{len(candidates)} sessions match; disambiguate with --pid:", file=sys.stderr)
         for line in candidate_lines(candidates, indent="  ", prefix="--pid"):
@@ -1184,8 +1263,8 @@ def send_command(args: argparse.Namespace) -> int:
 
     # Body: positional wins; otherwise read stdin (piped note).
 
-    if args.message is not None:
-        text = args.message
+    if message is not None:
+        text = message
     elif not sys.stdin.isatty():
         text = sys.stdin.read()
     else:

--- a/local_operator/guides/peer-messaging/GUIDE.md
+++ b/local_operator/guides/peer-messaging/GUIDE.md
@@ -230,12 +230,18 @@ silently and deliver to a session the command does not appear to name:
 ```
 $ lop send "release cutter" "gates are green" --pid 12345
 ambiguous recipient: 'release cutter' and --pid 12345 name different sessions.
-Drop one — `lop send --pid 12345 "gates are green"` to address by pid, or
-`lop send 'release cutter' "gates are green"` to address by name
+Drop one — `lop send --pid 12345 'gates are green'` to address by pid, or
+`lop send 'release cutter' 'gates are green'` to address by name
 ```
 
 Nothing is delivered there and the exit status is 1. `--pid` and `--session`
-are mutually exclusive too; argparse rejects that pair at parse time.
+are mutually exclusive too; argparse rejects that pair at parse time. When a
+substring matches several sessions, `lop send` lists them and asks you to
+**replace** the target with a `--pid` — appending the flag to the command you
+just typed produces exactly the refused form above.
+
+A blank selector (`--session ''`) is an error rather than a silent fallback to
+substring matching; drop the flag if you meant to address by name.
 
 **Pipe the body when it is long** or when it comes out of another command — not
 because the argument form does not work. Both forms are fully supported:
@@ -245,7 +251,20 @@ echo "the deploy finished; verify prod" | lop send --pid 12345 --wake
 git log -1 --stat | lop send "release cutter"
 ```
 
-A typed body argument wins over piped stdin when both are present.
+**Do not pipe a body and type one at the same time.** With a selector, a
+positional and a piped body are two candidate messages, so `lop send` refuses
+rather than picking a winner — silently discarding the payload you did not get
+is worse than a retype:
+
+```
+$ git log -1 --stat | lop send "release cutter" --pid 12345
+ambiguous body: 'release cutter' and the piped input both look like the message.
+Drop one — `lop send --pid 12345` to send the piped input, or
+`lop send --pid 12345 'release cutter'` with nothing piped to send 'release cutter'
+```
+
+Without a selector both positional slots are filled, so `lop send NAME "body"`
+with a pipe is unambiguous and the typed body wins.
 
 ### What the human sees
 

--- a/local_operator/guides/peer-messaging/GUIDE.md
+++ b/local_operator/guides/peer-messaging/GUIDE.md
@@ -213,31 +213,39 @@ sessions, `lop send` prints the candidates and exits non-zero asking you to
 disambiguate with `--pid`. If the only match is `wedged`, it says so rather
 than hanging on a dial.
 
-**With `--pid` or `--session`, pipe the body — a lone positional is read as the
-target, not the message.** `send` declares `target` and `message` as two
-optional positionals, so a *single* positional alongside `--pid`/`--session`
-binds to `target`, leaving `message` empty; the command then looks for a body
-on stdin, finds a terminal, and exits 1 with `no message given`. Nothing is
-delivered. Piping the body is the clean form:
+**Address the session exactly one way.** A `--pid`/`--session` selector already
+names the recipient, so a positional alongside one is the MESSAGE, not a second
+address:
 
 ```
-echo "the deploy finished; verify prod" | lop send --pid 12345 --wake   # works
-echo "gates are green" | lop send --session 7c44b23dc86f                # works
-lop send --pid 12345 --wake "the deploy finished; verify prod"          # exits 1
+lop send --pid 12345 "the deploy finished; verify prod"          # body
+lop send --pid 12345 --wake "the deploy finished; verify prod"   # body
+lop send "release cutter" "the deploy finished; verify prod"     # target + body
 ```
 
-A *second* positional does fill `message`, so a placeholder target delivers —
-the selector wins, because the resolver checks `--pid`/`--session` before it
-ever looks at `target`:
+Passing a positional *target* **and** a selector names two different sessions,
+so it is refused rather than resolved — the selector would otherwise win
+silently and deliver to a session the command does not appear to name:
 
 ```
-lop send ignored "the deploy finished; verify prod" --pid 12345         # works
+$ lop send "release cutter" "gates are green" --pid 12345
+ambiguous recipient: 'release cutter' and --pid 12345 name different sessions.
+Drop one — `lop send --pid 12345 "gates are green"` to address by pid, or
+`lop send 'release cutter' "gates are green"` to address by name
 ```
 
-That works, but it reads as though it addresses `ignored`; prefer the piped
-form. The plain positional form (`lop send "<target>" "message"`) is unaffected
-— both positionals are filled, so it stays the form to reach for at a
-terminal.
+Nothing is delivered there and the exit status is 1. `--pid` and `--session`
+are mutually exclusive too; argparse rejects that pair at parse time.
+
+**Pipe the body when it is long** or when it comes out of another command — not
+because the argument form does not work. Both forms are fully supported:
+
+```
+echo "the deploy finished; verify prod" | lop send --pid 12345 --wake
+git log -1 --stat | lop send "release cutter"
+```
+
+A typed body argument wins over piped stdin when both are present.
 
 ### What the human sees
 
@@ -258,9 +266,12 @@ lop send "peer-send design" "gates are green, ready for review"
 # Wake an idle session to act now
 lop send "release cutter" --wake "the deploy finished; verify prod"
 
-# Wake an idle session addressed by exact pid — body on stdin, per the
-# grammar note above
-echo "the deploy finished; verify prod" | lop send --pid 12345 --wake
+# Wake an idle session addressed by exact pid — with a selector, the single
+# positional IS the body
+lop send --pid 12345 --wake "the deploy finished; verify prod"
+
+# Refused: a positional target AND a selector name two different sessions
+lop send "release cutter" "gates are green" --pid 12345   # exit 1, nothing sent
 
 # Redirect a session mid-turn
 lop send "ingest refactor" --now "hold off — the schema changed"

--- a/local_operator/mobile/peer_send.py
+++ b/local_operator/mobile/peer_send.py
@@ -49,11 +49,43 @@ def resolve_peer_target(
     session_id, then the cwd basename. Only ``live`` records are eligible (a
     ``wedged`` owner will not service the socket promptly; ``stale`` is dead).
 
+    A selector (``pid``/``session``) alongside a ``target`` substring is REFUSED
+    rather than resolved. The two name different sessions, and the precedence
+    above would silently prefer the selector — delivering to a session the call
+    does not appear to name, and reporting success. That is a wrong-recipient
+    hazard, not an ergonomic wart, so it lives here in the shared core: a
+    conflict rule that existed only in ``cli.py`` would falsify this module's
+    claim to be the single source of truth and leave the ``send`` tool teaching
+    a different rule from the command.
+
     Returns ``(record, candidates, error)``: exactly one of ``record`` or
     ``error`` is meaningful; ``candidates`` is populated on an ambiguous substring
     so the caller can list them for disambiguation. The shape is identical for the
     CLI and the tool — only how each SURFACES the outcome differs.
+
+    The conflict wording uses the caller's own ``pid_hint``/``session_hint``
+    grammar for the same reason the "no target given" line does. The CLI never
+    reaches these branches in practice — ``cli._bind_send_positionals`` refuses
+    first, with a richer message that prints two retypeable command lines, and
+    argparse's mutually-exclusive group rejects pid+session at parse time — so
+    these are the tool's phrasing. Keeping them here anyway is the point: the
+    rule holds for ANY caller, including one added later that has no parser in
+    front of it.
     """
+    # Before any scan: a conflicting address is refused while the call is still
+    # inert, so no registry read and no dial can happen on an ambiguous request.
+    if pid is not None and session:
+        return None, [], f"pass either {pid_hint} or {session_hint}, not both"
+    if (pid is not None or session) and (target or "").strip():
+        return (
+            None,
+            [],
+            (
+                "pass either a target substring or an exact pid/session, not both — "
+                "they name different sessions"
+            ),
+        )
+
     scanned = registry.scan(config_dir())
     live = [(rec, state) for rec, state in scanned if state == "live"]
 

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -4636,11 +4636,20 @@ class SendParams(BaseModel):
         default=None,
         description=(
             "Peer to message: case-insensitive substring of the conversation name, "
-            "session id, or cwd basename (`lop sessions` lists what is running)."
+            "session id, or cwd basename (`lop sessions` lists what is running). "
+            "ALTERNATIVE to pid/session, not a companion — pass exactly one way of "
+            "addressing the peer; target together with pid or session is refused as "
+            "an ambiguous recipient."
         ),
     )
-    pid: int | None = Field(default=None, description="Exact pid of the peer session.")
-    session: str | None = Field(default=None, description="Exact session id of the peer.")
+    pid: int | None = Field(
+        default=None,
+        description=("Exact pid of the peer session. Use INSTEAD of target, never alongside it."),
+    )
+    session: str | None = Field(
+        default=None,
+        description=("Exact session id of the peer. Use INSTEAD of target, never alongside it."),
+    )
     message: str = Field(
         min_length=1,
         description="The message body; it lands in the peer's transcript as an inbound card.",
@@ -4733,9 +4742,11 @@ def build_send_tool(context: ToolContext) -> AgentTool | None:
         describe_approval=_describe_send_approval,
         description=(
             "Hand a message to another local lop session on this machine (no cmux). "
-            "Address the peer by `target` (name/cwd substring), `pid` (exact), or "
-            "`session` (exact session id); `lop sessions` lists what is running. By "
-            "default the message lands in the peer's mailbox AND wakes the peer if it "
+            "Address the peer by EXACTLY ONE of `target` (name/cwd substring), `pid` "
+            "(exact), or `session` (exact session id) — they are alternatives, and "
+            "passing a `target` together with a `pid`/`session` is refused as an "
+            "ambiguous recipient rather than resolved. `lop sessions` lists what is "
+            "running. By default the message lands in the peer's mailbox AND wakes the peer if it "
             "is idle, so an idle peer responds right away; `wake=False` is the quiet "
             "mailbox drop (read on the peer's next turn), and `now=True` steers "
             "mid-turn (opens a turn if the peer is idle). The result says how the "

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -4815,7 +4815,15 @@ async def execute_send(
         # ``pid=<n>`` rather than ``pid <n>``: the reader is a model that has to
         # turn this line into an argument, so the line is written in the
         # parameter syntax it will copy (review round 1, MINOR-1).
-        lines = [f"{len(candidates)} sessions match; retry with pid=<n>:"]
+        #
+        # "DROP `target` and retry with" rather than "retry with": the minimal
+        # edit a model makes to its previous call is to keep `target` and add
+        # `pid`, and that pair is now refused as an ambiguous recipient. The
+        # instruction must name the removal explicitly or it teaches the error.
+        lines = [
+            f"{len(candidates)} sessions match; drop `target` and retry with pid=<n> "
+            f"instead (passing both is refused):"
+        ]
         lines.extend(candidate_lines(candidates, indent="  ", prefix="pid="))
         return _error(tool_call_id, "send", "\n".join(lines))
     if error or record is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.41"
+version = "0.44.42"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/mobile/test_peer_send.py
+++ b/tests/unit/mobile/test_peer_send.py
@@ -52,13 +52,85 @@ def fake_scan(monkeypatch):
     return install
 
 
-def test_pid_wins_over_everything(fake_scan) -> None:
+def test_pid_with_a_target_substring_is_refused_as_ambiguous(fake_scan) -> None:
+    """A selector AND a substring name two different sessions, so the resolver
+    refuses instead of applying precedence.
+
+    This used to assert the opposite ("pid wins over everything"), which is the
+    behaviour that made `lop send other-name "body" --pid N` deliver to pid N
+    and report success while reading as though it addressed other-name. The
+    precedence is fine when only one address is given; silently picking a winner
+    between two is the wrong-recipient hazard. See docs/design/peer-send.md
+    §4.3.
+    """
     a = _Record(10, conversation_name="alpha")
     b = _Record(20, conversation_name="beta")
     fake_scan([(a, "live"), (b, "live")])
     record, candidates, error = peer_send.resolve_peer_target(pid=20, target="alpha")
+    assert record is None
+    assert candidates == []
+    assert "not both" in error
+
+
+def test_session_with_a_target_substring_is_refused_as_ambiguous(fake_scan) -> None:
+    a = _Record(10, conversation_name="alpha", session_id="exact-id")
+    fake_scan([(a, "live")])
+    record, _c, error = peer_send.resolve_peer_target(session="exact-id", target="alpha")
+    assert record is None
+    assert "not both" in error
+
+
+def test_pid_and_session_together_is_refused(fake_scan) -> None:
+    """The CLI can never reach this (argparse's mutually-exclusive group rejects
+    the pair at parse time), but the tool has no parser in front of it."""
+    a = _Record(10, session_id="exact-id")
+    fake_scan([(a, "live")])
+    record, _c, error = peer_send.resolve_peer_target(pid=10, session="exact-id")
+    assert record is None
+    assert "not both" in error
+
+
+def test_conflict_error_uses_the_callers_own_grammar(fake_scan) -> None:
+    """The CLI's hints must survive into the pid+session wording, the same way
+    they already do for "no target given"."""
+    fake_scan([])
+    _r, _c, error = peer_send.resolve_peer_target(
+        pid=10, session="exact-id", pid_hint="--pid", session_hint="--session"
+    )
+    assert error == "pass either --pid or --session, not both"
+
+
+def test_a_conflict_is_refused_before_the_registry_is_scanned(monkeypatch) -> None:
+    """The refusal has to be free: nothing resolved, nothing read, nothing
+    dialled on an ambiguously addressed call."""
+
+    def _boom(*_a, **_k):
+        raise AssertionError("registry must not be scanned on a conflicting address")
+
+    monkeypatch.setattr(peer_send.registry, "scan", _boom)
+    record, _c, error = peer_send.resolve_peer_target(pid=20, target="alpha")
+    assert record is None
+    assert "not both" in error
+
+
+def test_pid_still_resolves_when_it_is_the_only_address(fake_scan) -> None:
+    """The precedence path itself is untouched for a single-address call."""
+    a = _Record(10, conversation_name="alpha")
+    b = _Record(20, conversation_name="beta")
+    fake_scan([(a, "live"), (b, "live")])
+    record, candidates, error = peer_send.resolve_peer_target(pid=20)
     assert record is b
     assert candidates == []
+    assert error == ""
+
+
+def test_a_blank_target_beside_a_selector_is_not_a_conflict(fake_scan) -> None:
+    """An empty/whitespace target is absence, not a competing address — the tool
+    may pass target="" rather than omitting the field."""
+    b = _Record(20, conversation_name="beta")
+    fake_scan([(b, "live")])
+    record, _c, error = peer_send.resolve_peer_target(pid=20, target="   ")
+    assert record is b
     assert error == ""
 
 

--- a/tests/unit/test_cli_send.py
+++ b/tests/unit/test_cli_send.py
@@ -437,10 +437,18 @@ def test_a_non_utf8_pipe_is_a_clean_error_not_a_traceback(monkeypatch) -> None:
     assert red.call_args[0][0] == "no session found with pid 777777"
 
 
-def test_a_non_utf8_pipe_degrades_into_the_existing_body_refusal(monkeypatch) -> None:
-    """A binary body that DOES reach validation becomes the shared core's
-    existing, well-worded refusal rather than a new error class: undecodable
-    bytes replace to U+FFFD, which is a non-empty body under the cap."""
+def test_a_non_utf8_pipe_is_delivered_as_replacement_characters(monkeypatch) -> None:
+    """A binary body that reaches delivery is SENT as U+FFFD mojibake, not
+    refused (QA round 3, Q6).
+
+    ``validate_peer_body`` rejects only an empty or over-cap body, and
+    replacement characters are neither, so this path ends at rc=0 with degraded
+    text. Pinned explicitly because it is easy to assume the lenient decode
+    "falls through to a refusal" — it does not, and the earlier name and comment
+    here claimed exactly that. The prior behaviour was an uncaught traceback, so
+    delivering degraded text is the improvement; refusing would require
+    inventing a threshold for how much mojibake is too much.
+    """
     monkeypatch.setattr("sys.stdin", _BinaryStdin(b"\xa8\x8d\xff\xfe"))
     args = _parse_send(["--pid", "123"])
     record = _Record(os.getppid() + 9999)
@@ -478,16 +486,25 @@ def test_the_worked_example_never_echoes_a_piped_payload(monkeypatch, capsys) ->
     assert len(err) < 500
 
 
-def test_a_long_typed_body_is_elided_in_the_worked_example(monkeypatch, capsys) -> None:
-    """Same reason as the piped case: the line exists to show the SHAPE of the
-    command, and the user still has their own body one line up."""
+def test_a_long_typed_body_becomes_a_placeholder_not_a_truncation(monkeypatch, capsys) -> None:
+    """QA round 3, Q7.
+
+    A long body is replaced by ``'<your message>'``, not truncated. The line
+    exists to show the SHAPE of the command and the user still has their own
+    body one line up — but a truncation would PASTE AND RUN, silently
+    delivering a 60-character stub ending in "...". A placeholder cannot be
+    mistaken for a runnable command, which is the same reason the piped branch
+    prints ``<your piped input>``.
+    """
     monkeypatch.setattr("sys.stdin", _FakeTtyStdin())
     args = _parse_send(["alpha", "y" * 400])
     with patch("local_operator.cli._resolve_peer_target", return_value=(None, [_Record(10)], "")):
         send_command(args)
     err = capsys.readouterr().err
     assert "y" * 400 not in err
-    assert "..." in err
+    assert "'<your message>'" in err
+    # No truncated stub that could be pasted and delivered verbatim.
+    assert "yyy" not in err
 
 
 def test_a_short_typed_body_is_still_shown_in_full(monkeypatch, capsys) -> None:

--- a/tests/unit/test_cli_send.py
+++ b/tests/unit/test_cli_send.py
@@ -1,4 +1,13 @@
-"""The ``lop send`` self-send guard (U2).
+"""``lop send`` argument grammar and the self-send guard (U2).
+
+The first half of this file pins the ARGUMENT GRAMMAR: which positional means
+what once a ``--pid``/``--session`` selector is present. It is a regression
+guard for a shipped defect where ``lop send --pid N "hello"`` bound "hello" to
+``target``, left ``message`` empty and exited 1 with "no message given" — while
+``lop send other "body" --pid N`` delivered to pid N and reported success, a
+wrong-recipient hazard. See ``docs/design/peer-send.md`` §4.3.
+
+The second half pins the self-send guard.
 
 ``lop send`` is usually a child of the launching ``lop`` TUI, but not always:
 run from an agent's bash tool or through a shell wrapper it is a grandchild or
@@ -14,10 +23,13 @@ different pid.
 from __future__ import annotations
 
 import argparse
+import io
 import os
 from unittest.mock import patch
 
-from local_operator.cli import send_command
+import pytest
+
+from local_operator.cli import _bind_send_positionals, build_cli_parser, send_command
 
 
 def _send_args(**overrides) -> argparse.Namespace:
@@ -44,6 +56,201 @@ class _Record:
         self.cwd = "/tmp"
         self.control_port = 1
         self.control_key = "k"
+
+
+class _FakeTtyStdin:
+    """A stdin that claims to be a terminal.
+
+    The "no message given" path is only reachable when stdin is a TTY, and the
+    test runner's stdin is not one — so the interactive case has to be modelled
+    rather than inherited, otherwise the test silently exercises the pipe path.
+    """
+
+    def isatty(self) -> bool:
+        return True
+
+    def read(self) -> str:  # pragma: no cover - reaching this is the bug
+        raise AssertionError("stdin must not be read when it is a tty")
+
+
+def _parse_send(argv: "list[str]") -> argparse.Namespace:
+    """Parse a real ``lop send`` command line through the production parser.
+
+    The grammar cases go through ``build_cli_parser`` rather than a synthetic
+    Namespace on purpose: the defect lived in how argparse SLOTTED the
+    positionals, so a hand-built namespace would assert the fix while skipping
+    the thing that was broken.
+    """
+    return build_cli_parser().parse_args(["send"] + argv)
+
+
+def _bind(argv: "list[str]") -> "tuple[str | None, str | None, str]":
+    return _bind_send_positionals(_parse_send(argv))
+
+
+# --- Case 1-3: a selector present means a lone positional is the BODY ---
+
+
+def test_pid_with_one_positional_binds_it_as_the_message() -> None:
+    """THE DEFECT. ``lop send --pid N "body"`` used to bind "body" to target and
+    then fail with "no message given" — an error that was factually false."""
+    target, message, error = _bind(["--pid", "123", "hello there"])
+    assert (target, message, error) == (None, "hello there", "")
+
+
+def test_pid_with_wake_binds_the_message_and_keeps_the_flag() -> None:
+    """The form the peer-messaging guide documented verbatim, which could not work."""
+    args = _parse_send(["--pid", "123", "--wake", "the deploy finished; verify prod"])
+    target, message, error = _bind_send_positionals(args)
+    assert (target, message, error) == (None, "the deploy finished; verify prod", "")
+    assert args.wake is True
+
+
+def test_session_with_one_positional_binds_it_as_the_message() -> None:
+    target, message, error = _bind(["--session", "sess-abc", "hello there"])
+    assert (target, message, error) == (None, "hello there", "")
+
+
+# --- Case 4: no selector means the historical grammar, unchanged ---
+
+
+def test_two_positionals_without_a_selector_are_target_then_message() -> None:
+    target, message, error = _bind(["peer", "hello there"])
+    assert (target, message, error) == ("peer", "hello there", "")
+
+
+# --- Case 5-6: a positional target AND a selector is refused, nothing delivered ---
+
+
+def test_positional_target_plus_pid_is_refused_and_delivers_nothing() -> None:
+    """The wrong-recipient hazard. The assertion that matters is the NON-CALL:
+    the old behaviour delivered to --pid while naming another session and exited
+    0, so an exit code alone would not prove the hazard is gone."""
+    args = _parse_send(["some-other-session", "BODY", "--pid", "123"])
+    with (
+        patch("local_operator.cli._resolve_peer_target") as resolve,
+        patch("local_operator.mobile.peer_client.send_peer_message") as send,
+        patch("local_operator.cli._peer_red") as red,
+    ):
+        rc = send_command(args)
+    assert rc == 1
+    send.assert_not_called()
+    # Nothing was even resolved: the refusal is ahead of the registry scan.
+    resolve.assert_not_called()
+    message = red.call_args[0][0]
+    assert "ambiguous recipient" in message
+    # The error names BOTH readings and prints two retypeable commands, which is
+    # what makes the intentional break self-documenting (proposal §9 risk 1).
+    assert "some-other-session" in message
+    assert "--pid 123" in message
+    assert "to address by pid" in message
+    assert "to address by name" in message
+
+
+def test_positional_target_plus_session_is_refused_and_delivers_nothing() -> None:
+    args = _parse_send(["some-other-session", "BODY", "--session", "sess-abc"])
+    with (
+        patch("local_operator.cli._resolve_peer_target") as resolve,
+        patch("local_operator.mobile.peer_client.send_peer_message") as send,
+        patch("local_operator.cli._peer_red") as red,
+    ):
+        rc = send_command(args)
+    assert rc == 1
+    send.assert_not_called()
+    resolve.assert_not_called()
+    message = red.call_args[0][0]
+    assert "ambiguous recipient" in message
+    assert "--session sess-abc" in message
+    assert "to address by session id" in message
+
+
+# --- Case 7: the two selectors are mutually exclusive at the parser ---
+
+
+def test_pid_and_session_together_is_a_parser_error() -> None:
+    """argparse's own mutually-exclusive group rejects the pair, which is a
+    better error than a hand-written check and keeps the branch out of the
+    binder."""
+    with pytest.raises(SystemExit) as exc:
+        _parse_send(["--pid", "123", "--session", "sess-abc", "body"])
+    assert exc.value.code == 2
+
+
+# --- Case 8-9: the stdin paths are preserved exactly ---
+
+
+def test_name_alone_leaves_the_message_unbound_for_stdin() -> None:
+    """``cmd | lop send NAME`` — the documented pipe path."""
+    target, message, error = _bind(["peer"])
+    assert (target, message, error) == ("peer", None, "")
+
+
+def test_selector_alone_leaves_the_message_unbound_for_stdin() -> None:
+    """``cmd | lop send --pid N`` — the workaround the old guide taught. It is
+    pinned explicitly so a future refactor of the binder cannot drop it."""
+    target, message, error = _bind(["--pid", "123"])
+    assert (target, message, error) == (None, None, "")
+
+
+# --- Case 10-11: body precedence and the now-truthful "no message" error ---
+
+
+def test_typed_body_wins_over_piped_stdin(monkeypatch, capsys) -> None:
+    """Today ``echo X | lop send --pid N "Y"`` sent X, because "Y" was eaten as
+    the target and never looked at. After the fix the typed argument wins, which
+    matches every other CLI and rule 4 of the grammar."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("PIPED BODY\n"))
+    args = _parse_send(["--pid", "123", "TYPED BODY"])
+    record = _Record(os.getppid() + 9999)
+    with (
+        patch("local_operator.cli._resolve_peer_target", return_value=(record, [], "")),
+        patch("local_operator.mobile.peer_client.send_peer_message") as send,
+    ):
+        send_command(args)
+    assert send.call_args.kwargs["text"] == "TYPED BODY"
+
+
+def test_selector_with_no_body_on_a_tty_still_reports_no_message(monkeypatch) -> None:
+    """The "no message given" error survives — but is now reachable only when it
+    is TRUE, i.e. when no body was typed and stdin is a terminal."""
+
+    monkeypatch.setattr("sys.stdin", _FakeTtyStdin())
+    args = _parse_send(["--pid", "123"])
+    record = _Record(os.getppid() + 9999)
+    with (
+        patch("local_operator.cli._resolve_peer_target", return_value=(record, [], "")),
+        patch("local_operator.mobile.peer_client.send_peer_message") as send,
+        patch("local_operator.cli._peer_red") as red,
+    ):
+        rc = send_command(args)
+    assert rc == 1
+    send.assert_not_called()
+    assert "no message given" in red.call_args[0][0]
+
+
+# --- Case 12: the regression guard against "simplifying" the grammar ---
+
+
+def test_flag_then_body_still_parses_with_a_positional_target() -> None:
+    """``lop send NAME --wake "body"`` and ``--now "body"`` must keep working.
+
+    This is the guard against two "obvious" simplifications that are both
+    broken, and it is a PARSER-level test because that is where they break:
+
+    * ``message`` as ``nargs="*"`` — a single ``nargs="*"`` positional cannot
+      absorb words that follow an optional flag. This exact argv raises
+      SystemExit(2), "unrecognized arguments: act now".
+    * ``message`` as ``argparse.REMAINDER`` — binds ``message=['--wake', 'act
+      now']``, swallowing the FLAG into the body: the command exits 0, delivers,
+      and silently degrades wake to mailbox with "--wake" pasted into the text.
+
+    Both were measured, not assumed. See ``docs/design/peer-send.md`` §4.3.
+    """
+    args = _parse_send(["peer", "--wake", "act now"])
+    assert (args.target, args.message, args.wake) == ("peer", "act now", True)
+
+    args = _parse_send(["peer", "--now", "stop, do X instead"])
+    assert (args.target, args.message, args.steer) == ("peer", "stop, do X instead", True)
 
 
 def test_self_send_is_refused_before_any_network_call(capsys) -> None:

--- a/tests/unit/test_cli_send.py
+++ b/tests/unit/test_cli_send.py
@@ -195,12 +195,96 @@ def test_selector_alone_leaves_the_message_unbound_for_stdin() -> None:
 # --- Case 10-11: body precedence and the now-truthful "no message" error ---
 
 
-def test_typed_body_wins_over_piped_stdin(monkeypatch, capsys) -> None:
-    """Today ``echo X | lop send --pid N "Y"`` sent X, because "Y" was eaten as
-    the target and never looked at. After the fix the typed argument wins, which
-    matches every other CLI and rule 4 of the grammar."""
+def test_typed_body_beside_a_pipe_is_refused_not_silently_chosen(monkeypatch) -> None:
+    """A typed body AND a piped body with a selector is REFUSED.
+
+    This deliberately supersedes proposal §8 case 10, which specified that the
+    typed argument wins. Review round 1 (BLOCKER-1) showed the "pick a winner"
+    rule cannot be implemented safely: the binder has to choose the positional's
+    meaning before it can know whether a pipe carried anything, so whichever
+    body loses is discarded SILENTLY at exit 0. Two candidate bodies is the same
+    shape as two candidate recipients and gets the same answer — refuse. Nothing
+    is delivered, so the user cannot lose a payload without being told.
+    """
     monkeypatch.setattr("sys.stdin", io.StringIO("PIPED BODY\n"))
     args = _parse_send(["--pid", "123", "TYPED BODY"])
+    with (
+        patch("local_operator.cli._resolve_peer_target") as resolve,
+        patch("local_operator.mobile.peer_client.send_peer_message") as send,
+        patch("local_operator.cli._peer_red") as red,
+    ):
+        rc = send_command(args)
+    assert rc == 1
+    send.assert_not_called()
+    resolve.assert_not_called()
+    assert "ambiguous body" in red.call_args[0][0]
+
+
+def test_piped_body_with_a_target_and_selector_never_delivers_the_target(monkeypatch) -> None:
+    """BLOCKER-1 regression guard: the silent payload-loss case.
+
+    ``git log --stat | lop send alpha --pid 10`` — the exact form the CLI's own
+    ambiguity guidance leads a user to type — delivered the literal string
+    ``'alpha'`` with exit 0, discarding the commit log. The assertion that
+    matters is that the TARGET NAME is never delivered as a body: a wrong body
+    sent successfully is undetectable from the output, which is what made this
+    worse than the loud bug the PR set out to fix.
+    """
+    monkeypatch.setattr("sys.stdin", io.StringIO("commit abc123\n 5 files changed\n"))
+    args = _parse_send(["alpha", "--pid", "10"])
+    with (
+        patch("local_operator.cli._resolve_peer_target") as resolve,
+        patch("local_operator.mobile.peer_client.send_peer_message") as send,
+        patch("local_operator.cli._peer_red") as red,
+    ):
+        rc = send_command(args)
+    assert rc == 1
+    send.assert_not_called()
+    resolve.assert_not_called()
+    message = red.call_args[0][0]
+    assert "ambiguous body" in message
+    # Both recoveries are shown, and neither is the refused target+selector pair.
+    assert "`lop send --pid 10`" in message
+    assert "to send the piped input" in message
+
+
+def test_a_selector_alone_with_a_pipe_still_delivers_the_piped_body(monkeypatch) -> None:
+    """The documented workaround must survive the BLOCKER-1 fix: with no
+    positional at all, the piped bytes are the body and they are delivered."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("commit abc123\n 5 files changed\n"))
+    args = _parse_send(["--pid", "123"])
+    record = _Record(os.getppid() + 9999)
+    with (
+        patch("local_operator.cli._resolve_peer_target", return_value=(record, [], "")),
+        patch("local_operator.mobile.peer_client.send_peer_message") as send,
+    ):
+        send_command(args)
+    assert send.call_args.kwargs["text"] == "commit abc123\n 5 files changed\n"
+
+
+def test_an_empty_redirect_is_not_a_piped_body(monkeypatch) -> None:
+    """``lop send --pid N "hi" </dev/null`` must still deliver ``hi``.
+
+    ``isatty()`` is False for an empty redirect exactly as it is for a pipe
+    carrying data, so keying the rule off "stdin is not a tty" would turn every
+    ``</dev/null`` invocation into an ambiguity error. Only real bytes count.
+    """
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+    args = _parse_send(["--pid", "123", "hi"])
+    record = _Record(os.getppid() + 9999)
+    with (
+        patch("local_operator.cli._resolve_peer_target", return_value=(record, [], "")),
+        patch("local_operator.mobile.peer_client.send_peer_message") as send,
+    ):
+        send_command(args)
+    assert send.call_args.kwargs["text"] == "hi"
+
+
+def test_no_selector_keeps_the_historical_stdin_precedence(monkeypatch) -> None:
+    """Without a selector the grammar is unchanged: both positionals are filled,
+    so the typed body wins over the pipe with no ambiguity to resolve."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("PIPED BODY\n"))
+    args = _parse_send(["peer", "TYPED BODY"])
     record = _Record(os.getppid() + 9999)
     with (
         patch("local_operator.cli._resolve_peer_target", return_value=(record, [], "")),
@@ -208,6 +292,60 @@ def test_typed_body_wins_over_piped_stdin(monkeypatch, capsys) -> None:
     ):
         send_command(args)
     assert send.call_args.kwargs["text"] == "TYPED BODY"
+
+
+def test_candidate_guidance_tells_the_user_to_replace_the_target(monkeypatch, capsys) -> None:
+    """BLOCKER-2 regression guard for the CLI surface.
+
+    The old wording was ``disambiguate with --pid:``, and the invocation a user
+    naturally forms from it — re-run the command with the flag appended — is the
+    ``NAME BODY --pid N`` form the ambiguity guard refuses. The guidance must
+    name the REPLACEMENT, and must not tell the user to add a flag.
+    """
+    monkeypatch.setattr("sys.stdin", _FakeTtyStdin())
+    args = _parse_send(["alpha", "BODY"])
+    candidates = [_Record(10), _Record(20)]
+    with patch("local_operator.cli._resolve_peer_target", return_value=(None, candidates, "")):
+        rc = send_command(args)
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "replace the target" in err
+    assert "disambiguate with --pid" not in err
+    # The worked example is the form that actually succeeds: selector + body,
+    # with the target gone.
+    assert "`lop send --pid 10 BODY`" in err
+
+
+def test_shell_metacharacters_in_the_retype_suggestion_are_quoted() -> None:
+    """Architect MINOR-1: the suggestions are meant to be retypeable, so a body
+    containing backticks or ``$`` must not be mangled or command-substituted
+    when pasted into a shell."""
+    args = _parse_send(["alpha", "run `whoami` for $HOME", "--pid", "10"])
+    _t, _m, error = _bind_send_positionals(args, None)
+    # shlex.quote wraps it in single quotes, which bash does not expand.
+    assert "'run `whoami` for $HOME'" in error
+    assert '"run `whoami` for $HOME"' not in error
+
+
+def test_a_blank_target_beside_a_selector_is_absence_not_a_conflict() -> None:
+    """MAJOR-2: the CLI and the shared core must agree that an empty or
+    whitespace target is ABSENCE. The core strips before comparing
+    (``peer_send.py``), so the binder does too — otherwise the two layers
+    disagree about the same input, which is the drift this PR exists to end."""
+    target, message, error = _bind(["", "BODY", "--pid", "123"])
+    assert (target, message, error) == (None, "BODY", "")
+    target, message, error = _bind(["   ", "BODY", "--pid", "123"])
+    assert (target, message, error) == (None, "BODY", "")
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_a_blank_session_selector_is_an_error_not_a_grammar_switch(blank: str) -> None:
+    """MAJOR-1: ``--session ''`` and ``--session '   '`` used to bind oppositely
+    — the first fell through to the no-selector grammar (silently making the
+    body a TARGET), the second was honoured and pasted whitespace into the error
+    text. A selector the user explicitly passed but left blank is an error."""
+    _t, _m, error = _bind(["--session", blank, "hello"])
+    assert "empty --session" in error
 
 
 def test_selector_with_no_body_on_a_tty_still_reports_no_message(monkeypatch) -> None:
@@ -251,6 +389,37 @@ def test_flag_then_body_still_parses_with_a_positional_target() -> None:
 
     args = _parse_send(["peer", "--now", "stop, do X instead"])
     assert (args.target, args.message, args.steer) == ("peer", "stop, do X instead", True)
+
+
+def test_the_guide_quotes_the_ambiguity_error_verbatim() -> None:
+    """The §6 doc lockstep, asserted rather than claimed (review round 1,
+    MINOR-1).
+
+    GUIDE.md prints a transcript of the ambiguity refusal. Every other test here
+    asserts SUBSTRINGS of that error, so a rewording would drift the guide
+    silently — precisely the failure mode the lockstep exists to prevent. This
+    reconstructs the guide's quoted block (unwrapping its hard line breaks) and
+    compares it to what the binder actually produces.
+    """
+    from pathlib import Path
+
+    guide = (
+        Path(__file__).resolve().parents[2]
+        / "local_operator"
+        / "guides"
+        / "peer-messaging"
+        / "GUIDE.md"
+    ).read_text()
+
+    marker = '$ lop send "release cutter" "gates are green" --pid 12345'
+    assert marker in guide, "the guide no longer shows the refusal transcript"
+    block = guide[guide.index(marker) : guide.index("```", guide.index(marker))]
+    # The guide hard-wraps for readability; the error itself is one line.
+    documented = " ".join(block.strip().split("\n")[1:])
+
+    args = _parse_send(["release cutter", "gates are green", "--pid", "12345"])
+    _t, _m, actual = _bind_send_positionals(args, None)
+    assert documented == actual
 
 
 def test_self_send_is_refused_before_any_network_call(capsys) -> None:

--- a/tests/unit/test_cli_send.py
+++ b/tests/unit/test_cli_send.py
@@ -391,6 +391,115 @@ def test_flag_then_body_still_parses_with_a_positional_target() -> None:
     assert (args.target, args.message, args.steer) == ("peer", "stop, do X instead", True)
 
 
+class _BinaryStdin:
+    """A non-tty stdin carrying bytes that are not valid UTF-8.
+
+    Models a real `some-binary-producer | lop send …` (a gzip or an image piped
+    by mistake). The real `sys.stdin` is a strict-UTF-8 text wrapper over a
+    `.buffer`, so the fake has to expose the same shape for the decode path to
+    be exercised rather than bypassed.
+    """
+
+    def __init__(self, raw: bytes) -> None:
+        self.buffer = io.BytesIO(raw)
+
+    def isatty(self) -> bool:
+        return False
+
+    def read(self) -> str:  # pragma: no cover - the buffer path is the real one
+        raise AssertionError("the binary path must read sys.stdin.buffer")
+
+
+def test_a_non_utf8_pipe_is_a_clean_error_not_a_traceback(monkeypatch) -> None:
+    """Review round 2, MAJOR-1.
+
+    Reading stdin ahead of resolution widened the blast radius of a decode
+    failure: invocations that never consume the bytes (an unresolvable pid here)
+    used to print a clean red line because base never read at all, and began
+    raising UnicodeDecodeError out of ``send_command`` as a traceback. An
+    uncaught traceback is never an acceptable user-visible failure — the same U1
+    rule the delivery path already follows — so the read decodes leniently.
+    """
+    monkeypatch.setattr("sys.stdin", _BinaryStdin(b"\x1f\x8b\x08\x00\xa8\x8d\xff\xfe"))
+    args = _parse_send(["--pid", "777777"])
+    with (
+        patch(
+            "local_operator.cli._resolve_peer_target",
+            return_value=(None, [], "no session found with pid 777777"),
+        ),
+        patch("local_operator.mobile.peer_client.send_peer_message") as send,
+        patch("local_operator.cli._peer_red") as red,
+    ):
+        rc = send_command(args)
+    # The pre-existing error survives verbatim; the decode never surfaces.
+    assert rc == 1
+    send.assert_not_called()
+    assert red.call_args[0][0] == "no session found with pid 777777"
+
+
+def test_a_non_utf8_pipe_degrades_into_the_existing_body_refusal(monkeypatch) -> None:
+    """A binary body that DOES reach validation becomes the shared core's
+    existing, well-worded refusal rather than a new error class: undecodable
+    bytes replace to U+FFFD, which is a non-empty body under the cap."""
+    monkeypatch.setattr("sys.stdin", _BinaryStdin(b"\xa8\x8d\xff\xfe"))
+    args = _parse_send(["--pid", "123"])
+    record = _Record(os.getppid() + 9999)
+    with (
+        patch("local_operator.cli._resolve_peer_target", return_value=(record, [], "")),
+        patch("local_operator.mobile.peer_client.send_peer_message") as send,
+    ):
+        rc = send_command(args)
+    assert rc == 0
+    # Delivered as replacement characters, never as a crash.
+    assert "\ufffd" in send.call_args.kwargs["text"]
+
+
+def test_the_worked_example_never_echoes_a_piped_payload(monkeypatch, capsys) -> None:
+    """Architect round 2, MINOR-1.
+
+    The disambiguation example interpolated the body, so a piped payload was
+    dumped back to stderr in full (measured: a 10 KB pipe produced 10,147 bytes
+    of stderr) with an invitation to retype it — when the correct recovery for a
+    piped body is to RE-PIPE. The example now shows the shape of the working
+    command instead.
+    """
+    payload = "x" * 10000
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+    args = _parse_send(["alpha"])
+    candidates = [_Record(10), _Record(20)]
+    with patch("local_operator.cli._resolve_peer_target", return_value=(None, candidates, "")):
+        rc = send_command(args)
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert payload not in err
+    assert "<your piped input> | lop send --pid 10" in err
+    # The candidate list above it stays correct and complete.
+    assert "--pid 10" in err and "--pid 20" in err
+    assert len(err) < 500
+
+
+def test_a_long_typed_body_is_elided_in_the_worked_example(monkeypatch, capsys) -> None:
+    """Same reason as the piped case: the line exists to show the SHAPE of the
+    command, and the user still has their own body one line up."""
+    monkeypatch.setattr("sys.stdin", _FakeTtyStdin())
+    args = _parse_send(["alpha", "y" * 400])
+    with patch("local_operator.cli._resolve_peer_target", return_value=(None, [_Record(10)], "")):
+        send_command(args)
+    err = capsys.readouterr().err
+    assert "y" * 400 not in err
+    assert "..." in err
+
+
+def test_a_short_typed_body_is_still_shown_in_full(monkeypatch, capsys) -> None:
+    """The common case must stay genuinely helpful: a short typed body is
+    reproduced verbatim so the suggestion is copy-pasteable."""
+    monkeypatch.setattr("sys.stdin", _FakeTtyStdin())
+    args = _parse_send(["alpha", "gates are green"])
+    with patch("local_operator.cli._resolve_peer_target", return_value=(None, [_Record(10)], "")):
+        send_command(args)
+    assert "e.g. `lop send --pid 10 'gates are green'`" in capsys.readouterr().err
+
+
 def test_the_guide_quotes_the_ambiguity_error_verbatim() -> None:
     """The §6 doc lockstep, asserted rather than claimed (review round 1,
     MINOR-1).

--- a/tests/unit/tools/test_send_tool.py
+++ b/tests/unit/tools/test_send_tool.py
@@ -259,6 +259,11 @@ async def test_ambiguous_target_returns_candidates_and_asks_for_a_pid() -> None:
     assert "retry with pid=<n>" in result.text
     assert "multi session 0" in result.text
     assert "multi session 1" in result.text
+    # Review round 1, BLOCKER-2: the minimal edit a model makes to its previous
+    # call is to KEEP `target` and add `pid`, which the conflict rule now
+    # refuses. The instruction must name the removal, or it teaches the error.
+    assert "drop `target`" in result.text
+    assert "passing both is refused" in result.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

`lop send` declares `target` and `message` as two optional positionals ahead of the `--pid`/`--session` selectors, so argparse always fills `target` first. The natural invocation silently fails, and a second form delivers to the wrong recipient while reporting success.

Runtime → **`0.44.42`** (patch — a fix; user-visible CLI behaviour, but not a step-function capability per AGENTS.md "Versioning"). Rebased onto `cf916d99` after another lane published `0.44.41` mid-review.

Implements the architect's approved design proposal in full — §3 (design), §6 (lockstep docs), §7 (shared-core conflict rule), §8 (tests), respecting §9 (risks). The architect's reasoning, including the rejected alternatives, is recorded permanently in [`docs/design/peer-send.md` §4.3](https://github.com/damianvtran/local-operator/blob/dev-send-grammar/docs/design/peer-send.md#revision-argument-grammar).

## The defect

**1. The natural form cannot work.** `lop send --pid N "hello"` binds `"hello"` to `target`, leaves `message` empty, and exits 1 with:

```
no message given (pass it as an argument or pipe it on stdin)
```

That error is not merely unhelpful, it is **false** — the user *did* pass it as an argument. And it was the verbatim command the peer-messaging guide told users to type (`GUIDE.md:157`). **The guide documented a command that could not work**, which is the strongest evidence this is a grammar bug and not user error.

**2. ☠️ The wrong-recipient hazard.** `lop send other-name "body" --pid N` **delivers to pid N**, exits **0**, and reads as though it addresses `other-name`. The resolver checks `--pid`/`--session` before it ever looks at `target`, so the named target is silently ignored. The success line does print the true recipient — but a `--wake`/`--now` send has already interrupted the wrong session's work by then, and in a scripted loop nobody reads it. This is the finding that made the fix non-optional.

**3. The same latent hazard in the `send` tool.** `SendParams` accepted `target`, `pid` and `session` with no exclusion, and the shared core had no conflict branch at all.

## The fix

A selector **fully determines** the recipient, so a lone positional beside one has exactly one possible meaning: the body. There is no reading under which `lop send --pid 123 "hello"` means anything else — which is precisely why users type it.

- **`_bind_send_positionals(args) -> (target, message, error)`** (new, pure, beside `_resolve_peer_target`). Called at the **top** of `send_command`, ahead of resolution, so an ambiguous address is refused while the command is still **inert** — nothing scanned, nothing dialled.
  - selector + two positionals → **refused**, exit 1, nothing delivered;
  - selector + one positional → it is the **message**;
  - selector + none → stdin;
  - no selector → today's grammar, unchanged.
- **`--pid`/`--session` become a mutually exclusive group.** argparse's native `argument --session: not allowed with argument --pid` beats a hand-written check and removes a branch from the binder.
- **The conflict half lands in the SHARED core** (`mobile/peer_send.resolve_peer_target`), so the in-session `send` tool inherits it. A conflict rule living only in `cli.py` would falsify that module's documented claim to be "the single source of truth for the send-side decision logic" and leave the two surfaces teaching different rules. It uses the existing `pid_hint`/`session_hint` precedent so the CLI keeps its better-worded error.

The refusal names **both** readings and prints two retypeable commands, so the intentional break is self-documenting (§9 risk 1 — this wording is doing the work of a migration guide):

```
ambiguous recipient: 'release cutter' and --pid 12345 name different sessions.
Drop one — `lop send --pid 12345 "gates are green"` to address by pid, or
`lop send 'release cutter' "gates are green"` to address by name
```

### Why `nargs="*"` and `REMAINDER` were rejected

Both look obviously right and are both wrong; §4.3 records this because leaving it out is how the next agent re-derives the bug. Measured against the real parser, not reasoned about:

- **`nargs="*"`** — a single `nargs="*"` positional **cannot** absorb words after an optional flag. `["peer", "--wake", "act on this now"]` → `SystemExit(2)`, `unrecognized arguments`. Breaks three currently-documented forms.
- **`argparse.REMAINDER`** — binds `message=['--wake', 'act on this now']`, swallowing the **flag into the body**. The command parses, exits 0, delivers, and the delivery mode silently degrades from wake to mailbox with `--wake` pasted into the text. Worse than the bug being fixed.

A dash-leading body beside a selector needs `--` (`lop send --pid N -- "--dashy"`). That is argparse's standard behaviour and deliberately **not** special-cased (§9 risk 2); a bespoke escape would be a second grammar.

## Testing evidence — real execution

### 1. The pty reproduction, before and after

The architect's §1.2 probe re-run against this branch. The tty path is where the user-visible symptom lives and unit tests only approximate it.

**BEFORE** — all three natural forms exit 1 with the false error, and the hazard form reached the **dial**:

```
$ lop send --pid 24913 hello there
  exit=1  'no message given (pass it as an argument or pipe it on stdin)'
$ lop send --pid 24913 --wake the deploy finished; verify prod     # the guide's own command
  exit=1  'no message given (pass it as an argument or pipe it on stdin)'
$ lop send --session sess-fake-0001 hello there
  exit=1  'no message given (pass it as an argument or pipe it on stdin)'
$ lop send some-other-session hello there --pid 24913
  exit=1  "could not deliver: [Errno 61] Connect call failed ('127.0.0.1', 1)"   # ☠️ reached the DIAL
```

**AFTER** — the three fixed forms bind the body and reach delivery; the hazard is refused before anything is resolved:

```
$ lop send --pid 41462 hello there
  exit=1  "could not deliver: ..."          # reached delivery => the body bound
$ lop send --pid 41462 --wake the deploy finished; verify prod
  exit=1  "could not deliver: ..."          # reached delivery => the body bound
$ lop send --session sess-fake-0001 hello there
  exit=1  "could not deliver: ..."          # reached delivery => the body bound
$ lop send some-other-session hello there --pid 41462
  exit=1  "ambiguous recipient: 'some-other-session' and --pid 41462 name different sessions. ..."
```

(`could not deliver` here is the *expected* end state: the synthetic peer's `control_port` is a dead port on purpose. Reaching the dial is itself the proof that argument binding produced a target **and** a body.)

### 2. The full §3.3 matrix against a REAL receiver

The sender's own ack cannot prove delivery, so I stood up an actual control socket speaking the registrant's side of the `peer_message` op, published a registry record pointing at it, and appended every accepted message to a transcript. **The transcript rows are the evidence** — delivery confirmed at the RECEIVING end.

| case | invocation | rc | delivered rows | receiver saw |
|---|---|---|---|---|
| natural | `"receiver peer" "hello natural"` | 0 | **+1** | `text='hello natural' mode=mailbox wake=false` |
| **fixed** | `--pid N "hello by pid"` | 0 | **+1** | `text='hello by pid' mode=mailbox wake=false` |
| **fixed** (guide:157) | `--pid N --wake "the deploy finished; verify prod"` | 0 | **+1** | `text='the deploy finished; verify prod' wake=true` |
| **fixed** | `--session S "hello by session"` | 0 | **+1** | `text='hello by session' mode=mailbox` |
| guide:101 | `"receiver peer" --wake "act on this now"` | 0 | **+1** | `wake=true` — unchanged ✅ |
| guide:102 | `"receiver peer" --now "stop, do X instead"` | 0 | **+1** | `mode=steer` — unchanged ✅ |
| **hazard → error** | `"totally-unrelated-name" "BODY" --pid N` | **1** | **+0** | *nothing delivered* ☠️→✅ |
| **hazard → error** | `"totally-unrelated-name" "BODY" --session S` | **1** | **+0** | *nothing delivered* ☠️→✅ |
| dash body | `--pid N -- "--dashy"` | 0 | **+1** | `text='--dashy'` |
| dash body + target | `"receiver peer" "--not-a-flag but a body"` | 0 | **+1** | `text='--not-a-flag but a body'` |
| stdin, name | `echo … \| lop send "receiver peer"` | 0 | **+1** | `text='piped by name\n'` — **preserved** |
| stdin, selector | `echo … \| lop send --pid N` | 0 | **+1** | `text='piped by pid\n'` — **the documented workaround, preserved** |
| **refused** (round 1) | `echo "PIPED BODY" \| lop send --pid N "TYPED BODY"` | **1** | **+0** | ambiguous body — see BLOCKER-1 remediation |

**12 confirmed deliveries; 0 rows for either hazard form.**

### 3. The §4 failure-mode table

| # | invocation | rc | stderr |
|---|---|---|---|
| 1 | `lop send` | 1 | `no target given (pass a name/substring, --pid, or --session)` *(unchanged)* |
| 4 | `other "BODY" --pid N` | 1 | `ambiguous recipient: … to address by pid, or … to address by name` |
| 5 | `other "BODY" --session S` | 1 | same shape, `--session S` / "by session id" |
| 6 | `--pid N --session S "body"` | **2** | `argument --session: not allowed with argument --pid` *(argparse)* |
| 8 | `"receiver peer" ""` | 1 | `message is empty` *(unchanged)* |
| 12 | ambiguous substring | 0/1 | candidate list *(unchanged)* |

### 4. The in-session `send` tool inherits the refusal

Drove `execute_send` directly against the same isolated registry:

```
tool: target + pid       -> REFUSED  'pass either a target substring or an exact pid/session, not both — they name different sessions'
tool: target + session   -> REFUSED  (same)
tool: pid + session      -> REFUSED  'pass either an exact pid or a session id, not both'
tool: pid alone          -> DELIVERED  → receiver peer (pid N): delivered to the mailbox
tool: target alone       -> DELIVERED  → receiver peer (pid N): delivered to the mailbox
```

Receiver transcript: 2 rows (the two legitimate sends only). The approval card's label is unchanged for single-address calls (`pid 45913`, `receiver peer`).

> **Isolation.** Every probe ran under a scratch `LOCAL_OPERATOR_CONFIG_DIR`, so `registry.scan()` saw only synthetic peers I created. The operator's ~17 live sessions were never scanned, dialled, messaged or woken.

## Doc sync — all six §6 items

The four **user-facing** wordings were diffed **against each other**, not just against the code (§9 risk 3 — the realistic drift is the guide and README disagreeing on whether the ambiguous form errors or picks a winner). All four agree it **errors**.

1. **`guides/peer-messaging/GUIDE.md`** — "Choosing a target" gains the rule; the examples block is now correct (line 157's command works as written); an example of the refusal added. **The `0.44.40` stdin workaround wording ("pipe *because the argument does not work*") is removed** and replaced with "pipe for long bodies" — it is obsolete and must not survive this PR.
2. **`README.md`** §"↔ Cross-Session Communication" — the "refuses to guess" paragraph gains the ambiguity sentence (it already claimed the command refuses to guess, which was only true for substrings); `lop send --pid 12345 "…"` joins the fenced block.
3. **`tools/builtin.py`** — `SendParams` field descriptions and the tool description state `target` and `pid`/`session` are **alternatives, not a pair**.
4. **`cli.py` `--help`** — both `help=` strings per §3.1.
5. **`docs/design/peer-send.md` §4.3** — new "Revision: argument grammar" subsection. The old "`--pid`/`--session` override the positional `target`" note is kept and marked wrong rather than deleted, because that sentence reads as obviously correct and is how the defect gets re-derived.
6. **`prompts_md/system.md:160`** — re-read, **no change needed**: it already says "address the peer by `target` …, `pid` …, **or** `session`", which reads as alternatives, and it correctly steers agents to the tool.

The guide's quoted error string is **byte-exact** against production output, now enforced by `test_the_guide_quotes_the_ambiguity_error_verbatim` rather than merely checked once (round 1, MINOR-1).

## Migration

Three forms change; two of them are the bug.

| invocation | today | after | verdict |
|---|---|---|---|
| `NAME "body"` / `--wake` / `--now` / `cmd \| lop send NAME` | works | works | unchanged |
| `cmd \| lop send --pid N` | works | works | **unchanged — the documented workaround keeps working** |
| `--pid N "body"` | **fails** | delivers | fixed; only a failing form changes |
| `NAME "body" --pid N` | delivers to `--pid`, rc 0 | **rc 1, ambiguous** | **intentional break — this is the hazard** |
| `cmd \| lop send --pid N "typed"` | delivers *piped* body | **rc 1, ambiguous body** | refuses rather than silently discarding either body (round 1, BLOCKER-1) |

Nothing that works today *and means what it says* stops working. No deprecation shim: the two broken forms are a hard error and a strictly-better body choice.

## Tests

**`tests/unit/test_cli_send.py`** — all 12 §8 cases. They go through the **production parser** (`build_cli_parser`), not a hand-built Namespace, because the defect lived in how argparse *slotted* the positionals.

- **Cases 5/6 assert `send_peer_message` is NEVER CALLED**, and that `_resolve_peer_target` is never reached either. The hazard is *delivery*, so the guard is "nothing was delivered", not an exit code.
- **Case 12** is a parser-level regression guard pinning `peer --wake "act now"` / `peer --now "stop"`, with a comment naming `nargs="*"` and `REMAINDER` as **tested and rejected** — against a future "simplification".

**`tests/unit/mobile/test_peer_send.py`** — conflict cases for the core, including that a conflict is refused **before the registry is scanned**, and that a blank/whitespace target beside a selector is absence rather than a competing address. `test_pid_wins_over_everything` was **rewritten**: it pinned the exact hazard being removed, and its replacement documents why.

Per §8, **no e2e case** — the rebinding is pure and the delivery path below it is unchanged; `tests/e2e` guards freezes and this earns none of that stage's cost.

## Gates

| gate | result |
|---|---|
| `flake8 .` (whole tree) | ✅ clean |
| `black --check .` (26.1.0, whole tree) | ✅ 809 files unchanged |
| `isort --check .` (5.13.2, whole tree) | ✅ clean |
| `pyright --pythonpath .venv/bin/python .` (whole tree) | ✅ **0 errors, 0 warnings** |
| `tests/unit/test_cli_send.py` + `mobile/` + `tools/test_send_tool.py` + `session/test_session_peer.py` + `session/runtime/` + `tui/test_peer_message.py` | ✅ **347 passed** |

The remainder of `tests/unit` was delegated to CI rather than completed locally (this host is contended by sibling worktrees) — stated explicitly rather than implied. Every suite plausibly touched by the diff is in the row above.

**Round 1 remediation landed** (`8a49a6fd`): two blockers, two majors and six minor/nit findings answered — see the [remediation comment](https://github.com/damianvtran/local-operator/pull/556#issuecomment-5517552408). The headline change is that a typed body beside a piped body with a selector is now **refused** rather than one silently winning, superseding proposal §8 case 10.

**CI was green on `dc894af` — all 8 checks** (re-running on the new head), including the full unit suite:

| check | result |
|---|---|
| `test (3.12)` — **full `tests/unit`** | ✅ pass (32m15s) |
| `lint` | ✅ pass |
| `type-check` | ✅ pass |
| `tui-e2e (macos-latest)` | ✅ pass |
| `tui-e2e (ubuntu-latest)` | ✅ pass |
| `cli-sanity` | ✅ pass |
| `server-sanity` | ✅ pass |
| `pip-audit` | ✅ pass |
