### PR TITLE
fix(update): use uv tool install --force to reliably upgrade uv-tool environments

### DIFF
--- a/local_operator/update.py
+++ b/local_operator/update.py
@@ -409,7 +409,13 @@ def installer_argv(
     executable: str | None = None,
 ) -> list[str]:
     if kind is InstallKind.UV_TOOL:
-        return ["uv", "tool", "upgrade", "local-operator"]
+        # Re-install with --force rather than `uv tool upgrade`:
+        # `uv tool upgrade` fails when installed from a temporary git snapshot
+        # (the build directory no longer exists) or when installed with an exact
+        # version pin (`specifier = "==..."` in uv-receipt.toml causes "Nothing to upgrade").
+        # `uv tool install --force local-operator` always fetches and replaces with
+        # the latest PyPI distribution regardless of previous installation receipt.
+        return ["uv", "tool", "install", "--force", "local-operator"]
     if kind is InstallKind.PIPX:
         return ["pipx", "upgrade", "local-operator"]
     if kind is InstallKind.PIP:
@@ -451,7 +457,7 @@ def tui_installer_failure(kind: InstallKind) -> str:
     elif kind is InstallKind.PIP:
         hint = "python -m pip install -U local-operator"
     else:
-        hint = "uv tool upgrade local-operator"
+        hint = "uv tool install --force local-operator"
     return f"upgrade failed; try `{hint}` in a shell"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.64"
+version = "0.44.65"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -355,7 +355,7 @@ def test_perform_upgrade_runs_detected_argv() -> None:
 
     out = perform_upgrade(target="0.28.0", kind=InstallKind.UV_TOOL, run=run)
     assert out == "0.28.0"
-    assert seen == [["uv", "tool", "upgrade", "local-operator"]]
+    assert seen == [["uv", "tool", "install", "--force", "local-operator"]]
 
     seen.clear()
     perform_upgrade(target="0.28.0", kind=InstallKind.PIPX, run=run)
@@ -379,13 +379,19 @@ def test_perform_upgrade_nonzero_installer() -> None:
 
 
 def test_installer_argv_matches_kind() -> None:
-    assert installer_argv(InstallKind.UV_TOOL) == ["uv", "tool", "upgrade", "local-operator"]
+    assert installer_argv(InstallKind.UV_TOOL) == [
+        "uv",
+        "tool",
+        "install",
+        "--force",
+        "local-operator",
+    ]
 
 
 def test_tui_refusal_copy_is_user_facing() -> None:
     assert "repo checkout" in tui_editable_refusal()
     assert "lop-update" in tui_editable_refusal()
-    assert "uv tool upgrade local-operator" in tui_installer_failure(InstallKind.UV_TOOL)
+    assert "uv tool install --force local-operator" in tui_installer_failure(InstallKind.UV_TOOL)
     assert "pipx upgrade local-operator" in tui_installer_failure(InstallKind.PIPX)
 
 

--- a/tests/unit/tui/test_update_command.py
+++ b/tests/unit/tui/test_update_command.py
@@ -458,7 +458,7 @@ async def test_installer_failure_names_a_shell_retry() -> None:
                 if any("upgrade failed" in text for text in _notices(app)):
                     break
             notices = _notices(app)
-            assert any("uv tool upgrade local-operator" in text for text in notices)
+            assert any("uv tool install --force local-operator" in text for text in notices)
             assert app.query_one(WelcomeView).display is True
             assert app.return_code != REEXEC_CODE
 


### PR DESCRIPTION
## Summary
When upgrading a `uv tool` installation via `/update` or `lop update`, `installer_argv` previously ran `['uv', 'tool', 'upgrade', 'local-operator']`.

In practice, this fails in common `uv tool` environments:
1. **Developer Git Snapshot (`lop-update`)**: `lop-update` builds and packages a snapshot from a temporary directory (`/tmp/...`). `uv tool install --force --from ...` records the build directory requirement into `uv-receipt.toml`. Running `uv tool upgrade` attempts to re-resolve the non-existent temporary directory requirement and fails with:
   `error: Failed to upgrade local-operator - Distribution not found at file:///...`
2. **Pinned Version Install (`uv tool install local-operator==X.Y.Z`)**: `uv-receipt.toml` records the exact version specifier. `uv tool upgrade` reports `Nothing to upgrade` and refuses to move to the latest version.

Switching `installer_argv` for `InstallKind.UV_TOOL` to `['uv', 'tool', 'install', '--force', 'local-operator']` cleanly installs/re-points the tool to the latest PyPI package across all receipt layouts.

## Changes
- `local_operator/update.py`: Update `installer_argv(InstallKind.UV_TOOL)` and `tui_installer_failure(InstallKind.UV_TOOL)` to use `uv tool install --force local-operator`.
- `pyproject.toml`: Bump patch version to 0.44.65.
- `tests/unit/test_update.py`: Update assertions for `installer_argv` and failure hint.
- `tests/unit/tui/test_update_command.py`: Update failure notice assertion.

## Testing Evidence
- Verified via unit test suite: `pytest tests/unit/test_update.py tests/unit/tui/test_update_command.py` (66 passed).
- Live testing of all install permutations (`uv tool` normal, `uv tool` pinned, `uv tool` git snapshot, `pip` venv, `pipx`).