### PR TITLE
fix(jobs): persist a durable usage mutation, and fix three flakes in the resume suite

### DIFF
--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -474,7 +474,21 @@ class AsyncJobManager:
         self._invalidate_accounting()
 
     def detach_child_manager(self, job_id: str, descendant_usage: list[Usage]) -> None:
-        """Replace a live child edge with its final detached durable ledger."""
+        """Replace a live child edge with its final detached durable ledger.
+
+        ``descendant_usage`` is a DURABLE roster field, so this has the same
+        shape as :meth:`note_usage_changed`: without the announcement the
+        watermark-guarded writer treats the next persist as a no-op, measured
+        on a drained writer as ``gen 8 -> 8`` with ``descendant_usage`` landing
+        as ``[]`` on disk.
+
+        As there, no shipped path loses data — the subagent runner's
+        ``finally`` calls this just before ``_run_job`` settles the row and
+        fires ``_notify_job_change(persist_roster=True)``, and dispose bumps
+        the generation unconditionally. The bump is here for the same reason:
+        the seam owns its own durability rather than depending on each caller
+        remembering a second call.
+        """
         job = self._jobs.get(job_id)
         if job is None:
             return
@@ -484,28 +498,38 @@ class AsyncJobManager:
         job.descendant_usage = [item.model_copy(deep=True) for item in descendant_usage]
         job.child_jobs = None
         self._invalidate_accounting()
+        self._notify_roster_change()
 
     def note_usage_changed(self) -> None:
         """Invalidate after an in-place Usage mutation owned by a child relay.
 
         ``usage`` is a DURABLE roster field (see ``_ROSTER_ROW_FIELDS`` in
         ``session.py``), so mutating it changes the projection the resume
-        sidecar stores — not merely the live cost aggregate. Announcing it on
-        the roster seam is what marks that sidecar dirty, and it is load-bearing
-        because the session's writer is WATERMARK-GUARDED: it flushes only while
-        ``written_generation < generation``. A usage mutation that bumped no
-        generation therefore left the next ``_persist_subagent_roster()`` a
-        no-op, and the new tokens stayed off disk until some unrelated roster
-        event happened to bump the generation. Whether an unrelated event had
-        already drained the writer is what decided if those tokens survived a
-        restart — a real durability race, and the mechanism behind the #548
-        flake (a resumed session's folded predecessor came back billing 0
-        instead of its settled spend).
+        sidecar stores, not merely the live cost aggregate. The session's
+        writer is WATERMARK-GUARDED — it flushes only while
+        ``written_generation < generation`` — so a durable mutation that
+        announces nothing leaves the next ``_persist_subagent_roster()`` a
+        no-op. Called directly on a drained writer that is measurable:
+        ``gen 7 -> 7``, and the new tokens do not reach disk.
 
-        The production relay already follows this call with its own
-        ``_notify_roster_change()``. The duplicate generation bump costs no
-        extra I/O: the writer loops on the watermark so both bumps coalesce into
-        one pass, and the fingerprint guard drops a byte-identical payload.
+        NO SHIPPED PATH IS KNOWN TO LOSE DATA, and this is deliberately not
+        claimed as a user-facing billing bug. Two independent things cover it
+        today, both incidental rather than by design:
+
+        * the only production caller (``subagent.py``'s relay, on
+          ``message_end``) calls ``_notify_roster_change()`` on the very next
+          statement, against this same manager;
+        * ``Session._final_persist_snapshots`` bumps the generation
+          unconditionally, so a graceful dispose repairs an unannounced
+          mutation even if a caller forgot.
+
+        Reverting this call and driving a real child with real provider usage
+        therefore still persists and re-bills correctly. The bump is here so
+        the seam is SELF-SUFFICIENT: a future caller that mutates usage without
+        knowing to follow it with a second call, or a crash before dispose,
+        must not silently drop a durable field. It is cheap — the writer loops
+        on the watermark so both bumps coalesce into one pass, and the
+        fingerprint guard drops a byte-identical payload.
         """
         self._invalidate_accounting()
         self._notify_roster_change()

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -486,8 +486,29 @@ class AsyncJobManager:
         self._invalidate_accounting()
 
     def note_usage_changed(self) -> None:
-        """Invalidate after an in-place Usage mutation owned by a child relay."""
+        """Invalidate after an in-place Usage mutation owned by a child relay.
+
+        ``usage`` is a DURABLE roster field (see ``_ROSTER_ROW_FIELDS`` in
+        ``session.py``), so mutating it changes the projection the resume
+        sidecar stores — not merely the live cost aggregate. Announcing it on
+        the roster seam is what marks that sidecar dirty, and it is load-bearing
+        because the session's writer is WATERMARK-GUARDED: it flushes only while
+        ``written_generation < generation``. A usage mutation that bumped no
+        generation therefore left the next ``_persist_subagent_roster()`` a
+        no-op, and the new tokens stayed off disk until some unrelated roster
+        event happened to bump the generation. Whether an unrelated event had
+        already drained the writer is what decided if those tokens survived a
+        restart — a real durability race, and the mechanism behind the #548
+        flake (a resumed session's folded predecessor came back billing 0
+        instead of its settled spend).
+
+        The production relay already follows this call with its own
+        ``_notify_roster_change()``. The duplicate generation bump costs no
+        extra I/O: the writer loops on the watermark so both bumps coalesce into
+        one pass, and the fingerprint guard drops a byte-identical payload.
+        """
         self._invalidate_accounting()
+        self._notify_roster_change()
 
     def _notify_roster_change(self) -> None:
         """Publish and persist a mutation of the durable task-row projection."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.41"
+version = "0.44.42"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/session/test_resume_subagents_todos.py
+++ b/tests/unit/session/test_resume_subagents_todos.py
@@ -792,14 +792,23 @@ async def test_live_progress_never_schedules_the_roster_writer(tmp_path, monkeyp
     updates.clear()  # discard the join-time source reconciliation
 
     report = parent.jobs._progress_fn(job_id)
-    started = asyncio.get_running_loop().time()
     for index in range(60):
         report(f"boundary {index}")
     assert updates == []  # publication waits for the one 50 ms coalescer
     assert parent._subagent_roster_generation == generation
     assert parent._subagent_roster_writer is None
+    # The COALESCE is the property under test: 60 progress reports produce one
+    # publication, not 60. Its deadline lives in this wait — a slower host makes
+    # the wait take longer, never makes it publish twice.
+    #
+    # A second wall-clock assertion on the same elapsed time used to follow, and
+    # it measured the HOST rather than the code: `wait_for` already raises at the
+    # same 0.25 s bound, so it could only fire when the loop was descheduled
+    # between satisfying the predicate and reading the clock. On a contended
+    # machine that is routine — it failed 10/40 on an unmodified tree here,
+    # every one of them latency-shaped — so it reported scheduler pressure as a
+    # coalescing regression. Batching is asserted by the count below.
     await wait_for(lambda: bool(updates), timeout=0.25)
-    assert asyncio.get_running_loop().time() - started <= 0.25
     assert len(updates) == 1
     assert updates[0].changes["jobs"][0]["latest_details"] == {"progress": "boundary 59"}
     subscription.unsubscribe()

--- a/tests/unit/session/test_resume_subagents_todos.py
+++ b/tests/unit/session/test_resume_subagents_todos.py
@@ -269,9 +269,11 @@ async def test_live_continuation_preserves_prior_accounting_across_restart(tmp_p
     old_row = parent.jobs.get(old_id)
     assert old_row is not None
     old_row.usage = Usage(input_tokens=4, provider="test", model_id="m")
-    # ``usage`` is a durable roster field, so this announcement is what marks
-    # the sidecar dirty; the persist below is a no-op without it, and the
-    # tokens never reach disk (see AsyncJobManager.note_usage_changed).
+    # ``usage`` is a durable roster field, and this test mutates it DIRECTLY
+    # rather than through the relay, so nothing else announces it here. The
+    # announcement is what marks the sidecar dirty for the watermark-guarded
+    # writer (see AsyncJobManager.note_usage_changed, which also records why
+    # no shipped path depends on it).
     parent.jobs.note_usage_changed()
     await parent._persist_subagent_roster()
     await parent.dispose()
@@ -289,11 +291,13 @@ async def test_live_continuation_preserves_prior_accounting_across_restart(tmp_p
     # the-real-thing, and under load the fold has not landed when the
     # identity has (#463: ``assert 0 == 4`` on an otherwise-green commit).
     #
-    # This wait is reachable ONLY because the predecessor's usage actually
-    # reached the sidecar above. When it did not, the restored row billed 0,
-    # no later event could fix it, and this loop burned its whole timeout —
-    # the #548 CI failure. That is a durability bug, not a slow machine, so
-    # the fix is in the manager rather than in this deadline.
+    # This wait depends on the predecessor's usage having reached the sidecar
+    # above, which is why the direct mutation is announced. It is NOT the
+    # cause of the intermittent #548 CI failure in this file: reverting that
+    # announcement leaves this test passing (41/41 measured, including under
+    # concurrency). The flake was parent-turn quiescence in
+    # test_live_progress_never_schedules_the_roster_writer; see
+    # wait_for_settled_delivery.
     await wait_for(
         lambda: sum(item.input_tokens for item in resumed.jobs.accounting_components()) == 4,
         timeout=30.0,
@@ -321,16 +325,14 @@ async def test_usage_mutation_persists_when_the_writer_already_drained(tmp_path,
 
     ``usage`` is a durable roster field, but the session's writer is
     watermark-guarded: ``_persist_subagent_roster`` flushes only while
-    ``written_generation < generation``. So a usage mutation that announced
-    nothing on the roster seam left the very next persist a no-op and the
-    tokens off disk — the row came back from a resume billing 0.
+    ``written_generation < generation``. A mutation that announces nothing
+    therefore leaves the very next persist a no-op and the tokens off disk.
 
-    Whether it survived depended on a RACE with unrelated roster traffic: if
-    some other event had not yet drained the writer, the mutation rode along
-    on that pending flush and looked correct. This test pins the losing
-    interleaving deterministically by draining the writer FIRST, which is the
-    state a contended machine reaches on its own and is what made the sibling
-    accounting test fail intermittently in CI (#548).
+    Draining the writer FIRST is what makes this deterministic: it removes the
+    pending flush an unannounced mutation would otherwise ride along on. This
+    pins the manager seam's own contract — no shipped path depends on it
+    today (see ``AsyncJobManager.note_usage_changed`` for what covers it), and
+    this is NOT the cause of the #548 flake.
     """
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
 
@@ -358,6 +360,49 @@ async def test_usage_mutation_persists_when_the_writer_already_drained(tmp_path,
     resumed = _session(tmp_path, IdleStream())
     await resumed.async_init()
     assert sum(item.input_tokens for item in resumed.jobs.accounting_components()) == 4
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_detach_persists_descendant_usage_when_the_writer_already_drained(
+    tmp_path, monkeypatch
+):
+    """``detach_child_manager`` announces its durable write too.
+
+    Same seam contract as the usage mutation above, on the other durable
+    accounting field: ``descendant_usage`` is in the roster projection, so
+    replacing the live child edge with the detached ledger has to mark the
+    sidecar dirty. Without the announcement the drained writer skips the
+    persist and the field lands as ``[]`` on disk.
+
+    Also covered incidentally in production (the runner detaches just before
+    the row settles, and settling persists), so this pins the seam rather than
+    a reachable loss.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+
+    parent = _session(tmp_path, OneShotStream())
+    await parent.async_init()
+    job_id = parent._launch_subagent(label="nested", prompt="do a thing")
+    await wait_for(lambda: _status(parent, job_id) == "completed")
+
+    await parent._await_subagent_roster_writer()
+    assert parent._subagent_roster_written_generation == parent._subagent_roster_generation
+
+    parent.jobs.detach_child_manager(job_id, [Usage(input_tokens=7, provider="test", model_id="m")])
+    await parent._persist_subagent_roster()
+
+    sidecar = parent._transcript.directory / SUBAGENT_ROSTER_SIDECAR
+    persisted = json.loads(sidecar.read_text())
+    assert [
+        [item.get("input_tokens") for item in (row.get("descendant_usage") or [])]
+        for row in persisted["jobs"]
+    ] == [[7]]
+    await parent.dispose()
+
+    resumed = _session(tmp_path, IdleStream())
+    await resumed.async_init()
+    assert sum(item.input_tokens for item in resumed.jobs.accounting_components()) == 7
     await resumed.dispose()
 
 

--- a/tests/unit/session/test_resume_subagents_todos.py
+++ b/tests/unit/session/test_resume_subagents_todos.py
@@ -79,6 +79,36 @@ def _status(session, job_id: str) -> str | None:
     return None if job is None else job.status
 
 
+async def wait_for_settled_delivery(session, stream) -> None:
+    """Block until the auto-delivered parent turn a settled child triggers has
+    both STARTED and finished.
+
+    A completed subagent is not the end of the parent's activity: settlement
+    runs ``Session._on_job_completed``, which spawns a background parent turn
+    that feeds the child's result back into the conversation. That turn is a
+    real production behaviour, but it is asynchronous and nothing about the
+    child's ``completed`` status implies it has run — so a test that merely
+    waits on the child's status is waiting on a PROXY for parent quiescence
+    that the parent has not actually reached.
+
+    Both halves are load-bearing. Waiting only for "not streaming" can observe
+    the gap BEFORE the delivery turn starts and return immediately; waiting
+    only for the request count can return while the turn is still streaming.
+    Together they pin the turn's whole lifecycle, which is what makes a
+    following observation window contain only what the test provoked.
+
+    Without this, a delivery turn that happened to still be in flight published
+    its own ``streaming`` and ``history_cursor`` updates into a window the test
+    believed held only its own coalesced batch (measured: ``assert 3 == 1`` at
+    ~10% locally, and reproducible on demand by delaying the parent stream).
+    """
+    # The delivery turn's own provider call is the only unambiguous evidence it
+    # started; the launch turn is request #1.
+    await wait_for(lambda: len(stream.requests) >= 2)
+    await wait_for(lambda: not session.is_streaming)
+    await wait_for(lambda: not any(not task.done() for task in session._background_tasks))
+
+
 async def _todo(ctx, call_id: str, args: dict[str, object]) -> None:
     """Drive the todo tool with the full positional signature its guard
     decorator declares (signal / on_update default to ``None``)."""
@@ -239,6 +269,9 @@ async def test_live_continuation_preserves_prior_accounting_across_restart(tmp_p
     old_row = parent.jobs.get(old_id)
     assert old_row is not None
     old_row.usage = Usage(input_tokens=4, provider="test", model_id="m")
+    # ``usage`` is a durable roster field, so this announcement is what marks
+    # the sidecar dirty; the persist below is a no-op without it, and the
+    # tokens never reach disk (see AsyncJobManager.note_usage_changed).
     parent.jobs.note_usage_changed()
     await parent._persist_subagent_roster()
     await parent.dispose()
@@ -255,6 +288,12 @@ async def test_live_continuation_preserves_prior_accounting_across_restart(tmp_p
     # second after waiting on the first is wait-on-a-proxy-then-assert-on-
     # the-real-thing, and under load the fold has not landed when the
     # identity has (#463: ``assert 0 == 4`` on an otherwise-green commit).
+    #
+    # This wait is reachable ONLY because the predecessor's usage actually
+    # reached the sidecar above. When it did not, the restored row billed 0,
+    # no later event could fix it, and this loop burned its whole timeout —
+    # the #548 CI failure. That is a durability bug, not a slow machine, so
+    # the fix is in the manager rather than in this deadline.
     await wait_for(
         lambda: sum(item.input_tokens for item in resumed.jobs.accounting_components()) == 4,
         timeout=30.0,
@@ -272,6 +311,53 @@ async def test_live_continuation_preserves_prior_accounting_across_restart(tmp_p
     assert sum(item.input_tokens for item in restarted.jobs.accounting_components()) == 4
 
     await restarted.dispose()
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_usage_mutation_persists_when_the_writer_already_drained(tmp_path, monkeypatch):
+    """A settled child's usage reaches the sidecar even when the roster writer
+    has ALREADY caught up before the mutation.
+
+    ``usage`` is a durable roster field, but the session's writer is
+    watermark-guarded: ``_persist_subagent_roster`` flushes only while
+    ``written_generation < generation``. So a usage mutation that announced
+    nothing on the roster seam left the very next persist a no-op and the
+    tokens off disk — the row came back from a resume billing 0.
+
+    Whether it survived depended on a RACE with unrelated roster traffic: if
+    some other event had not yet drained the writer, the mutation rode along
+    on that pending flush and looked correct. This test pins the losing
+    interleaving deterministically by draining the writer FIRST, which is the
+    state a contended machine reaches on its own and is what made the sibling
+    accounting test fail intermittently in CI (#548).
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+
+    parent = _session(tmp_path, OneShotStream())
+    await parent.async_init()
+    job_id = parent._launch_subagent(label="accounted", prompt="do a thing")
+    await wait_for(lambda: _status(parent, job_id) == "completed")
+
+    # The whole point: no pending flush is left for the mutation to ride on.
+    await parent._await_subagent_roster_writer()
+    assert parent._subagent_roster_written_generation == parent._subagent_roster_generation
+
+    row = parent.jobs.get(job_id)
+    assert row is not None
+    row.usage = Usage(input_tokens=4, provider="test", model_id="m")
+    parent.jobs.note_usage_changed()
+    await parent._persist_subagent_roster()
+
+    sidecar = parent._transcript.directory / SUBAGENT_ROSTER_SIDECAR
+    persisted = json.loads(sidecar.read_text())
+    assert [(item.get("usage") or {}).get("input_tokens") for item in persisted["jobs"]] == [4]
+    await parent.dispose()
+
+    # And it survives the round trip a resume actually performs.
+    resumed = _session(tmp_path, IdleStream())
+    await resumed.async_init()
+    assert sum(item.input_tokens for item in resumed.jobs.accounting_components()) == 4
     await resumed.dispose()
 
 
@@ -690,10 +776,15 @@ async def test_snapshot_entry_is_written_for_a_launched_child(tmp_path, monkeypa
 async def test_live_progress_never_schedules_the_roster_writer(tmp_path, monkeypatch):
     """Transient activity publishes to frontends without touching durability."""
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
-    parent = _session(tmp_path, OneShotStream())
+    stream = OneShotStream()
+    parent = _session(tmp_path, stream)
     await parent.async_init()
     job_id = parent._launch_subagent(label="x", prompt="p")
     await wait_for(lambda: _status(parent, job_id) == "completed")
+    # The observation window below must contain ONLY the progress batch this
+    # test provokes, so the parent has to be genuinely idle first — see
+    # wait_for_settled_delivery for the turn that otherwise publishes into it.
+    await wait_for_settled_delivery(parent, stream)
     await parent._await_subagent_roster_writer()
     generation = parent._subagent_roster_generation
     updates = []


### PR DESCRIPTION
## Summary

`tests/unit/session/test_resume_subagents_todos.py` failed intermittently on PR #548 — a PR touching zero session code. It reproduced locally, so it is not a regression from any PR. Chasing it turned up **three independent defects** in one file.

**The cause of the observed CI flake is Finding 2** (parent-turn quiescence), which reproduces on clean `main` under concurrent suites. Findings 1 and 3 are separate real defects found along the way.

> **Corrected after review round 1.** This PR originally claimed Finding 1 was a user-visible billing loss and the cause of the #548 flake. The reviewer reproduced both claims and neither held; the code is unchanged and still correct, but the rationale in the docstring, the test comments, and this body has been rewritten to claim only what reproduces. Details in Finding 1.

None of these are fixed by raising a timeout, adding a sleep, or a retry.

## Finding 1 (API hardening): a durable-field seam that announces nothing

`AsyncJobManager.note_usage_changed` invalidated the live cost aggregate but announced nothing on the roster seam. `usage` is a **durable** roster field (`_ROSTER_ROW_FIELDS`), and the session's roster writer is watermark-guarded — `_persist_subagent_roster` flushes only while `written_generation < generation`. Called **directly on a drained writer** that is measurable:

```
{"seam": "note_usage_changed", "drained": true, "gen_before": 8, "gen_after": 8, "bumped": false, "persisted_usage": [null]}
```

**What this is not.** I originally reported this as a user-visible billing loss that caused the #548 flake. Review round 1 reproduced both claims and **neither survives**; I re-verified each independently before rewriting:

- **The only production caller already covers it.** `subagent.py:840-843` calls `note_usage_changed()` and then `_notify_roster_change()` on the very next statement, against the same manager (`owner_jobs is jobs_manager`). Driving a real child with real provider usage, **with the fix reverted**, then hard-stopping the parent before teardown: usage reaches disk and the resume bills correctly, **3/3** (`persisted_usage: [["e42cc3b4889b", 11]], resumed_billed: 11`).
- **A graceful dispose repairs it anyway.** `_final_persist_snapshots` bumps the generation unconditionally.
- **Reverting it does not reproduce the flake.** The accounting test passes 41/41 with the fix reverted (reviewer-measured, including 24 under 6-way concurrency).

**What it is:** legitimate API hardening. The seam should be self-sufficient rather than depending on every caller remembering a second call, or on teardown running at all. Kept, with the docstring rewritten to say exactly this — no shipped path is known to lose data, and the two things that cover it today are incidental rather than by design.

### m1 (from review): `detach_child_manager` had the identical shape — now fixed

`descendant_usage` is also a durable roster field, and `detach_child_manager` assigned it while announcing nothing:

```
{"seam": "detach_child_manager", "drained": true, "gen_before": 8, "gen_after": 8, "bumped": false, "persisted_descendant_usage": [[]]}
```

Same treatment, same rationale, plus a test that fails **5/5** without it (`assert [[]] == [[7]]`). After: `bumped: true, persisted_descendant_usage: [[7]]`. No hot-path cost — 200 back-to-back detaches still produce **1** sidecar write and 0.001 s on-loop.

## Finding 2 (test bug): waiting on a proxy for parent quiescence — the actual cause of the #548 flake

`test_live_progress_never_schedules_the_roster_writer` opened a frontend subscription and asserted the window held exactly one coalesced update. But a settled child triggers `Session._on_job_completed`, which spawns a **background parent turn** to feed the result back into the conversation. Nothing waited for it. When it was still in flight, *its* `streaming` and `history_cursor` publishes landed in the window:

```
=== LIVEPROG n=3 ===
seq=2 changes_keys=['jobs']            jobs=[('24055b5b3b62', 'completed', {'progress': 'boundary 59'})]
seq=3 changes_keys=['streaming']       jobs=[]
seq=4 changes_keys=['history_cursor']  jobs=[]
```

Reproduced **deterministically** by delaying the parent stream — `delay=0` passes, `delay=0.02–0.10` fails 100% with exactly the observed `assert 3 == 1` shape. **Fix:** a `wait_for_settled_delivery` helper that pins the delivery turn's whole lifecycle (it must have *started* — its own provider call — and *finished*). Both halves are load-bearing; either alone still races. All previously-failing delays now pass.

## Finding 3 (test bug): a wall-clock SLO that measured the host

`assert loop.time() - started <= 0.25` sat immediately after `wait_for(..., timeout=0.25)`, which already raises at the same bound. The extra assertion could only fire when the loop was descheduled between satisfying the predicate and reading the clock — it measured **host scheduling**, not code.

On an unmodified tree on this contended host it failed **10/40 (25%)**, every failure latency-shaped. Removed; the property under test (60 reports → 1 publication) is still asserted by `updates == []` before the coalescer fires and `len(updates) == 1` after.

## Measured failure rates

Machine is heavily contended (load average 96–166 on 14 cores, six other agents' suites running); the parallel numbers are noisy by nature and the serial ones are the trustworthy ones.

| configuration | before | after |
|---|---|---|
| whole file, serial, `-p no:randomly`, ×30 | 3/30 (10%) | — |
| whole file, serial, random order, ×30 | 4/30 (13%) | — |
| `live_progress` alone (unmodified tree), ×40 | 10/40 (25%) | — |
| accounting test alone, ×40 | 1/40 | — |
| usage-mutation loss, drained interleaving | **100%** | 0% |
| mech-2 reproduction, delays 0.02–0.10 | **100%** | 0/14 |
| **all three target tests, serial, ×100** (round-0 head) | — | **0/100** ✅ |
| **all four target tests, serial, ×60** (round-1 head) | — | **0/60** ✅ |
| `tests/unit/session`, parallel, ×8 full runs | — | **0/8** ✅ |

## Mutation proof (the tests can still fail)

| mutation | result |
|---|---|
| revert `note_usage_changed` fix | new test fails **5/5 deterministically**; the old accounting test caught it **0/5** (it does not cover this seam — see Finding 1) |
| revert `detach_child_manager` fix (m1) | new test fails **5/5 deterministically** (`assert [[]] == [[7]]`) |
| transient progress schedules the roster writer | `test_live_progress...` fails: `assert 71 == 11` |
| publish synchronously on every job change (no coalescing) | `test_live_progress...` fails **3/3** |

Two new tests (`test_usage_mutation_persists_when_the_writer_already_drained`, `test_detach_persists_descendant_usage_when_the_writer_already_drained`) pin each seam **deterministically** by draining the writer first.

## Audit for the same pattern

- `subscribe_frontend` + `_launch_subagent` in one test (finding 2's exact shape): **unique to this file**.
- `test_redundant_roster_events_skip_the_sidecar_write` — **a fourth, pre-existing flake in this same file**, independent of this change: **7/60 on clean `main`** vs 2/60 on this branch, `changed_keys: []` and `note_usage_changed` uncalled during the burst. Different mechanism (a genuinely new projection racing the burst); it only reproduces under load and I could not pin it deterministically, so it is **not fixed here** rather than guessed at. *Deferred — separate mechanism, needs its own reproduction.*
- Other wall-clock threshold asserts sharing finding 3's shape, left alone as out of scope: `test_conversation_name_persistence.py:275`, `test_session_peer.py:436`, `test_session.py:3114`, `runtime/test_process_reaper.py:179` (the last one was observed failing on this host). *Deferred — not exercised by this slice.*

No issues filed, per standing instructions.

## Gates

`flake8`, `black==26.1.0`, `isort==5.13.2`, `pyright` — all clean over the whole tree. Full `tests/unit`: `1 failed, 11029 passed`, the one failure being `tests/unit/model/test_prices.py::test_a_background_revalidation_gets_the_full_default_timeout`, which is **pre-existing and unrelated** — I measured 1/5 on clean `main`, the reviewer measured **4/5** on `cf916d99`, so treat it as substantially flaky rather than marginal (m2/n1 from review; it passes in isolation here). An earlier full run showed 85 `Errno 24: Too many open files` failures purely from host contention; they vanish with `ulimit -n 8192`.

Version: patch → `0.44.42` (test reliability + contained API hardening). Re-checked against `origin/main` (`cf916d99`, `0.44.41`) and PyPI (`0.44.41`) at bump time; `0.44.42` is free on both. One `chore(release)` at tip.
