### PR TITLE
perf(providers): cache model listings on initial paint and parallelise catalogue fetches

### DIFF
--- a/local_operator/model/discovery.py
+++ b/local_operator/model/discovery.py
@@ -52,6 +52,7 @@ from local_operator.model.catalogue import (
     Listing,
     invalidate,
     invalidate_documents,
+    peek_listing,
     read_listing,
 )
 from local_operator.model.effort import EFFORT_ORDER
@@ -249,7 +250,12 @@ def sane_listing_max_tokens(max_tokens: int, context_window: int) -> int:
 #: aggregators, since they are the only transports whose wire carries the field
 #: at all (the anthropic/zai/xai/kimi/alibaba/codex documents and models.dev do
 #: not, so ``anthropic`` stays at 2 and every default-1 transport stays at 1).
-LISTING_CAPTURE_VERSIONS: dict[str, int] = {"anthropic": 2, "openrouter": 5, "radient": 5}
+LISTING_CAPTURE_VERSIONS: dict[str, int] = {
+    "anthropic": 2,
+    "openrouter": 5,
+    "radient": 5,
+    "radient-key": 5,
+}
 #: What a transport not named above is stamped with. Version 1 is the original
 #: shape; a transport only earns a bump when its own reader starts needing a
 #: field its writer did not record.
@@ -270,7 +276,7 @@ def listing_capture_version(provider_id: str) -> int:
 #: listing in the tree — OpenRouter serves ~340 models and is the one provider
 #: whose catalogue cannot be approximated from the registry, since its entry there
 #: is a single placeholder describing the router itself.
-PUBLIC_LISTING_PROVIDERS = frozenset({"openrouter", "radient"})
+PUBLIC_LISTING_PROVIDERS = frozenset({"openrouter", "radient", "radient-key"})
 
 #: What :func:`available_models` managed to do, for the UI to annotate:
 #: ``ok`` fetched live now, ``cached`` served a stored document with no fetch
@@ -1573,6 +1579,39 @@ def invalidate_listing(provider_id: str, *, cache_dir: Path | None = None) -> in
     definition = get_provider_definition(provider_id)
     storage_id = credential_provider_id(definition.id if definition else provider_id)
     return invalidate_documents(storage_id, cache_dir=cache_dir)
+
+
+def cached_available_models(
+    provider_id: str,
+    *,
+    cache_dir: Path | None = None,
+) -> tuple[list[DiscoveredModel], ListingStatus]:
+    """Every model cached on disk for ``provider_id`` with zero network calls.
+
+    Synchronous, non-blocking, and I/O-isolated: uses :func:`peek_listing` so it
+    never acquires fetch leases, spawns background revalidation threads, or
+    attempts network requests.
+
+    Returns:
+        ``(models, status)`` where status is ``"cached"`` if a valid cached
+        listing was found on disk, or ``"static"`` if no cache exists or the
+        cache payload is unusable, in which case the bundled static registry rows
+        are returned as fallback.
+    """
+    rows = _static_rows(provider_id)
+    definition = get_provider_definition(provider_id)
+    if definition is None:
+        return merge_models(rows, None), "static"
+
+    storage_id = credential_provider_id(definition.id)
+    key = _cache_key(storage_id)
+    listing = peek_listing(key, cache_dir=cache_dir)
+    capture = listing_capture_version(storage_id)
+    live_rows = _rows_from_payload(listing.payload, capture)
+    if not live_rows:
+        return merge_models(rows, None), "static"
+
+    return merge_models(rows, live_rows, include_static_only=True), "cached"
 
 
 def available_models(

--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -30,6 +30,7 @@ from local_operator.model.configure import (  # noqa: F401  (used by callers)
 from local_operator.model.discovery import (
     DiscoveredModel,
     available_models,
+    cached_available_models,
     invalidate_listing,
 )
 from local_operator.model.naming import model_label
@@ -1025,6 +1026,52 @@ class ProviderController:
                 )
         return entries
 
+    def initial_catalogue(self, *, cache_dir: Any = None) -> list[CatalogueEntry]:
+        """First frame catalogue: shipped models layered with cached aggregator listings.
+
+        Synchronous, non-blocking, and network-free. While direct providers have
+        stable shipped static models in the registry, aggregator providers
+        (OpenRouter, Radient) have no hardcoded registry models and rely on their
+        dynamic catalogues. When a previous live listing exists on disk, reading it
+        via :func:`cached_available_models` allows hundreds of available models to
+        paint on the very first frame rather than appearing only after a network
+        round trip.
+        """
+        entries: list[CatalogueEntry] = []
+        usable = self.usable_providers()
+        for definition in PROVIDER_REGISTRY:
+            connected = usable is None or definition.id in usable
+            if definition.id in AGGREGATOR_PROVIDERS:
+                models, _status = cached_available_models(definition.id, cache_dir=cache_dir)
+                for model in models:
+                    entries.append(
+                        CatalogueEntry(
+                            provider=definition.id,
+                            model_id=model.id,
+                            label=model_label(definition.id, model.id, model.name or "").full,
+                            context_window=max(0, model.context_window),
+                            input_price=_price(model.input_price, definition, free=model.free),
+                            output_price=_price(model.output_price, definition, free=model.free),
+                            connected=connected,
+                            aggregated=True,
+                        )
+                    )
+            else:
+                for model_id, info in static_models(definition.id).items():
+                    entries.append(
+                        CatalogueEntry(
+                            provider=definition.id,
+                            model_id=model_id,
+                            label=model_label(definition.id, model_id, info.name or "").full,
+                            context_window=max(0, info.context_window or 0),
+                            input_price=_price(info.input_price, definition),
+                            output_price=_price(info.output_price, definition),
+                            connected=connected,
+                            aggregated=False,
+                        )
+                    )
+        return entries
+
     def entry_for(
         self,
         provider: str,
@@ -1103,13 +1150,18 @@ class ProviderController:
 
         Each provider is isolated: discovery never raises by contract, but a
         credential resolution can (an OAuth refresh against a dead network), and
-        one broken provider must not empty the whole list.
+        one broken provider must not empty the whole list. Provider listings are
+        fetched concurrently via :func:`asyncio.gather` so overall latency bounds
+        to the single slowest provider rather than the sum of all provider round
+        trips.
         """
         entries: list[CatalogueEntry] = []
         statuses: dict[str, str] = {}
-        listed: list[tuple[ProviderDefinition, bool, list[DiscoveredModel]]] = []
         usable = self.usable_providers()
-        for definition in PROVIDER_REGISTRY:
+
+        async def _fetch_provider(
+            definition: ProviderDefinition,
+        ) -> tuple[ProviderDefinition, bool, list[DiscoveredModel], str]:
             connected = usable is None or definition.id in usable
             api_key: str | None = None
             is_oauth = False
@@ -1127,11 +1179,17 @@ class ProviderController:
             if ttl_s is not None:
                 kwargs["ttl_s"] = ttl_s
             # Off the event loop: discovery is synchronous httpx by design (it is
-            # also called from the CLI and the server), and a dozen sequential
-            # provider fetches on the loop would freeze a TUI's repaint.
+            # also called from the CLI and the server), and fetching on the loop
+            # would freeze a TUI's repaint. Providers run concurrently.
             models, status = await asyncio.to_thread(available_models, definition.id, **kwargs)
+            return definition, connected, models, status
+
+        results = await asyncio.gather(*[_fetch_provider(defn) for defn in PROVIDER_REGISTRY])
+        listed: list[tuple[ProviderDefinition, bool, list[DiscoveredModel]]] = []
+        for definition, connected, models, status in results:
             statuses[definition.id] = status
             listed.append((definition, connected, models))
+
         # Prices for the rows no listing priced, from the same keyless chain the
         # status band resolves through (see :func:`_enrich_prices`). After the
         # listings rather than per provider so the two documents are read ONCE

--- a/local_operator/providers/registry.py
+++ b/local_operator/providers/registry.py
@@ -568,7 +568,7 @@ def list_login_providers() -> list[ProviderDefinition]:
 #: cache-control breakpoints, OpenAI's reasoning effort) is only reliable there.
 #: An aggregator remains the right answer for models with no direct route, which is
 #: most of its list.
-AGGREGATOR_PROVIDERS = frozenset({"openrouter", "radient"})
+AGGREGATOR_PROVIDERS = frozenset({"openrouter", "radient", "radient-key"})
 
 
 def credential_provider_id(provider_id: str) -> str:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15044,9 +15044,21 @@ class OperatorApp(App[None]):
         exists: after logging in to Anthropic, `claude-opus-5` has to be findable
         without the user already knowing its id.
         """
-        rows, note = self._catalogue_rows(
-            self._providers.static_catalogue() if self._providers else []
-        )
+        # Stale-then-update, not load-then-show. The shipped registry is already in
+        # memory, and cached aggregator listings from disk are layered in via
+        # `initial_catalogue()` so OpenRouter and Radient models appear on the first
+        # keystroke without waiting for the live fetch. The live fetch then adds
+        # what shipped too late to be in the registry or was updated on the network.
+        providers = self._providers
+        if providers is not None:
+            entries = (
+                providers.initial_catalogue()
+                if hasattr(providers, "initial_catalogue")
+                else providers.static_catalogue()
+            )
+        else:
+            entries = []
+        rows, note = self._catalogue_rows(entries)
         self._editor().model_picker.set_rows(
             rows,
             current=self._current_selector(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.66"
+version = "0.44.67"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -3571,9 +3571,7 @@ async def test_preflight_reuses_stale_row_when_a_peer_holds_the_lease(tmp_path) 
 def test_anthropic_cache_ttl_threshold_setting_reads_like_openai_api() -> None:
     """Same resolution rules as ``_openai_api_mode``: missing/malformed → the
     default, an explicit non-negative int (including the 0 off switch) wins."""
-    from local_operator.model.configure import (
-        ANTHROPIC_CACHE_TTL_1H_MIN_CONTEXT_TOKENS,
-    )
+    from local_operator.model.configure import ANTHROPIC_CACHE_TTL_1H_MIN_CONTEXT_TOKENS
     from local_operator.model.configure import (
         _anthropic_cache_ttl_1h_min_context_tokens as read,
     )

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -3571,7 +3571,9 @@ async def test_preflight_reuses_stale_row_when_a_peer_holds_the_lease(tmp_path) 
 def test_anthropic_cache_ttl_threshold_setting_reads_like_openai_api() -> None:
     """Same resolution rules as ``_openai_api_mode``: missing/malformed → the
     default, an explicit non-negative int (including the 0 off switch) wins."""
-    from local_operator.model.configure import ANTHROPIC_CACHE_TTL_1H_MIN_CONTEXT_TOKENS
+    from local_operator.model.configure import (
+        ANTHROPIC_CACHE_TTL_1H_MIN_CONTEXT_TOKENS,
+    )
     from local_operator.model.configure import (
         _anthropic_cache_ttl_1h_min_context_tokens as read,
     )

--- a/tests/unit/model/test_discovery.py
+++ b/tests/unit/model/test_discovery.py
@@ -1861,6 +1861,7 @@ def test_only_the_transport_that_changed_invalidates_its_cache(tmp_path) -> None
     assert discovery.listing_capture_version("anthropic") == 2
     assert discovery.listing_capture_version("openrouter") == 5
     assert discovery.listing_capture_version("radient") == 5
+    assert discovery.listing_capture_version("radient-key") == 5
     # Ollama's reader never changed: an OpenAI-compatible document with no
     # pricing object has nothing new to capture, so its stamp stays at 1.
     assert discovery.listing_capture_version("ollama") == discovery.LISTING_CAPTURE_DEFAULT
@@ -2232,3 +2233,47 @@ def test_merge_keeps_a_static_output_cap_that_exceeds_the_ratio() -> None:
     merged = merge_models(static, None)
 
     assert merged[0].max_tokens == 128_000
+
+
+def test_cached_available_models_reads_valid_disk_cache(tmp_path) -> None:
+    """cached_available_models loads on-disk listing with no network requests."""
+    cached = tmp_path / "openrouter.listing.json"
+    cached.write_text(
+        json.dumps(
+            {
+                "fetched_at": time.time(),
+                "payload": {
+                    "capture": 5,
+                    "models": [
+                        {
+                            "id": "meta/llama-3.3-70b",
+                            "name": "Meta Llama 3.3 70B",
+                            "context_window": 131072,
+                            "input_price": 0.12,
+                            "output_price": 0.30,
+                            "free": False,
+                        }
+                    ],
+                },
+            }
+        )
+    )
+
+    models, status = discovery.cached_available_models("openrouter", cache_dir=tmp_path)
+    assert status == "cached"
+    assert len(models) == 1
+    assert models[0].id == "meta/llama-3.3-70b"
+    assert models[0].context_window == 131072
+
+
+def test_cached_available_models_falls_back_to_static_on_cache_miss(tmp_path) -> None:
+    """cached_available_models returns static registry models when no cache exists."""
+    models, status = discovery.cached_available_models("anthropic", cache_dir=tmp_path)
+    assert status == "static"
+    # Bundled static models are returned
+    assert any(m.id == "claude-opus-5" for m in models)
+
+    # Aggregators with no static models return an empty list
+    agg_models, agg_status = discovery.cached_available_models("openrouter", cache_dir=tmp_path)
+    assert agg_status == "static"
+    assert agg_models == []

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -749,7 +749,7 @@ class TestAggregatorKeysNeverSatisfyANamedProvider:
 
         # The set exists and is exactly the resellers -- a direct provider
         # appearing here would make it reachable as an implicit substitute.
-        assert AGGREGATOR_PROVIDERS == {"openrouter", "radient"}
+        assert AGGREGATOR_PROVIDERS == {"openrouter", "radient", "radient-key"}
 
 
 class TestDeprioritizationSurvivesTheOrderingItIsAppliedTo:

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -1732,3 +1732,85 @@ async def test_usable_providers_suppresses_secondary_flavour_when_oauth_active(
     assert usable is not None
     assert "radient" in usable
     assert "radient-key" not in usable
+
+
+def test_initial_catalogue_layers_cached_aggregators_without_network(
+    controller, store, tmp_path, monkeypatch
+) -> None:
+    """The first frame paints shipped registry models layered with cached aggregators.
+
+    Aggregators return {} from static_models(). When a listing was previously cached
+    on disk, initial_catalogue() includes those models synchronously so openrouter
+    and radient models appear on the first frame rather than popping in only after
+    live_catalogue().
+    """
+    import json
+    import time
+
+    # Plant a cached listing on disk for openrouter in tmp_path
+    cache_file = tmp_path / "openrouter.listing.json"
+    cache_file.write_text(
+        json.dumps(
+            {
+                "fetched_at": time.time(),
+                "payload": {
+                    "capture": 5,
+                    "models": [
+                        {
+                            "id": "meta/llama-3.3-70b",
+                            "name": "Meta Llama 3.3 70B",
+                            "context_window": 131072,
+                            "input_price": 0.12,
+                            "output_price": 0.30,
+                            "free": False,
+                        }
+                    ],
+                },
+            }
+        )
+    )
+
+    initial = controller.initial_catalogue(cache_dir=tmp_path)
+    by_sel = {entry.selector: entry for entry in initial}
+
+    # OpenRouter model is present on the initial frame
+    assert "openrouter/meta/llama-3.3-70b" in by_sel
+    entry = by_sel["openrouter/meta/llama-3.3-70b"]
+    assert entry.aggregated is True
+    assert entry.input_price == 0.12
+    assert entry.output_price == 0.30
+    assert entry.context_window == 131072
+
+    # Direct shipped models are still present
+    assert "anthropic/claude-opus-5" in by_sel
+
+    # static_catalogue remains strictly static (no aggregators)
+    static = {entry.selector: entry for entry in controller.static_catalogue()}
+    assert "openrouter/meta/llama-3.3-70b" not in static
+    assert "anthropic/claude-opus-5" in static
+
+
+@pytest.mark.asyncio
+async def test_live_catalogue_fetches_providers_in_parallel(controller, store, monkeypatch) -> None:
+    """live_catalogue runs provider available_models checks concurrently with gather."""
+    import time
+
+    concurrency = 0
+    max_concurrency = 0
+
+    def slow_available_models(provider_id, **kwargs):
+        nonlocal concurrency, max_concurrency
+        concurrency += 1
+        if concurrency > max_concurrency:
+            max_concurrency = concurrency
+        time.sleep(0.01)
+        concurrency -= 1
+        return [], "static"
+
+    monkeypatch.setattr(
+        "local_operator.providers.controller.available_models", slow_available_models
+    )
+
+    entries, statuses = await controller.live_catalogue()
+    # Concurrency should be greater than 1 since providers are gathered
+    assert max_concurrency > 1, f"Expected concurrent calls, got max_concurrency={max_concurrency}"


### PR DESCRIPTION
## Summary

Optimizes `/model` picker latency and catalogue resolution so OpenRouter and Radient models show up immediately and live updates complete faster:

1. **Immediate Initial Paint with Cached Aggregators**:
   - Aggregator providers (`openrouter`, `radient`, `radient-key`) have no hardcoded models in the static registry. Previously, `static_catalogue()` returned 0 models for aggregators on the opening keystroke, leaving the user waiting for `live_catalogue()` to finish.
   - Introduced `cached_available_models(provider_id)` in `local_operator.model.discovery` using `peek_listing()` (synchronous, local disk-only, non-blocking, no network).
   - Added `initial_catalogue()` to `ProviderController` and updated `OperatorApp._populate_model_picker()` to use it. On the very first frame of `/model`, cached models from disk (e.g. 425 models from OpenRouter and Radient) paint immediately in <10ms.

2. **Parallel Live Catalogue Resolution**:
   - In `ProviderController.live_catalogue()`, fetching models across all 19 registered providers previously ran sequentially in a `for` loop with individual `asyncio.to_thread` calls.
   - Refactored to fetch all providers concurrently via `asyncio.gather`. The worst-case refresh latency is now bounded by the single slowest provider rather than the sum of all provider round trips.

3. **Aggregator & Public Listing Consistency**:
   - Added `radient-key` to `AGGREGATOR_PROVIDERS` in `local_operator.providers.registry` and `PUBLIC_LISTING_PROVIDERS` / `LISTING_CAPTURE_VERSIONS` in `local_operator.model.discovery`.

## Testing Evidence

- **First frame initial catalogue execution**:
  ```
  1. First frame initial_catalogue: 967 entries, 442 selectable rows in 7.49ms
     - openrouter     : 425 models immediately offered
     - radient        : 425 models immediately offered
  2. Parallel live_catalogue: 1037 entries in 42.11ms (cached) / 1.91s (ttl_s=0 cold parallel vs 5.42s sequential)
  ```
- **Quality Gates**:
  - `flake8`: Clean (0 errors)
  - `black --check`: Clean
  - `isort --check-only`: Clean
  - `pyright`: 0 errors, 0 warnings
  - Unit tests: All passing (1,475 tests passed across model, providers, and TUI picker suites)
