### PR TITLE
fix(evaluation): stop the harness telling a screen-driving model nothing changed

### DIFF
--- a/local_operator/evaluation/protocol.py
+++ b/local_operator/evaluation/protocol.py
@@ -413,7 +413,13 @@ class TypeAction(_Action):
     text: str = Field(min_length=1, max_length=MAX_TEXT_LENGTH, pattern=r"\S")
 
 
-_NAMED_KEYS = frozenset(
+#: The named keys ``KeyAction`` accepts, case-insensitively. Public because
+#: the episode system prompt must state this vocabulary rather than imply it:
+#: a model told only that "key" takes named keys guesses plausible synonyms
+#: the validator does not accept ("control", "escape", "return"), and each
+#: guess is a rejected reply that costs a billed corrective re-prompt. Derived
+#: from the enforcing set so the prompt cannot drift from what parses.
+NAMED_KEYS = frozenset(
     {
         "ALT",
         "BACKSPACE",
@@ -456,7 +462,7 @@ class KeyAction(_Action):
         normalized: list[str] = []
         for key in keys:
             candidate = key.upper() if len(key) > 1 else key
-            if candidate not in _NAMED_KEYS and candidate not in _PRINTABLE_KEYS:
+            if candidate not in NAMED_KEYS and candidate not in _PRINTABLE_KEYS:
                 raise ValueError(f"unknown key: {key!r}")
             normalized.append(candidate)
         if len(normalized) != len(set(normalized)):

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -815,7 +815,16 @@ class EpisodeRunner:
             # The diagnostic is what the model will be shown; it is published
             # as an artifact rather than squeezed into the identifier-shaped
             # ``diagnostic_code`` so the exact correction is auditable.
-            detail = self._publish(rejected.diagnostic.encode("utf-8"), media_type="text/plain")
+            #
+            # The REPLY is published alongside it, because the diagnostic
+            # alone does not say what the model was attempting. A Pydantic
+            # error names the fields it refused; it cannot tell a later reader
+            # whether the turn was a mistyped keyboard action or a stray
+            # sentence after the JSON. Without the reply, diagnosing a
+            # rejection class costs a whole re-run of a paid episode.
+            detail = self._publish(
+                _rejection_detail(rejected).encode("utf-8"), media_type="text/plain"
+            )
             self._append(
                 "error",
                 ErrorPayload(
@@ -1651,6 +1660,23 @@ def _incomplete_receipt(plan: CleanupPlan, action_id: str) -> CleanupReceipt:
         evidence_code="worker-unavailable",
         duration_ms=0,
     )
+
+
+def _rejection_detail(rejected: Any) -> str:
+    """The rejection artifact: why the reply was refused AND what it said.
+
+    Two sections rather than one blob, so a reader (or a script mining a batch
+    of bundles for rejection classes) can tell the harness's diagnostic apart
+    from the model's own words. A client that did not capture the reply --
+    every implementation of the protocol is free not to -- degrades to the
+    diagnostic alone rather than emitting an empty section that reads as "the
+    model said nothing".
+    """
+
+    reply = getattr(rejected, "reply", None)
+    if not reply:
+        return rejected.diagnostic
+    return f"{rejected.diagnostic}\n\n--- rejected reply ---\n{reply}"
 
 
 def _diagnostic(error: BaseException) -> str:

--- a/local_operator/evaluation/runner/model.py
+++ b/local_operator/evaluation/runner/model.py
@@ -130,6 +130,7 @@ class DecisionRejected(Exception):
         self,
         diagnostic: str,
         *,
+        reply: str | None = None,
         route: RouteIdentity | None = None,
         usage: ModelUsage | None = None,
         cost_micros: int = 0,
@@ -142,6 +143,15 @@ class DecisionRejected(Exception):
     ) -> None:
         super().__init__(diagnostic)
         self.diagnostic = diagnostic
+        # WHAT the model actually said, not just why it was refused. The
+        # diagnostic alone cannot answer the question a post-mortem asks --
+        # "was it trying to type?" -- because a Pydantic error names the
+        # fields it disliked and not the intent behind them. A real paid
+        # episode's three rejections were only reconstructible as far as
+        # "something with a `key` field" and "trailing junk after the JSON";
+        # the replies themselves were discarded, so the failure class could
+        # not be diagnosed without paying for the run again.
+        self.reply = reply
         # The served route matters even for a rejected reply: a fallback that
         # answered badly still moved the run off its pinned route.
         self.route = route

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -26,13 +26,19 @@ from __future__ import annotations
 import base64
 import json
 import re
+import textwrap
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping, Sequence, get_args, get_origin
 
 from local_operator.evaluation.adapters.supervisor import verify_artifact
 from local_operator.evaluation.evidence.models import RouteIdentity
-from local_operator.evaluation.protocol import ActionBatch, ComputerAction, Observation
+from local_operator.evaluation.protocol import (
+    NAMED_KEYS,
+    ActionBatch,
+    ComputerAction,
+    Observation,
+)
 from local_operator.evaluation.runner.model import (
     CompactionRecord,
     DecisionRejected,
@@ -70,9 +76,34 @@ MAX_REJECTED_REPLY_CHARS = 4_000
 #: changes the message being appended.
 UNCHANGED_OBSERVATION = "(unchanged)"
 
+#: Rendered when an observation carries NO text at all. Kept distinct from
+#: :data:`UNCHANGED_OBSERVATION` because the two mean opposite things and a
+#: model that conflates them loses its only textual progress signal: a
+#: benchmark whose adapter publishes the task once and then screenshots only
+#: (OSWorld) yields ``text=None`` on every step after the first, and folding
+#: those into "(unchanged)" told the model the SCREEN had not moved on every
+#: single turn of a real paid episode.
+NO_TEXTUAL_STATE = "(no textual state)"
+
+#: Appended to an observation whose frame bytes are byte-identical to the
+#: previous observation's. This is the only reliable "nothing happened" signal
+#: a screenshot-only benchmark has: without it a model that clicked a dead
+#: pixel sees a new observation id, a new image block, and no statement that
+#: the two images are the same, so re-deciding the same click is the rational
+#: reading of the context rather than a lapse.
+UNCHANGED_FRAMES_NOTE = (
+    "The screenshot is byte-identical to the previous observation's: your last "
+    "action changed nothing visible. Do not repeat it -- try a different "
+    "target, a different action kind, or wait for the surface to settle."
+)
+
 # The batch wire version this harness speaks; pinned here rather than taken
 # from a model reply.
 PROTOCOL_VERSION = "1.0"
+
+#: Function keys are collapsed to a range in the prompt rather than listed:
+#: F1-F24 is 24 of the vocabulary's 43 entries and the pattern is obvious.
+_FUNCTION_KEY = re.compile(r"F\d+")
 
 # Mirrors receipts.StrictIdentifier, which every evidence identifier must match.
 _IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]*")
@@ -101,11 +132,31 @@ def _action_schema_lines() -> list[str]:
             else:
                 rendered = _type_name(field.annotation)
             optional = "" if field.is_required() else " (optional)"
-            fields.append(f"{name}: {rendered}{optional}")
+            # The name is QUOTED like the two literal keys beside it. Rendered
+            # bare it reads as a label rather than a JSON key: a real episode
+            # answered the bare ``keys: [str, ...]`` line with ``"key":
+            # ["Alt", "F10"]`` and lost the turn to extra_forbidden/missing.
+            fields.append(f'"{name}": {rendered}{optional}')
         kind = action.model_fields["kind"].default
         detail = ", ".join(fields) if fields else "no further fields"
         lines.append(f'  {{"kind": "{kind}", "observation_id": "<id>", {detail}}}')
     return lines
+
+
+def _named_keys_line() -> str:
+    """The key vocabulary, wrapped, derived from the set the validator enforces.
+
+    Stated rather than implied. ``KeyAction`` accepts a closed set and rejects
+    everything else, so a model reaching for the obvious synonym loses the
+    turn: probed against the real parser, a reply of ``["control", "k"]`` is
+    refused with ``unknown key: 'control'`` while ``["ctrl", "k"]`` parses.
+    The function keys are collapsed to a range because listing F1-F24 in full
+    spends prompt budget on a pattern one phrase conveys.
+    """
+
+    named = sorted(key.lower() for key in NAMED_KEYS if not _FUNCTION_KEY.fullmatch(key))
+    wrapped = textwrap.wrap(", ".join(named) + ", and f1 through f24", width=68)
+    return textwrap.indent("\n".join(wrapped), "  ")
 
 
 def _type_name(annotation: Any) -> str:
@@ -138,17 +189,29 @@ def build_system_prompt() -> str:
 
 Each user message is one observation of the screen: its text, and a screenshot
 when one is attached. Your own earlier replies are the actions you already
-took; an observation reading "(unchanged)" has the same text as the one before
-it, and "[screenshot omitted ...]" marks an older screenshot that a newer one
-has replaced. A message starting <previous-context-summary> summarises turns
-that are no longer shown.
+took. "{UNCHANGED_OBSERVATION}" means the observation's TEXT repeats the
+previous one's; "{NO_TEXTUAL_STATE}" means the adapter published no text for
+this step, which is normal for a screenshot-only benchmark and means the
+screenshot is the whole state; "[screenshot omitted ...]" marks an older
+screenshot that a newer one has replaced. A message starting
+<previous-context-summary> summarises turns that are no longer shown.
+
+An observation that says the screenshot is byte-identical to the previous
+one's is telling you your last action did nothing. Treat that as evidence, not
+noise: repeating an action that already had no effect wastes the step budget.
+Change something -- a different target, a different action kind, a "wait" if
+the surface may still be painting, or a scroll to bring the target into view.
 
 Every observation lists its frames on a "Frames:" line as "<frame_id>
 (<width>x<height>)", one per attached screenshot, in order. Any action that
 takes a "frame_id" MUST use one of the ids named on the CURRENT observation's
-"Frames:" line, exactly as written, and its x/y must lie inside that frame's
-width and height (0-based). Never invent a frame id or number the frames
-yourself.
+"Frames:" line, exactly as written. Coordinates are in that frame's own pixel
+space: x/y are integers, the origin (0,0) is its TOP-LEFT corner, x grows
+right, y grows down, and both must lie inside the width and height given on
+that line (0-based, so the largest valid x is width-1). The screenshot you are
+shown IS that pixel space at exactly that size -- do not rescale it, do not
+normalize to 0-1, and do not assume a different resolution. Never invent a
+frame id or number the frames yourself.
 
 If a reply of yours is rejected, the next user message starts "Your previous
 reply was rejected:" and names the defect. Reply again for the SAME
@@ -165,8 +228,34 @@ looking at right now. These are the only permitted shapes:
 
 {chr(10).join(_action_schema_lines())}
 
-Where a field lists alternatives separated by "|", you must use exactly one of
-those literal values.
+Field names are JSON keys spelled exactly as quoted above -- "keys" is not
+"key", "text" is not "value". Where a field lists alternatives separated by
+"|", you must use exactly one of those literal values.
+
+You drive a real keyboard as well as a mouse, and most tasks cannot be done by
+clicking alone: entering a title, a search term, an address, a date, or a file
+name all require typing.
+
+* "type" enters literal text wherever the keyboard focus already is. It does
+  NOT click first, so focus the field with a click (or Tab) in an earlier
+  action, then type. It sends exactly the characters given and does not press
+  Enter for you.
+* "key" presses named keys, and presses the ones in a single action TOGETHER
+  as one chord: ["ctrl", "s"] is Ctrl+S, ["enter"] commits a field or dialog,
+  ["tab"] moves focus, ["esc"] dismisses, and ["ctrl", "a"] followed by a
+  "type" replaces a field's contents. Two presses in sequence are two separate
+  "key" actions, not one chord. A single printable character is also a key, so
+  ["ctrl", "k"] is valid. These are the ONLY named keys accepted, and a
+  synonym is rejected -- "ctrl" not "control", "esc" not "escape", "enter"
+  not "return":
+
+{_named_keys_line()}
+
+A batch may contain SEVERAL actions and they execute in order against the
+screen you are looking at, with one new observation at the end. That is how a
+click-then-type-then-Enter sequence is done in one step rather than three.
+Batch only what you can predict without seeing the screen in between; when the
+result of an action decides the next one, end the batch and look.
 
 Two actions end your turn in a special way, and each must be the ONLY action in
 its batch. Their fields are listed above; what the list cannot tell you is what
@@ -332,12 +421,24 @@ class _ContextBuilder:
         from local_operator.harness.types import ImageContent, Message, TextContent
 
         observation = turn.observation
-        text = observation.text or "(no textual state)"
+        text = observation.text
         # The adapter owns observation text and the runner never rewrites it;
         # the one dedup that is append-only-safe is choosing how to render the
         # message being appended, so a byte-identical repeat is sent as a
         # marker rather than as the same paragraph again.
-        rendered_text = UNCHANGED_OBSERVATION if text == self._previous_text else text
+        #
+        # ABSENT text is not UNCHANGED text. Only compare when the adapter
+        # actually published text on both turns: an adapter that publishes the
+        # goal once and screenshots thereafter (OSWorld) has ``text=None`` from
+        # step 1 on, and treating that as "unchanged" asserted that the screen
+        # had not moved on every turn of a real episode -- the exact signal the
+        # model needs to detect a no-op click, inverted into noise.
+        if text is None:
+            rendered_text = NO_TEXTUAL_STATE
+        elif self._previous_text is not None and text == self._previous_text:
+            rendered_text = UNCHANGED_OBSERVATION
+        else:
+            rendered_text = text
         self._previous_text = text
         lines = [
             f"Step: {observation.sequence}",
@@ -354,6 +455,12 @@ class _ContextBuilder:
             # that answer was delivered", as the system prompt promises.
             lines.append(f"Answer from the user: {previous.ask_answer}")
         lines.append(f"Frames: {_frames_line(observation)}")
+        if previous is not None and _frames_identical(previous.observation, observation):
+            # Stated on the observation itself rather than left for the model
+            # to infer by diffing two base64 image blocks, which no model does
+            # reliably. Digests are compared, not pixels: the frames are
+            # content-addressed already, so this costs nothing.
+            lines.append(UNCHANGED_FRAMES_NOTE)
         lines.extend(["", rendered_text])
         content: list[Any] = [TextContent(text="\n".join(lines))]
         for frame in observation.frames:
@@ -528,6 +635,9 @@ class ProviderModelClient:
             self._context.append_rejection(text, diagnostic)
             raise DecisionRejected(
                 diagnostic,
+                # Truncated with the same bound the context replay uses: a
+                # runaway reply must not be able to inflate the bundle either.
+                reply=text[:MAX_REJECTED_REPLY_CHARS],
                 route=self._route,
                 usage=usage,
                 cost_micros=cost_micros,
@@ -832,6 +942,24 @@ def _frames_line(observation: Observation) -> str:
         f"{frame.frame_id} ({frame.geometry.model_visible.width}x"
         f"{frame.geometry.model_visible.height})"
         for frame in observation.frames
+    )
+
+
+def _frames_identical(previous: Observation, current: Observation) -> bool:
+    """Whether two observations carry exactly the same frame bytes.
+
+    Compared by the frames' content-addressed digests, in order, so this is a
+    statement about the BYTES rather than a perceptual judgement the runner is
+    not entitled to make. An observation with no frames is never "identical":
+    a frameless benchmark has no screen to be unchanged, and claiming
+    otherwise would put a false no-op note on every one of its turns.
+    """
+
+    if not current.frames or len(previous.frames) != len(current.frames):
+        return False
+    return all(
+        before.artifact.sha256 == after.artifact.sha256
+        for before, after in zip(previous.frames, current.frames)
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.56"
+version = "0.44.58"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/evaluation/adapters/osworld/test_actions.py
+++ b/tests/unit/evaluation/adapters/osworld/test_actions.py
@@ -113,9 +113,9 @@ def test_out_of_frame_coordinate_raises_not_clamps() -> None:
 
 
 def test_every_named_key_has_a_mapping() -> None:
-    from local_operator.evaluation.protocol import _NAMED_KEYS
+    from local_operator.evaluation.protocol import NAMED_KEYS
 
-    for key in sorted(_NAMED_KEYS):
+    for key in sorted(NAMED_KEYS):
         compiled = actions.compile_action(KeyAction(observation_id="o", keys=(key,)), None)
         assert compiled is not None
         assert compiled.startswith("pyautogui.press(")

--- a/tests/unit/evaluation/runner/conftest.py
+++ b/tests/unit/evaluation/runner/conftest.py
@@ -341,6 +341,9 @@ class ScriptedModel:
             self.calls += 1
             raise DecisionRejected(
                 "Your previous reply was rejected: action references unknown frame_id '1'",
+                # A real client carries the reply so the bundle can record WHAT
+                # the model said, not only why it was refused.
+                reply='{"actions": [{"kind": "click", "frame_id": "1"}]}',
                 route=self.route,
                 usage=ModelUsage(input_tokens=10, output_tokens=5),
                 cost_micros=7,

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -794,6 +794,55 @@ async def test_one_rejected_decision_is_re_prompted_and_the_corrected_batch_proc
 
 
 @pytest.mark.asyncio
+async def test_a_rejected_decision_publishes_the_reply_beside_the_diagnostic(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """A diagnostic alone cannot answer "what was the model attempting?".
+
+    Bundle ep-ffda3fc88f81 recorded three ``decision-rejected`` errors whose
+    artifacts held only the Pydantic complaint. Whether those were failed
+    keyboard actions -- the difference between "the model never tried to type"
+    and "the model tried and the schema refused it" -- was not answerable from
+    the bundle, and answering it would have cost another paid run.
+    """
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    model = ScriptedModel(["reject", "finish"])
+    runner = _runner(tmp_path, episode_id, adapter=adapter, model=model)
+
+    outcome = await runner.run()
+
+    root = outcome.bundle_root
+    assert root is not None
+    errors = payloads(root, ErrorPayload)
+    assert len(errors) == 1
+    detail = errors[0].detail_artifact
+    assert detail is not None
+    recorded = (root / "artifacts" / detail.sha256).read_text()
+    # Both halves, and labelled: a reader can tell the harness's refusal from
+    # the model's own words.
+    assert "unknown frame_id '1'" in recorded
+    assert "--- rejected reply ---" in recorded
+    assert '{"actions": [{"kind": "click", "frame_id": "1"}]}' in recorded
+
+
+@pytest.mark.asyncio
+async def test_a_rejection_without_a_captured_reply_records_the_diagnostic_alone(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """``reply`` is optional on the protocol boundary, so a client that does not
+    capture it must degrade to the diagnostic rather than emit an empty section
+    that reads as "the model said nothing"."""
+
+    from local_operator.evaluation.runner.episode import _rejection_detail
+    from local_operator.evaluation.runner.model import DecisionRejected
+
+    assert _rejection_detail(DecisionRejected("refused")) == "refused"
+    assert _rejection_detail(DecisionRejected("refused", reply="")) == "refused"
+    assert "--- rejected reply ---" in _rejection_detail(DecisionRejected("refused", reply="{}"))
+
+
+@pytest.mark.asyncio
 async def test_exhausted_decision_retries_seal_as_a_model_failure(
     tmp_path: Path, episode_id: str
 ) -> None:

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -31,6 +31,7 @@ from local_operator.evaluation.protocol import (
 )
 from local_operator.evaluation.runner.model import DecisionRejected, EpisodeTurn
 from local_operator.evaluation.runner.provider_client import (
+    MAX_REJECTED_REPLY_CHARS,
     DecisionParseError,
     ProviderModelClient,
     build_system_prompt,
@@ -284,7 +285,9 @@ async def test_system_prompt_states_the_schema_the_protocol_enforces() -> None:
         assert kind in prompt
     # A sequence field must read as an array. Told only "value", a model emits
     # "ctrl+c" for KeyAction.keys, which is a hard non-retryable parse failure.
-    assert "keys: [str, ...]" in prompt
+    # The name is QUOTED because a bare one reads as a label, not a JSON key:
+    # a real episode answered the bare form with the singular "key".
+    assert '"keys": [str, ...]' in prompt
 
 
 def test_prompt_does_not_restate_literals_it_already_derives() -> None:
@@ -618,6 +621,43 @@ def _framed_observation(root: Path, sequence: int, *, text: str = "a screen") ->
         frames=(
             FrameRef(
                 frame_id=f"frame-{sequence}",
+                artifact=ArtifactRef(sha256=digest, media_type="image/png", byte_count=len(data)),
+                geometry=FrameGeometry(
+                    native=FrameSize(width=1, height=1),
+                    model_visible=FrameSize(width=1, height=1),
+                ),
+            ),
+        ),
+    )
+    return provisional.model_copy(update={"observation_id": observation_content_id(provisional)})
+
+
+def _distinct_framed_observation(root: Path, sequence: int, pixel: bytes) -> Observation:
+    """A framed observation whose frame bytes differ per ``pixel``.
+
+    ``_framed_observation`` republishes one constant PNG, which is what makes
+    it useful for the identical-frames case and useless for its negative.
+    """
+
+    from local_operator.compaction.png import encode_grayscale_png
+    from local_operator.evaluation.protocol import (
+        ArtifactRef,
+        FrameGeometry,
+        FrameRef,
+        FrameSize,
+    )
+
+    data = encode_grayscale_png(1, 1, pixel)
+    digest = _publish_frame(root, data)
+    provisional = Observation(
+        task_id="task-1",
+        episode_id="episode-1",
+        sequence=sequence,
+        observation_id="provisional",
+        text="a screen",
+        frames=(
+            FrameRef(
+                frame_id="screen",
                 artifact=ArtifactRef(sha256=digest, media_type="image/png", byte_count=len(data)),
                 geometry=FrameGeometry(
                     native=FrameSize(width=1, height=1),
@@ -1434,6 +1474,227 @@ async def test_unchanged_observation_text_is_marked_not_repeated(tmp_path: Path)
     second_user = fresh.requests[1].messages[2].content[0].text
     assert second_user.rstrip().endswith("(unchanged)")
     assert "identical" in fresh.requests[1].messages[0].content[0].text
+
+
+@pytest.mark.asyncio
+async def test_absent_observation_text_is_not_reported_as_unchanged(tmp_path: Path) -> None:
+    """The defect from bundle ep-ffda3fc88f81: 15 of 17 turns read "(unchanged)".
+
+    That adapter publishes the task text on step 0 and screenshots only
+    thereafter, so ``text`` is ``None`` from step 1 on. Comparing ``None`` to
+    ``None`` made every later turn claim the state had not changed -- against
+    frames that Pillow measures as 0.02%-93% different -- which destroyed the
+    model's only textual progress signal AND told it, falsely, that its
+    actions were no-ops.
+    """
+
+    stream = RecordingStream(_wait_reply)
+    client = _client(stream, tmp_path)
+    history: list[EpisodeTurn] = []
+    for sequence in range(3):
+        current = _framed_observation(tmp_path, sequence).model_copy(update={"text": None})
+        current = current.model_copy(
+            update={"observation_id": observation_content_id(current)},
+        )
+        history.append(EpisodeTurn(observation=current))
+        decision = await client.decide(current, tuple(history))
+        history[-1] = history[-1].model_copy(update={"batch": decision.action_batch})
+
+    rendered = [
+        message.content[0].text
+        for message in stream.requests[-1].messages
+        if message.role == "user" and isinstance(message.content[0], TextContent)
+    ]
+    assert len(rendered) == 3
+    for text in rendered:
+        assert text.rstrip().endswith("(no textual state)")
+        assert "(unchanged)" not in text
+
+
+@pytest.mark.asyncio
+async def test_identical_frames_are_declared_as_a_no_op(tmp_path: Path) -> None:
+    """A screenshot-only benchmark has no other way to say "nothing happened".
+
+    The real episode clicked pixel (674,44) four times. Nothing in its context
+    stated that two consecutive screenshots were the same image, so re-deciding
+    the same click was the rational reading rather than a lapse.
+    """
+
+    stream = RecordingStream(_wait_reply)
+    client = _client(stream, tmp_path)
+    history: list[EpisodeTurn] = []
+    # ``_framed_observation`` republishes the SAME 1x1 PNG for every sequence,
+    # so consecutive frames are byte-identical by construction.
+    for sequence in range(2):
+        current = _framed_observation(tmp_path, sequence)
+        history.append(EpisodeTurn(observation=current))
+        decision = await client.decide(current, tuple(history))
+        history[-1] = history[-1].model_copy(update={"batch": decision.action_batch})
+
+    first, second = (
+        message.content[0].text
+        for message in stream.requests[-1].messages
+        if message.role == "user" and isinstance(message.content[0], TextContent)
+    )
+    assert "byte-identical" not in first
+    assert "byte-identical to the previous observation's" in second
+    assert "Do not repeat it" in second
+    # The prompt has to teach the model what that sentence is for.
+    assert "did nothing" in stream.requests[-1].system_blocks[0]
+
+
+@pytest.mark.asyncio
+async def test_changed_frames_carry_no_no_op_note(tmp_path: Path) -> None:
+    """A false no-op note is worse than none: it would tell a model that a
+    working action failed."""
+
+    stream = RecordingStream(_wait_reply)
+    client = _client(stream, tmp_path)
+    history: list[EpisodeTurn] = []
+    for sequence, pixel in enumerate((b"\x00", b"\x7f")):
+        current = _distinct_framed_observation(tmp_path, sequence, pixel)
+        history.append(EpisodeTurn(observation=current))
+        decision = await client.decide(current, tuple(history))
+        history[-1] = history[-1].model_copy(update={"batch": decision.action_batch})
+
+    rendered = [
+        message.content[0].text
+        for message in stream.requests[-1].messages
+        if message.role == "user" and isinstance(message.content[0], TextContent)
+    ]
+    assert not any("byte-identical" in text for text in rendered)
+
+
+@pytest.mark.asyncio
+async def test_frameless_turns_never_claim_an_unchanged_screen(tmp_path: Path) -> None:
+    """A benchmark with no screen has no screen to be unchanged."""
+
+    stream = RecordingStream(_wait_reply)
+    client = _client(stream, tmp_path)
+    history: list[EpisodeTurn] = []
+    for sequence in range(2):
+        current = observation(sequence)
+        history.append(EpisodeTurn(observation=current))
+        decision = await client.decide(current, tuple(history))
+        history[-1] = history[-1].model_copy(update={"batch": decision.action_batch})
+
+    rendered = [
+        message.content[0].text
+        for message in stream.requests[-1].messages
+        if message.role == "user" and isinstance(message.content[0], TextContent)
+    ]
+    assert not any("byte-identical" in text for text in rendered)
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_reply_is_carried_on_the_exception_for_the_bundle(
+    tmp_path: Path,
+) -> None:
+    """Without the reply, a rejection class cannot be diagnosed after the fact.
+
+    The real episode's three ``decision-rejected`` errors recorded only the
+    Pydantic diagnostic, so "was the model trying to type?" was unanswerable
+    without paying for the run again.
+    """
+
+    current = _framed_observation(tmp_path, 0)
+    bad = json.dumps(
+        {
+            "actions": [
+                {"kind": "key", "observation_id": current.observation_id, "key": ["ctrl", "s"]}
+            ]
+        }
+    )
+    stream = RecordingStream(lambda _message: bad)
+
+    with pytest.raises(DecisionRejected) as info:
+        await _client(stream, tmp_path).decide(current, _turns(current))
+
+    assert info.value.reply == bad
+    assert '"key": ["ctrl", "s"]' in (info.value.reply or "")
+
+
+@pytest.mark.asyncio
+async def test_an_over_long_rejected_reply_is_bounded_on_the_exception(
+    tmp_path: Path,
+) -> None:
+    """A provider's max-token wall of prose must not ride into the bundle whole."""
+
+    current = _framed_observation(tmp_path, 0)
+    stream = RecordingStream(lambda _message: "x" * (MAX_REJECTED_REPLY_CHARS + 500))
+
+    with pytest.raises(DecisionRejected) as info:
+        await _client(stream, tmp_path).decide(current, _turns(current))
+
+    assert info.value.reply is not None
+    assert len(info.value.reply) == MAX_REJECTED_REPLY_CHARS
+
+
+def test_prompt_teaches_how_to_type_and_how_to_press_keys() -> None:
+    """The real episode emitted 16 actions, none of them a type or a key.
+
+    Clicking cannot enter a calendar title or a search term, so a prompt that
+    lists "type" in a schema table without saying it exists, that it follows
+    focus, and that "key" is a chord leaves the vocabulary technically
+    complete and practically unreachable.
+    """
+
+    prompt = build_system_prompt()
+
+    assert "keyboard" in prompt
+    # Typing follows focus; a model that thinks type() clicks first will type
+    # into whatever had focus and see nothing happen.
+    assert "wherever the keyboard focus already is" in prompt
+    # Asserted against the unwrapped text: the prompt's line breaks are
+    # cosmetic and a test that pins them fails on a reflow, not a regression.
+    flat = " ".join(prompt.split())
+    assert "does not press Enter for you" in flat
+    # A chord, not a sequence -- the distinction that decides Ctrl+S.
+    assert "TOGETHER" in prompt
+    assert '["ctrl", "s"]' in prompt
+    # Multi-action batches are what make click-then-type one step.
+    assert "execute in order" in prompt
+
+
+def test_prompt_lists_the_key_vocabulary_the_validator_enforces() -> None:
+    """``KeyAction`` accepts a closed set; an unlisted synonym is a lost turn.
+
+    Probed against the real parser: ``["control", "k"]`` is refused with
+    ``unknown key: 'control'`` while ``["ctrl", "k"]`` parses. A prompt that
+    only shows examples leaves the model to guess which spelling is the
+    accepted one.
+    """
+
+    from local_operator.evaluation.protocol import NAMED_KEYS
+
+    prompt = build_system_prompt()
+    flat = " ".join(prompt.split())
+
+    # Derived from the enforcing set, so a new named key cannot drift out of
+    # the instructions -- the same guarantee _action_schema_lines gives.
+    for key in NAMED_KEYS:
+        if key.startswith("F") and key[1:].isdigit():
+            continue
+        assert key.lower() in flat, key
+    assert "f1 through f24" in flat
+    # The three synonyms a model actually reaches for are named as wrong.
+    assert '"ctrl" not "control"' in flat
+    assert '"esc" not "escape"' in flat
+    assert '"enter" not "return"' in flat
+
+
+def test_prompt_states_the_coordinate_convention() -> None:
+    """A model told a frame's size but not its origin is guessing at half the
+    contract; the protocol clamps and then REJECTS, so a wrong convention is a
+    lost turn rather than a near miss."""
+
+    prompt = build_system_prompt()
+
+    assert "TOP-LEFT" in prompt
+    assert "x grows" in prompt and "y grows down" in prompt
+    assert "width-1" in prompt
+    # The screenshot is the pixel space -- no rescaling, no 0-1 normalization.
+    assert "normalize to 0-1" in prompt
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

A real paid OSWorld episode (`ep-ffda3fc88f81`, `openrouter/google/gemini-3.8-flash`, 20 model calls, $0.1233) emitted 16 actions: **14 clicks, one double-click, one wait, and zero `type` or `key` actions**. Six were near-duplicates and pixel `(674,44)` was clicked four times. Three of the four recorded errors were `decision-rejected` — ~15% of turns spent on replies the runner refused.

The task ("read an email, create calendar entries with titles and times") is unachievable without typing, so the natural reading is that the model is too weak. **Replaying that bundle's own artifacts through this rendering code shows most of it was the harness's fault.** This PR fixes the generalizable causes. No task knowledge is hardcoded, nothing is OSWorld-specific, and every change applies to any screen-driving benchmark.

## What the model was actually told, and why it failed

### 1. Absent observation text was reported as *unchanged* text — the repetition cause

`_ContextBuilder._render_observation` compared `observation.text or "(no textual state)"` against the previous turn's value:

```python
text = observation.text or "(no textual state)"
rendered_text = UNCHANGED_OBSERVATION if text == self._previous_text else text
```

An adapter that publishes the task once and screenshots thereafter — OSWorld does exactly this — yields `text=None` from step 1 onward. `None or "(no textual state)"` equals itself every time, so the harness printed **`(unchanged)` on 15 of the episode's 17 turns**, asserting that the screen had not moved.

It had. Measured with Pillow on the bundle's own frames:

| step transition | pixels changed | % of frame |
| --- | --- | --- |
| 0→1 | 1,387,920 | 66.93% |
| 1→2 | 1,934,727 | 93.30% |
| 2→3 | 1,437,698 | 69.33% |
| 3→4 | 3,910 | 0.19% |
| 5→6 | 343 | 0.02% |
| 6→7 | 919,444 | 44.34% |

Not one pair was identical. The model was told nothing changed while everything changed, on every turn after the first, which destroyed its only textual progress signal. Clicking the same pixel four times is the rational response to a context that insists the screen is frozen.

**Fix:** absent text and unchanged text are now distinct facts. `(no textual state)` means the adapter published none; `(unchanged)` means it published the same text twice and is only ever emitted when text actually exists on both turns.

### 2. Nothing signalled a *genuine* no-op

A screenshot-only benchmark hands the model a new observation id and a new image block whether or not anything happened, and no model reliably diffs two base64 blobs. There was no signal at all for the case the model most needs to detect.

**Fix:** consecutive observations whose frame **digests** match now say so explicitly, with an instruction not to repeat the action. Compared by content address rather than pixels (the frames are content-addressed already, so it costs nothing), never claimed for a frameless benchmark that has no screen to be unchanged, and never fired on changed frames — a false no-op note would tell a model its working action had failed.

### 3. The action schema rendered field names bare — a *proven* lost keyboard attempt

The schema block quoted two keys and left the rest bare:

```
{"kind": "key", "observation_id": "<id>", keys: [str, ...]}
```

Beside a quoted `"kind"`, the bare `keys:` reads as a label rather than a JSON key. The episode's first rejection artifact is exactly that mistake:

```
actions.0.key.keys  Field required [type=missing, input_value={'key': ['Alt', 'F10'], ...}]
actions.0.key.key   Extra inputs are not permitted [input_value=['Alt', 'F10']]
```

**The model *was* reaching for the keyboard — it tried to press Alt+F10 — and the prompt's own rendering cost it the turn.** This materially changes the diagnosis from "it never tried to type".

**Fix:** field names are quoted like the JSON keys they are.

### 4. The enforced key vocabulary was never stated

`KeyAction` accepts a closed 43-entry set and rejects everything else. Probed against the real parser:

```
["control", "k"]  -> REJECTED: unknown key: 'control'
["ctrl", "k"]     -> ACCEPTED
```

The prompt named no keys at all, so a model reaching for the obvious synonym lost a billed turn with nothing to tell it why.

**Fix:** the vocabulary is derived from `NAMED_KEYS` (promoted from `_NAMED_KEYS` precisely so the prompt cannot drift from what the validator enforces, the same discipline `_action_schema_lines` already uses) and the three synonyms models actually reach for are named as wrong. Function keys collapse to "f1 through f24" rather than spending 24 lines on an obvious pattern.

### 5. Nothing said how to type, or that a batch may hold several actions

`type` appeared in the schema table and nowhere else. The prompt never said typing follows existing focus, never said `key` presses a chord rather than a sequence, and never mentioned that a batch executes several actions in order — so click→type→Enter looked like three separate gambles rather than one step. It also never stated the coordinate convention the protocol validates against, leaving origin, direction, and scale to be guessed.

**Fix:** the prompt now states the keyboard contract, the batching affordance (verified against the adapter — `compile_batch` compiles one statement per action, executed in order with one observation at the end), and the coordinate convention: top-left origin, x right, y down, largest valid x is `width-1`, and the screenshot IS that pixel space at that size — no rescaling, no 0-1 normalization.

### 6. A rejected reply's content was discarded — a diagnosability defect

Only the Pydantic diagnostic was published. It names the fields it refused but not the intent behind them, so "was the model trying to type?" was **not answerable from the bundle** — the two `Extra data: line 1 column 351` rejections are still only knowable as "valid JSON followed by trailing junk". Diagnosing this failure class properly would have cost another paid run.

**Fix:** the model's actual reply is published beside the diagnostic under a labelled separator, bounded by the same `MAX_REJECTED_REPLY_CHARS` the context replay uses, degrading to the diagnostic alone for a client that does not capture it (`reply` is optional on the protocol boundary).

## Testing evidence

### Cloud-free replay of the real bundle

`/tmp/replay/replay_bundle.py` reconstructs the episode's `EpisodeTurn`s from the bundle's own observation and action artifacts and pushes them through the **same `_ContextBuilder` the live run used** — so this is the prompt the model actually received, not a reconstruction by hand.

**Before (on `origin/main`), turns 2-16 as the model saw them:**

```
Step: 2  | '(unchanged)'
Step: 3  | '(unchanged)'
Step: 4  | '(unchanged)'
...
Step: 16 | '(unchanged)'
```

**After:**

```
turns: 17
false (unchanged): 0
(no textual state): 16
no-op notes: 0        <- correct: no two frames in this episode are identical
```

15 false "nothing changed" claims eliminated; the no-op note correctly stays silent because this episode genuinely never repeated a frame.

### One live model call against a real bundle screenshot

Single OpenRouter call (~$0.01, key resolved through the harness's own `AuthStore`, never printed) against the episode's real step-3 screenshot, asked to search the mailbox:

**Old prompt:**
```json
{"actions": [{"kind": "key", "keys": ["control", "k"]}, {"kind": "type", "text": "FYP"}, {"kind": "key", "keys": ["enter"]}]}
```

**New prompt:**
```json
{"actions": [{"kind": "key", "keys": ["ctrl", "k"]}, {"kind": "type", "text": "FYP"}, {"kind": "key", "keys": ["enter"]}]}
```

Fed through the real `parse_decision`:

```
old-prompt reply (control) -> REJECTED: unknown key: 'control'
new-prompt reply (ctrl)    -> ACCEPTED
```

Same intent, same model, same screenshot — one parses and one is a wasted billed turn. This is the whole thesis of the PR in one comparison.

### Mutation proof

Every behaviour change was reverted individually and the intended test confirmed to fail:

| # | mutation | test that failed |
| --- | --- | --- |
| M1 | restore the `text or ...` dedup | `test_absent_observation_text_is_not_reported_as_unchanged` (reproduced the exact `(unchanged)` bug) |
| M2 | remove the no-op note | `test_identical_frames_are_declared_as_a_no_op` |
| M3 | fire the note unconditionally | `test_changed_frames_carry_no_no_op_note`, `test_frameless_turns_never_claim_an_unchanged_screen` |
| M4 | drop reply capture on the exception | `test_a_rejected_reply_is_carried_on_the_exception_for_the_bundle`, `test_an_over_long_rejected_reply_is_bounded_on_the_exception` |
| M5 | publish the diagnostic without the reply | `test_a_rejected_decision_publishes_the_reply_beside_the_diagnostic` |
| M6 | unquote the schema field names | `test_system_prompt_states_the_schema_the_protocol_enforces` |
| M7 | remove the keyboard guidance | `test_prompt_teaches_how_to_type_and_how_to_press_keys` |
| M8 | revert the coordinate convention | `test_prompt_states_the_coordinate_convention` |
| M9 | remove the derived key vocabulary | `test_prompt_lists_the_key_vocabulary_the_validator_enforces` |

### Gates (whole tree, exactly as CI)

```
.venv/bin/python -m flake8 .                              -> clean
uvx --from black==26.1.0 black --check .                  -> 830 files unchanged
uvx isort==5.13.2 --check .                               -> clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python . -> 0 errors, 0 warnings
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
  -> 11507 passed, 15 skipped in 522.68s
```

## Changes

- `local_operator/evaluation/runner/provider_client.py` — absent-vs-unchanged text; `_frames_identical` no-op signalling; quoted schema field names; `_named_keys_line()` derived vocabulary; coordinate convention; keyboard and batching guidance; `reply` carried on `DecisionRejected`.
- `local_operator/evaluation/runner/model.py` — `DecisionRejected.reply`, documenting why the diagnostic alone is insufficient.
- `local_operator/evaluation/runner/episode.py` — `_rejection_detail()` publishes reply beside diagnostic.
- `local_operator/evaluation/protocol.py` — `_NAMED_KEYS` → `NAMED_KEYS` so the prompt can derive from the enforcing set.
- Tests: 11 new cases in `test_provider_client.py` and `test_episode.py`; `conftest.py` fixture carries a reply.
- Version bumped to `0.44.58` (patch — reliability and prompt correctness, no new surface). Checked at push time against `main` (`0.44.56`), PyPI (`0.44.56`), and open PRs: #583 holds `0.44.56`, #581 holds `0.44.57`, #576 holds `0.45.0`.

## Honest judgement on this route's competitiveness

**The evidence does not support "the model is too weak" — it supports "the harness lied to it."** The model reached for the keyboard and was refused on a field-name technicality; it was told the screen was frozen on 15 of 17 turns while frames changed by up to 93%. Under the fixed prompt the same model produces a parser-accepted `key`+`type`+`key` batch on a real screenshot from the failed run.

What is **not** proven here: that this yields task *completion*. This PR proves step-level correctness, not trajectory-level. The task needs ~20+ correct steps (read an email, extract several defenses, resolve calendar conflicts, create entries), and a competitive OSWorld 2.0 score is a much higher bar than "makes progress". My expectation is the score moves off ~0; I would re-run this single task before committing to the full batch rather than assume it. The fatal `rpcremoteerror` that ended the episode is a separate adapter defect being fixed elsewhere and is untouched here.

## Not addressed (deliberately out of scope)

- The `rpcremoteerror` adapter RPC failure that terminated the episode — being fixed separately.
- Two of the three rejections were `Extra data: line 1 column 351` (valid JSON followed by trailing content). The prompt already says "a single JSON object and nothing else, with no prose and no code fence"; whether a stricter extraction (parsing the first complete JSON value rather than rejecting the whole reply) is the right call is a real design question, but it trades strictness for leniency at the protocol boundary and deserves its own decision rather than being folded into this diagnosis.
