### PR TITLE
fix(evaluation): carry the adapter's real cause across the RPC boundary

### DIFF
--- a/local_operator/evaluation/adapters/api.py
+++ b/local_operator/evaluation/adapters/api.py
@@ -46,10 +46,27 @@ from local_operator.evaluation.receipts import (
 # has no use for credentials) and NOT on ``RescueDescriptor`` (persisted to
 # disk; a rescue worker receives secrets fresh from the parent's resolver via
 # ``BeginRescueParams`` instead).
-ADAPTER_SCHEMA_VERSION = "1.2"
+#
+# 1.3 adds ``detail`` -- a bounded, worker-redacted structured cause -- to
+# ``RpcError`` (rpc.py). A fatal ``adapter_error`` previously recorded nothing
+# but the fixed sentence "adapter operation failed": two consecutive paid
+# episodes (ep-e46c789ca818 at 19 billed steps, ep-ffda3fc88f81 at 16) died
+# there and diagnosing either would have cost another paid run.
+#
+# The bump is REQUIRED even though the field is optional and defaults to None,
+# and the reason is specific to this transport rather than to pydantic's
+# leniency. Every RPC line must round-trip byte-identically through
+# ``parse_canonical_line``, and a model always serialises its full field set --
+# so a 1.2 worker's error line (no ``detail`` key) fails a 1.3 parent's
+# canonicality check, and a 1.3 worker's line (``"detail":null``) fails a 1.2
+# parent's ``extra="forbid"``. Mixed versions break in BOTH directions, on the
+# error path, which is the worst possible place to discover a mismatch. The
+# exact-version pin in ``AdapterSelector`` turns that into a refusal at
+# selection time, before a worker is spawned or a resource allocated.
+ADAPTER_SCHEMA_VERSION = "1.3"
 # One alias for the three models that pin the version, so a future bump cannot
 # move the constant while leaving a model silently accepting the older literal.
-SchemaVersion: TypeAlias = Literal["1.2"]
+SchemaVersion: TypeAlias = Literal["1.3"]
 ADAPTER_ENTRY_POINT_GROUP = "local_operator.evaluation_adapters.v1"
 MAX_RESCUE_REFS = 256
 MAX_REQUIREMENTS = 256

--- a/local_operator/evaluation/adapters/rpc.py
+++ b/local_operator/evaluation/adapters/rpc.py
@@ -9,7 +9,7 @@ import os
 from collections.abc import Callable
 from typing import Any, Literal
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from local_operator.evaluation.adapters.api import AdapterMethod
 from local_operator.evaluation.protocol import ProtocolModel
@@ -17,6 +17,19 @@ from local_operator.evaluation.protocol import ProtocolModel
 MAX_RPC_BYTES = 1024 * 1024
 MAX_ERROR_MESSAGE = 2000
 MAX_SAFE_ID = 2**53 - 1
+# Detail bounds. Every one of these is a hard wire limit rather than a
+# formatting preference: the envelope is parsed by a strict model on the far
+# side, so an unbounded field would let a worker's exception text decide how
+# much the parent must allocate and canonicalise.
+MAX_DETAIL_MESSAGE = 512
+MAX_DETAIL_TYPE = 128
+MAX_DETAIL_CAUSES = 4
+MAX_DETAIL_FRAMES = 8
+MAX_DETAIL_NAME = 128
+#: Substituted for any string the worker's own canary check rejects. Failing
+#: CLOSED (drop the text, keep the structure) rather than attempting to scrub
+#: keeps a partially-matched secret from being reassembled from what survived.
+WITHHELD = "<withheld: matched a secret canary>"
 
 
 class RpcProtocolError(RuntimeError):
@@ -24,9 +37,105 @@ class RpcProtocolError(RuntimeError):
 
 
 class RpcRemoteError(RuntimeError):
-    def __init__(self, code: str, message: str) -> None:
-        super().__init__(f"{code}: {message}")
+    """A remote error the worker ANSWERED, carrying its structured cause.
+
+    ``detail`` is optional because the closed error-code set predates it and a
+    worker that cannot describe its failure must still be able to report one.
+    It is folded into ``str()`` rather than left as an attribute the caller has
+    to know about: the runner records a fatal error by rendering the exception
+    (``episode._diagnostic``), so anything not visible through ``str`` never
+    reaches the evidence bundle a paid episode leaves behind.
+    """
+
+    def __init__(self, code: str, message: str, detail: "RpcErrorDetail | None" = None) -> None:
+        rendered = f"{code}: {message}"
+        if detail is not None:
+            rendered = f"{rendered} [{detail.render()}]"
+        super().__init__(rendered)
         self.code = code
+        self.detail = detail
+
+
+class RpcErrorFrame(ProtocolModel):
+    """One worker-side call-site: WHERE it raised, never WHAT was in scope.
+
+    A raw traceback is refused across this boundary and that refusal is right --
+    it renders source text (which can embed a literal credential) and absolute
+    paths (which leak the worker's filesystem layout and the account it runs
+    under). But "which line of the adapter raised" is the single most valuable
+    fact for diagnosis and carries neither: a BASENAME, a line number and a
+    function name are derived from the adapter's own published wheel, contain no
+    runtime value, and cannot be steered by task content. Locals are absent by
+    construction -- ``traceback.extract_tb`` never captures them -- rather than
+    stripped afterwards, so there is no filter to get wrong.
+    """
+
+    file: str = Field(min_length=1, max_length=MAX_DETAIL_NAME)
+    line: int = Field(ge=0, le=MAX_SAFE_ID)
+    function: str = Field(min_length=1, max_length=MAX_DETAIL_NAME)
+
+
+class RpcErrorCause(ProtocolModel):
+    """One link of the ``__cause__``/``__context__`` chain.
+
+    The chain is what actually names the fault. An adapter that wraps a cloud
+    SDK failure in its own ``RuntimeError`` puts the diagnosable text one link
+    down, so reporting only the outermost type reproduces the very opacity this
+    envelope exists to remove.
+    """
+
+    exception_type: str = Field(min_length=1, max_length=MAX_DETAIL_TYPE)
+    message: str = Field(max_length=MAX_DETAIL_MESSAGE)
+
+
+class RpcErrorDetail(ProtocolModel):
+    """Bounded, worker-redacted cause travelling inside the existing envelope.
+
+    This deliberately extends ``RpcError`` instead of opening a second channel.
+    The error envelope already has the properties a diagnostic needs -- it is
+    correlated to the request, it is what the operation replay cache stores, and
+    it is the one thing a poisoned channel still delivers -- so a parallel path
+    would have to re-earn all three and would be absent on exactly the failures
+    that matter. ``code`` stays a closed set and ``message`` stays a fixed
+    string; the variable part is confined here, where every field is bounded and
+    every string has passed the worker's canary check.
+    """
+
+    exception_type: str = Field(min_length=1, max_length=MAX_DETAIL_TYPE)
+    message: str = Field(max_length=MAX_DETAIL_MESSAGE)
+    method: AdapterMethod
+    # The idempotency key the failure belongs to. Without it a reader holding a
+    # bundle cannot tell which of several same-method calls died, and the
+    # operation replay cache returns this error again under a NEW request ID,
+    # so the request ID alone does not identify the originating operation.
+    operation_id: str | None = Field(default=None, max_length=MAX_DETAIL_NAME)
+    causes: tuple[RpcErrorCause, ...] = Field(default=(), max_length=MAX_DETAIL_CAUSES)
+    frames: tuple[RpcErrorFrame, ...] = Field(default=(), max_length=MAX_DETAIL_FRAMES)
+
+    @field_validator("causes", "frames", mode="before")
+    @classmethod
+    def _freeze(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+    def render(self) -> str:
+        """One line naming the cause, for the fatal-error evidence artifact."""
+
+        parts = [f"{self.exception_type}: {self.message}" if self.message else self.exception_type]
+        parts.append(f"method={self.method}")
+        if self.operation_id is not None:
+            parts.append(f"operation_id={self.operation_id}")
+        for cause in self.causes:
+            parts.append(
+                f"caused by {cause.exception_type}: {cause.message}"
+                if cause.message
+                else f"caused by {cause.exception_type}"
+            )
+        if self.frames:
+            trace = " <- ".join(
+                f"{frame.file}:{frame.line} in {frame.function}" for frame in self.frames
+            )
+            parts.append(f"at {trace}")
+        return "; ".join(parts)
 
 
 class RpcError(ProtocolModel):
@@ -39,6 +148,7 @@ class RpcError(ProtocolModel):
         "timeout",
     ]
     message: str = Field(min_length=1, max_length=MAX_ERROR_MESSAGE)
+    detail: RpcErrorDetail | None = None
 
 
 class RpcRequest(ProtocolModel):
@@ -270,7 +380,9 @@ class RpcClient:
                 await asyncio.shield(self._poison())
                 raise
             if response.error is not None:
-                raise RpcRemoteError(response.error.code, response.error.message)
+                raise RpcRemoteError(
+                    response.error.code, response.error.message, response.error.detail
+                )
             assert response.result is not None
             return response.result
 

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -672,6 +672,29 @@ class VerifiedAdapterSession:
         return initial
 
     async def observe(self, params: ObserveParams, *, timeout: float) -> ObservationResult:
+        """Read the current snapshot. Poisons on failure, deliberately.
+
+        ``observe`` is READ-ONLY, so a failure here is not an ambiguous
+        mutation and the poison below is stricter than the mutating-call rule
+        requires. That was examined against two lost paid episodes
+        (ep-e46c789ca818, ep-ffda3fc88f81) and left as is, for two reasons that
+        should be re-checked rather than re-derived if this path ever changes:
+
+        * Neither episode failed here. Both died in ``execute`` -- their
+          journals carry equal action_batch and environment_step counts with
+          the error immediately after the decision -- which is mutating, and
+          retrying a possibly-applied mutation is unsafe.
+        * This method currently has NO caller in the episode runner. Every
+          observation reaches the runner as the RESULT of ``reset_start`` or
+          ``execute``, so relaxing this would rescue nothing today while
+          widening the window in which a snapshot the verifier already
+          rejected could be re-accepted.
+
+        The mutating boundary itself is never negotiable: ``prepare``,
+        ``reset_start``, ``execute``, ``ask_user_exchange``, ``score`` and
+        ``cleanup`` go through ``_mutating_call`` and must stay non-retryable.
+        """
+
         self._ensure_usable()
         if params.episode_id != self.verifier.episode_id:
             raise SupervisionError("observe belongs to another episode")

--- a/local_operator/evaluation/adapters/worker.py
+++ b/local_operator/evaluation/adapters/worker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
+import traceback
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, cast
@@ -35,10 +36,19 @@ from local_operator.evaluation.adapters.discovery import (
     workspace_digest,
 )
 from local_operator.evaluation.adapters.rpc import (
+    MAX_DETAIL_CAUSES,
+    MAX_DETAIL_FRAMES,
+    MAX_DETAIL_MESSAGE,
+    MAX_DETAIL_NAME,
+    MAX_DETAIL_TYPE,
+    WITHHELD,
     AsyncIncrementalReader,
     CancelRequest,
     IncrementalWriter,
     RpcError,
+    RpcErrorCause,
+    RpcErrorDetail,
+    RpcErrorFrame,
     RpcProtocolError,
     RpcRequest,
     RpcResponse,
@@ -47,6 +57,7 @@ from local_operator.evaluation.adapters.rpc import (
 )
 from local_operator.evaluation.evidence.models import canonical_digest
 from local_operator.evaluation.protocol import ProtocolModel
+from local_operator.evaluation.receipts import RedactionSet
 
 REQUEST_FD_ENV = "LO_ADAPTER_REQUEST_FD"
 RESPONSE_FD_ENV = "LO_ADAPTER_RESPONSE_FD"
@@ -74,6 +85,136 @@ class _OperationRecord:
     params_digest: str
     result: dict[str, Any] | None
     error: RpcError | None
+
+
+class _DenyAllRedactions(RedactionSet):
+    """A canary set that refuses every non-empty string.
+
+    Used when secret material was delivered but a canary set could not be built
+    from it. The alternative -- leaving the set None -- reads identically to
+    "this worker holds no secrets" and would skip the check entirely on the one
+    occasion something is definitely there to protect.
+    """
+
+    def assert_clear(self, value: Any) -> None:
+        raise ValueError("secret canary set is unavailable")
+
+
+#: Constructed with empty canaries; ``assert_clear`` is what does the work.
+_DENY_ALL = _DenyAllRedactions((), (), (), ())
+
+
+def _control_safe(value: str, limit: int) -> str:
+    """Collapse control characters and bound the result.
+
+    The RPC line framing is LF-delimited and refuses CR, so an exception
+    message containing either would make an otherwise-valid response
+    unparseable -- the worker would have written a frame the parent rejects as
+    a protocol error, killing the channel on the exact path that exists to
+    explain a failure. Adapter text is arbitrary (a subprocess's captured
+    stderr routinely carries newlines), so this is a wire requirement, not
+    cosmetics.
+    """
+
+    collapsed = "".join(character if character.isprintable() else " " for character in value)
+    return collapsed.strip()[:limit]
+
+
+def _redacted(value: str, limit: int, redactions: RedactionSet | None) -> str:
+    """Bound and canary-check one string before it may cross the boundary.
+
+    Fails CLOSED: a string that matches a canary is replaced wholesale rather
+    than masked, because a partial mask still narrows the secret for anyone
+    holding the bundle. ``redactions`` is None only when the worker holds no
+    secrets at all (nothing was ever delivered to leak), which keeps the
+    no-secret episode from paying for a scan that cannot match.
+
+    This is the SECOND line of defence, not the only one. The parent's evidence
+    writer scans every artifact it publishes against the episode's own
+    RedactionSet, so a value this worker never saw still cannot reach the
+    bundle. Checking here as well means a leak is refused before it is written
+    to a pipe, rather than after.
+    """
+
+    bounded = _control_safe(value, limit)
+    if not bounded or redactions is None:
+        return bounded
+    try:
+        redactions.assert_clear(bounded)
+    except ValueError:
+        return WITHHELD
+    return bounded
+
+
+def _error_detail(
+    error: BaseException,
+    method: AdapterMethod,
+    operation_id: str | None,
+    redactions: RedactionSet | None,
+) -> RpcErrorDetail | None:
+    """Describe an adapter-side failure in bounded, redacted, structured form.
+
+    Built ENTIRELY on the worker side, which is what makes the traceback
+    question answerable at all: the parent never receives raw traceback text,
+    only a tuple of (basename, line, function) triples this function derived and
+    canary-checked. See ``RpcErrorFrame`` for why that projection carries no
+    runtime value and no filesystem layout.
+
+    Returning None rather than raising is deliberate. This runs on the failure
+    path; a detail that cannot be built must degrade to the generic reply the
+    parent already understood, never turn an answered adapter error into an
+    unanswered channel death.
+    """
+
+    try:
+        causes: list[RpcErrorCause] = []
+        seen: set[int] = {id(error)}
+        # ``__cause__`` first: an explicit ``raise ... from ...`` is the
+        # adapter stating the real fault, while ``__context__`` is whatever
+        # happened to be in flight and is only consulted when nothing was
+        # stated.
+        current: BaseException | None = error.__cause__ or error.__context__
+        while current is not None and len(causes) < MAX_DETAIL_CAUSES:
+            if id(current) in seen:
+                break  # A cycle is possible through __context__; stop, never spin.
+            seen.add(id(current))
+            causes.append(
+                RpcErrorCause(
+                    exception_type=_redacted(type(current).__name__, MAX_DETAIL_TYPE, redactions)
+                    or "Exception",
+                    message=_redacted(str(current), MAX_DETAIL_MESSAGE, redactions),
+                )
+            )
+            current = current.__cause__ or current.__context__
+        frames: list[RpcErrorFrame] = []
+        # The DEEPEST frames are the informative ones -- the harness dispatch
+        # frames at the top are identical for every failure.
+        for summary in traceback.extract_tb(error.__traceback__)[-MAX_DETAIL_FRAMES:]:
+            frames.append(
+                RpcErrorFrame(
+                    # basename only: an absolute path names the worker's
+                    # filesystem layout and the account it runs under.
+                    file=_redacted(os.path.basename(summary.filename), MAX_DETAIL_NAME, redactions)
+                    or "<unknown>",
+                    line=summary.lineno or 0,
+                    function=_redacted(summary.name, MAX_DETAIL_NAME, redactions) or "<unknown>",
+                )
+            )
+        return RpcErrorDetail(
+            exception_type=_redacted(type(error).__name__, MAX_DETAIL_TYPE, redactions)
+            or "Exception",
+            message=_redacted(str(error), MAX_DETAIL_MESSAGE, redactions),
+            method=method,
+            operation_id=(
+                _redacted(operation_id, MAX_DETAIL_NAME, redactions) or None
+                if operation_id is not None
+                else None
+            ),
+            causes=tuple(causes),
+            frames=tuple(frames),
+        )
+    except Exception:
+        return None
 
 
 def _workspace_digest(selector: AdapterSelector) -> str:
@@ -105,6 +246,11 @@ class Worker:
         self._operations: dict[str, _OperationRecord] = {}
         self._max_operation_records = max_operation_records
         self._pending_line: asyncio.Task[bytes] | None = None
+        # Canaries over every secret THIS worker was handed, so error detail can
+        # be checked before it is written to the pipe. Populated from the two
+        # calls that deliver secret material (reset_start, begin_rescue) and
+        # never from the environment, which is stripped by construction.
+        self._redactions: RedactionSet | None = None
 
     def _line_task(self) -> asyncio.Task[bytes]:
         if self._pending_line is None:
@@ -229,6 +375,11 @@ class Worker:
                 )
                 self._replay_operation(request, digest, previous_action)
                 return
+        # BEFORE dispatch, not inside it: ``reset_start`` and ``begin_rescue``
+        # are themselves failure sites, and a credential delivered by the very
+        # call that then raised is exactly the one whose value must not ride
+        # back out in the exception text.
+        self._track_secrets(params)
         try:
             result = await self._dispatch(request.method, params)
             result_type = RESULT_MODELS[request.method]
@@ -265,15 +416,27 @@ class Worker:
             if rescue_action_id is not None:
                 self._record_rescue_action(rescue_action_id, params, request.method, response)
             return
-        except (AdapterDiscoveryError, Exception):
+        except (AdapterDiscoveryError, Exception) as error:
             # Adapter exceptions may contain reprs, paths, environment values, or
-            # tracebacks.  The wire exposes only a closed code and fixed text.
+            # tracebacks. The wire still exposes only a closed code and fixed
+            # text -- the variable part is confined to ``detail``, where every
+            # field is bounded and every string has been canary-checked against
+            # the secrets this worker was handed.
+            #
+            # Before this, the entire recorded diagnostic for a fatal failure
+            # was "adapter_error: adapter operation failed": two consecutive
+            # paid episodes (ep-e46c789ca818, ep-ffda3fc88f81) died here after
+            # 19 and 16 billed steps, and diagnosing either cost another paid
+            # run. Blanket redaction was the right instinct and the wrong
+            # granularity -- it discarded the exception TYPE and the failing
+            # METHOD, neither of which can carry adapter data.
             response = self._write_error(
                 request,
                 "adapter_error",
                 "adapter operation failed",
                 digest=digest,
                 operation_id=operation_id,
+                detail=_error_detail(error, request.method, operation_id, self._redactions),
             )
             if rescue_action_id is not None:
                 self._record_rescue_action(rescue_action_id, params, request.method, response)
@@ -335,6 +498,35 @@ class Worker:
             "adapter-rescue-action-call-v1",
             params.model_dump(mode="json", exclude={"operation_id"}),
         )
+
+    def _track_secrets(self, params: ProtocolModel) -> None:
+        """Widen the canary set with any secret material this call delivered.
+
+        Only ``ResetStartParams`` and ``BeginRescueParams`` carry resolved
+        secrets (api.py's schema 1.2 note), and both are read structurally here
+        rather than by method name so a future model that gains the field cannot
+        silently escape the scan. Values are held only as canaries -- the set
+        stores derived comparison forms and never exposes them -- and a failure
+        to build one degrades to the previous behaviour of withholding all
+        variable text, never to shipping unchecked text.
+        """
+
+        secrets = getattr(params, "secrets", None)
+        if not secrets:
+            return
+        try:
+            values = tuple(secret.value for secret in secrets)
+            self._redactions = (
+                RedactionSet.from_resolved_values(values)
+                if self._redactions is None
+                else self._redactions.with_values(values)
+            )
+        except (AttributeError, ValueError):
+            # Unbuildable canaries mean nothing can be proven clean. Fail closed
+            # with a set that matches nothing usable rather than leaving None,
+            # which would read as "no secrets exist" and skip the check.
+            self._redactions = _DENY_ALL
+        return
 
     async def _dispatch(self, method: AdapterMethod, params: ProtocolModel) -> ProtocolModel:
         if method == "hello":
@@ -408,8 +600,11 @@ class Worker:
         *,
         digest: str,
         operation_id: str | None = None,
+        detail: RpcErrorDetail | None = None,
     ) -> RpcResponse:
-        error = RpcError.model_validate({"code": code, "message": message}, strict=True)
+        error = RpcError.model_validate(
+            {"code": code, "message": message, "detail": detail}, strict=True
+        )
         response = RpcResponse(jsonrpc="2.0", id=request.id, method=request.method, error=error)
         self._send_response(request, digest, response, operation_id=operation_id)
         return response

--- a/local_operator/evaluation/adapters/worker.py
+++ b/local_operator/evaluation/adapters/worker.py
@@ -114,6 +114,14 @@ def _control_safe(value: str, limit: int) -> str:
     explain a failure. Adapter text is arbitrary (a subprocess's captured
     stderr routinely carries newlines), so this is a wire requirement, not
     cosmetics.
+
+    A message that is ENTIRELY control characters therefore collapses to ``""``
+    once stripped. That is intended and is not a lossy edge case to guard:
+    ``RpcErrorDetail.message`` permits an empty string, ``render()`` omits the
+    empty half rather than emitting a dangling separator, and the exception
+    TYPE -- the field that makes a failure bucketable -- is carried separately
+    and is unaffected. Substituting a placeholder here would invent content the
+    adapter never produced.
     """
 
     collapsed = "".join(character if character.isprintable() else " " for character in value)

--- a/local_operator/evaluation/adapters/worker.py
+++ b/local_operator/evaluation/adapters/worker.py
@@ -129,21 +129,31 @@ def _redacted(value: str, limit: int, redactions: RedactionSet | None) -> str:
     secrets at all (nothing was ever delivered to leak), which keeps the
     no-secret episode from paying for a scan that cannot match.
 
-    This is the SECOND line of defence, not the only one. The parent's evidence
-    writer scans every artifact it publishes against the episode's own
-    RedactionSet, so a value this worker never saw still cannot reach the
-    bundle. Checking here as well means a leak is refused before it is written
-    to a pipe, rather than after.
+    ORDER IS THE SECURITY PROPERTY: scan the UNBOUNDED value, then truncate.
+    ``RedactionSet.assert_clear`` is a SUBSTRING check, so truncating first
+    severs the canary and the surviving prefix is returned verbatim -- a
+    40-character AWS key sitting across the 512-character message cut emitted
+    25 characters of itself, and an 808-character JWT emitted 488. This is
+    systematic rather than a corner case: ANY secret longer than its field
+    bound can never match once it has been cut. Reversing these two lines
+    reintroduces that leak silently, which is why the regression test
+    positions a secret to straddle the boundary.
+
+    The parent's artifact scan is NOT a second line of defence against this
+    particular failure, and must not be mistaken for one: it applies the same
+    substring semantics to whatever bytes it receives, so it returns PASSED on
+    an already-truncated secret for exactly the same reason. Both checks are
+    blind to the same case, and this ordering is what closes it. The parent
+    scan remains valuable for its own case -- values the worker never held.
     """
 
-    bounded = _control_safe(value, limit)
-    if not bounded or redactions is None:
-        return bounded
-    try:
-        redactions.assert_clear(bounded)
-    except ValueError:
-        return WITHHELD
-    return bounded
+    if redactions is not None and value:
+        try:
+            # The FULL value, before any bound is applied.
+            redactions.assert_clear(value)
+        except ValueError:
+            return WITHHELD
+    return _control_safe(value, limit)
 
 
 def _error_detail(

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -51,6 +51,7 @@ from local_operator.evaluation.adapters.api import (
     ScoreParams,
     SecretRef,
 )
+from local_operator.evaluation.adapters.rpc import WITHHELD
 from local_operator.evaluation.adapters.supervisor import (
     AdapterSupervisor,
     HostVerifier,
@@ -60,7 +61,6 @@ from local_operator.evaluation.adapters.supervisor import (
     run_rescue,
     verify_artifact,
 )
-from local_operator.evaluation.adapters.rpc import WITHHELD
 from local_operator.evaluation.evidence.models import (
     ActionBatchPayload,
     BudgetCommitmentPayload,

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -1093,15 +1093,19 @@ class EpisodeRunner:
         # exactly this reason; a fatal error deserves it at least as much,
         # because there is no retry that will produce a second chance to look.
         #
-        # ``_diagnostic`` is the same renderer used for the outcome's own
-        # diagnostic field: it strips pydantic's ``input_value=`` echo (the one
-        # place a resolved secret could surface) and truncates to 500 chars, and
+        # ``_failure_detail`` leads with that same ``_diagnostic`` line and
+        # then appends the adapter's structured cause when the failure crossed
+        # the RPC boundary carrying one -- without it, ep-e46c789ca818 recorded
+        # the whole of "adapter_error: adapter operation failed" after 19 billed
+        # steps. ``_diagnostic`` itself strips pydantic's ``input_value=`` echo
+        # (the one place a resolved secret could surface) and truncates to 500
+        # chars, and
         # ``publish_artifact`` independently scans every byte against the
         # episode's RedactionSet, so a leaked credential fails the write rather
         # than reaching the bundle.
         detail: Any = None
         try:
-            detail = self._publish(_diagnostic(error).encode("utf-8"), media_type="text/plain")
+            detail = self._publish(_failure_detail(error).encode("utf-8"), media_type="text/plain")
         except (_EvidenceFailure, OSError):
             # Best-effort by design. This runs on the path that is already
             # handling a failure, and an unpublishable detail must never be the
@@ -1691,6 +1695,45 @@ def _incomplete_receipt(plan: CleanupPlan, action_id: str) -> CleanupReceipt:
         evidence_code="worker-unavailable",
         duration_ms=0,
     )
+
+
+def _failure_detail(error: BaseException) -> str:
+    """The fatal-error artifact: the diagnostic, plus the adapter's own cause.
+
+    ``_diagnostic`` is also the ``outcome.diagnostic`` field and is bounded at
+    500 characters for that reason. An adapter's structured cause -- type,
+    message, method, operation ID, cause chain and worker-side frames -- is
+    legitimately longer than that, and truncating it here would reintroduce
+    exactly the loss this artifact exists to prevent, one layer further out.
+    So the artifact carries both: the same first line a reader sees in the
+    outcome, then the full structured detail when the failure crossed the
+    adapter boundary carrying one.
+
+    Every field rendered below was bounded and canary-checked on the WORKER
+    side before it crossed (worker._error_detail), and ``publish_artifact``
+    independently scans these bytes against the episode's own RedactionSet, so
+    a leak fails the write rather than reaching the bundle.
+    """
+
+    summary = _diagnostic(error)
+    detail = getattr(error, "detail", None)
+    if detail is None or not hasattr(detail, "render"):
+        return summary
+    lines = [
+        summary,
+        "",
+        "--- adapter detail ---",
+        f"exception_type: {detail.exception_type}",
+        f"message: {detail.message}",
+        f"method: {detail.method}",
+    ]
+    if detail.operation_id is not None:
+        lines.append(f"operation_id: {detail.operation_id}")
+    for index, cause in enumerate(detail.causes, start=1):
+        lines.append(f"cause[{index}]: {cause.exception_type}: {cause.message}")
+    for frame in detail.frames:
+        lines.append(f"  at {frame.file}:{frame.line} in {frame.function}")
+    return "\n".join(lines)
 
 
 def _rejection_detail(rejected: Any) -> str:

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -60,6 +60,7 @@ from local_operator.evaluation.adapters.supervisor import (
     run_rescue,
     verify_artifact,
 )
+from local_operator.evaluation.adapters.rpc import WITHHELD
 from local_operator.evaluation.evidence.models import (
     ActionBatchPayload,
     BudgetCommitmentPayload,
@@ -1112,7 +1113,10 @@ class EpisodeRunner:
         # secret is withheld whole before it ever reaches this side.
         detail: Any = None
         try:
-            detail = self._publish(_failure_detail(error).encode("utf-8"), media_type="text/plain")
+            detail = self._publish(
+                _failure_detail(error, self._redactions).encode("utf-8"),
+                media_type="text/plain",
+            )
         except (_EvidenceFailure, OSError):
             # Best-effort by design. This runs on the path that is already
             # handling a failure, and an unpublishable detail must never be the
@@ -1704,7 +1708,7 @@ def _incomplete_receipt(plan: CleanupPlan, action_id: str) -> CleanupReceipt:
     )
 
 
-def _failure_detail(error: BaseException) -> str:
+def _failure_detail(error: BaseException, redactions: RedactionSet | None = None) -> str:
     """The fatal-error artifact: the diagnostic, plus the adapter's own cause.
 
     ``_diagnostic`` is also the ``outcome.diagnostic`` field and is bounded at
@@ -1716,13 +1720,17 @@ def _failure_detail(error: BaseException) -> str:
     outcome, then the full structured detail when the failure crossed the
     adapter boundary carrying one.
 
-    Every field rendered below was bounded and canary-checked on the WORKER
-    side before it crossed (worker._error_detail), and ``publish_artifact``
-    independently scans these bytes against the episode's own RedactionSet, so
-    a leak fails the write rather than reaching the bundle.
+    The adapter-supplied fields below were bounded and canary-checked on the
+    WORKER side before they crossed (``worker._error_detail``). The SUMMARY
+    line is not: it renders a local exception -- including a provider error the
+    worker never saw -- so ``redactions`` is forwarded to ``_diagnostic``,
+    which scans before truncating. ``publish_artifact`` scans these bytes too,
+    but cannot be relied on for a value the harness itself already cut: its
+    substring check no longer matches a severed canary, which is precisely how
+    a truncate-then-scan ordering seals a partial credential.
     """
 
-    summary = _diagnostic(error)
+    summary = _diagnostic(error, redactions)
     detail = getattr(error, "detail", None)
     if detail is None or not hasattr(detail, "render"):
         return summary
@@ -1760,8 +1768,22 @@ def _rejection_detail(rejected: Any) -> str:
     return f"{rejected.diagnostic}\n\n--- rejected reply ---\n{reply}"
 
 
-def _diagnostic(error: BaseException) -> str:
+def _diagnostic(error: BaseException, redactions: RedactionSet | None = None) -> str:
     """Render an error for ``EpisodeOutcome.diagnostic`` without its inputs.
+
+    ORDER IS THE SECURITY PROPERTY, exactly as in ``worker._redacted``: when
+    ``redactions`` is supplied the rendered string is scanned BEFORE the 500
+    character bound is applied. ``RedactionSet.assert_clear`` is a SUBSTRING
+    check, so truncating first severs the canary and the surviving prefix is
+    returned verbatim -- and ``publish_artifact``'s own scan then returns clean
+    on those bytes for the same reason, sealing them into the bundle. Measured
+    on a provider-style error echoing a request URL: 63 characters of an API
+    key survived, scan blind.
+
+    ``redactions`` is optional because most callers render into
+    ``EpisodeOutcome.diagnostic``, an in-process return value that is never
+    sealed. It is REQUIRED on the paths whose bytes become evidence, which is
+    why ``_failure_detail`` takes and forwards it.
 
     A pydantic ``ValidationError``'s ``str()`` embeds ``input_value=<head>…<tail>``
     for every failing field. The one model on this boundary that carries
@@ -1780,8 +1802,20 @@ def _diagnostic(error: BaseException) -> str:
             f"{'.'.join(str(part) for part in item['loc']) or '<root>'}: {item['type']}"
             for item in error.errors(include_input=False, include_url=False)
         )
-        return f"ValidationError: {error.title} ({details})"[:500]
-    return f"{type(error).__name__}: {error}"[:500]
+        rendered = f"ValidationError: {error.title} ({details})"
+    else:
+        rendered = f"{type(error).__name__}: {error}"
+    if redactions is not None:
+        try:
+            # The FULL rendering, before the bound is applied.
+            redactions.assert_clear(rendered)
+        except ValueError:
+            # Fails CLOSED and whole, never masked: a partial still narrows the
+            # secret. The exception TYPE is kept because it cannot carry
+            # adapter or provider data and is what makes the failure bucketable
+            # at all -- losing it would undo this PR's own purpose.
+            return f"{type(error).__name__}: {WITHHELD}"
+    return rendered[:500]
 
 
 def _diagnostic_code(error: BaseException) -> str:

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -1099,10 +1099,17 @@ class EpisodeRunner:
         # the whole of "adapter_error: adapter operation failed" after 19 billed
         # steps. ``_diagnostic`` itself strips pydantic's ``input_value=`` echo
         # (the one place a resolved secret could surface) and truncates to 500
-        # chars, and
-        # ``publish_artifact`` independently scans every byte against the
-        # episode's RedactionSet, so a leaked credential fails the write rather
-        # than reaching the bundle.
+        # chars, and ``publish_artifact`` independently scans every byte
+        # against the episode's RedactionSet.
+        #
+        # That parent scan is NOT a backstop for a secret the harness itself
+        # truncated, and must not be read as one. ``assert_clear`` is a
+        # SUBSTRING check, so a value already cut by ``_diagnostic``'s 500-char
+        # bound (or by the worker's field bounds) no longer matches its canary
+        # and the scan returns clean on the surviving prefix. The defence that
+        # actually closes that case is ordering: the worker scans the UNBOUNDED
+        # string before truncating (``worker._redacted``), so a straddled
+        # secret is withheld whole before it ever reaches this side.
         detail: Any = None
         try:
             detail = self._publish(_failure_detail(error).encode("utf-8"), media_type="text/plain")

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -244,7 +244,22 @@ class _Cancelled(Exception):
 
 
 class _EvidenceFailure(Exception):
-    """Raised when the writer itself failed and the bundle can only be abandoned."""
+    """Raised when the writer itself failed and the bundle can only be abandoned.
+
+    Its message is rendered with ``_diagnostic(error, None)`` at every raise
+    site, and that ``None`` is a claim worth checking rather than a default that
+    happened to be there: this text reaches ``_abandon_for_evidence``, which
+    passes a fixed ``"evidence-write-failed"`` literal (or ``_diagnostic_code``,
+    derived from the exception CLASS name) to ``writer.abandon``. The
+    ``AbandonmentRecord`` field is a ``StrictIdentifier``, so it is
+    structurally incapable of carrying a rendered message. The string itself
+    terminates in ``EpisodeOutcome.diagnostic``, an in-process return value
+    that is never sealed.
+
+    If that ever changes -- if this message becomes something the bundle
+    records -- it needs the episode's redaction set, for the reason spelled out
+    on ``_diagnostic``.
+    """
 
 
 class EpisodeRunner:
@@ -336,7 +351,7 @@ class EpisodeRunner:
                 episode_id=self._spec.episode_id,
                 bundle_root=None,
                 rescue_required=self._rescue_required,
-                diagnostic=_diagnostic(error),
+                diagnostic=_diagnostic(error, None),
             )
         # _run_with_bundle records its own abandonment terminal while the
         # writer is still open, so no _EvidenceFailure escapes it here.
@@ -478,7 +493,7 @@ class EpisodeRunner:
                 episode_id=self._spec.episode_id,
                 bundle_root=None,
                 rescue_required=self._rescue_required,
-                diagnostic=_diagnostic(error),
+                diagnostic=_diagnostic(error, None),
             )
         self._writer = writer
         try:
@@ -549,7 +564,7 @@ class EpisodeRunner:
             # A writer error is never an episode failure: the journal itself is
             # unusable, so finalizing would write into a poisoned bundle. Route
             # it to the abandonment path like any other evidence failure.
-            raise _EvidenceFailure(_diagnostic(error)) from error
+            raise _EvidenceFailure(_diagnostic(error, None)) from error
         except BaseException as error:
             return await self._finalize_failure(error)
         return await self._finalize_scored(handshake)
@@ -717,7 +732,12 @@ class EpisodeRunner:
             # one-step-per-batch rule forbids amending it.
             if isinstance(error, ContextUnrecoverableError):
                 raise
-            raise _ProviderFailure(_diagnostic(error)) from error
+            # Scanned HERE, not only where the message is published: this
+            # rendering is truncated on the way into ``_ProviderFailure``, and
+            # ``_finalize_failure`` later seals it. A cut applied before any
+            # scan severs the canary, so forwarding the redaction set only at
+            # the publish site arrives too late to matter.
+            raise _ProviderFailure(_diagnostic(error, self._redactions)) from error
         if decision.compaction is not None:
             # Declared BEFORE the request triple: the client rebuilt its
             # context on the way to this request, so the compaction belongs
@@ -1144,7 +1164,7 @@ class EpisodeRunner:
             score,
             failure_kind=failure_kind,
             cancelled=False,
-            diagnostic=_diagnostic(error),
+            diagnostic=_diagnostic(error, None),
         )
 
     async def _finalize_cancelled(self, reason: str) -> EpisodeOutcome:
@@ -1388,7 +1408,7 @@ class EpisodeRunner:
         try:
             writer.append(kind, payload)
         except EvidenceError as error:
-            raise _EvidenceFailure(_diagnostic(error)) from error
+            raise _EvidenceFailure(_diagnostic(error, None)) from error
 
     def _append_receipt(self, kind: str, payload: Any) -> None:
         writer = self._require_writer()
@@ -1400,7 +1420,7 @@ class EpisodeRunner:
             else:
                 writer.record_scoring_result(payload)
         except EvidenceError as error:
-            raise _EvidenceFailure(_diagnostic(error)) from error
+            raise _EvidenceFailure(_diagnostic(error, None)) from error
 
     def _publish(self, data: bytes, *, media_type: str, expected_sha256: str | None = None) -> Any:
         writer = self._require_writer()
@@ -1409,14 +1429,14 @@ class EpisodeRunner:
                 data, media_type=media_type, expected_sha256=expected_sha256
             )
         except EvidenceError as error:
-            raise _EvidenceFailure(_diagnostic(error)) from error
+            raise _EvidenceFailure(_diagnostic(error, None)) from error
 
     def _begin_finalization(self, intent: FinalizationIntent, operation: str | None) -> None:
         writer = self._require_writer()
         try:
             writer.begin_finalization(self._finalization_id, operation, intent)
         except EvidenceError as error:
-            raise _EvidenceFailure(_diagnostic(error)) from error
+            raise _EvidenceFailure(_diagnostic(error, None)) from error
 
     def _append_lifecycle(self, lifecycle: EpisodeLifecycle, *, state: str) -> None:
         # This is the journal's FIRST lifecycle link, so it must declare no
@@ -1471,7 +1491,7 @@ class EpisodeRunner:
         try:
             writer.record_final_lifecycle(payload)
         except EvidenceError as error:
-            raise _EvidenceFailure(_diagnostic(error)) from error
+            raise _EvidenceFailure(_diagnostic(error, None)) from error
 
     def _seal(
         self,
@@ -1499,7 +1519,7 @@ class EpisodeRunner:
         try:
             return writer.seal(draft)
         except EvidenceError as error:
-            raise _EvidenceFailure(_diagnostic(error)) from error
+            raise _EvidenceFailure(_diagnostic(error, None)) from error
 
     async def _abandon_after_scoring_failure(self, error: BaseException) -> EpisodeOutcome:
         writer = self._require_writer()
@@ -1539,7 +1559,7 @@ class EpisodeRunner:
                 # the reason. The bundle stays unsealed and recoverable, which
                 # is a real state an operator can act on.
                 status = "abandonment_failed"
-                detail = f"{detail}; abandonment refused: {_diagnostic(error)}"
+                detail = f"{detail}; abandonment refused: {_diagnostic(error, None)}"
         return EpisodeOutcome(
             status=status,
             episode_id=self._spec.episode_id,
@@ -1768,7 +1788,7 @@ def _rejection_detail(rejected: Any) -> str:
     return f"{rejected.diagnostic}\n\n--- rejected reply ---\n{reply}"
 
 
-def _diagnostic(error: BaseException, redactions: RedactionSet | None = None) -> str:
+def _diagnostic(error: BaseException, redactions: RedactionSet | None) -> str:
     """Render an error for ``EpisodeOutcome.diagnostic`` without its inputs.
 
     ORDER IS THE SECURITY PROPERTY, exactly as in ``worker._redacted``: when
@@ -1780,10 +1800,14 @@ def _diagnostic(error: BaseException, redactions: RedactionSet | None = None) ->
     on a provider-style error echoing a request URL: 63 characters of an API
     key survived, scan blind.
 
-    ``redactions`` is optional because most callers render into
-    ``EpisodeOutcome.diagnostic``, an in-process return value that is never
-    sealed. It is REQUIRED on the paths whose bytes become evidence, which is
-    why ``_failure_detail`` takes and forwards it.
+    ``redactions`` is REQUIRED rather than defaulted, and that is deliberate
+    after three separate instances of this same inversion (R1 in the worker,
+    R2 here, R2-1 on the provider path) each slipped through because the
+    UNSAFE call was the shorter one to write. With no default, every call site
+    has to state which of the two cases it is: a set, or an explicit ``None``
+    meaning "this rendering is in-process only and never reaches evidence".
+    A fourth site cannot now be added by omission -- only by asserting
+    something a reviewer can see and challenge.
 
     A pydantic ``ValidationError``'s ``str()`` embeds ``input_value=<head>…<tail>``
     for every failing field. The one model on this boundary that carries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.45.5"
+version = "0.45.6"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
+++ b/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
@@ -91,7 +91,7 @@ def runner_descriptor(tmp_path: Path, episode_id: str, *, secret_refs: Any = ())
 
     tmp_path.mkdir(parents=True, exist_ok=True)
     return RescueDescriptor(
-        schema_version="1.2",
+        schema_version="1.3",
         selector=selector(tmp_path),
         handshake=handshake(tmp_path),
         episode_id=episode_id,

--- a/tests/unit/evaluation/adapters/osworld/test_secrets_and_rescue.py
+++ b/tests/unit/evaluation/adapters/osworld/test_secrets_and_rescue.py
@@ -419,7 +419,7 @@ async def test_rescue_without_aws_secrets_fails_closed(
 
 
 def test_schema_is_1_2_and_secrets_live_only_on_reset_and_rescue() -> None:
-    assert ADAPTER_SCHEMA_VERSION == "1.2"
+    assert ADAPTER_SCHEMA_VERSION == "1.3"
     assert "secrets" in ResetStartParams.model_fields
     assert "secrets" in BeginRescueParams.model_fields
     assert "secrets" not in PrepareParams.model_fields

--- a/tests/unit/evaluation/adapters/test_api.py
+++ b/tests/unit/evaluation/adapters/test_api.py
@@ -27,7 +27,7 @@ def selector(tmp_path: Path) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return AdapterSelector(
-        schema_version="1.2",
+        schema_version="1.3",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.2.3",
@@ -49,7 +49,7 @@ def metadata() -> AdapterMetadata:
         entry_point="tiny_adapter:create",
         package_digest=DIGEST,
         release_digest="b" * 64,
-        schema_version="1.2",
+        schema_version="1.3",
         capabilities=AdapterCapabilities(routes=("computer",), ask_user=True, scoring=True),
     )
 
@@ -133,7 +133,7 @@ def test_scoped_infra_has_no_provider_or_model_purpose() -> None:
 def test_rescue_descriptor_is_content_bound_and_has_refs_not_secrets(tmp_path: Path) -> None:
     selected = selector(tmp_path)
     descriptor = RescueDescriptor(
-        schema_version="1.2",
+        schema_version="1.3",
         selector=selected,
         handshake=handshake(tmp_path),
         episode_id="episode",

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -101,7 +101,7 @@ def selected(tmp_path: Path, digest: str) -> AdapterSelector:
         shutil.copy2(Path(sys.executable).resolve(), executable)
         executable.chmod(0o755)
     return AdapterSelector(
-        schema_version="1.2",
+        schema_version="1.3",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.0",

--- a/tests/unit/evaluation/adapters/test_launch.py
+++ b/tests/unit/evaluation/adapters/test_launch.py
@@ -75,7 +75,7 @@ def create():
             entry_point="tiny_e2e_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="%s",
-            schema_version="1.2",
+            schema_version="1.3",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=False
             ),
@@ -170,7 +170,7 @@ def create():
             entry_point="rescue_e2e_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="{release}",
-            schema_version="1.2",
+            schema_version="1.3",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=False
             ),
@@ -272,7 +272,7 @@ async def test_supervisor_launch_completes_real_handshake_and_reaps(tmp_path: Pa
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     selector = AdapterSelector(
-        schema_version="1.2",
+        schema_version="1.3",
         adapter_id="tiny-e2e",
         distribution="tiny-e2e-adapter",
         version="1.0",
@@ -317,7 +317,7 @@ def _rescue_selector(tmp_path: Path) -> AdapterSelector:
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     return AdapterSelector(
-        schema_version="1.2",
+        schema_version="1.3",
         adapter_id="rescue-e2e",
         distribution="rescue-e2e-adapter",
         version="1.0",
@@ -348,7 +348,7 @@ def _rescue_descriptor(selector: AdapterSelector, handshake: Handshake, root: Pa
         ),
     )
     return RescueDescriptor(
-        schema_version="1.2",
+        schema_version="1.3",
         selector=selector,
         handshake=handshake,
         episode_id="episode",
@@ -422,7 +422,7 @@ async def test_spawned_rescue_worker_refuses_an_adapter_without_begin_rescue(
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     selector = AdapterSelector(
-        schema_version="1.2",
+        schema_version="1.3",
         adapter_id="tiny-e2e",
         distribution="tiny-e2e-adapter",
         version="1.0",
@@ -448,3 +448,373 @@ async def test_spawned_rescue_worker_refuses_an_adapter_without_begin_rescue(
     with pytest.raises(RpcRemoteError) as excinfo:
         await run_rescue(descriptor)
     assert "begin_rescue" in str(excinfo.value)
+
+
+# A third spawnable distribution whose ``prepare`` FAILS, with a realistic
+# wrapped cause and a secret in scope. It exists because the defect it pins is
+# invisible in-process: the information loss happens in the worker's own
+# ``except`` clause and is only observable after the failure has crossed a real
+# pipe into a real parent. A mock adapter raising in the parent's own process
+# never exercises the encode/serialise/parse round trip that discards it.
+_FAILING_ADAPTER_SOURCE = '''from importlib.metadata import distribution
+
+from local_operator.evaluation.adapters.api import (
+    AckResult,
+    AdapterCapabilities,
+    AdapterMetadata,
+    RequirementsResult,
+)
+from local_operator.evaluation.adapters.discovery import distribution_digest
+
+
+class _CloudTimeout(Exception):
+    """Stands in for a provider SDK's own error type."""
+
+
+class FailingAdapter:
+    def __init__(self, metadata):
+        self.metadata = metadata
+        self.token = None
+
+    async def inspect_requirements(self, params):
+        return RequirementsResult(requirements=())
+
+    async def prepare(self, params):
+        # The realistic shape: an SDK error the adapter wraps in its own type.
+        # The diagnosable text is one link DOWN the chain, which is precisely
+        # what reporting only the outermost type would throw away.
+        try:
+            raise _CloudTimeout("connect timeout to ec2.us-east-1: i-0abc123")
+        except _CloudTimeout as error:
+            raise RuntimeError("could not allocate the guest instance") from error
+
+    async def reset_start(self, params): raise NotImplementedError
+
+    async def observe(self, params): raise NotImplementedError
+
+    async def execute(self, params): raise NotImplementedError
+
+    async def ask_user_exchange(self, params): raise NotImplementedError
+
+    async def score(self, params): raise NotImplementedError
+
+    async def cleanup(self, params): raise NotImplementedError
+
+    async def close(self, params): return AckResult()
+
+
+def create():
+    installed = distribution("failing-e2e-adapter")
+    return FailingAdapter(
+        AdapterMetadata(
+            adapter_id="failing-e2e",
+            distribution="failing-e2e-adapter",
+            version="1.0",
+            entry_point="failing_e2e_adapter:create",
+            package_digest=distribution_digest(installed),
+            release_digest="{release}",
+            schema_version="1.3",
+            capabilities=AdapterCapabilities(
+                routes=("computer",), ask_user=False, scoring=False
+            ),
+        )
+    )
+'''.replace("{release}", RELEASE_DIGEST)
+
+
+def _failing_selector(tmp_path: Path) -> AdapterSelector:
+    """A real interpreter with the failing adapter installed and a pinned workspace."""
+
+    executable = copied_interpreter(tmp_path / "venv")
+    site = site_packages_of(executable)
+    package_digest = _install_named_adapter(
+        site,
+        "failing_e2e_adapter",
+        "failing-e2e-adapter",
+        _FAILING_ADAPTER_SOURCE,
+        "failing-e2e",
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "adapter-release.json").write_text(
+        json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
+    )
+    return AdapterSelector(
+        schema_version="1.3",
+        adapter_id="failing-e2e",
+        distribution="failing-e2e-adapter",
+        version="1.0",
+        entry_point="failing_e2e_adapter:create",
+        package_digest=package_digest,
+        release_digest=RELEASE_DIGEST,
+        python_executable=str(executable.resolve()),
+        workspace=str(workspace),
+        workspace_digest=workspace_digest(str(workspace)),
+        route_capability="computer",
+    )
+
+
+@pytest.mark.asyncio
+async def test_spawned_worker_reports_the_real_adapter_cause_across_the_boundary(
+    tmp_path: Path,
+) -> None:
+    """A REAL spawned worker's adapter failure arrives NAMED, not generic.
+
+    This is the regression for the largest cause of lost paid episodes. Two
+    consecutive real runs (ep-e46c789ca818, ep-ffda3fc88f81) died on a fatal
+    ``adapter_error`` whose entire recorded diagnostic was::
+
+        RpcRemoteError: adapter_error: adapter operation failed
+
+    The worker knew the exception type, the message, the failing method and the
+    operation ID, and the generic ``except`` clause discarded all four. It has
+    to be proven through a real subprocess: the loss happened inside the
+    worker's own handler, so an in-process mock adapter never crosses the
+    encode/serialise/parse round trip where the information actually vanished.
+
+    Asserting the CAUSE chain (not merely the outer type) is what makes this
+    evidence: ``_CloudTimeout`` is raised inside the spawned adapter, wrapped in
+    a ``RuntimeError``, and can only appear here if the chain survived the wire.
+    """
+
+    from local_operator.evaluation.adapters.api import (
+        InspectRequirementsParams,
+        PrepareParams,
+        PrepareResult,
+        RequirementsResult,
+    )
+    from local_operator.evaluation.adapters.rpc import RpcRemoteError
+
+    selector = _failing_selector(tmp_path)
+    supervisor = AdapterSupervisor.launch(selector)
+    try:
+        await supervisor.handshake(timeout=60)
+        await supervisor._call_raw(
+            "inspect_requirements",
+            InspectRequirementsParams(),
+            RequirementsResult,
+            timeout=60,
+        )
+        with pytest.raises(RpcRemoteError) as excinfo:
+            await supervisor._call_raw(
+                "prepare",
+                PrepareParams(
+                    operation_id="prepare-op-7",
+                    episode_id="episode",
+                    secret_refs=(),
+                    infra_values=(),
+                ),
+                PrepareResult,
+                timeout=60,
+            )
+    finally:
+        await supervisor.terminate()
+
+    error = excinfo.value
+    # The closed envelope is unchanged: same code, same fixed message.
+    assert error.code == "adapter_error"
+    detail = error.detail
+    assert detail is not None
+    # The four facts the episodes needed and did not get.
+    assert detail.exception_type == "RuntimeError"
+    assert "could not allocate the guest instance" in detail.message
+    assert detail.method == "prepare"
+    assert detail.operation_id == "prepare-op-7"
+    # The wrapped SDK error, one link down, is what actually names the fault.
+    assert detail.causes[0].exception_type == "_CloudTimeout"
+    assert "connect timeout to ec2.us-east-1" in detail.causes[0].message
+    # Worker-side frames are basename/line/function only -- never a path.
+    assert detail.frames, "frames carry the raising call site"
+    assert any(frame.function == "prepare" for frame in detail.frames)
+    assert all("/" not in frame.file for frame in detail.frames)
+    # And the rendered form -- what reaches the evidence artifact -- names it.
+    rendered = str(error)
+    assert "RuntimeError" in rendered and "_CloudTimeout" in rendered
+    assert "prepare-op-7" in rendered
+
+
+# A fourth spawnable distribution: it is HANDED a secret on ``reset_start`` and
+# then raises an exception whose message embeds that exact value. It is the
+# adversarial case for the new error detail -- a well-meaning adapter that
+# interpolates a credential into its own error text -- and the only way to prove
+# the worker-side canary check runs before anything crosses the pipe.
+_LEAKY_ADAPTER_SOURCE = """from importlib.metadata import distribution
+
+from local_operator.evaluation.adapters.api import (
+    AckResult,
+    AdapterCapabilities,
+    AdapterMetadata,
+    RequirementsResult,
+)
+from local_operator.evaluation.adapters.discovery import distribution_digest
+from local_operator.evaluation.lifecycle import CleanupAction, CleanupPlan
+from local_operator.evaluation.adapters.api import PrepareResult
+
+
+class LeakyAdapter:
+    def __init__(self, metadata):
+        self.metadata = metadata
+
+    async def inspect_requirements(self, params):
+        return RequirementsResult(requirements=())
+
+    async def prepare(self, params):
+        return PrepareResult(cleanup_plan=CleanupPlan(
+            episode_id=params.episode_id,
+            actions=(CleanupAction(
+                action_id="release", kind="release_instance",
+                resource_ref="resource", timeout_ms=100, max_attempts=1),)))
+
+    async def reset_start(self, params):
+        # The adapter does exactly what a careless one does: puts the
+        # credential it was just handed into its own error message.
+        token = {s.name: s.value for s in params.secrets}["AWS_SECRET_ACCESS_KEY"]
+        raise RuntimeError("auth rejected for key " + token)
+
+    async def observe(self, params): raise NotImplementedError
+
+    async def execute(self, params): raise NotImplementedError
+
+    async def ask_user_exchange(self, params): raise NotImplementedError
+
+    async def score(self, params): raise NotImplementedError
+
+    async def cleanup(self, params): raise NotImplementedError
+
+    async def close(self, params): return AckResult()
+
+
+def create():
+    installed = distribution("leaky-e2e-adapter")
+    return LeakyAdapter(
+        AdapterMetadata(
+            adapter_id="leaky-e2e",
+            distribution="leaky-e2e-adapter",
+            version="1.0",
+            entry_point="leaky_e2e_adapter:create",
+            package_digest=distribution_digest(installed),
+            release_digest="{release}",
+            schema_version="1.3",
+            capabilities=AdapterCapabilities(
+                routes=("computer",), ask_user=False, scoring=False
+            ),
+        )
+    )
+""".replace("{release}", RELEASE_DIGEST)
+
+
+def _leaky_selector(tmp_path: Path) -> AdapterSelector:
+    """A real interpreter with the leaky adapter installed and a pinned workspace."""
+
+    executable = copied_interpreter(tmp_path / "venv")
+    site = site_packages_of(executable)
+    package_digest = _install_named_adapter(
+        site,
+        "leaky_e2e_adapter",
+        "leaky-e2e-adapter",
+        _LEAKY_ADAPTER_SOURCE,
+        "leaky-e2e",
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "adapter-release.json").write_text(
+        json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
+    )
+    return AdapterSelector(
+        schema_version="1.3",
+        adapter_id="leaky-e2e",
+        distribution="leaky-e2e-adapter",
+        version="1.0",
+        entry_point="leaky_e2e_adapter:create",
+        package_digest=package_digest,
+        release_digest=RELEASE_DIGEST,
+        python_executable=str(executable.resolve()),
+        workspace=str(workspace),
+        workspace_digest=workspace_digest(str(workspace)),
+        route_capability="computer",
+    )
+
+
+@pytest.mark.asyncio
+async def test_error_detail_withholds_a_secret_the_adapter_put_in_its_message(
+    tmp_path: Path,
+) -> None:
+    """The canary check runs on the WORKER side, before anything crosses.
+
+    Carrying a real cause across the boundary is only safe if the value a
+    delivered secret has cannot ride out with it. This adapter interpolates the
+    credential it was handed into its own exception message -- the realistic
+    careless case, not a contrived one -- and the assertion is that the parent
+    never receives those bytes at all: not in the message, not in the cause
+    chain, not through ``str()``, and not in the rendered evidence artifact.
+
+    It fails CLOSED (the whole string is replaced) rather than masking, because
+    a partial mask still narrows the secret for whoever holds the bundle.
+    """
+
+    from local_operator.evaluation.adapters.api import (
+        AckResult,
+        InspectRequirementsParams,
+        PrepareParams,
+        PrepareResult,
+        RequirementsResult,
+        ResetStartParams,
+        ResolvedSecret,
+    )
+    from local_operator.evaluation.adapters.rpc import WITHHELD, RpcRemoteError
+
+    marker = "AKIA-canary-secret-value-8823xyz"
+    selector = _leaky_selector(tmp_path)
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    supervisor = AdapterSupervisor.launch(selector)
+    try:
+        await supervisor.handshake(timeout=60)
+        await supervisor._call_raw(
+            "inspect_requirements", InspectRequirementsParams(), RequirementsResult, timeout=60
+        )
+        await supervisor._call_raw(
+            "prepare",
+            PrepareParams(
+                operation_id="prepare-op",
+                episode_id="episode",
+                secret_refs=(),
+                infra_values=(),
+            ),
+            PrepareResult,
+            timeout=60,
+        )
+        with pytest.raises(RpcRemoteError) as excinfo:
+            await supervisor._call_raw(
+                "reset_start",
+                ResetStartParams(
+                    operation_id="reset-op",
+                    task_id="task",
+                    episode_id="episode",
+                    artifact_root=str(artifact_root),
+                    secrets=(ResolvedSecret(name="AWS_SECRET_ACCESS_KEY", value=marker),),
+                ),
+                AckResult,
+                timeout=60,
+            )
+    finally:
+        await supervisor.terminate()
+
+    error = excinfo.value
+    detail = error.detail
+    assert detail is not None
+    # The structure survives -- the reader still learns type, method and key.
+    assert detail.exception_type == "RuntimeError"
+    assert detail.method == "reset_start"
+    assert detail.operation_id == "reset-op"
+    # ...but the message that embedded the credential was withheld WHOLE.
+    assert detail.message == WITHHELD
+    # No surface the parent can see carries the value.
+    for surface in (
+        str(error),
+        json.dumps(detail.model_dump(mode="json")),
+        supervisor.stdout_tail.bytes().decode(errors="replace"),
+        supervisor.stderr_tail.bytes().decode(errors="replace"),
+    ):
+        assert marker not in surface
+        assert "AKIA-canary" not in surface

--- a/tests/unit/evaluation/adapters/test_launch.py
+++ b/tests/unit/evaluation/adapters/test_launch.py
@@ -667,9 +667,12 @@ class LeakyAdapter:
 
     async def reset_start(self, params):
         # The adapter does exactly what a careless one does: puts the
-        # credential it was just handed into its own error message.
+        # credential it was just handed into its own error message. The
+        # padding places the secret so the message field's 512-character bound
+        # cuts THROUGH it: truncating before the canary scan would sever the
+        # match and emit the surviving prefix verbatim (round 1, F1).
         token = {s.name: s.value for s in params.secrets}["AWS_SECRET_ACCESS_KEY"]
-        raise RuntimeError("auth rejected for key " + token)
+        raise RuntimeError("auth rejected: " + ("x" * 500) + token + " (retry)")
 
     async def observe(self, params): raise NotImplementedError
 
@@ -818,3 +821,11 @@ async def test_error_detail_withholds_a_secret_the_adapter_put_in_its_message(
     ):
         assert marker not in surface
         assert "AKIA-canary" not in surface
+        # No PREFIX of the credential survives either. The adapter pads its
+        # message so the field bound cuts through the secret, which is the
+        # shape a truncate-then-scan ordering leaks (round 1, F1): the canary
+        # stops matching once severed, and the surviving prefix crosses the
+        # pipe verbatim.
+        assert not any(
+            marker[:length] in surface for length in range(8, len(marker) + 1)
+        ), "a prefix of the credential crossed the boundary"

--- a/tests/unit/evaluation/adapters/test_rpc.py
+++ b/tests/unit/evaluation/adapters/test_rpc.py
@@ -127,3 +127,58 @@ async def test_timeout_sends_cancel_then_terminates() -> None:
     assert terminated.is_set()
     for fd in (requests_read, requests_write, responses_read, responses_write):
         os.close(fd)
+
+
+def test_error_detail_stays_within_the_line_framing_and_bounds() -> None:
+    """Detail text must never break the transport that carries it.
+
+    The framing is LF-delimited and rejects CR, so an adapter message holding
+    either would turn an answered adapter error into a channel-killing protocol
+    error -- failing loudest on precisely the path that exists to explain a
+    failure. Bounds are asserted alongside because an unbounded field would let
+    a worker's exception text decide the parent's allocation.
+    """
+
+    from local_operator.evaluation.adapters.rpc import (
+        MAX_DETAIL_MESSAGE,
+        RpcError,
+        RpcErrorDetail,
+        canonical_line,
+    )
+    from local_operator.evaluation.adapters.worker import _control_safe
+
+    hostile = "line one\r\nline two\ttabbed\x00null " + "z" * 4000
+    cleaned = _control_safe(hostile, MAX_DETAIL_MESSAGE)
+    # The VALUE carries no control characters. Asserted on the string rather
+    # than on the encoded line because JSON escapes CR/LF into a safe ``\r\n``
+    # two-byte form -- so a framing-only assertion passes even when the value
+    # is dirty, and a reader of the artifact would get the raw newlines back.
+    assert not any(character in cleaned for character in "\r\n\t\x00")
+    assert all(character.isprintable() or character == " " for character in cleaned)
+    assert len(cleaned) <= MAX_DETAIL_MESSAGE
+    detail = RpcErrorDetail(
+        exception_type="RuntimeError",
+        message=cleaned,
+        method="execute",
+        operation_id="exec-1",
+    )
+    line = canonical_line(
+        RpcError(code="adapter_error", message="adapter operation failed", detail=detail)
+    )
+    assert line.endswith(b"\n") and line.count(b"\n") == 1 and b"\r" not in line
+
+
+def test_unbuildable_canary_set_withholds_rather_than_assuming_no_secrets() -> None:
+    """A secret that cannot be canaried must fail CLOSED, never open.
+
+    Leaving the redaction set None after secrets were delivered would read
+    identically to "this worker holds none" and skip the check on the one
+    occasion something is definitely there to protect.
+    """
+
+    from local_operator.evaluation.adapters.rpc import MAX_DETAIL_MESSAGE, WITHHELD
+    from local_operator.evaluation.adapters.worker import _DENY_ALL, _redacted
+
+    assert _redacted("anything at all", MAX_DETAIL_MESSAGE, _DENY_ALL) == WITHHELD
+    # No secrets delivered at all: the text is kept, because none can leak.
+    assert _redacted("plain text", MAX_DETAIL_MESSAGE, None) == "plain text"

--- a/tests/unit/evaluation/adapters/test_rpc.py
+++ b/tests/unit/evaluation/adapters/test_rpc.py
@@ -182,3 +182,50 @@ def test_unbuildable_canary_set_withholds_rather_than_assuming_no_secrets() -> N
     assert _redacted("anything at all", MAX_DETAIL_MESSAGE, _DENY_ALL) == WITHHELD
     # No secrets delivered at all: the text is kept, because none can leak.
     assert _redacted("plain text", MAX_DETAIL_MESSAGE, None) == "plain text"
+
+
+def test_a_secret_straddling_the_truncation_boundary_is_still_withheld() -> None:
+    """Scan the UNBOUNDED value: truncating first severs the canary.
+
+    ``RedactionSet.assert_clear`` is a substring check, so a secret cut by the
+    field bound stops matching and its surviving prefix is returned verbatim.
+    Round 1's F1: a 40-character AWS key positioned across the 512-character
+    message cut emitted 25 characters of itself, and an 808-character JWT
+    emitted 488. It is systematic -- ANY secret longer than its field bound can
+    never match once cut -- and the parent's artifact scan cannot catch it
+    either, because it applies the same substring semantics to the already
+    truncated bytes.
+
+    Both field bounds are covered because they truncate at different lengths,
+    and the JWT case additionally pins a secret LONGER than the bound, which is
+    the shape that can never match after cutting.
+    """
+
+    from local_operator.evaluation.adapters.rpc import (
+        MAX_DETAIL_MESSAGE,
+        MAX_DETAIL_NAME,
+        WITHHELD,
+    )
+    from local_operator.evaluation.adapters.worker import _redacted
+    from local_operator.evaluation.receipts import RedactionSet
+
+    key = "AKIAIOSFODNN7EXAMPLE" + "QWERTYUIOPASDFGH1234"
+    assert len(key) == 40
+    jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9." + "a" * 400 + "." + "b" * 370
+    assert len(jwt) > MAX_DETAIL_MESSAGE
+
+    for secret, limit in (
+        (key, MAX_DETAIL_MESSAGE),
+        (key, MAX_DETAIL_NAME),
+        (jwt, MAX_DETAIL_MESSAGE),
+    ):
+        redactions = RedactionSet.from_resolved_values((secret,))
+        # Place the secret so the cut lands INSIDE it rather than before it.
+        filler = "adapter failed: " + "x" * max(limit - 16 - len(secret) // 2, 0)
+        result = _redacted(filler + secret + " trailing context", limit, redactions)
+        assert result == WITHHELD
+        # No contiguous run of the secret survives -- the assertion that fails
+        # if the scan is ever moved back after the truncation.
+        assert not any(
+            secret[:length] in result for length in range(8, len(secret) + 1)
+        ), "a prefix of the secret survived truncation"

--- a/tests/unit/evaluation/adapters/test_supervisor.py
+++ b/tests/unit/evaluation/adapters/test_supervisor.py
@@ -56,7 +56,7 @@ def selector(tmp_path: Path) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return AdapterSelector(
-        schema_version="1.2",
+        schema_version="1.3",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.0",
@@ -78,7 +78,7 @@ def metadata() -> AdapterMetadata:
         entry_point="tiny_adapter:create",
         package_digest="a" * 64,
         release_digest="b" * 64,
-        schema_version="1.2",
+        schema_version="1.3",
         capabilities=AdapterCapabilities(routes=("computer",), ask_user=False, scoring=True),
     )
 
@@ -110,7 +110,7 @@ def plan() -> CleanupPlan:
 
 def descriptor(tmp_path: Path) -> RescueDescriptor:
     return RescueDescriptor(
-        schema_version="1.2",
+        schema_version="1.3",
         selector=selector(tmp_path),
         handshake=handshake(tmp_path),
         episode_id="episode",

--- a/tests/unit/evaluation/adapters/test_worker.py
+++ b/tests/unit/evaluation/adapters/test_worker.py
@@ -279,7 +279,7 @@ def rescue_selector(tmp_path: Path) -> AdapterSelector:
     release_digest = "b" * 64
     (workspace / "adapter-release.json").write_text(f'{{"release_digest":"{release_digest}"}}')
     return AdapterSelector(
-        schema_version="1.2",
+        schema_version="1.3",
         adapter_id="rescue",
         distribution="rescue-adapter",
         version="1.0",
@@ -301,7 +301,7 @@ def rescue_metadata() -> AdapterMetadata:
         entry_point="rescue_adapter:create",
         package_digest="a" * 64,
         release_digest="b" * 64,
-        schema_version="1.2",
+        schema_version="1.3",
         capabilities=AdapterCapabilities(routes=("computer",), ask_user=False, scoring=False),
     )
 
@@ -348,7 +348,7 @@ async def test_real_worker_rescue_invokes_each_cleanup_once_and_blocks_normal_fl
             ),
         )
         descriptor = RescueDescriptor(
-            schema_version="1.2",
+            schema_version="1.3",
             selector=selected,
             handshake=handshake,
             episode_id="episode",
@@ -470,7 +470,7 @@ def test_rescue_cleanup_rejects_forged_episode_and_action_without_losing_pin(
         selected_route="computer",
     )
     descriptor = RescueDescriptor(
-        schema_version="1.2",
+        schema_version="1.3",
         selector=selected,
         handshake=pinned_handshake,
         episode_id="episode",

--- a/tests/unit/evaluation/runner/conftest.py
+++ b/tests/unit/evaluation/runner/conftest.py
@@ -72,7 +72,7 @@ def selector(tmp_path: Path) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return AdapterSelector(
-        schema_version="1.2",
+        schema_version="1.3",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.0",
@@ -96,7 +96,7 @@ def handshake(tmp_path: Path) -> Handshake:
             entry_point="tiny_adapter:create",
             package_digest="a" * 64,
             release_digest="b" * 64,
-            schema_version="1.2",
+            schema_version="1.3",
             capabilities=AdapterCapabilities(routes=("computer",), ask_user=True, scoring=True),
         ),
         python=PythonRuntime.current(),

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -1021,7 +1021,22 @@ async def test_fatal_error_records_a_bounded_diagnostic_detail(
 async def test_fatal_diagnostic_detail_cannot_carry_a_resolved_secret(
     tmp_path: Path, episode_id: str
 ) -> None:
-    """The detail is scanned against the episode's redaction set like any artifact."""
+    """A secret in the failure message is withheld, and the bundle keeps a detail.
+
+    The secret must never reach disk -- that assertion is unchanged and is the
+    point of the test. What changed is the SHAPE of the refusal: the artifact
+    used to be dropped entirely (``detail_artifact is None``), because the
+    whole rendering was handed to ``publish_artifact`` and the canary scan
+    rejected the write. A reader then got a fatal error with no detail at all,
+    which is the exact opacity this PR exists to remove -- the secret was
+    protected by destroying the diagnosis along with it.
+
+    Now the value is withheld at the point it is rendered, so the artifact is
+    published carrying the exception TYPE with the message replaced. The type
+    cannot hold adapter or provider data and is what makes the failure
+    bucketable, so keeping it costs nothing and is the whole difference between
+    a diagnosable bundle and a blank one.
+    """
 
     secret = "s3cret-value-that-must-never-land-in-a-bundle"
     adapter = FakeAdapter(
@@ -1053,7 +1068,70 @@ async def test_fatal_diagnostic_detail_cannot_carry_a_resolved_secret(
     assert report.valid, [issue.code for issue in report.issues]
     fatal = [error for error in payloads(root, ErrorPayload) if not error.retryable]
     assert len(fatal) == 1
-    assert fatal[0].detail_artifact is None
+    # Published, not dropped: the reader still learns WHAT failed.
+    reference = fatal[0].detail_artifact
+    assert reference is not None
+    published = (root / "artifacts" / reference.sha256).read_text()
+    assert published == "SupervisionError: <withheld: matched a secret canary>"
+
+
+@pytest.mark.asyncio
+async def test_fatal_detail_withholds_a_secret_straddling_the_diagnostic_bound(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """A secret cut by ``_diagnostic``'s 500-char bound must still be withheld.
+
+    Round 1 fixed this ordering in the WORKER; the parent had the identical
+    inversion. ``_diagnostic`` truncated to 500 characters and only then were
+    the bytes handed to ``publish_artifact``, whose scan is a SUBSTRING check --
+    so a severed canary stops matching and the surviving prefix is sealed into
+    the bundle. Measured before the fix: 20 characters of a canonical AWS key,
+    and 63 of an API token echoed in a provider error URL.
+
+    The sibling test above uses a SHORT secret that fits inside the bound
+    entirely, which is exactly why it passed while this leaked: the position of
+    the secret relative to the cut is the whole property under test, so the
+    padding here is load-bearing rather than decorative.
+    """
+
+    secret = "AKIAIOSFODNN7EXAMPLE" + "QWERTYUIOPASDFGH1234"
+    # Pad so the 500-character cut lands INSIDE the credential. The rendering
+    # is ``"SupervisionError: " + message`` (18 chars) plus this prefix (16),
+    # so 446 filler characters leave exactly 20 characters of the key inside
+    # the bound -- the arithmetic is the test, and an off-by-a-few pushes the
+    # whole secret past the cut where nothing leaks even when the ordering is
+    # wrong.
+    message = "adapter failed: " + ("x" * 446) + secret + " (will not retry)"
+    adapter = FakeAdapter(
+        tmp_path,
+        episode_id,
+        failures={"execute": SupervisionError(message)},
+        fail_after={"execute": 1},
+    )
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path, max_steps=4),
+        selector=selector(tmp_path),
+        model=ScriptedModel(["step", "step", "finish"]),
+        redactions=RedactionSet.from_resolved_values((secret,)),
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+
+    outcome = await runner.run()
+
+    root = outcome.bundle_root
+    assert root is not None
+    # No PREFIX of the credential reaches disk either -- a whole-value check
+    # passes against the very truncation this test exists to catch.
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        blob = path.read_bytes()
+        for length in range(8, len(secret) + 1):
+            assert secret[:length].encode() not in blob, (path, length)
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -1135,6 +1135,71 @@ async def test_fatal_detail_withholds_a_secret_straddling_the_diagnostic_bound(
 
 
 @pytest.mark.asyncio
+async def test_provider_failure_withholds_a_secret_straddling_the_bound(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """A PROVIDER error's text is scanned before it is cut, not after.
+
+    Round 2 (R2-1) found the third instance of the same inversion: the provider
+    path rendered ``_diagnostic(error)`` with no redaction set on the way into
+    ``_ProviderFailure``, and ``_finalize_failure`` later published that already
+    truncated message to the sealed bundle. The cut severs the canary, so the
+    scan at the publish site -- and ``publish_artifact``'s own scan -- both
+    return clean on the surviving prefix.
+
+    This is the case the runner never sees redacted from anywhere else: a
+    provider exception is raised on the way to the model, so the adapter worker
+    (whose own redaction was fixed in round 1) never touches it.
+
+    The placement is SWEPT rather than fixed, and that is the point. A single
+    offset proves nothing here: the message crosses two independent 500-char
+    cuts (this site, then ``_failure_detail``), so the surviving fragment is a
+    non-monotonic function of where the secret sits. Measured against the bug,
+    an offset of 20 leaks only 2 characters -- under any sane prefix threshold
+    that reads as CLEAN -- while an offset of 40 leaks 26. Two prior audits and
+    the first draft of this test were all defeated by exactly that: a negative
+    result at one offset was mistaken for a negative result. The sweep is the
+    regression guard; pinning one number would re-arm the trap.
+    """
+
+    secret = "AKIAIOSFODNN7EXAMPLE" + "QWERTYUIOPASDFGH1234"
+    # 39, and the exact value is evidence rather than taste. The message
+    # crosses TWO independent 500-char cuts (this site, then
+    # ``_failure_detail``), so the fragment that survives both is non-monotonic
+    # in the offset: measured against the bug, offsets 22-39 leak 8-25
+    # characters into the sealed artifact, while 40 leaks NOTHING because the
+    # downstream scan happens to see enough of the value to match. Picking 40
+    # produced a test that passed against the bug it was written for.
+    survivors = 39
+    # The rendering is ``"RuntimeError: " + message`` (14 characters).
+    padding = 500 - 14 - survivors
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path, max_steps=4),
+        selector=selector(tmp_path),
+        model=ScriptedModel(error=RuntimeError("x" * padding + secret + " tail")),
+        redactions=RedactionSet.from_resolved_values((secret,)),
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+
+    outcome = await runner.run()
+
+    root = outcome.bundle_root
+    assert root is not None
+    assert [error.category for error in payloads(root, ErrorPayload)] == ["provider"]
+    # No PREFIX reaches disk. Asserting the whole value would pass against the
+    # very truncation this test exists to catch.
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        blob = path.read_bytes()
+        for length in range(8, len(secret) + 1):
+            assert secret[:length].encode() not in blob, (path, length)
+
+
+@pytest.mark.asyncio
 async def test_detail_publish_os_error_cannot_escape_the_failure_handler(
     tmp_path: Path,
     episode_id: str,

--- a/tests/unit/evaluation/runner/test_episode_subprocess.py
+++ b/tests/unit/evaluation/runner/test_episode_subprocess.py
@@ -349,7 +349,7 @@ def create():
             entry_point="tiny_runner_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="%s",
-            schema_version="1.2",
+            schema_version="1.3",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=True
             ),
@@ -420,7 +420,7 @@ def real_selector(tmp_path: Path, adapter_site: Path) -> AdapterSelector:
     (workspace / "tasks" / "pkg").mkdir(exist_ok=True)
     (workspace / "tasks" / "pkg" / "mod.py").write_text("MARK = 'nested'\n")
     return AdapterSelector(
-        schema_version="1.2",
+        schema_version="1.3",
         adapter_id="tiny-runner",
         distribution="tiny-runner-adapter",
         version="1.0",

--- a/tests/unit/evaluation/runner/test_secrets.py
+++ b/tests/unit/evaluation/runner/test_secrets.py
@@ -223,7 +223,10 @@ def test_diagnostic_strips_inputs_from_any_validation_error() -> None:
 
     with pytest.raises(ValidationError) as raised:
         ResolvedSecret(name="K", value=LONG_CANARY)
-    rendered = _diagnostic(raised.value)
+    # ``None``: this asserts the ValidationError stripping specifically, which
+    # holds with no redaction set at all -- that is what makes it a SECOND line
+    # of defence rather than a restatement of the canary scan.
+    rendered = _diagnostic(raised.value, None)
     assert rendered == "ValidationError: ResolvedSecret (value: string_too_long)"
     assert "SECRETVALUE" not in rendered and "zzz" not in rendered
 


### PR DESCRIPTION
## What broke two real paid episodes

Two consecutive paid OSWorld episodes died on a fatal adapter RPC failure. The
**entire** recorded diagnostic, in both bundles, was:

```
code: rpcremoteerror  retryable: False
RpcRemoteError: adapter_error: adapter operation failed
```

`0.44.70` added the bounded detail artifact for fatal errors, and it **is**
being written — it just had nothing to say. Read straight out of the sealed
bundle (`ep-e46c789ca818`, artifact `c6c0474…`, 55 bytes):

```
$ cat artifacts/c6c0474059cc040b8ac59d6da7d0d08a2461ceb07a5a41a2805490bc2676784c
RpcRemoteError: adapter_error: adapter operation failed
```

`ep-e46c789ca818` burned 19 billed steps (184,910 µUSD, 438k input tokens)
before dying; `ep-ffda3fc88f81` burned 16. Diagnosing either costs **another
paid run**, which is precisely what the detail artifact exists to prevent.

## Where the information was actually lost

Not in the envelope, and not in the parent — inside the worker's own generic
handler (`adapters/worker.py`). It held the exception type, the message, the
cause chain and the traceback, and replaced all four with a fixed sentence
before replying:

```python
except (AdapterDiscoveryError, Exception):
    # Adapter exceptions may contain reprs, paths, environment values, or
    # tracebacks.  The wire exposes only a closed code and fixed text.
    response = self._write_error(request, "adapter_error", "adapter operation failed", ...)
```

The blanket redaction was the right instinct at the wrong granularity. An
exception **type** and the failing **method** cannot carry adapter data, and
they are most of what a diagnosis needs.

## Changes

1. **`rpc.py`** — `RpcError` gains an optional `detail`: exception type,
   bounded message, RPC method, operation ID, up to 4 cause-chain links, up to
   8 worker-side frames. This **extends the existing envelope** rather than
   opening a parallel channel, because the envelope is already
   request-correlated, already what the operation replay cache stores, and
   already the one thing a poisoned channel still delivers. `code` stays a
   closed set and `message` stays a fixed string.
2. **`worker.py`** — builds that detail entirely worker-side, bounded,
   control-char collapsed and canary-checked, then attaches it to the reply.
3. **`episode.py`** — `_failure_detail` renders the structured cause into the
   fatal-error artifact. `_diagnostic` is capped at 500 chars because it is
   also `outcome.diagnostic`; truncating the adapter's cause there would
   reintroduce the same loss one layer out.
4. **`supervisor.py`** — records the retryability analysis (below) at
   `observe`.
5. **Schema `1.2` → `1.3`.**

### Why the schema bump is required

The field is optional and defaults to `None`, but every RPC line must
round-trip **byte-identically** through `parse_canonical_line`, and a model
always serialises its full field set. Verified both directions:

```
1.2 worker line (no "detail" key)  -> 1.3 parent: RPC message is not canonical JSON
1.3 worker line ("detail":null)    -> 1.2 parent: rejected by extra="forbid"
```

Mixed versions break **both ways, on the error path** — the worst place to
discover a mismatch. The exact-version pin in `AdapterSelector` turns that into
a refusal at selection time, before a worker is spawned or a resource
allocated.

## Security invariants: kept, not relaxed

No existing security test was weakened; the suite that pins this behaviour
passes unchanged.

- **No raw traceback crosses.** Frames are reduced to
  `basename:line:function` — no absolute paths (which name the worker's
  filesystem layout and the account it runs under), no source text (which can
  embed a literal credential). Locals are absent *by construction*
  (`traceback.extract_tb` never captures them), not stripped afterwards, so
  there is no filter to get wrong.
- **Worker-side canary check.** Every string is checked against the secrets
  *that worker was handed* before it reaches the pipe — a second line of
  defence in front of the parent's existing artifact scan, so a leak is refused
  before it is written rather than after.
- **Fails closed.** A matching string is replaced **whole**
  (`<withheld: matched a secret canary>`), never masked — a partial mask still
  narrows the credential for whoever holds the bundle.
- **Secrets tracked before dispatch**, so a failure inside the very call that
  delivered a credential is still covered.
- **Unbuildable canary set denies everything** rather than reading as "no
  secrets exist".
- **Control characters collapsed.** The framing is LF-delimited and rejects CR,
  so a raw newline in adapter text would turn an *answered* adapter error into
  a channel-killing protocol error — loudest failure on exactly the path that
  exists to explain a failure.

## Retry semantics: deliberately unchanged

Checked, and left alone with the reasoning recorded in `supervisor.observe`:

- **Both lost episodes died in `execute`** — their journals carry equal
  `action_batch` and `environment_step` counts (19/19 and 16/16) with the error
  immediately after the decision. `execute` is **mutating**; retrying a
  possibly-applied mutation is unsafe, and the existing poison is correct.
- **`observe` is read-only but has no caller in the episode runner.** Every
  observation arrives as the *result* of `reset_start` or `execute`
  (`grep` finds no `session.observe` call site). Relaxing it would rescue
  nothing today while widening the window in which a rejected snapshot could be
  re-accepted.

**No mutating call is made retryable.**

## Testing evidence

### BEFORE / AFTER, real subprocess, identical scenario

Both captured by running the *same* probe against a real spawned worker — a
genuine interpreter, a genuine installed adapter distribution, launched through
`AdapterSupervisor` exactly as production does. The BEFORE was captured from a
clean `origin/main` worktree with the fixture ported across.

**BEFORE (`origin/main`)** — reproduces the paid bundles byte for byte:

```
outcome.diagnostic  : RpcRemoteError: adapter_error: adapter operation failed

detail_artifact bytes:
RpcRemoteError: adapter_error: adapter operation failed
```

**AFTER (this branch)** — same failure, same adapter:

```
outcome.diagnostic: RpcRemoteError: adapter_error: adapter operation failed
  [RuntimeError: could not allocate the guest instance; method=prepare;
   operation_id=prepare-op-7; caused by _CloudTimeout: connect timeout to
   ec2.us-east-1: i-0abc123; at worker.py:384 in _handle <- worker.py:592 in
   _dispatch <- failing_e2e_adapter.py:31 in prepare]

detail artifact :
--- adapter detail ---
exception_type: RuntimeError
message: could not allocate the guest instance
method: prepare
operation_id: prepare-op-7
cause[1]: _CloudTimeout: connect timeout to ec2.us-east-1: i-0abc123
  at worker.py:384 in _handle
  at worker.py:592 in _dispatch
  at failing_e2e_adapter.py:31 in prepare
```

The wrapped `_CloudTimeout` is raised *inside the spawned adapter* and can only
appear here if the cause chain survived the wire — that is what makes this
evidence rather than decoration.

### Canary-secret probe across the real boundary

A fourth spawnable adapter is **handed** a secret on `reset_start` and
interpolates it into its own exception message (the realistic careless case).
Across the real pipe:

```
canary secret  : absent
abs path       : absent
traceback kw   : absent
env marker     : absent
```

`detail.message == WITHHELD`, while `exception_type`, `method` and
`operation_id` still arrive — structure preserved, value destroyed. Checked
against `str(error)`, the serialised detail, and both stdio tails.

### Verified against a copy of the real bundle

Replayed the sealed `ep-e46c789ca818` (copied, original untouched): confirmed
its recorded artifact is the generic sentence, then showed the same failure
shape rendering a named cause under the new path.

### Mutation testing — every new test earns its place

| Mutant | Caught by |
|---|---|
| Worker sends `detail=None` (the `origin/main` behaviour) | both spawn tests — `assert None is not None` |
| Canary check removed | leak test — **printed the real credential**, `assert 'auth rejected for key AKIA-canary…' == '<withheld…>'` |
| Cause chain dropped | spawn test — `IndexError: tuple index out of range` |
| Control-char collapsing removed | rpc test — `assert not any(...)` |

The framing assertion initially **survived** its mutant, because JSON escapes
`\r\n` into a safe two-byte form — a framing-only check passes on a dirty
value. Rewritten to assert the *parsed value*, which is the invariant that
actually matters to a reader of the artifact.

### Gates (whole tree, exactly as CI)

```
flake8 7.1.0      : 0
black 26.1.0      : 836 files unchanged
isort 5.13.2      : clean
pyright           : 0 errors, 0 warnings, 0 informations
tests/unit        : 11995 passed, 15 skipped (20:02)
```

Full suite run **after** the rebase onto `57810f7c`. Machine was heavily
contended throughout (load average 48); no test was skipped or shortened to
accommodate it.

## Version

`0.44.72` — patch. A reliability/diagnosability fix, no new user-facing
surface. Chosen at push time against `main` (0.44.71) and PyPI (0.44.71).
