### PR TITLE
fix(providers): suppress secondary alias flavours from usable providers when OAuth is active

### DIFF
--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -234,12 +234,21 @@ class ProviderController:
         the keystroke that opens the picker.
         """
         try:
-            stored = {row.provider for row in self.auth_store.list_credentials(provider=None)}
+            stored_rows = self.auth_store.list_credentials(provider=None)
+            stored = {row.provider for row in stored_rows}
+            oauth_providers = {
+                row.provider for row in stored_rows if row.credential_type == "oauth"
+            }
         except Exception:  # noqa: BLE001 — an unreadable store is reported, not raised
             return None
         usable: set[str] = set()
         for definition in PROVIDER_REGISTRY:
             storage = credential_provider_id(definition.id)
+            # If the user has an active OAuth sign-in under the base provider
+            # (e.g. `radient` OAuth), suppress secondary legacy API-key flavours
+            # (`radient-key`) from being treated as usable alternatives.
+            if definition.store_credentials_as and storage in oauth_providers:
+                continue
             if (
                 definition.allows_missing_api_key  # a local Ollama needs no credential
                 or storage in stored

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.64"
+version = "0.44.65"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -58,10 +58,16 @@ class FakeAuthStore:
         return [types.SimpleNamespace(**r) for r in rows]
 
     def upsert_credential(self, provider, credential):
+        declared = credential.get("type")
+        cred_type = (
+            declared
+            if declared in ("oauth", "api_key")
+            else ("oauth" if credential.get("refresh") and credential.get("access") else "api_key")
+        )
         row = {
             "id": self._next_id,
             "provider": provider,
-            "credential_type": "api_key" if "refresh" not in credential else "oauth",
+            "credential_type": cred_type,
             "data": credential,
             "identity_key": credential.get("email"),
         }
@@ -1712,3 +1718,17 @@ async def test_the_picker_ttl_is_the_only_ttl_override(controller, store, monkey
     calls.clear()
     await controller.live_catalogue(ttl_s=PICKER_TTL_S)
     assert {ttl for _, ttl in calls} == {PICKER_TTL_S}
+
+
+@pytest.mark.asyncio
+async def test_usable_providers_suppresses_secondary_flavour_when_oauth_active(
+    controller, store
+) -> None:
+    """When a base provider has an active OAuth credential, secondary alias flavours
+    (like `radient-key` for `radient`) must be omitted from usable_providers so they
+    do not pollute /model suggestions."""
+    store.upsert_credential("radient", {"access": "token", "type": "oauth"})
+    usable = controller.usable_providers()
+    assert usable is not None
+    assert "radient" in usable
+    assert "radient-key" not in usable


### PR DESCRIPTION
## Summary

When a user is signed in with Radient OAuth (or another base OAuth provider), secondary alias flavours like `radient-key` (configured with `store_credentials_as="radient"`) were resolving as usable because their storage ID pointed to the active credential. This caused duplicate `radient-key/*` rows to appear in the `/model` picker suggestions ahead of or alongside `radient/*`.

### Changes
- Updated `ProviderController.usable_providers()` to inspect stored credentials for active OAuth entries. When a base provider (e.g. `radient`) has an active OAuth credential, secondary flavours with `store_credentials_as` matching that base provider are excluded from the usable providers set.
- Added unit test in `tests/unit/providers/test_controller.py` asserting that `radient-key` is excluded from `usable_providers()` when `radient` has an active OAuth credential.
- Bumped version to `0.44.65`.

### Validation
- Unit tests: passed (`tests/unit/providers/test_controller.py`, `tests/unit/tui/test_model_picker.py`, `tests/unit/tui/test_command_picker.py`).
- Formatter/linter: flake8, black --check, isort --check-only, pyright passed clean.