### PR TITLE
fix(benchmarks): correct the OSWorld adapter venv recipe and the stale build version default

### DIFF
--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -218,7 +218,7 @@ episode needs no environment variables at all:
 python ~/local-operator/scripts/run_episode.py \
     --selector ~/worktrees/osworld/workspaces/0.1.1/selector.json \
     --task-id task_001 \
-    --route openrouter/deepseek/deepseek-v4-flash-vision-exp \
+    --route openrouter/google/gemini-3.8-flash \
     --run-root ~/worktrees/osworld/runs/$(date +%Y%m%d-%H%M%S) \
     --infra AWS_REGION=us-east-1 \
     --infra AWS_SUBNET_ID=subnet-f2f9adad \
@@ -242,8 +242,8 @@ a result and cannot be mistaken for one.
 The sealed `requested_route.model_id` is a **lossless fold** of the model id
 (`RouteIdentity` fields cannot carry `/`): `_` → `__`, `/` → `_s`, anything
 else outside `[A-Za-z0-9.:-]` → `_x<hh>` per UTF-8 byte, so
-`deepseek/deepseek-v4-flash-vision-exp` seals as
-`deepseek_sdeepseek-v4-flash-vision-exp` and `runner.route_ids.unfold_model_id`
+`google/gemini-3.8-flash` seals as
+`google_sgemini-3.8-flash` and `runner.route_ids.unfold_model_id`
 recovers it exactly. The manifest metadata also carries the raw id as
 `route_model_id`, so a reader never has to decode by hand.
 

--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -73,6 +73,7 @@ uv build --wheel --out-dir dist/
 #    `home` in pyvenv.cfg, and step 3a resolves libpython relative to it. A
 #    shim directory holds no lib/, so the copy silently finds nothing.
 VENV=/opt/lop-adapters/osworld-v2/0.1.1/venv
+WS=~/worktrees/osworld/workspaces/0.1.1/workspace   # the digest-pinned dir itself
 BASE=$(python3.12 -c 'import sys; print(sys.base_prefix)')   # e.g. ~/.local/share/uv/python/cpython-3.12.13-...
 "$BASE/bin/python3.12" -m venv --copies --without-pip "$VENV"
 
@@ -84,6 +85,8 @@ BASE=$(python3.12 -c 'import sys; print(sys.base_prefix)')   # e.g. ~/.local/sha
 #     the opaque "Failed to inspect Python interpreter". A framework or
 #     system python that links libpython by absolute path does not need it;
 #     the uv-managed CPython this recipe uses does.
+#     The copy is allowed to fail (a python that needs no dylib has none to
+#     copy); the -V beside it is the real check and catches a genuine miss.
 cp "$BASE/lib/libpython3.12.dylib" "$VENV/lib/" 2>/dev/null || true   # macOS only
 "$VENV/bin/python3.12" -V   # must print the version, not abort
 uv pip install --python "$VENV/bin/python3.12" \
@@ -99,36 +102,49 @@ uv pip install --python "$VENV/bin/python3.12" \
 uv export --frozen --no-emit-project --extra osworld --no-hashes \
     -o "$VENV/build/requirements.locked.txt"
 sed -i '' 's/^local-operator==.*/local-operator==<harness version>/' \
-    "$VENV/build/requirements.locked.txt"
+    "$VENV/build/requirements.locked.txt"   # macOS sed; GNU sed wants -i without ''
 uv pip install --python "$VENV/bin/python3.12" -r "$VENV/build/requirements.locked.txt"
 
 # The one expected `uv pip check` incompatibility is the documented
 # requests>=2.32 override onto OSWorld's ~=2.31 pin (see [tool.uv] above).
 
-# 4. materialise the workspace from the verified inputs root (no download;
+# 4. compute package_digest FIRST: it digests the installed wheel's RECORD and
+#    does not depend on the workspace, while step 5's --package-digest does
+#    depend on it. (Computing it after the build is what forces a second
+#    build with the real value.)
+PKG=$("$VENV/bin/python3.12" -c '
+from pathlib import Path
+from importlib.metadata import PathDistribution
+from local_operator.evaluation.adapters.discovery import distribution_digest
+import sysconfig
+sp = Path(sysconfig.get_paths()["purelib"])
+di = next(sp.glob("lop_osworld_v2_adapter-*.dist-info"))
+print(distribution_digest(PathDistribution(di)))
+')
+echo "package_digest   $PKG"
+
+# 5. materialise the workspace from the verified inputs root (no download;
 #    writes adapter-release.json, benchmark_release.json, task_hashes.json,
 #    adapter-provider.json, inputs.json, tasks/, all read-only).
 #    --out is the WORKSPACE directory itself, not its parent: it is what the
 #    selector's `workspace` field and workspace_digest address. Keep the
 #    selector and build-output.json in the parent so they are not inside the
 #    digest they describe.
-#    Run it with the venv's interpreter (it imports the harness), and note
-#    --version defaults to the adapter's own pyproject version.
+#    Run it with the venv's interpreter (it imports the harness). --version
+#    defaults to the adapter's own pyproject version and REFUSES a value that
+#    disagrees with it unless --allow-version-mismatch is passed.
 "$VENV/bin/python3.12" ~/local-operator/scripts/build_osworld_adapter.py \
     --benchmark-release osworld-v2-2026.08.08 \
     --inputs-root ~/worktrees/osworld \
-    --package-digest <package_digest from step 5> \
-    --out ~/worktrees/osworld/workspaces/0.1.1/workspace
+    --package-digest "$PKG" \
+    --out "$WS"
 
-# 5. compute the three digests the AdapterSelector needs
-python - <<'PY'
-from importlib.metadata import PathDistribution
-from local_operator.evaluation.adapters.discovery import (
-    distribution_digest, workspace_digest,
-)
-print("package_digest  ", distribution_digest(PathDistribution(<dist-info path>)))
-print("workspace_digest", workspace_digest("/opt/lop-adapters/osworld-v2/0.1.1/workspace"))
-PY
+# 6. the remaining digest the AdapterSelector needs (release_digest is printed
+#    by step 5 and written into adapter-release.json).
+"$VENV/bin/python3.12" -c "
+from local_operator.evaluation.adapters.discovery import workspace_digest
+print('workspace_digest', workspace_digest('$WS'))
+"
 ```
 
 `release_digest` is our attestation of the build:

--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -67,27 +67,58 @@ uv build --wheel --out-dir dist/
 #    `--copies` flag (that is uv pip's install link-mode). Use the stdlib
 #    venv, which DOES copy. `--without-pip` because uv pip installs the rest
 #    and the uv-managed interpreter's ensurepip can SIGABRT on macOS.
-python3.12 -m venv --copies --without-pip /opt/lop-adapters/osworld-v2/0.1.1/venv
-uv pip install --python /opt/lop-adapters/osworld-v2/0.1.1/venv/bin/python \
-    --no-deps dist/lop_osworld_v2_adapter-0.1.1-py3-none-any.whl
-uv pip install --python /opt/lop-adapters/osworld-v2/0.1.1/venv/bin/python \
-    -r <(uv export --frozen --no-emit-project)
-uv pip install --python /opt/lop-adapters/osworld-v2/0.1.1/venv/bin/python \
-    local-operator==<harness version>
+#
+#    Invoke the venv module through the interpreter's REAL path, never through
+#    a ~/.local/bin shim: venv records the invoking argv[0]'s directory as
+#    `home` in pyvenv.cfg, and step 3a resolves libpython relative to it. A
+#    shim directory holds no lib/, so the copy silently finds nothing.
+VENV=/opt/lop-adapters/osworld-v2/0.1.1/venv
+BASE=$(python3.12 -c 'import sys; print(sys.base_prefix)')   # e.g. ~/.local/share/uv/python/cpython-3.12.13-...
+"$BASE/bin/python3.12" -m venv --copies --without-pip "$VENV"
 
-# 3b. for the PAID path only: OSWorld itself is an extra (~380 packages) that
-#     the cloud-free wheel does not need. Install it into the same venv.
-uv pip install --python /opt/lop-adapters/osworld-v2/0.1.1/venv/bin/python \
-    "lop-osworld-v2-adapter[osworld] @ dist/lop_osworld_v2_adapter-0.1.1-py3-none-any.whl"
+# 3a. copy libpython beside the interpreter. REQUIRED on macOS and easy to
+#     miss: `--copies` copies the python binary but NOT the shared library it
+#     links, and the copied binary keeps `@rpath/libpython3.12.dylib` with an
+#     rpath of `<venv>/lib`. Without this the interpreter aborts on every
+#     invocation with "Library not loaded" (dyld) / SIGABRT, and uv reports
+#     the opaque "Failed to inspect Python interpreter". A framework or
+#     system python that links libpython by absolute path does not need it;
+#     the uv-managed CPython this recipe uses does.
+cp "$BASE/lib/libpython3.12.dylib" "$VENV/lib/" 2>/dev/null || true   # macOS only
+"$VENV/bin/python3.12" -V   # must print the version, not abort
+uv pip install --python "$VENV/bin/python3.12" \
+    --no-deps dist/lop_osworld_v2_adapter-0.1.1-py3-none-any.whl
+
+# 3b. install the locked set. For the PAID path export WITH the osworld extra
+#     (~380 packages the cloud-free wheel does not need); omit --extra for a
+#     cloud-free venv. Export to a FILE and keep it beside the venv: it is the
+#     record of what was actually installed, and the lock's own
+#     local-operator pin lags the harness (schema 1.2 and host_secrets only
+#     exist from 0.44.30+), so substitute the harness version you are running
+#     and note the substitution in the build record.
+uv export --frozen --no-emit-project --extra osworld --no-hashes \
+    -o "$VENV/build/requirements.locked.txt"
+sed -i '' 's/^local-operator==.*/local-operator==<harness version>/' \
+    "$VENV/build/requirements.locked.txt"
+uv pip install --python "$VENV/bin/python3.12" -r "$VENV/build/requirements.locked.txt"
+
+# The one expected `uv pip check` incompatibility is the documented
+# requests>=2.32 override onto OSWorld's ~=2.31 pin (see [tool.uv] above).
 
 # 4. materialise the workspace from the verified inputs root (no download;
 #    writes adapter-release.json, benchmark_release.json, task_hashes.json,
 #    adapter-provider.json, inputs.json, tasks/, all read-only).
-python ~/local-operator/scripts/build_osworld_adapter.py \
+#    --out is the WORKSPACE directory itself, not its parent: it is what the
+#    selector's `workspace` field and workspace_digest address. Keep the
+#    selector and build-output.json in the parent so they are not inside the
+#    digest they describe.
+#    Run it with the venv's interpreter (it imports the harness), and note
+#    --version defaults to the adapter's own pyproject version.
+"$VENV/bin/python3.12" ~/local-operator/scripts/build_osworld_adapter.py \
     --benchmark-release osworld-v2-2026.08.08 \
     --inputs-root ~/worktrees/osworld \
     --package-digest <package_digest from step 5> \
-    --out ~/worktrees/osworld/workspaces/0.1.1
+    --out ~/worktrees/osworld/workspaces/0.1.1/workspace
 
 # 5. compute the three digests the AdapterSelector needs
 python - <<'PY'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.49"
+version = "0.44.50"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/build_osworld_adapter.py
+++ b/scripts/build_osworld_adapter.py
@@ -67,6 +67,7 @@ import os
 import stat
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -81,6 +82,29 @@ _DEFAULT_PIN = (
     / "config"
     / "release-v2026.08.08.json"
 )
+
+
+_ADAPTER_PYPROJECT = (
+    Path(__file__).resolve().parents[1] / "benchmarks" / "osworld_v2_adapter" / "pyproject.toml"
+)
+
+
+def _adapter_version() -> str:
+    """The adapter distribution version declared in its pyproject.
+
+    Read from source rather than from ``importlib.metadata`` on purpose: this
+    script runs from the repository against a workspace that is built BEFORE
+    (or without) the wheel being installed into the caller's interpreter, so
+    the installed distribution is the wrong authority and may not exist at all.
+    A read failure is not fatal -- ``--version`` is still explicit on the
+    documented command line -- but it must not silently produce a wrong
+    attestation, so the fallback is an obviously-unreal marker.
+    """
+
+    try:
+        return str(tomllib.loads(_ADAPTER_PYPROJECT.read_text())["project"]["version"])
+    except (OSError, KeyError, tomllib.TOMLDecodeError):
+        return "unknown"
 
 
 class VerificationFailed(Exception):
@@ -277,7 +301,14 @@ def main(argv: list[str] | None = None) -> int:
         default=Path(os.environ.get("OSWORLD_INPUTS_ROOT", _DEFAULT_INPUTS_ROOT)),
     )
     parser.add_argument("--release-pin", type=Path, default=_DEFAULT_PIN)
-    parser.add_argument("--version", default="0.1.0")
+    # Defaults to the adapter's OWN declared version rather than a literal.
+    # The version is an input to ``_release_digest``, so a stale literal here
+    # silently mints a workspace whose release_digest attests a distribution
+    # version that was never built -- a wrong attestation that no digest check
+    # can catch, because every digest is internally consistent with it. Read
+    # from pyproject.toml so the default cannot drift from the wheel again
+    # (it already had: the literal still said 0.1.0 after the 0.1.1 bump).
+    parser.add_argument("--version", default=_adapter_version())
     parser.add_argument("--package-digest", default="0" * 64)
     args = parser.parse_args(argv)
 

--- a/scripts/build_osworld_adapter.py
+++ b/scripts/build_osworld_adapter.py
@@ -89,22 +89,27 @@ _ADAPTER_PYPROJECT = (
 )
 
 
-def _adapter_version() -> str:
-    """The adapter distribution version declared in its pyproject.
+def _adapter_version() -> str | None:
+    """The adapter distribution version declared in its pyproject, or None.
 
     Read from source rather than from ``importlib.metadata`` on purpose: this
     script runs from the repository against a workspace that is built BEFORE
     (or without) the wheel being installed into the caller's interpreter, so
     the installed distribution is the wrong authority and may not exist at all.
-    A read failure is not fatal -- ``--version`` is still explicit on the
-    documented command line -- but it must not silently produce a wrong
-    attestation, so the fallback is an obviously-unreal marker.
+
+    Returns None rather than a placeholder when the declaration cannot be read.
+    A placeholder would flow into ``_release_digest`` and mint a real,
+    well-formed workspace attesting a version that does not exist -- and since
+    ``adapter-release.json`` carries ONLY the digest (``discovery`` rejects any
+    other key), the artifact could not record its own doubt even if we wanted
+    it to. An unattributable attestation is worse than no artifact, so the
+    caller refuses to build instead.
     """
 
     try:
         return str(tomllib.loads(_ADAPTER_PYPROJECT.read_text())["project"]["version"])
     except (OSError, KeyError, tomllib.TOMLDecodeError):
-        return "unknown"
+        return None
 
 
 class VerificationFailed(Exception):
@@ -301,16 +306,61 @@ def main(argv: list[str] | None = None) -> int:
         default=Path(os.environ.get("OSWORLD_INPUTS_ROOT", _DEFAULT_INPUTS_ROOT)),
     )
     parser.add_argument("--release-pin", type=Path, default=_DEFAULT_PIN)
-    # Defaults to the adapter's OWN declared version rather than a literal.
-    # The version is an input to ``_release_digest``, so a stale literal here
-    # silently mints a workspace whose release_digest attests a distribution
-    # version that was never built -- a wrong attestation that no digest check
-    # can catch, because every digest is internally consistent with it. Read
-    # from pyproject.toml so the default cannot drift from the wheel again
-    # (it already had: the literal still said 0.1.0 after the 0.1.1 bump).
-    parser.add_argument("--version", default=_adapter_version())
+    # Left with NO argparse default: the adapter's own declared version is
+    # resolved below so that "not passed" stays distinguishable from "passed
+    # a value equal to the default". The version is an input to
+    # ``_release_digest``, so a value that does not match the distribution
+    # actually built mints a workspace attesting a version that never existed
+    # -- a wrong attestation no digest check can catch, because every digest
+    # is internally consistent with it. That already happened once: the
+    # literal default still said 0.1.0 after the 0.1.1 bump.
+    parser.add_argument("--version", default=None)
+    parser.add_argument(
+        "--allow-version-mismatch",
+        action="store_true",
+        help="permit --version to differ from the adapter's declared version "
+        "(for attesting a build of a version other than this tree's)",
+    )
     parser.add_argument("--package-digest", default="0" * 64)
     args = parser.parse_args(argv)
+
+    # Resolve the attested version under one rule: it must agree with what the
+    # tree declares, unless the operator says out loud that it should not.
+    # Building a version OTHER than the tree's is legitimate (re-attesting an
+    # older wheel against the same corpus), but it is a deliberate act, not
+    # something to accept silently -- silently accepting a mismatched value is
+    # the same shape as the stale-default defect this script already had.
+    declared = _adapter_version()
+    version = args.version if args.version is not None else declared
+    if version is None:
+        print(
+            "build_osworld_adapter: cannot determine the adapter version "
+            f"({_ADAPTER_PYPROJECT} is unreadable or declares none) and no "
+            "--version was given. Refusing to build: the version is an input "
+            "to release_digest, and adapter-release.json carries only that "
+            "digest, so the workspace could not record that its attestation "
+            "is unattributable.",
+            file=sys.stderr,
+        )
+        return 2
+    if args.version is not None and declared is not None and args.version != declared:
+        if not args.allow_version_mismatch:
+            print(
+                f"build_osworld_adapter: --version {args.version!r} disagrees with the "
+                f"version the adapter declares ({declared!r} in {_ADAPTER_PYPROJECT}). "
+                "release_digest attests the distribution that was built, so a "
+                "mismatch produces a workspace claiming a version nobody can "
+                "verify. Pass --allow-version-mismatch if that is deliberate.",
+                file=sys.stderr,
+            )
+            return 2
+        # Deliberate and stated: still say so, because the resulting digest is
+        # not reproducible from this tree alone.
+        print(
+            f"build_osworld_adapter: attesting {args.version!r} while this tree "
+            f"declares {declared!r} (--allow-version-mismatch).",
+            file=sys.stderr,
+        )
 
     pin = json.loads(Path(args.release_pin).read_bytes())
     if pin.get("release") != args.benchmark_release:
@@ -331,7 +381,7 @@ def main(argv: list[str] | None = None) -> int:
         out=args.out,
         facts=facts,
         release=args.benchmark_release,
-        version=args.version,
+        version=version,
         package_digest=args.package_digest,
     )
     print(

--- a/scripts/build_osworld_adapter.py
+++ b/scripts/build_osworld_adapter.py
@@ -112,6 +112,63 @@ def _adapter_version() -> str | None:
         return None
 
 
+class VersionRefused(Exception):
+    """The attested version cannot be trusted, so no workspace may be built.
+
+    Separate from ``VerificationFailed`` because it carries a different exit
+    code (2, a usage error) and fires BEFORE any input is read: the version is
+    a property of the build, not of the corpus.
+    """
+
+
+def resolve_attested_version(
+    *, requested: str | None, declared: str | None, allow_mismatch: bool
+) -> tuple[str, str | None]:
+    """The single implementation of "which version does this build attest".
+
+    Pure -- no argparse, no filesystem, no corpus -- so the tests exercise the
+    REAL resolution rather than re-implementing it. That distinction is not
+    academic: the digest regression test previously recomputed the rule itself
+    and therefore stayed green when the rule was mutated, which is the same
+    bypass the original stale-default defect exploited.
+
+    Returns the version to attest plus an optional advisory line the caller
+    should print. Raises ``VersionRefused`` when nothing trustworthy can be
+    attested.
+
+    The rule: the attested version must agree with what the tree declares
+    unless the operator says out loud that it should not. Attesting a version
+    OTHER than the tree's is legitimate (re-attesting an older wheel against
+    the same corpus) but deliberate, so it is opt-in and still announced --
+    the resulting digest is not reproducible from this tree alone.
+    """
+
+    version = requested if requested is not None else declared
+    if version is None:
+        raise VersionRefused(
+            "cannot determine the adapter version "
+            f"({_ADAPTER_PYPROJECT} is unreadable or declares none) and no "
+            "--version was given. Refusing to build: the version is an input "
+            "to release_digest, and adapter-release.json carries only that "
+            "digest, so the workspace could not record that its attestation "
+            "is unattributable."
+        )
+    if requested is not None and declared is not None and requested != declared:
+        if not allow_mismatch:
+            raise VersionRefused(
+                f"--version {requested!r} disagrees with the version the adapter "
+                f"declares ({declared!r} in {_ADAPTER_PYPROJECT}). release_digest "
+                "attests the distribution that was built, so a mismatch produces "
+                "a workspace claiming a version nobody can verify. Pass "
+                "--allow-version-mismatch if that is deliberate."
+            )
+        return version, (
+            f"attesting {requested!r} while this tree declares {declared!r} "
+            "(--allow-version-mismatch)."
+        )
+    return version, None
+
+
 class VerificationFailed(Exception):
     """An input does not match the pin. The message names the path."""
 
@@ -324,43 +381,20 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--package-digest", default="0" * 64)
     args = parser.parse_args(argv)
 
-    # Resolve the attested version under one rule: it must agree with what the
-    # tree declares, unless the operator says out loud that it should not.
-    # Building a version OTHER than the tree's is legitimate (re-attesting an
-    # older wheel against the same corpus), but it is a deliberate act, not
-    # something to accept silently -- silently accepting a mismatched value is
-    # the same shape as the stale-default defect this script already had.
-    declared = _adapter_version()
-    version = args.version if args.version is not None else declared
-    if version is None:
-        print(
-            "build_osworld_adapter: cannot determine the adapter version "
-            f"({_ADAPTER_PYPROJECT} is unreadable or declares none) and no "
-            "--version was given. Refusing to build: the version is an input "
-            "to release_digest, and adapter-release.json carries only that "
-            "digest, so the workspace could not record that its attestation "
-            "is unattributable.",
-            file=sys.stderr,
+    # Resolved BEFORE the corpus is touched: the version is a property of the
+    # build, not of the inputs, and refusing early means a bad attestation
+    # never gets as far as reading 4.2 GB of task bytes.
+    try:
+        version, advisory = resolve_attested_version(
+            requested=args.version,
+            declared=_adapter_version(),
+            allow_mismatch=args.allow_version_mismatch,
         )
+    except VersionRefused as error:
+        print(f"build_osworld_adapter: {error}", file=sys.stderr)
         return 2
-    if args.version is not None and declared is not None and args.version != declared:
-        if not args.allow_version_mismatch:
-            print(
-                f"build_osworld_adapter: --version {args.version!r} disagrees with the "
-                f"version the adapter declares ({declared!r} in {_ADAPTER_PYPROJECT}). "
-                "release_digest attests the distribution that was built, so a "
-                "mismatch produces a workspace claiming a version nobody can "
-                "verify. Pass --allow-version-mismatch if that is deliberate.",
-                file=sys.stderr,
-            )
-            return 2
-        # Deliberate and stated: still say so, because the resulting digest is
-        # not reproducible from this tree alone.
-        print(
-            f"build_osworld_adapter: attesting {args.version!r} while this tree "
-            f"declares {declared!r} (--allow-version-mismatch).",
-            file=sys.stderr,
-        )
+    if advisory is not None:
+        print(f"build_osworld_adapter: {advisory}", file=sys.stderr)
 
     pin = json.loads(Path(args.release_pin).read_bytes())
     if pin.get("release") != args.benchmark_release:

--- a/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
+++ b/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
@@ -443,31 +443,95 @@ def test_a_version_that_cannot_be_determined_refuses_to_build(
 
 
 def test_the_staged_pilot_release_digest_is_reproduced_from_committed_values() -> None:
-    """The pinned attestation of the staged pilot, recomputed from the tree.
+    """The pinned attestation of the staged pilot, through the REAL resolution.
 
-    This is the regression test the original defect needed: with the stale
-    ``0.1.0`` default it yields ``a15961b1...`` instead, so it fails outright
-    on the bug rather than only on a guard's error message.
+    This is the regression test the original defect needed: it fails outright
+    on the bug (the stale ``0.1.0`` version yields ``a15961b1...``) rather than
+    only on a guard's error message.
 
-    Hermetic because every input is committed or supplied here -- the adapter's
-    declared version, the release name and the task-hash manifest sha from
-    ``config/release-v2026.08.08.json``, plus the package digest of the wheel
-    the pilot installed. The COMPANION ``workspace_digest`` is deliberately not
-    asserted: it hashes the 4.2 GB gated corpus, which is an operator-fetched
-    input that CI does not have and must never download. That half is covered
-    structurally by the happy-path test above (a workspace ``workspace_digest``
-    accepts, rebuilt identically) and by the operator's build record.
+    It routes through ``resolve_attested_version`` -- the same call ``main``
+    makes -- rather than recomputing the rule. Calling ``_adapter_version()``
+    and passing the result straight to ``_release_digest`` would re-implement
+    the resolution, and a mutation to it would leave this test green: exactly
+    the bypass the original defect exploited, one level up.
+
+    Hermetic because every input is committed or supplied here -- the release
+    name and task-hash manifest sha from ``config/release-v2026.08.08.json``,
+    plus the package digest of the wheel the pilot installed. The COMPANION
+    ``workspace_digest`` is deliberately not asserted: it hashes the 4.2 GB
+    gated corpus, an operator-fetched input CI does not have and must never
+    download. That half is covered structurally by the happy-path test above
+    (a workspace ``workspace_digest`` accepts, rebuilt identically) and by the
+    operator's build record.
     """
 
     pin = json.loads(build._DEFAULT_PIN.read_text())
+    # Exactly what main does: nothing requested, so the tree's own declaration
+    # is what gets attested.
+    version, advisory = build.resolve_attested_version(
+        requested=None,
+        declared=build._adapter_version(),
+        allow_mismatch=False,
+    )
+    assert advisory is None
     digest = build._release_digest(
-        version=build._adapter_version() or "",
+        version=version,
         # The digest of the 0.1.1 wheel installed into the staged pilot venv.
         package_digest="69e8504d9caa6732940ec59030dc149f83549da7155fb828fa9f7de677d5a736",
         benchmark_release=pin["release"],
         task_manifest_sha256=pin["tasks"]["hash_manifest_sha256"],
     )
     assert digest == "d0067e23af3dc2ed790c2a8b802ee453200d516466ad27770d7f2bbe7b0b41cd"
+
+
+def test_main_takes_its_attested_version_from_the_resolver(
+    durable_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: Any
+) -> None:
+    """``main`` must OBTAIN the version from ``resolve_attested_version``.
+
+    Asserted structurally -- the resolver is replaced and its return value must
+    be what reaches ``_release_digest`` -- rather than by comparing versions.
+    A value comparison cannot detect this wiring at all: on the default path
+    ``args.version`` is None and the resolver returns ``declared``, and on the
+    override path the resolver returns ``args.version`` unchanged, so
+    "resolved" and "raw" are numerically identical on every reachable input.
+    Re-deriving the version at the call site is therefore an EQUIVALENT mutant
+    to any value assertion (verified: it passes one), while still being the
+    defect that matters -- two implementations of the rule, free to drift.
+
+    Runs against the fixture corpus, so it needs none of the gated inputs.
+    """
+
+    root, pin = _fixture_inputs(durable_path)
+    sentinel = "resolver-sentinel-version"
+    calls: list[dict[str, Any]] = []
+    seen: list[str] = []
+
+    def fake_resolver(
+        *, requested: str | None, declared: str | None, allow_mismatch: bool
+    ) -> tuple[str, str | None]:
+        calls.append(
+            {"requested": requested, "declared": declared, "allow_mismatch": allow_mismatch}
+        )
+        return sentinel, None
+
+    real_digest = build._release_digest
+
+    def spy(*, version: str, **kwargs: Any) -> str:
+        seen.append(version)
+        return real_digest(version=version, **kwargs)
+
+    monkeypatch.setattr(build, "resolve_attested_version", fake_resolver)
+    monkeypatch.setattr(build, "_release_digest", spy)
+
+    assert _run(root, pin, durable_path / "w") == 0
+    # main asked the resolver, handing it the real declared version...
+    assert calls == [
+        {"requested": None, "declared": build._adapter_version(), "allow_mismatch": False}
+    ]
+    # ...and attested exactly what it answered, rather than re-deriving it.
+    assert seen == [sentinel]
+    capsys.readouterr()
 
 
 def test_the_committed_release_pin_carries_the_known_hashes() -> None:

--- a/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
+++ b/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
@@ -185,7 +185,7 @@ def _fixture_inputs(tmp_path: Path, *, task_count: int = 3) -> tuple[Path, Path]
     return root, pin_path
 
 
-def _run(root: Path, pin: Path, out: Path) -> int:
+def _run(root: Path, pin: Path, out: Path, *extra: str) -> int:
     return build.main(
         [
             "--benchmark-release",
@@ -196,6 +196,7 @@ def _run(root: Path, pin: Path, out: Path) -> int:
             str(root),
             "--release-pin",
             str(pin),
+            *extra,
         ]
     )
 
@@ -333,6 +334,140 @@ def test_a_wrong_prepared_commit_fails(durable_path: Path, capsys: Any) -> None:
     pin.write_text(json.dumps(payload))
     assert _run(root, pin, durable_path / "w") == build.EXIT_VERIFY
     assert "prepared checkout HEAD" in capsys.readouterr().err
+
+
+# --- the attested version -------------------------------------------------
+#
+# ``version`` is an input to ``_release_digest``, and NOTHING downstream can
+# catch a wrong one: ``adapter-release.json`` carries only the digest, so every
+# digest stays internally consistent with whatever version went in. That is how
+# a stale ``--version 0.1.0`` default survived the 0.1.1 bump and silently
+# attested a distribution that was never built. These tests pin the two
+# fail-closed guards that replaced it, and the digests themselves, so a future
+# edit restoring a permissive default cannot pass with a green suite.
+
+
+def test_an_explicit_version_disagreeing_with_the_adapter_is_refused(
+    durable_path: Path, capsys: Any
+) -> None:
+    """A mismatched --version must refuse and leave NO artifact behind.
+
+    Exit code alone is not the assertion that matters: the defect being
+    guarded is a workspace that exists and looks pristine while attesting a
+    version nobody built, so the absence of the output path is the property.
+    """
+
+    root, pin = _fixture_inputs(durable_path)
+    out = durable_path / "workspace"
+    assert _run(root, pin, out, "--version", "9.9.9") == 2
+    err = capsys.readouterr().err
+    # Both values, so the operator can see which one is wrong.
+    assert "9.9.9" in err
+    assert build._adapter_version() in err
+    assert "--allow-version-mismatch" in err
+    assert not out.exists()
+
+
+def test_a_mismatched_version_builds_only_when_explicitly_allowed(
+    durable_path: Path, capsys: Any
+) -> None:
+    """The override exists for re-attesting another build, and announces itself.
+
+    Attesting a version other than this tree's is legitimate but deliberate,
+    so it must be unreachable by accident: the flag is opt-in (``store_true``,
+    default False), and taking it still prints what it did, because the
+    resulting digest is not reproducible from this tree alone.
+    """
+
+    root, pin = _fixture_inputs(durable_path)
+    out = durable_path / "workspace"
+    assert _run(root, pin, out, "--version", "9.9.9", "--allow-version-mismatch") == 0
+    captured = capsys.readouterr()
+    assert "9.9.9" in captured.err and build._adapter_version() in captured.err
+    assert out.exists()
+    # The attested version reached the digest: same inputs, different version,
+    # different release_digest -- which is the whole reason the guard exists.
+    allowed_digest = json.loads(captured.out)["release_digest"]
+    matching = durable_path / "workspace-matching"
+    assert _run(root, pin, matching) == 0
+    assert allowed_digest != json.loads(capsys.readouterr().out)["release_digest"]
+
+
+def test_the_mismatch_override_cannot_be_set_by_accident(durable_path: Path, capsys: Any) -> None:
+    """Omitting the flag must refuse even when everything else is identical.
+
+    Guards the shape of the option rather than its effect: a ``store_true``
+    silently changed to ``default=True``, or the flag being read from the
+    environment, would make the override the default and re-open the defect
+    while every other test here still passed.
+    """
+
+    root, pin = _fixture_inputs(durable_path)
+    # Identical invocation, flag omitted -> refused, nothing written.
+    assert _run(root, pin, durable_path / "w-off", "--version", "9.9.9") == 2
+    assert not (durable_path / "w-off").exists()
+    capsys.readouterr()
+    # Same again with the flag -> allowed. The ONLY difference is the flag.
+    assert (
+        _run(root, pin, durable_path / "w-on", "--version", "9.9.9", "--allow-version-mismatch")
+        == 0
+    )
+    assert (durable_path / "w-on").exists()
+
+
+def test_a_version_that_cannot_be_determined_refuses_to_build(
+    durable_path: Path, capsys: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No declared version and no --version must produce no artifact.
+
+    Reachable in practice by running the script from outside the repository
+    (``parents[1]`` then misses the adapter's pyproject), which is simulated
+    here by pointing the module's pyproject constant at a path that does not
+    exist. A placeholder version would mint a real, well-formed workspace
+    attesting something unverifiable, and ``discovery.verify_release_manifest``
+    requires ``adapter-release.json`` to be exactly ``{"release_digest": ...}``
+    -- so the artifact could not record its own doubt even if we wanted it to.
+    """
+
+    monkeypatch.setattr(build, "_ADAPTER_PYPROJECT", durable_path / "absent" / "pyproject.toml")
+    root, pin = _fixture_inputs(durable_path)
+    out = durable_path / "workspace"
+    assert _run(root, pin, out) == 2
+    err = capsys.readouterr().err
+    assert "cannot determine the adapter version" in err
+    assert not out.exists()
+    # ...but an explicit version still builds: the refusal is about not
+    # KNOWING, not about the file being absent.
+    assert _run(root, pin, out, "--version", "0.1.1") == 0
+    assert out.exists()
+
+
+def test_the_staged_pilot_release_digest_is_reproduced_from_committed_values() -> None:
+    """The pinned attestation of the staged pilot, recomputed from the tree.
+
+    This is the regression test the original defect needed: with the stale
+    ``0.1.0`` default it yields ``a15961b1...`` instead, so it fails outright
+    on the bug rather than only on a guard's error message.
+
+    Hermetic because every input is committed or supplied here -- the adapter's
+    declared version, the release name and the task-hash manifest sha from
+    ``config/release-v2026.08.08.json``, plus the package digest of the wheel
+    the pilot installed. The COMPANION ``workspace_digest`` is deliberately not
+    asserted: it hashes the 4.2 GB gated corpus, which is an operator-fetched
+    input that CI does not have and must never download. That half is covered
+    structurally by the happy-path test above (a workspace ``workspace_digest``
+    accepts, rebuilt identically) and by the operator's build record.
+    """
+
+    pin = json.loads(build._DEFAULT_PIN.read_text())
+    digest = build._release_digest(
+        version=build._adapter_version() or "",
+        # The digest of the 0.1.1 wheel installed into the staged pilot venv.
+        package_digest="69e8504d9caa6732940ec59030dc149f83549da7155fb828fa9f7de677d5a736",
+        benchmark_release=pin["release"],
+        task_manifest_sha256=pin["tasks"]["hash_manifest_sha256"],
+    )
+    assert digest == "d0067e23af3dc2ed790c2a8b802ee453200d516466ad27770d7f2bbe7b0b41cd"
 
 
 def test_the_committed_release_pin_carries_the_known_hashes() -> None:


### PR DESCRIPTION
## What

Two defects in the documented OSWorld adapter build path, both found by actually rebuilding the pilot workspace against the fixed harness (0.44.42, adapter 0.1.1) rather than by reading the recipe. Each produces a broken or **silently wrong** artifact instead of an error at the point of the mistake.

This is a docs + operator-script fix. No adapter source, no harness runtime code, no test changes. No AWS writes; no spend.

## Defect 1 — the README venv recipe yields a dead interpreter (macOS)

`python3.12 -m venv --copies` copies the python binary but **not** `libpython3.12.dylib`, while the copied binary keeps `@rpath/libpython3.12.dylib` resolving against `<venv>/lib`. Every invocation then aborts in dyld:

```
dyld[90662]: Library not loaded: @rpath/libpython3.12.dylib
  Referenced from: .../venvs/0.1.1/bin/python3.12
  Reason: tried: '.../venvs/0.1.1/lib/libpython3.12.dylib' (no such file)
```

and `uv` surfaces only the opaque `Failed to inspect Python interpreter ... exit status signal: 6 (SIGABRT)`, which does not name the cause.

Compounding it: venv records the **invoking** `argv[0]`'s directory as `home` in `pyvenv.cfg`. Invoking through the `~/.local/bin/python3.12` shim records `home = ~/.local/bin` — a directory with no `lib/` at all — so even a dylib copy relative to `home` finds nothing.

The recipe now resolves the interpreter's real `sys.base_prefix`, invokes venv through that path, copies the dylib explicitly, and **verifies the interpreter runs** before anything is installed into it.

That this step was always required is confirmed by the previously staged pilot: `~/worktrees/osworld/venvs/0.1.0/lib/libpython3.12.dylib` exists and is byte-identical (`sha256 83d9a1e4…`) to the one copied here. It was done by hand during staging and never written down — so the committed recipe could not reproduce the artifact the pilot actually ran on.

## Defect 2 — `--version` defaulted to a stale literal, minting a wrong attestation

`scripts/build_osworld_adapter.py` defaulted `--version` to the literal `"0.1.0"`. The adapter bumped to `0.1.1` in #543, so the default had already drifted.

This is not cosmetic. `--version` is an input to `_release_digest`:

```
sha256("lop-osworld-v2-adapter" || version || package_digest || release_name || task_manifest_sha256)
```

so the stale default mints a workspace whose `release_digest` — the attestation a leaderboard number carries — names a distribution version **that was never built**. No digest check can catch it, because every digest is internally consistent with the wrong value. An operator who follows the README (which does not pass `--version`) gets it silently.

It now defaults to the adapter's own declared `pyproject.toml` version, so it cannot drift from the wheel again. Read from source rather than `importlib.metadata` on purpose: the script runs from the repo against a workspace built before (or without) the wheel being installed into the caller's interpreter.

#543 noted this and deferred it ("the operator passes `--version` explicitly at build time, so it is left unchanged here"). Rebuilding the workspace is what showed the deferral does not hold: the documented command line does not pass it.

## Also — two README claims corrected against what the script does

- **`--out` is the workspace directory itself**, not its parent. It is what the selector's `workspace` field and `workspace_digest` address. The old example (`--out .../workspaces/0.1.1`) puts the task corpus where the selector and `build-output.json` belong, i.e. inside the digest that describes them.
- **The locked set is exported to a file** kept beside the venv, since it is the record of what was actually installed, and the lock's own `local-operator` pin lags the harness (the substitution has to be stated, not improvised).

## Testing evidence — the recipe was executed, not just edited

The corrected instructions were run verbatim to build a fresh interpreter, and the fixed script was run to build a fresh workspace.

**Interpreter, from the corrected step 3/3a:**

```
BASE=/Users/damian/.local/share/uv/python/cpython-3.12.13-macos-aarch64-none
$ "$BASE/bin/python3.12" -m venv --copies --without-pip "$VENV"
$ cp "$BASE/lib/libpython3.12.dylib" "$VENV/lib/"
$ "$VENV/bin/python3.12" -V
Python 3.12.13                    # (before the fix: SIGABRT)
symlink? real file OK             # discovery._symlink_free
$ uv pip install --python "$VENV/bin/python3.12" --no-deps dist/lop_osworld_v2_adapter-0.1.1-py3-none-any.whl
 + lop-osworld-v2-adapter==0.1.1
```

**Full pilot venv built the same way** (420 packages, `--extra osworld`):

```
local-operator 0.44.42   lop-osworld-v2-adapter 0.1.1   osworld 0.1.0 @ d578d2d4
boto3 1.43.86   requests 2.34.2
uv pip check: Found 1 incompatibility
  osworld requires requests~=2.31.0, but 2.34.2 is installed   # the documented [tool.uv] override
```

**The `--version` fix reproduces the hand-specified digests.** Building with `--version 0.1.1` explicit, then again with the new default and no flag:

```
default version: 0.1.1
release_digest    d0067e23af3dc2ed790c2a8b802ee453200d516466ad27770d7f2bbe7b0b41cd
workspace_digest  c512802639615cc6daecadccbccf972e3cd2750e0b136972ab4ae36c00f2a5f1   -> identical
```

For contrast, the stale `0.1.0` default against the same inputs produced `release_digest a15961b1…` — a different attestation from the same bytes, which is the defect.

**Input verification is unweakened** (negative control). Appending one byte to a copy of `task_001.py` in a duplicated inputs root:

```
build_osworld_adapter: verification failed: task file sha256 mismatch: .../gated/tasks/task_001.py
exit=4     # and no workspace written
```

**The workspace built by these instructions runs.** A FakeProvider episode end to end on the new artifacts:

```
status=completed  score.binary=1  reportability=synthetic_model  comparability=comparable
verify_bundle: valid=True  issues=[]
find <workspace> -newer selector.json   ->  0 files
workspace_digest after the episode      ->  unchanged, equals the pin
osworld_tag_audit.py --region us-east-1 ->  []   exit 0
```

## Gates (whole tree, as CI)

- `flake8 .` — clean
- `black --check .` (26.1.0) — clean, 814 files unchanged
- `isort --check-only .` — clean
- `pyright` — **0 errors, 0 warnings**
- `pytest tests/unit` — **11104 passed, 15 skipped** (23m14s; host under load 100+)
- `pytest tests/unit/evaluation` re-run on the final commit — **707 passed**

## Not addressed

- `benchmarks/osworld_v2_adapter/uv.lock` still pins `local-operator==0.44.26`. Left alone deliberately: refreshing it re-resolves 420 packages and would change the dependency surface under a pilot that is staged and about to spend, which is not this PR's slice. The substitution is now documented in the recipe and recorded in the build record beside the venv.
- The dylib copy is guarded `2>/dev/null || true` and commented "macOS only"; a framework/system python that links libpython by absolute path does not need it. Not detected programmatically, because the recipe is a documented sequence an operator reads, not a script.
