### PR TITLE
fix(evaluation): seal a verifiable bundle when an episode crashes mid-rollout

### DIFF
--- a/local_operator/evaluation/evidence/verify.py
+++ b/local_operator/evaluation/evidence/verify.py
@@ -792,7 +792,37 @@ def _verify_semantics(
             issues.error("receipt_binding_invalid", terminal_location)
         if len(terminal_states) != 1:
             issues.error("finalization_invalid", terminal_location)
-        if environment_step_seen and not last_step_terminal and not finish_action_seen:
+        # An episode that ran environment steps normally must show WHY it
+        # stopped stepping: either the environment ended the rollout
+        # (terminated/truncated) or the agent chose to stop (a `finish` batch).
+        # Without one of those, a bundle truncated mid-rollout would otherwise
+        # seal as if the run had reached its own conclusion.
+        #
+        # A CRASH is the third legitimate way to stop, and it leaves neither
+        # marker precisely because nothing got to decide: the last step
+        # completed, then the harness or environment broke. `failure_kind` on
+        # the terminal snapshot is that missing explanation, and it is not a
+        # weaker one -- it is written only by `record_final_lifecycle` under the
+        # finalizing marker, and it rides inside the hash-chained event payload,
+        # so it cannot be added to an existing bundle without breaking the
+        # chain. Requiring a rollout-completion marker on a crashed episode
+        # demanded evidence the crash definitionally destroys, which made every
+        # crash-terminated bundle unverifiable and therefore unsealable AND
+        # unabandonable -- unscoreable rather than merely unscored.
+        #
+        # `not results` keeps this narrow: a bundle carrying a scoring result
+        # claims a completed rollout, so it must still prove one. This admits a
+        # crash only into the unscored path, where the episode is already
+        # labelled a failure and can never be mistaken for a finished run.
+        crash_terminated = not results and any(
+            state.failure_kind is not None for state in terminal_states
+        )
+        if (
+            environment_step_seen
+            and not last_step_terminal
+            and not finish_action_seen
+            and not crash_terminated
+        ):
             issues.error("finalization_invalid", terminal_location)
         if terminal_output_observation is not None and not terminal_output_resolved:
             issues.error("receipt_binding_invalid", terminal_location)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.55"
+version = "0.44.57"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/evaluation/evidence/test_finalization.py
+++ b/tests/unit/evaluation/evidence/test_finalization.py
@@ -820,3 +820,387 @@ def test_terminal_conflict_and_outcome_tamper_are_detected(tmp_path: Path) -> No
         "outcome_mismatch",
         "counter_mismatch",
     } & {issue.code for issue in report.issues}
+
+
+def _crashed_mid_rollout(
+    root: Path, *, failure_kind: str | None = "crash", steps: int = 2
+) -> tuple[EvidenceWriter, ScoreArtifact]:
+    """Write the exact interleaving a crash-terminated episode leaves on disk.
+
+    ``steps`` non-terminal environment steps (no ``finish`` batch, nothing
+    terminated or truncated), then the adapter error, then the unscored
+    finalization, receipts, and the terminal snapshot -- the shape produced by
+    ``EpisodeRunner._finalize_failure`` when the environment RPC dies mid-run.
+    """
+
+    writer = EvidenceWriter.create(root, manifest(), RedactionSet.from_resolved_values(()))
+    try:
+        clock = 0
+        _append_provenance(writer, monotonic_ns=clock, wall_time_ms=clock)
+        clock += 2
+        action_artifact = writer.publish_artifact(b"safe", media_type="text/plain")
+        for index in range(steps):
+            writer.append(
+                "observation",
+                ObservationPayload(observation_id=f"observation-{index}", sequence=index),
+                monotonic_ns=clock,
+                wall_time_ms=clock,
+            )
+            clock += 1
+            writer.append(
+                "action_batch",
+                ActionBatchPayload(
+                    action_batch_id=f"batch-{index}",
+                    observation_id=f"observation-{index}",
+                    action_count=1,
+                    action_artifact=action_artifact,
+                ),
+                monotonic_ns=clock,
+                wall_time_ms=clock,
+            )
+            clock += 1
+            writer.append(
+                "environment_step",
+                EnvironmentStepPayload(
+                    step_id=f"step-{index}",
+                    action_batch_id=f"batch-{index}",
+                    receipt_id=DIGEST,
+                    input_observation_id=f"observation-{index}",
+                    output_observation_id=f"observation-{index + 1}",
+                    terminated=False,
+                    truncated=False,
+                ),
+                monotonic_ns=clock,
+                wall_time_ms=clock,
+            )
+            clock += 1
+        # The rollout's final output observation still lands: the step receipt
+        # resolved before the adapter broke.
+        writer.append(
+            "observation",
+            ObservationPayload(observation_id=f"observation-{steps}", sequence=steps),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.append(
+            "error",
+            {
+                "error_id": "err-306591b1400e",
+                "category": "adapter",
+                "diagnostic_code": "rpcremoteerror",
+                "retryable": False,
+            },
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.begin_finalization(
+            "final",
+            None,
+            FinalizationIntent(kind="unscored"),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        clock, _ = _append_final_receipts(writer, monotonic_ns=clock, wall_time_ms=clock)
+        score = ScoreArtifact(status="unscored", reason="crash")
+        writer.record_final_lifecycle(
+            LifecycleTransitionPayload(
+                previous_state_id=None,
+                state_id=OTHER_DIGEST,
+                state="completed",
+                finalization_id="final",
+                preflight_seal_id=DIGEST,
+                commitment_id=OTHER_DIGEST,
+                reconciliation_id=DIGEST,
+                reconciliation_reportable=True,
+                score_id=score.score_id,
+                cleanup_result_id=OTHER_DIGEST,
+                rescue_required=False,
+                failure_kind=failure_kind,  # pyright: ignore[reportArgumentType]
+            ),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+    except BaseException:
+        writer.close()
+        raise
+    return writer, score
+
+
+def test_crash_after_nonterminal_steps_verifies_and_seals_unscored(tmp_path: Path) -> None:
+    """A crash mid-rollout must seal as unscored, not fail verification.
+
+    Regression: the rollout-completion invariant demanded a terminated/truncated
+    step or a ``finish`` batch on every bundle carrying a terminal snapshot. A
+    crash leaves neither -- nothing got to decide the rollout was over -- so the
+    bundle failed its own seal verification AND the abandonment fallback,
+    leaving the episode unscoreable instead of unscored.
+    """
+
+    root = tmp_path / "bundle"
+    writer, score = _crashed_mid_rollout(root)
+    try:
+        report = verify_bundle(root)
+        assert report.valid, report.issues
+        assert report.terminal_state == "finalizing"
+        outcome = writer.seal(
+            OutcomeDraft(
+                finalization_id="final",
+                preflight_seal_id=DIGEST,
+                commitment_id=OTHER_DIGEST,
+                reconciliation_id=DIGEST,
+                cleanup_result_id=OTHER_DIGEST,
+                result=score,
+                reportability_label="unscored",
+                comparability_label="comparable",
+                ended_wall_time_ms=99,
+            )
+        )
+    finally:
+        writer.close()
+    assert outcome.result.status == "unscored" and outcome.result.reason == "crash"
+    sealed = verify_bundle(root)
+    assert sealed.valid, sealed.issues
+    assert sealed.terminal_state == "sealed"
+    assert sealed.outcome is not None
+    assert sealed.outcome.reportability_label == "unscored"
+
+
+def test_crash_abandonment_fallback_now_succeeds(tmp_path: Path) -> None:
+    """The safety net must work: a recovered crash bundle can be abandoned.
+
+    ``open_for_abandon``/``abandon`` both re-verify independently and refuse on
+    any error-severity issue, so the same over-broad invariant disabled the
+    fallback that exists precisely for a bundle nobody can seal.
+    """
+
+    root = tmp_path / "bundle"
+    writer, _ = _crashed_mid_rollout(root)
+    writer.close()
+
+    recovered = EvidenceWriter.open_for_abandon(root, RedactionSet.from_resolved_values(()))
+    try:
+        record = recovered.abandon("ambiguous_finalization", "rpcremoteerror")
+    finally:
+        recovered.close()
+    assert record.reason == "ambiguous_finalization"
+    report = verify_bundle(root)
+    assert report.valid, report.issues
+    assert report.terminal_state == "abandoned"
+
+
+def test_crash_bundle_missing_terminal_event_still_refuses(tmp_path: Path) -> None:
+    """Do not over-correct: a genuinely incomplete bundle must stay unsealed.
+
+    Same interleaving, but the process died BEFORE the terminal lifecycle event
+    reached the journal. There is no ``failure_kind`` to explain the truncated
+    rollout, so the bundle has no terminal state and cannot be sealed.
+    """
+
+    root = tmp_path / "bundle"
+    writer = EvidenceWriter.create(root, manifest(), RedactionSet.from_resolved_values(()))
+    try:
+        clock = 0
+        _append_provenance(writer, monotonic_ns=clock, wall_time_ms=clock)
+        clock += 2
+        action_artifact = writer.publish_artifact(b"safe", media_type="text/plain")
+        writer.append(
+            "observation",
+            ObservationPayload(observation_id="observation-0", sequence=0),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.append(
+            "action_batch",
+            ActionBatchPayload(
+                action_batch_id="batch-0",
+                observation_id="observation-0",
+                action_count=1,
+                action_artifact=action_artifact,
+            ),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.append(
+            "environment_step",
+            EnvironmentStepPayload(
+                step_id="step-0",
+                action_batch_id="batch-0",
+                receipt_id=DIGEST,
+                input_observation_id="observation-0",
+                output_observation_id="observation-1",
+                terminated=False,
+                truncated=False,
+            ),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.append(
+            "observation",
+            ObservationPayload(observation_id="observation-1", sequence=1),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.begin_finalization(
+            "final",
+            None,
+            FinalizationIntent(kind="unscored"),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        _append_final_receipts(writer, monotonic_ns=clock, wall_time_ms=clock)
+        score = ScoreArtifact(status="unscored", reason="crash")
+        with pytest.raises(EvidenceBundleInvalid):
+            writer.seal(
+                OutcomeDraft(
+                    finalization_id="final",
+                    preflight_seal_id=DIGEST,
+                    commitment_id=OTHER_DIGEST,
+                    reconciliation_id=DIGEST,
+                    cleanup_result_id=OTHER_DIGEST,
+                    result=score,
+                    reportability_label="unscored",
+                    comparability_label="comparable",
+                    ended_wall_time_ms=99,
+                )
+            )
+    finally:
+        writer.close()
+    report = verify_bundle(root)
+    assert report.terminal_state == "finalizing"
+    assert not any(
+        state.state == "completed"
+        for state in (
+            event.payload
+            for event in report.events
+            if isinstance(event.payload, LifecycleTransitionPayload)
+        )
+    )
+
+
+def test_truncated_rollout_without_failure_kind_still_refuses(tmp_path: Path) -> None:
+    """The invariant still bites where it was designed to.
+
+    A terminal snapshot claiming a clean run (``failure_kind=None``) over a
+    rollout that never terminated, truncated, or finished is exactly the
+    "sealed as if it concluded" case the check exists to catch.
+    """
+
+    root = tmp_path / "bundle"
+    writer, _ = _crashed_mid_rollout(root, failure_kind=None)
+    writer.close()
+    report = verify_bundle(root)
+    assert not report.valid
+    assert ("finalization_invalid", "events.jsonl") in {
+        (issue.code, issue.location) for issue in report.issues
+    }
+
+
+def test_scored_bundle_with_failure_kind_still_requires_completed_rollout(
+    tmp_path: Path,
+) -> None:
+    """A scoring result claims a finished rollout, so a crash excuse must not apply.
+
+    Pins the ``not results`` clause: without it, attaching any ``failure_kind``
+    to a scored bundle would waive the rollout-completion requirement and let a
+    run that never reached its own end be reported with a score.
+    """
+
+    root = tmp_path / "bundle"
+    writer = EvidenceWriter.create(root, manifest(), RedactionSet.from_resolved_values(()))
+    try:
+        clock = 0
+        _append_provenance(writer, monotonic_ns=clock, wall_time_ms=clock)
+        clock += 2
+        action_artifact = writer.publish_artifact(b"safe", media_type="text/plain")
+        writer.append(
+            "observation",
+            ObservationPayload(observation_id="observation-0", sequence=0),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.append(
+            "action_batch",
+            ActionBatchPayload(
+                action_batch_id="batch-0",
+                observation_id="observation-0",
+                action_count=1,
+                action_artifact=action_artifact,
+            ),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.append(
+            "environment_step",
+            EnvironmentStepPayload(
+                step_id="step-0",
+                action_batch_id="batch-0",
+                receipt_id=DIGEST,
+                input_observation_id="observation-0",
+                output_observation_id="observation-1",
+                terminated=False,
+                truncated=False,
+            ),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.append(
+            "observation",
+            ObservationPayload(observation_id="observation-1", sequence=1),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.begin_finalization(
+            "final",
+            "score-op",
+            FinalizationIntent(kind="score", scorer_id="scorer", scorer_version="1"),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        score = ScoreArtifact(status="scored", binary=1)
+        writer.record_scoring_result(
+            ScoringResultPayload(
+                finalization_id="final", scoring_operation_id="score-op", score=score
+            ),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        clock, _ = _append_final_receipts(writer, monotonic_ns=clock, wall_time_ms=clock)
+        writer.record_final_lifecycle(
+            LifecycleTransitionPayload(
+                previous_state_id=None,
+                state_id=OTHER_DIGEST,
+                state="completed",
+                finalization_id="final",
+                preflight_seal_id=DIGEST,
+                commitment_id=OTHER_DIGEST,
+                reconciliation_id=DIGEST,
+                reconciliation_reportable=True,
+                score_id=score.score_id,
+                cleanup_result_id=OTHER_DIGEST,
+                rescue_required=False,
+                failure_kind="scorer",
+            ),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+    finally:
+        writer.close()
+    report = verify_bundle(root)
+    assert not report.valid
+    assert ("finalization_invalid", "events.jsonl") in {
+        (issue.code, issue.location) for issue in report.issues
+    }


### PR DESCRIPTION
## Summary

A crash-terminated episode could not seal a verifiable evidence bundle, so **every episode ending in a crash was unscoreable rather than merely unscored** — blocking reporting of any OSWorld score for a run containing one. A real paid OSWorld episode (`ep-ffda3fc88f81`, 16 real environment steps on live AWS, ended by an adapter `rpcremoteerror`) landed on `status="abandonment_failed"`, `score=null`, `reportability_label=null`, with independent verification reporting exactly one issue: `code='finalization_invalid' severity='error' location='events.jsonl'`.

The bundle's **content was sound**: 121 chained events with intact hashes, a proper terminal sequence (`error` → `finalization_start(intent='unscored')` → `reconciliation` → `cleanup(rescue_required=true)` → `lifecycle_transition(failure_kind='crash')`), and correct cloud teardown (`rescue_complete=true`, empty audit). Only the verifier disagreed.

## Root cause

Both failures trace to **one** over-broad invariant in `_verify_semantics` (`verify.py:795`):

```python
if environment_step_seen and not last_step_terminal and not finish_action_seen:
    issues.error("finalization_invalid", terminal_location)
```

This requires every bundle carrying a terminal lifecycle snapshot to prove *why* it stopped stepping: either the environment ended the rollout (`terminated`/`truncated`) or the agent chose to stop (a `finish` action batch). That is a good invariant — without it a bundle truncated mid-rollout would seal as if the run had reached its own conclusion.

But **a crash is a third legitimate way to stop, and it leaves neither marker**, precisely because nothing got to decide the rollout was over: the last step completed, then the adapter broke. In the real bundle all 16 steps have `terminated=False, truncated=False` and all 16 action batches have `terminal=None`. The verifier was demanding evidence that a crash definitionally destroys.

**Two consequences, and the second is the more serious half:**

1. `seal()` re-verifies independently (`store.py:1315`) and refuses on any error-severity issue → `EvidenceBundleInvalid: bundle failed independent seal verification`.
2. `abandon()` — the safety net that exists *precisely* for a bundle nobody can seal — re-verifies the same way (`store.py:1477`) and refused for the identical reason → `abandonment refused: ... failed independent abandonment verification`.

So the single check disabled the primary path **and** its fallback, leaving the episode with no legal terminal at all. The `state.json` marker stuck at `"state": "finalizing"` / `"terminal_id": null` is a *symptom* of that refusal, not the cause — nothing was ever going to advance it, because both writers that advance it bailed out on the same verification error.

## The fix

`failure_kind` on the terminal snapshot is the missing explanation, and it is not a weaker one:

- it is written **only** by `record_final_lifecycle`, which refuses unless the durable finalizing marker is already on disk and its `finalization_id` matches;
- it rides **inside the hash-chained event payload** (`previous_event_sha256` covers the full record), so it cannot be added to an existing bundle without breaking the chain.

Gating on `not results` keeps the relaxation narrow: a bundle carrying a scoring result claims a completed rollout and must still prove one. A crash is therefore admitted **only** into the unscored path, where the episode is already labelled a failure and can never be mistaken for a finished run.

Net production change is 5 lines of logic (plus the comment explaining the invariant, since this machinery went through 7 review rounds in #495).

## Changes

- `local_operator/evaluation/evidence/verify.py` — narrow the rollout-completion invariant to exempt crash-terminated, unscored episodes.
- `tests/unit/evaluation/evidence/test_finalization.py` — 4 new tests (below).
- `pyproject.toml` — 0.44.55 → 0.44.57 (patch: bug fix).

## Testing evidence

**Acceptance criterion — the real bundle.** Verifier run over a *copy* of `ep-ffda3fc88f81` (original never modified; confirmed by `diff -rq`):

```
BEFORE fix:  valid=False  issues=(VerificationIssue(code='finalization_invalid', severity='error', location='events.jsonl'),)

AFTER fix:
--- BEFORE recovery ---            --- AFTER recovery (abandon) ---
valid          : True              valid          : True
terminal_state : finalizing        terminal_state : abandoned
issues         : ()                issues         : ()
failure_kind   : crash             reason         : ambiguous_finalization
intent         : unscored          intent         : unscored
```

The episode now verifies clean and reaches a real terminal, labelled **unscored/crash** — unscored for the right reason, rather than unsealable.

**New tests**, each exercising the real writer/verifier (not mocks):

| Test | Covers |
|---|---|
| `test_crash_after_nonterminal_steps_verifies_and_seals_unscored` | The exact interleaving: N non-terminal steps → crash → terminal transition. Verifies clean **and seals** to `terminal_state='sealed'`, `reportability_label='unscored'`. |
| `test_crash_abandonment_fallback_now_succeeds` | The safety net: `open_for_abandon` + `abandon` on a recovered crash bundle now succeeds where it previously refused (the process-died-before-marker recovery path). |
| `test_crash_bundle_missing_terminal_event_still_refuses` | **No over-correction**: process died *before* the terminal event reached the journal → no terminal state, `seal()` still raises `EvidenceBundleInvalid`. |
| `test_truncated_rollout_without_failure_kind_still_refuses` | The invariant still bites where designed: a snapshot claiming a clean run (`failure_kind=None`) over an unfinished rollout is still `finalization_invalid`. |
| `test_scored_bundle_with_failure_kind_still_requires_completed_rollout` | Pins the `not results` clause: a *scored* bundle cannot use a crash excuse to waive rollout completion. |

**Mutation-proving.** Every new test was proven to fail against the unfixed code, and each clause of the new predicate is pinned by a test that dies without it:

```
MUTANT: fix removed entirely                     2 failed  ← the two crash tests
MUTANT: crash_terminated = True                  2 failed
MUTANT: crash_terminated = bool(terminal_states)  2 failed  ← failure_kind clause pinned
MUTANT: crash_terminated = any(failure_kind...)   1 failed  ← `not results` clause pinned
MUTANT: crash_terminated = not results            1 failed
RESTORED (fix in place)                           6 passed
```

**Gates**, whole-tree, at the exact CI pins:

```
flake8==7.1.0            OK
black==26.1.0 --check    830 files would be left unchanged
isort==5.13.2 --check    OK
pyright==1.1.411         0 errors, 0 warnings, 0 informations
pytest tests/unit        11501 passed, 15 skipped (635s)
pytest tests/unit/evaluation  718 passed  (re-run after rebase)
```

## Notes

- Rebased onto `main` after 0.44.55 landed mid-work; version re-checked against `main`, PyPI, and all 9 open PRs immediately before push (`0.44.57` free — #580 took `.55`, #582 took `.56`).
- No AWS writes; the evidence bundle was only ever read, and recovery was exercised against copies in a scratch directory.

