### PR TITLE
fix(tui): treat a leading `/` as text unless the word is a real command

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -8842,7 +8842,45 @@ class OperatorApp(App[None]):
                 return
             self._run_shell_command(text)
             return
-        if text.startswith("/"):
+        if slash_command_for(text) is not None:
+            # RESOLVES, not merely slash-SHAPED. A leading `/` is a command only
+            # when the word after it is one; anything else is an ordinary
+            # character and the line is a prompt.
+            #
+            # It used to be the shape alone, which made the composer contradict
+            # itself. `Editor._compute_slash_runs` paints an unrecognised
+            # leading word with `text-area--slash-unknown` — its docstring says
+            # that muted treatment means "text that WILL be sent" — and then
+            # Enter answered `unknown command: /tmp/test — try /help` and threw
+            # the draft away. The reported case is the one a path makes
+            # unavoidable:
+            #
+            #     /tmp/test
+            #
+            #     The above is a test file path
+            #
+            # There is no way to type that message. The word is unknown, so no
+            # handler wants it; the old branch still claimed it, and the only
+            # workaround was to retype the message with the path moved off the
+            # front. Every absolute path, `/etc`, `//` in prose and a Windows
+            # share fell in the same hole.
+            #
+            # Resolving through the ONE resolver rather than re-deriving "is
+            # this a command" here is what keeps the two answers identical: the
+            # word the dispatch would look up is the word this branch tests, so
+            # a line cannot be claimed by a branch that then has no handler for
+            # it. A registry name is `[a-z]+` and a path's first token is not,
+            # so the two vocabularies cannot collide.
+            #
+            # The cost is that a genuine TYPO (`/usge`) is now sent to the model
+            # rather than warned about. That is the deliberate trade: the
+            # composer already paints it muted BEFORE Enter, the model answers
+            # "you probably meant /usage", and one wasted turn on a misspelling
+            # is recoverable where an unsendable message is not. The
+            # unknown-command notice still guards `_run_slash_command`'s other
+            # callers, which name a command explicitly (mobile `slash()`, the
+            # inline splice) and so have no prose to fall back to.
+            #
             # Nothing but dispatch. A slash command writes its own rows: the
             # ledger row for the one command permitted one (``SLASH_COMMANDS``,
             # ``echo``) is written by its HANDLER, at the point its effect

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -8601,6 +8601,51 @@ class OperatorApp(App[None]):
             "agent",
         }
 
+    def _dispatchable_slash(self, text: str) -> bool:
+        """Whether ``text`` names a command SOMETHING here can run.
+
+        The union of two vocabularies, because :meth:`_run_slash_command`
+        resolves routes from both and the submit gate must agree with the
+        dispatcher it guards or a line is claimed by neither:
+
+        * this build's registry (:func:`slash_command_for`), and
+        * the commands the session's OWNER advertises in its capability list.
+
+        The second term is the load-bearing one. ``slash_command_for`` answers
+        "does *this build* know the word", which is not the same question as
+        "can this word run": a viewer attached to an owner on a newer build
+        gets the owner's capabilities in ``frontend_state``, and the dispatch
+        at ``remote_capabilities.get(command)`` routes them even though no
+        registry entry exists — ``command`` deliberately falls back to
+        ``parts[0].lower()`` for exactly that case. Gating submit on the
+        registry alone therefore turned an advertised-but-unknown command into
+        PROSE, silently spending a model turn on a line the owner would have
+        run (review round 1, M1). Build skew is a live condition here, not a
+        hypothetical: see :meth:`_check_build_skew`, where ``lop-update``
+        replaces the install under a running viewer several times a day.
+
+        Kept as an app method rather than folded into ``slash_command_for``:
+        the resolver is a module-level pure function over the static registry —
+        the ONE authority on what a word MEANS — while owner capabilities are
+        per-session mutable state only the app can see. Merging them would give
+        the resolver a session dependency and make ``/x`` mean different things
+        in the same process.
+        """
+        if slash_command_for(text) is not None:
+            return True
+        token = text.split(maxsplit=1)[0].lower() if text.strip() else ""
+        if not token.startswith("/"):
+            return False
+        # Matched on the same key the dispatch builds its map with, so the two
+        # cannot disagree about spelling: `f"/{cap.command}"` there, the typed
+        # first token here, both case-folded.
+        return any(
+            f"/{capability.command}".lower() == token
+            for capability in getattr(
+                getattr(self._session, "frontend_state", None), "slash_capabilities", []
+            )
+        )
+
     def _bind_then_dispatch(
         self, text: str, attachments: Mapping[int, Marked] | None = None
     ) -> None:
@@ -8842,7 +8887,7 @@ class OperatorApp(App[None]):
                 return
             self._run_shell_command(text)
             return
-        if slash_command_for(text) is not None:
+        if self._dispatchable_slash(text):
             # RESOLVES, not merely slash-SHAPED. A leading `/` is a command only
             # when the word after it is one; anything else is an ordinary
             # character and the line is a prompt.
@@ -8865,21 +8910,45 @@ class OperatorApp(App[None]):
             # front. Every absolute path, `/etc`, `//` in prose and a Windows
             # share fell in the same hole.
             #
-            # Resolving through the ONE resolver rather than re-deriving "is
-            # this a command" here is what keeps the two answers identical: the
-            # word the dispatch would look up is the word this branch tests, so
-            # a line cannot be claimed by a branch that then has no handler for
-            # it. A registry name is `[a-z]+` and a path's first token is not,
-            # so the two vocabularies cannot collide.
+            # Asking `_dispatchable_slash` rather than re-deriving "is this a
+            # command" here is what keeps the two answers identical: it tests
+            # the same two vocabularies the dispatch below resolves against
+            # (this build's registry AND the owner's advertised capabilities),
+            # so a line cannot be claimed by a branch that then has no handler
+            # for it — in either direction.
             #
-            # The cost is that a genuine TYPO (`/usge`) is now sent to the model
-            # rather than warned about. That is the deliberate trade: the
-            # composer already paints it muted BEFORE Enter, the model answers
-            # "you probably meant /usage", and one wasted turn on a misspelling
-            # is recoverable where an unsendable message is not. The
-            # unknown-command notice still guards `_run_slash_command`'s other
-            # callers, which name a command explicitly (mobile `slash()`, the
-            # inline splice) and so have no prose to fall back to.
+            # The vocabularies DO overlap, and the rule is a trade rather than a
+            # partition. `/new`, `/copy`, `/search`, `/context`, `/session` and
+            # `/skills` are all registry names AND valid bare absolute paths, so
+            # a message opening with one of those as a bare path still
+            # dispatches. What cannot collide is a path with a SECOND segment:
+            # the token is split on whitespace, so `/new/year/plan.md` is one
+            # word matching no name and stays prose. The trade is deliberate —
+            # a bare `/new` opening a message is vanishingly rare next to
+            # `/tmp/...` (review round 1, m1).
+            #
+            # The cost is that a genuine TYPO is now sent to the model rather
+            # than warned about — but the composer's muted paint is NOT what
+            # covers the common case, and believing it does is a trap for
+            # anyone later touching the picker. Measured on the running app
+            # (design D3 / UX U-round, 140 cases): a NEAR-MISS like `/usge`
+            # keeps the command picker OPEN, and `_compute_slash_runs`
+            # deliberately suppresses the unknown paint while the picker is
+            # choosing — so `/usge` gets no muted treatment at all. What saves
+            # it is that Enter on an open picker ACCEPTS the highlighted row:
+            # `/usge` runs `/usage` and nothing is sent. Only a FAR miss
+            # (`/xyzzy`) closes the picker, and that is the case the muted paint
+            # signals before Enter. The two mechanisms partition the space
+            # exactly — 82 picker-rescued, 58 dim-painted, 0 both, 0 neither —
+            # so changing the picker's Enter handling would remove the ONLY
+            # signal on the near-miss half.
+            #
+            # Either way one wasted turn on a misspelling is recoverable (Up
+            # arrow returns the text verbatim) where an unsendable message is
+            # not. The unknown-command notice still guards
+            # `_run_slash_command`'s other callers, which name a command
+            # explicitly (mobile `slash()`, the inline splice) and so have no
+            # prose to fall back to.
             #
             # Nothing but dispatch. A slash command writes its own rows: the
             # ledger row for the one command permitted one (``SLASH_COMMANDS``,

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -1397,14 +1397,23 @@ async def test_an_echoing_first_action_still_retires_the_splash() -> None:
 
 @pytest.mark.asyncio
 async def test_an_unknown_command_names_what_was_typed() -> None:
-    """With the echo gone the warning is the ONLY place the mistyped word
-    appears; "unknown command" without the command is a dead end. Cased as
-    typed, too — reporting `/USGE` as `/usge` sends the user hunting for a
-    second typo they did not make."""
+    """The unknown-command warning still guards the callers that NAME a command.
+
+    The submit path no longer reaches it — an unresolved leading word is prose
+    now (see the path tests below) — but ``_run_slash_command`` has other
+    callers that pass a command by name rather than a line the user typed: the
+    mobile bridge's ``slash()`` and the inline mid-draft splice. Those have no
+    prose to fall back to, so a word with no handler must still say so rather
+    than silently doing nothing.
+
+    Cased as typed: reporting `/USGE` as `/usge` sends the user hunting for a
+    second typo they did not make.
+    """
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
-        await _submit(pilot, app, "/USGE")
+        app._run_slash_command("/USGE")
+        await pilot.pause()
         painted = _painted(app)
         rows = _user_rows(app)
         # A typo changed nothing, so the conversation has not started and the
@@ -1414,6 +1423,145 @@ async def test_an_unknown_command_names_what_was_typed() -> None:
     assert "unknown command" in painted, painted
     assert rows == [], rows
     assert welcome is True
+
+
+@pytest.mark.asyncio
+async def test_a_leading_file_path_is_sent_as_a_prompt() -> None:
+    """The reported bug, verbatim: a message that OPENS with a file path.
+
+        /tmp/test
+
+        The above is a test file path
+
+    ``/tmp`` is not a command, so nothing could run it — but the submit path
+    claimed every slash-SHAPED line, so Enter answered ``unknown command:
+    /tmp/test — try /help`` and threw the draft away. There was no way to type
+    the message at all: the only workaround was to reword it so the path did not
+    come first.
+
+    The whole line reaches the model, newlines and all. Asserted on
+    ``session.prompts`` rather than on the absence of the warning, because "no
+    warning" is also what a silently dropped message looks like.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/tmp/test\n\nThe above is a test file path")
+        painted = _painted(app)
+    assert session.prompts == ["/tmp/test\n\nThe above is a test file path"], session.prompts
+    assert "unknown command" not in painted, painted
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "typed",
+    [
+        "/tmp",
+        "/etc/hosts",
+        "/Users/ben/workspace/notes.md",
+        "/usr/local/bin/lop --help",
+        # A UNC share and a doubled slash: the second `/` is not a boundary the
+        # tokenizer would read as a command either, and neither is a word.
+        "//server/share/file.txt",
+        # A path whose first segment IS a command name. `slash_command_for`
+        # splits on WHITESPACE, so the token is `/new/year` — not `/new` — and
+        # the line stays prose. This is the case a naive "first path segment"
+        # rule would get wrong, which is why the resolver is the one authority.
+        "/new/year/plan.md",
+        "/help-me-out/with/this",
+    ],
+)
+async def test_every_path_shape_reaches_the_model(typed: str) -> None:
+    """A leading `/` is a command only when the word after it resolves.
+
+    Parametrised over the shapes a user actually pastes, because the failure was
+    never specific to `/tmp`: every absolute path, every doubled slash and every
+    unknown word fell into the same branch. The last two cases pin the rule to
+    WHITESPACE tokenisation — `/new` and `/help` are real commands, but
+    `/new/year/plan.md` and `/help-me-out/with/this` are single tokens that
+    match no registry name, so a rule that split on `/` instead would run a
+    command the user did not type.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, typed)
+        painted = _painted(app)
+    assert session.prompts == [typed], session.prompts
+    assert "unknown command" not in painted, painted
+
+
+@pytest.mark.asyncio
+async def test_a_real_command_still_wins_over_the_prose_fallback() -> None:
+    """The other half of the same rule: widening prose must not swallow commands.
+
+    A resolving word still dispatches and still sends NOTHING to the model — the
+    regression this change could plausibly cause is `/usage` arriving as a chat
+    message.
+
+    Two apps rather than two submits into one: `/usage` opens a PAGE that owns
+    the composer, so a second submit behind it never reaches the dispatch. That
+    is the panel's own behaviour and predates this change (verified against a
+    `/goal`-only run), but sharing an app would let it mask the assertion.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session), provider_controller=FakeProviderController())
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/usage")
+        panel_open = app.query_one(UsagePanel).display
+        rows = _user_rows(app)
+    assert panel_open is True
+    assert session.prompts == [], session.prompts
+    assert rows == [], rows
+
+    # An ARGUMENT-carrying command still dispatches too: `/goal` is the one
+    # echoing command, so its row proves the handler ran rather than the line
+    # having been sent as prose.
+    argued = FakeSession()
+    app = OperatorApp(lambda: _factory(argued))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/goal ship it")
+        rows = _user_rows(app)
+    assert argued.prompts == [], argued.prompts
+    assert rows == ["/goal ship it"], rows
+
+    # An ALIAS resolves through the same entry, so the branch that now asks the
+    # resolver must accept it exactly as it accepts the primary name.
+    aliased = FakeSession()
+    app = OperatorApp(lambda: _factory(aliased))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/config")  # alias of `/settings`
+        painted = _painted(app)
+    assert aliased.prompts == [], aliased.prompts
+    assert "unknown command" not in painted, painted
+
+
+@pytest.mark.asyncio
+async def test_an_unresolved_word_is_prose_not_a_swallowed_message() -> None:
+    """A genuine typo is now SENT rather than warned about — the stated trade.
+
+    Pinned deliberately: the composer paints an unrecognised leading word muted
+    before Enter (`text-area--slash-unknown`, "text that WILL be sent"), so the
+    user has already been told. One wasted turn on `/usge` is recoverable; a
+    message that cannot be typed at all is not.
+
+    The picker is dismissed with Esc first, exactly as ``_submit`` documents:
+    Enter on an open picker COMPLETES the highlighted row, so `/usge` would
+    otherwise fuzzy-match its way to `/usage` and never reach this path.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/usge")
+        painted = _painted(app)
+    assert session.prompts == ["/usge"], session.prompts
+    assert "unknown command" not in painted, painted
 
 
 def _dock_geometry(app: OperatorApp, editor: Editor) -> dict[str, int]:

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -26,7 +26,7 @@ from textual.containers import Container
 from local_operator.session.goal import MAX_GOAL_CHARS, GoalState
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import SLASH_COMMANDS, OperatorApp, slash_command_for
-from local_operator.tui.widgets.editor import Editor
+from local_operator.tui.widgets.editor import Editor, InlineCommandRequested
 from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView, UserBlock
 from local_operator.tui.widgets.usage_panel import UsagePanel
 from local_operator.tui.widgets.welcome import WelcomeView
@@ -1545,14 +1545,15 @@ async def test_a_real_command_still_wins_over_the_prose_fallback() -> None:
 async def test_an_unresolved_word_is_prose_not_a_swallowed_message() -> None:
     """A genuine typo is now SENT rather than warned about — the stated trade.
 
-    Pinned deliberately: the composer paints an unrecognised leading word muted
-    before Enter (`text-area--slash-unknown`, "text that WILL be sent"), so the
-    user has already been told. One wasted turn on `/usge` is recoverable; a
-    message that cannot be typed at all is not.
+    Note what this test does and does not pin. Esc is pressed first (see
+    ``_submit``), which is what makes the branch reachable at all: with the
+    picker OPEN — the state `/usge` is actually in while typing — Enter accepts
+    the highlighted row and runs `/usage`, so a real user's near-miss never
+    arrives here. This pins the far-miss shape, where the picker has closed and
+    the muted `text-area--slash-unknown` paint is the pre-submit signal.
 
-    The picker is dismissed with Esc first, exactly as ``_submit`` documents:
-    Enter on an open picker COMPLETES the highlighted row, so `/usge` would
-    otherwise fuzzy-match its way to `/usage` and never reach this path.
+    One wasted turn on a typo is recoverable (Up arrow returns the text); a
+    message that cannot be typed at all is not.
     """
     session = FakeSession()
     app = OperatorApp(lambda: _factory(session))
@@ -1562,6 +1563,85 @@ async def test_an_unresolved_word_is_prose_not_a_swallowed_message() -> None:
         painted = _painted(app)
     assert session.prompts == ["/usge"], session.prompts
     assert "unknown command" not in painted, painted
+
+
+@pytest.mark.asyncio
+async def test_a_command_only_the_owner_knows_still_routes() -> None:
+    """Build skew: the OWNER's vocabulary counts too, not just this build's.
+
+    A viewer attached to a runtime on a newer build receives that owner's
+    advertised capabilities in ``frontend_state``, and ``_run_slash_command``
+    routes on them — ``remote_capabilities.get(command)`` — with no registry
+    entry involved. Gating submit on ``slash_command_for`` alone therefore made
+    an advertised-but-locally-unknown command PROSE: the line was silently sent
+    to the model as a paid turn instead of running on the owner, where before
+    this change the slash-shape gate had let it through to dispatch (review
+    round 1, M1).
+
+    Not hypothetical — ``lop-update`` swaps the install under a running viewer
+    several times a day, which is why ``_check_build_skew`` exists. ``newthing``
+    is deliberately a name no registry entry can ever have, so this fails the
+    moment the gate stops consulting the owner.
+    """
+    from local_operator.session.frontend_state import (
+        CommandScope,
+        FrontendSessionState,
+        SlashCapability,
+    )
+
+    routed: list[tuple[str, str]] = []
+
+    class RoutedSession(FakeSession):
+        frontend_state: FrontendSessionState
+
+        async def route_shared_slash(self, command: str, args: str, images=()):  # noqa: ANN001
+            routed.append((command, args))
+            return "routed"
+
+    session = RoutedSession()
+    session.frontend_state = FrontendSessionState(
+        session_id=session.session_id,
+        epoch="owner",
+        slash_capabilities=[
+            SlashCapability(
+                command="newthing",
+                scope=CommandScope.AUTHORITATIVE_SESSION,
+                operation="slash",
+            )
+        ],
+    )
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/newthing arg")
+    assert routed == [("newthing", "arg")], routed
+    assert session.prompts == [], session.prompts
+
+
+@pytest.mark.asyncio
+async def test_the_inline_splice_still_warns_on_an_unknown_command() -> None:
+    """The unknown-command notice, reached through a CALLER rather than direct.
+
+    ``test_an_unknown_command_names_what_was_typed`` pins the notice by calling
+    ``_run_slash_command`` itself, which states the policy but exercises no
+    entry point (review round 1, m2). This drives the mid-draft inline splice —
+    a real caller that NAMES a command — through its own message handler, so
+    the claim that the naming callers keep their warning rests on one of them
+    actually running.
+
+    The draft is deliberately left in the composer: an inline command splices
+    the token out and keeps the surrounding message, so an unknown word must
+    warn rather than silently do nothing with the user's prose still unsent.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        app.on_inline_command_requested(InlineCommandRequested("/usge"))
+        await pilot.pause()
+        notices = _notice_texts(app)
+    assert any("unknown command: /usge" in text for text in notices), notices
+    assert session.prompts == [], session.prompts
 
 
 def _dock_geometry(app: OperatorApp, editor: Editor) -> dict[str, int]:


### PR DESCRIPTION
## The bug

A message that **opens with a file path** could not be sent at all:

```
/tmp/test

The above is a test file path
```

Enter answered `unknown command: /tmp/test — try /help` and threw the draft away.

`/tmp` is not a command, so nothing could ever have run it. The submit path
claimed every slash-**shaped** line and then had no handler for it, so the line
fell straight through to the `else` branch that reports a typo. The only
workaround was to reword the message so the path did not come first.

This is not specific to `/tmp`. Every absolute path (`/etc/hosts`,
`/Users/ben/notes.md`), every doubled slash (`//server/share`) and every unknown
word fell into the same branch.

## The composer already disagreed with the dispatcher

`Editor._compute_slash_runs` paints an unrecognised leading word with
`text-area--slash-unknown`, and its own docstring says what that means:

> An unrecognized word gets the muted `slash-unknown` treatment so an inert
> `/teem` reads as **text that WILL be sent**

So the user was shown prose, pressed Enter, and was told it was a broken
command. The two halves of the composer had different ideas about the same
line; this makes the dispatcher agree with what was already painted.

## The fix

`on_editor_submitted` now dispatches only when `slash_command_for` **resolves**
the word, instead of testing `text.startswith("/")`.

Asking the *same resolver the dispatch itself uses* — rather than re-deriving
"is this a command" at the branch — is what keeps the two answers identical. The
word this branch tests is the word `_run_slash_command` would look up, so a line
cannot be claimed by a branch that then has no handler for it. That property is
the reason the check is a resolver call and not a regex.

Registry names are `[a-z]+` and a path's first *whitespace-delimited* token is
not, so the two vocabularies cannot collide. The two cases that pin this:

| typed | token | outcome |
|---|---|---|
| `/new/year/plan.md` | `/new/year/plan.md` | prose — **not** the `/new` command |
| `/help-me-out/with/this` | `/help-me-out/with/this` | prose — **not** `/help` |

A rule that split on `/` instead of whitespace would run a command the user
never typed. Both are regression cases.

## The trade, stated deliberately

A genuine typo (`/usge`) is now **sent to the model** rather than warned about.
That is a real behaviour change and it is the intended one:

- the composer already paints it muted **before** Enter, so the user has been told;
- the model answers "you probably meant `/usage`";
- one wasted turn on a misspelling is recoverable — **a message that cannot be
  typed at all is not**.

The unknown-command notice is not deleted. It still guards
`_run_slash_command`'s other callers — the mobile bridge's `slash()` and the
inline mid-draft splice — which name a command explicitly and so have no prose
to fall back to. `test_an_unknown_command_names_what_was_typed` was repointed at
those callers rather than removed.

## Before / after

Both frames are the **real `OperatorApp`** under `run_test`, driven by actual
keystrokes (`/tmp/test`, `shift+enter` ×2, the sentence, `enter`) — not by
assigning `editor.text`. `before` is a throwaway worktree at `origin/main`
(`6cb60bb2`), since the shape of this bug is what does *not* reach the session.

**BEFORE — `origin/main`:**

```
! unknown command: /tmp/test — try /help

❯ Message Local Operator…

prompts reaching the model: []
```

The draft is gone and nothing was sent.

**AFTER — this branch:**

```
▌ /tmp/test
▌
▌ The above is a test file path

❯ Message Local Operator…

prompts reaching the model: ['/tmp/test\n\nThe above is a test file path']
```

The whole message reaches the model, newlines intact.

## Verification

**The new tests are proven regression guards.** Run against `origin/main`'s
`app.py` with the new test file: **9 of 10 fail**. Against this branch: all
pass. (The tenth is the alias/real-command case, which correctly passes on
both — it exists to catch this change over-reaching.)

Ten cases added to `tests/unit/tui/test_slash_echo.py`:

- `test_a_leading_file_path_is_sent_as_a_prompt` — the reported case verbatim,
  asserted on `session.prompts` rather than on the absence of the warning,
  because "no warning" is also what a silently dropped message looks like.
- `test_every_path_shape_reaches_the_model` — parametrised over 7 shapes:
  `/tmp`, `/etc/hosts`, `/Users/ben/workspace/notes.md`,
  `/usr/local/bin/lop --help`, `//server/share/file.txt`, plus the two
  whitespace-tokenisation cases in the table above.
- `test_a_real_command_still_wins_over_the_prose_fallback` — the regression this
  change could plausibly cause (`/usage` arriving as a chat message). Covers a
  bare command, an argument-carrying command (`/goal`, whose ledger row proves
  the *handler* ran) and an alias (`/config` → `settings`), since the branch now
  asks the resolver and an alias resolves through the same entry.
- `test_an_unresolved_word_is_prose_not_a_swallowed_message` — pins the stated
  trade so it cannot be reverted silently.

Each uses three separate apps rather than three submits into one: `/usage` opens
a page that owns the composer, so a second submit behind it never reaches the
dispatch. That is the panel's own pre-existing behaviour — verified against a
`/goal`-only run — but sharing an app would let it mask the assertion.

**Gates**, run exactly as the Makefile invokes them:

| gate | result |
|---|---|
| `tests/unit/tui` + `tests/unit/mobile` + `tests/unit/session` | **5827 passed**, 12 skipped |
| `tests/e2e -m e2e -n0` | **4 passed** |
| `tests/unit/tui/test_slash_echo.py` | **57 passed** |
| `flake8` (whole tree) | clean |
| `black --check` (pinned 26.1.0) | clean, 838 files |
| `isort --check-only` | clean |
| `pyright` | **0 errors, 0 warnings, 0 informations** |

Version bumped **0.45.3 → 0.45.4** — a patch, per AGENTS.md: a bug fix that
changes no capability a user would adopt.

Release: patch — a message that begins with a path (`/tmp/test`) can now be sent instead of being rejected as an unknown command and discarded.
