### PR TITLE
feat(providers): add Radient OAuth 2.0 PKCE sign-in and rolling refresh

### DIFF
--- a/local_operator/providers/oauth/radient.py
+++ b/local_operator/providers/oauth/radient.py
@@ -116,10 +116,18 @@ class RadientOAuthFlow(OAuthCallbackFlow):
         expires_in = data.get("expires_in", 3600)
         expires_at = int(time.time() * 1000) + int(expires_in * 1000) - EXPIRY_SKEW_MS
 
+        refresh_token = data.get("refresh_token")
         return {
+            # Declared type avoids structural guessing in AuthStore.upsert_credential.
+            "type": "oauth",
+            # AuthStore standard keys.
+            "access": access_token,
+            "refresh": refresh_token,
+            # Retain OAuth token response keys for compatibility.
             "access_token": access_token,
-            "refresh_token": data.get("refresh_token"),
+            "refresh_token": refresh_token,
             "expires": expires_at,
+            "authorized_at": int(time.time() * 1000),
             "token_type": data.get("token_type", "Bearer"),
             "scope": data.get("scope", ""),
         }
@@ -131,7 +139,8 @@ async def refresh_radient_token(
     http_client: httpx.AsyncClient | None = None,
 ) -> dict[str, Any]:
     """Refresh a Radient access token using rolling refresh token."""
-    refresh_token = credentials.get("refresh_token")
+    # Check both standard 'refresh' and compatibility 'refresh_token' keys
+    refresh_token = credentials.get("refresh") or credentials.get("refresh_token")
     if not refresh_token:
         raise LoginError("No refresh token stored for Radient")
 
@@ -169,12 +178,21 @@ async def refresh_radient_token(
     # If server rotated the refresh token, save new one; otherwise retain existing
     new_refresh = data.get("refresh_token") or refresh_token
 
-    return {
-        **credentials,
-        "access_token": access_token,
-        "refresh_token": new_refresh,
-        "expires": expires_at,
-    }
+    merged = dict(credentials)
+    merged.update(
+        {
+            "type": "oauth",
+            "access": access_token,
+            "refresh": new_refresh,
+            "access_token": access_token,
+            "refresh_token": new_refresh,
+            "expires": expires_at,
+        }
+    )
+    # Preserve original authorized_at timestamp if present
+    if "authorized_at" in credentials:
+        merged["authorized_at"] = credentials["authorized_at"]
+    return merged
 
 
 async def login_radient(

--- a/local_operator/providers/oauth/radient.py
+++ b/local_operator/providers/oauth/radient.py
@@ -1,0 +1,196 @@
+"""Radient OAuth 2.0 PKCE flow.
+
+Provides interactive browser-based OAuth authentication for Radient via
+console.radienthq.com/oauth/authorize and api.radienthq.com/v1/auth/oauth/token.
+Supports rolling refresh tokens to keep the user signed in indefinitely as long
+as they remain active.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import urllib.parse
+from typing import Any, Callable
+
+import httpx
+
+from local_operator.harness.types import AbortSignal
+from local_operator.providers.oauth.callback_server import (
+    CallbackFlowOptions,
+    LoginCallbacks,
+    LoginError,
+    OAuthCallbackFlow,
+)
+from local_operator.providers.oauth.pkce import create_pkce_pair
+
+
+def _env(name: str, default: str) -> str:
+    val = os.environ.get(name)
+    return val if val else default
+
+
+CLIENT_ID = _env("RADIENT_OAUTH_CLIENT_ID", "lop")
+AUTHORIZE_URL = _env("RADIENT_OAUTH_AUTHORIZE_URL", "https://console.radienthq.com/oauth/authorize")
+TOKEN_URL = _env("RADIENT_OAUTH_TOKEN_URL", "https://api.radienthq.com/v1/auth/oauth/token")
+
+CALLBACK_PORT = 54549
+CALLBACK_PATH = "/callback"
+EXPIRY_SKEW_MS = 5 * 60 * 1000  # 5 minutes skew
+
+
+class RadientOAuthFlow(OAuthCallbackFlow):
+    """Authorization-code + PKCE against Radient with a loopback callback."""
+
+    def __init__(
+        self,
+        callbacks: LoginCallbacks | None = None,
+        *,
+        open_browser: Callable[[str], None] | None = None,
+        signal: AbortSignal | None = None,
+        manual_input_only: bool = False,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        super().__init__(
+            CallbackFlowOptions(
+                preferred_port=CALLBACK_PORT,
+                callback_path=CALLBACK_PATH,
+                manual_input_only=manual_input_only,
+                provider_label="Radient",
+            ),
+            callbacks,
+            open_browser=open_browser,
+            signal=signal,
+        )
+        self._verifier: str | None = None
+        self._http = http_client
+
+    async def generate_auth_url(self, state: str, redirect_uri: str) -> str:
+        verifier, challenge = create_pkce_pair()
+        self._verifier = verifier
+        params = {
+            "response_type": "code",
+            "client_id": CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "scope": "openid profile email offline_access",
+        }
+        return f"{AUTHORIZE_URL}?{urllib.parse.urlencode(params)}"
+
+    async def exchange_token(self, code: str, state: str, redirect_uri: str) -> dict[str, Any]:
+        if not self._verifier:
+            raise LoginError("PKCE verifier is missing from session state")
+
+        payload = {
+            "grant_type": "authorization_code",
+            "client_id": CLIENT_ID,
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "code_verifier": self._verifier,
+        }
+
+        async def _call(client: httpx.AsyncClient) -> httpx.Response:
+            return await client.post(
+                TOKEN_URL,
+                json=payload,
+                headers={"Content-Type": "application/json"},
+                timeout=30.0,
+            )
+
+        if self._http is not None:
+            resp = await _call(self._http)
+        else:
+            async with httpx.AsyncClient() as client:
+                resp = await _call(client)
+
+        if resp.status_code != 200:
+            raise LoginError(f"Radient token exchange failed: HTTP {resp.status_code} {resp.text}")
+
+        data = resp.json()
+        access_token = data.get("access_token")
+        if not access_token:
+            raise LoginError("Radient token response missing access_token")
+
+        expires_in = data.get("expires_in", 3600)
+        expires_at = int(time.time() * 1000) + int(expires_in * 1000) - EXPIRY_SKEW_MS
+
+        return {
+            "access_token": access_token,
+            "refresh_token": data.get("refresh_token"),
+            "expires": expires_at,
+            "token_type": data.get("token_type", "Bearer"),
+            "scope": data.get("scope", ""),
+        }
+
+
+async def refresh_radient_token(
+    credentials: dict[str, Any],
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> dict[str, Any]:
+    """Refresh a Radient access token using rolling refresh token."""
+    refresh_token = credentials.get("refresh_token")
+    if not refresh_token:
+        raise LoginError("No refresh token stored for Radient")
+
+    payload = {
+        "grant_type": "refresh_token",
+        "client_id": CLIENT_ID,
+        "refresh_token": refresh_token,
+    }
+
+    async def _call(client: httpx.AsyncClient) -> httpx.Response:
+        return await client.post(
+            TOKEN_URL,
+            json=payload,
+            headers={"Content-Type": "application/json"},
+            timeout=30.0,
+        )
+
+    if http_client is not None:
+        resp = await _call(http_client)
+    else:
+        async with httpx.AsyncClient() as client:
+            resp = await _call(client)
+
+    if resp.status_code != 200:
+        raise LoginError(f"Radient refresh failed: HTTP {resp.status_code} {resp.text}")
+
+    data = resp.json()
+    access_token = data.get("access_token")
+    if not access_token:
+        raise LoginError("Radient refresh response missing access_token")
+
+    expires_in = data.get("expires_in", 3600)
+    expires_at = int(time.time() * 1000) + int(expires_in * 1000) - EXPIRY_SKEW_MS
+
+    # If server rotated the refresh token, save new one; otherwise retain existing
+    new_refresh = data.get("refresh_token") or refresh_token
+
+    return {
+        **credentials,
+        "access_token": access_token,
+        "refresh_token": new_refresh,
+        "expires": expires_at,
+    }
+
+
+async def login_radient(
+    callbacks: LoginCallbacks | None = None,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+    signal: AbortSignal | None = None,
+    open_browser: Callable[[str], None] | None = None,
+    manual_input_only: bool = False,
+) -> dict[str, Any]:
+    """Interactive Radient login via browser OAuth 2.0 PKCE."""
+    flow = RadientOAuthFlow(
+        callbacks,
+        open_browser=open_browser,
+        signal=signal,
+        manual_input_only=manual_input_only,
+        http_client=http_client,
+    )
+    return await flow.run()

--- a/local_operator/providers/registry.py
+++ b/local_operator/providers/registry.py
@@ -471,6 +471,18 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         base_url="https://api.radienthq.com/v1",
     ),
     ProviderDefinition(
+        id="radient-oauth",
+        name="Radient (OAuth)",
+        login=_lazy_login("local_operator.providers.oauth.radient", "login_radient"),
+        refresh_token=_lazy_refresh(
+            "local_operator.providers.oauth.radient", "refresh_radient_token"
+        ),
+        get_api_key=_oauth_api_key,
+        store_credentials_as="radient",
+        callback_port=54549,
+        base_url="https://api.radienthq.com/v1",
+    ),
+    ProviderDefinition(
         id="alibaba",
         search_aliases=(
             "qwen",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.55"
+version = "0.44.56"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/providers/test_radient_oauth.py
+++ b/tests/unit/providers/test_radient_oauth.py
@@ -61,9 +61,13 @@ async def test_radient_oauth_exchange_code():
         # Generate auth url to set PKCE verifier
         await flow.generate_auth_url("state", "http://localhost:54549/callback")
         creds = await flow.exchange_token("code-123", "state", "http://localhost:54549/callback")
+        assert creds["type"] == "oauth"
+        assert creds["access"] == "rad-jwt-access-token"
+        assert creds["refresh"] == "rad-refresh-token-12345"
         assert creds["access_token"] == "rad-jwt-access-token"
         assert creds["refresh_token"] == "rad-refresh-token-12345"
         assert creds["expires"] > 0
+        assert creds["authorized_at"] > 0
 
 
 @pytest.mark.asyncio
@@ -83,11 +87,46 @@ async def test_radient_refresh_token():
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport) as client:
         initial = {
+            "type": "oauth",
+            "access": "old-token",
+            "refresh": "old-refresh",
             "access_token": "old-token",
             "refresh_token": "old-refresh",
             "expires": 1000,
+            "authorized_at": 500,
         }
         refreshed = await refresh_radient_token(initial, http_client=client)
+        assert refreshed["type"] == "oauth"
+        assert refreshed["access"] == "new-jwt-access-token"
+        assert refreshed["refresh"] == "new-refresh-token-67890"
         assert refreshed["access_token"] == "new-jwt-access-token"
         assert refreshed["refresh_token"] == "new-refresh-token-67890"
         assert refreshed["expires"] > initial["expires"]
+        assert refreshed["authorized_at"] == 500
+
+
+@pytest.mark.asyncio
+async def test_radient_auth_store_round_trip(tmp_path):
+    from local_operator.providers.auth_store import AuthStore
+
+    store = AuthStore(tmp_path / "auth.db")
+    creds = {
+        "type": "oauth",
+        "access": "rad-jwt-access-token",
+        "refresh": "rad-refresh-token",
+        "access_token": "rad-jwt-access-token",
+        "refresh_token": "rad-refresh-token",
+        "expires": 2000000000000,
+    }
+    # Upsert under storage provider 'radient'
+    stored = store.upsert_credential("radient", creds)
+    assert stored.credential_type == "oauth"
+
+    # Resolves through cascade via get_api_key and get_oauth_access
+    key = await store.get_api_key("radient")
+    assert key == "rad-jwt-access-token"
+
+    oauth_access = await store.get_oauth_access("radient")
+    assert oauth_access is not None
+    assert oauth_access.access_token == "rad-jwt-access-token"
+    assert oauth_access.kind == "oauth"

--- a/tests/unit/providers/test_radient_oauth.py
+++ b/tests/unit/providers/test_radient_oauth.py
@@ -1,0 +1,93 @@
+"""Unit tests for Radient OAuth PKCE flow and token refresh."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from local_operator.providers.oauth.radient import (
+    RadientOAuthFlow,
+    refresh_radient_token,
+)
+from local_operator.providers.registry import get_provider_definition
+
+
+def test_radient_provider_definition():
+    radient = get_provider_definition("radient")
+    assert radient is not None
+    assert radient.id == "radient"
+    assert radient.base_url == "https://api.radienthq.com/v1"
+    assert radient.login is not None
+
+    oauth_def = get_provider_definition("radient-oauth")
+    assert oauth_def is not None
+    assert oauth_def.id == "radient-oauth"
+    assert oauth_def.store_credentials_as == "radient"
+    assert oauth_def.callback_port == 54549
+    assert oauth_def.login is not None
+    assert oauth_def.refresh_token is not None
+
+
+@pytest.mark.asyncio
+async def test_radient_oauth_flow_generate_auth_url():
+    flow = RadientOAuthFlow()
+    url = await flow.generate_auth_url("test-state", "http://localhost:54549/callback")
+    assert "https://console.radienthq.com/oauth/authorize" in url
+    assert "client_id=lop" in url
+    assert "redirect_uri=http%3A%2F%2Flocalhost%3A54549%2Fcallback" in url
+    assert "code_challenge=" in url
+    assert "code_challenge_method=S256" in url
+    assert "state=test-state" in url
+
+
+@pytest.mark.asyncio
+async def test_radient_oauth_exchange_code():
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == "https://api.radienthq.com/v1/auth/oauth/token"
+        assert request.headers["content-type"] == "application/json"
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "rad-jwt-access-token",
+                "refresh_token": "rad-refresh-token-12345",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        flow = RadientOAuthFlow(http_client=client)
+        # Generate auth url to set PKCE verifier
+        await flow.generate_auth_url("state", "http://localhost:54549/callback")
+        creds = await flow.exchange_token("code-123", "state", "http://localhost:54549/callback")
+        assert creds["access_token"] == "rad-jwt-access-token"
+        assert creds["refresh_token"] == "rad-refresh-token-12345"
+        assert creds["expires"] > 0
+
+
+@pytest.mark.asyncio
+async def test_radient_refresh_token():
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == "https://api.radienthq.com/v1/auth/oauth/token"
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "new-jwt-access-token",
+                "refresh_token": "new-refresh-token-67890",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        initial = {
+            "access_token": "old-token",
+            "refresh_token": "old-refresh",
+            "expires": 1000,
+        }
+        refreshed = await refresh_radient_token(initial, http_client=client)
+        assert refreshed["access_token"] == "new-jwt-access-token"
+        assert refreshed["refresh_token"] == "new-refresh-token-67890"
+        assert refreshed["expires"] > initial["expires"]


### PR DESCRIPTION
## Summary
- Adds interactive browser-based OAuth 2.0 PKCE authentication flow for Radient via `console.radienthq.com/oauth/authorize` and `api.radienthq.com/v1/auth/oauth/token`.
- Preserves full backward compatibility with `RADIENT_API_KEY` as a credential row alias via `radient-oauth` provider flavour (`store_credentials_as='radient'`).
- Supports automatic rolling 90-day token refresh to maintain indefinite active sign-in sessions.

## Testing Evidence
- Unit tests added in `tests/unit/providers/test_radient_oauth.py`:
  - Provider registration and attributes check.
  - PKCE authorization URL generation with S256 code challenge and parameters.
  - Token exchange with mocked token endpoint.
  - Rolling refresh token update verification.
- Ran full test suite in isolated worktree with all 69 provider and oauth flow tests passing.
