### PR TITLE
feat(providers): make radient default to OAuth and radient-key for legacy API key

### DIFF
--- a/local_operator/providers/registry.py
+++ b/local_operator/providers/registry.py
@@ -463,23 +463,26 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
     ),
     ProviderDefinition(
         id="radient",
+        search_aliases=("radient-oauth",),
         name="Radient",
         env_keys="RADIENT_API_KEY",
-        login=create_api_key_login(
-            "Radient", "https://radienthq.com/", "The console calls it a Radient Pass key."
-        ),
-        base_url="https://api.radienthq.com/v1",
-    ),
-    ProviderDefinition(
-        id="radient-oauth",
-        name="Radient (OAuth)",
         login=_lazy_login("local_operator.providers.oauth.radient", "login_radient"),
         refresh_token=_lazy_refresh(
             "local_operator.providers.oauth.radient", "refresh_radient_token"
         ),
         get_api_key=_oauth_api_key,
-        store_credentials_as="radient",
         callback_port=54549,
+        base_url="https://api.radienthq.com/v1",
+    ),
+    ProviderDefinition(
+        id="radient-key",
+        search_aliases=("radient-api-key",),
+        name="Radient (API key)",
+        env_keys="RADIENT_API_KEY",
+        login=create_api_key_login(
+            "Radient", "https://radienthq.com/", "The console calls it a Radient Pass key."
+        ),
+        store_credentials_as="radient",
         base_url="https://api.radienthq.com/v1",
     ),
     ProviderDefinition(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.60"
+version = "0.44.61"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -1251,6 +1251,7 @@ class TestLoginFlavourAliases:
             ("xai-oauth", "xai"),
             ("openai-device", "openai"),
             ("alibaba-token-plan-oauth", "alibaba-token-plan"),
+            ("radient-key", "radient"),
             # The flavour the bug was actually reported for.
             ("zai-oauth", "zai"),
         ):

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -1102,7 +1102,7 @@ def test_paste_key_providers_declare_that_they_require_a_prompt() -> None:
         "google",
         "mistral",
         "openrouter",
-        "radient",
+        "radient-key",
         "alibaba",
         "alibaba-token-plan",
         "alibaba-token-plan-oauth",

--- a/tests/unit/providers/test_radient_oauth.py
+++ b/tests/unit/providers/test_radient_oauth.py
@@ -18,14 +18,16 @@ def test_radient_provider_definition():
     assert radient.id == "radient"
     assert radient.base_url == "https://api.radienthq.com/v1"
     assert radient.login is not None
+    assert radient.refresh_token is not None
+    assert radient.callback_port == 54549
+    assert "radient-oauth" in radient.search_aliases
 
-    oauth_def = get_provider_definition("radient-oauth")
-    assert oauth_def is not None
-    assert oauth_def.id == "radient-oauth"
-    assert oauth_def.store_credentials_as == "radient"
-    assert oauth_def.callback_port == 54549
-    assert oauth_def.login is not None
-    assert oauth_def.refresh_token is not None
+    key_def = get_provider_definition("radient-key")
+    assert key_def is not None
+    assert key_def.id == "radient-key"
+    assert key_def.store_credentials_as == "radient"
+    assert key_def.login is not None
+    assert key_def.paste_prompt_required is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Sets `radient` to the OAuth 2.0 PKCE sign-in flow by default (so `/login radient` opens the browser OAuth flow).
- Renames the legacy API key paste login to `radient-key` (`store_credentials_as='radient'`), preserving full backward compatibility.
- Ensures `radient` is suggested first in autocomplete before `radient-key`.
- Bumps version to `0.44.61`.

## Testing Evidence
- `tests/unit/providers/test_radient_oauth.py` verified definition attributes and AuthStore round-trip.
- `tests/unit/providers/test_oauth_flows.py` and `test_auth_store.py` verified provider gates and alias resolution.
- Target tests passing (184 passed). Full provider suite (846 passed), E2E suite (4 passed).
