### PR TITLE
fix(evaluation): keep the evidence an interrupted episode already bought

### DIFF
--- a/local_operator/evaluation/evidence/verify.py
+++ b/local_operator/evaluation/evidence/verify.py
@@ -792,7 +792,52 @@ def _verify_semantics(
             issues.error("receipt_binding_invalid", terminal_location)
         if len(terminal_states) != 1:
             issues.error("finalization_invalid", terminal_location)
-        if environment_step_seen and not last_step_terminal and not finish_action_seen:
+        # An episode that ran environment steps must show WHY it stopped
+        # stepping: either the environment ended the rollout
+        # (terminated/truncated) or the agent chose to stop (a `finish` batch).
+        # Without one of those, a bundle truncated mid-rollout would otherwise
+        # seal as if the run had reached its own conclusion.
+        #
+        # That invariant holds only for an episode that was ALLOWED to end
+        # deliberately. A run interrupted mid-loop -- an adapter crash, a
+        # provider outage, an operator cancel -- stops after an ordinary
+        # non-terminal step, with no terminal step and no finish action,
+        # because the thing that would have produced one is exactly what
+        # broke. Requiring the deliberate ending there made every such bundle
+        # unsealable AND unabandonable -- unscoreable rather than merely
+        # unscored -- so a real paid episode that died at step 17 of 60
+        # destroyed the 16 steps of evidence it had already bought (observed
+        # as ep-ffda3fc88f81: `abandonment_failed`, score null, 37 artifacts
+        # stranded).
+        #
+        # The interruption is recorded by the terminal snapshot's
+        # ``failure_kind``, which the runner sets on precisely the failure and
+        # cancellation paths and leaves None on a clean completion. It is not a
+        # weaker explanation than a rollout-completion marker: it is written
+        # only by ``record_final_lifecycle`` under the finalizing marker, and
+        # it rides inside the hash-chained event payload, so it cannot be
+        # added to an existing bundle without breaking the chain.
+        #
+        # The exemption is deliberately narrower than "failure_kind is set". A
+        # bundle that claims BOTH an interruption and a score would otherwise
+        # launder a run that stopped early into a reportable result -- the
+        # score would be computed over a state the episode never deliberately
+        # reached. An interrupted episode is unscored by construction
+        # (``_finalize_failure`` seals ``ScoreArtifact(status="unscored")``),
+        # so requiring that here costs the real path nothing and keeps the
+        # laundering shape rejected.
+        unscored = (
+            not starts and not results and (outcome is None or outcome.result.status != "scored")
+        )
+        interrupted = (
+            len(terminal_states) == 1 and terminal_states[0].failure_kind is not None and unscored
+        )
+        if (
+            environment_step_seen
+            and not last_step_terminal
+            and not finish_action_seen
+            and not interrupted
+        ):
             issues.error("finalization_invalid", terminal_location)
         if terminal_output_observation is not None and not terminal_output_resolved:
             issues.error("receipt_binding_invalid", terminal_location)

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -1083,12 +1083,43 @@ class EpisodeRunner:
             category, reason, failure_kind = "model", "model_failure", "model"
         else:
             category, reason, failure_kind = "adapter", "crash", "crash"
+        # The bounded, redaction-scanned reason for the failure, not just its
+        # type. ``diagnostic_code`` is a StrictIdentifier derived from the
+        # exception CLASS ("rpcremoteerror"), which is enough to bucket a
+        # failure and never enough to diagnose one: the real episode
+        # ep-ffda3fc88f81 burned a paid 16-step run and left a reader nothing
+        # but that word and a null ``detail_artifact``. The rejected-decision
+        # path above already publishes its diagnostic as an artifact for
+        # exactly this reason; a fatal error deserves it at least as much,
+        # because there is no retry that will produce a second chance to look.
+        #
+        # ``_diagnostic`` is the same renderer used for the outcome's own
+        # diagnostic field: it strips pydantic's ``input_value=`` echo (the one
+        # place a resolved secret could surface) and truncates to 500 chars, and
+        # ``publish_artifact`` independently scans every byte against the
+        # episode's RedactionSet, so a leaked credential fails the write rather
+        # than reaching the bundle.
+        detail: Any = None
+        try:
+            detail = self._publish(_diagnostic(error).encode("utf-8"), media_type="text/plain")
+        except (_EvidenceFailure, OSError):
+            # Best-effort by design. This runs on the path that is already
+            # handling a failure, and an unpublishable detail must never be the
+            # reason a bundle loses its terminal -- the code, category and
+            # outcome diagnostic still reach the reader without it. ``OSError``
+            # is named alongside ``_EvidenceFailure`` because ``publish_artifact``
+            # poisons the writer and re-raises a RAW ``OSError`` on ambiguous I/O
+            # (ENOSPC/EIO), and ``_publish`` converts only ``EvidenceError`` -- so
+            # a disk failure here would otherwise escape ``_finalize_failure`` and
+            # cost the bundle its terminal: the exact shape this change removes.
+            detail = None
         self._append(
             "error",
             ErrorPayload(
                 error_id=f"err-{uuid.uuid4().hex[:12]}",
                 category=category,
                 diagnostic_code=_diagnostic_code(error),
+                detail_artifact=detail,
                 retryable=False,
             ),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.69"
+version = "0.44.67"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.67"
+<<<<<<< HEAD
+version = "0.44.70"
+=======
+version = "0.44.70"
+>>>>>>> 4d6718a7 (chore(release): 0.44.57)
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/evaluation/evidence/test_finalization.py
+++ b/tests/unit/evaluation/evidence/test_finalization.py
@@ -820,3 +820,454 @@ def test_terminal_conflict_and_outcome_tamper_are_detected(tmp_path: Path) -> No
         "outcome_mismatch",
         "counter_mismatch",
     } & {issue.code for issue in report.issues}
+
+
+def _crashed_mid_rollout(
+    root: Path, *, failure_kind: str | None = "crash", steps: int = 2
+) -> tuple[EvidenceWriter, ScoreArtifact]:
+    """Write the exact interleaving a crash-terminated episode leaves on disk.
+
+    ``steps`` non-terminal environment steps (no ``finish`` batch, nothing
+    terminated or truncated), then the adapter error, then the unscored
+    finalization, receipts, and the terminal snapshot -- the shape produced by
+    ``EpisodeRunner._finalize_failure`` when the environment RPC dies mid-run.
+    """
+
+    writer = EvidenceWriter.create(root, manifest(), RedactionSet.from_resolved_values(()))
+    try:
+        clock = 0
+        _append_provenance(writer, monotonic_ns=clock, wall_time_ms=clock)
+        clock += 2
+        action_artifact = writer.publish_artifact(b"safe", media_type="text/plain")
+        for index in range(steps):
+            writer.append(
+                "observation",
+                ObservationPayload(observation_id=f"observation-{index}", sequence=index),
+                monotonic_ns=clock,
+                wall_time_ms=clock,
+            )
+            clock += 1
+            writer.append(
+                "action_batch",
+                ActionBatchPayload(
+                    action_batch_id=f"batch-{index}",
+                    observation_id=f"observation-{index}",
+                    action_count=1,
+                    action_artifact=action_artifact,
+                ),
+                monotonic_ns=clock,
+                wall_time_ms=clock,
+            )
+            clock += 1
+            writer.append(
+                "environment_step",
+                EnvironmentStepPayload(
+                    step_id=f"step-{index}",
+                    action_batch_id=f"batch-{index}",
+                    receipt_id=DIGEST,
+                    input_observation_id=f"observation-{index}",
+                    output_observation_id=f"observation-{index + 1}",
+                    terminated=False,
+                    truncated=False,
+                ),
+                monotonic_ns=clock,
+                wall_time_ms=clock,
+            )
+            clock += 1
+        # The rollout's final output observation still lands: the step receipt
+        # resolved before the adapter broke.
+        writer.append(
+            "observation",
+            ObservationPayload(observation_id=f"observation-{steps}", sequence=steps),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.append(
+            "error",
+            {
+                "error_id": "err-306591b1400e",
+                "category": "adapter",
+                "diagnostic_code": "rpcremoteerror",
+                "retryable": False,
+            },
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.begin_finalization(
+            "final",
+            None,
+            FinalizationIntent(kind="unscored"),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        clock, _ = _append_final_receipts(writer, monotonic_ns=clock, wall_time_ms=clock)
+        score = ScoreArtifact(status="unscored", reason="crash")
+        writer.record_final_lifecycle(
+            LifecycleTransitionPayload(
+                previous_state_id=None,
+                state_id=OTHER_DIGEST,
+                state="completed",
+                finalization_id="final",
+                preflight_seal_id=DIGEST,
+                commitment_id=OTHER_DIGEST,
+                reconciliation_id=DIGEST,
+                reconciliation_reportable=True,
+                score_id=score.score_id,
+                cleanup_result_id=OTHER_DIGEST,
+                rescue_required=False,
+                failure_kind=failure_kind,  # pyright: ignore[reportArgumentType]
+            ),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+    except BaseException:
+        writer.close()
+        raise
+    return writer, score
+
+
+def test_crash_after_nonterminal_steps_verifies_and_seals_unscored(tmp_path: Path) -> None:
+    """A crash mid-rollout must seal as unscored, not fail verification.
+
+    Regression: the rollout-completion invariant demanded a terminated/truncated
+    step or a ``finish`` batch on every bundle carrying a terminal snapshot. A
+    crash leaves neither -- nothing got to decide the rollout was over -- so the
+    bundle failed its own seal verification AND the abandonment fallback,
+    leaving the episode unscoreable instead of unscored.
+    """
+
+    root = tmp_path / "bundle"
+    writer, score = _crashed_mid_rollout(root)
+    try:
+        report = verify_bundle(root)
+        assert report.valid, report.issues
+        assert report.terminal_state == "finalizing"
+        outcome = writer.seal(
+            OutcomeDraft(
+                finalization_id="final",
+                preflight_seal_id=DIGEST,
+                commitment_id=OTHER_DIGEST,
+                reconciliation_id=DIGEST,
+                cleanup_result_id=OTHER_DIGEST,
+                result=score,
+                reportability_label="unscored",
+                comparability_label="comparable",
+                ended_wall_time_ms=99,
+            )
+        )
+    finally:
+        writer.close()
+    assert outcome.result.status == "unscored" and outcome.result.reason == "crash"
+    sealed = verify_bundle(root)
+    assert sealed.valid, sealed.issues
+    assert sealed.terminal_state == "sealed"
+    assert sealed.outcome is not None
+    assert sealed.outcome.reportability_label == "unscored"
+
+
+def test_crash_abandonment_fallback_now_succeeds(tmp_path: Path) -> None:
+    """The safety net must work: a recovered crash bundle can be abandoned.
+
+    ``open_for_abandon``/``abandon`` both re-verify independently and refuse on
+    any error-severity issue, so the same over-broad invariant disabled the
+    fallback that exists precisely for a bundle nobody can seal.
+    """
+
+    root = tmp_path / "bundle"
+    writer, _ = _crashed_mid_rollout(root)
+    writer.close()
+
+    recovered = EvidenceWriter.open_for_abandon(root, RedactionSet.from_resolved_values(()))
+    try:
+        record = recovered.abandon("ambiguous_finalization", "rpcremoteerror")
+    finally:
+        recovered.close()
+    assert record.reason == "ambiguous_finalization"
+    report = verify_bundle(root)
+    assert report.valid, report.issues
+    assert report.terminal_state == "abandoned"
+
+
+def test_crash_bundle_missing_terminal_event_still_refuses(tmp_path: Path) -> None:
+    """Do not over-correct: a genuinely incomplete bundle must stay unsealed.
+
+    Same interleaving, but the process died BEFORE the terminal lifecycle event
+    reached the journal. There is no ``failure_kind`` to explain the truncated
+    rollout, so the bundle has no terminal state and cannot be sealed.
+    """
+
+    root = tmp_path / "bundle"
+    writer = EvidenceWriter.create(root, manifest(), RedactionSet.from_resolved_values(()))
+    try:
+        clock = 0
+        _append_provenance(writer, monotonic_ns=clock, wall_time_ms=clock)
+        clock += 2
+        action_artifact = writer.publish_artifact(b"safe", media_type="text/plain")
+        writer.append(
+            "observation",
+            ObservationPayload(observation_id="observation-0", sequence=0),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.append(
+            "action_batch",
+            ActionBatchPayload(
+                action_batch_id="batch-0",
+                observation_id="observation-0",
+                action_count=1,
+                action_artifact=action_artifact,
+            ),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.append(
+            "environment_step",
+            EnvironmentStepPayload(
+                step_id="step-0",
+                action_batch_id="batch-0",
+                receipt_id=DIGEST,
+                input_observation_id="observation-0",
+                output_observation_id="observation-1",
+                terminated=False,
+                truncated=False,
+            ),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.append(
+            "observation",
+            ObservationPayload(observation_id="observation-1", sequence=1),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.begin_finalization(
+            "final",
+            None,
+            FinalizationIntent(kind="unscored"),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        _append_final_receipts(writer, monotonic_ns=clock, wall_time_ms=clock)
+        score = ScoreArtifact(status="unscored", reason="crash")
+        with pytest.raises(EvidenceBundleInvalid):
+            writer.seal(
+                OutcomeDraft(
+                    finalization_id="final",
+                    preflight_seal_id=DIGEST,
+                    commitment_id=OTHER_DIGEST,
+                    reconciliation_id=DIGEST,
+                    cleanup_result_id=OTHER_DIGEST,
+                    result=score,
+                    reportability_label="unscored",
+                    comparability_label="comparable",
+                    ended_wall_time_ms=99,
+                )
+            )
+    finally:
+        writer.close()
+    report = verify_bundle(root)
+    assert report.terminal_state == "finalizing"
+    assert not any(
+        state.state == "completed"
+        for state in (
+            event.payload
+            for event in report.events
+            if isinstance(event.payload, LifecycleTransitionPayload)
+        )
+    )
+
+
+def test_truncated_rollout_without_failure_kind_still_refuses(tmp_path: Path) -> None:
+    """The invariant still bites where it was designed to.
+
+    A terminal snapshot claiming a clean run (``failure_kind=None``) over a
+    rollout that never terminated, truncated, or finished is exactly the
+    "sealed as if it concluded" case the check exists to catch.
+    """
+
+    root = tmp_path / "bundle"
+    writer, _ = _crashed_mid_rollout(root, failure_kind=None)
+    writer.close()
+    report = verify_bundle(root)
+    assert not report.valid
+    assert ("finalization_invalid", "events.jsonl") in {
+        (issue.code, issue.location) for issue in report.issues
+    }
+
+
+def test_scored_bundle_with_failure_kind_still_requires_completed_rollout(
+    tmp_path: Path,
+) -> None:
+    """A scoring result claims a finished rollout, so a crash excuse must not apply.
+
+    Pins the ``not results`` clause: without it, attaching any ``failure_kind``
+    to a scored bundle would waive the rollout-completion requirement and let a
+    run that never reached its own end be reported with a score.
+    """
+
+    root = tmp_path / "bundle"
+    writer = EvidenceWriter.create(root, manifest(), RedactionSet.from_resolved_values(()))
+    try:
+        clock = 0
+        _append_provenance(writer, monotonic_ns=clock, wall_time_ms=clock)
+        clock += 2
+        action_artifact = writer.publish_artifact(b"safe", media_type="text/plain")
+        writer.append(
+            "observation",
+            ObservationPayload(observation_id="observation-0", sequence=0),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.append(
+            "action_batch",
+            ActionBatchPayload(
+                action_batch_id="batch-0",
+                observation_id="observation-0",
+                action_count=1,
+                action_artifact=action_artifact,
+            ),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.append(
+            "environment_step",
+            EnvironmentStepPayload(
+                step_id="step-0",
+                action_batch_id="batch-0",
+                receipt_id=DIGEST,
+                input_observation_id="observation-0",
+                output_observation_id="observation-1",
+                terminated=False,
+                truncated=False,
+            ),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.append(
+            "observation",
+            ObservationPayload(observation_id="observation-1", sequence=1),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        writer.begin_finalization(
+            "final",
+            "score-op",
+            FinalizationIntent(kind="score", scorer_id="scorer", scorer_version="1"),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        score = ScoreArtifact(status="scored", binary=1)
+        writer.record_scoring_result(
+            ScoringResultPayload(
+                finalization_id="final", scoring_operation_id="score-op", score=score
+            ),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+        clock += 1
+        clock, _ = _append_final_receipts(writer, monotonic_ns=clock, wall_time_ms=clock)
+        writer.record_final_lifecycle(
+            LifecycleTransitionPayload(
+                previous_state_id=None,
+                state_id=OTHER_DIGEST,
+                state="completed",
+                finalization_id="final",
+                preflight_seal_id=DIGEST,
+                commitment_id=OTHER_DIGEST,
+                reconciliation_id=DIGEST,
+                reconciliation_reportable=True,
+                score_id=score.score_id,
+                cleanup_result_id=OTHER_DIGEST,
+                rescue_required=False,
+                failure_kind="scorer",
+            ),
+            monotonic_ns=clock,
+            wall_time_ms=clock,
+        )
+    finally:
+        writer.close()
+    report = verify_bundle(root)
+    assert not report.valid
+    assert ("finalization_invalid", "events.jsonl") in {
+        (issue.code, issue.location) for issue in report.issues
+    }
+
+
+def test_retrofitting_failure_kind_into_a_sealed_terminal_is_detected(
+    tmp_path: Path,
+) -> None:
+    """The exemption's security basis, pinned directly: ``failure_kind`` cannot be
+    added to an existing bundle without breaking the chain.
+
+    The exemption trusts ``failure_kind`` because it rides inside the
+    hash-chained terminal event and is written only under the finalizing marker.
+    This retrofits ``failure_kind`` into an already-SEALED terminal snapshot two
+    ways and asserts both are caught:
+
+    - NAIVE: edit the payload, keep the stored ``event_id`` -> the record no
+      longer hashes to its identity (``event_hash_mismatch``) and the sealed
+      outcome no longer binds the journal (``outcome_mismatch``).
+    - REHASHED: recompute the ``event_id`` for the edited record so the record
+      is internally consistent -> the sealed outcome's ``final_event_sha256``
+      still binds the ORIGINAL final event, so the retrofit is caught by
+      ``outcome_mismatch`` alone.
+
+    Without this pin the claim rides only on the generic payload-tamper test.
+    """
+
+    from local_operator.evaluation.evidence.models import EventRecord
+
+    def _sealed_bundle(root: Path) -> None:
+        writer, score = _finalized(root)
+        try:
+            writer.seal(_draft(score))
+        finally:
+            writer.close()
+        assert verify_bundle(root).terminal_state == "sealed"
+
+    # NAIVE retrofit: payload gains failure_kind, event_id is left stale.
+    naive = tmp_path / "naive"
+    _sealed_bundle(naive)
+    lines = (naive / "events.jsonl").read_bytes().splitlines()
+    rewritten = []
+    for line in lines:
+        event = json.loads(line)
+        if event["kind"] == "lifecycle_transition" and event["payload"].get("state") == "completed":
+            event["payload"]["failure_kind"] = "crash"
+        rewritten.append(json.dumps(event, separators=(",", ":"), sort_keys=True).encode() + b"\n")
+    (naive / "events.jsonl").write_bytes(b"".join(rewritten))
+    naive_codes = {issue.code for issue in verify_bundle(naive).issues}
+    assert not verify_bundle(naive).valid
+    assert {"event_hash_mismatch", "outcome_mismatch"} <= naive_codes
+
+    # REHASHED retrofit: the edited record is re-identified, so only the sealed
+    # outcome's binding of the final event catches it.
+    rehashed = tmp_path / "rehashed"
+    _sealed_bundle(rehashed)
+    lines = (rehashed / "events.jsonl").read_bytes().splitlines()
+    rewritten = []
+    for line in lines:
+        event = json.loads(line)
+        if event["kind"] == "lifecycle_transition" and event["payload"].get("state") == "completed":
+            event["payload"]["failure_kind"] = "crash"
+            record = EventRecord.model_validate({**event, "event_id": "0" * 64}, strict=True)
+            rewritten.append(record.to_canonical_json() + b"\n")
+        else:
+            rewritten.append(line + b"\n")
+    (rehashed / "events.jsonl").write_bytes(b"".join(rewritten))
+    rehashed_report = verify_bundle(rehashed)
+    assert not rehashed_report.valid
+    assert "outcome_mismatch" in {issue.code for issue in rehashed_report.issues}

--- a/tests/unit/evaluation/evidence/test_verify.py
+++ b/tests/unit/evaluation/evidence/test_verify.py
@@ -15,6 +15,8 @@ from local_operator.evaluation.evidence.models import (
     CleanupPayload,
     ContextCompactionPayload,
     EnvironmentStepPayload,
+    EventKind,
+    EventPayload,
     EventRecord,
     FinalizationIntent,
     LifecycleTransitionPayload,
@@ -868,3 +870,247 @@ print(json.dumps(loaded))
             "local_operator.evaluation",
         ):
             assert "local_operator.evaluation.evidence.models" not in result.stdout
+
+
+def _interrupted_bundle(
+    tmp_path: Path,
+    *,
+    failure_kind: str | None,
+    scored: bool = False,
+) -> Path:
+    """A bundle whose last step is an ordinary non-terminal one.
+
+    ``failure_kind`` None models an episode claiming it ended deliberately;
+    a value models one that was interrupted (crash, outage, cancel).
+    """
+
+    root = tmp_path / "bundle"
+    clock = iter(range(1, 1000))
+    with EvidenceWriter.create(root, manifest(), RedactionSet.from_resolved_values(())) as writer:
+        action = writer.publish_artifact(b"{}", media_type="application/json")
+
+        def at() -> int:
+            return next(clock)
+
+        def append(kind: EventKind, payload: EventPayload) -> None:
+            moment = at()
+            writer.append(kind, payload, monotonic_ns=moment, wall_time_ms=moment)
+
+        append(
+            "preflight",
+            PreflightPayload(
+                sealed_preflight_id=DIGEST, plan_id=DIGEST, receipt_ids=(), passed=True
+            ),
+        )
+        append(
+            "budget_commitment",
+            BudgetCommitmentPayload(
+                commitment_id=DIGEST,
+                budget_id=manifest().budget_id,
+                reservation_ids=(),
+                reserved_summary_digest=DIGEST,
+            ),
+        )
+        append(
+            "lifecycle_transition",
+            LifecycleTransitionPayload(
+                previous_state_id=None, state_id=DIGEST, state="running", commitment_id=DIGEST
+            ),
+        )
+        append("observation", ObservationPayload(observation_id="obs-0", sequence=0))
+        append(
+            "action_batch",
+            ActionBatchPayload(
+                action_batch_id="batch-0",
+                observation_id="obs-0",
+                action_count=1,
+                action_artifact=action,
+            ),
+        )
+        append(
+            "environment_step",
+            EnvironmentStepPayload(
+                step_id="step-0",
+                action_batch_id="batch-0",
+                receipt_id=DIGEST,
+                input_observation_id="obs-0",
+                output_observation_id="obs-1",
+                terminated=False,
+                truncated=False,
+            ),
+        )
+        append("observation", ObservationPayload(observation_id="obs-1", sequence=1))
+        score = (
+            ScoreArtifact(status="scored", binary=1)
+            if scored
+            else ScoreArtifact(status="unscored", reason="crash")
+        )
+        moment = at()
+        writer.begin_finalization(
+            "final",
+            "score-op" if scored else None,
+            (
+                FinalizationIntent(kind="score", scorer_id="scorer", scorer_version="1")
+                if scored
+                else FinalizationIntent(kind="unscored")
+            ),
+            monotonic_ns=moment,
+            wall_time_ms=moment,
+        )
+        if scored:
+            moment = at()
+            writer.record_scoring_result(
+                ScoringResultPayload(
+                    finalization_id="final", scoring_operation_id="score-op", score=score
+                ),
+                monotonic_ns=moment,
+                wall_time_ms=moment,
+            )
+        moment = at()
+        writer.record_reconciliation(
+            ReconciliationPayload(
+                reconciliation_id=DIGEST,
+                budget_id=manifest().budget_id,
+                commitment_id=DIGEST,
+                reportable=False,
+                provider_cost_microusd=0,
+                environment_cost_microusd=0,
+                total_cost_microusd=0,
+            ),
+            monotonic_ns=moment,
+            wall_time_ms=moment,
+        )
+        moment = at()
+        writer.record_cleanup(
+            CleanupPayload(
+                cleanup_result_id=DIGEST,
+                cleanup_plan_id=DIGEST,
+                receipt_ids=(),
+                rescue_required=False,
+            ),
+            monotonic_ns=moment,
+            wall_time_ms=moment,
+        )
+        moment = at()
+        writer.record_final_lifecycle(
+            LifecycleTransitionPayload(
+                previous_state_id=DIGEST,
+                state_id="a" * 64,
+                state="completed",
+                finalization_id="final",
+                preflight_seal_id=DIGEST,
+                commitment_id=DIGEST,
+                reconciliation_id=DIGEST,
+                reconciliation_reportable=False,
+                score_id=score.score_id,
+                cleanup_result_id=DIGEST,
+                rescue_required=False,
+                failure_kind=failure_kind,  # pyright: ignore[reportArgumentType]
+            ),
+            monotonic_ns=moment,
+            wall_time_ms=moment,
+        )
+    return root
+
+
+@pytest.mark.parametrize("failure_kind", ["crash", "infrastructure", "model", "cancelled"])
+def test_interrupted_episode_keeps_its_non_terminal_last_step(
+    tmp_path: Path, failure_kind: str
+) -> None:
+    """An episode that was stopped cannot also have ended deliberately.
+
+    Regression for ep-ffda3fc88f81: requiring a terminal step or a finish
+    action here made every interrupted run unsealable, so a paid 16-step
+    episode was thrown away wholesale.
+    """
+
+    root = _interrupted_bundle(tmp_path, failure_kind=failure_kind)
+    assert "finalization_invalid" not in codes(root)
+
+
+def test_completed_episode_still_needs_a_deliberate_ending(tmp_path: Path) -> None:
+    """The exemption is keyed on ``failure_kind``, so a clean run is unaffected.
+
+    Mutation guard: dropping the ``failure_kind`` condition and exempting every
+    terminal bundle would let an episode that simply stopped stepping claim a
+    normal completion.
+    """
+
+    root = _interrupted_bundle(tmp_path, failure_kind=None)
+    assert "finalization_invalid" in codes(root)
+
+
+def test_interruption_cannot_launder_a_scored_result(tmp_path: Path) -> None:
+    """A scored result never rides the interruption exemption.
+
+    The runner only seals a score with ``failure_kind=None``; this pins that a
+    bundle claiming BOTH a score and an interruption is still rejected, so the
+    exemption cannot be used to report a truncated run as a real score.
+    """
+
+    root = _interrupted_bundle(tmp_path, failure_kind="crash", scored=True)
+    assert "finalization_invalid" in codes(root)
+
+
+def _drop_events_rechain(root: Path, drop_kinds: set[str]) -> None:
+    """Remove events by kind and recompute the hash chain so only the named
+    events are missing -- every remaining record still validates and links.
+
+    Used to build scoring shapes the writer's phase machine refuses to emit
+    (a start with no result, a result with no start), so each clause of the
+    interruption exemption's ``unscored`` predicate can be pinned on its own.
+    """
+
+    events = [json.loads(line) for line in (root / "events.jsonl").read_bytes().splitlines()]
+    kept = [event for event in events if event["kind"] not in drop_kinds]
+    previous = manifest().manifest_digest
+    records = []
+    for sequence, event in enumerate(kept):
+        event = dict(event)
+        event["sequence"] = sequence
+        event["previous_event_sha256"] = previous
+        event["event_id"] = "0" * 64
+        record = EventRecord.model_validate(event, strict=True)
+        records.append(record.to_canonical_json())
+        previous = record.event_id
+    (root / "events.jsonl").write_bytes(b"\n".join(records) + b"\n")
+
+
+def _finalization_invalid_count(root: Path) -> int:
+    return sum(1 for issue in verify_bundle(root).issues if issue.code == "finalization_invalid")
+
+
+def test_scoring_start_without_result_still_refuses_interruption(tmp_path: Path) -> None:
+    """Pins the ``not starts`` clause of the exemption on its own.
+
+    Both laundering tests carry a scoring start AND a result together, so
+    dropping only ``not starts`` left them green. A bundle that opened scoring
+    (a ``scoring_start``) but never recorded a result still claims a run in
+    progress, so an interruption must not exempt it: with ``not starts`` gone
+    the exemption would fire here and the finalization_invalid disappears.
+    """
+
+    root = _interrupted_bundle(tmp_path, failure_kind="crash", scored=True)
+    _drop_events_rechain(root, {"scoring_result"})
+    assert "finalization_invalid" in codes(root)
+    # Exactly one: the exemption. Under the M4 mutation (drop ``not starts``)
+    # this count falls to zero.
+    assert _finalization_invalid_count(root) == 1
+
+
+def test_scoring_result_without_start_still_refuses_interruption(tmp_path: Path) -> None:
+    """Pins the ``not results`` clause of the exemption on its own.
+
+    Mirror of the start pin: a bundle carrying a scoring result but no start is
+    structurally invalid (one finalization_invalid), and the interruption
+    exemption must add a SECOND refusal because a result claims a completed
+    rollout. Dropping only ``not results`` (M5) exempts the bundle and the count
+    falls back to the single structural issue.
+    """
+
+    root = _interrupted_bundle(tmp_path, failure_kind="crash", scored=True)
+    _drop_events_rechain(root, {"scoring_start"})
+    assert "finalization_invalid" in codes(root)
+    # Two: the structural scoring violation plus the exemption. Under the M5
+    # mutation (drop ``not results``) this count falls to one.
+    assert _finalization_invalid_count(root) == 2

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -9,6 +9,7 @@ will take is indistinguishable from one that writes none.
 
 from __future__ import annotations
 
+import errno
 from pathlib import Path
 from typing import Any
 
@@ -22,7 +23,9 @@ from local_operator.evaluation.evidence.models import (
     ObservationPayload,
     ScoreArtifact,
 )
+from local_operator.evaluation.evidence.store import EvidenceWriter
 from local_operator.evaluation.evidence.verify import verify_bundle
+from local_operator.evaluation.receipts import RedactionSet
 from local_operator.evaluation.runner.episode import EpisodeRunner
 from tests.unit.evaluation.runner.conftest import (
     FakeAdapter,
@@ -910,3 +913,209 @@ async def test_zero_decision_retries_restores_one_strike(tmp_path: Path, episode
     assert outcome.status == "failed"
     assert outcome.score is not None and outcome.score.reason == "model_failure"
     assert model.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_crash_after_a_successful_step_still_seals(tmp_path: Path, episode_id: str) -> None:
+    """A run interrupted mid-loop keeps the evidence it already bought.
+
+    Regression for ep-ffda3fc88f81: a real paid episode drove 16 environment
+    steps, took an unretryable adapter error on the 17th, and lost ALL of it --
+    the bundle could neither seal nor be abandoned (``abandonment_failed``,
+    score null) because the verifier required a stepped episode to end on a
+    terminal step or a finish action, which is precisely what an interrupted
+    episode cannot produce. The failure is not adapter-specific: the same shape
+    killed a provider outage, so it is asserted here at the runner boundary.
+    """
+
+    adapter = FakeAdapter(
+        tmp_path,
+        episode_id,
+        failures={"execute": SupervisionError("worker died")},
+        fail_after={"execute": 1},
+    )
+    runner = _runner(
+        tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "step", "finish"])
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "failed"
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+    # The step that DID succeed is still in the bundle: that is the evidence
+    # the old behaviour threw away.
+    assert len(payloads(root, EnvironmentStepPayload)) == 1
+    assert outcome.score is not None and outcome.score.reason == "crash"
+
+
+@pytest.mark.asyncio
+async def test_provider_failure_after_a_step_still_seals(tmp_path: Path, episode_id: str) -> None:
+    """The same interruption through a non-adapter category."""
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    model = ScriptedModel(["step", "step", "finish"])
+    original = model.decide
+    calls = {"n": 0}
+
+    async def decide(observation: Any, history: Any) -> Any:
+        calls["n"] += 1
+        if calls["n"] > 1:
+            raise RuntimeError("provider exhausted retries")
+        return await original(observation, history)
+
+    model.decide = decide  # type: ignore[method-assign]
+    runner = _runner(tmp_path, episode_id, adapter=adapter, model=model)
+
+    outcome = await runner.run()
+
+    assert outcome.status == "failed"
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+    assert outcome.score is not None and outcome.score.reason == "infrastructure_failure"
+
+
+@pytest.mark.asyncio
+async def test_fatal_error_records_a_bounded_diagnostic_detail(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """An unretryable failure must be diagnosable without a paid rerun.
+
+    ``diagnostic_code`` is derived from the exception CLASS, so the real
+    episode recorded only "rpcremoteerror" with a null ``detail_artifact`` --
+    enough to bucket the failure, never enough to explain it.
+    """
+
+    adapter = FakeAdapter(
+        tmp_path,
+        episode_id,
+        failures={"execute": SupervisionError("worker died mid-observe")},
+        fail_after={"execute": 1},
+    )
+    runner = _runner(
+        tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "step", "finish"])
+    )
+
+    outcome = await runner.run()
+
+    root = outcome.bundle_root
+    assert root is not None
+    assert verify_bundle(root).valid
+    fatal = [error for error in payloads(root, ErrorPayload) if not error.retryable]
+    assert len(fatal) == 1
+    assert fatal[0].diagnostic_code == "supervisionerror"
+    detail = fatal[0].detail_artifact
+    assert detail is not None
+    text = (root / "artifacts" / detail.sha256).read_bytes().decode()
+    assert text == "SupervisionError: worker died mid-observe"
+    # Bounded: ``_diagnostic`` truncates, so a pathological message cannot
+    # inflate the bundle.
+    assert detail.byte_count <= 500
+
+
+@pytest.mark.asyncio
+async def test_fatal_diagnostic_detail_cannot_carry_a_resolved_secret(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """The detail is scanned against the episode's redaction set like any artifact."""
+
+    secret = "s3cret-value-that-must-never-land-in-a-bundle"
+    adapter = FakeAdapter(
+        tmp_path,
+        episode_id,
+        failures={"execute": SupervisionError(f"worker died using {secret}")},
+        fail_after={"execute": 1},
+    )
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path, max_steps=4),
+        selector=selector(tmp_path),
+        model=ScriptedModel(["step", "step", "finish"]),
+        redactions=RedactionSet.from_resolved_values((secret,)),
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+
+    outcome = await runner.run()
+
+    root = outcome.bundle_root
+    assert root is not None
+    # The leak must not reach disk anywhere in the bundle.
+    for path in root.rglob("*"):
+        if path.is_file():
+            assert secret.encode() not in path.read_bytes(), path
+    # And refusing the detail must not cost the bundle its terminal.
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+    fatal = [error for error in payloads(root, ErrorPayload) if not error.retryable]
+    assert len(fatal) == 1
+    assert fatal[0].detail_artifact is None
+
+
+@pytest.mark.asyncio
+async def test_detail_publish_os_error_cannot_escape_the_failure_handler(
+    tmp_path: Path,
+    episode_id: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A disk failure while publishing the fatal-error detail must not lose the terminal.
+
+    Regression for the round-1 review (R1-1): ``publish_artifact`` poisons the
+    writer and re-raises a RAW ``OSError`` on ambiguous I/O (ENOSPC/EIO), and
+    ``_publish`` converts only ``EvidenceError`` -- so before the catch at the
+    detail site was widened, an OSError there escaped ``_finalize_failure`` and
+    propagated out of ``run()``: the caller got a bare exception, no
+    ``EpisodeOutcome``, and a bundle with its steps but no terminal. That is the
+    exact "failure handler destroys the bundle's terminal" shape this PR exists
+    to remove, gated on a disk error instead of an adapter error.
+
+    The promise is best-effort publication, never best-effort terminal: the
+    detail may be lost, but ``run()`` must still return a structured outcome and
+    the bundle must stay recoverable (a fresh process can still abandon it).
+    """
+
+    detail_bytes = b"SupervisionError: worker died"
+    adapter = FakeAdapter(
+        tmp_path,
+        episode_id,
+        failures={"execute": SupervisionError("worker died")},
+        fail_after={"execute": 1},
+    )
+    runner = _runner(
+        tmp_path, episode_id, adapter=adapter, model=ScriptedModel(["step", "step", "finish"])
+    )
+
+    real_publish = EvidenceWriter.publish_artifact
+
+    def faulty_publish(self: Any, source: Any, *, media_type: str, **kwargs: Any) -> Any:
+        if bytes(source) == detail_bytes:
+            # The store's real contract on ambiguous I/O: poison, then re-raise
+            # the raw OSError (store.py publish_artifact).
+            self._poison()  # pyright: ignore[reportPrivateUsage]
+            raise OSError(errno.ENOSPC, "No space left on device")
+        return real_publish(self, source, media_type=media_type, **kwargs)
+
+    monkeypatch.setattr(EvidenceWriter, "publish_artifact", faulty_publish)
+
+    # Pre-fix this raised OSError out of run(); the fix returns an outcome.
+    outcome = await runner.run()
+
+    assert outcome.status == "abandonment_failed"
+    root = outcome.bundle_root
+    assert root is not None
+    # The evidence the episode already bought is still on disk.
+    report = verify_bundle(root)
+    assert len([e for e in report.events if isinstance(e.payload, EnvironmentStepPayload)]) == 1
+    # And the bundle is recoverable: a fresh process can still abandon it, so
+    # the terminal is reachable even though this run could not record it.
+    recovered = EvidenceWriter.open_for_abandon(root, RedactionSet.from_resolved_values(()))
+    try:
+        record = recovered.abandon("infrastructure_failure", "evidence-write-failed")
+    finally:
+        recovered.close()
+    assert record.reason == "infrastructure_failure"
+    assert verify_bundle(root).terminal_state == "abandoned"


### PR DESCRIPTION
## Consolidates PR #581

This PR now also carries **PR #581** (`dev-seal-finalization`, head
`4d6718a7`), which independently diagnosed the same root cause and fixed the
same `verify.py` hunk. The two fixes were merged here:

- The **stricter guard from this PR is the one shipped** — it is a superset of
  #581's: besides `failure_kind` on the terminal snapshot it additionally
  requires the bundle to be unscored (no scoring start, no scoring result,
  outcome not scored), which blocks the score-laundering shape #581's guard
  did not explicitly pin.
- The comment above the guard folds in #581's prose where it explains the
  mechanism more precisely (the hash-chain argument for why `failure_kind`
  is not a weaker explanation than a rollout-completion marker).
- **Both test files are kept**: #581's `tests/unit/evaluation/evidence/
  test_finalization.py` (seal/abandon paths, forged-finalization rejection,
  the scored-bundle-with-failure_kind pin) alongside this PR's additions to
  `test_verify.py` and `test_episode.py`. No #581 test asserted the weaker
  semantics — its crash bundles are unscored by construction, so they pass
  under the stricter guard unchanged.
- One `chore(release)` at tip: **0.45.1**, strictly above main (0.44.56),
  PyPI (0.44.56), and every open PR head (re-checked at bump and at push;
  highest was 0.45.0 on #576). Both source branches claimed 0.44.57.

PR #581 is closed as superseded by this one.

## What broke a real paid episode

Episode `ep-ffda3fc88f81` drove 16 environment steps on a live cloud desktop
(37 artifacts, 7.9 MB of frames, every step chained to the last), took an
unretryable adapter RPC error on the 17th, and lost **all of it**:

```
status: "abandonment_failed"
diagnostic: "EvidenceBundleInvalid: bundle failed independent seal verification;
             abandonment refused: EvidenceBundleInvalid: bundle failed independent
             abandonment verification"
score: null, reportability_label: null
```

Independent `verify_bundle` reported exactly one issue:
`code='finalization_invalid' severity='error' location='events.jsonl'`.

## Proven mechanism (reproduced cloud-free)

The RPC error ended the run — but it is **not** what made the run worthless.
The verifier required every episode that ever stepped to end *deliberately*:
its last step must be terminal (`terminated`/`truncated`) or a `finish` action
must be present (`verify.py`'s terminal check). An episode interrupted
mid-loop — adapter crash, provider outage, operator cancel — ends after an
ordinary non-terminal step, because the thing that would have produced the
terminal step is exactly what broke. So the bundle could neither seal nor be
abandoned, and the runner reported `abandonment_failed`.

Reproduced end-to-end with the real runner + `FakeAdapter` (no AWS): crash on
the second `execute` yields byte-identical `status`, `diagnostic`, and the same
`finalization_invalid` issue. The same shape kills a provider outage, so this
is not adapter-specific.

The fix is at the **verifier layer** and is benchmark-agnostic.

## Changes

1. **`verify.py`** — exempt exactly the interrupted case, keyed on the terminal
   snapshot's `failure_kind` (set on failure/cancel paths, `None` on a clean
   completion). The exemption additionally requires the bundle to be **unscored**,
   so a run that stopped early can never launder itself into a reportable score.
2. **`episode.py`** — record a bounded, redaction-scanned `detail_artifact` on
   the fatal error. `diagnostic_code` is derived from the exception *class*, so
   the paid episode recorded only `rpcremoteerror` with a null detail — enough
   to bucket a failure, never enough to diagnose one without paying for the run
   again. Publication is best-effort: it must never be the reason a bundle loses
   its terminal.

## Verification

- **Real bundle**: `verify_bundle(ep-ffda3fc88f81)` now returns `valid=True`,
  `issues=[]` (was `finalization_invalid`). Read-only; evidence untouched.
- **Regression tests** (`test_episode.py`): crash after a successful step seals;
  provider failure after a step seals; fatal error records a bounded diagnostic
  detail; a resolved secret cannot reach the bundle via that detail.
- **Verifier tests** (`test_verify.py`): interrupted episodes keep their
  non-terminal last step (crash/infrastructure/model/cancelled); a clean
  completion still needs a deliberate ending; an interruption cannot launder a
  scored result.
- **Finalization tests** (`test_finalization.py`, from #581): a crash
  mid-rollout verifies and seals unscored; the abandonment fallback succeeds on
  a recovered crash bundle; a crash bundle missing its terminal event still
  refuses; a truncated rollout without `failure_kind` still refuses; a scored
  bundle carrying a `failure_kind` still requires a completed rollout.
- **Mutation-proven on the consolidated head, both ways**: reverting the
  exemption to the original unconditional invariant fails 10 tests across both
  PRs' suites; dropping the unscored requirement from the exemption fails both
  laundering pins (`test_interruption_cannot_launder_a_scored_result` and
  `test_scored_bundle_with_failure_kind_still_requires_completed_rollout`).

## Gates (whole tree, as CI)

- `flake8` clean, `black --check` clean, `isort --check` clean, `pyright` 0 errors
- `tests/unit`: **11517 passed, 15 skipped**
- `tests/unit/evaluation`: **728 passed**
- `tests/e2e -m e2e -n0`: **4 passed**

## Retryability judgment (deliberate non-change)

The task asked whether the adapter error should be retried. It should **not**:
`execute` is a mutating call, and the supervisor poisons the session on any
failure of a mutating call (`_mutating_call` → `_poison_after_ambiguous_mutation`).
Retrying a possibly-applied mutation would double-apply the action and corrupt
the environment state the verifier tracks. The correct fix is to make the
*interruption* survivable (this PR), not to make the error retryable. The
worker's durable operation-replay cache already makes a *clean* retry of a
keyed method idempotent at the RPC layer; the poison gate is what prevents a
*dirty* retry, and that is the right behaviour.
