### PR TITLE
chore(release): bump version to 0.44.71

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.70"
+version = "0.44.71"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
`main` carries `0.44.70`, but that version was already tagged and released by #584 while #594 was in review. #594 (vendor-documented sampling defaults) is merged and unreleased, so the version on `main` is a collision rather than a shippable number.

Bumps to `0.44.71` so the sampling work can be released.

Release-mechanics only — no source changes.