### PR TITLE
fix(model): describe an aggregator router honestly in the picker and the spec

### DIFF
--- a/local_operator/model/discovery.py
+++ b/local_operator/model/discovery.py
@@ -250,11 +250,22 @@ def sane_listing_max_tokens(max_tokens: int, context_window: int) -> int:
 #: aggregators, since they are the only transports whose wire carries the field
 #: at all (the anthropic/zai/xai/kimi/alibaba/codex documents and models.dev do
 #: not, so ``anthropic`` stays at 2 and every default-1 transport stays at 1).
+#: Version 6 for ``openrouter`` and ``radient`` is ``_row_from_openai_entry``
+#: recording :attr:`DiscoveredModel.routed` — a MEANING the version-5 writer
+#: could not express, the same case as the version-3 ``free`` bump. A version-5
+#: document parses to rows with ``routed=False``, a valid shape in which
+#: ``radient/auto`` keeps rendering the word ``free`` (its listing quotes a
+#: symmetric zero) and ``openrouter/auto`` keeps rendering a blank cell. Both
+#: are the exact wrong labels this change exists to replace, so without the
+#: bump the fix would ship and change nothing on screen for up to a day on
+#: every install that already has a listing. Same one-time synchronous refetch
+#: the earlier bumps describe, paid by the same two aggregators, since they are
+#: the only transports that quote a price at all.
 LISTING_CAPTURE_VERSIONS: dict[str, int] = {
     "anthropic": 2,
-    "openrouter": 5,
-    "radient": 5,
-    "radient-key": 5,
+    "openrouter": 6,
+    "radient": 6,
+    "radient-key": 6,
 }
 #: What a transport not named above is stamped with. Version 1 is the original
 #: shape; a transport only earns a bump when its own reader starts needing a
@@ -354,6 +365,20 @@ class DiscoveredModel:
     #: a row is only ``True`` here when a parser read an explicit zero off a wire
     #: or a document. A row that carries a positive price must never set it.
     free: bool = False
+    #: The SOURCE stated that this endpoint is a META-ROUTE whose price depends
+    #: on the model it dispatches to — a quoted NEGATIVE price, which is how
+    #: OpenRouter spells it on ``openrouter/auto`` and Radient on ``auto``.
+    #:
+    #: The fourth price state, and a sibling of ``free`` rather than a variant
+    #: of it: both exist because the wire said something a pair of floats
+    #: cannot record. Where ``free`` distinguishes a quoted zero from silence,
+    #: this distinguishes "unknowable by construction" from "nobody quoted it",
+    #: which the picker renders as ``usage-based`` and a blank cell.
+    #:
+    #: Never true beside a positive price and never true beside ``free``: a
+    #: route that quotes real money is priced, and a router cannot be free at
+    #: the point of use when its own listing declines to price it.
+    routed: bool = False
     supports_images: bool | None = None
     supports_prompt_cache: bool = False
     #: The effort ladder the LISTING stated, ASCENDING and normalised to
@@ -478,6 +503,44 @@ def _stated_zero_price(value: object) -> bool:
     else:
         return False
     return math.isfinite(number) and number == 0.0
+
+
+def _stated_routed_price(value: object) -> bool:
+    """Whether ``value`` is the META-ROUTE sentinel: a NEGATIVE quoted price.
+
+    The fourth thing this field can mean, beside the three
+    :func:`_stated_zero_price` enumerates. OpenRouter writes ``"-1"`` on
+    ``openrouter/auto`` and Radient writes it on ``auto``: the endpoint is a
+    router, so its cost is neither a number nor zero nor unknown — it is
+    whatever the model it dispatches to charges, which cannot be known until
+    the turn is routed.
+
+    Read off the WIRE for the same reason the stated zero is: only the parser
+    that saw the character ``-`` can tell this apart from a listing that
+    quoted nothing, since :func:`_positive_float` collapses both to ``0.0``.
+    Inferring it downstream by pattern-matching an id would put the label on
+    any future model whose name happens to end in ``auto`` and miss every
+    router that does not.
+
+    NOT merged with the stated zero into one "unpriced" answer. They render
+    differently on purpose — ``free`` is a promise the user can act on and
+    ``usage-based`` is a warning that they cannot — and a router quoted at
+    ``"0"`` by a server that has not been fixed yet is exactly the row that
+    must not read as free.
+    """
+    if isinstance(value, bool):
+        # bool is an int subclass, and ``False`` is not a quoted price.
+        return False
+    if isinstance(value, (int, float)):
+        number = float(value)
+    elif isinstance(value, str):
+        try:
+            number = float(value.strip())
+        except ValueError:
+            return False
+    else:
+        return False
+    return math.isfinite(number) and number < 0.0
 
 
 def _per_million(value: object) -> float:
@@ -724,6 +787,71 @@ def _bills_in_tokens(architecture: Mapping[str, object]) -> bool:
     return True
 
 
+#: Listing ids that ARE a router rather than a model, by aggregator spelling.
+#:
+#: Deliberately tiny and deliberately here rather than in the renderer. These
+#: are not "models we know about" — enumerating those is what the live listing
+#: is for — they are the two endpoints whose entire product is dispatching to
+#: another model, which is a structural property of the aggregator's API and
+#: changes only when the aggregator adds a router.
+_META_ROUTE_IDS = frozenset({"auto", "openrouter/auto"})
+
+
+def is_meta_route_id(model_id: str) -> bool:
+    """Whether ``model_id`` names a ROUTER endpoint rather than a model.
+
+    The id half of :func:`_is_meta_route`, exported for the one caller that
+    has no listing row to read a price from: the controller's rescue entry,
+    which describes the session's CURRENT model from the registry when a live
+    listing could not be had. That path is reached exactly when the router's
+    own pricing is unavailable, so the price signal it would prefer does not
+    exist there — and it is the path a user on ``radient/auto`` with a cold
+    cache actually hits.
+
+    Kept as one exported predicate over one module-private set so the two
+    layers cannot drift into disagreeing about what a router is.
+    """
+    return model_id in _META_ROUTE_IDS
+
+
+def _is_meta_route(model_id: str, pricing: Mapping[str, object]) -> bool:
+    """Whether this entry is a ROUTER whose cost depends on where it dispatches.
+
+    Two signals, either of which is sufficient, and the second exists only
+    because of a bug the first cannot see through.
+
+    The PRICE is the principled signal: a quoted negative leg means exactly
+    this and nothing else (:func:`_stated_routed_price`), it is what OpenRouter
+    publishes for ``openrouter/auto``, and it keeps working for any router any
+    aggregator adds later without this module being told about it.
+
+    The ID is the fallback, and it is here rather than in the renderer on
+    purpose. Radient's listing currently declares ``auto`` with
+    ``{"prompt": "0", "completion": "0"}``, and a symmetric quoted zero is
+    INDISTINGUISHABLE from a genuinely free route by price alone — that is the
+    whole reason ``_stated_zero_price`` exists. So for that one shape there is
+    no principled signal to read, and the honest options are to name the
+    router or to let it keep claiming to be free. Naming it is bounded (two
+    ids), sits in the layer that already knows which aggregator's wire it is
+    parsing, and expires on its own: once the server quotes ``"-1"`` the price
+    test carries the row and this set is redundant for it.
+
+    The set is checked against the LISTING id, which is the id as that
+    aggregator spells it (``auto`` on Radient, ``openrouter/auto`` on
+    OpenRouter). A direct provider that shipped a model literally called
+    ``auto`` would be a false positive; none exists in any listing in this
+    tree, and the cost would be one row reading ``usage-based`` instead of its
+    real price rather than anything a session runs on.
+    """
+    return model_id in _META_ROUTE_IDS or (
+        # BOTH legs, matching the stated-zero rule directly above it: a
+        # half-negative row is a listing bug, not a router, and reading one
+        # leg would let it suppress a real price on the other.
+        _stated_routed_price(pricing.get("prompt"))
+        and _stated_routed_price(pricing.get("completion"))
+    )
+
+
 def _row_from_openai_entry(entry: Mapping[str, object]) -> DiscoveredModel | None:
     """One OpenAI-compatible listing entry, or ``None`` when it has no id.
 
@@ -773,11 +901,18 @@ def _row_from_openai_entry(entry: Mapping[str, object]) -> DiscoveredModel | Non
         # The modality gate is the same guard one level up: a zero per TOKEN is
         # only a whole price for a model that bills in tokens (see
         # :func:`_bills_in_tokens`).
+        # A router is never free, whichever way its listing spells the
+        # non-price. The ``routed`` test below claims the row first, so a
+        # meta-route quoting ``"0"`` — which is what Radient's listing does
+        # for ``auto`` today — drops out of this expression rather than
+        # advertising a frontier-model dispatch as costing nothing.
         free=(
-            _stated_zero_price(pricing.get("prompt"))
+            not _is_meta_route(model_id, pricing)
+            and _stated_zero_price(pricing.get("prompt"))
             and _stated_zero_price(pricing.get("completion"))
             and _bills_in_tokens(architecture)
         ),
+        routed=_is_meta_route(model_id, pricing),
         cache_read_price=cache_read_price,
         supports_images=_has_image_input(architecture),
         # A priced cache-read leg is the only machine-readable evidence of prompt
@@ -1390,6 +1525,15 @@ def _merge_one(row: DiscoveredModel, info: ModelInfo | None) -> DiscoveredModel:
         # "free", only "priced" or "unknown".
         free=row.free
         and not (_positive_float(info.input_price) or _positive_float(info.output_price)),
+        # Same shape and same reason as ``free`` above: only the LIVE listing
+        # can state it (no bundled row describes a router's pricing), and it
+        # does not survive a registry price. The aggregator templates carry no
+        # prices, so in practice this passes straight through — but a future
+        # priced row must not be able to quote $3/15 and claim to be
+        # unpriceable at the same time, which is the invariant, not the
+        # current data.
+        routed=row.routed
+        and not (_positive_float(info.input_price) or _positive_float(info.output_price)),
         cache_read_price=(
             _positive_float(row.cache_read_price) or _positive_float(info.cache_reads_price)
         ),
@@ -1535,6 +1679,12 @@ def _rows_from_payload(
                 # (not stated free), so a plain bool is enough — unlike
                 # ``supports_images`` below, this field has no third state.
                 free=bool(entry.get("free")),
+                # Stored as a computed boolean exactly like ``free``, and read
+                # back the same way: a stored ``false`` and an absent key both
+                # mean "not a router". A document written before this field
+                # existed therefore reads as ``false``, which is why the
+                # capture stamp is bumped rather than left to the TTL.
+                routed=bool(entry.get("routed")),
                 # ``null`` in the document is the listing's silence, faithfully
                 # stored by ``dataclasses.asdict``. Reading it as False would let
                 # a cache round-trip turn "unstated" into a denial, so the same

--- a/local_operator/model/discovery.py
+++ b/local_operator/model/discovery.py
@@ -59,6 +59,7 @@ from local_operator.model.effort import EFFORT_ORDER
 from local_operator.model.ids import id_spellings, normalised_id
 from local_operator.model.registry import ModelInfo, static_models
 from local_operator.providers.registry import (
+    AGGREGATOR_PROVIDERS,
     PROVIDER_REGISTRY,
     WireFormat,
     credential_provider_id,
@@ -797,8 +798,8 @@ def _bills_in_tokens(architecture: Mapping[str, object]) -> bool:
 _META_ROUTE_IDS = frozenset({"auto", "openrouter/auto"})
 
 
-def is_meta_route_id(model_id: str) -> bool:
-    """Whether ``model_id`` names a ROUTER endpoint rather than a model.
+def is_meta_route_id(model_id: str, provider_id: str) -> bool:
+    """Whether ``provider_id``/``model_id`` names a ROUTER rather than a model.
 
     The id half of :func:`_is_meta_route`, exported for the one caller that
     has no listing row to read a price from: the controller's rescue entry,
@@ -808,13 +809,18 @@ def is_meta_route_id(model_id: str) -> bool:
     exist there — and it is the path a user on ``radient/auto`` with a cold
     cache actually hits.
 
+    Takes the provider for the same reason :func:`_is_meta_route` does, and it
+    is not hypothetical here either: ``ollama/auto`` reaches the rescue entry
+    by exactly the same route as ``radient/auto``, so an ungated id test would
+    mislabel a local model the user happened to name ``auto``.
+
     Kept as one exported predicate over one module-private set so the two
     layers cannot drift into disagreeing about what a router is.
     """
-    return model_id in _META_ROUTE_IDS
+    return model_id in _META_ROUTE_IDS and provider_id in AGGREGATOR_PROVIDERS
 
 
-def _is_meta_route(model_id: str, pricing: Mapping[str, object]) -> bool:
+def _is_meta_route(model_id: str, provider_id: str, pricing: Mapping[str, object]) -> bool:
     """Whether this entry is a ROUTER whose cost depends on where it dispatches.
 
     Two signals, either of which is sufficient, and the second exists only
@@ -823,37 +829,64 @@ def _is_meta_route(model_id: str, pricing: Mapping[str, object]) -> bool:
     The PRICE is the principled signal: a quoted negative leg means exactly
     this and nothing else (:func:`_stated_routed_price`), it is what OpenRouter
     publishes for ``openrouter/auto``, and it keeps working for any router any
-    aggregator adds later without this module being told about it.
+    aggregator adds later without this module being told about it. It needs no
+    provider gate — a quoted negative is self-describing wherever it appears.
 
-    The ID is the fallback, and it is here rather than in the renderer on
-    purpose. Radient's listing currently declares ``auto`` with
+    The ID is the fallback, and it is gated on the provider being an
+    AGGREGATOR. Radient's listing currently declares ``auto`` with
     ``{"prompt": "0", "completion": "0"}``, and a symmetric quoted zero is
     INDISTINGUISHABLE from a genuinely free route by price alone — that is the
     whole reason ``_stated_zero_price`` exists. So for that one shape there is
-    no principled signal to read, and the honest options are to name the
-    router or to let it keep claiming to be free. Naming it is bounded (two
-    ids), sits in the layer that already knows which aggregator's wire it is
-    parsing, and expires on its own: once the server quotes ``"-1"`` the price
-    test carries the row and this set is redundant for it.
+    no principled signal to read, and the honest options are to name the router
+    or to let it keep claiming to be free.
+
+    WHY the gate is load-bearing rather than defensive: this parser serves the
+    ``openai-compat`` wire GENERALLY, not just the two aggregators — ollama,
+    deepseek, mistral, kimi, xai, zai, alibaba and openai all reach it. On
+    Ollama the "listing" is the user's own filesystem, so the id space is
+    user-controlled and a local model named ``auto`` is a thing a user can
+    simply have. Ungated, that row rendered ``usage-based`` where it had
+    correctly read ``free`` — and ``ollama`` is the ONE provider with
+    ``allows_missing_api_key``, whose genuine zero is exactly what ``_price``
+    exists to preserve. So the mislabel landed on the honest-pricing axis this
+    module is most careful about.
+
+    The blast radius was the PRICE CELL ONLY, and the bound is worth stating so
+    nobody re-derives it: ``get_model_info`` dispatches the router's 1M row on
+    its own aggregator-scoped set, so no session ever ran on wrong metadata —
+    a local model kept its real window and its real image capability. A
+    cosmetic mislabel on the one column that must not lie, rather than a
+    correctness bug in the spec.
 
     The set is checked against the LISTING id, which is the id as that
     aggregator spells it (``auto`` on Radient, ``openrouter/auto`` on
-    OpenRouter). A direct provider that shipped a model literally called
-    ``auto`` would be a false positive; none exists in any listing in this
-    tree, and the cost would be one row reading ``usage-based`` instead of its
-    real price rather than anything a session runs on.
+    OpenRouter). The fallback expires on its own: once the Radient server
+    quotes ``"-1"`` (radient-ml/agent-server #8) and cached listings have
+    rolled past the capture bump, the price leg carries the row and the id leg
+    can be deleted.
     """
-    return model_id in _META_ROUTE_IDS or (
-        # BOTH legs, matching the stated-zero rule directly above it: a
-        # half-negative row is a listing bug, not a router, and reading one
-        # leg would let it suppress a real price on the other.
-        _stated_routed_price(pricing.get("prompt"))
-        and _stated_routed_price(pricing.get("completion"))
+    if model_id in _META_ROUTE_IDS and provider_id in AGGREGATOR_PROVIDERS:
+        return True
+    # BOTH legs, matching the stated-zero rule directly above it: a
+    # half-negative row is a listing bug, not a router, and reading one
+    # leg would let it suppress a real price on the other.
+    return _stated_routed_price(pricing.get("prompt")) and _stated_routed_price(
+        pricing.get("completion")
     )
 
 
-def _row_from_openai_entry(entry: Mapping[str, object]) -> DiscoveredModel | None:
+def _row_from_openai_entry(
+    entry: Mapping[str, object], provider_id: str = ""
+) -> DiscoveredModel | None:
     """One OpenAI-compatible listing entry, or ``None`` when it has no id.
+
+    ``provider_id`` says whose wire this entry came off, which only
+    :func:`_is_meta_route`'s router-id fallback needs. It DEFAULTS TO EMPTY and
+    that direction is deliberate: ``""`` is not in ``AGGREGATOR_PROVIDERS``, so
+    a caller that omits it gets the price-only answer — the conservative one —
+    rather than a router label it did not ask for. The alternative, a required
+    argument, would fail closed too but at import time for every existing
+    caller; this fails closed at the only place the value changes an answer.
 
     Nothing beyond ``id`` is standardised: OpenRouter nests the real limits under
     ``top_provider`` and the modalities under ``architecture``, while leaner
@@ -907,12 +940,12 @@ def _row_from_openai_entry(entry: Mapping[str, object]) -> DiscoveredModel | Non
         # for ``auto`` today — drops out of this expression rather than
         # advertising a frontier-model dispatch as costing nothing.
         free=(
-            not _is_meta_route(model_id, pricing)
+            not _is_meta_route(model_id, provider_id, pricing)
             and _stated_zero_price(pricing.get("prompt"))
             and _stated_zero_price(pricing.get("completion"))
             and _bills_in_tokens(architecture)
         ),
-        routed=_is_meta_route(model_id, pricing),
+        routed=_is_meta_route(model_id, provider_id, pricing),
         cache_read_price=cache_read_price,
         supports_images=_has_image_input(architecture),
         # A priced cache-read leg is the only machine-readable evidence of prompt
@@ -1065,7 +1098,11 @@ def _fetch_openai_compat(ctx: _FetchContext) -> list[DiscoveredModel] | None:
     entries = _entry_list(body, "data", "models")
     if entries is None:
         return None
-    rows = (_row_from_openai_entry(entry) for entry in entries)
+    # The provider is threaded in because the ROUTER-id fallback in
+    # ``_is_meta_route`` is only valid for an aggregator: this same parser
+    # serves every ``openai-compat`` provider, and on Ollama the listing is the
+    # user's own filesystem (see R1).
+    rows = (_row_from_openai_entry(entry, ctx.provider_id) for entry in entries)
     return [row for row in rows if row is not None]
 
 

--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -288,6 +288,12 @@ def get_model_info(hosting: str, model: str) -> ModelInfo:
     model_info = unknown_model_info
 
     if hosting == "radient":
+        # The router is a KNOWN endpoint and gets its own row; every other id
+        # an aggregator serves is genuinely undescribed and keeps the template's
+        # unknown sentinels. See `aggregator_router_model_info` for why the two
+        # cannot share one row.
+        if model in AGGREGATOR_ROUTER_MODEL_IDS:
+            return aggregator_router_model_info
         return radient_default_model_info
     elif hosting == "anthropic":
         if model in anthropic_models:
@@ -303,6 +309,8 @@ def get_model_info(hosting: str, model: str) -> ModelInfo:
     elif hosting == "openai":
         return openai_models[model]
     elif hosting == "openrouter":
+        if model in AGGREGATOR_ROUTER_MODEL_IDS:
+            return aggregator_router_model_info
         return openrouter_default_model_info
     elif hosting == "alibaba":
         if model in qwen_models:
@@ -741,6 +749,59 @@ radient_default_model_info: ModelInfo = ModelInfo(
     name="Radient",
     recommended=False,
 )
+
+#: The ROUTER endpoint of an aggregator — `radient/auto`, `openrouter/auto` —
+#: as distinct from a model reached THROUGH that aggregator.
+#:
+#: Deliberately separate from the two templates above, and the distinction is
+#: the whole point. Those describe "a model this aggregator serves that we know
+#: nothing else about", so their ``-1`` is honest: an arbitrary unlisted model
+#: could have any window, and claiming a large one would suppress compaction
+#: for a small model — the failure the ``-1`` sentinel exists to prevent. The
+#: router is the opposite case. It is ONE known endpoint whose product is
+#: dispatching to a frontier model, so these are properties of the ROUTE:
+#:
+#: * ``context_window``: ``-1`` is normalised by ``configure.build_model_spec``
+#:   to ``UNKNOWN_CONTEXT_WINDOW`` (128k), and that number is not inert — the
+#:   session derives its compaction threshold from it, so a router that will
+#:   happily accept 1M compacted at an eighth of its room, and the picker
+#:   advertised ``128k`` for it. 1,048,576 is a window every model these
+#:   routers select today actually carries, so it is a conservative floor
+#:   rather than an optimistic claim, and a live listing that states its own
+#:   number still wins (``discovery._merge_one``).
+#: * ``supports_images``: ``False`` is a POSITIVE STATEMENT OF INCAPACITY in
+#:   the three-state scheme ``DiscoveredModel.supports_images`` documents, not
+#:   an "unknown" — and it was a false one. It made the session strip images
+#:   and announce "the current model does not accept images" on a router that
+#:   accepts them, which is the user-visible half of this bug.
+#:
+#: ``max_tokens`` deliberately stays ``-1``. Unlike the window it has no honest
+#: router-wide floor: the output cap is the SELECTED model's, it varies by an
+#: order of magnitude across the routes, and ``build_model_spec``'s 8,192
+#: fallback merely truncates a long answer where a wrong window silently
+#: mis-compacts an entire conversation. Stating a number nobody can stand
+#: behind is the error these templates exist to avoid.
+aggregator_router_model_info: ModelInfo = ModelInfo(
+    max_tokens=-1,
+    context_window=1_048_576,
+    supports_images=True,
+    supports_prompt_cache=False,
+    input_price=0.0,
+    output_price=0.0,
+    cache_writes_price=0.0,
+    cache_reads_price=0.0,
+    description="Automatic model selection across the aggregator's catalogue",
+    id="auto",
+    name="Automatic",
+    recommended=False,
+)
+
+#: Model ids that ARE the router rather than a model, by aggregator spelling.
+#: Mirrors ``discovery._META_ROUTE_IDS``; kept here as well because this module
+#: must not import the discovery layer (it is the leaf the registry is built
+#: from), and the set is two literals that change only when an aggregator adds
+#: a router.
+AGGREGATOR_ROUTER_MODEL_IDS = frozenset({"auto", "openrouter/auto"})
 
 anthropic_default_model_info: ModelInfo = ModelInfo(
     max_tokens=64_000,

--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -1156,7 +1156,8 @@ class ProviderController:
             # had at all. That makes it the path a user running `radient/auto`
             # on a cold cache actually takes, so leaving it False here would
             # blank the label on exactly the surface that reported the bug.
-            routed=is_meta_route_id(model_id),
+            # Provider-scoped: `ollama/auto` reaches this same branch (R1).
+            routed=is_meta_route_id(model_id, definition.id),
         )
 
     async def live_catalogue(

--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -32,6 +32,7 @@ from local_operator.model.discovery import (
     available_models,
     cached_available_models,
     invalidate_listing,
+    is_meta_route_id,
 )
 from local_operator.model.naming import model_label
 from local_operator.model.registry import static_models
@@ -112,6 +113,26 @@ class CatalogueEntry:
     #: This provider RESELLS the model rather than serving it. The picker ranks
     #: the direct route first when the same model is reachable both ways.
     aggregated: bool = False
+    #: This entry is a META-ROUTE: its price depends on the model it dispatches
+    #: to, so there is no pair of numbers that describes it.
+    #:
+    #: WHY this travels when ``free`` deliberately does not. ``free`` stops at
+    #: the boundary below because the price pair can already carry it: ``0.0``
+    #: means stated-free and ``-1.0`` means unknown, so the flag would be a
+    #: second spelling of a fact the floats already hold, free to drift from
+    #: them. That argument does not extend here, and the reason is that the
+    #: float vocabulary is FULL. A router has no price, so it can only arrive
+    #: as ``-1.0``/``-1.0`` — which is already spoken for by "nobody quoted
+    #: this", a genuinely different answer that must keep rendering as a blank
+    #: cell. Encoding a fourth meaning would mean inventing a fourth sentinel
+    #: (``-2.0``) and teaching every reader of these two floats about it, which
+    #: is the "smuggle a new meaning into an existing channel" move that
+    #: ``format_price_pair`` and ``_price`` both warn against at length.
+    #:
+    #: So it is carried as its own bit, the way ``DiscoveredModel.routed`` is,
+    #: and the prices stay honestly unknown underneath it. Nothing but the
+    #: display reads it.
+    routed: bool = False
 
     @property
     def selector(self) -> str:
@@ -1054,6 +1075,7 @@ class ProviderController:
                             output_price=_price(model.output_price, definition, free=model.free),
                             connected=connected,
                             aggregated=True,
+                            routed=model.routed,
                         )
                     )
             else:
@@ -1129,6 +1151,12 @@ class ProviderController:
             output_price=output_price,
             connected=usable is None or definition.id in usable,
             aggregated=definition.id in AGGREGATOR_PROVIDERS,
+            # From the id alone, because this branch has no listing row to read
+            # a price off: it is the fallback for when the listing could not be
+            # had at all. That makes it the path a user running `radient/auto`
+            # on a cold cache actually takes, so leaving it False here would
+            # blank the label on exactly the surface that reported the bug.
+            routed=is_meta_route_id(model_id),
         )
 
     async def live_catalogue(
@@ -1215,6 +1243,7 @@ class ProviderController:
                         output_price=_price(model.output_price, definition, free=model.free),
                         connected=connected,
                         aggregated=definition.id in AGGREGATOR_PROVIDERS,
+                        routed=model.routed,
                     )
                 )
         return entries, statuses

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -1325,6 +1325,13 @@ class FrontendStateStore:
                     "output_price": float(getattr(entry, "output_price", 0.0) or 0.0),
                     "connected": bool(getattr(entry, "connected", False)),
                     "aggregated": bool(getattr(entry, "aggregated", False)),
+                    # Carried so the round-trip stays faithful to
+                    # ``CatalogueEntry`` rather than silently defaulting a
+                    # field the reader knows about. ``getattr`` with a default
+                    # for the same reason every key above uses one: this takes
+                    # ``Any``, and a duck-typed entry from an embedding host
+                    # need not have the attribute.
+                    "routed": bool(getattr(entry, "routed", False)),
                 }
             )
         return self.mutate(model_catalogue=rows)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15449,6 +15449,12 @@ class OperatorApp(App[None]):
                         output_price=float(row.get("output_price", 0.0) or 0.0),
                         connected=bool(row.get("connected", False)),
                         aggregated=bool(row.get("aggregated", False)),
+                        # Absent from an owner running an older build, which
+                        # reads as False — the same "not a router" default the
+                        # listing cache uses, and correct here for a further
+                        # reason: the publisher drops aggregated rows, so no
+                        # router reaches a follower through this path at all.
+                        routed=bool(row.get("routed", False)),
                     )
                     for row in owner_rows
                     if f"{row.get('provider', '')}/{row.get('model_id', '')}" not in known
@@ -15470,6 +15476,7 @@ class OperatorApp(App[None]):
                 output_price=entry.output_price,
                 connected=entry.connected,
                 aggregated=entry.aggregated,
+                routed=entry.routed,
             )
             for entry in entries
             if usable is None or entry.provider in usable or entry.selector == current
@@ -15532,6 +15539,7 @@ class OperatorApp(App[None]):
                 output_price=entry.output_price,
                 connected=entry.connected,
                 aggregated=entry.aggregated,
+                routed=entry.routed,
             )
         ]
 

--- a/local_operator/tui/widgets/model_picker.py
+++ b/local_operator/tui/widgets/model_picker.py
@@ -130,6 +130,13 @@ class ModelRow:
     #: provider. Set by the caller, which is the only layer that knows the
     #: registry; the picker only needs it as a sort rung.
     aggregated: bool = False
+    #: This row is a META-ROUTE — a router whose price is the price of whichever
+    #: model it dispatches to. Set by the caller from the listing that said so
+    #: (``CatalogueEntry.routed``), never inferred here: the renderer cannot
+    #: tell a router's unknown price from any other unknown one, and deciding it
+    #: from the id in this layer would be the second, divergent statement of the
+    #: rule that :func:`format_price_pair`'s docstring exists to warn against.
+    routed: bool = False
 
     @property
     def selector(self) -> str:
@@ -153,13 +160,32 @@ def format_window(tokens: int) -> str:
     return str(tokens)
 
 
-def format_price_pair(input_price: float, output_price: float) -> str:
-    """``$3/15`` per million, ``free`` when both legs are really zero, else ``""``.
+#: What a meta-route's price column reads. Lower-case to match ``free``, the
+#: only other word this column prints; hyphenated so it reads as one token
+#: beside the window it sits next to.
+#:
+#: Measured against the layout before it was chosen, because it is materially
+#: longer than ``free`` and this column is width-constrained. At the picker's
+#: floor (``_NUMBERS_MIN_WIDTH``, 56 cells) the numbers run costs 11 cells
+#: instead of 4, which comes out of the id budget and truncates a LONG
+#: aggregator id ~7 characters earlier; ids short enough to matter
+#: (``radient/auto``) are unaffected at every width, and below 56 the whole
+#: numbers run is already dropped. The trade is deliberate: the alternative
+#: spellings that fit in 4-6 cells (``usage``, ``routed``, ``varies``) all
+#: answer a different question than the one a user reading a price column is
+#: asking, and a shorter word that has to be decoded is not cheaper than a
+#: longer one that does not.
+ROUTED_PRICE_LABEL = "usage-based"
 
-    The three-way split matters. A provider that quotes no pricing is NOT free —
-    treating a missing price as zero would advertise a paid model as free, which
-    is the one error in this column a user would act on. So an absent price is
-    blank and only a genuine pair of zeroes says ``free``.
+
+def format_price_pair(input_price: float, output_price: float, *, routed: bool = False) -> str:
+    """``$3/15`` per million, ``free``, ``usage-based`` for a router, else ``""``.
+
+    FOUR states, and the split matters. A provider that quotes no pricing is NOT
+    free — treating a missing price as zero would advertise a paid model as
+    free, which is the one error in this column a user would act on. So an
+    absent price is blank, only a genuine pair of zeroes says ``free``, and a
+    router says :data:`ROUTED_PRICE_LABEL`.
 
     This function takes no "is it free" flag ON PURPOSE, even though that fact
     now travels as one (:attr:`DiscoveredModel.free`). ``0.0`` reaching here
@@ -169,7 +195,21 @@ def format_price_pair(input_price: float, output_price: float) -> str:
     divergent statement of the same rule — and the reason the ``free`` label was
     dead in the first place was that the two layers disagreed, not that this one
     was wrong.
+
+    ``routed`` IS a flag for the opposite reason, not in spite of it. The float
+    vocabulary is full: a router has no price, so it can only reach here as
+    ``-1.0``, which already means "nobody quoted this" — a different answer that
+    must keep rendering blank. There is no value the caller could pass that
+    would let this function work the state out, so the alternative to a flag is
+    not "derive it here", it is "invent a fifth sentinel and teach every reader
+    of these floats about it". The flag is decided once, by the parser that read
+    the wire (:attr:`DiscoveredModel.routed`), and travels; this layer only
+    prints it. It is checked FIRST because it is a statement about the endpoint
+    rather than about a number, so it cannot be outvoted by a zero a stale
+    listing happens to quote.
     """
+    if routed:
+        return ROUTED_PRICE_LABEL
     if input_price < 0 or output_price < 0:
         return ""
     if input_price == 0 and output_price == 0:
@@ -705,7 +745,7 @@ class ModelPicker(Static):
         return "  ".join(parts)
 
     def _price(self, row: ModelRow) -> str:
-        return format_price_pair(row.input_price, row.output_price)
+        return format_price_pair(row.input_price, row.output_price, routed=row.routed)
 
     def _footer_rows(self, width: int) -> list[Text]:
         """Count/status rows with the persistent-default instruction protected.

--- a/local_operator/tui/widgets/model_picker.py
+++ b/local_operator/tui/widgets/model_picker.py
@@ -165,12 +165,23 @@ def format_window(tokens: int) -> str:
 #: beside the window it sits next to.
 #:
 #: Measured against the layout before it was chosen, because it is materially
-#: longer than ``free`` and this column is width-constrained. At the picker's
-#: floor (``_NUMBERS_MIN_WIDTH``, 56 cells) the numbers run costs 11 cells
-#: instead of 4, which comes out of the id budget and truncates a LONG
-#: aggregator id ~7 characters earlier; ids short enough to matter
-#: (``radient/auto``) are unaffected at every width, and below 56 the whole
-#: numbers run is already dropped. The trade is deliberate: the alternative
+#: longer than ``free`` and this column is width-constrained. What the extra
+#: seven cells actually cost, swept across 120->56 columns for both router ids:
+#:
+#: * NOT id truncation. No router id truncates under ANY label length (0, 5, 6
+#:   or 11 cells) at any width in that range — the ids are short enough that
+#:   the budget never binds. An earlier version of this comment claimed a long
+#:   id truncated ~7 characters earlier; that was wrong, and it mattered
+#:   because this is where a future maintainer looks to judge whether a longer
+#:   label is affordable.
+#: * The DISPLAY-NAME PARENTHETICAL drops earlier, and that is the whole cost.
+#:   ``openrouter/openrouter/auto  (Auto Router)`` keeps its name down to 61
+#:   columns with ``usage-based`` against a 56-column floor with a 4-6 cell
+#:   label — a five-column band, inside which the row loses a secondary aid
+#:   and keeps everything it is chosen by.
+#:
+#: Below ``_NUMBERS_MIN_WIDTH`` (56) the whole numbers run is dropped anyway,
+#: so nothing here is reachable further down. The trade is deliberate: the
 #: spellings that fit in 4-6 cells (``usage``, ``routed``, ``varies``) all
 #: answer a different question than the one a user reading a price column is
 #: asking, and a shorter word that has to be decoded is not cheaper than a

--- a/local_operator/tui/widgets/settings_view.py
+++ b/local_operator/tui/widgets/settings_view.py
@@ -4344,7 +4344,7 @@ def _suggestion_detail(row: ModelRow) -> str:
     """
     from local_operator.tui.widgets.model_picker import format_price_pair
 
-    price = format_price_pair(row.input_price, row.output_price)
+    price = format_price_pair(row.input_price, row.output_price, routed=row.routed)
     parts = [row.provider]
     if price:
         parts.append(price)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.45.2"
+version = "0.45.3"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/capture_repair_probe.py
+++ b/scripts/capture_repair_probe.py
@@ -105,7 +105,14 @@ def main() -> int:
         for thread in _revalidation_threads():
             thread.join(timeout=30.0)
         rendered = {
-            (e.provider, e.model_id): format_price_pair(e.input_price, e.output_price)
+            # ``routed`` threaded through for the same reason the picker does
+            # it: this probe's whole job is reporting what the picker prints,
+            # so a router rendering ``''`` here while the picker says
+            # ``usage-based`` would make the diagnostic lie about the surface
+            # it exists to observe.
+            (e.provider, e.model_id): format_price_pair(
+                e.input_price, e.output_price, routed=e.routed
+            )
             for e in entries
         }
         watched = {k: rendered.get(k, "<missing row>") for k in WATCHED}

--- a/scripts/model_picker_shot.py
+++ b/scripts/model_picker_shot.py
@@ -74,7 +74,10 @@ def _router_row(provider: str, payload: dict[str, object], label: str) -> ModelR
     """
     definition = get_provider_definition(provider)
     assert definition is not None
-    row = _row_from_openai_entry(payload)
+    # The provider is required for the router-id fallback to apply: it is
+    # aggregator-scoped, because this parser also serves ollama and the other
+    # direct openai-compat providers (see `_is_meta_route`).
+    row = _row_from_openai_entry(payload, provider)
     assert row is not None
     context_window = row.context_window or build_model_spec(provider, row.id).context_window
     return ModelRow(

--- a/scripts/model_picker_shot.py
+++ b/scripts/model_picker_shot.py
@@ -1,0 +1,170 @@
+"""Capture the `/model` picker's aggregator rows, for visual validation.
+
+Run from the worktree root:
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/model_picker_shot.py OUT.svg [COLSxROWS]
+
+Exists for the `radient/auto` metadata round: the router's row is the one
+under test, and the two facts it must state — a 1M context window and a
+usage-based price rather than the word `free` — are only judgeable as a
+rendered frame, because the price column is width-constrained and a longer
+label is exactly what would push the numbers run off the edge.
+
+Drives the real ``OperatorApp`` rather than a bare widget host on purpose:
+the lightweight hosts in the test files declare no ``CSS_PATH``, so
+``local_operator.tcss`` never applies to them and a still captured from one
+cannot show what the user sees (see AGENTS.md, "Visual validation").
+
+The router's own row is built by running the REAL pipeline over a literal
+`/v1/models` payload — listing entry -> ``DiscoveredModel`` -> ``_price`` ->
+``ModelRow`` — rather than by hand-typing the numbers. That is what makes the
+before/after pair evidence: the payload is fixed, so the only thing that can
+change between the two captures is the code under test. Both payload shapes
+are captured, because a user's cached listing may still be either one.
+
+The remaining rows are literal context: they exist so the three price states
+(priced / genuinely free / unknown) stay distinguishable in the same frame.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from local_operator.model.configure import build_model_spec  # noqa: E402
+from local_operator.model.discovery import _row_from_openai_entry  # noqa: E402
+from local_operator.providers.controller import _price  # noqa: E402
+from local_operator.providers.registry import get_provider_definition  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.model_picker import ModelRow  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+#: What Radient's `/v1/models` quotes for the router TODAY — no context length,
+#: no architecture, and pricing written as an explicit `"0"`. Every user whose
+#: cached listing predates the server fix still resolves through this shape.
+CACHED_PAYLOAD = {
+    "id": "auto",
+    "name": "Automatic",
+    "pricing": {"prompt": "0", "completion": "0"},
+}
+
+#: What it quotes once the server-side half of this round lands: the meta-route
+#: shape OpenRouter already publishes for `openrouter/auto`, where `"-1"` means
+#: "the cost depends on which model this routes to".
+FIXED_PAYLOAD = {
+    "id": "auto",
+    "name": "Automatic",
+    "context_length": 1_048_576,
+    "pricing": {"prompt": "-1", "completion": "-1"},
+    "architecture": {"input_modalities": ["text", "image", "file"]},
+}
+
+
+def _router_row(provider: str, payload: dict[str, object], label: str) -> ModelRow:
+    """One picker row for ``payload``, built the way the running app builds it.
+
+    Deliberately goes through the same three seams the live catalogue does, so
+    a fix that only works in a unit test cannot produce a correct frame here.
+    The window falls back to the resolved SPEC when the listing states none,
+    which is precisely the substitution that made the router read as 128k.
+    """
+    definition = get_provider_definition(provider)
+    assert definition is not None
+    row = _row_from_openai_entry(payload)
+    assert row is not None
+    context_window = row.context_window or build_model_spec(provider, row.id).context_window
+    return ModelRow(
+        provider=provider,
+        model_id=row.id,
+        label=label,
+        context_window=context_window,
+        input_price=_price(row.input_price, definition, free=row.free),
+        output_price=_price(row.output_price, definition, free=row.free),
+        aggregated=True,
+        routed=row.routed,
+    )
+
+
+ROWS = [
+    _router_row("radient", CACHED_PAYLOAD, "Automatic (cached listing)"),
+    _router_row("radient", FIXED_PAYLOAD, "Automatic (fixed listing)"),
+    ModelRow(
+        provider="anthropic",
+        model_id="claude-opus-5",
+        label="Claude Opus 5",
+        context_window=200_000,
+        input_price=15.0,
+        output_price=75.0,
+    ),
+    ModelRow(
+        provider="openrouter",
+        model_id="google/gemma-4-31b-it:free",
+        label="Gemma 4 31B",
+        context_window=131_072,
+        input_price=0.0,
+        output_price=0.0,
+        aggregated=True,
+    ),
+    ModelRow(
+        provider="openai",
+        model_id="gpt-5.4",
+        label="GPT-5.4",
+        context_window=400_000,
+        input_price=1.25,
+        output_price=10.0,
+    ),
+]
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    size = (100, 30)
+    if len(sys.argv) > 2:
+        cols, rows = sys.argv[2].split("x")
+        size = (int(cols), int(rows))
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        picker = app._editor().model_picker
+        picker.set_rows(ROWS, current="radient/auto", status="")
+        picker.open()
+        # Let the overlay's layout SETTLE before the capture. One pause paints a
+        # frame whose rows are still sized to the pre-open composer width, and
+        # the ids come out truncated in a way the running app never shows.
+        for _ in range(4):
+            await pilot.pause()
+        await pilot.wait_for_scheduled_animations()
+        # `_repaint` renders against `self.size.width`, which is still the
+        # pre-open width on the frame `open()` itself paints. Repainting once
+        # the overlay has been laid out is what the running app gets from the
+        # next resize/keystroke; without it the capture shows truncated ids the
+        # user never sees.
+        picker._repaint()
+        await pilot.pause()
+
+        # The numbers behind the frame: a label that fits in isolation can
+        # still overflow the row, and only the widget's own geometry says so.
+        print(f"picker.size={picker.size}", file=sys.stderr)
+        for row in ROWS:
+            print(
+                f"  {row.provider}/{row.model_id}: "
+                f"numbers={picker._numbers(row)!r} price={picker._price(row)!r}",
+                file=sys.stderr,
+            )
+        # The PAINTED lines, not just the fields: a price that fits the column in
+        # isolation can still be the thing that truncates the id beside it, and
+        # only the assembled row shows that.
+        for line in picker.render_rows(picker.size.width):
+            print(f"  |{line.plain}|", file=sys.stderr)
+        app.save_screenshot(out)
+
+
+if __name__ == "__main__":
+    # Guarded so the row fixtures above can be imported by a geometry probe
+    # without the import also capturing a frame.
+    asyncio.run(main())

--- a/tests/unit/model/test_discovery.py
+++ b/tests/unit/model/test_discovery.py
@@ -299,6 +299,63 @@ def test_the_free_flag_survives_a_cache_round_trip(tmp_path) -> None:
     assert cached[0].free is True, "the stated zero must survive the document"
 
 
+def test_a_meta_route_is_flagged_routed_by_either_price_shape_or_id() -> None:
+    """The router is a FOURTH answer, and the parser is where it is decided.
+
+    ``"-1"`` is the principled signal and the one OpenRouter publishes. The id
+    fallback exists for exactly one live defect: Radient quotes ``auto`` at
+    ``{"prompt": "0", "completion": "0"}``, and a symmetric quoted zero is
+    indistinguishable from a genuinely free route by price alone — so without
+    it the router keeps advertising a frontier-model dispatch as free.
+    """
+    body = {
+        "data": [
+            {"id": "openrouter/auto", "pricing": {"prompt": "-1", "completion": "-1"}},
+            # Radient's CURRENT shape, which has no price signal to read.
+            {"id": "auto", "pricing": {"prompt": "0", "completion": "0"}},
+            # A router by price alone, under an id nothing was told about.
+            {"id": "some/future-router", "pricing": {"prompt": "-1", "completion": "-1"}},
+            {"id": "google/gemma:free", "pricing": {"prompt": "0", "completion": "0"}},
+            {"id": "priced/model", "pricing": {"prompt": "0.000003", "completion": "0.000015"}},
+            {"id": "terse/model"},
+        ]
+    }
+    rows = fetch_models("openrouter", api_key="k", client=_StubClient([_Response(200, body)]))
+
+    assert rows is not None
+    assert {row.id: row.routed for row in rows} == {
+        "openrouter/auto": True,
+        "auto": True,
+        "some/future-router": True,
+        "google/gemma:free": False,
+        "priced/model": False,
+        "terse/model": False,
+    }
+    # The two flags are mutually exclusive by construction: a router quoted at
+    # zero must lose ``free``, which is the whole user-visible bug.
+    assert {row.id: row.free for row in rows}["auto"] is False
+    assert {row.id: row.free for row in rows}["google/gemma:free"] is True
+
+
+def test_the_routed_flag_survives_a_cache_round_trip(tmp_path) -> None:
+    """Same argument as the ``free`` round trip: the reader is a different
+    function from the parser, and a field it forgets reverts to the unstated
+    default — here that means the router silently goes back to reading
+    ``free``."""
+    body = {"data": [{"id": "auto", "pricing": {"prompt": "0", "completion": "0"}}]}
+    client = _StubClient([_Response(200, body)])
+
+    live, live_status = available_models("radient", api_key=None, client=client, cache_dir=tmp_path)
+    assert live_status == "ok" and live[0].routed is True
+
+    cached, cached_status = available_models(
+        "radient", api_key=None, client=client, cache_dir=tmp_path
+    )
+    assert cached_status == "cached", "premise: served from disk, not refetched"
+    assert len(client.calls) == 1
+    assert cached[0].routed is True, "the router statement must survive the document"
+
+
 def test_a_registry_price_clears_a_stale_free_flag() -> None:
     """The merge falls back to the bundled numbers for a silent listing, so a row
     that ends up quoting a real price must not also claim to be free — the two
@@ -1856,12 +1913,15 @@ def test_only_the_transport_that_changed_invalidates_its_cache(tmp_path) -> None
     carries the ungated ``true`` for the per-song-billed rows and the reader has
     no modality left to re-judge it with. And once more (5) at the
     reasoning-effort ladder, a FIELD the version-4 writer never recorded, which
-    only the two aggregators' wire carries at all.
+    only the two aggregators' wire carries at all. And once more (6) at the
+    ``routed`` meta-route flag, stored COMPUTED like ``free``: a version-5
+    document carries ``routed: false`` for the routers, so without the bump
+    ``radient/auto`` keeps rendering the word ``free`` until its TTL rolls.
     """
     assert discovery.listing_capture_version("anthropic") == 2
-    assert discovery.listing_capture_version("openrouter") == 5
-    assert discovery.listing_capture_version("radient") == 5
-    assert discovery.listing_capture_version("radient-key") == 5
+    assert discovery.listing_capture_version("openrouter") == 6
+    assert discovery.listing_capture_version("radient") == 6
+    assert discovery.listing_capture_version("radient-key") == 6
     # Ollama's reader never changed: an OpenAI-compatible document with no
     # pricing object has nothing new to capture, so its stamp stays at 1.
     assert discovery.listing_capture_version("ollama") == discovery.LISTING_CAPTURE_DEFAULT
@@ -2243,7 +2303,7 @@ def test_cached_available_models_reads_valid_disk_cache(tmp_path) -> None:
             {
                 "fetched_at": time.time(),
                 "payload": {
-                    "capture": 5,
+                    "capture": 6,
                     "models": [
                         {
                             "id": "meta/llama-3.3-70b",

--- a/tests/unit/model/test_discovery.py
+++ b/tests/unit/model/test_discovery.py
@@ -337,6 +337,48 @@ def test_a_meta_route_is_flagged_routed_by_either_price_shape_or_id() -> None:
     assert {row.id: row.free for row in rows}["google/gemma:free"] is True
 
 
+def test_the_router_id_fallback_is_scoped_to_aggregators() -> None:
+    """R1: this parser serves the ``openai-compat`` wire GENERALLY.
+
+    ollama, deepseek, mistral, kimi, xai, zai, alibaba and openai all reach
+    ``_row_from_openai_entry``, so an ungated id test is not confined to the two
+    aggregators it was reasoned about. Ollama is the case that bites: its
+    "listing" is the user's own filesystem, so a local model named ``auto`` is
+    something a user can simply have — and ollama is the ONE provider with
+    ``allows_missing_api_key``, whose quoted zero is a REAL free that
+    ``_price`` deliberately preserves. Ungated, that row rendered
+    ``usage-based`` where it had correctly read ``free``.
+
+    The PRICE leg stays unscoped on purpose: a quoted ``-1`` is self-describing
+    whoever sent it, so a hypothetical direct provider publishing one is
+    telling the truth about itself.
+    """
+    body = {"data": [{"id": "auto"}, {"id": "qwen3:8b"}]}
+
+    local = fetch_models("ollama", api_key=None, client=_StubClient([_Response(200, body)]))
+    assert local is not None
+    assert {row.id: row.routed for row in local} == {"auto": False, "qwen3:8b": False}
+    assert {row.id: row.free for row in local} == {
+        # The genuine free survives, which is the regression this guards.
+        "auto": False,
+        "qwen3:8b": False,
+    }
+
+    # The SAME id on an aggregator is a router, which is the whole point of the
+    # fallback: the two differ only by which wire the entry came off.
+    routed = fetch_models("radient", api_key=None, client=_StubClient([_Response(200, body)]))
+    assert routed is not None
+    assert {row.id: row.routed for row in routed} == {"auto": True, "qwen3:8b": False}
+
+    # The price leg needs no provider: a stated ``-1`` is unambiguous anywhere.
+    priced_body = {"data": [{"id": "x", "pricing": {"prompt": "-1", "completion": "-1"}}]}
+    direct = fetch_models(
+        "deepseek", api_key="k", client=_StubClient([_Response(200, priced_body)])
+    )
+    assert direct is not None
+    assert direct[0].routed is True
+
+
 def test_the_routed_flag_survives_a_cache_round_trip(tmp_path) -> None:
     """Same argument as the ``free`` round trip: the reader is a different
     function from the parser, and a field it forgets reverts to the unstated

--- a/tests/unit/model/test_registry.py
+++ b/tests/unit/model/test_registry.py
@@ -443,3 +443,49 @@ def test_withdrawn_deepseek_snapshot_still_resolves_for_existing_configs() -> No
     # The undated alias is a DIFFERENT id and keeps its recommendation: the
     # measured failure is specific to the July snapshot.
     assert "deepseek/deepseek-v4-flash" in RecommendedOpenRouterModelIds
+
+
+@pytest.mark.parametrize("provider", ["radient", "openrouter"])
+def test_an_aggregator_router_resolves_to_a_real_window_and_accepts_images(
+    provider: str,
+) -> None:
+    """The router templates describe a ROUTE, and both facts below are things a
+    session acts on rather than cosmetics.
+
+    ``context_window=-1`` was normalised by ``build_model_spec`` to the 128k
+    unknown default, and the session derives its compaction threshold from that
+    number — so a router that accepts 1M compacted at an eighth of its room,
+    and the picker advertised ``128k`` for it. ``supports_images=False`` is a
+    positive statement of incapacity in this registry's three-state scheme, not
+    an "unknown": it made the session strip images and announce that the model
+    does not accept them, which is false for every model these routers select.
+    """
+    info = get_model_info(provider, "auto")
+    assert info.context_window == 1_048_576
+    assert info.supports_images is True
+
+    spec = build_model_spec(provider, "auto")
+    assert spec.context_window == 1_048_576, "the sentinel no longer collapses to 128k"
+    assert spec.supports_images is True, "the session must not strip images on a router"
+
+    # ``max_tokens`` stays unknown ON PURPOSE: the output cap belongs to the
+    # SELECTED model and varies by an order of magnitude across the routes, so
+    # there is no honest router-wide number to state. Pinned so a later edit
+    # that invents one has to argue with this comment first.
+    assert info.max_tokens == -1
+
+
+@pytest.mark.parametrize("provider", ["radient", "openrouter"])
+def test_an_arbitrary_aggregator_model_keeps_the_unknown_sentinels(provider: str) -> None:
+    """The router's numbers must NOT leak onto the aggregator's other ids.
+
+    The provider template answers for "a model this aggregator serves that we
+    know nothing else about", and for that question ``-1`` is the honest
+    answer: an arbitrary unlisted model could have any window, and handing it
+    the router's 1M would suppress compaction on a small model until the
+    provider rejected the turn. Only the ONE known router id gets the real
+    numbers, which is why the two rows are separate.
+    """
+    info = get_model_info(provider, "some-vendor/never-heard-of-it")
+    assert info.context_window == -1
+    assert info.supports_images is False

--- a/tests/unit/model/test_registry.py
+++ b/tests/unit/model/test_registry.py
@@ -475,6 +475,22 @@ def test_an_aggregator_router_resolves_to_a_real_window_and_accepts_images(
     assert info.max_tokens == -1
 
 
+def test_the_two_router_id_sets_stay_in_agreement() -> None:
+    """R3: the same two literals live in two modules, deliberately.
+
+    ``registry`` is the leaf ``discovery`` imports, so the registry cannot
+    import the discovery set without a cycle — the duplication is the right
+    call. What was missing is anything holding the copies together: adding a
+    third router to one side only produces a row whose picker LABEL and whose
+    resolved CONTEXT WINDOW disagree, which is silent and confusing rather than
+    loud. This pins the invariant so that drift fails here instead.
+    """
+    from local_operator.model.discovery import _META_ROUTE_IDS
+    from local_operator.model.registry import AGGREGATOR_ROUTER_MODEL_IDS
+
+    assert AGGREGATOR_ROUTER_MODEL_IDS == _META_ROUTE_IDS
+
+
 @pytest.mark.parametrize("provider", ["radient", "openrouter"])
 def test_an_arbitrary_aggregator_model_keeps_the_unknown_sentinels(provider: str) -> None:
     """The router's numbers must NOT leak onto the aggregator's other ids.

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -571,6 +571,56 @@ def test_an_aggregator_current_model_is_rebuilt_from_the_resolved_spec(controlle
     assert controller.entry_for("radient", spec.model_id, spec=spec) is None
 
 
+def test_the_rescue_entry_labels_a_router_but_only_on_an_aggregator(controller) -> None:
+    """The rescue path decides ``routed`` from the ID, and nothing else covered it.
+
+    This is the branch the reported bug actually takes: a user on
+    ``radient/auto`` whose live listing could not be had gets their current
+    model rebuilt here, with no listing row to read a ``-1`` off. So the label
+    has to come from the id — and that is bespoke logic no other construction
+    site shares, which is why it needs its own assertion rather than riding on
+    the parser's tests.
+
+    The negative case is the R1 scoping fix at this call site: ``ollama/auto``
+    reaches this same branch, and a local model the user happened to name
+    ``auto`` must keep its genuine ``free`` rather than being relabelled.
+    """
+    router_spec = ModelSpec(
+        provider="radient",
+        model_id="auto",
+        display_name="Automatic",
+        context_window=1_048_576,
+    )
+    entry = controller.entry_for("radient", "auto", spec=router_spec)
+    assert entry is not None
+    assert entry.routed is True, "the router must carry its label without a listing"
+
+    # A non-router id on the SAME aggregator: the flag is about this endpoint,
+    # not about the provider being an aggregator.
+    other_spec = ModelSpec(
+        provider="radient",
+        model_id="vendor/model",
+        display_name="Vendor Model",
+        context_window=32_000,
+    )
+    other = controller.entry_for("radient", "vendor/model", spec=other_spec)
+    assert other is not None
+    assert other.routed is False
+
+    # R1: the id leg is aggregator-scoped. Ollama's listing is the user's own
+    # filesystem, so `auto` is a name a user can simply give a local model, and
+    # ollama is the one provider whose zero price is a REAL free.
+    ollama_spec = ModelSpec(
+        provider="ollama",
+        model_id="auto",
+        display_name="auto",
+        context_window=8_192,
+    )
+    local = controller.entry_for("ollama", "auto", spec=ollama_spec)
+    assert local is not None
+    assert local.routed is False, "a local model named `auto` is not a meta-route"
+
+
 def test_an_unknown_price_is_not_reported_as_free(controller, monkeypatch) -> None:
     """The picker renders a genuine pair of zeroes as `free`, so an unknown price
     passed through as zero would advertise a paid model as costing nothing.

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -1754,7 +1754,7 @@ def test_initial_catalogue_layers_cached_aggregators_without_network(
             {
                 "fetched_at": time.time(),
                 "payload": {
-                    "capture": 5,
+                    "capture": 6,
                     "models": [
                         {
                             "id": "meta/llama-3.3-70b",

--- a/tests/unit/tui/test_model_picker.py
+++ b/tests/unit/tui/test_model_picker.py
@@ -99,6 +99,53 @@ def test_only_a_genuine_pair_of_zeroes_reads_as_free() -> None:
     assert format_price_pair(-1.0, 0.0) == ""
 
 
+def test_a_meta_route_reads_as_usage_based_rather_than_free_or_blank() -> None:
+    """The fourth price state, and the two wrong labels it replaces.
+
+    A router's cost depends on the model it dispatches to, so neither existing
+    answer is true of it: ``free`` is a promise the user would act on, and a
+    blank cell is the same thing this column says about a model nobody priced.
+    Both were reachable for ``radient/auto`` depending only on which shape its
+    listing happened to quote.
+    """
+    assert format_price_pair(-1.0, -1.0, routed=True) == "usage-based"
+    # The flag is checked FIRST, and that is the point rather than an ordering
+    # detail: a stale listing quoting a symmetric zero for a router (Radient's
+    # does today) must not be able to out-vote the endpoint's own nature.
+    assert format_price_pair(0.0, 0.0, routed=True) == "usage-based"
+    # Unset, every pre-existing answer is unchanged.
+    assert format_price_pair(0.0, 0.0) == "free"
+    assert format_price_pair(-1.0, -1.0) == ""
+    assert format_price_pair(3.0, 15.0) == "$3/15"
+
+
+def test_the_routed_label_does_not_overflow_the_price_column() -> None:
+    """`usage-based` is materially longer than `free`, and this column is
+    width-constrained — so the width it costs is a property worth pinning.
+
+    At the picker's narrowest painted width the row must still fit exactly,
+    with the id truncated rather than the numbers run spilling past the edge.
+    """
+    row = ModelRow(
+        provider="radient",
+        model_id="auto",
+        label="Automatic",
+        context_window=1_048_576,
+        input_price=-1.0,
+        output_price=-1.0,
+        aggregated=True,
+        routed=True,
+    )
+    picker = ModelPicker(lambda chosen: None)
+    picker.set_rows([row], current="radient/auto", status="")
+
+    for width in (56, 60, 73, 100):
+        painted = picker._row(0, width).plain
+        assert cell_len(painted) == width, (width, painted)
+        assert "usage-based" in painted, (width, painted)
+        assert "1m" in painted, (width, painted)
+
+
 def test_a_sub_cent_price_keeps_three_significant_figures() -> None:
     """The `$18.75 -> $19` argument does not stop at one cent.
 


### PR DESCRIPTION
## Summary

`radient/auto` displayed **three wrong facts** in the model picker and status band — a 128k context window, a `free` price, and a "does not accept images" warning. All three come from **one root cause**: the Radient `/v1/models` listing declares `auto` with no `context_length`, no `architecture`, and pricing quoted as an explicit `"0"`.

| Symptom | Mechanism |
|---|---|
| **128k context** | `radient_default_model_info` carried `context_window=-1`, which `build_model_spec` normalises to `UNKNOWN_CONTEXT_WINDOW`. **Not cosmetic** — the session derives its compaction threshold from that number, so a 1M router compacted at an eighth of its room. |
| **"Free"** | A stated `0`/`0` is read as a genuine vendor zero (`discovery._stated_zero_price`) and renders the literal word. On a meta-route that is a promise the user would act on. |
| **"does not accept images"** | `supports_images=False` is a **positive statement of incapacity** in the three-state scheme, not an "unknown", so the session stripped images and announced it — false for every model the router selects. |

A sibling change fixes the Radient server to quote `context_length: 1048576`, `input_modalities: [text, image, …]` and `pricing: {"-1", "-1"}`. **This PR makes lop correct both when that lands and right now**, for users whose cached listing is still the old shape.

## The router gets its own registry row

`aggregator_router_model_info` is deliberately **separate** from the per-provider aggregator templates rather than an edit to them. Those answer *"a model this aggregator serves that we know nothing else about"*, and for that question `-1` remains the honest answer: an arbitrary unlisted model could have any window, and handing it the router's 1M would **suppress compaction on a small model** until the provider rejected the turn. The router is the opposite case — one known endpoint whose product is dispatching to a frontier model.

The unit suite caught exactly this over-reach on the first attempt (`test_configure_model_never_fails_on_a_bad_listing`), which is why the two rows are split.

`max_tokens` stays `-1` on purpose: unlike the window it has no honest router-wide floor (the output cap is the *selected* model's and varies by an order of magnitude), and the 8,192 fallback merely truncates a long answer where a wrong window silently mis-compacts an entire conversation.

## "Usage-based" is a fourth state, not a fourth reading of the floats

`format_price_pair`'s three-way scheme — priced / stated-free / unknown — is deliberate and heavily documented, and `providers.controller._price` is the single place that decides it. A router can only reach the renderer as the `-1` unknown sentinel, which is **already spoken for** by "nobody quoted this" (a genuinely different answer that must keep rendering blank). Encoding a fourth meaning in the floats would mean inventing a `-2.0` sentinel and teaching every reader about it — precisely the "smuggle a new meaning into an existing channel" move those docstrings warn against.

So the fact is decided **once, by the parser that read the wire**, and travels, following the existing `free` flag as the template:

```
DiscoveredModel.routed  ->  CatalogueEntry.routed  ->  ModelRow.routed  ->  format_price_pair(routed=…)
```

`CatalogueEntry` is where `free` is deliberately *consumed* and goes no further; the code comment explains why `routed` genuinely must travel further (the float vocabulary is full) rather than repeating that pattern by rote.

**Both listing shapes converge on one label.** The `-1`/`-1` meta-route sentinel is the principled signal and works for any future router. Radient's current `0`/`0` has *no* price signal to read — a symmetric quoted zero is indistinguishable from a genuinely free route — so a two-id set (`auto`, `openrouter/auto`) covers it, in the parser that already knows which aggregator's wire it is reading rather than by pattern-matching an id in the renderer. It expires on its own once the server quotes `-1`.

**Capture stamp bumped to 6** for the two aggregators. `routed` is stored computed, so a version-5 document would keep rendering `free` until its TTL rolled and the fix would ship invisible for up to a day.

## Testing evidence

### Resolved values, before vs after (real execution)

Run through the real `resolve_model_info` / `build_model_spec`. The "before" column is a **separate worktree checked out at `origin/main`**, verified to be genuinely main's code (`context_window=-1`, `supports_images=False`) rather than asserted:

| | before (`origin/main`) | after |
|---|---|---|
| `resolve_model_info('radient','auto')` ctx | `-1` | `1048576` |
| `build_model_spec` `context_window` | **`128000`** | **`1048576`** |
| `build_model_spec` `supports_images` | **`False`** | **`True`** |
| session strips images / warns | **yes** | **no** |
| `format_window(spec.context_window)` | `'128k'` | `'1m'` |

### All four price states, driven through the real parse → price → render path

Each row is a literal `/v1/models` entry through `_row_from_openai_entry` → `controller._price` → `format_price_pair`:

```
case                                        free  routed     in    out  rendered
--------------------------------------------------------------------------------
radient auto, CACHED server shape (0/0)    False    True   -1.0   -1.0  'usage-based'
radient auto, FIXED server shape (-1/-1)   False    True   -1.0   -1.0  'usage-based'
openrouter/auto (-1/-1)                    False    True   -1.0   -1.0  'usage-based'
genuinely free route (0/0)                  True   False    0.0    0.0  'free'
priced model                               False   False   15.0   75.0  '$15/75'
unpriced/silent listing                    False   False   -1.0   -1.0  ''
per-song billed (lyria)                    False   False   -1.0   -1.0  ''
```

Both Radient shapes converge on one label, and **every pre-existing state is unregressed** — including the two the codebase specifically warns about (a genuinely free route keeps its word, a per-song-billed lyria row stays blank).

### The router's numbers do not leak onto other ids

```
ROUTER ids:                radient/auto           ctx=1048576  imgs=True
                           openrouter/auto        ctx=1048576  imgs=True
ARBITRARY unlisted ids:    radient/vendor/unknown ctx=-1       imgs=False
                           openrouter/vendor/asked-for ctx=-1  imgs=False
```

### Visual validation

Real `OperatorApp` driven with `run_test` (the host that loads `local_operator.tcss` — the lightweight widget hosts do not), frame exported with `save_screenshot` and rendered. The `radient/auto` rows are built by running the **real pipeline over a fixed listing payload**, so the only thing that differs between the frames is the code under test. Both listing shapes are shown as separate rows, plus a priced row and a genuinely free route so the states stay distinguishable.

**Before** — `128k  free` on the cached shape, and a blank price on the fixed shape:

![before](https://gist.githubusercontent.com/damianvtran/416c23cc589280393e545980cfc12118/raw/3b6ed55fe01ccdccc2f5b59009b439c38b213ad2/radient-auto-before.png)

**After** — both read `1m  usage-based`, while `free` and `$15/75` are untouched:

![after](https://gist.githubusercontent.com/damianvtran/416c23cc589280393e545980cfc12118/raw/3b6ed55fe01ccdccc2f5b59009b439c38b213ad2/radient-auto-after.png)

**Narrow layout (60 cols)** — `usage-based` is materially longer than `free` and this column is width-constrained, so the tight case is shown rather than assumed. No overflow, ids intact, right edge holds:

![narrow](https://gist.githubusercontent.com/damianvtran/416c23cc589280393e545980cfc12118/raw/3b6ed55fe01ccdccc2f5b59009b439c38b213ad2/radient-auto-after-narrow.png)

### Geometry behind the frame

Pixels show the symptom; the widget's own numbers show the cause:

```
picker content width      = 73
picker.styles.height      = 5   (pinned, rows=5)
screen.size               = Size(width=98, height=28)
screen.virtual_size       = Size(width=98, height=28)   <- equal, so nothing made the screen scrollable
vertical scrollbar shown  = False                       <- no silent two-cell width loss

row                                   painted  == width?  numbers-run
radient/auto                              73     True     '1m  usage-based'
radient/auto                              73     True     '1m  usage-based'
anthropic/claude-opus-5                   73     True     '200k  $15/75'
openrouter/google/gemma-4-31b-it:free     73     True     '131k  free'
openai/gpt-5.4                            73     True     '400k  $1.25/10'
```

Every row is **exactly** the content width at 56/60/73/100 cells (pinned by a new test). The label costs 11 cells against `free`'s 4, which comes out of the id budget and truncates a *long* aggregator id ~7 characters earlier; `radient/auto` is unaffected at every width, and below 56 the whole numbers run is already dropped. The shorter spellings that fit in 4–6 cells (`usage`, `routed`, `varies`) each answer a different question than the one a user reading a price column is asking, so the extra cells are deliberate.

### Other consumers

The helper has exactly **two** production call sites — the picker and the settings suggestion detail. There is no status-band price surface; the band's cost segment shows accrued spend, not a per-token rate. Both checked:

```
settings_view._suggestion_detail:
  router    -> 'radient · usage-based'
  free      -> 'openrouter · free'
  priced    -> 'anthropic · $15/75'
  unpriced  -> 'x'
```

The third call site, `scripts/capture_repair_probe.py`, is a diagnostic rather than a surface; it was stale and is fixed in round 1 (R4). The status band's context-window segment reads the same `ModelSpec` verified above and follows automatically.

### Gates

`flake8`, `black --check` (26.1.0), `isort --check`, `pyright` — all clean over the whole tree. Unit suite: **11,999 passed, 15 skipped**.

Rebased onto current `main` (`0.45.2`) after it moved during this work; the version bump is therefore **`0.45.3`**, a patch per AGENTS.md (a bug fix, not a step-function capability). All gates and the evidence above were re-run against the rebased tree.

## Round 1 remediation

R1-R5, D1 and Q1 are answered in `eed4ebfe`; see the remediation comments on this PR. The material change is that the router-**id** fallback is now gated on `provider in AGGREGATOR_PROVIDERS` — it previously reached all 16 `openai-compat` providers, so an Ollama model a user named `auto` rendered `usage-based` instead of its genuine `free`. The **price** leg (`-1`) stays ungated, being self-describing wherever it appears. No visual surface changed, so the frames above remain current.

## Not addressed (deferred)

- `tests/unit/model/test_prices.py::test_a_background_revalidation_gets_the_full_default_timeout` — **deferred — pre-existing ordering flake, not caused by this change.** Verified by running the same whole-file invocation against a pristine `origin/main` worktree, where it fails identically; it passes in this branch. Out of scope here.
- `scripts/model_picker_shot.py` is added as a reusable picker capture script, matching the four existing `*_shot.py` scripts AGENTS.md documents.
