### PR TITLE
fix(evaluation): keep a decision whose model appended trailing junk

### DIFF
--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -46,10 +46,13 @@ from local_operator.evaluation.runner.model import (
     ModelDecision,
     ModelUsage,
 )
+from local_operator.logger import get_logger
 
 if TYPE_CHECKING:
     from local_operator.compaction.thresholds import CompactionSettings
     from local_operator.harness.types import Message
+
+logger = get_logger(__name__)
 
 #: Frames kept verbatim in the history by default. A GUI agent reads the
 #: screen as STATE: the current frame is what it acts on and the last couple
@@ -69,6 +72,13 @@ DEFAULT_REBUILD_EVERY_FRAMES = 8
 #: must see WHAT it said to fix it -- but a runaway reply (a provider's
 #: max-token wall of prose) must not cost the whole window on the retry.
 MAX_REJECTED_REPLY_CHARS = 4_000
+
+#: Longest run of tolerated trailing noise quoted into the observable warning
+#: when a decision parses as a leading JSON value followed by junk. The point
+#: of the quote is to let a reader RECOGNISE what the model appended, not to
+#: reproduce it: a model that ran away into a wall of prose must not be able to
+#: push a bounded log line into an unbounded one.
+MAX_TOLERATED_TRAILING_CHARS = 200
 
 #: Rendered in place of an observation's text when it is byte-identical to the
 #: previous turn's. The adapter owns observation text and the runner never
@@ -275,6 +285,64 @@ class DecisionParseError(ValueError):
     """The provider returned something that is not a usable action batch."""
 
 
+def _decode_leading_json(payload: str) -> tuple[Any, str]:
+    """Decode the leading JSON value and return it with any trailing noise.
+
+    ``json.loads`` demands that the WHOLE string be one value, so a model that
+    emitted a complete, correct batch and then appended a stray token lost the
+    entire turn to ``Extra data: line 1 column 318 (char 317)``. That is a real
+    and repeated failure -- one sealed episode paid for it three times, each a
+    billed call discarded over noise the harness had already finished reading
+    past. ``raw_decode`` stops at the end of the first complete value and says
+    where it stopped, which is exactly the question being asked here.
+
+    The tolerance is deliberately ONE-SIDED, because the three shapes are not
+    equally knowable:
+
+    * **Trailing noise** (``{...}原始内容``, ``{...} Hope that helps!``) is
+      tolerated. The decision is already complete and unambiguous at the point
+      the junk starts; nothing after it can change which actions were chosen.
+    * **Leading noise** (``Sure, here you go: {...}``) is NOT skipped. Hunting
+      forward for the first ``{`` means guessing where the value begins, and a
+      preamble that itself contains a brace makes that guess wrong silently --
+      the failure mode is executing a DIFFERENT batch than the model sent,
+      which is far worse than losing the turn. A leading-junk reply still gets
+      the ordinary parse error and a corrective re-prompt.
+    * **Two concatenated objects** (``{...}{...}``) is genuinely ambiguous --
+      which batch did the model mean? -- so it is NOT tolerated either. Silently
+      taking the first would execute a decision the model may have superseded.
+
+    The ambiguity probe is deliberately narrowed to a trailing OBJECT. A
+    decision is always an object, so only a second object can be a competing
+    decision; asking the broader question "does the remainder parse as any
+    JSON value?" misreads ordinary prose whose first word happens to be a JSON
+    literal ("true story, that worked", "42 windows were listed", a quoted
+    sentence) as a second decision, and would reject the very turn this
+    function exists to save.
+    """
+
+    decoder = json.JSONDecoder()
+    try:
+        decoded, end = decoder.raw_decode(payload)
+    except json.JSONDecodeError as error:
+        # Includes the leading-junk case: raw_decode starts at offset 0, so a
+        # preamble fails here rather than being skipped past.
+        raise DecisionParseError(f"decision is not valid JSON: {error}") from error
+    trailing = payload[end:].strip()
+    if trailing.startswith("{"):
+        try:
+            decoder.raw_decode(trailing)
+        except json.JSONDecodeError:
+            # A brace that does not open a complete object is prose, not a
+            # competing decision ("{note: see above}"), so it stays tolerated.
+            pass
+        else:
+            raise DecisionParseError(
+                "decision carries more than one JSON object; send exactly one action batch"
+            )
+    return decoded, trailing
+
+
 def parse_decision(
     payload: str,
     observation: Observation,
@@ -296,14 +364,31 @@ def parse_decision(
     screen the environment has already moved past. ``ActionBatch.validate_for``
     rejects that at the adapter boundary, so the failure is surfaced here where
     it can be attributed to the model and fed back to it.
+
+    Strict about the DECISION, not about the framing around it: text appended
+    after a complete batch is tolerated and reported rather than costing the
+    turn (see :func:`_decode_leading_json` for which shapes are and are not
+    tolerated, and why the tolerance only ever runs forwards).
     """
 
-    try:
-        decoded: Any = json.loads(payload)
-    except json.JSONDecodeError as error:
-        raise DecisionParseError(f"decision is not valid JSON: {error}") from error
+    decoded, trailing = _decode_leading_json(payload)
     if not isinstance(decoded, Mapping):
         raise DecisionParseError("decision must be a JSON object")
+    if trailing:
+        # Tolerated, but never silent. A model that reliably appends junk is a
+        # signal worth seeing -- it may point at a prompt or provider problem
+        # -- and a tolerance nobody can observe is indistinguishable from the
+        # harness quietly mangling a reply. Bounded because the remainder is
+        # untrusted model output of arbitrary length.
+        quoted = trailing[:MAX_TOLERATED_TRAILING_CHARS]
+        if len(trailing) > MAX_TOLERATED_TRAILING_CHARS:
+            quoted += "[...]"
+        logger.warning(
+            "decision carried %d character(s) of trailing text after a complete "
+            "JSON value; the batch was accepted and the remainder ignored: %r",
+            len(trailing),
+            quoted,
+        )
     actions = decoded.get("actions")
     if not isinstance(actions, list) or not actions:
         raise DecisionParseError("decision must carry a non-empty actions array")

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -80,6 +80,14 @@ MAX_REJECTED_REPLY_CHARS = 4_000
 #: push a bounded log line into an unbounded one.
 MAX_TOLERATED_TRAILING_CHARS = 200
 
+#: How many candidate ``{`` positions the trailing-remainder scan may try
+#: before giving up. Each failed decode rescans forward one character, so an
+#: unbounded scan over a remainder full of bare braces goes quadratic -- the
+#: same bound, and the same reason, as ``_iter_json_objects`` in the tool
+#: layer. Giving up means "no competing batch found", which degrades to the
+#: tolerant path rather than to an error.
+_MAX_TRAILING_DECODE_ATTEMPTS = 256
+
 #: Rendered in place of an observation's text when it is byte-identical to the
 #: previous turn's. The adapter owns observation text and the runner never
 #: second-guesses it; this is the one append-only-safe dedup, because it only
@@ -308,20 +316,42 @@ def _decode_leading_json(payload: str) -> tuple[Any, str]:
       the failure mode is executing a DIFFERENT batch than the model sent,
       which is far worse than losing the turn. A leading-junk reply still gets
       the ordinary parse error and a corrective re-prompt.
-    * **Two concatenated objects** (``{...}{...}``) is genuinely ambiguous --
-      which batch did the model mean? -- so it is NOT tolerated either. Silently
-      taking the first would execute a decision the model may have superseded.
+    * **A second batch for the SAME observation**, anywhere in the remainder,
+      is genuinely ambiguous -- which one did the model mean? -- so it is NOT
+      tolerated. Taking the first would execute a decision the model may have
+      superseded.
 
-    The ambiguity probe is deliberately narrowed to a trailing OBJECT. A
-    decision is always an object, so only a second object can be a competing
-    decision; asking the broader question "does the remainder parse as any
-    JSON value?" misreads ordinary prose whose first word happens to be a JSON
-    literal ("true story, that worked", "42 windows were listed", a quoted
-    sentence) as a second decision, and would reject the very turn this
-    function exists to save.
+    What makes the third rule safe to apply ANYWHERE, rather than only to an
+    immediately adjacent object, is that it keys on ``observation_id``. Two
+    weaker probes were measured against the real bundle and both fail:
+
+    * "Does the remainder start with ``{``?" only catches a directly adjacent
+      object. One character of anything else -- a comma, a newline, prose,
+      ``原始内容`` -- disables it, so a superseding batch behind a separator is
+      dropped silently, which is precisely what this rule claims to prevent.
+    * "Does anything in the remainder parse as JSON?" over-fires: it rejects
+      all three real bundle turns, because a model that quotes the harness's
+      own ``The rejected reply was: {...}`` feedback back at itself carries a
+      well-formed batch in its prose. Those batches are HISTORY, not a
+      competing decision -- in every one of the three they bind a DIFFERENT
+      observation than the turn being decided.
+
+    Binding on the observation id separates those two cases exactly: a batch
+    naming this observation is a decision about the screen in front of the
+    model and therefore competes; a batch naming any other observation is a
+    quotation of an older turn and cannot. ``ActionBatch`` would refuse the
+    latter as stale anyway, so nothing executable is being discarded.
     """
 
     decoder = json.JSONDecoder()
+    # ``json.loads`` skips leading whitespace and ``raw_decode`` does not, so
+    # stripping here keeps this helper's contract identical to the call it
+    # replaced. Doing it inside rather than relying on the caller matters
+    # because this is a general entry point: a second caller that forgot to
+    # strip would lose a turn to a leading newline, which is exactly the class
+    # of loss this function exists to prevent. Only leading WHITESPACE is
+    # skipped -- leading junk still fails at offset 0, by design.
+    payload = payload.lstrip()
     try:
         decoded, end = decoder.raw_decode(payload)
     except json.JSONDecodeError as error:
@@ -329,18 +359,77 @@ def _decode_leading_json(payload: str) -> tuple[Any, str]:
         # preamble fails here rather than being skipped past.
         raise DecisionParseError(f"decision is not valid JSON: {error}") from error
     trailing = payload[end:].strip()
-    if trailing.startswith("{"):
-        try:
-            decoder.raw_decode(trailing)
-        except json.JSONDecodeError:
-            # A brace that does not open a complete object is prose, not a
-            # competing decision ("{note: see above}"), so it stays tolerated.
-            pass
-        else:
-            raise DecisionParseError(
-                "decision carries more than one JSON object; send exactly one action batch"
-            )
+    if trailing and _competing_batch_offset(trailing, decoded, decoder) is not None:
+        raise DecisionParseError(
+            "decision carries a second action batch for the same observation; "
+            "send exactly one action batch"
+        )
     return decoded, trailing
+
+
+def _competing_batch_offset(trailing: str, decoded: Any, decoder: json.JSONDecoder) -> int | None:
+    """Offset of a second batch in ``trailing`` that competes with ``decoded``.
+
+    "Competes" means it names the SAME ``observation_id``: only a decision
+    about the screen currently in front of the model can supersede the one
+    already parsed. See :func:`_decode_leading_json` for why that test, rather
+    than adjacency or bare JSON-ness, is the one that separates a superseding
+    batch from the harness feedback a model quotes back at itself.
+
+    Returns ``None`` when the remainder is ordinary prose, which is the common
+    case and the one that must stay cheap.
+    """
+
+    observation_ids = _batch_observation_ids(decoded)
+    if not observation_ids:
+        return None
+    # A decision is always an object, so only "{" can start a competing batch;
+    # the scan is bounded the same way ``_iter_json_objects`` is bounded, since
+    # a remainder full of bare braces would otherwise cost a rescan each.
+    index = 0
+    attempts = 0
+    while attempts < _MAX_TRAILING_DECODE_ATTEMPTS:
+        start = trailing.find("{", index)
+        if start < 0:
+            return None
+        attempts += 1
+        try:
+            candidate, end = decoder.raw_decode(trailing, start)
+        except (ValueError, RecursionError):
+            # RecursionError as well as ValueError: the C decoder recurses per
+            # nesting level and raises it (NOT a ValueError subclass) on a
+            # deeply nested payload. Untrusted model output must degrade to
+            # "no competing batch found", never to an unexpected exception.
+            index = start + 1
+            continue
+        index = max(end, start + 1)
+        if not isinstance(candidate, Mapping):
+            continue
+        if _batch_observation_ids(candidate) & observation_ids:
+            return start
+    return None
+
+
+def _batch_observation_ids(value: Any) -> set[str]:
+    """The observation ids an action-batch-shaped object binds to.
+
+    Read from the ACTIONS rather than from a top-level ``observation_id``: a
+    model reply carries the id per action (the runner supplies the batch-level
+    one itself), so a top-level lookup finds nothing on the very shape this
+    needs to compare. Returns an empty set for anything that is not batch
+    shaped, which the caller treats as "not a competing decision".
+    """
+
+    if not isinstance(value, Mapping):
+        return set()
+    actions = value.get("actions")
+    if not isinstance(actions, list) or not actions:
+        return set()
+    return {
+        action["observation_id"]
+        for action in actions
+        if isinstance(action, Mapping) and isinstance(action.get("observation_id"), str)
+    }
 
 
 def parse_decision(
@@ -367,8 +456,10 @@ def parse_decision(
 
     Strict about the DECISION, not about the framing around it: text appended
     after a complete batch is tolerated and reported rather than costing the
-    turn (see :func:`_decode_leading_json` for which shapes are and are not
-    tolerated, and why the tolerance only ever runs forwards).
+    turn, while a second batch for the SAME observation anywhere in that text
+    is still refused as ambiguous (see :func:`_decode_leading_json` for which
+    shapes are and are not tolerated, and why the tolerance only ever runs
+    forwards).
     """
 
     decoded, trailing = _decode_leading_json(payload)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.71"
+version = "0.44.72"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.72"
+version = "0.45.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import logging
 from pathlib import Path
 from typing import Any, AsyncIterator, Callable
 
@@ -32,6 +33,7 @@ from local_operator.evaluation.protocol import (
 from local_operator.evaluation.runner.model import DecisionRejected, EpisodeTurn
 from local_operator.evaluation.runner.provider_client import (
     MAX_REJECTED_REPLY_CHARS,
+    MAX_TOLERATED_TRAILING_CHARS,
     DecisionParseError,
     ProviderModelClient,
     build_system_prompt,
@@ -210,6 +212,129 @@ def test_parse_decision_rejects_a_batch_bound_to_a_stale_observation() -> None:
 def test_parse_decision_rejects_malformed_replies(payload: str) -> None:
     with pytest.raises(DecisionParseError):
         parse_decision(payload, observation(), route=ROUTE)
+
+
+@pytest.mark.parametrize(
+    "junk",
+    [
+        # Verbatim from sealed bundle ep-e46c789ca818, which paid for this
+        # three times in one episode.
+        "原始内容",
+        " Hope that helps!",
+        "\n\n```",
+        "\nLet me know if you want me to continue.",
+    ],
+)
+def test_parse_decision_tolerates_trailing_junk_after_a_complete_value(junk: str) -> None:
+    """A complete batch is not made unusable by what the model appended to it.
+
+    The decision is already unambiguous where the junk starts, so discarding a
+    billed turn over it buys nothing.
+    """
+
+    current = observation()
+
+    decision = parse_decision(type_payload(current) + junk, current, route=ROUTE)
+
+    action = decision.action_batch.actions[0]
+    assert isinstance(action, TypeAction)
+    # The action is what the model plainly intended, not a salvaged fragment.
+    assert action.text == "hello"
+    decision.action_batch.validate_for(current)
+
+
+def test_parse_decision_reports_tolerated_trailing_junk(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tolerated is not the same as silent: the remainder stays observable."""
+
+    current = observation()
+
+    with caplog.at_level(logging.WARNING):
+        parse_decision(type_payload(current) + "原始内容", current, route=ROUTE)
+
+    assert "原始内容" in caplog.text
+    assert "trailing text" in caplog.text
+
+
+def test_parse_decision_bounds_the_reported_trailing_junk(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A runaway remainder must not turn a log line into a wall of prose."""
+
+    current = observation()
+    junk = "x" * (MAX_TOLERATED_TRAILING_CHARS + 500)
+
+    with caplog.at_level(logging.WARNING):
+        parse_decision(type_payload(current) + junk, current, route=ROUTE)
+
+    assert "[...]" in caplog.text
+    # The full remainder is counted but never quoted in full.
+    assert str(len(junk)) in caplog.text
+    assert "x" * (MAX_TOLERATED_TRAILING_CHARS + 1) not in caplog.text
+
+
+def test_parse_decision_rejects_two_concatenated_batches() -> None:
+    """Which batch did the model mean? Guessing could execute the wrong one.
+
+    Unlike trailing prose, a second COMPLETE value is a genuine ambiguity, and
+    executing a superseded decision is worse than losing the turn.
+    """
+
+    current = observation()
+    payload = type_payload(current) + finish_payload(current)
+
+    with pytest.raises(DecisionParseError, match="more than one JSON object"):
+        parse_decision(payload, current, route=ROUTE)
+
+
+@pytest.mark.parametrize(
+    "junk",
+    [
+        "\ntrue story, that worked",
+        "\nnull hypothesis rejected",
+        "\n42 windows were listed",
+        '\n"that should do it"',
+        "\n{note: see the window list above}",
+    ],
+)
+def test_parse_decision_tolerates_prose_that_opens_like_json(junk: str) -> None:
+    """Only a second OBJECT can be a competing decision.
+
+    Asking the broader "does the remainder parse as any JSON value?" would
+    class prose beginning with a JSON literal as a second batch and reject the
+    very turn the tolerance exists to save. A brace that does not open a
+    complete object is prose too.
+    """
+
+    current = observation()
+
+    decision = parse_decision(type_payload(current) + junk, current, route=ROUTE)
+
+    action = decision.action_batch.actions[0]
+    assert isinstance(action, TypeAction)
+    assert action.text == "hello"
+
+
+def test_parse_decision_rejects_leading_junk_before_the_value() -> None:
+    """Skipping forward to the first brace means guessing where the value
+    starts, and a preamble containing a brace makes that guess wrong silently
+    -- executing a DIFFERENT batch than was sent."""
+
+    current = observation()
+
+    with pytest.raises(DecisionParseError, match="not valid JSON"):
+        parse_decision("Sure, here you go: " + type_payload(current), current, route=ROUTE)
+
+
+def test_parse_decision_still_rejects_a_truncated_value() -> None:
+    """Tolerance is for what follows a COMPLETE value, never for an incomplete
+    one: a batch cut off mid-emission is not a decision."""
+
+    current = observation()
+
+    with pytest.raises(DecisionParseError, match="not valid JSON"):
+        parse_decision(type_payload(current)[:-5], current, route=ROUTE)
 
 
 def test_parse_decision_rejects_a_wrong_discriminator_key() -> None:

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -274,18 +274,78 @@ def test_parse_decision_bounds_the_reported_trailing_junk(
     assert "x" * (MAX_TOLERATED_TRAILING_CHARS + 1) not in caplog.text
 
 
-def test_parse_decision_rejects_two_concatenated_batches() -> None:
+@pytest.mark.parametrize(
+    "separator",
+    [
+        # Direct adjacency is the one shape a real model is LEAST likely to
+        # emit, and covering only it is what let a separator-bypass hide here.
+        "",
+        " ",
+        ",",
+        "\n",
+        "原始内容",
+        "\n\nOops, that was wrong. The correct batch is:\n",
+        "\n```\n```json\n",
+        "x" * 1000,
+    ],
+)
+def test_parse_decision_rejects_a_superseding_batch_behind_any_separator(
+    separator: str,
+) -> None:
     """Which batch did the model mean? Guessing could execute the wrong one.
 
-    Unlike trailing prose, a second COMPLETE value is a genuine ambiguity, and
-    executing a superseded decision is worse than losing the turn.
+    The ambiguity does not depend on the two objects being adjacent, so
+    neither may the guard: a second batch for the SAME observation is a
+    competing decision wherever it sits in the remainder.
     """
 
     current = observation()
-    payload = type_payload(current) + finish_payload(current)
+    payload = type_payload(current) + separator + finish_payload(current)
 
-    with pytest.raises(DecisionParseError, match="more than one JSON object"):
+    with pytest.raises(DecisionParseError, match="second action batch"):
         parse_decision(payload, current, route=ROUTE)
+
+
+def test_parse_decision_tolerates_a_quoted_batch_for_another_observation() -> None:
+    """The shape the real bundle actually emits, and why the guard keys on the
+    observation id rather than on JSON-ness.
+
+    A model that quotes the harness's own ``The rejected reply was: {...}``
+    feedback back at itself carries a well-formed batch in its prose. That is
+    HISTORY -- it names an OLDER observation -- so it cannot supersede the
+    decision just parsed, and ``ActionBatch`` would refuse it as stale anyway.
+    Rejecting on it would discard the very turns this tolerance exists to save.
+    """
+
+    current = observation()
+    stale = observation(1)
+    quoted = json.dumps(
+        {"actions": [{"kind": "key", "observation_id": stale.observation_id, "keys": ["ctrl"]}]}
+    )
+    payload = type_payload(current) + "\nThe rejected reply was:\n  " + quoted
+
+    decision = parse_decision(payload, current, route=ROUTE)
+
+    action = decision.action_batch.actions[0]
+    assert isinstance(action, TypeAction)
+    assert action.text == "hello"
+
+
+@pytest.mark.parametrize("whitespace", ["  ", "\n", "\t", "\r\n"])
+def test_parse_decision_accepts_leading_whitespace(whitespace: str) -> None:
+    """Parity with the ``json.loads`` this replaced, which skipped leading
+    whitespace where ``raw_decode`` does not.
+
+    Pinned inside the helper rather than left to the caller's ``.strip()``:
+    this is a general entry point, and a second caller that forgot to strip
+    would lose a turn to a leading newline.
+    """
+
+    current = observation()
+
+    decision = parse_decision(whitespace + type_payload(current), current, route=ROUTE)
+
+    assert isinstance(decision.action_batch.actions[0], TypeAction)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/evaluation/test_protocol.py
+++ b/tests/unit/evaluation/test_protocol.py
@@ -737,6 +737,33 @@ def test_key_validation_and_historical_double_click_are_explicit() -> None:
         KeyAction(observation_id="observation-7", keys=("NOT_A_KEY",))
 
 
+def test_named_key_case_is_not_meaningful_but_character_case_is() -> None:
+    """The case boundary, pinned where it actually sits.
+
+    A named key is a NAME for a physical key, so its case carries no meaning
+    and every spelling folds to one value. A single character is the character
+    that gets typed, so 'A' and 'a' are different requests and must survive
+    verbatim -- folding them would silently turn a capital into a lowercase
+    letter. Locked because both halves are easy to break while the other keeps
+    passing.
+    """
+
+    for spelling in ("ctrl", "CTRL", "Ctrl", "cTrL"):
+        assert KeyAction(observation_id="observation-7", keys=(spelling,)).keys == ("CTRL",)
+
+    # Case-folding a chord must not merge two distinct characters into one.
+    assert KeyAction(observation_id="observation-7", keys=("A",)).keys == ("A",)
+    assert KeyAction(observation_id="observation-7", keys=("a",)).keys == ("a",)
+    assert KeyAction(observation_id="observation-7", keys=("shift", "A")).keys == ("SHIFT", "A")
+
+
+def test_type_action_text_is_never_case_folded() -> None:
+    """Typed text is content, not a key name: its case is the user's data."""
+
+    text = "Hello World"
+    assert TypeAction(observation_id="observation-7", text=text).text == text
+
+
 def test_user_facing_strings_and_identifiers_reject_whitespace_only_values() -> None:
     with pytest.raises(ValidationError):
         TypeAction(observation_id="observation-7", text="   ")


### PR DESCRIPTION
## What broke a real paid episode

A model emitted a **complete, valid action batch** and then appended a stray
token. The harness threw the whole turn away. Verbatim from sealed bundle
`ep-e46c789ca818` (artifact `ef704f36…`):

```
{"actions":[{"kind":"type","observation_id":"d1e6…938a","text":"wmctrl -l\n"}],"episode_id":"ep-e46c789ca818","kind":"action_batch","observation_id":"d1e6…938a","protocol_version":"1.0","task_id":"task_001"}原始内容
```

```
decision is not valid JSON: Extra data: line 1 column 318 (char 317)
```

The decision was fully parseable up to char 317. Everything the harness needed
was already read; `原始内容` is noise appended *after* an unambiguous decision.
This cost a billed call and a full turn — **three times in that one episode**,
and **5 of the 6** decision rejections across every sealed bundle available.

`parse_decision` used `json.loads`, which demands the entire reply be one JSON
value. That is a rule about the *framing around* a decision, not about the
decision itself.

## The fix

`json.JSONDecoder().raw_decode()` stops at the end of the first complete value
and reports where it stopped — exactly the question being asked. The tolerance
is deliberately **one-sided**, because the three shapes are not equally
knowable:

| Shape | Disposition | Why |
|---|---|---|
| `{…}原始内容`, `{…} Hope that helps!` | **tolerated** | decision already complete and unambiguous where junk starts; nothing after can change which actions were chosen |
| `Sure, here you go: {…}` (leading) | **rejected** | skipping to the first `{` guesses where the value begins; a preamble containing a brace makes that guess wrong *silently* — executing a **different** batch than was sent, worse than losing the turn |
| a second batch for the **same observation**, *anywhere* in the remainder | **rejected** | genuinely ambiguous — which did the model mean? Taking the first could execute a decision the model superseded |

**The third rule keys on `observation_id`, and that is what makes it safe to
apply anywhere.** Two weaker probes were measured against the real bundle and
both fail:

- *"Does the remainder start with `{`?"* catches only a directly adjacent
  object. One character of anything else — a comma, a newline, prose, `原始内容`
  — disables it, so a superseding batch behind a separator is dropped silently.
- *"Does anything in the remainder parse as JSON?"* over-fires: it **rejects all
  three real bundle turns**, because a model that quotes the harness's own
  `The rejected reply was: {...}` feedback back at itself carries a well-formed
  batch inside its prose.

Binding on the observation id separates those exactly. A batch naming *this*
observation is a decision about the screen in front of the model and competes; a
batch naming any *other* observation is a quotation of an older turn and cannot
— in all three bundle replies the embedded batch binds a **different**
observation, and `ActionBatch` refuses it as stale anyway, so nothing executable
is discarded.

**Tolerated is never silent.** The remainder is logged at WARNING, bounded to
200 chars and quoted, so a model reliably emitting junk stays visible instead
of being swallowed:

```
decision carried 1661 character(s) of trailing text after a complete JSON value;
the batch was accepted and the remainder ignored: "原始内容\n\n---\nYour task…[...]"
```

## Before / after against the real parser

Both columns drive the **real `parse_decision`** with the **verbatim** replies
from the sealed bundle (observation ids rebound to a reconstructed observation
carrying the same 1920×1080 `screen` frame, so `validate_for` binds as it did
in the live run).

**BEFORE — `origin/main`** (reproduces the bundle's exact char offsets):

```
REJECTED  ef704f36: decision is not valid JSON: Extra data: line 1 column 318 (char 317)
REJECTED  70d5422b: decision is not valid JSON: Extra data: line 1 column 350 (char 349)
REJECTED  3dc0aeec: decision is not valid JSON: Extra data: line 1 column 349 (char 348)
```

**AFTER — this branch** (each yields what the model plainly intended):

```
ACCEPTED  ef704f36: kind=type 'wmctrl -l\n'
ACCEPTED  70d5422b: kind=click x=250 y=240
ACCEPTED  3dc0aeec: kind=click x=18 y=750
```

## Correction: the reported second defect does not exist

This PR was briefed to also fix a **case-sensitive key rejection**, quoting
`action_batch[0].kind.keys[0]: Unexpected value 'CTRL'`. **That defect is not
real, and no code was changed for it.** Recording the disproof so nobody
re-derives it:

- `KeyAction._known_unique_keys` (`protocol.py`) **already** folds named-key
  case — `candidate = key.upper() if len(key) > 1 else key`. At `origin/main`,
  `keys=["CTRL","ALT","t"]` parses and normalises to `('CTRL','ALT','t')`;
  `ctrl` / `CTRL` / `Ctrl` are all accepted.
- Verified against `local_operator 0.44.66` — the build the bundle manifest
  names (`harness_version: 0.44.66`) as having run the episode — same result.
- The `Unexpected value 'CTRL'` string is **not a harness diagnostic**. It sits
  **inside the model's own reply**, past the trailing-junk boundary: the sole
  harness diagnostic is line 1 (`Extra data…`), `raw_decode` ends the real JSON
  at char 317, and every occurrence of that string is at offset > 317. The
  model *hallucinated* a plausible-looking harness error as part of the junk.
- The string exists nowhere in this repo nor in the installed 0.44.70 tree.

So defect 2 was defect 1, misread. Fixing the trailing-junk parse removes it.

Per maintainer decision, **discriminator/enum case-folding was deliberately not
added**: there is zero evidence any model has emitted an upper-case
discriminator, and widening a load-bearing discriminator's vocabulary is a
permanent commitment. What *is* added is regression coverage locking the
existing, correct boundary: **named keys fold case; a single character does
not** (`'A'` ≠ `'a'` — different keystrokes); **typed text never does**.

## Scope

General harness fix at the shared source (`parse_decision`), used by the
evaluation runner and every surface that parses a model decision. **No
OSWorld special-casing, no benchmark knowledge, no adapter-local change.** It
does not alter what parses *as* a decision — only what framing around one is
fatal.

## Testing evidence

Real execution against the real parser, not a green suite alone.

**Adversarial edge matrix — 18/18 as intended** (driving `parse_decision`):

```
OK clean batch (no junk)          accept     OK LEADING prose               reject
OK trailing CJK (bundle verbatim) accept     OK leading brace then prose    reject
OK trailing markdown fence        accept     OK two complete batches        reject
OK trailing whitespace only       accept     OK truncated mid-value         reject
OK trailing bare word             accept     OK empty string                reject
OK trailing NUL / control bytes   accept     OK whitespace only             reject
OK trailing 1MB of prose          accept     OK bare JSON string            reject
OK batch + trailing bare number   accept     OK top-level array             reject
OK batch + trailing JSON null     accept
OK batch + trailing array         accept
MISMATCHES: 0
```

**Mutation testing — every new test proven able to fail.** Each mutation was
applied to the real source, the suite run, and the source restored:

| # | Mutation | Result |
|---|---|---|
| M1 | `raw_decode` → `json.loads` (revert the fix) | **7 failed** (the tolerance tests) |
| M2 | drop the two-object guard | **kills** `rejects_two_concatenated_batches` |
| M3 | skip forward to first `{` (tolerate leading junk) | **kills** `rejects_leading_junk_before_the_value` |
| M4 | remove the warning (tolerate silently) | **kills** both observability tests |
| M5 | remove the 200-char quote bound | **kills** `bounds_the_reported_trailing_junk` |
| M6 | stop folding named-key case | **kills** the key-case test |
| M7 | over-fold — upper-case single chars too (`'a'`→`'A'`) | **kills** the key-case test |
| M8 | case-fold `TypeAction.text` | **kills** `type_action_text_is_never_case_folded` |
| M9 | widen probe to any JSON value (the flaw I caught) | **kills** `tolerates_prose_that_opens_like_json` |
| M10 | revert to the narrow `startswith("{")` guard (the F1 defect) | **kills** 5 separator cases |
| M11 | drop the observation-id binding (reject any trailing batch) | **kills** `tolerates_a_quoted_batch_for_another_observation` |
| M12 | remove the leading-`lstrip` (the F2 regression) | **kills** all 4 whitespace cases |

**Gates — whole tree, exactly as CI:**

```
flake8 .                     clean
black --check .              836 files unchanged   (black==26.1.0)
isort --check .              clean                 (isort==5.13.2)
pyright                      0 errors, 0 warnings, 0 informations
pytest tests/unit -q         11897 passed, 15 skipped in 440.62s
```

TUI tests ran under `env -u NO_COLOR TERM=xterm-256color`. Host was heavily
contended (load avg 26–37 from sibling worktrees); the suite was allowed to run
to completion rather than reporting a starved number.

## Not addressed

- **A separate "a second batch was found and dropped" warning.** Now dead code:
  a batch for this observation is a hard reject, and the only other case is a
  batch bound to a *different* observation, which `ActionBatch` proves
  unexecutable and which the existing bounded remainder warning already
  reports. *deferred — unreachable by construction.*
- **Discriminator/enum case-sensitivity** (`kind:"KEY"`, `button:"LEFT"`,
  `status:"DONE"` are rejected while `keys` folds case). Real inconsistency,
  deliberately deferred — no evidence any model has hit it, and widening a
  discriminator is permanent. *deferred — unevidenced; revisit with a bundle
  showing a model hitting it.*
- The **6th** rejection across all bundles is a genuine field-name error
  (`key` vs `keys`), correctly rejected. Out of scope.

Version **0.44.72** (patch — a bug fix; per AGENTS.md materiality), strictly
above main (0.44.71) and PyPI (0.44.71) at bump time.
