### PR TITLE
fix(providers): recover a turn an aggregator killed with a relayed upstream 404

### DIFF
--- a/local_operator/incidents.py
+++ b/local_operator/incidents.py
@@ -51,37 +51,48 @@ SESSION_CREDENTIAL_MESSAGE_TYPE = "session_credential"
 #: replays the switch history too.
 SESSION_MODEL_SWITCH_MESSAGE_TYPE = "session_model_switch"
 
+#: Provider wordings that mean "this request does not fit", in every phrasing
+#: the vendors actually use (anthropic's "prompt is too long", google's token
+#: counts, the openai family's "maximum context length").
+#:
+#: Exported rather than inlined into :data:`_RULES` because the provider layer
+#: needs the same judgement: ``clients._relayed_upstream_failure`` has to know
+#: that a RELAYED overflow complaint is deterministic — the request is too big
+#: and will stay too big — so it must not be retried as upstream weather. Two
+#: independently-maintained lists in one repo would silently drift into
+#: disagreeing about what an overflow looks like, and the failure mode of that
+#: drift (a turn retried for ~35s against a defect no wait can fix) is exactly
+#: what this list exists to prevent.
+CONTEXT_LENGTH_MARKERS: tuple[str, ...] = (
+    "context length",
+    "context window",
+    "maximum context",
+    "too long for the model",
+    "prompt is too long",
+    "request too large",
+    "request was too large",
+    "input too large",
+    "input was too large",
+    # The SIZE-of-body wordings, which none of the above matched.
+    # "Request exceeds the maximum size" is Anthropic's literal 413
+    # text, and a session that hit it was classified ``unknown`` with
+    # an empty hint — so the model was told nothing actionable and
+    # retried the identical 34 MB request, forever. The rest cover the
+    # proxy edge and the provider's own error code.
+    #
+    # Matched on wording, NOT on a bare "413": that substring occurs
+    # in ordinary token and byte counts ("used 413000 tokens" already
+    # classifies correctly as rate-limit) and would misfire.
+    "exceeds the maximum size",
+    "request_too_large",
+    "request entity too large",
+    "payload too large",
+)
+
 #: Ordered (category, patterns) rules. First category whose pattern matches
 #: (case-insensitive) wins; order is specificity, not severity.
 _RULES: list[tuple[str, tuple[str, ...]]] = [
-    (
-        "context-length",
-        (
-            "context length",
-            "context window",
-            "maximum context",
-            "too long for the model",
-            "prompt is too long",
-            "request too large",
-            "request was too large",
-            "input too large",
-            "input was too large",
-            # The SIZE-of-body wordings, which none of the above matched.
-            # "Request exceeds the maximum size" is Anthropic's literal 413
-            # text, and a session that hit it was classified ``unknown`` with
-            # an empty hint — so the model was told nothing actionable and
-            # retried the identical 34 MB request, forever. The rest cover the
-            # proxy edge and the provider's own error code.
-            #
-            # Matched on wording, NOT on a bare "413": that substring occurs
-            # in ordinary token and byte counts ("used 413000 tokens" already
-            # classifies correctly as rate-limit) and would misfire.
-            "exceeds the maximum size",
-            "request_too_large",
-            "request entity too large",
-            "payload too large",
-        ),
-    ),
+    ("context-length", CONTEXT_LENGTH_MARKERS),
     (
         "rate-limit",
         (

--- a/local_operator/incidents.py
+++ b/local_operator/incidents.py
@@ -90,11 +90,22 @@ CONTEXT_LENGTH_MARKERS: tuple[str, ...] = (
     # Vendors that describe the same overflow by COUNTING tokens rather than by
     # naming the context. Added after an audit found the list recognised 6 of
     # 10 real vendor wordings: google/vertex ("input token count ... exceeds"),
-    # mistral ("too many tokens"), and bedrock ("input is too long") all fell
-    # through, which for the provider layer meant a deterministic overflow was
-    # retried as though it were upstream weather.
-    "token count",
-    "too many tokens",
+    # mistral ("too many tokens in prompt"), and bedrock ("input is too long")
+    # all fell through, which for the provider layer meant a deterministic
+    # overflow was retried as though it were upstream weather.
+    #
+    # Qualified rather than bare, because this list is the FIRST rule in
+    # `_RULES` and therefore outranks "rate-limit". A bare "token count"
+    # swallows a TPM message that happens to quote one ("Limit 90000 token
+    # count per min"), and a bare "too many tokens" is verbatim AWS Bedrock's
+    # ThrottlingException -- both are rate limits, and miscategorising them
+    # tells the user to /compact a request whose only problem is that it
+    # arrived too soon. The qualifiers name the INPUT, which a throttle never
+    # does.
+    "input token count",
+    "prompt token count",
+    "too many tokens in prompt",
+    "too many input tokens",
     "input is too long",
 )
 

--- a/local_operator/incidents.py
+++ b/local_operator/incidents.py
@@ -87,6 +87,15 @@ CONTEXT_LENGTH_MARKERS: tuple[str, ...] = (
     "request_too_large",
     "request entity too large",
     "payload too large",
+    # Vendors that describe the same overflow by COUNTING tokens rather than by
+    # naming the context. Added after an audit found the list recognised 6 of
+    # 10 real vendor wordings: google/vertex ("input token count ... exceeds"),
+    # mistral ("too many tokens"), and bedrock ("input is too long") all fell
+    # through, which for the provider layer meant a deterministic overflow was
+    # retried as though it were upstream weather.
+    "token count",
+    "too many tokens",
+    "input is too long",
 )
 
 #: Ordered (category, patterns) rules. First category whose pattern matches

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -428,6 +428,19 @@ _OPAQUE_AGGREGATOR_MESSAGE = "provider returned error"
 #: what made the previous attempt fragile: new provider, new dialect, same bug.
 _RELAYED_UPSTREAM_STATUSES = frozenset({404})
 
+#: Statuses this predicate may reclassify AT ALL, whatever the body says.
+#:
+#: Everything outside it keeps the meaning its status already carries, because
+#: those statuses are about the CALLER rather than about a request: 401/403 are
+#: the credential (recovered by rotation), 402 is billing, 429 is quota (a wait
+#: the driver already honours). Marking any of them retryable sends the request
+#: back down the same-credential ladder ahead of the recovery that would
+#: actually work.
+#:
+#: 5xx is excluded for the opposite reason: it is already transient, so passing
+#: it through here would change nothing while widening the blast radius.
+_RELAY_ELIGIBLE_STATUSES = frozenset({400, 404})
+
 #: Raw bodies short enough to prove nobody tried to say anything. Retained from
 #: the ORIGINAL opaque-aggregator fix (session e13d092c093c): a relayed 400
 #: whose ``metadata.raw`` is a bare sentinel carries no diagnostics at all, so
@@ -506,56 +519,55 @@ def _strip_quote_pair(text: str) -> str:
 
 
 def _relayed_upstream_failure(status: int | None, error: Mapping[str, Any]) -> bool:
-    """Is this 4xx an UPSTREAM failure the aggregator merely relayed?
+    """Is this failure an UPSTREAM blip the aggregator merely relayed?
 
     OpenRouter forwards an origin provider's failure as ``{"message":
-    "Provider returned error", "metadata": {"raw": ...}}``. The presence of
-    that envelope is the load-bearing signal: the aggregator's OWN refusals
-    (an unknown model slug, a routing preference it cannot satisfy) are flat
-    bodies that name the problem and carry no ``metadata.raw`` at all. So a
-    wrapped 4xx describes something that happened at the ORIGIN, on the far
-    side of a network hop the caller cannot see or influence.
+    "Provider returned error", "metadata": {"raw": ...}}``. That envelope is
+    the entry condition: the aggregator's OWN refusals (an unknown model slug,
+    a routing preference it cannot satisfy) are flat bodies that name the
+    problem and carry no ``metadata.raw``, so they never reach this predicate.
 
-    Two shapes take this path, for the same reason — the status line is the
-    aggregator's relay choice rather than evidence our request was wrong:
+    The envelope establishes PROVENANCE only. It says the failure happened at
+    the origin; it says nothing about whether a retry could help, and an early
+    draft that stopped there retried malformed requests 12 times over ~35s for
+    defects no wait can fix. Three gates narrow it, in this order:
 
-    - ``raw`` is a bare sentinel (observed: ``"ERROR"``, provider "Stealth"),
-      so the body says nothing a caller could act on.
-    - ``raw`` holds real upstream prose that nevertheless describes the
-      PROVIDER's state rather than our bytes. Session 2be018a98088 recorded
-      ``"The requested model was not found."`` relayed under a 404 from Meta
-      for ``meta/muse-spark-1.3`` — twice in 75 seconds, with six successful
-      calls on the identical model id in between, on a model whose single
-      endpoint reported 99.98% uptime. Read literally the text looks like an
-      answer, which is why the old wording-only predicate missed it; but a
-      model id that works either side of the failure cannot be the cause, and
-      classifying it ``request`` killed the turn with no retry and no
-      failover.
+    1. **Status eligibility** (:data:`_RELAY_ELIGIBLE_STATUSES`). Only 400 and
+       404 may be reclassified at all. 401/403/402/429 describe the CALLER's
+       standing and each has its own recovery -- rotation, a bill, a wait --
+       which marking them retryable would push behind a pointless retry ladder.
+    2. **A body that says NOTHING** (:data:`_OPAQUE_RAW_SENTINELS`) is weather
+       on either eligible status, 400 included. This is the original
+       opaque-aggregator fix (session e13d092c093c): a bare ``"ERROR"`` from a
+       provider named "Stealth", arriving intermittently on a request that
+       answered 200 seconds later. A body with no diagnostics cannot be a
+       complaint about our request.
+    3. **A body that says something real** is weather only on a **404**. Every
+       relayed complaint about our request observed across six model families
+       is a **400**, in every vendor dialect, because "the request was bad" is
+       what 400 MEANS -- an origin reaching for 404 is describing a resource on
+       its own side. An intermediate draft tried to narrow by the OpenAI-dialect
+       ``param`` field instead and was blind to anthropic, google and cohere,
+       which do not send it; the status line is the only part of the contract
+       every provider agrees on.
 
-    The envelope alone is NOT enough, and an earlier draft of this function
-    that stopped there was wrong. ``metadata.raw`` establishes provenance —
-    the failure happened at the origin — but says nothing about whether a
-    retry could help: live probes showed malformed requests arriving fully
-    wrapped, and treating the envelope as sufficient retried each of them 12
-    times over ~35s for a defect no wait can fix.
+    The failure this exists for, on the 404 path: session 2be018a98088 recorded
+    ``"The requested model was not found."`` relayed under a 404 from Meta for
+    ``meta/muse-spark-1.3`` -- twice in 75 seconds, with six successful calls on
+    the identical model id in between, on a model whose single endpoint reported
+    99.98% uptime. Read literally the text looks like an answer, which is why a
+    wording-only predicate missed it; but a model id that works either side of
+    the failure cannot be the cause, and classifying it ``request`` killed the
+    turn with no retry and no failover.
 
-    The narrowing that works is the STATUS, per
-    :data:`_RELAYED_UPSTREAM_STATUSES`: only a relayed **404** is treated as
-    weather. Every relayed complaint about our request observed across six
-    model families is a **400**, in every vendor dialect, so excluding 400
-    fails those fast without parsing anyone's error schema. A second draft
-    tried to narrow by the OpenAI-dialect ``param`` field instead and was blind
-    to anthropic, google and cohere, which do not send it — the status line is
-    the only part of the contract every provider agrees on.
+    Two carve-outs then guard the 404 path itself, both meaning "this describes
+    our bytes, not the provider's state":
 
-    Two further carve-outs then guard the 404 path itself, both meaning "this
-    describes our bytes, not the provider's state":
-
-    - :data:`_UPSTREAM_REQUEST_FIELD_KEY` — a 404 that nevertheless names the
+    - :data:`_UPSTREAM_REQUEST_FIELD_KEY` -- a 404 that nevertheless names the
       offending field of our request is believed on the more specific evidence.
-    - :data:`~local_operator.incidents.CONTEXT_LENGTH_MARKERS` — an overflow
-      complaint is deterministic however it is delivered, and the canonical
-      list is shared with the harness so the two cannot drift.
+    - :data:`~local_operator.incidents.CONTEXT_LENGTH_MARKERS` -- an overflow is
+      deterministic however it is delivered, and the canonical list is shared
+      with the harness so the two cannot drift.
 
     Two deliberate widenings remain, both toward "treat no-information as
     transient":
@@ -563,15 +575,13 @@ def _relayed_upstream_failure(status: int | None, error: Mapping[str, Any]) -> b
     - The outer message is matched after trimming and case-folding, so
       ``"Provider returned error "`` matches too. The casing and padding on the
       wire are the aggregator's formatting, not part of the signal.
-    - A body whose ``raw`` is a bare sentinel (observed: ``"ERROR"``, provider
-      "Stealth") carries no ``param`` and no overflow wording, so it lands here
-      naturally rather than needing a rule of its own. This is the case most
-      likely to shadow a real upstream error whose message happens to be one
-      word; the cost of that collision is bounded retries, and the cost of the
-      opposite mistake is a dead turn.
+    - The sentinel rule (gate 2) may shadow a real upstream error whose message
+      happens to be the single word "error". The cost of that collision is
+      bounded retries; the cost of the opposite mistake is a dead turn, so the
+      tie is broken toward retrying.
 
     The price is latency, not correctness, and it is not small: a genuinely
-    broken request that gets past both carve-outs saturates the driver's
+    broken request that gets past every gate saturates the driver's
     server-fault budget (12 requests per target) before surfacing. MEASURED at
     the production defaults (``maxRetries`` 10, 500ms base, 8s cap): **33.5s on
     a single target and 100.1s across a 3-target chain**, at 12 requests per
@@ -583,7 +593,7 @@ def _relayed_upstream_failure(status: int | None, error: Mapping[str, Any]) -> b
     accepted trade-off, and an unverified number in it is the same defect it
     criticises an earlier draft for.
 
-    That is the accepted trade: a shape that survives both carve-outs is by
+    That is the accepted trade: a shape that survives every gate is by
     construction unattributable, so the alternative is killing a turn that
     rotation or a fallback could have served.
     """
@@ -596,11 +606,20 @@ def _relayed_upstream_failure(status: int | None, error: Mapping[str, Any]) -> b
         # evidence of an upstream hop at all, so the body keeps whatever its
         # status already meant. It is necessary but NOT sufficient.
         return False
+    if status is not None and status not in _RELAY_ELIGIBLE_STATUSES:
+        # Auth (401/403), payment (402) and quota (429) describe the CALLER's
+        # standing with the provider, not the health of a request, and each has
+        # its own recovery -- rotation, a bill, a wait. This gate must come
+        # BEFORE the sentinel check: an earlier draft short-circuited a bare
+        # sentinel to `retryable` on any status, which bought a 401 ten
+        # same-credential retries (~51s) before rotation was even reached,
+        # because the driver's retry ladder returns early on `not retryable`.
+        return False
     text = _strip_quote_pair(_openrouter_upstream_text(error).strip()).lower()
     if text in _OPAQUE_RAW_SENTINELS:
-        # Says NOTHING. Whatever the status, a body with no diagnostics cannot
-        # be a complaint about our request, so it is weather on any status --
-        # which is what the original opaque-aggregator fix established.
+        # Says NOTHING. A body with no diagnostics at all cannot be a complaint
+        # about our request, so it is weather even on a 400 -- which is what the
+        # original opaque-aggregator fix established and what this preserves.
         return True
     if status is not None and status not in _RELAYED_UPSTREAM_STATUSES:
         # It said something real. Only a relayed 404 is weather; a relayed 400

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -245,7 +245,9 @@ def _extract_error_message(response: httpx.Response, payload: Any = _UNSET) -> s
     if isinstance(payload, Mapping):
         error = payload.get("error")
         if isinstance(error, Mapping):
-            message = _first_text(error.get("message"), error.get("detail"), error.get("msg"))
+            message = _attributed_relay_message(
+                _first_text(error.get("message"), error.get("detail"), error.get("msg")), error
+            )
             upstream = _openrouter_upstream_text(error)
             if message and upstream and upstream not in message:
                 return _capped(f"{message}: {upstream}")
@@ -261,6 +263,31 @@ def _extract_error_message(response: httpx.Response, payload: Any = _UNSET) -> s
 
 def _capped(text: str) -> str:
     return text.strip()[:MAX_ERROR_MESSAGE_CHARS].strip()
+
+
+def _attributed_relay_message(message: str, error: Mapping[str, Any]) -> str:
+    """Name the ORIGIN provider in an aggregator's generic relay message.
+
+    "Provider returned error" is the least useful sentence in any frame: it
+    says a provider failed without saying WHICH, and the reader is already
+    looking at an aggregator, so "provider" is ambiguous between the gateway
+    and the model host. ``metadata.provider_name`` carries the answer, so the
+    frame reads ``Meta returned error: ...`` instead — which is the difference
+    between a user suspecting their own model id and knowing the upstream host
+    is unwell.
+
+    Only the exact generic phrase is rewritten. A relay message that already
+    says something specific is left alone, and a body with no
+    ``provider_name`` keeps the original wording rather than inventing an
+    attribution the wire did not supply.
+    """
+    if message.strip().lower() != _OPAQUE_AGGREGATOR_MESSAGE:
+        return message
+    metadata = error.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return message
+    provider = _first_text(metadata.get("provider_name"))
+    return f"{provider} returned error" if provider else message
 
 
 def _openrouter_upstream_text(error: Mapping[str, Any]) -> str:
@@ -302,6 +329,43 @@ _OPAQUE_AGGREGATOR_MESSAGE = "provider returned error"
 #: upstream body — "context length exceeded", a JSON error object — is
 #: actionable and must keep its ``request`` classification.
 _OPAQUE_RAW_SENTINELS = frozenset({"error"})
+
+#: Statuses an aggregator will RELAY from an origin provider that are otherwise
+#: read as "the request itself was refused". 401/403 stay out: those describe
+#: the caller's credential at the aggregator and must keep reaching credential
+#: rotation rather than being retried as weather. 429 is already quota and 5xx
+#: is already transient, so neither needs this path.
+#:
+#: 404 is the member that matters and the reason this set exists. OpenRouter
+#: answers a model id it does not know with a FLAT 400 that names the slug
+#: ("meta/muse-spark-9.9 is not a valid model ID"), and a routing refusal it
+#: decided itself with a FLAT 404 whose message names the routing preference
+#: ("No allowed providers are available for the selected model...") — both are
+#: the aggregator's own words, and neither carries ``metadata.raw``. Verified
+#: against the live API on 2026-09-04. A 404 that arrives WRAPPED in the relay
+#: envelope is therefore never "the client asked for a model that does not
+#: exist": it is the ORIGIN provider's own 404 forwarded verbatim, which for a
+#: single-endpoint model is a transient failure to resolve its own snapshot.
+_RELAYED_UPSTREAM_STATUSES = frozenset({400, 404})
+
+#: Upstream wordings that stay ``request`` even when relayed, because they
+#: describe the BYTES we sent: they will fail identically on a retry and on
+#: every fallback target, so retrying them buys minutes of backoff and the
+#: same answer. Deliberately NARROW and matched as phrases rather than single
+#: words — a loose marker ("invalid", "error") would drag genuine upstream
+#: weather back into ``request`` and re-create the dead turn this predicate
+#: exists to prevent. When a wording is ambiguous the tie is broken toward
+#: transient, because the cost of that mistake is bounded retries while the
+#: cost of the opposite is a killed turn.
+_DETERMINISTIC_UPSTREAM_MARKERS = (
+    "context length",
+    "context_length",
+    "maximum context",
+    "too many tokens",
+    "is not a valid model",
+    "max_tokens",
+    "max_output_tokens",
+)
 
 #: How many matched quote pairs :func:`_strip_quote_pair` will peel. Real
 #: bodies use at most one or two layers; the cap exists so a body made of
@@ -348,17 +412,37 @@ def _strip_quote_pair(text: str) -> str:
     return text
 
 
-def _is_opaque_aggregator_400(error: Mapping[str, Any]) -> bool:
-    """An aggregator 400 carrying NO actionable upstream diagnostics.
+def _relayed_upstream_failure(status: int | None, error: Mapping[str, Any]) -> bool:
+    """Is this 4xx an UPSTREAM failure the aggregator merely relayed?
 
-    OpenRouter forwards an upstream failure as ``{"message": "Provider
-    returned error", "metadata": {"raw": ...}}``. When ``raw`` holds real
-    diagnostics the composed message names the actual problem and the 400 is
-    an answer — kind ``request``, no retry. When ``raw`` is a bare sentinel
-    (observed: ``"ERROR"``, from a provider named "Stealth"), the body says
-    nothing a caller could fix, and the status line is the aggregator's relay
-    choice rather than evidence the request was wrong. Those are classified
-    transient so the failover cascade runs.
+    OpenRouter forwards an origin provider's failure as ``{"message":
+    "Provider returned error", "metadata": {"raw": ...}}``. The presence of
+    that envelope is the load-bearing signal: the aggregator's OWN refusals
+    (an unknown model slug, a routing preference it cannot satisfy) are flat
+    bodies that name the problem and carry no ``metadata.raw`` at all. So a
+    wrapped 4xx describes something that happened at the ORIGIN, on the far
+    side of a network hop the caller cannot see or influence.
+
+    Two shapes take this path, for the same reason — the status line is the
+    aggregator's relay choice rather than evidence our request was wrong:
+
+    - ``raw`` is a bare sentinel (observed: ``"ERROR"``, provider "Stealth"),
+      so the body says nothing a caller could act on.
+    - ``raw`` holds real upstream prose that nevertheless describes the
+      PROVIDER's state rather than our bytes. Session 2be018a98088 recorded
+      ``"The requested model was not found."`` relayed under a 404 from Meta
+      for ``meta/muse-spark-1.3`` — twice in 75 seconds, with six successful
+      calls on the identical model id in between, on a model whose single
+      endpoint reported 99.98% uptime. Read literally the text looks like an
+      answer, which is why the old wording-only predicate missed it; but a
+      model id that works either side of the failure cannot be the cause, and
+      classifying it ``request`` killed the turn with no retry and no
+      failover.
+
+    :data:`_DETERMINISTIC_UPSTREAM_MARKERS` carves back out the relayed
+    wordings that genuinely describe our bytes (context length, a malformed
+    parameter): those fail identically on every retry and every fallback, so
+    they keep ``request`` and surface immediately.
 
     Two deliberate widenings, both toward "treat no-information as transient":
 
@@ -379,17 +463,33 @@ def _is_opaque_aggregator_400(error: Mapping[str, Any]) -> bool:
     per target) before surfacing. Measured against the default 500ms base delay
     and the 8s backoff cap, that is 64-76s of sleep on a single target and
     roughly 4-5 minutes across a 3-target fallback chain. A user hitting a
-    PERSISTENT aggregator 400 therefore waits minutes for a failure that
+    PERSISTENT relayed 4xx therefore waits minutes for a failure that
     previously surfaced immediately. That is the accepted trade: this shape is
     by construction unattributable, so the alternative is killing a turn that
     rotation or a fallback could have served — but it is a real cost, not the
     rounding error an earlier draft of this docstring implied.
+
+    The marker carve-out is what keeps that cost bounded to the cases that
+    deserve it: the failures a user can actually fix by changing the request
+    still fail fast, and only the ones no retry could have prevented pay for
+    the cascade.
     """
+    if status is not None and status not in _RELAYED_UPSTREAM_STATUSES:
+        return False
     message = _first_text(error.get("message"))
     if message.lower() != _OPAQUE_AGGREGATOR_MESSAGE:
         return False
+    metadata = error.get("metadata")
+    if not isinstance(metadata, Mapping) or not _first_text(metadata.get("raw")):
+        # The relay envelope is the whole signal. "Provider returned error"
+        # with nothing wrapped inside it is not evidence of an upstream hop,
+        # so it keeps whatever its status already meant.
+        return False
     upstream = _openrouter_upstream_text(error)
-    return _strip_quote_pair(upstream.strip()).lower() in _OPAQUE_RAW_SENTINELS
+    stripped = _strip_quote_pair(upstream.strip()).lower()
+    if stripped in _OPAQUE_RAW_SENTINELS:
+        return True
+    return not any(marker in stripped for marker in _DETERMINISTIC_UPSTREAM_MARKERS)
 
 
 def _compat_stream_error(chunk: Mapping[str, Any]) -> ProviderError:
@@ -418,9 +518,11 @@ def _compat_stream_error(chunk: Mapping[str, Any]) -> ProviderError:
     error = chunk.get("error")
     status: int | None = None
     error_type = ""
-    opaque_aggregator_400 = False
+    relayed_upstream = False
     if isinstance(error, Mapping):
-        message = _first_text(error.get("message"), error.get("detail"), error.get("msg"))
+        message = _attributed_relay_message(
+            _first_text(error.get("message"), error.get("detail"), error.get("msg")), error
+        )
         upstream = _openrouter_upstream_text(error)
         if message and upstream and upstream not in message:
             message = f"{message}: {upstream}"
@@ -434,13 +536,13 @@ def _compat_stream_error(chunk: Mapping[str, Any]) -> ProviderError:
         metadata = error.get("metadata")
         if isinstance(metadata, Mapping):
             error_type = str(metadata.get("error_type") or "")
-        # The SAME opaque relay body arrives on this channel whenever the
-        # gateway had already committed HTTP 200 before the upstream failed, so
-        # it has to classify the same way here as in `raise_for_status` -- a
-        # turn must not die on the relay channel the aggregator happened to
-        # pick. Judged on the chunk's `code` rather than a status line, because
-        # in-band that is where the 400 lives.
-        opaque_aggregator_400 = status == 400 and _is_opaque_aggregator_400(error)
+        # The SAME relay body arrives on this channel whenever the gateway had
+        # already committed HTTP 200 before the upstream failed, so it has to
+        # classify the same way here as in `raise_for_status` -- a turn must
+        # not die on the relay channel the aggregator happened to pick. Judged
+        # on the chunk's `code` rather than a status line, because in-band that
+        # is where the status lives.
+        relayed_upstream = _relayed_upstream_failure(status, error)
     else:
         message = _first_text(error)
     if not message:
@@ -450,7 +552,7 @@ def _compat_stream_error(chunk: Mapping[str, Any]) -> ProviderError:
     return ProviderError(
         status,
         _capped(message),
-        retryable=(opaque_aggregator_400 or status is None or status == 429 or status >= 500),
+        retryable=(relayed_upstream or status is None or status == 429 or status >= 500),
         auth_error=status in (401, 403),
     )
 
@@ -563,12 +665,13 @@ def raise_for_status(response: httpx.Response) -> None:
     # 408/504 are the two "ran out of time" statuses; 429 and 5xx are the
     # classic retryables. Everything else in 4xx is an answer, not a blip.
     retryable = status == 429 or status >= 500 or status in (408, 504)
-    # ...except an aggregator 400 whose body carries no usable diagnostics:
-    # that is an upstream failure relayed under a 400, not a request the
-    # provider read and refused, so it must reach the failover cascade. See
-    # :func:`_is_opaque_aggregator_400` for the shape and the evidence.
+    # ...except a 4xx the aggregator RELAYED from an origin provider (the
+    # `metadata.raw` envelope). That is an upstream failure wearing a client
+    # status, not a request the provider read and refused, so it must reach
+    # the failover cascade. See :func:`_relayed_upstream_failure` for the
+    # shapes and the recorded evidence.
     error = payload.get("error") if isinstance(payload, Mapping) else None
-    if status == 400 and isinstance(error, Mapping) and _is_opaque_aggregator_400(error):
+    if isinstance(error, Mapping) and _relayed_upstream_failure(status, error):
         retryable = True
     raise ProviderError(
         status,

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -51,6 +51,7 @@ from local_operator.harness.types import (
     ToolCall,
     Usage,
 )
+from local_operator.incidents import CONTEXT_LENGTH_MARKERS
 from local_operator.providers.failover import ProviderError
 
 if TYPE_CHECKING:
@@ -210,6 +211,14 @@ def _usd_cost(raw_usage: Mapping[str, Any] | None) -> float | None:
 #: the transcript on it.
 MAX_ERROR_MESSAGE_CHARS = 500
 
+#: Longest ``metadata.provider_name`` that will be rendered into a frame as an
+#: attribution. Real names are short ("Meta", "OpenAI", "Azure", "Stealth");
+#: the ceiling exists because the value is provider-controlled text sharing a
+#: 500-char budget with the upstream diagnostics, and an attribution long
+#: enough to evict the actual error message would make the frame strictly less
+#: useful than the generic wording it replaced.
+_MAX_PROVIDER_NAME_CHARS = 60
+
 
 def _extract_error_message(response: httpx.Response, payload: Any = _UNSET) -> str:
     """The provider's OWN words about the failure, from whichever slot it used.
@@ -280,14 +289,25 @@ def _attributed_relay_message(message: str, error: Mapping[str, Any]) -> str:
     says something specific is left alone, and a body with no
     ``provider_name`` keeps the original wording rather than inventing an
     attribution the wire did not supply.
+
+    The value is provider-controlled text landing in a user-facing frame, so it
+    is bounded on two axes before use. Length: the composed message is capped
+    at :data:`MAX_ERROR_MESSAGE_CHARS`, so an absurdly long name would push the
+    upstream diagnostics — the part that says what actually went wrong — off
+    the end. Shape: a name carrying a newline would render as a forged second
+    line, so whitespace is collapsed. A name that is implausible after
+    normalisation is dropped rather than trusted; the original wording is
+    strictly better than a mangled attribution.
     """
     if message.strip().lower() != _OPAQUE_AGGREGATOR_MESSAGE:
         return message
     metadata = error.get("metadata")
     if not isinstance(metadata, Mapping):
         return message
-    provider = _first_text(metadata.get("provider_name"))
-    return f"{provider} returned error" if provider else message
+    provider = " ".join(_first_text(metadata.get("provider_name")).split())
+    if not provider or len(provider) > _MAX_PROVIDER_NAME_CHARS:
+        return message
+    return f"{provider} returned error"
 
 
 def _openrouter_upstream_text(error: Mapping[str, Any]) -> str:
@@ -315,6 +335,35 @@ def _openrouter_upstream_text(error: Mapping[str, Any]) -> str:
     return raw.strip()[:500]
 
 
+def _openrouter_upstream_error(error: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """The origin provider's STRUCTURED error object out of ``metadata.raw``.
+
+    :func:`_openrouter_upstream_text` returns only the human sentence, which is
+    all the message cascade needs. Classification needs the sibling fields too
+    — chiefly ``param``, the field name that proves the origin was complaining
+    about our request rather than about itself — so the same JSON is parsed
+    once more here into its object form.
+
+    Returns ``None`` whenever ``raw`` is absent, unparseable, or not an error
+    object, so every caller treats "no structured detail" as the absence of a
+    signal rather than as evidence either way.
+    """
+    metadata = error.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return None
+    raw = metadata.get("raw")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    try:
+        inner = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(inner, Mapping):
+        return None
+    nested = inner.get("error")
+    return nested if isinstance(nested, Mapping) else inner
+
+
 #: Aggregators answer an UPSTREAM provider failure with an HTTP 400 whose body
 #: names nothing: the outer message is exactly "Provider returned error" and
 #: ``metadata.raw`` holds a bare sentinel instead of the origin provider's
@@ -324,11 +373,6 @@ def _openrouter_upstream_text(error: Mapping[str, Any]) -> str:
 #: on the wire ("Provider returned error", raw "ERROR") is the aggregator's,
 #: not part of the signal.
 _OPAQUE_AGGREGATOR_MESSAGE = "provider returned error"
-
-#: Raw bodies short enough to prove nobody tried to say anything. A real
-#: upstream body — "context length exceeded", a JSON error object — is
-#: actionable and must keep its ``request`` classification.
-_OPAQUE_RAW_SENTINELS = frozenset({"error"})
 
 #: Statuses an aggregator will RELAY from an origin provider that are otherwise
 #: read as "the request itself was refused". 401/403 stay out: those describe
@@ -348,24 +392,29 @@ _OPAQUE_RAW_SENTINELS = frozenset({"error"})
 #: single-endpoint model is a transient failure to resolve its own snapshot.
 _RELAYED_UPSTREAM_STATUSES = frozenset({400, 404})
 
-#: Upstream wordings that stay ``request`` even when relayed, because they
-#: describe the BYTES we sent: they will fail identically on a retry and on
-#: every fallback target, so retrying them buys minutes of backoff and the
-#: same answer. Deliberately NARROW and matched as phrases rather than single
-#: words — a loose marker ("invalid", "error") would drag genuine upstream
-#: weather back into ``request`` and re-create the dead turn this predicate
-#: exists to prevent. When a wording is ambiguous the tie is broken toward
-#: transient, because the cost of that mistake is bounded retries while the
-#: cost of the opposite is a killed turn.
-_DETERMINISTIC_UPSTREAM_MARKERS = (
-    "context length",
-    "context_length",
-    "maximum context",
-    "too many tokens",
-    "is not a valid model",
-    "max_tokens",
-    "max_output_tokens",
-)
+#: The upstream field name that proves a relayed error is about OUR BYTES.
+#:
+#: This is the load-bearing discriminator, and it replaces an earlier attempt
+#: that keyed on the mere PRESENCE of the relay envelope. That attempt was
+#: wrong, and the way it was wrong is worth recording: the envelope is a
+#: PROVENANCE signal (this failure came from an origin provider) and says
+#: nothing about RETRYABILITY. Live probes on 2026-09-04 confirmed it —
+#: a malformed tool name and an invalid response_format schema both came back
+#: fully wrapped, ``provider_name`` "OpenAI"/"Azure", and would have been
+#: retried for ~35s across 12 requests apiece for a defect no wait can fix.
+#:
+#: What actually separates the two, measured across seven malformed-request
+#: shapes against the live API: an origin provider refusing our REQUEST names
+#: the offending field in ``param`` ("tools[0].function.name",
+#: "messages[0].role", "response_format"). The recorded incident
+#: ("The requested model was not found.", relayed under a 404 from Meta for a
+#: model id that worked six times in the surrounding 75 seconds) carries NO
+#: ``param`` — there is no field of ours to point at, because nothing about
+#: our request was the problem.
+#:
+#: ``type`` deliberately does NOT feature: all three bodies above are
+#: ``invalid_request_error``, so it cannot tell them apart.
+_UPSTREAM_REQUEST_FIELD_KEY = "param"
 
 #: How many matched quote pairs :func:`_strip_quote_pair` will peel. Real
 #: bodies use at most one or two layers; the cap exists so a body made of
@@ -377,16 +426,20 @@ _MAX_QUOTE_PEELS = 4
 def _strip_quote_pair(text: str) -> str:
     """Peel MATCHED surrounding quote pairs off ``text``.
 
-    ``str.strip('"\'')`` would take any leading/trailing run of either
-    character, so unbalanced junk like ``\'\'\'ERROR""`` would reduce to the
-    sentinel and be treated as no-information. That only ever widens the match,
-    but the widening should be a decision rather than an accident of the API —
-    so pairs are peeled one at a time and an unbalanced body keeps its quotes
-    and stays ``request``.
+    Its caller is the overflow-marker check in
+    :func:`_relayed_upstream_failure`: a quoted ``"context length exceeded"``
+    must match the same markers as the bare sentence, or a deterministic
+    overflow would be retried as weather purely because the aggregator quoted
+    it. Normalising the quoting is what makes that comparison honest.
+
+    ``str.strip('"\'')`` would take any leading/trailing RUN of either
+    character, silently reshaping unbalanced junk like ``\'\'\'ERROR""``. Pairs
+    are peeled one at a time instead, so what reaches the markers differs from
+    the wire only by quoting the wire actually applied.
 
     The peel LOOPS rather than running once to cover a value that arrives
-    already wrapped more than once — e.g. ``'"ERROR"'`` — which costs nothing
-    to absorb and keeps the predicate insensitive to how many layers of
+    already wrapped more than once — e.g. ``'"context length"'`` — which costs
+    nothing to absorb and keeps the check insensitive to how many layers of
     quoting an aggregator applied.
 
     A JSON-encoded ``raw`` whose inner value is itself a string (the
@@ -439,40 +492,53 @@ def _relayed_upstream_failure(status: int | None, error: Mapping[str, Any]) -> b
       classifying it ``request`` killed the turn with no retry and no
       failover.
 
-    :data:`_DETERMINISTIC_UPSTREAM_MARKERS` carves back out the relayed
-    wordings that genuinely describe our bytes (context length, a malformed
-    parameter): those fail identically on every retry and every fallback, so
-    they keep ``request`` and surface immediately.
+    The envelope alone is NOT enough, and an earlier draft of this function
+    that stopped there was wrong. ``metadata.raw`` establishes provenance —
+    the failure happened at the origin — but says nothing about whether a
+    retry could help. Live probes on 2026-09-04 settled it: a malformed tool
+    name and an invalid ``response_format`` schema both arrive fully wrapped,
+    and treating the envelope as sufficient retried each of them 12 times over
+    ~35s for a defect no wait can fix.
 
-    Two deliberate widenings, both toward "treat no-information as transient":
+    So provenance is narrowed by two carve-outs, both meaning "this describes
+    our bytes, not the provider's state":
+
+    - :data:`_UPSTREAM_REQUEST_FIELD_KEY` — the origin named the offending
+      field of our request in ``param``. Measured across seven malformed-request
+      shapes, every one names a field; the recorded incident names none.
+    - :data:`~local_operator.incidents.CONTEXT_LENGTH_MARKERS` — an overflow
+      complaint is deterministic even when ``param`` is absent, and the
+      canonical list is shared with the harness so the two cannot drift.
+
+    Two deliberate widenings remain, both toward "treat no-information as
+    transient":
 
     - The outer message is matched after trimming and case-folding, so
       ``"Provider returned error "`` matches too. The casing and padding on the
       wire are the aggregator's formatting, not part of the signal.
-    - :func:`_openrouter_upstream_text` unwraps a nested ``error`` object, so
-      ``{"error": {"message": "ERROR"}}`` resolves to the same bare sentinel and
-      also matches. A body that structurally tried to say something but whose
-      content is still the word "error" carries no more actionable information
-      than the flat sentinel. This is the case most likely to shadow a real
-      upstream error whose message happens to be that single word; the cost of
-      that collision is bounded retries, and the cost of the opposite mistake
-      is a dead turn.
+    - A body whose ``raw`` is a bare sentinel (observed: ``"ERROR"``, provider
+      "Stealth") carries no ``param`` and no overflow wording, so it lands here
+      naturally rather than needing a rule of its own. This is the case most
+      likely to shadow a real upstream error whose message happens to be one
+      word; the cost of that collision is bounded retries, and the cost of the
+      opposite mistake is a dead turn.
 
     The price is latency, not correctness, and it is not small: a genuinely
-    broken request now saturates the driver's server-fault budget (12 requests
-    per target) before surfacing. Measured against the default 500ms base delay
-    and the 8s backoff cap, that is 64-76s of sleep on a single target and
-    roughly 4-5 minutes across a 3-target fallback chain. A user hitting a
-    PERSISTENT relayed 4xx therefore waits minutes for a failure that
-    previously surfaced immediately. That is the accepted trade: this shape is
-    by construction unattributable, so the alternative is killing a turn that
-    rotation or a fallback could have served — but it is a real cost, not the
-    rounding error an earlier draft of this docstring implied.
+    broken request that gets past both carve-outs saturates the driver's
+    server-fault budget (12 requests per target) before surfacing. MEASURED at
+    the production defaults (``maxRetries`` 10, 500ms base, 8s cap): **33.5s on
+    a single target and 100.1s across a 3-target chain**, at 12 requests per
+    target and 36 across three. An earlier draft of this docstring estimated
+    64-76s and 4-5 minutes from the backoff ladder alone; the real figures are
+    roughly half that, because credential rotation resets the ladder and jitter
+    shaves ~12.5% more. The request counts were right and the wall-clock was
+    not — recorded precisely because this paragraph is the written record of an
+    accepted trade-off, and an unverified number in it is the same defect it
+    criticises an earlier draft for.
 
-    The marker carve-out is what keeps that cost bounded to the cases that
-    deserve it: the failures a user can actually fix by changing the request
-    still fail fast, and only the ones no retry could have prevented pay for
-    the cascade.
+    That is the accepted trade: a shape that survives both carve-outs is by
+    construction unattributable, so the alternative is killing a turn that
+    rotation or a fallback could have served.
     """
     if status is not None and status not in _RELAYED_UPSTREAM_STATUSES:
         return False
@@ -481,15 +547,25 @@ def _relayed_upstream_failure(status: int | None, error: Mapping[str, Any]) -> b
         return False
     metadata = error.get("metadata")
     if not isinstance(metadata, Mapping) or not _first_text(metadata.get("raw")):
-        # The relay envelope is the whole signal. "Provider returned error"
-        # with nothing wrapped inside it is not evidence of an upstream hop,
-        # so it keeps whatever its status already meant.
+        # The relay envelope establishes PROVENANCE: without it there is no
+        # evidence of an upstream hop at all, so the body keeps whatever its
+        # status already meant. It is necessary but NOT sufficient — see below.
         return False
-    upstream = _openrouter_upstream_text(error)
-    stripped = _strip_quote_pair(upstream.strip()).lower()
-    if stripped in _OPAQUE_RAW_SENTINELS:
-        return True
-    return not any(marker in stripped for marker in _DETERMINISTIC_UPSTREAM_MARKERS)
+    upstream = _openrouter_upstream_error(error)
+    if upstream is not None and _first_text(upstream.get(_UPSTREAM_REQUEST_FIELD_KEY)):
+        # The origin named a field of OUR request. That is a defect in the
+        # bytes we sent: it will fail identically on a retry and on every
+        # fallback target, so it stays `request` and surfaces immediately.
+        return False
+    text = _strip_quote_pair(_openrouter_upstream_text(error).strip()).lower()
+    if any(marker in text for marker in CONTEXT_LENGTH_MARKERS):
+        # An overflow complaint is deterministic in the same way even when the
+        # provider omits `param`: the request is too big and will stay too big.
+        # Sourced from the harness's canonical list so this file and
+        # `incidents.py` cannot drift into disagreeing about what an overflow
+        # looks like.
+        return False
+    return True
 
 
 def _compat_stream_error(chunk: Mapping[str, Any]) -> ProviderError:

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import httpx
 
+from local_operator.ansi import sanitize_prompt_line
 from local_operator.compaction.thresholds import (
     CompactionSettings,
     resolve_threshold_percent,
@@ -291,21 +292,43 @@ def _attributed_relay_message(message: str, error: Mapping[str, Any]) -> str:
     attribution the wire did not supply.
 
     The value is provider-controlled text landing in a user-facing frame, so it
-    is bounded on two axes before use. Length: the composed message is capped
-    at :data:`MAX_ERROR_MESSAGE_CHARS`, so an absurdly long name would push the
-    upstream diagnostics — the part that says what actually went wrong — off
-    the end. Shape: a name carrying a newline would render as a forged second
-    line, so whitespace is collapsed. A name that is implausible after
-    normalisation is dropped rather than trusted; the original wording is
-    strictly better than a mangled attribution.
+    is bounded on three axes before use.
+
+    Sanitised through :func:`~local_operator.ansi.sanitize_prompt_line`, the
+    primitive the approval prompts already use, rather than a second local
+    rule. It covers the three hazards this value carries, and an earlier draft
+    that hand-rolled only the third missed the first two:
+
+    - **Control sequences.** An unstripped name can carry ``ESC[2K`` to erase
+      the line already drawn or an OSC to rewrite the terminal title, so the
+      frame is not merely wrong but destructive — review demonstrated the
+      notice rendering as nothing but its ``!`` glyph. Collapsing whitespace
+      does not touch these, because ESC is not whitespace.
+    - **Bidi/format characters.** ``U+202E`` reverses the rendered order of
+      what follows, so an attribution can be made to read as something else
+      entirely while comparing equal to neither.
+    - **Whitespace**, so a name cannot forge a second line.
+
+    Length is then bounded separately by :data:`_MAX_PROVIDER_NAME_CHARS`: the
+    composed message shares :data:`MAX_ERROR_MESSAGE_CHARS` with the upstream
+    diagnostics, so an absurdly long attribution would push the part that says
+    what actually went wrong off the end.
+
+    A name that is empty or implausible afterwards is dropped rather than
+    trusted: the aggregator's original wording is strictly better than a
+    mangled attribution.
     """
     if message.strip().lower() != _OPAQUE_AGGREGATOR_MESSAGE:
         return message
     metadata = error.get("metadata")
     if not isinstance(metadata, Mapping):
         return message
-    provider = " ".join(_first_text(metadata.get("provider_name")).split())
-    if not provider or len(provider) > _MAX_PROVIDER_NAME_CHARS:
+    provider = sanitize_prompt_line(
+        _first_text(metadata.get("provider_name")), limit=_MAX_PROVIDER_NAME_CHARS
+    )
+    if not provider or len(provider) >= _MAX_PROVIDER_NAME_CHARS:
+        # At the limit the value was TRUNCATED, so it is not a name the wire
+        # actually sent; a half-name is a worse attribution than none.
         return message
     return f"{provider} returned error"
 
@@ -374,46 +397,63 @@ def _openrouter_upstream_error(error: Mapping[str, Any]) -> Mapping[str, Any] | 
 #: not part of the signal.
 _OPAQUE_AGGREGATOR_MESSAGE = "provider returned error"
 
-#: Statuses an aggregator will RELAY from an origin provider that are otherwise
-#: read as "the request itself was refused". 401/403 stay out: those describe
-#: the caller's credential at the aggregator and must keep reaching credential
-#: rotation rather than being retried as weather. 429 is already quota and 5xx
-#: is already transient, so neither needs this path.
+#: Statuses on which a relayed upstream failure is treated as WEATHER.
 #:
-#: 404 is the member that matters and the reason this set exists. OpenRouter
-#: answers a model id it does not know with a FLAT 400 that names the slug
-#: ("meta/muse-spark-9.9 is not a valid model ID"), and a routing refusal it
-#: decided itself with a FLAT 404 whose message names the routing preference
-#: ("No allowed providers are available for the selected model...") — both are
-#: the aggregator's own words, and neither carries ``metadata.raw``. Verified
-#: against the live API on 2026-09-04. A 404 that arrives WRAPPED in the relay
-#: envelope is therefore never "the client asked for a model that does not
-#: exist": it is the ORIGIN provider's own 404 forwarded verbatim, which for a
-#: single-endpoint model is a transient failure to resolve its own snapshot.
-_RELAYED_UPSTREAM_STATUSES = frozenset({400, 404})
+#: Deliberately just 404, and the exclusion of 400 is the load-bearing part.
+#:
+#: An earlier draft included 400 and narrowed it afterwards by looking for the
+#: OpenAI-dialect ``param`` field. That was dialect-blind: anthropic (via
+#: Vertex), google AI Studio and cohere all describe a malformed request
+#: WITHOUT a ``param`` key, so their refusals were still retried 12 times over
+#: ~35s for defects no wait can fix.
+#:
+#: Probing a deliberately malformed request across six model families on
+#: 2026-09-04 showed the status line already carries the signal, in every
+#: dialect, without parsing vendor-specific fields:
+#:
+#:   openai / anthropic / google / meta  -> HTTP 400 (relay envelope present)
+#:   cohere / mistral                    -> HTTP 404 (NO envelope; unroutable)
+#:
+#: Every relayed complaint about our REQUEST is a 400; not one is a 404. That
+#: is the contract a caller can rely on, because "the request was bad" is what
+#: 400 MEANS -- an origin provider reaching for 404 is saying something about a
+#: resource on ITS side, not about our bytes.
+#:
+#: So a relayed 400 keeps ``request`` and fails fast, and only a relayed 404 --
+#: the recorded incident's shape -- is retried. 401/403 stay out: those describe
+#: the caller's credential and must keep reaching credential rotation. 429 is
+#: already quota and 5xx already transient, so neither needs this path.
+#:
+#: This also removes the need to understand any vendor's error schema, which is
+#: what made the previous attempt fragile: new provider, new dialect, same bug.
+_RELAYED_UPSTREAM_STATUSES = frozenset({404})
 
-#: The upstream field name that proves a relayed error is about OUR BYTES.
+#: Raw bodies short enough to prove nobody tried to say anything. Retained from
+#: the ORIGINAL opaque-aggregator fix (session e13d092c093c): a relayed 400
+#: whose ``metadata.raw`` is a bare sentinel carries no diagnostics at all, so
+#: it cannot be a complaint about our request and stays weather. A relayed 400
+#: that says something real is a refusal and is NOT retried — that is the
+#: distinction the status set above cannot make on its own.
+_OPAQUE_RAW_SENTINELS = frozenset({"error"})
+
+#: An upstream field name that proves a relayed error is about OUR BYTES.
 #:
-#: This is the load-bearing discriminator, and it replaces an earlier attempt
-#: that keyed on the mere PRESENCE of the relay envelope. That attempt was
-#: wrong, and the way it was wrong is worth recording: the envelope is a
-#: PROVENANCE signal (this failure came from an origin provider) and says
-#: nothing about RETRYABILITY. Live probes on 2026-09-04 confirmed it —
-#: a malformed tool name and an invalid response_format schema both came back
-#: fully wrapped, ``provider_name`` "OpenAI"/"Azure", and would have been
-#: retried for ~35s across 12 requests apiece for a defect no wait can fix.
+#: Belt-and-braces rather than the primary signal. The status set above does
+#: the real work: a relayed 400 is already kept as ``request``, and every
+#: malformed-request shape observed in the wild is a 400. This key covers the
+#: hypothetical origin that reaches for 404 while still pointing at a field of
+#: our request -- a body that contradicts itself, where the field name is the
+#: more specific evidence and is therefore believed.
 #:
-#: What actually separates the two, measured across seven malformed-request
-#: shapes against the live API: an origin provider refusing our REQUEST names
-#: the offending field in ``param`` ("tools[0].function.name",
-#: "messages[0].role", "response_format"). The recorded incident
-#: ("The requested model was not found.", relayed under a 404 from Meta for a
-#: model id that worked six times in the surrounding 75 seconds) carries NO
-#: ``param`` — there is no field of ours to point at, because nothing about
-#: our request was the problem.
+#: It is deliberately NOT relied on alone. ``param`` is an OpenAI-dialect
+#: field: anthropic (via Vertex), google AI Studio and cohere describe a
+#: malformed request without it, so a predicate resting on this key is blind to
+#: exactly the providers this harness uses most. That was a real defect, caught
+#: in review, and the comment stays as the reason nobody should promote this
+#: check back to primary.
 #:
-#: ``type`` deliberately does NOT feature: all three bodies above are
-#: ``invalid_request_error``, so it cannot tell them apart.
+#: ``type`` does not feature at all: the incident and the malformed-request
+#: bodies are both ``invalid_request_error``, so it separates nothing.
 _UPSTREAM_REQUEST_FIELD_KEY = "param"
 
 #: How many matched quote pairs :func:`_strip_quote_pair` will peel. Real
@@ -495,20 +535,27 @@ def _relayed_upstream_failure(status: int | None, error: Mapping[str, Any]) -> b
     The envelope alone is NOT enough, and an earlier draft of this function
     that stopped there was wrong. ``metadata.raw`` establishes provenance —
     the failure happened at the origin — but says nothing about whether a
-    retry could help. Live probes on 2026-09-04 settled it: a malformed tool
-    name and an invalid ``response_format`` schema both arrive fully wrapped,
-    and treating the envelope as sufficient retried each of them 12 times over
-    ~35s for a defect no wait can fix.
+    retry could help: live probes showed malformed requests arriving fully
+    wrapped, and treating the envelope as sufficient retried each of them 12
+    times over ~35s for a defect no wait can fix.
 
-    So provenance is narrowed by two carve-outs, both meaning "this describes
-    our bytes, not the provider's state":
+    The narrowing that works is the STATUS, per
+    :data:`_RELAYED_UPSTREAM_STATUSES`: only a relayed **404** is treated as
+    weather. Every relayed complaint about our request observed across six
+    model families is a **400**, in every vendor dialect, so excluding 400
+    fails those fast without parsing anyone's error schema. A second draft
+    tried to narrow by the OpenAI-dialect ``param`` field instead and was blind
+    to anthropic, google and cohere, which do not send it — the status line is
+    the only part of the contract every provider agrees on.
 
-    - :data:`_UPSTREAM_REQUEST_FIELD_KEY` — the origin named the offending
-      field of our request in ``param``. Measured across seven malformed-request
-      shapes, every one names a field; the recorded incident names none.
+    Two further carve-outs then guard the 404 path itself, both meaning "this
+    describes our bytes, not the provider's state":
+
+    - :data:`_UPSTREAM_REQUEST_FIELD_KEY` — a 404 that nevertheless names the
+      offending field of our request is believed on the more specific evidence.
     - :data:`~local_operator.incidents.CONTEXT_LENGTH_MARKERS` — an overflow
-      complaint is deterministic even when ``param`` is absent, and the
-      canonical list is shared with the harness so the two cannot drift.
+      complaint is deterministic however it is delivered, and the canonical
+      list is shared with the harness so the two cannot drift.
 
     Two deliberate widenings remain, both toward "treat no-information as
     transient":
@@ -540,8 +587,6 @@ def _relayed_upstream_failure(status: int | None, error: Mapping[str, Any]) -> b
     construction unattributable, so the alternative is killing a turn that
     rotation or a fallback could have served.
     """
-    if status is not None and status not in _RELAYED_UPSTREAM_STATUSES:
-        return False
     message = _first_text(error.get("message"))
     if message.lower() != _OPAQUE_AGGREGATOR_MESSAGE:
         return False
@@ -549,21 +594,28 @@ def _relayed_upstream_failure(status: int | None, error: Mapping[str, Any]) -> b
     if not isinstance(metadata, Mapping) or not _first_text(metadata.get("raw")):
         # The relay envelope establishes PROVENANCE: without it there is no
         # evidence of an upstream hop at all, so the body keeps whatever its
-        # status already meant. It is necessary but NOT sufficient — see below.
+        # status already meant. It is necessary but NOT sufficient.
+        return False
+    text = _strip_quote_pair(_openrouter_upstream_text(error).strip()).lower()
+    if text in _OPAQUE_RAW_SENTINELS:
+        # Says NOTHING. Whatever the status, a body with no diagnostics cannot
+        # be a complaint about our request, so it is weather on any status --
+        # which is what the original opaque-aggregator fix established.
+        return True
+    if status is not None and status not in _RELAYED_UPSTREAM_STATUSES:
+        # It said something real. Only a relayed 404 is weather; a relayed 400
+        # is the origin refusing our request, in every vendor dialect.
         return False
     upstream = _openrouter_upstream_error(error)
     if upstream is not None and _first_text(upstream.get(_UPSTREAM_REQUEST_FIELD_KEY)):
-        # The origin named a field of OUR request. That is a defect in the
-        # bytes we sent: it will fail identically on a retry and on every
-        # fallback target, so it stays `request` and surfaces immediately.
+        # A 404 that nevertheless names a field of OUR request contradicts
+        # itself; the field name is the more specific evidence, so it wins and
+        # the error stays `request`.
         return False
-    text = _strip_quote_pair(_openrouter_upstream_text(error).strip()).lower()
     if any(marker in text for marker in CONTEXT_LENGTH_MARKERS):
-        # An overflow complaint is deterministic in the same way even when the
-        # provider omits `param`: the request is too big and will stay too big.
-        # Sourced from the harness's canonical list so this file and
-        # `incidents.py` cannot drift into disagreeing about what an overflow
-        # looks like.
+        # An overflow is deterministic however it is delivered: the request is
+        # too big and will stay too big. Sourced from the harness's canonical
+        # list so this file and `incidents.py` cannot drift apart.
         return False
     return True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.45.6"
+version = "0.45.7"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -1595,19 +1595,100 @@ class TestRelayedUpstream404:
         error = self._error(httpx.Response(404, json=body))
         assert (error.kind, error.retryable) == ("request", False)
 
-    def test_relayed_body_about_our_bytes_stays_request(self) -> None:
-        """The carve-out. A relayed complaint about the REQUEST fails
-        identically on every retry and every fallback target, so it keeps
-        ``request`` and surfaces at once \u2014 this is what bounds the latency cost
-        of the widening to the failures a retry could actually have served."""
+    def test_a_relayed_complaint_naming_a_request_field_stays_request(self) -> None:
+        """Review finding B1, pinned.
+
+        The relay envelope proves PROVENANCE, not retryability. These bodies
+        were captured from the LIVE API on 2026-09-04 by sending deliberately
+        malformed requests: each arrives fully wrapped, with a
+        ``provider_name``, and each is a defect in our own bytes that no retry
+        can fix. An earlier draft keyed on the envelope alone and retried them
+        12 times over ~35s apiece.
+
+        What separates them from the incident is ``param``: the origin names
+        the offending field of OUR request. The incident names none, because
+        nothing about the request was the problem."""
+        for inner in (
+            {
+                "message": "Invalid 'tools[0].function.name': does not match pattern.",
+                "type": "invalid_request_error",
+                "param": "tools[0].function.name",
+                "code": "invalid_value",
+            },
+            {
+                "message": "Invalid schema for response_format 'x'.",
+                "type": "invalid_request_error",
+                "param": "response_format",
+                "code": None,
+            },
+            {
+                "message": "Invalid value: 'wizard'.",
+                "type": "invalid_request_error",
+                "param": "messages[0].role",
+            },
+        ):
+            error = self._error(
+                httpx.Response(400, json=self._relay(400, json.dumps({"error": inner}), "OpenAI"))
+            )
+            assert (error.kind, error.retryable) == ("request", False), inner["param"]
+
+    def test_type_alone_cannot_discriminate(self) -> None:
+        """Why the predicate does not key on ``type``.
+
+        The incident and the malformed-request bodies are BOTH
+        ``invalid_request_error``. Only the presence of ``param`` tells them
+        apart, so a future edit that reaches for ``type`` instead has this test
+        to explain why that cannot work."""
+        shared = {"message": "...", "type": "invalid_request_error"}
+        weather = self._error(
+            httpx.Response(404, json=self._relay(404, json.dumps({"error": dict(shared)})))
+        )
+        ours = self._error(
+            httpx.Response(
+                400, json=self._relay(400, json.dumps({"error": {**shared, "param": "top_p"}}))
+            )
+        )
+        assert weather.kind == "transient"
+        assert ours.kind == "request"
+
+    def test_relayed_overflow_without_param_stays_request(self) -> None:
+        """Review finding M1, pinned.
+
+        A provider can report an overflow WITHOUT naming a param -- anthropic's
+        "prompt is too long" and google's token-count wording both do. Those
+        are deterministic in the same way (the request is too big and stays too
+        big), so they are carved out by the harness's canonical
+        ``CONTEXT_LENGTH_MARKERS`` rather than by a second list maintained
+        here, which is what stops the two from drifting apart."""
         for text in (
+            "prompt is too long: 250000 tokens > 200000 maximum",
+            "The input token count exceeds the maximum context window",
             "This model's maximum context length is 16385 tokens",
-            "`max_output_tokens` The number must be `>= 16`.",
         ):
             error = self._error(
                 httpx.Response(400, json=self._relay(400, json.dumps({"error": {"message": text}})))
             )
             assert (error.kind, error.retryable) == ("request", False), text
+
+    def test_the_shared_marker_list_is_the_harness_one(self) -> None:
+        """The carve-out must stay wired to the canonical list, not a copy.
+
+        Asserting identity rather than contents is deliberate: a test that
+        re-listed the wordings would itself become the third copy this finding
+        was about."""
+        from local_operator.incidents import CONTEXT_LENGTH_MARKERS as canonical
+        from local_operator.providers import clients
+
+        assert clients.CONTEXT_LENGTH_MARKERS is canonical
+
+    def test_a_quoted_overflow_is_still_recognised(self) -> None:
+        """Quoting is the aggregator's formatting, not part of the signal: a
+        quoted overflow must carve out exactly like a bare one, or a
+        deterministic failure would be retried purely because it arrived
+        wrapped in quotes."""
+        raw = json.dumps("This model's maximum context length is 16385 tokens")
+        error = self._error(httpx.Response(400, json=self._relay(400, raw)))
+        assert (error.kind, error.retryable) == ("request", False)
 
     def test_relayed_401_still_reaches_credential_rotation(self) -> None:
         """401/403 are deliberately OUT of the relayed set: they describe the
@@ -1615,6 +1696,44 @@ class TestRelayedUpstream404:
         retried as weather."""
         error = self._error(httpx.Response(401, json=self._relay(401, "ERROR")))
         assert error.kind == "auth"
+
+    def test_an_absurdly_long_provider_name_is_not_rendered(self) -> None:
+        """Review finding M3, pinned.
+
+        ``provider_name`` is provider-controlled text sharing the 500-char
+        frame budget with the upstream diagnostics. A 300-char attribution
+        would push the part that says what actually went wrong off the end,
+        making the frame strictly worse than the generic wording it replaced,
+        so an implausible name is dropped instead of trusted."""
+        body = {
+            "error": {
+                "message": "Provider returned error",
+                "code": 404,
+                "metadata": {
+                    "raw": json.dumps({"error": {"message": "the real diagnostics"}}),
+                    "provider_name": "X" * 300,
+                },
+            }
+        }
+        error = self._error(httpx.Response(404, json=body))
+        assert "the real diagnostics" in error.message
+        assert "XXX" not in error.message
+
+    def test_a_provider_name_cannot_forge_a_second_line(self) -> None:
+        """A name carrying a newline would render as a forged extra line in the
+        frame, so whitespace is collapsed rather than passed through."""
+        body = {
+            "error": {
+                "message": "Provider returned error",
+                "code": 404,
+                "metadata": {
+                    "raw": json.dumps({"error": {"message": "real"}}),
+                    "provider_name": "Meta\nAPPROVED BY: nobody",
+                },
+            }
+        }
+        error = self._error(httpx.Response(404, json=body))
+        assert "\n" not in error.message
 
     def test_message_without_provider_name_keeps_its_wording(self) -> None:
         """Attribution is never invented: a relay body that omits

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -1379,7 +1379,7 @@ class TestErrorMessageExtraction:
             )
         )
         assert error.message == (
-            "Provider returned error: Quota exceeded for quota metric 'Requests'"
+            "Google returned error: Quota exceeded for quota metric 'Requests'"
         )
         assert error.kind == "quota"
 
@@ -1429,8 +1429,10 @@ class TestOpaqueAggregator400:
         """The exact wire body from the session: bare "ERROR" in ``raw``."""
         error = self._error(httpx.Response(400, json=self._openrouter_body("ERROR")))
         assert (error.kind, error.retryable) == ("transient", True)
-        # The frame still shows what the wire said — no invented diagnostics.
-        assert error.message == "Provider returned error: ERROR"
+        # The frame still shows what the wire said — no invented diagnostics —
+        # but the generic "Provider" is replaced by the origin host the
+        # aggregator named, so the reader knows WHO failed.
+        assert error.message == "Stealth returned error: ERROR"
 
     def test_a_quoted_json_string_sentinel_is_transient_too(self) -> None:
         """``raw`` is defined as JSON-encoded, so the sentinel can arrive as
@@ -1488,19 +1490,144 @@ class TestOpaqueAggregator400:
         error = self._error(httpx.Response(400, json=body))
         assert (error.kind, error.retryable) == ("transient", True)
 
-    def test_unbalanced_quote_runs_stay_request(self) -> None:
-        """Only MATCHED quote pairs are peeled. ``str.strip`` would take any run
-        of either character and reduce this to the sentinel; an unbalanced body
-        is malformed rather than empty, so it keeps its ``request`` answer."""
+    def test_unbalanced_quote_runs_are_transient_too(self) -> None:
+        """Only MATCHED quote pairs are peeled, so this does NOT reduce to the
+        sentinel — and under the relay rule it no longer needs to. A malformed
+        run of quotes inside the relay envelope still describes nothing the
+        caller could fix, so it takes the same transient path as the sentinel.
+
+        This inverts the previous expectation deliberately. The old predicate
+        could only reach transient through an exact sentinel match, which made
+        "unbalanced ⇒ request" the accidental default; the rule now keys on the
+        envelope, and only :data:`_DETERMINISTIC_UPSTREAM_MARKERS` pulls a
+        relayed body back to ``request``."""
         error = self._error(httpx.Response(400, json=self._openrouter_body("'''ERROR\"\"")))
-        assert (error.kind, error.retryable) == ("request", False)
+        assert (error.kind, error.retryable) == ("transient", True)
 
     def test_opaque_5xx_shape_is_unchanged(self) -> None:
-        """The predicate only widens 400s: a 5xx carrying the same opaque body
-        was already retryable by status and must stay that way."""
+        """A 5xx carrying the same opaque body was already retryable by status
+        and must stay that way."""
         body = self._openrouter_body("ERROR")
         body["error"]["code"] = 502
         error = self._error(httpx.Response(502, json=body))
+        assert (error.kind, error.retryable) == ("transient", True)
+
+
+class TestRelayedUpstream404:
+    """A relayed upstream 404 whose text READS like an answer but is weather.
+
+    Session 2be018a98088 (2026-09-04) died twice in 75 seconds on
+    ``openrouter/meta/muse-spark-1.3`` with HTTP 404 and the upstream words
+    "The requested model was not found." Six successful calls on the IDENTICAL
+    model id landed between the two failures, and the model's single endpoint
+    reported 99.98% 30-minute uptime, so the id cannot have been the cause: it
+    was Meta transiently failing to resolve its own snapshot, relayed by
+    OpenRouter under a 404.
+
+    The old predicate missed it on two counts \u2014 it was gated on 400, and it
+    demanded a bare sentinel where this body carried plausible prose \u2014 so the
+    failure was classified ``request`` and the turn was aborted with no retry
+    and no failover.
+
+    The discrimination pinned here is STRUCTURAL, verified against the live API
+    on 2026-09-04: OpenRouter answers a model id it does not know with a flat
+    400 naming the slug, and a routing refusal with a flat 404 naming the
+    preference. Neither carries ``metadata.raw``. Only a genuine relay does.
+    """
+
+    def _error(self, response: httpx.Response) -> ProviderError:
+        with pytest.raises(ProviderError) as excinfo:
+            raise_for_status(response)
+        return excinfo.value
+
+    @staticmethod
+    def _relay(status: int, raw: str, provider: str = "Meta") -> dict[str, Any]:
+        return {
+            "error": {
+                "message": "Provider returned error",
+                "code": status,
+                "metadata": {"raw": raw, "provider_name": provider, "is_byok": False},
+            }
+        }
+
+    def test_the_recorded_404_is_transient_and_names_the_upstream(self) -> None:
+        """The exact wire body from the session."""
+        raw = json.dumps(
+            {
+                "error": {
+                    "message": "The requested model was not found.",
+                    "type": "invalid_request_error",
+                }
+            }
+        )
+        error = self._error(httpx.Response(404, json=self._relay(404, raw)))
+        assert (error.kind, error.retryable) == ("transient", True)
+        # The frame must name Meta rather than the ambiguous "Provider": the
+        # user is looking at an aggregator, so "provider" alone does not say
+        # whether the gateway or the model host failed.
+        assert str(error) == (
+            "transient provider error (HTTP 404): "
+            "Meta returned error: The requested model was not found."
+        )
+
+    def test_flat_unknown_model_400_still_fails_fast(self) -> None:
+        """OpenRouter's OWN refusal of a bad slug: flat body, no relay
+        envelope, names the slug. This is the case a user really can fix, so it
+        must keep failing immediately instead of burning the retry budget."""
+        body = {"error": {"message": "meta/muse-spark-9.9 is not a valid model ID", "code": 400}}
+        error = self._error(httpx.Response(400, json=body))
+        assert (error.kind, error.retryable) == ("request", False)
+
+    def test_flat_routing_404_still_fails_fast(self) -> None:
+        """The aggregator's own routing refusal, also flat and also actionable
+        (the caller's provider preference is wrong)."""
+        body = {
+            "error": {
+                "message": (
+                    "No allowed providers are available for the selected model. "
+                    "Providers serving meta/muse-spark-1.3-20260902: meta, but your "
+                    "request's provider.only preference permits only: groq."
+                ),
+                "code": 404,
+                "metadata": {"available_providers": ["meta"], "requested_providers": ["groq"]},
+            }
+        }
+        error = self._error(httpx.Response(404, json=body))
+        assert (error.kind, error.retryable) == ("request", False)
+
+    def test_relayed_body_about_our_bytes_stays_request(self) -> None:
+        """The carve-out. A relayed complaint about the REQUEST fails
+        identically on every retry and every fallback target, so it keeps
+        ``request`` and surfaces at once \u2014 this is what bounds the latency cost
+        of the widening to the failures a retry could actually have served."""
+        for text in (
+            "This model's maximum context length is 16385 tokens",
+            "`max_output_tokens` The number must be `>= 16`.",
+        ):
+            error = self._error(
+                httpx.Response(400, json=self._relay(400, json.dumps({"error": {"message": text}})))
+            )
+            assert (error.kind, error.retryable) == ("request", False), text
+
+    def test_relayed_401_still_reaches_credential_rotation(self) -> None:
+        """401/403 are deliberately OUT of the relayed set: they describe the
+        caller's credential and must keep reaching rotation rather than being
+        retried as weather."""
+        error = self._error(httpx.Response(401, json=self._relay(401, "ERROR")))
+        assert error.kind == "auth"
+
+    def test_message_without_provider_name_keeps_its_wording(self) -> None:
+        """Attribution is never invented: a relay body that omits
+        ``provider_name`` keeps the aggregator's original wording."""
+        body = {
+            "error": {
+                "message": "Provider returned error",
+                "code": 404,
+                "metadata": {"raw": json.dumps({"error": {"message": "upstream exploded"}})},
+            }
+        }
+        error = self._error(httpx.Response(404, json=body))
+        assert error.message == "Provider returned error: upstream exploded"
         assert (error.kind, error.retryable) == ("transient", True)
 
 
@@ -1550,7 +1677,7 @@ class TestOpaqueAggregator400InBand:
         error = await self._stream_error(self._chunk("ERROR"))
         assert error.status == 400
         assert (error.kind, error.retryable) == ("transient", True)
-        assert "Provider returned error" in str(error)
+        assert "Stealth returned error" in str(error)
 
     async def test_in_band_actionable_diagnostics_stay_request(self) -> None:
         """Real upstream diagnostics in-band are still an answer, not weather."""

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import unicodedata
 from collections.abc import Sequence
 from typing import Any, Literal
 
@@ -1490,19 +1491,19 @@ class TestOpaqueAggregator400:
         error = self._error(httpx.Response(400, json=body))
         assert (error.kind, error.retryable) == ("transient", True)
 
-    def test_unbalanced_quote_runs_are_transient_too(self) -> None:
+    def test_unbalanced_quote_runs_stay_request(self) -> None:
         """Only MATCHED quote pairs are peeled, so this does NOT reduce to the
-        sentinel — and under the relay rule it no longer needs to. A malformed
-        run of quotes inside the relay envelope still describes nothing the
-        caller could fix, so it takes the same transient path as the sentinel.
+        sentinel -- and on a 400 that is the whole question.
 
-        This inverts the previous expectation deliberately. The old predicate
-        could only reach transient through an exact sentinel match, which made
-        "unbalanced ⇒ request" the accidental default; the rule now keys on the
-        envelope, and only :data:`_DETERMINISTIC_UPSTREAM_MARKERS` pulls a
-        relayed body back to ``request``."""
+        A body that says something, even something malformed, is the origin
+        refusing our request, and a relayed 400 is not retried. Only a body
+        that reduces exactly to the sentinel proves nobody tried to say
+        anything. ``str.strip`` would take any run of either character and
+        collapse this to "error", handing it the transient path by accident;
+        peeling pairs keeps that a decision rather than an artefact of the
+        API."""
         error = self._error(httpx.Response(400, json=self._openrouter_body("'''ERROR\"\"")))
-        assert (error.kind, error.retryable) == ("transient", True)
+        assert (error.kind, error.retryable) == ("request", False)
 
     def test_opaque_5xx_shape_is_unchanged(self) -> None:
         """A 5xx carrying the same opaque body was already retryable by status
@@ -1690,6 +1691,54 @@ class TestRelayedUpstream404:
         error = self._error(httpx.Response(400, json=self._relay(400, raw)))
         assert (error.kind, error.retryable) == ("request", False)
 
+    def test_a_relayed_400_fails_fast_in_every_vendor_dialect(self) -> None:
+        """Review finding B2 (round 2), pinned.
+
+        The round-1 fix keyed on the OpenAI-dialect ``param`` field, which
+        anthropic (via Vertex), google AI Studio and cohere do not send \u2014 so
+        their malformed requests were still retried 12 times over ~35s. These
+        bodies were captured from the LIVE API on 2026-09-04 and carry NO
+        ``param``.
+
+        The dialect-independent signal is the status. Probing a deliberately
+        malformed request across six model families, every relayed complaint
+        about our request was a 400 and not one was a 404, because "the request
+        was bad" is what 400 MEANS. Keying on it needs no vendor schema
+        knowledge, which is what made the previous attempt fragile: new
+        provider, new dialect, same bug."""
+        for provider, inner in (
+            ("Google", {"message": "tools.0.custom.name: String should match pattern"}),
+            (
+                "Google AI Studio",
+                {"message": "Invalid function name.", "code": 400, "status": "INVALID_ARGUMENT"},
+            ),
+            ("Cohere", {"message": "invalid request: tool name invalid"}),
+            ("Meta", {"message": "`max_output_tokens` The number must be `>= 16`."}),
+        ):
+            error = self._error(
+                httpx.Response(400, json=self._relay(400, json.dumps({"error": inner}), provider))
+            )
+            assert (error.kind, error.retryable) == ("request", False), provider
+
+    def test_a_relayed_overflow_on_a_404_stays_request(self) -> None:
+        """QA finding Q3 (round 2), pinned.
+
+        An overflow is deterministic however it is delivered, so it must not
+        take the 404 weather path. These are the vendor wordings an audit found
+        the canonical list missing \u2014 google/vertex counts tokens, mistral and
+        bedrock phrase it differently again \u2014 each of which would otherwise
+        have re-created the very cascade this PR removes."""
+        for text in (
+            "The input token count (1200000) exceeds the maximum number of tokens allowed",
+            "Too many tokens in prompt",
+            "Input is too long for requested model",
+            "prompt is too long: 250000 tokens > 200000 maximum",
+        ):
+            error = self._error(
+                httpx.Response(404, json=self._relay(404, json.dumps({"error": {"message": text}})))
+            )
+            assert (error.kind, error.retryable) == ("request", False), text
+
     def test_relayed_401_still_reaches_credential_rotation(self) -> None:
         """401/403 are deliberately OUT of the relayed set: they describe the
         caller's credential and must keep reaching rotation rather than being
@@ -1719,21 +1768,46 @@ class TestRelayedUpstream404:
         assert "the real diagnostics" in error.message
         assert "XXX" not in error.message
 
-    def test_a_provider_name_cannot_forge_a_second_line(self) -> None:
-        """A name carrying a newline would render as a forged extra line in the
-        frame, so whitespace is collapsed rather than passed through."""
-        body = {
-            "error": {
-                "message": "Provider returned error",
-                "code": 404,
-                "metadata": {
-                    "raw": json.dumps({"error": {"message": "real"}}),
-                    "provider_name": "Meta\nAPPROVED BY: nobody",
-                },
-            }
+    def test_a_hostile_provider_name_cannot_corrupt_the_frame(self) -> None:
+        """Review B3 / QA Q2 (round 2), pinned.
+
+        ``provider_name`` is provider-controlled text rendered into a terminal
+        frame. An earlier draft collapsed whitespace only, which left ESC
+        untouched \u2014 QA drove the real app and found the notice rendering as
+        nothing but its ``!`` glyph, with a live ``ESC[2J`` and an OSC title
+        injection reaching the terminal.
+
+        Sanitised through the approval prompts' own primitive, so control
+        sequences, C1 8-bit forms, and bidi/format characters (which reverse
+        rendered order without being control codes) are all neutralised by the
+        rule the rest of the app already trusts."""
+        hostile = {
+            "ansi-erase": "Meta\x1b[2K\x1b[1G",
+            "ansi-clear": "Meta\x1b[2J",
+            "osc-title": "Meta\x1b]0;pwned\x07",
+            "c1-csi": "Meta\x9b31m",
+            "bel": "Meta\x07",
+            "nul": "Meta\x00",
+            "rtl-override": "Meta\u202e",
+            "zero-width-joiner": "Me\u200dta",
+            "newline": "Meta\nFAKE: approved",
         }
-        error = self._error(httpx.Response(404, json=body))
-        assert "\n" not in error.message
+        for label, name in hostile.items():
+            body = {
+                "error": {
+                    "message": "Provider returned error",
+                    "code": 404,
+                    "metadata": {
+                        "raw": json.dumps({"error": {"message": "the real diagnostics"}}),
+                        "provider_name": name,
+                    },
+                }
+            }
+            message = self._error(httpx.Response(404, json=body)).message
+            assert "the real diagnostics" in message, label
+            for char in message:
+                assert unicodedata.category(char) != "Cf", (label, message)
+                assert not (ord(char) < 0x20 or 0x80 <= ord(char) <= 0x9F), (label, message)
 
     def test_message_without_provider_name_keeps_its_wording(self) -> None:
         """Attribution is never invented: a relay body that omits

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -1739,12 +1739,28 @@ class TestRelayedUpstream404:
             )
             assert (error.kind, error.retryable) == ("request", False), text
 
-    def test_relayed_401_still_reaches_credential_rotation(self) -> None:
-        """401/403 are deliberately OUT of the relayed set: they describe the
-        caller's credential and must keep reaching rotation rather than being
-        retried as weather."""
-        error = self._error(httpx.Response(401, json=self._relay(401, "ERROR")))
-        assert error.kind == "auth"
+    def test_caller_status_bodies_never_become_retryable(self) -> None:
+        """Review finding M1 (round 3), pinned.
+
+        401/403/402 describe the CALLER's standing, not a request, and each has
+        its own recovery: rotation, or a bill. A draft that short-circuited a
+        bare sentinel to retryable before checking the status bought a 401 ten
+        same-credential retries (~51s) before rotation was reached, because the
+        driver's ladder returns early on ``not retryable``.
+
+        Asserts ``retryable`` as well as ``kind`` deliberately: the previous
+        version of this test checked only the kind, so it passed throughout the
+        regression and did not test the thing its name promised. 429 is
+        included to pin the other direction -- it was already retryable by
+        status and must stay so."""
+        for status, kind, retryable in (
+            (401, "auth", False),
+            (403, "auth", False),
+            (402, "quota", False),
+            (429, "quota", True),
+        ):
+            error = self._error(httpx.Response(status, json=self._relay(status, "ERROR")))
+            assert (error.kind, error.retryable) == (kind, retryable), status
 
     def test_an_absurdly_long_provider_name_is_not_rendered(self) -> None:
         """Review finding M3, pinned.

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -1164,6 +1164,119 @@ async def test_opaque_aggregator_400_in_band_fails_over_instead_of_aborting() ->
     assert len(primary_requests) <= 12
 
 
+async def test_relayed_upstream_404_recovers_instead_of_killing_the_turn() -> None:
+    """The session 2be018a98088 failure, end to end.
+
+    An aggregator answered the PRIMARY with HTTP 404 and the RELAYED upstream
+    words "The requested model was not found." for a model id that worked six
+    times in the surrounding 75 seconds. Classified ``request`` on the strength
+    of that wording, the turn was aborted instantly with no retry and no
+    failover; classified as the relayed upstream blip it is, the same transient
+    machinery that serves an opaque sentinel must serve it and the turn must
+    still produce an answer.
+
+    Built through the real wire mapper so the test pins the behaviour against
+    the exact bytes OpenRouter sent, not a hand-stamped classification."""
+    from local_operator.providers.clients import raise_for_status
+
+    def _relayed_404() -> ProviderError:
+        try:
+            raise_for_status(
+                httpx.Response(
+                    404,
+                    json={
+                        "error": {
+                            "message": "Provider returned error",
+                            "code": 404,
+                            "metadata": {
+                                "raw": json.dumps(
+                                    {
+                                        "error": {
+                                            "message": "The requested model was not found.",
+                                            "type": "invalid_request_error",
+                                        }
+                                    }
+                                ),
+                                "provider_name": "Meta",
+                                "is_byok": False,
+                            },
+                        }
+                    },
+                )
+            )
+        except ProviderError as exc:
+            return exc
+        raise AssertionError("raise_for_status must raise")
+
+    # Precondition: the frame the user reads names the upstream host rather
+    # than the ambiguous generic "Provider".
+    assert "Meta returned error" in str(_relayed_404())
+
+    attempts: list[str | None] = []
+    served = ScriptedClient([StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")])
+
+    def fail_like_the_session(
+        request: ChatRequest, api_key: str | None, oauth_access: Any = None
+    ) -> AsyncIterator[Any]:
+        attempts.append(api_key)
+        raise _relayed_404()
+
+    async def client_for(spec: ModelSpec) -> Any:
+        if spec.provider == "anthropic":
+            return served
+        return _FnClient(fail_like_the_session)
+
+    settings = {
+        "retry": {
+            "baseDelayMs": 1,
+            "maxRetries": 2,
+            "fallbackChains": {"default": ["anthropic/claude-x"]},
+        }
+    }
+    auth = FakeAuth({"openai": ["k1", "k2"], "anthropic": ["k3"]})
+    got = [event async for event in stream_with_failover(_request(), auth, settings, client_for)]
+    assert any(isinstance(e, StreamTextDelta) and e.delta == "ok" for e in got)
+    assert served.calls == 1, "the turn must be served instead of dying on the 404"
+    assert len(attempts) >= 2, "the 404 must be retried, not aborted on first sight"
+    assert auth.rotations, "the sibling rotation must actually have run"
+
+
+async def test_flat_unknown_model_404_still_aborts_immediately() -> None:
+    """The other side of the line, end to end.
+
+    A model id the AGGREGATOR itself rejects is flat (no ``metadata.raw``) and
+    actionable, so it must still abort the turn at once. Without this the
+    widening would trade a dead turn for minutes of pointless backoff on a
+    request no retry can fix."""
+    from local_operator.providers.clients import raise_for_status
+
+    attempts: list[str | None] = []
+
+    def refuse(
+        request: ChatRequest, api_key: str | None, oauth_access: Any = None
+    ) -> AsyncIterator[Any]:
+        attempts.append(api_key)
+        raise_for_status(
+            httpx.Response(
+                400,
+                json={"error": {"message": "openai/nope-9.9 is not a valid model ID", "code": 400}},
+            )
+        )
+        raise AssertionError("unreachable")
+
+    async def client_for(spec: ModelSpec) -> Any:
+        return _FnClient(refuse)
+
+    auth = FakeAuth({"openai": ["k1", "k2"]})
+    settings = {"retry": {"baseDelayMs": 1, "maxRetries": 2, "fallbackChains": {}}}
+    with pytest.raises(ProviderError) as excinfo:
+        async for _ in stream_with_failover(_request(), auth, settings, client_for):
+            pass
+    assert excinfo.value.kind == "request"
+    assert "is not a valid model ID" in str(excinfo.value)
+    assert len(attempts) == 1, "a bad model id must surface at once, not after a cascade"
+
+
 async def test_transport_retries_honor_budget_same_key_first() -> None:
     """PR-06: retryable 5xx consumes retry.maxRetries on the SAME key with
     backoff BEFORE any credential rotation."""

--- a/tests/unit/test_incidents.py
+++ b/tests/unit/test_incidents.py
@@ -93,3 +93,50 @@ def test_model_switch_without_previous_label_reads_cleanly():
 def test_model_switch_message_type_constant_is_stable():
     # Persisted into transcripts; renaming it would orphan replay of old sessions.
     assert SESSION_MODEL_SWITCH_MESSAGE_TYPE == "session_model_switch"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "This model's maximum context length is 16385 tokens",
+        "prompt is too long: 250000 tokens > 200000 maximum",
+        "The input token count (1200000) exceeds the maximum number of tokens allowed",
+        "The request exceeds the model's maximum context window",
+        "Too many tokens in prompt",
+        "too many tokens: input is larger than the model's context length",
+        "request too large for model",
+        "Input is too long for requested model",
+    ],
+)
+def test_every_vendor_overflow_wording_is_recognised(raw: str) -> None:
+    """The overflow rule has to cover how vendors ACTUALLY phrase it.
+
+    An audit against real vendor output found the list recognising 6 of 10
+    wordings: google/vertex counts input tokens, mistral and bedrock phrase it
+    differently again. The gap mattered beyond this classifier, because
+    `providers.clients` shares the list to decide that a relayed overflow is
+    deterministic and must not be retried as upstream weather.
+    """
+    assert classify_incident(raw).category == "context-length"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        # Verbatim AWS Bedrock ThrottlingException wording.
+        "ThrottlingException: Too many tokens, please wait before trying again.",
+        # A TPM limit that quotes a token count in passing.
+        "Rate limit reached for gpt-4: Limit 90000 token count per min",
+        "Number of request tokens has exceeded your per-minute rate limit",
+    ],
+)
+def test_a_throttle_that_mentions_tokens_is_not_an_overflow(raw: str) -> None:
+    """Rate limits must not be read as context overflows.
+
+    context-length is the FIRST rule, so it outranks rate-limit: a bare "too
+    many tokens" or "token count" marker captures these and tells the user to
+    /compact a request whose only problem is that it arrived too soon. The
+    markers are therefore qualified to name the INPUT, which a throttle never
+    does.
+    """
+    assert classify_incident(raw).category != "context-length"


### PR DESCRIPTION
## A turn died on a model that was working

Session `2be018a98088` died **twice in 75 seconds** on
`openrouter/meta/muse-spark-1.3`:

```
✕ invalid request (HTTP 404): Provider returned error: The requested model was not found.
```

Read literally, that says we sent a bad model id. We did not. From the session
transcript:

| evidence | value |
|---|---|
| failures | 23:49:40 and 23:50:55 |
| **successful calls on the identical model id between them** | **6** (23:50:14 → 23:50:54) |
| successful calls in the session total | 80 (2 failures = 2.4%) |
| `selected_model` / `effective_model` on both failed turns | `openrouter` / `meta/muse-spark-1.3` — no fallback substitution |
| endpoint uptime (30m) | 99.98%, single endpoint |
| time from request to dead turn | **~1.0s** — no retry, no rotation, no failover |

A model id that works either side of a failure cannot be the cause. Meta
transiently failed to resolve its own snapshot and OpenRouter relayed that 404
verbatim; the harness read the relayed words as our mistake and killed the turn.

## Why the existing guard missed it

`_is_opaque_aggregator_400` exists for exactly this "upstream blip wearing a
client-error status" case, and its own docstring warns that the cost of the
opposite mistake "is a dead turn". It missed on two counts:

1. it was gated on `status == 400`, so a relayed **404** never reached it;
2. it required `metadata.raw` to be a bare `"ERROR"` sentinel, and this body
   carried plausible prose.

So the classification fell through to `request` — "a 4xx the provider read and
refused" — which `failover.py` treats as deterministic in its bytes and aborts
on rather than retrying.

## The discrimination is structural, not lexical

Matching on wording would be a guess. Probed against the **live OpenRouter API**
(2026-09-04), the two situations are structurally distinct:

| what happened | status | body shape | `metadata.raw`? |
|---|---|---|---|
| unknown model slug | **400** | flat, *names the slug*: `meta/muse-spark-9.9 is not a valid model ID` | **no** |
| routing preference unsatisfiable | **404** | flat, *names the preference*: `No allowed providers are available…` | **no** |
| **origin provider failed** | 400/404 | `{"message": "Provider returned error", "metadata": {"raw": …, "provider_name": "Meta"}}` | **yes** |

The aggregator's **own** refusals are flat and name the problem. Only a relay of
an origin provider's failure carries the `metadata.raw` envelope — so a wrapped
4xx is by construction a report about the far side of a network hop the caller
cannot see, not about our bytes.

`_relayed_upstream_failure` keys on that envelope. `401`/`403` are deliberately
excluded: they describe the caller's credential and must keep reaching rotation.

## Keeping the latency cost bounded

The widening is not free — the docstring measures a persistent failure at 4-5
minutes across a 3-target chain. `_DETERMINISTIC_UPSTREAM_MARKERS` carves back
out the relayed wordings that genuinely describe the request (context length,
`max_output_tokens`): those fail identically on every retry and every fallback,
so they keep `request` and surface at once.

The markers are deliberately **narrow phrases, not single words** — a loose
marker like `"invalid"` or `"error"` would drag genuine upstream weather back
into `request` and re-create the dead turn. Where a wording is ambiguous the tie
breaks toward transient: bounded retries versus a killed turn.

## Representing the error properly

`Provider returned error` is the least useful sentence in any frame: it says a
provider failed without saying **which**, while the reader is looking at an
aggregator, so "provider" is ambiguous between the gateway and the model host.
`metadata.provider_name` already carries the answer:

```
before:  invalid request (HTTP 404): Provider returned error: The requested model was not found.
after:   transient provider error (HTTP 404): Meta returned error: The requested model was not found.
```

That is the difference between suspecting your own model id and knowing the
upstream host is unwell. Attribution is never invented — a body without
`provider_name` keeps its original wording.

## Testing evidence

Not a green suite: a fake relay reproducing the recorded wire body, driven
through the **real** `stream_with_failover` + real HTTP client, on both
branches.

**Pre-stream channel (the recorded failure):**

```
===== BEFORE (origin/main) =====
RESULT: TURN DIED -> invalid request (HTTP 404): Provider returned error: The requested model was not found.
upstream calls: 1 | models sent: ['meta/muse-spark-1.3']

===== AFTER (dev-relay-error) =====
RESULT: TURN SURVIVED -> text = 'recovered'
upstream calls: 2 | models sent: ['meta/muse-spark-1.3', 'meta/muse-spark-1.3']
```

**In-band channel** (gateway commits HTTP 200, then relays the same failure —
which channel it picks is not something the caller can influence):

```
BEFORE: TURN DIED -> invalid request (HTTP 404): Provider returned error: The requested model was not found.
AFTER:  TURN SURVIVED -> text = 'recovered-inband'
```

**The guard case — a genuinely bad model id must still fail fast:**

```
AFTER:  TURN DIED -> invalid request (HTTP 400): meta/muse-spark-9.9 is not a valid model ID   [1 call, 1.6s]
BEFORE: TURN DIED -> invalid request (HTTP 400): meta/muse-spark-9.9 is not a valid model ID   [1 call]
```

Identical before and after — the widening costs nothing on the case a user can
actually fix.

**Live API probes** (real key, `meta/muse-spark-1.3`): 45/45 calls returned 200,
confirming the model id is valid and the failure was transient.

## Gates

| gate | result |
|---|---|
| `pytest tests/unit` | **12047 passed**, 16 skipped |
| `flake8` (7.1.0, CI pin) | clean |
| `black --check` (26.1.0, CI pin) | 836 files unchanged |
| `isort --check .` (5.13.2, CI pin) | clean |
| `pyright` | 0 errors |

Note: the venv's local `isort` had drifted to 9.0.1, which reports 3
pre-existing errors on files this PR does not touch **and** proposes formatting
that contradicts `black`. The CI-pinned 5.13.2 passes clean; nothing here
depends on the drifted version.
