### PR TITLE
chore(release): 0.44.43 — lop send argument grammar

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.42"
+version = "0.44.43"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Version bump so the `lop send` argument-grammar fix can publish. PR #556 merged as `91078872` **after** v0.44.42 was tagged (that tag points at `1e9a07f3`), so the fix is on `main` but in no release.

## Unreleased commit

- `91078872` **fix(cli): bind `lop send` positionals against the selector flags (#556)** — `lop send --pid N "body"` used to exit 1 delivering nothing, and `lop send other-name "body" --pid N` delivered to the pid while reading as though it addressed the name. Both are fixed, with the guide, README, `--help` and the `send` tool descriptions brought into lockstep.

## Version rationale

Patch, per AGENTS.md materiality: a user-visible CLI fix, not a step-function capability. 0.44.43 confirmed 404 on PyPI and untagged.

## Testing

One-line version change, no `.py` behaviour touched. #556 itself carried three terminal review rounds (reviewer, architect, QA) and 8/8 CI green on its final head.