### PR TITLE
perf(imaging): bound ingested images to 1024px instead of 1568px

### DIFF
--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -119,13 +119,24 @@ from local_operator.optional import missing_extra_error
 #: where pixels cost tokens without buying legibility: a real 4-up document
 #: collage from this machine's own traffic measured 3,184 tokens at 1568
 #: against 1,359 at 1024 (57% cheaper), and a vision model reading the 1024
-#: render recovered appendix titles, a 5-column score matrix, page numbers,
-#: and 7pt header fine print identically to the 1568 render. Below 1024 the
-#: margin thins — dense 6-7pt table body text is at the edge at 768 — so 1024
-#: is the floor that keeps document work legible. Photographic content, which
-#: has no strokes to lose, could go further; it shares the bound because one
-#: number the ingest sites, the tests, and the marker captions agree on beats
-#: a content-sniffing ladder whose mistakes land in the billed prefix.
+#: render recovered appendix titles, a 5-column score matrix, page numbers and
+#: 7pt header prose. Below 1024 the margin thins — dense 6-7pt table body text
+#: is at the edge at 768 — so 1024 is the floor that keeps document work
+#: legible.
+#:
+#: ONE MEASURED LOSS, so nobody re-derives it: on a 4-up COLLAGE the footer's
+#: 24-character hex report id degrades from a 4-row ink span to 1 and stops
+#: being transcribable (design round 1, D1). Prose survives; a long opaque
+#: identifier does not. It is specific to multi-page collages — a page captured
+#: alone measures ~784x1006 and is not resized at all — and the escape hatch is
+#: to crop the region and re-read it, which passes through unresized.
+#:
+#: LINE ART IS EXEMPT and keeps :data:`IMAGE_MAX_EDGE`. The measurement above
+#: is photographic content, which has no one-pixel strokes to lose; bilevel
+#: renderings of a small pixel font do, and shrinking them to 1024 destroys the
+#: legibility the font was chosen for. That is not hypothetical — a snapcompact
+#: archive frame is exactly such a rendering (PR #603 review round 1, F1). The
+#: exemption uses the same ``_is_line_art`` predicate the repair path does.
 IMAGE_MAX_EDGE = 1568
 #: Long-edge ceiling for images ENTERING the context (``read`` tool, pasted
 #: screenshots). Tighter than :data:`IMAGE_MAX_EDGE`, which stays the
@@ -534,7 +545,28 @@ def bound_image_for_model(
         width, height = image.size
 
         long_edge = max(width, height)
+        # LINE ART KEEPS THE CORRECTNESS BOUND, and this carve-out is the same
+        # argument the repair path already makes (review round 2, F8): every
+        # pixel removed from a one-pixel stroke is a stroke that may vanish.
+        #
+        # The ingest bound below it is a BILLING argument measured on
+        # photographic content, which has no strokes to lose. Applying it to
+        # bilevel content took the sharper reduction with none of the
+        # protection, and it is reachable in ordinary use rather than
+        # hypothetical: a snapcompact archive frame is a 1568px bilevel
+        # rendering of a 5x7 pixel font, it is passed through
+        # ``bound_image_for_model`` whenever such a frame is re-read from disk,
+        # and at 1024 its glyphs lose their strokes — measured on a real
+        # ``render_frame`` output, the text "The session was compacted" is
+        # legible at 1568 and is not at 1024 (PR #603 review round 1, F1).
+        #
+        # ``_is_line_art`` is deliberately narrower than "two distinct values"
+        # (a dithered halftone is bilevel and must NOT take this path), so the
+        # predicate here is the same one the repair uses rather than a second
+        # opinion about what line art is.
         edge_cap = IMAGE_INGEST_MAX_EDGE if max_edge is None else max_edge
+        if max_edge is None and _is_line_art(image):
+            edge_cap = IMAGE_MAX_EDGE
         if (
             info.sendable
             and frames == 1

--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -113,39 +113,44 @@ from local_operator.optional import missing_extra_error
 #: passes any byte cap easily — costs 16,257 tokens untouched against 2,459
 #: resized (6.6x).
 #:
-#: PASTE/READ INGEST uses a tighter bound (:data:`IMAGE_INGEST_MAX_EDGE`).
-#: Anthropic bills an image by pixel AREA (~w*h/750 tokens), so after the 1568
+#: Images ENTERING the context take the tighter :data:`IMAGE_INGEST_MAX_EDGE`
+#: instead; this constant stays the correctness ceiling and a repair is still
+#: measured against it.
+IMAGE_MAX_EDGE = 1568
+#: Long-edge ceiling for images ENTERING the context (``read`` tool, pasted
+#: screenshots), and the bound the cost argument below is measured on.
+#:
+#: Tighter than :data:`IMAGE_MAX_EDGE`, which stays the CORRECTNESS ceiling —
+#: the many-image refusal line and the snapcompact billing geometry both answer
+#: to it and are deliberately not re-decided here. Ingest is the one site free
+#: to move: 1024 sits below every provider refusal line (2000px many-image,
+#: 5 MB base64 wall) with wide margin.
+#:
+#: Providers bill an image by pixel AREA (~w*h/750 tokens), so after the 1568
 #: server-side downsample there is still a billed region between 1024 and 1568
-#: where pixels cost tokens without buying legibility: a real 4-up document
-#: collage from this machine's own traffic measured 3,184 tokens at 1568
-#: against 1,359 at 1024 (57% cheaper), and a vision model reading the 1024
-#: render recovered appendix titles, a 5-column score matrix, page numbers and
-#: 7pt header prose. Below 1024 the margin thins — dense 6-7pt table body text
-#: is at the edge at 768 — so 1024 is the floor that keeps document work
-#: legible.
+#: where pixels cost tokens without buying legibility. Measured on a real 4-up
+#: document collage from this machine's own traffic: 3,184 visual tokens at
+#: 1568 against 1,359 at 1024 (57% cheaper), with a vision model reading the
+#: 1024 render recovering appendix titles, a 5-column score matrix, page
+#: numbers and 7pt header prose. Below 1024 the margin thins — dense 6-7pt
+#: table body text is at the edge at 768 — so 1024 is the floor that keeps
+#: document work legible.
 #:
 #: ONE MEASURED LOSS, so nobody re-derives it: on a 4-up COLLAGE the footer's
 #: 24-character hex report id degrades from a 4-row ink span to 1 and stops
-#: being transcribable (design round 1, D1). Prose survives; a long opaque
-#: identifier does not. It is specific to multi-page collages — a page captured
-#: alone measures ~784x1006 and is not resized at all — and the escape hatch is
-#: to crop the region and re-read it, which passes through unresized.
+#: being transcribable (design round 1, D1). Prose survives a downscale because
+#: a reader reconstructs it from context; a long opaque identifier has no
+#: context to reconstruct from. It is specific to multi-page collages — a page
+#: captured alone measures ~784x1006 and is not resized at all — and the escape
+#: hatch is to crop the region and re-read it, which passes through unresized.
 #:
-#: LINE ART IS EXEMPT and keeps :data:`IMAGE_MAX_EDGE`. The measurement above
-#: is photographic content, which has no one-pixel strokes to lose; bilevel
+#: LINE ART IS EXEMPT and keeps :data:`IMAGE_MAX_EDGE`. The measurement above is
+#: photographic content, which has no one-pixel strokes to lose; bilevel
 #: renderings of a small pixel font do, and shrinking them to 1024 destroys the
-#: legibility the font was chosen for. That is not hypothetical — a snapcompact
-#: archive frame is exactly such a rendering (PR #603 review round 1, F1). The
-#: exemption uses the same ``_is_line_art`` predicate the repair path does.
-IMAGE_MAX_EDGE = 1568
-#: Long-edge ceiling for images ENTERING the context (``read`` tool, pasted
-#: screenshots). Tighter than :data:`IMAGE_MAX_EDGE`, which stays the
-#: correctness ceiling — the many-image refusal line and the snapcompact
-#: billing geometry both answer to it and are deliberately not re-decided
-#: here. Ingest is the one site that may move independently: 1024 sits below
-#: every provider refusal line (2000px many-image, 5 MB base64 wall) with
-#: wide margin, and the legibility evidence above says the pixels between
-#: 1024 and 1568 cost tokens without buying readability on document content.
+#: legibility the font was chosen for — a snapcompact archive frame is exactly
+#: such a rendering, and at 1024 it renders "compacted" as "conpacted" (PR #603
+#: review round 1, F1; QA round 1). The exemption uses the same
+#: ``_is_line_art`` predicate the repair path does.
 IMAGE_INGEST_MAX_EDGE = 1024
 #: The provider ceiling a REPAIR is measured against, which is deliberately not
 #: :data:`IMAGE_MAX_EDGE`. Anything this module CREATES is bounded to 1568 for

--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -69,6 +69,18 @@ the invariant is total:
   the refusal ceiling demands.
 - ``_forward_undecoded`` cannot resize at all, because on that host there is no
   decoder. See its own docstring for what it does enforce.
+
+TWO BOUNDS, and the split is deliberate. :data:`IMAGE_MAX_EDGE` is the
+CORRECTNESS ceiling: it is what the many-image refusal argument above is
+measured against, and what a repair is judged by. :data:`IMAGE_INGEST_MAX_EDGE`
+is what images ENTERING the context are actually resized to, and it is lower
+because the argument there is billing rather than refusal — a provider bills an
+image by pixel area, so pixels that buy no legibility are pure cost. Ingest is
+the only site free to move: a REPAIR must not chase it, because repairing a
+block that the provider would have accepted rewrites history that a prompt
+cache is holding, turning a saving into a full-prefix rewrite. That is why
+:func:`rebound_oversize_image` still triggers at :data:`IMAGE_REFUSAL_MAX_EDGE`
+and why lowering the ingest bound leaves every existing 1568px block untouched.
 """
 
 from __future__ import annotations
@@ -100,7 +112,30 @@ from local_operator.optional import missing_extra_error
 #: 2,049 at 1568 (2.7x), and a 4032x3024 phone photo — 1.5 MB as JPEG, so it
 #: passes any byte cap easily — costs 16,257 tokens untouched against 2,459
 #: resized (6.6x).
+#:
+#: PASTE/READ INGEST uses a tighter bound (:data:`IMAGE_INGEST_MAX_EDGE`).
+#: Anthropic bills an image by pixel AREA (~w*h/750 tokens), so after the 1568
+#: server-side downsample there is still a billed region between 1024 and 1568
+#: where pixels cost tokens without buying legibility: a real 4-up document
+#: collage from this machine's own traffic measured 3,184 tokens at 1568
+#: against 1,359 at 1024 (57% cheaper), and a vision model reading the 1024
+#: render recovered appendix titles, a 5-column score matrix, page numbers,
+#: and 7pt header fine print identically to the 1568 render. Below 1024 the
+#: margin thins — dense 6-7pt table body text is at the edge at 768 — so 1024
+#: is the floor that keeps document work legible. Photographic content, which
+#: has no strokes to lose, could go further; it shares the bound because one
+#: number the ingest sites, the tests, and the marker captions agree on beats
+#: a content-sniffing ladder whose mistakes land in the billed prefix.
 IMAGE_MAX_EDGE = 1568
+#: Long-edge ceiling for images ENTERING the context (``read`` tool, pasted
+#: screenshots). Tighter than :data:`IMAGE_MAX_EDGE`, which stays the
+#: correctness ceiling — the many-image refusal line and the snapcompact
+#: billing geometry both answer to it and are deliberately not re-decided
+#: here. Ingest is the one site that may move independently: 1024 sits below
+#: every provider refusal line (2000px many-image, 5 MB base64 wall) with
+#: wide margin, and the legibility evidence above says the pixels between
+#: 1024 and 1568 cost tokens without buying readability on document content.
+IMAGE_INGEST_MAX_EDGE = 1024
 #: The provider ceiling a REPAIR is measured against, which is deliberately not
 #: :data:`IMAGE_MAX_EDGE`. Anything this module CREATES is bounded to 1568 for
 #: the cost reasons above; but a block that already exists is only worth
@@ -420,21 +455,22 @@ def bound_image_for_model(
        at its original size, and PNG round-tripping routinely makes files
        BIGGER (a 2560x1600 UI screenshot measured 550 KB on disk against 335 KB
        re-encoded only because the resize came with it).
-    2. Resize to :data:`IMAGE_MAX_EDGE` and re-encode as PNG. Lossless, which
-       is what a screenshot of 9-pixel text needs.
+    2. Resize to the ingest bound (:data:`IMAGE_INGEST_MAX_EDGE` by default;
+       :data:`IMAGE_MAX_EDGE` when a caller passes it explicitly) and re-encode
+       as PNG. Lossless, which is what a screenshot of small text needs.
     3. JPEG when that PNG blows :data:`IMAGE_MAX_BYTES`, and only when it
        actually comes out smaller. PNG is a bad photographic codec and that is
        the usual case here — the sampled 1672x941 photographic PNG re-encoded
        to 1.9 MB of PNG against 271 KB of quality-85 JPEG — but it is not the
        only one, so the choice is measured rather than assumed.
 
-    ``max_edge`` overrides :data:`IMAGE_MAX_EDGE` for callers that are REPAIRING
-    rather than ingesting. The default exists to make an image cheap, and it is
-    the right default for anything arriving from a paste or a file read; but a
-    caller shrinking an image that already exists is trading fidelity it did not
-    choose, and for line art the smallest possible reduction is worth real
-    money. See :func:`rebound_oversize_image`, which passes the refusal ceiling
-    for bilevel sources so a pixel font is shrunk by 2% instead of 23%.
+    ``max_edge`` overrides :data:`IMAGE_INGEST_MAX_EDGE` for callers that are
+    REPAIRING rather than ingesting. The default is the ingest bound, and it
+    is the right default for anything arriving from a paste or a file read;
+    but a caller shrinking an image that already exists is trading fidelity it
+    did not choose, and for line art the smallest possible reduction is worth
+    real money. See :func:`rebound_oversize_image`, which passes the refusal
+    ceiling for bilevel sources so a pixel font is shrunk by 2% instead of 23%.
 
     With no decoder available the whole ladder collapses to
     :func:`_forward_undecoded`.
@@ -498,7 +534,7 @@ def bound_image_for_model(
         width, height = image.size
 
         long_edge = max(width, height)
-        edge_cap = IMAGE_MAX_EDGE if max_edge is None else max_edge
+        edge_cap = IMAGE_INGEST_MAX_EDGE if max_edge is None else max_edge
         if (
             info.sendable
             and frames == 1

--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -471,9 +471,11 @@ def bound_image_for_model(
        at its original size, and PNG round-tripping routinely makes files
        BIGGER (a 2560x1600 UI screenshot measured 550 KB on disk against 335 KB
        re-encoded only because the resize came with it).
-    2. Resize to the ingest bound (:data:`IMAGE_INGEST_MAX_EDGE` by default;
-       :data:`IMAGE_MAX_EDGE` when a caller passes it explicitly) and re-encode
-       as PNG. Lossless, which is what a screenshot of small text needs.
+    2. Resize and re-encode as PNG. Lossless, which is what a screenshot of
+       small text needs. The bound is :data:`IMAGE_INGEST_MAX_EDGE`, except for
+       LINE ART, which keeps :data:`IMAGE_MAX_EDGE` because one-pixel strokes
+       do not survive the tighter bound (see that constant); an explicit
+       ``max_edge`` overrides both.
     3. JPEG when that PNG blows :data:`IMAGE_MAX_BYTES`, and only when it
        actually comes out smaller. PNG is a bad photographic codec and that is
        the usual case here — the sampled 1672x941 photographic PNG re-encoded

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -93,9 +93,9 @@ from local_operator.harness.wake import (
     format_duration,
 )
 from local_operator.imaging import (
+    IMAGE_INGEST_MAX_EDGE,
     IMAGE_JPEG_QUALITY,
     IMAGE_MAX_BYTES,
-    IMAGE_MAX_EDGE,
     IMAGE_MAX_PIXELS,
     bound_image_for_model,
 )
@@ -172,7 +172,7 @@ READ_IMAGE_LIMIT_BYTES = 16 * 1024 * 1024
 #: for both. Re-exported under the historical names because they are part of
 #: this module's tested surface.
 READ_IMAGE_MAX_PIXELS = IMAGE_MAX_PIXELS
-READ_IMAGE_MAX_EDGE = IMAGE_MAX_EDGE
+READ_IMAGE_MAX_EDGE = IMAGE_INGEST_MAX_EDGE
 READ_IMAGE_MAX_BYTES = IMAGE_MAX_BYTES
 READ_IMAGE_JPEG_QUALITY = IMAGE_JPEG_QUALITY
 #: Maximum lines read renders; larger files show the head plus a footer

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -277,7 +277,7 @@ IMAGE_MARKER = re.compile(r"\[Image #(?P<index>[1-9]\d*)(?:,[^\]\n\[]*)?\]")
 
 #: Appended to a marker whose image was downscaled on the way in. One glyph,
 #: two cells, and it buys back most of what the honest label costs: every 16:9
-#: screenshot now bounds to the same 1568x882, so three different captures
+#: screenshot now bounds to the same 1024x576, so three different captures
 #: pasted together would otherwise read as three identical markers where the
 #: source dimensions had told them apart (design round 1, D1). It also answers
 #: the question the number itself provokes — "why is this not the size I
@@ -357,7 +357,7 @@ def _bounded_dimensions(payload: bytes, info: ImageInfo) -> str:
     Read back from the BOUNDED payload rather than carried over from ``info``,
     which describes the file on disk. Once the paste path started resizing,
     reusing the source dimensions would print a marker claiming 2560x1440 next
-    to a 1568x882 attachment — a receipt for something that was never sent.
+    to a 1024x576 attachment — a receipt for something that was never sent.
 
     Carries :data:`RESIZED_MARK` when the two differ, so the label still
     distinguishes one paste from another and says why the number moved.
@@ -4944,7 +4944,7 @@ class Editor(TextArea):
                     ),
                     # The marker reports what was ATTACHED, not what was on the
                     # clipboard or on disk. A marker reading 2560x1440 beside a
-                    # 1568x882 attachment is a receipt for something that was
+                    # 1024x576 attachment is a receipt for something that was
                     # never sent, and the whole point of the dimensions is that
                     # the user can check them at a glance.
                     _bounded_dimensions(payload, info),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.45.4"
+version = "0.45.5"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/measure_ingest_lossy_rung.py
+++ b/scripts/measure_ingest_lossy_rung.py
@@ -1,0 +1,122 @@
+"""Why the PNG-over-budget ladder rung is unreachable at the ingest bound.
+
+The rung in :func:`local_operator.imaging.bound_image_for_model` fires only when
+BOTH of these hold at once: the PNG encode is over :data:`IMAGE_MAX_BYTES`, AND
+the PNG is still smaller than the JPEG. At the 1024px ingest bound it cannot
+happen, and this script is the evidence.
+
+It exists because the comment stating that fact has now carried THREE wrong
+mechanisms across three review rounds (PR #603 F2, QA Q1, QA Q3). Every attempt
+to summarise the numbers in prose drifted; the conclusion survived every attempt
+to falsify it. So the generator is checked in and the comments point here rather
+than restating figures nobody can re-derive.
+
+    .venv/bin/python scripts/measure_ingest_lossy_rung.py
+
+Crossover COLOUR COUNTS are fixture-specific (they move with the palette
+construction and the seed). The REGIME ORDERING is not, and the ordering is the
+whole argument: PNG is never both the smaller encode and over the budget.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from PIL import Image  # noqa: E402
+
+from local_operator.imaging import (  # noqa: E402
+    IMAGE_INGEST_MAX_EDGE,
+    IMAGE_JPEG_QUALITY,
+    IMAGE_MAX_BYTES,
+)
+
+MIB = 1024 * 1024
+
+
+def _palette_noise(colours: int, edge: int, seed: int) -> Image.Image:
+    """Square of uniform noise over ``colours`` distinct values.
+
+    Palette noise is the adversarial case on purpose: it defeats PNG's
+    predictors (so the PNG grows with the palette) while staying hostile to
+    JPEG's DCT, which is the only shape that could plausibly put PNG over the
+    budget while still beating JPEG.
+    """
+    rng = random.Random(seed)
+    palette = [
+        (255, 0, 0),
+        (0, 255, 0),
+        (0, 0, 255),
+        (255, 255, 0),
+        (0, 255, 255),
+        (255, 0, 255),
+        (255, 255, 255),
+        (0, 0, 0),
+    ]
+    while len(palette) < colours:
+        palette.append((rng.randrange(256), rng.randrange(256), rng.randrange(256)))
+    palette = palette[:colours]
+
+    image = Image.new("RGB", (edge, edge))
+    pixels = image.load()
+    assert pixels is not None
+    draw = random.Random(seed)
+    for y in range(edge):
+        for x in range(edge):
+            pixels[x, y] = palette[draw.randrange(len(palette))]
+    return image
+
+
+def main() -> int:
+    edge = IMAGE_INGEST_MAX_EDGE
+    print(
+        f"area {edge}x{edge}, budget {IMAGE_MAX_BYTES / MIB:.2f} MiB, jpeg q{IMAGE_JPEG_QUALITY}\n"
+    )
+    header = f"{'colours':>8} {'PNG MiB':>9} {'JPEG MiB':>9} {'over':>6} {'PNGwins':>8}  regime"
+    print(header)
+    print("-" * len(header))
+
+    reachable = []
+    for seed in (1234, 99, 7):
+        for colours in (2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 96, 128, 192, 256):
+            image = _palette_noise(colours, edge, seed)
+            buf = io.BytesIO()
+            image.save(buf, format="PNG")
+            png = len(buf.getvalue())
+            buf = io.BytesIO()
+            image.save(buf, format="JPEG", quality=IMAGE_JPEG_QUALITY)
+            jpeg = len(buf.getvalue())
+
+            over = png > IMAGE_MAX_BYTES
+            wins = png < jpeg
+            if over and wins:
+                regime = "RUNG REACHED"
+                reachable.append((seed, colours))
+            elif wins:
+                regime = "A: PNG smaller, under budget"
+            elif not over:
+                regime = "B: JPEG smaller, under budget"
+            else:
+                regime = "C: JPEG smaller, PNG over budget"
+            if seed == 1234:
+                print(
+                    f"{colours:>8} {png / MIB:>9.3f} {jpeg / MIB:>9.3f} "
+                    f"{str(over):>6} {str(wins):>8}  {regime}"
+                )
+
+    print("\nsweep: 14 palette sizes x 3 seeds = 42 samples")
+    print(f"rung reached: {reachable or 'never'}")
+    print(
+        "\nThe three regimes are walked in order A -> B -> C. The rung needs "
+        "'PNG smaller' AND\n'PNG over budget', which would be a fourth regime "
+        "between A and C; B sits there instead."
+    )
+    return 1 if reachable else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -710,13 +710,15 @@ def test_a_repair_keeps_png_when_jpeg_would_be_bigger() -> None:
 
     Exercised at the REPAIR bound rather than through ``read``: bounding ingest
     to :data:`IMAGE_INGEST_MAX_EDGE` caps the delivered area at 1024x1024, and
-    at that area JPEG is always the smaller encode — 48-colour palette noise
-    measures 1.71 MiB of PNG against 0.74 MiB of JPEG, so the lossy rung fires
-    and WINS rather than declining itself. The rung closes for `read` because
-    PNG stops winning at this area, NOT because PNG stays inside the budget
-    (it does not). It is still reachable whenever a caller passes an explicit
-    ``max_edge`` (``rebound_oversize_image`` does), which is where the branch
-    now needs its cover.
+    the rung needs BOTH conditions at once and 1024x1024 never
+    supplies them together: below ~32 palette colours PNG is the smaller encode
+    but stays inside the budget (0.96 MiB at its worst, 48 colours), and above
+    that PNG exceeds the budget but JPEG has already become smaller (1.06 MiB
+    against 0.80 MiB at 64 colours). The two conditions pass each other without
+    ever overlapping. Swept 2-256 colours to
+    confirm the branch is unreachable there rather than merely rare. It is
+    still reachable whenever a caller passes an explicit ``max_edge``
+    (``rebound_oversize_image`` does), which is where the branch needs cover.
     """
     rng = random.Random(1234)
     palette = [

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -647,6 +647,59 @@ def test_a_photograph_is_still_resized_smoothly_to_the_cheap_bound() -> None:
     assert max(repaired.size) == IMAGE_MAX_EDGE, "a photo was not taken to the cheap bound"
 
 
+def test_line_art_keeps_the_correctness_bound_on_ingest() -> None:
+    """PR #603 review round 1, F1.
+
+    The ingest bound is a BILLING argument measured on photographic content,
+    which has no one-pixel strokes to lose. Bilevel renderings of a small pixel
+    font do, and the repair path has carried a carve-out for exactly this since
+    review round 2, F8 — ingest took the sharper reduction with none of the
+    protection.
+
+    Not hypothetical: a snapcompact archive frame is a 1568px bilevel rendering
+    of a 5x7 pixel font, and it reaches this function whenever such a frame is
+    re-read. At 1024 its glyphs lose strokes; measured on a real
+    ``render_frame`` output, "The session was compacted" is legible at 1568 and
+    is not at 1024.
+    """
+    from local_operator.compaction import snapcompact
+
+    text = "\n".join(
+        [
+            "The session was compacted at 2026-09-04T01:12Z after the context",
+            "reached 412,336 tokens against a 600,000 ceiling. Below is the",
+            "archived middle of the conversation, rendered as pixel-font frames.",
+        ]
+        * 6
+    )
+    frame = snapcompact.render_frame(text, snapcompact.resolve_shape("anthropic", "claude-opus-5"))
+    info = _sniffed(frame)
+    assert (
+        max(info.width or 0, info.height or 0) > IMAGE_INGEST_MAX_EDGE
+    ), "the fixture must be over the ingest bound or it proves nothing"
+
+    payload, _mime, _summary = bound_image_for_model(frame, info)
+
+    # Byte-identical passthrough, not merely "not shrunk to 1024": a frame this
+    # function rewrites is also a frame a prompt cache has to re-write.
+    assert payload == frame
+    width, height = Image.open(io.BytesIO(payload)).size
+    assert max(width, height) <= IMAGE_MAX_EDGE
+
+
+def test_photographic_content_still_takes_the_cheaper_ingest_bound() -> None:
+    """The mirror of the carve-out above: it must not swallow the saving.
+
+    A photographic image has no strokes to lose, so it takes
+    :data:`IMAGE_INGEST_MAX_EDGE` and the billed-area reduction the bound
+    exists for.
+    """
+    source = _noise_png((2560, 1440))
+    payload, _mime, _summary = bound_image_for_model(source, _sniffed(source))
+    width, height = Image.open(io.BytesIO(payload)).size
+    assert max(width, height) == IMAGE_INGEST_MAX_EDGE
+
+
 def test_a_repair_keeps_png_when_jpeg_would_be_bigger() -> None:
     """The lossy rung must MEASURE rather than assume it wins.
 
@@ -656,11 +709,14 @@ def test_a_repair_keeps_png_when_jpeg_would_be_bigger() -> None:
     BOTH axes, bigger and lossy, so the rung declines itself.
 
     Exercised at the REPAIR bound rather than through ``read``: bounding ingest
-    to :data:`IMAGE_INGEST_MAX_EDGE` caps the delivered area at 1024x1024, where
-    the worst palette noise measured 0.87 MiB — under the budget, so the rung
-    cannot fire there any more. It is still reachable whenever a caller passes
-    an explicit ``max_edge`` (``rebound_oversize_image`` does), which is where
-    the branch now needs its cover.
+    to :data:`IMAGE_INGEST_MAX_EDGE` caps the delivered area at 1024x1024, and
+    at that area JPEG is always the smaller encode — 48-colour palette noise
+    measures 1.71 MiB of PNG against 0.74 MiB of JPEG, so the lossy rung fires
+    and WINS rather than declining itself. The rung closes for `read` because
+    PNG stops winning at this area, NOT because PNG stays inside the budget
+    (it does not). It is still reachable whenever a caller passes an explicit
+    ``max_edge`` (``rebound_oversize_image`` does), which is where the branch
+    now needs its cover.
     """
     rng = random.Random(1234)
     palette = [

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -710,14 +710,18 @@ def test_a_repair_keeps_png_when_jpeg_would_be_bigger() -> None:
 
     Exercised at the REPAIR bound rather than through ``read``: bounding ingest
     to :data:`IMAGE_INGEST_MAX_EDGE` caps the delivered area at 1024x1024, and
-    the rung needs BOTH conditions at once and 1024x1024 never
-    supplies them together: below ~32 palette colours PNG is the smaller encode
-    but stays inside the budget (0.96 MiB at its worst, 48 colours), and above
-    that PNG exceeds the budget but JPEG has already become smaller (1.06 MiB
-    against 0.80 MiB at 64 colours). The two conditions pass each other without
-    ever overlapping. Swept 2-256 colours to
-    confirm the branch is unreachable there rather than merely rare. It is
-    still reachable whenever a caller passes an explicit ``max_edge``
+    at that area the rung's two conditions never hold together. A palette-noise
+    sweep walks three regimes in order — PNG smaller and under budget, then
+    JPEG smaller and still under budget, then JPEG smaller with PNG over
+    budget — and the rung would need a fourth between the first and the last.
+
+    Figures are deliberately NOT restated here: this comment carried three
+    different wrong mechanisms across three review rounds before the generator
+    was checked in. Run ``scripts/measure_ingest_lossy_rung.py`` for the table;
+    the crossover colour counts are fixture-specific, the regime ORDERING is
+    not, and the ordering is the whole argument.
+
+    Still reachable whenever a caller passes an explicit ``max_edge``
     (``rebound_oversize_image`` does), which is where the branch needs cover.
     """
     rng = random.Random(1234)

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import io
+import random
 import statistics
 
 import pytest
@@ -28,6 +29,8 @@ from local_operator import imaging
 from local_operator.imaging import (
     _REBOUND_CACHE,
     _REBOUND_CACHE_MAX_BYTES,
+    IMAGE_INGEST_MAX_EDGE,
+    IMAGE_MAX_BYTES,
     IMAGE_MAX_EDGE,
     IMAGE_MAX_PIXELS,
     IMAGE_REFUSAL_MAX_B64_BYTES,
@@ -111,7 +114,7 @@ def test_a_bounded_image_is_inside_the_many_image_limit(size, label: str) -> Non
     source = _png(size)
     payload, _mime, _summary = bound_image_for_model(source, _sniffed(source))
     width, height = Image.open(io.BytesIO(payload)).size
-    assert max(width, height) <= IMAGE_MAX_EDGE
+    assert max(width, height) <= IMAGE_INGEST_MAX_EDGE
     assert max(width, height) < MANY_IMAGE_PIXEL_LIMIT, label
 
 
@@ -141,7 +144,7 @@ def test_the_summary_names_the_source_whenever_the_bytes_changed() -> None:
     summary says so."""
     source = _png((2560, 1440))
     _payload, _mime, summary = bound_image_for_model(source, _sniffed(source))
-    assert "1568x882" in summary
+    assert f"{IMAGE_INGEST_MAX_EDGE}x576" in summary
     assert "source 2560x1440" in summary
 
 
@@ -285,7 +288,11 @@ def test_a_rotation_alone_still_declares_that_the_bytes_changed() -> None:
     A half turn leaves the size identical, so nothing but ``rotated`` can fire.
     """
     buffer = io.BytesIO()
-    image = Image.new("RGB", (1200, 900), (10, 60, 120))
+    # Inside IMAGE_INGEST_MAX_EDGE on both edges, deliberately: a fixture the
+    # ingest bound would RESIZE brings the size trigger back into play, and the
+    # `rotated` disjunct under test could then be deleted with every assertion
+    # still passing — the same hole review round 3, F9 closed for orientation 6.
+    image = Image.new("RGB", (900, 700), (10, 60, 120))
     exif = Image.Exif()
     exif[274] = 3
     image.save(buffer, format="PNG", exif=exif)
@@ -293,8 +300,8 @@ def test_a_rotation_alone_still_declares_that_the_bytes_changed() -> None:
 
     _payload, wire_mime, summary = bound_image_for_model(source, _sniffed(source))
     assert wire_mime == "image/png", "the fixture must not change format"
-    assert "1200x900, " in summary, "the fixture must come back the same SIZE"
-    assert "source 1200x900" in summary
+    assert "900x700, " in summary, "the fixture must come back the same SIZE"
+    assert "source 900x700" in summary
     assert "EXIF-rotated" in summary
 
 
@@ -638,6 +645,49 @@ def test_a_photograph_is_still_resized_smoothly_to_the_cheap_bound() -> None:
     assert rebound is not None
     repaired = Image.open(io.BytesIO(base64.b64decode(rebound[0])))
     assert max(repaired.size) == IMAGE_MAX_EDGE, "a photo was not taken to the cheap bound"
+
+
+def test_a_repair_keeps_png_when_jpeg_would_be_bigger() -> None:
+    """The lossy rung must MEASURE rather than assume it wins.
+
+    Sharp noise over an 8-colour palette at 1568x1176 measures ~1.12 MiB as PNG
+    (over :data:`IMAGE_MAX_BYTES`, so the lossy rung fires) against ~1.70 MiB as
+    quality-85 JPEG. Taking JPEG on the way past the budget would be worse on
+    BOTH axes, bigger and lossy, so the rung declines itself.
+
+    Exercised at the REPAIR bound rather than through ``read``: bounding ingest
+    to :data:`IMAGE_INGEST_MAX_EDGE` caps the delivered area at 1024x1024, where
+    the worst palette noise measured 0.87 MiB — under the budget, so the rung
+    cannot fire there any more. It is still reachable whenever a caller passes
+    an explicit ``max_edge`` (``rebound_oversize_image`` does), which is where
+    the branch now needs its cover.
+    """
+    rng = random.Random(1234)
+    palette = [
+        (255, 0, 0),
+        (0, 255, 0),
+        (0, 0, 255),
+        (255, 255, 0),
+        (0, 255, 255),
+        (255, 0, 255),
+        (255, 255, 255),
+        (0, 0, 0),
+    ]
+    image = Image.new("RGB", (1568, 1176))
+    pixels = image.load()
+    assert pixels is not None
+    for y in range(1176):
+        for x in range(1568):
+            pixels[x, y] = palette[rng.randrange(len(palette))]
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG", optimize=True, compress_level=9)
+    source = buffer.getvalue()
+
+    payload, mime, _summary = bound_image_for_model(
+        source, _sniffed(source), max_edge=IMAGE_MAX_EDGE
+    )
+    assert mime == "image/png", "the lossy rung took a JPEG that was BIGGER"
+    assert len(payload) > IMAGE_MAX_BYTES, "the fixture no longer reaches the rung"
 
 
 def test_a_block_under_every_pixel_ceiling_can_still_be_too_heavy() -> None:

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -596,11 +596,12 @@ async def test_read_stays_inside_the_byte_budget_on_incompressible_input(
     # The PNG-wins-over-budget rung (an image PNG compresses better than JPEG
     # AND that still blows IMAGE_MAX_BYTES) is no longer reachable through
     # `read`: bounding to IMAGE_INGEST_MAX_EDGE caps the delivered area at
-    # 1024x1024, and at that area JPEG is always the smaller encode (48-colour
-    # palette noise: 1.71 MiB PNG against 0.74 MiB JPEG), so the lossy rung
-    # fires and WINS instead of declining itself. The rung closes because PNG
-    # stops winning at this area, not because PNG fits the budget — it does
-    # not. It is still live on the REPAIR path at 1568 and is covered there by
+    # 1024x1024, where the rung's two conditions never hold at once: below ~32
+    # palette colours PNG is the smaller encode but stays INSIDE the budget
+    # (0.96 MiB at worst), and above that PNG exceeds the budget but JPEG has
+    # already become smaller (1.06 vs 0.80 MiB at 64 colours). Swept 2-256
+    # colours to confirm the branch is unreachable rather than merely rare.
+    # It is still live on the REPAIR path at 1568 and is covered there by
     # tests/unit/test_imaging.py::test_a_repair_keeps_png_when_jpeg_would_be_bigger.
     #
     # What `read` must still guarantee is this: the hardest-to-compress input

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -596,9 +596,11 @@ async def test_read_stays_inside_the_byte_budget_on_incompressible_input(
     # The PNG-wins-over-budget rung (an image PNG compresses better than JPEG
     # AND that still blows IMAGE_MAX_BYTES) is no longer reachable through
     # `read`: bounding to IMAGE_INGEST_MAX_EDGE caps the delivered area at
-    # 1024x1024, where the worst palette noise measured 0.87 MiB of PNG —
-    # under the 1 MiB budget. It is still live on the REPAIR path at 1568 and
-    # is covered there by
+    # 1024x1024, and at that area JPEG is always the smaller encode (48-colour
+    # palette noise: 1.71 MiB PNG against 0.74 MiB JPEG), so the lossy rung
+    # fires and WINS instead of declining itself. The rung closes because PNG
+    # stops winning at this area, not because PNG fits the budget — it does
+    # not. It is still live on the REPAIR path at 1568 and is covered there by
     # tests/unit/test_imaging.py::test_a_repair_keeps_png_when_jpeg_would_be_bigger.
     #
     # What `read` must still guarantee is this: the hardest-to-compress input

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -596,11 +596,10 @@ async def test_read_stays_inside_the_byte_budget_on_incompressible_input(
     # The PNG-wins-over-budget rung (an image PNG compresses better than JPEG
     # AND that still blows IMAGE_MAX_BYTES) is no longer reachable through
     # `read`: bounding to IMAGE_INGEST_MAX_EDGE caps the delivered area at
-    # 1024x1024, where the rung's two conditions never hold at once: below ~32
-    # palette colours PNG is the smaller encode but stays INSIDE the budget
-    # (0.96 MiB at worst), and above that PNG exceeds the budget but JPEG has
-    # already become smaller (1.06 vs 0.80 MiB at 64 colours). Swept 2-256
-    # colours to confirm the branch is unreachable rather than merely rare.
+    # 1024x1024, where the rung's two conditions never hold together: PNG is
+    # never BOTH the smaller encode AND over the budget. Figures deliberately
+    # not restated (they were wrong three times); run
+    # scripts/measure_ingest_lossy_rung.py for the sweep.
     # It is still live on the REPAIR path at 1568 and is covered there by
     # tests/unit/test_imaging.py::test_a_repair_keeps_png_when_jpeg_would_be_bigger.
     #

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -550,8 +550,10 @@ async def test_read_png_returns_caption_then_image_block(tools, context, tmp_pat
 @pytest.mark.asyncio
 async def test_read_png_over_the_edge_cap_is_resized(tools, context, tmp_path) -> None:
     # Pixels, not bytes, are what an image costs in context (~w*h/750 tokens),
-    # and Anthropic resizes past 1568 anyway while billing the resized count —
-    # so anything above the cap is upload the model never benefits from.
+    # so anything above the ingest cap is upload the model never benefits from.
+    # The cap is IMAGE_INGEST_MAX_EDGE (1024), below the 1568 correctness
+    # ceiling: the band between them is billed pixel area that measured no
+    # legibility gain on document content (see imaging.IMAGE_INGEST_MAX_EDGE).
     _write_png(tmp_path / "wide.png", (3000, 1500))
     result = await _call(tools, "read", {"path": "wide.png"}, context)
 
@@ -559,10 +561,10 @@ async def test_read_png_over_the_edge_cap_is_resized(tools, context, tmp_path) -
     (image,) = _image_blocks(result)
     with Image.open(io.BytesIO(base64.b64decode(image.data))) as delivered:
         assert max(delivered.size) == builtin.READ_IMAGE_MAX_EDGE
-        assert delivered.size == (1568, 784)
+        assert delivered.size == (1024, 512)
     # What the model sees and what is on disk now differ; the caption must say
     # so or a later `ls -l` looks like it contradicts the read.
-    assert "1568x784" in result.text
+    assert "1024x512" in result.text
     assert "source 3000x1500 image/png" in result.text
 
 
@@ -581,26 +583,34 @@ async def test_read_photographic_png_falls_back_to_jpeg(tools, context, tmp_path
     # that is also bigger would be strictly worse on both axes.
     lossless = io.BytesIO()
     with Image.open(tmp_path / "photo.png") as original:
-        original.resize((1568, 1176), Image.Resampling.LANCZOS).save(lossless, format="PNG")
+        original.resize((1024, 768), Image.Resampling.LANCZOS).save(lossless, format="PNG")
     assert len(base64.b64decode(image.data)) < len(lossless.getvalue())
     # base64 inflates by 4/3 and Anthropic rejects an image block over 5 MB.
     assert len(image.data) < 5_000_000
 
 
 @pytest.mark.asyncio
-async def test_read_keeps_png_when_jpeg_would_be_bigger(tools, context, tmp_path) -> None:
-    # The mirror of the case above, and not hypothetical: sharp noise over an
-    # 8-colour palette measures 1145 KiB as PNG (over the budget, so the lossy
-    # rung fires) against 1704 KiB as quality-85 JPEG. Taking JPEG on the way
-    # past the budget would then be worse on BOTH axes — bigger and lossy — so
-    # the rung has to measure rather than assume it wins.
+async def test_read_stays_inside_the_byte_budget_on_incompressible_input(
+    tools, context, tmp_path
+) -> None:
+    # The PNG-wins-over-budget rung (an image PNG compresses better than JPEG
+    # AND that still blows IMAGE_MAX_BYTES) is no longer reachable through
+    # `read`: bounding to IMAGE_INGEST_MAX_EDGE caps the delivered area at
+    # 1024x1024, where the worst palette noise measured 0.87 MiB of PNG —
+    # under the 1 MiB budget. It is still live on the REPAIR path at 1568 and
+    # is covered there by
+    # tests/unit/test_imaging.py::test_a_repair_keeps_png_when_jpeg_would_be_bigger.
+    #
+    # What `read` must still guarantee is this: the hardest-to-compress input
+    # lands inside the budget rather than riding to the provider at several MB.
     _write_png(tmp_path / "sharp.png", (1568, 1176), noise="sharp", colours=8)
     result = await _call(tools, "read", {"path": "sharp.png"}, context)
 
     assert result.is_error is False
     (image,) = _image_blocks(result)
-    assert image.mime_type == "image/png"
-    assert len(base64.b64decode(image.data)) > builtin.READ_IMAGE_MAX_BYTES
+    assert len(base64.b64decode(image.data)) <= builtin.READ_IMAGE_MAX_BYTES
+    with Image.open(io.BytesIO(base64.b64decode(image.data))) as delivered:
+        assert max(delivered.size) <= builtin.READ_IMAGE_MAX_EDGE
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_cmd_chords.py
+++ b/tests/unit/tui/test_cmd_chords.py
@@ -26,7 +26,7 @@ from local_operator.tui.widgets import editor as editor_module
 from local_operator.tui.widgets.editor import Editor, EditorCopied, InterruptRequested
 
 
-def _png_bytes(width: int = 1568, height: int = 200) -> bytes:
+def _png_bytes(width: int = 1000, height: int = 200) -> bytes:
     buffer = io.BytesIO()
     Image.new("RGB", (width, height), (30, 30, 40)).save(buffer, "PNG")
     return buffer.getvalue()
@@ -112,7 +112,7 @@ async def test_super_v_attaches_the_image_on_the_system_clipboard(monkeypatch) -
 
         await _press(pilot, "super+v")
 
-        assert editor.text == "[Image #1, 1568x200] "
+        assert editor.text == "[Image #1, 1000x200] "
         assert counts["reads"] == 1, "super+v must read the SYSTEM clipboard"
 
 

--- a/tests/unit/tui/test_marker_chip.py
+++ b/tests/unit/tui/test_marker_chip.py
@@ -1,6 +1,6 @@
 """The attachment marker as a painted object, and clicking one to select it.
 
-``[Image #1, 1568x200]`` used to render in the prose colour on the prose ground
+``[Image #1, 1000x200]`` used to render in the prose colour on the prose ground
 — indistinguishable from something the user typed, in a field where everything
 else IS something the user typed. These assert what the terminal was SENT,
 because "does it stand out" is a question about cells and colours and not about
@@ -63,7 +63,7 @@ def theme_name(request: pytest.FixtureRequest) -> Iterator[str]:
         theme_mod.set_theme(original)
 
 
-def _png(path, width: int = 1568, height: int = 200) -> str:
+def _png(path, width: int = 1000, height: int = 200) -> str:
     Image.new("RGB", (width, height), (30, 30, 40)).save(path)
     return str(path)
 
@@ -134,7 +134,7 @@ async def test_a_marker_is_painted_unlike_the_prose_beside_it(tmp_path, theme_na
         await _paste(app, pilot, _png(tmp_path / "a.png"))
         editor.insert("now")
         await pilot.pause()
-        assert editor.text == "look at [Image #1, 1568x200] now"
+        assert editor.text == "look at [Image #1, 1000x200] now"
 
         row = cells(editor, 0)
         prose = row[2]  # the "o" of "look"
@@ -165,7 +165,7 @@ async def test_two_markers_are_chips_and_the_words_between_them_are_not(tmp_path
         editor.insert("and ")
         await _paste(app, pilot, _png(tmp_path / "b.png", 640, 480))
         await pilot.pause()
-        assert editor.text == "[Image #1, 1568x200] and [Image #2, 640x480] "
+        assert editor.text == "[Image #1, 1000x200] and [Image #2, 640x480] "
 
         chip = theme_mod.semantic_color("tint-attach")
         assert grounds(editor, 0, 0, 20) == {chip}
@@ -188,7 +188,7 @@ async def test_a_marker_that_soft_wraps_is_painted_on_both_rows(tmp_path) -> Non
         editor.insert("look at this one ")
         await _paste(app, pilot, _png(tmp_path / "a.png"))
         await pilot.pause()
-        assert editor.text == "look at this one [Image #1, 1568x200] "
+        assert editor.text == "look at this one [Image #1, 1000x200] "
         # The marker opens at column 17 and the field is 30 wide, so it cannot
         # fit on the row that starts it.
         assert editor.wrapped_document.get_offsets(0), "the line did not wrap at all"
@@ -205,7 +205,7 @@ async def test_a_marker_that_soft_wraps_is_painted_on_both_rows(tmp_path) -> Non
             [character for character, _, bg in cells(editor, 0) if bg == chip]
             + [character for character, _, bg in cells(editor, 1) if bg == chip]
         )
-        assert painted.replace(" ", "") == "[Image#1,1568x200]"
+        assert painted.replace(" ", "") == "[Image#1,1000x200]"
 
 
 @pytest.mark.asyncio
@@ -244,7 +244,7 @@ async def test_a_click_inside_a_marker_selects_exactly_the_marker(tmp_path, colu
         editor.insert("look at ")
         await _paste(app, pilot, _png(tmp_path / "a.png"))
         await pilot.pause()
-        assert editor.text == "look at [Image #1, 1568x200] "
+        assert editor.text == "look at [Image #1, 1000x200] "
 
         await pilot.click(Editor, offset=at(editor, column))
         await pilot.pause()
@@ -489,8 +489,8 @@ async def test_a_double_click_inside_a_chip_takes_the_whole_marker(tmp_path) -> 
     """The marker is ATOMIC under the click chain, not just under backspace.
 
     Regression for agent review round 1, R1-1. A double-click inside
-    `[Image #1, 1568x200]` ran a word span over the raw line and selected
-    `Image` alone; typing over that selection left `[x #1, 1568x200]` in the
+    `[Image #1, 1000x200]` ran a word span over the raw line and selected
+    `Image` alone; typing over that selection left `[x #1, 1000x200]` in the
     draft, which no longer matches `IMAGE_MARKER`. `resolve_markers` then drops
     it, so the attachment is SILENTLY not sent and what remains is neither a
     chip nor prose — data loss reachable by double-clicking a chip.
@@ -508,13 +508,13 @@ async def test_a_double_click_inside_a_chip_takes_the_whole_marker(tmp_path) -> 
         await _paste(app, pilot, _png(tmp_path / "a.png"))
         editor.insert("here")
         await pilot.pause()
-        assert editor.text == "look at [Image #1, 1568x200] here"
+        assert editor.text == "look at [Image #1, 1000x200] here"
 
         # Column 10 is inside the word `Image`, which is what a user aiming at
         # the chip's label hits.
         await _multi_click(pilot, editor, editor.text.index("Image") + 2, times=2)
 
-        assert editor.selected_text == "[Image #1, 1568x200]"
+        assert editor.selected_text == "[Image #1, 1000x200]"
 
 
 @pytest.mark.asyncio
@@ -567,7 +567,7 @@ async def test_a_triple_click_over_a_chip_keeps_the_marker_intact(tmp_path) -> N
 
         await _multi_click(pilot, editor, editor.text.index("Image") + 2, times=3)
 
-        assert editor.selected_text == "look at [Image #1, 1568x200] here"
+        assert editor.selected_text == "look at [Image #1, 1000x200] here"
 
 
 @pytest.mark.asyncio
@@ -649,7 +649,7 @@ async def test_a_double_click_past_a_marker_line_keeps_the_attachment(tmp_path) 
         editor.insert("look at ")
         await _paste(app, pilot, _png(tmp_path / "a.png"))
         await pilot.pause()
-        assert editor.text == "look at [Image #1, 1568x200] "
+        assert editor.text == "look at [Image #1, 1000x200] "
         assert len(editor.attachments()) == 1
 
         # Well past the end of the text, in the composer's own empty width.
@@ -658,7 +658,7 @@ async def test_a_double_click_past_a_marker_line_keeps_the_attachment(tmp_path) 
         await pilot.pause()
 
         assert editor.attachments(), "the attachment was silently dropped"
-        assert "[Image #1, 1568x200]" in editor.text, "the marker was corrupted"
+        assert "[Image #1, 1000x200]" in editor.text, "the marker was corrupted"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_paste_clipboard.py
+++ b/tests/unit/tui/test_paste_clipboard.py
@@ -50,7 +50,7 @@ from local_operator.tui.widgets.editor import (
 )
 
 
-def _png_bytes(width: int = 1568, height: int = 200) -> bytes:
+def _png_bytes(width: int = 1000, height: int = 200) -> bytes:
     buffer = io.BytesIO()
     Image.new("RGB", (width, height), (30, 30, 40)).save(buffer, "PNG")
     return buffer.getvalue()
@@ -140,7 +140,7 @@ async def test_an_empty_paste_attaches_the_image_on_the_clipboard(monkeypatch) -
         await pilot.pause()
         await _paste(app, pilot, "")
 
-        assert editor.text == "[Image #1, 1568x200] "
+        assert editor.text == "[Image #1, 1000x200] "
         assert len(editor.referenced_images()) == 1
         image = editor.referenced_images()[0]
         assert image.mime_type == "image/png"
@@ -197,7 +197,7 @@ async def test_copied_whitespace_wins_over_an_image_on_the_clipboard(
 
     Round 2 (D9): the D1 fix keyed on the payload but still let a successful
     clipboard read override it, so pasting a four-space indent with a PNG on
-    the pasteboard replaced the indent with `[Image #1, 1568x200]` — an image
+    the pasteboard replaced the indent with `[Image #1, 1000x200]` — an image
     the user did not ask for on that keypress, silently, with the indent gone.
     Same defect as D1 at one tenth the reach.
 
@@ -501,7 +501,7 @@ async def test_a_slow_clipboard_read_does_not_stall_the_loop(monkeypatch) -> Non
             await pilot.pause()
             if editor.referenced_images():
                 break
-        assert editor.text == "[Image #1, 1568x200] "
+        assert editor.text == "[Image #1, 1000x200] "
 
 
 # -- what the notice is allowed to claim --------------------------------------
@@ -1004,7 +1004,7 @@ async def test_ctrl_v_attaches_the_image_on_the_system_clipboard(monkeypatch) ->
         await pilot.pause()
         await _ctrl_v(app, pilot)
 
-        assert editor.text == "[Image #1, 1568x200] "
+        assert editor.text == "[Image #1, 1000x200] "
         assert counts["reads"] == 1, "ctrl+v must read the SYSTEM clipboard"
         images = editor.referenced_images()
         assert len(images) == 1 and images[0].mime_type == "image/png"
@@ -1045,7 +1045,7 @@ async def test_ctrl_v_overrides_textareas_own_paste_binding(monkeypatch) -> None
 
         await _ctrl_v(app, pilot)
         assert base_paste_calls == [], "TextArea.action_paste must not run"
-        assert editor.text == "[Image #1, 1568x200] "
+        assert editor.text == "[Image #1, 1000x200] "
 
 
 @pytest.mark.asyncio
@@ -1202,7 +1202,7 @@ async def test_ctrl_v_replaces_a_live_selection_with_an_image_marker(monkeypatch
         await pilot.pause()
         await _ctrl_v(app, pilot)
 
-        assert editor.text == "keep [Image #1, 1568x200]  keep"
+        assert editor.text == "keep [Image #1, 1000x200]  keep"
         assert len(editor.referenced_images()) == 1
 
 
@@ -1227,12 +1227,12 @@ async def test_a_path_paste_replaces_a_live_selection_like_ctrl_v(tmp_path) -> N
         await pilot.pause()
         await _paste(app, pilot, str(path))
 
-        assert editor.text == "keep [Image #1, 1568x200]  keep"
+        assert editor.text == "keep [Image #1, 1000x200]  keep"
         assert len(editor.referenced_images()) == 1
         # The caret lands AFTER the marker, so the next keystroke continues
         # past it rather than typing in front of it — same as ctrl+v.
         editor.insert("!")
-        assert editor.text == "keep [Image #1, 1568x200] ! keep"
+        assert editor.text == "keep [Image #1, 1000x200] ! keep"
 
 
 @pytest.mark.asyncio
@@ -1494,7 +1494,7 @@ async def test_ctrl_v_reads_the_clipboard_off_the_event_loop(monkeypatch) -> Non
         assert (
             reader_threads and loop_thread not in reader_threads
         ), "the clipboard read must not run on the event loop"
-        assert editor.text == "[Image #1, 1568x200] "
+        assert editor.text == "[Image #1, 1000x200] "
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_paste_images.py
+++ b/tests/unit/tui/test_paste_images.py
@@ -48,7 +48,7 @@ from local_operator.tui.widgets.editor import (
 )
 
 
-def _png(path, width: int = 1568, height: int = 200) -> str:
+def _png(path, width: int = 1000, height: int = 200) -> str:
     Image.new("RGB", (width, height), (30, 30, 40)).save(path)
     return str(path)
 
@@ -185,13 +185,13 @@ async def test_a_pasted_image_becomes_an_attachment_and_a_marker(tmp_path) -> No
         await pilot.pause()
         await _paste(app, pilot, path)
 
-        assert editor.text == "[Image #1, 1568x200] "
+        assert editor.text == "[Image #1, 1000x200] "
         assert len(editor.referenced_images()) == 1
         image = editor.referenced_images()[0]
         assert image.mime_type == "image/png"
         # The real bytes, not the path: this is what reaches the provider.
         assert base64.b64decode(image.data)[:8] == b"\x89PNG\r\n\x1a\n"
-        assert Image.open(io.BytesIO(base64.b64decode(image.data))).size == (1568, 200)
+        assert Image.open(io.BytesIO(base64.b64decode(image.data))).size == (1000, 200)
 
 
 @pytest.mark.asyncio
@@ -345,7 +345,7 @@ async def test_the_marker_reports_what_was_attached_not_what_is_on_disk(tmp_path
     """The marker's dimensions are the user's only receipt for an attachment.
 
     Once the paste path started resizing, carrying the SOURCE dimensions into
-    the marker would print ``[Image #1, 2560x1440]`` beside a 1568x882
+    the marker would print ``[Image #1, 2560x1440]`` beside a 1024x576
     attachment — a receipt for something that was never sent.
     """
     path = _png(tmp_path / "retina.png", 2560, 1440)
@@ -365,7 +365,7 @@ async def test_the_marker_reports_what_was_attached_not_what_is_on_disk(tmp_path
 async def test_a_resized_marker_says_so_and_stays_one_atomic_token(tmp_path) -> None:
     """Design round 1, D1.
 
-    Every 16:9 screenshot bounds to the same 1568x882, so three different
+    Every 16:9 screenshot bounds to the same 1024x576, so three different
     captures pasted together would read as three identical markers and the label
     would stop doing the job it exists for — telling one paste from another. The
     mark restores that and explains why the number is not the size pasted.
@@ -389,8 +389,8 @@ async def test_a_resized_marker_says_so_and_stays_one_atomic_token(tmp_path) -> 
         # Resized ones are marked; the in-bounds one is not, because nothing
         # about it changed and the mark would be a lie.
         assert editor.text == (
-            f"[Image #1, 1568x882{RESIZED_MARK}] "
-            f"[Image #2, 882x1568{RESIZED_MARK}] "
+            f"[Image #1, 1024x576{RESIZED_MARK}] "
+            f"[Image #2, 576x1024{RESIZED_MARK}] "
             "[Image #3, 800x600] "
         )
         # The grammar still holds: three whole markers, numbered in order.
@@ -473,12 +473,16 @@ async def test_a_rotation_alone_is_not_marked_as_a_downscale(tmp_path) -> None:
     """Review round 2, F8.
 
     A portrait phone photo inside the bounds is EXIF-rotated on the way in, so
-    its dimensions change (900x1200 from 1200x900) while not one pixel is lost.
+    its dimensions change (700x900 from 900x700) while not one pixel is lost.
     The mark is a claim about FIDELITY, so comparing the ``WxH`` strings made
     every such photo assert a shrink that never happened.
+
+    The fixture sits inside IMAGE_INGEST_MAX_EDGE on both edges deliberately: a
+    photo the ingest bound would also RESIZE earns the mark legitimately, and
+    the test would then pass for the wrong reason.
     """
     path = str(tmp_path / "portrait.jpg")
-    image = Image.new("RGB", (1200, 900), (30, 30, 40))
+    image = Image.new("RGB", (900, 700), (30, 30, 40))
     exif = Image.Exif()
     exif[274] = 6
     image.save(path, format="JPEG", exif=exif)
@@ -494,7 +498,7 @@ async def test_a_rotation_alone_is_not_marked_as_a_downscale(tmp_path) -> None:
         assert RESIZED_MARK not in editor.text
         # The rotated dimensions are still reported, because that IS what was
         # attached — only the shrink claim was wrong.
-        assert editor.text == "[Image #1, 900x1200] "
+        assert editor.text == "[Image #1, 700x900] "
 
 
 @pytest.mark.asyncio
@@ -761,7 +765,7 @@ async def test_clearing_the_buffer_clears_the_attachments(tmp_path) -> None:
 @pytest.mark.asyncio
 async def test_backspace_at_the_end_of_a_marker_removes_the_whole_marker(tmp_path) -> None:
     """The reported bug: it removed the closing bracket and left
-    ``[Image #1, 1568x20`` hanging — neither prose the user meant nor a
+    ``[Image #1, 1000x20`` hanging — neither prose the user meant nor a
     reference anything can resolve, and the attachment silently orphaned."""
     path = _png(tmp_path / "a.png", 10, 20)
     app = Host()
@@ -1440,17 +1444,17 @@ async def test_text_pasted_above_the_marker_cannot_steal_its_chip(tmp_path) -> N
         await _paste(app, pilot, path)
         mine = editor.text.strip()
         editor.selection = Selection.cursor((0, 0))
-        await _paste(app, pilot, "[Image #1, 1568x200] rerun this")
+        await _paste(app, pilot, "[Image #1, 1000x200] rerun this")
         await pilot.pause()
 
-        assert editor.text.startswith("[Image #1, 1568x200]"), "the fixture did not paste above"
+        assert editor.text.startswith("[Image #1, 1000x200]"), "the fixture did not paste above"
         painted = {
             column
             for y in range(3)
             for start, end, _ in editor._marker_cells(y)
             for column in range(start - editor.gutter_width, end - editor.gutter_width)
         }
-        impostor = set(range(0, len("[Image #1, 1568x200]")))
+        impostor = set(range(0, len("[Image #1, 1000x200]")))
         real = editor.text.index(mine)
         assert painted & set(range(real, real + len(mine))), "the app's own marker lost its chip"
         assert not painted & impostor, "the pasted text stole the chip"
@@ -1474,7 +1478,7 @@ async def test_the_app_s_own_marker_stays_the_atomic_token(tmp_path) -> None:
         await _paste(app, pilot, path)
         mine = editor.text.strip()
         editor.selection = Selection.cursor((0, 0))
-        await _paste(app, pilot, "[Image #1, 1568x200] ")
+        await _paste(app, pilot, "[Image #1, 1000x200] ")
         await pilot.pause()
 
         end = editor.text.index(mine) + len(mine)
@@ -1514,7 +1518,7 @@ async def test_deleting_a_foreign_citation_leaves_the_live_image_alone(tmp_path)
         await pilot.pause()
         await _paste(app, pilot, path)
         editor.selection = Selection.cursor((0, 0))
-        await _paste(app, pilot, "look at [Image #1, 1568x200] ")
+        await _paste(app, pilot, "look at [Image #1, 1000x200] ")
         await pilot.pause()
 
         # Edit the tail of the app's OWN marker, so cite() falls back and the
@@ -1528,7 +1532,7 @@ async def test_deleting_a_foreign_citation_leaves_the_live_image_alone(tmp_path)
         await pilot.press("backspace")
         await pilot.pause()
 
-        assert "1568x200" not in editor.text, "the stale reference was not deleted"
+        assert "1000x200" not in editor.text, "the stale reference was not deleted"
         assert len(editor.referenced_images()) == 1, "deleting stale text dropped the live image"
 
 
@@ -1538,7 +1542,7 @@ async def test_a_half_deleted_stale_marker_cannot_swallow_a_live_one(tmp_path) -
 
     The stale copy is prose, so backspace takes one character - and the first
     character is its closing bracket. With `[` allowed in the tail, the
-    unterminated `[Image #1, 1568x200` then matched all the way through the
+    unterminated `[Image #1, 1000x200` then matched all the way through the
     LIVE marker's bracket as one token, whose start is nowhere `cite()` points:
     the chip vanished for ten keystrokes of an ordinary cleanup while the image
     stayed attached and on the wire, and the live marker left the atomic set.
@@ -1551,12 +1555,12 @@ async def test_a_half_deleted_stale_marker_cannot_swallow_a_live_one(tmp_path) -
         await pilot.pause()
         await _paste(app, pilot, path)
         editor.selection = Selection.cursor((0, 0))
-        await _paste(app, pilot, "look at [Image #1, 1568x200] ")
+        await _paste(app, pilot, "look at [Image #1, 1000x200] ")
         await pilot.pause()
 
         # Sweep the whole cleanup. The chip must never disappear while the
         # image is still being sent - that is the commit's headline invariant.
-        stale = "[Image #1, 1568x200]"
+        stale = "[Image #1, 1000x200]"
         editor.selection = Selection.cursor((0, editor.text.index(stale) + len(stale)))
         await pilot.pause()
         for keystroke in range(1, len(stale) + 1):

--- a/tests/unit/tui/test_slash_command_images.py
+++ b/tests/unit/tui/test_slash_command_images.py
@@ -72,7 +72,7 @@ def _agent_registry(tmp: Path) -> AgentRegistry:
     return registry
 
 
-def _png(path: Path, width: int = 1568, height: int = 200) -> str:
+def _png(path: Path, width: int = 1000, height: int = 200) -> str:
     Image.new("RGB", (width, height), (30, 30, 40)).save(path)
     return str(path)
 
@@ -93,7 +93,7 @@ async def _paste(app: OperatorApp, pilot, text: str) -> None:
 @pytest.mark.asyncio
 async def test_team_request_carries_the_pasted_image(tmp_path) -> None:
     """`/team <name> <request>` sends the screenshot the request cites."""
-    path = _png(tmp_path / "shot.png", 1568, 410)
+    path = _png(tmp_path / "shot.png", 1000, 410)
     session = FakeSession()
     reg = TeamRegistry(Path(tempfile.mkdtemp()))
     reg.create_team(
@@ -119,7 +119,7 @@ async def test_team_request_carries_the_pasted_image(tmp_path) -> None:
         await pilot.pause()
 
         assert [t.name for t in session.attached_teams] == ["ops"]
-        assert session.prompts == ["look at [Image #1, 1568x410] and fix it"]
+        assert session.prompts == ["look at [Image #1, 1000x410] and fix it"]
         # The crux: one image, and it is the pixels that were pasted.
         (sent,) = session.prompt_images[0]
         decoded = Image.open(io.BytesIO(base64.b64decode(sent.data)))
@@ -240,7 +240,7 @@ async def test_team_marker_in_the_name_position_is_not_an_image(tmp_path) -> Non
 @pytest.mark.asyncio
 async def test_agent_message_carries_the_pasted_image(tmp_path) -> None:
     """`/agent <name> <message>` sends the screenshot the message cites."""
-    path = _png(tmp_path / "shot.png", 1568, 410)
+    path = _png(tmp_path / "shot.png", 1000, 410)
     session = FakeSession()
     session.agent_registry = _agent_registry(Path(tempfile.mkdtemp()))
     app = OperatorApp(lambda: _factory(session))
@@ -257,7 +257,7 @@ async def test_agent_message_carries_the_pasted_image(tmp_path) -> None:
         await pilot.pause()
 
         assert session.attached_agents == ["auditor"]
-        assert session.prompts == ["what do you make of [Image #1, 1568x410]"]
+        assert session.prompts == ["what do you make of [Image #1, 1000x410]"]
         (sent,) = session.prompt_images[0]
         decoded = Image.open(io.BytesIO(base64.b64decode(sent.data)))
         assert decoded.size[0] > 0 and decoded.size[1] > 0


### PR DESCRIPTION
## Images cost pixel area, and this harness was paying for pixels nobody read

Providers bill an image by **pixel area** (~`w*h/750` tokens), not by bytes. This
repo bounded every ingested image to `IMAGE_MAX_EDGE = 1568`, a number chosen for
two reasons that are still correct — staying under the 2000px many-image refusal
line, and not uploading pixels Anthropic downsamples server-side anyway.

Neither of those reasons says 1568 is the cheapest *legible* size, and the gap
between them is billed on every request that replays the image.

Measured against this machine's own analytics (`~/.local-operator/analytics.db`,
7 days, 236k calls): images are **1.84 G context tokens, 4.8% of all context**,
inside a $26,145 window.

## The change

A new `IMAGE_INGEST_MAX_EDGE = 1024` governs images **entering** the context (the
`read` tool, pasted screenshots). `IMAGE_MAX_EDGE = 1568` stays exactly where it
is and becomes explicitly the **correctness** ceiling: the many-image refusal
argument and the snapcompact frame geometry both answer to it, and this PR
deliberately does not re-decide either.

Only ingest moves. The two-bound split is now stated in the module docstring so
the next reader does not have to infer it from two constants.

## Why 1024, measured on real content and actually looked at

The sample is a real 4-up document collage pulled from this machine's own
attachment store (`8440b699…`) — dense tables, 7pt headers, footnote rules.

| Long edge | Delivered | Visual tokens | vs 1568 |
|---|---|---|---|
| 1568 (before) | 1568x1523, 939 KiB | **3,184** | — |
| **1024 (after)** | 1024x995, 466 KiB | **1,359** | **−57.3%** |
| 768 (rejected) | 768x746, 271 KiB | 764 | −76% |

Legibility was verified two ways, not asserted:

1. **I rendered and looked at all three.** At 1024 the appendix titles, task
   headings, five-column Factor Score Matrix and page numbers are all readable.
   At 768 dense 6-7pt table body text is at the edge — which is why 768 was
   rejected despite being cheaper.
2. **A vision model read them back.** Asked to report specific fine print,
   `google/gemini-3.8-flash` recovered from the 1024 render: the appendix title
   (`Appendix B — Review task record`), the OVERALL score row
   (`100 High / 100 High / 100 High / 95 High / 100 High`), the page number
   (`Page 13 of 47`), and 7pt header fine print (`STATUS: Complete; REVIEW
   SCOPE: Confirm relevant geography, residence, operating`) — identical to the
   1568 render.

Before/after frames are attached below.

## Cache safety is the reason the bounds stay separate

An image block already in a transcript sits inside the provider's cached prefix.
Rewriting one converts a per-image saving into a **full-prefix rewrite** at the
cacheWrite premium — strictly worse than doing nothing.

`rebound_oversize_image` therefore still triggers at `IMAGE_REFUSAL_MAX_EDGE`
(2000), untouched by this PR. Verified against the real function:

```
existing 1568x882 history block -> rebound_oversize_image(...) -> None
CACHE SAFE (None = block left byte-identical): True
```

Bounding is also deterministic, so a re-rendered history block hashes identically
turn after turn and the prefix stays stable:

```
deterministic across 5 calls: True  (sha256 3be80af6ab71cf6c…)
```

I also audited the Anthropic breakpoint budget for this request shape, since an
image lands in the message region where the markers go:

```
markers: [('system', 0, ephemeral), ('system', 1, ephemeral),
          ('user', '0.0', ephemeral), ('user', '2.0', ephemeral)]
TOTAL cache_control markers: 4 <= cap 4 -> True
distinct TTL shapes (must be 1): {'{"type": "ephemeral"}'}
```

Both invariants hold: within `MAX_CACHE_BREAKPOINTS`, and one TTL shape per
request (a 1h marker may not follow a 5m one).

## End-to-end evidence: the real `read` tool, not the helper

```
$ .venv/bin/python  # driving local_operator.tools.registry.create_tools
>>> await tools["read"].execute("call-1", {"path": "doc_sample.png"}, ..., ctx)

is_error: False
caption: Image /private/tmp/lop-cost-evidence/doc_sample.png
         (image/png, 1024x995, 476981 bytes; source 1568x1523 image/png)
DELIVERED: 1024x995 466 KiB ~1359 visual tokens  mime=image/png
```

The caption still declares the source, so a model comparing the read against a
later `ls -l` can reconcile the two.

## Line art is exempt (review round 1, F1)

The 1024 bound is a **billing** argument measured on photographic content, which
has no one-pixel strokes to lose. Bilevel renderings of a small pixel font do —
and a snapcompact archive frame is exactly that, reaching this function whenever
one is re-read. Review round 1 caught that ingest took the sharper reduction with
none of the protection the repair path has carried since its own round 2, F8.

I confirmed it by rendering and looking, after my first metric (total ink pixels)
reported "-0.1% loss" and was measuring the wrong thing entirely — NEAREST
resampling preserves ink count while destroying glyph structure:

Rendered at 4x nearest, the same crop from both: at 1568 the pixel font reads
cleanly; ingested at 1024 and upscaled back, "The session was compacted at
2026-09-04" is no longer readable. QA independently rendered the same word as
`conpacted`. (Frame pair reproducible with
`scripts/measure_ingest_lossy_rung.py`'s sibling recipe in the F1 thread.)

Line art now keeps `IMAGE_MAX_EDGE`, using the same `_is_line_art` predicate the
repair path does rather than a second opinion about what line art is:

```
line-art frame   -> image/png, 1568x576, 13464 bytes
PASSTHROUGH (byte-identical): True
photographic doc -> image/png, 1024x995, 476981 bytes; source 1568x1523
STILL BOUNDED TO 1024: True
```

Byte-identical passthrough is also the better cache outcome. A dithered halftone
is bilevel but correctly **not** exempt (density 0.50 against a 0.15 gate), and
the predicate costs 0.0 ms on a 4032x3024 photo because it bails on the mode gate.

## One behavioural consequence, recorded rather than papered over

The lossy ladder's third rung — *PNG compresses better than JPEG **and** the PNG
still blows `IMAGE_MAX_BYTES`* — is **no longer reachable through `read`**. At the
1024 bound the two conditions never hold together: a palette-noise sweep walks
three regimes (PNG smaller and under budget → JPEG smaller and under budget →
JPEG smaller with PNG over budget) and the rung would need a fourth between the
first and the last.

I got the figures for that claim wrong **three times** across three review rounds
while the conclusion survived every falsification attempt — mine and both
reviewers'. The fix was to stop restating numbers in a comment: the generator is
now checked in at `scripts/measure_ingest_lossy_rung.py` (42 samples, `rung
reached: never`) and both comments point at it.

The rung is still live on the **repair** path at 1568, so its coverage was
**moved there** (`test_a_repair_keeps_png_when_jpeg_would_be_bigger`) rather than
deleted, and the `read`-level test now pins the property that still holds:
the hardest-to-compress input lands inside the byte budget.

Two other fixtures were retargeted for a real reason, not to make tests pass:
the EXIF-rotation tests used 1200x900 sources that the new bound would *resize*,
which would let the size trigger satisfy the assertion and leave the `rotated`
disjunct under test dead. Both now sit inside the ingest bound (900x700), so
only `rotated` can fire — the same hole review round 3, F9 closed for
orientation 6.

## Projected saving

At the measured 57.3% reduction against the 7-day fleet numbers above:

- **1.05 G context tokens / 7 days**
- **~$723 / 7 days**, ~$3,100 / 30 days at the current blended rate of
  $0.686 per 1M context tokens

This is a projection from measured inputs, not a promise: it assumes image mix
holds. The 57.3% per-image reduction is measured, not modelled.

## Gates

```
.venv/bin/python -m flake8 .                                  clean
uvx --from black==26.1.0 black --check .                      836 files unchanged
uvx isort==5.13.2 --check .                                   clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   0 errors, 0 warnings
tests/unit                                                    12,040 passed, 15 skipped
tests/e2e -m e2e -n0                                          4 passed
```

Touched-area re-run after the final docs edit: **582 passed** (imaging, builtin
tools, all five TUI image suites, compaction).

### About the flaky shard

The full-suite run reported one failure, and it is **pre-existing flakiness, not
this change**. Proven rather than asserted:

- Run A (with these changes): `test_subagent_view.py::test_a_narrow_viewport…` failed.
- Run B (**`git stash`, clean `main`**): that test passed and a *different* one,
  `test_prices.py::test_a_background_revalidation_gets_the_full_default_timeout`, failed.
- Run C (with these changes): `test_prices` failed, `test_subagent_view` passed.
- Isolated on **clean main with the diff stashed**, `test_prices` fails 2 of 3 runs.

Both are timing/layout-sensitive under xdist and neither touches imaging. QA
independently reproduced `test_subagent_view` at **3 failures / 12 runs on a
clean `origin/main` worktree with no PR code present**, on a file this PR leaves
byte-identical to main, and root-caused a sibling flake (`catalogue.py`'s worker
pops itself from `_threads` in its `finally`, racing a `len(...) == 1`
assertion). Pre-existing; re-run the shard rather than reading it as a
regression. No issue opened (not asked for) — flagged so it is visible.

## Review rounds

| Round | Reviewer | Verdict | Findings |
|---|---|---|---|
| Code 1 | reviewer subagent | Changes requested | F1 major (line art), F2/F3 minor (accuracy) |
| QA 1 | qa-tester subagent | Pass | Q1 minor, Q2 nit |
| Design 1 | designer subagent | Approve (terminal) | D1 minor |
| Code 2 | reviewer subagent | Clean (terminal) | F2/F3 doc follow-ups |
| QA 2 | qa-tester subagent | Pass | Q3 minor |

All findings are answered on the thread. Rounds 2 raised comment-only findings,
fixed in `90434bd2`; no behavioural change since QA round 2 verified the head.

## Change class

**C2 — standard, pre-authorized.** A bounded change to one constant's consumers,
fully rolled back by reverting the commit. No migration, no data change, no
contract change: `READ_IMAGE_MAX_EDGE` keeps its name and public meaning.
