### PR TITLE
feat(tui): recognise $skill invocations inline, not just as a prefix

### DIFF
--- a/local_operator/skills/invoke.py
+++ b/local_operator/skills/invoke.py
@@ -24,18 +24,58 @@ it to the model together with the request. Three properties are deliberate:
 
 The recognition rule is narrow on purpose, because ``$`` is also money and
 also shell. A token is an invocation only when it is the FIRST token of the
-buffer, and only when what follows the ``$`` matches a DISCOVERED SKILL NAME.
-``$100 for the redesign`` matches no skill and is plain prose; so is a stray
-``$`` alone. That is what keeps this from needing an escape rule: the
-vocabulary decides, so nothing that is not a skill name is ever captured.
+text being submitted, and only when what follows the ``$`` matches a
+DISCOVERED SKILL NAME. ``$100 for the redesign`` matches no skill and is plain
+prose; so is a stray ``$`` alone. That is what keeps this from needing an
+escape rule: the vocabulary decides, so nothing that is not a skill name is
+ever captured.
+
+**The position rule is enforced by the COMPOSER, not by this parser being the
+only grammar there is.** The composer's picker opens on a ``$`` anywhere a word
+boundary allows, and accepting a row REASSEMBLES the draft — the token moves to
+the front with the surviving prose as its request, staged for the user to read
+and send (``command_picker.completion_for``'s ``SKILL`` branch, and
+``Editor._complete_skill``). So the user can reach a skill mid-sentence while
+what arrives HERE is still a prefix. Keeping this parser anchored is therefore
+not a limitation to be lifted later; it is what buys two properties that inline
+matching would cost:
+
+- A pasted document whose line 3 reads ``$research …`` never fires a skill
+  nobody asked for (see ``app._expand_invocation``, which parses the TYPED line
+  before pastes are spliced in for exactly this reason).
+- The money / shell-variable guard stays trivially safe HERE. Because this
+  parser only ever looks at offset 0, ``a $5 coffee`` and ``echo $PATH`` are
+  prose by construction: no rule has to be argued about, because there is no
+  position at which they could match.
+
+Which layer enforces what is worth being exact about, since the composer now
+has a grammar of its own. THIS module decides what a submitted string MEANS,
+and it is anchored. The composer decides what OPENS A LIST, and it is inline —
+so it carries the mid-draft half of the shell-variable guard that anchoring
+gives this module for free: an inline ``$`` ranks by CASE-SENSITIVE PREFIX and
+only when the typed query contains a LOWERCASE LETTER
+(``command_picker.skill_suggestions``), because any match there kept the picker
+open and turned the user's Enter into a completion that rewrote their draft
+instead of sending it (``$LANG`` reaching a ``planning`` skill, ``$DEBUG``
+reaching ``debug``, and a bare trailing ``$`` reaching the entire vocabulary).
+Fuzzy and case-insensitive matching both survive at the leading position, where
+a ``$`` typed first is unambiguous.
+
+The caveat below therefore has a WIDER inline reach than "a skill named after a
+variable", and it is worth being exact: inline matching is by PREFIX, so any
+lowercase-containing token that prefixes any skill name matches — ``$path``
+reaches ``pathfinder``, ``$lang`` reaches ``language-tutor``, and lowercase
+environment variables like ``$http_proxy`` are in the same class. Accepted for
+the same reason as below: the vocabulary is the user's, and no rule here can
+outrank it.
 
 The converse is worth stating plainly: matching is case-insensitive and the
 vocabulary is user-controlled, so a skill actually NAMED ``path`` or ``editor``
-would make ``$PATH is unset`` or ``$EDITOR is vim`` invoke it. Nothing here can
-tell those apart from a deliberate invocation — the name is the whole grammar —
-and the transcript row shows what was typed either way, so the user can see it
-happened. Naming a skill after a common environment variable is the thing to
-avoid.
+would make ``$PATH is unset`` or ``$EDITOR is vim`` invoke it — at the LEADING
+position, where this parser looks. Nothing here can tell those apart from a
+deliberate invocation — the name is the whole grammar — and the transcript row
+shows what was typed either way, so the user can see it happened. Naming a
+skill after a common environment variable is the thing to avoid.
 """
 
 from __future__ import annotations
@@ -52,9 +92,11 @@ from local_operator.skills.discovery import Skill
 #: token — ``$research.`` parses the name ``research.``, misses the vocabulary
 #: and is sent as prose, which is the safe direction but not a sentence that
 #: invokes. ``$research,`` DOES work, since ``,`` is outside the class.
-#: Anchored at the start:
-#: an invocation is a prefix, never something found mid-draft. A ``$`` followed
-#: by nothing usable does not match at all.
+#: Anchored at the start: what is SUBMITTED is a prefix, because the composer
+#: reassembles an inline ``$`` to the front before Enter (see the module
+#: docstring). A ``$`` still sitting mid-draft at submit time was never engaged
+#: through the picker and is prose. A ``$`` followed by nothing usable does not
+#: match at all.
 _INVOCATION_RE = re.compile(r"^\$([A-Za-z0-9][A-Za-z0-9._-]*)")
 
 #: The opening tag of a rendered payload, capturing the typed line stored in
@@ -91,6 +133,11 @@ def parse_invocation(text: str, skills: Mapping[str, Skill]) -> SkillInvocation 
     skill name, or when the name is followed immediately by a word character
     the pattern would have to swallow. Never raises: an unparseable draft is
     always just a draft.
+
+    Deliberately ANCHORED even though the composer's picker is inline: the
+    composer reassembles the token to the front before submit, so a ``$`` that
+    is still mid-text when this runs is prose the user typed, not an invocation
+    they engaged. See the module docstring for the two properties that buys.
 
     Matching is case-insensitive because skill names are lower-case by
     convention while a sentence-start ``$Research`` is a natural thing to type,

--- a/local_operator/tui/widgets/command_picker.py
+++ b/local_operator/tui/widgets/command_picker.py
@@ -158,10 +158,12 @@ class PickerMode(Enum):
     COMMAND = "command"
     ARGUMENT = "argument"
     #: The ``$skill`` manual-invocation list. A third mode rather than a reuse
-    #: of ``COMMAND`` because the two complete differently: a command word is
-    #: inline and caret-anchored, while a ``$`` token is only ever the FIRST
-    #: token of the buffer, and Enter on a skill row must not run anything —
-    #: an invocation produces a PROMPT the user still has to write.
+    #: of ``COMMAND`` because the two complete differently. Both are inline and
+    #: caret-anchored, but a ``$`` token that is NOT at the buffer start ranks
+    #: by CASE-SENSITIVE prefix and only when the query carries a lowercase
+    #: letter (:func:`skill_suggestions`), and Enter on a skill row must
+    #: not run anything — an invocation produces a PROMPT the user still has to
+    #: write.
     SKILL = "skill"
 
 
@@ -202,15 +204,16 @@ class SlashContext(NamedTuple):
     end: int
 
 
-#: A slash opens a command only at a WORD BOUNDARY: the buffer start, or right
+#: A sigil opens a token only at a WORD BOUNDARY: the line start, or right
 #: after whitespace. This is what keeps ``src/foo`` and ``and/or`` from opening
 #: the picker — the ``/`` there is glued to a preceding non-space character, so
 #: it is punctuation inside a word, not the start of a command. The rule is the
 #: same one a shell or an editor command palette uses to tell a path apart from
 #: a command, and it is the ONE thing that makes inline detection safe to run on
-#: every keystroke of ordinary prose.
+#: every keystroke of ordinary prose. ``$`` leans on it harder still: it is the
+#: whole reason ``costs$5`` and ``a$b`` cannot open a skill list.
 def _is_boundary(line: str, index: int) -> bool:
-    """Whether ``line[index]`` (a ``/``) begins a fresh token."""
+    """Whether ``line[index]`` (a sigil) begins a fresh token."""
     return index == 0 or line[index - 1].isspace()
 
 
@@ -272,21 +275,39 @@ def _active_slash(line: str, column: int, commands: frozenset[str] = frozenset()
     the last-slash-before-caret rule apply. Empty ``commands`` (the pure-parser
     default) disables claiming and keeps the simple behaviour.
     """
-    slashes = _boundary_slashes(line)
+    claim = _claiming_command(line, commands)
     candidate: int | None = None
-    for index in slashes:
-        word, sep, _ = line[index + 1 :].partition(" ")
-        if sep and commands and word.lower() in commands:
-            # A recognised, terminated command. Its argument runs to the end of
-            # the line, so if the caret is anywhere past this slash it is inside
-            # THIS command — return it and stop, ignoring every later slash.
-            if column > index:
-                return index
-            # Caret is before this command entirely; nothing earlier can claim.
-            return candidate
+    for index in _boundary_slashes(line):
+        if index == claim:
+            # The claiming command's argument runs to the end of the line, so a
+            # caret past this slash is inside THIS command and every later slash
+            # is argument text. A caret before it is outside the claim entirely,
+            # and nothing earlier can claim, so the running candidate stands.
+            return index if column > index else candidate
         if index <= column:
             candidate = index
     return candidate
+
+
+def _claiming_command(line: str, commands: frozenset[str] = frozenset()) -> int | None:
+    """Index of the boundary ``/`` whose command has CLAIMED the rest of ``line``.
+
+    A recognised command word terminated by a space owns everything after it as
+    its argument; the earliest one on the line wins. ``None`` when no command has
+    claimed — including the pure-parser default of an empty vocabulary.
+
+    Factored out because ``$`` needs the same answer (see :func:`skill_token`):
+    now that a skill token is inline, ``/team ops $research`` is possible, and a
+    second copy of this rule for the other sigil is how the two lists would end
+    up disagreeing about who owns one caret.
+    """
+    if not commands:
+        return None
+    for index in _boundary_slashes(line):
+        word, sep, _ = line[index + 1 :].partition(" ")
+        if sep and word.lower() in commands:
+            return index
+    return None
 
 
 def slash_context(
@@ -448,45 +469,96 @@ def slash_argument(
     return None if context is None else context.value
 
 
-def skill_token(text: str, cursor: int | None = None) -> SlashContext | None:
-    """The ``$skill`` token being typed at the start of the buffer, or ``None``.
+def skill_token(
+    text: str, cursor: int | None = None, commands: frozenset[str] = frozenset()
+) -> SlashContext | None:
+    """The ``$skill`` token being typed at the caret, or ``None``.
 
-    The ``$`` counterpart to :func:`slash_context`, and deliberately STRICTER
-    than it in two ways.
+    The ``$`` counterpart to :func:`slash_context`, and now inline on the same
+    terms: a user who has typed a message can append ``$research`` at the caret,
+    or drop one at the start of a later line, and get the list. Reaching for a
+    skill after writing the request is the ordinary way people work, and
+    requiring the sigil first meant retyping the draft around it.
 
-    It is **not inline**. A ``/`` opens a command anywhere a boundary allows,
-    because a user who has typed a message may still want to route it. A ``$``
-    is only an invocation as the buffer's FIRST token: mid-draft, ``$`` is
-    overwhelmingly money or a shell variable, and there is no second syntax to
-    disambiguate them. Restricting the position is what removes the need for an
-    escape rule — ``a $5 coffee`` cannot be a token by construction.
+    The **word BOUNDARY** rule is what makes that safe, and it is the same rule
+    (:func:`_is_boundary`) that keeps ``src/foo`` from opening a command list:
+    a ``$`` glued to a preceding non-space character is punctuation inside a
+    word, never a sigil. ``costs$5`` and ``a$b`` therefore cannot open the list
+    at all. A boundary ``$`` followed by money (``costs $5``) DOES open it, and
+    that is harmless by the same argument the vocabulary has always carried:
+    ``5`` matches no skill name, so the list comes back empty and closes itself.
+    Nothing is ever captured that is not a discovered skill.
 
     It is **word-phase only**, like :func:`slash_context`: the terminating
     space means the user has moved on to the request, where a skill list is
     stale advice.
 
+    ``commands`` is the recognised command vocabulary, and it arbitrates against
+    ``/``. Once a recognised command on the line has been TERMINATED by a space
+    it owns the rest of that line as its argument (see :func:`_active_slash`), so
+    the ``$`` in ``/team ops $research`` is argument text the user is writing,
+    not a skill token competing for the same picker. That claim is the ONLY
+    overlap the two sigils can have now that ``$`` is inline; without it the two
+    lists would fight over one caret. Empty ``commands`` (the pure-parser
+    default) disables claiming, matching every other parser here.
+
     ``query`` is ``""`` for a bare ``$``, which opens the list on the full set.
     The caret must be INSIDE the token; moving it out into the request closes
     the list, which is what makes the picker phase a property of the parse.
 
-    LEADING WHITESPACE is skipped, matching both :func:`slash_context` (which
-    opens on ``  /he``) and the submit-side parser in
-    :mod:`local_operator.skills.invoke`, which ``lstrip``s. Requiring column 0
-    made the two disagree: ``  $research fix`` offered no list while still
-    expanding on Enter, so the invocation fired with no UI cue that it would.
-    Only spaces and tabs are skipped \u2014 a ``$`` after a NEWLINE is on a second
-    line and is not the buffer's first token.
+    LEADING WHITESPACE is preserved rather than special-cased: an indented
+    ``  $research`` is a boundary ``$`` on its line like any other, so the
+    picker still opens on it and still agrees with the submit-side parser in
+    :mod:`local_operator.skills.invoke`, which ``lstrip``s.
     """
-    indent = len(text) - len(text.lstrip(" \t"))
-    if not text.startswith("$", indent):
+    line, line_start, column = _line_of_cursor(text, cursor)
+    # A recognised, terminated command claims the rest of its line, so a `$`
+    # inside its argument is plain text. The slash parsers read the same claim
+    # through `_active_slash`, so the two sigils cannot disagree about who owns
+    # the caret.
+    claim = _claiming_command(line, commands)
+    if claim is not None and column > claim:
         return None
-    cursor = len(text) if cursor is None else cursor
-    end = indent + 1
-    while end < len(text) and not text[end].isspace():
+    dollar = _active_sigil(line, column, "$")
+    if dollar is None:
+        return None
+    end = dollar + 1
+    while end < len(line) and not line[end].isspace():
         end += 1
-    if cursor > end:
+    if column > end:
         return None
-    return SlashContext(indent, text[indent + 1 : end], end)
+    return SlashContext(line_start + dollar, line[dollar + 1 : end], line_start + end)
+
+
+def skill_token_is_leading(text: str, token: SlashContext) -> bool:
+    """Whether ``token`` opens ``text``, ignoring leading whitespace.
+
+    THE definition of "leading" for the ``$`` grammar, in one place because two
+    separate decisions turn on it and they must not drift: whether the fuzzy
+    matcher may run (:func:`skill_suggestions`) and whether accepting a row has
+    to reassemble the buffer (:func:`_reassembled_skill`). Both are asking the
+    same question — is this token already the prefix the anchored submit-side
+    parser reads? — so both read the same answer.
+
+    Whitespace-only lead, matching ``parse_invocation``'s ``lstrip``: an
+    indented ``  $research`` is still the buffer's first token.
+    """
+    return not text[: token.start].strip()
+
+
+def _active_sigil(line: str, column: int, sigil: str) -> int | None:
+    """Index of the boundary ``sigil`` the cursor is editing, or ``None``.
+
+    The sigil-agnostic core of :func:`_active_slash`'s last-token-before-caret
+    rule, without the command-claiming clause: ``$`` has no vocabulary of its
+    own to terminate a token with, so the LAST boundary sigil at or before the
+    caret is always the one being edited (``$a $re|`` is ``$re``).
+    """
+    candidate: int | None = None
+    for index, char in enumerate(line):
+        if char == sigil and _is_boundary(line, index) and index <= column:
+            candidate = index
+    return candidate
 
 
 class CompletionMode(Enum):
@@ -542,9 +614,28 @@ def completion_for(
     parse the caller would otherwise have had to repeat.
     """
     if mode is CompletionMode.SKILL:
-        token = skill_token(text, caret)
+        token = skill_token(text, caret, known)
         if token is None:
             return None
+        # INLINE ENGAGE, modelled exactly as NAME_ARGUMENT models it below. A
+        # `$` is inline now, so a draft can survive OUTSIDE the token — either
+        # before it (`fix this $res`) or on another line — and the submit-side
+        # parser is still ANCHORED at the buffer start on purpose (see
+        # `local_operator.skills.invoke`: an anchored parser is what keeps a
+        # pasted document whose line 3 reads `$research …` from firing a skill
+        # nobody asked for). Reassembly is what bridges the two: the token moves
+        # to the FRONT with the surviving draft as its request, so the anchored
+        # parser sees exactly the shape it was written for.
+        #
+        # Modelled HERE rather than only in `Editor._complete_skill` because the
+        # composer's inline GHOST is derived from this same call; a renderer-side
+        # exception would reintroduce the two-implementations drift this helper
+        # exists to prevent (the B1 note below). As there, the result is NOT an
+        # append, so `ghost_for`'s `startswith` rule withholds the ghost of its
+        # own accord — the honest outcome for a whole-buffer reordering.
+        reassembled = _reassembled_skill(text, token, row_name)
+        if reassembled is not None:
+            return reassembled
         # Same trailing-space contract as the command word: it terminates the
         # token, closes the list, and opens the request. The suffix beyond the
         # token is preserved because a user can complete a `$skill` typed in
@@ -596,6 +687,46 @@ def completion_for(
         if outside:
             return _reassembled_completion(filled, caret_after, known)
     return filled, caret_after
+
+
+def _reassembled_skill(text: str, token: SlashContext, row_name: str) -> tuple[str, int] | None:
+    """Move an inline ``$`` token to the FRONT, surviving draft as its request.
+
+    ``None`` whenever nothing but whitespace precedes the token, which is the
+    ONLY case reassembly is for. A token that already opens the draft is already
+    the prefix the submit parser wants, so the span replacement in
+    :func:`completion_for` is the whole answer — for the bare ``$res`` and
+    equally for ``$res fix bug``, whose request already sits in the right place
+    and must be preserved verbatim rather than rebuilt. What inline detection
+    newly allows is prose BEFORE the token (``fix this $res``, or a ``$``
+    opening line 2), and that is exactly the shape an anchored parser cannot
+    read. Testing the text before the token, rather than "any draft outside it",
+    is what keeps this branch to the case it exists for.
+
+    Computed from the ORIGINAL text rather than from a filled buffer (the way
+    :func:`_reassembled_completion` has to be): the ``$`` token's span is known
+    before the name is inserted, since ``row_name`` replaces the token whole and
+    cannot move its start. One derivation, no re-parse.
+
+    The trailing space leaves the caret in the request with its separator
+    already typed — the same place ``$research `` parks it on the bare path — so
+    continuing to type the request is the same gesture whether or not a draft
+    was reassembled into it. It costs nothing downstream: ``parse_invocation``
+    strips the request.
+    """
+    if skill_token_is_leading(text, token):
+        return None
+    # One adjoining separator goes with the token, the same rule the slash
+    # splice and reassembly use, so ``msg $res`` and ``$res\nmsg`` both collapse
+    # to just ``msg`` instead of leaving the gap the token used to occupy.
+    start, end = token.start, token.end
+    if start > 0 and text[start - 1] in " \t\n":
+        start -= 1
+    elif end < len(text) and text[end] in " \t\n":
+        end += 1
+    rest = (text[:start] + text[end:]).strip()
+    assembled = f"${row_name} {rest} "
+    return assembled, len(assembled)
 
 
 def _reassembled_completion(
@@ -688,6 +819,118 @@ def command_suggestions(query: str, commands: list[SlashCommand]) -> list[tuple[
     lowered = query.lower()
     prefixed = [pair for pair in matches if pair[0].lower().startswith(lowered)]
     return prefixed or matches
+
+
+def skill_suggestions(
+    query: str, choices: list[ArgumentChoice], inline: bool
+) -> list[tuple[str, ArgumentChoice]]:
+    """``$skill`` rows for ``query`` — LOWERCASE-EVIDENCE PREFIX when inline.
+
+    At the START of the buffer a ``$`` is unambiguous — the user typed a sigil
+    first and nothing else can be meant, which is exactly what the anchored
+    submit-side parser relies on — so the full case-insensitive fuzzy matcher
+    runs there: ``$rsrch`` still finds ``research``, ``$Research`` at a sentence
+    start still works, and a bare ``$`` still opens the whole catalogue to
+    browse. INLINE, the sigil's position tells you nothing, and money or a shell
+    variable is the overwhelmingly more likely reading.
+
+    Matching inline is actively harmful rather than merely noisy, because a
+    non-empty match set is what keeps the picker OPEN, an open SKILL list makes
+    Enter complete a row instead of submitting (see the key routing in
+    ``Editor``), and the draft is then rewritten to ``$<skill> <prose> `` with
+    nothing sent and no undo — ``ctrl+z`` does not recover it. So the question
+    this function answers is not "what ranks well" but "is there POSITIVE
+    EVIDENCE the user meant a skill". Two conditions carry that evidence:
+
+    1. The query contains a LOWERCASE LETTER. Skill names are lowercase by
+       convention; shell and environment variables are uppercase by an equally
+       strong one (``$PATH``, ``$HOME``, ``$DEBUG``, ``$LANG``).
+    2. The query is a CASE-SENSITIVE PREFIX of the name.
+
+    Testing evidence on the QUERY — what the user typed — rather than trusting
+    the vocabulary is what makes this robust, and it is the correction to an
+    earlier version of this rule that rested on skill names being lowercase.
+    Nothing enforces that: ``discovery`` takes frontmatter ``name`` or the
+    directory name with only ``.strip()``, so a skill really can be called
+    ``DEBUG`` or ``AWS_PROFILE_SWITCHER``. Condition 1 holds regardless, because
+    it never consults the name. Enforcing lowercase at discovery instead was
+    rejected: it would silently rewrite user-supplied names that ``skill://``
+    URLs, the conflict detector and the rendered payload all echo back, which is
+    a far wider blast radius than a composer ranking rule deserves.
+
+    Together the two conditions close four distinct ways a non-invocation used
+    to reach a row inline. Each was found in a separate review round, which is
+    why they are enumerated rather than summarised:
+
+    - SUBSEQUENCE. ``translate to $LANG`` scored ``LANG`` against ``planning``
+      (l-a-n-g, clearing :data:`FUZZY_MIN_QUERY_CHARS`). Condition 2 removes it.
+    - CASE-FOLDED PREFIX. ``"DEBUG".lower()`` IS ``"debug"``, so ``echo $DEBUG``
+      reached a ``debug`` skill. Condition 2, being case-sensitive, removes it.
+    - UPPERCASE-NAMED SKILL. A skill named ``DEBUG`` made ``$DEBUG`` a
+      case-sensitive prefix again, voiding the rule above. Condition 1 removes
+      it, because the evidence is read off the query.
+    - CASELESS TOKENS, which no case rule can help with because they have no
+      case at all: an EMPTY query (a bare trailing ``$`` in ``the price is $``,
+      which returned the entire vocabulary), and digit or underscore tokens
+      (``costs $5`` against a skill named ``5things``, ``$_private``). Condition
+      1 removes both — neither contains a lowercase letter. That the money case
+      is caught by the same clause matters: money is the founding justification
+      for this whole grammar being narrow.
+
+    The empty-query case deserves its reasoning recorded, because the user
+    passes through it on every keystroke of a legitimate inline ``$research``.
+    The list simply arrives one keystroke later inline than it does leading: ``$``
+    shows nothing, ``$r`` shows the matches. That is the right trade — mid-prose
+    a bare ``$`` is money or the start of a variable far more often than an
+    invocation, the cost of waiting one character is a keystroke while the cost
+    of guessing wrong is the user's draft, and the list still appears long before
+    the name is finished. At the LEADING position a bare ``$`` remains an
+    unambiguous request to see the catalogue, and still opens the full list.
+
+    ``startswith`` rather than ``casefold`` is deliberate and load-bearing for
+    Unicode safety: it does no case folding at all, so no FOLDING match can
+    arise — the Turkish dotless-i and the ``ß``/``SS`` expansions never open a
+    row a byte-comparison would not. ``$İ`` and ``$STRASSE`` return nothing
+    because they carry no lowercase letter (condition 1 below), not because of
+    anything Unicode-specific. A bare ``$ß`` DOES open a row against a skill
+    literally named ``ßeta`` — ``ß`` is a lowercase letter and a case-sensitive
+    prefix, so that is the accepted prefix class documented below, not a folding
+    surprise. Do not "improve" ``startswith`` into a folding comparison.
+
+    Tokens in a script WITHOUT case (CJK, Arabic, Hebrew, Thai) can never open a
+    row inline at any length, since condition 1 is never satisfied — unlike
+    ``$5things`` which recovers at its second character. That fails safe (Enter
+    sends the prose) and the leading position still lists everything, so it is a
+    known corner, not a defect.
+
+    What this deliberately does NOT cover, stated at its true width: ANY
+    lowercase-containing token that is a case-sensitive prefix of ANY skill name
+    matches inline. This is PREFIX matching, not equality, so it is wider than
+    "a skill named exactly ``path``" — ``pathfinder`` catches ``$path``,
+    ``language-tutor`` catches ``$lang``, ``terminal`` catches ``$term``, and
+    ``shellcheck`` catches ``$shell``. Lowercase environment variables such as
+    ``$http_proxy`` and ``$ld_library_path`` are genuinely in this class. It is
+    accepted rather than unnoticed: closing it would need a rule that outranks
+    the user's own vocabulary, and the same trade is already documented in
+    :mod:`local_operator.skills.invoke` as "do not name a skill after an
+    environment variable".
+    """
+    if not inline:
+        return argument_suggestions(query, choices)
+    # Condition 1, and the reason it is tested on the query rather than the
+    # name: an empty query and a caseless one (``$5``, ``$_private``) both fail
+    # it, which is what makes the money guard and the bare-``$`` guard the same
+    # clause rather than three special cases.
+    if not any(char.islower() for char in query):
+        return []
+    # Condition 2. Ranked by the shared scorer, then FILTERED — not a separate
+    # prefix scorer — so row ORDER stays the one the user learned from every
+    # other list; the gate only removes rows the scorer reached by subsequence
+    # or by case-folding. ``pair[0]`` is the choice's NAME, never the alias that
+    # matched (``match_choices`` always returns the name), so if skill rows ever
+    # gain aliases an alias-only match is filtered out here -- fail-CLOSED, the
+    # safe direction for a gate whose whole job is to not open on a non-name.
+    return [pair for pair in match_choices(query, choices) if pair[0].startswith(query)]
 
 
 def argument_suggestions(
@@ -803,6 +1046,11 @@ class CommandPicker(Static):
         self._suppress_report = False
         self._commands: list[SlashCommand] = []
         self._command_names: frozenset[str] = frozenset()
+        #: Whether the ``$`` token the SKILL list is showing for sits INLINE
+        #: rather than at the buffer start. Latched by ``sync_skills`` so the
+        #: app's one-tick-later ``set_choices`` refill re-derives under the same
+        #: prefix gate; see :func:`skill_suggestions` for what that gate stops.
+        self._skill_inline: bool = False
         self._choices: list[ArgumentChoice] = []
         self._mode = PickerMode.COMMAND
         self._matches: list[_Suggestion] = []
@@ -867,7 +1115,16 @@ class CommandPicker(Static):
         # the user types another character. Gating this on ARGUMENT alone is
         # exactly why a bare ``$`` painted nothing.
         if self._mode in (PickerMode.ARGUMENT, PickerMode.SKILL):
-            matches = argument_suggestions(self._query, self._choices)
+            # SKILL re-derives through its own gate: this refill lands a tick
+            # after the keystroke that opened the list, so reaching for
+            # ``argument_suggestions`` here would restore the fuzzy rows
+            # ``sync_skills`` had just excluded and hand an inline ``$LANG``
+            # back the open list that makes Enter rewrite the draft.
+            matches = (
+                skill_suggestions(self._query, self._choices, self._skill_inline)
+                if self._mode is PickerMode.SKILL
+                else argument_suggestions(self._query, self._choices)
+            )
             seeding = highlight is not None and not self._query and not self._chosen_by_hand
             if seeding:
                 # Silence `_apply`'s own report: it fires for row 0 before the
@@ -1072,14 +1329,29 @@ class CommandPicker(Static):
         scorer that ranks commands and providers — ``$cr`` finds
         ``code-review`` by the rule the user already learned from ``/lgt``
         finding ``logout``.
+
+        ``cursor`` locates the active ``$`` token now that one can sit anywhere a
+        boundary allows, exactly as :meth:`sync` locates an inline ``/``. The
+        recognised vocabulary comes from this picker's own registry, so a ``$``
+        inside an engaged command's argument reads as plain text here for the
+        same reason it does there.
         """
-        token = skill_token(text, cursor)
+        token = skill_token(text, cursor, self._command_names)
         if token is None:
             self._dismissed_query = None
             self._mode = PickerMode.SKILL
             self._close()
             return
-        self._apply(PickerMode.SKILL, token.query, argument_suggestions(token.query, self._choices))
+        # Remembered, not just used: ``set_choices`` re-derives this same list
+        # one message-loop tick later (the app answers ``SkillQueryOpened``
+        # asynchronously) and has no text to re-parse, so a gate applied only
+        # here would be silently undone by the refill.
+        self._skill_inline = not skill_token_is_leading(text, token)
+        self._apply(
+            PickerMode.SKILL,
+            token.query,
+            skill_suggestions(token.query, self._choices, self._skill_inline),
+        )
 
     def sync_argument(self, query: str) -> None:
         """Re-derive the ARGUMENT suggestions for the current command.

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -5295,11 +5295,15 @@ class Editor(TextArea):
         inside one phase does not re-open an Esc-dismissed list.
         """
         cursor = self._caret_offset()
-        # Checked FIRST and short-circuiting: a `$` token is anchored at offset
-        # 0, so it cannot overlap a slash construct, and answering it here
-        # keeps the three phases mutually exclusive without the slash parsers
-        # having to know the sigil exists.
-        if skill_token(self.text, cursor) is not None:
+        # Checked FIRST and short-circuiting, but the reason is no longer "a `$`
+        # is anchored at offset 0": it is inline now, so `/team ops $research`
+        # puts both sigils on one line. `skill_token` takes the recognised
+        # vocabulary and declines whenever a terminated command has CLAIMED the
+        # caret's position, which is the same claim `slash_context` and
+        # `slash_argument` resolve their own nested slashes with. The two answers
+        # are therefore disjoint by construction, and this order only decides who
+        # is asked first — not who wins.
+        if skill_token(self.text, cursor, self._command_names) is not None:
             return "skill"
         if (
             slash_argument(self.text, self._argument_commands, cursor, self._command_names)
@@ -5342,12 +5346,13 @@ class Editor(TextArea):
         the caret sits, not just what the buffer contains.
         """
         cursor = self._caret_offset()
-        # The `$skill` list is derived before either slash list for the reason
-        # given in `_picker_phase`: the token owns offset 0 exclusively, so
-        # there is no arbitration to do and the slash parsers stay unaware of
-        # it. The rows themselves are pushed by the app (SkillQueryOpened),
-        # exactly as an argument list's are.
-        if skill_token(self.text, cursor) is not None:
+        # The `$skill` list is derived before either slash list, and the
+        # arbitration that makes that safe is inside the parse rather than in
+        # this ordering — see `_picker_phase`: an inline `$` sitting in an
+        # engaged command's argument is claimed by that command and never
+        # answers here. The rows themselves are pushed by the app
+        # (SkillQueryOpened), exactly as an argument list's are.
+        if skill_token(self.text, cursor, self._command_names) is not None:
             if not self._skill_choices_requested:
                 self._skill_choices_requested = True
                 self.post_message(SkillQueryOpened())
@@ -6037,9 +6042,25 @@ class Editor(TextArea):
         The trailing space is deliberate and is what the picker's close depends
         on: it terminates the token, so the list drops away on the same
         keystroke that chose from it and the caret lands where the request is
-        typed. Same contract as :meth:`_complete_name_argument`, minus the
-        inline reassembly — a ``$`` token is anchored at the buffer start, so
-        there is never a preceding draft to move it in front of.
+        typed.
+
+        The same shape as :meth:`_complete_name_argument`, inline reassembly
+        included. A ``$`` is inline now, so a draft can survive outside the
+        token (``fix this $res``, or a ``$`` opening line 2); accepting a row
+        then moves the whole construct to the FRONT with that draft as the
+        request — ``$research fix this `` — and STAGES it. Nothing submits:
+        neither Tab nor Enter ever does for a skill row, because a completed
+        ``$skill `` is the opening of a prompt the user is still writing (see the
+        key routing). The user reads the assembled line and presses Enter.
+
+        Reassembly is what lets the submit-side parser stay ANCHORED at the
+        buffer start (:mod:`local_operator.skills.invoke`) while the composer is
+        inline: by the time Enter is pressed the token IS the prefix.
+
+        ``completion_for`` models both edits — the span replacement and the
+        reassembly — so the buffer written here is the exact buffer the ghost
+        predicted, structurally rather than by two edits happening to agree
+        (review round 1, B1).
         """
         completed = self._completion_for(CompletionMode.SKILL, name)
         if completed is None:

--- a/tests/unit/tui/test_skill_invocation.py
+++ b/tests/unit/tui/test_skill_invocation.py
@@ -16,10 +16,14 @@ import pytest
 
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.command_picker import (
+    ArgumentChoice,
     CompletionMode,
     PickerMode,
     completion_for,
+    ghost_for,
+    skill_suggestions,
     skill_token,
+    skill_token_is_leading,
 )
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.transcript import TranscriptView
@@ -45,6 +49,42 @@ def skill_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         (skill_dir / "SKILL.md").write_text(front + body)
     monkeypatch.setenv("LOCAL_OPERATOR_SKILL_EXTRA_ROOTS", str(root))
     # cwd walk-up must not pick up a real project root on the dev machine.
+    monkeypatch.chdir(tmp_path)
+    return root
+
+
+@pytest.fixture
+def shell_lookalike_skills(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A vocabulary that COLLIDES with common shell variables, both ways.
+
+    Separate from ``skill_root`` on purpose, and the names are the whole point:
+    a shell-variable test run against a vocabulary the query cannot reach passes
+    for a reason that has nothing to do with the gate under test, and reports a
+    live defect as fixed. Two collision classes have to be reachable here:
+
+    - SUBSEQUENCE — `LANG` reaches `planning` (l-a-n-g).
+    - PREFIX, case-folded — `DEBUG`/`RESEARCH`/`HOME`/`PATH` are exact
+      case-insensitive prefixes of `debug`/`research`/`home`/`path`. This class
+      survived the first fix, because `"DEBUG".lower()` IS `"debug"`.
+
+    `home` and `path` are named after environment variables deliberately: they
+    are the worst realistic case, and the accepted lowercase caveat is asserted
+    against `path` rather than left implicit.
+    """
+    root = tmp_path / "skills"
+    for name, description, body in [
+        ("planning", "Plan a piece of work.", "Break it into slices."),
+        ("research", "Investigate a question.", "Read primary sources."),
+        ("debug", "Diagnose a failure.", "Reproduce it first."),
+        ("home", "Tidy the home directory.", "List what is there."),
+        ("path", "Inspect the executable path.", "Print each entry."),
+    ]:
+        skill_dir = root / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: {description}\n---\n\n{body}"
+        )
+    monkeypatch.setenv("LOCAL_OPERATOR_SKILL_EXTRA_ROOTS", str(root))
     monkeypatch.chdir(tmp_path)
     return root
 
@@ -440,6 +480,492 @@ class TestReviewRegressions:
             assert editor.text == "  $research "
 
 
+class TestInlineInvocation:
+    """`$` reaches the picker anywhere `/` does, and reassembles like it.
+
+    The composer, not the submit parser, is where the position rule now lives:
+    `parse_invocation` stays anchored (see the last test in this class), and
+    accepting an inline row moves the token to the front so it still sees a
+    prefix.
+    """
+
+    async def _draft(self, app: OperatorApp, pilot, text: str) -> Editor:
+        """Type ``text`` into a focused composer with the caret at its end."""
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        editor.load_text(text)
+        editor.move_cursor(editor._end_of_buffer())
+        for _ in range(50):
+            await pilot.pause()
+            if editor.picker.is_open():
+                break
+        return editor
+
+    @pytest.mark.asyncio
+    async def test_a_token_after_prose_opens_the_list(self, skill_root) -> None:
+        """The case the feature exists for: remembering the skill afterwards."""
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, "fix the flaky login test $res")
+            assert editor.picker.is_open(), "inline `$` offered no list"
+            assert editor.picker.mode is PickerMode.SKILL
+            assert "research" in [name for name, _ in editor.picker._matches]
+
+    @pytest.mark.asyncio
+    async def test_a_token_opening_a_later_line_opens_the_list(self, skill_root) -> None:
+        """Dropping the sigil on its own line below the draft works too."""
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, "fix the flaky login test\n$res")
+            assert editor.picker.is_open()
+            assert editor.picker.mode is PickerMode.SKILL
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("text", ["a$res", "costs$5"])
+    async def test_a_glued_sigil_never_opens_the_list(self, skill_root, text) -> None:
+        """The boundary rule, at the surface the user actually sees."""
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, text)
+            assert not editor.picker.is_open()
+
+    @pytest.mark.asyncio
+    async def test_money_at_a_boundary_opens_nothing_because_nothing_matches(
+        self, skill_root
+    ) -> None:
+        """`costs $5` parses as a token and closes on the EMPTY match set.
+
+        The parser-level half is asserted in `TestSkillTokenParser`; this is the
+        half the user sees, and it is why no digit guard is needed: the
+        vocabulary decides, exactly as it always has.
+        """
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, "costs $5")
+            assert not editor.picker.is_open()
+
+    @pytest.mark.asyncio
+    async def test_a_sigil_inside_an_engaged_command_is_plain_text(self, skill_root) -> None:
+        """`/team ops $research` is a request about a skill, not an invocation.
+
+        The arbitration case that only became possible when `$` went inline.
+        """
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, "/team ops $res")
+            assert editor.picker.mode is not PickerMode.SKILL
+
+    @pytest.mark.asyncio
+    async def test_enter_reassembles_the_draft_and_stages_it(self, skill_root) -> None:
+        """Accepting an inline row stages `$research <draft> ` — and sends nothing.
+
+        The whole inline contract in one keystroke: the token moves to the front
+        so the anchored submit parser can read it, the draft becomes the request
+        rather than being consumed as a name, and the buffer is STAGED for the
+        user to read and send themselves.
+        """
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, "fix the flaky login test $res")
+            assert editor.picker.is_open()
+            await pilot.press("enter")
+            await pilot.pause()
+            assert editor.text == "$research fix the flaky login test "
+            assert session.prompts == [], "a skill row must never submit"
+            # Caret at the end, where the request continues.
+            assert editor._caret_offset() == len(editor.text)
+
+    @pytest.mark.asyncio
+    async def test_the_staged_line_then_sends_as_an_invocation(self, skill_root) -> None:
+        """Enter on the staged line fires the skill with the draft as its request.
+
+        Drives the whole path — type inline, engage, send — because the point of
+        reassembly is that the ANCHORED submit parser reads what it produced.
+        """
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await self._draft(app, pilot, "fix the flaky login test $res")
+            await pilot.press("enter")
+            await pilot.pause()
+            await pilot.press("enter")
+            await _await_prompt(pilot, session)
+        assert len(session.prompts) == 1
+        sent = session.prompts[0]
+        assert "Read primary sources." in sent
+        assert "fix the flaky login test" in sent
+
+    @pytest.mark.asyncio
+    async def test_a_mid_message_sigil_submitted_raw_is_still_prose(self, skill_root) -> None:
+        """`parse_invocation` stays ANCHORED; only the composer went inline.
+
+        The property the anchoring buys, asserted at the submit path rather than
+        at the parser: a `$research` that was never engaged through the picker —
+        a pasted document, a sentence about a skill — must not fire one.
+        """
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        text = "we should use $research for this"
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await _submit(app, pilot, text)
+            await _await_prompt(pilot, session)
+        assert session.prompts == [text]
+
+    @pytest.mark.asyncio
+    async def test_a_bare_prefix_still_behaves_exactly_as_before(self, skill_root) -> None:
+        """No draft outside the token means no reassembly: unchanged behaviour."""
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, "$resea")
+            await pilot.press("enter")
+            await pilot.pause()
+            assert editor.text == "$research "
+            assert session.prompts == []
+
+
+class TestInlineShellVariablesAreNotInvocations:
+    """An inline `$VAR` must never take the Enter that was meant to send.
+
+    The boundary rule alone does not tell a shell variable from an invocation,
+    and a matching row turns that gap into DATA LOSS: a non-empty match set keeps
+    the SKILL list open, an open SKILL list makes Enter complete a row instead of
+    submitting, and the draft is rewritten to `$<skill> <prose> ` with nothing
+    sent and no undo.
+
+    Two rounds of review found two distinct classes reaching a row:
+
+    - SUBSEQUENCE — `translate to $LANG` scored `LANG` against `planning`.
+    - PREFIX COLLISION — `echo $DEBUG` against `debug`, which survived a
+      case-INSENSITIVE prefix gate because `"DEBUG".lower()` IS `"debug"`.
+
+    Case-sensitive prefix matching inline removes both, on the convention that
+    shell variables are UPPERCASE and skill names lowercase. Leading-position
+    behaviour is untouched: a `$` typed first is unambiguous, so fuzzy AND
+    case-insensitive matching both survive there.
+
+    Every case below runs against `shell_lookalike_skills`, whose vocabulary
+    CONTAINS the colliding names — the previous version of these tests passed
+    against a vocabulary that could not reach them, which is why it reported a
+    live defect as fixed.
+    """
+
+    async def _draft(self, app: OperatorApp, pilot, text: str) -> Editor:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        editor.load_text(text)
+        editor.move_cursor(editor._end_of_buffer())
+        for _ in range(50):
+            await pilot.pause()
+            if editor.picker.is_open():
+                break
+        return editor
+
+    @pytest.mark.asyncio
+    async def test_enter_on_an_inline_shell_variable_sends_the_prose(
+        self, shell_lookalike_skills
+    ) -> None:
+        """THE regression assertion: the prompt goes out verbatim.
+
+        Asserted on what was SENT rather than on the picker's state, because the
+        defect's cost was the send that never happened. A test that only checked
+        `is_open()` would pass against a build that still swallowed the Enter.
+        """
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        text = "echo $DEBUG"
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, text)
+            assert not editor.picker.is_open(), "an inline `$VAR` opened a skill list"
+            await pilot.press("enter")
+            await _await_prompt(pilot, session)
+        assert session.prompts == [text]
+
+    @pytest.mark.asyncio
+    async def test_enter_on_a_bare_trailing_sigil_sends_the_prose(
+        self, shell_lookalike_skills
+    ) -> None:
+        """`the price is $` + Enter must SEND, not open the catalogue.
+
+        The empty-query hole: it returned the whole vocabulary inline, so Enter
+        completed row 0 and the draft became `$debug the price is `. Asserted on
+        the send, like its siblings, because the cost was the send that never
+        happened.
+        """
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        text = "the price is $"
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, text)
+            assert not editor.picker.is_open(), "a bare inline `$` opened the catalogue"
+            await pilot.press("enter")
+            await _await_prompt(pilot, session)
+        assert session.prompts == [text]
+
+    @pytest.mark.asyncio
+    async def test_the_list_arrives_one_keystroke_into_an_inline_name(
+        self, shell_lookalike_skills
+    ) -> None:
+        """`$` shows nothing inline; `$r` shows the matches.
+
+        The deliberate cost of closing the empty-query hole, pinned so the
+        one-keystroke delay is a decision rather than a surprise. The feature
+        still works — the list appears long before the name is finished.
+        """
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, "fix this $")
+            assert not editor.picker.is_open()
+            editor.load_text("fix this $r")
+            editor.move_cursor(editor._end_of_buffer())
+            for _ in range(50):
+                await pilot.pause()
+                if editor.picker.is_open():
+                    break
+            assert editor.picker.is_open(), "the list never arrived for an inline name"
+            assert "research" in [name for name, _ in editor.picker._matches]
+
+    @pytest.mark.asyncio
+    async def test_a_bare_leading_sigil_still_browses_the_catalogue(
+        self, shell_lookalike_skills
+    ) -> None:
+        """`$` at position 0 is an unambiguous ask — existing behaviour."""
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, "$")
+            assert editor.picker.is_open(), "a leading `$` stopped browsing the catalogue"
+            assert len(editor.picker._matches) == 5
+
+    @pytest.mark.asyncio
+    async def test_enter_on_a_fuzzy_cousin_also_sends_the_prose(
+        self, shell_lookalike_skills
+    ) -> None:
+        """The subsequence class, asserted on the send for the same reason."""
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        text = "translate to $LANG"
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, text)
+            assert not editor.picker.is_open()
+            await pilot.press("enter")
+            await _await_prompt(pilot, session)
+        assert session.prompts == [text]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Prefix collisions: each query IS the skill name once case-folded,
+            # so every one of these opened a list before the case rule. No `=1`
+            # or other suffix — that made the query miss for reasons unrelated
+            # to the gate, which is how this defect shipped as fixed.
+            "echo $DEBUG",
+            "unset $DEBUG",
+            "use $Debug",
+            "run with $RESEARCH",
+            "echo $PATH",
+            "echo $HOME",
+            # Subsequence: `LANG` against `planning`.
+            "translate to $LANG",
+        ],
+    )
+    async def test_no_list_opens_for_an_inline_shell_variable(
+        self, shell_lookalike_skills, text
+    ) -> None:
+        """Each query CAN reach a skill in this vocabulary, and must not."""
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, text)
+            assert not editor.picker.is_open()
+
+    @pytest.mark.asyncio
+    async def test_an_inline_prefix_still_opens_the_list(self, shell_lookalike_skills) -> None:
+        """The case the inline feature exists for is untouched by the gate."""
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, "fix this $re")
+            assert editor.picker.is_open()
+            assert editor.picker.mode is PickerMode.SKILL
+            assert [name for name, _ in editor.picker._matches] == ["research"]
+
+    @pytest.mark.asyncio
+    async def test_a_leading_token_keeps_fuzzy_matching(self, shell_lookalike_skills) -> None:
+        """`$rsrch` at position 0 is unambiguous, so typo tolerance survives."""
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, "$rsrch")
+            assert editor.picker.is_open(), "the leading position lost fuzzy matching"
+            assert "research" in [name for name, _ in editor.picker._matches]
+
+    @pytest.mark.asyncio
+    async def test_a_leading_token_keeps_case_insensitive_matching(
+        self, shell_lookalike_skills
+    ) -> None:
+        """`$Research` at a sentence start must keep working.
+
+        The case rule is scoped to INLINE precisely so this stays true: at the
+        leading position the sigil's own position is the signal, so case carries
+        no information and a capitalised sentence start is ordinary typing.
+        """
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, "$Research")
+            assert editor.picker.is_open(), "the leading position lost case-insensitivity"
+            assert "research" in [name for name, _ in editor.picker._matches]
+
+    def test_the_gate_is_ranked_then_filtered_not_rescored(self):
+        """Prefix rows keep the shared scorer's ORDER; the gate only cuts."""
+        choices = [ArgumentChoice(name, "") for name in ["planning", "research", "debug"]]
+        # Inline: `LANG` reaches `planning` fuzzily and must be excluded...
+        assert skill_suggestions("LANG", choices, inline=True) == []
+        # ...as must `DEBUG`, which reaches `debug` by an exact case-folded
+        # prefix rather than by subsequence — the class the first fix missed.
+        assert skill_suggestions("DEBUG", choices, inline=True) == []
+        # ...while the leading position still finds them by the same queries.
+        assert [name for name, _ in skill_suggestions("rsrch", choices, inline=False)] == [
+            "research"
+        ]
+        assert [name for name, _ in skill_suggestions("DEBUG", choices, inline=False)] == ["debug"]
+        # A bare `$` INLINE now offers nothing — see
+        # `test_an_empty_inline_query_offers_nothing` for why an empty query
+        # carries no evidence. It remains the whole vocabulary when LEADING.
+        assert skill_suggestions("", choices, inline=True) == []
+        assert len(skill_suggestions("", choices, inline=False)) == 3
+
+    def test_a_lowercase_collision_is_the_accepted_caveat(self):
+        """A lowercase token that PREFIXES a skill name matches — by design.
+
+        Pinned at its TRUE WIDTH rather than as "a skill named exactly `path`":
+        this is prefix matching, so `pathfinder` catches `$path` and
+        `language-tutor` catches `$lang`. Lowercase environment variables like
+        `$http_proxy` are genuinely in this class. Accepted, not unnoticed —
+        closing it would need a rule outranking the user's own vocabulary.
+        """
+        wide = [ArgumentChoice(name, "") for name in ["pathfinder", "language-tutor"]]
+        assert [n for n, _ in skill_suggestions("path", wide, inline=True)] == ["pathfinder"]
+        assert [n for n, _ in skill_suggestions("lang", wide, inline=True)] == ["language-tutor"]
+        # The UPPERCASE form a shell actually uses is what the gate stops.
+        assert skill_suggestions("PATH", wide, inline=True) == []
+
+    def test_an_empty_inline_query_offers_nothing(self):
+        """A bare trailing `$` in prose is money, not a request for the list.
+
+        It returned the WHOLE vocabulary before, so Enter completed row 0 and
+        `the price is $` became `$planning the price is `. No case rule can
+        catch this: an empty query has no case to inspect, which is why the gate
+        tests for POSITIVE lowercase evidence instead of for uppercase.
+        """
+        choices = [ArgumentChoice(name, "") for name in ["planning", "research"]]
+        assert skill_suggestions("", choices, inline=True) == []
+        # Leading keeps browsing: `$` typed first is an unambiguous ask.
+        assert len(skill_suggestions("", choices, inline=False)) == 2
+
+    def test_caseless_tokens_offer_nothing_inline(self):
+        """Digits and underscores carry no case, so they carry no evidence.
+
+        `costs $5` against a skill named `5things` is the money case that
+        justifies this whole grammar being narrow, and it is closed by the same
+        clause as the empty query rather than by a special case.
+
+        `$_private` is NOT in this class and must not be asserted into it: it
+        contains lowercase letters, so it is the accepted prefix caveat above.
+        Only the genuinely caseless prefix `$_` is closed here.
+        """
+        choices = [ArgumentChoice(name, "") for name in ["5things", "_private"]]
+        assert skill_suggestions("5", choices, inline=True) == []
+        assert skill_suggestions("_", choices, inline=True) == []
+        assert skill_suggestions("_PRIVATE", choices, inline=True) == []
+        # The lowercase-bearing form is the documented caveat, not a defect.
+        assert [n for n, _ in skill_suggestions("_private", choices, inline=True)] == ["_private"]
+
+    def test_an_uppercase_named_skill_does_not_void_the_guard(self):
+        """A skill really named `DEBUG` must not make `$DEBUG` match again.
+
+        The rule reads evidence off the QUERY, never off the vocabulary, because
+        nothing enforces lowercase names: `discovery` takes frontmatter `name`
+        or the directory name with only `.strip()`. Resting the guard on a
+        convention the code does not enforce is what this pins shut.
+        """
+        choices = [ArgumentChoice(name, "") for name in ["DEBUG", "AWS_PROFILE_SWITCHER"]]
+        assert skill_suggestions("DEBUG", choices, inline=True) == []
+        assert skill_suggestions("AWS_PROFILE", choices, inline=True) == []
+        # Leading position is unchanged: position is the signal there.
+        assert [n for n, _ in skill_suggestions("DEBUG", choices, inline=False)] == ["DEBUG"]
+
+    def test_unicode_hazards_stay_closed(self):
+        """`startswith` does no case folding, so the folding traps cannot arise.
+
+        Recorded as a REASON, not a coincidence: `casefold` would map `ß` to
+        `ss` and the Turkish dotless `ı`/`İ` across the ASCII `i`, which is how
+        a "tidier" comparison would reopen this. Do not swap it.
+
+        The `Café`/`café-audit` pair is the one that actually DISCRIMINATES the
+        mutation, and it is the whole point of this test. The mixed-case query
+        subsequence-matches, so the scorer surfaces the row and it reaches the
+        gate; `Café` carries a lowercase letter, so condition 1 lets it through
+        to the comparison; `"café-audit".startswith("Café")` is False, so the
+        row is dropped. A `casefold` comparison would map both sides to lower and
+        reopen it — verified: swapping `startswith` for a folding compare turns
+        this assertion red, where the `İ`/`STRASSE` cases below would stay green
+        either way because they carry no lowercase letter and condition 1 closes
+        them before the comparison is ever reached.
+        """
+        # The discriminating case: the scorer surfaces the row, condition 1 lets
+        # it reach the comparison, and only `startswith` (not `casefold`) keeps
+        # it closed. This is the assertion the casefold mutation fails.
+        assert skill_suggestions("Café", [ArgumentChoice("café-audit", "")], inline=True) == []
+        # These carry no lowercase letter, so condition 1 closes them before the
+        # comparison — included as the shape of the hazard, not as its guard.
+        closed_before_comparison = [ArgumentChoice(name, "") for name in ["istanbul", "strasse"]]
+        for query in ["İ", "STRASSE"]:
+            assert skill_suggestions(query, closed_before_comparison, inline=True) == []
+
+    def test_leading_is_whitespace_tolerant(self):
+        """An indented `  $rsrch` is still the buffer's first token.
+
+        Pins the predicate both the fuzzy gate and the reassembly read, so they
+        cannot drift apart on the definition of "leading".
+        """
+        token = skill_token("  $rsrch")
+        assert token is not None
+        assert skill_token_is_leading("  $rsrch", token)
+        inline_token = skill_token("fix $rsrch")
+        assert inline_token is not None
+        assert not skill_token_is_leading("fix $rsrch", inline_token)
+
+
 class TestSkillTokenParser:
     """The pure parse, independent of any app."""
 
@@ -454,10 +980,63 @@ class TestSkillTokenParser:
     def test_space_closes_the_token(self):
         assert skill_token("$research go") is None
 
-    def test_only_at_the_buffer_start(self):
-        """Mid-draft `$` is money or a shell variable, never an invocation."""
-        assert skill_token("a $research") is None
-        assert skill_token("costs $5") is None
+    def test_inline_after_prose_opens_the_token(self):
+        """A `$` at a word boundary mid-draft IS a token now.
+
+        This used to assert ``None``: the token was anchored at the buffer
+        start, so reaching for a skill after writing the request meant retyping
+        the draft around the sigil. The submit-side parser is still anchored —
+        what changed is that the COMPOSER reassembles the token to the front
+        before Enter, so the picker can open wherever a boundary allows.
+        """
+        token = skill_token("a $research")
+        assert token is not None and token.query == "research"
+
+    def test_the_boundary_rule_is_what_replaced_the_position_rule(self):
+        """A `$` glued to a word is punctuation, not a sigil.
+
+        The guard that used to be "offset 0 only" is now the same word-boundary
+        rule `/` has always used, and it is what keeps inline detection safe to
+        run on every keystroke of ordinary prose.
+        """
+        assert skill_token("a$b") is None
+        assert skill_token("costs$5") is None
+
+    def test_money_after_a_space_is_left_to_the_vocabulary(self):
+        """`costs $5` opens a token whose query matches NO skill.
+
+        Deliberately closed at the PICKER rather than at the parser. `5` is a
+        boundary token like any other, and the module's standing rule is that
+        the vocabulary decides what is an invocation — a digit guard here would
+        be a second, weaker rule saying the same thing. The picker test below
+        pins the user-visible half: no list opens.
+        """
+        token = skill_token("costs $5")
+        assert token is not None and token.query == "5"
+
+    def test_a_terminated_command_claims_the_rest_of_its_line(self):
+        """`$` inside an engaged command's argument is plain text.
+
+        The arbitration that replaced "a `$` is anchored at offset 0, so it
+        cannot overlap a slash construct". `/team ops $research` is possible now,
+        and the claiming rule `_active_slash` already implements for nested
+        slashes decides it: a recognised, TERMINATED command owns the rest of its
+        line as its argument.
+        """
+        commands = frozenset({"team", "model"})
+        assert skill_token("/team ops $research", None, commands) is None
+        # The claim needs BOTH halves. An UNRECOGNISED word claims nothing, so
+        # the `$` after it is an ordinary boundary token.
+        token = skill_token("/teem $research", None, commands)
+        assert token is not None and token.query == "research"
+        # And with no vocabulary at all — the pure-parser default — nothing can
+        # be recognised, so nothing claims.
+        assert skill_token("/team ops $research") is not None
+
+    def test_a_token_opening_a_later_line_is_found(self):
+        """A `$` at the start of line 2 is a boundary token on ITS line."""
+        token = skill_token("fix the bug\n$res")
+        assert token is not None and token.query == "res"
 
     def test_caret_outside_the_token_closes_it(self):
         assert skill_token("$research go", 11) is None
@@ -472,3 +1051,47 @@ class TestSkillTokenParser:
         result = completion_for("$res fix bug", 4, CompletionMode.SKILL, "research", ())
         assert result is not None
         assert result[0] == "$research fix bug"
+
+    def test_inline_completion_reassembles_the_draft_to_the_front(self):
+        """The token moves to the front with the surviving draft as its request.
+
+        The `$` twin of `/team`'s inline engage, and the reason the submit-side
+        parser can stay anchored: by the time Enter is pressed the token IS the
+        prefix. Staged, not submitted — the caret lands at the end so the user
+        can keep writing.
+        """
+        text = "fix this $res"
+        result = completion_for(text, len(text), CompletionMode.SKILL, "research", ())
+        assert result == ("$research fix this ", len("$research fix this "))
+
+    def test_inline_completion_across_lines_reassembles_too(self):
+        """A `$` opening line 2 collapses onto one staged line."""
+        text = "fix this\n$res"
+        result = completion_for(text, len(text), CompletionMode.SKILL, "research", ())
+        assert result is not None
+        assert result[0] == "$research fix this "
+
+    def test_a_leading_token_is_not_reassembled(self):
+        """Already the prefix, so the request is preserved where it was typed.
+
+        Reassembly is only for prose BEFORE the token — the shape an anchored
+        submit parser cannot read. Rebuilding a leading token's request would
+        churn a buffer that is already correct.
+        """
+        text = "$res fix bug"
+        result = completion_for(text, 4, CompletionMode.SKILL, "research", ())
+        assert result == ("$research fix bug", len("$research") + 1)
+
+    def test_the_reassembled_ghost_is_withheld(self):
+        """A reordering is not an append, so no honest ghost describes it.
+
+        The consequence `completion_for` already documents for NAME_ARGUMENT,
+        asserted for SKILL: `ghost_for`'s `startswith` rule declines of its own
+        accord rather than painting characters Tab does not produce.
+        """
+        text = "fix this $res"
+        completion = completion_for(text, len(text), CompletionMode.SKILL, "research", ())
+        assert ghost_for(completion, text) == ""
+        # The bare-prefix case IS an append, and still previews.
+        bare = completion_for("$res", 4, CompletionMode.SKILL, "research", ())
+        assert ghost_for(bare, "$res") == "earch "


### PR DESCRIPTION
# PR Description

## Summary of Changes

`$skill` invocation now works **inline**, the same way `/` commands already do. Previously a `$skill` was only recognised as the composer buffer's *first* token; you had to type the sigil before anything else. Now you can write your message and reach for a skill at the end (`fix the flaky login test $research`), or drop one at the start of a later line.

Accepting a row **reassembles** the buffer to a staged `$research fix the flaky login test ` line — nothing is submitted, you read the assembled line and press Enter — exactly mirroring how `/team`/`/goal` inline-engage today. The submit-side parser (`skills.invoke.parse_invocation`) stays **anchored** at the buffer start, so a pasted document whose line 3 reads `$research …` still fires nothing; the composer's reassembly is what puts the token where the anchored parser expects it.

<!-- SCREENSHOTS -->

## The hard part: not eating the user's prose

`$` is money and shell variables far more than it is an invocation mid-sentence, and an open skill list makes Enter *complete a row* instead of submitting — so a wrong match silently rewrites the draft and sends nothing. Each of these classes was found and closed:

| Class | Example | Closed by |
|---|---|---|
| Fuzzy subsequence | `$LANG` → `planning` | prefix-only ranking inline |
| Case-folded prefix | `$DEBUG` → `debug` | case-**sensitive** compare |
| Empty query | `the price is $` → whole list | require a lowercase letter in the query |
| Uppercase-named skill | `$DEBUG` → skill named `DEBUG` | same predicate, tested on the query not the name |
| Caseless token | `$5` → `5things` | same predicate |

The unifying rule, inline: **the query must contain a lowercase letter and be a case-sensitive prefix of a skill name.** Shell/env vars are uppercase by convention, skill names lowercase — case is the discriminator where position tells you nothing. The **leading** position keeps full case-insensitive fuzzy, so `$Research` at a sentence start still works and `$` alone still opens the whole catalogue for browsing.

**Accepted, documented caveat:** a lowercase token that is a case-sensitive prefix of a skill name still matches inline (`$path` → a `pathfinder` skill). Closing it would require overriding the user's own vocabulary; it is stated at true prefix width in the code and mirrors the existing `skills.invoke` caveat ("don't name a skill after an environment variable").

Arbitration with `/` is real now that `/team ops $research` is possible: the claiming rule `_active_slash` already uses for nested slashes is factored into `_claiming_command` and read by both sigils, so a `$` inside a terminated recognised command's argument is plain text and the three picker phases stay mutually exclusive.

## Related Issue(s)

- Related: #...

## Impact

- **No breaking changes.** Leading-position `$skill` behaviour is unchanged; this only adds inline recognition. The submit-side grammar is untouched.
- No dependency updates.
- **Security/data-loss:** the whole design centres on *not* silently rewriting a user's draft. Every draft-destroying class above is closed and pinned by a test that asserts the prose was **sent verbatim**.

## Testing Details

- **33 new tests** in `tests/unit/tui/test_skill_invocation.py`, including pilot tests driving real keystrokes through `run_test()` that assert `session.prompts == [<the prose>]` — the assertion that catches the whole defect family.
- Mutation-checked: each gate's regression tests were confirmed to go **red** when the gate is neutered, then green when restored.
- Phase exclusivity brute-forced (skill / command / argument never co-fire at one caret).
- Full suite: **4736 passed, 12 skipped** on `tests/unit/tui` + `tests/unit/skills`.
- Gates over the whole tree: `flake8`, `black --check`, `isort --check`, `pyright` — all clean.
- Frames above rendered from the real `OperatorApp` via `run_test()` and inspected.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [ ] I have linked all related issues.

