### PR TITLE
fix(providers): send each model family its vendor-documented sampling values

### DIFF
--- a/local_operator/bootstrap.py
+++ b/local_operator/bootstrap.py
@@ -180,7 +180,10 @@ async def initialize_operator(
     credential_manager: CredentialManager,
     agent_registry: AgentRegistry,
     env_config: EnvConfig,
-    sampling_overrides: Optional[dict[str, float]] = None,
+    # Values are Optional because a model whose family policy is to OMIT
+    # carries ``None`` on its spec; the filter below drops those so an absent
+    # knob is never turned into an explicit send.
+    sampling_overrides: Optional[dict[str, Optional[float]]] = None,
     scheduler_service: Optional[SchedulerService] = None,
     status_queue: Optional[StatusQueue] = None,
     request_hosting: Optional[str] = None,

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1571,8 +1571,16 @@ class ModelSpec(BaseModel):
     # only chat/completions.
     supports_responses_api: bool = False
     base_url: str | None = None  # override for OpenAI-compatible endpoints
-    temperature: float = 0.2
-    top_p: float = 0.9
+    # ``None`` means OMIT: send no key at all and let the vendor's own default
+    # apply. That is now the common case rather than an exotic one — most
+    # current families either reject the pair, ignore it, or document a default
+    # this app has no business overriding (see ``_SAMPLING_POLICY``). Optional
+    # rather than a magic float because there is no in-band float that means
+    # "unset", and the wire clients must distinguish "send 0.0" from "send
+    # nothing". Derived in ``build_model_spec`` so no wire client needs
+    # model-name knowledge.
+    temperature: float | None = None
+    top_p: float | None = None
     reasoning: bool = False
     # Explicit provider reasoning level. Fallback routes may change providers,
     # so the effort rides on the resolved spec rather than global session state.

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -26,7 +26,7 @@ import os
 import re
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 
 from pydantic import BaseModel, SecretStr
 
@@ -233,6 +233,7 @@ _NO_SAMPLING_PARAMS = re.compile(
 #: ``kimi-k2-0711-preview`` must not match on its ``k2`` fragment.
 _KIMI_PINNED_SAMPLING = re.compile(r"^(?:k\d+(?:-|$)|kimi-for-coding)")
 
+
 #: The per-family SAMPLING POLICY table: what this app may assert about
 #: ``temperature``/``top_p``, keyed on the MODEL id.
 #:
@@ -277,11 +278,51 @@ _KIMI_PINNED_SAMPLING = re.compile(r"^(?:k\d+(?:-|$)|kimi-for-coding)")
 #: ``_EFFORT_TABLE`` documents. Unanchored, so an aggregator prefix
 #: (``google/…``) and ``:free``/``-preview``/``-thinking`` suffixes still match.
 #:
+#: SCOPED TO CHAT/COMPLETION sampling. Every row is derived from a vendor's
+#: chat-model documentation, and ``routes/speech.py`` is a second consumer that
+#: resolves speech ids (``whisper-1``, ``gpt-4o-mini-tts``) through the same
+#: table. Today they all reach the OMIT fallback, which is correct for them, so
+#: this is a caveat rather than a defect — but a speech id sharing a prefix with
+#: a chat family would inherit reasoning that was never about speech endpoints,
+#: and that is the point at which this table needs a speech-aware branch rather
+#: than another row.
+#:
 #: FIRST MATCH WINS, so a narrower row must precede a broader one.
-_SamplingPolicy = tuple[Optional[float], Optional[float]]
+#: A family's sampling rule: the seeded ``temperature``/``top_p`` (``None``
+#: meaning "send no key"), plus whether the vendor REJECTS a value it did not
+#: ask for.
+#:
+#: ``rejects`` is a third state rather than a second ``None``, because the two
+#: reasons to send nothing have opposite consequences for an explicit override,
+#: and conflating them reopens the exact outage this table exists to close:
+#:
+#: * Vendor IGNORES the value (Gemini 3.x). Our default assertion is pointless,
+#:   so we drop it — but a user or agent that deliberately sets one loses
+#:   nothing by having it sent, so the escape hatch stays open.
+#: * Vendor REJECTS the value (Anthropic ≥4.7: "all other values will be
+#:   rejected with a 400 error"; OpenAI GPT-6: "Remove `temperature`,
+#:   `top_p`"). An override here is not a preference, it is a turn that fails
+#:   EVERY time. A stored agent ``temperature`` is the shape the server's own
+#:   API examples advertise, so this is an ordinary path, not an exotic one.
+#:
+#: Note this cannot be expressed by comparing against a ``(None, None)``
+#: sentinel: equal constant tuples are interned to one object, so two such
+#: sentinels would be indistinguishable by identity and silently collapse into
+#: each other.
+class _SamplingPolicy(NamedTuple):
+    temperature: Optional[float]
+    top_p: Optional[float]
+    rejects: bool = False
 
-#: Send neither key and let the vendor's own default apply.
-_OMIT_SAMPLING: _SamplingPolicy = (None, None)
+
+#: Send neither key and let the vendor's own default apply. An explicit user or
+#: agent value STILL RIDES on top of this.
+_OMIT_SAMPLING = _SamplingPolicy(None, None)
+
+#: Send neither key, and SUPPRESS an explicit override too — the same judgement
+#: :data:`_NO_SAMPLING_PARAMS` already makes for Claude 5+ and the o-series,
+#: kept here so each family's rule sits beside the vendor citation for it.
+_REJECT_SAMPLING = _SamplingPolicy(None, None, rejects=True)
 
 _SAMPLING_POLICY: tuple[tuple[re.Pattern[str], _SamplingPolicy], ...] = (
     # -- Google ------------------------------------------------------------
@@ -301,27 +342,38 @@ _SAMPLING_POLICY: tuple[tuple[re.Pattern[str], _SamplingPolicy], ...] = (
     # Seeded rather than omitted because these are the documented per-model
     # defaults the API's own getModel reports (temperature 1.0, topP 0.95), and
     # keeping the keys present preserves a real, tunable knob.
-    (re.compile(r"gemini"), (1.0, 0.95)),
+    (re.compile(r"gemini"), _SamplingPolicy(1.0, 0.95)),
     # -- Anthropic ---------------------------------------------------------
     # "Models released after Claude Opus 4.6 do not support setting
     # temperature. A value of 1.0 will be accepted for backwards compatibility,
     # all other values will be rejected with a 400 error."
     # (https://platform.claude.com/docs/en/api/messages.md). This is a LIVE
     # OUTAGE on 4.7/4.8: the app sent 0.2, which is exactly the rejected case.
-    # 4.5/4.6 still honour the pair and must not regress, so the arm starts at
-    # generation 4.7 and is written forward. Generation 5+ is already covered
-    # by _NO_SAMPLING_PARAMS below.
-    (re.compile(r"claude-[a-z]+-4[.-](?:[7-9]|\d{2,3})(?!\d)"), _OMIT_SAMPLING),
+    #
+    # REJECT, not OMIT: "rejected with a 400" means an override cannot be
+    # honoured either. Dropping only our own default would leave a stored agent
+    # temperature failing every turn on this family — the same outage, moved
+    # from the default path to the override path.
+    #
+    # The arm starts at 4.7 and reads forward so it cannot reach back over
+    # 4.5/4.6, which genuinely honour the pair (see the fallback note below for
+    # what actually happens to them). Generation 5+ is already covered by
+    # _NO_SAMPLING_PARAMS.
+    (re.compile(r"claude-[a-z]+-4[.-](?:[7-9]|\d{2,3})(?!\d)"), _REJECT_SAMPLING),
     # -- OpenAI ------------------------------------------------------------
     # GPT-6 Astra: "Unsupported parameters: Remove `temperature`, `top_p`, and
     # `top_logprobs`."
     # (https://developers.openai.com/api/docs/guides/latest-model.md).
     # Forward-reading over the generation digit, because the pre-existing
     # literal `gpt-5` in _NO_SAMPLING_PARAMS does not match `gpt-6-astra`.
-    # UNKNOWN: GPT-5.6 is not covered by primary docs; it keeps the omission by
-    # precaution, which is both the safe direction and the already-shipped
-    # behaviour.
-    (re.compile(r"gpt-(?:[5-9]|\d{2,})"), _OMIT_SAMPLING),
+    # UNKNOWN: GPT-5.6 is not covered by primary docs; it keeps the suppression
+    # by precaution, which is both the safe direction and the already-shipped
+    # behaviour (the literal `gpt-5` arm in _NO_SAMPLING_PARAMS already strips
+    # the pair for the 5.x line).
+    #
+    # REJECT, not OMIT: "Unsupported parameters: Remove ..." is a rejection, so
+    # an override must be suppressed rather than forwarded into a 400.
+    (re.compile(r"gpt-(?:[5-9]|\d{2,})"), _REJECT_SAMPLING),
     # -- DeepSeek ----------------------------------------------------------
     # V4 runs with thinking ON by default, and "Thinking mode does not support
     # the temperature, top_p, presence_penalty, or frequency_penalty parameters
@@ -344,6 +396,15 @@ _SAMPLING_POLICY: tuple[tuple[re.Pattern[str], _SamplingPolicy], ...] = (
     # narrower provider-keyed rule is retained: it is the one case with a
     # documented ROUTE difference, and it still guards ids like `k3` that carry
     # no vendor name at all.
+    #
+    # OMIT rather than REJECT, deliberately, even though the CURRENT lineup
+    # does reject: this row also catches legacy ids (`kimi-k2-0711-preview`,
+    # `moonshot-v1-128k`) that accept the pair, and a mainland-specific policy
+    # is UNVERIFIED. Suppressing an override for the whole name-space would
+    # take a working setting away from models that honour it, on evidence that
+    # only covers the current models. The ids whose rejection IS documented and
+    # was observed live keep their hard suppression through
+    # _KIMI_PINNED_SAMPLING above, which is scoped to exactly those.
     (re.compile(r"kimi|moonshot"), _OMIT_SAMPLING),
     # -- Alibaba / Qwen ----------------------------------------------------
     # The one vendor publishing a real per-model default table: "Qwen3-Coder
@@ -357,7 +418,7 @@ _SAMPLING_POLICY: tuple[tuple[re.Pattern[str], _SamplingPolicy], ...] = (
     # compaction through the same spec as its coding turns, and 0.2 is the
     # exact assertion this table exists to stop making. Note that qwen3.8 with
     # thinking on auto-clamps temperature below 0.6 regardless.
-    (re.compile(r"qwen|qwq|qvq"), (0.7, 0.8)),
+    (re.compile(r"qwen|qwq|qvq"), _SamplingPolicy(0.7, 0.8)),
     # -- Z.AI / GLM --------------------------------------------------------
     # Honoured, but RANGE-rejected (temperature [0.0, 1.0], top_p [0.01, 1.0])
     # and silently ignored when `do_sample=false`. The defaults are per-series
@@ -573,23 +634,28 @@ def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = Non
     # pair on the mainland host — see _KIMI_PINNED_SAMPLING.
     if canonical == "kimi" and _KIMI_PINNED_SAMPLING.match(lowered):
         supports_sampling_params = False
-    # The per-family policy. Unlike the two rules above this is NOT about
-    # rejection — most of these families accept the pair and then ignore it, or
-    # honour it at a value nothing here should be inventing. `None` means the
-    # key is omitted so the vendor's own default applies; see _SAMPLING_POLICY
-    # for each row's citation.
+    # The per-family policy. Most of these families accept the pair and then
+    # ignore it, or honour it at a value nothing here should be inventing, so a
+    # `None` here only means "we stop asserting" and an explicit override still
+    # rides. A row marked `rejects` is the stronger case and clears
+    # `supports_sampling_params` below; see _SAMPLING_POLICY for each row's
+    # citation.
     #
     # A user-supplied model (ollama) never consults the id-keyed table: its ids
     # are arbitrary and its publisher's Modelfile has already set the tuning we
     # would be overwriting.
-    sampling_temperature: Optional[float] = DEFAULT_TEMPERATURE
-    sampling_top_p: Optional[float] = DEFAULT_TOP_P
+    #
+    # No initial value: every branch below assigns, and seeding this with
+    # DEFAULT_TEMPERATURE/DEFAULT_TOP_P left the app-wide constants looking like
+    # a live default in the one file whose job is to stop them being one.
+    policy: _SamplingPolicy
     if canonical in _USER_SUPPLIED_MODEL_PROVIDERS:
-        sampling_temperature, sampling_top_p = _OMIT_SAMPLING
+        policy = _OMIT_SAMPLING
+
     else:
-        for pattern, (policy_temperature, policy_top_p) in _SAMPLING_POLICY:
+        for pattern, matched_policy in _SAMPLING_POLICY:
             if pattern.search(lowered):
-                sampling_temperature, sampling_top_p = policy_temperature, policy_top_p
+                policy = matched_policy
                 break
         else:
             # The FALLBACK, and the most consequential row of all. Every vendor
@@ -597,13 +663,28 @@ def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = Non
             # one is near 0.2 — so asserting the app-wide constant over a model
             # nobody has characterised is the very defect this table fixes.
             # Silence is the honest answer for an unknown model.
-            sampling_temperature, sampling_top_p = _OMIT_SAMPLING
-        # The provider's own listing may only NARROW what the table decided: a
-        # stated allowlist that omits `temperature` is the aggregator telling us
-        # it will not forward the key. Silence never widens an OMIT back into a
-        # send — see `_listing_forbids_sampling`.
-        if _listing_forbids_sampling(canonical, model_name):
-            sampling_temperature, sampling_top_p = _OMIT_SAMPLING
+            #
+            # This is also where Anthropic 4.5/4.6 land. They HONOUR the pair,
+            # and deliberately get no row of their own: omitting yields
+            # Anthropic's own 1.0, which is exactly what a row would have to
+            # seed, so a row would add a maintained constant that could only
+            # drift. The 4.7+ arm above is written forward purely so it cannot
+            # reach back over them.
+            policy = _OMIT_SAMPLING
+    sampling_temperature, sampling_top_p = policy.temperature, policy.top_p
+    # A vendor that REJECTS an unrequested value cannot honour an override
+    # either: forwarding one is a documented HTTP 400 on every turn, which is
+    # the same outage this table closes, merely moved onto the override path.
+    # `supports_sampling_params` is the existing mechanism for exactly that, so
+    # a rejecting row clears it rather than inventing a second suppression.
+    if policy.rejects:
+        supports_sampling_params = False
+    # The provider's own listing may only NARROW what the table decided: a
+    # stated allowlist that omits `temperature` is the aggregator telling us
+    # it will not forward the key. Silence never widens an OMIT back into a
+    # send — see `_listing_forbids_sampling`.
+    if _listing_forbids_sampling(canonical, model_name):
+        sampling_temperature = sampling_top_p = None
     # A GUARDED read, not `info.name`. `info` is duck-typed here — the legacy
     # public helpers and the tests hand in stand-ins, and `name` is the one
     # attribute name that collides with something that is not a string on almost
@@ -2101,10 +2182,20 @@ def configure_model(
     # DEFAULT_TOP_P, which meant the model's own seed — Google's 1.0/0.95 for
     # Gemini 2.x — was overwritten with the app-wide 0.2/0.9 on the main
     # construction path, making a per-model default impossible to express.
-    # ``None`` is the "caller said nothing" sentinel; both real override paths
-    # (an agent record's stored knobs via ``_AGENT_SAMPLING_FIELDS``, and the
-    # server's per-request ``ChatRequest.options``) already omit the argument
-    # entirely unless a value is set, so the sentinel costs them nothing.
+    # ``None`` is the "caller said nothing" sentinel. The override path this
+    # serves is an agent record's stored knobs, which reach here via
+    # ``_AGENT_SAMPLING_FIELDS`` and already omit the argument entirely unless a
+    # value is set, so the sentinel costs them nothing.
+    #
+    # Deliberately NOT claimed for the server's per-request ``ChatRequest
+    # .options``: those routes mutate the SCALAR
+    # ``model_configuration.temperature``, while the wire reads the SPEC, and
+    # the two are independent fields set once at construction — so that path
+    # does not currently reach the provider. It is broken identically before
+    # this change and is out of scope here, but the claim does not belong in a
+    # comment the next reader will trust. ``bootstrap.py``'s
+    # ``sampling_overrides`` seam IS correct and does reach the spec via
+    # ``set_model``.
     sampling_overrides: dict[str, float] = {}
     if temperature is not None:
         sampling_overrides["temperature"] = temperature

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -136,8 +136,10 @@ class ModelConfiguration:
     instance: Any
     info: ModelInfo
     api_key: Optional[SecretStr]
-    temperature: float
-    top_p: float
+    # ``None`` mirrors the spec's OMIT: no value is sent and the vendor's own
+    # default applies. See ``_SAMPLING_POLICY``.
+    temperature: Optional[float]
+    top_p: Optional[float]
     top_k: Optional[int]
     max_tokens: Optional[int]
     frequency_penalty: Optional[float]
@@ -153,8 +155,8 @@ class ModelConfiguration:
         instance: Any = None,
         info: ModelInfo | None = None,
         api_key: Optional[SecretStr] = None,
-        temperature: float = DEFAULT_TEMPERATURE,
-        top_p: float = DEFAULT_TOP_P,
+        temperature: Optional[float] = DEFAULT_TEMPERATURE,
+        top_p: Optional[float] = DEFAULT_TOP_P,
         top_k: Optional[int] = None,
         max_tokens: Optional[int] = None,
         frequency_penalty: Optional[float] = None,
@@ -230,6 +232,169 @@ _NO_SAMPLING_PARAMS = re.compile(
 #: the endpoint that pins the values. Anchored at the start:
 #: ``kimi-k2-0711-preview`` must not match on its ``k2`` fragment.
 _KIMI_PINNED_SAMPLING = re.compile(r"^(?:k\d+(?:-|$)|kimi-for-coding)")
+
+#: The per-family SAMPLING POLICY table: what this app may assert about
+#: ``temperature``/``top_p``, keyed on the MODEL id.
+#:
+#: **The defect this table exists to fix.** The app shipped a hardcoded
+#: ``temperature=0.2``/``top_p=0.9`` to every provider on every turn. That pair
+#: is not a conservative default — it is an INVENTED number asserted over each
+#: vendor's own documented one, and a survey of the primary docs found not a
+#: single major vendor whose default is anywhere near it (essentially all are
+#: 1.0, with top_p 0.95). Several current families reject the parameter with a
+#: hard 400, and several more accept it and silently ignore it. The reported
+#: symptom was Gemini 3 looping, but that was one visible face of a general bug.
+#:
+#: **Why OMIT is the default answer rather than a seeded number.** An absent key
+#: resolves to whatever the vendor currently considers correct, so a vendor
+#: retune reaches users for free and the value can never drift stale. It is also
+#: literally what Google's migration guide prescribes ("removing this
+#: parameter"), and it drops an assertion this app never earned. Sending an
+#: explicit value is not even neutral on aggregators: OpenRouter notes a sent
+#: value "may differ from omitting it (for example, it can affect provider-side
+#: cache keys)". A row therefore SEEDS a number only where the vendor documents
+#: something we cannot obtain by staying silent.
+#:
+#: **Why the rows are keyed on the model, not the provider.** Same reasoning
+#: already argued for :data:`_NO_SAMPLING_PARAMS` below: a sampling contract is
+#: a property of the model, and the same weights answer on the direct route, on
+#: OpenRouter and on Radient. A provider-keyed rule would fix one route and
+#: leave the aggregator routes carrying the bug — which is what users actually
+#: hit.
+#:
+#: **Independent knobs.** ``temperature`` and ``top_p`` are decided separately
+#: per row because vendors diverge on them constantly (Qwen documents 0.7 with
+#: top_p 0.8; Gemini 2.5 is 1.0/0.95). ``None`` means OMIT.
+#:
+#: Patterns read FORWARD over the generation digit (``[7-9]|\d{2,3}``) rather
+#: than pinning to today's numbers: a newer generation is far likelier to keep a
+#: restriction than to revert it, and the failure directions are asymmetric — a
+#: false negative is a 400 or a loop on every turn, a false positive only falls
+#: back to the vendor's own default. ``[.-]`` matches both spellings vendors
+#: ship (``gemini-3-flash`` and ``gemini-3.8-flash``), mirroring
+#: ``model/effort.py``; the ``\d{2,3}`` bound and ``(?!\d)`` guard stop an
+#: 8-digit snapshot date reading as a generation number, the exact trap
+#: ``_EFFORT_TABLE`` documents. Unanchored, so an aggregator prefix
+#: (``google/…``) and ``:free``/``-preview``/``-thinking`` suffixes still match.
+#:
+#: FIRST MATCH WINS, so a narrower row must precede a broader one.
+_SamplingPolicy = tuple[Optional[float], Optional[float]]
+
+#: Send neither key and let the vendor's own default apply.
+_OMIT_SAMPLING: _SamplingPolicy = (None, None)
+
+_SAMPLING_POLICY: tuple[tuple[re.Pattern[str], _SamplingPolicy], ...] = (
+    # -- Google ------------------------------------------------------------
+    # Gemini 3+: the reported bug. "For all Gemini 3 models, we strongly
+    # recommend keeping the temperature parameter at its default value of 1.0
+    # ... Changing the temperature (setting it below 1.0) may lead to
+    # unexpected behavior, such as looping or degraded performance, particularly
+    # in complex mathematical or reasoning tasks." — and, in the migration
+    # checklist, "we recommend removing this parameter"
+    # (https://ai.google.dev/gemini-api/docs/gemini-3). 3.6+ goes further and
+    # ignores custom values outright. Omitting satisfies every one of those
+    # readings at once, including the cell we could not resolve (whether
+    # 3.1-pro honours or ignores the value).
+    (re.compile(r"gemini-(?:[3-9]|\d{2,3})(?:[.-]\d+)?(?!\d)"), _OMIT_SAMPLING),
+    # Gemini <=2.5 genuinely HONOURS the pair, so dropping it would trade a
+    # working feature for nothing — the "worse bug" the note below warns about.
+    # Seeded rather than omitted because these are the documented per-model
+    # defaults the API's own getModel reports (temperature 1.0, topP 0.95), and
+    # keeping the keys present preserves a real, tunable knob.
+    (re.compile(r"gemini"), (1.0, 0.95)),
+    # -- Anthropic ---------------------------------------------------------
+    # "Models released after Claude Opus 4.6 do not support setting
+    # temperature. A value of 1.0 will be accepted for backwards compatibility,
+    # all other values will be rejected with a 400 error."
+    # (https://platform.claude.com/docs/en/api/messages.md). This is a LIVE
+    # OUTAGE on 4.7/4.8: the app sent 0.2, which is exactly the rejected case.
+    # 4.5/4.6 still honour the pair and must not regress, so the arm starts at
+    # generation 4.7 and is written forward. Generation 5+ is already covered
+    # by _NO_SAMPLING_PARAMS below.
+    (re.compile(r"claude-[a-z]+-4[.-](?:[7-9]|\d{2,3})(?!\d)"), _OMIT_SAMPLING),
+    # -- OpenAI ------------------------------------------------------------
+    # GPT-6 Astra: "Unsupported parameters: Remove `temperature`, `top_p`, and
+    # `top_logprobs`."
+    # (https://developers.openai.com/api/docs/guides/latest-model.md).
+    # Forward-reading over the generation digit, because the pre-existing
+    # literal `gpt-5` in _NO_SAMPLING_PARAMS does not match `gpt-6-astra`.
+    # UNKNOWN: GPT-5.6 is not covered by primary docs; it keeps the omission by
+    # precaution, which is both the safe direction and the already-shipped
+    # behaviour.
+    (re.compile(r"gpt-(?:[5-9]|\d{2,})"), _OMIT_SAMPLING),
+    # -- DeepSeek ----------------------------------------------------------
+    # V4 runs with thinking ON by default, and "Thinking mode does not support
+    # the temperature, top_p, presence_penalty, or frequency_penalty parameters
+    # ... setting these parameters will not trigger an error but will also have
+    # no effect" (https://api-docs.deepseek.com/guides/thinking_mode). Sending
+    # them is pure noise.
+    #
+    # NOTE for future readers: DeepSeek's older task-table page recommends
+    # temperature 0.0 for coding. It predates V4 and thinking mode, and
+    # DeepSeek's own coding-agent benchmarks are run at 1.0/0.95 — so that row
+    # is stale and must not be revived here.
+    (re.compile(r"deepseek"), _OMIT_SAMPLING),
+    # -- Moonshot / Kimi ---------------------------------------------------
+    # The whole current lineup PINS the pair rather than honouring it: K3
+    # "`temperature=1.0`, `top_p=0.95` ... are fixed; omit them from requests",
+    # and K2.7 Code "will use a fixed value 1.0. Any other value will result in
+    # an error." This generalises what _KIMI_PINNED_SAMPLING below already
+    # established live on the coding host (HTTP 400 "invalid temperature: only
+    # 1 is allowed for this model") from a host quirk to the family. That
+    # narrower provider-keyed rule is retained: it is the one case with a
+    # documented ROUTE difference, and it still guards ids like `k3` that carry
+    # no vendor name at all.
+    (re.compile(r"kimi|moonshot"), _OMIT_SAMPLING),
+    # -- Alibaba / Qwen ----------------------------------------------------
+    # The one vendor publishing a real per-model default table: "Qwen3-Coder
+    # series, qwen-max series ... 0.7" temperature, with top_p 0.8. Seeded
+    # rather than omitted because those are model-specific numbers that differ
+    # from the 1.0 the rest of the industry uses, so silence would not
+    # reproduce them.
+    #
+    # Deliberately the DEFAULT row (0.7/0.8), not Qwen's separate coding row
+    # (temperature 0.2): this app runs summarisation, commit messages and
+    # compaction through the same spec as its coding turns, and 0.2 is the
+    # exact assertion this table exists to stop making. Note that qwen3.8 with
+    # thinking on auto-clamps temperature below 0.6 regardless.
+    (re.compile(r"qwen|qwq|qvq"), (0.7, 0.8)),
+    # -- Z.AI / GLM --------------------------------------------------------
+    # Honoured, but RANGE-rejected (temperature [0.0, 1.0], top_p [0.01, 1.0])
+    # and silently ignored when `do_sample=false`. The defaults are per-series
+    # — 1.0 for GLM-5.x/4.7/4.6 but 0.6 for the GLM-4.5 series
+    # (https://docs.z.ai/api-reference/llm/chat-completion) — so any single
+    # seeded number would be wrong for one series or the other. Omission is the
+    # only answer correct for every series at once, and it also honours their
+    # guidance to "recommend choosing only one for tuning".
+    (re.compile(r"glm"), _OMIT_SAMPLING),
+    # -- Mistral -----------------------------------------------------------
+    # Mistral deliberately publishes no static default: it exposes
+    # `default_model_temperature` per model card and directs callers to the
+    # /models listing. We cannot hardcode what the vendor refuses to fix, and
+    # omission lets their served default apply.
+    (re.compile(r"mistral|magistral|ministral|codestral|devstral|pixtral"), _OMIT_SAMPLING),
+    # -- xAI / Grok --------------------------------------------------------
+    # UNKNOWN defaults: xAI's REST reference types both parameters as
+    # `number | null` and states no default anywhere. Omission is the only
+    # honest option; inventing 1.0 here would repeat the original mistake in a
+    # new place.
+    (re.compile(r"grok"), _OMIT_SAMPLING),
+)
+
+#: Providers whose models are USER-SUPPLIED, whose publisher tuning we must not
+#: overrule. Keyed on the PROVIDER because that is genuinely what decides it:
+#: the ids are arbitrary (``qwen3:32b``, custom Modelfiles, quantised
+#: rebrands), so no id pattern can establish family membership — and the `qwen`
+#: row above would otherwise seize a locally-served Qwen whose Modelfile has
+#: already been tuned by whoever published it.
+#:
+#: Ollama's own defaults are temperature 0.8 / top_p 0.9; a model's Modelfile
+#: ``PARAMETER temperature`` overrides those, and a per-request value overrides
+#: the Modelfile — there is no "unset" sentinel. So sending 0.2/0.9 silently
+#: DISCARDED whatever the model's publisher tuned it to (Qwen3 ships 0.7/0.8, a
+#: DeepSeek-R1 Modelfile 0.6). We cannot know what the user pulled, so we must
+#: not overrule what its publisher set.
+_USER_SUPPLIED_MODEL_PROVIDERS = frozenset({"ollama"})
 
 #: OpenAI introduced the public Responses route for the GPT-5 generation. The
 #: direct `/v1/models` listing exposes ids but no capability flags, so an
@@ -408,6 +573,37 @@ def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = Non
     # pair on the mainland host — see _KIMI_PINNED_SAMPLING.
     if canonical == "kimi" and _KIMI_PINNED_SAMPLING.match(lowered):
         supports_sampling_params = False
+    # The per-family policy. Unlike the two rules above this is NOT about
+    # rejection — most of these families accept the pair and then ignore it, or
+    # honour it at a value nothing here should be inventing. `None` means the
+    # key is omitted so the vendor's own default applies; see _SAMPLING_POLICY
+    # for each row's citation.
+    #
+    # A user-supplied model (ollama) never consults the id-keyed table: its ids
+    # are arbitrary and its publisher's Modelfile has already set the tuning we
+    # would be overwriting.
+    sampling_temperature: Optional[float] = DEFAULT_TEMPERATURE
+    sampling_top_p: Optional[float] = DEFAULT_TOP_P
+    if canonical in _USER_SUPPLIED_MODEL_PROVIDERS:
+        sampling_temperature, sampling_top_p = _OMIT_SAMPLING
+    else:
+        for pattern, (policy_temperature, policy_top_p) in _SAMPLING_POLICY:
+            if pattern.search(lowered):
+                sampling_temperature, sampling_top_p = policy_temperature, policy_top_p
+                break
+        else:
+            # The FALLBACK, and the most consequential row of all. Every vendor
+            # default established in the survey is 1.0 or unpublished, and not
+            # one is near 0.2 — so asserting the app-wide constant over a model
+            # nobody has characterised is the very defect this table fixes.
+            # Silence is the honest answer for an unknown model.
+            sampling_temperature, sampling_top_p = _OMIT_SAMPLING
+        # The provider's own listing may only NARROW what the table decided: a
+        # stated allowlist that omits `temperature` is the aggregator telling us
+        # it will not forward the key. Silence never widens an OMIT back into a
+        # send — see `_listing_forbids_sampling`.
+        if _listing_forbids_sampling(canonical, model_name):
+            sampling_temperature, sampling_top_p = _OMIT_SAMPLING
     # A GUARDED read, not `info.name`. `info` is duck-typed here — the legacy
     # public helpers and the tests hand in stand-ins, and `name` is the one
     # attribute name that collides with something that is not a string on almost
@@ -461,6 +657,8 @@ def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = Non
         base_url=definition.base_url if definition else None,
         reasoning=reasoning,
         supports_sampling_params=supports_sampling_params,
+        temperature=sampling_temperature,
+        top_p=sampling_top_p,
         reasoning_efforts=effort_levels,
         reasoning_effort=reasoning_effort,
         # The seed and the restore point are the same value at build time; they
@@ -695,6 +893,10 @@ def _info_from_listing(
         # `source` is the canonical provider id ("openrouter"/"radient"), which
         # is the key `build_model_spec` reads under.
         _remember_listing_entry_effort(source, model_name, model)
+        # Same raw entry, second fact: whether the aggregator's own allowlist
+        # names `temperature`. Warmed here so the narrowing never has to reach
+        # for the network on a paint path.
+        _remember_listing_sampling_support(source, model_name, model)
         return mapped
     raise ValueError(f"Model not found from {source} models API: {model_name}")
 
@@ -1495,6 +1697,9 @@ def invalidate_model_info_cache() -> None:
     # leaving that cached would keep the band on the table's answer for a full
     # bucket after the user pasted the key that would have corrected it.
     _effort_memo.clear()
+    # The sampling-support memo is warmed by the same listing read and degrades
+    # for the same fixable reasons, so it is invalidated together with it.
+    _sampling_support_memo.clear()
 
 
 def resolve_model_info(provider: str, model_id: str) -> ModelInfo:
@@ -1630,6 +1835,11 @@ def resolve_model_info_paint(provider: str, model_id: str) -> tuple[ModelInfo, b
 #: paragraph above applies to keeping the ladder off ``ModelInfo``.
 _effort_memo: dict[tuple[str, str, int], tuple[str, ...] | None] = {}
 
+#: Same shape and lifetime as :data:`_effort_memo`, for the aggregator
+#: ``supported_parameters`` allowlist. ``True``/``False`` is the listing's own
+#: answer; a MISSING key means it said nothing and the curated table decides.
+_sampling_support_memo: dict[tuple[str, str, int], bool] = {}
+
 
 def _listing_effort(provider: str, model_id: str) -> tuple[str, ...] | None:
     """What the provider's listing said this model's effort ladder is.
@@ -1699,6 +1909,66 @@ def _remember_listing_effort(provider: str, model_id: str, row: "DiscoveredModel
     _store_listing_effort(provider, model_id, row.reasoning_efforts)
 
 
+def _listing_forbids_sampling(provider: str, model_id: str) -> bool:
+    """True when the provider's own listing says this model takes no sampling.
+
+    OpenRouter publishes a ``supported_parameters`` ALLOWLIST per model, and 78
+    of 425 models omit ``temperature`` from it. That is a genuine per-model fact
+    the hand-written table cannot keep up with, so a model the table has never
+    heard of still gets the right answer on an aggregator route.
+
+    It may only NARROW, never widen, and that asymmetry is the whole design.
+    The listing answers "will the aggregator FORWARD this parameter", not "will
+    the model HONOUR it": ``google/gemini-3.8-flash`` lists ``temperature`` as
+    supported because OpenRouter forwards it and Google then ignores it. So a
+    listing that stays silent can never overturn a curated OMIT row, and only a
+    stated absence adds an omission the table missed. Same division of labour as
+    :func:`_listing_effort`, where the provider's own answer wins but silence
+    defers to the table.
+
+    Memo-only and non-raising for the same reasons as that function: this sits
+    on a path reachable from a TUI repaint, so a cold memo must degrade to the
+    table rather than reach for the network.
+    """
+    try:
+        bucket = int(time.time() // DEFAULT_TTL_S)
+        supported = _sampling_support_memo.get((provider, model_id, bucket))
+        # `None` is "the listing said nothing", which defers to the table.
+        # Only an explicit allowlist that omits the key is a denial.
+        return supported is False
+    except Exception:  # noqa: BLE001 — never worth a failed start
+        return False
+
+
+def _remember_listing_sampling_support(provider: str, model_id: str, entry: BaseModel) -> None:
+    """Record whether ``entry``'s ``supported_parameters`` allowlist names
+    ``temperature``.
+
+    Absent or unparseable leaves the memo untouched, so the curated table keeps
+    its answer rather than being overruled by a listing that simply does not
+    publish the field (Radient's passthrough semantics are UNVERIFIED, so its
+    listing must not be read as a denial).
+    """
+    try:
+        supported = _extra(entry, "supported_parameters")
+        if not isinstance(supported, (list, tuple)):
+            return
+        names = {str(item).lower() for item in supported}
+        if not names:
+            return
+        bucket = int(time.time() // DEFAULT_TTL_S)
+        _sampling_support_memo[(provider, model_id, bucket)] = "temperature" in names
+        if len(_sampling_support_memo) > _EFFORT_MEMO_MAX:
+            for key in [key for key in _sampling_support_memo if key[2] != bucket]:
+                del _sampling_support_memo[key]
+            for key in list(_sampling_support_memo)[
+                : len(_sampling_support_memo) - _EFFORT_MEMO_MAX
+            ]:
+                del _sampling_support_memo[key]
+    except Exception as exc:  # noqa: BLE001 — never worth a failed start
+        logger.debug("could not read %s sampling support for %s: %s", provider, model_id, exc)
+
+
 def refresh_model_info_background(provider: str, model_id: str) -> None:
     """Resolve one model off-loop so the NEXT paint sees the real price.
 
@@ -1760,8 +2030,8 @@ def configure_model(
     credential_manager: CredentialManager | None = None,
     model_info_client: ModelListingClient | None = None,
     env_config: EnvConfig | None = None,
-    temperature: float = DEFAULT_TEMPERATURE,
-    top_p: float = DEFAULT_TOP_P,
+    temperature: Optional[float] = None,
+    top_p: Optional[float] = None,
     top_k: Optional[int] = None,
     max_tokens: Optional[int] = None,
     frequency_penalty: Optional[float] = None,
@@ -1825,7 +2095,23 @@ def configure_model(
     # Without this copy an agent's stored temperature (and the server's
     # per-request ``options``) would be recorded on the ModelConfiguration and
     # then silently dropped on the way to the provider.
-    spec = spec.model_copy(update={"temperature": temperature, "top_p": top_p})
+    #
+    # ONLY when the caller genuinely passed one. This used to copy
+    # unconditionally from parameters defaulting to DEFAULT_TEMPERATURE/
+    # DEFAULT_TOP_P, which meant the model's own seed — Google's 1.0/0.95 for
+    # Gemini 2.x — was overwritten with the app-wide 0.2/0.9 on the main
+    # construction path, making a per-model default impossible to express.
+    # ``None`` is the "caller said nothing" sentinel; both real override paths
+    # (an agent record's stored knobs via ``_AGENT_SAMPLING_FIELDS``, and the
+    # server's per-request ``ChatRequest.options``) already omit the argument
+    # entirely unless a value is set, so the sentinel costs them nothing.
+    sampling_overrides: dict[str, float] = {}
+    if temperature is not None:
+        sampling_overrides["temperature"] = temperature
+    if top_p is not None:
+        sampling_overrides["top_p"] = top_p
+    if sampling_overrides:
+        spec = spec.model_copy(update=sampling_overrides)
     # Radient base URL is env-overridable (legacy EnvConfig behaviour).
     if canonical == "radient" and env_config is not None:
         base_url = env_config.radient_api_base_url
@@ -1838,8 +2124,11 @@ def configure_model(
         instance=None,
         info=model_info,
         api_key=api_key,
-        temperature=temperature,
-        top_p=top_p,
+        # The legacy scalar attributes mirror what the spec will actually send,
+        # so a reader of ModelConfiguration.temperature sees the value in force
+        # rather than a default the spec has already overridden.
+        temperature=spec.temperature,
+        top_p=spec.top_p,
         top_k=top_k,
         max_tokens=max_tokens,
         frequency_penalty=frequency_penalty,

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -641,15 +641,25 @@ def _sampling_params(request: ChatRequest, *, top_p_key: str = "top_p") -> dict[
 
     ``top_p_key`` exists only because Gemini spells it ``topP``; the capability
     itself is provider-independent and lives on the spec.
+
+    Each knob is resolved INDEPENDENTLY, and a ``None`` on the spec means OMIT
+    that key so the vendor's own default applies (see ``_SAMPLING_POLICY``).
+    Vendors diverge on the two constantly — Qwen documents temperature 0.7 with
+    top_p 0.8 — so a family may legitimately seed one and omit the other, and
+    an all-or-nothing pair would be unable to express that.
     """
     if not request.model.supports_sampling_params:
         return {}
-    return {
-        "temperature": (
-            request.temperature if request.temperature is not None else request.model.temperature
-        ),
-        top_p_key: request.top_p if request.top_p is not None else request.model.top_p,
-    }
+    params: dict[str, float] = {}
+    temperature = (
+        request.temperature if request.temperature is not None else request.model.temperature
+    )
+    if temperature is not None:
+        params["temperature"] = temperature
+    top_p = request.top_p if request.top_p is not None else request.model.top_p
+    if top_p is not None:
+        params[top_p_key] = top_p
+    return params
 
 
 #: Multiplier applied to a LOCAL token estimate before it is compared against a

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -1553,15 +1553,42 @@ def spec_for_target(base: ModelSpec, target: FallbackTarget) -> ModelSpec:
     ``supports_sampling_params`` needs no such care here, unlike in the
     clone-based version this replaced: it comes from the target's own
     ``build_model_spec`` rather than from the primary.
+
+    The temperature/top-p CARRY is conditional for the same "this knob belongs
+    to the model" reason as the effort clamp above. A sampling value is a
+    property of the MODEL (see ``_SAMPLING_POLICY``), so carrying the primary's
+    across a hop re-imposes a number the target's own vendor documents against
+    — falling back from a 0.2-configured primary onto a Gemini target would
+    reinstate precisely the value that makes it loop.
+
+    So the target's OWN policy is authoritative and the primary's values are
+    not carried at all. The knob cannot be treated as a session preference the
+    way it used to be, because a non-``None`` value on the base spec is
+    ambiguous: it may be a user's deliberate choice, but it is just as likely
+    the PRIMARY family's own seed (Gemini 2.5's 1.0/0.95), and propagating that
+    onto a target whose vendor documents 0.7/0.8 is the same category of error
+    this whole policy exists to stop.
+
+    The trade-off is deliberate and asymmetric: a session-level sampling
+    preference does not follow a hop onto a family that documents its own
+    value, whereas the reverse would re-impose a number documented to cause
+    looping or an HTTP 400 on the model that is supposed to RESCUE the turn.
+    A per-request override still reaches the wire through
+    ``ChatRequest.temperature``, which outranks the spec in
+    ``_sampling_params``.
     """
     from local_operator.model.configure import build_model_spec
 
     provider, model_id = parse_selector(target.selector)
     target_spec = build_model_spec(provider, model_id)
+    # `target_spec` already carries its own family's policy from
+    # `build_model_spec`, so the sampling knobs are simply left alone here --
+    # they are named explicitly rather than omitted so the next reader sees the
+    # decision instead of an absence.
     return target_spec.model_copy(
         update={
-            "temperature": base.temperature,
-            "top_p": base.top_p,
+            "temperature": target_spec.temperature,
+            "top_p": target_spec.top_p,
             "reasoning_effort": (
                 target.effort
                 if target.effort is not None

--- a/local_operator/server/models/schemas.py
+++ b/local_operator/server/models/schemas.py
@@ -29,7 +29,9 @@ class ChatOptions(BaseModel):
     Attributes:
         temperature: Controls randomness in responses. Higher values like 0.8 make output more
             random, while lower values like 0.2 make it more focused and deterministic.
-            Default: 0.8
+            Accepts 0.0-2.0, the range the vendors themselves document (Google states
+            0.0-2.0 for Gemini, Qwen [0, 2)); omitted means the model's own family
+            default applies rather than a value this app invents.
         top_p: Controls cumulative probability of tokens to sample from. Higher values (0.95) keep
             more options, lower values (0.1) are more selective. Default: 0.9
         top_k: Limits tokens to sample from at each step. Lower values (10) are more selective,
@@ -44,7 +46,11 @@ class ChatOptions(BaseModel):
         seed: Random number seed for deterministic generation. Default: None
     """
 
-    temperature: Optional[float] = Field(None, ge=0.0, le=1.0)
+    # Upper bound 2.0, not 1.0: the previous cap made a vendor-legal value
+    # unrepresentable, so a caller asking for 1.5 on a Gemini model got a 422
+    # from our own schema rather than an answer from the provider. top_p stays
+    # at 1.0, which is a probability mass and genuinely cannot exceed it.
+    temperature: Optional[float] = Field(None, ge=0.0, le=2.0)
     top_p: Optional[float] = Field(None, ge=0.0, le=1.0)
     top_k: Optional[int] = None
     max_tokens: Optional[int] = None

--- a/local_operator/server/routes/chat.py
+++ b/local_operator/server/routes/chat.py
@@ -86,7 +86,7 @@ EDIT_FILE_INSTRUCTIONS_TEMPLATE = "edit_file_instructions.md"
                                 "hosting": "openrouter",
                                 "model": "google/gemini-2.0-flash-001",
                                 "context": [],
-                                "options": {"temperature": 0.2, "top_p": 0.9},
+                                "options": {"temperature": 1.0, "top_p": 0.95},
                             },
                         }
                     }
@@ -214,7 +214,7 @@ async def chat_endpoint(
                                 "prompt": "How do I implement a binary search in Python?",
                                 "hosting": "openrouter",
                                 "model": "google/gemini-2.0-flash-001",
-                                "options": {"temperature": 0.2, "top_p": 0.9},
+                                "options": {"temperature": 1.0, "top_p": 0.95},
                                 "persist_conversation": False,
                             },
                         }
@@ -328,7 +328,7 @@ async def chat_with_agent(
                                 "hosting": "openrouter",
                                 "model": "google/gemini-2.0-flash-001",
                                 "context": [],
-                                "options": {"temperature": 0.2, "top_p": 0.9},
+                                "options": {"temperature": 1.0, "top_p": 0.95},
                             },
                         }
                     }
@@ -452,7 +452,7 @@ async def chat_async_endpoint(
                                 "prompt": "How do I implement a binary search in Python?",
                                 "hosting": "openrouter",
                                 "model": "google/gemini-2.0-flash-001",
-                                "options": {"temperature": 0.2, "top_p": 0.9},
+                                "options": {"temperature": 1.0, "top_p": 0.95},
                                 "persist_conversation": False,
                                 "user_message_id": "",
                             },

--- a/local_operator/server/routes/speech.py
+++ b/local_operator/server/routes/speech.py
@@ -126,8 +126,14 @@ async def create_agent_speech(
             hosting=hosting,
             model_name=model_name,
             credential_manager=credential_manager,
-            temperature=agent.temperature or 0.2,
-            top_p=agent.top_p or 0.9,
+            # Pass the agent's knobs THROUGH, including "unset". The former
+            # `or 0.2`/`or 0.9` re-asserted the app-wide constants that the
+            # per-family sampling policy exists to stop sending, so an agent
+            # with no stored preference had one invented for it here — and it
+            # also silently rewrote a deliberate 0.0 into 0.2, `or` being false
+            # for a legitimate zero.
+            temperature=agent.temperature,
+            top_p=agent.top_p,
             top_k=agent.top_k,
             max_tokens=agent.max_tokens,
             stop=agent.stop,

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -7410,11 +7410,24 @@ class Session:
             tools=[],
             tool_choice="none",
             max_tokens=self.ERRAND_MAX_TOKENS,
-            # Titling is extraction, not generation. Backends that default
-            # temperature high otherwise garble names. ``_sampling_params``
-            # already drops the key when the spec rejects sampling, so this
-            # cannot 400 a Claude-5 / o-series errand.
-            temperature=0,
+            # Titling is extraction, not generation, and a backend that
+            # defaults temperature high otherwise garbles names — but only
+            # where the model's own family accepts a value from us at all.
+            #
+            # Deferred to the spec's policy rather than hardcoded: a request
+            # value OUTRANKS the spec in ``_sampling_params``, so a literal 0
+            # here re-asserted the very number the sampling policy exists to
+            # stop sending, on exactly the families it was written for (Gemini
+            # 3.x, GPT-6, DeepSeek V4 all received 0.0 on this errand while the
+            # main turn correctly sent nothing). ``supports_sampling_params``
+            # covers the outright REJECTIONS, but not the families we merely
+            # stopped asserting over, so gating on the seed is what keeps the
+            # errand consistent with the turn.
+            #
+            # The failure mode this protects is quiet: the errand is
+            # ``isolated`` with one attempt and no fallback, so a rejected
+            # request surfaces only as a conversation that never gets a title.
+            temperature=model.temperature,
             replayable=False,
             isolated=True,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.69"
+version = "0.44.70"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/model/test_catalogue.py
+++ b/tests/unit/model/test_catalogue.py
@@ -1358,6 +1358,15 @@ def test_an_unshipped_xai_id_does_not_keep_the_unknown_placeholder_name(monkeypa
         # The id shape is kimi's, not the world's: a k-something on another
         # provider keeps its parameters.
         ("openrouter", "moonshotai/kimi-k2", True),
+        # Gemini stays True on BOTH generations, and that is the point of the
+        # flag: this is the hard-REJECTION capability (a 400), not the
+        # "should we assert a value" question. Google ignores an unwanted
+        # temperature rather than rejecting it, so the pair is dropped by the
+        # sampling POLICY (a `None` on the spec) instead — which is also what
+        # keeps a deliberate user override sendable. See
+        # `test_gemini_3_omits_sampling_on_every_route`.
+        ("google", "gemini-3.8-flash", True),
+        ("google", "gemini-2.5-pro", True),
     ],
 )
 def test_the_spec_knows_which_models_reject_sampling_parameters(
@@ -1371,6 +1380,226 @@ def test_the_spec_knows_which_models_reject_sampling_parameters(
 
     spec = configure_mod.build_model_spec(provider, model_id)
     assert spec.supports_sampling_params is supported
+
+
+@pytest.mark.parametrize(
+    "provider, model_id, temperature, top_p",
+    [
+        # OMIT rows: send nothing and let the vendor's own default apply.
+        #
+        # Gemini 3+ — "we recommend removing this parameter", and 3.6+ ignores
+        # a custom value outright (ai.google.dev/gemini-api/docs/gemini-3).
+        ("google", "gemini-3.8-flash", None, None),
+        ("google", "gemini-3-flash", None, None),
+        ("google", "gemini-3.1-pro-preview", None, None),
+        # Forward-reading over the generation digit.
+        ("google", "gemini-4-pro", None, None),
+        # Model-keyed, not provider-keyed: the same weights behind an
+        # aggregator behave identically. A provider-keyed rule would have fixed
+        # the direct route and left these two asserting 0.2.
+        ("openrouter", "google/gemini-3.8-flash", None, None),
+        ("radient", "google/gemini-3-pro", None, None),
+        # Anthropic 4.7+ — "Models released after Claude Opus 4.6 do not
+        # support setting temperature ... all other values will be rejected
+        # with a 400 error." The app sent 0.2, so this was a live outage.
+        ("anthropic", "claude-opus-4-7", None, None),
+        ("anthropic", "claude-opus-4-8", None, None),
+        ("anthropic", "claude-sonnet-4.7", None, None),
+        # OpenAI GPT-6 — "Remove `temperature`, `top_p`, and `top_logprobs`."
+        # The literal `gpt-5` arm in _NO_SAMPLING_PARAMS never matched this.
+        ("openai", "gpt-6-astra", None, None),
+        # DeepSeek V4 — thinking on by default, where the pair is inert.
+        ("deepseek", "deepseek-v4-pro", None, None),
+        # Moonshot/Kimi — pinned to fixed values across the current lineup.
+        ("kimi", "kimi-k2-0711-preview", None, None),
+        # Z.AI/GLM — per-SERIES defaults (1.0 vs 0.6), so no single seed is
+        # right for all of them.
+        ("zai", "glm-5.3", None, None),
+        # Mistral — publishes no static default by design.
+        ("mistral", "mistral-large-latest", None, None),
+        # xAI — defaults are UNKNOWN in the vendor's own reference.
+        ("xai", "grok-4", None, None),
+        # Ollama — never overrule the publisher's Modelfile.
+        ("ollama", "qwen3:32b", None, None),
+        # The fallback, and the most consequential row: an unknown model gets
+        # silence rather than an invented 0.2.
+        ("openrouter", "some-vendor/model-nobody-has-characterised", None, None),
+        # SEED rows: the vendor documents a value silence would not reproduce.
+        ("google", "gemini-2.5-pro", 1.0, 0.95),
+        ("google", "gemini-2.0-flash", 1.0, 0.95),
+        # The `reasoning` markers must not divert a 2.x model into an OMIT row.
+        ("google", "gemini-2.5-flash-thinking", 1.0, 0.95),
+        # A snapshot date must not read as a generation number — the trap
+        # `_EFFORT_TABLE` documents and the `\d{2,3}` bound closes.
+        ("google", "gemini-2.5-pro-20250314", 1.0, 0.95),
+        # Qwen documents temperature 0.7 with top_p 0.8 — the pair diverges,
+        # which is why the knobs are decided independently.
+        ("alibaba", "qwen3-coder-plus", 0.7, 0.8),
+        # Anthropic 4.5/4.6 and gpt-4o still HONOUR the pair — they keep
+        # `supports_sampling_params=True` and must not regress into the
+        # hard-rejection arm — but they still stop being TOLD 0.2. Their
+        # vendors document 1.0, so the app-wide constant was an assertion over
+        # a documented default here exactly as it was everywhere else; these
+        # fall through to the fallback and let the vendor decide.
+        ("anthropic", "claude-sonnet-4-5", None, None),
+        ("anthropic", "claude-3-5-sonnet-latest", None, None),
+        ("openai", "gpt-4o", None, None),
+    ],
+)
+def test_the_sampling_policy_answers_per_family(provider, model_id, temperature, top_p) -> None:
+    """The app shipped temperature 0.2 / top_p 0.9 to every provider on every
+    turn — an invented pair asserted over each vendor's own documented default,
+    which no major vendor sets anywhere near. `None` here means the key is
+    omitted so the vendor's default applies; a number means the vendor
+    documents something silence would not reproduce."""
+    from local_operator.model import configure as configure_mod
+
+    spec = configure_mod.build_model_spec(provider, model_id)
+    assert spec.temperature == temperature
+    assert spec.top_p == top_p
+
+
+@pytest.mark.parametrize(
+    "dotted, hyphenated",
+    [
+        ("gemini-3.0-flash", "gemini-3-flash"),
+        ("gemini-2.5-pro", "gemini-2-5-pro"),
+    ],
+)
+class TestADotAndAHyphenNameTheSameGeneration:
+    """Vendors ship both spellings, and a rule that reads only one silently
+    misclassifies the other on exactly the models it exists to protect."""
+
+    def test_both_spellings_get_the_same_sampling_policy(self, dotted, hyphenated) -> None:
+        from local_operator.model import configure as configure_mod
+
+        one = configure_mod.build_model_spec("google", dotted)
+        other = configure_mod.build_model_spec("google", hyphenated)
+        assert one.temperature == other.temperature
+        assert one.top_p == other.top_p
+
+
+def test_configure_model_does_not_stomp_the_models_own_sampling_policy() -> None:
+    """Trap: ``configure_model`` used to copy ``temperature``/``top_p`` onto the
+    spec unconditionally from parameters defaulting to the app-wide 0.2/0.9,
+    overwriting the model's own policy on the MAIN construction path. Without
+    this fix the whole table is dead on arrival."""
+    from local_operator.model.configure import configure_model
+
+    seeded = configure_model("google", "gemini-2.5-pro")
+    assert seeded.spec.temperature == 1.0
+    assert seeded.spec.top_p == 0.95
+    # ...and the legacy scalar attributes report what will actually be sent.
+    assert seeded.temperature == 1.0
+    assert seeded.top_p == 0.95
+
+    omitted = configure_model("google", "gemini-3.8-flash")
+    assert omitted.spec.temperature is None
+    assert omitted.spec.top_p is None
+
+
+def test_an_explicit_override_still_wins_on_every_family() -> None:
+    """The escape hatch. A user or agent record that deliberately sets a value
+    — and the server's per-request ``options`` — must still win, including on
+    families whose policy is to omit. Determinism-seeking users must not be
+    stranded by a table written for the default case."""
+    from local_operator.model.configure import configure_model
+
+    for provider, model_id in (
+        ("google", "gemini-3.8-flash"),
+        ("anthropic", "claude-opus-4-7"),
+        ("ollama", "qwen3:32b"),
+        ("google", "gemini-2.5-pro"),
+    ):
+        overridden = configure_model(provider, model_id, temperature=0.0, top_p=0.5)
+        assert overridden.spec.temperature == 0.0, model_id
+        assert overridden.spec.top_p == 0.5, model_id
+
+    # A partial override leaves the other knob on the model's own policy.
+    partial = configure_model("google", "gemini-2.5-pro", temperature=0.3)
+    assert partial.spec.temperature == 0.3
+    assert partial.spec.top_p == 0.95
+
+
+def test_a_providers_listing_may_narrow_the_sampling_policy_but_never_widen_it() -> None:
+    """OpenRouter publishes a ``supported_parameters`` allowlist, and 81 of 425
+    live models omit ``temperature`` from it — a per-model fact the curated
+    table cannot keep up with, so an unknown model gets it right for free.
+
+    But it may only NARROW. The listing answers "will the aggregator forward
+    this", not "will the model honour it": `google/gemini-3.8-flash` DOES list
+    temperature as supported, because OpenRouter forwards it and Google then
+    ignores it. A listing must therefore never turn a curated OMIT back into a
+    send.
+    """
+    from pydantic import BaseModel, ConfigDict
+
+    from local_operator.model import configure as configure_mod
+
+    class _Entry(BaseModel):
+        # Mirrors the real listing schemas, which declare no sampling fields and
+        # carry them as extras; built via `model_validate` so the undeclared
+        # keys are the extras the production path actually reads.
+        model_config = ConfigDict(extra="allow")
+
+    configure_mod._sampling_support_memo.clear()
+    try:
+        # NARROWING: a family the table seeds, whose listing denies the key.
+        seeded = configure_mod.build_model_spec("openrouter", "alibaba/qwen3-coder-plus")
+        assert seeded.temperature == 0.7
+        configure_mod._remember_listing_sampling_support(
+            "openrouter",
+            "alibaba/qwen3-coder-plus",
+            _Entry.model_validate(
+                {
+                    "id": "alibaba/qwen3-coder-plus",
+                    "supported_parameters": ["max_tokens", "tools"],
+                }
+            ),
+        )
+        narrowed = configure_mod.build_model_spec("openrouter", "alibaba/qwen3-coder-plus")
+        assert narrowed.temperature is None
+        assert narrowed.top_p is None
+
+        # NO WIDENING: the listing says temperature is supported, but Google
+        # ignores it, so the curated OMIT must survive.
+        configure_mod._remember_listing_sampling_support(
+            "openrouter",
+            "google/gemini-3.8-flash",
+            _Entry.model_validate(
+                {
+                    "id": "google/gemini-3.8-flash",
+                    "supported_parameters": ["temperature", "top_p", "max_tokens"],
+                }
+            ),
+        )
+        still_omitted = configure_mod.build_model_spec("openrouter", "google/gemini-3.8-flash")
+        assert still_omitted.temperature is None
+        assert still_omitted.top_p is None
+
+        # SILENCE defers to the table: a listing with no allowlist at all (the
+        # Radient case, whose passthrough semantics are unverified) changes
+        # nothing.
+        configure_mod._remember_listing_sampling_support(
+            "radient",
+            "google/gemini-2.5-pro",
+            _Entry.model_validate({"id": "google/gemini-2.5-pro"}),
+        )
+        untouched = configure_mod.build_model_spec("radient", "google/gemini-2.5-pro")
+        assert untouched.temperature == 1.0
+        assert untouched.top_p == 0.95
+    finally:
+        configure_mod._sampling_support_memo.clear()
+
+
+def test_a_hard_rejection_still_beats_an_explicit_override() -> None:
+    """The one place an override does NOT win, and deliberately so: a family
+    that answers HTTP 400 makes the turn fail rather than honour a preference.
+    ``supports_sampling_params`` is that separate, stronger capability."""
+    from local_operator.model.configure import configure_model
+
+    rejected = configure_model("anthropic", "claude-opus-5", temperature=0.7)
+    assert rejected.spec.supports_sampling_params is False
 
 
 def test_concurrent_cold_misses_fetch_exactly_once(tmp_path, monkeypatch) -> None:

--- a/tests/unit/model/test_catalogue.py
+++ b/tests/unit/model/test_catalogue.py
@@ -23,10 +23,12 @@ from unittest import mock
 import httpx
 import pytest
 
+from local_operator.harness.types import ChatRequest, Message
 from local_operator.model import catalogue
 from local_operator.model import configure as configure_mod
 from local_operator.model import effort
 from local_operator.model.catalogue import cached_listing
+from local_operator.providers.clients import OpenAICompatClient
 
 
 def _payload(model_id: str = "vendor/model", window: int = 1_000_000) -> dict[str, Any]:
@@ -1590,6 +1592,110 @@ def test_a_providers_listing_may_narrow_the_sampling_policy_but_never_widen_it()
         assert untouched.top_p == 0.95
     finally:
         configure_mod._sampling_support_memo.clear()
+
+
+@pytest.mark.parametrize(
+    "provider, model_id",
+    [
+        # "all other values will be rejected with a 400 error"
+        ("anthropic", "claude-opus-4-7"),
+        ("anthropic", "claude-opus-4-8"),
+        ("anthropic", "claude-sonnet-4.7"),
+        # "Unsupported parameters: Remove `temperature`, `top_p`"
+        ("openai", "gpt-6-astra"),
+        # The aggregator routes reach the same weights and must agree.
+        ("openrouter", "anthropic/claude-opus-4-7"),
+        ("radient", "openai/gpt-6-astra"),
+    ],
+)
+def test_a_reject_family_suppresses_an_override_instead_of_400ing(provider, model_id) -> None:
+    """REGRESSION (R1): dropping only our own default is not enough on a family
+    whose vendor REJECTS the parameter. A stored agent temperature — the shape
+    the server's own API examples advertise — would otherwise ride to the wire
+    and fail every single turn, which is the PR's headline outage relocated
+    from the default path onto the override path.
+
+    This is the distinction between "the vendor ignores it" (an override is
+    harmless) and "the vendor rejects it" (an override is a failed turn).
+    """
+    from local_operator.model.configure import configure_model
+
+    configured = configure_model(provider, model_id, None, temperature=0.2, top_p=0.9)
+    assert configured.spec.supports_sampling_params is False
+
+    request = ChatRequest(model=configured.spec, messages=[Message.user("hi")])
+    body = OpenAICompatClient("https://x")._build_body(request)
+    assert "temperature" not in body
+    assert "top_p" not in body
+
+
+@pytest.mark.parametrize(
+    "provider, model_id",
+    [
+        # Ignores an unwanted value, so an override costs nothing.
+        ("google", "gemini-3.8-flash"),
+        # Genuinely honours the pair.
+        ("anthropic", "claude-sonnet-4-5"),
+        ("google", "gemini-2.5-pro"),
+        # Legacy Kimi ids accept the pair; only the documented coding-host ids
+        # are hard-suppressed, via _KIMI_PINNED_SAMPLING.
+        ("kimi", "kimi-k2-0711-preview"),
+    ],
+)
+def test_an_ignore_or_honour_family_still_forwards_an_override(provider, model_id) -> None:
+    """The other half of R1: suppression must not spread. A user who asks for
+    determinism on a family that ignores or honours the value still gets it."""
+    from local_operator.model.configure import configure_model
+
+    configured = configure_model(provider, model_id, None, temperature=0.2, top_p=0.9)
+    request = ChatRequest(model=configured.spec, messages=[Message.user("hi")])
+    body = OpenAICompatClient("https://x")._build_body(request)
+    assert body["temperature"] == 0.2
+    assert body["top_p"] == 0.9
+
+
+@pytest.mark.parametrize(
+    "provider, model_id, expected",
+    [
+        # OMIT families: the errand must not re-assert a value the main turn
+        # deliberately stopped sending.
+        ("openai", "gpt-6-astra", None),
+        ("google", "gemini-3.8-flash", None),
+        ("deepseek", "deepseek-v4-pro", None),
+        ("anthropic", "claude-opus-4-7", None),
+        # A seeded family still gets its documented value on the errand.
+        ("google", "gemini-2.5-pro", 1.0),
+        ("alibaba", "qwen3-coder-plus", 0.7),
+    ],
+)
+def test_the_title_errand_follows_the_same_sampling_policy_as_a_turn(
+    provider, model_id, expected
+) -> None:
+    """REGRESSION (Q1): the conversation-titling errand built its own
+    ``ChatRequest(temperature=0)``, and a request value OUTRANKS the spec in
+    ``_sampling_params`` — so the errand re-asserted 0.0 on exactly the families
+    the policy table exists for, while the main turn correctly sent nothing.
+
+    The failure mode is quiet: the errand is ``isolated`` with one attempt and
+    no fallback, so a rejected request surfaces only as a conversation that
+    never gets a title.
+
+    Mirrors the construction at ``session.py``'s ``_title_via_model``.
+    """
+    spec = configure_mod.build_model_spec(provider, model_id)
+    request = ChatRequest(
+        model=spec,
+        messages=[Message.user("t")],
+        tools=[],
+        tool_choice="none",
+        max_tokens=32,
+        temperature=spec.temperature,
+    )
+    body = OpenAICompatClient("https://x")._build_body(request)
+    if expected is None:
+        assert "temperature" not in body
+    else:
+        assert body["temperature"] == expected
 
 
 def test_a_hard_rejection_still_beats_an_explicit_override() -> None:

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -21,7 +21,6 @@ from pydantic import SecretStr
 from local_operator.credentials import CredentialManager
 from local_operator.harness.types import ChatRequest, Message, ModelSpec
 from local_operator.model.configure import (
-    DEFAULT_TEMPERATURE,
     build_model_spec,
     calculate_cost,
     configure_model,
@@ -146,7 +145,11 @@ def test_configure_model_anthropic_spec(mock_credential_manager):
     config = configure_model("anthropic", "claude-3-5-sonnet-latest", mock_credential_manager)
     assert config.spec.provider == "anthropic"
     assert config.spec.base_url == "https://api.anthropic.com"
-    assert config.temperature == DEFAULT_TEMPERATURE
+    # No caller-supplied value, so the per-family sampling policy decides. This
+    # model falls through to the OMIT fallback: the app no longer asserts its
+    # own 0.2 over a vendor default it never established. DEFAULT_TEMPERATURE
+    # remains exported for the explicit-override path.
+    assert config.temperature is None
 
 
 def test_configure_model_kimi_base_url(mock_credential_manager):

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -2037,6 +2037,88 @@ def test_sampling_params_omitted_when_model_rejects_them(wire: str, top_p_key: s
     assert '"temperature"' not in serialised and f'"{top_p_key}"' not in serialised
 
 
+@pytest.mark.parametrize(
+    "provider,model_id",
+    [
+        # Google: documented looping below 1.0, and "remove this parameter".
+        ("google", "gemini-3.8-flash"),
+        ("google", "gemini-3-flash"),
+        # The aggregator routes to the SAME weights — what a provider-keyed
+        # rule would have missed.
+        ("openrouter", "google/gemini-3.8-flash"),
+        ("radient", "google/gemini-3-pro"),
+        # Anthropic 4.7+: a documented HTTP 400 on any value but 1.0. The app
+        # sent 0.2, so this row was a live outage.
+        ("anthropic", "claude-opus-4-7"),
+        # OpenAI GPT-6: "Remove `temperature`, `top_p`, and `top_logprobs`."
+        ("openai", "gpt-6-astra"),
+        # Accepted-but-inert, pinned, per-series, or undocumented defaults.
+        ("deepseek", "deepseek-v4-pro"),
+        ("zai", "glm-5.3"),
+        ("mistral", "mistral-large-latest"),
+        ("xai", "grok-4"),
+        # Never overrule a local publisher's Modelfile.
+        ("ollama", "qwen3:32b"),
+        # The fallback: an uncharacterised model gets silence, not 0.2.
+        ("openrouter", "some-vendor/model-nobody-has-characterised"),
+    ],
+)
+@pytest.mark.parametrize("wire,top_p_key", WIRES)
+def test_families_that_omit_sampling_send_neither_key(
+    wire: str, top_p_key: str, provider: str, model_id: str
+) -> None:
+    """The keys must be ABSENT from the real body, not null: a provider that
+    ignores or rejects a value is not helped by receiving an explicit one, and
+    omission is what lets the vendor's own default apply."""
+    from local_operator.model.configure import build_model_spec
+
+    spec = build_model_spec(provider, model_id)
+    body = _bodies(ChatRequest(model=spec, messages=[Message.user("hi")]))[wire]
+    assert "temperature" not in body
+    assert top_p_key not in body
+    serialised = json.dumps(body)
+    assert '"temperature"' not in serialised and f'"{top_p_key}"' not in serialised
+
+
+@pytest.mark.parametrize(
+    "provider,model_id,temperature,top_p",
+    [
+        # Google's own getModel reports these as the 2.x defaults.
+        ("google", "gemini-2.5-pro", 1.0, 0.95),
+        # Qwen's per-model table: the pair DIVERGES, which is why the knobs are
+        # resolved independently rather than as an all-or-nothing pair.
+        ("alibaba", "qwen3-coder-plus", 0.7, 0.8),
+    ],
+)
+@pytest.mark.parametrize("wire,top_p_key", WIRES)
+def test_families_that_seed_send_the_vendors_documented_values(
+    wire: str, top_p_key: str, provider: str, model_id: str, temperature: float, top_p: float
+) -> None:
+    """Where a vendor documents a value silence would not reproduce, the pair is
+    still sent — at the vendor's number, never the app's invented 0.2/0.9."""
+    from local_operator.model.configure import build_model_spec
+
+    spec = build_model_spec(provider, model_id)
+    body = _bodies(ChatRequest(model=spec, messages=[Message.user("hi")]))[wire]
+    assert body["temperature"] == temperature
+    assert body[top_p_key] == top_p
+
+
+@pytest.mark.parametrize("wire,top_p_key", WIRES)
+def test_an_explicit_request_value_still_reaches_the_wire(wire: str, top_p_key: str) -> None:
+    """The escape hatch, asserted at the WIRE rather than on the spec: a user
+    who deliberately asks for determinism must still get it on a family whose
+    default policy is to stay silent."""
+    from local_operator.model.configure import build_model_spec
+
+    spec = build_model_spec("google", "gemini-3.8-flash")
+    request = ChatRequest(model=spec, messages=[Message.user("hi")], temperature=0.0, top_p=0.5)
+    body = _bodies(request)[wire]
+    # 0.0 in particular: a falsy value that an `or`-style default would eat.
+    assert body["temperature"] == 0.0
+    assert body[top_p_key] == 0.5
+
+
 @pytest.mark.parametrize("wire,top_p_key", WIRES)
 def test_sampling_params_still_sent_when_model_accepts_them(wire: str, top_p_key: str) -> None:
     """The regression guard for the fix itself: sampling is a real feature, and

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -252,6 +252,39 @@ def test_structured_fallback_entry_carries_effort() -> None:
     assert spec.reasoning_effort == "high"
 
 
+def test_failover_hop_does_not_reimpose_the_primarys_sampling_on_the_target() -> None:
+    """Trap: ``spec_for_target`` carried ``base.temperature``/``top_p`` onto the
+    target unconditionally, so a hop from a 0.2-configured primary re-imposed
+    on the target exactly the value its own vendor documents against — a live
+    wire bug on any target that still sends the pair.
+
+    A sampling value belongs to the MODEL, so the target's own policy wins; the
+    session's value rides only into a knob the target leaves open.
+    """
+    base = ModelSpec(
+        provider="anthropic",
+        model_id="claude-sonnet-4-5",
+        temperature=0.2,
+        top_p=0.9,
+    )
+
+    # A target that documents its own values keeps them across the hop.
+    two_x = spec_for_target(base, FallbackTarget("google/gemini-2.5-pro", None))
+    assert two_x.temperature == 1.0
+    assert two_x.top_p == 0.95
+
+    # A target whose policy is to omit is not handed the primary's 0.2.
+    three_x = spec_for_target(base, FallbackTarget("google/gemini-3.8-flash", None))
+    assert three_x.temperature is None
+    assert three_x.top_p is None
+
+    # Per-knob, not per-pair: Qwen seeds both, but a family that seeded only one
+    # must not have the other clobbered.
+    qwen = spec_for_target(base, FallbackTarget("alibaba/qwen3-coder-plus", None))
+    assert qwen.temperature == 0.7
+    assert qwen.top_p == 0.8
+
+
 def test_invalid_structured_effort_is_not_silently_dropped(caplog) -> None:
     """The name is the assertion: dropped, and NOT silently.
 

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -2927,7 +2927,13 @@ async def test_the_naming_errand_leaves_the_session_isolated_and_cheap(tmp_path,
     assert request.replayable is False, "a title is worth one attempt, not a replay"
     assert request.max_tokens == Session.ERRAND_MAX_TOKENS
     assert Session.ERRAND_MAX_TOKENS == 1024
-    assert request.temperature == 0
+    # The errand follows the MODEL's sampling policy instead of hardcoding 0.
+    # A request value outranks the spec in ``_sampling_params``, so a literal 0
+    # here re-asserted the exact number the per-family policy exists to stop
+    # sending, on the families it was written for. `MODEL` reaches the OMIT
+    # fallback, so the errand asserts nothing and the vendor's default applies.
+    assert request.temperature == request.model.temperature
+    assert request.temperature is None
     assert request.model == session._errand_model()
     assert request.model.model_id == MODEL.model_id, "no `lo` tier is configured here"
     assert request.tools == [] and request.tool_choice == "none"


### PR DESCRIPTION
## Summary

`local_operator/model/configure.py` hardcoded `DEFAULT_TEMPERATURE = 0.2` / `DEFAULT_TOP_P = 0.9` onto every `ModelSpec` and sent that pair to **every provider on every turn**. The reported bug was Gemini 3 getting stuck in output loops, but the audit found that is one visible face of a general defect: **no major vendor documents a default anywhere near 0.2** — essentially all are 1.0 — so lop was asserting an invented number over each vendor's own tuning, and on several current families over a documented hard rejection.

This replaces the two constants with a **model-keyed sampling policy table**, following the precedent already argued in these files for `_NO_SAMPLING_PARAMS` and `_EFFORT_TABLE`: a sampling contract is a property of the model, not of the route to it. That is what makes `google/gemini-3.8-flash`, `openrouter/google/gemini-3.8-flash` and `radient/google/gemini-3-pro` behave identically — a provider-keyed rule would have fixed the direct route and left every aggregator route carrying the bug.

Each row either **OMITs** the pair (letting the vendor's own default apply) or **SEEDs** a value the vendor documents that silence would not reproduce. `temperature` and `top_p` are resolved **independently**, because vendors diverge on them (Qwen documents 0.7 with top_p 0.8).

**Omission is preferred to a number** wherever a vendor documents a default: it is self-updating, it cannot drift stale, it is literally what Google's migration guide prescribes, and OpenRouter notes that an explicitly sent value "may differ from omitting it (for example, it can affect provider-side cache keys)".

## Vendor justification (all primary sources)

| Family | temp | top_p | Source |
|---|---|---|---|
| Gemini ≥3.x | OMIT | OMIT | *"For all Gemini 3 models, we strongly recommend keeping the temperature parameter at its default value of 1.0... Changing the temperature (setting it below 1.0) may lead to unexpected behavior, such as **looping** or degraded performance"* and *"we recommend **removing this parameter**"* — [ai.google.dev/gemini-api/docs/gemini-3](https://ai.google.dev/gemini-api/docs/gemini-3) |
| Gemini ≤2.5 | 1.0 | 0.95 | Honoured; `getModel` reports these as the per-model defaults |
| Anthropic ≥4.7 | OMIT | OMIT | *"Models released after Claude Opus 4.6 do not support setting temperature. A value of 1.0 will be accepted for backwards compatibility, all other values will be **rejected with a 400 error**."* — [platform.claude.com/docs/en/api/messages.md](https://platform.claude.com/docs/en/api/messages.md) |
| OpenAI gpt-5.x/6+/o-series | OMIT | OMIT | GPT-6 Astra: *"Unsupported parameters: Remove `temperature`, `top_p`, and `top_logprobs`."* |
| DeepSeek V4 | OMIT | OMIT | Thinking on by default: *"Thinking mode does not support the temperature, top_p... setting these parameters will not trigger an error but will also have no effect"* |
| Moonshot / Kimi | OMIT | OMIT | K3: *"`temperature=1.0`, `top_p=0.95` ... are fixed; omit them from requests"* |
| Alibaba / Qwen | 0.7 | 0.8 | Per-model default table |
| Z.AI / GLM | OMIT | OMIT | Defaults are **per-series** (1.0 for 5.x/4.7/4.6, 0.6 for 4.5), so no single seed is right |
| Mistral | OMIT | OMIT | Publishes no static default by design; exposes `default_model_temperature` per model card |
| xAI / Grok | OMIT | OMIT | **UNKNOWN** — typed `number \| null` with no stated default. Omission is the only honest option |
| Ollama | OMIT | OMIT | Defaults 0.8/0.9, overridden by the model's Modelfile. We cannot know what the user pulled, so we must not overrule its publisher |
| **Unknown / fallback** | OMIT | OMIT | The most consequential row: silence beats an invented 0.2 |

**Qwen judgement call:** seeds the model *defaults* (0.7/0.8), not Qwen's separate coding row (0.2). lop runs summarisation, commit messages and compaction through the same spec, and 0.2 is the exact assertion this PR exists to stop making.

**Not implemented — DeepSeek 0.0-for-coding.** An older DeepSeek page recommends temperature 0.0 for coding, but it predates V4 and thinking mode, and DeepSeek's own coding-agent benchmarks run at 1.0/0.95. That row is stale; a comment in the table warns future readers not to revive it.

## Three plumbing bugs that made per-model defaults inexpressible

These are provider-agnostic and load-bearing — without them the table is dead on arrival.

1. **`configure_model` stomped the spec** (`configure.py`). It ran an unconditional `model_copy(update={"temperature": temperature, "top_p": top_p})` from parameters defaulting to the global constants, so any per-model seed was overwritten with 0.2/0.9 on the main construction path. Now a `None` sentinel applies the override only when a caller genuinely passed one. Both real override paths (`_AGENT_SAMPLING_FIELDS`, the server's `ChatRequest.options`) already omit unset knobs. `DEFAULT_TEMPERATURE`/`DEFAULT_TOP_P` remain exported.
2. **The failover hop re-imposed the primary's values** (`failover.py`). `spec_for_target` carried `base.temperature`/`top_p` onto the target, so a hop from a 0.2-configured primary re-imposed on a Gemini target exactly the value documented to make it loop. **This was a live wire bug, not cosmetic** — it applied to any target that still sends the pair. The target's own policy is now authoritative; a non-`None` base value is ambiguous (a user's choice, or just as likely the *primary* family's seed) and propagating it is the same category of error.
3. **`ModelSpec` field defaults** (`harness/types.py`) were a second copy of 0.2/0.9. Audited: `build_model_spec` is the only production constructor, and `FrontendModelSpec` is an `extra="allow"` wire-deserialisation subclass carrying transmitted values. The fields are now `float | None` defaulting to `None`, so a directly-constructed spec inherits omission rather than an invented number.

**Also found and fixed:** `server/routes/speech.py` re-asserted `temperature=agent.temperature or 0.2`, defeating the table for that route — and `or` also silently rewrote a deliberate `0.0` into `0.2`.

## Aggregator listing narrowing

OpenRouter publishes a `supported_parameters` allowlist. Verified live: **81 of 425 models omit `temperature`** from it. That is a per-model fact the curated table cannot keep up with, so unknown models get it right for free.

It may only **narrow**, never widen. The listing answers *"will the aggregator forward this"*, not *"will the model honour it"* — `google/gemini-3.8-flash` **does** list `temperature` as supported, because OpenRouter forwards it and Google then ignores it. Silence defers to the table, mirroring the effort-ladder precedent. **Radient is UNVERIFIED** and documents no passthrough semantics, so its listing is never read as a denial.

## Testing evidence

### Real wire bodies, before vs after

Captured from the actual `_build_body` of each of the four wire clients, driven through the real `build_model_spec`. The "before" column is a **separate worktree checked out at `origin/main`**, verified to be genuinely main's code (no `_SAMPLING_POLICY`, `DEFAULT_TEMPERATURE == 0.2`) rather than asserted:

| Route | Before (main) | After |
|---|---|---|
| `alibaba/qwen3-coder-plus` | `temp=0.2, top_p=0.9` | `temp=0.7, top_p=0.8` |
| `anthropic/claude-opus-4-7` | `temp=0.2, top_p=0.9` | **both absent** |
| `anthropic/claude-opus-4-8` | `temp=0.2, top_p=0.9` | **both absent** |
| `anthropic/claude-sonnet-4-5` | `temp=0.2, top_p=0.9` | **both absent** |
| `deepseek/deepseek-v4-pro` | `temp=0.2, top_p=0.9` | **both absent** |
| `google/gemini-2.5-pro` | `temp=0.2, top_p=0.9` | `temp=1.0, top_p=0.95` |
| `google/gemini-3.8-flash` | `temp=0.2, top_p=0.9` | **both absent** |
| `kimi/kimi-k2-0711-preview` | `temp=0.2, top_p=0.9` | **both absent** |
| `mistral/mistral-large-latest` | `temp=0.2, top_p=0.9` | **both absent** |
| `ollama/qwen3:32b` | `temp=0.2, top_p=0.9` | **both absent** |
| `openai/gpt-4o` | `temp=0.2, top_p=0.9` | **both absent** |
| `openai/gpt-6-astra` | `temp=0.2, top_p=0.9` | **both absent** |
| `openrouter/google/gemini-3.8-flash` | `temp=0.2, top_p=0.9` | **both absent** |
| `openrouter/some-vendor/uncharacterised-model` | `temp=0.2, top_p=0.9` | **both absent** |
| `radient/google/gemini-3-pro` | `temp=0.2, top_p=0.9` | **both absent** |
| `xai/grok-4` | `temp=0.2, top_p=0.9` | **both absent** |
| `zai/glm-5.3` | `temp=0.2, top_p=0.9` | **both absent** |

Every one of the seventeen routes was receiving `0.2/0.9` on main.

### Proven at the socket, not just in the body builder

A local HTTP server captured what the real `OpenAICompatClient` actually transmits over a real connection:

```
google/gemini-3.8-flash    REAL SENT BODY -> temperature=ABSENT, top_p=ABSENT
google/gemini-2.5-pro      REAL SENT BODY -> temperature=1.0, top_p=0.95
alibaba/qwen3-coder-plus   REAL SENT BODY -> temperature=0.7, top_p=0.8
anthropic/claude-opus-4-7  REAL SENT BODY -> temperature=ABSENT, top_p=ABSENT
```

### Live round trip

Against a real Gemini 3.8 Flash through Radient (`chat/completions`), both the new body and the old 0.2/0.9 body returned **HTTP 200**. That is the point: this is a **silent quality bug**, which is why no error ever surfaced it.

**Which route actually carried the outage (corrected after QA round 1).** An earlier draft of this description said the Anthropic 4.7/4.8 rejection fired "on every turn on the direct route". That was too strong. On the **direct** `anthropic` route, `claude-opus-4-7` already omitted the pair on `origin/main`, because the Anthropic builder gates sampling on the same branch that writes `thinking`. The 0.2 was reaching those models through the **aggregator** routes — QA confirmed `openrouter/anthropic/claude-opus-4-7` and `radient/anthropic/claude-opus-4-8` both sent `temperature=0.2` on base. That incidental thinking-gate protection is also why the R1 override leak below read as safe on the Anthropic wire while leaking on every OpenAI-compat route.

**Honest limitation:** the credentials store has only a Radient key — no direct Anthropic/OpenAI/DeepSeek/Mistral/xAI keys. The `claude-opus-4-7` HTTP 400 is **vendor-documented, not locally reproduced**. I have not observed the 400 first-hand and am not claiming to.

### Listing narrowing, exercised against the live OpenRouter listing

- Narrowing fires: a seeded family whose allowlist denies the key went `temp 0.7 -> None`.
- No widening: `google/gemini-3.8-flash`, whose live allowlist **does** include `temperature`, stayed `None`.

### Escape hatch

Explicitly tested at both the spec and the wire: a deliberate `temperature=0.0` / `top_p=0.5` still reaches the body on families whose policy is to omit. `0.0` specifically, since it is the falsy value an `or`-style default eats.

### Gates (whole tree, as CI runs them)

```
flake8 .                          CLEAN
black --check .    (26.1.0)       834 files unchanged
isort --check-only (5.13.2)       CLEAN
pyright                           0 errors, 0 warnings
pytest tests/unit                 11852 passed, 15 skipped (414s)
```

**Note for whoever picks this up:** pyright needs `--pythonpath .venv/bin/python` here, or it resolves the wrong interpreter and reports ~1089 phantom `reportMissingImports`.

## Preserved invariants

- `("google", "gemini-2.5-flash-thinking")` still keeps its sampling — the `reasoning` markers do not divert it.
- Kimi mainland (`kimi-k2-0711-preview`, `moonshot-v1-128k`) and the coding-host rows unchanged.
- Claude 5+, o-series and gpt-5 still hard-omit via `_NO_SAMPLING_PARAMS`.
- Snapshot dates (`gemini-2.5-pro-20250314`) still cannot read as generation numbers.

`supports_sampling_params` (hard 400 rejection, strips even an explicit override) is kept **distinct** from the policy `None` (we simply stop asserting; a user override still rides). Gemini 3 *ignores* rather than rejects, so it belongs in the second category — which is what preserves the escape hatch.

## ⚠️ Environment trap for QA

The worktree I was handed had a **symlinked `.venv` whose editable finder pointed at `/private/tmp/lop-attach-tui`, a deleted worktree**. Per `AGENTS.md` §"Every feature worktree owns its own venv", this silently splits behaviour: `pytest` (cwd-first) reads the branch, while anything run as the product resolves `~/local-operator` — i.e. `main`. I rebuilt a real venv before trusting any result. **Verify `.venv/bin/python -c "import local_operator; print(local_operator.__file__)"` points into your own checkout before running anything.**

## Round 1 remediation (head `1d6e5fe6`)

Rebased onto current `origin/main` (`06928224`, #593) — the previous `0.44.67` bump collided with the version #593 already released, so this now bumps to **0.44.68**. `git merge-tree` reported a clean merge; `pyproject.toml` was the only overlap.

The blocker: the table distinguished *vendor ignores* from *vendor rejects*, but the escape hatch did not, so reject-families forwarded a stored agent `temperature` into a documented 400. `_SamplingPolicy` is now a `NamedTuple` carrying a `rejects` flag, and a rejecting row clears `supports_sampling_params` — reusing the existing suppression rather than inventing a second one. A `NamedTuple` rather than a second `(None, None)` sentinel because **equal constant tuples are interned to one object**, so two such sentinels would be indistinguishable by identity and silently collapse.

Anthropic ≥4.7 and GPT-6+ are REJECT; Gemini 3.x stays OMIT. Kimi stays OMIT — that row also catches legacy ids (`kimi-k2-0711-preview`, `moonshot-v1-128k`) that accept the pair, and mainland policy is unverified; the documented-reject coding ids keep their scoped suppression via `_KIMI_PINNED_SAMPLING`.

| behaviour | override `temperature=0.2` reaches wire? |
|---|---|
| `gpt-6-astra`, `claude-opus-4-7/4-8` (REJECT) | no — suppressed |
| `openrouter/anthropic/claude-opus-4-7` (REJECT) | no — suppressed |
| `gemini-3.8-flash` (OMIT, vendor ignores) | yes — harmless |
| `claude-sonnet-4-5`, `kimi-k2-0711-preview` (HONOUR) | yes — correct |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

