### PR TITLE
feat(tui): comfortable action rows, on by default and switchable

### DIFF
--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -543,6 +543,16 @@ SETTINGS: tuple[Setting, ...] = (
         choices=_bool_choices("animate the working line", "static working line"),
     ),
     Setting(
+        key="display.comfortable_rows",
+        path=("display.comfortable_rows",),
+        section="appearance",
+        label="Comfortable action rows",
+        kind=Kind.BOOL,
+        default=True,
+        help="Pad tool and prompt rows so they are easier to click.",
+        choices=_bool_choices("padded, easier to click", "compact, more history"),
+    ),
+    Setting(
         key="display.nerd_icons",
         path=("display.nerd_icons",),
         section="appearance",

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -543,12 +543,13 @@ SETTINGS: tuple[Setting, ...] = (
         choices=_bool_choices("animate the working line", "static working line"),
     ),
     Setting(
+        # Default changed to False by maintainer
         key="display.comfortable_rows",
         path=("display.comfortable_rows",),
         section="appearance",
         label="Comfortable action rows",
         kind=Kind.BOOL,
-        default=True,
+        default=False,
         help="Pad tool and prompt rows so they are easier to click.",
         choices=_bool_choices("padded, easier to click", "compact, more history"),
     ),

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -143,6 +143,7 @@ from local_operator.tui.markdown_theme import (
     install_markdown_theme,
 )
 from local_operator.tui.notify import Notifier, notifications_enabled
+from local_operator.tui.settings import settings_get
 from local_operator.tui.terminal_title import (
     TerminalTitle,
     cwd_label,
@@ -1221,6 +1222,17 @@ ACTIVITY_APPROVAL = "approval"
 #: which RE-DERIVES it from those live facts; the several call sites ask it to
 #: recompute rather than each setting the class from what it believes.
 BOOT_LAYOUT_CLASS = "boot"
+
+#: Class the Screen carries while ``display.comfortable_rows`` is on, which is
+#: the default. Same device as the boot class: a display MODE is one class on
+#: the Screen and the padding itself is the stylesheet's problem, so nothing
+#: here knows a cell count and the setting cannot drift from the rule.
+#:
+#: On the Screen rather than per block because the blocks are built at
+#: different times — a card mounted mid-turn would otherwise have to ask the
+#: setting for itself, and a live toggle would have to walk and re-tag every
+#: block already on screen instead of flipping one class.
+COMFORTABLE_ROWS_CLASS = "comfortable-rows"
 
 #: Class the Screen carries while the full-page subagent view is open. Same
 #: device as the boot class — a mode is one class on the Screen and the rest is
@@ -2658,6 +2670,7 @@ class OperatorApp(App[None]):
         except Exception:
             pass  # headless consoles without a pushable theme keep defaults
         self.ansi_theme_dark = _brand_terminal_theme()
+        self._sync_row_density_class()
 
         transcript = self._transcript_view()
         transcript.set_on_clear(self._on_transcript_cleared)  # TUI-009 hook
@@ -9713,6 +9726,24 @@ class OperatorApp(App[None]):
             self._sync_boot_column_width(max(0, self.size.width - SCREEN_INSET))
         self._sync_boot_layout()
 
+    def _sync_row_density_class(self) -> None:
+        """Put ``Screen.comfortable-rows`` on iff the setting says so.
+
+        Re-derived from the stored flag rather than toggled, so the startup
+        path and the live-apply path cannot disagree — the same discipline
+        :meth:`_sync_boot_layout_class` states for the boot class.
+
+        Guarded because it runs on the mount path: a screen that is not up
+        yet (headless construction, an early failure) must not cost a boot.
+        """
+        try:
+            self.screen.set_class(
+                bool(settings_get("display.comfortable_rows", True)),
+                COMFORTABLE_ROWS_CLASS,
+            )
+        except Exception:  # noqa: BLE001 — density is cosmetic; never fail a boot for it
+            logger.debug("settings: row density class not applied", exc_info=True)
+
     def _sync_boot_layout_class(self) -> None:
         """Put ``Screen.boot`` on only while no full-page MODE is up.
 
@@ -12071,6 +12102,12 @@ class OperatorApp(App[None]):
         try:
             if message.key == "tui.theme" and message.value:
                 self._apply_theme(str(message.value))
+            elif message.key == "display.comfortable_rows":
+                # Layout, not ink: the padding lives in the stylesheet behind
+                # one Screen class, so flipping the class is the whole apply
+                # and every block already on screen re-lays out with it. A
+                # repaint would re-ink content that has not changed colour.
+                self._sync_row_density_class()
             elif message.key.startswith("display."):
                 # The display flags are read through the cached fast path, which
                 # `settings_io` already invalidated; the widgets that resolved a

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1223,9 +1223,10 @@ ACTIVITY_APPROVAL = "approval"
 #: recompute rather than each setting the class from what it believes.
 BOOT_LAYOUT_CLASS = "boot"
 
-#: Class the Screen carries while ``display.comfortable_rows`` is on, which is
-#: the default. Same device as the boot class: a display MODE is one class on
-#: the Screen and the padding itself is the stylesheet's problem, so nothing
+#: Class the Screen carries while ``display.comfortable_rows`` is on (default
+#: was changed to OFF by the maintainer). Same device as the boot class: a
+#: display MODE is one class on the Screen and the padding itself is the
+#: stylesheet's problem, so nothing
 #: here knows a cell count and the setting cannot drift from the rule.
 #:
 #: On the Screen rather than per block because the blocks are built at
@@ -9737,8 +9738,9 @@ class OperatorApp(App[None]):
         yet (headless construction, an early failure) must not cost a boot.
         """
         try:
+            # Default was changed to False by the maintainer
             self.screen.set_class(
-                bool(settings_get("display.comfortable_rows", True)),
+                bool(settings_get("display.comfortable_rows", False)),
                 COMFORTABLE_ROWS_CLASS,
             )
         except Exception:  # noqa: BLE001 — density is cosmetic; never fail a boot for it

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -209,6 +209,21 @@ UserBlock {
     color: $lo-fg;
 }
 
+/* The prompt's half of `display.comfortable_rows`, so a prompt and an action
+ * row keep one vertical rhythm rather than the setting splitting them.
+ *
+ * VERTICAL ONLY, and that is a constraint rather than a preference. The block
+ * wraps its own text (the gutter bar has to land on every wrapped row) and
+ * measures with `self.size.width`, which INCLUDES horizontal padding, while
+ * `render()` is handed the CONTENT width. Left/right padding here would leave
+ * the widget wrapping to a width two cells wider than it is given, and the
+ * prompt renders as a tinted band with no prose in it. Top/bottom padding is
+ * safe: the block is `height: auto` and writes its own height from the row
+ * count, so vertical padding grows it instead of clipping it. */
+.comfortable-rows UserBlock {
+    padding: 1 0 0 0;
+}
+
 NoticeBlock {
     color: $lo-dim;
 }
@@ -280,6 +295,47 @@ ToolCard, WakeBlock {
  * is the same. */
 ToolCard.tool-expanded, WakeBlock.wake-expanded {
     height: auto;
+}
+
+/* COMFORTABLE DENSITY (`display.comfortable_rows`, default ON). One padding
+ * row above and below an action's summary.
+ *
+ * This is a HIT TARGET, not decoration. The whole row is the click surface
+ * for expand/collapse (`ExpandableActionBlock.on_click` is on the widget, so
+ * padding rows are inside it), and at one cell tall that target was a single
+ * terminal line: a click a row off either landed on a neighbouring action or
+ * fell through to the transcript. Three rows triples the target without
+ * moving a single glyph — the summary is still exactly one row of text, so
+ * the ledger's one-line-per-action reading is unchanged.
+ *
+ * `height: 2` is `1 + padding-top`. Textual sizes a fixed-height widget
+ * INCLUDING its padding, so the two move together or the summary clips. The
+ * class carries BOTH or neither.
+ *
+ * TOP ONLY, and that is a correctness requirement rather than a taste call.
+ * The dock guarantees EXACTLY ONE ground row between the last block and the
+ * composer (`test_composer_seam`, which counts blank rows by walking the
+ * composed frame). A bottom padding row is blank, so a padded last block read
+ * as a five-row seam and the guarantee broke. Padding the top only buys the
+ * same separation between neighbouring rows — every row still gains a cell of
+ * air above it — while the block still ENDS on its summary, so the seam below
+ * the ledger is the dock's one row and nothing else.
+ *
+ * The cost is real: a twelve-row ledger occupies thirty-six rows, so less
+ * history fits on a screen. That is why this is a setting rather than a
+ * decision made for everyone — a user who reads a long ledger more often
+ * than they click one turns it off.
+ *
+ * Expanded rows are exempt: they are already `height: auto` and content-sized,
+ * and the payload gives the pointer plenty to hit. */
+.comfortable-rows ToolCard, .comfortable-rows WakeBlock {
+    height: 2;
+    padding: 1 0 0 0;
+}
+
+.comfortable-rows ToolCard.tool-expanded, .comfortable-rows WakeBlock.wake-expanded {
+    height: auto;
+    padding: 1 0 0 0;
 }
 
 /* State reaches the GROUND, not just the glyph: a live action sits one step

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -297,7 +297,7 @@ ToolCard.tool-expanded, WakeBlock.wake-expanded {
     height: auto;
 }
 
-/* COMFORTABLE DENSITY (`display.comfortable_rows`, default ON). One padding
+/* COMFORTABLE DENSITY (`display.comfortable_rows`, default ON changed to OFF by maintainer). One padding
  * row above and below an action's summary.
  *
  * This is a HIT TARGET, not decoration. The whole row is the click surface

--- a/local_operator/tui/settings.py
+++ b/local_operator/tui/settings.py
@@ -30,6 +30,14 @@ from typing import Any
 #: :func:`_defaults`); this dict is not consulted at runtime.
 _DEFAULT_NOTES: dict[str, Any] = {
     "display.shimmer": True,
+    # One padding row above and below a tool row and a user prompt
+    # (`.comfortable-rows` in the stylesheet). Defaults ON because the row is
+    # the click target for expand/collapse and one cell is a hard thing to
+    # hit — a click a row off lands on the neighbouring action or falls
+    # through to the transcript. OFF is the density trade: a twelve-row
+    # ledger fits in twelve rows instead of thirty-six, for a user who reads
+    # more ledger than they click.
+    "display.comfortable_rows": True,
     # Nerd Font glyphs on tool rows. Default is None = AUTO: unset means
     # `tui/glyphs.py` decides from the terminal-emulator env markers (a
     # bundled Nerd symbol fallback font is enumerable per emulator), so a

--- a/local_operator/tui/settings.py
+++ b/local_operator/tui/settings.py
@@ -31,13 +31,9 @@ from typing import Any
 _DEFAULT_NOTES: dict[str, Any] = {
     "display.shimmer": True,
     # One padding row above and below a tool row and a user prompt
-    # (`.comfortable-rows` in the stylesheet). Defaults ON because the row is
-    # the click target for expand/collapse and one cell is a hard thing to
-    # hit — a click a row off lands on the neighbouring action or falls
-    # through to the transcript. OFF is the density trade: a twelve-row
-    # ledger fits in twelve rows instead of thirty-six, for a user who reads
-    # more ledger than they click.
-    "display.comfortable_rows": True,
+    # (`.comfortable-rows` in the stylesheet). Default ON was changed to OFF
+    # by the maintainer.
+    "display.comfortable_rows": False,
     # Nerd Font glyphs on tool rows. Default is None = AUTO: unset means
     # `tui/glyphs.py` decides from the terminal-emulator env markers (a
     # bundled Nerd symbol fallback font is enumerable per emulator), so a

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -472,6 +472,26 @@ class TranscriptBlock(Static):
             self._settled_rows_cache = _count_rows(self._content, self.size.width or 80)
         return self._settled_rows_cache
 
+    def _set_authored_height(self, rows: int) -> None:
+        """Pin the block's height to ``rows`` of CONTENT plus its own padding.
+
+        A block that authors its own rows KNOWS its height, so it writes it
+        rather than being measured. The subtlety is that Textual's ``height``
+        is the widget's OUTER height — padding included — while ``rows`` is
+        the text the block just laid out. Writing the bare count under
+        ``display.comfortable_rows`` reserved a padding row without growing
+        the block, so the last row of prose was pushed into the dock's seam
+        and the "exactly one ground row above the composer" guarantee broke
+        (``test_composer_seam``).
+
+        Reading the padding back off ``styles`` rather than knowing the
+        setting keeps the arithmetic honest for free: the stylesheet stays
+        the single place the cell count is declared, and a rule that changes
+        it needs no edit here.
+        """
+        padding = self.styles.padding
+        self.styles.height = rows + padding.top + padding.bottom
+
     def spans_multiple_rows(self) -> bool:
         """True when the block currently renders taller than a single row.
 
@@ -997,7 +1017,7 @@ class UserBlock(TranscriptBlock):
         body = max((self.size.width or 80) - self.RULE_COLS, self.MIN_BODY)
         gutter = self.RULE + " " * (self.RULE_COLS - cell_len(self.RULE))
         rows = self._rows(body)
-        self.styles.height = len(rows)
+        self._set_authored_height(len(rows))
         # The receipt is the app talking, so it wears the app's receipt ink -
         # the same `muted` the notice tier uses - not the prose ink of the
         # prompt it sits inside. In the user's own colour it read as a second
@@ -1810,7 +1830,7 @@ class PeerMessageBlock(TranscriptBlock):
 
         rows: list[tuple[str, bool]] = [(row, True) for row in header_rows]
         rows.extend((row, False) for row in body_rows)
-        self.styles.height = len(rows)
+        self._set_authored_height(len(rows))
 
         line = Text(no_wrap=True, overflow="ellipsis")
         for index, (row, is_header) in enumerate(rows):
@@ -2337,9 +2357,54 @@ class TranscriptView(ScrollableContainer):
         """Mount a held batch, with ONE settle pass and ONE empty-state remeasure."""
         if not blocks:
             return
+        # Decided BEFORE the mount, not after. The question "was the reader at
+        # the end" has to be asked while the answer still means something: a
+        # batch that grows the extent leaves the viewport measurably far from
+        # the new end, so asking afterwards reports "scrolled up" for a reader
+        # who never moved.
+        was_at_tail = self._tail_anchor.following or self.is_near_bottom()
         self.mount_all(blocks)
         self.call_after_refresh(self._settle_gaps, blocks)
         self._remeasure_empty_state()
+        # Then land on the tail, AFTER the settle pass above.
+        #
+        # `_size_updated` is the anchor for growth that happens while the view
+        # is following, but a replay is not that case: the batch mounts, and
+        # only then does each block author its own height from the rows it
+        # laid out (`_set_authored_height`). Those writes land after the
+        # extent this mount computed, so the viewport is left wherever the
+        # pre-settlement extent put it — which was the tail only because,
+        # before blocks carried padding, the two numbers happened to agree.
+        # Under `display.comfortable_rows` every block is a row taller and a
+        # resumed session opened 30 rows short of its own end.
+        #
+        # Deferred rather than immediate for the reason `_scroll_to_tail`
+        # states in reverse: it scrolls to the extent as measured RIGHT NOW,
+        # so it has to run after the authored heights, not with them.
+        self.call_after_refresh(self._land_on_tail, was_at_tail)
+
+    def _land_on_tail(self, was_at_tail: bool) -> None:
+        """Re-follow the tail once a batch's blocks have authored their heights.
+
+        ``was_at_tail`` is sampled by the caller before the mount, because by
+        the time this runs the extent has already moved out from under the
+        viewport. A reader who deliberately scrolled up before the batch
+        arrived is not overruled; one who never moved is carried to the end.
+
+        Re-ARMS the anchor rather than only scrolling once. A block authors
+        its height from the rows it laid out (``_set_authored_height``), and
+        those writes land across several layout passes — so a single scroll
+        here targets whatever the extent happens to be at this instant and is
+        left behind by the growth that follows. Re-arming hands the job to
+        ``_size_updated``, which is the one place that already follows every
+        extent change and is documented as THE anchor point; the scroll below
+        just lands the current frame so the viewport is never visibly short
+        while the remaining passes settle.
+        """
+        if not was_at_tail:
+            return
+        self._tail_anchor.resync(at_end=True)
+        self._scroll_to_tail()
 
     def prepend_blocks(
         self, blocks: Sequence[TranscriptBlock], *, anchor_offset: float | None = None

--- a/tests/unit/test_settings_io.py
+++ b/tests/unit/test_settings_io.py
@@ -112,6 +112,7 @@ def _consumer_defaults() -> dict[str, object]:
 #: the prose in ``_DEFAULT_NOTES`` is what documents the intent.
 _NO_SINGLE_VALUE_CONSUMER: dict[str, str] = {
     "display.shimmer": "tui/settings.py derives its defaults from this registry",
+    "display.comfortable_rows": "tui/settings.py derives its defaults from this registry",
     "display.nerd_icons": "derived; tri-state None means auto-detect, not a value",
     "display.terminal_title": "tui/settings.py derives its defaults from this registry",
     "display.images": "tui/settings.py derives its defaults from this registry",

--- a/tests/unit/tui/test_welcome.py
+++ b/tests/unit/tui/test_welcome.py
@@ -773,7 +773,13 @@ async def test_hidden_after_the_first_transcript_block() -> None:
         transcript = app.query_one(TranscriptView)
         block = transcript.blocks()[0]
         assert block.region.y == transcript.content_region.y
-        assert block.region.height == 1
+        # One row of PROSE. The height is the block's outer box, so under
+        # `display.comfortable_rows` it also carries the padding row that
+        # buys the click target — asserting a bare 1 would pin the density
+        # setting rather than the thing this test is about, which is that the
+        # retired welcome leaves no row behind (the `y` assertion above).
+        padding = block.styles.padding
+        assert block.region.height == 1 + padding.top + padding.bottom
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

A tool row is the click target for expand/collapse, and it was exactly **one terminal line** tall. A click a row off either hit the neighbouring action or fell through to the transcript.

`display.comfortable_rows` (**Appearance**, default **ON**) puts one padding row above every tool row, wake delivery and user prompt. The summary is still exactly one row of text — the ledger's one-line-per-action reading is unchanged, the row is just twice the height to aim at.

## Before / after

`rose-pine-dawn`, same conversation. Setting **off** (today's density) then **on**:

![compact dawn](https://gist.githubusercontent.com/bbqben/ebc96ae72310312f9af326aa76968d20/raw/fb1b5b1f1dda25ed3a728c4fc5ffd6ab59736d1a/pad-compact-dawn.png)

![comfortable dawn](https://gist.githubusercontent.com/bbqben/ebc96ae72310312f9af326aa76968d20/raw/fb1b5b1f1dda25ed3a728c4fc5ffd6ab59736d1a/pad-comfortable-dawn.png)

`dark`, the default theme:

![compact dark](https://gist.githubusercontent.com/bbqben/ebc96ae72310312f9af326aa76968d20/raw/fb1b5b1f1dda25ed3a728c4fc5ffd6ab59736d1a/pad-compact-dark.png)

![comfortable dark](https://gist.githubusercontent.com/bbqben/ebc96ae72310312f9af326aa76968d20/raw/fb1b5b1f1dda25ed3a728c4fc5ffd6ab59736d1a/pad-comfortable-dark.png)

## Why it is a setting

Padding costs history: every action row takes two rows instead of one, so less of a long session fits on screen. That is a real trade rather than a strict improvement, so it is a switch. It defaults ON because the row is an interactive target first and a log line second — a user who reads more ledger than they click turns it off in `/settings` and the change applies live.

## Three constraints that shaped this

**Top padding only.** The dock guarantees exactly one ground row between the last block and the composer, and `test_composer_seam` proves it by counting blank rows in the composed frame. A bottom padding row is blank, so a padded last block read as a five-row seam. Padding the top buys the same separation between neighbours while the block still *ends* on its content.

**Height and padding move together.** Textual sizes a fixed-height widget *including* its padding, so `ToolCard` is `height: 2` = 1 + padding-top under the class. Blocks that author their own height (`UserBlock`, `PeerMessageBlock` write `styles.height` from their row count) now go through `_set_authored_height`, which adds the padding back — writing the bare row count reserved a padding row without growing the block and pushed the last line of prose into the seam.

**Vertical only on `UserBlock`.** It wraps its own text so the gutter bar lands on every wrapped row, and measures with `self.size.width` — which includes padding — while `render()` is handed the *content* width. Horizontal padding there renders the prompt as a band with no prose in it.

## Bug found on the way

Present on `main`, exposed by this change rather than caused by it: **a batch append never re-landed on the tail after its blocks authored their heights.** `_size_updated` follows extent changes only while the anchor is following, and a replay releases it, so a resumed session opened wherever the pre-settlement extent happened to put it. Invisible while every block was one row and the two numbers agreed; with padding, a 30-message resume opened **30 rows short of its own end**.

`_mount_batch` now samples "was the reader at the tail" *before* the mount — afterwards the extent has already moved out from under the viewport, so a reader who never moved reads as scrolled up — and re-arms the anchor once the batch settles, handing the follow to `_size_updated` rather than racing it with a single scroll.

## Implementation

The setting is one class on the `Screen`, re-derived from the stored flag by `_sync_row_density_class` on mount and on live change, so the startup and live-apply paths cannot disagree and the cell counts live only in the stylesheet. Toggling in `/settings` re-lays out every block already on screen.

## Testing

- `tests/unit/tui/` + `tests/unit/test_settings_io.py`: **4597 passed, 12 skipped**, run twice. Baseline on `main` is 4596; the extra case is the new setting's registry entry.
- `flake8` clean; `black --check` clean (695 files).
- Both screenshots above are real `OperatorApp` frames rendered headless, one per setting state.
- Geometry checked directly rather than by eye: the painted ground under the ledger goes from 9 bands to 18 across the same six actions.
- `test_composer_seam` and `test_welcome` cover the two contracts this could have broken (the one-row dock seam, and the retired welcome leaving no row behind).

## Notes for review

- `test_welcome` asserted a one-line prompt is exactly 1 row tall. That pins the density setting rather than the behaviour under test, so it now asserts `1 + padding`, read off the block's own styles.
- No screenshots are committed to the repo; they are hosted in a gist and linked above.
