### PR TITLE
feat(tools): coerce job_id shapes and resolve labels in wait and jobs

### DIFF
--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -7369,6 +7369,115 @@ class TaskParams(BaseModel):
         return self
 
 
+def _coerce_job_targets(value: Any) -> Any:
+    """Accept the string shapes models emit for job ids instead of a bare id or array.
+
+    Observed live in transcripts (e.g. with Gemini 3.8 Flash, or when quoting):
+    models pass ``job_id`` as a stringified list ``'["id1", "id2"]'`` or
+    unquoted bracketed string ``'[id1, id2]'``, or a single element list / string.
+    Unwraps JSON lists, unquoted bracketed strings, and lists with stringified items.
+    """
+
+    def _parse_str(text: str) -> list[str]:
+        text = text.strip()
+        if not text:
+            return []
+        if text.startswith("["):
+            try:
+                parsed = json.loads(text)
+            except ValueError:
+                parsed = None
+            if isinstance(parsed, list):
+                res: list[str] = []
+                for item in parsed:
+                    if isinstance(item, str):
+                        res.extend(_parse_str(item))
+                return res
+            inner = text[1:]
+            if inner.endswith("]"):
+                inner = inner[:-1]
+            items = [item.strip().strip("'\"") for item in inner.split(",")]
+            res = []
+            for item in items:
+                if item:
+                    res.extend(_parse_str(item) if item.startswith("[") else [item])
+            return res
+        return [text]
+
+    if isinstance(value, str):
+        items = _parse_str(value)
+        if len(items) == 1:
+            return items[0]
+        if len(items) > 1:
+            return items
+        return value
+    if isinstance(value, (list, tuple)):
+        items = []
+        for x in value:
+            if isinstance(x, str):
+                items.extend(_parse_str(x))
+            else:
+                items.append(x)
+        if len(items) == 1 and isinstance(items[0], str):
+            return items[0]
+        return items
+    return value
+
+
+def _coerce_single_job_id(value: Any) -> Any:
+    """Unwrap a single job ID from string, bracketed string, or list."""
+    if value is None:
+        return None
+    coerced = _coerce_job_targets(value)
+    if isinstance(coerced, list):
+        if len(coerced) == 1 and isinstance(coerced[0], str):
+            return coerced[0]
+        if len(coerced) == 0:
+            return ""
+        # If multiple were somehow provided to a single-id field, pick the first
+        return coerced[0] if isinstance(coerced[0], str) else str(coerced[0])
+    return coerced
+
+
+def _resolve_job_target(target: str, jobs: Any, comms: Any = None) -> tuple[str | None, str | None]:
+    """Resolve a target (canonical ID or label) to a canonical job ID.
+
+    Priority:
+    1. Direct match in jobs manager (ID).
+    2. Subagent comms resolution if comms available (resolves label or ID).
+    3. Label match among jobs in `jobs.list()`. If multiple match, prioritize running
+       jobs (`job.status == 'running'`), matching comms.resolve behavior.
+    Returns (job_id, error_message).
+    """
+    target = target.strip()
+    if not target:
+        return None, "empty target"
+    if jobs.get(target) is not None:
+        return target, None
+    if comms is not None and hasattr(comms, "resolve"):
+        try:
+            resolved, error = comms.resolve(target)
+            if error is None and len(resolved) == 1:
+                return resolved[0], None
+        except Exception:
+            pass
+    try:
+        all_jobs = jobs.list()
+    except Exception:
+        all_jobs = []
+    matches = [j for j in all_jobs if getattr(j, "label", None) == target]
+    if len(matches) == 1:
+        return matches[0].id, None
+    if len(matches) > 1:
+        live = [j for j in matches if getattr(j, "status", None) == "running"]
+        if len(live) == 1:
+            return live[0].id, None
+        if len(live) > 1:
+            return live[0].id, None
+        return matches[0].id, None
+    return None, f"unknown job {target}"
+
+
 class WaitParams(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -7379,6 +7488,12 @@ class WaitParams(BaseModel):
             "each child in turn."
         )
     )
+
+    @field_validator("job_id", mode="before")
+    @classmethod
+    def _coerce_job_id(cls, value: Any) -> Any:
+        return _coerce_job_targets(value)
+
     wait_ms: int = Field(
         # The ceiling and the default are sized to the work agents actually
         # await, not to a round-trip latency. Measured on this host's own
@@ -7419,6 +7534,12 @@ class JobsParams(BaseModel):
         default=None,
         description="Job to peek at or cancel (required for those ops).",
     )
+
+    @field_validator("job_id", mode="before")
+    @classmethod
+    def _coerce_job_id(cls, value: Any) -> Any:
+        return _coerce_single_job_id(value)
+
     since: int | None = Field(
         default=None,
         description=(
@@ -7577,11 +7698,22 @@ async def execute_wait(
             "wait",
             "job tracking is not available in this session (no job manager attached).",
         )
-    job_ids = [params.job_id] if isinstance(params.job_id, str) else list(params.job_id)
-    job_ids = [job_id for job_id in dict.fromkeys(job_ids) if job_id]
-    if not job_ids:
+    raw_ids = [params.job_id] if isinstance(params.job_id, str) else list(params.job_id)
+    raw_ids = [target for target in dict.fromkeys(raw_ids) if target]
+    if not raw_ids:
         return _error(tool_call_id, "wait", "no job id given")
-    missing = [job_id for job_id in job_ids if jobs.get(job_id) is None]
+
+    comms = context.subagent_comms if context else None
+    job_ids: list[str] = []
+    missing: list[str] = []
+    for target in raw_ids:
+        canonical_id, _err = _resolve_job_target(target, jobs, comms)
+        if canonical_id is not None and jobs.get(canonical_id) is not None:
+            if canonical_id not in job_ids:
+                job_ids.append(canonical_id)
+        else:
+            missing.append(target)
+
     if missing:
         return _error(tool_call_id, "wait", f"unknown job {', '.join(missing)}")
 
@@ -7988,11 +8120,15 @@ async def execute_jobs(
         # ``Session`` builds its own ``AsyncJobManager`` and nothing reassigns
         # a child's, so a child's manager never holds its parent's rows and
         # there is no cross-session id to reach in the first place.
-        job = jobs.get(params.job_id)
+        comms = context.subagent_comms if context else None
+        target = params.job_id
+        canonical_id, _err = _resolve_job_target(target, jobs, comms)
+        job = jobs.get(canonical_id) if canonical_id else None
         if job is None:
             return _error(tool_call_id, "jobs", f"unknown job {params.job_id}")
+        effective_id = job.id
         if params.op == "cancel":
-            cancelled = await jobs.cancel(params.job_id)
+            cancelled = await jobs.cancel(effective_id)
             if not cancelled:
                 # cancel() refuses a job that already settled, which is not a
                 # failure worth erroring on: the caller wanted it stopped and
@@ -8001,14 +8137,14 @@ async def execute_jobs(
                 return _text(
                     tool_call_id,
                     "jobs",
-                    f"job {params.job_id} was not cancelled (status: {job.status})",
-                    details={"job_id": params.job_id, "status": job.status, "cancelled": False},
+                    f"job {effective_id} was not cancelled (status: {job.status})",
+                    details={"job_id": effective_id, "status": job.status, "cancelled": False},
                 )
             return _text(
                 tool_call_id,
                 "jobs",
-                f"cancelled job {params.job_id} ({job.label})",
-                details={"job_id": params.job_id, "cancelled": True},
+                f"cancelled job {effective_id} ({job.label})",
+                details={"job_id": effective_id, "cancelled": True},
             )
         return _peek_job(tool_call_id, jobs, job, params.since or 0, context)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.58"
+version = "0.44.59"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tools/test_task_wait_jobs.py
+++ b/tests/unit/tools/test_task_wait_jobs.py
@@ -687,3 +687,91 @@ async def test_peek_and_cancel_reach_jobs_the_listing_shows(tmp_path):
     cancelled = await _call(tools, "jobs", {"op": "cancel", "job_id": grandchild}, context)
     assert cancelled.is_error is False, "cancel could not address a job the listing showed"
     await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_wait_and_jobs_coercion_and_label_resolution(tmp_path):
+    """Test job_id stringified list coercion and label resolution across wait and jobs."""
+    manager = AsyncJobManager()
+    quick_id = manager.register("task", "worker-fast", _quick_runner)
+    slow_id = manager.register("task", "worker-slow", _slow_runner)
+
+    context = ToolContext(cwd=str(tmp_path), session_id="s", jobs=manager)
+    tools = _tools(context)
+
+    # 1. wait with stringified list JSON: '["<job_id>"]'
+    waited_json = await _call(
+        tools, "wait", {"job_id": f'["{quick_id}"]', "wait_ms": 1000}, context
+    )
+    assert waited_json.is_error is False
+    assert waited_json.details is not None
+    assert waited_json.details["status"] == "completed"
+
+    # 2. wait with unquoted brackets: '[<job_id>]'
+    waited_unquoted = await _call(
+        tools, "wait", {"job_id": f"[{quick_id}]", "wait_ms": 1000}, context
+    )
+    assert waited_unquoted.is_error is False
+
+    # 3. wait with list of ids: ['<id1>', '<id2>']
+    waited_list = await _call(
+        tools, "wait", {"job_id": [quick_id, slow_id], "wait_ms": 1000}, context
+    )
+    assert waited_list.is_error is False
+    assert waited_list.details is not None
+    assert waited_list.details["status"] == "completed"
+
+    # 4. wait by label (worker-fast)
+    waited_by_label = await _call(
+        tools, "wait", {"job_id": "worker-fast", "wait_ms": 1000}, context
+    )
+    assert waited_by_label.is_error is False
+    assert waited_by_label.details is not None
+    assert waited_by_label.details["status"] == "completed"
+
+    # 5. jobs(op="peek") and jobs(op="cancel") with stringified list and by label
+    peek_json = await _call(tools, "jobs", {"op": "peek", "job_id": f'["{slow_id}"]'}, context)
+    assert peek_json.is_error is False
+
+    peek_label = await _call(tools, "jobs", {"op": "peek", "job_id": "worker-slow"}, context)
+    assert peek_label.is_error is False
+
+    cancel_label = await _call(tools, "jobs", {"op": "cancel", "job_id": "worker-slow"}, context)
+    assert cancel_label.is_error is False
+    assert (cancel_label.details or {})["cancelled"] is True
+
+    # 6. wait with truly unknown job still returns clean error
+    unknown_wait = await _call(
+        tools, "wait", {"job_id": '["nonexistent-job-xyz"]', "wait_ms": 100}, context
+    )
+    assert unknown_wait.is_error is True
+    assert "unknown job nonexistent-job-xyz" in unknown_wait.text
+
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_wait_by_label_prioritizes_running_job(tmp_path):
+    """When multiple jobs share a label, running job is prioritized over settled."""
+    manager = AsyncJobManager()
+    settled_id = manager.register("task", "duplicate-worker", _quick_runner)
+
+    def _settled() -> bool:
+        j = manager.get(settled_id)
+        return j is not None and j.status == "completed"
+
+    await wait_for(_settled)
+
+    running_id = manager.register("task", "duplicate-worker", _slow_runner)
+    await asyncio.sleep(0)
+
+    context = ToolContext(cwd=str(tmp_path), session_id="s", jobs=manager)
+    tools = _tools(context)
+
+    # Cancel by label should target the running job
+    cancelled = await _call(tools, "jobs", {"op": "cancel", "job_id": "duplicate-worker"}, context)
+    assert cancelled.is_error is False
+    assert (cancelled.details or {})["cancelled"] is True
+    assert (cancelled.details or {})["job_id"] == running_id
+
+    await manager.dispose()


### PR DESCRIPTION
## Summary
Fix an issue where `wait` (and `jobs` peek/cancel) tool calls fail with `unknown job ["<job_id>"]` across sessions when models (notably Gemini 3.8 Flash, or when quoting) pass `job_id` as a stringified list `'["deb693febe0b"]'` or unquoted bracketed list `'[deb693febe0b]'`.

Also adds label resolution to `wait` and `jobs`, matching the behavior in `hub`, so waiting on or peeking/cancelling by subagent label resolves to the canonical job id.

## Changes
1. **`local_operator/tools/builtin.py`**:
   - Added `_coerce_job_targets` and `_coerce_single_job_id` helpers to unwrap JSON arrays, unquoted bracketed strings, and stringified items.
   - Added before-validators on `WaitParams.job_id` and `JobsParams.job_id`.
   - Added `_resolve_job_target` to resolve targets by direct ID lookup, `context.subagent_comms.resolve(target)`, or matching `job.label` across registered jobs in `jobs.list()` (prioritizing running jobs when multiple match).
   - Updated `execute_wait` and `execute_jobs` to resolve targets before executing and reporting unknown jobs.
2. **`pyproject.toml`**: Bump version to `0.44.59`.
3. **`tests/unit/tools/test_task_wait_jobs.py`**:
   - Added unit tests for stringified lists, unquoted bracketed strings, list of IDs, wait by label, running job prioritization, and error cases.

## Testing Evidence
- Ran full test suite in `tests/unit/tools/test_task_wait_jobs.py`: 26 passed.
- All linters and type checkers clean: `flake8`, `black --check`, `isort --check`, `pyright`.
