### PR TITLE
fix(browser): name subagent tab groups after the work they do

### DIFF
--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -1243,6 +1243,13 @@ async def _build_child_session(
         session_id=transcript.directory.name,
         agent_id=parent_session.agent_id,
         job_id=job_id,
+        # The child's own name for display surfaces that must not render a
+        # fleet of children identically (browser tab groups today). Set on the
+        # CONSTRUCTION context for the same defensive-parity reason
+        # ``variables`` is: what actually reaches an executing tool is the
+        # child ``Session``'s per-turn rebuild, which receives it via the
+        # ``job_label=`` argument below.
+        job_label=label,
         has_ui=parent_session._has_ui,
         request_approval=request_approval,
         # The parent's variable store. DEFENSIVE PARITY, not a bug fix: no
@@ -1364,6 +1371,22 @@ async def _build_child_session(
         # ``Session._build_tool_context``; the construction-time context above
         # only feeds createIf.
         job_id=job_id,
+        # The label the operator launched this child under, and the PARENT's
+        # live title holder. Together they are the only identity a subagent
+        # has: naming runs in the TUI host and the owned-session runtime, so a
+        # one-shot child never generates a title of its own and every display
+        # surface asking "which session is this?" had nothing to answer with.
+        #
+        # The holder is SHARED, not copied, and that is what makes a parent
+        # renamed after launch (the usual case — the naming errand lands a
+        # second or two into the parent's first turn, while children are
+        # launched later) reach the child's next tab-group reconcile. Passing
+        # the string would freeze whatever the title was at launch.
+        #
+        # Display-only on both counts: a child is authorized by its own
+        # ``session_id``, never by a name it borrowed from its parent.
+        job_label=label,
+        parent_conversation_name=parent_session.conversation_name_state,
         # The PARENT's comms instance, so the child's every-turn tool context
         # rebuild keeps pointing at the agent that delegated to it instead of
         # minting a private one nobody is listening to.

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -107,6 +107,7 @@ import asyncio
 import contextlib
 import logging
 import uuid
+import weakref
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
@@ -1087,6 +1088,42 @@ def _child_mcp_wiring(parent_session: "Session", *, restricted: bool = False) ->
     )
 
 
+def _parent_display_name_resolver(parent_session: "Session") -> Callable[[], str]:
+    """A callable returning the parent's DISPLAY name at the moment it is asked.
+
+    The child's browser tab group reads ``<parent conversation> › <job label>``,
+    and both halves have to survive nesting. Handing the child the parent's
+    title HOLDER only worked one level down: a middle child never generates a
+    title of its own (naming runs in the TUI host and the owned-session
+    runtime, neither of which a one-shot child passes through), so its holder
+    is permanently empty and a grandchild fell back to the cwd that every
+    sibling of every conversation shares — two ``qa`` grandchildren under two
+    different conversations rendered identically. Delegation really does nest:
+    a child of a top-level session keeps ``task``/``wait``/``jobs`` (see the
+    depth-aware prune below), which is exactly the manager-fans-out-to-workers
+    shape. Resolving through ``_display_session_name`` instead walks the
+    lineage to whichever ancestor actually holds a title.
+
+    Called per read rather than snapshotted, because a parent is normally named
+    a second or two into its first turn while its children are launched later:
+    a string captured here would be "" for the child's whole life.
+
+    WEAK reference on purpose. Every other parent-derived value the child gets
+    is a shared collaborator (the comms surface, the variable store, the job
+    manager's parent row); this one would be a strong child→parent edge that
+    pins the parent's entire object graph — transcript, tools, MCP manager —
+    for as long as a detached child outlives it. A dead parent simply has no
+    name to lend, and the caller degrades to the cwd form it already handles.
+    """
+    parent_ref = weakref.ref(parent_session)
+
+    def resolve() -> str:
+        parent = parent_ref()
+        return parent._display_session_name() if parent is not None else ""
+
+    return resolve
+
+
 async def _build_child_session(
     *,
     label: str,
@@ -1371,22 +1408,17 @@ async def _build_child_session(
         # ``Session._build_tool_context``; the construction-time context above
         # only feeds createIf.
         job_id=job_id,
-        # The label the operator launched this child under, and the PARENT's
-        # live title holder. Together they are the only identity a subagent
-        # has: naming runs in the TUI host and the owned-session runtime, so a
-        # one-shot child never generates a title of its own and every display
-        # surface asking "which session is this?" had nothing to answer with.
-        #
-        # The holder is SHARED, not copied, and that is what makes a parent
-        # renamed after launch (the usual case — the naming errand lands a
-        # second or two into the parent's first turn, while children are
-        # launched later) reach the child's next tab-group reconcile. Passing
-        # the string would freeze whatever the title was at launch.
+        # The label the operator launched this child under, and a resolver for
+        # the PARENT's display name. Together they are the only identity a
+        # subagent has: naming runs in the TUI host and the owned-session
+        # runtime, so a one-shot child never generates a title of its own and
+        # every display surface asking "which session is this?" had nothing to
+        # answer with.
         #
         # Display-only on both counts: a child is authorized by its own
         # ``session_id``, never by a name it borrowed from its parent.
         job_label=label,
-        parent_conversation_name=parent_session.conversation_name_state,
+        parent_display_name=_parent_display_name_resolver(parent_session),
         # The PARENT's comms instance, so the child's every-turn tool context
         # rebuild keeps pointing at the agent that delegated to it instead of
         # minting a private one nobody is listening to.

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -718,6 +718,29 @@ class ToolContext(BaseModel):
     # Optional and display-only for the same reason ``session_name`` is:
     # identity and authorization continue to use ``session_id``.
     session_name_provider: Callable[[], str] | None = None
+    # The DELEGATED-WORK label, set only on a subagent's context: the short
+    # name its parent launched it under (``zoom-scroll-fix``, ``bridge-qa``).
+    #
+    # A subagent has no conversation title and can never grow one — title
+    # generation lives in the TUI host and the owned-session runtime, and a
+    # one-shot child runs through neither, so every subagent session directory
+    # on disk has no ``title.json``. That is by design (a child answers one
+    # prompt and exits; naming it would cost a provider call for a title
+    # nobody resumes), but it left every display surface that asks "which
+    # session is this?" with nothing to say — browser tab groups above all,
+    # where a fleet of children rendered as a wall of identical pills.
+    #
+    # The label is the identity the OPERATOR already recognises: it is what
+    # they typed into ``task``, what the jobs list shows, and what they address
+    # with ``hub``. Display-only and never an identity, exactly like
+    # ``session_name`` — a child is authorized by ``session_id``/``requester``,
+    # and two children may legitimately carry the same label.
+    #
+    # Named after ``job_id`` above rather than after the browser's wire field:
+    # this is the human name of the same background job that field identifies,
+    # and calling it ``session_label`` would collide with the DERIVED display
+    # value the browser bridge already sends under that exact key.
+    job_label: str = ""
     # Resolver hook for lazy internal URLs (``skill://`` and ``guide://``);
     # returns content or None when the URL is not handled. Installed by session.
     resolve_internal_url: Callable[[str], str | None] | None = None

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1382,12 +1382,18 @@ class Session:
         #: whole of its display identity. Reaches tools via
         #: ``_build_tool_context``; display-only, never an authorization input.
         job_label: str = "",
-        #: The PARENT's live title holder, on a subagent only. Shared rather
-        #: than copied so a parent named or renamed AFTER this child launched
-        #: still reaches the child's display surfaces — the common case, since
-        #: the parent's naming errand lands early in its first turn while
-        #: children are launched later. ``None`` on every top-level session.
-        parent_conversation_name: ConversationName | None = None,
+        #: The parent's own :meth:`_display_session_name`, on a subagent only.
+        #: A RESOLVER rather than the parent's title holder, for two reasons
+        #: that are really one: it re-reads on every call, so a parent named or
+        #: renamed AFTER this child launched still reaches the child's display
+        #: surfaces (the common case — the naming errand lands early in the
+        #: parent's first turn while children are launched later); and it
+        #: resolves TRANSITIVELY, so a grandchild under a middle child whose
+        #: own holder is permanently empty still reads the top-level
+        #: conversation's title instead of falling through to the shared cwd.
+        #: A holder cannot do the second: the middle child has no title of its
+        #: own to hold. ``None`` on every top-level session.
+        parent_display_name: Callable[[], str] | None = None,
         #: The parent↔child messaging surface (``harness.comms.SubagentComms``).
         #: A top-level session mints its own; a CHILD is handed its parent's,
         #: which is what makes ``hub`` inside a subagent talk to the agent that
@@ -1445,7 +1451,7 @@ class Session:
         self._variables = variables
         self._job_id = job_id
         self._job_label = job_label
-        self._parent_conversation_name = parent_conversation_name
+        self._parent_display_name = parent_display_name
         self._subagent_comms = subagent_comms
         self.agent_registry = agent_registry
         self.team_registry = team_registry
@@ -3215,28 +3221,41 @@ class Session:
         live title instead, so a delegated tab group reads
         ``<parent conversation> › <job label>`` rather than a bare fallback.
 
-        Read through the shared holder on every call, never cached: the parent
-        is normally named a second or two into its first turn while its
-        children are launched later, so a value snapshotted at the child's
-        construction would be the empty string for the child's whole life.
-        That staleness is the exact failure this method exists to close, and it
-        is why :meth:`_build_tool_context` passes this as the PROVIDER as well
-        as the snapshot.
+        Resolved on every call, never cached: the parent is normally named a
+        second or two into its first turn while its children are launched
+        later, so a value snapshotted at the child's construction would be the
+        empty string for the child's whole life. That staleness is the exact
+        failure this method exists to close, and it is why
+        :meth:`_build_tool_context` passes this as the PROVIDER as well as the
+        snapshot.
+
+        RECURSIVE by construction, because delegation nests: a child of a
+        top-level session keeps ``task``/``wait``/``jobs`` (see
+        ``harness.subagent``), so a manager fanning out to workers is depth 2
+        and the operator's usual shape. The middle child has no title of its
+        own and can never grow one, so asking it for its *holder* yields ""
+        forever and a grandchild fell back to the cwd every sibling of every
+        conversation shares — two ``qa`` grandchildren under two different
+        conversations rendered identically, the very collision this method
+        exists to prevent. Asking the parent for its resolved DISPLAY name
+        instead walks the chain to whichever ancestor actually holds a title.
+        The walk is bounded by the lineage depth built at construction (no
+        cycle is constructible: a parent always predates its child).
 
         Display only. Identity and authorization stay on ``session_id`` — a
         child borrowing its parent's name for a tab pill must never be read as
         a child acting with its parent's identity.
 
         Deliberately does NOT reach for a parent's title on an unnamed FORK:
-        a fork is not a child, holds no ``_parent_conversation_name``, and
+        a fork is not a child, holds no ``_parent_display_name``, and
         ``_load_conversation_name`` declines the inheritance on purpose (see
         :attr:`wears_inherited_title`). Its display label stays the cwd
         substitution every unnamed session gets.
         """
         own = self._conversation_name.text
-        if own or self._parent_conversation_name is None:
+        if own or self._parent_display_name is None:
             return own
-        return self._parent_conversation_name.text
+        return self._parent_display_name()
 
     @property
     def wears_inherited_title(self) -> bool:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1378,7 +1378,7 @@ class Session:
         #: subagent (``zoom-scroll-fix``, ``bridge-qa``). A child never
         #: generates a conversation title — naming runs in the TUI host and the
         #: owned-session runtime, neither of which a one-shot child passes
-        #: through — so this plus ``parent_conversation_name`` below is the
+        #: through — so this plus ``parent_display_name`` below is the
         #: whole of its display identity. Reaches tools via
         #: ``_build_tool_context``; display-only, never an authorization input.
         job_label: str = "",

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1374,6 +1374,20 @@ class Session:
         #: rebuilt every turn, so anything set only on the construction-time
         #: context reaches the createIf check and never the executor.
         job_id: str | None = None,
+        #: The short name this session was DELEGATED under, set only on a
+        #: subagent (``zoom-scroll-fix``, ``bridge-qa``). A child never
+        #: generates a conversation title — naming runs in the TUI host and the
+        #: owned-session runtime, neither of which a one-shot child passes
+        #: through — so this plus ``parent_conversation_name`` below is the
+        #: whole of its display identity. Reaches tools via
+        #: ``_build_tool_context``; display-only, never an authorization input.
+        job_label: str = "",
+        #: The PARENT's live title holder, on a subagent only. Shared rather
+        #: than copied so a parent named or renamed AFTER this child launched
+        #: still reaches the child's display surfaces — the common case, since
+        #: the parent's naming errand lands early in its first turn while
+        #: children are launched later. ``None`` on every top-level session.
+        parent_conversation_name: ConversationName | None = None,
         #: The parent↔child messaging surface (``harness.comms.SubagentComms``).
         #: A top-level session mints its own; a CHILD is handed its parent's,
         #: which is what makes ``hub`` inside a subagent talk to the agent that
@@ -1430,6 +1444,8 @@ class Session:
         self._goal_state = goal_state if goal_state is not None else GoalState()
         self._variables = variables
         self._job_id = job_id
+        self._job_label = job_label
+        self._parent_conversation_name = parent_conversation_name
         self._subagent_comms = subagent_comms
         self.agent_registry = agent_registry
         self.team_registry = team_registry
@@ -3188,6 +3204,39 @@ class Session:
     def conversation_name(self) -> str:
         """The conversation's title ("" until one is set or generated)."""
         return self._conversation_name.text
+
+    def _display_session_name(self) -> str:
+        """The conversation title DISPLAY surfaces should show for this session.
+
+        Identical to :attr:`conversation_name` for a top-level session. On a
+        SUBAGENT — which has no title of its own and can never generate one,
+        since naming runs in the TUI host and the owned-session runtime and a
+        one-shot child passes through neither — it resolves to the PARENT's
+        live title instead, so a delegated tab group reads
+        ``<parent conversation> › <job label>`` rather than a bare fallback.
+
+        Read through the shared holder on every call, never cached: the parent
+        is normally named a second or two into its first turn while its
+        children are launched later, so a value snapshotted at the child's
+        construction would be the empty string for the child's whole life.
+        That staleness is the exact failure this method exists to close, and it
+        is why :meth:`_build_tool_context` passes this as the PROVIDER as well
+        as the snapshot.
+
+        Display only. Identity and authorization stay on ``session_id`` — a
+        child borrowing its parent's name for a tab pill must never be read as
+        a child acting with its parent's identity.
+
+        Deliberately does NOT reach for a parent's title on an unnamed FORK:
+        a fork is not a child, holds no ``_parent_conversation_name``, and
+        ``_load_conversation_name`` declines the inheritance on purpose (see
+        :attr:`wears_inherited_title`). Its display label stays the cwd
+        substitution every unnamed session gets.
+        """
+        own = self._conversation_name.text
+        if own or self._parent_conversation_name is None:
+            return own
+        return self._parent_conversation_name.text
 
     @property
     def wears_inherited_title(self) -> bool:
@@ -5094,15 +5143,22 @@ class Session:
             session_id=self._session_id,
             # Re-read the live holder every turn so generated, user-set, and
             # resumed titles reach display-only browser metadata after renames.
-            session_name=self.conversation_name,
+            # On a CHILD this resolves to the parent's title (see
+            # :meth:`_display_session_name`), which is the only conversation
+            # name a subagent has.
+            session_name=self._display_session_name(),
             # Per-turn is not enough on its own: this context is a SNAPSHOT
             # taken once at turn start, and the naming errand lands a second or
             # two into the FIRST turn — so a browse in that turn read "" even
             # after the title existed, and the tab group latched the fallback
             # label for the life of the tab. The callable re-reads the holder at
             # tool-call time. Display-only, like ``session_name`` itself.
-            session_name_provider=lambda: self.conversation_name,
+            session_name_provider=self._display_session_name,
             agent_id=self._agent_id,
+            # The delegated name, on a subagent only. Empty on every top-level
+            # session, which is what keeps ``_browser_subagent_label``'s
+            # ``job_id`` discriminator honest.
+            job_label=self._job_label,
             has_ui=self._has_ui,
             resolve_internal_url=self._skill_resolver,
             request_approval=None if self._yolo else self._request_approval,

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -6155,6 +6155,16 @@ _BROWSER_SESSION_LABEL_CLUSTERS = 30
 #: root, where ``cwd_label`` itself declines to answer.
 _BROWSER_FALLBACK_LABEL = "Session"
 
+#: Separator between a subagent's parent conversation and its own job label.
+#: U+203A, matching the TUI's own ``lo › <cwd>`` composition rather than
+#: introducing a second convention for the same "A, narrowed to B" relation.
+_BROWSER_SUBAGENT_SEPARATOR = " › "
+
+#: Below this many clusters a clipped parent title identifies no conversation
+#: (``Fi…`` names nothing), so the child's label stands alone instead of
+#: wearing a stub prefix. See :func:`_browser_subagent_label`.
+_BROWSER_SUBAGENT_PARENT_MIN = 8
+
 
 def _browser_live_session_name(context: ToolContext | None) -> str:
     """The session's title as of NOW, not as of the turn's context snapshot.
@@ -6208,13 +6218,31 @@ def _browser_session_label(context: ToolContext | None) -> str:
     intentionally broader than the known bidi and zero-width set: browser tab
     chrome is too small to make invisible direction changes attributable.
 
-    An UNNAMED session falls back to its working directory's basename, which is
-    the same substitution the TUI's status band and terminal title already make
-    in this exact slot (``tui/terminal_title.cwd_label`` — ``lo › <cwd>``). The
-    slot has always held "the best label we have", and a directory the user
-    chose the session for distinguishes three concurrent groups where three
-    copies of ``Session`` do not.
+    A SUBAGENT is named first, before any title lookup, because it is the one
+    session kind that can never acquire a title: naming lives in the TUI host
+    and the owned-session runtime, and a one-shot child runs through neither
+    (confirmed on this machine — no subagent session directory holds a
+    ``title.json``). Its context carries no ``session_name`` and its cwd is its
+    PARENT's, so every child of one parent derived the identical cwd label and
+    a fleet of them rendered as ``LO · local-operator (2)``/``(3)``/… — the
+    ordinal is the only thing that differed, and it names nothing. See
+    :func:`_browser_subagent_label` for the form and why the parent's name is
+    carried alongside the child's.
+
+    An UNNAMED top-level session falls back to its working directory's
+    basename, which is the same substitution the TUI's status band and terminal
+    title already make in this exact slot (``tui/terminal_title.cwd_label`` —
+    ``lo › <cwd>``). The slot has always held "the best label we have", and a
+    directory the user chose the session for distinguishes three concurrent
+    groups where three copies of ``Session`` do not.
     """
+    # Subagent first: a child's own ``session_name`` is empty by construction,
+    # but the cwd fallback below would still answer (with the parent's
+    # directory) and thereby hide the far more specific label the parent
+    # launched this child under. Order is the whole fix.
+    subagent = _browser_clean_label(_browser_subagent_label(context))
+    if subagent:
+        return _browser_clip_label(subagent)
     # Emptiness is decided by the SANITISED text, not by ``str.strip()``.
     # ``strip()`` removes whitespace but NOT the Cf/Cc classes, so a title of
     # nothing but zero-width or bidi characters (U+200B, U+FEFF, U+2060,
@@ -6228,23 +6256,125 @@ def _browser_session_label(context: ToolContext | None) -> str:
         cleaned = _browser_clean_label(_browser_cwd_label(context.cwd))
     if not cleaned:
         return _BROWSER_FALLBACK_LABEL
+    return _browser_clip_label(cleaned)
 
+
+def _browser_clusters(text: str) -> list[str]:
+    """``text`` split into grapheme-ish clusters (base char + its marks).
+
+    The pill's budget is counted in what the user perceives as characters, so
+    combining marks and modifier symbols ride with the base they attach to
+    rather than each costing a slot. Approximates ``Intl.Segmenter``, which is
+    what the extension side counts with; exactness is not required because
+    both sides only ever clip, never realign.
+    """
     clusters: list[str] = []
-    for char in cleaned:
+    for char in text:
         if clusters and (unicodedata.combining(char) or unicodedata.category(char) == "Sk"):
             clusters[-1] += char
         else:
             clusters.append(char)
-    if len(clusters) <= _BROWSER_SESSION_LABEL_CLUSTERS:
+    return clusters
+
+
+def _browser_clip_label(cleaned: str, budget: int = _BROWSER_SESSION_LABEL_CLUSTERS) -> str:
+    """``cleaned`` cut to ``budget`` grapheme clusters, ellipsised if cut.
+
+    Split out of :func:`_browser_session_label` so the subagent form goes
+    through the SAME clip as a conversation title: both are user-visible text
+    of unbounded length landing in the same 30-cluster pill, and a second
+    hand-rolled truncation beside this one is how the two drift apart. Expects
+    text that has already been through :func:`_browser_clean_label`.
+
+    ``budget`` is a parameter only because the subagent composition spends part
+    of the pill on the child's label and the separator; every other caller
+    takes the full width.
+    """
+    clusters = _browser_clusters(cleaned)
+    if len(clusters) <= budget:
         return cleaned
 
-    clipped = "".join(clusters[:_BROWSER_SESSION_LABEL_CLUSTERS]).rstrip()
+    clipped = "".join(clusters[:budget]).rstrip()
     # Prefer a complete word when that still leaves a useful title; long words
     # fall back to the grapheme-safe hard boundary rather than an empty label.
     word_boundary = clipped.rfind(" ")
     if word_boundary >= 8:
         clipped = clipped[:word_boundary].rstrip()
     return f"{clipped}…" if clipped else _BROWSER_FALLBACK_LABEL
+
+
+def _browser_subagent_label(context: ToolContext | None) -> str:
+    """``<parent title> › <job label>`` for a subagent, else ``""``.
+
+    ``job_id`` is the discriminator, not ``job_label``: it is what the harness
+    sets on exactly the child contexts and on nothing else, so a top-level
+    session can never be mistaken for one. A child whose label is missing or
+    sanitises away still gets the parent's name rather than falling through to
+    the shared-cwd label every sibling would also derive.
+
+    BOTH halves are carried because each answers a different question the
+    operator actually asks of a tab group. The child's label says WHICH slice
+    of work this is (it is what they typed into ``task`` and what the jobs list
+    and ``hub`` address it by); the parent's title says WHICH CONVERSATION
+    spawned it, which is the part that separates two concurrent sessions both
+    running a child called ``qa``. The separator is U+203A, matching the TUI's
+    own ``lo › <cwd>`` composition rather than inventing a second convention.
+
+    The parent's name is read through the normal live/snapshot chain, so a
+    parent titled after this child was launched still reaches the pill on the
+    child's next command.
+
+    When the composition does not fit, the PARENT half is what gets clipped —
+    the child's label is kept whole. Clipping the composed string as one unit
+    (the obvious implementation) is wrong here and was measured to be: a real
+    pair, ``Fix Slack-reported UI zoom and overlap bugs`` + ``zoom-scroll-fix``,
+    clipped to ``Fix Slack-reported UI zoom…`` and lost the label entirely,
+    leaving every sibling of that parent identical again — precisely the
+    failure this function exists to fix. The label is the distinguishing half
+    (siblings share a parent by definition), so it holds its ground and the
+    shared prefix absorbs the loss.
+    """
+    if context is None or context.job_id is None:
+        return ""
+    label = _browser_clean_label(context.job_label)
+    # The parent's title, never the child's: a child has no ``session_name`` of
+    # its own, and the provider chain is what picks up a parent renamed since
+    # launch. Falls back to the parent's cwd basename for an unnamed parent —
+    # the same substitution a top-level session gets — so the composed form
+    # degrades to `<dir> › <label>` rather than to a bare label.
+    parent = _browser_clean_label(_browser_live_session_name(context))
+    if not parent and context.cwd:
+        parent = _browser_clean_label(_browser_cwd_label(context.cwd))
+    if not (parent and label):
+        # Only one half is available, so the caller's full-width clip applies
+        # to it unchanged.
+        return label or parent
+    # Budget in CLUSTERS, matching what the clip and the extension count, and
+    # measure the composed result rather than assuming it fits: a parent that
+    # is already short enough must not be ellipsised for nothing.
+    room = (
+        _BROWSER_SESSION_LABEL_CLUSTERS
+        - len(_browser_clusters(label))
+        - len(_browser_clusters(_BROWSER_SUBAGENT_SEPARATOR))
+    )
+    # A parent squeezed below ``_BROWSER_SUBAGENT_PARENT_MIN`` is not worth
+    # showing — ``Fi…`` identifies no conversation and merely steals room from
+    # the half that does identify something — so the label stands alone. This
+    # also covers a label long enough to fill the pill by itself, where ``room``
+    # goes negative; the caller then clips the label on the normal path.
+    if room < _BROWSER_SUBAGENT_PARENT_MIN:
+        return label
+    # ``_browser_clip_label`` treats its budget as the count of clusters it
+    # KEEPS and then appends an ellipsis, so a clipped string is one cluster
+    # wider than the budget asked for. That is deliberate parity with the
+    # extension's ``cleanLabel`` (``slice(0, MAX) + "…"``) and is left alone
+    # there. Here the composition has a hard ceiling to respect, so the
+    # ellipsis is paid for out of the parent's room — but only when the parent
+    # actually needs clipping, or a title that already fit would be ellipsised
+    # for nothing.
+    if len(_browser_clusters(parent)) > room:
+        parent = _browser_clip_label(parent, room - 1)
+    return f"{parent}{_BROWSER_SUBAGENT_SEPARATOR}{label}"
 
 
 def _browser_cwd_label(cwd: str) -> str:

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -4794,6 +4794,36 @@ def build_send_tool(context: ToolContext) -> AgentTool | None:
     )
 
 
+def _peer_sender_conversation_name(context: ToolContext) -> str:
+    """The name a peer's inbound card should show for THIS session.
+
+    ``session_name`` alone is wrong on a subagent. It resolves to the PARENT's
+    title (a child has none of its own and can never grow one), so a peer
+    message sent by a child presented under its parent's conversation name
+    while the ``session_id`` beside it correctly named the child — two
+    different sessions in one card. Composing the child's own label onto it is
+    the same answer the browser tab pill gives (``<parent> › <label>``), and
+    for the same reason: the label is the only name the child actually owns.
+
+    Composed here rather than through :func:`_browser_subagent_label` even
+    though the form is identical: that function budgets the result to the
+    browser pill's 30 clusters, a constraint a peer card does not have (a
+    registry-sourced ``conversation_name`` runs to ``MAX_TITLE_CHARS``), and
+    borrowing it would silently ellipsise a name for a surface that had room.
+
+    Display only, on the FALLBACK path alone — a host that published a registry
+    record names the sender from that record and never reaches here. Identity
+    stays ``session_id``, which is the child's throughout.
+    """
+    # Both fields, matching the browser side's discriminator: ``job_id`` alone
+    # is also carried by server sessions, and only a subagent has a label.
+    if context.job_id is None or not context.job_label.strip():
+        return context.session_name
+    parent = context.session_name.strip()
+    label = context.job_label.strip()
+    return f"{parent}{_BROWSER_SUBAGENT_SEPARATOR}{label}" if parent else label
+
+
 @_guard("send")
 async def execute_send(
     tool_call_id: str,
@@ -4869,12 +4899,13 @@ async def execute_send(
     if "session_id" not in sender and context is not None:
         # No registry record named this process (a reduced host that never
         # published one): fall back to the ToolContext identity so the peer's
-        # inbound indicator can still name the sender. session_name maps to
+        # inbound indicator can still name the sender. The name maps to
         # ``conversation_name`` because that is the key the indicator reads.
         if context.session_id:
             sender["session_id"] = context.session_id
-        if context.session_name:
-            sender["conversation_name"] = context.session_name
+        name = _peer_sender_conversation_name(context)
+        if name:
+            sender["conversation_name"] = name
 
     from local_operator.mobile.peer_client import send_peer_message
 
@@ -6286,6 +6317,16 @@ def _browser_clip_label(cleaned: str, budget: int = _BROWSER_SESSION_LABEL_CLUST
     hand-rolled truncation beside this one is how the two drift apart. Expects
     text that has already been through :func:`_browser_clean_label`.
 
+    ``budget`` is inclusive of the ellipsis, so the RESULT never exceeds it.
+    It previously counted the clusters KEPT and then appended the ellipsis on
+    top, which returned 31 clusters against a documented 30 — harmless in
+    practice, since the extension's ``cleanLabel`` re-clips anything it is sent
+    (its ``slice(0, MAX) + "…"`` has the same shape), but it made every
+    statement of the ceiling in this module false by one and left the composed
+    subagent form paying for the ellipsis with a hand-rolled ``budget - 1``.
+    A pill one cluster shorter is the price of a bound that is actually true;
+    the extension now never has to re-clip a label this side produced.
+
     ``budget`` is a parameter only because the subagent composition spends part
     of the pill on the child's label and the separator; every other caller
     takes the full width.
@@ -6294,7 +6335,7 @@ def _browser_clip_label(cleaned: str, budget: int = _BROWSER_SESSION_LABEL_CLUST
     if len(clusters) <= budget:
         return cleaned
 
-    clipped = "".join(clusters[:budget]).rstrip()
+    clipped = "".join(clusters[: max(budget - 1, 0)]).rstrip()
     # Prefer a complete word when that still leaves a useful title; long words
     # fall back to the grapheme-safe hard boundary rather than an empty label.
     word_boundary = clipped.rfind(" ")
@@ -6306,11 +6347,19 @@ def _browser_clip_label(cleaned: str, budget: int = _BROWSER_SESSION_LABEL_CLUST
 def _browser_subagent_label(context: ToolContext | None) -> str:
     """``<parent title> › <job label>`` for a subagent, else ``""``.
 
-    ``job_id`` is the discriminator, not ``job_label``: it is what the harness
-    sets on exactly the child contexts and on nothing else, so a top-level
-    session can never be mistaken for one. A child whose label is missing or
-    sanitises away still gets the parent's name rather than falling through to
-    the shared-cwd label every sibling would also derive.
+    ``job_id`` is the discriminator, not ``job_label``: the TUI host leaves it
+    unset, so the operator's own session can never be mistaken for a child. It
+    is NOT unique to subagents — a server-side session carries one too (see
+    ``server/utils/operator.py`` and the queued-job path) — which is why the
+    two fields are required TOGETHER below rather than ``job_id`` alone: only
+    ``_build_child_session`` sets ``job_label``, so a server session reaches
+    the ``label or parent`` branch and keeps its own title unchanged. Stated
+    because a future reader deciding what may set ``job_id`` would otherwise
+    rely on an exclusivity that does not hold.
+
+    A child whose label is missing or sanitises away still gets the parent's
+    name rather than falling through to the shared-cwd label every sibling
+    would also derive.
 
     BOTH halves are carried because each answers a different question the
     operator actually asks of a tab group. The child's label says WHICH slice
@@ -6333,6 +6382,14 @@ def _browser_subagent_label(context: ToolContext | None) -> str:
     failure this function exists to fix. The label is the distinguishing half
     (siblings share a parent by definition), so it holds its ground and the
     shared prefix absorbs the loss.
+
+    Past a point there is nothing left to absorb it with, and the parent half
+    DISAPPEARS rather than shrinking to a stub: with a 30-cluster pill, a
+    3-cluster separator and an 8-cluster minimum for a parent worth reading,
+    that happens once the child's own label reaches 20 clusters. Beyond that
+    the pill is the bare label — correct (the label is what distinguishes
+    siblings) but worth knowing when a fleet of long-labelled children shows
+    no conversation prefix at all.
     """
     if context is None or context.job_id is None:
         return ""
@@ -6364,16 +6421,11 @@ def _browser_subagent_label(context: ToolContext | None) -> str:
     # goes negative; the caller then clips the label on the normal path.
     if room < _BROWSER_SUBAGENT_PARENT_MIN:
         return label
-    # ``_browser_clip_label`` treats its budget as the count of clusters it
-    # KEEPS and then appends an ellipsis, so a clipped string is one cluster
-    # wider than the budget asked for. That is deliberate parity with the
-    # extension's ``cleanLabel`` (``slice(0, MAX) + "…"``) and is left alone
-    # there. Here the composition has a hard ceiling to respect, so the
-    # ellipsis is paid for out of the parent's room — but only when the parent
-    # actually needs clipping, or a title that already fit would be ellipsised
-    # for nothing.
+    # Guarded rather than clipped unconditionally: ``_browser_clip_label``
+    # returns its input untouched when it already fits, so this only spells out
+    # that a parent short enough to fit is never ellipsised for nothing.
     if len(_browser_clusters(parent)) > room:
-        parent = _browser_clip_label(parent, room - 1)
+        parent = _browser_clip_label(parent, room)
     return f"{parent}{_BROWSER_SUBAGENT_SEPARATOR}{label}"
 
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -10659,6 +10659,16 @@ class OperatorApp(App[None]):
             agent_id=getattr(session, "agent_id", "") or "",
             has_ui=True,
             variables=getattr(session, "variables", None),
+            # Bang mode builds its OWN context rather than reusing the
+            # session's per-turn one (it runs outside a turn), so the title has
+            # to be carried explicitly or every display-only consumer sees an
+            # unnamed session. `getattr` because this path also runs before a
+            # session exists; the provider re-reads the holder so a title that
+            # lands while a long `! cmd` is running is still current.
+            session_name=getattr(session, "conversation_name", "") or "",
+            session_name_provider=(
+                None if session is None else (lambda: getattr(session, "conversation_name", ""))
+            ),
         )
 
         def on_update(update: AgentToolUpdate) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.62"
+version = "0.44.63"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/browser_bridge/test_tool_selection.py
+++ b/tests/unit/browser_bridge/test_tool_selection.py
@@ -613,7 +613,9 @@ async def test_browser_session_label_is_sanitized_and_host_derived(monkeypatch) 
         ("", "Session"),
         ("\x00\x7f\x85\u202d\u2066\ufeff", "Session"),
         ("  one\t two\nthree  ", "one two three"),
-        ("e\u0301" * 31, "e\u0301" * 30 + "…"),
+        # 29 clusters kept plus the ellipsis: the 30-cluster cap is inclusive
+        # of the ellipsis the clipper appends, so the RESULT never exceeds it.
+        ("e\u0301" * 31, "e\u0301" * 29 + "…"),
     ],
 )
 def test_browser_session_label_edge_cases(name: str, expected: str) -> None:
@@ -717,8 +719,9 @@ def test_unnamed_session_labels_itself_by_cwd_not_a_bare_fallback() -> None:
     # survives exactly there — `LO · /` names a session no better than
     # `LO · Session` does.
     assert builtin._browser_session_label(ToolContext(cwd="/")) == "Session"
-    # The cwd goes through the same sanitizer/clipper as a title.
-    assert builtin._browser_session_label(ToolContext(cwd="/tmp/" + "d" * 40)) == "d" * 30 + "…"
+    # The cwd goes through the same sanitizer/clipper as a title, ellipsis
+    # included in the 30-cluster budget.
+    assert builtin._browser_session_label(ToolContext(cwd="/tmp/" + "d" * 40)) == "d" * 29 + "…"
 
 
 def test_live_session_name_beats_the_per_turn_snapshot() -> None:
@@ -1098,3 +1101,83 @@ def test_a_label_that_fills_the_pill_alone_drops_the_parent_rather_than_a_stub()
     )
     assert "›" not in label
     assert label.startswith("an-enormous-child-label")
+
+
+def test_a_clipped_label_respects_the_documented_cluster_cap() -> None:
+    # The clip counts the ellipsis it appends. It used to keep `budget`
+    # clusters and then add one, so every label it touched came back at 31
+    # against a documented 30 — harmless (the extension re-clips) but it made
+    # the ceiling this module states false, on the plain-title path as much as
+    # on the composed one.
+    cap = builtin._BROWSER_SESSION_LABEL_CLUSTERS
+    for text in (
+        "d" * 40,
+        "Fix Slack-reported UI zoom and overlap bugs today",
+        "e\u0301" * 40,
+    ):
+        clipped = builtin._browser_clip_label(text)
+        assert len(builtin._browser_clusters(clipped)) <= cap, clipped
+
+
+def test_the_composed_subagent_pill_never_exceeds_the_cap() -> None:
+    # Q2's case: parent + separator + label, at the length where the parent is
+    # clipped and the ellipsis has to be paid for out of its room.
+    for label in ("zoom-scroll-fix", "a-really-very-long-subagent-job-label", "qa"):
+        pill = builtin._browser_session_label(
+            ToolContext(
+                session_id="child-1",
+                job_id="job-1",
+                job_label=label,
+                session_name_provider=lambda: "Fix Slack-reported UI zoom and overlap bugs",
+            )
+        )
+        assert len(builtin._browser_clusters(pill)) <= builtin._BROWSER_SESSION_LABEL_CLUSTERS, pill
+
+
+def test_a_server_session_carrying_a_job_id_keeps_its_own_title() -> None:
+    # `job_id` is NOT unique to subagents — a server-side session carries one
+    # too — so the composition requires a `job_label` as well. A server session
+    # must render its own conversation title, unchanged.
+    context = ToolContext(
+        session_id="server-1",
+        job_id="queued-job",
+        job_label="",
+        cwd="/Users/damian/local-operator",
+        session_name_provider=lambda: "Reduce agent RAM usage",
+    )
+    assert builtin._browser_session_label(context) == "Reduce agent RAM usage"
+
+
+def test_a_peer_message_from_a_child_is_not_signed_with_its_parents_name() -> None:
+    # The `send` fallback path reads the ToolContext when no registry record
+    # names the process. `session_name` on a child resolves to its PARENT's
+    # title, so the card presented one session's name beside another's id.
+    child = ToolContext(
+        session_id="child-1",
+        job_id="job-1",
+        job_label="bridge-qa",
+        session_name="Fix the tab groups",
+    )
+    assert builtin._peer_sender_conversation_name(child) == "Fix the tab groups › bridge-qa"
+
+    # A top-level session is untouched, and so is a server session (job_id set,
+    # no label): both sign with their own title.
+    top = ToolContext(session_id="s", session_name="Fix the tab groups")
+    assert builtin._peer_sender_conversation_name(top) == "Fix the tab groups"
+    server = ToolContext(session_id="s", job_id="queued-job", session_name="Reduce agent RAM")
+    assert builtin._peer_sender_conversation_name(server) == "Reduce agent RAM"
+
+    # An unnamed parent leaves the child its own label rather than a bare
+    # separator, and the peer card is NOT clipped to the browser pill's width.
+    orphan = ToolContext(session_id="child-2", job_id="job-2", job_label="bridge-qa")
+    assert builtin._peer_sender_conversation_name(orphan) == "bridge-qa"
+    long_parent = ToolContext(
+        session_id="child-3",
+        job_id="job-3",
+        job_label="zoom-scroll-fix",
+        session_name="Fix Slack-reported UI zoom and overlap bugs",
+    )
+    assert (
+        builtin._peer_sender_conversation_name(long_parent)
+        == "Fix Slack-reported UI zoom and overlap bugs › zoom-scroll-fix"
+    )

--- a/tests/unit/browser_bridge/test_tool_selection.py
+++ b/tests/unit/browser_bridge/test_tool_selection.py
@@ -967,3 +967,134 @@ async def test_retitle_declines_rather_than_sending_a_constant_identity(monkeypa
 
     await builtin.retitle_browser_surface(surface, ToolContext(session_id="real", session_name="N"))
     assert calls == ["session:real"]
+
+
+# ---------------------------------------------------------------------------
+# Subagent tab groups: a delegated child has no title and can never grow one.
+# ---------------------------------------------------------------------------
+# Reported as `LO · Session` on the operator's screen. The cwd substitution
+# above fixed that for TOP-LEVEL sessions, but a subagent's context carries its
+# PARENT's cwd, so every child of one parent derived the identical label and a
+# fleet of them rendered as `local-operator (2)`/`(3)`/… — distinct only by an
+# ordinal that names nothing. Title generation lives in the TUI host and the
+# owned-session runtime; a one-shot child passes through neither, so it has no
+# title of its own and never will (no subagent session directory on disk holds
+# a `title.json`). Its identity is the label its parent launched it under.
+
+
+def test_a_subagent_is_named_by_its_parent_and_its_own_job_label() -> None:
+    context = ToolContext(
+        session_id="child-1",
+        job_id="job-1",
+        job_label="zoom-scroll-fix",
+        # The PARENT's cwd and the parent's title: a child has neither of its
+        # own, which is the whole reason both halves are needed.
+        cwd="/Users/damian/local-operator",
+        # Short enough that both halves fit whole — the clipping behaviour when
+        # they do not has its own test below.
+        session_name_provider=lambda: "Tab groups",
+    )
+    assert builtin._browser_session_label(context) == "Tab groups › zoom-scroll-fix"
+
+
+def test_two_siblings_of_one_parent_do_not_collide() -> None:
+    # The failure the ordinal was papering over: same parent, same cwd, so
+    # before the label was carried these two produced identical pills.
+    def child(label: str) -> str:
+        return builtin._browser_session_label(
+            ToolContext(
+                session_id=f"child-{label}",
+                job_id=f"job-{label}",
+                job_label=label,
+                cwd="/Users/damian/local-operator",
+                session_name_provider=lambda: "Fix the tab groups",
+            )
+        )
+
+    assert child("bridge-qa") != child("tabgroup-naming")
+
+
+def test_job_id_not_job_label_is_what_marks_a_context_as_a_child() -> None:
+    # A top-level session must never be composed as a subagent. `job_id` is set
+    # by the harness on exactly the child contexts; `job_label` is display text
+    # that a host could plausibly leave empty.
+    parent = ToolContext(session_id="s", cwd="/Users/damian/local-operator", job_id=None)
+    assert builtin._browser_session_label(parent) == "local-operator"
+
+
+def test_a_child_of_an_unnamed_parent_still_beats_the_bare_cwd() -> None:
+    # The parent has no title yet (it is named a second or two into its first
+    # turn, and children are launched later). The cwd stands in for the parent
+    # half, but the child's label is what makes the pill distinguishable.
+    context = ToolContext(
+        session_id="child-1",
+        job_id="job-1",
+        job_label="bridge-qa",
+        cwd="/Users/damian/local-operator",
+        session_name_provider=lambda: "",
+    )
+    assert builtin._browser_session_label(context) == "local-operator › bridge-qa"
+
+
+def test_a_child_with_no_usable_label_falls_back_to_its_parents_name() -> None:
+    # A label that sanitises away must not drop the child to the bare fallback.
+    context = ToolContext(
+        session_id="child-1",
+        job_id="job-1",
+        job_label="\u200b\u202e",
+        cwd="/Users/damian/local-operator",
+        session_name_provider=lambda: "Fix the tab groups",
+    )
+    assert builtin._browser_session_label(context) == "Fix the tab groups"
+
+
+def test_a_renamed_parent_reaches_a_running_childs_next_command() -> None:
+    # The rename case, from the child's side: the parent's holder is SHARED
+    # with the child, so a title generated or `/rename`d after the child was
+    # launched is picked up by its next reconcile rather than latching the
+    # launch-time value.
+    name = {"text": ""}
+    context = ToolContext(
+        session_id="child-1",
+        job_id="job-1",
+        job_label="qa",
+        cwd="/Users/damian/proj",
+        session_name_provider=lambda: name["text"],
+    )
+    assert builtin._browser_session_label(context) == "proj › qa"
+    name["text"] = "Fix the tab groups"
+    assert builtin._browser_session_label(context) == "Fix the tab groups › qa"
+
+
+def test_the_childs_label_survives_a_parent_title_too_long_to_fit() -> None:
+    # Clipping the composed string as ONE unit loses the distinguishing half:
+    # measured on a real pair, `Fix Slack-reported UI zoom and overlap bugs` +
+    # `zoom-scroll-fix` clipped to `Fix Slack-reported UI zoom…` and dropped
+    # the label entirely, re-creating the collision. The parent absorbs the cut.
+    label = builtin._browser_session_label(
+        ToolContext(
+            session_id="child-1",
+            job_id="job-1",
+            job_label="zoom-scroll-fix",
+            session_name_provider=lambda: "Fix Slack-reported UI zoom and overlap bugs",
+        )
+    )
+    assert label.endswith("› zoom-scroll-fix")
+    # And the composition still respects the pill budget the extension clips at
+    # (the ellipsis the clipper appends is paid out of the parent's room).
+    assert len(builtin._browser_clusters(label)) <= builtin._BROWSER_SESSION_LABEL_CLUSTERS
+
+
+def test_a_label_that_fills_the_pill_alone_drops_the_parent_rather_than_a_stub() -> None:
+    # `Fi…` identifies no conversation and only steals room from the half that
+    # does, so below the minimum the label stands alone.
+    label = builtin._browser_session_label(
+        ToolContext(
+            session_id="child-1",
+            job_id="job-1",
+            job_label="an-enormous-child-label-that-fills-it",
+            session_name_provider=lambda: "Some Parent Conversation",
+        )
+    )
+    assert "›" not in label
+    assert label.startswith("an-enormous-child-label")

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -2475,5 +2475,131 @@ async def test_a_top_level_session_is_never_composed_as_a_subagent(tmp_path):
     context = parent._build_tool_context()
     assert context.job_id is None and context.job_label == ""
     # The exact label the operator's pill should have read.
-    assert builtin._browser_session_label(context) == "Debug browser extension port…"
+    assert builtin._browser_session_label(context) == "Debug browser extension…"
     await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_grandchilds_pill_names_the_conversation_not_the_shared_cwd(tmp_path, monkeypatch):
+    """Depth 2 must resolve to the TOP-LEVEL title, not fall back to the cwd.
+
+    Delegation nests: a child of a top-level session keeps ``task``/``wait``/
+    ``jobs``, so a manager fanning out to workers is depth 2 and is the shape
+    the operator actually runs. The middle child has no title of its own and
+    can never grow one, so handing a grandchild the middle child's title
+    HOLDER yielded "" forever and the pill fell through to the parent cwd that
+    every session in the repo shares. Resolving the parent's DISPLAY name
+    walks past the untitled middle to the conversation that owns the work.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    from local_operator.tools import builtin
+
+    top = make_session(tmp_path, OneShotStream(), cwd="/Users/damian/local-operator")
+    top.set_conversation_name("Fix browser tab group naming")
+    middle = await build_child(top)
+    grandchild = await build_child(middle, job_id="job-2")
+
+    assert middle.conversation_name == "", "a subagent never holds a title of its own"
+    assert (
+        builtin._browser_session_label(grandchild._build_tool_context())
+        == "Fix browser tab group… › sub"
+    )
+
+    await grandchild.dispose()
+    await middle.dispose()
+    await top.dispose()
+
+
+@pytest.mark.asyncio
+async def test_grandchildren_of_different_conversations_do_not_collide(tmp_path, monkeypatch):
+    """The reported collision, one level deeper than the direct-child fix.
+
+    Two managers under two different conversations each fan out to a worker
+    called ``qa``. Before the transitive resolution both rendered
+    ``local-operator › qa`` — the same class of indistinguishable pill the
+    direct-child case was fixed for.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    from local_operator.tools import builtin
+
+    async def qa_pill(title: str, session_dir: str) -> str:
+        top = make_session(
+            tmp_path / session_dir, OneShotStream(), cwd="/Users/damian/local-operator"
+        )
+        top.set_conversation_name(title)
+        manager = await build_child(top)
+        worker = await build_child(manager, job_id="job-2")
+        pill = builtin._browser_session_label(worker._build_tool_context())
+        await worker.dispose()
+        await manager.dispose()
+        await top.dispose()
+        return pill
+
+    first = await qa_pill("Fix browser tab group naming", "a")
+    second = await qa_pill("Add Radient OAuth PKCE sign-in", "b")
+
+    assert first != second
+    assert first.endswith("› sub") and second.endswith("› sub")
+
+
+@pytest.mark.asyncio
+async def test_a_late_rename_of_the_grandparent_reaches_the_grandchild(tmp_path, monkeypatch):
+    """The live-resolution property has to survive the extra hop.
+
+    A title normally lands a second or two into the top-level session's first
+    turn, while children — and their children — are launched later. Each hop
+    resolves on read, so the rename reaches depth 2 on the grandchild's next
+    command exactly as it reaches depth 1.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    from local_operator.tools import builtin
+
+    top = make_session(tmp_path, OneShotStream(), cwd="/Users/damian/local-operator")
+    middle = await build_child(top)
+    grandchild = await build_child(middle, job_id="job-2")
+
+    # Unnamed grandparent: the cwd stands in, and the label still separates it
+    # from its siblings.
+    assert builtin._browser_session_label(grandchild._build_tool_context()) == (
+        "local-operator › sub"
+    )
+
+    top.set_conversation_name("Fix tab groups")
+    assert (
+        builtin._browser_session_label(grandchild._build_tool_context()) == "Fix tab groups › sub"
+    )
+
+    await grandchild.dispose()
+    await middle.dispose()
+    await top.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_parent_name_resolver_holds_its_parent_weakly(tmp_path, monkeypatch):
+    """The display-name resolver must not add a child→parent retention edge.
+
+    A detached child can outlive the session that launched it, and a strong
+    reference back would pin the parent's whole graph — transcript, tools, MCP
+    manager — for that child's lifetime. Asserted on the resolver itself
+    rather than through a live child, because a child already shares its
+    parent's ``SubagentComms`` and that edge (not this one) governs when a
+    parent is actually collectable; this test pins the property THIS code owns.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    from local_operator.harness import subagent as subagent_mod
+
+    parent = make_session(tmp_path, OneShotStream(), cwd="/Users/damian/local-operator")
+    parent.set_conversation_name("Fix tab groups")
+    resolve = subagent_mod._parent_display_name_resolver(parent)
+    assert resolve() == "Fix tab groups"
+
+    parent_ref = weakref.ref(parent)
+    await parent.dispose()
+    del parent
+    for _ in range(3):
+        gc.collect()
+        await asyncio.sleep(0)
+
+    # The resolver alone never kept it alive, and a dead parent lends no name.
+    assert parent_ref() is None
+    assert resolve() == ""

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -2414,3 +2414,66 @@ async def test_hub_ask_reaches_a_child_under_the_eager_task_factory(tmp_path, mo
         await parent.dispose()
     finally:
         loop.set_task_factory(old_factory)
+
+
+@pytest.mark.asyncio
+async def test_a_childs_tool_context_carries_its_label_and_its_parents_live_title(
+    tmp_path, monkeypatch
+):
+    """The browser tab group of a delegated child must name the work, not `Session`.
+
+    A subagent never generates a conversation title — naming runs in the TUI
+    host and the owned-session runtime and a one-shot child passes through
+    neither — so its ONLY display identity is the label its parent launched it
+    under plus its parent's title. Both have to survive the trip to the
+    EXECUTE-time context (``_build_tool_context``), which is rebuilt per turn
+    and is the one a tool actually sees; the construction-time context that
+    ``create_tools`` inspects is not it.
+
+    The parent's title is asserted through a rename performed AFTER the child
+    was built, because that is the real sequence: a parent is named a second or
+    two into its first turn while its children are launched later, so a value
+    snapshotted at child construction would be empty for the child's whole life.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    from local_operator.tools import builtin
+
+    stream = OneShotStream()
+    # A real cwd, because the unnamed-parent half of the label falls back to
+    # its basename and the Session default (".") has none.
+    parent = make_session(tmp_path, stream, cwd="/Users/damian/local-operator")
+    child = await build_child(parent)
+
+    context = child._build_tool_context()
+    assert context.job_label == "sub"
+    assert context.job_id == "job-1"
+    # Its own identity is untouched: the borrowed NAME must never become a
+    # borrowed identity.
+    assert context.session_id == child.session_id != parent.session_id
+
+    # Unnamed parent: the child is still distinguishable from its siblings by
+    # its own label, where before it fell back to the cwd every sibling shares.
+    assert builtin._browser_session_label(context).endswith("› sub")
+
+    # The rename case, end to end through the real holder the child was handed.
+    parent.set_conversation_name("Fix tab groups")
+    assert builtin._browser_session_label(child._build_tool_context()) == "Fix tab groups › sub"
+
+    await child.dispose()
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_top_level_session_is_never_composed_as_a_subagent(tmp_path):
+    """The discriminator must not misfire on the operator's own session."""
+    from local_operator.tools import builtin
+
+    stream = OneShotStream()
+    parent = make_session(tmp_path, stream)
+    parent.set_conversation_name("Debug browser extension port binding issue")
+
+    context = parent._build_tool_context()
+    assert context.job_id is None and context.job_label == ""
+    # The exact label the operator's pill should have read.
+    assert builtin._browser_session_label(context) == "Debug browser extension port…"
+    await parent.dispose()

--- a/tests/unit/session/test_tool_context_parity.py
+++ b/tests/unit/session/test_tool_context_parity.py
@@ -53,6 +53,11 @@ SENTINELS: dict[str, Any] = {
     "agent_id": "sentinel-agent",
     "has_ui": True,
     "job_id": "sentinel-job",
+    # The short name a subagent was delegated under. Dropped on the way to the
+    # executor, a child's browser tab group falls back to its PARENT's cwd —
+    # which every sibling shares — and a fleet of children renders as one
+    # repeated pill distinguished only by an ordinal.
+    "job_label": "sentinel-job-label",
     "variables": VariableStore(cwd="/tmp", config_values={"SENTINEL_VAR": "1"}),
     "request_approval": lambda tool_name, description: None,
     "resolve_internal_url": lambda url: None,

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -25,6 +25,7 @@ from local_operator.harness.types import (
     ImageContent,
     NoticeEvent,
     TextContent,
+    ToolResult,
 )
 from local_operator.paths import config_dir
 from local_operator.session.mcp_status import McpStartupOutcome
@@ -9925,3 +9926,53 @@ async def test_the_picker_shows_a_model_released_since_the_listing_was_cached() 
         offered = {row.model_id for row in picker.rows()}
     assert "claude-fable-5-1" in offered, offered
     assert ctrl.fetches == 1, "and it cost exactly one live listing"
+
+
+@pytest.mark.asyncio
+async def test_a_bang_command_carries_the_conversation_title_to_its_tools() -> None:
+    """Bang mode builds its OWN ToolContext, outside any turn.
+
+    ``Session._build_tool_context`` is what carries the title to every ordinary
+    tool call, and this path deliberately does not use it (there is no turn to
+    build one for). It therefore has to carry the title itself, or every
+    display-only consumer — the browser tab group above all — sees an unnamed
+    session for the whole of a `! cmd`.
+
+    The provider is asserted alongside the snapshot because a `! cmd` can
+    outlive the naming errand that titles the conversation.
+    """
+    session = FakeSession()
+    session.set_conversation_name("Debug browser extension port binding issue")
+    seen: list[Any] = []
+
+    async def fake_execute_bash(tool_call_id, args, signal, on_update, context):
+        seen.append(context)
+        return ToolResult(
+            tool_call_id=tool_call_id,
+            tool_name="bash",
+            content=[TextContent(text="exit code: 0")],
+        )
+
+    app = OperatorApp(lambda: _factory(session))
+    with patch("local_operator.tools.builtin.execute_bash", fake_execute_bash):
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            editor = app.query_one(Editor)
+            editor.focus()
+            await pilot.press("!")
+            for key in "echo hi":
+                await pilot.press("space" if key == " " else key)
+            await pilot.press("enter")
+            for _ in range(200):
+                await pilot.pause()
+                if seen:
+                    break
+
+    assert seen, "the bang command never reached a tool"
+    context = seen[-1]
+    assert context.session_name == "Debug browser extension port binding issue"
+    # Live too: a title that lands while a long `! cmd` runs must still reach
+    # the tab group, exactly as it does on the per-turn path.
+    session.set_conversation_name("Renamed mid-command")
+    assert context.session_name_provider is not None
+    assert context.session_name_provider() == "Renamed mid-command"


### PR DESCRIPTION
## Root cause

**Correction to the brief's hypothesis first.** Candidate 1 (the tool-construction
context being captured and winning over the execute-time one) is **disproven**:
`execute_browser` is a module-level function with no closure over the construction
context, and the per-turn context built by `Session._build_tool_context` is the one
that reaches every tool call. The execute-time context does win.

What actually happened has two parts:

1. **The operator's screenshot predates the fix that already shipped.** The incident
   tab was opened at `2026-09-02 21:10:23` (transcript ts `1788397823`, session
   `2d3373a1c698`, title *"Fix Slack-reported UI zoom and overlap bugs"*). The fix for
   exactly that symptom — `session_name_provider` + the cwd fallback — merged in
   #555 (`1568599e`) at `2026-09-03 01:11:47`, **four hours later**. The operator's
   session process was running the pre-fix code, which read only the per-turn
   `session_name` snapshot and returned the bare `Session` fallback. That cause is
   already fixed on main; the screenshot is not evidence of a residual defect.

2. **The residual live defect: subagents.** A delegated child has no conversation
   title and can never grow one — naming runs in the TUI host and the owned-session
   runtime, and a one-shot child passes through neither (verified on this machine:
   no subagent session directory holds a `title.json`; 718 of 778 browsing sessions
   here are subagents, all untitled). Its context carried no `session_name` and its
   cwd was its **parent's**, so every child of one parent derived the identical cwd
   label and a fleet of them rendered as one repeated pill distinguished only by an
   ordinal that names nothing.

## The fix

- **New `ToolContext.job_label` field** — the short name a subagent was delegated
  under (`zoom-scroll-fix`, `bridge-qa`). Plumbed from `harness/subagent.py` through
  `Session.__init__` into the per-turn `_build_tool_context`, so the execute-time
  context carries it.
- **The pill composes as `<parent title> › <job label>`** — the separator matching
  the TUI's own `lo › <cwd>` convention. The parent half is read through the shared
  `ConversationName` holder, so a parent named or `/rename`d **after** launch still
  reaches the child's next command. When the composition does not fit the 30-cluster
  pill, the **parent** is what gets clipped — the label is the distinguishing half
  (siblings share a parent by definition).
- **Bang mode** built its own `ToolContext` outside any turn and omitted the title
  entirely; it now carries it, with a provider so a title landing mid-command is
  still current.
- **Security boundary intact**: the label is display-only; identity stays on
  `session_id`/`requester`. A child borrowing its parent's name for a pill is never
  a child acting with its parent's identity. Sanitisation runs on both sides.

## Evidence (real execution)

**Wire capture — `session_label` on outgoing RPCs, main vs branch** (intercepted at
`_bridge_call`, the single choke point every browser RPC passes through):

| path | main | branch |
|---|---|---|
| named foreground session | `Debug browser extension port…` | `Debug browser extension port…` |
| subagent A (`tabgroup-naming`) | `local-operator` | `Debug brows… › tabgroup-naming` |
| subagent B (`bridge-qa`) | `local-operator` | `Debug browser… › bridge-qa` |
| subagent C (`designer`) | `local-operator` | `Debug browser… › designer` |
| child, parent not yet named | `proj` | `proj › qa` |
| same child after parent renamed | `Fix the tab group naming` | `Fix the tab group naming › qa` |
| retitle RPC pushed by session | `Fix the tab group naming` | `Fix the tab group naming › qa` |

On main, **all three subagents send the identical label** — the exact collision the
ordinal was papering over. `requester` (identity) is unchanged in every case.

**Sibling disambiguation** — a fleet of six children off the operator's actual
session (`ab90e52f53e6`):

```
child job label    MAIN pill                    BRANCH pill
tabgroup-naming    LO · local-operator          LO · Debug brows… › tabgroup-naming
bridge-qa          LO · local-operator          LO · Debug browser… › bridge-qa
reviewer           LO · local-operator          LO · Debug browser… › reviewer
qa-tester          LO · local-operator          LO · Debug browser… › qa-tester
designer           LO · local-operator          LO · Debug browser… › designer
ux-reviewer        LO · local-operator          LO · Debug browser… › ux-reviewer

distinct pills on MAIN  : 1 of 6   <-- all six collide
distinct pills on BRANCH: 6 of 6
```

**Live real-extension capture** — drove the paired extension (0.1.7) against the
running daemon with `example.com` (operator-approved). Opened a tab as this subagent
session (running the installed 0.44.54 = main), which sent `session_label='tmp'`
(the residual defect reproduced live: a child with no title falls to its cwd
basename), then issued a follow-up `goto` which re-ran `reconcileCommandTab` against
the live group — confirming the rename-refresh path works end to end. The group pill
itself is browser chrome outside the page viewport, so it cannot be screenshotted;
the label is verified programmatically via the outgoing `session_label` and the
extension's reconcile behaviour.

**Regression tests** — 9 new tests, all fail on main and pass on this branch:
- `test_tool_selection.py`: subagent naming, sibling non-collision, `job_id`
  discriminator, unnamed-parent fallback, invisible-label fallback, rename
  propagation, long-parent clipping, label-fills-pill case.
- `test_launch_subagent.py`: end-to-end wiring through a real parent `Session` and
  a real `_build_child_session` child, including a rename performed after the child
  was built.
- `test_app_pilot.py`: bang mode carries the title and a live provider.
- `test_tool_context_parity.py`: registered `job_label` in the sentinel table (the
  existing derived guard caught the new field and forced the registration).

## Gates

- `flake8`, `black --check` (26.1.0), `isort --check-only` (5.13.2), `pyright` — all
  clean over the whole tree.
- Full unit suite: **11506 passed, 15 skipped** (one pre-existing load-flake in
  `tests/unit/model/test_prices.py::test_a_background_revalidation_gets_the_full_default_timeout`
  — a background-thread spawn race; both files byte-identical to main, passes 5/5 in
  isolation; not touched by this change).

## Store constraint

**`extension/` is untouched by this change** — zero files under `extension/` in the
diff. The fix is entirely Python-side. The manifest's `permissions` and
`host_permissions` are unchanged, so the 0.1.5 → 0.1.7 version-line-only property
holds for any build produced from this branch.

## Versioning

PATCH bump to **0.44.56** (verified free against `git tag`, `gh release list`, and
the PyPI JSON API immediately before committing). This is a fix to existing
behaviour, not a new surface.
