### PR TITLE
feat(skills): improve skill protocol documentation, guidance, and discovery

### DIFF
--- a/local_operator/prompts_md/system.md
+++ b/local_operator/prompts_md/system.md
@@ -194,6 +194,14 @@ which mechanisms merely look authoritative; grepping the code instead is how
 you end up editing a file nothing reads. One read up front beats a confident
 wrong answer.
 
+Selected skills appear in `<skills>`. Skills provide domain-specific procedures,
+rules, and reference material for tasks and workflows. You MUST use the `read`
+tool with `skill://<name>` to read a skill's body, and `skill://<name>/<relpath>`
+to read its reference files (listed at the end of the skill body). You must
+NEVER search the filesystem, use bash (`find`, `ls`), or use glob/grep to find
+or inspect skills; always use `skill://` reads. If a skill name is unknown or
+missing, `read skill://` (or `read skill://<name>`) lists the available skills.
+
 Browser work goes through the `browser` tool when it is listed, and nowhere
 else. It drives the user's own browser, so logins and cookies persist between
 calls and between sessions and you can ask the user to sign in by hand and then

--- a/local_operator/skills/index.py
+++ b/local_operator/skills/index.py
@@ -287,9 +287,13 @@ def render_block(skills: list[Skill]) -> str:
         # virtual resource protocol. This cost stays local to selected skills.
         selected_urls = ", ".join(f"`{resource_url('skill', skill.name)}`" for skill in user_skills)
         lines = [
-            f"Read these selected skills before proceeding: {selected_urls}. The skill "
-            "body ends with its reference files; read those with "
-            "`skill://<name>/<path>`, never a raw filesystem path.",
+            (
+                "Skills provide domain-specific instructions and workflows. Read these selected "
+                f"skills immediately before proceeding: {selected_urls}. Do not search the "
+                "filesystem or use bash/glob to locate skills — skills are virtual resources "
+                "loaded only via `skill://`. The skill body ends with its reference files; read "
+                "those with `skill://<name>/<path>`, never a raw filesystem path."
+            ),
             "<skills>",
         ]
         lines.extend(f"- {skill.name}: {skill.description}" for skill in user_skills)

--- a/local_operator/skills/protocol.py
+++ b/local_operator/skills/protocol.py
@@ -392,7 +392,11 @@ def resolve_resource_url(
     name = unquote(parts.netloc)
     title = label.title()
     if not name:
-        raise ValueError(f"{title} URL missing a name: expected {scheme}://<name>")
+        available = ", ".join(sorted(resources.keys())) or "(none)"
+        raise ValueError(
+            f"{title} URL missing a name: expected {scheme}://<name>\n"
+            f"Available {label}s: {available}"
+        )
 
     resource = resources.get(name)
     if resource is None:

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -2349,7 +2349,21 @@ async def execute_read(
     cwd = _safe_cwd(context)
     path, inside, resolvable = _resolve_workspace_path(target, cwd)
     if not path.exists():
-        return _error(tool_call_id, "read", f"Path does not exist: {path}")
+        message = f"Path does not exist: {path}"
+        # Skills are virtual resources, not files on disk. Point the agent to
+        # skill://<name> when it tries to read a discovered or guessed SKILL.md.
+        folded_parts = [p.casefold() for p in path.parts]
+        if "skills" in folded_parts and path.name.casefold() == "skill.md":
+            skill_name = path.parent.name
+            resource = (
+                f"skill://{skill_name}"
+                if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", skill_name)
+                else "skill://<name>"
+            )
+            message += (
+                f". Skills are virtual resources loaded via `skill://`: read with `{resource}`."
+            )
+        return _error(tool_call_id, "read", message)
 
     # Outside-workspace reads escalate to an approval prompt regardless of
     # the read tier auto-approval the host normally applies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.61"
+version = "0.44.62"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/skills/test_api.py
+++ b/tests/unit/skills/test_api.py
@@ -101,6 +101,17 @@ class TestMakeSkillResolver:
         assert content is not None
         assert "# alpha" in content
 
+    def test_empty_name_returns_error_message_with_available_skills(self, tmp_path: Path) -> None:
+        skills = {
+            "alpha": _make_skill(tmp_path, "alpha"),
+            "beta": _make_skill(tmp_path, "beta"),
+        }
+        resolver = make_skill_resolver(skills)
+        content = resolver("skill://")
+        assert content is not None
+        assert "missing a name" in content
+        assert "Available skills: alpha, beta" in content
+
     def test_unknown_name_returns_error_message_as_content(self, tmp_path: Path) -> None:
         # RS-09: the adapter never raises; the available-names list reaches
         # the model as a clean tool result instead of an exception envelope.

--- a/tests/unit/skills/test_index.py
+++ b/tests/unit/skills/test_index.py
@@ -291,9 +291,11 @@ class TestRenderBlock:
             ),
         ]
         assert render_block(skills) == (
-            "Read these selected skills before proceeding: `skill://alpha`, "
-            "`skill://beta`. The skill body ends with its reference files; read those "
-            "with `skill://<name>/<path>`, never a raw filesystem path.\n"
+            "Skills provide domain-specific instructions and workflows. Read these selected "
+            "skills immediately before proceeding: `skill://alpha`, `skill://beta`. Do not search "
+            "the filesystem or use bash/glob to locate skills — skills are virtual resources "
+            "loaded only via `skill://`. The skill body ends with its reference files; read "
+            "those with `skill://<name>/<path>`, never a raw filesystem path.\n"
             "<skills>\n"
             "- alpha: first skill\n"
             "- beta: second skill\n"

--- a/tests/unit/skills/test_protocol.py
+++ b/tests/unit/skills/test_protocol.py
@@ -58,8 +58,9 @@ class TestBareReads:
         )
 
     def test_empty_name_raises(self, skills: dict[str, Skill]) -> None:
-        with pytest.raises(ValueError, match="missing a name"):
+        with pytest.raises(ValueError, match="missing a name") as excinfo:
             resolve_skill_url("skill://", skills)
+        assert "Available skills: alpha, beta" in str(excinfo.value)
 
 
 class TestUnknownName:

--- a/tests/unit/test_prompts_api.py
+++ b/tests/unit/test_prompts_api.py
@@ -142,6 +142,9 @@ def test_dotted_path_lookup() -> None:
 def test_system_md_loads_and_renders() -> None:
     text = render_template("system.md", {})
     assert "Local Operator" in text
+    assert "<skills>" in text
+    assert "skill://<name>" in text
+    assert "skill://<name>/<relpath>" in text
 
 
 def test_system_md_states_harness_identity() -> None:

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -777,6 +777,33 @@ async def test_read_skill_url_via_resolver(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_read_missing_skill_path_suggests_protocol(tools, context, tmp_path) -> None:
+    result = await _call(
+        tools,
+        "read",
+        {"path": "/tmp/custom/skills/team-workflow/SKILL.md"},
+        context,
+    )
+    assert result.is_error is True
+    assert "Path does not exist" in result.text
+    assert "Skills are virtual resources loaded via `skill://`" in result.text
+    assert "`skill://team-workflow`" in result.text
+
+
+@pytest.mark.asyncio
+async def test_read_missing_plain_path_keeps_plain_error(tools, context, tmp_path) -> None:
+    result = await _call(
+        tools,
+        "read",
+        {"path": "nonexistent.txt"},
+        context,
+    )
+    assert result.is_error is True
+    assert "Path does not exist" in result.text
+    assert "skill://" not in result.text
+
+
+@pytest.mark.asyncio
 async def test_read_skill_url_without_resolver(tmp_path) -> None:
     context = ToolContext(cwd=str(tmp_path), session_id="s")  # no resolver installed
     tools = {t.name: t for t in create_tools(context)}


### PR DESCRIPTION
## Summary
Improve the way skills are suggested and prompted to the agent so that sessions consistently use the `skill://` protocol rather than searching the filesystem with bash (`find`, `ls`), glob, or grep.

### Key Changes
1. **System Prompt (`local_operator/prompts_md/system.md`)**:
   - Added explicit documentation for `<skills>` and the `skill://` protocol directly alongside `<mcps>` and `<guides>`.
   - Explains that skills provide domain-specific procedures and workflows, instructs reading via `skill://<name>` and references via `skill://<name>/<relpath>`, forbids filesystem sweeps, and notes that `read skill://` lists available skills.

2. **Skill Block Formatting (`local_operator/skills/index.py`)**:
   - Enhanced `render_block` instructions to emphasize that skills provide domain-specific instructions and workflows.
   - Added explicit reminder that skills are virtual resources loaded only via `skill://` and warns against filesystem searches.

3. **Discovery & Self-Correction via `skill://` (`local_operator/skills/protocol.py`)**:
   - In `resolve_resource_url`, when an empty name is given (`skill://` or `guide://`), the error message lists all available skills/guides (`Available skills: ...`), allowing the agent to discover them cleanly.

4. **Runtime Guidance on Misdirected Reads (`local_operator/tools/builtin.py`)**:
   - In `execute_read`, if a requested path does not exist and contains `skills` ending with `SKILL.md`, appended helpful guidance redirecting to `skill://<name>`.

5. **Version Bump**:
   - Bumped patch version in `pyproject.toml` to `0.44.62`.

## Testing Evidence
- Verified all quality gates pass locally:
  - `flake8`: clean
  - `black --check .`: clean
  - `isort --check .`: clean
  - `pyright`: 0 errors, 0 warnings
  - `pytest tests/unit`: 11,648 passed