### PR TITLE
feat(providers): send complete OpenRouter app attribution headers

### DIFF
--- a/local_operator/clients/openrouter.py
+++ b/local_operator/clients/openrouter.py
@@ -97,8 +97,10 @@ class OpenRouterClient:
         headers = {
             "Authorization": f"Bearer {self.api_key.get_secret_value()}",
             "Content-Type": "application/json",
-            "X-Title": self.app_title,
             "HTTP-Referer": self.http_referer,
+            "X-OpenRouter-Title": self.app_title,
+            "X-Title": self.app_title,
+            "X-OpenRouter-Categories": "cli-agent,personal-agent",
         }
 
         try:

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -387,7 +387,15 @@ class ValidationDescriptor:
 VALIDATION_ENDPOINTS: dict[str, ValidationDescriptor] = {
     "deepseek": ValidationDescriptor("https://api.deepseek.com/v1/models"),
     "openai": ValidationDescriptor("https://api.openai.com/v1/models"),
-    "openrouter": ValidationDescriptor("https://openrouter.ai/api/v1/models"),
+    "openrouter": ValidationDescriptor(
+        "https://openrouter.ai/api/v1/models",
+        extra_headers={
+            "HTTP-Referer": "https://local-operator.com",
+            "X-OpenRouter-Title": "Local Operator",
+            "X-Title": "Local Operator",
+            "X-OpenRouter-Categories": "cli-agent,personal-agent",
+        },
+    ),
     "radient": ValidationDescriptor("https://api.radienthq.com/v1/models"),
     "anthropic": ValidationDescriptor(
         "https://api.anthropic.com/v1/models",

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -88,6 +88,22 @@ class WireClient(Protocol):
 # ---------------------------------------------------------------------------
 
 
+def openrouter_attribution_headers() -> dict[str, str]:
+    """Attribution headers identifying Local Operator to OpenRouter.
+
+    OpenRouter uses these headers to credit requests to Local Operator in app
+    rankings and public showcase discovery. Both `X-Title` (backward-compatible
+    alias) and `X-OpenRouter-Title` (preferred modern header) are sent along with
+    the canonical referer and marketplace category tags.
+    """
+    return {
+        "HTTP-Referer": "https://local-operator.com",
+        "X-OpenRouter-Title": "Local Operator",
+        "X-Title": "Local Operator",
+        "X-OpenRouter-Categories": "cli-agent,personal-agent",
+    }
+
+
 def _error_payload(response: httpx.Response) -> Any:
     """The parsed error body, or ``None`` when it is not JSON.
 
@@ -2674,10 +2690,7 @@ def client_for_spec(
     )
     extra_headers = None
     if spec.provider == "openrouter":
-        extra_headers = {
-            "HTTP-Referer": "https://local-operator.com",
-            "X-Title": "Local Operator",
-        }
+        extra_headers = openrouter_attribution_headers()
     elif spec.provider == "kimi":
         # The OAuth grant is minted against a device fingerprint; every
         # inference call must present the same X-Msh-* headers or the provider

--- a/local_operator/skills/embeddings.py
+++ b/local_operator/skills/embeddings.py
@@ -33,7 +33,10 @@ from typing import Any, Callable, Protocol, runtime_checkable
 
 import httpx
 
-from local_operator.providers.clients import raise_for_status
+from local_operator.providers.clients import (
+    openrouter_attribution_headers,
+    raise_for_status,
+)
 from local_operator.providers.failover import (
     ProviderError,
     backoff_delay_ms,
@@ -311,10 +314,15 @@ class ApiEmbedder:
         """
         for attempt in range(1, EMBED_MAX_ATTEMPTS + 1):
             last = attempt >= EMBED_MAX_ATTEMPTS
+            headers: dict[str, str] = {"Authorization": f"Bearer {self.api_key}"}
+            # When proxying embedding calls through OpenRouter, provide app
+            # attribution headers so requests are properly identified and ranked.
+            if "openrouter.ai" in self.base_url:
+                headers.update(openrouter_attribution_headers())
             try:
                 response = await self._client.post(
                     f"{self.base_url}/embeddings",
-                    headers={"Authorization": f"Bearer {self.api_key}"},
+                    headers=headers,
                     json={"model": self.model, "input": texts},
                     timeout=60.0,
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.44"
+version = "0.44.45"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/clients/test_openrouter.py
+++ b/tests/unit/clients/test_openrouter.py
@@ -80,6 +80,18 @@ def test_list_models_success(
     with patch("requests.get", mock_requests_get):
         response = openrouter_client.list_models()
 
+    mock_requests_get.assert_called_once_with(
+        "https://openrouter.ai/api/v1/models",
+        headers={
+            "Authorization": "Bearer test_api_key",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://local-operator.com",
+            "X-OpenRouter-Title": "Local Operator",
+            "X-Title": "Local Operator",
+            "X-OpenRouter-Categories": "cli-agent,personal-agent",
+        },
+    )
+
     assert isinstance(response, OpenRouterListModelsResponse)
     assert len(response.data) == len(mock_model_data)
     for i, model in enumerate(response.data):

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -2550,7 +2550,13 @@ async def test_recovery_probe_failure_leaves_the_block_standing(tmp_path) -> Non
             {"data": [{"id": "test_model"}]},
             True,
             "https://openrouter.ai/api/v1/models",
-            {"Authorization": "Bearer test_key"},
+            {
+                "HTTP-Referer": "https://local-operator.com",
+                "X-OpenRouter-Title": "Local Operator",
+                "X-Title": "Local Operator",
+                "X-OpenRouter-Categories": "cli-agent,personal-agent",
+                "Authorization": "Bearer test_key",
+            },
         ),
         (
             "anthropic",

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -3836,6 +3836,23 @@ def test_client_for_spec_passes_anthropic_ttl_threshold() -> None:
     assert client._cache_ttl_1h_min_context_tokens == 123_456
 
 
+def test_client_for_spec_openrouter_attribution_headers() -> None:
+    """OpenRouter specs attach app attribution headers for rankings and discovery."""
+    from local_operator.providers.clients import openrouter_attribution_headers
+
+    expected = {
+        "HTTP-Referer": "https://local-operator.com",
+        "X-OpenRouter-Title": "Local Operator",
+        "X-Title": "Local Operator",
+        "X-OpenRouter-Categories": "cli-agent,personal-agent",
+    }
+    assert openrouter_attribution_headers() == expected
+
+    client = client_for_spec(_spec(provider="openrouter", model_id="anthropic/claude-3.5-sonnet"))
+    assert isinstance(client, OpenAICompatClient)
+    assert client._extra_headers == expected
+
+
 async def test_anthropic_usage_parses_cache_creation_ttl_split() -> None:
     """``usage.cache_creation`` splits the write count by TTL; both slices land
     on the Usage event and the sum still equals ``cache_write_tokens``."""

--- a/tests/unit/skills/test_embeddings.py
+++ b/tests/unit/skills/test_embeddings.py
@@ -113,6 +113,26 @@ class TestApiEmbedder:
         assert b"text-embedding-3-small" in captured["payload"]  # default model
 
     @pytest.mark.asyncio
+    async def test_openrouter_embeddings_include_attribution_headers(self) -> None:
+        """When targeting OpenRouter, ApiEmbedder sends app attribution headers."""
+        captured_headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, json={"data": [{"embedding": [0.6, 0.8]}]})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        embedder = ApiEmbedder(
+            base_url="https://openrouter.ai/api/v1", api_key="sk-or-test", client=client
+        )
+        await embedder.embed(["test text"])
+        assert captured_headers.get("http-referer") == "https://local-operator.com"
+        assert captured_headers.get("x-openrouter-title") == "Local Operator"
+        assert captured_headers.get("x-title") == "Local Operator"
+        assert captured_headers.get("x-openrouter-categories") == "cli-agent,personal-agent"
+        assert captured_headers.get("authorization") == "Bearer sk-or-test"
+
+    @pytest.mark.asyncio
     async def test_http_error_raises_embedding_error(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(500, json={"error": "boom"})


### PR DESCRIPTION
## Description
Sends complete OpenRouter application attribution and discovery metadata across all OpenRouter requests (inference/wire client, model listings, embeddings, and endpoint validation):
- `HTTP-Referer: https://local-operator.com`
- `X-OpenRouter-Title: Local Operator`
- `X-Title: Local Operator` (backwards-compatible alias)
- `X-OpenRouter-Categories: cli-agent,personal-agent`

Includes reusable helper `openrouter_attribution_headers()` in `local_operator.providers.clients` and comprehensive test coverage. Bump version to `0.44.45`.

## Evidence
- Unit tests added and passing in `test_clients.py`, `test_openrouter.py`, `test_embeddings.py`, and `test_configure.py`.
- Quality gates passed cleanly: `flake8`, `black --check`, `isort --check`, `pyright`.