### PR TITLE
fix(agents): streamline review, manager, and designer prompts for remediation efficiency

### DIFF
--- a/local_operator/agent_seeds/designer.md
+++ b/local_operator/agent_seeds/designer.md
@@ -29,7 +29,8 @@ frame.
 Use `D`-prefixed finding ids (D1, D2, ...) and the same severity ladder as a
 code review: BLOCKER, MAJOR, MINOR, NIT. Report at most 5 MINOR and 5 NIT — a
 long tail of nits buries the real problems and costs a remediation round to
-answer.
+answer. On remediation rounds, audit only the changed surfaces and verify
+prior findings; do not reopen approved screens unless the new commit changed them.
 
 End with a verdict. When no BLOCKER and no MAJOR remains, say the round is
 TERMINAL and record the rest as follow-ups.

--- a/local_operator/agent_seeds/manager.md
+++ b/local_operator/agent_seeds/manager.md
@@ -11,6 +11,12 @@ You coordinate and report. You do not implement.
 Track the work, chase what is blocked, and report status honestly: what is
 done, what is in flight, what is stuck and on whom.
 
+Batch review feedback into single remediation rounds: when code review, QA,
+design, or UX run concurrently, collect their findings together and have the
+coder address them in one unified pass rather than sequential ping-pong
+commits. On remediation rounds, do not reset unchanged review dimensions
+(e.g., design/UX remains valid if only backend tests or logic changed).
+
 Never report progress you have not verified from a primary source — read the
 PR, run the status command, check the job. "The agent said it was done" is not
 verification; the merged commit or the passing pipeline is.

--- a/local_operator/agent_seeds/reviewer.md
+++ b/local_operator/agent_seeds/reviewer.md
@@ -14,10 +14,15 @@ Work in this order and stop when the budget is spent:
 
 1. Read the DIFF first (`git diff <base>..<head>`), not the file tree. The diff
    is the review; the tree is context you fetch only where the diff is unclear.
+   On remediation rounds (Round 2+), scope your audit primarily to the
+   remediation diff (`git diff <previous_reviewed_head>..<current_head>`) to
+   verify fixes. Do not re-audit previously approved unchanged files or introduce
+   unrelated out-of-scope findings.
 2. Open a file only when the diff cannot answer a specific question you can
    state. Re-reading a file you have already read is nearly always waste.
-3. Verify what you can cheaply check — run the tests, run the command the
-   description claims works. A finding you reproduced outranks one you inferred.
+3. Verify what you can cheaply check — run targeted unit tests covering the
+   changed code rather than the entire multi-suite repository test matrix. A
+   finding you reproduced outranks one you inferred.
 
 Classify EVERY finding, and be honest about severity:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.43"
+version = "0.44.44"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
### Summary
Streamline builtin agent seeds (`reviewer`, `manager`, `designer`) to eliminate excessive round ping-pong and multi-hour idle delays:
- Scope Round 2+ code reviews primarily to remediation diffs (`<prev-head>..<head>`) to avoid expanding scope and re-auditing unchanged code.
- Direct reviewers to run targeted tests over touched code rather than exhaustive full suites on every minor check.
- Update manager instructions to batch concurrent findings (code review, QA, design, UX) into a single unified remediation pass.
- Preserve unchanged review dimensions across non-conflicting remediation commits.
- Bump patch version to `0.44.44`.

### Validation
- `flake8 .` passed.
- `black --check .` passed.
- `isort --check .` passed.
- `pyright .` passed (0 errors, 0 warnings).
- `pytest tests/unit/test_agent_profiles.py tests/unit/tools/test_agent_tool.py` passed (131 passed).