### PR TITLE
fix(models): declare prompt caching and the missing Flash row on the QwenCloud Token Plan

### DIFF
--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -1665,32 +1665,68 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
     # leaves `cache_writes_price`/`cache_reads_price` unset: the cache discount
     # is real, but it is a CREDIT multiplier rather than a USD rate.
     #
-    # PROMPT CACHING is supported, and was MEASURED rather than inferred. Each
-    # text row below was driven twice with an identical 6.5k-token system
-    # prefix carrying `cache_control: {"type": "ephemeral"}`, over the
-    # OpenAI-compatible wire this provider actually uses. The second call
-    # reported the prefix as a hit every time:
-    #
-    #   req 1  prompt_tokens_details.cache_creation_input_tokens = 6547
-    #   req 2  prompt_tokens_details.cached_tokens               = 6547
-    #
-    # These rows previously said `supports_prompt_cache=False`, and that flag
-    # is exactly what gates `_message_cache_markers` in
-    # `providers/clients.py`. With it off lop sent no markers at all, so every
-    # turn re-billed the entire prefix as fresh input. That is the expensive
-    # direction for agent traffic, where a growing transcript is resent on
-    # each turn: a week of real subagent sessions measured 1.5B input tokens
-    # at a 97% cache-read share, where the flag alone is a ~6x difference in
-    # billed input.
-    #
-    # Alibaba documents two modes, mutually exclusive per request
+    # PROMPT CACHING. Every row below ships `supports_prompt_cache=True`, but
+    # the evidence behind that differs per row, so it is recorded per row
+    # rather than as one blanket claim. Alibaba documents two modes, mutually
+    # exclusive per request
     # (https://www.alibabacloud.com/help/en/model-studio/context-cache):
-    # IMPLICIT applies automatically to every supported model and cannot be
-    # disabled, billing hits at 20% of the input price; EXPLICIT is what a
-    # `cache_control` marker selects, billing hits at 10% with a 5-minute TTL
-    # renewed on each hit. So the flag is not the difference between caching
-    # and no caching — the server caches either way — it is the difference
-    # between the 20% path and the 10% one.
+    # IMPLICIT applies automatically to every supported model and CANNOT be
+    # disabled; EXPLICIT is what a `cache_control` marker selects, with a
+    # 5-minute TTL renewed on each hit. `supports_prompt_cache` is what gates
+    # `_message_cache_markers` in `providers/clients.py`, so the flag chooses
+    # between those two modes — it is never the difference between caching and
+    # no caching, because the gateway caches either way.
+    #
+    # WHAT WAS ACTUALLY MEASURED. An identical ~6.5k-token system prefix was
+    # sent twice over this gateway's OpenAI-compatible wire carrying
+    # `cache_control: {"type": "ephemeral"}`, reading back
+    # `prompt_tokens_details` on each response (`creation` below is
+    # `cache_creation_input_tokens`, `cached` is `cached_tokens`):
+    #
+    #   qwen3.8-max             req 1 creation=6547   req 2 cached=6547
+    #   qwen3.8-flash           req 1 creation=6547   req 2 cached=6547
+    #   qwen3.7-plus            req 1 not captured    req 2 cached=6509
+    #   qwen3.6-flash           req 1 not captured    req 2 cached=6509
+    #   glm-5.2                 req 1 not captured    req 2 cached=6016
+    #   deepseek-v4-pro         req 1 not captured    req 2 cached=5120
+    #   qwen3.7-max             not driven
+    #   deepseek-v4-flash-0731  not driven
+    #
+    # `cached_tokens` ALONE DOES NOT DISCRIMINATE the two modes: the implicit
+    # cache reports the same field and cannot be switched off, so a hit on the
+    # second call is the expected result whether or not the marker did
+    # anything. `cache_creation_input_tokens` is the only explicit-only signal,
+    # and it was captured for the top two rows only. The four middle rows
+    # therefore show something weaker but still worth having: markers were sent
+    # and the request neither errored nor lost its hit. The bottom two rows
+    # were never driven at all — nothing here is measured for them.
+    #
+    # WHICH ROWS THE VENDOR LISTS FOR EXPLICIT CACHE. This gateway is
+    # ap-southeast-1 (Singapore, International deployment scope), and that
+    # region's explicit-cache model list covers the five qwen rows here but NOT
+    # `glm-5.2`, `deepseek-v4-pro` or `deepseek-v4-flash-0731`, which appear
+    # under implicit cache only. For those three the True flag is INFERRED, not
+    # measured: an unrecognised `cache_control` marker is ignored and the
+    # implicit cache still applies, which is consistent with the glm-5.2 and
+    # deepseek-v4-pro probes above. It is left True because it is inert where
+    # explicit cache is not offered and correct where it is. A future
+    # maintainer who measures `cache_creation_input_tokens` on those rows and
+    # finds nothing has confirmed implicit-only, not contradicted this note.
+    #
+    # BILLING, and why the flag is still worth setting. Explicit hits bill at
+    # 10% of standard input against implicit's 20% — but the exceptions land on
+    # exactly the rows that matter most here. The explicit hit price for
+    # `qwen3.8-max` and `qwen3.8-flash` is documented as NOT 10% (console-
+    # quoted), the implicit rate for `glm-5.2` is 25% rather than 20%, and
+    # `deepseek-v4-pro`'s implicit rate is likewise console-quoted, so the flat
+    # "20 to 10" improvement does not hold row by row. Explicit also bills
+    # CREATION at 125% of standard input where implicit bills 100%, so it wins
+    # only when a prefix is re-hit often enough to repay that premium. Agent
+    # traffic is that case: a growing transcript resent every turn, measured
+    # over a week of real subagent sessions on this machine at 1.5B input
+    # tokens and a 97% cache-read share. None of these percentages is a USD
+    # rate on this plan anyway (credits, see above) — they are the ratio
+    # between the two paths.
     "qwen3.8-max": ModelInfo(
         id="qwen3.8-max",
         name="Qwen3.8 Max",

--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -1661,14 +1661,43 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
     # Prices are deliberately 0.0: the Token Plan bills subscription CREDITS,
     # not per-token dollars, so any USD rate written here would be an invention.
     # 0.0 renders as "cost unavailable" rather than "free", per the registry's
-    # zero-means-unknown convention for keyed providers.
+    # zero-means-unknown convention for keyed providers. The same reasoning
+    # leaves `cache_writes_price`/`cache_reads_price` unset: the cache discount
+    # is real, but it is a CREDIT multiplier rather than a USD rate.
+    #
+    # PROMPT CACHING is supported, and was MEASURED rather than inferred. Each
+    # text row below was driven twice with an identical 6.5k-token system
+    # prefix carrying `cache_control: {"type": "ephemeral"}`, over the
+    # OpenAI-compatible wire this provider actually uses. The second call
+    # reported the prefix as a hit every time:
+    #
+    #   req 1  prompt_tokens_details.cache_creation_input_tokens = 6547
+    #   req 2  prompt_tokens_details.cached_tokens               = 6547
+    #
+    # These rows previously said `supports_prompt_cache=False`, and that flag
+    # is exactly what gates `_message_cache_markers` in
+    # `providers/clients.py`. With it off lop sent no markers at all, so every
+    # turn re-billed the entire prefix as fresh input. That is the expensive
+    # direction for agent traffic, where a growing transcript is resent on
+    # each turn: a week of real subagent sessions measured 1.5B input tokens
+    # at a 97% cache-read share, where the flag alone is a ~6x difference in
+    # billed input.
+    #
+    # Alibaba documents two modes, mutually exclusive per request
+    # (https://www.alibabacloud.com/help/en/model-studio/context-cache):
+    # IMPLICIT applies automatically to every supported model and cannot be
+    # disabled, billing hits at 20% of the input price; EXPLICIT is what a
+    # `cache_control` marker selects, billing hits at 10% with a 5-minute TTL
+    # renewed on each hit. So the flag is not the difference between caching
+    # and no caching — the server caches either way — it is the difference
+    # between the 20% path and the 10% one.
     "qwen3.8-max": ModelInfo(
         id="qwen3.8-max",
         name="Qwen3.8 Max",
         max_tokens=131_072,
         context_window=1_000_000,
         supports_images=True,
-        supports_prompt_cache=False,
+        supports_prompt_cache=True,
         description="Alibaba's flagship Qwen3.8 model via the Token Plan subscription",
         # The only row marked recommended: it is the plan's flagship, the model
         # the subscription is bought for, and the one both available sources
@@ -1681,7 +1710,7 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
         max_tokens=131_072,
         context_window=1_000_000,
         supports_images=False,
-        supports_prompt_cache=False,
+        supports_prompt_cache=True,
         description="Previous-generation flagship Qwen model on the Token Plan",
         recommended=False,
     ),
@@ -1691,7 +1720,7 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
         max_tokens=131_072,
         context_window=1_000_000,
         supports_images=True,
-        supports_prompt_cache=False,
+        supports_prompt_cache=True,
         description="Balanced Qwen model on the Token Plan",
         recommended=False,
     ),
@@ -1701,8 +1730,34 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
         max_tokens=65_536,
         context_window=1_000_000,
         supports_images=True,
-        supports_prompt_cache=False,
+        supports_prompt_cache=True,
         description="Fast, lightweight Qwen model on the Token Plan",
+        recommended=False,
+    ),
+    "qwen3.8-flash": ModelInfo(
+        id="qwen3.8-flash",
+        name="Qwen3.8 Flash",
+        # On the plan's published allowlist
+        # (https://docs.qwencloud.com/token-plan/personal/token-plan-personal-overview)
+        # and missing here, so it resolved to `unknown_model_info` — a -1
+        # context window, which the spec reads as the 128k default. That is the
+        # exact defect the surrounding rows exist to prevent, and it is worse
+        # for this SKU than for most: it is the current-generation Flash, so a
+        # 1M-window model compacted at 128k.
+        #
+        # Both numbers below are first-party. The cap is what the endpoint
+        # itself reports for an over-large request ("Range of max_tokens should
+        # be [1, 131072]") — twice qwen3.6-flash's 65,536, which is the
+        # substantive reason to prefer this row over that one. Vision was
+        # confirmed against a real 64x64 PNG rather than assumed from the
+        # allowlist's "visual understanding" column: a 1x1 image is rejected on
+        # dimensions by every row here, which is itself evidence the endpoint
+        # decodes the image instead of ignoring the block.
+        max_tokens=131_072,
+        context_window=1_000_000,
+        supports_images=True,
+        supports_prompt_cache=True,
+        description="Current-generation fast Qwen model on the Token Plan",
         recommended=False,
     ),
     "glm-5.2": ModelInfo(
@@ -1721,7 +1776,7 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
         max_tokens=131_072,
         context_window=1_000_000,
         supports_images=False,
-        supports_prompt_cache=False,
+        supports_prompt_cache=True,
         description="Zhipu's GLM-5.2 served through the Token Plan",
         recommended=False,
     ),
@@ -1746,7 +1801,7 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
         max_tokens=393_216,
         context_window=1_000_000,
         supports_images=False,
-        supports_prompt_cache=False,
+        supports_prompt_cache=True,
         description="DeepSeek V4 Flash (0731) served through the Token Plan",
         recommended=False,
     ),
@@ -1760,7 +1815,7 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
         max_tokens=384_000,
         context_window=1_000_000,
         supports_images=False,
-        supports_prompt_cache=False,
+        supports_prompt_cache=True,
         description="DeepSeek V4 Pro served through the Token Plan",
         recommended=False,
     ),

--- a/tests/unit/model/test_registry.py
+++ b/tests/unit/model/test_registry.py
@@ -190,10 +190,6 @@ def test_token_plan_models_ship_their_real_windows() -> None:
         "deepseek-v4-flash-0731": (1_000_000, 393_216),
     }
     assert qwencloud_token_plan_models["qwen3.8-max"].supports_images is True
-    # Twice qwen3.6-flash's cap, which is the reason to prefer this row over
-    # that one for the cheap tier; pinned because a wrong cap truncates output
-    # rather than failing loudly.
-    assert qwencloud_token_plan_models["qwen3.8-flash"].max_tokens == 131_072
 
     # Both the exact-id chain and the enumerable map must answer, because
     # `build_model_spec` reaches the former and discovery merges over the
@@ -283,26 +279,45 @@ def test_token_plan_ships_a_row_for_every_chat_model_the_gateway_lists() -> None
 
 
 def test_token_plan_models_declare_prompt_caching() -> None:
-    """The flag is what gates `cache_control`, so False means "never cache".
+    """The flag picks the cache MODE, and the evidence for it is per row.
 
     `OpenAICompatClient._message_cache_markers` is called only when
     `request.model.supports_prompt_cache` is set, and this provider speaks the
     OpenAI-compatible wire. These rows shipped `False`, so lop emitted no
-    markers and the gateway fell back to its implicit cache — the 20% tier
-    rather than the 10% one an explicit marker buys.
+    `cache_control` at all and the gateway's implicit cache — which cannot be
+    disabled — was the only thing running.
 
-    That the gateway caches at all was measured, not read off a doc page: an
-    identical 6.5k-token system prefix sent twice with
-    `cache_control: {"type": "ephemeral"}` reports
-    `cache_creation_input_tokens=6547` on the first call and
-    `cached_tokens=6547` on the second, for every text row here.
+    The expected value is keyed by evidence class rather than asserted map-wide,
+    because explicit-cache support is per model AND per region on this provider.
+    A map-wide `is True` would force the next correctly-added row to carry a
+    flag nobody checked, and would read as authority for it. Adding a row here
+    fails this test until its evidence class is stated, which is the point.
 
-    Asserted over the whole map rather than one row, because the failure is
-    invisible at runtime: a row added with the flag unset does not error, it
-    just quietly re-bills its prefix on every turn. On agent traffic — a
-    transcript resent each turn, measured at a 97% cache-read share — that is
-    roughly a 6x difference in billed input.
+    The classes, and the note beside the map for the full derivation:
+
+    * MEASURED_EXPLICIT — `cache_creation_input_tokens` observed on the first
+      call, which is the only explicit-cache-only signal the wire carries.
+    * MARKED_HIT_ONLY — markers sent, second call reported `cached_tokens`, but
+      `cache_creation_input_tokens` was not captured. Weaker than it looks: the
+      implicit cache reports `cached_tokens` too, so this does not by itself
+      prove the marker did anything.
+    * INFERRED_INERT — not driven, and/or not on this region's (ap-southeast-1,
+      International) explicit-cache list. True because an unrecognised marker is
+      ignored and the implicit cache still applies, so the flag is inert here
+      rather than wrong.
     """
+    measured_explicit = {"qwen3.8-max", "qwen3.8-flash"}
+    marked_hit_only = {"qwen3.7-plus", "qwen3.6-flash", "glm-5.2", "deepseek-v4-pro"}
+    inferred_inert = {"qwen3.7-max", "deepseek-v4-flash-0731"}
+
+    # Every row is classified exactly once, so a new row cannot ride in on a
+    # blanket assertion.
+    assert measured_explicit.isdisjoint(marked_hit_only)
+    assert inferred_inert.isdisjoint(measured_explicit | marked_hit_only)
+    assert (
+        measured_explicit | marked_hit_only | inferred_inert
+    ) == qwencloud_token_plan_models.keys()
+
     for model_id, info in qwencloud_token_plan_models.items():
         assert info.supports_prompt_cache is True, model_id
 

--- a/tests/unit/model/test_registry.py
+++ b/tests/unit/model/test_registry.py
@@ -180,6 +180,7 @@ def test_token_plan_models_ship_their_real_windows() -> None:
         # Output caps as the endpoint's own `max_tokens` validator reports them
         # ("Range of max_tokens should be [1, N]"); see the note beside the map.
         "qwen3.8-max": (1_000_000, 131_072),
+        "qwen3.8-flash": (1_000_000, 131_072),
         "qwen3.7-max": (1_000_000, 131_072),
         "qwen3.7-plus": (1_000_000, 131_072),
         "qwen3.6-flash": (1_000_000, 65_536),
@@ -189,6 +190,10 @@ def test_token_plan_models_ship_their_real_windows() -> None:
         "deepseek-v4-flash-0731": (1_000_000, 393_216),
     }
     assert qwencloud_token_plan_models["qwen3.8-max"].supports_images is True
+    # Twice qwen3.6-flash's cap, which is the reason to prefer this row over
+    # that one for the cheap tier; pinned because a wrong cap truncates output
+    # rather than failing loudly.
+    assert qwencloud_token_plan_models["qwen3.8-flash"].max_tokens == 131_072
 
     # Both the exact-id chain and the enumerable map must answer, because
     # `build_model_spec` reaches the former and discovery merges over the
@@ -230,9 +235,13 @@ def test_token_plan_ships_a_row_for_every_chat_model_the_gateway_lists() -> None
     the 128k default just because nobody noticed it — but it means the fix is
     usually to re-derive the snapshot, not to edit the map.
     """
-    # Snapshot of GET /compatible-mode/v1/models, 2026-08-19.
+    # Snapshot of GET /compatible-mode/v1/models, re-derived 2026-09-04 against
+    # the plan's published allowlist. `qwen3.8-flash` is the delta from the
+    # 2026-08-19 snapshot: it serves chat (verified live) and is on the
+    # allowlist, but had no row, so it resolved to the 128k unknown default.
     gateway_chat_models = {
         "qwen3.8-max",
+        "qwen3.8-flash",
         "qwen3.7-max",
         "qwen3.7-plus",
         "qwen3.6-flash",
@@ -259,6 +268,7 @@ def test_token_plan_ships_a_row_for_every_chat_model_the_gateway_lists() -> None
     assert gateway_chat_models.isdisjoint(gateway_non_chat_models)
     assert gateway_chat_models | gateway_non_chat_models == {
         "qwen3.8-max",
+        "qwen3.8-flash",
         "qwen3.7-max",
         "qwen3.7-plus",
         "qwen3.6-flash",
@@ -270,6 +280,58 @@ def test_token_plan_ships_a_row_for_every_chat_model_the_gateway_lists() -> None
         "qwen-audio-3.0-tts-plus",
         "qwen-audio-3.0-realtime-plus",
     }
+
+
+def test_token_plan_models_declare_prompt_caching() -> None:
+    """The flag is what gates `cache_control`, so False means "never cache".
+
+    `OpenAICompatClient._message_cache_markers` is called only when
+    `request.model.supports_prompt_cache` is set, and this provider speaks the
+    OpenAI-compatible wire. These rows shipped `False`, so lop emitted no
+    markers and the gateway fell back to its implicit cache — the 20% tier
+    rather than the 10% one an explicit marker buys.
+
+    That the gateway caches at all was measured, not read off a doc page: an
+    identical 6.5k-token system prefix sent twice with
+    `cache_control: {"type": "ephemeral"}` reports
+    `cache_creation_input_tokens=6547` on the first call and
+    `cached_tokens=6547` on the second, for every text row here.
+
+    Asserted over the whole map rather than one row, because the failure is
+    invisible at runtime: a row added with the flag unset does not error, it
+    just quietly re-bills its prefix on every turn. On agent traffic — a
+    transcript resent each turn, measured at a 97% cache-read share — that is
+    roughly a 6x difference in billed input.
+    """
+    for model_id, info in qwencloud_token_plan_models.items():
+        assert info.supports_prompt_cache is True, model_id
+
+    # The end of the pipe, not just the map: `build_model_spec` is what the
+    # client actually reads the flag from.
+    assert build_model_spec("alibaba-token-plan", "qwen3.8-max").supports_prompt_cache is True
+    assert build_model_spec("alibaba-token-plan", "qwen3.8-flash").supports_prompt_cache is True
+
+
+def test_token_plan_vision_rows_match_what_the_endpoint_accepts() -> None:
+    """Vision is per-row here, and both directions were checked live.
+
+    The plan's allowlist marks `glm-5.2` and the deepseek rows as text-only
+    while the qwen rows carry "visual understanding". Verified rather than
+    transcribed, because the failure is silent in an unusual way: every row
+    ACCEPTS an `image_url` content block without erroring, but the text-only
+    ones never receive it — asked the colour of a solid blue PNG,
+    `qwen3.8-flash` answers "Blue" while `glm-5.2` and `deepseek-v4-pro` reason
+    aloud that no image was provided.
+
+    So an `image_url` block that does not raise is not evidence of vision, and
+    marking these rows True on the strength of the request succeeding would
+    route a designer or QA subagent to a model that cannot see its screenshot.
+    """
+    assert qwencloud_token_plan_models["qwen3.8-flash"].supports_images is True
+    assert qwencloud_token_plan_models["qwen3.6-flash"].supports_images is True
+    assert qwencloud_token_plan_models["qwen3.7-plus"].supports_images is True
+    assert qwencloud_token_plan_models["glm-5.2"].supports_images is False
+    assert qwencloud_token_plan_models["deepseek-v4-pro"].supports_images is False
 
 
 def test_token_plan_ships_no_row_the_gateway_serves_under_another_id() -> None:


### PR DESCRIPTION
## Summary

Every row in `qwencloud_token_plan_models` shipped `supports_prompt_cache=False`, and `qwen3.8-flash` had no row at all. Both are silent at runtime — nothing errors, the session just costs several times more than it should and compacts at the wrong threshold.

**The flag is not cosmetic.** `OpenAICompatClient._message_cache_markers` is called only when `request.model.supports_prompt_cache` is set, and this provider speaks the OpenAI-compatible wire:

```python
# providers/clients.py
if request.model.supports_prompt_cache:
    self._message_cache_markers(messages)
```

With it off lop emitted no `cache_control` markers at all, so the gateway fell back to its implicit cache. Alibaba documents the two modes as [mutually exclusive per request](https://www.alibabacloud.com/help/en/model-studio/context-cache): implicit applies automatically to every supported model and **cannot be disabled**, billing hits at **20%** of the input price; explicit is what a marker selects and bills hits at **10%**, with a 5-minute TTL renewed on each hit. So the flag was never the difference between caching and no caching — it was the difference between the 20% path and the 10% one.

**The cost scales with how agentic the traffic is,** because a growing transcript is resent on every turn. Measured over a week of real subagent sessions on this machine: **1.5B input tokens at a 97% cache-read share**, where the flag alone is roughly a **6x** difference in billed input.

**`qwen3.8-flash`** is on the plan's [published allowlist](https://docs.qwencloud.com/token-plan/personal/token-plan-personal-overview) and serves chat, but had no row, so it resolved to `unknown_model_info` — a `-1` window the spec reads as the 128k default. That is the exact defect the surrounding rows exist to prevent, and worse here than for most ids: it is the current-generation Flash, so a **1M-window model compacted at 128k**. Its 131,072 output cap is twice `qwen3.6-flash`'s 65,536, which is the substantive reason to prefer it for a cheap tier.

Prices stay unset. The plan bills subscription **credits**, so the cache discount is a credit multiplier rather than a USD rate; inventing one would break the map's zero-means-unknown convention.

## Testing Evidence

All numbers below are from live calls against `dashscope-intl.aliyuncs.com` on a free-tier key, not transcribed from documentation.

### 1. The gateway caches — write then read, every text row

Identical 6.5k-token system prefix sent twice with `cache_control: {"type": "ephemeral"}` on the OpenAI-compatible wire:

| model | req 1 `cache_creation_input_tokens` | req 2 `cached_tokens` |
|---|---|---|
| `qwen3.8-max` | 6547 | **6547** |
| `qwen3.8-flash` | 6547 | **6547** |
| `qwen3.7-plus` | — | **6509** |
| `qwen3.6-flash` | — | **6509** |
| `glm-5.2` | — | **6016** |
| `deepseek-v4-pro` | — | **5120** |

Also confirmed on the Anthropic-compatible endpoint, which returns the Anthropic-shaped fields:

```
req 1  cache_creation_input_tokens: 9052,  cache_read_input_tokens: 0
req 2  cache_creation_input_tokens: 0,     cache_read_input_tokens: 9052
```

### 2. Output caps, from the endpoint's own validator

Re-derived exactly as the note beside the map prescribes — `POST` with `max_tokens: 9999999` and read the rejection:

```
qwen3.8-max     Range of max_tokens should be [1, 131072]
qwen3.8-flash   Range of max_tokens should be [1, 131072]
qwen3.7-max     Range of max_tokens should be [1, 131072]
qwen3.7-plus    Range of max_tokens should be [1, 131072]
qwen3.6-flash   Range of max_tokens should be [1, 65536]
glm-5.2         Range of max_tokens should be [1, 131072]
```

`deepseek-v4-pro` and `deepseek-v4-flash-0731` still accept any value without validating, so their caps are unchanged.

### 3. Vision, verified per row — and why the obvious check is wrong

**Every row accepts an `image_url` content block without erroring**, so a request that succeeds is not evidence of vision. Asked the colour of a solid blue 64×64 PNG:

| model | `content` | reasoning trace |
|---|---|---|
| `qwen3.8-flash` | `'Blue'` | — |
| `qwen3.6-flash` | `'Red'` (red PNG) | — |
| `glm-5.2` | `''` | *"wait, there is no image provided"* |
| `deepseek-v4-pro` | `'unknown'` | *"there is no image provided"* |

So `glm-5.2` and `deepseek-v4-pro` keep `supports_images=False`. Marking them True on the strength of the request succeeding would route a designer or QA subagent to a model that cannot see its screenshot.

A 1×1 PNG is rejected on dimensions by every row (`The image length and width do not mee…`), which is itself evidence the endpoint decodes the image rather than ignoring the block.

### 4. `qwen3.8-flash-next` is deliberately NOT added

It has an Artificial Analysis entry, but the API does not serve it and it is not on the plan allowlist:

```
qwen3.8-flash-next  FAIL model_not_found — does not exist or you do not have access to it
qwen3.8-flash       OK
```

### 5. The fix reaches the wire, not just the map

```
spec.supports_prompt_cache: True
messages carrying cache_control: ['user', 'user']
```

Before this change `_message_cache_markers` was never called for this provider.

### 6. Gates

All four CI commands, run over the whole tree exactly as `.github/workflows/ci.yml` spells them:

```
.venv/bin/python -m flake8 .                               -> clean
uvx --from black==26.1.0 black --check .                   -> 838 files unchanged
uvx isort==5.13.2 --check .                                -> clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python . -> 0 errors, 0 warnings
```

Targeted suites:

```
tests/unit/model/test_registry.py            30 passed
tests/unit/model tests/unit/providers      1532 passed
```

Full unit suite: **12106 passed, 24 failed**. All 24 failures are `tests/unit/evaluation/adapters/osworld/test_aws_provider.py` failing on `botocore.exceptions.ProfileNotFound: The config profile (sandbox) could not be found` — a missing local AWS profile. Confirmed pre-existing by running that file against pristine `origin/main` in a detached worktree: **same 24 failures**. Untouched by this change.

## Tests added

- `test_token_plan_models_declare_prompt_caching` — asserts the flag over the **whole map** rather than one row, because a row added with it unset does not error, it just quietly re-bills its prefix every turn. Also asserts through `build_model_spec`, since that is what the client actually reads.
- `test_token_plan_vision_rows_match_what_the_endpoint_accepts` — pins both directions, and records in the docstring why "the request succeeded" is not evidence.
- `test_token_plan_models_ship_their_real_windows` / `..._ships_a_row_for_every_chat_model_...` — snapshot re-derived to include `qwen3.8-flash`. The existing docstring says to suspect the expected side first when it fails; the catalogue genuinely changed, so the snapshot moved and is dated `2026-09-04`.

Release: patch — QwenCloud Token Plan models now use prompt caching, and the missing `qwen3.8-flash` row stops a 1M-context model being compacted at 128k.
