### PR TITLE
fix(browser-bridge): keep the bridge usable when the heartbeat writer dies

### DIFF
--- a/docs/evidence/browser-bridge-resilience/repro_phantom.py
+++ b/docs/evidence/browser-bridge-resilience/repro_phantom.py
@@ -1,0 +1,113 @@
+"""RC3/RC4 + the repair verb: a driven tab, its close, and a phantom cleaned.
+
+Shows the user's exact complaint and its fix without needing a real browser:
+a driven tab is advertised, `tab_closed` clears exactly that tab, and a
+phantom left behind by a worker that died without announcing anything is
+reconciled by `lop browser status --repair`.
+
+    .venv/bin/python docs/evidence/browser-bridge-resilience/repro_phantom.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+# See repro_rc1.py: sys.path[0] is the SCRIPT's directory, so pin this repo.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from local_operator.browser_bridge import install as bridge_install  # noqa: E402
+from local_operator.browser_bridge.daemon import create_app  # noqa: E402
+
+
+def free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+async def main() -> int:
+    import uvicorn
+
+    root = Path(tempfile.mkdtemp(prefix="lop-phantom-"))
+    port = free_port()
+    app = create_app(port, root)
+    service = app.state.bridge
+    # An attached browser, deliberately unpaired (see repro_rc1.py: faking
+    # paired without a pairing file makes the revocation watcher sever it).
+    service.link.websocket = object()  # type: ignore[assignment]
+
+    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error"))
+    serving = asyncio.create_task(server.serve())
+    while not server.started:
+        await asyncio.sleep(0.05)
+
+    def _health_sync() -> dict:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=3) as response:
+            return json.loads(response.read().decode())
+
+    async def health() -> dict:
+        # Off-thread: a blocking urlopen on the serving loop deadlocks.
+        return await asyncio.to_thread(_health_sync)
+
+    phantom = "http://127.0.0.1:8974/r3-notice-amber.svg"
+    failures = 0
+
+    service.link.note_driven("bridge:9:zz", phantom, "amber")
+    state = await health()
+    tabs = len(state["driven_tabs"])
+    print(f"[1 driving]   current_url={state['current_url']}  driven_tabs={tabs}")
+    failures += 0 if len(state["driven_tabs"]) == 1 else 1
+
+    # A second session's tab: closing one must not blank the other (RC4).
+    service.link.note_driven("bridge:10:yy", "https://example.com", "Example")
+    service.link.note_closed("bridge:10:yy")
+    state = await health()
+    print(
+        f"[2 one close] current_url={state['current_url']}  driven_tabs={len(state['driven_tabs'])}"
+        "   <- the other session's tab survived"
+    )
+    failures += 0 if len(state["driven_tabs"]) == 1 else 1
+
+    # RC3: the tab_closed the extension now sends clears the driven record.
+    service.link.note_closed("bridge:9:zz")
+    state = await health()
+    tabs = len(state["driven_tabs"])
+    print(f"[3 closed]    current_url={state['current_url']!r}  driven_tabs={tabs}")
+    failures += 0 if state["current_url"] == "" else 1
+
+    # The leak case: a worker that died without announcing anything, so the
+    # daemon still advertises a tab whose browser is gone. This is the state
+    # the user could not clear.
+    service.link.note_driven("bridge:9:zz", phantom, "amber")
+    service.link.websocket = None
+    state = await health()
+    print(f"[4 phantom]   current_url={state['current_url']}   <- advertised, browser gone")
+
+    result = await asyncio.to_thread(bridge_install.repair, port, root)
+    for line in result["steps"]:
+        print(f"   repair: {line}")
+    state = await health()
+    print(f"[5 repaired]  current_url={state['current_url']!r}  ok={result['ok']}")
+    failures += 0 if (state["current_url"] == "" and result["ok"]) else 1
+
+    server.should_exit = True
+    await serving
+
+    if failures:
+        print(f"\nRESULT: FAILED ({failures} check(s))")
+        return 1
+    print(
+        "\nRESULT: PASS — a closed tab clears exactly its own driven record, and a phantom "
+        "left by a dead worker is reconciled by --repair."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/docs/evidence/browser-bridge-resilience/repro_rc1.py
+++ b/docs/evidence/browser-bridge-resilience/repro_rc1.py
@@ -1,0 +1,165 @@
+"""Deterministic reproduction of RC1: a transient publish() error kills the
+heartbeat task forever, so state.available() goes False permanently while the
+daemon keeps serving /health 200.
+
+Run against a checkout to see which behaviour it has:
+
+    .venv/bin/python docs/evidence/browser-bridge-resilience/repro_rc1.py
+
+Exit code 0 = the loop SURVIVED (fixed build). Exit code 1 = the loop DIED
+(the main-branch bug). Uses a temp root, a real uvicorn server on an ephemeral
+port, and a real HTTP /health probe — no mocking of the transport.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+# Running a script puts the SCRIPT's directory on sys.path[0], not the cwd, so
+# an editable install elsewhere on the machine would otherwise win the import
+# and the evidence would describe the wrong checkout. Pin the repo this file
+# lives in, ahead of everything else.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from local_operator.browser_bridge import state as state_store  # noqa: E402
+from local_operator.browser_bridge.daemon import create_app  # noqa: E402
+
+
+def free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+async def main() -> int:
+    import uvicorn
+
+    package = Path(__import__("local_operator").__file__ or ".").parent
+    print(f"[checkout]  {package}")
+    root = Path(tempfile.mkdtemp(prefix="lop-rc1-"))
+    port = free_port()
+    app = create_app(port, root)
+    service = app.state.bridge
+    # Pretend a browser is attached: availability requires extension_connected.
+    # publish() recomputes extension_connected from the LINK on every tick, so
+    # a fake socket has to stay set for the file to keep advertising a browser
+    # — otherwise the heartbeat honestly republishes "no extension attached"
+    # and availability is false for a reason that has nothing to do with RC1.
+    #
+    # Deliberately NOT paired: availability does not require pairing (an
+    # unpaired-but-connected extension is advertised so the tool can return the
+    # actionable 'lop browser pair' error). Faking paired=True without a
+    # pairing FILE makes the revocation watcher correctly sever the link after
+    # REVOKE_WATCH_S, which would clear extension_connected for a reason that
+    # has nothing to do with the heartbeat bug under test.
+    service.link.websocket = object()  # type: ignore[assignment]
+
+    # Shrink the cadence so the reproduction takes seconds, not minutes. The
+    # bug is about the loop dying, not about the interval length.
+    state_store.HEARTBEAT_INTERVAL_S = 0.2
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+    serving = asyncio.create_task(server.serve())
+    while not server.started:
+        await asyncio.sleep(0.05)
+
+    def _health_sync() -> int:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=3) as response:
+            return int(response.status)
+
+    # The probe must not block the loop the server is serving from, or it
+    # deadlocks against itself. Off-thread keeps it a real HTTP request.
+    async def health() -> int:
+        return await asyncio.to_thread(_health_sync)
+
+    def heartbeat_age() -> float:
+        raw = json.loads((root / "run/browser/bridge.json").read_text())
+        return time.time() - float(raw["heartbeat_at"])
+
+    await asyncio.sleep(0.6)
+    print(
+        f"[baseline]  /health={await health()}  available={state_store.available(root)}  "
+        f"heartbeat_age={heartbeat_age():.2f}s"
+    )
+
+    # Inject the exact failure the machine hit: ENOSPC out of publish().
+    real_publish = state_store.publish
+    failures = {"count": 0}
+
+    def exploding_publish(state, root_arg=None):  # type: ignore[no-untyped-def]
+        failures["count"] += 1
+        if failures["count"] <= 5:
+            raise OSError(28, "No space left on device")
+        return real_publish(state, root_arg)
+
+    state_store.publish = exploding_publish  # type: ignore[assignment]
+    print("[inject]    publish() now raises OSError(ENOSPC) for 5 calls")
+    await asyncio.sleep(2.0)
+    state_store.publish = real_publish  # type: ignore[assignment]
+    print("[recover]   publish() restored; disk is 'free' again")
+    await asyncio.sleep(1.0)
+
+    task = service._heartbeat_task
+    task_dead = task is None or task.done()
+    age = heartbeat_age()
+    status = await health()
+    live = state_store.available(root)
+    current = state_store.read(root)
+    # Print every term of the availability predicate, not just its verdict:
+    # a bare False is indistinguishable between "heartbeat stale" and "the
+    # test rig never marked an extension attached".
+    print(
+        f"[after]     /health={status}  available={live}  heartbeat_age={age:.2f}s  "
+        f"heartbeat_task_dead={task_dead}"
+    )
+    if current is not None:
+        print(
+            f"[terms]     extension_connected={current.extension_connected}  "
+            f"pid_alive={state_store.pid_alive(current.pid)}  "
+            f"liveness={state_store.liveness(root)[0].value}"
+        )
+
+    # The decisive consequence. A dead writer never refreshes the file again,
+    # so its age CLIMBS in real time and crosses HEARTBEAT_TIMEOUT_S for good:
+    # unavailable not just now but permanently. A live writer holds the age
+    # near zero. Sampling the age twice measures exactly that, without having
+    # to sit out the full 45s timeout.
+    #
+    # (Evaluating available() at a simulated future timestamp would be
+    # meaningless here: it asks "would this file be stale in 46s" while a
+    # healthy daemon is about to rewrite it 230 times in that window.)
+    first_age = heartbeat_age()
+    await asyncio.sleep(1.0)
+    second_age = heartbeat_age()
+    climbing = second_age > first_age + 0.5
+    print(
+        f"[verdict]   age {first_age:.2f}s -> {second_age:.2f}s  "
+        f"writer_stopped={climbing}  available_now={state_store.available(root)}"
+    )
+
+    server.should_exit = True
+    await serving
+
+    if task_dead or not live or climbing:
+        print(
+            "\nRESULT: BROKEN — heartbeat writer died on a transient error; the daemon "
+            "answers /health 200 but every session now sees the bridge as unavailable."
+        )
+        return 1
+    print(
+        "\nRESULT: SURVIVED — the heartbeat loop absorbed the errors, kept looping, and "
+        "republished a fresh heartbeat once the write succeeded again."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Local Operator",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Connect Local Operator to the browser you already use, entirely on your machine.",
   "permissions": ["debugger", "tabs", "tabGroups", "scripting", "storage", "alarms", "webNavigation", "notifications"],
   "host_permissions": ["<all_urls>"],

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-operator-browser-extension",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "packageManager": "pnpm@11.22.0",
   "scripts": {

--- a/extension/src/commands/nav.ts
+++ b/extension/src/commands/nav.ts
@@ -249,10 +249,18 @@ async function closeSurface(token: string, surface: StoredSurface): Promise<void
  * precisely the hijack this model removes.
  */
 export async function close(params: Record<string, unknown>): Promise<Record<string, unknown>> {
+  // The closed handle is RETURNED (`closed`, not `tab` — `tab` on a result is
+  // the handle of a tab that still exists, and worker.ts reads it as such) so
+  // the worker can name the surface in its `tab_closed` announcement even in
+  // the no-param call shape. Without it that shape announced an empty handle,
+  // which the daemon can only read as "blank every driven record" — including
+  // other sessions' live tabs. The daemon knows the token here; not sending it
+  // was the only reason the clear-all path was reachable from a routine close.
   if (params.tab !== undefined && params.tab !== null && params.tab !== "") {
     const surface = await requireSurface(params.tab);
-    await closeSurface(surfaceToken(surface), surface);
-    return {};
+    const token = surfaceToken(surface);
+    await closeSurface(token, surface);
+    return { closed: token };
   }
   const surfaces = await liveSurfaces();
   const entries = Object.entries(surfaces);
@@ -273,5 +281,5 @@ export async function close(params: Record<string, unknown>): Promise<Record<str
   }
   const [token, surface] = entries[0]!;
   await closeSurface(token, surface);
-  return {};
+  return { closed: token };
 }

--- a/extension/src/protocol.gen.ts
+++ b/extension/src/protocol.gen.ts
@@ -52,7 +52,7 @@ export interface PairResult { event: 'pair_result'; ok: boolean; token: string; 
 export interface Ping { event: 'ping'; }
 export interface Pong { event: 'pong'; }
 export interface TabClosed { event: 'tab_closed'; tab: string; }
-export interface TabUpdate { event: 'tab_update'; url: string; title: string; }
+export interface TabUpdate { event: 'tab_update'; tab: string; url: string; title: string; }
 export interface AwaitingOrigin { event: 'awaiting_origin'; id: string; origin: string; }
 export interface AwaitingOriginCleared { event: 'awaiting_origin_cleared'; id: string; }
 export interface Unpair { event: 'unpair'; }

--- a/extension/src/state.ts
+++ b/extension/src/state.ts
@@ -214,6 +214,20 @@ export function ownsRedacted(fullToken: string, redacted: string): boolean {
   return fullToken.startsWith(redacted.slice(0, -1));
 }
 
+/**
+ * Whether a token has been through {@link redactToken}.
+ *
+ * A redacted handle names a tab without proving ownership of it, so it must
+ * never be reported to the daemon as the handle of a driven tab: it would key
+ * a SECOND record for a tab already tracked under its full token, and that
+ * duplicate outlives the real close as a phantom advertising a dead URL. The
+ * worker uses this to downgrade such a handle to "unknown" rather than
+ * inventing an identity for it.
+ */
+export function isRedactedToken(token: string): boolean {
+  return token.endsWith("…");
+}
+
 export function parseSurface(token: unknown): { tabId: number; nonce: string } | undefined {
   if (typeof token !== "string") return undefined;
   const match = /^bridge:(\d+):([a-z0-9_-]+)$/i.exec(token);

--- a/extension/src/tab-lifecycle.ts
+++ b/extension/src/tab-lifecycle.ts
@@ -1,0 +1,54 @@
+import { pruneSurface } from "./cdp";
+import { getSurfaces } from "./state";
+
+/**
+ * Reconciliation for tabs that go away WITHOUT a `close` command.
+ *
+ * WHY THIS EXISTS: the daemon advertises what it is "driving" so the popup and
+ * `lop browser status` can show the human which page an agent is on. That
+ * record was only ever cleared on disconnect or on a `tab_closed` event — and
+ * nothing in this extension ever SENT `tab_closed`. There was no
+ * `chrome.tabs.onRemoved` listener at all, so a tab closed by the user, by the
+ * agent's own `close`, or by a crash left the daemon advertising it forever.
+ * A user who closed every tab in Chrome still saw `driving: <dead url>`, which
+ * read as a phantom lock nobody could clear.
+ *
+ * The surface map was equally affected: entries were reclaimed only lazily,
+ * when some later command happened to touch them (`requireSurface`, the `tabs`
+ * listing). Until then a dead tab still counted against MAX_SURFACES, so
+ * sessions that died without closing could exhaust the cap with ghosts and
+ * deny `open` to everyone with a `tab_limit`.
+ *
+ * MV3 CONSTRAINT: the listener that calls this MUST be registered at the top
+ * level of the worker (see worker.ts), not inside a callback or after an
+ * await. A service worker is torn down when idle and re-instantiated on an
+ * event; only listeners registered during that synchronous first evaluation
+ * are wired up to wake it. A listener added later simply does not exist for
+ * the events that would have woken the worker — the same reasoning reconnect.ts
+ * applies to timers vs alarms.
+ */
+
+/** Whether a removed tab id belongs to a surface we own, and its handle. */
+export async function ownedSurfaceFor(tabId: number): Promise<string | undefined> {
+  const surfaces = await getSurfaces();
+  for (const [token, surface] of Object.entries(surfaces)) {
+    if (surface.tabId === tabId) return token;
+  }
+  return undefined;
+}
+
+/**
+ * Reclaim one removed tab and report the handle to announce as `tab_closed`.
+ *
+ * Returns `undefined` for a tab we do not own — the user's own tabs are none
+ * of our business, and announcing them would blank a driven record that is
+ * still live. Cleanup goes through `pruneSurface`, the ONE dead-surface path
+ * (map entry + log ring buffer + debugger attachment), so this cannot become
+ * the fourth site that leaks one of the three (cdp.ts finding m1).
+ */
+export async function reclaimRemovedTab(tabId: number): Promise<string | undefined> {
+  const token = await ownedSurfaceFor(tabId);
+  if (!token) return undefined;
+  await pruneSurface(token, tabId);
+  return token;
+}

--- a/extension/src/worker.ts
+++ b/extension/src/worker.ts
@@ -10,7 +10,7 @@ import { BridgeCommandError } from "./cdp";
 import { clearAllAccessGrants, revokeExactOrigin, revokeLoopbackHost } from "./access-grants";
 import { ACCESS_EXPIRY_ALARM } from "./approval-store";
 import { expireAccessRequest, resolveOrigin, restoreAccessQueue, setPendingObserver } from "./origins";
-import { DEFAULT_PORT, getLocal } from "./state";
+import { DEFAULT_PORT, getLocal, isRedactedToken } from "./state";
 import { reconcileCommandTab, retitle } from "./tab-groups";
 import { reclaimRemovedTab } from "./tab-lifecycle";
 import {
@@ -194,15 +194,32 @@ async function dispatch(request: { id: string; method: string; params: Record<st
       // Without it the daemon kept ONE global "driving" slot that the most
       // recent command overwrote, which framed a multi-tab world as a single
       // binding. `goto` returns no handle, so echo the request's own tab.
-      const handle = typeof result.tab === "string" ? result.tab : String(request.params.tab ?? "");
+      //
+      // Only a FULL handle may key a driven record. A handle-less `status`
+      // answers with a REDACTED token (an unproven caller must not receive the
+      // drive capability), and forwarding that string created a second key for
+      // a tab already tracked under its full token — a duplicate that survived
+      // the real close and advertised a dead URL forever, which is the phantom
+      // this change removes. A redacted token is therefore reported as no
+      // handle at all, so the daemon refreshes the most recent record instead
+      // of forking one.
+      const raw = typeof result.tab === "string" ? result.tab : String(request.params.tab ?? "");
+      const handle = isRedactedToken(raw) ? "" : raw;
       send({ event: "tab_update", tab: handle, url: result.url, title: String(result.title ?? "") });
     }
     // An explicit `close` retires the surface, so tell the daemon now rather
     // than relying on the onRemoved listener: chrome.tabs.remove fires
     // onRemoved too, but announcing here keeps the driven record accurate even
     // if the worker is torn down before that event is delivered.
+    // Prefer the handle the command RESOLVED (`closed`) over the one the
+    // request carried: `close` legitimately accepts no `tab` param (the
+    // pre-multi-tab shape that closes the sole surface), and announcing ""
+    // there tells the daemon to blank EVERY driven record, other sessions'
+    // live tabs included. The command knows exactly which surface it retired,
+    // so it says so and the daemon drops precisely that one.
     if (request.method === "close") {
-      send({ event: "tab_closed", tab: String(request.params.tab ?? "") });
+      const closed = typeof result.closed === "string" ? result.closed : String(request.params.tab ?? "");
+      send({ event: "tab_closed", tab: isRedactedToken(closed) ? "" : closed });
     }
     await respond({ id: request.id, ok: true, result });
   } catch (error) {

--- a/extension/src/worker.ts
+++ b/extension/src/worker.ts
@@ -12,6 +12,7 @@ import { ACCESS_EXPIRY_ALARM } from "./approval-store";
 import { expireAccessRequest, resolveOrigin, restoreAccessQueue, setPendingObserver } from "./origins";
 import { DEFAULT_PORT, getLocal } from "./state";
 import { reconcileCommandTab, retitle } from "./tab-groups";
+import { reclaimRemovedTab } from "./tab-lifecycle";
 import {
   RECONNECT_ALARM_NAME,
   RECONNECT_ALARM_PERIOD_MINUTES,
@@ -189,7 +190,19 @@ async function dispatch(request: { id: string; method: string; params: Record<st
     // Push the driven page so the daemon (and the Connected popup) can show
     // the human what the agent is on (finding U3).
     if (typeof result.url === "string" && result.url) {
-      send({ event: "tab_update", url: result.url, title: String(result.title ?? "") });
+      // Carry the surface handle so the daemon tracks this tab individually.
+      // Without it the daemon kept ONE global "driving" slot that the most
+      // recent command overwrote, which framed a multi-tab world as a single
+      // binding. `goto` returns no handle, so echo the request's own tab.
+      const handle = typeof result.tab === "string" ? result.tab : String(request.params.tab ?? "");
+      send({ event: "tab_update", tab: handle, url: result.url, title: String(result.title ?? "") });
+    }
+    // An explicit `close` retires the surface, so tell the daemon now rather
+    // than relying on the onRemoved listener: chrome.tabs.remove fires
+    // onRemoved too, but announcing here keeps the driven record accurate even
+    // if the worker is torn down before that event is delivered.
+    if (request.method === "close") {
+      send({ event: "tab_closed", tab: String(request.params.tab ?? "") });
     }
     await respond({ id: request.id, ok: true, result });
   } catch (error) {
@@ -360,6 +373,40 @@ alive = true;
 void restoreAccessQueue()
   .catch((error) => console.warn("approval queue restore failed", error))
   .finally(() => void connect());
+
+// TOP-LEVEL REGISTRATION IS LOAD-BEARING (MV3): a service worker is torn down
+// when idle and re-instantiated by an event, and only listeners registered
+// during that synchronous first evaluation are wired up to wake it. Registered
+// inside a callback or after an await, this listener would silently not exist
+// for the very events it must catch — the same lifecycle reasoning reconnect.ts
+// applies to timers. It is deliberately not behind a connection check: a tab
+// closed while the socket is down must still be reclaimed locally, and the
+// daemon clears its own driven records on disconnect anyway.
+//
+// This is what makes "the user closed the tab" reach the daemon at all. Before
+// it, nothing ever sent tab_closed and `status` advertised a dead tab forever.
+chrome.tabs.onRemoved.addListener((tabId) => {
+  void reclaimRemovedTab(tabId)
+    .then((token) => {
+      // Only OUR surfaces are announced: the user's own tabs are not ours to
+      // report, and announcing one would clear a driven record still in use.
+      if (token) send({ event: "tab_closed", tab: token });
+    })
+    .catch((error) => console.warn("tab close reclaim failed", error));
+});
+
+// A tab REPLACED (prerender activation, or a crashed tab restored under a new
+// id) keeps the page but retires the old tab id, so the surface bound to that
+// id is dead exactly as if it had been removed. Chrome fires no onRemoved for
+// the replaced id, so without this the surface would linger as a ghost against
+// the cap until some later command happened to notice.
+chrome.tabs.onReplaced.addListener((_addedTabId, removedTabId) => {
+  void reclaimRemovedTab(removedTabId)
+    .then((token) => {
+      if (token) send({ event: "tab_closed", tab: token });
+    })
+    .catch((error) => console.warn("tab replace reclaim failed", error));
+});
 
 chrome.storage.onChanged.addListener((changes, area) => {
   if (area === "session" && changes.accessQueue) {

--- a/extension/tests/driven-handles.integration.test.mjs
+++ b/extension/tests/driven-handles.integration.test.mjs
@@ -64,7 +64,7 @@ function installChrome(surfaces) {
     windows: { get: async () => ({ id: 1 }), getCurrent: async () => ({ id: 1 }) },
     runtime: {
       getURL: (p) => `chrome-extension://test/${p}`,
-      getManifest: () => ({ version: "0.1.6" }),
+      getManifest: () => ({ version: "0.1.7" }),
       onStartup: { addListener: () => {} }, onInstalled: { addListener: () => {} },
       onMessage: { addListener: () => {} }, sendMessage: async () => {},
     },

--- a/extension/tests/driven-handles.integration.test.mjs
+++ b/extension/tests/driven-handles.integration.test.mjs
@@ -1,0 +1,174 @@
+/* What the worker tells the daemon it is DRIVING, and what it says went away.
+ *
+ * These drive real `status`/`close` commands through the real worker dispatch
+ * over a stub socket, because both defects they guard live in the seam between
+ * a command's RESULT and the event the worker derives from it — reading either
+ * side alone shows nothing wrong.
+ *
+ * 1. A handle-less `status` answers with a REDACTED handle (an unproven caller
+ *    must not receive the drive capability). Forwarded as a `tab_update`
+ *    handle it keyed a SECOND driven record for one tab, and that duplicate
+ *    survived the real close, advertising a dead URL forever — the phantom
+ *    this release exists to remove, reintroduced one layer down.
+ * 2. `close` legitimately takes no `tab` param (the pre-multi-tab shape that
+ *    closes the sole surface). Announcing `tab: ""` there tells the daemon to
+ *    blank EVERY driven record, other sessions' live tabs included, even
+ *    though the extension knew exactly which surface it had just retired.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const NONCE = "abcdef0123456789abcdef0123456789";
+const TOKEN = `bridge:42:${NONCE}`;
+
+/** Chrome surface big enough to evaluate worker.ts and serve one live tab. */
+function installChrome(surfaces) {
+  const areas = { session: new Map(Object.entries({ surfaces })), local: new Map() };
+  const removed = [];
+  const makeArea = (name) => ({
+    get: async (keys) => {
+      const out = {};
+      for (const key of Array.isArray(keys) ? keys : [keys]) {
+        if (areas[name].has(key)) out[key] = areas[name].get(key);
+      }
+      return out;
+    },
+    set: async (obj) => { for (const [k, v] of Object.entries(obj)) areas[name].set(k, v); },
+    remove: async (keys) => { for (const k of Array.isArray(keys) ? keys : [keys]) areas[name].delete(k); },
+  });
+  globalThis.chrome = {
+    storage: { session: makeArea("session"), local: makeArea("local"), onChanged: { addListener: () => {} } },
+    alarms: { create: () => {}, clear: async () => {}, onAlarm: { addListener: () => {} } },
+    action: Object.fromEntries(
+      ["setBadgeBackgroundColor", "setBadgeTextColor", "setBadgeText", "setTitle"].map((m) => [m, async () => {}]),
+    ),
+    debugger: {
+      attach: async () => {}, detach: async () => {}, sendCommand: async () => ({}),
+      onEvent: { addListener: () => {} }, onDetach: { addListener: () => {} },
+    },
+    tabs: {
+      get: async (tabId) => ({ id: tabId, url: "https://example.com/live", title: "Live" }),
+      remove: async (tabId) => { removed.push(tabId); },
+      onRemoved: { addListener: () => {} }, onReplaced: { addListener: () => {} },
+      onUpdated: { addListener: () => {} },
+    },
+    tabGroups: undefined,
+    notifications: { create: async () => {}, clear: async () => {}, onClicked: { addListener: () => {} } },
+    windows: { get: async () => ({ id: 1 }), getCurrent: async () => ({ id: 1 }) },
+    runtime: {
+      getURL: (p) => `chrome-extension://test/${p}`,
+      getManifest: () => ({ version: "0.1.6" }),
+      onStartup: { addListener: () => {} }, onInstalled: { addListener: () => {} },
+      onMessage: { addListener: () => {} }, sendMessage: async () => {},
+    },
+  };
+  return {
+    removed,
+    surfaces: () => areas.session.get("surfaces"),
+    restore: () => {
+      delete globalThis.chrome;
+      delete globalThis.WebSocket;
+      Reflect.deleteProperty(globalThis, "navigator");
+    },
+  };
+}
+
+/** Load worker.ts with a socket that records frames and can inject requests. */
+async function loadWorker(surfaces) {
+  const chromeState = installChrome(surfaces);
+  const frames = [];
+  let socket;
+  // `navigator` is a getter-only global on modern Node, so it must be
+  // redefined rather than assigned (a plain assignment throws).
+  Object.defineProperty(globalThis, "navigator", {
+    value: { userAgent: "node-test" },
+    configurable: true,
+    writable: true,
+  });
+  globalThis.WebSocket = class {
+    static OPEN = 1;
+    readyState = 1;
+    constructor() { socket = this; queueMicrotask(() => this.onopen?.()); }
+    send(data) { frames.push(JSON.parse(String(data))); }
+    close() {}
+  };
+  const dir = await mkdtemp(join(tmpdir(), "lop-driven-handles-it-"));
+  const outfile = join(dir, "module.mjs");
+  await build({ entryPoints: ["src/worker.ts"], bundle: true, platform: "node", format: "esm", outfile });
+  await import(pathToFileURL(outfile) + `?${Date.now()}`);
+  for (let i = 0; i < 40 && !frames.some((f) => f.event === "hello"); i++) await tick();
+  assert.ok(frames.some((f) => f.event === "hello"), "worker connected");
+  return {
+    frames,
+    chromeState,
+    /** Feed a daemon->extension request in and wait for its response. */
+    async request(method, params) {
+      const id = `req-${frames.length}`;
+      socket.onmessage?.({ data: JSON.stringify({ id, method, params }) });
+      for (let i = 0; i < 200 && !frames.some((f) => f.id === id); i++) await tick();
+      const response = frames.find((f) => f.id === id);
+      assert.ok(response, `no response to ${method}`);
+      return response;
+    },
+    close: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
+const surface = { tabId: 42, nonce: NONCE, epoch: 1, createdAt: 1, lastUsedAt: 2 };
+
+test("a handle-less status never reports a redacted handle as a driven tab", async () => {
+  const worker = await loadWorker({ [TOKEN]: surface });
+  try {
+    const response = await worker.request("status", {});
+    assert.equal(response.ok, true);
+    // The command still redacts, which is the security property (M1).
+    assert.equal(response.result.tab, "bridge:42:abcdef…");
+    const updates = worker.frames.filter((f) => f.event === "tab_update");
+    assert.equal(updates.length, 1, "one navigation, one update");
+    // ...but the EVENT carries no handle, so the daemon refreshes the record
+    // it already has instead of forking a second key for the same tab.
+    assert.equal(updates[0].tab, "", "redacted handle must not key a driven record");
+    assert.equal(updates[0].url, "https://example.com/live");
+  } finally { await worker.close(); worker.chromeState.restore(); }
+});
+
+test("a keyed status reports the real handle, so per-tab tracking still works", async () => {
+  const worker = await loadWorker({ [TOKEN]: surface });
+  try {
+    const response = await worker.request("status", { tab: TOKEN });
+    assert.equal(response.ok, true);
+    const updates = worker.frames.filter((f) => f.event === "tab_update");
+    assert.equal(updates.at(-1).tab, TOKEN, "a proven caller's own handle is forwarded intact");
+  } finally { await worker.close(); worker.chromeState.restore(); }
+});
+
+test("close with no tab param announces the surface it actually retired", async () => {
+  const worker = await loadWorker({ [TOKEN]: surface });
+  try {
+    const response = await worker.request("close", {});
+    assert.equal(response.ok, true);
+    const closes = worker.frames.filter((f) => f.event === "tab_closed");
+    assert.equal(closes.length, 1);
+    // Without this the frame carried "", which the daemon can only read as
+    // "blank every driven record" — including other sessions' live tabs.
+    assert.equal(closes[0].tab, TOKEN, "the sole-surface close shape names its own handle");
+    assert.deepEqual(worker.chromeState.removed, [42], "the tab really was closed");
+  } finally { await worker.close(); worker.chromeState.restore(); }
+});
+
+test("close with an explicit tab param announces that same handle", async () => {
+  const worker = await loadWorker({ [TOKEN]: surface });
+  try {
+    const response = await worker.request("close", { tab: TOKEN });
+    assert.equal(response.ok, true);
+    const closes = worker.frames.filter((f) => f.event === "tab_closed");
+    assert.equal(closes.at(-1).tab, TOKEN);
+  } finally { await worker.close(); worker.chromeState.restore(); }
+});

--- a/extension/tests/origins.integration.test.mjs
+++ b/extension/tests/origins.integration.test.mjs
@@ -88,7 +88,7 @@ function installChromeStub(actionFailures = new Set(), notificationFailures = ne
     },
     runtime: {
       getURL: (path) => `chrome-extension://test/${path}`,
-      getManifest: () => ({ version: "0.1.6" }),
+      getManifest: () => ({ version: "0.1.7" }),
       onStartup: { addListener: () => {} }, onInstalled: { addListener: () => {} },
       onMessage: { addListener: () => {} }, sendMessage: async () => {},
     },

--- a/extension/tests/origins.integration.test.mjs
+++ b/extension/tests/origins.integration.test.mjs
@@ -60,6 +60,13 @@ function installChromeStub(actionFailures = new Set(), notificationFailures = ne
       onEvent: { addListener: () => {}, removeListener: () => {} },
       onDetach: { addListener: () => {} }, sendCommand: async () => ({}),
     },
+    // The worker registers tab-lifecycle listeners at TOP LEVEL (MV3 requires
+    // it: only listeners present during the first synchronous evaluation wake
+    // a suspended worker), so they are wired up merely by importing it.
+    tabs: {
+      get: async () => ({}), remove: async () => {},
+      onRemoved: { addListener: () => {} }, onReplaced: { addListener: () => {} },
+    },
     notifications: {
       create: async (...args) => {
         notificationCalls.push(["create", args]);

--- a/extension/tests/pure.test.mjs
+++ b/extension/tests/pure.test.mjs
@@ -444,7 +444,8 @@ test("surface tokens resolve only with an exact nonce-bearing handle", async () 
 test("redacted handles are recognizable by their owner but not driveable", async () => {
   const module = await load("src/state.ts");
   try {
-    const { surfaceToken, redactToken, ownsRedacted, resolveSurfaceToken } = module.loaded;
+    const { surfaceToken, redactToken, ownsRedacted, resolveSurfaceToken, isRedactedToken } =
+      module.loaded;
     const surface = { tabId: 42, nonce: "abcdef0123456789abcdef0123456789", epoch: 1, createdAt: 1, lastUsedAt: 2 };
     const token = surfaceToken(surface);
     const redacted = redactToken(token);
@@ -459,6 +460,13 @@ test("redacted handles are recognizable by their owner but not driveable", async
     assert.equal(resolveSurfaceToken(redacted, { [token]: surface }), undefined);
     // Unredacted comparison still exact-matches (defensive path).
     assert.equal(ownsRedacted(token, token), true);
+    // A redacted token is DETECTABLE as such, which is what stops worker.ts
+    // forwarding it as a tab_update handle. Doing so keyed a second driven
+    // record for one tab, and that duplicate outlived the real close as a
+    // phantom advertising a dead URL — the ghost this release removes.
+    assert.equal(isRedactedToken(redacted), true);
+    assert.equal(isRedactedToken(token), false);
+    assert.equal(isRedactedToken(""), false);
   } finally { await module.close(); }
 });
 

--- a/extension/tests/release.test.mjs
+++ b/extension/tests/release.test.mjs
@@ -56,7 +56,7 @@ async function runRelease(args, handlers) {
 
 test("manifest requests tabGroups exactly once", async () => {
   const manifest = JSON.parse(await readFile(new URL("../manifest.json", import.meta.url), "utf8"));
-  assert.equal(manifest.version, "0.1.6");
+  assert.equal(manifest.version, "0.1.7");
   assert.equal(manifest.permissions.filter((permission) => permission === "tabGroups").length, 1);
 });
 

--- a/extension/tests/tab-lifecycle.integration.test.mjs
+++ b/extension/tests/tab-lifecycle.integration.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// The bundle pulls in cdp.ts -> log-capture.ts, which touches chrome APIs at
+// module scope, so the stub has to be installed BEFORE the dynamic import
+// rather than after it.
+async function loadModule(initialSurfaces = {}) {
+  const chromeState = installChrome(initialSurfaces);
+  const dir = await mkdtemp(join(tmpdir(), "lop-tab-lifecycle-it-"));
+  const outfile = join(dir, "module.mjs");
+  await build({ entryPoints: ["src/tab-lifecycle.ts"], bundle: true, platform: "node", format: "esm", outfile });
+  return {
+    loaded: await import(pathToFileURL(outfile) + `?${Date.now()}`),
+    chromeState,
+    close: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
+/** Minimal chrome surface: the surfaces map, tabs, and a debugger that records
+ * detach calls so the "prune reclaims everything" property is observable. */
+function installChrome(initialSurfaces = {}) {
+  let surfaces = structuredClone(initialSurfaces);
+  const detached = [];
+  globalThis.chrome = {
+    storage: {
+      session: {
+        get: async (keys) => {
+          const all = { surfaces, refs: {} };
+          if (Array.isArray(keys)) return Object.fromEntries(keys.map((k) => [k, all[k]]));
+          return all;
+        },
+        set: async (value) => {
+          if (value.surfaces) surfaces = structuredClone(value.surfaces);
+        },
+      },
+    },
+    debugger: {
+      attach: async () => {},
+      detach: async ({ tabId }) => { detached.push(tabId); },
+      sendCommand: async () => ({}),
+      // log-capture.ts subscribes at module scope, so these must exist before
+      // the bundle is imported or evaluation throws.
+      onEvent: { addListener: () => {} },
+      onDetach: { addListener: () => {} },
+    },
+    tabs: { get: async () => ({}), onRemoved: { addListener: () => {} } },
+  };
+  return { detached, surfaces: () => surfaces };
+}
+
+test("a removed tab we own is reclaimed and reported by handle", async () => {
+  const token = "bridge:42:abc123";
+  const module = await loadModule({ [token]: { tabId: 42, nonce: "abc123", epoch: 1, createdAt: 1, lastUsedAt: 2 } });
+  const chromeState = module.chromeState;
+  try {
+    const announced = await module.loaded.reclaimRemovedTab(42);
+    // The handle is what the daemon needs: it clears exactly this tab rather
+    // than blanking every session's driven record.
+    assert.equal(announced, token);
+    // Full reclaim, so a dead tab cannot hold a slot against MAX_SURFACES.
+    assert.deepEqual(chromeState.surfaces(), {});
+  } finally {
+    await module.close();
+  }
+});
+
+test("a tab we do not own is ignored", async () => {
+  const token = "bridge:42:abc123";
+  const module = await loadModule({ [token]: { tabId: 42, nonce: "abc123", epoch: 1, createdAt: 1, lastUsedAt: 2 } });
+  const chromeState = module.chromeState;
+  try {
+    // The user closing one of their OWN tabs must not announce anything: a
+    // tab_closed here would clear a driven record that is still live.
+    assert.equal(await module.loaded.reclaimRemovedTab(999), undefined);
+    assert.deepEqual(Object.keys(chromeState.surfaces()), [token]);
+  } finally {
+    await module.close();
+  }
+});
+
+test("reclaiming is idempotent so a double event cannot throw", async () => {
+  const token = "bridge:7:dead99";
+  const module = await loadModule({ [token]: { tabId: 7, nonce: "dead99", epoch: 1, createdAt: 1, lastUsedAt: 2 } });
+  try {
+    assert.equal(await module.loaded.reclaimRemovedTab(7), token);
+    // onRemoved after an explicit close (chrome.tabs.remove fires it too).
+    assert.equal(await module.loaded.reclaimRemovedTab(7), undefined);
+  } finally {
+    await module.close();
+  }
+});
+
+test("ownedSurfaceFor picks the right surface among several", async () => {
+  const module = await loadModule({
+    "bridge:1:aaa": { tabId: 1, nonce: "aaa", epoch: 1, createdAt: 1, lastUsedAt: 1 },
+    "bridge:2:bbb": { tabId: 2, nonce: "bbb", epoch: 1, createdAt: 1, lastUsedAt: 2 },
+  });
+  try {
+    assert.equal(await module.loaded.ownedSurfaceFor(2), "bridge:2:bbb");
+    assert.equal(await module.loaded.ownedSurfaceFor(3), undefined);
+  } finally {
+    await module.close();
+  }
+});

--- a/local_operator/browser_bridge/backend.py
+++ b/local_operator/browser_bridge/backend.py
@@ -68,12 +68,15 @@ HEALTH_PROBE_TIMEOUT_S = 1.5
 
 
 def bridge_browser_available(root: Path | None = None) -> bool:
-    """File-only createIf probe: no socket, no subprocess, never raises.
+    """File-only "known-good right now" probe: no socket, no subprocess, never raises.
 
-    Stays file-only on purpose: this runs while constructing EVERY session and
-    while gating the tool, where a socket round-trip would tax startup for
-    every session on the machine. The stale-but-alive rescue lives in
-    :func:`bridge_browser_reachable`, on the browser path.
+    Stays file-only on purpose: it runs while constructing EVERY session, where
+    a socket round-trip would tax startup for every session on the machine. The
+    stale-but-alive rescue lives in :func:`bridge_browser_reachable`, on the
+    browser path.
+
+    Use :func:`bridge_browser_advertisable` for tool GATING, which is a weaker
+    commitment and must not hide a stale-but-alive daemon.
     """
     try:
         return state_store.available(root)
@@ -81,7 +84,27 @@ def bridge_browser_available(root: Path | None = None) -> bool:
         return False
 
 
-async def bridge_browser_reachable(root: Path | None = None) -> bool:
+def bridge_browser_advertisable(root: Path | None = None) -> bool:
+    """File-only gate for whether the `browser` TOOL is offered at all.
+
+    Same cost and the same no-socket/no-subprocess contract as
+    :func:`bridge_browser_available`, but it also accepts a STALE heartbeat
+    whose pid is alive, so the RC2 rescue in ``execute_browser`` can actually
+    be reached on a host with no cmux. See
+    :func:`local_operator.browser_bridge.state.advertisable` for the full
+    reasoning and the hot-path constraint it preserves.
+    """
+    try:
+        return state_store.advertisable(root)
+    except Exception:  # noqa: BLE001 - session startup must not fail on discovery
+        return False
+
+
+async def bridge_browser_reachable(
+    root: Path | None = None,
+    *,
+    classified: tuple[state_store.Liveness, state_store.BridgeState | None] | None = None,
+) -> bool:
     """Availability for the BROWSER PATH: file first, socket only to acquit.
 
     The file heartbeat is a proxy that lies in both directions, and when it
@@ -100,9 +123,14 @@ async def bridge_browser_reachable(root: Path | None = None) -> bool:
       bounded ``/health`` request before condemning the bridge.
 
     A daemon that answers is available regardless of what the file says.
+
+    ``classified`` lets a caller that has ALREADY classified the daemon pass
+    its answer in, so one browser action performs one file read instead of
+    several and the demotion diagnostic cannot describe a different reading
+    than the decision it explains.
     """
     try:
-        status, current = state_store.liveness(root)
+        status, current = classified if classified is not None else state_store.liveness(root)
     except Exception:  # noqa: BLE001 - discovery must never raise at a call site
         return False
     if status is state_store.Liveness.FRESH:

--- a/local_operator/browser_bridge/backend.py
+++ b/local_operator/browser_bridge/backend.py
@@ -59,11 +59,68 @@ class BridgeUnreachable(RuntimeError):
     pass
 
 
+#: Ceiling on the confirmation probe below. It runs at most once per browser
+#: action and ONLY when the cheap file check was about to condemn a daemon
+#: whose pid is still alive, so it is never on the common path. Short because
+#: a loopback /health answers in single-digit milliseconds; anything slower is
+#: a daemon that is genuinely not serving.
+HEALTH_PROBE_TIMEOUT_S = 1.5
+
+
 def bridge_browser_available(root: Path | None = None) -> bool:
-    """File-only createIf probe: no socket, no subprocess, never raises."""
+    """File-only createIf probe: no socket, no subprocess, never raises.
+
+    Stays file-only on purpose: this runs while constructing EVERY session and
+    while gating the tool, where a socket round-trip would tax startup for
+    every session on the machine. The stale-but-alive rescue lives in
+    :func:`bridge_browser_reachable`, on the browser path.
+    """
     try:
         return state_store.available(root)
     except Exception:  # noqa: BLE001 - session startup must not fail on discovery
+        return False
+
+
+async def bridge_browser_reachable(root: Path | None = None) -> bool:
+    """Availability for the BROWSER PATH: file first, socket only to acquit.
+
+    The file heartbeat is a proxy that lies in both directions, and when it
+    lied the failure was silent and total: a daemon whose heartbeat writer had
+    died kept serving ``/health`` while every session read the file, concluded
+    the extension was gone, and fell back to cmux — disagreeing with
+    ``lop browser status``, which reads the live socket. Nothing reconciled
+    them, so both the agent and the user concluded a phantom tab held a lock.
+
+    The contract that removes the contradiction, without slowing the common
+    case:
+
+    - ``FRESH``  → available. No probe (the overwhelmingly common path).
+    - ``ABSENT`` → unavailable. No probe; there is nothing to acquit.
+    - ``STALE``  → the file cannot tell, and the pid is alive, so spend ONE
+      bounded ``/health`` request before condemning the bridge.
+
+    A daemon that answers is available regardless of what the file says.
+    """
+    try:
+        status, current = state_store.liveness(root)
+    except Exception:  # noqa: BLE001 - discovery must never raise at a call site
+        return False
+    if status is state_store.Liveness.FRESH:
+        return True
+    if status is not state_store.Liveness.STALE or current is None:
+        return False
+    return await _health_ok(current.port)
+
+
+async def _health_ok(port: int) -> bool:
+    """One bounded loopback /health probe; any failure means "not reachable"."""
+    try:
+        async with httpx.AsyncClient(timeout=HEALTH_PROBE_TIMEOUT_S) as client:
+            response = await client.get(f"http://127.0.0.1:{port}/health")
+        return response.status_code == 200 and bool(
+            response.json().get("extension_connected", False)
+        )
+    except Exception:  # noqa: BLE001 - unreachable, malformed, or timed out
         return False
 
 

--- a/local_operator/browser_bridge/daemon.py
+++ b/local_operator/browser_bridge/daemon.py
@@ -56,9 +56,13 @@ PAIR_TTL_S = 120.0
 PAIR_MAX_ATTEMPTS = 5
 PAIRING_FILENAME = "browser/pairing.json"
 PENDING_FILENAME = "run/browser/pairing-pending.json"
-#: Ceiling on the supervisor's per-failure backoff. A loop whose iteration
-#: keeps raising must not spin a core or flood the log, but must still recover
-#: promptly once the cause clears, so the delay grows to this and stops.
+#: Ceiling on the supervisor's per-failure backoff. The delay is the number of
+#: CONSECUTIVE failures in seconds (1s, 2s, 3s …), clamped here: linear rather
+#: than exponential on purpose, because these loops recover the moment the
+#: cause clears and an exponential delay would keep the bridge unavailable long
+#: after the disk drained. A loop whose iteration keeps raising still must not
+#: spin a core or flood the log, which is what the clamp guarantees — it is
+#: reached after this many consecutive failures, not after a few.
 SUPERVISOR_BACKOFF_CAP_S = 30.0
 #: Poll granularity for the extendable command wait. A pending future is
 #: normally resolved by the receive loop the instant the response lands; this
@@ -118,6 +122,45 @@ def reset_pairing(root: Path | None = None) -> None:
 #: extension build). One reserved key keeps a mixed-version pair reporting a
 #: single driven tab rather than one phantom per navigation.
 _UNKEYED_TAB = ""
+
+#: Marks a REDACTED surface handle (`state.ts:redactToken` truncates the nonce
+#: and appends this). The extension redacts every handle that leaves it other
+#: than the caller's own `open` response, so a redacted token can arrive as a
+#: command result and must never be treated as a real handle: see
+#: :func:`_is_real_handle`.
+_REDACTION_MARK = "\u2026"
+
+
+def _handle_matches_listed(handle: str, listed: str) -> bool:
+    """Whether our full ``handle`` names the surface a listing entry describes.
+
+    The `tabs` listing redacts handles (the full token IS the drive capability,
+    so listing it would hand every session control of every tab), which still
+    leaves enough nonce to recognise one's OWN handle by prefix. This is the
+    daemon-side twin of `state.ts:ownsRedacted`; keep the two in step.
+    """
+    if listed.endswith(_REDACTION_MARK):
+        return handle.startswith(listed[: -len(_REDACTION_MARK)])
+    return handle == listed
+
+
+def _is_real_handle(tab: str) -> bool:
+    """Whether ``tab`` is a full surface handle that may KEY a driven record.
+
+    A handle-less `status` returns a redacted token (`bridge:7:abcdef\u2026`)
+    because an unproven caller must not receive the drive capability. That is
+    still a non-empty string, so it was accepted as a handle and became a
+    SECOND key for a tab already tracked under its full token — the driven
+    count over-reported, and after the tab genuinely closed `note_closed(full)`
+    dropped only the full key, leaving the redacted entry advertising a dead
+    URL forever. That is exactly the phantom this change exists to remove,
+    reintroduced one layer down.
+
+    A redacted handle proves nothing about which tab it names, so it is treated
+    as ABSENT: the update refreshes the most recent record instead of forking a
+    new one, which is the same safe reading a handle-less update already gets.
+    """
+    return bool(tab) and not tab.endswith(_REDACTION_MARK)
 
 
 @dataclass
@@ -193,9 +236,16 @@ class ExtensionLink:
           the same navigation. Creating an unkeyed entry there would double-
           count one tab. So when tabs are already tracked, a handle-less update
           REFRESHES the most recent one instead of adding to the map.
+
+        A REDACTED handle counts as absent for both purposes; see
+        :func:`_is_real_handle`. The daemon enforces this even though the
+        current extension no longer sends one, because the two run independent
+        release cycles and an old or third-party build must not be able to
+        plant a phantom.
         """
-        key = tab or _UNKEYED_TAB
-        if not tab and self.driven:
+        keyed = _is_real_handle(tab)
+        key = tab if keyed else _UNKEYED_TAB
+        if not keyed and self.driven:
             latest = self._latest_driven()
             key = next((k for k, v in self.driven.items() if v is latest), _UNKEYED_TAB)
         self.driven[key] = DrivenTab(url=url, title=title, updated_at=time.time())
@@ -203,15 +253,25 @@ class ExtensionLink:
     def note_closed(self, tab: str) -> None:
         """Drop one closed tab, or every tab when the handle is unknown.
 
-        A handle-less ``tab_closed`` comes either from an older extension or
-        from a teardown that could not name the surface; blanking everything is
-        the safe reading there, because the alternative (keeping entries alive)
-        is exactly the phantom this fixes. A handle-carrying event drops only
-        that tab, so one session closing its tab never blanks another's.
+        A handle-carrying event drops ONLY that tab, so one session closing its
+        tab never blanks another's. It deliberately does NOT also drop the
+        unkeyed record: that record belongs to a DIFFERENT, older peer (it only
+        exists in a mixed-version pair), and dropping it made a new session
+        closing its own tab blank an old extension's still-live entry — the
+        docstring promised isolation the code did not deliver. The unkeyed
+        record is cleared by its own handle-less close, by `disconnect`, or by
+        `repair`; a stale one is self-correcting on the peer's next update.
+
+        A handle-less (or redacted, which proves nothing — see
+        :func:`_is_real_handle`) ``tab_closed`` cannot name what went away, so
+        it blanks everything: the alternative, keeping entries alive, is
+        exactly the phantom this fixes. Callers that CAN name the surface must
+        do so — `worker.ts` resolves the sole-surface `close` shape to its real
+        handle before announcing, so this clear-all stays what it is documented
+        to be: the last resort for a peer that genuinely cannot say.
         """
-        if tab:
+        if _is_real_handle(tab):
             self.driven.pop(tab, None)
-            self.driven.pop(_UNKEYED_TAB, None)
         else:
             self.driven.clear()
 
@@ -355,9 +415,9 @@ class BridgeService:
                     failures,
                     exc_info=True,
                 )
-                # Back off a little on a persistently failing iteration so a
-                # synchronous failure cannot become a busy loop, capped so
-                # recovery is still prompt once the cause clears.
+                # Back off one second per consecutive failure so a synchronous
+                # failure cannot become a busy loop, clamped at
+                # SUPERVISOR_BACKOFF_CAP_S. Linear, so recovery stays prompt.
                 await asyncio.sleep(min(SUPERVISOR_BACKOFF_CAP_S, float(failures)))
 
     async def _heartbeat_tick(self) -> None:
@@ -892,11 +952,27 @@ class BridgeService:
                 raw = await self._dispatch_serialized(request)
                 payload: Any = json.loads(bytes(raw.body).decode("utf-8"))
                 listed = (payload.get("result") or {}).get("tabs", []) if payload.get("ok") else []
-                live_urls = {
-                    str(entry.get("url", "")) for entry in listed if isinstance(entry, dict)
-                }
+                entries = [entry for entry in listed if isinstance(entry, dict)]
+                live_handles = [str(entry.get("tab", "")) for entry in entries]
+                live_urls = {str(entry.get("url", "")) for entry in entries}
                 for key, tab in before.items():
-                    if tab.url and tab.url not in live_urls:
+                    # Match on the SURFACE HANDLE, which is stable, rather than
+                    # on the URL, which is not: the listing reads chrome.tabs at
+                    # call time, so a tab that navigated after its last
+                    # tab_update (or is still resolving a redirect) presents a
+                    # different URL and was dropped as a phantom while genuinely
+                    # live. Harmless-but-wrong is still wrong for a verb
+                    # advertised as safe to run while sessions are driving.
+                    if _is_real_handle(key):
+                        alive = any(
+                            _handle_matches_listed(key, listed_handle)
+                            for listed_handle in live_handles
+                        )
+                    else:
+                        # The unkeyed record (an older extension) has no handle
+                        # to match on, so the URL remains the only signal.
+                        alive = not tab.url or tab.url in live_urls
+                    if not alive:
                         self.link.driven.pop(key, None)
                         cleaned.append(tab.url)
             except Exception:  # noqa: BLE001 - repair must never fail loudly

--- a/local_operator/browser_bridge/daemon.py
+++ b/local_operator/browser_bridge/daemon.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import errno
 import hashlib
 import json
 import logging
@@ -17,8 +18,9 @@ import os
 import secrets
 import time
 from contextlib import asynccontextmanager, suppress
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Awaitable, Callable
 
 import uvicorn
 from pydantic import ValidationError
@@ -54,6 +56,10 @@ PAIR_TTL_S = 120.0
 PAIR_MAX_ATTEMPTS = 5
 PAIRING_FILENAME = "browser/pairing.json"
 PENDING_FILENAME = "run/browser/pairing-pending.json"
+#: Ceiling on the supervisor's per-failure backoff. A loop whose iteration
+#: keeps raising must not spin a core or flood the log, but must still recover
+#: promptly once the cause clears, so the delay grows to this and stops.
+SUPERVISOR_BACKOFF_CAP_S = 30.0
 #: Poll granularity for the extendable command wait. A pending future is
 #: normally resolved by the receive loop the instant the response lands; this
 #: only bounds how quickly a deadline EXTENSION (awaiting_origin) is noticed.
@@ -108,6 +114,21 @@ def reset_pairing(root: Path | None = None) -> None:
             path.unlink()
 
 
+#: Key for driven-tab records that arrive without a surface handle (an older
+#: extension build). One reserved key keeps a mixed-version pair reporting a
+#: single driven tab rather than one phantom per navigation.
+_UNKEYED_TAB = ""
+
+
+@dataclass
+class DrivenTab:
+    """One tab the extension is currently driving, as last reported."""
+
+    url: str
+    title: str
+    updated_at: float
+
+
 class ExtensionLink:
     """The one connected extension plus in-flight request correlation."""
 
@@ -122,13 +143,77 @@ class ExtensionLink:
         # this to extend the deadline past the base command timeout (A3), and
         # the popup/status surfaces read it so a pending approval is visible.
         self.awaiting_origin: dict[str, str] = {}
-        # Last known URL/title of the tab the agent drives, pushed by the
-        # extension so the Connected popup and `status` can show the human WHAT
-        # is being driven — the tab is inactive, so the debugger infobar alone
-        # is not a signal the user sees (finding U3).
-        self.current_url = ""
-        self.current_title = ""
+        # Last known URL/title PER DRIVEN TAB, keyed by the extension's surface
+        # handle, pushed by the extension so the Connected popup and `status`
+        # can show the human WHAT is being driven — the tab is inactive, so the
+        # debugger infobar alone is not a signal the user sees (finding U3).
+        #
+        # Per-tab rather than one global slot: sessions get a tab each (up to
+        # MAX_SURFACES), so a single last-writer-wins field showed whichever
+        # tab was touched most recently as though it were THE bound tab. When
+        # that tab then closed without anything clearing the field, `status`
+        # advertised a URL whose tab — and whose server — were long gone, which
+        # read to both the user and the agent as a system-wide lock held by a
+        # phantom. A dict makes "how many tabs are driven" answerable, and
+        # makes closing one tab clear exactly that tab.
+        self.driven: dict[str, DrivenTab] = {}
         self.send_lock = asyncio.Lock()
+
+    @property
+    def current_url(self) -> str:
+        """Most recently driven live tab's URL, or "" when none is driven.
+
+        Kept as a property because /health, the popup, and `status` are an
+        established contract; "" now genuinely means "nothing is driven"
+        rather than "nobody has updated this field yet".
+        """
+        latest = self._latest_driven()
+        return latest.url if latest else ""
+
+    @property
+    def current_title(self) -> str:
+        latest = self._latest_driven()
+        return latest.title if latest else ""
+
+    def _latest_driven(self) -> DrivenTab | None:
+        return max(self.driven.values(), key=lambda tab: tab.updated_at, default=None)
+
+    def note_driven(self, tab: str, url: str, title: str) -> None:
+        """Record/refresh one driven tab.
+
+        The handle is absent in two cases, and conflating them would invent
+        phantoms — the exact class of bug this change removes:
+
+        - An OLDER extension that only ever sent a bare ``tab_update``. There
+          is no handle to be had, so those collapse onto one reserved key and a
+          mixed-version pair reports a single driven tab, not one entry per
+          navigation.
+        - A handle-less command RESULT (``goto`` returns url/title but no
+          ``tab``) arriving just after the worker's keyed ``tab_update`` for
+          the same navigation. Creating an unkeyed entry there would double-
+          count one tab. So when tabs are already tracked, a handle-less update
+          REFRESHES the most recent one instead of adding to the map.
+        """
+        key = tab or _UNKEYED_TAB
+        if not tab and self.driven:
+            latest = self._latest_driven()
+            key = next((k for k, v in self.driven.items() if v is latest), _UNKEYED_TAB)
+        self.driven[key] = DrivenTab(url=url, title=title, updated_at=time.time())
+
+    def note_closed(self, tab: str) -> None:
+        """Drop one closed tab, or every tab when the handle is unknown.
+
+        A handle-less ``tab_closed`` comes either from an older extension or
+        from a teardown that could not name the surface; blanking everything is
+        the safe reading there, because the alternative (keeping entries alive)
+        is exactly the phantom this fixes. A handle-carrying event drops only
+        that tab, so one session closing its tab never blanks another's.
+        """
+        if tab:
+            self.driven.pop(tab, None)
+            self.driven.pop(_UNKEYED_TAB, None)
+        else:
+            self.driven.clear()
 
     async def send(self, payload: dict[str, Any]) -> None:
         websocket = self.websocket
@@ -145,8 +230,9 @@ class ExtensionLink:
                 future.set_exception(RuntimeError("extension disconnected"))
         self.pending.clear()
         self.awaiting_origin.clear()
-        self.current_url = ""
-        self.current_title = ""
+        # Nothing is driven once the browser is gone: the surfaces live in the
+        # extension's session storage and do not outlive the connection.
+        self.driven.clear()
 
 
 class BridgeService:
@@ -165,6 +251,9 @@ class BridgeService:
         self._heartbeat_task: asyncio.Task[None] | None = None
         self._ping_task: asyncio.Task[None] | None = None
         self._revoke_task: asyncio.Task[None] | None = None
+        # Consecutive failed discovery-file writes, so recovery can be logged
+        # once rather than on every tick (see publish_safely).
+        self._publish_failures = 0
         # Per-tab command serialization. v1 is explicitly a SINGLE active
         # browser surface (one extension, one dedicated tab): the design's
         # "session->tab table" is deferred, and instead of silently
@@ -181,19 +270,113 @@ class BridgeService:
         self.state.browser_name = self.link.browser
         state_store.publish(self.state, self.root)
 
-    async def _heartbeat(self) -> None:
-        while True:
+    def publish_safely(self) -> bool:
+        """Publish discovery state, absorbing a failed write instead of raising.
+
+        Every event-driven caller (pairing, connect, disconnect, tab updates)
+        used to publish inline and unguarded. A single failed write there took
+        down whichever coroutine happened to be running, and on the heartbeat
+        path it killed the only task that refreshes the file — after which
+        ``state.available()`` was false for EVERY session on the machine, for
+        the rest of the daemon's life, while ``/health`` kept answering 200.
+        That contradiction is the whole incident (a full disk raised ENOSPC out
+        of ``tempfile.mkstemp``; nothing restarted the writer or logged that it
+        had gone).
+
+        Publishing is a best-effort CACHE refresh, never a correctness
+        requirement: the daemon's authoritative state lives in memory and is
+        served by ``/health``. So a failed write is logged and swallowed, and
+        the next heartbeat tick retries — which is what makes recovery
+        automatic once the disk drains.
+        """
+        try:
             self.publish()
-            await asyncio.sleep(state_store.HEARTBEAT_INTERVAL_S)
+            if self._publish_failures:
+                logger.warning(
+                    "browser bridge state file writable again after %d failed attempt(s)",
+                    self._publish_failures,
+                )
+                self._publish_failures = 0
+            return True
+        except OSError as error:
+            self._publish_failures += 1
+            # ENOSPC is the one a user can actually act on, and it is what
+            # bit this machine, so it gets its own actionable line rather than
+            # being buried in a generic write failure.
+            if error.errno == errno.ENOSPC:
+                logger.error(
+                    "browser bridge cannot write %s: the disk is full. Sessions will fall "
+                    "back to cmux until space is freed; the daemon keeps serving /health "
+                    "and recovers on its own once the write succeeds.",
+                    state_store.state_path(self.root),
+                )
+            else:
+                logger.warning(
+                    "browser bridge state publish failed (attempt %d); retrying next tick",
+                    self._publish_failures,
+                    exc_info=True,
+                )
+        except Exception:  # noqa: BLE001 - a cache refresh may never kill a loop
+            self._publish_failures += 1
+            logger.warning(
+                "browser bridge state publish failed unexpectedly (attempt %d)",
+                self._publish_failures,
+                exc_info=True,
+            )
+        return False
+
+    async def _supervise(self, name: str, body: Callable[[], Awaitable[None]]) -> None:
+        """Run one iteration-based background loop forever, come what may.
+
+        The three background loops here are LIVENESS infrastructure: if one
+        exits, the daemon does not crash and nothing notices — it just quietly
+        stops doing its job, which is strictly worse than a crash because the
+        process keeps answering /health as though it were healthy. That is how
+        a full disk turned into "every session falls back to cmux forever while
+        status says the extension is connected".
+
+        So no per-iteration exception may end a loop. Cancellation still ends
+        it promptly (shutdown depends on that), and a genuinely persistent
+        failure is rate-limited in the log rather than spun on — a tight retry
+        loop against a broken syscall would burn a core and flood the log.
+        """
+        failures = 0
+        while True:
+            try:
+                await body()
+                failures = 0
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 - a supervisory loop must not die
+                failures += 1
+                logger.warning(
+                    "browser bridge %s loop iteration failed (%d consecutive); continuing",
+                    name,
+                    failures,
+                    exc_info=True,
+                )
+                # Back off a little on a persistently failing iteration so a
+                # synchronous failure cannot become a busy loop, capped so
+                # recovery is still prompt once the cause clears.
+                await asyncio.sleep(min(SUPERVISOR_BACKOFF_CAP_S, float(failures)))
+
+    async def _heartbeat_tick(self) -> None:
+        self.publish_safely()
+        await asyncio.sleep(state_store.HEARTBEAT_INTERVAL_S)
+
+    async def _ping_tick(self) -> None:
+        await asyncio.sleep(PING_INTERVAL_S)
+        if self.link.websocket is not None:
+            try:
+                await self.link.send({"event": "ping"})
+            except Exception:  # noqa: BLE001 - receive loop owns teardown
+                logger.debug("browser extension ping failed", exc_info=True)
+
+    async def _heartbeat(self) -> None:
+        await self._supervise("heartbeat", self._heartbeat_tick)
 
     async def _ping(self) -> None:
-        while True:
-            await asyncio.sleep(PING_INTERVAL_S)
-            if self.link.websocket is not None:
-                try:
-                    await self.link.send({"event": "ping"})
-                except Exception:  # noqa: BLE001 - receive loop owns teardown
-                    logger.debug("browser extension ping failed", exc_info=True)
+        await self._supervise("ping", self._ping_tick)
 
     def _live_pairing_matches(self) -> bool:
         """Whether the ON-DISK pairing still authorizes the connected extension.
@@ -224,27 +407,35 @@ class BridgeService:
                 # popup renders \"waiting to pair\" rather than a mystery drop.
                 await websocket.close(code=4003)
         self.link.disconnect()
-        self.publish()
+        self.publish_safely()
+
+    async def _revocation_tick(self) -> None:
+        await asyncio.sleep(REVOKE_WATCH_S)
+        if (
+            self.link.websocket is not None
+            and self.link.paired
+            and not self._live_pairing_matches()
+        ):
+            logger.info("pairing revoked on disk; closing the live extension socket")
+            await self.revoke()
 
     async def _watch_revocation(self) -> None:
         """Poll the pairing file so an out-of-process revoke severs a live link.
 
         Cheap (one stat-and-parse every few seconds) and only acts on the
         transition from paired-with-file to paired-without-file, so it never
-        fights the handshake that is mid-flight.
+        fights the handshake that is mid-flight. Supervised: a transient read
+        error must not silently disarm revocation for the daemon's lifetime,
+        which would leave a revoked browser able to drive until it reconnected.
         """
-        while True:
-            await asyncio.sleep(REVOKE_WATCH_S)
-            if (
-                self.link.websocket is not None
-                and self.link.paired
-                and not self._live_pairing_matches()
-            ):
-                logger.info("pairing revoked on disk; closing the live extension socket")
-                await self.revoke()
+        await self._supervise("revocation-watch", self._revocation_tick)
 
     async def startup(self) -> None:
-        self.publish()
+        # Startup publishes through the guarded path too: a daemon that cannot
+        # write its discovery file on a full disk must still boot and serve
+        # /health, so that `lop browser status` and the tool's socket probe can
+        # both still reach it and report the truth.
+        self.publish_safely()
         self._heartbeat_task = asyncio.create_task(self._heartbeat())
         self._ping_task = asyncio.create_task(self._ping())
         self._revoke_task = asyncio.create_task(self._watch_revocation())
@@ -358,7 +549,7 @@ class BridgeService:
         with suppress(OSError):
             _pending_path(self.root).unlink()
         self.link.paired = True
-        self.publish()
+        self.publish_safely()
         return PairResult(ok=True, token=token)
 
     async def extension(self, websocket: WebSocket) -> None:
@@ -393,7 +584,7 @@ class BridgeService:
         self.link.paired = self._valid_saved_token(extension_id, hello.token)
         if not self.link.paired:
             self._ensure_pending(extension_id)
-        self.publish()
+        self.publish_safely()
         await self.link.send(HelloAck(paired=self.link.paired).model_dump(mode="json"))
         try:
             while True:
@@ -413,7 +604,7 @@ class BridgeService:
                     request_id = str(frame.get("id", ""))
                     if request_id:
                         self.link.awaiting_origin[request_id] = str(frame.get("origin", ""))
-                        self.publish()
+                        self.publish_safely()
                     continue
                 if frame.get("event") == "awaiting_origin_cleared":
                     # The extension's queue entry for this command is gone
@@ -424,7 +615,7 @@ class BridgeService:
                     request_id = str(frame.get("id", ""))
                     if request_id and request_id in self.link.awaiting_origin:
                         self.link.awaiting_origin.pop(request_id, None)
-                        self.publish()
+                        self.publish_safely()
                     continue
                 if frame.get("event") == "unpair":
                     # The options page "Unpair this browser" reaches the daemon
@@ -435,14 +626,20 @@ class BridgeService:
                 if frame.get("event") == "tab_update":
                     # Pushed by the extension on navigation so the popup reflects
                     # the driven site promptly even between commands (U3).
-                    self.link.current_url = str(frame.get("url", ""))
-                    self.link.current_title = str(frame.get("title", ""))
-                    self.publish()
+                    self.link.note_driven(
+                        str(frame.get("tab", "")),
+                        str(frame.get("url", "")),
+                        str(frame.get("title", "")),
+                    )
+                    self.publish_safely()
                     continue
                 if frame.get("event") == "tab_closed":
-                    self.link.current_url = ""
-                    self.link.current_title = ""
-                    self.publish()
+                    # The extension reports the CLOSED SURFACE by handle, so
+                    # only that tab is dropped: with several sessions driving a
+                    # tab each, blanking everything on one close (as this did)
+                    # would have reported the survivors as gone.
+                    self.link.note_closed(str(frame.get("tab", "")))
+                    self.publish_safely()
                     continue
                 if frame.get("event") in ("pong", "origin_decision"):
                     continue
@@ -455,9 +652,13 @@ class BridgeService:
                 if response.ok and response.result:
                     url = response.result.get("url")
                     if isinstance(url, str) and url:
-                        self.link.current_url = url
                         title = response.result.get("title")
-                        self.link.current_title = title if isinstance(title, str) else ""
+                        handle = response.result.get("tab")
+                        self.link.note_driven(
+                            handle if isinstance(handle, str) else "",
+                            url,
+                            title if isinstance(title, str) else "",
+                        )
                 self.link.awaiting_origin.pop(response.id, None)
                 future = self.link.pending.pop(response.id, None)
                 if future is not None and not future.done():
@@ -467,7 +668,7 @@ class BridgeService:
         finally:
             if self.link.websocket is websocket:
                 self.link.disconnect()
-                self.publish()
+                self.publish_safely()
 
     async def rpc(self, http_request: HttpRequest) -> JSONResponse:
         supplied = http_request.headers.get("x-bridge-key", "")
@@ -650,7 +851,69 @@ class BridgeService:
                 "browser": self.link.browser,
                 "current_url": self.link.current_url,
                 "current_title": self.link.current_title,
+                # How many tabs are driven, and their URLs. `current_url` alone
+                # framed a multi-tab world as one binding, so a stale value
+                # read as a system-wide lock; the count lets `status` say "no
+                # tabs driven" (or name all of them) truthfully.
+                "driven_tabs": [
+                    {"url": tab.url, "title": tab.title}
+                    for tab in sorted(
+                        self.link.driven.values(), key=lambda t: t.updated_at, reverse=True
+                    )
+                ],
                 "pending_origin": pending[0] if pending else "",
+            }
+        )
+
+    async def repair(self, _request: HttpRequest) -> JSONResponse:
+        """Reconcile advertised state against reality, and report what changed.
+
+        The incident left the user with no way to say "clear whatever you think
+        you are holding": the daemon advertised a driven tab that no longer
+        existed and a heartbeat that had stopped, and the only remedy anyone
+        could think of was killing a healthy daemon.
+
+        Safe while sessions are live, by construction: it asks the EXTENSION
+        which surfaces really exist and drops only the records that reality
+        does not back. It never closes a tab, never touches pairing, and never
+        cancels an in-flight command — so a session driving a live tab keeps
+        driving it. Unauthenticated like /health because it is loopback-only
+        and confers no drive capability.
+        """
+        cleaned: list[str] = []
+        before = dict(self.link.driven)
+        if self.link.websocket is not None and before:
+            # The extension's own live-surface listing is the ground truth;
+            # anything we advertise that it does not list is a ghost. `tabs`
+            # prunes dead surfaces extension-side as it lists, so this also
+            # reclaims handles leaked by a session that died without `close`.
+            try:
+                request = Request(id=f"repair-{secrets.token_hex(4)}", method="tabs", params={})
+                raw = await self._dispatch_serialized(request)
+                payload: Any = json.loads(bytes(raw.body).decode("utf-8"))
+                listed = (payload.get("result") or {}).get("tabs", []) if payload.get("ok") else []
+                live_urls = {
+                    str(entry.get("url", "")) for entry in listed if isinstance(entry, dict)
+                }
+                for key, tab in before.items():
+                    if tab.url and tab.url not in live_urls:
+                        self.link.driven.pop(key, None)
+                        cleaned.append(tab.url)
+            except Exception:  # noqa: BLE001 - repair must never fail loudly
+                logger.warning("browser bridge repair could not list tabs", exc_info=True)
+        elif before:
+            # No browser attached: nothing can be driven, so every record is a
+            # ghost by definition.
+            cleaned = [tab.url for tab in before.values() if tab.url]
+            self.link.driven.clear()
+        republished = self.publish_safely()
+        return JSONResponse(
+            {
+                "status": "ok",
+                "cleared_tabs": cleaned,
+                "driven_tabs": len(self.link.driven),
+                "heartbeat_republished": republished,
+                "extension_connected": self.link.websocket is not None,
             }
         )
 
@@ -669,6 +932,7 @@ def create_app(port: int = DEFAULT_PORT, root: Path | None = None) -> Starlette:
     app = Starlette(
         routes=[
             Route("/health", service.health, methods=["GET"]),
+            Route("/repair", service.repair, methods=["POST"]),
             Route("/rpc", service.rpc, methods=["POST"]),
             WebSocketRoute("/extension", service.extension),
         ],

--- a/local_operator/browser_bridge/daemon.py
+++ b/local_operator/browser_bridge/daemon.py
@@ -246,8 +246,34 @@ class ExtensionLink:
         keyed = _is_real_handle(tab)
         key = tab if keyed else _UNKEYED_TAB
         if not keyed and self.driven:
-            latest = self._latest_driven()
-            key = next((k for k, v in self.driven.items() if v is latest), _UNKEYED_TAB)
+            # A REDACTED handle may not KEY a record, but it still carries
+            # enough nonce to RECOGNISE the one it belongs to, so match it
+            # before falling back to recency. The fallback is only safe when
+            # nothing names the tab: the two sides count "most recent" on
+            # DIFFERENT clocks — `nav.ts` resolves a handle-less command
+            # against the most recently USED surface (bumped by every
+            # tab-scoped command), while `_latest_driven` sees the most
+            # recently UPDATED record — so a handle-less `status` describing
+            # tab A could refresh tab B's record with A's URL. Cosmetic (it
+            # heals on B's next keyed update and forks no phantom), but the
+            # daemon already owns the exact matcher `repair()` uses for this
+            # question, so recency is the wrong answer when a handle is here.
+            # Only a REDACTED token can name a tab; a truly handle-less update
+            # (an old build) stays on the documented recency path, where an
+            # existing unkeyed record would otherwise self-match on "".
+            matched = (
+                next(
+                    (key_ for key_ in self.driven if _handle_matches_listed(key_, tab)),
+                    None,
+                )
+                if tab
+                else None
+            )
+            if matched is not None:
+                key = matched
+            else:
+                latest = self._latest_driven()
+                key = next((k for k, v in self.driven.items() if v is latest), _UNKEYED_TAB)
         self.driven[key] = DrivenTab(url=url, title=title, updated_at=time.time())
 
     def note_closed(self, tab: str) -> None:

--- a/local_operator/browser_bridge/gen_ts.py
+++ b/local_operator/browser_bridge/gen_ts.py
@@ -65,7 +65,7 @@ export interface PairResult {{ event: 'pair_result'; ok: boolean; token: string;
 export interface Ping {{ event: 'ping'; }}
 export interface Pong {{ event: 'pong'; }}
 export interface TabClosed {{ event: 'tab_closed'; tab: string; }}
-export interface TabUpdate {{ event: 'tab_update'; url: string; title: string; }}
+export interface TabUpdate {{ event: 'tab_update'; tab: string; url: string; title: string; }}
 export interface AwaitingOrigin {{ event: 'awaiting_origin'; id: string; origin: string; }}
 export interface AwaitingOriginCleared {{ event: 'awaiting_origin_cleared'; id: string; }}
 export interface Unpair {{ event: 'unpair'; }}

--- a/local_operator/browser_bridge/install.py
+++ b/local_operator/browser_bridge/install.py
@@ -14,6 +14,7 @@ import shutil
 import subprocess
 import sys
 import time
+import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -90,6 +91,110 @@ def health(port: int = DEFAULT_PORT, timeout: float = 3.0) -> dict[str, Any] | N
             return value if isinstance(value, dict) else None
     except Exception:  # noqa: BLE001 - a probe answers absent rather than raising
         return None
+
+
+def stale_heartbeat_age(root: Path | None = None) -> float | None:
+    """Heartbeat age when the discovery file is stale but the daemon is alive.
+
+    ``None`` whenever there is nothing worth reporting (no daemon, or a fresh
+    heartbeat). This is the diagnostic that makes the incident's central
+    contradiction visible: ``status`` reads the live socket, every session
+    reads this file, and when the file stops being refreshed the two disagree
+    silently — status says "connected" while every session falls back to cmux.
+    """
+    try:
+        status_value, current = state_store.liveness(root)
+    except Exception:  # noqa: BLE001 - a diagnostic never raises
+        return None
+    if status_value is not state_store.Liveness.STALE or current is None:
+        return None
+    return state_store.heartbeat_age(current)
+
+
+def repair(port: int | None = None, root: Path | None = None) -> dict[str, Any]:
+    """Reconcile the daemon's advertised state against reality.
+
+    The user's remedy in the incident was "there isn't one": the bridge
+    advertised a tab that no longer existed and a heartbeat that had stopped,
+    and the only lever anyone had was killing a healthy daemon. This asks the
+    daemon to prune what reality does not back and to republish a fresh
+    heartbeat, then reports what it cleaned.
+
+    Safe while sessions are live: the daemon's ``/repair`` closes no tab,
+    cancels no in-flight command, and touches no pairing.
+    """
+    current = state_store.read(root)
+    resolved_port = port or (current.port if current else DEFAULT_PORT)
+    steps: list[str] = []
+    if current is None:
+        return {
+            "ok": False,
+            "steps": steps,
+            "error": "no bridge daemon state found; 'lop browser install' starts it.",
+        }
+    age = state_store.heartbeat_age(current)
+    steps.append(f"daemon pid {current.pid} on port {resolved_port}, heartbeat {age:.0f}s old")
+    if not state_store.pid_alive(current.pid):
+        return {
+            "ok": False,
+            "steps": steps,
+            "error": (
+                f"daemon pid {current.pid} is not running; run 'lop browser restart' "
+                "to start a fresh one."
+            ),
+        }
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{resolved_port}/repair", data=b"", method="POST"
+        )
+        with urllib.request.urlopen(request, timeout=5.0) as response:
+            payload: Any = json.loads(response.read().decode())
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            # The daemon answers, but predates /repair. Restarting is the right
+            # advice and the reason matters: this is exactly the long-running
+            # daemon whose heartbeat died, so it is the one most likely to be
+            # running older code than the CLI asking it to repair itself.
+            return {
+                "ok": False,
+                "steps": steps,
+                "error": (
+                    f"the daemon on port {resolved_port} is running a build with no "
+                    "/repair endpoint (it predates this fix). Run 'lop browser restart' "
+                    "to load the current build."
+                ),
+            }
+        return {
+            "ok": False,
+            "steps": steps,
+            "error": f"daemon returned HTTP {error.code} on port {resolved_port}.",
+        }
+    except Exception as error:  # noqa: BLE001 - report, do not raise, at a CLI edge
+        return {
+            "ok": False,
+            "steps": steps,
+            "error": (
+                f"daemon is not answering on port {resolved_port} ({error}); "
+                "run 'lop browser restart'."
+            ),
+        }
+    cleared = payload.get("cleared_tabs") or []
+    if cleared:
+        for url in cleared:
+            steps.append(f"cleared phantom driven tab: {url}")
+    else:
+        steps.append("no phantom driven tabs to clear")
+    steps.append(f"driven tabs now: {payload.get('driven_tabs', 0)}")
+    if payload.get("heartbeat_republished"):
+        fresh = state_store.read(root)
+        refreshed = state_store.heartbeat_age(fresh) if fresh else None
+        steps.append(
+            "heartbeat republished"
+            + (f" (now {refreshed:.0f}s old)" if refreshed is not None else "")
+        )
+    else:
+        steps.append("heartbeat could NOT be republished — check disk space and permissions")
+    return {"ok": True, "steps": steps, "error": ""}
 
 
 def install(port: int = DEFAULT_PORT, *, dry_run: bool = False) -> dict[str, object]:

--- a/local_operator/browser_bridge/protocol.py
+++ b/local_operator/browser_bridge/protocol.py
@@ -226,15 +226,33 @@ class Pong(WireModel):
 
 
 class TabClosed(WireModel):
+    """Extension -> daemon: one driven tab is gone.
+
+    Emitted from the extension's top-level ``chrome.tabs.onRemoved`` /
+    ``onReplaced`` listeners and on an explicit ``close``, so a tab closed by
+    the USER clears the daemon's driven record too. Nothing sent this event
+    before, which is why ``status`` could advertise a tab that had been closed
+    hours earlier. ``tab`` names the surface so one session's close cannot
+    blank another session's still-live tab; an empty value means "unknown",
+    which the daemon treats as clear-all.
+    """
+
     event: Literal["tab_closed"] = "tab_closed"
-    tab: str
+    tab: str = ""
 
 
 class TabUpdate(WireModel):
     """Extension -> daemon: the driven tab navigated. Lets the daemon report the
-    current page to the Connected popup without an extra RPC (finding U3)."""
+    current page to the Connected popup without an extra RPC (finding U3).
+
+    ``tab`` is the surface handle: driven pages are tracked PER TAB, because a
+    single global slot showed whichever tab was touched last as though it were
+    the one bound tab. Defaulted for compatibility with an older extension that
+    sent no handle.
+    """
 
     event: Literal["tab_update"] = "tab_update"
+    tab: str = ""
     url: str = ""
     title: str = ""
 

--- a/local_operator/browser_bridge/state.py
+++ b/local_operator/browser_bridge/state.py
@@ -41,6 +41,7 @@ class BridgeState(BaseModel):
 
 
 def run_dir(root: Path | None = None) -> Path:
+    """The run directory, CREATED and locked down. Only writers may call this."""
     directory = (root or config_dir()) / RUN_DIRNAME
     directory.mkdir(parents=True, exist_ok=True)
     os.chmod(directory, 0o700)
@@ -48,7 +49,19 @@ def run_dir(root: Path | None = None) -> Path:
 
 
 def state_path(root: Path | None = None) -> Path:
-    return run_dir(root) / STATE_FILENAME
+    """Where the discovery file lives. Pure path arithmetic: creates NOTHING.
+
+    It used to route through :func:`run_dir`, which mkdirs and chmods, so every
+    READER and every diagnostic performed a write. That turned the ENOSPC log
+    line in ``BridgeService.publish_safely`` into a second ``OSError`` raised
+    from inside the handler for the first one: on a fresh config dir with a
+    full disk the daemon failed to boot, in precisely the disk-full scenario
+    this module is meant to survive. An error path may never perform the
+    operation that is failing, and detection may never mutate the filesystem
+    (see :func:`read`), so the path is now derived without touching disk and
+    only the writer (:func:`publish`) asks for the directory to exist.
+    """
+    return (root or config_dir()) / RUN_DIRNAME / STATE_FILENAME
 
 
 def publish(state: BridgeState, root: Path | None = None) -> Path:
@@ -144,17 +157,49 @@ def liveness(
 
 
 def available(root: Path | None = None, *, now: float | None = None) -> bool:
-    """Cheap file-only availability gate used while constructing every session.
+    """Cheap file-only availability gate: FRESH only, no socket, never probes.
 
-    Deliberately still FILE-ONLY and still false for a stale heartbeat: this
-    runs while constructing every session and on the `createIf` tool-gating
-    path, where a blocking socket probe would tax startup for every session on
-    the machine. A stale-but-alive daemon is rescued on the browser path
-    instead, by :func:`~local_operator.browser_bridge.backend.
+    Deliberately still FILE-ONLY and still false for a stale heartbeat. It
+    answers "is the bridge known-good right now", which is the question the
+    backend-selection paths ask. A stale-but-alive daemon is acquitted on the
+    browser path instead, by :func:`~local_operator.browser_bridge.backend.
     bridge_browser_reachable`, which pays for one bounded probe only when it is
     about to condemn the bridge.
+
+    For TOOL GATING use :func:`advertisable` instead — see why there.
     """
     return liveness(root, now=now)[0] is Liveness.FRESH
+
+
+def advertisable(root: Path | None = None, *, now: float | None = None) -> bool:
+    """Whether the `browser` TOOL should be offered. FRESH or STALE-but-alive.
+
+    Gating is a weaker commitment than execution: advertising the tool only
+    promises the agent can ASK, and `execute_browser` still decides — with a
+    real socket probe — whether the extension answers, falling back to cmux or
+    returning the typed demotion diagnostic. So the gate must not apply the
+    stricter :func:`available` test.
+
+    It did, and that is a hole in the RC2 rescue: gating ran the FRESH-only
+    check, so on an extension-only host (no cmux, the ordinary configuration
+    for the extension) a daemon whose heartbeat writer had died was never
+    advertised at all. The tool list is built once per session, so that session
+    had NO browser tool for its lifetime, `execute_browser` was never reached,
+    the socket probe never ran, and the demotion hint — whose every call site
+    is inside `execute_browser` — could not fire. The agent got no fallback and
+    no diagnostic: strictly worse than the incident this fixes, since it cannot
+    even discover that a healthy daemon is sitting there.
+
+    The CONSTRAINT that made the gate file-only still holds and is respected:
+    this is synchronous and runs while constructing EVERY session, so it must
+    not block or do unbounded I/O. It does neither. STALE is already
+    established by :func:`liveness` from one file read plus ``os.kill(pid, 0)``
+    — no socket is opened here and no subprocess is spawned, so the hot path
+    keeps its measured sub-millisecond cost. When in doubt this errs toward
+    advertising: a tool that explains why it cannot reach the bridge beats a
+    tool that silently does not exist.
+    """
+    return liveness(root, now=now)[0] in (Liveness.FRESH, Liveness.STALE)
 
 
 def remove(root: Path | None = None) -> None:

--- a/local_operator/browser_bridge/state.py
+++ b/local_operator/browser_bridge/state.py
@@ -7,6 +7,7 @@ session can never consume a half-written key or port.
 
 from __future__ import annotations
 
+import enum
 import json
 import os
 import tempfile
@@ -92,17 +93,68 @@ def pid_alive(pid: int) -> bool:
     return True
 
 
-def available(root: Path | None = None, *, now: float | None = None) -> bool:
-    """Cheap file-only availability gate used while constructing every session."""
-    current = read(root)
-    if current is None:
-        return False
+def heartbeat_age(current: BridgeState, *, now: float | None = None) -> float:
+    """Seconds since the daemon last republished. Negative ages clamp to 0.
+
+    Clock skew (or a state file written by a daemon whose clock ran ahead) must
+    never read as "fresher than fresh" and must never render as a negative age
+    in diagnostics, so the floor is 0.
+    """
     timestamp = time.time() if now is None else now
-    return (
-        current.extension_connected
-        and pid_alive(current.pid)
-        and timestamp - current.heartbeat_at <= HEARTBEAT_TIMEOUT_S
-    )
+    return max(0.0, timestamp - current.heartbeat_at)
+
+
+class Liveness(enum.Enum):
+    """What the discovery FILE alone can honestly conclude about the daemon.
+
+    The file heartbeat is a liveness PROXY, and it lies in both directions: it
+    goes stale while the daemon is perfectly healthy (the heartbeat writer can
+    die on its own — see ``BridgeService._supervise``, or the daemon can be
+    SIGSTOPped) and it stays fresh for a few seconds after a daemon is killed.
+    Collapsing that into one bool is what made a healthy daemon read as a
+    permanent "no": every session silently fell back to cmux while
+    ``lop browser status`` — which reads the LIVE ``/health`` socket — kept
+    reporting the extension connected, and nothing reconciled the two.
+
+    So the file answers three states, not two, and the caller decides how much
+    a given answer is worth paying for:
+
+    - ``ABSENT``  no daemon, or no browser attached. A definite no; never probe.
+    - ``FRESH``   heartbeat inside the timeout. A definite yes; never probe.
+    - ``STALE``   heartbeat expired but the pid is ALIVE and an extension was
+      attached when the file was last written. Genuinely unknown from the file:
+      only a socket round-trip can settle it (``bridge_browser_reachable``).
+    """
+
+    ABSENT = "absent"
+    FRESH = "fresh"
+    STALE = "stale"
+
+
+def liveness(
+    root: Path | None = None, *, now: float | None = None
+) -> tuple[Liveness, BridgeState | None]:
+    """Classify the daemon from the file alone: no socket, no subprocess."""
+    current = read(root)
+    if current is None or not current.extension_connected or not pid_alive(current.pid):
+        return Liveness.ABSENT, current
+    if heartbeat_age(current, now=now) <= HEARTBEAT_TIMEOUT_S:
+        return Liveness.FRESH, current
+    return Liveness.STALE, current
+
+
+def available(root: Path | None = None, *, now: float | None = None) -> bool:
+    """Cheap file-only availability gate used while constructing every session.
+
+    Deliberately still FILE-ONLY and still false for a stale heartbeat: this
+    runs while constructing every session and on the `createIf` tool-gating
+    path, where a blocking socket probe would tax startup for every session on
+    the machine. A stale-but-alive daemon is rescued on the browser path
+    instead, by :func:`~local_operator.browser_bridge.backend.
+    bridge_browser_reachable`, which pays for one bounded probe only when it is
+    about to condemn the bridge.
+    """
+    return liveness(root, now=now)[0] is Liveness.FRESH
 
 
 def remove(root: Path | None = None) -> None:

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -410,7 +410,15 @@ def build_cli_parser() -> argparse.ArgumentParser:
     browser_subparsers = browser_parser.add_subparsers(dest="browser_command")
     install_browser = browser_subparsers.add_parser("install", help="Install the bridge daemon")
     install_browser.add_argument("--port", type=int, default=4099)
-    browser_subparsers.add_parser("status", help="Show daemon, extension and pairing status")
+    status_browser = browser_subparsers.add_parser(
+        "status", help="Show daemon, extension and pairing status"
+    )
+    status_browser.add_argument(
+        "--repair",
+        action="store_true",
+        help="Reconcile advertised state against reality: drop tabs that no longer "
+        "exist and republish a fresh heartbeat. Safe while sessions are live.",
+    )
     for action in ("start", "stop", "restart"):
         browser_subparsers.add_parser(action, help=f"{action.capitalize()} the daemon")
     pair_browser = browser_subparsers.add_parser("pair", help="Show the extension pairing code")
@@ -1070,6 +1078,15 @@ def browser_command(args: argparse.Namespace) -> int:
         print("  load the Local Operator extension, then run `lop browser pair`.")
         return 0
     if command == "status":
+        if getattr(args, "repair", False):
+            repair = browser_install.repair()
+            for line in repair["steps"]:
+                print(f"  {line}")
+            if not repair["ok"]:
+                print(f"\n\033[1;31m{repair['error']}\033[0m")
+                return 1
+            print("\nbrowser bridge state reconciled.")
+            return 0
         result = browser_install.status()
         health = result.get("health") or {}
         assert isinstance(health, dict)
@@ -1084,9 +1101,41 @@ def browser_command(args: argparse.Namespace) -> int:
             print(
                 "                     (browser not currently attached; it reconnects when opened)"
             )
-        driven = health.get("current_url")
-        if connected and driven:
-            print(f"driving:             {driven}")
+        # Driven tabs, PLURAL and counted. `driving: <url>` implied a single
+        # system-wide binding; with one tab per session that framing turned a
+        # stale URL into "something is holding the bridge". Say how many tabs
+        # are live, name them, and say "none" explicitly rather than printing
+        # nothing (which read as "it isn't telling me").
+        driven_tabs = health.get("driven_tabs")
+        if connected:
+            if isinstance(driven_tabs, list):
+                if driven_tabs:
+                    label = f"{len(driven_tabs)} tab{'s' if len(driven_tabs) != 1 else ''}"
+                    print(f"driving:             {label}")
+                    for entry in driven_tabs:
+                        if isinstance(entry, dict):
+                            print(f"                     - {entry.get('url', '')}")
+                else:
+                    print("driving:             no tabs driven")
+            elif health.get("current_url"):
+                # Older daemon still running under a newer CLI.
+                print(f"driving:             {health.get('current_url')}")
+        # A stale heartbeat is THE thing to surface here. status reads the live
+        # /health socket while every session reads the discovery file, so when
+        # the two disagree status looks authoritative and sessions silently
+        # fall back to cmux. Showing the age makes that contradiction visible
+        # and names the fix instead of leaving both parties to guess.
+        stale_age = browser_install.stale_heartbeat_age()
+        if stale_age is not None:
+            print(
+                f"\n\033[1;33mheartbeat:           STALE by {stale_age:.0f}s "
+                "(discovery file is not being refreshed)\033[0m"
+            )
+            print(
+                "                     sessions will fall back to cmux despite the daemon "
+                "being healthy."
+            )
+            print("                     run 'lop browser status --repair' to reconcile.")
         print(f"port:                {result['port']}")
         print(f"log:                 {result['log']}")
         return 0 if result["healthy"] else 1

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -6039,6 +6039,54 @@ def bridge_browser_available() -> bool:
     return available()
 
 
+async def bridge_browser_reachable() -> bool:
+    """Browser-path availability: the file probe, plus one socket confirmation.
+
+    Used instead of :func:`bridge_browser_available` everywhere a browser
+    ACTION decides which backend to use, because the cheap file probe reports a
+    healthy daemon as gone once its heartbeat writer stops. It only pays for a
+    socket when it is about to condemn a bridge whose pid is alive.
+
+    The cheap check runs FIRST and short-circuits, so the common case costs
+    exactly what it did before and no socket is opened. The probe exists only
+    to ACQUIT a daemon the file was about to condemn.
+    """
+    if bridge_browser_available():
+        return True
+    from local_operator.browser_bridge.backend import (
+        bridge_browser_reachable as reachable,
+    )
+
+    return await reachable()
+
+
+def _bridge_demotion_hint() -> str:
+    """Why the extension is not being used, when it looked like it should be.
+
+    A session that had been driving the extension and then finds it
+    unavailable used to get a bare "not supported on the cmux backend", with
+    nothing linking that to the bridge having gone away. That is what led an
+    agent to conclude the bridge was "bound" by an orphan tab and abandon it
+    for a whole session. Naming the demotion and the one-line repair turns an
+    hour of guessing into a single command.
+    """
+    from local_operator.browser_bridge import state as state_store
+
+    try:
+        status, current = state_store.liveness()
+    except Exception:  # noqa: BLE001 - a diagnostic may never raise
+        return ""
+    if status is state_store.Liveness.STALE and current is not None:
+        age = state_store.heartbeat_age(current)
+        return (
+            f" NOTE: this session was DEMOTED from the extension to cmux — the bridge daemon "
+            f"(pid {current.pid}) is running but its discovery heartbeat is {age:.0f}s stale, "
+            "so it advertised itself as unavailable. Run 'lop browser status --repair' to "
+            "reconcile it, then retry."
+        )
+    return ""
+
+
 def _browser_requester(context: ToolContext | None, tool_call_id: str) -> str:
     """The session-scoped identity the extension binds approvals to.
 
@@ -6831,7 +6879,10 @@ async def execute_browser(
             f"unknown action: {action} (expected one of {', '.join(BROWSER_ACTIONS)})",
         )
     cmux_available = cmux_browser_available()
-    bridge_available = bridge_browser_available()
+    # The socket-confirming probe, not the bare file check: a healthy daemon
+    # whose heartbeat writer stopped must not silently demote this session to
+    # cmux. It costs a round-trip only in the stale-but-alive case.
+    bridge_available = await bridge_browser_reachable()
     if not cmux_available and not bridge_available:
         return _error(
             tool_call_id,
@@ -6862,7 +6913,7 @@ async def execute_browser(
                 f"'{action}' is not supported on the cmux backend — cmux has no "
                 "site-permission prompts; navigation works directly. This action only "
                 "exists for the Local Operator browser extension ('lop browser status' / "
-                "'lop browser install').",
+                "'lop browser install')." + _bridge_demotion_hint(),
             )
         return await _bridge_access(tool_call_id, action, params, context)
 
@@ -6903,7 +6954,7 @@ async def execute_browser(
                 "'tabs' is not supported on the cmux backend — use the Local Operator "
                 "browser extension (run 'lop browser status' / 'lop browser install' to "
                 "set it up). cmux has no multi-tab surface registry, so this action only "
-                "works through the extension bridge.",
+                "works through the extension bridge." + _bridge_demotion_hint(),
             )
         return await _bridge_tabs(tool_call_id, state)
     if not state.surface_id:
@@ -6921,7 +6972,7 @@ async def execute_browser(
             f"'{action}' is not supported on the cmux backend — use the Local Operator "
             "browser extension (run 'lop browser status' / 'lop browser install' to set it "
             "up). cmux has no console-log tap or background-tab scroll primitive, so this "
-            "action only works through the extension bridge.",
+            "action only works through the extension bridge." + _bridge_demotion_hint(),
         )
     # ONE liveness probe here rather than one per action body, and never inside
     # a poll loop: cmux answers a dead handle by silently retargeting the

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -6039,7 +6039,21 @@ def bridge_browser_available() -> bool:
     return available()
 
 
-async def bridge_browser_reachable() -> bool:
+def bridge_browser_advertisable() -> bool:
+    """Tool-GATING discovery: cheap, file-only, but honest about a stale daemon.
+
+    Kept distinct from :func:`bridge_browser_available` because gating asks a
+    weaker question than backend selection does; see
+    :func:`local_operator.browser_bridge.state.advertisable`.
+    """
+    from local_operator.browser_bridge.backend import (
+        bridge_browser_advertisable as advertisable,
+    )
+
+    return advertisable()
+
+
+async def bridge_browser_reachable(classified: tuple[Any, Any] | None = None) -> bool:
     """Browser-path availability: the file probe, plus one socket confirmation.
 
     Used instead of :func:`bridge_browser_available` everywhere a browser
@@ -6049,7 +6063,9 @@ async def bridge_browser_reachable() -> bool:
 
     The cheap check runs FIRST and short-circuits, so the common case costs
     exactly what it did before and no socket is opened. The probe exists only
-    to ACQUIT a daemon the file was about to condemn.
+    to ACQUIT a daemon the file was about to condemn. ``classified`` is a
+    reading the caller already took; it is handed to the probe so that a
+    condemning action classifies the daemon once instead of once per consumer.
     """
     if bridge_browser_available():
         return True
@@ -6057,10 +6073,20 @@ async def bridge_browser_reachable() -> bool:
         bridge_browser_reachable as reachable,
     )
 
-    return await reachable()
+    return await reachable(classified=classified)
 
 
-def _bridge_demotion_hint() -> str:
+def _bridge_liveness() -> tuple[Any, Any]:
+    """Classify the daemon from the file, never raising at a diagnostic site."""
+    from local_operator.browser_bridge import state as state_store
+
+    try:
+        return state_store.liveness()
+    except Exception:  # noqa: BLE001 - a diagnostic may never raise
+        return None, None
+
+
+def _bridge_demotion_hint(classified: tuple[Any, Any] | None = None) -> str:
     """Why the extension is not being used, when it looked like it should be.
 
     A session that had been driving the extension and then finds it
@@ -6069,13 +6095,18 @@ def _bridge_demotion_hint() -> str:
     agent to conclude the bridge was "bound" by an orphan tab and abandon it
     for a whole session. Naming the demotion and the one-line repair turns an
     hour of guessing into a single command.
+
+    ``classified`` is the ``(status, state)`` the caller already computed. Each
+    demotion path had re-read the discovery file here, which cost a second read
+    per demoted action and, worse, could disagree with the classification that
+    caused the demotion: a heartbeat refreshed in between made this return ""
+    and silently dropped the diagnostic in exactly the race where the daemon
+    had just recovered. Reusing the caller's answer keeps the message and the
+    decision consistent by construction.
     """
     from local_operator.browser_bridge import state as state_store
 
-    try:
-        status, current = state_store.liveness()
-    except Exception:  # noqa: BLE001 - a diagnostic may never raise
-        return ""
+    status, current = classified if classified is not None else _bridge_liveness()
     if status is state_store.Liveness.STALE and current is not None:
         age = state_store.heartbeat_age(current)
         return (
@@ -6879,10 +6910,14 @@ async def execute_browser(
             f"unknown action: {action} (expected one of {', '.join(BROWSER_ACTIONS)})",
         )
     cmux_available = cmux_browser_available()
+    # Classify the daemon ONCE per action and reuse that answer for both the
+    # backend decision and the demotion diagnostic, so they can never describe
+    # different readings of a file that may change between two reads.
+    bridge_liveness = _bridge_liveness()
     # The socket-confirming probe, not the bare file check: a healthy daemon
     # whose heartbeat writer stopped must not silently demote this session to
     # cmux. It costs a round-trip only in the stale-but-alive case.
-    bridge_available = await bridge_browser_reachable()
+    bridge_available = await bridge_browser_reachable(classified=bridge_liveness)
     if not cmux_available and not bridge_available:
         return _error(
             tool_call_id,
@@ -6913,7 +6948,7 @@ async def execute_browser(
                 f"'{action}' is not supported on the cmux backend — cmux has no "
                 "site-permission prompts; navigation works directly. This action only "
                 "exists for the Local Operator browser extension ('lop browser status' / "
-                "'lop browser install')." + _bridge_demotion_hint(),
+                "'lop browser install')." + _bridge_demotion_hint(bridge_liveness),
             )
         return await _bridge_access(tool_call_id, action, params, context)
 
@@ -6954,7 +6989,7 @@ async def execute_browser(
                 "'tabs' is not supported on the cmux backend — use the Local Operator "
                 "browser extension (run 'lop browser status' / 'lop browser install' to "
                 "set it up). cmux has no multi-tab surface registry, so this action only "
-                "works through the extension bridge." + _bridge_demotion_hint(),
+                "works through the extension bridge." + _bridge_demotion_hint(bridge_liveness),
             )
         return await _bridge_tabs(tool_call_id, state)
     if not state.surface_id:
@@ -6972,7 +7007,8 @@ async def execute_browser(
             f"'{action}' is not supported on the cmux backend — use the Local Operator "
             "browser extension (run 'lop browser status' / 'lop browser install' to set it "
             "up). cmux has no console-log tap or background-tab scroll primitive, so this "
-            "action only works through the extension bridge." + _bridge_demotion_hint(),
+            "action only works through the extension bridge."
+            + _bridge_demotion_hint(bridge_liveness),
         )
     # ONE liveness probe here rather than one per action body, and never inside
     # a poll loop: cmux answers a dead handle by silently retargeting the
@@ -7173,7 +7209,15 @@ def build_browser_tool(context: ToolContext | None) -> AgentTool | None:
     cmux and (outside this tool) playwright are fallbacks for hosts without the
     extension. The full setup/permissions playbook lives in ``guide://browser``.
     """
-    if not cmux_browser_available() and not bridge_browser_available():
+    # Gating deliberately uses the WEAKER `advertisable` test, not the
+    # backend-selection one: a stale-but-alive daemon must still put the tool
+    # in the inventory so `execute_browser`'s bounded socket probe can acquit
+    # it (or produce the typed demotion diagnostic). With the strict check
+    # here, an extension-only host whose heartbeat writer had died offered no
+    # browser tool at all for the whole session — no fallback and no way to
+    # discover the healthy daemon. Still file-only and still synchronous: this
+    # runs while constructing every session and opens no socket.
+    if not cmux_browser_available() and not bridge_browser_advertisable():
         return None
     return AgentTool(
         name="browser",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.50"
+version = "0.44.51"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/browser_bridge/test_daemon.py
+++ b/tests/unit/browser_bridge/test_daemon.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import time
+from contextlib import suppress
 from pathlib import Path
 
 import pytest
 from starlette.testclient import TestClient
 
+from local_operator.browser_bridge import state as state_store
 from local_operator.browser_bridge.daemon import create_app, pairing_status
 from local_operator.browser_bridge.protocol import PROTO_VERSION
 
@@ -274,3 +276,185 @@ async def test_await_lock_key_evicted_on_normal_and_error_exits(
         Request(id="r-timeout", method="await_access", params={"url": "https://x.example"})
     )
     assert service._tab_locks == {}
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_survives_publish_failure(tmp_path: Path, monkeypatch) -> None:
+    """RC1: a transient publish error must not kill the heartbeat writer.
+
+    The incident: ENOSPC escaped ``while True: publish(); sleep()``, the task
+    died, and nothing restarted it — so ``state.available()`` was False for
+    every session on the machine for the daemon's whole life while ``/health``
+    kept answering 200. The loop must absorb the error, keep ticking, and
+    republish once writes succeed again.
+    """
+    import asyncio
+
+    from local_operator.browser_bridge import daemon as daemon_module
+
+    monkeypatch.setattr(state_store, "HEARTBEAT_INTERVAL_S", 0.01)
+    service = daemon_module.BridgeService(root=tmp_path)
+    service.link.websocket = object()  # type: ignore[assignment]
+
+    calls = {"n": 0}
+    real_publish = state_store.publish
+
+    def flaky(state_value, root=None):  # type: ignore[no-untyped-def]
+        calls["n"] += 1
+        if calls["n"] <= 3:
+            raise OSError(28, "No space left on device")
+        return real_publish(state_value, root)
+
+    monkeypatch.setattr(state_store, "publish", flaky)
+    task = asyncio.create_task(service._heartbeat())
+    try:
+        # Long enough for the failures AND several successful ticks after.
+        for _ in range(200):
+            await asyncio.sleep(0.01)
+            if calls["n"] > 6:
+                break
+        assert not task.done(), "heartbeat task died on a transient publish error"
+        assert state_store.available(tmp_path), "heartbeat never recovered after writes resumed"
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_supervised_loop_keeps_running_after_repeated_failures(tmp_path: Path) -> None:
+    """The class of bug, not the one syscall: no supervisory loop may exit."""
+    import asyncio
+
+    from local_operator.browser_bridge import daemon as daemon_module
+
+    service = daemon_module.BridgeService(root=tmp_path)
+    seen = {"n": 0}
+
+    async def always_raises() -> None:
+        seen["n"] += 1
+        raise RuntimeError("boom")
+
+    # Backoff is capped per failure; shrink it so the test is fast.
+    task = asyncio.create_task(service._supervise("test", always_raises))
+    try:
+        for _ in range(300):
+            await asyncio.sleep(0.01)
+            if seen["n"] >= 2:
+                break
+        assert seen["n"] >= 2, "supervisor stopped re-running a failing iteration"
+        assert not task.done()
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_supervised_loop_still_honours_cancellation(tmp_path: Path) -> None:
+    """Shutdown depends on cancellation winning over the catch-all."""
+    import asyncio
+
+    from local_operator.browser_bridge import daemon as daemon_module
+
+    service = daemon_module.BridgeService(root=tmp_path)
+
+    async def forever() -> None:
+        await asyncio.sleep(3600)
+
+    task = asyncio.create_task(service._supervise("test", forever))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+def test_publish_safely_swallows_oserror_and_reports_failure(tmp_path: Path, monkeypatch) -> None:
+    """A failed cache write is logged and absorbed, never propagated."""
+    from local_operator.browser_bridge import daemon as daemon_module
+
+    service = daemon_module.BridgeService(root=tmp_path)
+
+    def boom(state_value, root=None):  # type: ignore[no-untyped-def]
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(state_store, "publish", boom)
+    assert service.publish_safely() is False
+    monkeypatch.undo()
+    assert service.publish_safely() is True
+
+
+def test_driven_tabs_are_tracked_per_tab_and_cleared_on_close() -> None:
+    """RC3/RC4: closing one tab clears exactly that tab, not the world."""
+    from local_operator.browser_bridge import daemon as daemon_module
+
+    link = daemon_module.ExtensionLink()
+    assert link.current_url == ""
+
+    link.note_driven("bridge:1:aa", "https://one.example", "One")
+    link.note_driven("bridge:2:bb", "https://two.example", "Two")
+    assert len(link.driven) == 2
+    # Most recent wins the single-slot compatibility view.
+    assert link.current_url == "https://two.example"
+
+    link.note_closed("bridge:2:bb")
+    assert len(link.driven) == 1
+    assert link.current_url == "https://one.example"
+
+    # The user's exact complaint: the last tab closing must clear "driving".
+    link.note_closed("bridge:1:aa")
+    assert link.driven == {}
+    assert link.current_url == ""
+    assert link.current_title == ""
+
+
+def test_handleless_update_refreshes_rather_than_forking_a_phantom() -> None:
+    """A `goto` result carries no handle; it must not double-count the tab."""
+    from local_operator.browser_bridge import daemon as daemon_module
+
+    link = daemon_module.ExtensionLink()
+    link.note_driven("bridge:1:aa", "https://one.example", "One")
+    link.note_driven("", "https://one.example/next", "Next")
+    assert len(link.driven) == 1
+    assert link.current_url == "https://one.example/next"
+
+
+def test_tab_closed_event_clears_driven_state_over_the_socket(tmp_path: Path) -> None:
+    """End to end over the real websocket: tab_closed empties `driving`."""
+    app = create_app(root=tmp_path)
+    with TestClient(app) as client:
+        with client.websocket_connect("/extension", headers={"origin": ORIGIN}) as socket:
+            socket.send_json(
+                {
+                    "event": "hello",
+                    "proto": PROTO_VERSION,
+                    "token": "",
+                    "extension_version": "0.1.6",
+                    "browser": "Chrome/152",
+                }
+            )
+            socket.receive_json()
+            socket.send_json(
+                {
+                    "event": "tab_update",
+                    "tab": "bridge:7:cc",
+                    "url": "https://example.com",
+                    "title": "Example",
+                }
+            )
+            for _ in range(50):
+                if client.get("/health").json()["current_url"]:
+                    break
+                time.sleep(0.02)
+            health = client.get("/health").json()
+            assert health["current_url"] == "https://example.com"
+            assert len(health["driven_tabs"]) == 1
+
+            socket.send_json({"event": "tab_closed", "tab": "bridge:7:cc"})
+            for _ in range(50):
+                if not client.get("/health").json()["current_url"]:
+                    break
+                time.sleep(0.02)
+            cleared = client.get("/health").json()
+            assert cleared["current_url"] == ""
+            assert cleared["driven_tabs"] == []

--- a/tests/unit/browser_bridge/test_remediation_round1.py
+++ b/tests/unit/browser_bridge/test_remediation_round1.py
@@ -123,9 +123,12 @@ def test_health_reports_driven_url_and_pending_origin(tmp_path: Path) -> None:
     app = create_app(root=tmp_path)
     with TestClient(app) as client:
         service = app.state.bridge
-        service.link.current_url = "https://example.com/page"
-        service.link.current_title = "Example"
+        # Driven pages are tracked per tab now (a single global slot could not
+        # be cleared per tab, which is how a closed tab stayed "driving"
+        # forever), so record one through the same API the receive loop uses.
+        service.link.note_driven("bridge:1:aa", "https://example.com/page", "Example")
         service.link.awaiting_origin["r-1"] = "https://bank.example"
         health = client.get("/health").json()
         assert health["current_url"] == "https://example.com/page"
+        assert health["current_title"] == "Example"
         assert health["pending_origin"] == "https://bank.example"

--- a/tests/unit/browser_bridge/test_remediation_round1_review.py
+++ b/tests/unit/browser_bridge/test_remediation_round1_review.py
@@ -1,0 +1,218 @@
+"""Regression tests for the round-1 REVIEW remediation on PR #563 (F2/F3, Q1).
+
+Each test here fails on the branch as it stood at review time. They guard the
+three defects that reviewers found in the incident fix itself — the gaps were
+in *reaching* the fix, not in the fix, which is exactly the kind of hole a unit
+test closes cheaply and a manual pass keeps re-opening.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.browser_bridge import state
+from local_operator.browser_bridge.daemon import BridgeService, ExtensionLink
+from local_operator.browser_bridge.protocol import PROTO_VERSION
+from local_operator.tools import builtin
+
+
+def _record(**updates: Any) -> state.BridgeState:
+    values: dict[str, Any] = {
+        "pid": os.getpid(),
+        "port": 4099,
+        "session_key": "k" * 32,
+        "proto": PROTO_VERSION,
+        "extension_connected": True,
+        "paired": True,
+    }
+    values.update(updates)
+    return state.BridgeState.model_validate(values)
+
+
+def _publish_stale(root: Path) -> None:
+    """A daemon whose pid is alive but whose heartbeat writer has stopped."""
+    current = _record()
+    state.publish(current, root)
+    current.heartbeat_at = time.time() - state.HEARTBEAT_TIMEOUT_S - 1
+    # publish() refreshes the heartbeat by contract, so the stale JSON is
+    # written directly rather than weakening the publisher for a test.
+    state.state_path(root).write_text(current.model_dump_json())
+
+
+# --------------------------------------------------------------------------
+# F2 / Q2 — the stale-but-alive rescue must be REACHABLE on an extension-only
+# host. Gating used the FRESH-only check, so a session on a host with no cmux
+# got no browser tool at all and `execute_browser` — where the socket probe and
+# the demotion diagnostic both live — was never reached.
+# --------------------------------------------------------------------------
+
+
+def test_stale_daemon_is_advertisable_even_though_it_is_not_available(tmp_path: Path) -> None:
+    _publish_stale(tmp_path)
+    status, _ = state.liveness(tmp_path)
+    assert status is state.Liveness.STALE
+    # The strict gate still says no: backend selection must keep asking for a
+    # daemon that is known-good, and the socket probe does the acquitting.
+    assert state.available(tmp_path) is False
+    # The gating gate says yes, so the tool reaches execute_browser.
+    assert state.advertisable(tmp_path) is True
+
+
+def test_advertisable_is_false_when_the_daemon_is_really_gone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Advertising is weaker than availability, not unconditional."""
+    assert state.advertisable(tmp_path) is False
+    _publish_stale(tmp_path)
+    monkeypatch.setattr(state, "pid_alive", lambda _pid: False)
+    assert state.advertisable(tmp_path) is False
+    state.publish(_record(extension_connected=False), tmp_path)
+    assert state.advertisable(tmp_path) is False
+
+
+def test_stale_but_alive_daemon_still_advertises_the_browser_tool(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The finding itself: extension-only host + stale heartbeat => tool exists.
+
+    Without the fix `build_browser_tool` returns None here, the session runs
+    its whole life with no browser tool, and the agent cannot even discover the
+    healthy daemon sitting behind the stale file.
+    """
+    _publish_stale(tmp_path)
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(builtin, "cmux_browser_available", lambda: False)
+
+    assert builtin.bridge_browser_available() is False
+    assert builtin.bridge_browser_advertisable() is True
+    tool = builtin.build_browser_tool(None)
+    assert tool is not None
+    assert tool.name == "browser"
+
+
+def test_gating_opens_no_socket_and_spawns_nothing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The constraint that made the gate file-only: it runs per session.
+
+    Gating must stay synchronous and non-blocking, so it may not open a socket
+    (the acquitting probe belongs on the browser path) — a regression here taxes
+    the construction of every session on the machine.
+    """
+    import socket as socket_module
+
+    _publish_stale(tmp_path)
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(builtin, "cmux_browser_available", lambda: False)
+
+    def no_sockets(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("tool gating opened a socket")
+
+    monkeypatch.setattr(socket_module, "socket", no_sockets)
+    monkeypatch.setattr(socket_module, "create_connection", no_sockets)
+
+    started = time.monotonic()
+    assert builtin.build_browser_tool(None) is not None
+    # Generous: the point is "no network round-trip", not a benchmark.
+    assert time.monotonic() - started < 0.5
+
+
+# --------------------------------------------------------------------------
+# F3 — a REDACTED surface handle must never key a driven record.
+# --------------------------------------------------------------------------
+
+
+def test_redacted_handle_does_not_fork_a_second_driven_record() -> None:
+    """`status` with no tab returns a redacted token; it must not become a key.
+
+    Without the fix this leaves two records for one tab, and the redacted one
+    survives the real close as a phantom advertising a dead URL — the exact
+    ghost this PR exists to remove.
+    """
+    link = ExtensionLink()
+    link.note_driven("bridge:7:abcdef0123456789", "https://example.com", "Example")
+    # What a handle-less `status` reports back through the worker.
+    link.note_driven("bridge:7:abcdef\u2026", "https://example.com", "Example")
+
+    assert list(link.driven) == ["bridge:7:abcdef0123456789"]
+    assert len(link.driven) == 1
+
+    link.note_closed("bridge:7:abcdef0123456789")
+    assert link.driven == {}
+    assert link.current_url == ""
+
+
+def test_redacted_close_does_not_silently_blank_every_record() -> None:
+    """A redacted handle proves nothing, so it is treated as no handle."""
+    link = ExtensionLink()
+    link.note_driven("bridge:1:aaaaaaaaaaaa", "https://one.example", "One")
+    link.note_driven("bridge:2:bbbbbbbbbbbb", "https://two.example", "Two")
+    assert len(link.driven) == 2
+    link.note_closed("bridge:9:cccccc\u2026")
+    # Cannot name a surface => the safe reading is "nothing is provably driven"
+    # rather than keeping entries that may be ghosts.
+    assert link.driven == {}
+
+
+def test_keyed_close_leaves_another_peers_unkeyed_record_alone() -> None:
+    """Q3: the docstring promised isolation the code did not deliver.
+
+    A handle-carrying close used to also pop the unkeyed record, so in a
+    mixed-version pair one session closing its own tab blanked an OLDER
+    extension's still-live entry.
+    """
+    link = ExtensionLink()
+    link.note_driven("", "https://legacy.example", "Legacy")  # old extension
+    link.note_driven("bridge:3:dddddddddddd", "https://new.example", "New")
+    link.note_closed("bridge:3:dddddddddddd")
+    assert list(link.driven) == [""]
+    assert link.current_url == "https://legacy.example"
+
+
+# --------------------------------------------------------------------------
+# Q1 — the ENOSPC error path must not perform the write that is failing.
+# --------------------------------------------------------------------------
+
+
+def test_state_path_creates_nothing(tmp_path: Path) -> None:
+    """Readers and diagnostics must not mkdir; only the writer may."""
+    root = tmp_path / "fresh"
+    path = state.state_path(root)
+    assert path.name == state.STATE_FILENAME
+    assert not root.exists(), "state_path() created the config dir"
+    assert not path.parent.exists(), "state_path() created the run dir"
+    # The writer still creates it, so publishing is unaffected.
+    state.publish(_record(), root)
+    assert path.exists()
+
+
+def test_publish_safely_absorbs_enospc_on_a_config_dir_that_does_not_exist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Q1: building the ENOSPC log line used to raise a second ENOSPC.
+
+    `state_path()` went through `run_dir()`, which mkdirs — so on a fresh
+    config dir with a full disk the handler for "cannot write, disk is full"
+    itself tried to write, and `publish_safely` raised from inside the branch
+    whose whole contract is that it does not. The daemon then failed to boot,
+    in exactly the disk-full scenario this change is about.
+    """
+    root = tmp_path / "never-created"
+    service = BridgeService(root=root)
+
+    def full_disk(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    # Fail the real write the way a full disk does, leaving the run dir absent.
+    monkeypatch.setattr(state, "publish", full_disk)
+    monkeypatch.setattr("local_operator.browser_bridge.daemon.state_store.publish", full_disk)
+
+    assert service.publish_safely() is False  # absorbed, not raised
+    assert service._publish_failures == 1
+    assert not root.exists(), "the ENOSPC handler created the directory it could not write"

--- a/tests/unit/browser_bridge/test_remediation_round2_review.py
+++ b/tests/unit/browser_bridge/test_remediation_round2_review.py
@@ -1,0 +1,77 @@
+"""Regression test for the round-2 QA remediation on PR #563 (Q5).
+
+Round 1 stopped a redacted handle from FORKING a phantom record. Q5 is the
+milder shape that survived it: a redacted handle still could not name a tab, so
+a handle-less command result refreshed the most recently updated record — which
+is not necessarily the tab the extension was describing. This test fails on the
+round-2 head (`aebea0c5`), where `note_driven` fell straight through to recency.
+"""
+
+from __future__ import annotations
+
+import time
+
+from local_operator.browser_bridge.daemon import ExtensionLink
+
+
+def test_redacted_handle_refreshes_its_own_record_not_the_most_recent() -> None:
+    """Q5: the two sides count "most recent" on different clocks.
+
+    `nav.ts` resolves a handle-less command against the most recently USED
+    surface (bumped by every tab-scoped command), while the daemon's recency
+    fallback sees the most recently UPDATED record. When those disagree — tab A
+    used last, tab B updated last — a handle-less `status` describing A used to
+    overwrite B's record with A's URL, so `status` and the popup misreported
+    which tab held which page. A redacted token cannot KEY a record, but it
+    carries enough nonce to RECOGNISE one, so it must be matched rather than
+    guessed at.
+    """
+    link = ExtensionLink()
+    link.note_driven("bridge:11:aaaaaa0123456789", "https://site-a.example/a", "A")
+    # A distinct timestamp is what makes B the most recently UPDATED record;
+    # without it the recency fallback is a coin flip rather than a wrong answer.
+    time.sleep(0.01)
+    link.note_driven("bridge:22:bbbbbb0123456789", "https://site-b.example/b", "B")
+
+    # A is most recently USED on the extension clock, so a handle-less `status`
+    # reports A — with its handle redacted on the way out.
+    link.note_driven("bridge:11:aaaaaa\u2026", "https://site-a.example/a", "A")
+
+    assert link.driven["bridge:22:bbbbbb0123456789"].url == "https://site-b.example/b"
+    assert link.driven["bridge:11:aaaaaa0123456789"].url == "https://site-a.example/a"
+    assert len(link.driven) == 2, "matching a redacted handle must not fork a record"
+
+
+def test_unrecognised_redacted_handle_still_falls_back_to_recency() -> None:
+    """The fallback stays reachable for a handle we do not track.
+
+    Matching is an improvement on the guess, not a replacement for it: a peer
+    can report a surface the daemon has no record of (it reconnected, or the
+    record was repaired away). That must still refresh rather than fork, which
+    is what keeps a mixed-version pair reporting one driven tab.
+    """
+    link = ExtensionLink()
+    link.note_driven("bridge:11:aaaaaa0123456789", "https://site-a.example", "A")
+    time.sleep(0.01)
+    link.note_driven("bridge:22:bbbbbb0123456789", "https://site-b.example", "B")
+
+    link.note_driven("bridge:99:zzzzzz\u2026", "https://site-z.example", "Z")
+
+    assert len(link.driven) == 2
+    assert link.driven["bridge:22:bbbbbb0123456789"].url == "https://site-z.example"
+
+
+def test_handle_less_update_still_collapses_onto_the_unkeyed_record() -> None:
+    """An old build sends no handle at all, and must not self-match on "".
+
+    The unkeyed record is keyed by the empty string, so a matcher that accepted
+    an empty token would prefix-match it against every key. A genuinely
+    handle-less update therefore stays on the recency path, which is what makes
+    three navigations from a 0.1.5 extension one record instead of three.
+    """
+    link = ExtensionLink()
+    for url in ("https://legacy.example/1", "https://legacy.example/2"):
+        link.note_driven("", url, "Legacy")
+
+    assert list(link.driven) == [""]
+    assert link.current_url == "https://legacy.example/2"

--- a/tests/unit/browser_bridge/test_state.py
+++ b/tests/unit/browser_bridge/test_state.py
@@ -47,3 +47,38 @@ def test_availability_matrix(tmp_path: Path, monkeypatch) -> None:
     current.heartbeat_at = time.time()
     state.state_path(tmp_path).write_text(current.model_dump_json())
     assert not state.available(tmp_path)
+
+
+def test_liveness_distinguishes_absent_fresh_and_stale(tmp_path: Path, monkeypatch) -> None:
+    """The three-state classification RC2 depends on.
+
+    ``available()`` collapses to a bool for the cheap session-construction
+    gate, but the browser path needs to tell "no daemon" from "daemon alive,
+    file stale" — only the latter is worth a socket probe.
+    """
+    assert state.liveness(tmp_path)[0] is state.Liveness.ABSENT
+
+    state.publish(record(), tmp_path)
+    assert state.liveness(tmp_path)[0] is state.Liveness.FRESH
+
+    current = record()
+    state.publish(current, tmp_path)
+    current.heartbeat_at = time.time() - state.HEARTBEAT_TIMEOUT_S - 1
+    state.state_path(tmp_path).write_text(current.model_dump_json())
+    status, read_back = state.liveness(tmp_path)
+    assert status is state.Liveness.STALE
+    assert read_back is not None
+    # The age is what `lop browser status` renders and what the demotion hint
+    # quotes, so it must be a real elapsed figure, not a flag.
+    assert state.heartbeat_age(read_back) > state.HEARTBEAT_TIMEOUT_S
+
+    # A stale file whose process is GONE is absent, not stale: there is
+    # nothing alive to acquit, so no probe should ever be spent on it.
+    monkeypatch.setattr(state, "pid_alive", lambda _pid: False)
+    assert state.liveness(tmp_path)[0] is state.Liveness.ABSENT
+
+
+def test_heartbeat_age_never_reports_negative(tmp_path: Path) -> None:
+    """Clock skew must not render as a negative age in diagnostics."""
+    current = record(heartbeat_at=time.time() + 30)
+    assert state.heartbeat_age(current) == 0.0

--- a/tests/unit/browser_bridge/test_tool_selection.py
+++ b/tests/unit/browser_bridge/test_tool_selection.py
@@ -16,7 +16,9 @@ from local_operator.tools import builtin
 )
 def test_builder_selection(monkeypatch, cmux: bool, bridge: bool, advertised: bool) -> None:
     monkeypatch.setattr(builtin, "cmux_browser_available", lambda: cmux)
-    monkeypatch.setattr(builtin, "bridge_browser_available", lambda: bridge)
+    # Gating asks `advertisable`, not `available`: see
+    # test_stale_but_alive_daemon_still_advertises_the_browser_tool.
+    monkeypatch.setattr(builtin, "bridge_browser_advertisable", lambda: bridge)
     assert (builtin.build_browser_tool(None) is not None) is advertised
 
 


### PR DESCRIPTION
## Incident

An agent fleet (session `2d3373a1c698`) lost the browser extension mid-session. Every `browser` call silently degraded to the cmux backend — `scroll`/`logs`/`tabs` returned "not supported on the cmux backend" — while `lop browser status` simultaneously reported:

```
extension connected: yes
paired:              yes
driving:             http://127.0.0.1:8974/r3-notice-amber.svg
```

…a URL whose server was already dead. The user closed **every** tab in Chrome; status still claimed it was driving that URL. Both the agent and the user concluded the bridge was "bound" by an orphan tab and abandoned the extension for the rest of the session.

Nothing was bound. Four independent defects combined into one unrecoverable, undiagnosable state, and the machine was still sitting in it (daemon pid 1646) when this work started.

## Live reproduction, before any change

The broken daemon was investigated before restarting anything:

```
$ cat ~/.local-operator/run/browser/bridge.json     # heartbeat_at 1788386598
$ python3 -c 'import time; print(time.time())'      # 1788398281  -> 11,683s (3.2h) stale
$ ps -o pid,etime -p 1646                           # 1646  05-02:58:37   ALIVE
$ curl -s localhost:4099/health                     # HTTP 200, extension_connected: true
$ curl -s http://127.0.0.1:8974/r3-notice-amber.svg # 000 — connection refused (server dead)
$ grep -n 'Errno 28' ~/Library/Logs/local-operator/browser-bridge.log
534:OSError: [Errno 28] No space left on device: '.../.bridge.fsfgktwb.tmp'
```

The traceback in that log ends in `_heartbeat` → `publish` → `state.publish` → `tempfile.mkstemp`. The heartbeat died at 18:03; the tool failures began at 21:01 — **the heartbeat death precedes the symptom by three hours.**

## Root causes and fixes

### RC1 — a supervisory loop died silently and disabled the bridge for every session (primary)

`BridgeService._heartbeat` was `while True: self.publish(); await sleep(15)`. When the disk filled, ENOSPC escaped the loop, the task **died**, and nothing restarted or noticed it. `state.available()` requires `now - heartbeat_at <= 45s`, so with no writer it returned False **forever** → `bridge_browser_available()` False → every new `open` silently routed to cmux, while `lop browser status` (which reads the live `/health` socket, not the file) kept saying "connected: yes". That contradiction *is* the incident.

Fixed as a class of bug, not one syscall: `_supervise()` wraps `_heartbeat`, `_ping` and `_watch_revocation` so a per-iteration exception is logged and the loop **continues**, with capped backoff so a persistently failing iteration cannot spin a core or flood the log. `CancelledError` still propagates, so shutdown is unaffected. Publishing became `publish_safely()` — a best-effort cache refresh that is retried on the next tick, with a distinct, actionable log line for ENOSPC. Every event-path `publish()` call now goes through it, so no transient write failure can kill a coroutine.

**Evidence** (`docs/evidence/browser-bridge-resilience/repro_rc1.py`, runs a real uvicorn daemon and forces `publish` to raise):

```
########## MAIN (origin/main) ##########
[baseline]  /health=200  available=True  heartbeat_age=0.04s
[inject]    publish() now raises OSError(ENOSPC) for 5 calls
[recover]   publish() restored; disk is 'free' again
[after]     /health=200  available=True  heartbeat_age=3.05s  heartbeat_task_dead=True
[verdict]   age 3.05s -> 4.05s  writer_stopped=True
RESULT: BROKEN — heartbeat writer died on a transient error

########## FIX (this branch) ##########
[after]     /health=200  available=True  heartbeat_age=0.03s  heartbeat_task_dead=False
[terms]     extension_connected=True  pid_alive=True  liveness=fresh
[verdict]   age 0.05s -> 0.03s  writer_stopped=False
RESULT: SURVIVED — the loop absorbed the errors and republished once writes succeeded
```

On `main` the age climbs without bound (unavailable permanently once it crosses 45s); on this branch it stays at ~0.03s. The daemon logs `disk is full` per failure and `state file writable again after 5 failed attempt(s)` on recovery.

### RC2 — the file heartbeat is a liveness proxy that lies in both directions

A stale file meant "unavailable" even though the daemon answered `/health` instantly. `state.liveness()` now classifies three states — `ABSENT` / `FRESH` / `STALE` — instead of collapsing to one bool. The cheap file probe stays the fast path for session construction and tool gating (unchanged, non-blocking, no socket); the browser path uses `bridge_browser_reachable()`, which short-circuits on `FRESH` and spends **one bounded 1.5s `/health` probe only when it is about to condemn a daemon whose pid is alive**. The common case is not slower.

**Evidence — against the actual broken daemon (pid 1646), before it was restarted:**

```
file-only available():        False   <- why the fleet fell back to cmux for hours
socket-confirmed reachable(): True    <- the daemon was healthy the whole time
```

### RC3 — the extension never sent `tab_closed`, so "driving" was never cleared

`ExtensionLink.current_url` was only reset on `disconnect()` and on a `tab_closed` event — and **nothing in the extension ever sent one**. There was no `chrome.tabs.onRemoved` listener anywhere in `extension/src`. So a tab closed by the agent, the user, or a crash was advertised as "driving" forever. That is exactly the "something is bound despite me closing all tabs" the user hit.

Added top-level `chrome.tabs.onRemoved` and `onReplaced` listeners (top-level registration is load-bearing under MV3 — only listeners present during the worker's first synchronous evaluation survive suspension; the reasoning in `reconnect.ts` applies). They reclaim **only surfaces we own** through the single `pruneSurface` path (map entry + log ring buffer + debugger attachment), so a user's own tabs are never announced and a dead tab can no longer hold a slot against `MAX_SURFACES`. An explicit `close` announces too. The daemon's handler no longer blanks state unconditionally: `tab_closed` carries the handle and drops exactly that tab.

**Evidence — a real tab through the live paired extension.** With the shipped stack (extension 0.1.5 + installed daemon):

```
# tab open and driven:
current_url: 'http://127.0.0.1:8974/'   driving: http://127.0.0.1:8974/
# after browser action='close':
current_url: 'http://127.0.0.1:8974/'   driving: http://127.0.0.1:8974/   <- PHANTOM
```

The tab is gone; the daemon still advertises it. Later, with the local server also stopped, the shipped daemon *still* advertised `http://127.0.0.1:8974/` — a URL with no tab and no server, reproducing the user's report exactly.

Feeding the identical frames the fixed extension now emits into the fixed daemon:

```
[driving]  current_url: http://127.0.0.1:8974/   driven_tabs: 1
[closed]   current_url: ''                       driven_tabs: 0
```

### RC4 — "driving" was a single-tab concept in a multi-tab world

`MAX_SURFACES` is 8 and each session owns a tab, but `current_url` was one global last-writer-wins slot, so status showed whichever tab was touched most recently as though it were *the* bound tab — which is what made a stale URL read as a system-wide lock. Driven pages are now tracked **per tab** (`driven: dict[str, DrivenTab]`, exposed as `driven_tabs` on `/health`), and `lop browser status` reports the count and lists them, or says `no tabs driven`. `current_url`/`current_title` remain as properties over the most-recent live tab, so the popup contract and older daemons still work.

## Also addressed

- **A repair verb.** `lop browser status --repair` reconciles advertised state against reality: it asks the extension which surfaces genuinely exist, drops the records reality does not back, and republishes a fresh heartbeat. Safe while sessions are live — it closes no tab, cancels no in-flight command, touches no pairing. A daemon predating the endpoint gets a precise diagnosis rather than a misleading "not answering":
  ```
  $ lop browser status --repair          # against live pid 1646
  daemon pid 1646 on port 4099, heartbeat 15351s old
  the daemon on port 4099 is running a build with no /repair endpoint
  (it predates this fix). Run 'lop browser restart' to load the current build.
  ```
- **Silent demotion is itself a defect.** The cmux-fallback errors for `scroll`/`logs`/`tabs`/access actions now append, when the bridge is stale-but-alive:
  ```
  NOTE: this session was DEMOTED from the extension to cmux — the bridge daemon
  (pid 1646) is running but its discovery heartbeat is 15347s stale, so it
  advertised itself as unavailable. Run 'lop browser status --repair' to
  reconcile it, then retry.
  ```
  That is the difference between the agent recovering in one step and burning an hour, as it did.
- **Diagnosability.** `status` surfaces a stale heartbeat instead of hiding it behind the live `/health` read — the two sources disagreeing was the single most confusing part of the incident:
  ```
  heartbeat:           STALE by 15341s (discovery file is not being refreshed)
                       sessions will fall back to cmux despite the daemon being healthy.
                       run 'lop browser status --repair' to reconcile.
  ```
- **Ghost surfaces.** `tabs`/`liveSurfaces` already prune dead entries, and `onRemoved` now reclaims eagerly, so a session that dies without `close` can no longer exhaust the cap and deny `open` to everyone with a `tab_limit`.

## Regression tests (each fails without the corresponding fix)

- `test_heartbeat_loop_survives_publish_failure` — ENOSPC from `publish` must not kill the writer; availability recovers.
- `test_supervised_loop_keeps_running_after_repeated_failures` / `..._still_honours_cancellation` — the class of bug, and that shutdown still works.
- `test_publish_safely_swallows_oserror_and_reports_failure`.
- `test_liveness_distinguishes_absent_fresh_and_stale`, `test_heartbeat_age_never_reports_negative`.
- `test_driven_tabs_are_tracked_per_tab_and_cleared_on_close`, `test_handleless_update_refreshes_rather_than_forking_a_phantom`, `test_tab_closed_event_clears_driven_state_over_the_socket` (end-to-end over the real websocket).
- `extension/tests/tab-lifecycle.integration.test.mjs` — owned tab reclaimed and announced; a tab we do not own ignored; reclaim idempotent; correct surface chosen among several.

Two existing tests were updated for real interface changes, not to paper over failures: `test_health_reports_driven_url_and_pending_origin` now records through `note_driven` (the single mutable slot is gone), and the worker's chrome stub in `origins.integration.test.mjs` gained the `tabs` namespace the new top-level listeners require.

## Gates

| Gate | Result |
|---|---|
| `flake8` | clean |
| `black --check` (26.1.0) | clean, 816 files |
| `isort --check-only` | clean |
| `pyright` | 0 errors, 0 warnings |
| `pytest tests/unit` | **11,111 passed**, 15 skipped |
| `pnpm typecheck` | clean |
| `pnpm test` (extension) | **71 passed** |

> The full unit suite needs `ulimit -n 8192`; at this machine's default 256 a batch of unrelated tests fails with `Errno 24: Too many open files`. Verified pre-existing and environmental — the same files pass in isolation with the limit raised.

## Version

Patch per AGENTS.md materiality: a reliability fix, not a step-function capability. `0.44.43 → 0.44.44`. Extension `0.1.5 → 0.1.6` (`manifest.json`, `package.json`, and the version assertion in `release.test.mjs`), since `extension/src` changed.

## Deliberately not fixed

- **The extension in Chrome is still the 0.1.5 build.** The `tab_closed` emitter ships in 0.1.6, so the real-browser half of RC3 was proven by driving a real tab through the live extension (capturing the phantom) and then feeding the exact frames 0.1.6 emits into the fixed daemon. Landing this needs an extension reload/store push to take effect end to end.
- **The disk is still at ~92%.** The trigger that started this remains loaded; this change makes the bridge survive and self-report it, not prevent it.
- `state.publish` still writes via `mkstemp`+`os.replace` (correct for atomicity); no retry was added *inside* publish because the surviving heartbeat loop already retries every 15s.
