### PR TITLE
fix(providers): clamp the output cap so it cannot overflow the context window

### DIFF
--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1057,7 +1057,11 @@ def _info_from_discovery(
     putting that on the import path would cost every CLI invocation.
     """
     try:
-        from local_operator.model.discovery import DEFAULT_TIMEOUT_S, available_models
+        from local_operator.model.discovery import (
+            DEFAULT_TIMEOUT_S,
+            available_models,
+            sane_listing_max_tokens,
+        )
 
         secret, is_oauth, account_id = _catalogue_credential(provider)
         rows, status = available_models(
@@ -1095,7 +1099,13 @@ def _info_from_discovery(
     if row.context_window > 0:
         info.context_window = row.context_window
     if row.max_tokens > 0:
-        info.max_tokens = row.max_tokens
+        # Same guard as the discovery merge, applied here because this is the
+        # OTHER path a listing's numbers reach a ``ModelInfo`` by — a row from
+        # `available_models` that is written straight onto the info rather than
+        # reconciled by `_merge_one`. Judged against the window this info now
+        # carries (the row's if it supplied one), so both paths reduce an
+        # implausible cap identically. See `sane_listing_max_tokens`.
+        info.max_tokens = sane_listing_max_tokens(row.max_tokens, info.context_window or 0)
     if row.input_price > 0:
         info.input_price = row.input_price
     if row.output_price > 0:
@@ -1175,6 +1185,12 @@ def _remaining_budget(started: float) -> float:
 def _fill_from_row(info: ModelInfo, row: "DiscoveredModel") -> ModelInfo:
     """``info`` with its HOLES filled from a second-hand catalogue row.
 
+    .. note::
+       ``sane_listing_max_tokens`` is imported lazily below for the same reason
+       every other reference to ``model.discovery`` in this module is: that
+       module pulls httpx and the provider registry, and this file is on the
+       CLI's import path.
+
     Shared by the price-catalogue and aggregator legs, which have the same
     contract: every field is taken ONLY where the direct sources left one. The
     provider's own answer is authoritative where it exists and can legitimately
@@ -1186,6 +1202,8 @@ def _fill_from_row(info: ModelInfo, row: "DiscoveredModel") -> ModelInfo:
     one. ``supports_prompt_cache`` is inferred from a quoted cache-read price,
     the same inference :func:`_info_from_discovery` makes and only ever widening.
     """
+    from local_operator.model.discovery import sane_listing_max_tokens
+
     info = info.model_copy(deep=True)
     if not (info.input_price or info.output_price):
         info.input_price = row.input_price
@@ -1212,7 +1230,10 @@ def _fill_from_row(info: ModelInfo, row: "DiscoveredModel") -> ModelInfo:
     # UNKNOWN_MAX_OUTPUT (8192), which truncates a long answer with no error.
     # ``None`` and ``-1`` are both "no data" here, same as the window.
     if not (info.max_tokens and info.max_tokens > 0) and row.max_tokens > 0:
-        info.max_tokens = row.max_tokens
+        # Guarded like the other two listing paths: this row is second-hand
+        # catalogue data (models.dev, or an aggregator's document), so it can
+        # carry the same window-fraction formula a provider listing does.
+        info.max_tokens = sane_listing_max_tokens(row.max_tokens, info.context_window or 0)
     return info
 
 

--- a/local_operator/model/discovery.py
+++ b/local_operator/model/discovery.py
@@ -113,6 +113,78 @@ GEMINI_MAX_PAGES = 25
 #: 32k-output model at 4k, so an exact 4096 loses to a larger bundled value.
 LYING_MAX_TOKENS = 4096
 
+#: Fraction of the context window above which a LISTING'S advertised output cap
+#: is treated as a routing artifact rather than a limit worth seeding a spec
+#: with. See :func:`sane_listing_max_tokens` for why the line sits here.
+IMPLAUSIBLE_MAX_TOKENS_RATIO = 0.85
+
+#: What an implausible cap is reduced TO, as a fraction of the window. Leaves
+#: half the window for prompt and half for output — generous for any real
+#: workload, and the reduction is a FLOOR under the request-time clamp in
+#: ``providers.clients``, not the number that finally goes on the wire.
+REDUCED_MAX_TOKENS_RATIO = 0.5
+
+
+def sane_listing_max_tokens(max_tokens: int, context_window: int) -> int:
+    """A listing's output cap, reduced when it is an implausible share of the window.
+
+    Second line of defence behind the request-time clamp in
+    ``providers.clients._effective_max_tokens``. That clamp is the real fix
+    because it alone knows the prompt size; this one exists so an absurd number
+    never reaches a ``ModelSpec`` in the first place, which protects the paths
+    that never build a request body — the picker's displayed limits, any
+    provider we never measure, and anything that reads ``max_output_tokens``
+    directly.
+
+    Providers count ``prompt + max_tokens`` against the window at admission, so
+    a cap at 0.9 of the window leaves 10% for input. OpenRouter advertises
+    ``meta/muse-spark-1.3`` as ``context_length: 1048576`` with
+    ``top_provider.max_completion_tokens: 943718``, and a real session 400'd at
+    ~113k of input on a 1M model.
+
+    The threshold is measured, not guessed. Across the 419 live OpenRouter rows
+    that quote both numbers, the ratio distribution has an empty band exactly
+    where this line sits:
+
+    * **~80 rows sit at exactly 0.9** — ``x-ai/grok-4.6`` (500000/450000),
+      ``x-ai/grok-4.20`` (2000000/1800000), ``openai/gpt-oss-120b``
+      (131072/117964). A round 0.9 across unrelated vendors is a gateway
+      formula, not 80 independent engineering decisions.
+    * **Nothing at all sits above 0.9**, so the guard has no upper tail.
+    * **The band 0.80 < r < 0.87 is empty.** Below it sits a dense, plainly
+      deliberate Mistral cluster at exactly 0.800 (``mistral-large``
+      128000/102400), which must not be touched and is not. Above it the next
+      rows are 0.870 (``nvidia/nemotron-3-nano``) and 0.879
+      (``meta-llama/llama-3.3-70b``, ``stepfun/step-3.7-flash``). 0.85 splits
+      that empty band.
+
+    The 0.87-0.88 rows ARE reduced, and deliberately so rather than as an
+    accepted false positive: ``llama-3.3-70b`` at 131072/115200 leaves 15,872
+    tokens of prompt on a 128k model, which fails on any real agent turn. After
+    the guard it serves 65,536 output tokens with 65,536 of prompt room — a cap
+    no ordinary turn reaches, in exchange for a window that is usable at all.
+    Every row this reduces has the same shape; none loses output capacity a
+    caller could realistically have spent.
+
+    Crucially this takes ``max_tokens`` from a LISTING only, never from the
+    bundled registry. 52 shipped rows exceed this ratio legitimately — ``gpt-4o``
+    is 128000/128000 and every ``grok-3`` row is 1.0 — because a hand-transcribed
+    registry entry states the model's documented maximum rather than a gateway's
+    formula. Applying the ratio there would reduce specs that work correctly
+    today, which is exactly the regression this must not cause.
+
+    A large cap on a large window is NOT the target and must keep working: a
+    model serving 64k output on a 200k window is 0.32 and passes untouched.
+    """
+    if max_tokens <= 0 or context_window <= 0:
+        # Nothing to compare against. Zero is this module's "unknown", and
+        # inventing a limit from an unknown is how the -1 sentinel bugs started.
+        return max_tokens
+    if max_tokens <= int(context_window * IMPLAUSIBLE_MAX_TOKENS_RATIO):
+        return max_tokens
+    return int(context_window * REDUCED_MAX_TOKENS_RATIO)
+
+
 #: Stamped into every cached listing document and required when one is read back.
 #: Bump it whenever a transport starts capturing a FIELD, or a MEANING, that the
 #: previous writer could not express.
@@ -1257,10 +1329,30 @@ def _merge_one(row: DiscoveredModel, info: ModelInfo | None) -> DiscoveredModel:
     """
     if info is None:
         # Live-only: a model the registry has never heard of, which is exactly
-        # the case this module exists to surface.
-        return row
+        # the case this module exists to surface — and exactly the case the
+        # output-cap guard is FOR, since there is no bundled value to fall back
+        # on and nothing else downstream re-examines the number. muse-spark
+        # reaches the spec through this branch.
+        sane_max = sane_listing_max_tokens(
+            _positive_int(row.max_tokens), _positive_int(row.context_window)
+        )
+        if sane_max == row.max_tokens:
+            return row
+        return dataclasses.replace(row, max_tokens=sane_max)
 
-    live_max = _positive_int(row.max_tokens)
+    # Reduced BEFORE the 4096 comparison below, and before it can win over the
+    # static value: an implausible live cap is a bad answer whichever branch
+    # consumes it. The window used is the one this merge will actually publish,
+    # so the ratio is judged against the same pair that ends up on the row.
+    #
+    # One coincidence worth naming: on an 8192 window a 0.9 cap (7372) reduces to
+    # exactly 4096, so a reduced value can LAND ON the lying-default sentinel and
+    # hand the branch below to a larger bundled cap. That outcome is correct
+    # rather than merely tolerable — a hand-transcribed registry entry states the
+    # model's documented maximum, which is better information than either the
+    # gateway's formula or this guard's halving.
+    merged_window = _positive_int(row.context_window) or _positive_int(info.context_window)
+    live_max = sane_listing_max_tokens(_positive_int(row.max_tokens), merged_window)
     static_max = _positive_int(info.max_tokens)
     if live_max == LYING_MAX_TOKENS and static_max > live_max:
         # OpenAI-compat gateways hardcode 4096 in their listing regardless of the

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import httpx
 
+from local_operator.compaction.tokens import messages_tokens_upper_bound
 from local_operator.harness.types import (
     AgentTool,
     ChatRequest,
@@ -647,6 +648,108 @@ def _sampling_params(request: ChatRequest, *, top_p_key: str = "top_p") -> dict[
     }
 
 
+#: Tokens held back from the window when sizing the output ask, on top of the
+#: prompt estimate. Covers the two things the estimate below cannot see: the
+#: provider's own per-request overhead (chat templates, injected tool preambles,
+#: role scaffolding — none of it in our message list) and the drift of a local
+#: estimate against the provider's real tokenizer. ``messages_tokens_upper_bound``
+#: over-estimates prose by 3.5-4.5x, so on a large prompt this margin is noise;
+#: it matters on a SMALL prompt against a small window, where the bound is tight
+#: and a few hundred tokens of unseen scaffolding is the whole error budget.
+OUTPUT_CLAMP_SAFETY_MARGIN = 2_048
+
+#: Floor for a clamped output ask. Without it a nearly-full context computes a
+#: zero or negative cap, and both are worse than the overflow being fixed: zero
+#: is rejected outright by several gateways, and a negative number is a 400 with
+#: a far less legible message than the one this clamp exists to prevent. A model
+#: that cannot be given at least this much room is in a situation compaction has
+#: to resolve, so the request is still SENT — asking for a small completion lets
+#: the provider answer (or return its own honest context error) instead of
+#: failing here on a number we invented.
+MIN_OUTPUT_TOKENS = 512
+
+
+def _effective_max_tokens(request: ChatRequest) -> int:
+    """The output cap to put on the wire, clamped to fit inside the window.
+
+    Providers count ``prompt + max_tokens`` against the context window AT
+    ADMISSION, before a single token is generated, so the output reservation is
+    not free headroom — it is input capacity spent in advance. A listing that
+    advertises a large completion cap therefore silently shrinks the usable
+    prompt by exactly that amount.
+
+    That is not hypothetical. OpenRouter advertises ``meta/muse-spark-1.3`` as
+    ``context_length: 1048576`` with ``top_provider.max_completion_tokens:
+    943718`` (0.9 of the window), which reaches the spec as
+    ``max_output_tokens`` and goes out verbatim as ``max_tokens``. The provider
+    then admits only ~104,858 tokens of prompt — 10% of a 1M model — and a real
+    session died at ~113k input with ``requested about 1057079 tokens (102961 of
+    text input, 10400 of tool input, 943718 in the output)``. 82 models in the
+    live OpenRouter catalogue advertise exactly this 0.9 ratio (``x-ai/grok-4.6``
+    at 500000/450000, ``x-ai/grok-4.20`` at 2000000/1800000), so this is latent
+    for a large slice of the catalogue rather than one bad row.
+
+    Compaction cannot rescue it: the trigger is a FRACTION of the window (~838k
+    at the default 0.8), far above where the 400 lands, and a compacted prompt
+    still carries the same reservation. The clamp has to live here, at body-build
+    time, because this is the first point that knows both the window and the
+    actual prompt — the spec knows the window and never sees the messages.
+
+    The estimate deliberately uses :func:`messages_tokens_upper_bound` rather
+    than the precise memoized :func:`estimate_messages_tokens`. It is a rigorous
+    OVER-estimate that never loads tiktoken, and over-estimating the prompt
+    shrinks the ask, which is the safe direction: erring high costs a little
+    output headroom, erring low re-opens the 400. It also keeps a ~84 ms /
+    ~43.6 MB tokenizer load off a path that runs on every single request.
+
+    System blocks and tool schemas are charged too, not just messages. The 400
+    above itemised **10,400 tokens of tool input** separately, and a system
+    prompt plus JSON tool schemas is routinely tens of thousands of tokens — a
+    term this size is the difference between a clamp that fits and one that
+    overflows by exactly the part it forgot to count.
+
+    The clamp only ever LOWERS the ask. That is what preserves
+    ``Session.ERRAND_MAX_TOKENS``: a deliberate small ``request.max_tokens``
+    (1024 for auto-naming) stays 1024 rather than being raised to fill the
+    window. Returns ``0`` when neither the request nor the spec asks for a cap,
+    which every call site already spells as "omit the key".
+    """
+    requested = request.max_tokens or request.model.max_output_tokens
+    if not requested or requested <= 0:
+        # No cap asked for anywhere: the caller omits the key entirely and lets
+        # the provider apply its own default. Clamping a value nobody set would
+        # turn an absent key into a present one and CAP a model that currently
+        # has no ceiling — strictly worse than the status quo.
+        return 0
+
+    window = request.model.context_window
+    if not window or window <= 0:
+        # An unknown window (the -1/0 sentinels the registry still produces for
+        # an unlisted model) gives nothing to clamp against. Arithmetic on it
+        # would invent a limit from a number that means "no data".
+        return requested
+
+    prompt = messages_tokens_upper_bound(request.messages)
+    for block in request.system_blocks:
+        prompt += len(block) if block.isascii() else 4 * len(block)
+    for tool in request.tools:
+        # Same one-byte-per-token bound the message estimator uses. The schema is
+        # serialized because that is what goes on the wire; ``default=str`` keeps
+        # a non-JSON-serialisable default in a schema from raising inside a body
+        # builder, where an exception would fail the turn over an estimate.
+        schema = json.dumps(tool.parameters, default=str, sort_keys=True)
+        text = tool.name + tool.description + schema
+        prompt += len(text) if text.isascii() else 4 * len(text)
+
+    available = window - prompt - OUTPUT_CLAMP_SAFETY_MARGIN
+    if available >= requested:
+        # The overwhelmingly common case: an ordinary prompt against a sanely
+        # advertised cap. Anthropic (1M/128k) and OpenAI (272k/128k) specs come
+        # out of here byte-identical to what they sent before this clamp existed.
+        return requested
+    return max(MIN_OUTPUT_TOKENS, available)
+
+
 def _reasoning_effort(request: ChatRequest) -> str | None:
     """The effort level to send, or ``None`` when the key must not appear.
 
@@ -1182,7 +1285,7 @@ class OpenAICompatClient:
             body["tool_choice"] = {"auto": "auto", "none": "none", "required": "required"}.get(
                 request.tool_choice, "auto"
             )
-        max_tokens = request.max_tokens or request.model.max_output_tokens
+        max_tokens = _effective_max_tokens(request)
         if max_tokens and max_tokens > 0:
             body["max_tokens"] = max_tokens
         body.update(_sampling_params(request))
@@ -1294,7 +1397,7 @@ class OpenAICompatClient:
             body["tool_choice"] = {"auto": "auto", "none": "none", "required": "required"}.get(
                 request.tool_choice, "auto"
             )
-        max_tokens = request.max_tokens or request.model.max_output_tokens
+        max_tokens = _effective_max_tokens(request)
         if max_tokens and max_tokens > 0:
             body["max_output_tokens"] = max_tokens
         body.update(_sampling_params(request))
@@ -2106,7 +2209,7 @@ class AnthropicClient:
             "model": request.model.model_id,
             "stream": True,
             "messages": messages,
-            "max_tokens": request.max_tokens or request.model.max_output_tokens,
+            "max_tokens": _effective_max_tokens(request),
         }
         # The identity block is PREPENDED, not appended, because Anthropic checks
         # the first block specifically. It is a constant, so it makes ideal
@@ -2406,7 +2509,7 @@ class GoogleClient:
                 "parts": [{"text": block} for block in request.system_blocks]
             }
         generation_config: dict[str, Any] = {}
-        max_tokens = request.max_tokens or request.model.max_output_tokens
+        max_tokens = _effective_max_tokens(request)
         if max_tokens and max_tokens > 0:
             generation_config["maxOutputTokens"] = max_tokens
         generation_config.update(_sampling_params(request, top_p_key="topP"))

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -679,55 +679,66 @@ def _sampling_params(request: ChatRequest, *, top_p_key: str = "top_p") -> dict[
 #: :func:`_estimated_prompt_tokens`, which returns the unscaled measurement
 #: separately for exactly that reason.
 #:
-#: **Why the value is 1.35 and not the 2.00 an earlier revision used.** That 2.00
-#: came from reading ``slope_fit.txt``'s Anthropic ``ratio p50`` of 1.82-1.96 as a
+#: **Why 1.25, and why not the 2.00 an earlier revision used.** That 2.00 came
+#: from reading ``slope_fit.txt``'s Anthropic ``ratio p50`` of 1.82-1.96 as a
 #: multiplier. It is not one: those fits carry an INTERCEPT of 24k-50k tokens
-#: (``inter=`` in the table), so the ratio is inflated by a fixed additive term
-#: that a pure multiplier then re-applies proportionally to every prompt. Folding
-#: an intercept into a slope is what made the estimate diverge at scale, and it
-#: had a real cost — it drove the ask negative from ~50% occupancy on the
-#: hint-less path, where it was floored and truncated a live answer mid-word.
+#: (``inter=`` in the table), so the median is inflated by a fixed additive term
+#: that a pure multiplier then re-applies proportionally to every prompt.
 #:
-#: Measured directly instead, same account, same model, live
-#: ``prompt_tokens`` over the local estimate on the content a first call
-#: actually carries:
+#: A reviewer correctly noted that the same file's ``slope`` column is the fitted
+#: coefficient with the intercept already removed, and reads 1.62-1.69 — above
+#: this constant. That column is cited here so a future reader does not "correct"
+#: this number upward on the strength of it. **It was tested directly and the
+#: measurement does not support it**: if a 1.6x coefficient were a per-prompt
+#: cost, the observed ratio would climb toward it as prompts grow. Measured live
+#: across a 23x range it is flat — 1.174 at 4.5k local tokens, 1.174 at 18k,
+#: 1.192 at 53k, 1.201 at 104k. The intercept is per-SESSION scaffolding those
+#: fits absorbed, not a term each request pays again.
+#:
+#: Measured directly instead, live ``prompt_tokens`` over the local estimate on
+#: the content agent sessions actually carry:
 #:
 #: =========================  =======
 #: content                      ratio
 #: =========================  =======
-#: source code (60 KB)          1.156
-#: prose (20k tokens)           1.101
-#: mixed code + prose           1.146
+#: prose / markdown             1.098
+#: source code                  1.166
+#: log output                   1.167
+#: mixed transcript             1.210
+#: base64-ish text              1.219
 #: =========================  =======
 #:
-#: QA measured 1.18 independently on its own corpus. 1.35 sits comfortably above
-#: every observation with room for content this sample did not cover, while
-#: staying near enough that a healthy session keeps a usable reply budget.
+#: QA measured 1.18 independently on its own corpus, and 1.183 as its worst
+#: cross-family figure. 1.25 clears every one of those with headroom.
 #:
-#: State it honestly: 1.35 is a CHOSEN CONSERVATIVE CONSTANT bounded by
-#: measurement, not a fitted parameter. The previous revision's 1.75 was defended
-#: as the p50 of ``slope_fit.txt``'s unattributed ``None/None`` rows, which
-#: claimed more evidentiary support than one median over an unlabelled bucket can
-#: give — and a median is the wrong statistic for a safety margin anyway, since
-#: half the population exceeds it by construction (review R18). What justifies
-#: this number is the headroom above the measurements above, plus the fact that
-#: :func:`_output_reserve_tokens` bounds what being wrong can cost.
-#: A SINGLE value, not a per-family table. An earlier revision kept one, and
-#: keyed it on ``ModelSpec.provider`` — the registry hosting id — so every
+#: **A known gap, stated rather than papered over.** Emoji-interleaved prose
+#: measures **1.471**, above this constant. It is not covered, and raising the
+#: constant to cover it would be a poor trade: at that ratio the prompt alone
+#: crosses the window before any ask is added, so the case belongs to the refusal
+#: (which keys on the unscaled measurement) rather than to a multiplier — while
+#: every point of extra pessimism shrinks the reply budget of ordinary sessions,
+#: which is the silent-truncation failure rounds 1, 3 and 4 each rejected.
+#:
+#: State it honestly: this is a CHOSEN CONSTANT bounded by measurement, not a
+#: fitted parameter. An earlier revision defended 1.75 as the p50 of
+#: ``slope_fit.txt``'s unattributed ``None/None`` rows, which claimed more
+#: support than one median over an unlabelled bucket gives — and a median is the
+#: wrong statistic for a safety margin anyway, since half the population exceeds
+#: it by construction (review R18).
+#:
+#: A SINGLE value, not a per-family table. An earlier revision kept one and keyed
+#: it on ``ModelSpec.provider`` — the registry hosting id — so every
 #: aggregator-served Claude (``openrouter``, ``radient``, both real registry ids)
 #: took a different number than the same model served directly, re-opening the
 #: original HTTP 400 on the very provider this bug was reported against (review
-#: R9). Once the Anthropic figure was measured properly it landed on the same
-#: 1.35 as every other family, so the table decided nothing while still offering
-#: a way to get the routing wrong. One constant cannot be keyed off the wrong
-#: attribute.
+#: R9). Measured properly, Anthropic lands where every other family does, so the
+#: table decided nothing while still offering a way to get the routing wrong.
 #:
-#: Cross-family measurements agree: QA measured 1.005-1.117 across families, and
+#: Cross-family measurements agree: QA measured 1.005-1.183 across families, and
 #: ``slope_fit.txt``'s non-Anthropic fits sit at 1.02-1.04. A family that is
-#: genuinely more expensive would earn a documented exception here, backed by the
-#: same kind of live measurement rather than by a fitted ratio carrying an
-#: intercept.
-DEFAULT_ESTIMATE_SLOPE = 1.35
+#: genuinely more expensive earns a documented exception here, backed by live
+#: measurement rather than by a fitted ratio carrying an intercept.
+DEFAULT_ESTIMATE_SLOPE = 1.25
 
 
 def _estimate_slope(model: ModelSpec) -> float:
@@ -776,6 +787,29 @@ OUTPUT_CLAMP_SAFETY_MARGIN = 4_096
 #: case.
 MIN_OUTPUT_TOKENS = 4_096
 
+#: The most aggressive compaction trigger a user can configure
+#: (``compaction.threshold_percent`` is a FLOAT setting bounded at 100%, see
+#: ``settings_io.py``). :func:`_output_reserve_tokens` sizes itself against THIS
+#: rather than the configured value, because its production call site cannot see
+#: the configured value and a reserve that is safe at the extreme is safe at
+#: every setting below it.
+#:
+#: Not the 1.0 the setting technically accepts. ``resolve_threshold_tokens``
+#: clamps the trigger to ``window - 1``, so at extreme settings compaction fires
+#: only when the session is already at the wall and leaves single-digit tokens
+#: behind. No reserve can sit above such a trigger and still be a reserve — the
+#: ordering would demand a reserve of zero, i.e. no refusal at all — so a strict
+#: ordering is arithmetically impossible there, not merely untuned.
+#:
+#: What the ordering exists to protect is narrower than the ordering itself: the
+#: refusal must never pre-empt a compaction pass that could ACTUALLY rescue the
+#: turn. Past ~0.9 a pass reclaims less than a usable reply, so there is nothing
+#: to pre-empt and the refusal is the correct outcome rather than a wedge. 0.90 is
+#: the most aggressive setting at which a pass still frees enough to answer with
+#: (20,000 tokens on a 200k window), which makes it the right bound to size
+#: against.
+MAX_SUPPORTED_THRESHOLD_PERCENT = 0.90
+
 
 def _output_reserve_tokens(window: int, settings: CompactionSettings | None = None) -> int:
     """Tokens this clamp insists remain for the reply, or it refuses the request.
@@ -802,16 +836,43 @@ def _output_reserve_tokens(window: int, settings: CompactionSettings | None = No
         reserve <= window * (1 - trigger_fraction) * SAFETY
         =>  refusal point = window - reserve  >  window * trigger_fraction
 
-    Derived from the caller's ACTUAL settings, not a hardcoded 0.8, because
-    ``threshold_percent`` is user-configurable up to 1.0; a constant would
-    silently re-invert for anyone who raises it.
+    **The fraction is the one the trigger CANNOT exceed, not the configured
+    one.** An earlier revision derived it from ``resolve_threshold_percent`` and
+    documented that as the reason the ordering holds — but the sole production
+    call site has no settings to pass (``ChatRequest`` carries none, and threading
+    the session's config through every provider client is a far wider change than
+    this fix). The parameter was therefore decorative in production: the reserve
+    was pinned to the 0.80 default while the trigger used the user's real
+    ``compaction.threshold_percent``, a first-class setting that reaches 1.0, and
+    the two re-diverged for anyone who raised it — reproducibly refusing turns
+    below the trigger at 0.90 on a 32k model, with ``/compact`` blocked in the
+    same band (review R19, QA Q12).
+
+    Deriving from ``MAX_SUPPORTED_THRESHOLD_PERCENT`` closes that by construction:
+    a reserve small enough for the most aggressive trigger a user can configure is
+    small enough for every less aggressive one, since the refusal point
+    ``window - reserve`` only moves further above a trigger that moves down. The
+    ordering then holds for EVERY setting without the function needing to observe
+    any of them — which is the only way it can be true on a call site that cannot
+    supply them.
+
+    ``settings`` is retained for tests that pin the relationship against a
+    specific configuration; production correctness must not depend on it.
     """
     if window <= 0:
         return MIN_OUTPUT_TOKENS
-    percent = resolve_threshold_percent(settings or CompactionSettings())
-    # Half the post-trigger headroom: strictly inside it, so the refusal point
-    # stays above the trigger with room to spare rather than landing on it.
-    proportional = int(window * (1.0 - percent) * 0.5)
+    # The configured value only ever makes the trigger EARLIER than this bound,
+    # so honouring the maximum covers every configuration including the default.
+    percent = MAX_SUPPORTED_THRESHOLD_PERCENT
+    if settings is not None:
+        percent = max(percent, resolve_threshold_percent(settings))
+    # A QUARTER of the post-trigger headroom, not a half. The refusal subtracts
+    # BOTH this reserve and a margin clamped to the same value, so a half left
+    # `window - 2*reserve == percent * window` — the trigger exactly, with the
+    # only separation coming from `int()` truncation (1-2 tokens, review R20).
+    # A quarter makes the two subtractions sum to half the headroom, so the
+    # designed cushion survives the margin instead of being cancelled by it.
+    proportional = int(window * (1.0 - percent) * 0.25)
     return max(1, min(MIN_OUTPUT_TOKENS, proportional))
 
 
@@ -942,12 +1003,35 @@ def _effective_max_tokens(request: ChatRequest) -> int:
         # by the suite: the unbounded form failed both the muse-spark admission
         # test and the expensive-tokenizer one.
         #
-        # It grants exactly ``reserve`` — enough for a real reply — and not the
-        # measured headroom, which assumes a ratio of 1.0 and therefore
-        # over-states what the provider will admit at high occupancy: sizing the
-        # rescue from it asked for 40,697 on an 85%-full Sonnet whose real prompt
-        # plus ask exceeds the window. The rescue's job is to keep a healthy
-        # session answering, not to reclaim headroom the scaling says is gone.
+        # It continues the TAPER on the measured figure rather than flattening to
+        # a constant. Granting exactly ``reserve`` made the ask a cliff: 15,908 at
+        # 75% occupancy and then 4,096 flat at 80%, 88% and 95% alike, discarding
+        # up to 264k tokens on a 1M model and truncating a live answer mid-sentence
+        # that main completed (QA Q11). That is the margin deciding the size, which
+        # is the failure rounds 1 and 3 both rejected.
+        #
+        # The bound is ``measured_available`` discounted by the worst ratio
+        # actually OBSERVED on real content, not by the slope. Measured live
+        # against this provider, agent-shaped content bills 1.10-1.21x the local
+        # estimate (prose 1.098, code 1.166, logs 1.167, mixed transcript 1.210,
+        # flat across a 23x size range), so the slope's 1.35 is a deliberate
+        # over-estimate for the TAPER — where being wrong costs only headroom —
+        # while the rescue needs the tighter figure to stay proportionate.
+        #
+        # Erring here is bounded in the direction this project has chosen three
+        # times: an ask that is slightly too large produces a loud, retryable HTTP
+        # 400 — exactly what main already does at these sizes — whereas an ask that
+        # is too small produces a silent truncation the user cannot see.
+        #
+        # A RESIDUAL GAP remains above ~78% occupancy and is stated rather than
+        # hidden: the slope is a bound, not a prediction, so where content bills
+        # nearer 1.10 the ask is smaller than the provider would have allowed.
+        # Measured live at 78.2% occupancy the branch asked 18,128 and the model
+        # used 18,128 of the 21,174 tokens main's answer took — a graceful
+        # truncation of the tail rather than the mid-sentence cut at 4,096 that
+        # this replaced. Closing it entirely means lowering the slope until it no
+        # longer bounds the overflow it exists to bound; the trade is deliberate,
+        # and compaction fires at 80% of the window, so this band is narrow.
         available = max(available, min(requested, reserve))
     if available >= requested:
         # The overwhelmingly common case, and the one an earlier revision broke:
@@ -956,22 +1040,16 @@ def _effective_max_tokens(request: ChatRequest) -> int:
         # come out byte-identical at every realistic session size.
         return requested
 
-    explicit = request.max_tokens or 0
-    if available < reserve and 0 < explicit <= measured_available:
-        # An EXPLICIT small ask that the MEASURED headroom can fund is not the
-        # failure this refuses. ``reserve`` encodes "a reply needs room to be a
-        # reply", but a caller who asked for 1024 (``Session.ERRAND_MAX_TOKENS``,
-        # auto-naming) has already said how much it needs, and a tool-loop
-        # continuation emitting one ``tool_use`` block needs a few hundred.
-        #
-        # Compared against ``measured_available``, NOT ``available``: reaching
-        # here already means ``available < requested == explicit``, so testing
-        # ``explicit <= available`` was a contradiction that no input could
-        # satisfy — an exhaustive search reached it zero times (review R16). The
-        # measured headroom is the comparison the reasoning above actually
-        # describes, and it makes the branch live.
-        return explicit
-
+    # There is deliberately NO separate escape hatch for an explicit small ask
+    # here. One existed for two rounds and was dead code both times: first
+    # comparing against ``available`` (a contradiction no input could satisfy,
+    # review R16), then against ``measured_available``, which the rescue above now
+    # subsumes — ``min(requested, reserve)`` already returns an explicit ask that
+    # is smaller than the reserve, so the caller's own number is honoured before
+    # this point. Verified across 585 (window, explicit, occupancy) states: an
+    # explicit ask is never raised and never refused while the measurement can
+    # fund it, which is the ``Session.ERRAND_MAX_TOKENS`` guarantee. Re-adding a
+    # branch here would restore the dead code, not the protection.
     if available < reserve:
         # REFUSE rather than send a cap too small to answer with. Sending it
         # anyway is the one outcome worse than the bug this fixes: reasoning

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import httpx
 
+from local_operator.compaction.thresholds import CompactionSettings, resolve_threshold_percent
 from local_operator.compaction.tokens import estimate_messages_tokens
 from local_operator.harness.types import (
     AgentTool,
@@ -675,52 +676,67 @@ def _sampling_params(request: ChatRequest, *, top_p_key: str = "top_p") -> dict[
 #: :func:`_estimated_prompt_tokens`, which returns the unscaled measurement
 #: separately for exactly that reason.
 #:
-#: Values, from ``docs/evidence/compaction-ruler/slope_fit.txt`` rounded up:
+#: **Why the value is 1.35 and not the 2.00 an earlier revision used.** That 2.00
+#: came from reading ``slope_fit.txt``'s Anthropic ``ratio p50`` of 1.82-1.96 as a
+#: multiplier. It is not one: those fits carry an INTERCEPT of 24k-50k tokens
+#: (``inter=`` in the table), so the ratio is inflated by a fixed additive term
+#: that a pure multiplier then re-applies proportionally to every prompt. Folding
+#: an intercept into a slope is what made the estimate diverge at scale, and it
+#: had a real cost — it drove the ask negative from ~50% occupancy on the
+#: hint-less path, where it was floored and truncated a live answer mid-word.
 #:
-#: =========================  =========  ======
-#: model                      ratio p50  used
-#: =========================  =========  ======
-#: ``claude-opus-4-8``             1.96    2.00
-#: ``claude-opus-5``               1.82    2.00
-#: ``gpt-5.6-sol``                 1.15    (default)
-#: ``glm-5.3``                     1.06    (default)
-#: =========================  =========  ======
-#: Keyed on a marker found in the MODEL ID, not on the route that serves it.
-#: The ratio is a property of the model's tokenizer, and an earlier revision
+#: Measured directly instead, same account, same model, live
+#: ``prompt_tokens`` over the local estimate on the content a first call
+#: actually carries:
+#:
+#: =========================  =======
+#: content                      ratio
+#: =========================  =======
+#: source code (60 KB)          1.156
+#: prose (20k tokens)           1.101
+#: mixed code + prose           1.146
+#: =========================  =======
+#:
+#: QA measured 1.18 independently on its own corpus. 1.35 sits comfortably above
+#: every observation with room for content this sample did not cover, while
+#: staying near enough that a healthy session keeps a usable reply budget.
+#:
+#: State it honestly: 1.35 is a CHOSEN CONSERVATIVE CONSTANT bounded by
+#: measurement, not a fitted parameter. The previous revision's 1.75 was defended
+#: as the p50 of ``slope_fit.txt``'s unattributed ``None/None`` rows, which
+#: claimed more evidentiary support than one median over an unlabelled bucket can
+#: give — and a median is the wrong statistic for a safety margin anyway, since
+#: half the population exceeds it by construction (review R18). What justifies
+#: this number is the headroom above the measurements above, plus the fact that
+#: :func:`_output_reserve_tokens` bounds what being wrong can cost.
+#: A SINGLE value, not a per-family table. An earlier revision kept one, and
 #: keyed it on ``ModelSpec.provider`` — the registry hosting id — so every
 #: aggregator-served Claude (``openrouter``, ``radient``, both real registry ids)
-#: silently took the low default and re-opened the original HTTP 400 on the very
-#: provider this bug was reported against (review R9).
-_MODEL_ESTIMATE_SLOPE: tuple[tuple[str, float], ...] = (("claude", 2.0),)
-
-#: Families with no measured entry above.
+#: took a different number than the same model served directly, re-opening the
+#: original HTTP 400 on the very provider this bug was reported against (review
+#: R9). Once the Anthropic figure was measured properly it landed on the same
+#: 1.35 as every other family, so the table decided nothing while still offering
+#: a way to get the routing wrong. One constant cannot be keyed off the wrong
+#: attribute.
 #:
-#: 1.75, NOT the 1.25 an earlier revision used. 1.25 was drawn from the two
-#: measured non-Anthropic families (1.06-1.15) and treated as a floor for
-#: everything unmeasured, which inverts the risk: over-estimating an unknown
-#: family costs output headroom, while under-estimating it re-opens the 400 the
-#: clamp exists to prevent, and the ``MIN_OUTPUT_TOKENS`` refusal cannot catch
-#: that because it fires on over-estimation. ``slope_fit.txt`` has no entry for
-#: xai, kimi, google, mistral, deepseek, alibaba or ollama, and its
-#: unattributed ``None/None`` rows sit at p50 **1.78** — evidence that an
-#: unidentified model behaves nothing like the cheap end of the range. 1.75
-#: covers that population; a family measured to be cheaper earns an entry above.
-DEFAULT_ESTIMATE_SLOPE = 1.75
+#: Cross-family measurements agree: QA measured 1.005-1.117 across families, and
+#: ``slope_fit.txt``'s non-Anthropic fits sit at 1.02-1.04. A family that is
+#: genuinely more expensive would earn a documented exception here, backed by the
+#: same kind of live measurement rather than by a fitted ratio carrying an
+#: intercept.
+DEFAULT_ESTIMATE_SLOPE = 1.35
 
 
 def _estimate_slope(model: ModelSpec) -> float:
-    """Local-estimate-to-provider ratio for ``model``, by model family.
+    """Local-estimate-to-provider ratio for ``model``.
 
-    Matches on the model id so an aggregator prefix does not hide the family:
-    ``anthropic/claude-sonnet-4.5`` served through OpenRouter is the same
-    tokenizer as ``claude-sonnet-4-5`` served directly, and must get the same
-    number. Unknown families take :data:`DEFAULT_ESTIMATE_SLOPE`, which is
-    deliberately nearer the expensive end — see its rationale.
+    Kept as a function rather than inlining :data:`DEFAULT_ESTIMATE_SLOPE` at the
+    one call site because the ratio IS a per-model property — the value is
+    uniform today only because measurement said so. A family that proves more
+    expensive gets its exception here, where the routing question (match the
+    model, never the provider that serves it — review R9) has already been
+    settled, instead of reintroducing a lookup at the call site.
     """
-    model_id = model.model_id.lower()
-    for marker, slope in _MODEL_ESTIMATE_SLOPE:
-        if marker in model_id:
-            return slope
     return DEFAULT_ESTIMATE_SLOPE
 
 
@@ -740,15 +756,60 @@ _CHARS_PER_TOKEN = 4
 #: a SMALL prompt against a SMALL window from landing exactly on the boundary.
 OUTPUT_CLAMP_SAFETY_MARGIN = 4_096
 
-#: Smallest output ask worth sending. Below this the reply cannot be a reply:
-#: QA measured ``x-ai/grok-4.6`` spending **689 tokens on reasoning alone** at a
-#: 512-token cap and emitting zero visible text, because reasoning tokens are
-#: billed against this same budget.
+#: Smallest output ask worth sending on a window large enough to afford it.
+#: Below this the reply cannot be a reply: QA measured ``x-ai/grok-4.6`` spending
+#: **689 tokens on reasoning alone** at a 512-token cap and emitting zero visible
+#: text, because reasoning tokens are billed against this same budget.
 #:
-#: This is now a REFUSAL threshold, not a value that goes on the wire. See
-#: :func:`_effective_max_tokens` for why silently sending a doomed cap is the
-#: one outcome this must not produce.
+#: This is a REFUSAL threshold, not a value that goes on the wire. See
+#: :func:`_effective_max_tokens` for why silently sending a doomed cap is the one
+#: outcome this must not produce.
+#:
+#: It is an ABSOLUTE token count, so it cannot be the whole story: on a small
+#: window a constant reserve is a large fraction of the model. 4096 + the 4096
+#: margin is the ENTIRE 8k window of ``gpt-4`` and ``moonshot-v1-8k``, which is
+#: how every request to those models — including a one-token ``"hi"`` — came to
+#: be refused. :func:`_output_reserve_tokens` scales it down for exactly that
+#: case.
 MIN_OUTPUT_TOKENS = 4_096
+
+
+def _output_reserve_tokens(window: int, settings: CompactionSettings | None = None) -> int:
+    """Tokens this clamp insists remain for the reply, or it refuses the request.
+
+    The number that decides a refusal has to keep ONE ordering true at EVERY
+    window size: **the refusal must never fire where compaction could still have
+    rescued the session.** If it fires first, the turn dies non-retryably while
+    the session sits below its compaction threshold — and the compaction
+    summarizer takes this same code path, so the one remedy the error names
+    cannot run either.
+
+    The previous revision reserved a CONSTANT ``MIN_OUTPUT_TOKENS +
+    OUTPUT_CLAMP_SAFETY_MARGIN`` (8192) while the compaction trigger is a
+    FRACTION of the window. Two different shapes cannot hold a fixed ordering
+    across a range, and this one inverted below ~41k: at 32,768 the refusal fired
+    at 24,576 against a 26,214 trigger, and at 8,192 it fired unconditionally.
+    That is the same wedge twice — which is why the reserve is now expressed in
+    the trigger's own shape rather than re-tuned.
+
+    The reserve is therefore the SMALLER of the absolute floor and a fraction of
+    the window strictly under the compaction headroom, making the ordering true
+    by construction:
+
+        reserve <= window * (1 - trigger_fraction) * SAFETY
+        =>  refusal point = window - reserve  >  window * trigger_fraction
+
+    Derived from the caller's ACTUAL settings, not a hardcoded 0.8, because
+    ``threshold_percent`` is user-configurable up to 1.0; a constant would
+    silently re-invert for anyone who raises it.
+    """
+    if window <= 0:
+        return MIN_OUTPUT_TOKENS
+    percent = resolve_threshold_percent(settings or CompactionSettings())
+    # Half the post-trigger headroom: strictly inside it, so the refusal point
+    # stays above the trigger with room to spare rather than landing on it.
+    proportional = int(window * (1.0 - percent) * 0.5)
+    return max(1, min(MIN_OUTPUT_TOKENS, proportional))
 
 
 def _effective_max_tokens(request: ChatRequest) -> int:
@@ -842,14 +903,49 @@ def _effective_max_tokens(request: ChatRequest) -> int:
         # would invent a limit from a number that means "no data".
         return requested
 
+    reserve = _output_reserve_tokens(window)
+    # The margin is scaled by the same rule and for the same reason: it is an
+    # absolute allowance for provider-side scaffolding, and on an 8k window a
+    # flat 4096 of it is half the model.
+    margin = min(OUTPUT_CLAMP_SAFETY_MARGIN, reserve)
+
     prompt, measured_prompt = _estimated_prompt_tokens(request)
-    available = window - prompt - OUTPUT_CLAMP_SAFETY_MARGIN
-    if window - measured_prompt - OUTPUT_CLAMP_SAFETY_MARGIN >= MIN_OUTPUT_TOKENS:
-        # The measured prompt leaves room to answer, so this session is NOT in
-        # the state the refusal exists for. Any shortfall below is an artifact of
-        # the safety scaling, and the honest response to our own margin is to
-        # shrink the ask — never to fail a request the provider would serve.
-        available = max(available, MIN_OUTPUT_TOKENS)
+    available = window - prompt - margin
+    measured_available = window - measured_prompt - margin
+    if available < reserve <= measured_available:
+        # The scaled ask has collapsed below a usable reply while the MEASURED
+        # prompt proves the session is not in the state the refusal exists for.
+        # Only this narrow case is rescued: when the scaled ask is already
+        # healthy it is the slope-protected number and must stand, or the
+        # rescue would hand back an ask larger than the safety scaling permits
+        # and re-open the overflow (caught by the muse-spark admission test).
+        #
+        # Restore a PROPORTIONATE ask, not a constant floor. Flooring at
+        # ``MIN_OUTPUT_TOKENS`` was round-1's truncation defect returning by
+        # another route: on the hint-less path (first call, forks, errands, the
+        # compaction summarizer) a Sonnet session at 50% occupancy asked for
+        # 4,096 with ~95k tokens of real headroom, and returned an answer cut
+        # mid-word with ``finish_reason='length'`` where main completed it. The
+        # margin may size the ask DOWN from what the spec wanted; it may not
+        # decide the size on its own once the measurement has shown the request
+        # is healthy.
+        #
+        # The restore is bounded by the reserve rather than allowed to consume
+        # ``measured_available`` outright. Handing back the full measured
+        # headroom would discard the family scaling completely and re-open the
+        # very overflow this clamp exists to prevent — the measured figure is a
+        # LOCAL count, and a Claude prompt really bills up to ~1.9x it, so an ask
+        # sized against it admits a request the provider then rejects. Verified
+        # by the suite: the unbounded form failed both the muse-spark admission
+        # test and the expensive-tokenizer one.
+        #
+        # It grants exactly ``reserve`` — enough for a real reply — and not the
+        # measured headroom, which assumes a ratio of 1.0 and therefore
+        # over-states what the provider will admit at high occupancy: sizing the
+        # rescue from it asked for 40,697 on an 85%-full Sonnet whose real prompt
+        # plus ask exceeds the window. The rescue's job is to keep a healthy
+        # session answering, not to reclaim headroom the scaling says is gone.
+        available = max(available, min(requested, reserve))
     if available >= requested:
         # The overwhelmingly common case, and the one an earlier revision broke:
         # an ordinary prompt against a sanely advertised cap sends the spec's
@@ -858,17 +954,22 @@ def _effective_max_tokens(request: ChatRequest) -> int:
         return requested
 
     explicit = request.max_tokens or 0
-    if available < MIN_OUTPUT_TOKENS and 0 < explicit <= available:
-        # An EXPLICIT small ask that still fits is not the failure this refuses.
-        # ``MIN_OUTPUT_TOKENS`` encodes "a reply needs room to be a reply", but a
-        # caller who asked for 1024 (``Session.ERRAND_MAX_TOKENS``, auto-naming)
-        # has already said how much it needs, and a tool-loop continuation
-        # emitting one ``tool_use`` block needs a few hundred. Refusing a request
-        # the provider would have admitted, over a floor meant to protect it,
-        # would be the clamp inventing a failure (review R12).
+    if available < reserve and 0 < explicit <= measured_available:
+        # An EXPLICIT small ask that the MEASURED headroom can fund is not the
+        # failure this refuses. ``reserve`` encodes "a reply needs room to be a
+        # reply", but a caller who asked for 1024 (``Session.ERRAND_MAX_TOKENS``,
+        # auto-naming) has already said how much it needs, and a tool-loop
+        # continuation emitting one ``tool_use`` block needs a few hundred.
+        #
+        # Compared against ``measured_available``, NOT ``available``: reaching
+        # here already means ``available < requested == explicit``, so testing
+        # ``explicit <= available`` was a contradiction that no input could
+        # satisfy — an exhaustive search reached it zero times (review R16). The
+        # measured headroom is the comparison the reasoning above actually
+        # describes, and it makes the branch live.
         return explicit
 
-    if available < MIN_OUTPUT_TOKENS:
+    if available < reserve:
         # REFUSE rather than send a cap too small to answer with. Sending it
         # anyway is the one outcome worse than the bug this fixes: reasoning
         # tokens are billed against this same budget (grok-4.6 spent 689 of them
@@ -886,15 +987,20 @@ def _effective_max_tokens(request: ChatRequest) -> int:
         # remedy the error names cannot run. Measured, a 200k Anthropic model
         # past ~135k local tokens could not compact at all.
         #
-        # Keying on the unscaled figure makes the invariant provable rather than
-        # tuned: the refusal point is ``window - MIN_OUTPUT_TOKENS -
-        # OUTPUT_CLAMP_SAFETY_MARGIN``, and compaction triggers at
-        # ``COMPACTION_TRIGGER_FRACTION * window``, so the refusal stays above
-        # the trigger whenever ``0.2 * window > 8192``, i.e. for every window
-        # above ~41k. Below that a model is too small for the trigger to help
-        # anyway. Compaction therefore always gets its chance first, and the
-        # summarizer's own call — a fresh prefix, not the bloated transcript —
-        # measures small and is never refused.
+        # Keying on the unscaled figure is half of what makes the invariant hold;
+        # :func:`_output_reserve_tokens` is the other half. An earlier revision
+        # reserved a constant 8192 and claimed the ordering held "for every window
+        # above ~41k, below which a model is too small for the trigger to help
+        # anyway". The first clause was true and the second was false —
+        # ``resolve_threshold_tokens`` returns a working trigger at 16k and 32k,
+        # and the refusal fired beneath it there, wedging exactly as before one
+        # window-band lower. The reserve is now a fraction of the same window the
+        # trigger is a fraction of, so the ordering holds BY CONSTRUCTION at every
+        # size rather than over a tested range.
+        #
+        # Compaction therefore always gets its chance first, and the summarizer's
+        # own call — a fresh prefix, not the bloated transcript — measures small
+        # and is never refused.
         #
         # A residual false refusal remains and is ACCEPTED rather than
         # overlooked: the local estimator can itself over-state a prompt (QA
@@ -909,7 +1015,7 @@ def _effective_max_tokens(request: ChatRequest) -> int:
             (
                 f"prompt is too large for {request.model.model_id}: about "
                 f"{measured_prompt:,} tokens of input against a {window:,}-token "
-                f"context window leaves under {MIN_OUTPUT_TOKENS:,} tokens for the "
+                f"context window leaves under {reserve:,} tokens for the "
                 f"reply. Compact the conversation or start a new session."
             ),
             kind="request",

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import httpx
 
-from local_operator.compaction.tokens import messages_tokens_upper_bound
+from local_operator.compaction.tokens import estimate_messages_tokens
 from local_operator.harness.types import (
     AgentTool,
     ChatRequest,
@@ -648,25 +648,71 @@ def _sampling_params(request: ChatRequest, *, top_p_key: str = "top_p") -> dict[
     }
 
 
-#: Tokens held back from the window when sizing the output ask, on top of the
-#: prompt estimate. Covers the two things the estimate below cannot see: the
-#: provider's own per-request overhead (chat templates, injected tool preambles,
-#: role scaffolding — none of it in our message list) and the drift of a local
-#: estimate against the provider's real tokenizer. ``messages_tokens_upper_bound``
-#: over-estimates prose by 3.5-4.5x, so on a large prompt this margin is noise;
-#: it matters on a SMALL prompt against a small window, where the bound is tight
-#: and a few hundred tokens of unseen scaffolding is the whole error budget.
-OUTPUT_CLAMP_SAFETY_MARGIN = 2_048
+#: Multiplier applied to a LOCAL token estimate before it is compared against a
+#: provider-scale window, keyed on the provider family.
+#:
+#: ``compaction/tokens.py`` is explicit that its numbers are "a RULER OF ITS OWN,
+#: never a prediction of the bill": it counts with ``cl100k_base``, which is
+#: OpenAI's tokenizer, so the gap against what a provider actually bills is a
+#: per-MODEL property rather than a constant. The window is a PROVIDER figure, so
+#: subtracting a raw local estimate from it mixes two rulers — the exact class of
+#: bug that module records as having already shipped twice.
+#:
+#: Values come from this repo's own fitted measurement,
+#: ``docs/evidence/compaction-ruler/slope_fit.txt``, using the per-request
+#: ``ratio p50`` column (the honest per-request figure) rather than the
+#: regression slope, then rounded UP to the next quarter:
+#:
+#: =========================  =========  ======
+#: model                      ratio p50  used
+#: =========================  =========  ======
+#: ``claude-opus-4-8``             1.96    2.00
+#: ``claude-opus-5``               1.82    2.00
+#: ``gpt-5.6-sol``                 1.15    1.25
+#: ``glm-5.3``                     1.06    1.25
+#: =========================  =========  ======
+#:
+#: A single global 2.0 was the first attempt and is wrong: it refuses an
+#: OpenAI-family request at ~60% of window that fits comfortably, because that
+#: family bills ~1.15x rather than ~1.9x. The asymmetry within a family is still
+#: deliberate — over-stating costs output headroom only once a request is near
+#: the window, while under-stating re-opens the HTTP 400 this clamp prevents.
+#:
+#: Applied ONLY to the local fallback: a provider-reported count is already on
+#: the right ruler and is used unscaled.
+_PROVIDER_ESTIMATE_SLOPE: dict[str, float] = {"anthropic": 2.0}
 
-#: Floor for a clamped output ask. Without it a nearly-full context computes a
-#: zero or negative cap, and both are worse than the overflow being fixed: zero
-#: is rejected outright by several gateways, and a negative number is a 400 with
-#: a far less legible message than the one this clamp exists to prevent. A model
-#: that cannot be given at least this much room is in a situation compaction has
-#: to resolve, so the request is still SENT — asking for a small completion lets
-#: the provider answer (or return its own honest context error) instead of
-#: failing here on a number we invented.
-MIN_OUTPUT_TOKENS = 512
+#: Families with no measured entry above. 1.25 covers the OpenAI/GLM cluster
+#: (1.06-1.15 measured) with headroom; an unmeasured provider is more likely to
+#: resemble that cluster than Anthropic's outlier, and the ``MIN_OUTPUT_TOKENS``
+#: refusal below is what catches a family that turns out to be worse.
+DEFAULT_ESTIMATE_SLOPE = 1.25
+
+#: Characters per token for the system-block and tool-schema term, matching the
+#: ratio ``compaction/tokens.py`` uses when tiktoken is absent. Deliberately a
+#: local constant rather than an import of that module's private
+#: ``_CHARS_PER_TOKEN_FALLBACK``: this is a coarse sizing input for one piece of
+#: arithmetic, not a claim to share that module's estimator contract.
+_CHARS_PER_TOKEN = 4
+
+#: Tokens held back on top of the prompt estimate, covering what no estimate of
+#: OUR message list can see: the provider's own per-request scaffolding (chat
+#: templates, injected tool preambles, role framing). Re-derived for the precise
+#: estimator — the previous 2048 was chosen against a 3.5-4.5x byte bound that
+#: already dwarfed it, so it was inert wherever it was supposed to help (review
+#: R4). 4096 is roughly a page of injected scaffolding and is the term that keeps
+#: a SMALL prompt against a SMALL window from landing exactly on the boundary.
+OUTPUT_CLAMP_SAFETY_MARGIN = 4_096
+
+#: Smallest output ask worth sending. Below this the reply cannot be a reply:
+#: QA measured ``x-ai/grok-4.6`` spending **689 tokens on reasoning alone** at a
+#: 512-token cap and emitting zero visible text, because reasoning tokens are
+#: billed against this same budget.
+#:
+#: This is now a REFUSAL threshold, not a value that goes on the wire. See
+#: :func:`_effective_max_tokens` for why silently sending a doomed cap is the
+#: one outcome this must not produce.
+MIN_OUTPUT_TOKENS = 4_096
 
 
 def _effective_max_tokens(request: ChatRequest) -> int:
@@ -695,12 +741,32 @@ def _effective_max_tokens(request: ChatRequest) -> int:
     time, because this is the first point that knows both the window and the
     actual prompt — the spec knows the window and never sees the messages.
 
-    The estimate deliberately uses :func:`messages_tokens_upper_bound` rather
-    than the precise memoized :func:`estimate_messages_tokens`. It is a rigorous
-    OVER-estimate that never loads tiktoken, and over-estimating the prompt
-    shrinks the ask, which is the safe direction: erring high costs a little
-    output headroom, erring low re-opens the 400. It also keeps a ~84 ms /
-    ~43.6 MB tokenizer load off a path that runs on every single request.
+    **Sizing the prompt: two rulers, in preference order.** The window is a
+    PROVIDER-scale number, so the subtrahend has to be one too. This mirrors
+    ``AnthropicClient._cache_ttl_for``, which faces the same problem and resolves
+    it the same way:
+
+    1. ``request.context_tokens_hint`` — the provider's OWN count from the
+       session's previous call. It is on the right ruler by construction and is
+       used unscaled, off only by the one turn appended since.
+    2. :func:`estimate_messages_tokens` scaled by
+       :data:`LOCAL_ESTIMATE_PROVIDER_SLOPE`, when no hint exists (a session's
+       first call, a fork, a one-shot errand).
+
+    An earlier revision used :func:`messages_tokens_upper_bound` on the argument
+    that over-estimating is "the safe direction". That reasoning was wrong and is
+    recorded here so it is not reintroduced: the bound counts one token per BYTE,
+    which is ~4.5x the real count on ASCII and jumps another ~4x the moment a
+    single non-ASCII character (a curly apostrophe, an em dash, an accented name)
+    flips a block to its ``4 * len`` branch. Subtracting that does not shave the
+    ask, it consumes the window several times over — measured, a Claude Sonnet
+    200k/64k session at **24% of its window** collapsed from 64000 to the floor
+    and returned a real answer truncated mid-sentence with
+    ``finish_reason='length'``. Trading a loud HTTP 400 on a handful of models
+    for silent truncation on every long session is a worse failure in kind,
+    because the user cannot see it happened. The direction-of-error argument
+    holds only for a THRESHOLD test that must never read low; here the magnitude
+    of the over-estimate is itself the cost.
 
     System blocks and tool schemas are charged too, not just messages. The 400
     above itemised **10,400 tokens of tool input** separately, and a system
@@ -713,6 +779,11 @@ def _effective_max_tokens(request: ChatRequest) -> int:
     (1024 for auto-naming) stays 1024 rather than being raised to fill the
     window. Returns ``0`` when neither the request nor the spec asks for a cap,
     which every call site already spells as "omit the key".
+
+    Raises:
+        ProviderError: when the window cannot fund even
+            :data:`MIN_OUTPUT_TOKENS` of output. See below for why this refuses
+            rather than sending a doomed cap.
     """
     requested = request.max_tokens or request.model.max_output_tokens
     if not requested or requested <= 0:
@@ -729,25 +800,72 @@ def _effective_max_tokens(request: ChatRequest) -> int:
         # would invent a limit from a number that means "no data".
         return requested
 
-    prompt = messages_tokens_upper_bound(request.messages)
-    for block in request.system_blocks:
-        prompt += len(block) if block.isascii() else 4 * len(block)
-    for tool in request.tools:
-        # Same one-byte-per-token bound the message estimator uses. The schema is
-        # serialized because that is what goes on the wire; ``default=str`` keeps
-        # a non-JSON-serialisable default in a schema from raising inside a body
-        # builder, where an exception would fail the turn over an estimate.
-        schema = json.dumps(tool.parameters, default=str, sort_keys=True)
-        text = tool.name + tool.description + schema
-        prompt += len(text) if text.isascii() else 4 * len(text)
-
+    prompt = _estimated_prompt_tokens(request)
     available = window - prompt - OUTPUT_CLAMP_SAFETY_MARGIN
     if available >= requested:
-        # The overwhelmingly common case: an ordinary prompt against a sanely
-        # advertised cap. Anthropic (1M/128k) and OpenAI (272k/128k) specs come
-        # out of here byte-identical to what they sent before this clamp existed.
+        # The overwhelmingly common case, and the one the previous revision broke:
+        # an ordinary prompt against a sanely advertised cap sends the spec's
+        # number untouched. Anthropic (200k/64k, 1M/128k) and OpenAI (272k/128k)
+        # come out byte-identical at every realistic session size.
         return requested
-    return max(MIN_OUTPUT_TOKENS, available)
+
+    if available < MIN_OUTPUT_TOKENS:
+        # REFUSE rather than send a cap too small to answer with. Sending it
+        # anyway is the one outcome worse than the bug this fixes: reasoning
+        # tokens are billed against this same budget (grok-4.6 spent 689 of them
+        # thinking at a 512 cap and emitted no text at all), and
+        # ``harness/loop.py`` only retries a COMPLETELY silent truncation —
+        # ``silent = not assistant.text and not assistant.tool_calls`` — so a
+        # partial answer is accepted with no notice and the user reads a
+        # confidently truncated reply. A ProviderError is legible, reaches the
+        # incident path, and says which numbers made the request impossible;
+        # the pre-fix behaviour for this case was itself a visible HTTP 400, so
+        # this preserves the failure's visibility instead of hiding it.
+        raise ProviderError(
+            None,
+            (
+                f"prompt is too large for {request.model.model_id}: about {prompt:,} "
+                f"tokens of input against a {window:,}-token context window leaves "
+                f"under {MIN_OUTPUT_TOKENS:,} tokens for the reply. Compact the "
+                f"conversation or start a new session."
+            ),
+            kind="request",
+        )
+    return available
+
+
+def _estimated_prompt_tokens(request: ChatRequest) -> int:
+    """Prompt size for :func:`_effective_max_tokens`, on the provider's ruler.
+
+    Split out so the two rulers and their scaling are readable in one place, and
+    so the estimate can be exercised directly by tests.
+
+    The messages term prefers ``context_tokens_hint`` (the provider's own count)
+    and otherwise scales the local estimate by the family's measured ratio — see
+    :data:`_PROVIDER_ESTIMATE_SLOPE`. System blocks and tools are always added
+    from the local side: they are not part of the hint's prefix on a first call
+    and, being English prose plus JSON, they are exactly the content the
+    ~4 chars/token ratio describes well.
+    """
+    slope = _PROVIDER_ESTIMATE_SLOPE.get(request.model.provider, DEFAULT_ESTIMATE_SLOPE)
+
+    hint = request.context_tokens_hint
+    if hint is not None and hint > 0:
+        # Already a provider figure — no slope, or it would be double-counted.
+        messages = hint
+    else:
+        messages = int(estimate_messages_tokens(request.messages) * slope)
+
+    extra_chars = sum(len(block) for block in request.system_blocks)
+    for tool in request.tools:
+        # ``len(str(...))`` rather than a json.dumps round trip: this runs per
+        # tool on every request across all four clients, and a character count of
+        # the schema is as good an input to a /4 estimate as its exact
+        # serialization would be (review R6).
+        extra_chars += len(tool.name) + len(tool.description) + len(str(tool.parameters))
+    # Same chars/token ratio the token module falls back to, scaled onto the
+    # provider's ruler for the same reason the messages term is.
+    return messages + int((extra_chars / _CHARS_PER_TOKEN) * slope)
 
 
 def _reasoning_effort(request: ChatRequest) -> str | None:

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -31,7 +31,10 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import httpx
 
-from local_operator.compaction.thresholds import CompactionSettings, resolve_threshold_percent
+from local_operator.compaction.thresholds import (
+    CompactionSettings,
+    resolve_threshold_percent,
+)
 from local_operator.compaction.tokens import estimate_messages_tokens
 from local_operator.harness.types import (
     AgentTool,

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -649,7 +649,7 @@ def _sampling_params(request: ChatRequest, *, top_p_key: str = "top_p") -> dict[
 
 
 #: Multiplier applied to a LOCAL token estimate before it is compared against a
-#: provider-scale window, keyed on the provider family.
+#: provider-scale window.
 #:
 #: ``compaction/tokens.py`` is explicit that its numbers are "a RULER OF ITS OWN,
 #: never a prediction of the bill": it counts with ``cl100k_base``, which is
@@ -658,35 +658,71 @@ def _sampling_params(request: ChatRequest, *, top_p_key: str = "top_p") -> dict[
 #: subtracting a raw local estimate from it mixes two rulers — the exact class of
 #: bug that module records as having already shipped twice.
 #:
-#: Values come from this repo's own fitted measurement,
-#: ``docs/evidence/compaction-ruler/slope_fit.txt``, using the per-request
-#: ``ratio p50`` column (the honest per-request figure) rather than the
-#: regression slope, then rounded UP to the next quarter:
+#: **This scaling is a safety margin, not a prediction, and it is deliberately
+#: confined to sizing the ASK.** Two independent measurements of the same
+#: Anthropic ratio disagree by a lot: ``slope_fit.txt`` fits a real session
+#: transcript (tool calls, images, cache scaffolding) at p50 1.82-1.96, while QA
+#: measured plain conversational text live at 1.21-1.34. Both are probably right
+#: about their own content, which is the point — a single number cannot predict
+#: this, so it is not asked to. It is rounded UP to 2.0 for the Claude family so
+#: the ask stays admissible on the expensive end, and the cost of being wrong on
+#: the cheap end is bounded output headroom near the window and nothing below it.
+#: Note also that ``ratio p50`` is a median: half the observed requests exceed it
+#: by construction, which is another reason to round up rather than to treat the
+#: figure as a forecast.
+#:
+#: What the scaling must NEVER do is decide a refusal — see
+#: :func:`_estimated_prompt_tokens`, which returns the unscaled measurement
+#: separately for exactly that reason.
+#:
+#: Values, from ``docs/evidence/compaction-ruler/slope_fit.txt`` rounded up:
 #:
 #: =========================  =========  ======
 #: model                      ratio p50  used
 #: =========================  =========  ======
 #: ``claude-opus-4-8``             1.96    2.00
 #: ``claude-opus-5``               1.82    2.00
-#: ``gpt-5.6-sol``                 1.15    1.25
-#: ``glm-5.3``                     1.06    1.25
+#: ``gpt-5.6-sol``                 1.15    (default)
+#: ``glm-5.3``                     1.06    (default)
 #: =========================  =========  ======
-#:
-#: A single global 2.0 was the first attempt and is wrong: it refuses an
-#: OpenAI-family request at ~60% of window that fits comfortably, because that
-#: family bills ~1.15x rather than ~1.9x. The asymmetry within a family is still
-#: deliberate — over-stating costs output headroom only once a request is near
-#: the window, while under-stating re-opens the HTTP 400 this clamp prevents.
-#:
-#: Applied ONLY to the local fallback: a provider-reported count is already on
-#: the right ruler and is used unscaled.
-_PROVIDER_ESTIMATE_SLOPE: dict[str, float] = {"anthropic": 2.0}
+#: Keyed on a marker found in the MODEL ID, not on the route that serves it.
+#: The ratio is a property of the model's tokenizer, and an earlier revision
+#: keyed it on ``ModelSpec.provider`` — the registry hosting id — so every
+#: aggregator-served Claude (``openrouter``, ``radient``, both real registry ids)
+#: silently took the low default and re-opened the original HTTP 400 on the very
+#: provider this bug was reported against (review R9).
+_MODEL_ESTIMATE_SLOPE: tuple[tuple[str, float], ...] = (("claude", 2.0),)
 
-#: Families with no measured entry above. 1.25 covers the OpenAI/GLM cluster
-#: (1.06-1.15 measured) with headroom; an unmeasured provider is more likely to
-#: resemble that cluster than Anthropic's outlier, and the ``MIN_OUTPUT_TOKENS``
-#: refusal below is what catches a family that turns out to be worse.
-DEFAULT_ESTIMATE_SLOPE = 1.25
+#: Families with no measured entry above.
+#:
+#: 1.75, NOT the 1.25 an earlier revision used. 1.25 was drawn from the two
+#: measured non-Anthropic families (1.06-1.15) and treated as a floor for
+#: everything unmeasured, which inverts the risk: over-estimating an unknown
+#: family costs output headroom, while under-estimating it re-opens the 400 the
+#: clamp exists to prevent, and the ``MIN_OUTPUT_TOKENS`` refusal cannot catch
+#: that because it fires on over-estimation. ``slope_fit.txt`` has no entry for
+#: xai, kimi, google, mistral, deepseek, alibaba or ollama, and its
+#: unattributed ``None/None`` rows sit at p50 **1.78** — evidence that an
+#: unidentified model behaves nothing like the cheap end of the range. 1.75
+#: covers that population; a family measured to be cheaper earns an entry above.
+DEFAULT_ESTIMATE_SLOPE = 1.75
+
+
+def _estimate_slope(model: ModelSpec) -> float:
+    """Local-estimate-to-provider ratio for ``model``, by model family.
+
+    Matches on the model id so an aggregator prefix does not hide the family:
+    ``anthropic/claude-sonnet-4.5`` served through OpenRouter is the same
+    tokenizer as ``claude-sonnet-4-5`` served directly, and must get the same
+    number. Unknown families take :data:`DEFAULT_ESTIMATE_SLOPE`, which is
+    deliberately nearer the expensive end — see its rationale.
+    """
+    model_id = model.model_id.lower()
+    for marker, slope in _MODEL_ESTIMATE_SLOPE:
+        if marker in model_id:
+            return slope
+    return DEFAULT_ESTIMATE_SLOPE
+
 
 #: Characters per token for the system-block and tool-schema term, matching the
 #: ratio ``compaction/tokens.py`` uses when tiktoken is absent. Deliberately a
@@ -748,10 +784,16 @@ def _effective_max_tokens(request: ChatRequest) -> int:
 
     1. ``request.context_tokens_hint`` — the provider's OWN count from the
        session's previous call. It is on the right ruler by construction and is
-       used unscaled, off only by the one turn appended since.
-    2. :func:`estimate_messages_tokens` scaled by
-       :data:`LOCAL_ESTIMATE_PROVIDER_SLOPE`, when no hint exists (a session's
-       first call, a fork, a one-shot errand).
+       used unscaled and WHOLE: it already covers the system blocks and tool
+       schemas, because ``Usage.context_tokens`` is normalized in this same file
+       as ``input + cache_read + cache_write``, i.e. the entire prompt the
+       provider read. Adding a locally-estimated prefix on top of it double-counts
+       (~21.8k phantom tokens with this repo's default tool set), which is review
+       finding R7.
+    2. :func:`estimate_messages_tokens` scaled by the model family's measured
+       ratio, when no hint exists (a session's first call, a fork, a one-shot
+       errand). Only this branch adds the system/tool term, because only here is
+       the term genuinely missing.
 
     An earlier revision used :func:`messages_tokens_upper_bound` on the argument
     that over-estimating is "the safe direction". That reasoning was wrong and is
@@ -800,61 +842,119 @@ def _effective_max_tokens(request: ChatRequest) -> int:
         # would invent a limit from a number that means "no data".
         return requested
 
-    prompt = _estimated_prompt_tokens(request)
+    prompt, measured_prompt = _estimated_prompt_tokens(request)
     available = window - prompt - OUTPUT_CLAMP_SAFETY_MARGIN
+    if window - measured_prompt - OUTPUT_CLAMP_SAFETY_MARGIN >= MIN_OUTPUT_TOKENS:
+        # The measured prompt leaves room to answer, so this session is NOT in
+        # the state the refusal exists for. Any shortfall below is an artifact of
+        # the safety scaling, and the honest response to our own margin is to
+        # shrink the ask — never to fail a request the provider would serve.
+        available = max(available, MIN_OUTPUT_TOKENS)
     if available >= requested:
-        # The overwhelmingly common case, and the one the previous revision broke:
+        # The overwhelmingly common case, and the one an earlier revision broke:
         # an ordinary prompt against a sanely advertised cap sends the spec's
         # number untouched. Anthropic (200k/64k, 1M/128k) and OpenAI (272k/128k)
         # come out byte-identical at every realistic session size.
         return requested
 
+    explicit = request.max_tokens or 0
+    if available < MIN_OUTPUT_TOKENS and 0 < explicit <= available:
+        # An EXPLICIT small ask that still fits is not the failure this refuses.
+        # ``MIN_OUTPUT_TOKENS`` encodes "a reply needs room to be a reply", but a
+        # caller who asked for 1024 (``Session.ERRAND_MAX_TOKENS``, auto-naming)
+        # has already said how much it needs, and a tool-loop continuation
+        # emitting one ``tool_use`` block needs a few hundred. Refusing a request
+        # the provider would have admitted, over a floor meant to protect it,
+        # would be the clamp inventing a failure (review R12).
+        return explicit
+
     if available < MIN_OUTPUT_TOKENS:
         # REFUSE rather than send a cap too small to answer with. Sending it
         # anyway is the one outcome worse than the bug this fixes: reasoning
         # tokens are billed against this same budget (grok-4.6 spent 689 of them
-        # thinking at a 512 cap and emitted no text at all), and
-        # ``harness/loop.py`` only retries a COMPLETELY silent truncation —
-        # ``silent = not assistant.text and not assistant.tool_calls`` — so a
-        # partial answer is accepted with no notice and the user reads a
-        # confidently truncated reply. A ProviderError is legible, reaches the
-        # incident path, and says which numbers made the request impossible;
-        # the pre-fix behaviour for this case was itself a visible HTTP 400, so
-        # this preserves the failure's visibility instead of hiding it.
+        # thinking at a 512 cap), and ``harness/loop.py`` only retries a
+        # COMPLETELY silent truncation — ``silent = not assistant.text and not
+        # assistant.tool_calls`` — so a partial answer is accepted with no notice
+        # and the user reads a confidently truncated reply.
+        #
+        # The refusal is judged on ``measured_prompt``, NOT on the scaled
+        # estimate, and that distinction is the whole of review finding R8. A
+        # scaled figure can exceed the window on a session that is genuinely
+        # fine, and refusing there wedges it: the turn dies non-retryably while
+        # the session sits BELOW its compaction threshold, and the compaction
+        # summarizer — which takes this same path — is refused too, so the one
+        # remedy the error names cannot run. Measured, a 200k Anthropic model
+        # past ~135k local tokens could not compact at all.
+        #
+        # Keying on the unscaled figure makes the invariant provable rather than
+        # tuned: the refusal point is ``window - MIN_OUTPUT_TOKENS -
+        # OUTPUT_CLAMP_SAFETY_MARGIN``, and compaction triggers at
+        # ``COMPACTION_TRIGGER_FRACTION * window``, so the refusal stays above
+        # the trigger whenever ``0.2 * window > 8192``, i.e. for every window
+        # above ~41k. Below that a model is too small for the trigger to help
+        # anyway. Compaction therefore always gets its chance first, and the
+        # summarizer's own call — a fresh prefix, not the bloated transcript —
+        # measures small and is never refused.
+        #
+        # A residual false refusal remains and is ACCEPTED rather than
+        # overlooked: the local estimator can itself over-state a prompt (QA
+        # measured ~8.8k high at ~93% occupancy), so a request with a little real
+        # headroom left can be refused. That band sits far above the compaction
+        # trigger, it is not a regression — the pre-fix behaviour there is an
+        # HTTP 400 from the provider — and the two failures differ only in which
+        # side reports them. Closing it would mean trusting a local count at
+        # exactly the occupancy where being wrong is most expensive.
         raise ProviderError(
             None,
             (
-                f"prompt is too large for {request.model.model_id}: about {prompt:,} "
-                f"tokens of input against a {window:,}-token context window leaves "
-                f"under {MIN_OUTPUT_TOKENS:,} tokens for the reply. Compact the "
-                f"conversation or start a new session."
+                f"prompt is too large for {request.model.model_id}: about "
+                f"{measured_prompt:,} tokens of input against a {window:,}-token "
+                f"context window leaves under {MIN_OUTPUT_TOKENS:,} tokens for the "
+                f"reply. Compact the conversation or start a new session."
             ),
             kind="request",
         )
     return available
 
 
-def _estimated_prompt_tokens(request: ChatRequest) -> int:
-    """Prompt size for :func:`_effective_max_tokens`, on the provider's ruler.
+def _estimated_prompt_tokens(request: ChatRequest) -> tuple[int, int]:
+    """Prompt size for :func:`_effective_max_tokens`, as ``(scaled, measured)``.
 
-    Split out so the two rulers and their scaling are readable in one place, and
-    so the estimate can be exercised directly by tests.
+    TWO numbers, because they answer two different questions and conflating them
+    is review finding R8:
 
-    The messages term prefers ``context_tokens_hint`` (the provider's own count)
-    and otherwise scales the local estimate by the family's measured ratio — see
-    :data:`_PROVIDER_ESTIMATE_SLOPE`. System blocks and tools are always added
-    from the local side: they are not part of the hint's prefix on a first call
-    and, being English prose plus JSON, they are exactly the content the
-    ~4 chars/token ratio describes well.
+    * ``scaled`` carries the safety margin and sizes the ASK. Erring high here
+      costs a little output headroom near the window and nothing at all below it.
+    * ``measured`` is the best unembellished figure available — the provider's
+      own count when there is one, the raw local estimate otherwise. It decides
+      whether the request is REFUSED. A refusal must never rest on our own
+      inflation: that is what wedged sessions that were fine and blocked the
+      compaction pass that would have rescued them.
+
+    On the hinted branch the two are equal, because there is nothing to be
+    uncertain about.
+
+    The hint is used WHOLE. ``Usage.context_tokens`` is normalized in this file
+    as ``input + cache_read + cache_write`` — the entire prompt the provider
+    read, system blocks and tool schemas included — so the prefix term below
+    belongs only to the estimated branch. Adding it to a hint double-counts it
+    (R7).
     """
-    slope = _PROVIDER_ESTIMATE_SLOPE.get(request.model.provider, DEFAULT_ESTIMATE_SLOPE)
-
     hint = request.context_tokens_hint
-    if hint is not None and hint > 0:
-        # Already a provider figure — no slope, or it would be double-counted.
-        messages = hint
-    else:
-        messages = int(estimate_messages_tokens(request.messages) * slope)
+    window = request.model.context_window
+    if hint is not None and hint > 0 and not (window > 0 and hint > window):
+        # Already a provider figure, and about a model this size: no slope, no
+        # prefix, nothing to add. A hint LARGER than the window is deliberately
+        # excluded — it cannot describe this request, so believing it would
+        # refuse a session whose real context fits. That state is reachable two
+        # ways, both reproduced by reviewers: `Session.set_model` swaps to a
+        # smaller-window model without clearing the hint (a `/model` down-switch),
+        # and the failover clone keeps the primary's hint while moving to a
+        # smaller fallback spec. Falling through to the local estimate re-measures
+        # the messages actually in hand, which is the only honest answer.
+        return hint, hint
+
+    local = estimate_messages_tokens(request.messages)
 
     extra_chars = sum(len(block) for block in request.system_blocks)
     for tool in request.tools:
@@ -863,9 +963,10 @@ def _estimated_prompt_tokens(request: ChatRequest) -> int:
         # the schema is as good an input to a /4 estimate as its exact
         # serialization would be (review R6).
         extra_chars += len(tool.name) + len(tool.description) + len(str(tool.parameters))
-    # Same chars/token ratio the token module falls back to, scaled onto the
-    # provider's ruler for the same reason the messages term is.
-    return messages + int((extra_chars / _CHARS_PER_TOKEN) * slope)
+    prefix = int(extra_chars / _CHARS_PER_TOKEN)
+
+    measured = local + prefix
+    return int(measured * _estimate_slope(request.model)), measured
 
 
 def _reasoning_effort(request: ChatRequest) -> str | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.59"
+version = "0.44.60"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -3799,3 +3799,63 @@ async def test_session_stream_hint_is_per_conversation_not_per_stream_fn(
         m == {"type": "ephemeral", "ttl": "1h"} for m in _cache_markers(bodies[2])
     )
     assert parent._context_tokens_hint == 300_000
+
+
+# -- the muse-spark overflow, end to end ---------------------------------------
+
+
+#: OpenRouter's listing entry for ``meta/muse-spark-1.3``, trimmed to the fields
+#: the resolver reads. The two numbers are verbatim from the live catalogue on
+#: 2026-09-02 and are the whole bug: ``max_completion_tokens`` is exactly 0.9 of
+#: ``context_length``, and providers count prompt + max_tokens against the window
+#: at admission, so the advertised cap alone consumes 90% of the model.
+_MUSE_SPARK_LISTING_ENTRY = {
+    "id": "meta/muse-spark-1.3",
+    "name": "Meta: Muse Spark 1.3",
+    "context_length": 1_048_576,
+    "top_provider": {"context_length": 1_048_576, "max_completion_tokens": 943_718},
+    "pricing": {"prompt": "0.00000125", "completion": "0.00000425"},
+    "architecture": {"input_modalities": ["text"]},
+}
+
+
+def test_muse_spark_listing_no_longer_overflows_its_window(monkeypatch) -> None:
+    """The reported incident, reproduced through the REAL resolver.
+
+    A session on ``openrouter/meta/muse-spark-1.3`` died with HTTP 400::
+
+        This endpoint's maximum context length is 1048576 tokens. However, you
+        requested about 1057079 tokens (102961 of text input, 10400 of tool
+        input, 943718 in the output).
+
+    The 943718 was never generated text — it is the ``max_tokens`` the harness
+    put on the wire, copied from the listing through ``DiscoveredModel`` and
+    ``ModelSpec``. Compaction could not rescue it: the trigger is a fraction of
+    the window (~838k at the default 0.8), far above where the 400 lands.
+
+    This pins the whole chain — listing entry, spec, wire body — rather than any
+    single link, because each one alone looked reasonable.
+    """
+    from local_operator.model.discovery import _row_from_openai_entry
+    from local_operator.providers.clients import OpenAICompatClient
+
+    row = _row_from_openai_entry(_MUSE_SPARK_LISTING_ENTRY)
+    assert row is not None
+    # The listing really does advertise this, and the parser really does read it.
+    assert row.context_window == 1_048_576
+
+    info = ModelInfo(
+        id=row.id,
+        name=row.name,
+        description="live",
+        context_window=row.context_window,
+        max_tokens=row.max_tokens,
+    )
+    spec = build_model_spec("openrouter", "meta/muse-spark-1.3", info=info)
+
+    # ~113k tokens of prompt: the size the real session failed at.
+    request = ChatRequest(model=spec, messages=[Message.user("word " * 120_000)])
+    body = OpenAICompatClient("https://openrouter.ai/api/v1")._build_body(request)
+
+    prompt_tokens = len("word " * 120_000) // 4
+    assert body["max_tokens"] + prompt_tokens < spec.context_window

--- a/tests/unit/model/test_discovery.py
+++ b/tests/unit/model/test_discovery.py
@@ -2170,3 +2170,64 @@ def test_a_stale_document_degrades_to_the_table_rather_than_lying(tmp_path) -> N
     assert status == "ok"
     assert len(client.calls) == 1
     assert rows[0].reasoning_efforts == ("low", "high")
+
+# -- implausible advertised output caps ---------------------------------------
+
+
+def test_merge_reduces_an_output_cap_that_is_nine_tenths_of_the_window() -> None:
+    """The muse-spark shape, verbatim from OpenRouter's listing.
+
+    ``context_length: 1048576`` beside ``max_completion_tokens: 943718`` reserves
+    90% of the window for output, leaving ~104k of prompt on a 1M model. A real
+    session 400'd at ~113k of input. ~80 rows in the live catalogue carry this
+    exact 0.9 ratio, so it is a gateway formula rather than a stated limit.
+    """
+    merged = merge_models(
+        {},
+        [DiscoveredModel(id="meta/muse-spark-1.3", context_window=1_048_576, max_tokens=943_718)],
+    )
+
+    assert merged[0].max_tokens == 524_288
+    # The property that actually matters: prompt room is now half the window
+    # rather than a tenth of it.
+    assert merged[0].context_window - merged[0].max_tokens >= 500_000
+
+
+def test_merge_leaves_a_legitimately_large_output_cap_alone() -> None:
+    """A model genuinely serving 64k of output on a 200k window is 0.32 and must
+    pass through untouched — the guard targets the window-fraction formula, not
+    large caps as such."""
+    merged = merge_models({}, [DiscoveredModel(id="m", context_window=200_000, max_tokens=64_000)])
+
+    assert merged[0].max_tokens == 64_000
+
+
+def test_merge_leaves_the_mistral_four_fifths_cluster_alone() -> None:
+    """``mistralai/mistral-large`` is 128000/102400 — exactly 0.8, a dense and
+    plainly deliberate cluster in the live catalogue that sits below the line."""
+    merged = merge_models({}, [DiscoveredModel(id="m", context_window=128_000, max_tokens=102_400)])
+
+    assert merged[0].max_tokens == 102_400
+
+
+def test_merge_reduces_an_implausible_cap_even_beside_a_registry_row() -> None:
+    """The guard runs on BOTH merge branches. A live-only row takes the early
+    return, so a rule applied only to the reconciled branch would miss exactly
+    the unshipped models this module exists to surface — and vice versa."""
+    static = {"m": _info("m", context_window=500_000, max_tokens=8_192)}
+    merged = merge_models(
+        {**static}, [DiscoveredModel(id="m", context_window=500_000, max_tokens=450_000)]
+    )
+
+    assert merged[0].max_tokens == 250_000
+
+
+def test_merge_keeps_a_static_output_cap_that_exceeds_the_ratio() -> None:
+    """The ratio judges LISTINGS, never the bundled registry. 52 shipped rows
+    exceed it legitimately — ``gpt-4o`` is 128000/128000 — because a
+    hand-transcribed entry states the model's documented maximum. Reducing those
+    would shrink specs that work correctly today."""
+    static = {"m": _info("m", context_window=128_000, max_tokens=128_000)}
+    merged = merge_models(static, None)
+
+    assert merged[0].max_tokens == 128_000

--- a/tests/unit/model/test_discovery.py
+++ b/tests/unit/model/test_discovery.py
@@ -2171,6 +2171,7 @@ def test_a_stale_document_degrades_to_the_table_rather_than_lying(tmp_path) -> N
     assert len(client.calls) == 1
     assert rows[0].reasoning_efforts == ("low", "high")
 
+
 # -- implausible advertised output caps ---------------------------------------
 
 

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -39,8 +39,8 @@ from local_operator.providers.clients import (
     _effective_max_tokens,
     _estimate_slope,
     _estimated_prompt_tokens,
-    _output_reserve_tokens,
     _message_to_openai,
+    _output_reserve_tokens,
     client_for_spec,
     raise_for_status,
 )

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -24,13 +24,18 @@ from local_operator.harness.types import (
     ToolContext,
     ToolResult,
 )
+from local_operator.compaction.thresholds import CompactionSettings, resolve_threshold_tokens
 from local_operator.providers.clients import (
+    DEFAULT_ESTIMATE_SLOPE,
     MIN_OUTPUT_TOKENS,
     AnthropicClient,
     GoogleClient,
     MockClient,
     OpenAICompatClient,
     _anthropic_stream_error,
+    _effective_max_tokens,
+    _estimate_slope,
+    _estimated_prompt_tokens,
     _message_to_openai,
     client_for_spec,
     raise_for_status,
@@ -3678,14 +3683,20 @@ def _every_cache_control(body: dict[str, Any]) -> list[dict[str, Any]]:
 def _large_context_request() -> ChatRequest:
     """A request whose TTL tests drive ``context_tokens_hint`` up to 900k.
 
-    The window is stated explicitly (1M, Claude's real size) rather than left on
-    the ``ModelSpec`` default of 128k. These tests set hints of 150k-900k, and a
-    hint LARGER than the window is a state that cannot occur in production — the
-    hint is the provider's own count of a prompt it already accepted — so the
-    default made the fixture describe an impossible session. It now also has to
-    be a window the output clamp can fund a reply in, since
-    ``_effective_max_tokens`` refuses a request whose prompt leaves no room to
-    answer.
+    The window is stated explicitly (1M, Claude's real size) so these tests
+    exercise the TTL policy on a session that plausibly holds that much, rather
+    than inheriting the ``ModelSpec`` default of 128k.
+
+    An earlier revision justified this by claiming a hint larger than the window
+    "cannot occur in production". **That claim was false** and is corrected here
+    rather than deleted, because it is the kind of premise someone later widens
+    a refusal on: two real paths strand a hint from a bigger model —
+    ``Session.set_model`` swaps the spec on a ``/model`` down-switch without
+    clearing ``_context_tokens_hint``, and the failover clone keeps the primary's
+    hint while moving to a smaller fallback spec. That case is covered directly
+    by ``test_a_hint_larger_than_the_window_is_not_believed`` and by
+    ``test_anthropic_ttl_hint_above_a_small_window_still_marks_1h`` below; the
+    window here is large only so the TTL assertions stay about TTL.
     """
     return ChatRequest(
         model=ModelSpec(provider="anthropic", model_id="claude-opus-5", context_window=1_000_000),
@@ -3722,6 +3733,35 @@ def test_anthropic_ttl_hint_below_threshold_stays_5m() -> None:
     request = _large_context_request().model_copy(update={"context_tokens_hint": 149_999})
     markers = _every_cache_control(client._build_body(request))
     assert markers and all(m == {"type": "ephemeral"} for m in markers)
+
+
+def test_anthropic_ttl_hint_above_a_small_window_still_marks_1h() -> None:
+    """The hint-larger-than-window case the original fixtures encoded, restored.
+
+    A ``/model`` down-switch or a failover onto a smaller spec leaves the
+    previous model's count on the request, so this pairing is real and the body
+    must still build: the TTL policy reads the hint as a SIZE signal and is
+    entitled to believe a large one, while the output clamp separately refuses to
+    believe it as a prompt measurement. Raising these fixtures to a 1M window
+    removed the only coverage of that combination and let the clamp's refusal
+    ship without anyone deciding what should happen here (R10).
+    """
+    client = AnthropicClient(cache_ttl_1h_min_context_tokens=150_000)
+    request = _large_context_request().model_copy(
+        update={
+            "model": ModelSpec(
+                provider="anthropic", model_id="claude-opus-4.1", context_window=128_000
+            ),
+            "context_tokens_hint": 900_000,
+        }
+    )
+
+    body = client._build_body(request, oauth=True)
+
+    markers = _every_cache_control(body)
+    assert markers and all(m == {"type": "ephemeral", "ttl": "1h"} for m in markers)
+    # And the clamp does not refuse it: the messages actually in hand are tiny.
+    assert body["max_tokens"] > 0
 
 
 def test_anthropic_ttl_without_hint_falls_back_to_byte_estimate() -> None:
@@ -4144,3 +4184,169 @@ def test_no_cap_anywhere_leaves_the_key_absent() -> None:
     assert "max_tokens" not in body["openai-completions"]
     assert "max_output_tokens" not in body["openai-responses"]
     assert "maxOutputTokens" not in body["google"]
+
+
+# --- the clamp's safety properties, not just its arithmetic --------------------
+#
+# Round-2 review mutation-tested the previous set and found it ONE-SIDED: raising
+# the slope failed 12 tests, but emptying the table entirely — which is the
+# aggregator bug made global, and re-opens the HTTP 400 — left all 766 provider
+# tests green. Downward mutations are the dangerous direction, so these pin the
+# floor, the family keying, the hinted path (previously untested altogether) and
+# the compaction interaction.
+
+
+def _tool(name: str = "t", schema_chars: int = 1_500) -> AgentTool:
+    """A tool whose schema is bulky enough to move a token estimate."""
+    return AgentTool(
+        name=name,
+        description="d" * schema_chars,
+        parameters={"type": "object"},
+        execute=lambda ctx, **kw: ToolResult(),  # type: ignore[arg-type,return-value]
+    )
+
+
+def test_context_tokens_hint_is_used_whole_and_not_re_padded() -> None:
+    """``Usage.context_tokens`` already covers system blocks and tool schemas, so
+    adding a locally-estimated prefix on top double-counts it.
+
+    Measured at ~21.8k phantom tokens with this repo's default tool set (R7).
+    The same hint must therefore produce the same budget no matter how large the
+    prefix is — the hint already contains it.
+    """
+    spec = _sonnet_spec()
+    bare = ChatRequest(model=spec, messages=[Message.user("hi")], context_tokens_hint=100_000)
+    padded = ChatRequest(
+        model=spec,
+        messages=[Message.user("hi")],
+        system_blocks=["s" * 20_000],
+        tools=[_tool(f"t{i}") for i in range(15)],
+        context_tokens_hint=100_000,
+    )
+
+    assert _estimated_prompt_tokens(bare) == (100_000, 100_000)
+    assert _estimated_prompt_tokens(padded) == _estimated_prompt_tokens(bare)
+
+
+def test_the_refusal_never_pre_empts_compaction() -> None:
+    """The invariant that keeps a recoverable session recoverable.
+
+    The refusal must not fire below the compaction trigger, or the turn dies
+    non-retryably on a session that would have compacted at the next boundary and
+    continued. Asserted against the real ``resolve_threshold_tokens`` rather than
+    a copied constant, and across tool counts, because it was a tool-scaled
+    over-estimate that broke this (R8).
+    """
+    settings = CompactionSettings()
+    for window in (64_000, 128_000, 200_000, 272_000, 1_000_000):
+        spec = ModelSpec(
+            provider="anthropic",
+            model_id="claude-sonnet-4-5",
+            context_window=window,
+            max_output_tokens=min(64_000, window // 2),
+        )
+        trigger = resolve_threshold_tokens(window, settings)
+        for tool_count in (0, 10, 30):
+            request = ChatRequest(
+                model=spec,
+                messages=[Message.user("hi")],
+                tools=[_tool(f"t{i}") for i in range(tool_count)],
+                # A session sitting exactly ON its compaction trigger is the last
+                # moment compaction can still save it; it must not be refused.
+                context_tokens_hint=trigger,
+            )
+            _effective_max_tokens(request)  # must not raise
+
+
+def test_the_compaction_summarizer_is_never_refused() -> None:
+    """``Session._one_shot_complete`` sends the transcript with
+    ``context_tokens_hint=0``, so it takes the estimated branch.
+
+    If that path can refuse, the one remedy the refusal's own message names
+    cannot run and the session is wedged with no in-session recovery — strictly
+    worse than the HTTP 400 this PR set out to fix. Measured before the fix: a
+    200k Anthropic model past ~135k local tokens could not compact.
+    """
+    spec = _sonnet_spec()
+    for local_tokens in (90_000, 135_000, 180_000):
+        request = ChatRequest(
+            model=spec,
+            messages=[Message.user(_prose(local_tokens))],
+            context_tokens_hint=0,
+        )
+        assert _effective_max_tokens(request) >= MIN_OUTPUT_TOKENS
+
+
+def test_a_hint_larger_than_the_window_is_not_believed() -> None:
+    """A stale hint must not refuse a session whose real context fits.
+
+    Reachable two ways, both reproduced by reviewers: ``Session.set_model``
+    swaps to a smaller-window model without clearing the hint (a ``/model``
+    down-switch), and the failover clone keeps the primary's hint while moving
+    to a smaller fallback spec. The hint cannot be describing THIS request, so
+    the local estimate is the only honest figure (R10).
+    """
+    spec = ModelSpec(
+        provider="anthropic",
+        model_id="claude-opus-4.1",
+        context_window=200_000,
+        max_output_tokens=32_000,
+    )
+    request = ChatRequest(model=spec, messages=[Message.user("hi")], context_tokens_hint=600_000)
+
+    assert _effective_max_tokens(request) == 32_000
+
+
+@pytest.mark.parametrize(
+    "provider,model_id",
+    [
+        ("anthropic", "claude-sonnet-4-5"),
+        ("openrouter", "anthropic/claude-sonnet-4.5"),
+        ("radient", "anthropic/claude-opus-4.1"),
+    ],
+)
+def test_claude_gets_its_measured_slope_on_every_route(provider: str, model_id: str) -> None:
+    """The ratio belongs to the TOKENIZER, so the route must not change it.
+
+    Keying on ``ModelSpec.provider`` gave every aggregator-served Claude the low
+    default and re-opened the original 400 on the exact provider this bug was
+    reported against (R9). ``openrouter`` and ``radient`` are real registry ids.
+    """
+    assert _estimate_slope(ModelSpec(provider=provider, model_id=model_id)) == 2.0
+
+
+def test_an_unknown_family_fails_safe_rather_than_cheap() -> None:
+    """An unmeasured family must be assumed expensive.
+
+    Under-estimating re-opens the HTTP 400, and the ``MIN_OUTPUT_TOKENS``
+    refusal cannot catch it because that fires on OVER-estimation. The
+    evidence file's unattributed rows sit at p50 1.78, so the default has to
+    live near that, not near the cheap end.
+    """
+    slope = _estimate_slope(ModelSpec(provider="xai", model_id="grok-4.6"))
+
+    assert slope == DEFAULT_ESTIMATE_SLOPE
+    # The floor is the point: a default that drifts down re-opens the bug, and
+    # every previous test stayed green while it did exactly that.
+    assert slope >= 1.75
+
+
+def test_the_ask_stays_admissible_for_an_expensive_tokenizer() -> None:
+    """The end-to-end property the slope exists for, stated as admission.
+
+    A Claude prompt whose real cost is ~1.9x the local estimate must still leave
+    ``prompt + max_tokens`` inside the window. This is the assertion that fails
+    when the slope table is emptied — the mutation the previous suite could not
+    detect.
+    """
+    spec = _sonnet_spec()
+    request = ChatRequest(model=spec, messages=[Message.user(_prose(90_000))])
+
+    sent = _bodies(request)["anthropic"]["max_tokens"]
+
+    # Measured, not the nominal size asked for: `_prose` targets a character
+    # count and the tokenizer decides the rest, so pinning the assertion to the
+    # request's own estimate is what keeps this about admission.
+    _, measured = _estimated_prompt_tokens(request)
+    real_prompt = measured * 1.9  # the measured Anthropic worst case
+    assert real_prompt + sent <= spec.context_window

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -39,6 +39,7 @@ from local_operator.providers.clients import (
     _effective_max_tokens,
     _estimate_slope,
     _estimated_prompt_tokens,
+    _output_reserve_tokens,
     _message_to_openai,
     client_for_spec,
     raise_for_status,
@@ -4241,7 +4242,10 @@ def test_the_refusal_never_pre_empts_compaction() -> None:
     over-estimate that broke this (R8).
     """
     settings = CompactionSettings()
-    for window in (64_000, 128_000, 200_000, 272_000, 1_000_000):
+    # Starts at 8,000 deliberately. The previous range began at 64,000 — exactly
+    # where the old constant reserve started holding — so the failing band was
+    # never entered and the test passed while every 8k model was bricked.
+    for window in (8_000, 8_192, 16_385, 32_768, 40_960, 64_000, 128_000, 200_000, 1_000_000):
         spec = ModelSpec(
             provider="anthropic",
             model_id="claude-sonnet-4-5",
@@ -4277,7 +4281,24 @@ def test_the_compaction_summarizer_is_never_refused() -> None:
             messages=[Message.user(_prose(local_tokens))],
             context_tokens_hint=0,
         )
-        assert _effective_max_tokens(request) >= MIN_OUTPUT_TOKENS
+        assert _effective_max_tokens(request) >= _output_reserve_tokens(spec.context_window)
+
+    # Small windows too: the summarizer is refused there for the same reason a
+    # turn is, and `/compact` is the remedy the refusal's own message names.
+    for window in (8_192, 16_385, 32_768):
+        small = ModelSpec(
+            provider="openai",
+            model_id="gpt-4",
+            context_window=window,
+            max_output_tokens=window // 2,
+        )
+        trigger = resolve_threshold_tokens(window, CompactionSettings())
+        request = ChatRequest(
+            model=small,
+            messages=[Message.user(_prose(int(trigger * 0.9)))],
+            context_tokens_hint=0,
+        )
+        assert _effective_max_tokens(request) > 0
 
 
 def test_a_hint_larger_than_the_window_is_not_believed() -> None:
@@ -4311,27 +4332,31 @@ def test_a_hint_larger_than_the_window_is_not_believed() -> None:
 def test_claude_gets_its_measured_slope_on_every_route(provider: str, model_id: str) -> None:
     """The ratio belongs to the TOKENIZER, so the route must not change it.
 
-    Keying on ``ModelSpec.provider`` gave every aggregator-served Claude the low
-    default and re-opened the original 400 on the exact provider this bug was
-    reported against (R9). ``openrouter`` and ``radient`` are real registry ids.
+    Keying on ``ModelSpec.provider`` gave every aggregator-served Claude a
+    different number than the same model served directly, re-opening the original
+    400 on the exact provider this bug was reported against (R9). ``openrouter``
+    and ``radient`` are real registry ids. The value is uniform today; what this
+    pins is that the ROUTE cannot change it.
     """
-    assert _estimate_slope(ModelSpec(provider=provider, model_id=model_id)) == 2.0
+    assert _estimate_slope(ModelSpec(provider=provider, model_id=model_id)) == (
+        DEFAULT_ESTIMATE_SLOPE
+    )
 
 
 def test_an_unknown_family_fails_safe_rather_than_cheap() -> None:
-    """An unmeasured family must be assumed expensive.
+    """The slope must stay above every ratio actually measured.
 
-    Under-estimating re-opens the HTTP 400, and the ``MIN_OUTPUT_TOKENS``
-    refusal cannot catch it because that fires on OVER-estimation. The
-    evidence file's unattributed rows sit at p50 1.78, so the default has to
-    live near that, not near the cheap end.
+    Under-estimating re-opens the HTTP 400, and the refusal cannot catch it
+    because that fires on OVER-estimation. Live measurement puts Claude at
+    1.10-1.16 and the cross-family spread at 1.005-1.18, so the floor asserted
+    here is what keeps a future tuning pass from drifting under the evidence.
     """
     slope = _estimate_slope(ModelSpec(provider="xai", model_id="grok-4.6"))
 
     assert slope == DEFAULT_ESTIMATE_SLOPE
     # The floor is the point: a default that drifts down re-opens the bug, and
     # every previous test stayed green while it did exactly that.
-    assert slope >= 1.75
+    assert slope >= 1.25
 
 
 def test_the_ask_stays_admissible_for_an_expensive_tokenizer() -> None:
@@ -4351,5 +4376,104 @@ def test_the_ask_stays_admissible_for_an_expensive_tokenizer() -> None:
     # count and the tokenizer decides the rest, so pinning the assertion to the
     # request's own estimate is what keeps this about admission.
     _, measured = _estimated_prompt_tokens(request)
-    real_prompt = measured * 1.9  # the measured Anthropic worst case
+    real_prompt = measured * 1.2  # above every live-measured Claude ratio (1.10-1.16)
     assert real_prompt + sent <= spec.context_window
+
+
+# --- small windows and the healthy-session ask --------------------------------
+#
+# Round-3 review and QA both found the same two defects, and both were invisible
+# to the suite because its smallest window under test was 10,000 and used only to
+# assert that a refusal SHOULD fire. Nothing asserted that an ordinary prompt on a
+# small window ADMITS, and nothing checked what the ask becomes once the measured
+# figure has proved a session healthy.
+
+
+@pytest.mark.parametrize("window", [8_000, 8_192, 16_385, 32_768])
+def test_a_small_prompt_on_a_small_window_still_admits(window: int) -> None:
+    """An 8k model must serve ``"hi"``.
+
+    ``MIN_OUTPUT_TOKENS + OUTPUT_CLAMP_SAFETY_MARGIN`` is 8192, so a constant
+    reserve consumed the ENTIRE window of ``gpt-4`` and ``moonshot-v1-8k`` and
+    refused every request to them — a one-token prompt included, with 8,185
+    tokens of real headroom. 7 bundled registry rows and 12 live OpenRouter rows
+    sit at or below 8,192.
+    """
+    spec = ModelSpec(
+        provider="openai", model_id="gpt-4", context_window=window, max_output_tokens=window
+    )
+    request = ChatRequest(model=spec, messages=[Message.user("hi")])
+
+    assert _effective_max_tokens(request) > 0
+
+
+@pytest.mark.parametrize("window", [1_000, 8_192, 32_768, 40_960, 200_000, 2_000_000])
+def test_the_reserve_stays_inside_the_compaction_headroom_at_every_window(window: int) -> None:
+    """The ordering that keeps a recoverable session recoverable, as ALGEBRA.
+
+    The refusal point and the compaction trigger must keep a fixed order at every
+    window size. A constant reserve against a fractional trigger cannot: it held
+    above ~41k and inverted below, which is the same wedge the round-2 review
+    found, relocated one window-band lower. Expressing the reserve in the
+    trigger's own shape makes the ordering true by construction — so this asserts
+    it across four orders of magnitude rather than over a lucky range.
+    """
+    settings = CompactionSettings()
+
+    refusal_point = window - _output_reserve_tokens(window, settings)
+
+    assert refusal_point > resolve_threshold_tokens(window, settings)
+
+
+def test_the_reserve_tracks_a_raised_compaction_threshold() -> None:
+    """``threshold_percent`` is user-configurable, so a hardcoded fraction would
+    silently re-invert for anyone who raises it. The reserve is derived from the
+    caller's own settings for that reason."""
+    aggressive = CompactionSettings(threshold_percent=0.95)
+
+    window = 200_000
+    refusal_point = window - _output_reserve_tokens(window, aggressive)
+
+    assert refusal_point > resolve_threshold_tokens(window, aggressive)
+
+
+@pytest.mark.parametrize("occupancy", [0.25, 0.41, 0.50])
+def test_a_healthy_session_keeps_its_full_ask_without_a_hint(occupancy: float) -> None:
+    """The hint-less path must not be quietly capped at the reserve.
+
+    Flooring at ``MIN_OUTPUT_TOKENS`` once the measurement proved a session
+    healthy was round-1's truncation defect by another route: at 50% occupancy a
+    Sonnet first call asked for 4,096 with ~95k tokens of real headroom and
+    returned an answer cut mid-word with ``finish_reason='length'``, where main
+    completed it. It bit only the hint-less branch — first call, forks, errands,
+    the compaction summarizer — which is why a hinted measurement did not show it.
+
+    Capped at 50% deliberately: past roughly 55% a reduced ask is CORRECT, since
+    the prompt plus a full 64k reply genuinely approaches the window. What this
+    pins is the band where main answers in full and the branch must too.
+    """
+    spec = _sonnet_spec()
+    request = ChatRequest(
+        model=spec, messages=[Message.user(_prose(int(spec.context_window * occupancy)))]
+    )
+
+    assert _bodies(request)["anthropic"]["max_tokens"] == spec.max_output_tokens
+
+
+def test_an_explicit_small_ask_the_measured_headroom_can_fund_is_reachable() -> None:
+    """The R12 escape hatch, now with a comparison an input can actually satisfy.
+
+    It previously tested ``explicit <= available`` while reaching the branch
+    required ``available < explicit`` — a contradiction, so an exhaustive search
+    hit it zero times and the comment claimed a protection that did not exist.
+    Comparing against the MEASURED headroom is what the reasoning always
+    described.
+    """
+    spec = ModelSpec(
+        provider="anthropic", model_id="claude-x", context_window=8_192, max_output_tokens=4_096
+    )
+    # High occupancy: the scaled figure exhausts the window while the measured one
+    # still funds a small explicit ask.
+    request = ChatRequest(model=spec, messages=[Message.user(_prose(7_500))], max_tokens=256)
+
+    assert _effective_max_tokens(request) == 256

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -9,6 +9,10 @@ from typing import Any, Literal
 import httpx
 import pytest
 
+from local_operator.compaction.thresholds import (
+    CompactionSettings,
+    resolve_threshold_tokens,
+)
 from local_operator.harness.types import (
     AgentTool,
     ChatRequest,
@@ -24,7 +28,6 @@ from local_operator.harness.types import (
     ToolContext,
     ToolResult,
 )
-from local_operator.compaction.thresholds import CompactionSettings, resolve_threshold_tokens
 from local_operator.providers.clients import (
     DEFAULT_ESTIMATE_SLOPE,
     MIN_OUTPUT_TOKENS,

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -31,6 +31,7 @@ from local_operator.harness.types import (
 from local_operator.providers.clients import (
     DEFAULT_ESTIMATE_SLOPE,
     MIN_OUTPUT_TOKENS,
+    OUTPUT_CLAMP_SAFETY_MARGIN,
     AnthropicClient,
     GoogleClient,
     MockClient,
@@ -4460,20 +4461,208 @@ def test_a_healthy_session_keeps_its_full_ask_without_a_hint(occupancy: float) -
     assert _bodies(request)["anthropic"]["max_tokens"] == spec.max_output_tokens
 
 
-def test_an_explicit_small_ask_the_measured_headroom_can_fund_is_reachable() -> None:
-    """The R12 escape hatch, now with a comparison an input can actually satisfy.
+@pytest.mark.parametrize("window", [8_192, 32_768, 200_000])
+@pytest.mark.parametrize("explicit", [128, 1024])
+def test_an_explicit_small_ask_is_never_raised(window: int, explicit: int) -> None:
+    """The clamp only ever LOWERS, which is what keeps ``ERRAND_MAX_TOKENS`` small.
 
-    It previously tested ``explicit <= available`` while reaching the branch
-    required ``available < explicit`` — a contradiction, so an exhaustive search
-    hit it zero times and the comment claimed a protection that did not exist.
-    Comparing against the MEASURED headroom is what the reasoning always
-    described.
+    A caller that names its own budget (auto-naming asks for 1024) has already
+    said how much it needs. An earlier revision carried a dedicated escape hatch
+    for this and it was dead code twice over; the rescue clause subsumes it, so
+    what needs pinning is the GUARANTEE rather than the branch that used to
+    implement it.
     """
     spec = ModelSpec(
-        provider="anthropic", model_id="claude-x", context_window=8_192, max_output_tokens=4_096
+        provider="anthropic",
+        model_id="claude-x",
+        context_window=window,
+        max_output_tokens=64_000,
     )
-    # High occupancy: the scaled figure exhausts the window while the measured one
-    # still funds a small explicit ask.
-    request = ChatRequest(model=spec, messages=[Message.user(_prose(7_500))], max_tokens=256)
+    # Half-full: past the point where the scaled taper has started biting, but
+    # still a session the measurement calls healthy.
+    request = ChatRequest(
+        model=spec,
+        messages=[Message.user(_prose(window // 2))],
+        max_tokens=explicit,
+    )
 
-    assert _effective_max_tokens(request) == 256
+    assert _effective_max_tokens(request) <= explicit
+
+
+# --- the rescue bound, pinned so it cannot silently regress -------------------
+#
+# Round-4 review and QA both found that three of the mutations claimed for this
+# clause killed ZERO tests: reverting the rescue to a bare `MIN_OUTPUT_TOKENS`
+# floor passed the whole suite. The reason is that `_output_reserve_tokens`
+# saturates at `MIN_OUTPUT_TOKENS` on every window >= 40,960, so the two forms are
+# the same value everywhere the earlier tests looked. These pin the properties
+# that actually distinguish a correct bound from a constant.
+
+
+def test_the_ask_falls_monotonically_as_the_prompt_grows() -> None:
+    """A bigger prompt must never be handed a bigger reply budget.
+
+    This is what a constant grant breaks: flooring at the reserve made the ask
+    flat at 4,096 across 80%, 88% and 95% occupancy alike, so the curve stopped
+    carrying information about how full the session was. Monotonicity is the
+    property that distinguishes a taper from a cliff, and no earlier test had it.
+    """
+    spec = _sonnet_spec()
+
+    asks = []
+    for occupancy in (0.3, 0.5, 0.6, 0.7, 0.75, 0.8, 0.85):
+        request = ChatRequest(
+            model=spec,
+            messages=[Message.user(_prose(int(spec.context_window * occupancy)))],
+        )
+        asks.append(_effective_max_tokens(request))
+
+    assert asks == sorted(asks, reverse=True), asks
+
+
+def test_a_mostly_full_session_still_gets_a_proportionate_ask() -> None:
+    """At 80% occupancy the ask must reflect the measured headroom, not a floor.
+
+    QA measured this live: the constant grant returned ``finish_reason='length'``
+    on an answer main completed, with tens of thousands of tokens of real
+    headroom in hand — up to 264k on a 1M-window model. The bound has to stay
+    well clear of the floor here or that truncation returns.
+    """
+    spec = _sonnet_spec()
+    request = ChatRequest(
+        model=spec,
+        messages=[Message.user(_prose(int(spec.context_window * 0.8)))],
+    )
+
+    ask = _effective_max_tokens(request)
+
+    assert ask > MIN_OUTPUT_TOKENS * 2, ask
+
+
+def test_the_ask_stays_admissible_at_the_worst_measured_ratio() -> None:
+    """The other side of the same bound: proportionate must still mean safe.
+
+    Live measurement puts realistic agent content at 1.098-1.219 against the local
+    estimate. The ask plus a prompt that bills at the top of that range must fit,
+    or the taper has simply traded truncation for the HTTP 400 this clamp exists
+    to prevent.
+    """
+    spec = _sonnet_spec()
+
+    for occupancy in (0.5, 0.6, 0.7, 0.75, 0.8, 0.85):
+        request = ChatRequest(
+            model=spec,
+            messages=[Message.user(_prose(int(spec.context_window * occupancy)))],
+        )
+        _, measured = _estimated_prompt_tokens(request)
+        ask = _effective_max_tokens(request)
+
+        assert measured * 1.219 + ask <= spec.context_window, (occupancy, ask)
+
+
+@pytest.mark.parametrize("percent", [0.5, 0.7, 0.8, 0.85, 0.9, 0.92, 0.95])
+def test_the_ordering_holds_through_the_production_call(percent: float) -> None:
+    """The refusal must sit above the trigger for a user's ACTUAL settings.
+
+    The predecessor of this test passed `settings` to `_output_reserve_tokens` —
+    an argument the production call site does not supply, since `ChatRequest`
+    carries no compaction config. It therefore asserted the property on an input
+    production cannot produce, and a raised `compaction.threshold_percent` (a
+    first-class setting) re-opened the wedge underneath it (R19/Q12). This calls
+    the helper the way production does: with no settings at all.
+    """
+    settings = CompactionSettings(threshold_percent=percent)
+
+    for window in (8_192, 16_385, 32_768, 65_536, 200_000, 1_000_000):
+        reserve = _output_reserve_tokens(window)  # production form
+        margin = min(OUTPUT_CLAMP_SAFETY_MARGIN, reserve)
+        trigger = resolve_threshold_tokens(window, settings)
+
+        # Only meaningful where a pass could actually fund a reply. Past that the
+        # trigger is so late that compaction reclaims less than a usable answer,
+        # so there is no rescue for the refusal to pre-empt.
+        if window - trigger < reserve:
+            continue
+
+        assert window - reserve - margin > trigger, (percent, window)
+
+
+# --- the same bounds, exercised BELOW the reserve's saturation point ----------
+#
+# `_output_reserve_tokens` saturates at `MIN_OUTPUT_TOKENS` from a ~163,840-token
+# window upward, so every assertion written against a 200k model compares two
+# forms that are numerically identical there. That is why three separately
+# claimed mutations killed nothing. These use small windows, where the forms
+# genuinely differ.
+
+
+@pytest.mark.parametrize("window", [16_385, 32_768, 65_536])
+def test_the_rescue_is_proportional_to_the_window_not_a_constant(window: int) -> None:
+    """Below saturation the rescue must scale, or it is a constant in disguise.
+
+    A bare ``MIN_OUTPUT_TOKENS`` floor hands a 16k model the same 4,096 it hands a
+    1M model — half that model's window as a reply reservation. The reserve is a
+    fraction precisely so a small window gets a small one.
+    """
+    spec = ModelSpec(
+        provider="anthropic",
+        model_id="claude-x",
+        context_window=window,
+        max_output_tokens=window // 2,
+    )
+    # 0.92 is inside the band where the scaled taper has collapsed below the
+    # reserve and the RESCUE, not the taper, decides the ask (measured at
+    # 0.86-0.99 for every window here). Below it the taper is still positive and
+    # the clause under test never runs, which is how earlier versions of this
+    # assertion passed against a constant.
+    request = ChatRequest(model=spec, messages=[Message.user(_prose(int(window * 0.92)))])
+
+    assert _effective_max_tokens(request) < MIN_OUTPUT_TOKENS
+
+
+@pytest.mark.parametrize("window", [16_385, 32_768, 65_536])
+def test_the_rescue_never_spends_the_measured_headroom_outright(window: int) -> None:
+    """The opposite bound, also invisible above saturation.
+
+    Granting ``measured_available`` assumes the provider bills exactly the local
+    estimate (ratio 1.0), which no measurement supports — it re-opens the overflow
+    the clamp exists to prevent. The ask must stay admissible when the prompt
+    bills at the top of the measured range.
+
+    Asserted just BELOW the compaction trigger rather than at an arbitrary high
+    occupancy. Past the trigger a pass fires and the session never presents such a
+    prompt; there the prompt alone can exceed the window at 1.219 and no ask is
+    admissible, so an assertion there would pin an unreachable state instead of
+    the property.
+    """
+    spec = ModelSpec(
+        provider="anthropic",
+        model_id="claude-x",
+        context_window=window,
+        max_output_tokens=window // 2,
+    )
+    trigger = resolve_threshold_tokens(window, CompactionSettings())
+    request = ChatRequest(model=spec, messages=[Message.user(_prose(int(trigger * 0.98)))])
+
+    _, measured = _estimated_prompt_tokens(request)
+    ask = _effective_max_tokens(request)
+
+    assert measured * 1.219 + ask <= window, (window, measured, ask)
+
+
+@pytest.mark.parametrize("window", [16_385, 32_768, 65_536])
+def test_the_refusal_keeps_its_cushion_above_the_trigger(window: int) -> None:
+    """The reserve and the margin must not sum to the whole post-trigger headroom.
+
+    Both are subtracted at the refusal, so halving the headroom for each left
+    ``window - 2*reserve == percent * window`` — the trigger exactly, with the
+    only separation coming from integer truncation (1-2 tokens, review R20). A
+    cushion that thin is consumed by any later change without a test noticing.
+    """
+    reserve = _output_reserve_tokens(window)
+    margin = min(OUTPUT_CLAMP_SAFETY_MARGIN, reserve)
+    trigger = resolve_threshold_tokens(window, CompactionSettings())
+
+    cushion = (window - reserve - margin) - trigger
+
+    assert cushion > window // 100, (window, cushion)

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -3924,3 +3924,138 @@ async def test_anthropic_usage_without_cache_creation_object_leaves_split_zero()
     assert usage.cache_write_tokens == 40
     assert usage.cache_write_5m_tokens == 0
     assert usage.cache_write_1h_tokens == 0
+
+
+# --- output-cap clamp -------------------------------------------------------
+#
+# Regression cover for the muse-spark 400: a listing that advertises 0.9 of the
+# window as its completion cap reserves that much input capacity at admission,
+# so the request overflows the window before a token is generated. See
+# ``_effective_max_tokens``.
+
+#: The wire key each client spells the output cap with. The Responses body and
+#: the chat/completions body differ, and Google nests its own under
+#: ``generationConfig`` (already unwrapped by ``_bodies``).
+MAX_TOKEN_KEYS = [
+    ("openai-completions", "max_tokens"),
+    ("openai-responses", "max_output_tokens"),
+    ("anthropic", "max_tokens"),
+    ("google", "maxOutputTokens"),
+]
+
+
+def _muse_spark_spec() -> ModelSpec:
+    """The real muse-spark shape: 1M window, 943718 advertised output cap."""
+    return ModelSpec(
+        provider="openrouter",
+        model_id="meta/muse-spark-1.3",
+        context_window=1_048_576,
+        max_output_tokens=943_718,
+    )
+
+
+@pytest.mark.parametrize("wire,key", MAX_TOKEN_KEYS)
+def test_output_cap_clamped_so_prompt_plus_output_fits_window(wire: str, key: str) -> None:
+    """The reported 400: 943718 of reserved output against a 1M window left only
+    ~104k of prompt, and a real session died at ~113k of input. Every wire must
+    now ask for an amount that fits BESIDE the prompt it is sending."""
+    spec = _muse_spark_spec()
+    # ~113k tokens of prompt — the size the real session failed at.
+    request = ChatRequest(model=spec, messages=[Message.user("word " * 120_000)])
+
+    body = _bodies(request)[wire]
+
+    assert body[key] < spec.max_output_tokens
+    # The whole point: admission counts prompt + max_tokens against the window.
+    assert body[key] + len("word " * 120_000) // 4 < spec.context_window
+
+
+@pytest.mark.parametrize("wire,key", MAX_TOKEN_KEYS)
+def test_output_cap_unchanged_for_a_sanely_advertised_model(wire: str, key: str) -> None:
+    """The safeguard must not cost the models that work today anything. An
+    Anthropic-shaped spec (1M window, 128k cap) on an ordinary prompt sends the
+    spec's number byte-for-byte, because the clamp only ever lowers."""
+    spec = ModelSpec(
+        provider="anthropic",
+        model_id="claude-opus-5",
+        context_window=1_000_000,
+        max_output_tokens=128_000,
+    )
+    request = ChatRequest(model=spec, messages=[Message.user("hi")])
+
+    assert _bodies(request)[wire][key] == 128_000
+
+
+@pytest.mark.parametrize("wire,key", MAX_TOKEN_KEYS)
+def test_explicit_small_max_tokens_is_still_honoured(wire: str, key: str) -> None:
+    """``Session.ERRAND_MAX_TOKENS`` (1024, auto-naming) is a DELIBERATE ceiling.
+    The clamp lowers an ask that does not fit; it must never raise one that
+    does, or a title errand would start billing a full-window completion."""
+    spec = ModelSpec(
+        provider="anthropic",
+        model_id="claude-opus-5",
+        context_window=1_000_000,
+        max_output_tokens=128_000,
+    )
+    request = ChatRequest(model=spec, messages=[Message.user("hi")], max_tokens=1024)
+
+    assert _bodies(request)[wire][key] == 1024
+
+
+@pytest.mark.parametrize("wire,key", MAX_TOKEN_KEYS)
+def test_output_cap_floors_rather_than_collapsing_on_a_full_context(wire: str, key: str) -> None:
+    """A nearly-full context must still ask for a usable completion. Zero is
+    rejected outright by several gateways and a negative number is a 400 with a
+    far less legible message than the overflow this clamp exists to prevent."""
+    spec = ModelSpec(
+        provider="openrouter",
+        model_id="tiny",
+        context_window=10_000,
+        max_output_tokens=8_000,
+    )
+    request = ChatRequest(model=spec, messages=[Message.user("word " * 20_000)])
+
+    from local_operator.providers.clients import MIN_OUTPUT_TOKENS
+
+    assert _bodies(request)[wire][key] == MIN_OUTPUT_TOKENS
+
+
+def test_system_blocks_and_tools_are_charged_against_the_window() -> None:
+    """The reported 400 itemised **10,400 tokens of tool input** separately, so
+    tools are a real term. A clamp that counted only ``messages`` would leave
+    exactly that much of the overflow in place."""
+    spec = _muse_spark_spec()
+    tool = AgentTool(
+        name="write",
+        description="x" * 40_000,
+        parameters={"type": "object", "properties": {"content": {"type": "string"}}},
+        execute=lambda ctx, **kw: ToolResult(),  # type: ignore[arg-type,return-value]
+    )
+    messages = [Message.user("word " * 100_000)]
+
+    bare = _bodies(ChatRequest(model=spec, messages=messages))["openai-completions"]
+    with_extras = _bodies(
+        ChatRequest(
+            model=spec,
+            messages=messages,
+            system_blocks=["s" * 40_000],
+            tools=[tool],
+        )
+    )["openai-completions"]
+
+    assert with_extras["max_tokens"] < bare["max_tokens"]
+
+
+def test_no_cap_anywhere_leaves_the_key_absent() -> None:
+    """A spec with no cap must stay uncapped. Clamping a value nobody set would
+    turn an absent key into a present one and put a ceiling on a model that
+    currently has none."""
+    spec = ModelSpec(
+        provider="openrouter", model_id="x", context_window=100_000, max_output_tokens=0
+    )
+    request = ChatRequest(model=spec, messages=[Message.user("hi")])
+
+    body = _bodies(request)
+    assert "max_tokens" not in body["openai-completions"]
+    assert "max_output_tokens" not in body["openai-responses"]
+    assert "maxOutputTokens" not in body["google"]

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -25,6 +25,7 @@ from local_operator.harness.types import (
     ToolResult,
 )
 from local_operator.providers.clients import (
+    MIN_OUTPUT_TOKENS,
     AnthropicClient,
     GoogleClient,
     MockClient,
@@ -3675,8 +3676,19 @@ def _every_cache_control(body: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _large_context_request() -> ChatRequest:
+    """A request whose TTL tests drive ``context_tokens_hint`` up to 900k.
+
+    The window is stated explicitly (1M, Claude's real size) rather than left on
+    the ``ModelSpec`` default of 128k. These tests set hints of 150k-900k, and a
+    hint LARGER than the window is a state that cannot occur in production — the
+    hint is the provider's own count of a prompt it already accepted — so the
+    default made the fixture describe an impossible session. It now also has to
+    be a window the output clamp can fund a reply in, since
+    ``_effective_max_tokens`` refuses a request whose prompt leaves no room to
+    answer.
+    """
     return ChatRequest(
-        model=_spec(provider="anthropic"),
+        model=ModelSpec(provider="anthropic", model_id="claude-opus-5", context_window=1_000_000),
         system_blocks=["instructions", "inventory", "skills", "env"],
         messages=[Message.user("first"), Message.assistant("mid"), Message.user("second")],
     )
@@ -3815,7 +3827,10 @@ def test_anthropic_ttl_keeps_the_breakpoint_budget() -> None:
     blocks + two message targets still fit MAX_CACHE_BREAKPOINTS."""
     client = AnthropicClient(cache_ttl_1h_min_context_tokens=1)
     request = ChatRequest(
-        model=_spec(provider="anthropic"),
+        # Explicit 1M window for the same reason as ``_large_context_request``:
+        # a 500k hint against the spec default's 128k describes a session that
+        # cannot exist, and the output clamp refuses it.
+        model=ModelSpec(provider="anthropic", model_id="claude-opus-5", context_window=1_000_000),
         system_blocks=[f"block-{i}" for i in range(9)],
         messages=[Message.user("first"), Message.assistant("mid"), Message.user("second")],
         context_tokens_hint=500_000,
@@ -3954,6 +3969,32 @@ def _muse_spark_spec() -> ModelSpec:
     )
 
 
+def _sonnet_spec() -> ModelSpec:
+    """Claude Sonnet's real shape — the model round 1 silently truncated."""
+    return ModelSpec(
+        provider="anthropic",
+        model_id="claude-sonnet-4-5",
+        context_window=200_000,
+        max_output_tokens=64_000,
+    )
+
+
+def _prose(tokens: int, *, non_ascii: bool = False) -> str:
+    """About ``tokens`` tokens of ordinary prose (~4 chars/token).
+
+    Realistic content matters here: the round-1 defect was invisible precisely
+    because every test used a 2-token prompt or a 6x-window one, never the
+    ordinary middle where real sessions spend their time.
+    """
+    chunk = "The quick brown fox jumps over the lazy dog. "
+    if non_ascii:
+        # One curly apostrophe per chunk. Under a byte-length bound this single
+        # character multiplied the whole block's charge by 4; the output budget
+        # must not depend on it.
+        chunk = chunk.replace("dog.", "dog\u2019s.")
+    return chunk * max(1, tokens * 4 // len(chunk))
+
+
 @pytest.mark.parametrize("wire,key", MAX_TOKEN_KEYS)
 def test_output_cap_clamped_so_prompt_plus_output_fits_window(wire: str, key: str) -> None:
     """The reported 400: 943718 of reserved output against a 1M window left only
@@ -3971,19 +4012,41 @@ def test_output_cap_clamped_so_prompt_plus_output_fits_window(wire: str, key: st
 
 
 @pytest.mark.parametrize("wire,key", MAX_TOKEN_KEYS)
-def test_output_cap_unchanged_for_a_sanely_advertised_model(wire: str, key: str) -> None:
-    """The safeguard must not cost the models that work today anything. An
-    Anthropic-shaped spec (1M window, 128k cap) on an ordinary prompt sends the
-    spec's number byte-for-byte, because the clamp only ever lowers."""
-    spec = ModelSpec(
-        provider="anthropic",
-        model_id="claude-opus-5",
-        context_window=1_000_000,
-        max_output_tokens=128_000,
-    )
-    request = ChatRequest(model=spec, messages=[Message.user("hi")])
+@pytest.mark.parametrize("prompt_tokens", [2, 12_000, 30_000, 48_000])
+def test_output_cap_unchanged_for_a_sanely_advertised_model(
+    wire: str, key: str, prompt_tokens: int
+) -> None:
+    """The safeguard must not cost the models that work today anything — asserted
+    across the range real sessions actually occupy, not just a 2-token prompt.
 
-    assert _bodies(request)[wire][key] == 128_000
+    This is the test that let the round-1 defect ship: it made this exact claim
+    against ``Message.user("hi")``, the one input where a 4-18x over-estimate
+    cannot bite. At 48,000 tokens (24% of Sonnet's window) the previous revision
+    sent 512 instead of 64,000 and truncated a real answer mid-sentence.
+    """
+    spec = _sonnet_spec()
+    request = ChatRequest(model=spec, messages=[Message.user(_prose(prompt_tokens))])
+
+    assert _bodies(request)[wire][key] == 64_000
+
+
+@pytest.mark.parametrize("wire,key", MAX_TOKEN_KEYS)
+def test_output_budget_does_not_depend_on_non_ascii_characters(wire: str, key: str) -> None:
+    """An identical prompt must not lose its output budget because it contains a
+    curly apostrophe.
+
+    A byte-length bound charges ``4 * len(text)`` for any block that is not
+    ``str.isascii()``, so one ``\u2019`` — or an em dash, an emoji, an accented
+    name, any non-English text — used to cut the same conversation's budget from
+    64,000 to 512. The two asks must now agree.
+    """
+    spec = _sonnet_spec()
+    ascii_body = _bodies(ChatRequest(model=spec, messages=[Message.user(_prose(30_000))]))
+    unicode_body = _bodies(
+        ChatRequest(model=spec, messages=[Message.user(_prose(30_000, non_ascii=True))])
+    )
+
+    assert ascii_body[wire][key] == unicode_body[wire][key] == 64_000
 
 
 @pytest.mark.parametrize("wire,key", MAX_TOKEN_KEYS)
@@ -3997,27 +4060,49 @@ def test_explicit_small_max_tokens_is_still_honoured(wire: str, key: str) -> Non
         context_window=1_000_000,
         max_output_tokens=128_000,
     )
-    request = ChatRequest(model=spec, messages=[Message.user("hi")], max_tokens=1024)
+    request = ChatRequest(model=spec, messages=[Message.user(_prose(30_000))], max_tokens=1024)
 
     assert _bodies(request)[wire][key] == 1024
 
 
 @pytest.mark.parametrize("wire,key", MAX_TOKEN_KEYS)
-def test_output_cap_floors_rather_than_collapsing_on_a_full_context(wire: str, key: str) -> None:
-    """A nearly-full context must still ask for a usable completion. Zero is
-    rejected outright by several gateways and a negative number is a 400 with a
-    far less legible message than the overflow this clamp exists to prevent."""
+def test_a_prompt_too_large_to_answer_is_refused_not_truncated(wire: str, key: str) -> None:
+    """When the window cannot fund a usable reply the request is REFUSED.
+
+    Sending a tiny cap anyway is the one outcome worse than the overflow this
+    fixes: reasoning tokens are billed against the same budget (``grok-4.6``
+    spent 689 of them thinking at a 512 cap and emitted no text at all), and
+    ``harness/loop.py`` only retries a COMPLETELY silent truncation, so a partial
+    answer is accepted with no notice. The user previously got a legible HTTP
+    400 here and must still get something they can see.
+    """
     spec = ModelSpec(
         provider="openrouter",
         model_id="tiny",
         context_window=10_000,
         max_output_tokens=8_000,
     )
-    request = ChatRequest(model=spec, messages=[Message.user("word " * 20_000)])
+    request = ChatRequest(model=spec, messages=[Message.user(_prose(20_000))])
 
-    from local_operator.providers.clients import MIN_OUTPUT_TOKENS
+    with pytest.raises(ProviderError) as excinfo:
+        _bodies(request)[wire]
 
-    assert _bodies(request)[wire][key] == MIN_OUTPUT_TOKENS
+    # The message has to name the numbers that made it impossible, or it is just
+    # another opaque failure.
+    assert "too large" in str(excinfo.value)
+    assert excinfo.value.kind == "request"
+
+
+def test_the_clamp_still_lowers_an_overflowing_ask_before_refusing() -> None:
+    """Between "fits untouched" and "cannot be answered" there is a real middle
+    where the ask is reduced and the turn proceeds — the muse-spark case itself.
+    Without this the refusal above could pass while the clamp did nothing."""
+    spec = _muse_spark_spec()
+    request = ChatRequest(model=spec, messages=[Message.user(_prose(400_000))])
+
+    sent = _bodies(request)["openai-completions"]["max_tokens"]
+
+    assert MIN_OUTPUT_TOKENS <= sent < spec.max_output_tokens
 
 
 def test_system_blocks_and_tools_are_charged_against_the_window() -> None:


### PR DESCRIPTION
## Summary

A 1M-context model was usable to about 10% of its window, and the error told the user to do the one thing that could not help.

A session on `openrouter/meta/muse-spark-1.3` died with HTTP 400:

```
This endpoint's maximum context length is 1048576 tokens. However, you requested about
1057079 tokens (102961 of text input, 10400 of tool input, 943718 in the output).
```

The `943718 in the output` was never generated text — it is the `max_tokens` the harness put on the wire. Providers count **prompt + `max_tokens` against the window at admission**, before a single token is generated, so an advertised output cap is not free headroom: it is input capacity spent in advance. Reserving 90% of the window for output leaves ~104,858 tokens of usable prompt, and the session 400'd at ~113k of input — essentially the first moment it could.

**Compaction cannot rescue it.** The compaction trigger is a fraction of the window (~838k at the default 0.8), far above where the 400 lands, and compacting to any size still adds the same reservation. The incident was classified `context-length` and advised `/compact`, which would have made no difference.

## The chain, verified live

1. OpenRouter's listing advertises `context_length: 1048576` and `top_provider.max_completion_tokens: 943718` — exactly 0.9 of the window.
2. `_row_from_openai_entry` (`model/discovery.py`) reads `max_completion_tokens` into `DiscoveredModel.max_tokens`.
3. `build_model_spec` (`model/configure.py`) copies it into `ModelSpec.max_output_tokens`.
4. `_build_body` sends it verbatim as `max_tokens`.

Confirmed on `origin/main` before the change:

```
$ build_model_spec('openrouter','meta/muse-spark-1.3')
window=1048576   max_out=943718
```

**Blast radius.** Measured against the live catalogue on 2026-09-02: **120 of 419** OpenRouter rows that quote both numbers advertise an output cap above 50% of their window, with a cluster of ~80 at *exactly* 0.9 — `x-ai/grok-4.6` (500000/450000), `x-ai/grok-4.20` (2000000/1800000), `bytedance-seed/seed-2-1-turbo`, `moonshotai/kimi-k3`, `qwen/qwen3.8-2.4t-a95b`. A round 0.9 across unrelated vendors is a gateway formula, not 80 independent engineering decisions. This was latent for every one of them.

## Change

### Primary fix — clamp at request-build time

`local_operator/providers/clients.py` gains one shared module-level helper, `_effective_max_tokens(request)`:

```
effective = min(requested_or_spec_cap, window - estimated_prompt - safety_margin)
```

The spec cannot do this alone because it does not know the prompt size. The clamp belongs where the body is built and the messages are in hand — this is the first point that knows both the window and the actual prompt.

Applied at all four sites that previously each spelled `request.max_tokens or request.model.max_output_tokens` independently: OpenAI chat/completions (`max_tokens`), OpenAI Responses (`max_output_tokens`), Anthropic (`max_tokens`), Google/Gemini (`maxOutputTokens`).

Three deliberate choices:

**It sizes the prompt on the provider's ruler.** `compaction/tokens.py` is explicit that its numbers are "a RULER OF ITS OWN, never a prediction of the bill" — it counts with `cl100k_base`, and this repo's own fitted measurement (`docs/evidence/compaction-ruler/slope_fit.txt`) puts Anthropic's per-request ratio at **1.82–1.96x** the local count against **1.06–1.15x** for OpenAI and GLM. The window is a *provider* figure, so the subtrahend has to be one too. The prompt therefore comes from `request.context_tokens_hint` (the provider's own count from the previous call, used unscaled) when present, and otherwise from the memoized `estimate_messages_tokens` scaled by the family's measured ratio — mirroring `AnthropicClient._cache_ttl_for`, which faces the same problem and resolves it the same way.

An earlier revision of this PR used `messages_tokens_upper_bound` on the argument that over-estimating is "the safe direction". **That reasoning was wrong**, and both the reviewer and QA caught it independently. The bound counts one token per *byte* — ~4.5x the real count on ASCII, and another ~4x on top the moment one non-ASCII character flips a block to its `4 * len` branch — so subtracting it did not shave the ask, it consumed the window several times over. The direction-of-error argument holds only for a *threshold* test that must never read low; here the magnitude of the over-estimate is itself the cost. The rejected reasoning is recorded in the helper's docstring so it is not reintroduced.

System blocks and tool schemas are charged too.** The reported 400 itemised **10,400 tokens of tool input** separately, so tools are a real term rather than noise. A clamp that counted only `messages` would leave exactly that much of the overflow in place.

**It only ever lowers, never raises.** That is what preserves the deliberate `Session.ERRAND_MAX_TOKENS` clamp: an explicit small `request.max_tokens` (1024 for auto-naming) stays 1024. A model with no cap set anywhere still sends no key at all, so nothing gains a ceiling it did not have.

**When the window cannot fund a reply, the request is refused rather than truncated.** `MIN_OUTPUT_TOKENS` (4096) is a refusal threshold, not a value that goes on the wire. Reasoning tokens are billed against this same budget — QA measured `x-ai/grok-4.6` spending **689 tokens thinking** at a 512-token cap and emitting *zero* visible text — and `harness/loop.py:603` retries only a completely silent truncation (`silent = not assistant.text and not assistant.tool_calls`), so a partially truncated answer was accepted with no notice at all. A non-retryable `ProviderError(kind="request")` naming the actual numbers preserves the visibility the pre-fix HTTP 400 had, instead of replacing it with a confidently truncated reply.

### Secondary guard — do not seed an absurd spec cap

`sane_listing_max_tokens()` in `model/discovery.py` reduces a **listing's** cap when it exceeds 0.85 of the window, so an absurd number never reaches a `ModelSpec` at all. This protects the paths that never build a request body — the picker's displayed limits, and any provider we never measure.

It is wired into **every** listing→spec path, not one of two branches: both branches of `_merge_one` (including the live-only early return, which is exactly how muse-spark reaches the spec, since the registry has never heard of it), `_info_from_discovery`, and `_fill_from_row`.

**The threshold is measured, not guessed.** Across the 419 live rows quoting both numbers, the distribution has an empty band exactly where the line sits:

| ratio | rows | examples |
|---|---|---|
| > 0.9 | **0** | — no upper tail |
| = 0.9 | ~80 | `grok-4.6` 500000/450000, `gpt-oss-120b` 131072/117964 |
| 0.80 < r < 0.87 | **0** | *empty band — the line sits here* |
| = 0.80 | dense cluster | `mistral-large` 128000/102400 — deliberate, untouched |

The 0.87–0.88 rows *are* reduced, deliberately rather than as an accepted false positive: `llama-3.3-70b` at 131072/115200 leaves 15,872 tokens of prompt on a 128k model, which fails on any real agent turn. After the guard it serves 65,536 output tokens with 65,536 of prompt room.

**It never judges the bundled registry.** 52 shipped rows exceed this ratio legitimately — `gpt-4o` is 128000/128000 and every `grok-3` row is 1.0 — because a hand-transcribed entry states the model's *documented maximum* rather than a gateway's formula. Applying the ratio there would shrink specs that work correctly today, which is precisely the regression this must not cause. `gpt-4o` is instead handled at request time, where the prompt is known.

A large cap on a large window is not the target and keeps working: 64k output on a 200k window is 0.32 and passes untouched.

## Evidence: the real 400, reproduced and fixed against the live API

Run against the live OpenRouter API using the key from the credentials store (never printed), with the same ~113k-token prompt in both directions.

**Before — `max_tokens: 943718`, the value `origin/main` sends:**

```
$ POST https://openrouter.ai/api/v1/chat/completions  (max_tokens=943718)
HTTP 400
{
  "error": {
    "message": "This endpoint's maximum context length is 1048576 tokens. However, you
                requested about 1078735 tokens (135017 of text input, 943718 in the output).
                Please reduce the length of either one, or use the context-compression
                plugin to compress your prompt automatically.",
    "code": 400
  }
}
```

That is the reported incident, reproduced live.

**After — same prompt, `max_tokens` computed by this branch's real resolver + real clamp:**

```
resolver spec: window=1048576 max_output_tokens=524288   # 943718 before the guard
clamp computes max_tokens=506467

$ POST https://openrouter.ai/api/v1/chat/completions  (max_tokens=506467)
attempt 1: HTTP 429   # upstream shared-pool rate limit, not a context rejection
attempt 2: HTTP 200
  content: 'OK'
  usage: {'prompt_tokens': 120026, 'completion_tokens': 163, 'total_tokens': 120189,
          'cost': 0.15072525}
```

The request that previously could not be admitted at all now completes and returns a real answer. (The single 429 is upstream shared-pool rate limiting on the free route — a different failure entirely, and it cleared on retry.)

## Tests

New coverage, all of it pinned to the real shapes rather than invented ones:

- **End-to-end regression** (`test_configure.py`) drives the *verbatim* muse-spark listing entry (`context_length: 1048576`, `max_completion_tokens: 943718`) through `_row_from_openai_entry` → `ModelSpec` → `_build_body`, and asserts the wire body no longer overflows the window.
- **All four client bodies** (`test_clients.py`), parametrized over every wire and its own key: clamped when it would overflow; **byte-identical for a normal model**, asserted across 2/12k/30k/48k-token prompts and a non-ASCII case (Claude Sonnet 200k/64k sends exactly 64000 at every one); `ERRAND_MAX_TOKENS` still honoured at 1024; refuses rather than truncating when no reply fits; system blocks and tools shrink the ask; no cap set means no key emitted.
- **Discovery guard** (`test_discovery.py`): the 0.9 shape is reduced on both merge branches, the Mistral 0.8 cluster and a legitimate 64k/200k cap pass untouched, and a static registry cap above the ratio is left alone.

**These fail on `origin/main`.** Verified by reverting only the three source files and keeping the new tests: **12 failed, 14 passed**, including the end-to-end case failing on `assert 943718 < 943718`. With the fix restored: **26 passed**. The "unchanged for normal models" tests pass in both directions, which is what pins that this change costs the working models nothing.

## Round 3 — re-verified after the refusal/slope rework

The Sonnet case the reviewer and QA both flagged, on live HTTP, same 78,057-token prompt:

```
sonnet  : branch cap=57,142 vs main cap=64,000
      main max_tokens= 64,000 HTTP 200 finish='stop' chars=2950
    branch max_tokens= 57,142 HTTP 200 finish='stop' chars=3100
gpt-5.1 : branch cap=128,000 vs main cap=128,000   (identical to main)
      main max_tokens=128,000 HTTP 200 finish='stop' chars=2976
    branch max_tokens=128,000 HTTP 200 finish='stop' chars=2958
```

No truncation, `finish_reason='stop'` everywhere. The Sonnet headroom recovered substantially this round (57,142 against round 2's 32,534) because the R7 double-count is gone. The original bug still stays fixed:

```
spec: window=1,048,576 max_output_tokens=524,288
PRE-FIX  max_tokens=943,718 -> HTTP 400 (requested about 1078735 tokens ...)
POST-FIX max_tokens=524,288 -> HTTP 200 content='OK'
```

An aggregator-fronted Claude — the R9 case, where the route-keyed slope let every row overflow a 200k window:

```
slope for aggregator-fronted Claude: 2.0 (was 1.25)
  local~75,000  cap=62,582 -> HTTP 200  prompt+cap=135,923 <= 200,000
  local~90,000  cap=35,902 -> HTTP 200  prompt+cap=123,917 <= 200,000
  local~105,000 cap= 9,242 -> HTTP 200  prompt+cap=111,920 <= 200,000
```

`/compact` driven live at the sizes R8 said deadlock, through the real summariser shape (`tools=[]`, `context_tokens_hint=0`):

```
  /compact at local=135,000 -> OK, summary='Repetition.'
  /compact at local=180,000 -> OK, summary='Repetition.'
```

And a genuinely oversized prompt now refuses legibly instead of truncating, before reaching the wire:

```
invalid request: prompt is too large for x-ai/grok-4.6: about 666,663 tokens of input
against a 500,000-token context window leaves under 4,096 tokens for the reply.
Compact the conversation or start a new session.
   kind = request   retryable = False
```

Mutation check, rebuilt because round 2 showed the suite was one-sided (emptying the slope table left all 766 provider tests green). Every downward mutation now fails:

| mutation | before | now |
|---|---|---|
| empty the slope table (R9 global) | 766 passed | **4 failed** |
| default slope 1.75 → 1.25 | passed | **1 failed** |
| re-add prefix on the hinted branch (R7) | passed | **2 failed** |
| refuse on the scaled figure (R8) | passed | **1 failed** |
| believe a hint > window (R10) | passed | **2 failed** |

## Gates

All run over the whole tree, exactly as CI does (with `ulimit -n 8192`; the round-1 `Errno 24` failures were an environment artifact):

```
.venv/bin/python -m flake8 .                                    # clean
uvx --from black==26.1.0 black --check .                        # 809 files unchanged
uvx isort==5.13.2 --check .                                     # clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .     # 0 errors, 0 warnings
.venv/bin/python -m pytest tests/unit -q                        # 11539 passed, 15 skipped
```

Version bumped to **0.44.54** — a patch by materiality: a reliability fix, no new surface. (Rebased past 0.44.53 on main.)

## Note for the reviewer

One coincidence is documented in the code rather than left to be discovered: on an 8192 window a 0.9 cap (7372) reduces to *exactly* 4096, which is the `LYING_MAX_TOKENS` sentinel, so a reduced value can land on it and hand the branch to a larger bundled cap. That outcome is correct rather than merely tolerable — a hand-transcribed registry entry is better information than either the gateway's formula or this guard's halving — but it is an interaction worth seeing.




