### PR TITLE
fix(harness): continue a turn the network cut short instead of ending the run

### DIFF
--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -140,6 +140,39 @@ STEERING_INTERRUPT_POLL_S = 0.25
 #: without burning the user's quota on a model that cannot answer today.
 MAX_EMPTY_TRUNCATION_RETRIES = 2
 
+#: How many times ONE run will continue a turn that the network cut short —
+#: the laptop closed at home and opened at work, which is minutes of no route
+#: to anywhere.
+#:
+#: The provider layer already waits that reconnect out patiently
+#: (``CONNECTIVITY_MAX_RETRIES``, ~9 minutes of backoff against the SAME
+#: target). This is the outer budget for the case that wait was not enough, and
+#: it is deliberately small: each continuation buys another full patient wait,
+#: so three is ~27 minutes of tolerated outage — past any plausible commute —
+#: while still bounded, because a genuinely dead network has to surface an
+#: error rather than pin the session in a silent retry forever.
+#:
+#: Only a CONNECTIVITY loss is continued, never an ordinary stream error. When
+#: the machine is offline nothing was wrong with the request, the credential or
+#: the provider, so re-asking is the whole fix; a 5xx or a refusal means the
+#: provider DID answer, and replaying that turn would re-bill it to hide a
+#: failure the user needs to see.
+MAX_CONNECTIVITY_CONTINUATIONS = 3
+
+#: What the loop tells the model after the network cut its answer short.
+#:
+#: Phrased as an instruction about what the USER can see, because that is the
+#: constraint the model cannot infer: the partial text is in the transcript and
+#: has already been read, so restarting the answer would show it twice. It is a
+#: user-role message rather than a bare trailing assistant turn on purpose —
+#: see the call site: prefilling is rejected by current Claude models.
+CONNECTIVITY_CONTINUATION_PROMPT = (
+    "[system] Your previous response was cut off mid-sentence by a network "
+    "interruption. The partial text above has already been shown to the user. "
+    "Continue it seamlessly from exactly where it stopped — do not repeat any "
+    "of it, do not restart, and do not apologise or mention the interruption."
+)
+
 
 def _lower_effort(model: "ModelSpec") -> str | None:
     """The effort one rung below ``model.reasoning_effort`` on its own ladder.
@@ -488,6 +521,11 @@ class AgentLoop:
         # that DID produce text or calls is truncated, not silent, and keeps
         # the old pair-and-stop behaviour.
         empty_truncation_retries = 0
+        # Turns this run has continued after the network cut them short. Run-
+        # scoped, not per-turn: a laptop carried between networks can interrupt
+        # the same run more than once, and the budget bounds the RUN's total
+        # tolerance for that rather than handing each turn a fresh allowance.
+        connectivity_continuations = 0
         # The effort ceiling an empty-truncation retreat imposed; rides on
         # every request under it so the session's frozen auto-effort cannot
         # raise the retry back to the rung that produced nothing.
@@ -538,6 +576,7 @@ class AgentLoop:
                             return
 
                     assistant, stop_reason, stream_error = None, "stop", None
+                    turn_connectivity_loss = False
                     async for event in self._model_turn(
                         context,
                         config,
@@ -555,10 +594,104 @@ class AgentLoop:
                                 event.stop_reason,
                                 event.error,
                             )
+                            turn_connectivity_loss = event.connectivity_loss
                         else:
                             yield event
                     if assistant is None:
                         raise RuntimeError("model turn produced no assistant message")
+
+                    if turn_connectivity_loss:
+                        # THE NETWORK WENT AWAY MID-TURN — the laptop was closed
+                        # at home and opened at work. The provider layer has
+                        # already spent its patient budget waiting for a route
+                        # back (~9 min of connectivity backoff), and there is
+                        # still none, so this is the outer, coarser retry.
+                        #
+                        # Only reachable once output was already forwarded: with
+                        # nothing forwarded, the failover driver retries in place
+                        # and the turn never ends this way. That is exactly why
+                        # the driver CANNOT fix this case itself — those deltas
+                        # are already in the user's transcript, so re-issuing the
+                        # same request there would stream them a second time
+                        # (the invariant `test_a_turn_does_NOT_replay_output_the_
+                        # user_already_read` locks down). Continuing HERE is what
+                        # makes a retry safe: the partial answer is committed to
+                        # the context as an assistant message just below, so the
+                        # next request carries it as history and the model writes
+                        # only the REMAINDER. Nothing the user has read is
+                        # re-rendered, because the continuation is a new message
+                        # rather than a replay of the old one.
+                        #
+                        # The cost of that safety is honesty about the seam: the
+                        # model resumes from the text, not from its own hidden
+                        # state, so a sentence cut mid-word is continued rather
+                        # than rewritten. That beats the alternative this
+                        # replaces, which was ending the entire run.
+                        if connectivity_continuations < MAX_CONNECTIVITY_CONTINUATIONS:
+                            connectivity_continuations += 1
+                            # Dangling tool calls are DROPPED, not paired. A call
+                            # whose arguments were still streaming when the socket
+                            # died is truncated JSON — executing it would run a
+                            # tool the model never finished asking for. Clearing
+                            # them also keeps the wire legal without synthetic
+                            # results: no tool_use block means no unmatched
+                            # tool_result, and the retry re-decides what to call.
+                            assistant.tool_calls = []
+                            if assistant.text:
+                                # The partial answer becomes history, which is
+                                # what makes the continuation additive instead of
+                                # a replay.
+                                #
+                                # The partial text is committed VERBATIM,
+                                # trailing space and all, so the transcript is
+                                # byte-for-byte what the user actually read. That
+                                # is safe only because of the continuation
+                                # message appended directly below: Anthropic
+                                # rejects trailing whitespace on a FINAL
+                                # assistant message ("final assistant content
+                                # cannot end with trailing whitespace"), and an
+                                # interrupted delta is exactly how one is
+                                # produced — but this message is never final, so
+                                # the rule does not apply and nothing has to be
+                                # trimmed away from what was displayed.
+                                context.messages.append(assistant)
+                                new_messages.append(assistant)
+                                # A CONTINUATION INSTRUCTION, not a bare trailing
+                                # assistant turn. Leaving the partial answer last
+                                # is "prefilling", which current Claude models
+                                # refuse outright ("Prefilling assistant messages
+                                # is not supported for this model", HTTP 400) —
+                                # so the very models this harness defaults to
+                                # would turn a recoverable network blip into a
+                                # hard failure. A user-role instruction is legal
+                                # on every wire, keeps the alternation Anthropic
+                                # documents, and states the constraint the model
+                                # must respect: continue, do not restart, because
+                                # the user has ALREADY READ the text above.
+                                context.messages.append(
+                                    Message.user(CONNECTIVITY_CONTINUATION_PROMPT)
+                                )
+                            # No text and no calls? The message is DROPPED rather
+                            # than committed: there is nothing to continue from,
+                            # and an assistant message with no content blocks is
+                            # rejected outright on the Anthropic wire
+                            # ("text content blocks must be non-empty"), which
+                            # would kill the very run this is rescuing. The retry
+                            # simply re-asks the original question.
+                            yield NoticeEvent(
+                                text=(
+                                    "network connection lost mid-response — "
+                                    "reconnected, continuing where it left off"
+                                ),
+                                kind="warning",
+                            )
+                            has_more_tool_calls = True
+                            continue
+                        # Budget spent and still offline: fall through to the
+                        # terminal branch below, which surfaces the provider's
+                        # own diagnostic error. A dead network must end the run
+                        # with a bounded, named failure rather than retry forever.
+
                     if assistant.usage is not None and assistant.usage.context_tokens:
                         # Only a REPORTED count advances the hint: a wire that
                         # omits it must not blank a figure the previous call
@@ -873,6 +1006,9 @@ class AgentLoop:
         provider_payload: dict[str, Any] | None = None
         stop_reason = "stop"
         error: str | None = None
+        # Set only by the except arm below, from the exception's own flag: the
+        # harness cannot import ``providers`` to classify this itself.
+        connectivity_loss = False
 
         yield TurnStartEvent()
         yield MessageStartEvent(message=assistant)
@@ -1040,6 +1176,19 @@ class AgentLoop:
             )
             stop_reason = "aborted" if (signal is not None and signal.aborted) else "error"
             error = error or str(exc)
+            # A stream the NETWORK cut, as opposed to one a provider failed. Read
+            # off the exception rather than re-classified here: the single
+            # definition lives in ``providers.failover.is_connectivity_loss`` and
+            # rides out on ``RenderedStreamError.connectivity_loss``. ``getattr``
+            # because this arm also catches defects and third-party exceptions,
+            # which carry no such attribute.
+            #
+            # Not applied to an ABORT: the user pressed the key, and a turn they
+            # stopped must stay stopped even if a connectivity error is what the
+            # cancelled socket happened to raise on its way out.
+            connectivity_loss = stop_reason == "error" and bool(
+                getattr(exc, "connectivity_loss", False)
+            )
 
         if signal is not None and signal.aborted:
             # A stream CUT by the abort ends without its ``StreamEndEvent``, so
@@ -1114,7 +1263,12 @@ class AgentLoop:
             pass
 
         yield MessageEndEvent(message=assistant)
-        yield _ModelTurnResult(message=assistant, stop_reason=stop_reason, error=error)
+        yield _ModelTurnResult(
+            message=assistant,
+            stop_reason=stop_reason,
+            error=error,
+            connectivity_loss=connectivity_loss,
+        )
 
     @staticmethod
     def _assemble_tool_call(state: dict[str, Any]) -> ToolCall:
@@ -2161,3 +2315,7 @@ class _ModelTurnResult:
     message: Message
     stop_reason: str
     error: str | None = None
+    #: The stream died because the MACHINE was offline, not because the provider
+    #: answered badly. Carried out to the run loop, which continues such a turn
+    #: instead of ending the run on it — see ``MAX_CONNECTIVITY_CONTINUATIONS``.
+    connectivity_loss: bool = False

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -145,12 +145,16 @@ MAX_EMPTY_TRUNCATION_RETRIES = 2
 #: to anywhere.
 #:
 #: The provider layer already waits that reconnect out patiently
-#: (``CONNECTIVITY_MAX_RETRIES``, ~9 minutes of backoff against the SAME
-#: target). This is the outer budget for the case that wait was not enough, and
-#: it is deliberately small: each continuation buys another full patient wait,
-#: so three is ~27 minutes of tolerated outage — past any plausible commute —
-#: while still bounded, because a genuinely dead network has to surface an
-#: error rather than pin the session in a silent retry forever.
+#: (``CONNECTIVITY_MAX_RETRIES`` = 15 attempts against the SAME target, a 60s
+#: cap). This is the outer budget for the case that wait was not enough, and it
+#: is deliberately small: each continuation buys another full patient wait.
+#:
+#: MEASURED, not estimated, by summing the real delay function over the jitter:
+#: one patient wait averages ~7.9 min, so the initial attempt plus three
+#: continuations tolerates ~32 min of outage (~29-34 min across the jitter
+#: range) — past any plausible commute — while staying bounded, because a
+#: genuinely dead network has to surface an error rather than pin the session in
+#: a silent retry forever.
 #:
 #: Only a CONNECTIVITY loss is continued, never an ordinary stream error. When
 #: the machine is offline nothing was wrong with the request, the credential or
@@ -629,15 +633,47 @@ class AgentLoop:
                         # replaces, which was ending the entire run.
                         if connectivity_continuations < MAX_CONNECTIVITY_CONTINUATIONS:
                             connectivity_continuations += 1
-                            # Dangling tool calls are DROPPED, not paired. A call
-                            # whose arguments were still streaming when the socket
-                            # died is truncated JSON — executing it would run a
-                            # tool the model never finished asking for. Clearing
-                            # them also keeps the wire legal without synthetic
-                            # results: no tool_use block means no unmatched
-                            # tool_result, and the retry re-decides what to call.
-                            assistant.tool_calls = []
-                            if assistant.text:
+                            # TRUNCATED calls are dropped; COMPLETE ones are not.
+                            # A call still being dictated when the socket died is
+                            # truncated JSON, and executing it would run a tool
+                            # the model never finished asking for. But a call
+                            # whose arguments finished arriving BEFORE the cut is
+                            # a complete request the model did make, and throwing
+                            # it away loses real work twice over: the tool never
+                            # runs, and the continuation prompt below then
+                            # describes a turn that was "cut off mid-sentence"
+                            # while the model's own record of having asked for
+                            # the call has been deleted from history.
+                            #
+                            # `_assemble_tool_call` already draws the line: it
+                            # parses the accumulated JSON and leaves `arguments`
+                            # empty while keeping `raw_arguments` when the parse
+                            # failed. So "parsed, or had nothing to parse" is
+                            # complete, and "had raw text that would not parse"
+                            # is truncated. A call with NO raw arguments at all
+                            # is a zero-argument call, which is complete.
+                            truncated = [
+                                call
+                                for call in assistant.tool_calls
+                                if call.raw_arguments and not call.arguments
+                            ]
+                            assistant.tool_calls = [
+                                call for call in assistant.tool_calls if call not in truncated
+                            ]
+                            # WHITESPACE-ONLY TEXT IS NOT TEXT. The wire builders
+                            # drop an assistant turn whose text is whitespace-only
+                            # (`_is_empty_assistant`, clients.py: "Whitespace-only
+                            # text counts as empty"), so a model that emitted a
+                            # single newline before the cut would have its turn
+                            # vanish from the request while the continuation
+                            # prompt went on referring to "the partial text
+                            # above" — pointing at nothing. The guard is aligned
+                            # with the serializer so that case routes to the
+                            # drop-and-re-ask arm instead. Tool calls ARE content
+                            # by that same predicate, so a turn carrying only a
+                            # complete call is still committable.
+                            resumable_text = bool(assistant.text.strip())
+                            if resumable_text or assistant.tool_calls:
                                 # The partial answer becomes history, which is
                                 # what makes the continuation additive instead of
                                 # a replay.
@@ -645,43 +681,104 @@ class AgentLoop:
                                 # The partial text is committed VERBATIM,
                                 # trailing space and all, so the transcript is
                                 # byte-for-byte what the user actually read. That
-                                # is safe only because of the continuation
-                                # message appended directly below: Anthropic
-                                # rejects trailing whitespace on a FINAL
-                                # assistant message ("final assistant content
-                                # cannot end with trailing whitespace"), and an
-                                # interrupted delta is exactly how one is
-                                # produced — but this message is never final, so
-                                # the rule does not apply and nothing has to be
-                                # trimmed away from what was displayed.
+                                # is safe only because SOMETHING always follows it
+                                # below — the continuation prompt, or a tool
+                                # result for a surviving call: Anthropic rejects
+                                # trailing whitespace on a FINAL assistant
+                                # message ("final assistant content cannot end
+                                # with trailing whitespace"), and an interrupted
+                                # delta is exactly how one is produced. This
+                                # message is never final, so the rule does not
+                                # apply and nothing has to be trimmed away from
+                                # what was displayed.
                                 context.messages.append(assistant)
                                 new_messages.append(assistant)
-                                # A CONTINUATION INSTRUCTION, not a bare trailing
-                                # assistant turn. Leaving the partial answer last
-                                # is "prefilling", which current Claude models
-                                # refuse outright ("Prefilling assistant messages
-                                # is not supported for this model", HTTP 400) —
-                                # so the very models this harness defaults to
-                                # would turn a recoverable network blip into a
-                                # hard failure. A user-role instruction is legal
-                                # on every wire, keeps the alternation Anthropic
-                                # documents, and states the constraint the model
-                                # must respect: continue, do not restart, because
-                                # the user has ALREADY READ the text above.
-                                context.messages.append(
-                                    Message.user(CONNECTIVITY_CONTINUATION_PROMPT)
-                                )
-                            # No text and no calls? The message is DROPPED rather
-                            # than committed: there is nothing to continue from,
-                            # and an assistant message with no content blocks is
-                            # rejected outright on the Anthropic wire
-                            # ("text content blocks must be non-empty"), which
-                            # would kill the very run this is rescuing. The retry
-                            # simply re-asks the original question.
+                                if assistant.tool_calls:
+                                    # PAIR the survivors. An assistant turn
+                                    # carrying a `tool_use` block with no matching
+                                    # `tool_result` is a 400 on the Anthropic
+                                    # wire, and this turn becomes history for the
+                                    # retry rather than being executed — the
+                                    # network died before the loop could run it.
+                                    # The same synthetic `aborted` result every
+                                    # other abandoned-turn path here uses, so the
+                                    # model learns the call did not run and may
+                                    # re-issue it, which is strictly more
+                                    # information than the call having vanished.
+                                    self._append_results(
+                                        context,
+                                        [
+                                            self._synthetic_result(call, ABORTED_RESULT_TEXT)
+                                            for call in assistant.tool_calls
+                                        ],
+                                        new_messages,
+                                        redact=config.redact_tool_result,
+                                    )
+                                elif resumable_text:
+                                    # A CONTINUATION INSTRUCTION, not a bare
+                                    # trailing assistant turn. Leaving the partial
+                                    # answer last is "prefilling", which current
+                                    # Claude models refuse outright ("Prefilling
+                                    # assistant messages is not supported for this
+                                    # model", HTTP 400) — so the very models this
+                                    # harness defaults to would turn a recoverable
+                                    # network blip into a hard failure. A
+                                    # user-role instruction is legal on every
+                                    # wire, keeps the alternation Anthropic
+                                    # documents, and states the constraint the
+                                    # model must respect: continue, do not
+                                    # restart, because the user has ALREADY READ
+                                    # the text above.
+                                    #
+                                    # Appended to new_messages as well as to the
+                                    # live context, because `new_messages` is what
+                                    # `AgentEndEvent` hands to the host to
+                                    # PERSIST. Left out, a resumed session reads
+                                    # the partial answer glued directly to its
+                                    # continuation with no record that a network
+                                    # interruption sat between them — and a run
+                                    # that continued more than once persisted a
+                                    # run of consecutive assistant messages that
+                                    # no longer explains itself, which compaction
+                                    # then summarises. It is harness chrome, so
+                                    # the front ends suppress it on replay the
+                                    # same way they already suppress the
+                                    # compaction continuation prompt.
+                                    prompt = Message.user(CONNECTIVITY_CONTINUATION_PROMPT)
+                                    context.messages.append(prompt)
+                                    new_messages.append(prompt)
+                            # Neither text nor a surviving call? The message is
+                            # DROPPED rather than committed: there is nothing to
+                            # continue from, and an assistant message with no
+                            # content blocks is rejected outright on the Anthropic
+                            # wire ("text content blocks must be non-empty"),
+                            # which would kill the very run this is rescuing. The
+                            # retry simply re-asks the original question.
+                            #
+                            # The turn is CLOSED before continuing. `TurnEndEvent`
+                            # is what drives a front end's per-turn reconciliation
+                            # — in the TUI, `_retire_live_tool_cards`, the only
+                            # routine path that settles rows for calls that never
+                            # ran. Without it a call the model was still dictating
+                            # when the socket died leaves a spinner animating
+                            # forever on a turn that ended, and the working line
+                            # keeps announcing "composing a call" while the
+                            # continued turn streams prose. Every other continuing
+                            # path in this loop reaches a TurnEndEvent; this one
+                            # must too.
+                            yield TurnEndEvent(message=assistant, tool_results=[])
+                            # The notice states what HAS happened, not what is
+                            # hoped for. It is emitted BEFORE the retry, so it
+                            # cannot honestly claim a reconnection — on a
+                            # genuinely dead network the old wording told the user
+                            # three times that the machine had reconnected and
+                            # then ended the run. Naming the budget also shows it
+                            # being spent rather than repeating one identical line.
                             yield NoticeEvent(
                                 text=(
                                     "network connection lost mid-response — "
-                                    "reconnected, continuing where it left off"
+                                    f"retrying ({connectivity_continuations}/"
+                                    f"{MAX_CONNECTIVITY_CONTINUATIONS})"
                                 ),
                                 kind="warning",
                             )

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -714,7 +714,40 @@ class AgentLoop:
                                         new_messages,
                                         redact=config.redact_tool_result,
                                     )
-                                elif resumable_text:
+                                if resumable_text:
+                                    # KEYED ON PROSE ALONE, independently of the
+                                    # pairing above — an `elif` here silently lost
+                                    # the instruction for the one shape that most
+                                    # needs it. A cut that produced BOTH partial
+                                    # prose and a complete call took the pairing
+                                    # arm and never reached this one, so text the
+                                    # user had already read was committed to
+                                    # history with nothing telling the model not
+                                    # to repeat it, and the answer could restart
+                                    # mid-sentence ("Paris is the capital of Paris
+                                    # is the capital of France."). Keeping the
+                                    # calls (above) is what made that shape
+                                    # reachable: before it, any turn with a call
+                                    # had its calls cleared and fell into the
+                                    # text arm, which did append this prompt.
+                                    #
+                                    # Ordering is load-bearing: the synthetic tool
+                                    # results are appended FIRST, so the prompt
+                                    # still lands after them and the `tool_use` →
+                                    # `tool_result` adjacency the wire requires is
+                                    # never broken by a user turn wedged between.
+                                    # Verified on both real serializers for this
+                                    # shape: Anthropic gets blocks
+                                    # `[[text],[text,tool_use],[tool_result],[text]]`
+                                    # with no unpaired id, OpenAI gets roles
+                                    # `user,assistant,tool,user`. Anthropic renders
+                                    # a `tool_result` as a USER turn, so the prompt
+                                    # follows one — legal since Anthropic began
+                                    # accepting consecutive same-role messages
+                                    # (Oct 2024), and the alternation concern the
+                                    # comment below raises is about a TRAILING
+                                    # assistant turn, which this shape never has.
+                                    #
                                     # A CONTINUATION INSTRUCTION, not a bare
                                     # trailing assistant turn. Leaving the partial
                                     # answer last is "prefilling", which current
@@ -743,7 +776,13 @@ class AgentLoop:
                                     # then summarises. It is harness chrome, so
                                     # the front ends suppress it on replay the
                                     # same way they already suppress the
-                                    # compaction continuation prompt.
+                                    # compaction continuation prompt. REPLAY is
+                                    # the only surface that needs it: this row
+                                    # reaches the transcript via
+                                    # `_persist_new_messages`, which appends
+                                    # without emitting a `MessageStartEvent`, so
+                                    # there is no live announcement to suppress
+                                    # and the announce loop is correctly untouched.
                                     prompt = Message.user(CONNECTIVITY_CONTINUATION_PROMPT)
                                     context.messages.append(prompt)
                                     new_messages.append(prompt)

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -79,6 +79,18 @@ class RenderedStreamError(Exception):
     not import the provider layer — the dependency only runs the other way.
     """
 
+    #: The MACHINE was offline (DNS/route/socket failed before any HTTP), as
+    #: opposed to a provider that answered badly. Declared here, on the base
+    #: class, precisely BECAUSE the harness must not import ``providers``: the
+    #: loop has to tell "the laptop moved between wifi networks" apart from "the
+    #: provider 500ed" to decide whether an interrupted turn may be continued,
+    #: and this attribute is the only channel that does not invert the layering.
+    #: ``providers.failover.ProviderError`` sets it from ``is_connectivity_loss``
+    #: (the single classifier — this is a carrier, never a second definition);
+    #: every other stream error keeps the ``False`` default, so a client that
+    #: knows nothing about it behaves exactly as before.
+    connectivity_loss: bool = False
+
 
 # ---------------------------------------------------------------------------
 # Content blocks

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -30,6 +30,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from local_operator.harness.comms import HUB_MESSAGE_TYPE, extract_parent_message
+from local_operator.harness.loop import CONNECTIVITY_CONTINUATION_PROMPT
 from local_operator.harness.types import (
     AgentEndEvent,
     AgentEvent,
@@ -627,6 +628,13 @@ def fold_messages_to_entries(history: list[AgentMessage]) -> list[TranscriptEntr
                     TranscriptEntry(id=message.id, kind="parent_message", text=parent_message.body)
                 )
                 continue
+            if message.text == CONNECTIVITY_CONTINUATION_PROMPT:
+                # Harness chrome, not the user's words: the loop persists this
+                # so the TRANSCRIPT records why one answer arrived in two
+                # pieces, but no front end paints it as a user bubble — the
+                # live run showed a notice instead. Same rule as the TUI's
+                # replay suppression; the surfaces must not diverge.
+                continue
             # Carry image attachments as references so an image-only prompt
             # (the composer allows "" text + images) renders its thumbnails on
             # replay instead of round-tripping as an empty bubble — the same
@@ -761,6 +769,11 @@ class ProjectionFold:
                     )
                 continue
             if message.role == "user":
+                if message.text == CONNECTIVITY_CONTINUATION_PROMPT:
+                    # Harness chrome — see ``fold_messages_to_entries``, whose
+                    # rule this mirrors so the attaching phone and the
+                    # lazy-loaded page agree about the same row.
+                    continue
                 parent_message = extract_parent_message(message.text)
                 if parent_message is not None:
                     # A persisted hub steer renders as the parent's own words,

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -313,6 +313,15 @@ class ProviderError(RenderedStreamError):
         self.retryable = retryable
         self.retry_after_ms = retry_after_ms
         self.auth_error = auth_error
+        #: Stamped at construction so the flag travels with the exception across
+        #: the layer boundary (see ``RenderedStreamError.connectivity_loss``):
+        #: the harness must decide whether an interrupted turn is continuable,
+        #: and it cannot import this module to ask. Computed by the SAME
+        #: classifier every other call site uses rather than re-derived, so
+        #: there is still exactly one definition of "the machine is offline".
+        #: Safe to evaluate here — the classifier reads only ``status`` and
+        #: ``message``, both already assigned above.
+        self.connectivity_loss = is_connectivity_loss(self)
 
     def __str__(self) -> str:
         """``<kind> (HTTP <status>, retry in <wait>): <the provider's words>``.

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -151,6 +151,69 @@ _CONNECTIVITY_LOSS_MARKERS = (
     "errno 50",
 )
 
+#: Transport failures that mean "a connection that was ALREADY WORKING died" —
+#: the mid-stream counterpart to :data:`_CONNECTIVITY_LOSS_MARKERS`, and
+#: deliberately a SEPARATE tuple consulted only by
+#: :func:`is_mid_stream_connectivity_loss`.
+#:
+#: The two lists answer different questions and must not be merged. The markers
+#: above are all PRE-connection evidence: a name that would not resolve, a route
+#: that did not exist. A socket that dies AFTER the response body started cannot
+#: produce any of them — the name already resolved and the route already existed
+#: — so it raises one of these classes instead, frequently with an EMPTY message
+#: (``httpx.ReadError('')`` is what a TCP RST mid-body actually surfaces as, so
+#: matching on text alone catches nothing and the class name is the whole of the
+#: evidence).
+#:
+#: Why these are treated as the local link failing rather than the provider
+#: failing, when the same classes could mean either: by the time this predicate
+#: is asked, bytes have ALREADY flowed on this connection. The name resolved,
+#: the route existed, the provider accepted the request and began answering. A
+#: provider that was healthy enough to start streaming and then drops the TCP
+#: connection without an HTTP status is far more likely to be on the other side
+#: of a link that just went away (the laptop closed at home and opened at work)
+#: than to have failed in a way worth rotating credentials over — and a provider
+#: that genuinely failed mid-answer says so IN BAND, with a status or an error
+#: chunk, which :func:`is_mid_stream_connectivity_loss` excludes on ``status``.
+#:
+#: ``httpx.ProtocolError`` is included for its ``RemoteProtocolError`` member
+#: ("peer closed connection without sending complete message body"), which is
+#: how a truncated chunked body arrives. ``LocalProtocolError`` rides the same
+#: base but cannot occur here: it is raised while BUILDING a request, before
+#: any byte is forwarded, so this predicate is never reached with one.
+_MID_STREAM_TRANSPORT_LOSS_CLASSES: tuple[type[BaseException], ...] = (
+    httpx.ReadError,
+    httpx.WriteError,
+    httpx.CloseError,
+    httpx.ReadTimeout,
+    httpx.WriteTimeout,
+    httpx.ProtocolError,
+)
+
+#: Class NAMES for the wrapped-``ProviderError`` path, where the exception
+#: object is gone and its class name survives only as the HEAD of ``message``
+#: (``"<ClassName>: <detail>"``, or the bare name when the detail is empty —
+#: see :func:`wrap_transport_error`), which is precisely why that wrap puts the
+#: class name there rather than only the detail.
+#:
+#: Matched with ``startswith`` rather than a substring scan, because these are
+#: only evidence in the NAME position: a provider whose prose happens to say
+#: "read error" is describing its own trouble, not this machine's socket. The
+#: bare name is matched (no trailing colon) because ``httpx.ReadError('')``
+#: wraps to exactly ``"ReadError"`` with no colon at all — and an empty message
+#: is the single most common shape of a real mid-body RST.
+#:
+#: The CONCRETE classes are enumerated, not the bases: nothing raises a bare
+#: ``ProtocolError``. Kept adjacent to the class tuple so the two cannot drift.
+_MID_STREAM_TRANSPORT_LOSS_NAMES = (
+    "readerror",
+    "writeerror",
+    "closeerror",
+    "readtimeout",
+    "writetimeout",
+    "remoteprotocolerror",
+)
+
 
 def _is_usage_limit(status: int | None, message: str) -> bool:
     """429, or a body that SAYS it ran out.
@@ -295,6 +358,7 @@ class ProviderError(RenderedStreamError):
         retry_after_ms: int | None = None,
         auth_error: bool = False,
         kind: ProviderErrorKind | None = None,
+        transport: bool = False,
     ) -> None:
         provider_text = message.strip() if isinstance(message, str) else str(message)
         #: Classified BEFORE the floor text is substituted, so the classifier only
@@ -313,6 +377,23 @@ class ProviderError(RenderedStreamError):
         self.retryable = retryable
         self.retry_after_ms = retry_after_ms
         self.auth_error = auth_error
+        #: PROVENANCE, not classification: this error was built from a transport
+        #: exception this machine's own client raised (:func:`wrap_transport_error`
+        #: is the only writer), rather than parsed out of something a provider
+        #: SAID. It exists because the two are indistinguishable by text, and one
+        #: of them is a lie: an in-band error chunk on an HTTP 200 stream carries
+        #: no status, so a provider describing its OWN upstream trouble
+        #: ("upstream: network is unreachable at edge") reads exactly like this
+        #: machine's socket dying. Message text alone cannot tell a failure this
+        #: process observed from a failure a provider narrated, and
+        #: :func:`is_mid_stream_connectivity_loss` gates a control-flow decision
+        #: on that difference — whether to CONTINUE the turn or surface it.
+        #:
+        #: Deliberately not consulted by :func:`is_connectivity_loss`, whose
+        #: pre-connect semantics and callers are unchanged by this PR: a client
+        #: that builds its own connectivity ``ProviderError`` must keep taking
+        #: the patient path there.
+        self.transport = transport
         #: Stamped at construction so the flag travels with the exception across
         #: the layer boundary (see ``RenderedStreamError.connectivity_loss``):
         #: the harness must decide whether an interrupted turn is continuable,
@@ -321,7 +402,33 @@ class ProviderError(RenderedStreamError):
         #: there is still exactly one definition of "the machine is offline".
         #: Safe to evaluate here — the classifier reads only ``status`` and
         #: ``message``, both already assigned above.
-        self.connectivity_loss = is_connectivity_loss(self)
+        #:
+        #: This is the PRE-CONNECT half only. The mid-stream half cannot be
+        #: decided here, because it turns on a fact no exception carries:
+        #: whether bytes had already reached the caller on this connection.
+        #: Only the driver knows that (``forwarded_any``), so it is the driver
+        #: that upgrades this flag on the mid-stream raise path — see
+        #: :func:`is_mid_stream_connectivity_loss` and its two call sites in
+        #: :func:`stream_with_failover`.
+        #:
+        #: Gated on ``transport`` — provenance — as well as on the classifier,
+        #: and that gate is load-bearing rather than defensive. This flag DRIVES
+        #: CONTROL FLOW in the harness (continue the turn, or end the run), and
+        #: :func:`is_connectivity_loss` alone cannot support that weight: a
+        #: provider's in-band error chunk on an HTTP 200 stream carries no
+        #: status, so a provider describing its OWN upstream trouble
+        #: ("upstream: network is unreachable at edge") matches the offline
+        #: markers word for word. Believed, it would make the loop silently
+        #: re-ask a turn the provider had already failed — burning the budget
+        #: and hiding a failure the user needs to see — instead of surfacing it.
+        #: Requiring that OUR client observed the failure is what makes the
+        #: distinction, because the text cannot.
+        #:
+        #: :func:`is_connectivity_loss` itself is deliberately NOT gated this
+        #: way: its callers choose a backoff, where believing such a provider
+        #: merely means waiting patiently on one that is genuinely unwell, and
+        #: changing it would alter behaviour this fix has no business touching.
+        self.connectivity_loss = transport and is_connectivity_loss(self)
 
     def __str__(self) -> str:
         """``<kind> (HTTP <status>, retry in <wait>): <the provider's words>``.
@@ -527,6 +634,74 @@ def is_transient_error(error: BaseException) -> bool:
     return classify_provider_error(error) in ("transient", "timeout")
 
 
+def is_mid_stream_connectivity_loss(error: BaseException) -> bool:
+    """The link died AFTER the answer started — a turn worth CONTINUING.
+
+    The mid-stream sibling of :func:`is_connectivity_loss`, and deliberately a
+    second predicate rather than a widening of the first. The two are asked at
+    different moments, about different evidence, to decide different things,
+    and merging them would break both:
+
+    - :func:`is_connectivity_loss` is asked BEFORE any byte was forwarded, to
+      choose a patient minutes-long backoff over a fast retry-and-rotate. Its
+      markers are pre-connection facts (a name that would not resolve, a route
+      that did not exist), and they must stay that way: a provider that is
+      genuinely broken has to keep the fast retry AND the fallback walk that
+      routes around it. Handing it the ~9-minute patient wait while suppressing
+      rotation would turn one sick provider into a stalled session.
+    - This predicate is asked only once deltas have ALREADY reached the user,
+      to decide whether the interrupted turn may be resumed. Bytes having
+      flowed is the whole of the difference: the name resolved, the route
+      existed, and the provider accepted the request and began answering, so a
+      transport death *now* is far more likely to be the local link than the
+      provider. That is an inference the pre-connect caller cannot make and
+      must not inherit.
+
+    Concretely, the exception families are disjoint. A mid-body TCP RST raises
+    ``httpx.ReadError`` (routinely with an EMPTY message), a truncated chunked
+    body raises ``RemoteProtocolError``, a silent link drop trips the stall
+    watchdog's ``ReadTimeout`` — none of which can carry a DNS or route marker,
+    which is why the pre-connect list classifies every one of them ``False``.
+
+    ``status`` must still be absent, and that guard is doing real work here: a
+    provider that answered — with an HTTP status, or with an in-band error
+    chunk carrying one — reported its OWN failure, and replaying that turn
+    would re-bill it while hiding a failure the user needs to see. Only a
+    STATUS-LESS transport death qualifies.
+    """
+    if isinstance(error, ProviderError):
+        if error.status is not None:
+            return False
+        # A provider that ANSWERED must not be able to talk its way into this
+        # branch with its own prose. `wrap_transport_error` is the only writer
+        # of a status-less transport failure, and it stamps this flag; an error
+        # parsed out of a provider's error CHUNK never has it, however much its
+        # message sounds like a socket failure (see `ProviderError.transport`).
+        if not error.transport:
+            return False
+        # Only the NAME position counts — see the marker tuple.
+        return error.message.lower().startswith(_MID_STREAM_TRANSPORT_LOSS_NAMES)
+    return isinstance(error, _MID_STREAM_TRANSPORT_LOSS_CLASSES)
+
+
+def _mark_mid_stream_connectivity(error: ProviderError) -> None:
+    """Upgrade ``connectivity_loss`` on an error raised AFTER deltas were sent.
+
+    Called from the two ``forwarded_any`` raise sites in
+    :func:`stream_with_failover`, and only from there, because "bytes already
+    reached the caller" is the fact the classification turns on and the driver
+    is the only frame that holds it. Doing it here rather than in
+    ``ProviderError.__init__`` is what keeps the pre-connect classifier honest:
+    the same ``ReadError`` seen BEFORE any delta stays an ordinary transient
+    and keeps its fast retry and its fallback walk.
+
+    Never clears the flag — a pre-connect connectivity loss that somehow
+    surfaces here is still one. Only ever an upgrade.
+    """
+    if is_mid_stream_connectivity_loss(error):
+        error.connectivity_loss = True
+
+
 def is_connectivity_loss(error: BaseException) -> bool:
     """The MACHINE is offline — DNS/route/socket-connect failed before any HTTP.
 
@@ -546,6 +721,24 @@ def is_connectivity_loss(error: BaseException) -> bool:
     ``kind``: :func:`wrap_transport_error` keeps these ``kind="transient"``
     because "transient provider error" is the right frame for the user, so the
     class/errno text is the only signal that separates them from a 5xx.
+
+    KNOWN IMPRECISION, deliberately left alone here. The ``status is None``
+    guard means "no HTTP response", but an in-band error CHUNK on an HTTP 200
+    stream also has no status (``_ANTHROPIC_ERROR_STATUS`` returns ``None`` for
+    an unknown type), so a provider narrating its OWN upstream trouble —
+    ``{"type": "upstream_error", "message": "upstream: network is unreachable
+    at edge"}`` — matches these markers and classifies as this machine being
+    offline. The consequence HERE is benign and arguably right: the caller
+    waits patiently instead of hammering a provider whose upstream is down, and
+    a provider that keeps saying it eventually exhausts the patient budget.
+
+    It is NOT benign for a control-flow decision, which is why
+    :func:`is_mid_stream_connectivity_loss` — the predicate that decides whether
+    to CONTINUE an interrupted turn — additionally requires
+    ``ProviderError.transport``, i.e. that our own client raised the failure
+    rather than a provider having described one. Tightening this function the
+    same way would change the patient-backoff behaviour of every existing
+    caller, which is out of scope for the mid-stream fix that needed it.
     """
     if isinstance(error, ProviderError):
         # `message` already carries the wrapped "<ClassName>: <detail>" text
@@ -1761,6 +1954,10 @@ def wrap_transport_error(exc: BaseException) -> ProviderError:
         f"{name}: {detail}" if detail else name,
         retryable=True,
         kind="timeout" if timed_out else "transient",
+        # PROVENANCE: this failure was observed by our own client, not narrated
+        # by a provider. `is_mid_stream_connectivity_loss` needs that distinction
+        # and cannot recover it from the text — see `ProviderError.transport`.
+        transport=True,
     )
 
 
@@ -2199,7 +2396,15 @@ async def stream_with_failover(
                 raise
             except ProviderError as exc:
                 if forwarded_any:
-                    raise  # partial output already reached the caller
+                    # Partial output already reached the caller, so this attempt
+                    # cannot be retried HERE — replaying it would stream deltas
+                    # the user has already read. Before it goes up, mark whether
+                    # it is the kind of failure the LOOP can continue instead:
+                    # only this frame knows bytes were forwarded, which is the
+                    # whole of the mid-stream inference (see
+                    # `is_mid_stream_connectivity_loss`).
+                    _mark_mid_stream_connectivity(exc)
+                    raise
                 record(exc, primary=is_primary)
                 target_retry_after_ms = max(target_retry_after_ms, exc.retry_after_ms or 0)
                 # A pre-wrapped connectivity loss (a client that turns httpx into
@@ -2322,6 +2527,12 @@ async def stream_with_failover(
                     # so the loop printed ``str(httpx.ConnectTimeout())`` (which
                     # is the empty string) into the frame AND a full traceback
                     # into the log.
+                    #
+                    # This is the arm a real mid-stream cut arrives on: no client
+                    # catches httpx, so a socket that dies mid-body reaches here
+                    # raw as `ReadError`/`RemoteProtocolError`/`ReadTimeout`.
+                    # Mark it continuable before it leaves — see the sibling arm.
+                    _mark_mid_stream_connectivity(wrapped)
                     raise wrapped from exc
                 record(wrapped, primary=is_primary)
                 # This is the arm a CONNECTIVITY LOSS actually arrives on: no

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3901,6 +3901,7 @@ class OperatorApp(App[None]):
         # must not either (see the `role == "user"` branch). Deferred once to
         # the top of this method rather than inside the loop, matching the
         # file's other lazy session.* imports.
+        from local_operator.harness.loop import CONNECTIVITY_CONTINUATION_PROMPT
         from local_operator.session.session import _CONTINUATION_PROMPT
 
         for message in history:
@@ -4016,7 +4017,16 @@ class OperatorApp(App[None]):
                     # Replay must make the same choice, or a resumed session
                     # shows rows the live one deliberately suppressed — the
                     # live/replay divergence review round 2 pinned.
-                    if text in (LOOP_PROMPT, _CONTINUATION_PROMPT):
+                    #
+                    # The network-continuation prompt joins them for the same
+                    # reason: it is persisted so the TRANSCRIPT explains why one
+                    # answer arrived in two pieces, but the user never typed it
+                    # and the live run showed a NoticeEvent instead.
+                    if text in (
+                        LOOP_PROMPT,
+                        _CONTINUATION_PROMPT,
+                        CONNECTIVITY_CONTINUATION_PROMPT,
+                    ):
                         continue
                     # A `$skill` invocation persists as its EXPANDED payload,
                     # because that is what the model was sent. Replaying it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.45.1"
+version = "0.45.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -2933,6 +2933,22 @@ def test_a_provider_that_answered_cannot_claim_the_machine_is_offline() -> None:
     assert not spoof.transport
     _mark_mid_stream_connectivity(spoof)
     assert not spoof.connectivity_loss
+    # THE CASE THAT ACTUALLY NEEDS THE PROVENANCE GATE. The spoof above is
+    # already rejected by the NAME-position match — its message does not begin
+    # with a mid-stream class name — so it holds whether or not `transport` is
+    # checked, and on its own it left the gate untested. This one clears the
+    # name match exactly: a provider narrating its own upstream trouble in a
+    # word-for-word imitation of what our client writes for a severed socket.
+    # Only provenance separates them, so deleting the `transport` gate flips
+    # this assertion and nothing else does.
+    impersonation = ProviderError(
+        None,
+        "ReadError: upstream link to model host reset",
+        retryable=True,
+    )
+    assert not impersonation.transport
+    _mark_mid_stream_connectivity(impersonation)
+    assert not impersonation.connectivity_loss
     # And a provider that answered with a STATUS is never continuable either.
     for status in (500, 503, 429, 401, 400):
         answered = ProviderError(status, "boom", retryable=True)
@@ -3178,6 +3194,15 @@ async def test_connectivity_continuation_keeps_a_COMPLETE_tool_call() -> None:
         and m.tool_call_id == carried[0].tool_calls[0].id
     ]
     assert len(paired) == 1
+    # R9: THE PROSE STILL GETS ITS CONTINUATION INSTRUCTION. A cut that produced
+    # both partial text and a complete call used to take the pairing arm and skip
+    # the prompt, so "Let me check that. " was committed as history with nothing
+    # saying not to repeat it — the model may restart the sentence and the user
+    # reads it twice. The prompt must follow the tool result, not sit between the
+    # `tool_use` and its `tool_result`, or the wire is illegal.
+    roles = [m.role for m in retry_history if isinstance(m, Message)]
+    assert roles == ["user", "assistant", "tool", "user"], roles
+    assert retry_history[-1].text == loop_module.CONNECTIVITY_CONTINUATION_PROMPT
     assert any(isinstance(m, Message) and m.text == "done" for m in messages)
 
 

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -10,6 +10,7 @@ import time
 from collections import Counter
 from typing import Any, Literal
 
+import httpx
 import pytest
 
 import local_operator.harness.loop as loop_module
@@ -47,9 +48,15 @@ from local_operator.harness.types import (
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
     ToolResult,
+    TurnEndEvent,
+    TurnStartEvent,
     Usage,
 )
-from local_operator.providers.failover import ProviderError
+from local_operator.providers.failover import (
+    ProviderError,
+    _mark_mid_stream_connectivity,
+    wrap_transport_error,
+)
 
 MODEL = ModelSpec(provider="test", model_id="m")
 
@@ -2835,16 +2842,102 @@ class FailingStream:
         return [f"{m.role}:{m.text}" for m in self.requests[index].messages]
 
 
-def _offline() -> ProviderError:
-    """The wrapped error a closed-then-moved laptop actually produces."""
-    error = ProviderError(
-        None,
-        "ConnectError: [Errno 8] nodename nor servname provided, or not known",
-        retryable=True,
-        kind="transient",
-    )
-    assert error.connectivity_loss, "fixture must be classified as a connectivity loss"
+#: The exceptions a REAL severed socket raises mid-answer, captured from a live
+#: provider whose TCP connection was killed with SO_LINGER{1,0} half way through
+#: an SSE body. This tuple is the fixture population these tests must exercise,
+#: and writing it as exception OBJECTS rather than as message strings is the
+#: point: an earlier round of these tests built every fixture from a hand-typed
+#: ``ConnectError`` string and then asserted its own premise
+#: (``assert error.connectivity_loss``), so the suite stayed green while the
+#: shipped binary did not continue a single real mid-stream cut. A fixture that
+#: cannot fail cannot catch a classifier that never matches.
+#:
+#: An EMPTY message is deliberately first: ``httpx.ReadError('')`` is the single
+#: most common shape of a mid-body RST, and it is precisely the one a
+#: text-matching classifier cannot see.
+_REAL_MID_STREAM_EXCEPTIONS: tuple[Exception, ...] = (
+    httpx.ReadError(""),
+    httpx.ReadError("[Errno 54] Connection reset by peer"),
+    httpx.RemoteProtocolError("peer closed connection without sending complete message body"),
+    # What a SILENT drop (lid closed, no RST) produces: the stall watchdog in
+    # clients.py constructs exactly this after STREAM_READ_TIMEOUT_S.
+    httpx.ReadTimeout("stream stalled: no data for 180s"),
+    httpx.WriteError("[Errno 32] Broken pipe"),
+)
+
+
+def _offline(exc: Exception | None = None) -> ProviderError:
+    """A mid-stream cut as the DRIVER hands it to the loop.
+
+    Built by pushing a real ``httpx`` exception through the same two functions
+    the live path uses — ``wrap_transport_error`` then the driver's
+    ``forwarded_any`` marking — instead of asserting a hand-written string is
+    classified the way the test wants. Nothing here asserts the premise: if the
+    classifier stops recognising a severed socket, the fixture stops carrying
+    the flag and the behavioural tests below fail, which is how it should have
+    been able to catch Q1.
+
+    Defaults to the empty-message ``ReadError`` observed against a real killed
+    connection, so the DEFAULT fixture is the hardest case rather than the
+    easiest.
+    """
+    error = wrap_transport_error(exc if exc is not None else httpx.ReadError(""))
+    _mark_mid_stream_connectivity(error)
     return error
+
+
+def _offline_preconnect() -> ProviderError:
+    """A PRE-connection connectivity loss (DNS/route), for the arm that owns it.
+
+    Kept distinct from :func:`_offline` because the two are classified by
+    different predicates for different reasons — see
+    ``is_mid_stream_connectivity_loss``.
+    """
+    return wrap_transport_error(
+        httpx.ConnectError("[Errno 8] nodename nor servname provided, or not known")
+    )
+
+
+@pytest.mark.parametrize("exc", _REAL_MID_STREAM_EXCEPTIONS, ids=lambda e: type(e).__name__)
+def test_every_real_mid_stream_exception_is_continuable(exc: Exception) -> None:
+    """THE Q1 REGRESSION GUARD, at the classifier boundary.
+
+    Each of these is an exception a real severed socket raises, and every one of
+    them classified ``False`` before this fix — so the loop's continuation
+    branch, which is reachable ONLY after deltas were forwarded, had a live
+    population of exactly the failures it could not recognise.
+
+    Asserted on objects httpx itself constructs, so this cannot be satisfied by
+    a marker string that merely looks like one.
+    """
+    wrapped = wrap_transport_error(exc)
+    # Before the driver marks it, a mid-stream shape is an ORDINARY transient:
+    # seen pre-connect it must keep its fast retry and its fallback walk.
+    assert not wrapped.connectivity_loss
+    _mark_mid_stream_connectivity(wrapped)
+    assert wrapped.connectivity_loss, f"{type(exc).__name__} must be continuable mid-stream"
+
+
+def test_a_provider_that_answered_cannot_claim_the_machine_is_offline() -> None:
+    """R6: an in-band error chunk has no status, so its TEXT alone used to be
+    enough to route a provider's own upstream trouble down the continue path.
+
+    Provenance is what separates them: only ``wrap_transport_error`` — our own
+    client observing a socket die — sets ``transport``.
+    """
+    spoof = ProviderError(
+        None,
+        "upstream_error: upstream: network is unreachable at edge",
+        retryable=True,
+    )
+    assert not spoof.transport
+    _mark_mid_stream_connectivity(spoof)
+    assert not spoof.connectivity_loss
+    # And a provider that answered with a STATUS is never continuable either.
+    for status in (500, 503, 429, 401, 400):
+        answered = ProviderError(status, "boom", retryable=True)
+        _mark_mid_stream_connectivity(answered)
+        assert not answered.connectivity_loss
 
 
 @pytest.mark.asyncio
@@ -2965,9 +3058,19 @@ async def test_connectivity_continuation_budget_surfaces_a_bounded_error() -> No
     ends = [e for e in events if isinstance(e, AgentEndEvent)]
     assert len(ends) == 1
     assert ends[0].error is not None
-    assert "Errno 8" in ends[0].error
+    # The provider layer's own diagnostic survives to the frame: the run ends
+    # NAMED (here the severed-socket class), never as a bare hang or an empty
+    # string — which is what `wrap_transport_error` keeps the class name for.
+    assert "ReadError" in ends[0].error
     # Bounded: the initial attempt plus exactly the continuation budget.
     assert len(stream.requests) == MAX_CONNECTIVITY_CONTINUATIONS + 1
+    # And the budget is SPENT VISIBLY: one notice per continuation, each naming
+    # its position, rather than three identical claims of a reconnection.
+    notices = [e.text for e in events if isinstance(e, NoticeEvent)]
+    assert notices == [
+        f"network connection lost mid-response — retrying ({n}/{MAX_CONNECTIVITY_CONTINUATIONS})"
+        for n in range(1, MAX_CONNECTIVITY_CONTINUATIONS + 1)
+    ]
 
 
 @pytest.mark.asyncio
@@ -3013,6 +3116,168 @@ async def test_connectivity_continuation_drops_truncated_tool_calls() -> None:
         not m.tool_calls for m in messages if isinstance(m, Message) and m.role == "assistant"
     )
     assert any(isinstance(m, Message) and m.text == "done" for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_connectivity_continuation_keeps_a_COMPLETE_tool_call() -> None:
+    """A call whose arguments FINISHED arriving before the cut is not truncated.
+
+    The sibling test above drops a half-dictated call, which is right. Dropping
+    a complete one is not: the tool never runs, the model must re-derive it, and
+    the continuation prompt then describes a turn whose own record of having
+    asked for a tool has been deleted from the history it is being asked to
+    continue.
+
+    The surviving call is PAIRED rather than executed — the network died before
+    the loop could run it, and an unmatched ``tool_use`` block is a 400 on the
+    Anthropic wire — so the model sees the call it made did not run and may
+    re-issue it.
+    """
+    executed: list[str] = []
+
+    class _CompleteCallStream:
+        def __init__(self) -> None:
+            self.requests: list[ChatRequest] = []
+
+        def __call__(self, request: ChatRequest, signal: AbortSignal | None):
+            index = len(self.requests)
+            self.requests.append(request)
+
+            async def gen():
+                if index == 0:
+                    yield StreamTextDelta(delta="Let me check that. ")
+                    # Arguments complete: valid JSON, fully arrived...
+                    yield tool_call_delta(0, id="c1", name="echo", args='{"text": "hello"}')
+                    # ...and only THEN the socket dies.
+                    raise _offline()
+                yield StreamTextDelta(delta="done")
+                yield StreamEndEvent(stop_reason="stop")
+
+            return gen()
+
+    stream = _CompleteCallStream()
+    config = make_config(stream)
+    messages = await AgentLoop().run_to_end(
+        [Message.user("go")], LoopContext(tools=[echo_tool(executed)]), config, None
+    )
+
+    # It is not EXECUTED — the turn was abandoned, not completed.
+    assert executed == []
+    # But it survives in history, so the model's own record is intact.
+    retry_history = stream.requests[1].messages
+    carried = [m for m in retry_history if isinstance(m, Message) and m.tool_calls]
+    assert len(carried) == 1
+    assert carried[0].tool_calls[0].name == "echo"
+    assert carried[0].tool_calls[0].arguments == {"text": "hello"}
+    # And it is PAIRED, so the wire stays legal.
+    paired = [
+        m
+        for m in retry_history
+        if isinstance(m, Message)
+        and m.role == "tool"
+        and m.tool_call_id == carried[0].tool_calls[0].id
+    ]
+    assert len(paired) == 1
+    assert any(isinstance(m, Message) and m.text == "done" for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_connectivity_continuation_closes_the_turn_it_abandons() -> None:
+    """Every TurnStart gets a TurnEnd, including on the continuation path.
+
+    ``TurnEndEvent`` is what drives a front end's per-turn reconciliation — in
+    the TUI, ``_retire_live_tool_cards``, the only routine path that settles a
+    row for a call that never ran. Without it the abandoned turn's composing
+    spinner animates forever and the working line goes on announcing "composing
+    a call" while the continued turn streams prose.
+    """
+
+    class _ComposingThenCut:
+        def __init__(self) -> None:
+            self.requests: list[ChatRequest] = []
+
+        def __call__(self, request: ChatRequest, signal: AbortSignal | None):
+            index = len(self.requests)
+            self.requests.append(request)
+
+            async def gen():
+                if index == 0:
+                    yield StreamTextDelta(delta="one moment ")
+                    yield tool_call_delta(0, id="c1", name="echo", args='{"text": "hal')
+                    raise _offline()
+                yield StreamTextDelta(delta="done")
+                yield StreamEndEvent(stop_reason="stop")
+
+            return gen()
+
+    events = []
+    async for event in AgentLoop().run(
+        [Message.user("go")],
+        LoopContext(tools=[echo_tool([])]),
+        make_config(_ComposingThenCut()),
+        None,
+    ):
+        events.append(event)
+
+    starts = [e for e in events if isinstance(e, TurnStartEvent)]
+    ends = [e for e in events if isinstance(e, TurnEndEvent)]
+    assert len(starts) == 2
+    assert len(ends) == len(starts), "an abandoned turn must still be closed"
+    # And the close lands BEFORE the continuation's TurnStart, so a front end
+    # reconciles the dead turn's rows before the next one opens its own.
+    order = [type(e).__name__ for e in events if isinstance(e, (TurnStartEvent, TurnEndEvent))]
+    assert order == ["TurnStartEvent", "TurnEndEvent", "TurnStartEvent", "TurnEndEvent"]
+
+
+@pytest.mark.asyncio
+async def test_connectivity_continuation_prompt_is_persisted() -> None:
+    """The prompt reaches the TRANSCRIPT, not just the live request.
+
+    ``new_messages`` is what ``AgentEndEvent`` hands the host to persist. With
+    the prompt appended only to the live context, a resumed session read the
+    partial answer glued straight to its continuation with no record that a
+    network interruption sat between them — and a run that continued more than
+    once persisted a run of consecutive assistant messages that no longer
+    explains itself, which compaction then summarises.
+    """
+    stream = FailingStream([_offline(), None])
+    messages = await AgentLoop().run_to_end(
+        [Message.user("go")], LoopContext(), make_config(stream), None
+    )
+
+    roles = [m.role for m in messages if isinstance(m, Message)]
+    assert roles == ["assistant", "user", "assistant"], "no consecutive assistant runs"
+    prompts = [
+        m
+        for m in messages
+        if isinstance(m, Message) and m.text == loop_module.CONNECTIVITY_CONTINUATION_PROMPT
+    ]
+    assert len(prompts) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_whitespace_only_partial_is_dropped_not_referenced() -> None:
+    """R4: the guard must agree with the SERIALIZER about what counts as text.
+
+    Both wire builders drop an assistant turn whose text is whitespace-only
+    (``_is_empty_assistant``: "Whitespace-only text counts as empty"). A model
+    that emits a newline before the cut therefore had its turn vanish from the
+    request while the prompt went on telling it to continue "the partial text
+    above" — text no wire carried. Aligning the guard routes this to the
+    drop-and-re-ask arm instead.
+    """
+    stream = FailingStream([_offline(), None], partial="\n")
+    await AgentLoop().run_to_end([Message.user("go")], LoopContext(), make_config(stream), None)
+
+    retry = stream.requests[1].messages
+    assert not any(isinstance(m, Message) and m.role == "assistant" for m in retry)
+    # No dangling reference to text the model cannot see: the original question
+    # is simply re-asked.
+    assert not any(
+        isinstance(m, Message) and m.text == loop_module.CONNECTIVITY_CONTINUATION_PROMPT
+        for m in retry
+    )
+    assert [m.role for m in retry if isinstance(m, Message)] == ["user"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -15,6 +15,7 @@ import pytest
 import local_operator.harness.loop as loop_module
 from local_operator.harness.loop import (
     ABORT_DRAIN_TIMEOUT_S,
+    MAX_CONNECTIVITY_CONTINUATIONS,
     STEERING_INTERRUPT_POLL_S,
     AgentLoop,
     LoopContext,
@@ -2793,3 +2794,297 @@ async def test_a_raising_fork_predicate_never_breaks_the_turn():
 
     assert executed == ["echo"]
     assert any(isinstance(m, Message) and m.text == "done" for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# Mid-stream connectivity loss: the laptop closed at home, opened at work
+# ---------------------------------------------------------------------------
+
+
+class FailingStream:
+    """Fake stream_fn whose Nth call dies PART WAY THROUGH the answer.
+
+    The failure is raised after the deltas have already been yielded, which is
+    the only shape that matters here: with nothing forwarded the provider layer
+    retries in place and the loop never sees a failure at all.
+    """
+
+    def __init__(
+        self, failures: list[BaseException | None], *, partial: str = "The answer is "
+    ) -> None:
+        self.failures = failures
+        self.partial = partial
+        self.requests: list[ChatRequest] = []
+
+    def __call__(self, request: ChatRequest, signal: AbortSignal | None):
+        index = len(self.requests)
+        self.requests.append(request)
+        failure = self.failures[index] if index < len(self.failures) else None
+
+        async def gen():
+            if failure is not None:
+                yield StreamTextDelta(delta=self.partial)
+                raise failure
+            yield StreamTextDelta(delta="42.")
+            yield StreamEndEvent(stop_reason="stop")
+
+        return gen()
+
+    def history(self, index: int) -> list[str]:
+        """``role:text`` of the messages the Nth request carried."""
+        return [f"{m.role}:{m.text}" for m in self.requests[index].messages]
+
+
+def _offline() -> ProviderError:
+    """The wrapped error a closed-then-moved laptop actually produces."""
+    error = ProviderError(
+        None,
+        "ConnectError: [Errno 8] nodename nor servname provided, or not known",
+        retryable=True,
+        kind="transient",
+    )
+    assert error.connectivity_loss, "fixture must be classified as a connectivity loss"
+    return error
+
+
+@pytest.mark.asyncio
+async def test_connectivity_loss_after_deltas_continues_the_turn() -> None:
+    """THE REPORTED BUG: the network changed mid-answer and killed the session.
+
+    The provider layer cannot retry this — the deltas are already on the user's
+    screen — so before this fix the run ended with `stop_reason="error"`. Now
+    the partial answer is committed as history and the turn continues, so the
+    user sees ONE uninterrupted answer.
+    """
+    stream = FailingStream([_offline(), None])
+    config = make_config(stream)
+
+    events = []
+    async for event in AgentLoop().run([Message.user("go")], LoopContext(), config, None):
+        events.append(event)
+
+    # The run did NOT end in an error: that is the whole fix.
+    ends = [e for e in events if isinstance(e, AgentEndEvent)]
+    assert len(ends) == 1
+    assert ends[0].error is None
+    assert ends[0].aborted is False
+
+    # The user sees the partial answer and its continuation, each exactly once.
+    on_screen = "".join(e.delta for e in events if e.type == "message_update")
+    assert on_screen == "The answer is 42."
+
+    # A visible notice explains the seam rather than the text silently jumping.
+    notices = [e.text for e in events if isinstance(e, NoticeEvent)]
+    assert any("network connection lost" in text for text in notices)
+
+    # THE NO-DUPLICATION INVARIANT, asserted structurally: the retry carries the
+    # partial answer as HISTORY, so the model writes the remainder instead of
+    # re-streaming what was already read.
+    history = stream.history(1)
+    assert history[:2] == ["user:go", "assistant:The answer is "]
+
+    # And it asks for a CONTINUATION rather than leaving the partial answer as a
+    # trailing assistant turn. That shape is load-bearing, not cosmetic: a
+    # trailing assistant message is a "prefill", which current Claude models
+    # reject with HTTP 400 ("Prefilling assistant messages is not supported for
+    # this model") — so the default model of this harness would turn a
+    # recoverable blip into a hard failure. Ending on a user turn also keeps the
+    # role alternation Anthropic documents.
+    assert len(history) == 3
+    assert history[2].startswith("user:")
+    assert "cut off" in history[2]
+
+    # The partial text keeps its trailing space, so the transcript is exactly
+    # what the user read. Legal only because the assistant turn is not final.
+    assert stream.requests[1].messages[-2].text == "The answer is "
+    assert stream.requests[1].messages[-1].role == "user"
+
+
+@pytest.mark.asyncio
+async def test_connectivity_loss_does_not_duplicate_the_partial_text() -> None:
+    """The continuation must never re-render text already in the transcript.
+
+    Asserted on the FINAL assembled messages as well as on the stream, because
+    a duplicate that only shows up in the persisted transcript is still a
+    duplicate the user reads on reload.
+    """
+    stream = FailingStream([_offline(), None])
+    config = make_config(stream)
+
+    messages = await AgentLoop().run_to_end([Message.user("go")], LoopContext(), config, None)
+
+    assistant_text = "".join(
+        m.text for m in messages if isinstance(m, Message) and m.role == "assistant"
+    )
+    assert assistant_text == "The answer is 42."
+    assert assistant_text.count("The answer is ") == 1
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_5xx_after_deltas_still_ends_the_run() -> None:
+    """A PROVIDER failure mid-answer keeps the old terminal behaviour.
+
+    The distinction the fix rests on: an offline machine means nothing was wrong
+    with the request, so re-asking is the entire fix. A 500 means the provider
+    DID answer — replaying that turn would re-bill it and paper over a failure
+    the user needs to see.
+    """
+    boom = ProviderError(500, "internal server error", retryable=True)
+    assert not boom.connectivity_loss
+    stream = FailingStream([boom, None])
+    config = make_config(stream)
+
+    events = []
+    async for event in AgentLoop().run([Message.user("go")], LoopContext(), config, None):
+        events.append(event)
+
+    ends = [e for e in events if isinstance(e, AgentEndEvent)]
+    assert len(ends) == 1
+    assert ends[0].error is not None
+    assert "internal server error" in ends[0].error
+    # It never retried: one request only.
+    assert len(stream.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_connectivity_continuation_budget_surfaces_a_bounded_error() -> None:
+    """A genuinely dead network must END the run, not retry forever.
+
+    Every attempt fails offline, so the run exhausts
+    MAX_CONNECTIVITY_CONTINUATIONS and then surfaces the provider's own
+    diagnostic error — bounded, named, and not a hang.
+    """
+    failures: list[BaseException | None] = [_offline() for _ in range(20)]
+    stream = FailingStream(failures)
+    config = make_config(stream)
+
+    events = []
+    async for event in AgentLoop().run([Message.user("go")], LoopContext(), config, None):
+        events.append(event)
+
+    ends = [e for e in events if isinstance(e, AgentEndEvent)]
+    assert len(ends) == 1
+    assert ends[0].error is not None
+    assert "Errno 8" in ends[0].error
+    # Bounded: the initial attempt plus exactly the continuation budget.
+    assert len(stream.requests) == MAX_CONNECTIVITY_CONTINUATIONS + 1
+
+
+@pytest.mark.asyncio
+async def test_connectivity_continuation_drops_truncated_tool_calls() -> None:
+    """A tool call still streaming when the socket died is DROPPED, not run.
+
+    Its arguments are truncated JSON: executing it would run a call the model
+    never finished asking for. Dropping it also keeps the wire legal — no
+    tool_use block means no unmatched tool_result.
+    """
+    executed: list[str] = []
+
+    class _PartialCallStream:
+        def __init__(self) -> None:
+            self.requests: list[ChatRequest] = []
+
+        def __call__(self, request: ChatRequest, signal: AbortSignal | None):
+            index = len(self.requests)
+            self.requests.append(request)
+
+            async def gen():
+                if index == 0:
+                    yield StreamTextDelta(delta="reading it ")
+                    # Arguments cut mid-JSON by the network going away.
+                    yield tool_call_delta(0, id="c1", name="echo", args='{"text": "hal')
+                    raise _offline()
+                yield StreamTextDelta(delta="done")
+                yield StreamEndEvent(stop_reason="stop")
+
+            return gen()
+
+    stream = _PartialCallStream()
+    config = make_config(stream)
+
+    messages = await AgentLoop().run_to_end(
+        [Message.user("go")], LoopContext(tools=[echo_tool(executed)]), config, None
+    )
+
+    # The half-dictated call never ran.
+    assert executed == []
+    # And no assistant message carries it, so the wire stays legal.
+    assert all(
+        not m.tool_calls for m in messages if isinstance(m, Message) and m.role == "assistant"
+    )
+    assert any(isinstance(m, Message) and m.text == "done" for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_connectivity_loss_before_any_delta_is_unchanged() -> None:
+    """The pre-first-token case belongs to the PROVIDER layer and must stay
+    there: nothing was forwarded, so the driver retries in place and the loop
+    never sees a failed turn at all. Asserted here so the harness fix cannot
+    quietly start intercepting a case it does not own."""
+
+    class _EmptyThenOk:
+        def __init__(self) -> None:
+            self.requests: list[ChatRequest] = []
+
+        def __call__(self, request: ChatRequest, signal: AbortSignal | None):
+            self.requests.append(request)
+
+            async def gen():
+                # No delta before the end: the provider layer's own retry would
+                # have handled a failure here, so the loop sees a clean turn.
+                yield StreamTextDelta(delta="42.")
+                yield StreamEndEvent(stop_reason="stop")
+
+            return gen()
+
+    stream = _EmptyThenOk()
+    config = make_config(stream)
+
+    events = []
+    async for event in AgentLoop().run([Message.user("go")], LoopContext(), config, None):
+        events.append(event)
+
+    assert len(stream.requests) == 1
+    assert [e.text for e in events if isinstance(e, NoticeEvent)] == []
+
+
+@pytest.mark.asyncio
+async def test_connectivity_continuation_request_is_wire_legal_for_anthropic() -> None:
+    """The continuation must SERIALIZE legally, not merely look right in the loop.
+
+    Two Anthropic rules make the obvious implementation — leave the partial
+    answer as the last message and re-send — a hard 400, which would convert a
+    recoverable network blip into a dead run on this harness's own default
+    model:
+
+    * a trailing assistant message is a PREFILL, and current Claude models
+      answer "Prefilling assistant messages is not supported for this model";
+    * a final assistant message may not end in whitespace, and an interrupted
+      delta ("The answer is ") is precisely how one is produced.
+
+    Asserted through the REAL client body builder rather than by re-reading the
+    loop's own list, because the serializer is where the rule actually bites.
+    """
+    from local_operator.providers.clients import AnthropicClient
+
+    stream = FailingStream([_offline(), None])
+    config = make_config(stream)
+    await AgentLoop().run_to_end([Message.user("go")], LoopContext(), config, None)
+
+    retry_request = stream.requests[1]
+    body = AnthropicClient("https://api.anthropic.com")._build_body(
+        ChatRequest(
+            model=ModelSpec(provider="anthropic", model_id="claude-opus-5"),
+            messages=retry_request.messages,
+        )
+    )
+    roles = [entry["role"] for entry in body["messages"]]
+
+    # Not a prefill: the request ends on a user turn.
+    assert roles[-1] == "user"
+    # Roles alternate, which is what Anthropic documents for its turn model.
+    assert roles == ["user", "assistant", "user"]
+    # The one assistant turn is not final, so its trailing space is legal and
+    # the transcript can stay byte-identical to what was displayed.
+    assistant_text = body["messages"][1]["content"][0]["text"]
+    assert assistant_text == "The answer is "

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -4066,6 +4066,125 @@ async def test_connectivity_loss_backoff_is_abortable() -> None:
     await task
 
 
+class _CutAfterDeltas:
+    """A wire client that forwards deltas and THEN dies, like a real severed
+    socket — the only shape that reaches the driver's ``forwarded_any`` arms."""
+
+    def __init__(self, exc: BaseException, deltas: int) -> None:
+        self._exc = exc
+        self._deltas = deltas
+        self.forwarded = 0
+
+    async def stream(
+        self, request: ChatRequest, api_key: str | None, oauth_access: Any = None
+    ) -> AsyncIterator[Any]:
+        for index in range(self._deltas):
+            self.forwarded += 1
+            yield StreamTextDelta(delta=f"delta-{index} ")
+        raise self._exc
+
+
+async def _drive_until_error(
+    exc_factory: Any, *, deltas: int
+) -> tuple[list[Any], ProviderError | None]:
+    """Run the REAL ``stream_with_failover`` against a client that cuts out.
+
+    Deliberately goes through the driver rather than calling the classifier: the
+    property under test is the WIRING, so anything that hands the marking to the
+    test instead of making the driver perform it would defeat the purpose.
+    """
+
+    async def client_for(spec: ModelSpec) -> Any:
+        return _CutAfterDeltas(exc_factory(), deltas)
+
+    # Budgets floored so a shape that is NOT continuable still terminates fast
+    # rather than sitting in the patient wait this test is not about.
+    settings = {
+        "retry": {
+            "baseDelayMs": 1,
+            "maxRetries": 1,
+            "connectivityMaxRetries": 0,
+            "fallbackChains": {},
+        }
+    }
+    forwarded: list[Any] = []
+    try:
+        async for event in stream_with_failover(
+            _request(), FakeAuth({"openai": ["k"]}), settings, client_for
+        ):
+            forwarded.append(event)
+    except ProviderError as error:
+        return forwarded, error
+    return forwarded, None
+
+
+@pytest.mark.parametrize(
+    ("arm", "exc_factory"),
+    [
+        # The arm a REAL mid-stream cut lands on: no client in clients.py catches
+        # httpx, so a socket that dies mid-body arrives here raw (failover.py's
+        # own comment says so). QA's narrower mutation deletes only this one.
+        ("raw-httpx", lambda: httpx.ReadError("")),
+        # The sibling arm, for a client that wrapped the transport failure into a
+        # ProviderError itself before it reached the driver.
+        ("pre-wrapped", lambda: wrap_transport_error(httpx.ReadError(""))),
+    ],
+)
+async def test_the_driver_marks_a_cut_that_already_forwarded_bytes(
+    arm: str, exc_factory: Any
+) -> None:
+    """THE Q1 WIRING GUARD — the driver must do the marking, not the fixture.
+
+    ``is_mid_stream_connectivity_loss`` is only ever reachable because
+    ``stream_with_failover`` calls ``_mark_mid_stream_connectivity`` at its two
+    ``forwarded_any`` raise sites. Every other test in the tree marks the error
+    ITSELF and so asserts the predicate while leaving the call sites untested:
+    both were deleted during review with the whole suite staying green, while
+    the mutant reproduced the original bug against a real severed socket.
+
+    This test therefore asserts the flag on an error that escaped the REAL
+    driver, having never touched the marker helper in test code. Delete either
+    call site and the matching parametrisation fails.
+    """
+    forwarded, error = await _drive_until_error(exc_factory, deltas=2)
+
+    # Bytes really did reach the caller — the premise of the whole inference.
+    assert len(forwarded) == 2, "the cut must land AFTER deltas or it tests nothing"
+    assert error is not None
+    assert error.connectivity_loss, (
+        f"the {arm} forwarded_any arm did not mark the escaping error continuable — "
+        "the loop cannot continue a turn it is never told was interrupted"
+    )
+
+
+@pytest.mark.parametrize(
+    ("arm", "exc_factory"),
+    [
+        ("raw-httpx", lambda: httpx.ReadError("")),
+        ("pre-wrapped", lambda: wrap_transport_error(httpx.ReadError(""))),
+    ],
+)
+async def test_the_driver_does_NOT_mark_a_cut_that_forwarded_nothing(
+    arm: str, exc_factory: Any
+) -> None:
+    """The control that keeps the mark inside the ``forwarded_any`` gate.
+
+    The SAME exception raised before any delta must stay an ordinary transient:
+    it keeps the fast retry and the fallback walk, and must never inherit the
+    patient minutes-long wait. Without this, "fixing" the guard above by marking
+    unconditionally — in ``wrap_transport_error`` or ``ProviderError.__init__``
+    — would pass while handing a genuinely broken provider a stalled session.
+    """
+    forwarded, error = await _drive_until_error(exc_factory, deltas=0)
+
+    assert forwarded == []
+    assert error is not None
+    assert not error.connectivity_loss, (
+        f"the {arm} pre-connect path must not be marked continuable — nothing was "
+        "forwarded, so there is no answer to continue and no offline inference to draw"
+    )
+
+
 def test_connectivity_config_keys_parse_camel_and_snake() -> None:
     """Both key spellings parse; defaults survive a reconnect out of the box."""
     camel = RetrySettings.from_settings(


### PR DESCRIPTION
**Base / scope:** `06928224..HEAD` — the real merge-base. (`6437caf6` predates merged #593, so a diff from there also contains #593's discovery/controller/registry/TUI changes, which this PR does not author.)

## Summary

A network change mid-turn (laptop closed at home, opened at work) killed the running session. This makes the harness **continue** such a turn instead of ending the run.

The patient connectivity backoff in `providers/failover.py` already exists and is correct (`CONNECTIVITY_MAX_RETRIES = 15`, ~9 min of waiting, 60s cap). The gap is that **both** of its arms sit behind `if forwarded_any: raise` — and `forwarded_any` flips the moment the first delta reaches the caller. So the patient path is reachable **only before the first token**. Once the model has started answering, a connectivity loss is re-raised on the first failure with zero retries, which sets `stop_reason="error"` and ends the run at `loop.py:570`. `replayable` requests buffer instead of forwarding, which is why one-shot errands survived and interactive turns did not.

**The driver cannot fix this in place**, and that constraint shapes the whole change: those deltas are already in the user's transcript, so re-issuing the same request there would stream them a second time — exactly what `test_a_turn_does_NOT_replay_output_the_user_already_read` locks down. The retry therefore belongs one layer up, where the partial answer can be committed as history and the model asked to write only the remainder.

### What changed

1. **`RenderedStreamError.connectivity_loss`** (`harness/types.py`) — carries the classification across the layer boundary. The harness deliberately must not import `providers`, and it needs to tell "the machine went offline" apart from "the provider 500ed" to decide whether a turn is continuable. `ProviderError` stamps it from the existing `is_connectivity_loss`, so this is a carrier, never a second definition.

2. **The loop continues the turn** (`harness/loop.py`) — up to `MAX_CONNECTIVITY_CONTINUATIONS` (3, each buying another full patient wait; **measured** at ~7.9 min per wait, so ~32 min of tolerated outage across four attempts — ~29-34 min over the jitter), emits a `NoticeEvent`, and **falls through to the existing terminal branch** when the budget is spent, so a genuinely dead network still surfaces a bounded, named error rather than hanging.

3. **The continuation is a user-role instruction, not a trailing assistant turn.** This is load-bearing, not cosmetic. The obvious implementation — leave the partial answer last and re-send — is a **prefill**, which current Claude models reject with `400 "Prefilling assistant messages is not supported for this model"`; a final assistant message also may not end in whitespace, and an interrupted delta (`"The answer is "`) is precisely how one is produced. The naive shape would have turned a recoverable blip into a hard failure on this harness's own default model. Verified through the real Anthropic/OpenAI/Google body builders, and regression-tested.

4. **Truncated tool calls are dropped, not paired.** A call still streaming when the socket died is truncated JSON — executing it would run a call the model never finished asking for. Dropping it also keeps the wire legal: no `tool_use` block means no unmatched `tool_result`.

A mid-stream **5xx keeps the old terminal behaviour**: the provider *did* answer, and replaying that turn would re-bill it while hiding a failure the user needs to see.

## Testing Evidence

### Reproduction — provider level (`repro_midstream.py`, unchanged by design)

The driver's behaviour is deliberately **not** altered; case B must still not replay at that layer:

```
A offline BEFORE any delta  -> attempts=2, sleeps_ms=[423], text=['done'], error=None
B offline AFTER deltas      -> attempts=1, sleeps_ms=[],    text=['partial '], error='ProviderError: transient ... [Errno 8] ...'
C offline AFTER, replayable -> attempts=2, sleeps_ms=[381], text=['done'], error=None
```

### Reproduction — session level (the actual bug)

Drives the **real `AgentLoop` over the real `stream_with_failover`** and asks the only question that matters: did the run end, and what is on screen?

**BEFORE (on `main`)** — the session dies mid-answer:
```
--- connectivity loss mid-answer ---
  attempts                 1
  user_sees                'The answer is '
  notices                  []
  run_error                'transient provider error: ConnectError: [Errno 8] nodename nor servname provided, or not known'
```

**AFTER** — the turn continues, no duplicated text, run survives:
```
--- connectivity loss mid-answer ---
  attempts                 2
  user_sees                'The answer is 42.'
  notices                  ['network connection lost mid-response — reconnected, continuing where it left off']
  run_error                None
  retry_carried_history    ['user:what is the answer?',
                            'assistant:The answer is ',
                            'user:[system] Your previous response was cut off mid-sentence ... do not repeat any of it ...']
```

**Control — a provider 500 mid-answer is unchanged** (still terminal, still one attempt, never replayed):
```
--- provider 500 mid-answer ---
  attempts                 1
  user_sees                'The answer is '
  run_error                'transient provider error: HTTPStatusError: 500 Server Error'
```

### Wire legality, checked against the real serializers

```
openai roles:    ['user', 'assistant', 'user']
google roles:    ['user', 'model',     'user']
anthropic roles: ['user', 'assistant', 'user']   final role = user  => not a prefill
assistant text preserved verbatim ('The answer is ') — legal because it is not the final message
```

### Falsification (the tests can actually fail)

Neutering the fix (`connectivity_loss = False`) fails the 4 behavioural tests while the invariant guards keep passing:
```
FAILED test_connectivity_loss_after_deltas_continues_the_turn        - run ended with Errno 8
FAILED test_connectivity_loss_does_not_duplicate_the_partial_text    - 'The answer is ' != 'The answer is 42.'
FAILED test_connectivity_continuation_budget_surfaces_a_bounded_error - assert 1 == 4
FAILED test_connectivity_continuation_drops_truncated_tool_calls     - assert False
```
Reverting only the continuation-message shape (back to the naive prefill) fails the wire-legality test:
```
FAILED test_connectivity_continuation_request_is_wire_legal_for_anthropic - assert 'assistant' == 'user'
```

### Coverage added (`tests/unit/harness/test_loop.py`, 8 tests)

| Case | Expectation |
|---|---|
| loss before any delta | unchanged — owned by the provider layer, loop never intercepts |
| loss after deltas | retried, run survives, **no duplicated text** |
| replayable | unchanged (`tests/unit/providers/test_failover.py` still green) |
| mid-stream 5xx after deltas | still terminal, **must not replay** |
| patient budget exhausted | bounded, named error (`initial + MAX_CONNECTIVITY_CONTINUATIONS` requests) |
| truncated tool call | dropped, never executed, wire stays legal |
| Anthropic serialization | ends on a user turn; not a prefill |

The two locked invariants are intact: `test_a_turn_does_NOT_replay_output_the_user_already_read` and `test_an_openrouter_error_chunk_after_partial_output_arrives_named` both still pass (269 passed across `test_loop.py` + `test_failover.py`).

### Quality gates (whole tree, exactly as CI)

- `flake8 .` — clean
- `black --check .` (pinned 26.1.0) — 834 files unchanged
- `isort --check .` — clean
- `pyright` — **0 errors, 0 warnings, 0 informations**
- Unit suite — **11,769 passed, 15 skipped** in 451s

## Version

`0.44.68` — **patch**, per AGENTS.md "Versioning": a reliability fix (retries/backoff), not a step-function capability.

## Deliberately not addressed

- **The seam is textual, not stateful.** The model resumes from the text it already produced, not from its own hidden reasoning state, so a sentence cut mid-word is *continued* rather than rewritten. That is a real limitation of any resumption that refuses to re-render text the user has read — and it beats ending the run.
- **A turn interrupted during reasoning-only output** (no text, no calls) drops the empty message and re-asks the original question rather than resuming the thought; there is nothing to resume from, and an empty assistant message is a 400 on the Anthropic wire.
- ~~**`ReadTimeout` / stalled streams are untouched.**~~ **Corrected in round 1 (Q1).** This was not a scope choice but the defect itself: the mid-stream exception family (`ReadError`, `RemoteProtocolError`, `ReadTimeout`, `WriteError`) is the *entire live population* of the continuation branch, so scoping the gate to pre-connect DNS/route markers meant it never opened. Now handled by a separate `is_mid_stream_connectivity_loss`; the pre-connect `is_connectivity_loss` keeps its narrow semantics. See the round-1 QA remediation comment.

