### PR TITLE
refactor(release): remove required-reviewer gate from store release workflows

### DIFF
--- a/.github/workflows/chrome-web-store-promote.yml
+++ b/.github/workflows/chrome-web-store-promote.yml
@@ -22,9 +22,13 @@ concurrency:
 jobs:
   promote:
     runs-on: ubuntu-latest
-    # Promotion is a distinct, explicit launch decision. Keep this environment
-    # protected even if staging already required approval so review completion
-    # cannot make a public release happen automatically.
+    # Promotion is a distinct, explicit launch decision: dispatching this
+    # workflow is the act of publishing. The environment's former
+    # required-reviewer gate was removed by operator decision on 2026-09-03, so
+    # once dispatched, promotion completes automatically; the environment still
+    # scopes the release variables and the main-only deployment branch policy,
+    # and the launch decision rides on the reviewed-merge-to-main process plus
+    # the WIF attribute condition pinning refs/heads/main.
     environment: chrome-web-store-production
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/chrome-web-store.yml
+++ b/.github/workflows/chrome-web-store.yml
@@ -26,9 +26,13 @@ concurrency:
 jobs:
   stage:
     runs-on: ubuntu-latest
-    # Protect this environment with required reviewers. Uploading creates the
-    # store draft and submission, so authentication must not happen before the
-    # human release decision even though approval cannot expose a long-lived key.
+    # The environment scopes the release variables and the main-only deployment
+    # branch policy; its former required-reviewer gate was removed by operator
+    # decision on 2026-09-03 so a store release runs end to end automatically.
+    # The launch decision now rides on the reviewed-merge-to-main process,
+    # enforced by the WIF attribute condition pinning refs/heads/main and the
+    # ancestry check below. Uploading creates the store draft and submission, so
+    # only reviewed commits on main may reach the token-bearing upload client.
     environment: chrome-web-store
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -39,9 +43,10 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --no-tags origin main
-          # Environment approval protects credentials, but it must not authorize
-          # arbitrary branch code. Only reviewed commits already on main may run
-          # the build and the token-bearing upload client.
+          # With no human approval gate on the environment, this ancestry check
+          # and the WIF attribute condition pinning refs/heads/main are what keep
+          # arbitrary branch code away from the credentials: only reviewed commits
+          # already on main may run the build and the token-bearing upload client.
           git merge-base --is-ancestor HEAD origin/main || {
             echo "::error::the selected ref must resolve to a commit on main"
             exit 1

--- a/docs/store/submission-checklist.md
+++ b/docs/store/submission-checklist.md
@@ -305,11 +305,22 @@ client secret, refresh token, or third-party upload action, and do not bump the
 pinned action SHAs without reviewing the new revision.
 
 Both workflows **fail closed**: before authenticating they verify through the
-GitHub API that their environment exists with at least one required reviewer
-and a custom deployment branch policy allowing exactly `main`, and that every
-release variable is defined **on the environment itself**. Repository- or
-organization-scoped copies are rejected so nobody can bypass environment
-protection by defining the same names at a broader scope.
+GitHub API that their environment exists with a custom deployment branch
+policy allowing exactly `main`, and that every release variable is defined
+**on the environment itself**. Repository- or organization-scoped copies are
+rejected so nobody can bypass environment protection by defining the same
+names at a broader scope.
+
+The environments previously also carried at least one required reviewer, and
+that human gate was removed by deliberate operator decision on 2026-09-03 so
+a store release completes end to end automatically. Do not re-add it without
+reopening that decision. The protections that remain are the real boundary:
+the WIF attribute condition pinning the numeric repository ID and
+`refs/heads/main` (so only reviewed code on main can mint a token), the
+exact-main deployment branch policy, the environment-scoped variables, and
+each workflow's own `git merge-base --is-ancestor HEAD origin/main` check.
+The launch decision now rides on the reviewed-merge-to-main process plus that
+WIF ref pin.
 
 Define these environment variables (identifiers, not secrets) on **each** of
 `chrome-web-store` and `chrome-web-store-production`:
@@ -338,25 +349,31 @@ assertion.repository_id == "922327641" && assertion.ref == "refs/heads/main"
 ```
 
 Grant the pool principal `roles/iam.workloadIdentityUser` on the service
-account scoped with the same `attribute.repository_id` value. Configure
-required reviewers on both GitHub environments; production should use the
-stricter launch approvers. Dispatch both workflows from `main` — the WIF ref
-condition and each workflow's own main-ancestry check reject anything else.
+account scoped with the same `attribute.repository_id` value. Do **not**
+configure required reviewers on either GitHub environment — the human approval
+gate was removed by operator decision on 2026-09-03 (see above); each
+environment keeps its custom deployment branch policy allowing exactly `main`
+and its environment-scoped variables. Dispatch both workflows from `main` —
+the WIF ref condition and each workflow's own main-ancestry check reject
+anything else.
 
 1. Run **Chrome Web Store staged release** manually with a commit/tag already on
-   `main` and the exact manifest version. After environment approval it installs
-   frozen dependencies, runs typecheck/tests, builds exactly the source-map-free
-   zip, verifies manifest/package/input versions and an explicit zip allowlist,
-   uploads it, and submits with `STAGED_PUBLISH` at 100% deployment. If the
+   `main` and the exact manifest version. With no environment approval gate it
+   runs immediately: it installs frozen dependencies, runs typecheck/tests,
+   builds exactly the source-map-free zip, verifies manifest/package/input
+   versions and an explicit zip allowlist, uploads it, and submits with
+   `STAGED_PUBLISH` at 100% deployment. If the
    store reports the upload as asynchronous, the run fails closed — the API's
    global upload status cannot be bound to this zip — and is safe to re-run
    once processing finishes.
 2. Wait for Chrome review and verify `fetchStatus` reports that exact version as
    `STAGED`. Review the approved package/listing before launch.
-3. Run **Promote staged Chrome Web Store release** with that exact version. Its
-   separate protected production environment is the explicit launch approval;
-   it refuses non-staged, mismatched, or partially-deployed versions and
-   verifies the result is `PUBLISHED` at 100% deployment.
+3. Run **Promote staged Chrome Web Store release** with that exact version. The
+   dispatch itself is the explicit launch decision — the production
+   environment no longer pauses for a human approver (removed by operator
+   decision on 2026-09-03) — and the run refuses non-staged, mismatched, or
+   partially-deployed versions and verifies the result is `PUBLISHED` at 100%
+   deployment.
 
 The existing GitHub Release asset behavior remains unchanged and independent of
 store publication.

--- a/extension/scripts/verify-release-environment.sh
+++ b/extension/scripts/verify-release-environment.sh
@@ -37,13 +37,18 @@ get_github_json() {
 get_github_json "environments/$ENVIRONMENT_NAME" "$tmp_dir/environment.json"
 
 # Merely naming an environment in workflow YAML creates an unprotected one on a
-# typo. Required reviewers and an exact main-only deployment policy therefore
-# have to be observed through GitHub's API before OIDC authentication can run.
-jq -e '
-  (.protection_rules // [])
-  | any(.type == "required_reviewers" and ((.reviewers // []) | length > 0))
-' "$tmp_dir/environment.json" >/dev/null \
-  || fail "$ENVIRONMENT_NAME must have at least one required reviewer"
+# typo, so the exact main-only deployment policy has to be observed through
+# GitHub's API before OIDC authentication can run.
+#
+# A "required reviewers" protection rule used to be enforced here as well. It
+# was removed by operator decision on 2026-09-03 so a store release completes
+# end to end without a human approval pause. Do not re-add it thinking it was
+# lost: the retained boundary is the GCP Workload Identity Federation
+# attribute condition, which mints a token only for the pinned numeric
+# repository ID on refs/heads/main, combined with this script's exact-main
+# deployment-branch-policy check, the environment-scoped variable check below,
+# and each workflow's own merge-base ancestry check. The launch decision now
+# rides on the reviewed-merge-to-main process that the WIF ref pin enforces.
 jq -e '
   .deployment_branch_policy.protected_branches == false
   and .deployment_branch_policy.custom_branch_policies == true
@@ -73,5 +78,5 @@ while [[ $# -gt 0 ]]; do
     || fail "$name does not match the environment-scoped value on $ENVIRONMENT_NAME"
 done
 
-printf 'validated protected environment %s (required reviewer, main-only, environment-scoped variables)\n' \
+printf 'validated protected environment %s (main-only, environment-scoped variables)\n' \
   "$ENVIRONMENT_NAME"

--- a/extension/tests/release.test.mjs
+++ b/extension/tests/release.test.mjs
@@ -176,50 +176,105 @@ test("promotion refuses a staged revision below 100 percent", async () => {
   );
 });
 
-test("protected environment verifier rejects a non-custom branch policy and accepts exact configuration", async () => {
-  // The required-reviewers check was removed by operator decision on
-  // 2026-09-03 (see verify-release-environment.sh), so the rejection path now
-  // exercises the remaining environment-level guard: the custom
-  // deployment-branch-policy shape that allows exactly `main`.
-  let validBranchPolicy = false;
+// The required-reviewers check was removed by operator decision on 2026-09-03
+// (see verify-release-environment.sh). Every guard that REMAINS is asserted
+// here one mutation at a time, because a suite that only covers the accept
+// path plus one rejection stays green when a retained guard is deleted — and
+// these guards are now the whole fail-closed contract, so a silent regression
+// in one of them is exactly what would let an unprotected environment mint a
+// release token. Each case perturbs a single field of the valid configuration.
+const VALID_ENVIRONMENT = {
+  deployment_branch_policy: { protected_branches: false, custom_branch_policies: true },
+};
+const VALID_BRANCHES = { total_count: 1, branch_policies: [{ name: "main", type: "branch" }] };
+const VALID_VARIABLES = {
+  variables: [
+    { name: "CWS_EXTENSION_ID", value: extensionId },
+    { name: "CWS_PUBLISHER_ID", value: "publisher" },
+  ],
+};
+
+async function runVerifier({ environment = VALID_ENVIRONMENT, branches = VALID_BRANCHES, variables = VALID_VARIABLES } = {}) {
   const server = createServer((request, response) => {
     let payload;
-    if (request.url.endsWith("/environments/chrome-web-store")) {
-      payload = {
-        deployment_branch_policy: validBranchPolicy
-          ? { protected_branches: false, custom_branch_policies: true }
-          : { protected_branches: true, custom_branch_policies: false },
-      };
-    } else if (request.url.includes("deployment-branch-policies")) {
-      payload = { total_count: 1, branch_policies: [{ name: "main", type: "branch" }] };
+    if (request.url.includes("deployment-branch-policies")) {
+      payload = branches;
+    } else if (request.url.includes("/variables")) {
+      payload = variables;
     } else {
-      payload = {
-        variables: [
-          { name: "CWS_EXTENSION_ID", value: extensionId },
-          { name: "CWS_PUBLISHER_ID", value: "publisher" },
-        ],
-      };
+      payload = environment;
     }
     response.writeHead(200, { "Content-Type": "application/json" }).end(JSON.stringify(payload));
   });
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
-  const env = {
-    ...process.env,
-    GITHUB_TOKEN: "test-token",
-    GITHUB_REPOSITORY: "owner/repository",
-    GITHUB_API_URL: `http://127.0.0.1:${server.address().port}`,
-  };
-  const args = [
-    "scripts/verify-release-environment.sh", "chrome-web-store",
-    "CWS_EXTENSION_ID", extensionId,
-    "CWS_PUBLISHER_ID", "publisher",
-  ];
   try {
-    await assert.rejects(run("bash", args, { cwd: import.meta.dirname + "/..", env }), /custom deployment branch policy/);
-    validBranchPolicy = true;
-    const result = await run("bash", args, { cwd: import.meta.dirname + "/..", env });
-    assert.match(result.stdout, /validated protected environment chrome-web-store/);
+    return await run("bash", [
+      "scripts/verify-release-environment.sh", "chrome-web-store",
+      "CWS_EXTENSION_ID", extensionId,
+      "CWS_PUBLISHER_ID", "publisher",
+    ], {
+      cwd: import.meta.dirname + "/..",
+      env: {
+        ...process.env,
+        GITHUB_TOKEN: "test-token",
+        GITHUB_REPOSITORY: "owner/repository",
+        GITHUB_API_URL: `http://127.0.0.1:${server.address().port}`,
+      },
+    });
   } finally {
     await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
   }
+}
+
+test("protected environment verifier accepts the exact configuration", async () => {
+  const result = await runVerifier();
+  assert.match(result.stdout, /validated protected environment chrome-web-store/);
+});
+
+test("protected environment verifier requires a custom deployment branch policy", async () => {
+  await assert.rejects(
+    runVerifier({ environment: { deployment_branch_policy: { protected_branches: true, custom_branch_policies: false } } }),
+    /must use a custom deployment branch policy/,
+  );
+});
+
+test("protected environment verifier requires exactly the main branch", async () => {
+  // Both halves matter: an extra allowed branch is a bypass, and a single
+  // policy naming something other than main is a different bypass.
+  await assert.rejects(
+    runVerifier({
+      branches: {
+        total_count: 2,
+        branch_policies: [{ name: "main", type: "branch" }, { name: "release/*", type: "branch" }],
+      },
+    }),
+    /must allow exactly the main branch/,
+  );
+  await assert.rejects(
+    runVerifier({ branches: { total_count: 1, branch_policies: [{ name: "develop", type: "branch" }] } }),
+    /must allow exactly the main branch/,
+  );
+});
+
+test("protected environment verifier requires every variable at environment scope", async () => {
+  // A variable absent from the environment listing is the repository- or
+  // organization-scoped case the script exists to reject.
+  await assert.rejects(
+    runVerifier({ variables: { variables: [{ name: "CWS_PUBLISHER_ID", value: "publisher" }] } }),
+    /CWS_EXTENSION_ID must be defined on chrome-web-store/,
+  );
+});
+
+test("protected environment verifier rejects a variable whose value drifted", async () => {
+  await assert.rejects(
+    runVerifier({
+      variables: {
+        variables: [
+          { name: "CWS_EXTENSION_ID", value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+          { name: "CWS_PUBLISHER_ID", value: "publisher" },
+        ],
+      },
+    }),
+    /CWS_EXTENSION_ID does not match the environment-scoped value/,
+  );
 });

--- a/extension/tests/release.test.mjs
+++ b/extension/tests/release.test.mjs
@@ -176,14 +176,19 @@ test("promotion refuses a staged revision below 100 percent", async () => {
   );
 });
 
-test("protected environment verifier rejects missing reviewers and accepts exact configuration", async () => {
-  let protectedEnvironment = false;
+test("protected environment verifier rejects a non-custom branch policy and accepts exact configuration", async () => {
+  // The required-reviewers check was removed by operator decision on
+  // 2026-09-03 (see verify-release-environment.sh), so the rejection path now
+  // exercises the remaining environment-level guard: the custom
+  // deployment-branch-policy shape that allows exactly `main`.
+  let validBranchPolicy = false;
   const server = createServer((request, response) => {
     let payload;
     if (request.url.endsWith("/environments/chrome-web-store")) {
       payload = {
-        protection_rules: protectedEnvironment ? [{ type: "required_reviewers", reviewers: [{ id: 1 }] }] : [],
-        deployment_branch_policy: { protected_branches: false, custom_branch_policies: true },
+        deployment_branch_policy: validBranchPolicy
+          ? { protected_branches: false, custom_branch_policies: true }
+          : { protected_branches: true, custom_branch_policies: false },
       };
     } else if (request.url.includes("deployment-branch-policies")) {
       payload = { total_count: 1, branch_policies: [{ name: "main", type: "branch" }] };
@@ -210,8 +215,8 @@ test("protected environment verifier rejects missing reviewers and accepts exact
     "CWS_PUBLISHER_ID", "publisher",
   ];
   try {
-    await assert.rejects(run("bash", args, { cwd: import.meta.dirname + "/..", env }), /required reviewer/);
-    protectedEnvironment = true;
+    await assert.rejects(run("bash", args, { cwd: import.meta.dirname + "/..", env }), /custom deployment branch policy/);
+    validBranchPolicy = true;
     const result = await run("bash", args, { cwd: import.meta.dirname + "/..", env });
     assert.match(result.stdout, /validated protected environment chrome-web-store/);
   } finally {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.63"
+version = "0.44.64"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
# PR Description

## Summary of Changes

Removes the human required-reviewer gate from the Chrome Web Store release
workflows so a store release runs end to end automatically, per an explicit
operator decision on 2026-09-03. The `chrome-web-store.yml` dispatch for
extension 0.1.7 paused at the `chrome-web-store` environment's reviewer gate;
the operator judged that approval excess and directed that both the stage and
promote environments run without a human reviewer, now and going forward.

- `extension/scripts/verify-release-environment.sh` drops the
  `required_reviewers` protection-rule check. Every other fail-closed guard
  stays: the environment must use a custom deployment branch policy, the
  policy must allow **exactly** `main`, and every release variable must be
  defined on the environment itself (repository/organization scope is
  rejected). The header comment now records why the gate was removed and what
  the retained boundary is, so a future reader does not re-add it thinking it
  was lost.
- `.github/workflows/chrome-web-store.yml` and
  `chrome-web-store-promote.yml`: comments updated to describe the new model
  honestly — the environments still scope the variables and the branch policy;
  the launch decision now rides on the reviewed-merge-to-main process plus the
  WIF ref pin. No job steps changed.
- `docs/store/submission-checklist.md`: the "Automated updates after the first
  public release" section and the setup instructions now state that no
  required reviewers are configured, name the protections that remain, and
  date the removal as a deliberate operator decision (2026-09-03).
- `extension/tests/release.test.mjs`: the verifier test previously asserted
  rejection of an environment without required reviewers; it now exercises the
  remaining environment-level rejection path (a non-custom deployment branch
  policy) and still asserts acceptance of the exact configuration.

## Security model — what changed and what did not

The real boundary was never the reviewer gate; it is the GCP Workload Identity
Federation attribute condition, which mints a token only for the pinned
numeric repository ID (`922327641`) on `refs/heads/main`. That condition, the
exact-main deployment branch policy, the environment-scoped variable check,
and each workflow's own `git merge-base --is-ancestor HEAD origin/main` check
are all unchanged. Only reviewed code on main can reach the token-bearing
upload client; the reviewer was a human-decision layer on top, and that layer
is what this PR removes.

## Related Issue(s)

- None (operator-directed change; no issue filed).

## Impact

- No breaking changes. No dependency updates. No changes to the extension
  manifest, permissions, or store package contents.
- Security implication: deliberate and scoped — the human approval pause is
  removed; the machine-enforced boundary (WIF ref pin + main-only policy +
  env-scoped variables + ancestry checks) is retained verbatim.
- The GitHub environment reviewer configuration itself is removed separately
  by the operator via the API after this merges; nothing in this PR touches
  live environment settings, and no store workflow is dispatched here.

## Testing Details

Real execution, not inference:

- `extension/tests/release.test.mjs` rewritten verifier test run against the
  modified script through a local HTTP mock of the GitHub API: the rejection
  path (`must use a custom deployment branch policy`) and the acceptance path
  (`validated protected environment chrome-web-store`) both verified. Full
  extension suite: **81/81 pass** (`pnpm test` after
  `pnpm install --frozen-lockfile`).
- `bash -n extension/scripts/verify-release-environment.sh` — syntax clean.
- Both modified workflow YAMLs parse cleanly (`yaml.safe_load`).
- Full Python gates exactly as CI, over the whole tree:
  - `flake8` — clean
  - `black --check` (26.1.0) — 832 files unchanged
  - `isort --check-only` (5.13.2) — clean
  - `pyright` — 0 errors, 0 warnings
  - `pytest tests/unit -q` — **11502 passed, 15 skipped** in 427s

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.
