### PR TITLE
feat(tui): spend the transcript's colour budget on outcome, structure and tool identity

### DIFF
--- a/local_operator/tui/bindings.py
+++ b/local_operator/tui/bindings.py
@@ -1,0 +1,706 @@
+"""The element -> token binding table for the transcript and tool row.
+
+Design proposal: `docs/proposals/theme-colour-budget.md` §2. Before this
+module, ``element -> token`` lived as inline ``Style(color=semantic_color(...))``
+calls scattered across ``markdown_theme.py`` and ``tool_card.py`` (§2.1) — no
+object existed to enumerate elements from, so a rebinding was a multi-file
+edit with no way to see the whole map, and the perceptual-distinctness gate
+§4 wants could not be written at all.
+
+:data:`BINDINGS` is the single source of truth. Widgets no longer call
+``theme.semantic_color`` directly for the transcript/tool-row surfaces they
+own; they resolve a stable element id through :func:`style`,
+:func:`markdown_theme` or :func:`syntax_styles` instead. ``semantic_color``
+itself stays public and unchanged (§2.2) — 365 call sites across 27 files
+reach it, and this table covers only the two surfaces the colour-budget
+proposal measured and changed.
+
+This module imports :mod:`local_operator.tui.theme` and nothing else in the
+TUI, so it stays importable from a test with no app running.
+
+**Role, by convention** (not derived — written per binding so the table stays
+self-documenting): a binding's :class:`Role` reflects what question THIS
+USE of the ink answers, not merely which token it happens to spend.
+``warning`` (amber) is one of the budget's three OUTCOME tokens (§1.2), but
+the syntax ramp's ``code.string``/``code.number``/``code.keyword_constant``
+spend it on code LITERALS, not on "did this work?" — so those three are
+:attr:`Role.NEUTRAL` despite the token, matching §1.5's "syntax highlighting
+... is inside budget" (an accepted existing use, not a new one). The inverse
+case is ``markdown.h1``: it spends `accent`, whose canonical role is
+LIVENESS, to buy document STRUCTURE (§1.3, Rule C) — there is no fourth
+"structure" role in the enum, and §8 risk 2 frames the h1 accent explicitly
+as growing the LIVENESS accent-site count from four to five ("the accent
+list grows ... a sixth requires removing one"), so it is counted there
+rather than invented a role that would let it dodge the budget it is
+spending against.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping
+
+from pygments.token import (
+    Comment,
+    Error,
+    Generic,
+    Keyword,
+    Name,
+    Number,
+    Operator,
+    Punctuation,
+    String,
+    Token,
+    _TokenType,
+)
+from rich.style import Style
+from rich.theme import Theme
+
+from local_operator.tui import theme as theme_mod
+
+_C = theme_mod.semantic_color
+
+
+class Role(Enum):
+    """Which of the budget's three spending questions (§1.2) a hue answers.
+
+    ``NEUTRAL`` is the ramp everything else lives on. ``GROUND`` is not a
+    spending category at all — it marks a binding that paints a SURFACE
+    (a background token) rather than ink on one, kept separate so the
+    budget conformance check (§2.5 check 3, §4.2) can filter grounds out
+    before counting hues.
+    """
+
+    OUTCOME = "outcome"
+    REFERENCE = "reference"
+    LIVENESS = "liveness"
+    NEUTRAL = "neutral"
+    GROUND = "ground"
+
+
+class Surface(Enum):
+    """Where an element can appear on screen.
+
+    The unit the distinctness gate (§4.2) scopes its pairwise checks to: a
+    picker row and a code comment are never on screen together, so demanding
+    they be perceptually distinct would be the over-strict gate that fails
+    every theme for a collision nobody can see (§2.2).
+    """
+
+    TRANSCRIPT = "transcript"
+    TOOL_ROW = "tool_row"
+    PICKER = "picker"
+    STATUS = "status"
+    PANEL = "panel"
+
+
+@dataclass(frozen=True)
+class Binding:
+    """One thing the user can see, and the ink it is painted in."""
+
+    #: Stable id, e.g. ``"tool.status.success_glyph"`` or ``"markdown.h1"``.
+    element: str
+    #: A :data:`theme.SEMANTIC_TOKENS` member.
+    token: str
+    #: The token of the surface this element renders ON. Documentation for
+    #: the future contrast/distinctness gates, not consumed by :func:`style`
+    #: — the widget's own background (a TCSS rule or a sibling GROUND
+    #: binding) is what actually paints the ground.
+    ground: str
+    role: Role
+    surface: Surface
+    bold: bool = False
+    #: The design rationale, moved here VERBATIM from its old call site.
+    note: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Markdown prose (`markdown_theme.brand_markdown_theme`, §2.1 ~20 entries).
+# Surface: TRANSCRIPT. Ground: `bg` — the island ground behind AssistantBlock
+# and RichBlock text; there is no elevation step for prose (local_operator.tcss
+# AssistantBlock/RichBlock carry no `background:` of their own).
+# ---------------------------------------------------------------------------
+_MARKDOWN_BINDINGS: tuple[Binding, ...] = (
+    Binding("markdown.paragraph", "fg", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding("markdown.text", "fg", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding("markdown.em", "fg", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding("markdown.strong", "fg", "bg", Role.NEUTRAL, Surface.TRANSCRIPT, bold=True),
+    Binding(
+        "markdown.code",
+        "signal",
+        "bg",
+        Role.REFERENCE,
+        Surface.TRANSCRIPT,
+        note=(
+            "`signal`, not `string`: inline code in agent prose is overwhelmingly "
+            "file paths and identifiers, which is the case theme.py reserves "
+            "`signal` for. It also frees the greens to mean only "
+            'added-or-succeeded rather than doubling as "code literal".'
+        ),
+    ),
+    # `code_block` needs an explicit `bg` PAINT on top of its `fg` ink (the
+    # original literal set both `color` and `bgcolor`) — one element, two
+    # tokens. The table names one ink per element; `markdown_theme()` adds
+    # the ground explicitly for this one binding via its own `ground` field.
+    # See the module docstring in `markdown_theme.py` for why: a bare-ink
+    # `Style` here would inherit whatever background rich composits under
+    # it, which for a fenced block should always be the island `bg`.
+    Binding("markdown.code_block", "fg", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding(
+        "markdown.block_quote",
+        "label",
+        "bg",
+        Role.REFERENCE,
+        Surface.TRANSCRIPT,
+        note=(
+            "A quote is someone ELSE'S words inside the answer — a log line, "
+            "a spec, a message being replied to. On `muted` it was the same "
+            "ink as a settled tool name and h3, so the one thing a reader "
+            "most needs to know about it (this is not the assistant talking) "
+            "was carried only by the leading glyph. `label` marks it as meta "
+            "and the italic does the rest; rich draws no quote gutter here, "
+            "so ink and slant are the only channels available."
+        ),
+    ),
+    Binding("markdown.list", "fg", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding(
+        "markdown.item.bullet",
+        "label",
+        "bg",
+        Role.REFERENCE,
+        Surface.TRANSCRIPT,
+        note=(
+            "The MARKER, never the item's text. A list is the shape agent "
+            "output takes most often — findings, steps, options — and on `dim` "
+            "the markers were the same ink as the success glyph, the duration "
+            "and the expand hint, so the one cue that says 'these are "
+            "countable, parallel things' was the quietest mark on the row. "
+            "`label` is the ramp's meta hue and already means 'structure "
+            "about the content rather than the content', which is exactly "
+            "what a bullet is. It is one glyph per line, so the hue costs "
+            "almost no area — the item text stays `fg` and unchanged."
+        ),
+    ),
+    Binding(
+        "markdown.item.number",
+        "label",
+        "bg",
+        Role.REFERENCE,
+        Surface.TRANSCRIPT,
+        note="The ordinal, same argument as `markdown.item.bullet`.",
+    ),
+    Binding(
+        "markdown.hr",
+        "dim",
+        "bg",
+        Role.NEUTRAL,
+        Surface.TRANSCRIPT,
+        note=(
+            "`dim`, not `edge`. A horizontal rule is a drawn object the "
+            "reader is meant to SEE; `edge` is the hairline-border token, and "
+            "bound as ink it measures under 3:1 against `bg` — WCAG's floor "
+            "for a non-text graphical object — in 54 of 54 themes, and under "
+            "1.5:1 in 42 of them (min 1.10:1, rose-pine-moon). That is a "
+            "binding defect, not a palette defect: no theme can fix it by "
+            "choosing a better `edge`, because a visible `edge` would stop "
+            "being a hairline. `dim` is the sheet's own separator ink and "
+            "clears 3:1 in all 54 (min 3.61:1)."
+        ),
+    ),
+    # h1 is the ONE structural hue the budget allows (§1.2 Rule C) — see the
+    # module docstring for why this is classified LIVENESS (the token's
+    # canonical role) rather than a role the enum does not have.
+    Binding(
+        "markdown.h1",
+        "accent",
+        "bg",
+        Role.LIVENESS,
+        Surface.TRANSCRIPT,
+        bold=True,
+        note=(
+            "Headings carry a real three-step ramp. With no rules, panels, "
+            "or size changes available in a terminal, WEIGHT and TINT are "
+            "the only depth cues there are — h5/h6 previously matched h3/h4 "
+            "minus the bold, which flattened the tail of long documents "
+            "into a single indistinguishable level.\n\n"
+            "h1 is the exception, and it is the ONE structural hue the "
+            "budget allows: h1, h2 and strong were all literally "
+            "`Style(color=fg, bold=True)` — identical pixels — so a long "
+            "answer had no top-level anchor and every bolded phrase in the "
+            "prose competed with the title. Lightness is the axis with the "
+            "least room left on it (h2-h6 already spend three rungs of it), "
+            "so the anchor is bought with hue instead. Once per document, "
+            "and h2-h6 stay on the neutral ramp: this is the whole "
+            "structural allowance, not the start of a heading palette. "
+            "It makes h1 a fifth accent site — see local_operator.tcss."
+        ),
+    ),
+    Binding(
+        "markdown.h2",
+        "label",
+        "bg",
+        Role.REFERENCE,
+        Surface.TRANSCRIPT,
+        bold=True,
+        note=(
+            "`label`, not `fg`. h2 is the level assistants ACTUALLY emit — a "
+            "reply is `## What I found` / `## What I changed` all the way "
+            "down, and `#` is nearly never written — so this is the heading "
+            "that carries structure in practice. On `fg` it was byte-identical "
+            "to `markdown.strong` (same hex, same weight), which made a "
+            "section header and a bolded phrase the same pixels: the reader "
+            "had no way to tell where a section began. h1 already spends the "
+            "one structural accent, and a second accent site would break the "
+            "enumeration in local_operator.tcss, so h2 takes `label` — the "
+            "ramp's meta hue, already distinct from prose, and the only token "
+            "that separates the two without growing the accent budget."
+        ),
+    ),
+    Binding("markdown.h3", "muted", "bg", Role.NEUTRAL, Surface.TRANSCRIPT, bold=True),
+    Binding("markdown.h4", "muted", "bg", Role.NEUTRAL, Surface.TRANSCRIPT, bold=True),
+    Binding("markdown.h5", "dim", "bg", Role.NEUTRAL, Surface.TRANSCRIPT, bold=True),
+    Binding("markdown.h6", "dim", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding("markdown.link", "signal", "bg", Role.REFERENCE, Surface.TRANSCRIPT),
+    Binding("markdown.link_url", "signal", "bg", Role.REFERENCE, Surface.TRANSCRIPT),
+)
+
+# ---------------------------------------------------------------------------
+# Code fence syntax ramp (`IslandSyntaxTheme`, §2.1 14 entries). Surface:
+# TRANSCRIPT. Ground: `bg`, same as the markdown prose it sits inside.
+# ---------------------------------------------------------------------------
+_CODE_BINDINGS: tuple[Binding, ...] = (
+    Binding("code.token", "fg", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding("code.comment", "dim", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding(
+        "code.keyword",
+        "muted",
+        "bg",
+        Role.NEUTRAL,
+        Surface.TRANSCRIPT,
+        note=(
+            "NOT accent: syntax highlighting would spend the running-indicator "
+            "budget on every `def` in the transcript. Keywords are already "
+            "distinguished by position, and the ramp keeps Name.Function at muted."
+        ),
+    ),
+    # `warning` (amber) here is the code-literal hue, not the outcome hue —
+    # see the module docstring for why this is NEUTRAL despite the token.
+    Binding(
+        "code.keyword_constant",
+        "warning",
+        "bg",
+        Role.NEUTRAL,
+        Surface.TRANSCRIPT,
+        note=(
+            "`warning` (amber), NOT `string`. The `string` token resolves to the "
+            "same hex as `success`, which is the diff-added green — so a fence "
+            'containing a literal put `"ok"` and a write row\'s `+12` in one '
+            "viewport in one colour, and that pairing (a code block beside a "
+            "tool row) is the single most common shape of agent output. Amber "
+            "already carries Number and Keyword.Constant, so this groups every "
+            "LITERAL under one hue and leaves the green meaning only "
+            '"added or succeeded".'
+        ),
+    ),
+    Binding("code.name", "fg", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding("code.name_function", "muted", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding("code.name_class", "muted", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding("code.name_builtin", "muted", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding("code.string", "warning", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding("code.number", "warning", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding("code.operator", "muted", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding("code.punctuation", "dim", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding("code.error", "danger", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    Binding("code.generic", "fg", "bg", Role.NEUTRAL, Surface.TRANSCRIPT),
+    # The fence's own background (`IslandSyntaxTheme.get_background_style`
+    # and the `Syntax(..., background_color=...)` argument in
+    # `IslandCodeBlock`). A GROUND binding renders ON itself: it establishes
+    # the surface rather than sitting on one.
+    Binding("code.background", "bg", "bg", Role.GROUND, Surface.TRANSCRIPT),
+)
+
+#: `IslandSyntaxTheme`'s pygments token -> element name. Kept here, next to
+#: the bindings it names, rather than in `markdown_theme.py`: this table IS
+#: the "one place" the element vocabulary is declared.
+_SYNTAX_TOKEN_ELEMENTS: tuple[tuple[_TokenType, str], ...] = (
+    (Token, "code.token"),
+    (Comment, "code.comment"),
+    (Keyword, "code.keyword"),
+    (Keyword.Constant, "code.keyword_constant"),
+    (Name, "code.name"),
+    (Name.Function, "code.name_function"),
+    (Name.Class, "code.name_class"),
+    (Name.Builtin, "code.name_builtin"),
+    (String, "code.string"),
+    (Number, "code.number"),
+    (Operator, "code.operator"),
+    (Punctuation, "code.punctuation"),
+    (Error, "code.error"),
+    (Generic, "code.generic"),
+)
+
+# ---------------------------------------------------------------------------
+# Tool row (`widgets/tool_card.py`, §2.1 ~28 call sites). Surface: TOOL_ROW.
+# Ground varies with the card's state: `surface` once settled, `raised`
+# while running, `tint-danger` when failed (local_operator.tcss ToolCard
+# rules). A handful of elements (args/output body ink) render across more
+# than one of those grounds depending on state; each is given the ground it
+# predominantly appears against and the ambiguity is called out in the
+# handoff rather than modelled — the table has no per-state ground axis.
+# ---------------------------------------------------------------------------
+_TOOL_ROW_BINDINGS: tuple[Binding, ...] = (
+    # -- _append_live_body: the running card's own block ------------------
+    Binding("tool.live.dim", "dim", "raised", Role.NEUTRAL, Surface.TOOL_ROW),
+    Binding(
+        "tool.live.header",
+        "accent",
+        "raised",
+        Role.LIVENESS,
+        Surface.TOOL_ROW,
+        note=(
+            "Accent, the same ink the running icon spends: this row is the "
+            'card\'s answer to "is it alive", and it has to survive a still frame.'
+        ),
+    ),
+    # -- _append_input_body: arguments -------------------------------------
+    Binding("tool.args.dim", "dim", "surface", Role.NEUTRAL, Surface.TOOL_ROW),
+    Binding("tool.args.label", "label", "surface", Role.REFERENCE, Surface.TOOL_ROW),
+    Binding("tool.args.value", "fg", "surface", Role.NEUTRAL, Surface.TOOL_ROW),
+    # -- _append_output_body: plain result expansion -----------------------
+    Binding("tool.output.dim", "dim", "surface", Role.NEUTRAL, Surface.TOOL_ROW),
+    Binding("tool.output.error", "danger", "tint-danger", Role.OUTCOME, Surface.TOOL_ROW),
+    # -- _append_search_body ------------------------------------------------
+    Binding("tool.search.dim", "dim", "surface", Role.NEUTRAL, Surface.TOOL_ROW),
+    Binding("tool.search.title", "fg", "surface", Role.NEUTRAL, Surface.TOOL_ROW, bold=True),
+    Binding("tool.search.url", "signal", "surface", Role.REFERENCE, Surface.TOOL_ROW),
+    Binding(
+        "tool.search.snippet",
+        "muted",
+        "surface",
+        Role.NEUTRAL,
+        Surface.TOOL_ROW,
+        note=(
+            "Snippets and the actionable footer must meet normal-text "
+            "contrast; `dim` is reserved for structural metadata."
+        ),
+    ),
+    # -- _append_fetch_body ---------------------------------------------------
+    Binding("tool.fetch.dim", "dim", "surface", Role.NEUTRAL, Surface.TOOL_ROW),
+    Binding(
+        "tool.fetch.signal",
+        "signal",
+        "surface",
+        Role.REFERENCE,
+        Surface.TOOL_ROW,
+        note=(
+            "D3: the final URL is the card's anchor, so it rides `signal` "
+            "blue like web_search's URLs instead of receding into the dim "
+            'metadata. The "Fetched:" label and the trailing `· status · '
+            "ctype · cache` metadata stay dim; only the URL(s) lift.\n\n"
+            "Reused for the `sparse/JS-gated` advisory row: the one advisory "
+            "row earns attention: it is the signal to reach for browser, "
+            "not structural chrome."
+        ),
+    ),
+    Binding("tool.fetch.snippet", "muted", "surface", Role.NEUTRAL, Surface.TOOL_ROW),
+    Binding(
+        "tool.fetch.error",
+        "danger",
+        "surface",
+        Role.OUTCOME,
+        Surface.TOOL_ROW,
+        bold=True,
+        note=(
+            "F1: the non-2xx error row rides `danger`, bold — the strongest "
+            "treatment on the card, so a block/error page cannot be mistaken "
+            "for successful content. Matches the tool result's is_error flag."
+        ),
+    ),
+    # -- _append_diff_body ----------------------------------------------------
+    Binding("tool.diff.added", "success", "surface", Role.OUTCOME, Surface.TOOL_ROW),
+    Binding("tool.diff.removed", "danger", "surface", Role.OUTCOME, Surface.TOOL_ROW),
+    Binding("tool.diff.hunk", "muted", "surface", Role.NEUTRAL, Surface.TOOL_ROW),
+    Binding("tool.diff.context", "dim", "surface", Role.NEUTRAL, Surface.TOOL_ROW),
+    # -- _build_row: the one-line summary ------------------------------------
+    Binding("tool.row.dim", "dim", "surface", Role.NEUTRAL, Surface.TOOL_ROW),
+    Binding(
+        "tool.row.name_running",
+        "string",
+        "raised",
+        Role.NEUTRAL,
+        Surface.TOOL_ROW,
+        note=(
+            "Two-step fade on settle: the live row keeps the string green on "
+            "the name and readable `muted` body text; a settled row drops both "
+            "one step so the running row is the brightest thing on screen. "
+            "Composing counts as live: the model is actively producing this "
+            "call, and a row that dimmed while its arguments streamed would "
+            "read as a finished action rather than as the one thing "
+            "currently happening."
+        ),
+    ),
+    Binding(
+        "tool.row.name_settled",
+        "muted",
+        "surface",
+        Role.NEUTRAL,
+        Surface.TOOL_ROW,
+        note=(
+            "The fallback for a tool with no category — an MCP call, or a "
+            "builtin this table has not classified. Categorised tools use "
+            "`tool.row.name_<category>` below; this stays the neutral it has "
+            "always been so an unknown tool is quiet rather than mis-filed."
+        ),
+    ),
+    # A settled row's name, by what the tool DID. Before this the whole ledger
+    # was one grey, so the only rows carrying any hue at all were the failed
+    # one and the running one — you could see that something broke, but not
+    # scan for what touched your files.
+    #
+    # Liveness still wins: `_build_row` only reaches these once a row has
+    # settled, so the running row keeps `tool.row.name_running` and there is
+    # exactly one mechanism per meaning. Identity is a property of a finished
+    # row; "what is happening now" outranks "what kind of thing it was".
+    Binding(
+        "tool.row.name_read",
+        "tool-read",
+        "surface",
+        Role.REFERENCE,
+        Surface.TOOL_ROW,
+        note=(
+            "Looked at the world, changed nothing: read, glob, grep, "
+            "web_fetch, web_search, browser, the variable readers. Derives "
+            "from `signal`, whose contract is already 'links, file paths' — "
+            "reading is reference-shaped, so the default costs no new hue."
+        ),
+    ),
+    Binding(
+        "tool.row.name_mutate",
+        "tool-mutate",
+        "surface",
+        Role.NEUTRAL,
+        Surface.TOOL_ROW,
+        note=(
+            "Changed a file: write, edit. Derives from `muted` — deliberately "
+            "NOT `warning`. A row that edited a file is not a warning, and "
+            "borrowing the alarm hue would both lie about the row and hand "
+            "control of tool names to whoever tunes `warning`. A theme that "
+            "wants edits to stand out authors `tool-mutate`."
+        ),
+    ),
+    Binding(
+        "tool.row.name_exec",
+        "tool-exec",
+        "surface",
+        Role.NEUTRAL,
+        Surface.TOOL_ROW,
+        note=(
+            "Ran something: bash, eval. Derives from `muted` for the same "
+            "reason as mutate — the neutral ramp, not an outcome hue."
+        ),
+    ),
+    Binding(
+        "tool.row.name_meta",
+        "tool-meta",
+        "surface",
+        Role.REFERENCE,
+        Surface.TOOL_ROW,
+        note=(
+            "Coordination rather than work on the machine: task, agent, hub, "
+            "todo, send, wake, ask. Derives from `label`, whose contract is "
+            "already 'violet meta: tips, skill labels' — the closest existing "
+            "match, so again no new hue by default."
+        ),
+    ),
+    Binding("tool.row.summary_running", "muted", "raised", Role.NEUTRAL, Surface.TOOL_ROW),
+    Binding("tool.row.summary_settled", "dim", "surface", Role.NEUTRAL, Surface.TOOL_ROW),
+    Binding(
+        "tool.row.chip_running",
+        "dim",
+        "raised",
+        Role.NEUTRAL,
+        Surface.TOOL_ROW,
+        note=(
+            "Chrome quieter than the fact while live (the summary is "
+            "`muted` there); one step BRIGHTER than the fact once settled, "
+            "when the summary drops to `dim` — the attribution is the thing "
+            "a reader scrolling back is hunting for, and a chip that faded "
+            "to the same ink as the command stopped separating the two "
+            "(design round 1, D1). It survives every shed rung because the "
+            "budget above already paid for it."
+        ),
+    ),
+    Binding("tool.row.chip_settled", "muted", "surface", Role.NEUTRAL, Surface.TOOL_ROW),
+    Binding(
+        "tool.row.icon_running",
+        "accent",
+        "raised",
+        Role.LIVENESS,
+        Surface.TOOL_ROW,
+        note=(
+            "The icon carries the running state: accent while live (D26 — a "
+            'still frame must read "live" without the shimmer), dim once '
+            "settled. This is one of the five places in the app the accent "
+            "green is spent."
+        ),
+    ),
+    Binding("tool.row.icon_settled", "dim", "surface", Role.NEUTRAL, Surface.TOOL_ROW),
+    Binding(
+        "tool.row.slot_offer",
+        "dim",
+        "surface",
+        Role.NEUTRAL,
+        Surface.TOOL_ROW,
+        note=(
+            "Generic tool output stays quiet until the row is targeted. "
+            "Search sources are the primary result, not diagnostics, so "
+            "their disclosure remains visible at rest and in colorless "
+            "terminals."
+        ),
+    ),
+    Binding(
+        "tool.row.slot_notice",
+        "muted",
+        "surface",
+        Role.NEUTRAL,
+        Surface.TOOL_ROW,
+        note=(
+            "`muted`, one step brighter than the offer's `dim`: this is not "
+            "something the eye may skip. Walk the ladder — full phrase, then "
+            "the three-cell glyph — and take the first rung the row can hold "
+            "with nothing reserved for the summary. Only when even ⟨∅⟩ will "
+            "not fit does the answer go unsaid, and by then the row is down "
+            "to its icon and its outcome anyway."
+        ),
+    ),
+    # -- _status_runs: the running-row duration ------------------------------
+    Binding("tool.status.running_duration", "dim", "raised", Role.NEUTRAL, Surface.TOOL_ROW),
+    # -- _diff_runs: the status column's +N/-N pill --------------------------
+    Binding("tool.status.diff_added", "success", "surface", Role.OUTCOME, Surface.TOOL_ROW),
+    Binding("tool.status.diff_removed", "danger", "surface", Role.OUTCOME, Surface.TOOL_ROW),
+    # -- _outcome_runs: the settled glyph + duration -------------------------
+    Binding("tool.status.duration", "dim", "surface", Role.NEUTRAL, Surface.TOOL_ROW),
+    Binding(
+        "tool.status.success_glyph",
+        "success",
+        "surface",
+        Role.OUTCOME,
+        Surface.TOOL_ROW,
+        note=(
+            "The GLYPH carries `success`; the duration stays `dim`. This "
+            'narrows D12 ("success is quiet — check + duration both dim"), '
+            "and the half it keeps is the important half: a ledger where "
+            "every completed row shouts is a ledger nobody scans.\n\n"
+            "What it overturns is quiet implemented as BRIGHTNESS, which is "
+            "the axis the whole transcript already competes on. Measured on a "
+            "rendered frame, the outcome (`✓`), the cost (`0.4s`) and the "
+            "affordance (`⟨expand⟩`) came out in ONE hex on the same row — "
+            "three different kinds of fact in one ink, so an operator hunting "
+            "twenty rows for the one that failed was scanning for a shape and "
+            "the colour channel carried nothing. Hue at low salience was "
+            "available and unspent: `success` is defined by every theme and "
+            "ships at >=4.0:1 on `surface` in all 54.\n\n"
+            "The row stays quiet in the sense that matters — the glyph is ONE "
+            "cell, the duration and command stay neutral, the row's ground is "
+            "unchanged. Same trade theme.py:50-55 already made for "
+            "`tint-select`, where pure luminance steps measured 1.096:1 and "
+            "were found imperceptible: D12 reached for the axis that token "
+            "had already been shown to have no room on.\n\n"
+            "The duration is a COST, not an outcome, so it keeps `dim` — as "
+            "does the expand hint, which is an affordance. `NoticeKind.success` "
+            "stays `fg` (transcript.py): that rationale is about three greens "
+            "on one surface, and this puts the green on the tool row, which is "
+            "exactly where the notice was told not to put a second one."
+        ),
+    ),
+    # `interrupted` is deliberately NOT re-tinted to an outcome hue: the
+    # docstring's contract is that ✓/✗/⊘ separate by SHAPE alone in a
+    # colourless frame, and interrupted stays on the neutral ramp so that
+    # contract is not quietly walked back by a future palette author reaching
+    # for a fourth outcome colour.
+    Binding("tool.status.interrupted", "dim", "surface", Role.NEUTRAL, Surface.TOOL_ROW),
+    Binding("tool.status.error_glyph", "danger", "tint-danger", Role.OUTCOME, Surface.TOOL_ROW),
+)
+
+BINDINGS: tuple[Binding, ...] = _MARKDOWN_BINDINGS + _CODE_BINDINGS + _TOOL_ROW_BINDINGS
+
+#: Derived index. Built once at import time — `BINDINGS` is a module-level
+#: constant tuple, never mutated after definition.
+BY_ELEMENT: Mapping[str, Binding] = {binding.element: binding for binding in BINDINGS}
+
+assert len(BY_ELEMENT) == len(BINDINGS), "duplicate element id in BINDINGS"
+
+
+def style(element: str) -> Style:
+    """Resolve one binding to a rich ``Style`` against the current theme.
+
+    ``Role.GROUND`` bindings paint a background (they ARE a surface, not
+    ink on one); everything else paint foreground colour, plus ``bold=True``
+    when the binding asks for it. ``bold`` is passed only when ``True`` and
+    left unset (``None``) otherwise, matching every pre-refactor call site —
+    none of them passed ``bold=False`` explicitly. Rich's ``Style`` treats
+    ``bold=None`` (inherit whatever composites underneath, e.g. `markdown.code`
+    nested inside `markdown.strong`) and ``bold=False`` (force it off)
+    differently, so passing ``False`` here would be a real behaviour change,
+    not a no-op.
+    """
+    binding = BY_ELEMENT[element]
+    if binding.role is Role.GROUND:
+        return Style(bgcolor=_C(binding.token))
+    if binding.bold:
+        return Style(color=_C(binding.token), bold=True)
+    return Style(color=_C(binding.token))
+
+
+def markdown_theme() -> Theme:
+    """Element-style theme for rich ``Markdown``, replacing the inline dict
+    that used to live at ``markdown_theme.py:125-157``.
+
+    Three elements need more than :func:`style` gives them: ``markdown.em``
+    and ``markdown.block_quote`` are italic, and ``markdown.link_url`` is
+    underlined. Neither is a colour
+    decision the budget tracks, so they are composed on top here rather than
+    adding non-colour fields to :class:`Binding`. ``markdown.code_block``
+    similarly needs its `ground` painted explicitly (see the binding's note)
+    on top of its ink.
+    """
+    styles = {element: style(element) for element in _element_names(_MARKDOWN_BINDINGS)}
+    styles["markdown.em"] = styles["markdown.em"] + Style(italic=True)
+    styles["markdown.block_quote"] = styles["markdown.block_quote"] + Style(italic=True)
+    styles["markdown.link_url"] = styles["markdown.link_url"] + Style(underline=True)
+    code_block = BY_ELEMENT["markdown.code_block"]
+    styles["markdown.code_block"] = styles["markdown.code_block"] + Style(
+        bgcolor=_C(code_block.ground)
+    )
+    return Theme(styles, inherit=True)
+
+
+def syntax_styles() -> dict[_TokenType, Style]:
+    """Pygments token -> ``Style``, replacing ``IslandSyntaxTheme.__init__``'s
+    inline dict."""
+    return {token_type: style(element) for token_type, element in _SYNTAX_TOKEN_ELEMENTS}
+
+
+def ground_hex(element: str) -> str:
+    """Resolve a ``Role.GROUND`` binding straight to a hex string.
+
+    The fourth seam, alongside :func:`style`, :func:`markdown_theme` and
+    :func:`syntax_styles` (§2.5 check 2's AST gate enumerates all four as
+    sanctioned). It exists because two rich APIs
+    (``SyntaxTheme.get_background_style`` and ``Syntax(background_color=...)``
+    — see ``markdown_theme.IslandSyntaxTheme``/``IslandCodeBlock``) want a raw
+    hex, not a ``Style``, and pulling the hex back out of
+    ``style(element).bgcolor`` would couple that call site to rich's
+    ``Color`` internals for no reason. Raises ``KeyError`` for an unknown
+    element and ``ValueError`` for a non-``GROUND`` one — a ground reader
+    reaching for ink would be its own kind of bug.
+    """
+    binding = BY_ELEMENT[element]
+    if binding.role is not Role.GROUND:
+        raise ValueError(f"{element!r} is not a Role.GROUND binding")
+    return _C(binding.token)
+
+
+def _element_names(bindings: tuple[Binding, ...]) -> tuple[str, ...]:
+    return tuple(binding.element for binding in bindings)

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -30,13 +30,13 @@
  *     the moment the user takes it back. (It used to say "a turn is live",
  *     which was not true of site 4 and so was not true of the frames: a picker
  *     highlight is not liveness, it is the other half of the same sentence.)
- *     It is spent on exactly four sites, and the list is exhaustive —
+ *     It is spent on exactly five sites, and the list is exhaustive —
  *     `grep -rn 'accent' local_operator/tui`
  *     plus `$lo-accent` in this file should find no others. Grep the WORD, not
  *     `semantic_color("accent")`: shimmer.py reaches it through its own
  *     `_style("accent")` helper and command_picker.py through
  *     `semantic_color("accent" if selected else "fg")`, so the narrower pattern
- *     silently misses two of the four and reads as a clean audit.
+ *     silently misses two of the five and reads as a clean audit.
  *       1. the working line's shimmer crest      (shimmer.py)
  *       2. a running tool's glyph                (widgets/tool_card.py)
  *       3. the status band's streaming spinner   (widgets/status_line.py)
@@ -61,10 +61,21 @@
  *          paints them in three different row kinds at once, and a reader
  *          auditing the frame would otherwise count three new accent sites
  *          against a list claiming to be exhaustive (design round 1, D5).
- *     It was FIVE until the focused input chevron gave its site back. Focus is
- *     not liveness, and painting both green put a green chevron two rows above
- *     the band's green spinner meaning something else (D5, round 11). Focus is
- *     a brightness step in the neutral ramp now — see `#prompt-chevron`.
+ *       5. a markdown h1                        (markdown_theme.py)
+ *          The one site that is NOT liveness, and it is admitted knowingly.
+ *          h1, h2 and strong all painted `fg` bold — the same pixels — so a
+ *          long answer had no top-level anchor, and the neutral ramp had no
+ *          rung left to buy one with (h2-h6 already spend three). Structure
+ *          at the top of a document is worth one hue; h2-h6 stay neutral and
+ *          this does not generalise to a heading palette. Cheapest site to
+ *          give back if it reads badly — `label` is the alternative.
+ *     It was FIVE, then FOUR when the focused input chevron gave its site
+ *     back — focus is not liveness, and painting both green put a green
+ *     chevron two rows above the band's green spinner meaning something else
+ *     (D5, round 11). Focus is a brightness step in the neutral ramp now —
+ *     see `#prompt-chevron`. It is FIVE again because h1 was added on the
+ *     budget written up in `docs/proposals/theme-colour-budget.md`; that is a
+ *     budget decision, deliberately taken, not a site that crept in.
  *     Everything else is warm neutrals. Links and file paths are the `signal`
  *     blue and deliberately NOT green; `/usage` provider headings are `label`;
  *     the brand glyph in the band is `muted`, because a mark that is always on
@@ -197,14 +208,20 @@ TranscriptBlock, UserBlock, NoticeBlock, RichBlock, AssistantBlock, ToolCard, Wa
     margin-top: 1;
 }
 
-/* The prompt's own ink. The gutter bar and the prose are both styled per-span
- * by the widget (see `UserBlock` in widgets/transcript.py, which owns the
- * treatment because it has to wrap the text itself to keep the bar on every
- * row), so this is the base the sheet would fall back to and the one place a
- * reader grepping the stylesheet for "user" finds the pointer. There is
- * deliberately no background here: elevation-as-a-background-step is spent in
- * full on the tool ledger, whose FILL carries the outcome, and a second slab
- * kind on the same surface turns the transcript into a stack of cards. */
+/* The prompt's own ink. The gutter bar and the prose are both styled
+ * per-span by the widget (see `UserBlock` in widgets/transcript.py, which
+ * owns the treatment because it has to wrap the text itself to keep the bar
+ * on every row); this is the base the sheet would fall back to and the one
+ * place a reader grepping the stylesheet for "user" finds the pointer.
+ *
+ * NO background. A `tint-user` ground shipped briefly and was removed on
+ * review: a tinted band behind every prompt reads as a slab in a transcript
+ * whose only other fill is the tool ledger, and the two competed. The
+ * gutter bar already marks a prompt on every wrapped row, and the adaptive
+ * `.gap-above` rule already brackets it, so the ground was a third cue for
+ * something two were carrying. What the removal keeps from that argument:
+ * the ledger's fill carries the OUTCOME, and nothing else in the transcript
+ * should wear a fill that could be mistaken for it. */
 UserBlock {
     color: $lo-fg;
 }

--- a/local_operator/tui/markdown_theme.py
+++ b/local_operator/tui/markdown_theme.py
@@ -1,10 +1,14 @@
 """Island markdown styling — the markdown ramp for the brand kit (D1/D2).
 
-Two layers, both sourced from the theme's semantic tokens:
+Two layers. The colour decisions themselves — ``element -> token`` — live in
+:mod:`local_operator.tui.bindings` (§2 of ``docs/proposals/theme-colour-
+budget.md``); this module wires that table into rich's markdown and syntax
+protocols:
 
-- :data:`brand_markdown_theme` — a rich ``Theme`` mapping rich-markdown's
-  element styles onto the island ramp (headings bold fg, code string-green
-  with no background slab, quotes muted, bullets dim, links `signal`). The app
+- :data:`brand_markdown_theme` — a rich ``Theme`` built from
+  :func:`bindings.markdown_theme`, mapping rich-markdown's element styles
+  onto the island ramp (headings bold fg, code string-green with no
+  background slab, quotes muted, bullets dim, links `signal`). The app
   pushes it onto ``app.console`` once.
 - :class:`IslandCodeBlock` — code fences rendered on the island ground with
   brand syntax colors and zero padding, replacing rich's default Monokai
@@ -19,27 +23,14 @@ from __future__ import annotations
 
 from typing import cast
 
-from pygments.token import (
-    Comment,
-    Error,
-    Generic,
-    Keyword,
-    Name,
-    Number,
-    Operator,
-    Punctuation,
-    String,
-    Token,
-    _TokenType,
-)
+from pygments.token import Token, _TokenType
 from rich.markdown import CodeBlock, Heading, Markdown
 from rich.style import Style
 from rich.syntax import Syntax, SyntaxTheme, TokenType
+from rich.text import Text
 from rich.theme import Theme
 
-from local_operator.tui import theme as theme_mod
-
-_C = theme_mod.semantic_color
+from local_operator.tui import bindings
 
 #: Root of the pygments token hierarchy — the terminal fallback for a token
 #: whose whole ancestry is absent from the ramp.
@@ -47,37 +38,12 @@ _TOKEN_ROOT = Token
 
 
 class IslandSyntaxTheme(SyntaxTheme):
-    """Code colors built from the island ramp: keywords muted, string green,
-    number/warning amber, comment dim. Replaces the Monokai slab palette."""
+    """Code colors built from the island ramp via :mod:`bindings`: keywords
+    muted, string green, number/warning amber, comment dim. Replaces the
+    Monokai slab palette."""
 
     def __init__(self) -> None:
-        self._styles: dict[_TokenType, Style] = {
-            Token: Style(color=_C("fg")),
-            Comment: Style(color=_C("dim")),
-            # NOT accent: syntax highlighting would spend the running-indicator
-            # budget on every `def` in the transcript. Keywords are already
-            # distinguished by position, and the ramp keeps Name.Function at muted.
-            Keyword: Style(color=_C("muted")),
-            Keyword.Constant: Style(color=_C("warning")),
-            Name: Style(color=_C("fg")),
-            Name.Function: Style(color=_C("muted")),
-            Name.Class: Style(color=_C("muted")),
-            Name.Builtin: Style(color=_C("muted")),
-            # `warning` (amber), NOT `string`. The `string` token resolves to the
-            # same hex as `success`, which is the diff-added green — so a fence
-            # containing a literal put `"ok"` and a write row's `+12` in one
-            # viewport in one colour, and that pairing (a code block beside a
-            # tool row) is the single most common shape of agent output. Amber
-            # already carries Number and Keyword.Constant, so this groups every
-            # LITERAL under one hue and leaves the green meaning only "added or
-            # succeeded".
-            String: Style(color=_C("warning")),
-            Number: Style(color=_C("warning")),
-            Operator: Style(color=_C("muted")),
-            Punctuation: Style(color=_C("dim")),
-            Error: Style(color=_C("danger")),
-            Generic: Style(color=_C("fg")),
-        }
+        self._styles: dict[_TokenType, Style] = bindings.syntax_styles()
 
     def get_style_for_token(self, token_type: TokenType) -> Style:
         """Walk up the token hierarchy to the nearest ramp entry.
@@ -101,7 +67,7 @@ class IslandSyntaxTheme(SyntaxTheme):
         return self._styles[_TOKEN_ROOT]
 
     def get_background_style(self) -> Style:  # type: ignore[override]
-        return Style(bgcolor=_C("bg"))
+        return Style(bgcolor=bindings.ground_hex("code.background"))
 
 
 class IslandCodeBlock(CodeBlock):
@@ -115,46 +81,20 @@ class IslandCodeBlock(CodeBlock):
             theme=IslandSyntaxTheme(),
             word_wrap=True,
             padding=0,
-            background_color=_C("bg"),
+            background_color=bindings.ground_hex("code.background"),
         )
 
 
 def brand_markdown_theme() -> Theme:
     """Element-style theme for rich Markdown, resolved against the current
-    ramp. Rebuild after a theme switch (epoch change)."""
-    return Theme(
-        {
-            "markdown.paragraph": Style(color=_C("fg")),
-            "markdown.text": Style(color=_C("fg")),
-            "markdown.em": Style(color=_C("fg"), italic=True),
-            "markdown.strong": Style(color=_C("fg"), bold=True),
-            # `signal`, not `string`: inline code in agent prose is overwhelmingly
-            # file paths and identifiers, which is the case theme.py reserves
-            # `signal` for. It also frees the greens to mean only
-            # added-or-succeeded rather than doubling as "code literal".
-            "markdown.code": Style(color=_C("signal")),
-            "markdown.code_block": Style(color=_C("fg"), bgcolor=_C("bg")),
-            "markdown.block_quote": Style(color=_C("muted")),
-            "markdown.list": Style(color=_C("fg")),
-            "markdown.item.bullet": Style(color=_C("dim")),
-            "markdown.item.number": Style(color=_C("dim")),
-            "markdown.hr": Style(color=_C("edge")),
-            # Headings carry a real three-step ramp. With no rules, panels,
-            # or size changes available in a terminal, WEIGHT and TINT are
-            # the only depth cues there are — h5/h6 previously matched h3/h4
-            # minus the bold, which flattened the tail of long documents
-            # into a single indistinguishable level.
-            "markdown.h1": Style(color=_C("fg"), bold=True),
-            "markdown.h2": Style(color=_C("fg"), bold=True),
-            "markdown.h3": Style(color=_C("muted"), bold=True),
-            "markdown.h4": Style(color=_C("muted"), bold=True),
-            "markdown.h5": Style(color=_C("dim"), bold=True),
-            "markdown.h6": Style(color=_C("dim")),
-            "markdown.link": Style(color=_C("signal")),
-            "markdown.link_url": Style(color=_C("signal"), underline=True),
-        },
-        inherit=True,
-    )
+    ramp. Rebuild after a theme switch (epoch change).
+
+    The element -> token decisions (including every design rationale — the
+    h1 accent, the `hr` rebind, the `signal` inline-code choice) live in
+    :mod:`local_operator.tui.bindings` (``docs/proposals/theme-colour-
+    budget.md`` §2); see :func:`bindings.markdown_theme` for the note text.
+    """
+    return bindings.markdown_theme()
 
 
 _installed = False
@@ -174,6 +114,21 @@ def install_markdown_theme() -> None:
     def _flat_heading(self: Heading, console, options):  # type: ignore[no-untyped-def]
         text = self.text
         text.justify = "left"
+        # Leading ABOVE a heading, scaled by level. Every gap in a rendered
+        # answer measured 48.8px — one uniform rhythm from h1 to body prose —
+        # so when two levels shared an ink there was no second channel holding
+        # the structure up, and a long reply read as one undifferentiated
+        # stripe. Space is the cheapest hierarchy available here: it competes
+        # with no token, spends nothing from the accent budget, and works
+        # identically in all 54 themes because it is not a colour at all.
+        #
+        # rich yields headings inside a stream of blocks, so a leading blank
+        # line is the only lever — there is no margin box to set. h1/h2 get
+        # one; h3 and below get none, because a sub-step that pushes air is
+        # louder than the section it sits under, and the tail of a document
+        # is where density matters most.
+        if self.tag in ("h1", "h2"):
+            yield Text("")
         yield text
 
     Heading.__rich_console__ = _flat_heading  # type: ignore[method-assign]

--- a/local_operator/tui/palettes/rose_pine.py
+++ b/local_operator/tui/palettes/rose_pine.py
@@ -179,10 +179,47 @@ PALETTES: list[ThemeSpec] = [
             "signal": "#41787a",  # foam #56949f: 3.14:1 (< 4), held off pine
             "label": "#7d6694",  # iris #907aa9: 3.47:1 (< 4) — 7.8 ΔE
             "tint-danger": "#f6e2e3",
-            "tint-select": "#f0e8e3",  # rose cast, just under the paper
-            "tint-select-hi": "#e8ddd6",
+            # Selection/focus, AUTHORED rather than left on the rose cast.
+            # `#f0e8e3` measured ΔE 1.71 from `surface` — a focused tool row
+            # was indistinguishable from an unfocused one, and dawn was the
+            # only theme with the defect (dark 8.54, github-light 8.74,
+            # solarized-light 6.65). The paper has no well to sink into, so
+            # the step is bought in CHROMA at near-constant luminance.
+            #
+            # IRIS: dawn's canonical meta accent, already what `label`
+            # spends, which makes it the right hue for a selection that is
+            # chrome rather than content. Measured: ΔE 10.05 from `surface`,
+            # at 1.157:1 against `bg` — well inside the 2.2 tint ceiling.
+            "tint-select": "#e9e2f2",
+            "tint-select-hi": "#ded2ee",
             "tint-attach": "#e8eef0",  # foam-leaning wash
             "tint-attach-hi": "#d2e0e2",
+            # The user's own prompt ground. The per-theme derivation solves
+            # for maximum separation and lands on green-teal (159°) here,
+            # which is correct by the metric and wrong for the eye: it fights
+            # the warm paper. Blue is the one hue family dawn's palette does
+            # not already spend — love/gold/rose are warm, pine/foam sit at
+            # 180-200°, iris is violet — so a cool cast separates from the
+            # ground instead of competing with it. Measured: ΔE 10.0 from
+            # `bg` and 9.8 from its worst rival ground, both above the §9
+            # floors, at 245° — the best of the blues tested (230/245/260).
+            # Tool categories. The derivation leaves mutate/exec on the
+            # neutral ramp, which is the safe default for 54 themes but keeps
+            # dawn's ledger a single grey. Dawn has six solved accents and was
+            # spending two, so these are authored from the canonical set it
+            # already carries: foam for reading, gold for changing a file,
+            # iris for running something, rose for coordination.
+            #
+            # Every value is a token dawn has already solved for WCAG on this
+            # paper (all four measure >= 4.31:1 on `surface`), the four
+            # separate from each other by >= 22.1 ΔE00, and each stays >= 11.6
+            # ΔE00 from BOTH outcome hues — a category must never be mistaken
+            # for a verdict. `success` is deliberately not reused here: it is
+            # the ✓ one column to the right on the same row.
+            "tool-read": "#41787a",  # foam — same hue as file paths, deliberately
+            "tool-mutate": "#9e6200",  # gold
+            "tool-exec": "#7d6694",  # iris
+            "tool-meta": "#a8594f",  # rose
         },
     ),
 ]

--- a/local_operator/tui/theme.py
+++ b/local_operator/tui/theme.py
@@ -176,10 +176,70 @@ DEFAULT_THEME = "dark"
 #: palette author's typo, not an extension point).
 SEMANTIC_TOKENS: tuple[str, ...] = tuple(_SEMANTIC_ALIASES["dark"])
 
+#: Tokens a theme MAY set but need not — the total-function contract above
+#: applies only to :data:`SEMANTIC_TOKENS`. The tool-category family is the
+#: first entry: absent, `register_theme` fills each from its source token so
+#: all 54 existing palettes keep working with zero edits (§3's "no palette
+#: rewrite" rule) and the default look does not change for a theme that has
+#: not opted in. Present, the author's value wins outright — the derivation
+#: never overrides an explicit choice. A theme may still not invent tokens
+#: outside this set plus :data:`SEMANTIC_TOKENS`; that half of the gate stays
+#: total.
+OPTIONAL_TOKENS: tuple[str, ...] = (
+    # The tool-category family. A settled tool row's NAME is currently one
+    # grey for every tool, so a ledger cannot be scanned for "what did this
+    # actually do to my machine" — only the failed row and the running row
+    # carry any hue at all.
+    #
+    # These are their own tokens rather than a reuse of `warning`/`accent`
+    # for a reason worth keeping: those names have contracts (`warning` means
+    # a warning happened; `accent` is "the one green: live indicator, focus"),
+    # and binding tool identity to them means a theme author tuning `warning`
+    # for alarm legibility silently retunes tool names. A token that means
+    # what it says can be tuned for the job it actually does.
+    #
+    # The CATEGORY axis is not invented here: `glyphs.PLAIN_TOOL_ICONS`
+    # already groups its fallbacks by shell/read/mutate/search/meta for the
+    # same reason, so this reuses that vocabulary instead of minting a rival.
+    "tool-read",
+    "tool-mutate",
+    "tool-exec",
+    "tool-meta",
+)
+
+#: Derivation sources for the tool-category family, in the ramp's own terms.
+#: Conservative on purpose — `read` and `meta` land on tokens whose existing
+#: contracts already fit (`signal` is "links, file paths"; `label` is "violet
+#: meta"), and the two categories with no natural home lean on the neutral
+#: ramp rather than borrowing an OUTCOME hue, because a row that changed a
+#: file is not a warning and must not look like one. A theme that wants four
+#: loud categories authors them.
+_TOOL_CATEGORY_SOURCE: dict[str, str] = {
+    "tool-read": "signal",
+    "tool-mutate": "muted",
+    "tool-exec": "muted",
+    "tool-meta": "label",
+}
+
 #: Palette hexes must be exactly ``#rrggbb``. Short forms and named colors are
 #: rejected at registration: the TCSS variable block and the terminal-theme
 #: mapping both slice these strings positionally.
 _HEX_RE = re.compile(r"#[0-9a-fA-F]{6}")
+
+
+def _fill_tool_categories(tokens: dict[str, str]) -> None:
+    """Give a ramp its tool-category tokens, leaving authored values alone.
+
+    Mutates in place. Each missing token takes its source token's value
+    (:data:`_TOOL_CATEGORY_SOURCE`), so a theme that never heard of this
+    family renders exactly as it does today:
+    `read` picks up the reference hue it already uses for file paths, `meta`
+    the violet it already uses for meta, and `mutate`/`exec` stay on the
+    neutral ramp. No theme changes appearance unless it opts in.
+    """
+    for token, source in _TOOL_CATEGORY_SOURCE.items():
+        if token not in tokens and source in tokens:
+            tokens[token] = tokens[source]
 
 
 @dataclass(frozen=True)
@@ -210,10 +270,18 @@ def _builtin_spec(name: str, label: str, description: str, dark: bool) -> ThemeS
     The two brand ramps keep their raw-token + alias form because the raw
     names (``amber``, ``paper``, ``ink``) are pinned by tests and still
     emitted as TCSS variables; everything else registers semantic-only.
+
+    Built directly rather than through :func:`register_theme` (there is
+    nothing to validate — the alias map is this module's own data), so the
+    optional-token fill-in that function does for curated palettes is
+    repeated here: neither brand ramp authors the tool-category family in
+    :data:`BRAND_TOKENS`, so both get the derived values, same as any curated
+    theme that does not opt in.
     """
     tokens = {
         semantic: BRAND_TOKENS[name][raw] for semantic, raw in _SEMANTIC_ALIASES[name].items()
     }
+    _fill_tool_categories(tokens)
     return ThemeSpec(name=name, label=label, description=description, dark=dark, tokens=tokens)
 
 
@@ -267,15 +335,28 @@ def register_theme(spec: ThemeSpec) -> None:
     A theme is data, so every mistake a palette author can make is caught
     HERE, at registration, rather than at render time in whichever widget
     first asks for the missing token.
+
+    :data:`SEMANTIC_TOKENS` stays a total function — every one of the 23 is
+    still required, and an unrecognised key is still rejected. The gate's
+    total-ness now spans two sets rather than one: a key must be in
+    ``SEMANTIC_TOKENS`` or :data:`OPTIONAL_TOKENS` to be accepted, and every
+    name in ``SEMANTIC_TOKENS`` (never an optional one) must be present. An
+    optional token a theme omits is filled in below from its deriver rather
+    than left missing — the CALLER (every other reader in this module) still
+    sees a total ``spec.tokens`` and never has to branch on whether a theme
+    opted in. The tool-category family is what ``OPTIONAL_TOKENS`` carries
+    today; another would need its own fill wired in here alongside it.
     """
     if spec.name in _THEMES:
         raise ValueError(f"theme {spec.name!r} is already registered")
     missing = [token for token in SEMANTIC_TOKENS if token not in spec.tokens]
     if missing:
         raise ValueError(f"theme {spec.name!r} is missing tokens: {', '.join(missing)}")
-    unknown = [token for token in spec.tokens if token not in SEMANTIC_TOKENS]
+    allowed = set(SEMANTIC_TOKENS) | set(OPTIONAL_TOKENS)
+    unknown = [token for token in spec.tokens if token not in allowed]
     if unknown:
         raise ValueError(f"theme {spec.name!r} has unknown tokens: {', '.join(unknown)}")
+    _fill_tool_categories(spec.tokens)
     malformed = [
         f"{token}={value!r}" for token, value in spec.tokens.items() if not _HEX_RE.fullmatch(value)
     ]
@@ -358,6 +439,13 @@ def tcss_variable_map(theme: str | None = None) -> dict[str, str]:
 
     Textual injects these via ``App.get_css_variables``; the TCSS file then
     references ``var(--lo-<name>)`` and never a literal hex.
+
+    Optional tokens (``OPTIONAL_TOKENS``) are emitted alongside the required
+    ones: ``get_tokens`` on the two brand ramps answers with the RAW
+    ``BRAND_TOKENS`` vocabulary, which never authors the tool-category family
+    (the fill runs in :func:`_builtin_spec`, not in ``BRAND_TOKENS`` itself),
+    so without this the sheet's ``$lo-tool-*`` would be undefined for
+    ``dark`` and ``light`` alone even though every curated theme resolves it.
     """
     name = theme or _current_theme
     variables: dict[str, str] = {}
@@ -365,6 +453,8 @@ def tcss_variable_map(theme: str | None = None) -> dict[str, str]:
         variables[f"lo-{token}"] = hex_value
     for semantic in SEMANTIC_TOKENS:
         variables[f"lo-{semantic}"] = semantic_color(semantic, name)
+    for optional in OPTIONAL_TOKENS:
+        variables[f"lo-{optional}"] = semantic_color(optional, name)
     return variables
 
 

--- a/local_operator/tui/widgets/aside_panel.py
+++ b/local_operator/tui/widgets/aside_panel.py
@@ -565,7 +565,7 @@ class AsidePanel(Static):
     ) -> list[Text]:
         """The question on the transcript's spine: dim mark, ``fg`` prose.
 
-        NOT the accent. The stylesheet enumerates the four sites the one green
+        NOT the accent. The stylesheet enumerates the five sites the one green
         is spent on and ends "Before adding a sixth, take one away" — and this
         would be by far the largest of them, three wrapped questions being some
         hundreds of cells. The accent also MEANS "a turn is live", which a

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -10,9 +10,13 @@ child session's retained events as a transcript.
 Rows are live by construction: the app repaints the panel on every Subagent*
 event AND on the 1 Hz job poll, and the panel advances its own spinner while
 anything is running — motion, not colour, says "alive": the accent green is
-spent at exactly four sites (see the tcss preamble) and a fifth spinner is
-not one of them. Settled rows follow the tool ledger's ink law: ✓ dim,
-✗ danger, nothing else.
+spent at exactly five sites (see the tcss preamble) and a sixth spinner is
+not one of them. Settled rows do NOT follow the tool ledger's "✓ success"
+ink law — that overturn (see `tool_card.py`) was deliberately bounded to the
+TOOL LEDGER; `status_glyph` keeps this panel's ✓ dim on completion, the same
+as ✗ and every other settled state, because a subagent's own transcript
+already carries the colour and this row is a job-manager summary, not the
+ledger.
 """
 
 from __future__ import annotations

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -33,10 +33,13 @@ across::
   ``-N`` in the danger tint, rendered ONLY when the tool result actually
   reported them (an unknown count renders nothing — never ``+0 -0``)
 - status right-aligned (D6): EMPTY while running — no trailing glyph, the
-  column stays clear until the duration lands (D28); ``✓ duration`` all
-  dim on success (D12: only failure gets color); ``✗ error`` danger with
-  the duration dim as a second run (D13); ``⊘ interrupted`` dim when the
-  turn ended before completion (TUI-019). The duration is right-justified
+  column stays clear until the duration lands (D28); the glyph carries the
+  outcome ink and the duration rides beside it as a second run — ``✓``
+  colored ``success`` with a dim duration (narrowing D12: see the rationale
+  at ``_outcome_runs`` and
+  ``bindings.BY_ELEMENT["tool.status.success_glyph"].note``); ``✗ error``
+  danger with the duration dim as a second run (D13); ``⊘ interrupted`` dim
+  when the turn ended before completion (TUI-019). The duration is right-justified
   into a fixed :data:`DURATION_COL` so the outcome glyph sits in a STABLE
   column — otherwise ``✓ 0.4s`` and ``✓ 12.3s`` put the glyph one cell
   apart, and the pass/fail scan that right-alignment exists to serve has to
@@ -93,7 +96,7 @@ from rich.text import Text
 from textual.timer import Timer
 
 from local_operator.ansi import strip_control_sequences
-from local_operator.tui import theme as theme_mod
+from local_operator.tui import bindings
 from local_operator.tui.glyphs import display_name, tool_icon
 from local_operator.tui.widgets.transcript import (
     TOOL_NAME_COL,
@@ -162,6 +165,55 @@ NOTICE_SECONDS = 2.0
 #: ten: the icon column now carries identity, and the two cells it costs come
 #: out of the name rather than out of the summary. The transcript owns the
 #: shared value and may widen it — see :attr:`TranscriptView.tool_name_col`.
+#: Tool -> ledger category, mirroring `glyphs.PLAIN_TOOL_ICONS`' own
+#: shell/read/mutate/search/meta grouping rather than inventing a second
+#: taxonomy. The axis is what the call DID to the machine, which is the
+#: question a ledger is scanned for: reading is safe, mutating is not, and
+#: executing is the one you re-read before trusting.
+#:
+#: Anything absent — an `mcp__*` call, a new builtin — falls through to
+#: `tool.row.name_settled`, the neutral this column has always used. An
+#: unclassified tool is quiet, never mis-filed.
+_TOOL_CATEGORY: dict[str, str] = {
+    "read": "tool.row.name_read",
+    "glob": "tool.row.name_read",
+    "grep": "tool.row.name_read",
+    "web_fetch": "tool.row.name_read",
+    "web_search": "tool.row.name_read",
+    "browser": "tool.row.name_read",
+    "list_variables": "tool.row.name_read",
+    "read_variable": "tool.row.name_read",
+    "write": "tool.row.name_mutate",
+    "edit": "tool.row.name_mutate",
+    "bash": "tool.row.name_exec",
+    "eval": "tool.row.name_exec",
+    "task": "tool.row.name_meta",
+    "agent": "tool.row.name_meta",
+    "hub": "tool.row.name_meta",
+    "todo": "tool.row.name_meta",
+    "send": "tool.row.name_meta",
+    "wake": "tool.row.name_meta",
+    "ask": "tool.row.name_meta",
+}
+
+
+def _category_element(tool_name: str) -> str:
+    """The binding id for ``tool_name``'s settled name span.
+
+    Case-insensitive because ``tool_name`` is MODEL-controlled — a provider
+    that echoes ``Bash`` back must land in the same category as ``bash``,
+    exactly as :func:`glyphs.tool_icon` already reasons about its own lookup.
+
+    The map stores WHOLE element ids rather than a category name spliced into
+    an f-string. The f-string version left `tool.row.name_` as the only
+    literal in the source, so the binding-table coverage gate — which reads
+    this module's AST to prove every element it paints is declared — saw a
+    prefix that matches no binding and could no longer verify the five that
+    are. A gate that cannot see the call sites is not a gate.
+    """
+    return _TOOL_CATEGORY.get(tool_name.strip().lower(), "tool.row.name_settled")
+
+
 NAME_COL = TOOL_NAME_COL
 #: The ceiling that widening respects. Past roughly this width the eye stops
 #: scanning a column of names and starts reading a list of them.
@@ -1694,8 +1746,8 @@ class ToolCard(ExpandableActionBlock):
         :data:`LIVE_MAX_LINES` for why this block keeps the end where the
         settled block keeps the beginning.
         """
-        dim = Style(color=theme_mod.semantic_color("dim"))
-        accent = Style(color=theme_mod.semantic_color("accent"))
+        dim = bindings.style("tool.live.dim")
+        accent = bindings.style("tool.live.header")
         line_width = max(1, width - 2 - OUTPUT_INDENT)
         indent = " " * OUTPUT_INDENT
         # State, then time, then the caveat — read left to right that is "it is
@@ -1718,8 +1770,8 @@ class ToolCard(ExpandableActionBlock):
             if not self._live:
                 header = f"{header} · {LIVE_HEADER_PENDING}"
         row.append("\n" + indent, style=dim)
-        # Accent, the same ink the running icon spends: this row is the card's
-        # answer to "is it alive", and it has to survive a still frame.
+        # See `bindings.BY_ELEMENT["tool.live.header"].note` for why this rides
+        # `accent`.
         row.append(truncate_cells(header, line_width), style=accent)
         if self._live_elided or self._live_dropped > 0:
             plural = "s" if self._live_dropped != 1 else ""
@@ -1746,9 +1798,9 @@ class ToolCard(ExpandableActionBlock):
         """
         if not self._args:
             return
-        dim = Style(color=theme_mod.semantic_color("dim"))
-        label = Style(color=theme_mod.semantic_color("label"))
-        body = Style(color=theme_mod.semantic_color("fg"))
+        dim = bindings.style("tool.args.dim")
+        label = bindings.style("tool.args.label")
+        body = bindings.style("tool.args.value")
         line_width = max(1, width - 2 - OUTPUT_INDENT)
         indent = " " * OUTPUT_INDENT
         for key, value in self._args.items():
@@ -1792,8 +1844,8 @@ class ToolCard(ExpandableActionBlock):
         truncates per line: one output line is one row, so the expanded
         height is exactly what the marker promises and never reflows.
         """
-        dim = Style(color=theme_mod.semantic_color("dim"))
-        body = Style(color=theme_mod.semantic_color("danger")) if self._state == "error" else dim
+        dim = bindings.style("tool.output.dim")
+        body = bindings.style("tool.output.error") if self._state == "error" else dim
         line_width = max(1, width - 2 - OUTPUT_INDENT)
         indent = " " * OUTPUT_INDENT
         shown = self._output[:EXPAND_MAX_LINES]
@@ -1808,10 +1860,10 @@ class ToolCard(ExpandableActionBlock):
 
     def _append_search_body(self, row: Text, width: int) -> None:
         """Search expansion hierarchy: titles lead, URLs signal, snippets recede."""
-        fg = Style(color=theme_mod.semantic_color("fg"), bold=True)
-        signal = Style(color=theme_mod.semantic_color("signal"))
-        muted = Style(color=theme_mod.semantic_color("muted"))
-        dim = Style(color=theme_mod.semantic_color("dim"))
+        fg = bindings.style("tool.search.title")
+        signal = bindings.style("tool.search.url")
+        muted = bindings.style("tool.search.snippet")
+        dim = bindings.style("tool.search.dim")
         line_width = max(1, width - 2 - OUTPUT_INDENT)
         indent = " " * OUTPUT_INDENT
         shown = self._output[:EXPAND_MAX_LINES]
@@ -1824,8 +1876,7 @@ class ToolCard(ExpandableActionBlock):
             elif stripped.startswith(("Provider:", "Sources:")):
                 ink = dim
             else:
-                # Snippets and the actionable footer must meet normal-text
-                # contrast; ``dim`` is reserved for structural metadata.
+                # See `bindings.BY_ELEMENT["tool.search.snippet"].note`.
                 ink = muted
             row.append("\n" + indent, style=dim)
             row.append(truncate_cells(line, line_width), style=ink)
@@ -1843,32 +1894,26 @@ class ToolCard(ExpandableActionBlock):
         normal contrast, the same hierarchy the search card uses to keep its
         structural rows from competing with the result.
         """
-        signal = Style(color=theme_mod.semantic_color("signal"))
-        muted = Style(color=theme_mod.semantic_color("muted"))
-        dim = Style(color=theme_mod.semantic_color("dim"))
-        danger = Style(color=theme_mod.semantic_color("danger"), bold=True)
+        signal = bindings.style("tool.fetch.signal")
+        muted = bindings.style("tool.fetch.snippet")
+        dim = bindings.style("tool.fetch.dim")
+        danger = bindings.style("tool.fetch.error")
         line_width = max(1, width - 2 - OUTPUT_INDENT)
         indent = " " * OUTPUT_INDENT
         shown = self._output[:EXPAND_MAX_LINES]
         for line in shown:
             stripped = line.strip()
             if stripped.startswith("⚠ HTTP"):
-                # F1: the non-2xx error row rides `danger`, bold — the strongest
-                # treatment on the card, so a block/error page cannot be mistaken
-                # for successful content. Matches the tool result's is_error flag.
+                # See `bindings.BY_ELEMENT["tool.fetch.error"].note` (F1).
                 ink = danger
             elif stripped.startswith("Fetched:"):
-                # D3: the final URL is the card's anchor, so it rides `signal`
-                # blue like web_search's URLs instead of receding into the dim
-                # metadata. The "Fetched:" label and the trailing `· status ·
-                # ctype · cache` metadata stay dim; only the URL(s) lift.
+                # See `bindings.BY_ELEMENT["tool.fetch.signal"].note` (D3).
                 self._append_fetched_row(row, line, line_width, indent, dim, signal)
                 continue
             elif stripped.startswith("Rendered:"):
                 ink = dim
             elif stripped.startswith("sparse/JS-gated"):
-                # The one advisory row earns attention: it is the signal to reach
-                # for browser, not structural chrome.
+                # See `bindings.BY_ELEMENT["tool.fetch.signal"].note`.
                 ink = signal
             else:
                 ink = muted
@@ -1923,10 +1968,10 @@ class ToolCard(ExpandableActionBlock):
         coloured line never reads as a wall of tint. The nameless ``---/+++``
         file headers are filtered out below rather than tinted.
         """
-        success = Style(color=theme_mod.semantic_color("success"))
-        danger = Style(color=theme_mod.semantic_color("danger"))
-        muted = Style(color=theme_mod.semantic_color("muted"))
-        dim = Style(color=theme_mod.semantic_color("dim"))
+        success = bindings.style("tool.diff.added")
+        danger = bindings.style("tool.diff.removed")
+        muted = bindings.style("tool.diff.hunk")
+        dim = bindings.style("tool.diff.context")
         line_width = max(1, width - 2 - OUTPUT_INDENT)
         indent = " " * OUTPUT_INDENT
         # The `---`/`+++` file headers are dropped: the tool diffs one file's
@@ -1977,17 +2022,22 @@ class ToolCard(ExpandableActionBlock):
 
     def _build_row(self, width: int) -> Text:
         """The single summary row — the ONE-LINE guarantee lives here."""
-        dim = Style(color=theme_mod.semantic_color("dim"))
-        muted = Style(color=theme_mod.semantic_color("muted"))
-        # Two-step fade on settle: the live row keeps the string green on the
-        # name and readable `muted` body text; a settled row drops both one
-        # step so the running row is the brightest thing on screen.
-        # Composing counts as live: the model is actively producing this call,
-        # and a row that dimmed while its arguments streamed would read as a
-        # finished action rather than as the one thing currently happening.
+        dim = bindings.style("tool.row.dim")
+        # See `bindings.BY_ELEMENT["tool.row.name_running"].note` for the
+        # two-step fade this implements.
         running = self._state in ("running", "composing")
-        name_style = Style(color=theme_mod.semantic_color("string")) if running else muted
-        summary_style = muted if running else dim
+        # Liveness outranks identity: a live row keeps the fade's green, and
+        # the category hue applies only once the row has settled. Two signals
+        # on one span would mean the ledger said "what kind" and "is it live"
+        # in the same place, which is how the outcome column lost its own
+        # meaning before D12 was narrowed.
+        name_style = (
+            bindings.style("tool.row.name_running")
+            if running
+            else bindings.style(_category_element(self.tool_name))
+        )
+        summary_element = "tool.row.summary_running" if running else "tool.row.summary_settled"
+        summary_style = bindings.style(summary_element)
         width = max(width - 2, 10)  # 1-cell inner padding each side (kit rule)
 
         # Status segment (right-aligned), capped at width // 3 (D8) and then
@@ -2048,12 +2098,10 @@ class ToolCard(ExpandableActionBlock):
         # back: at 46 columns the floor dropped the notice too, so activating
         # an inert row left a byte-identical frame.
         slot = ""
-        slot_token = "dim"
+        slot_element = "tool.row.slot_offer"
         remaining = max(0, width - prefix_cells - status_cells - 2)
         if self.can_expand():
-            # Generic tool output stays quiet until the row is targeted. Search
-            # sources are the primary result, not diagnostics, so their
-            # disclosure remains visible at rest and in colorless terminals.
+            # See `bindings.BY_ELEMENT["tool.row.slot_offer"].note`.
             if (
                 self.tool_name.lower() == "web_search"
                 or self._is_fetch_card
@@ -2064,13 +2112,8 @@ class ToolCard(ExpandableActionBlock):
                 if remaining - (cell_len(offer) + 1) >= _SUMMARY_FLOOR:
                     slot = offer
         elif self._notice:
-            # `muted`, one step brighter than the offer's `dim`: this is not
-            # something the eye may skip. Walk the ladder — full phrase, then
-            # the three-cell glyph — and take the first rung the row can hold
-            # with nothing reserved for the summary. Only when even ⟨∅⟩ will
-            # not fit does the answer go unsaid, and by then the row is down
-            # to its icon and its outcome anyway.
-            slot_token = "muted"
+            # See `bindings.BY_ELEMENT["tool.row.slot_notice"].note`.
+            slot_element = "tool.row.slot_notice"
             for rung in NOTICE_LADDER.get(self._notice, (self._notice,)):
                 if cell_len(rung) + 1 <= remaining:
                     slot = rung
@@ -2131,23 +2174,19 @@ class ToolCard(ExpandableActionBlock):
             summary = truncate_cells(self._summary, budget)
 
         row = _row_text()
-        # The icon carries the running state: accent while live (D26 — a still
-        # frame must read "live" without the shimmer), dim once settled. This
-        # is one of the five places in the app the accent green is spent.
-        icon_style = Style(color=theme_mod.semantic_color("accent")) if running else dim
+        # See `bindings.BY_ELEMENT["tool.row.icon_running"].note`.
+        icon_style = (
+            bindings.style("tool.row.icon_running")
+            if running
+            else bindings.style("tool.row.icon_settled")
+        )
         row.append(icon + " ", style=icon_style)
         row.append(name, style=name_style)
         row.append(" ", style=dim)
         if row_chip:
-            # Chrome quieter than the fact while live (the summary is
-            # `muted` there); one step BRIGHTER than the fact once settled,
-            # when the summary drops to `dim` — the attribution is the thing
-            # a reader scrolling back is hunting for, and a chip that faded
-            # to the same ink as the command stopped separating the two
-            # (design round 1, D1). It survives every shed rung because the
-            # budget above already paid for it.
-            chip_style = muted if not running else dim
-            row.append(row_chip, style=chip_style)
+            # See `bindings.BY_ELEMENT["tool.row.chip_running"].note`.
+            chip_element = "tool.row.chip_settled" if not running else "tool.row.chip_running"
+            row.append(row_chip, style=bindings.style(chip_element))
         row.append(summary, style=summary_style)
 
         # ONE right-aligned tail: the slot and the status share a single pad,
@@ -2161,7 +2200,7 @@ class ToolCard(ExpandableActionBlock):
             used = cell_len(row.plain)
             row.append(" " * max(1, width - used - tail_cells), style=dim)
             if slot:
-                row.append(slot, style=Style(color=theme_mod.semantic_color(slot_token)))
+                row.append(slot, style=bindings.style(slot_element))
                 row.append(" ", style=dim)
             for text, style in status_runs:
                 row.append(text, style=style)
@@ -2248,7 +2287,7 @@ class ToolCard(ExpandableActionBlock):
             elapsed = self._elapsed()
             if elapsed is None:
                 return []
-            dim = Style(color=theme_mod.semantic_color("dim"))
+            dim = bindings.style("tool.status.running_duration")
             text = format_duration(max(0, int(elapsed)))
             return [("  ", dim), (text.rjust(DURATION_COL), dim)]
         core = self._outcome_runs(cap, terse=terse)
@@ -2265,9 +2304,9 @@ class ToolCard(ExpandableActionBlock):
         """``+N`` / ``-N`` counters, tinted success/danger. Empty when unknown."""
         runs: list[tuple[str, Style]] = []
         if self._added > 0:
-            runs.append((f"+{self._added} ", Style(color=theme_mod.semantic_color("success"))))
+            runs.append((f"+{self._added} ", bindings.style("tool.status.diff_added")))
         if self._removed > 0:
-            runs.append((f"-{self._removed} ", Style(color=theme_mod.semantic_color("danger"))))
+            runs.append((f"-{self._removed} ", bindings.style("tool.status.diff_removed")))
         return runs
 
     def _outcome_runs(self, cap: int = 0, *, terse: bool = False) -> list[tuple[str, Style]]:
@@ -2294,7 +2333,7 @@ class ToolCard(ExpandableActionBlock):
         outranks explanation, because a row that cannot say which tool failed
         has stopped being a ledger entry.
         """
-        dim = Style(color=theme_mod.semantic_color("dim"))
+        dim = bindings.style("tool.status.duration")
         if self._duration is None:
             # A REPLAYED row: the transcript records what a tool did, never how
             # long it took. `self._duration or 0.0` rendered that as `0.0s`,
@@ -2317,8 +2356,9 @@ class ToolCard(ExpandableActionBlock):
                 duration = format_duration(elapsed)
             duration = duration.rjust(DURATION_COL)
         if self._state == "success":
-            # D12: success is quiet — check + duration both dim, no reason.
-            return [(f"{ICON_SUCCESS} ", dim), (duration, dim)]
+            # See `bindings.BY_ELEMENT["tool.status.success_glyph"].note`.
+            success_ink = bindings.style("tool.status.success_glyph")
+            return [(f"{ICON_SUCCESS} ", success_ink), (duration, dim)]
 
         # The GLYPH sits in the status column with the duration, not at the head
         # of the reason (D20). The right edge is where an operator scans a run
@@ -2338,10 +2378,13 @@ class ToolCard(ExpandableActionBlock):
         # carries the state alone — which it can, being distinguishable from
         # ✓ and ✗ with no colour at all.
         if self._state == "interrupted":
-            glyph, reason, tint = ICON_INTERRUPTED, "interrupted", dim
+            # `bindings.BY_ELEMENT["tool.status.interrupted"]` deliberately
+            # keeps `dim`, not a hue: see its note.
+            glyph, reason = ICON_INTERRUPTED, "interrupted"
+            tint = bindings.style("tool.status.interrupted")
             abbreviates = False
         else:
-            danger = Style(color=theme_mod.semantic_color("danger"))
+            danger = bindings.style("tool.status.error_glyph")
             glyph, reason, tint = ICON_ERROR, self._error, danger
             abbreviates = True
 

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -782,11 +782,21 @@ class UserBlock(TranscriptBlock):
     unmistakably the author's. A rule at column 2 with prose at 4, or prose left
     at 0, would have made the two systems share an origin and collide.
 
-    **No background tint.** Elevation-as-a-background-step is already spent, in
-    full, on the tool ledger — every tool row is a filled slab, and that fill
-    CARRIES the outcome. A second slab kind on the same surface makes the
-    transcript a stack of cards and demotes the one element whose fill means
-    something. The gutter column carries the whole signal instead.
+    **The prompt carries NO background.** Elevation-as-a-background-step is
+    already spent, in full, on the tool ledger — every tool row is a filled
+    slab, and that fill CARRIES the outcome. A second slab kind on the same
+    surface makes the transcript a stack of cards and demotes the one element
+    whose fill means something.
+
+    A ``tint-user`` ground shipped briefly against that argument, on the
+    grounds that a solved CHROMA cast is not an elevation step and so does not
+    add a second slab KIND. The measurement held up — the cast moved mean
+    ΔL* 0.39 where the ledger's fill moves 3.52 — and the frame still lost:
+    a tinted band behind every prompt read as a slab regardless of the axis it
+    was built on, and competed with the ledger for the same glance. Removed on
+    review. The gutter bar already marks a prompt on every wrapped row and the
+    adaptive ``.gap-above`` rule already brackets it; the ground was a third
+    cue for something two were carrying.
 
     **The rule is ``dim``, not the accent**, and it does not need a hue to
     carry. What makes it read is EXTENT: it is the only CONTINUOUS multi-row
@@ -802,13 +812,22 @@ class UserBlock(TranscriptBlock):
     The accent is ruled out on its own budget: it is spent on exactly five
     sites (enumerated in ``local_operator.tcss``) and means "a turn is live", so
     a green column beside every prompt would be the largest accent surface in
-    the app and would mean nothing. ``dim`` is the sheet's own separator ink and
-    measures 4.55:1 on the dark ground and 3.77:1 on paper — clearing the 3:1
-    floor for a graphical object in both ramps while staying below the body ink,
-    which the brighter neutral does not (it wins on dark and drops under the
-    floor on paper). ``▌`` (LEFT HALF BLOCK) buys the weight back through the
-    GLYPH — half a cell of solid ink, where ``│`` would draw the left edge of a
-    box the minimalism contract forbids.
+    the app and would mean nothing. That argument stands and is why the rule is
+    not the accent — but it was over-applied to mean the rule could carry no
+    hue at all, and ``dim`` is the sheet's own SEPARATOR ink: the same grey as
+    a list bullet and a settled tool row's command. The one element a reader
+    scrolls back to find was drawn in the ink used for everything incidental.
+
+    The rule is ``signal`` — the REFERENCE hue, "links, file paths", the things
+    you go back and look at. A prompt is the reference case. It is spent on the
+    RULE alone, which is the only CONTINUOUS multi-row column in the transcript
+    and therefore the cheapest place a hue can go: one half-cell per row, no
+    area, nothing tinted. ``▌`` (LEFT HALF BLOCK) buys the weight back through
+    the GLYPH — half a cell of solid ink, where ``│`` would draw the left edge
+    of a box the minimalism contract forbids. Held to the 3:1 floor a graphical
+    object answers to, ``signal`` clears it in all 54 themes (worst 4.27:1,
+    ``everforest-light``); ``dim``'s own 4.55:1 dark / 3.77:1 paper is what it
+    replaces.
 
     **Spacing is unchanged.** :attr:`SPACING_LEAD` already opens a row above
     every prompt and the block below is always a different
@@ -830,7 +849,27 @@ class UserBlock(TranscriptBlock):
     #: inlined so the two candidate weights could be rendered and COMPARED at
     #: 120 and 60 columns instead of argued about; see the class docstring for
     #: why the answer is not the accent.
-    RULE_TOKEN = "dim"
+    #:
+    #: The rule is ``signal``, not ``dim``. A prompt had no colour of its own
+    #: anywhere: the bar was the transcript's separator ink, the same grey as
+    #: a list bullet and a settled tool row's command, so the one element a
+    #: reader scrolls back to FIND was drawn in the ink used for everything
+    #: incidental. ``signal`` is the ramp's REFERENCE hue — "links, file
+    #: paths", the things you go back and look at — and a prompt is the
+    #: reference case: what you asked, which is what a scroll-back is for.
+    #:
+    #: On the RULE, not on the prose or a ground. The bar is the only
+    #: CONTINUOUS multi-row column in the transcript, so it is the cheapest
+    #: place to spend a hue — one half-cell per row, no area. ``TEXT_TOKEN``
+    #: stays ``fg`` because a prompt is body text and must not be tinted, and
+    #: a background was tried and removed (see the class docstring): a fill
+    #: behind every prompt competed with the ledger, which is the one surface
+    #: whose fill carries meaning.
+    #:
+    #: Measured as a graphical object (the 3:1 non-text floor, which is what
+    #: a solid block glyph is held to): ``signal`` clears it in all 54 themes,
+    #: worst case 4.27:1 on ``everforest-light``.
+    RULE_TOKEN = "signal"
     TEXT_TOKEN = "fg"
 
     #: Narrowest body the text is wrapped into. Below ``RULE_COLS + MIN_BODY``

--- a/local_operator/tui/widgets/welcome.py
+++ b/local_operator/tui/widgets/welcome.py
@@ -29,11 +29,15 @@ Five things make this a design decision rather than a splash screen:
   deviates because the product owner asked for a *centered* view and a border
   would violate the density contract. Structure comes from the logo lockup,
   the tint ramp, and one blank row between sections.
-- **No accent.** The one green is reserved for the running indicator, links,
-  the focused chevron, and the command picker's selected row. The wordmark is
-  the brightest thing here (``fg``) precisely because it is a single row; the
-  four-row mark sits a step back at ``muted`` so a boot frame is not a wall
-  of bright blocks.
+- **No accent.** The one green is reserved for the sites ``local_operator.tcss``
+  enumerates, and a boot frame is none of them. Named by REFERENCE rather than
+  restated here: this used to list "the running indicator, links, the focused
+  chevron, and the command picker's selected row", and by the time the chevron
+  had given its site back and links had settled on ``signal``, two of those
+  four were wrong. A budget restated in five files is a budget enforced in
+  none. The wordmark is the brightest thing here (``fg``) precisely because it
+  is a single row; the four-row mark sits a step back at ``muted`` so a boot
+  frame is not a wall of bright blocks.
 - **It degrades in a fixed order.** Terminals are not a fixed canvas, so the
   view sheds decoration before information: the logo goes first, the hints
   second, the status rows last, and the credential warning never — a

--- a/tests/unit/tui/test_bindings.py
+++ b/tests/unit/tui/test_bindings.py
@@ -1,0 +1,492 @@
+"""The binding table's own contract (§2.5 of the colour-budget proposal).
+
+Four things asserted here:
+
+- **coverage** (check 1) — every element the transcript and tool row actually
+  paint resolves through :data:`bindings.BY_ELEMENT`. This is what stops the
+  table drifting from reality: a rebinding that only touches the call site
+  (or a call site that only touches a literal) would otherwise go unnoticed.
+- **totality** — every binding resolves to a real :data:`theme.SEMANTIC_TOKENS`
+  member and a real ground, for every registered theme, not just the two
+  brand ramps.
+- **no bypass** (check 2) — no migrated module calls ``theme.semantic_color``
+  directly outside :mod:`bindings`'s own sanctioned seams (:func:`style`,
+  :func:`markdown_theme`, :func:`syntax_styles`, :func:`ground_hex`). Coverage
+  alone cannot catch this: a widget that reaches around the table and calls
+  ``semantic_color`` straight from a fresh call site never references an
+  element id at all, so nothing in check 1 sees it. This is the AST
+  allow-list proposal §2.5 check 2 specifies.
+- **equivalence with the pre-refactor call sites** — :func:`bindings.style`
+  and the two adapters reproduce the exact rich ``Style`` objects the old
+  inline ``Style(color=semantic_color(...))`` calls produced. This is the
+  slice's hard requirement (§6 Slice 2: "behaviour must be byte-identical to
+  post-slice-1") turned into a running assertion rather than a one-time
+  manual diff.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+from rich.style import Style
+
+from local_operator.tui import bindings, theme
+from local_operator.tui.bindings import BINDINGS, BY_ELEMENT, Binding, Role, Surface
+
+
+@pytest.fixture(autouse=True)
+def _restore_theme() -> None:
+    """`theme.current_theme()` is a module singleton (see `test_theme.py`);
+    this file switches it repeatedly and must not leak a choice into whatever
+    test runs next in the same process."""
+    original = theme.current_theme()
+    yield
+    theme.set_theme(original)
+
+
+# ---------------------------------------------------------------------------
+# Totality: every binding is well-formed against the live theme registry.
+# ---------------------------------------------------------------------------
+
+
+def test_bindings_table_has_no_duplicate_elements() -> None:
+    """One row per element — a duplicate would make `BY_ELEMENT` non-total
+    in the direction that matters (silently keeping the second definition)."""
+    elements = [binding.element for binding in BINDINGS]
+    assert len(elements) == len(set(elements))
+
+
+@pytest.mark.parametrize("theme_name", theme.available_themes())
+def test_every_binding_resolves_to_a_real_token(theme_name: str) -> None:
+    """Every ``token`` and ``ground`` is a live semantic token, for EVERY
+    registered theme (not just the two brand ramps `theme.py`'s own totality
+    check already covers) — a curated palette missing a token this table
+    reaches for would otherwise only fail once a user actually selected it."""
+    for binding in BINDINGS:
+        # Raises KeyError (an assertion failure, via pytest.fail below) for
+        # an unknown token — exercised directly rather than through
+        # `pytest.raises` so every bad binding is named, not just the first.
+        try:
+            theme.semantic_color(binding.token, theme_name)
+            theme.semantic_color(binding.ground, theme_name)
+        except KeyError as exc:
+            pytest.fail(f"{binding.element}: {exc}")
+
+
+def test_every_binding_declares_a_role_and_surface() -> None:
+    """`role`/`surface` are what makes the budget (§1.2) and the future
+    surface-scoped distinctness gate (§4.2) machine-checkable; a binding
+    with neither would silently opt out of both."""
+    for binding in BINDINGS:
+        assert isinstance(binding.role, Role), binding.element
+        assert isinstance(binding.surface, Surface), binding.element
+
+
+def test_ground_bindings_carry_no_note_free_pass() -> None:
+    """Sanity check on the table's own shape: a `Binding` is frozen, so this
+    just confirms construction produced the dataclass this module expects
+    (guards against a future edit accidentally swapping in a plain tuple)."""
+    for binding in BINDINGS:
+        assert isinstance(binding, Binding)
+
+
+def test_ground_hex_matches_style_for_every_ground_binding() -> None:
+    """`ground_hex()` (the fourth seam markdown_theme.py now calls instead of
+    reaching for `theme.semantic_color` directly) must agree with `style()`
+    for every `Role.GROUND` row, in every registered theme — the two are
+    reading the same binding through two different rich-facing shapes
+    (a raw hex vs. a `Style(bgcolor=...)`), and a divergence between them
+    would mean one of the two seams drifted from `BY_ELEMENT`."""
+    ground_elements = [b.element for b in BINDINGS if b.role is Role.GROUND]
+    assert ground_elements, "expected at least one Role.GROUND binding"
+    for theme_name in ("dark", "light", "rose-pine-dawn"):
+        theme.set_theme(theme_name)
+        for element in ground_elements:
+            assert bindings.ground_hex(element) == bindings.style(element).bgcolor.name
+
+
+def test_ground_hex_rejects_a_non_ground_element() -> None:
+    """`ground_hex` is for GROUND rows only — an ink binding reaching for it
+    would be a call-site bug (the wrong seam for what it wants), not a
+    legitimate use, so it raises rather than silently returning ink as if it
+    were a surface."""
+    with pytest.raises(ValueError):
+        bindings.ground_hex("markdown.h1")
+
+
+# ---------------------------------------------------------------------------
+# Coverage: every element the transcript / tool row paint is IN the table.
+# `bindings.markdown_theme()` / `syntax_styles()` are exercised directly —
+# they are exhaustive over `_MARKDOWN_BINDINGS` / `_CODE_BINDINGS` by
+# construction (§2.5 check 1's real content, since those two adapters ARE
+# the exhaustive readers). The tool-row half is checked by asserting the
+# ids actually referenced from `widgets/tool_card.py`'s source are present —
+# see `test_tool_card_source_only_uses_declared_elements` below, which is
+# what makes the gate demonstrably able to FAIL (§6 Slice 2 verification).
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_theme_covers_every_rich_markdown_element() -> None:
+    """`bindings.markdown_theme()` names every element the old inline dict
+    at `markdown_theme.py:125-157` did — the coverage claim for prose."""
+    expected = {
+        "markdown.paragraph",
+        "markdown.text",
+        "markdown.em",
+        "markdown.strong",
+        "markdown.code",
+        "markdown.code_block",
+        "markdown.block_quote",
+        "markdown.list",
+        "markdown.item.bullet",
+        "markdown.item.number",
+        "markdown.hr",
+        "markdown.h1",
+        "markdown.h2",
+        "markdown.h3",
+        "markdown.h4",
+        "markdown.h5",
+        "markdown.h6",
+        "markdown.link",
+        "markdown.link_url",
+    }
+    got = set(bindings.markdown_theme().styles)
+    assert expected <= got, expected - got
+
+
+def test_syntax_styles_covers_every_pygments_token_the_ramp_named() -> None:
+    """`bindings.syntax_styles()` names every pygments token
+    `IslandSyntaxTheme.__init__` used to."""
+    from pygments.token import (
+        Comment,
+        Error,
+        Generic,
+        Keyword,
+        Name,
+        Number,
+        Operator,
+        Punctuation,
+        String,
+        Token,
+    )
+
+    expected = {
+        Token,
+        Comment,
+        Keyword,
+        Keyword.Constant,
+        Name,
+        Name.Function,
+        Name.Class,
+        Name.Builtin,
+        String,
+        Number,
+        Operator,
+        Punctuation,
+        Error,
+        Generic,
+    }
+    got = set(bindings.syntax_styles())
+    assert expected <= got, expected - got
+
+
+#: Every element id actually referenced in `widgets/tool_card.py`, gathered
+#: by source inspection rather than hand transcription — the whole point of
+#: a coverage test is that it reads the real call sites, not a list an
+#: editor could let drift from them.
+#:
+#: Collects every string constant shaped like a binding id (``tool.*``),
+#: not only literals passed straight to `bindings.style(...)`: several call
+#: sites route through a variable chosen by an if/else first (``slot_element
+#: = "tool.row.slot_offer"`` ... later ``bindings.style(slot_element)``), and
+#: narrowing to direct-call literals would silently miss exactly those. The
+#: shape filter (rather than intersecting with `BY_ELEMENT` up front) is
+#: what keeps this able to catch a REMOVED binding — intersecting first
+#: would make a missing element invisible by construction.
+def _tool_card_referenced_elements() -> set[str]:
+    import ast
+    import inspect
+
+    from local_operator.tui.widgets import tool_card
+
+    source = inspect.getsource(tool_card)
+    tree = ast.parse(source)
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and node.value.startswith("tool.")
+    }
+
+
+def test_tool_card_source_only_uses_declared_elements() -> None:
+    """Every literal element id `tool_card.py` passes to `bindings.style`
+    names a real row in the table.
+
+    This is the check that could not be written before this module existed
+    (§2.1: "there is no object to enumerate elements from"), and it is the
+    coverage gate proper: a call site referencing a removed or misspelled
+    element fails HERE instead of at render time inside whichever widget
+    happens to ask first.
+    """
+    referenced = _tool_card_referenced_elements()
+    assert referenced, "expected to find bindings.style(...) calls in tool_card.py"
+    missing = referenced - set(BY_ELEMENT)
+    assert not missing, f"tool_card.py references undeclared elements: {missing}"
+
+
+def test_removing_a_referenced_binding_is_caught(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The gate actually FAILS on a deliberately introduced violation (§6
+    Slice 2: "the coverage test must fail if a binding is removed —
+    demonstrate that, don't assert it").
+
+    Simulates the removal by shrinking `BY_ELEMENT` to omit one element the
+    source references, then re-running the same check the test above makes
+    inline (duplicated rather than refactored into a shared helper, so this
+    test still fails even if a future edit changes how the real test reads
+    `BY_ELEMENT`).
+    """
+    referenced = _tool_card_referenced_elements()
+    victim = "tool.status.success_glyph"
+    assert victim in referenced  # the removal has to be observable
+    thinned = {element: binding for element, binding in BY_ELEMENT.items() if element != victim}
+    monkeypatch.setattr(bindings, "BY_ELEMENT", thinned)
+    missing = referenced - set(bindings.BY_ELEMENT)
+    assert missing == {victim}
+
+
+# ---------------------------------------------------------------------------
+# No bypass (§2.5 check 2): a migrated module may not call
+# `theme.semantic_color` directly. Coverage (above) catches a call site that
+# references a REMOVED element; it cannot catch one that never references an
+# element at all — a fresh `Style(color=theme_mod.semantic_color("dim"))`
+# dropped into a migrated module reads a real token and renders a real
+# style, so nothing about it looks broken, and no `BY_ELEMENT` lookup is
+# anywhere near it. That is the gap §2.5 check 2's AST allow-list exists to
+# close: it does not ask "does this resolve", it asks "does this call site
+# exist at all outside the table's own seams".
+# ---------------------------------------------------------------------------
+
+#: Modules migrated onto the table (§2.5 check 2's ratchet — "a file joins it
+#: when it is migrated, and can never leave"). `tool_card.py` and
+#: `markdown_theme.py` are the two this slice covers.
+#:
+#: `transcript.py` is a KNOWN, DELIBERATE exception, not a failure: it is not
+#: yet migrated (its ``UserBlock``/``NoticeBlock``/notice-kind call sites are
+#: exactly the ones `local_operator.tcss`'s own §2.3-option-(b) split leaves
+#: outside this table's scope for now), so it is not on this list. Adding it
+#: without migrating its call sites first would fail this gate for a module
+#: nobody has touched — the ratchet only tightens once, on purpose.
+_MIGRATED_MODULES: tuple[str, ...] = (
+    "local_operator.tui.markdown_theme",
+    "local_operator.tui.widgets.tool_card",
+)
+
+
+def _semantic_color_call_sites(source: str) -> set[tuple[str, int]]:
+    """Every direct ``semantic_color(...)`` call in ``source``, as
+    ``(qualname, lineno)`` pairs — empty for a module that only reaches the
+    ramp through :mod:`bindings`.
+
+    Two aliasing shapes appear in this codebase and both are followed:
+    ``theme_mod.semantic_color(...)`` (an attribute call through
+    ``from local_operator.tui import theme as theme_mod``) and a bare-name
+    alias — either ``_C = theme_mod.semantic_color`` (bindings.py's own
+    pattern, before this slice) or ``from local_operator.tui.theme import
+    semantic_color``. :func:`bindings.style`/:func:`bindings.markdown_theme`/
+    :func:`bindings.syntax_styles`/:func:`bindings.ground_hex` are the
+    sanctioned seams and live in ``bindings.py`` itself, which this check
+    never inspects — a migrated module is expected to call THOSE, not
+    ``semantic_color``.
+    """
+    tree = ast.parse(source)
+
+    module_aliases: set[str] = set()
+    name_aliases: set[str] = {"semantic_color"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "local_operator.tui":
+            for alias in node.names:
+                if alias.name == "theme":
+                    module_aliases.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "local_operator.tui.theme":
+                    module_aliases.add(alias.asname or "theme")
+        elif isinstance(node, ast.ImportFrom) and node.module == "local_operator.tui.theme":
+            for alias in node.names:
+                if alias.name == "semantic_color":
+                    name_aliases.add(alias.asname or alias.name)
+
+    # Second pass: `_C = theme_mod.semantic_color` binds a bare name to the
+    # attribute alias found above — needs the module aliases resolved first,
+    # and the assignment may appear before or after the import in source.
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "semantic_color"
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id in module_aliases
+        ):
+            name_aliases.add(node.targets[0].id)
+
+    stack: list[str] = []
+    sites: set[tuple[str, int]] = set()
+
+    class _Visitor(ast.NodeVisitor):
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            stack.append(node.name)
+            self.generic_visit(node)
+            stack.pop()
+
+        def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+            stack.append(node.name)
+            self.generic_visit(node)
+            stack.pop()
+
+        visit_FunctionDef = _visit_function
+        visit_AsyncFunctionDef = _visit_function
+
+        def visit_Call(self, node: ast.Call) -> None:
+            func = node.func
+            is_hit = (isinstance(func, ast.Name) and func.id in name_aliases) or (
+                isinstance(func, ast.Attribute)
+                and func.attr == "semantic_color"
+                and isinstance(func.value, ast.Name)
+                and func.value.id in module_aliases
+            )
+            if is_hit:
+                qualname = ".".join(stack) if stack else "<module>"
+                sites.add((qualname, node.lineno))
+            self.generic_visit(node)
+
+    _Visitor().visit(tree)
+    return sites
+
+
+def _module_source_path(dotted_name: str):
+    import importlib
+
+    module = importlib.import_module(dotted_name)
+    assert module.__file__ is not None, dotted_name
+    from pathlib import Path
+
+    return Path(module.__file__)
+
+
+@pytest.mark.parametrize("module_name", _MIGRATED_MODULES)
+def test_migrated_module_never_calls_semantic_color_directly(module_name: str) -> None:
+    """§2.5 check 2, the real check: NOT "was a binding removed" (coverage,
+    above) but "did a call site go around the table entirely". A migrated
+    module must reach the ramp only through :mod:`bindings`'s own seams.
+
+    See :func:`test_the_bypass_gate_actually_fails` for proof this is not a
+    check that can never fail — it deliberately introduces the exact
+    violation this test polices, watches it fail, then restores the file
+    byte-identically.
+    """
+    source = _module_source_path(module_name).read_text()
+    sites = _semantic_color_call_sites(source)
+    assert not sites, f"{module_name} calls semantic_color directly outside bindings.py: {sites}"
+
+
+def test_the_bypass_gate_actually_fails() -> None:
+    """The gate is not decoration: prove it catches a REAL bypass by
+    introducing one and watching the same check the parametrized test above
+    runs report it.
+
+    §6: "a gate not proven to fail is not a gate." This is that proof for
+    check 2, the same way `test_removing_a_referenced_binding_is_caught` is
+    that proof for check 1 — and it follows the same shape: read the real
+    source, mutate the STRING, assert on the mutated string, never write
+    back to disk. `tests/unit` runs under pytest-xdist (`-n auto` in
+    `pyproject.toml`); several workers import `markdown_theme.py`
+    concurrently, so writing a bypass to the real file (even briefly, even
+    restored in a `finally`) would race a sibling worker's import against
+    the mutated bytes — this was tried and reproduced exactly that failure.
+    The disk-level version of this demonstration — edit the file, run the
+    suite, `git diff` to confirm, restore, run green — is the one-time
+    manual proof recorded in the slice's own handoff, not a standing test.
+    """
+    original = _module_source_path("local_operator.tui.markdown_theme").read_text()
+    assert not _semantic_color_call_sites(original), "fixture module must start clean"
+
+    bypass = original.replace(
+        "from local_operator.tui import bindings\n",
+        "from local_operator.tui import bindings\n"
+        "from local_operator.tui import theme as theme_mod\n",
+        1,
+    ).replace(
+        "    def get_background_style(self) -> Style:  # type: ignore[override]\n"
+        '        return Style(bgcolor=bindings.ground_hex("code.background"))\n',
+        "    def get_background_style(self) -> Style:  # type: ignore[override]\n"
+        '        return Style(bgcolor=theme_mod.semantic_color("bg"))  # BYPASS\n',
+        1,
+    )
+    assert bypass != original, "fixture edit did not match the file's current text"
+
+    caught = _semantic_color_call_sites(bypass)
+    assert caught, "the introduced bypass was not detected — gate is not a gate"
+    assert any(line == "IslandSyntaxTheme.get_background_style" for line, _ in caught)
+
+
+# ---------------------------------------------------------------------------
+# Equivalence: bindings.style() reproduces the exact old inline Style().
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("theme_name", ["dark", "light", "rose-pine-dawn"])
+class TestStyleMatchesPreRefactorLiterals:
+    """One assertion per pre-refactor call site (§2.1's ~28 tool_card.py
+    entries plus the two markdown/syntax dicts), spelled as the literal the
+    old code used to construct — so a change to `bindings.style()` that
+    silently altered a resolution would fail a *specific*, named case
+    instead of a generic round-trip check."""
+
+    def test_tool_status_success_glyph(self, theme_name: str) -> None:
+        theme.set_theme(theme_name)
+        assert bindings.style("tool.status.success_glyph") == Style(
+            color=theme.semantic_color("success")
+        )
+
+    def test_tool_status_error_glyph(self, theme_name: str) -> None:
+        theme.set_theme(theme_name)
+        assert bindings.style("tool.status.error_glyph") == Style(
+            color=theme.semantic_color("danger")
+        )
+
+    def test_tool_diff_added_and_removed(self, theme_name: str) -> None:
+        theme.set_theme(theme_name)
+        assert bindings.style("tool.diff.added") == Style(color=theme.semantic_color("success"))
+        assert bindings.style("tool.diff.removed") == Style(color=theme.semantic_color("danger"))
+
+    def test_tool_row_icon_running_is_accent(self, theme_name: str) -> None:
+        theme.set_theme(theme_name)
+        assert bindings.style("tool.row.icon_running") == Style(
+            color=theme.semantic_color("accent")
+        )
+
+    def test_tool_row_name_running_is_string(self, theme_name: str) -> None:
+        theme.set_theme(theme_name)
+        assert bindings.style("tool.row.name_running") == Style(
+            color=theme.semantic_color("string")
+        )
+
+    def test_markdown_h1_is_bold_accent(self, theme_name: str) -> None:
+        theme.set_theme(theme_name)
+        assert bindings.style("markdown.h1") == Style(
+            color=theme.semantic_color("accent"), bold=True
+        )
+
+    def test_markdown_hr_is_dim_not_edge(self, theme_name: str) -> None:
+        theme.set_theme(theme_name)
+        assert bindings.style("markdown.hr") == Style(color=theme.semantic_color("dim"))
+
+    def test_markdown_code_is_signal(self, theme_name: str) -> None:
+        theme.set_theme(theme_name)
+        assert bindings.style("markdown.code") == Style(color=theme.semantic_color("signal"))

--- a/tests/unit/tui/test_bindings.py
+++ b/tests/unit/tui/test_bindings.py
@@ -27,6 +27,7 @@ Four things asserted here:
 from __future__ import annotations
 
 import ast
+from collections.abc import Iterator
 
 import pytest
 from rich.style import Style
@@ -36,7 +37,7 @@ from local_operator.tui.bindings import BINDINGS, BY_ELEMENT, Binding, Role, Sur
 
 
 @pytest.fixture(autouse=True)
-def _restore_theme() -> None:
+def _restore_theme() -> Iterator[None]:
     """`theme.current_theme()` is a module singleton (see `test_theme.py`);
     this file switches it repeatedly and must not leak a choice into whatever
     test runs next in the same process."""
@@ -103,7 +104,12 @@ def test_ground_hex_matches_style_for_every_ground_binding() -> None:
     for theme_name in ("dark", "light", "rose-pine-dawn"):
         theme.set_theme(theme_name)
         for element in ground_elements:
-            assert bindings.ground_hex(element) == bindings.style(element).bgcolor.name
+            bgcolor = bindings.style(element).bgcolor
+            # rich's Style.bgcolor is Color | None; a GROUND binding always sets
+            # it, so this narrows the type for pyright rather than guarding a
+            # real runtime possibility.
+            assert bgcolor is not None
+            assert bindings.ground_hex(element) == bgcolor.name
 
 
 def test_ground_hex_rejects_a_non_ground_element() -> None:

--- a/tests/unit/tui/test_palette_contrast.py
+++ b/tests/unit/tui/test_palette_contrast.py
@@ -77,8 +77,17 @@ _ALL_THEMES = theme.available_themes()
 
 @pytest.mark.parametrize("name", _ALL_THEMES)
 def test_theme_is_total(name: str) -> None:
+    """Every required token is present; nothing outside the known vocabulary is.
+
+    ``theme.OPTIONAL_TOKENS`` (the tool-category family) sits outside the
+    required set but is always resolved by ``register_theme`` — a theme that
+    does not author one still ends up with a filled value, so ``spec.tokens``
+    is exactly ``SEMANTIC_TOKENS | OPTIONAL_TOKENS`` for every registered
+    theme, never a partial set.
+    """
     spec = theme.theme_spec(name)
-    assert set(spec.tokens) == set(theme.SEMANTIC_TOKENS)
+    assert set(theme.SEMANTIC_TOKENS) <= set(spec.tokens)
+    assert set(spec.tokens) == set(theme.SEMANTIC_TOKENS) | set(theme.OPTIONAL_TOKENS)
     assert spec.label, f"{name} has no picker label"
     assert spec.description, f"{name} has no picker description"
 
@@ -147,6 +156,7 @@ def test_elevation_is_monotonic(name: str) -> None:
 
 @pytest.mark.parametrize("name", _ALL_THEMES)
 def test_tints_are_casts_not_slabs(name: str) -> None:
+    """Every tint stays a cast, not a slab: near the ground in luminance."""
     tokens = theme.theme_spec(name).tokens
     failures: list[str] = []
     for token in ("tint-danger", "tint-select", "tint-select-hi"):

--- a/tests/unit/tui/test_user_block.py
+++ b/tests/unit/tui/test_user_block.py
@@ -305,7 +305,7 @@ async def test_a_prompt_in_the_nested_subagent_body_paints_every_row_it_reserves
 
 
 def test_the_rule_never_spends_the_accent() -> None:
-    """The accent green is spent on four sites and means "a turn is live".
+    """The accent green is spent on five sites and means "a turn is live".
 
     A green column beside every prompt would be the largest accent surface in
     the app and would mean nothing — see the exhaustive list in


### PR DESCRIPTION
## What this fixes

The transcript reads flat in every theme, and the cause is not the palettes.

Three tokens — `fg`, `muted`, `dim` — carry **33 of 50** transcript ink slots, and that number is **identical in all 54 themes**. A figure that does not move when the palette changes is not a property of the palette. `rose-pine-dawn` authors all six canonical Rosé Pine accents; a settled transcript reached two of them.

The existing gate cannot see this: every check in `test_palette_contrast.py` is WCAG luminance, so **23 distinct greys would pass**. Contrast was never the problem — separation was.
## Before / after

**Before (current `main`) left, after right.** Rendered from the real `OperatorApp`; each frame parsed to confirm the resolved hex, not eyeballed. `rose-pine-dawn` is shown inline per scenario; **12 themes total** are collapsed under each (dracula, alucard, github-light, catppuccin-mocha, tokyo-night, gruvbox, nord, one-dark, solarized-dark, monokai, everforest).

> Note: the tool-category hues are **optional** tokens with a conservative default derivation — `read`-family picks up the reference hue, but `edit`/`bash` fall to the neutral ramp unless a theme authors `tool-mutate`/`tool-exec`. So in most themes you'll see the read-family coloured and edit/bash still neutral; `rose-pine-dawn` is the one theme that authors all four. This is deliberate (a theme opts in), not a rendering gap.

### headings

_h1 accent / h2 meta-hue, both distinct from inline bold; leading above h1/h2; rule now visible_

![headings rose-pine-dawn](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/headings-rose-pine-dawn.png)

<details><summary>11 more themes — dark & light</summary>

**dracula**

![headings dracula](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/headings-dracula.png)

**catppuccin-mocha**

![headings catppuccin-mocha](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/headings-catppuccin-mocha.png)

**tokyo-night**

![headings tokyo-night](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/headings-tokyo-night.png)

**gruvbox**

![headings gruvbox](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/headings-gruvbox.png)

**nord**

![headings nord](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/headings-nord.png)

**one-dark**

![headings one-dark](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/headings-one-dark.png)

**solarized-dark**

![headings solarized-dark](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/headings-solarized-dark.png)

**monokai**

![headings monokai](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/headings-monokai.png)

**everforest**

![headings everforest](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/headings-everforest.png)

**github-light**

![headings github-light](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/headings-github-light.png)

**alucard**

![headings alucard](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/headings-alucard.png)

</details>

### answer

_the realistic `##`-led reply — section headers, list markers, italic blockquote_

![answer rose-pine-dawn](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/answer-rose-pine-dawn.png)

<details><summary>11 more themes — dark & light</summary>

**dracula**

![answer dracula](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/answer-dracula.png)

**catppuccin-mocha**

![answer catppuccin-mocha](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/answer-catppuccin-mocha.png)

**tokyo-night**

![answer tokyo-night](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/answer-tokyo-night.png)

**gruvbox**

![answer gruvbox](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/answer-gruvbox.png)

**nord**

![answer nord](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/answer-nord.png)

**one-dark**

![answer one-dark](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/answer-one-dark.png)

**solarized-dark**

![answer solarized-dark](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/answer-solarized-dark.png)

**monokai**

![answer monokai](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/answer-monokai.png)

**everforest**

![answer everforest](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/answer-everforest.png)

**github-light**

![answer github-light](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/answer-github-light.png)

**alucard**

![answer alucard](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/answer-alucard.png)

</details>

### ledger

_settled tool names by category; running row keeps its green_

![ledger rose-pine-dawn](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/ledger-rose-pine-dawn.png)

<details><summary>11 more themes — dark & light</summary>

**dracula**

![ledger dracula](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/ledger-dracula.png)

**catppuccin-mocha**

![ledger catppuccin-mocha](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/ledger-catppuccin-mocha.png)

**tokyo-night**

![ledger tokyo-night](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/ledger-tokyo-night.png)

**gruvbox**

![ledger gruvbox](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/ledger-gruvbox.png)

**nord**

![ledger nord](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/ledger-nord.png)

**one-dark**

![ledger one-dark](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/ledger-one-dark.png)

**solarized-dark**

![ledger solarized-dark](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/ledger-solarized-dark.png)

**monokai**

![ledger monokai](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/ledger-monokai.png)

**everforest**

![ledger everforest](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/ledger-everforest.png)

**github-light**

![ledger github-light](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/ledger-github-light.png)

**alucard**

![ledger alucard](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/ledger-alucard.png)

</details>

### session

_the prompt gutter now carries the reference hue; no background slab_

![session rose-pine-dawn](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/session-rose-pine-dawn.png)

<details><summary>11 more themes — dark & light</summary>

**dracula**

![session dracula](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/session-dracula.png)

**catppuccin-mocha**

![session catppuccin-mocha](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/session-catppuccin-mocha.png)

**tokyo-night**

![session tokyo-night](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/session-tokyo-night.png)

**gruvbox**

![session gruvbox](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/session-gruvbox.png)

**nord**

![session nord](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/session-nord.png)

**one-dark**

![session one-dark](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/session-one-dark.png)

**solarized-dark**

![session solarized-dark](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/session-solarized-dark.png)

**monokai**

![session monokai](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/session-monokai.png)

**everforest**

![session everforest](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/session-everforest.png)

**github-light**

![session github-light](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/session-github-light.png)

**alucard**

![session alucard](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/session-alucard.png)

</details>

### code

_syntax ramp unchanged — this PR does not touch fence colours_

![code rose-pine-dawn](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/code-rose-pine-dawn.png)

<details><summary>11 more themes — dark & light</summary>

**dracula**

![code dracula](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/code-dracula.png)

**catppuccin-mocha**

![code catppuccin-mocha](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/code-catppuccin-mocha.png)

**tokyo-night**

![code tokyo-night](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/code-tokyo-night.png)

**gruvbox**

![code gruvbox](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/code-gruvbox.png)

**nord**

![code nord](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/code-nord.png)

**one-dark**

![code one-dark](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/code-one-dark.png)

**solarized-dark**

![code solarized-dark](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/code-solarized-dark.png)

**monokai**

![code monokai](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/code-monokai.png)

**everforest**

![code everforest](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/code-everforest.png)

**github-light**

![code github-light](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/code-github-light.png)

**alucard**

![code alucard](https://gist.githubusercontent.com/bbqben/99546d33372ad111db3056e681de553a/raw/75d6899ddfd44b496ef88d3c736322f68e267567/code-alucard.png)

</details>

## The changes

Each is a case where a mark that carries meaning was drawn in the ink used for everything incidental.

| Element | Before | After |
|---|---|---|
| `markdown.h2` | `fg` — **byte-identical to `markdown.strong`** | `label` |
| `markdown.h1` | `fg` | `accent`, plus leading above h1/h2 |
| Settled tool name | one grey for every tool | `tool-read` / `tool-mutate` / `tool-exec` / `tool-meta` |
| Success glyph | `dim` (same hex as duration and expand hint) | `success` |
| `markdown.hr` | `edge` — under 3:1 on `bg` in **54/54** themes | `dim` |
| List markers, blockquotes | `dim` / `muted` | `label` (quotes also italic) |
| Prompt gutter rule | `dim`, the sheet's separator ink | `signal` |

### Tool identity gets its own tokens, not borrowed ones

`tool-read` / `tool-mutate` / `tool-exec` / `tool-meta` are **optional** tokens filled by derivation, so all 54 themes keep working with zero edits and none changes appearance unless it opts in.

They are deliberately not a reuse of `warning`/`accent`. Those names have contracts — *"a warning happened"*, *"the one green: live indicator, focus"* — and binding tool identity to them means a theme author tuning `warning` for alarm legibility silently retunes tool names. The category axis is not invented either: `glyphs.PLAIN_TOOL_ICONS` already groups its fallbacks by shell/read/mutate/search/meta.

**Liveness outranks identity**: a running row keeps its existing green name, and the category hue applies only once the row settles — one mechanism per meaning.

### The prompt gets a colour, on its rule

The bar is the only *continuous multi-row column* in the transcript, so it is the cheapest place a hue can go: one half-cell per row, zero area, nothing tinted.

A **background** was implemented, rendered, reviewed and **rejected** first — a fill behind every prompt competes with the tool ledger, the one surface whose fill carries meaning. That work is not in this branch; only the conclusion is.

### What is deliberately unchanged

- **Bold and italic.** `warning` falls below the 4.5:1 body-text floor in 5 of 54 themes and `label` in 4. A marker or a quote can sit at 4.3:1; a bolded phrase is *body text*, and running the most-read ink below its own floor to make it pop is the wrong trade. Bold keeps weight, which already distinguishes it.
- **`NoticeKind.success`** stays neutral — three greens on one surface is a real problem.
- **Syntax keywords** stay `muted`.
- The accent stays scarce. The enumeration in `local_operator.tcss` is reconciled (it said four, two other files said five) and h1 is added to it explicitly.

## The binding table

The first commit is a pure refactor with no visible change. Colour decisions lived in four places with no shared vocabulary, which had three costs:

1. A gate asserting two elements stay distinguishable **could not be written** — distinctness is pairwise over co-occurring elements, and there was no object to enumerate elements from.
2. The budget could not be audited. The stylesheet told the reader to `grep -rn 'accent'` and warned the obvious narrower grep misses two of four sites. It had already drifted.
3. Rebinding one element was a multi-file edit.

`bindings.py` carries element → token, the ground it renders on, a `Role` (making the budget machine-checkable) and a `Surface` (encoding co-occurrence, so a future gate is not forced to demand a picker row be distinguishable from a code comment). Every rationale comment moved into `Binding.note` **verbatim**.

`semantic_color` stays public and unchanged — 365 call sites across 27 files reach the theme, and routing all of them through bindings is a rewrite, not a fix.

**The new coverage gate earned its place twice during development**: it rejected an f-string that made call sites invisible to the AST walk, and flake8 caught the dead local that change left behind.

## Verification

- **4589 passed, 12 skipped** (`tests/unit/tui/`), on the tree merged with `main`, not just at the branch head.
- flake8 and black clean.
- Rendered before/after frames across **5 scenarios × 5 themes** (`rose-pine-dawn`, `dark`, `github-light`, `dracula`, `alucard`), each parsed to confirm the resolved hex — not eyeballed.

Measured in `rose-pine-dawn`:

| | before | after |
|---|---|---|
| h1 | `#4d496b` | `#a8594f` |
| h2 | `#4d496b` | `#7d6694` |
| inline bold | `#4d496b` | `#4d496b` (unchanged) |
| **h2 == bold?** | **yes** | **no** |
| `read`/`grep`/`glob` | `#6a6681` | `#41787a` |
| `edit` | `#6a6681` | `#9e6200` |
| `bash` (settled) | `#6a6681` | `#7d6694` |
| `bash` (running) | — | green, distinct from settled |

Distinct tool-name inks in a 13-row ledger: **1 → 4**.

## Notes for review

- Throwaway prototype artifacts (the scenario gallery, flatness/census scripts, rendered evidence) are deliberately **not** in this branch. They live on a local prototype branch; only code and its rationale ship here.
- `rose-pine-dawn` authors an iris focus tint alongside the tool hues. That fixes a separate measured defect — a focused tool row sat ΔE00 **1.71** from an unfocused one, and dawn was the only theme with it (dark 8.54, github-light 8.74).


