### PR TITLE
feat(harness): make lop drivable as a supervised agent harness

### DIFF
--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -689,6 +689,15 @@ def build_cli_parser() -> argparse.ArgumentParser:
         dest="agent_id",
         help="ID of the agent to use for this execution (alternative to --agent by name)",
     )
+    exec_parser.add_argument(
+        "--control",
+        action="store_true",
+        help=(
+            "Publish a session record and serve the control socket for this run, "
+            "so an external supervisor can steer, cancel and answer gates "
+            "mid-run. Prints the endpoint on stderr. Off by default."
+        ),
+    )
 
     # --- Additive auth subcommands (rewrite) -------------------------------
     login_parser = subparsers.add_parser(
@@ -3815,6 +3824,10 @@ def main() -> int:
                 model=args.model,
                 train=args.train,
                 resume=getattr(args, "resume", None),
+                # getattr, like the additive flags above it: `exec` is not the
+                # only subcommand routed through this Namespace in tests, and a
+                # missing attribute must read as "off", never raise.
+                control=bool(getattr(args, "control", False)),
             )
             # Startup preflight (CL-06) for the FOREGROUND path: hosting/
             # model (agent > flag > config) + API-key resolution fail fast

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -866,6 +866,36 @@ def _propagate_global_flags(parser: argparse.ArgumentParser) -> None:
                 dest="resume",
                 help="Resume a previous session by id. Pass with no id for the most recent.",
             )
+            # The run-shaping trio, for the same reason and by the same
+            # mechanism. An external supervisor driving `lop exec` composes its
+            # argv programmatically and naturally writes the flags AFTER the
+            # subcommand — `lop exec - --json --model X` — which failed with
+            # "unrecognized arguments" and an exit 2 that reads like a bad
+            # install rather than a word-order rule. They select which model
+            # answers and where it runs, so silently ignoring them would be
+            # worse than the parse error: the run would proceed against the
+            # wrong model, in the wrong directory.
+            subparser.add_argument(
+                "--hosting",
+                type=str,
+                default=argparse.SUPPRESS,
+                dest="hosting",
+                help="Hosting platform for this run (e.g. anthropic, openai, openrouter)",
+            )
+            subparser.add_argument(
+                "--model",
+                type=str,
+                default=argparse.SUPPRESS,
+                dest="model",
+                help="Model to use for this run",
+            )
+            subparser.add_argument(
+                "--run-in",
+                type=str,
+                default=argparse.SUPPRESS,
+                dest="run_in",
+                help="Working directory to run the operator in",
+            )
             _propagate_global_flags(subparser)
 
 

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -695,7 +695,10 @@ def build_cli_parser() -> argparse.ArgumentParser:
         help=(
             "Publish a session record and serve the control socket for this run, "
             "so an external supervisor can steer, cancel and answer gates "
-            "mid-run. Prints the endpoint on stderr. Off by default."
+            "mid-run. Prints the endpoint on stderr. Off by default. "
+            "Note: this routes tool approvals to the supervisor, so a run "
+            "WITHOUT --yolo parks on each gate until one answers (then denies). "
+            "An unattended run wants --control --yolo."
         ),
     )
 

--- a/local_operator/exec_mode.py
+++ b/local_operator/exec_mode.py
@@ -68,6 +68,14 @@ class ExecArgs:
     #: through so `exec` continues a session rather than silently starting a new
     #: one and reporting success against the wrong history.
     resume: str | None = None
+    #: Publish a discovery record and serve the control socket for this run, so
+    #: an external supervisor can steer, cancel and answer gates mid-run. OFF by
+    #: default — the reasoning for opt-in (session-list pollution, daemon
+    #: adoption, heartbeat cadence, import weight) is in
+    #: :mod:`local_operator.session.runtime.exec_control`, which owns the
+    #: mechanism. Carried through to the worker so `--background --control` is
+    #: the same request run elsewhere, exactly like ``resume``.
+    control: bool = False
 
 
 def slugify(command: str, max_length: int = 40) -> str:
@@ -101,6 +109,12 @@ def build_worker_argv(command: str, exec_args: ExecArgs) -> list[str]:
         argv.extend(["--hosting", exec_args.hosting])
     if exec_args.model:
         argv.extend(["--model", exec_args.model])
+    if exec_args.control:
+        # A detached run is the one that most needs steering — nobody is
+        # watching its log — so the flag has to survive the process boundary.
+        # Dropped here it would be accepted by the front end and silently lost,
+        # the identical failure the ``resume`` note below records.
+        argv.append("--control")
     if exec_args.resume:
         # Serialized like every other field, because `--background` is supposed to
         # be the same request run elsewhere. Omitted, `exec --background --resume`
@@ -367,6 +381,10 @@ def run_exec(command: str, args: ExecArgs) -> int:
 
     A ``command`` of ``-`` means "read the prompt from stdin"; it is resolved
     here so the foreground and ``--background`` paths run the same text.
+
+    ``--control`` wraps the foreground run in a session runtime (record +
+    control socket) so a supervisor can steer and cancel it; the endpoint goes
+    to STDERR because stdout is the payload stream.
     """
     command = resolve_prompt(command)
     if not command:
@@ -385,7 +403,37 @@ def run_exec(command: str, args: ExecArgs) -> int:
         session = factory()
         if asyncio.iscoroutine(session):
             session = await session
-        return await run_print_mode(session, [command], json_mode=args.json_mode)
+        # Function-local by contract: the runtime pulls asyncio and the owned
+        # handle's composition root, and ``tests/unit/test_import_graph.py``
+        # pins what ``import local_operator.cli`` may load. Imported even when
+        # the flag is off is still too early — this module is imported by the
+        # CLI dispatch — so the import sits inside the run, not at module scope.
+        from local_operator.session.runtime.exec_control import maybe_start_exec_control
+
+        control = await maybe_start_exec_control(
+            session,
+            enabled=args.control,
+            cwd=os.getcwd(),
+            yolo=args.yolo,
+        )
+        if control is not None:
+            # STDERR: stdout carries the NDJSON event stream (or the final
+            # assistant text), and a supervisor parsing it line-by-line would
+            # choke on a chrome line. Same rule headless_print states for every
+            # other progress line.
+            print(control.endpoint_line, file=sys.stderr, flush=True)
+        # The surface must close BEFORE run_print_mode disposes the session, and
+        # that dispose is inside run_print_mode's own ``finally`` — so the
+        # ordering cannot be expressed from out here and is handed in as the
+        # ``before_dispose`` hook instead. A short run that finishes before the
+        # first 15 s heartbeat therefore still announces its stop and unpublishes
+        # its record; nothing is left for a scanner to reap.
+        return await run_print_mode(
+            session,
+            [command],
+            json_mode=args.json_mode,
+            before_dispose=(control.aclose if control is not None else None),
+        )
 
     try:
         return asyncio.run(runner())

--- a/local_operator/exec_mode.py
+++ b/local_operator/exec_mode.py
@@ -330,6 +330,30 @@ def _make_default_session_factory(exec_args: ExecArgs) -> SessionFactory:
     return factory
 
 
+#: The conventional "read the prompt from stdin" argument, as codex and other
+#: CLI harnesses spell it. Supervisors pipe a composed prompt file rather than
+#: passing it in argv, which is both visible in ``ps`` and bounded by ARG_MAX.
+STDIN_PROMPT_SENTINEL = "-"
+
+
+def resolve_prompt(command: str, *, stdin_text: str | None = None) -> str:
+    """Return the prompt to run, reading stdin when ``command`` is ``-``.
+
+    Resolved BEFORE the ``--background`` branch on purpose: the background
+    worker receives its prompt through argv (:func:`build_worker_argv`), so a
+    stdin prompt left unresolved would spawn a worker whose prompt is the
+    literal ``-`` — the same class of silent-wrong-input bug the ``resume``
+    field documents having already been fixed once, one process boundary out.
+
+    ``stdin_text`` is injectable so the behaviour is testable without a real
+    pipe on the process.
+    """
+    if command != STDIN_PROMPT_SENTINEL:
+        return command
+    text = sys.stdin.read() if stdin_text is None else stdin_text
+    return text.strip()
+
+
 def run_exec(command: str, args: ExecArgs) -> int:
     """Entry point for the ``exec`` subcommand (README contract: exit 0 on
     success, non-zero on error).
@@ -340,7 +364,14 @@ def run_exec(command: str, args: ExecArgs) -> int:
     first, prompt once, map error/abort to exit 1. A ``prompt()`` that
     RAISES also maps to exit 1 with the error on stderr (CL-19), never the
     interactive red banner: exec is machine-driven.
+
+    A ``command`` of ``-`` means "read the prompt from stdin"; it is resolved
+    here so the foreground and ``--background`` paths run the same text.
     """
+    command = resolve_prompt(command)
+    if not command:
+        print("exec failed: empty prompt", file=sys.stderr)
+        return 1
     if args.background:
         return _spawn_background(command, args)
 

--- a/local_operator/exec_worker.py
+++ b/local_operator/exec_worker.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import inspect
+import os
 import signal
 import sys
 from pathlib import Path
@@ -60,6 +61,11 @@ def build_parser() -> argparse.ArgumentParser:
         dest="job_id",
         help="Ledger job id; when set, the worker appends a terminal record"
         " (finished_at + exit_code) to the JSONL ledger on exit",
+    )
+    parser.add_argument(
+        "--control",
+        action="store_true",
+        help="Publish a session record and serve the control socket for this run",
     )
     parser.add_argument("--hosting", type=str, default=None, help="Hosting platform override")
     parser.add_argument("--model", type=str, default=None, help="Model override")
@@ -166,8 +172,29 @@ def run(
         session: SessionProtocol = await source if inspect.isawaitable(source) else source
         session_box.append(session)
 
+        # Function-local for the same reason as the engine imports above: a
+        # detached worker pays for the runtime stack only when asked for it.
+        from local_operator.session.runtime.exec_control import maybe_start_exec_control
+
+        control = await maybe_start_exec_control(
+            session,
+            enabled=bool(getattr(parsed, "control", False)),
+            cwd=os.getcwd(),
+            yolo=bool(getattr(parsed, "yolo", False)),
+        )
+        if control is not None:
+            # The spawner redirected this process's stderr to the job log, which
+            # is where a supervisor of a detached run looks for the endpoint —
+            # stdout still belongs to the NDJSON stream even here.
+            print(control.endpoint_line, file=sys.stderr, flush=True)
+
         prompt_task = asyncio.ensure_future(
-            run_print_mode(session, [parsed.prompt], json_mode=parsed.json_mode)
+            run_print_mode(
+                session,
+                [parsed.prompt],
+                json_mode=parsed.json_mode,
+                before_dispose=(control.aclose if control is not None else None),
+            )
         )
         interrupt_task = asyncio.ensure_future(interrupted.wait())
         await asyncio.wait({prompt_task, interrupt_task}, return_when=asyncio.FIRST_COMPLETED)

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -60,10 +60,12 @@ from local_operator.harness.types import (
     MessageUpdateEvent,
     ModelSpec,
     NoticeEvent,
+    ProviderTurnStartEvent,
     RenderedStreamError,
     StaleAside,
     StreamEndEvent,
     StreamEvent,
+    StreamStartEvent,
     StreamTextDelta,
     StreamToolCallDelta,
     StreamUsageEvent,
@@ -945,7 +947,19 @@ class AgentLoop:
                             redact=config.redact_tool_result,
                         )
 
-                    if signal is not None and signal.aborted:
+                    graceful_cancel = False
+                    if config.graceful_cancel_requested is not None:
+                        # Asked HERE, at the boundary, precisely because the
+                        # tools that just ran may have pushed a commit or opened
+                        # a merge request. A supervisor's cancel stops the run
+                        # without tearing one of those in half; the completed
+                        # work stays in the transcript and the turn ends as
+                        # aborted, exactly like a signalled stop would.
+                        try:
+                            graceful_cancel = bool(config.graceful_cancel_requested())
+                        except Exception:  # noqa: BLE001 — a broken host hook must not strand the turn
+                            graceful_cancel = False
+                    if (signal is not None and signal.aborted) or graceful_cancel:
                         # The abort landed while the batch was running. Its
                         # results are already appended above (every call paired,
                         # cancelled ones as synthetic ``aborted`` results), so
@@ -1184,7 +1198,18 @@ class AgentLoop:
             )
             stream = _abortable_stream(config.stream_fn(request, signal), signal)
             async for event in stream:
-                if isinstance(event, StreamTextDelta):
+                if isinstance(event, StreamStartEvent):
+                    # The provider is generating for THIS request. Republish it
+                    # as a harness event so supervisors get a boundary that
+                    # means "on the wire" — ``MessageStartEvent`` above is
+                    # yielded from a placeholder before the request is even
+                    # built, so it cannot carry that meaning.
+                    yield ProviderTurnStartEvent(
+                        response_id=event.response_id,
+                        provider=model.provider,
+                        model_id=model.model_id,
+                    )
+                elif isinstance(event, StreamTextDelta):
                     text_parts.append(event.delta)
                     yield MessageUpdateEvent(message=assistant, delta=event.delta)
                 elif isinstance(event, StreamToolCallDelta):

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -957,7 +957,8 @@ class AgentLoop:
                         # aborted, exactly like a signalled stop would.
                         try:
                             graceful_cancel = bool(config.graceful_cancel_requested())
-                        except Exception:  # noqa: BLE001 — a broken host hook must not strand the turn
+                        # A broken host hook must not strand the turn.
+                        except Exception:  # noqa: BLE001
                             graceful_cancel = False
                     if (signal is not None and signal.aborted) or graceful_cancel:
                         # The abort landed while the batch was running. Its

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1074,7 +1074,18 @@ class ProviderTurnStartEvent(AgentEvent[Literal["provider_turn_start"]]):
     ``response_id`` is the provider's native turn identity, or ``None`` when
     the provider exposes none (Google). A consumer that requires no-replay
     proof must treat ``None`` as indeterminate and fail closed rather than
-    substituting an id of its own.
+    substituting an id of its own. It is always emitted, even with a null id:
+    a MISSING boundary cannot be distinguished from "the request never went
+    out", so a consumer would wait forever instead of failing closed.
+
+    **One turn may emit SEVERAL of these, and the LATEST supersedes.** A
+    credential rotation or a provider fallback retries the request, and each
+    attempt that reaches a provider announces its own boundary with its own
+    id. This is not a duplicate to be deduplicated: the earlier attempt failed
+    before rendering anything, so its id names a turn that produced no output,
+    while the last one names the turn actually being served. A consumer
+    committing no-replay proof must therefore key on the most recent id rather
+    than the first, or it will hold proof for an attempt that was abandoned.
     """
 
     type: Literal["provider_turn_start"] = "provider_turn_start"

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1056,6 +1056,33 @@ class AgentEndEvent(AgentEvent[Literal["agent_end"]]):
     context_tokens: int | None = None
 
 
+class ProviderTurnStartEvent(AgentEvent[Literal["provider_turn_start"]]):
+    """The provider began generating for the request that is on the wire.
+
+    THE acceptance boundary for an external supervisor. A runtime that drives
+    lop as a subprocess (Minerva's agent-runtime-svc does) commits "this prompt
+    was accepted and must not be resubmitted" when it sees this event, because
+    resubmitting a prompt the provider already acted on can duplicate external
+    side effects — a pushed commit, an opened MR, a sent message.
+
+    It is deliberately NOT ``message_start``. The loop yields that one from a
+    bare placeholder message before the ``ChatRequest`` exists, so a boundary
+    keyed on it would mark a prompt un-retryable that DNS, auth, or a rate
+    limit could still reject — silently losing the work while the supervisor
+    believed it was accepted.
+
+    ``response_id`` is the provider's native turn identity, or ``None`` when
+    the provider exposes none (Google). A consumer that requires no-replay
+    proof must treat ``None`` as indeterminate and fail closed rather than
+    substituting an id of its own.
+    """
+
+    type: Literal["provider_turn_start"] = "provider_turn_start"
+    response_id: str | None = None
+    provider: str | None = None
+    model_id: str | None = None
+
+
 class TurnStartEvent(AgentEvent[Literal["turn_start"]]):
     type: Literal["turn_start"] = "turn_start"
 
@@ -1469,6 +1496,13 @@ class LoopConfig(BaseModel):
         default=None, exclude=True
     )
     has_steering_messages: Callable[[], bool] | None = Field(default=None, exclude=True)
+    #: Asks the host whether a boundary-respecting cancel is pending. Consulted
+    #: at the post-tool boundary, where every call in the batch has produced a
+    #: paired result and the next model request has not yet been spent — so a
+    #: supervisor can stop a run WITHOUT cutting a tool that has external side
+    #: effects (a push, an MR write) mid-flight. ``None`` leaves the behaviour
+    #: exactly as it was: only the abort signal ends a turn early.
+    graceful_cancel_requested: Callable[[], bool] | None = Field(default=None, exclude=True)
     get_aside_messages: Callable[[], Awaitable[list[Aside]]] | None = Field(
         default=None, exclude=True
     )
@@ -1788,6 +1822,30 @@ class ChatRequest(BaseModel):
     isolated: bool = False
 
 
+class StreamStartEvent(BaseModel):
+    """The provider began responding to THIS request, on the wire.
+
+    Emitted by a wire client the moment the provider reveals its own identity
+    for the turn — the first chunk of an OpenAI-compatible stream, the
+    ``response.created`` event on the Responses API, Anthropic's
+    ``message_start``. It exists to give supervisors a boundary that means
+    "the request crossed the wire and the provider started generating", which
+    is NOT what ``MessageStartEvent`` means: the loop emits that one from a
+    bare placeholder message before the ``ChatRequest`` is even constructed
+    (see ``loop.py``), so a supervisor keying "accepted" on it would mark a
+    prompt un-retryable that DNS, auth, or a rate limit could still reject.
+
+    ``response_id`` is the provider's native turn identity, and is the token an
+    external runtime commits as no-replay proof. It is ``None`` when the
+    provider exposes no stable per-response id on its streaming surface
+    (Google), and a consumer must then treat acceptance as indeterminate
+    rather than inventing one.
+    """
+
+    type: Literal["start"] = "start"
+    response_id: str | None = None
+
+
 class StreamTextDelta(BaseModel):
     type: Literal["text_delta"] = "text_delta"
     delta: str
@@ -1822,4 +1880,6 @@ class StreamEndEvent(BaseModel):
     error: str | None = None
 
 
-StreamEvent = StreamTextDelta | StreamToolCallDelta | StreamUsageEvent | StreamEndEvent
+StreamEvent = (
+    StreamStartEvent | StreamTextDelta | StreamToolCallDelta | StreamUsageEvent | StreamEndEvent
+)

--- a/local_operator/headless_print.py
+++ b/local_operator/headless_print.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import json
 import sys
-from typing import Any, Callable
+from typing import Any, Awaitable, Callable
 
 from rich.console import Console
 
@@ -327,7 +327,10 @@ def _args_summary(args: dict[str, Any]) -> str:
 
 
 async def run_print_mode(
-    session: SessionProtocol, messages: list[str], json_mode: bool = False
+    session: SessionProtocol,
+    messages: list[str],
+    json_mode: bool = False,
+    before_dispose: Callable[[], Awaitable[None]] | None = None,
 ) -> int:
     """One-shot headless run mirroring the print-mode semantics.
 
@@ -336,6 +339,17 @@ async def run_print_mode(
     mode prints the last assistant text to stdout; json mode already emitted
     one line per event. Returns 0 on success, 1 when any turn errored or was
     aborted. Disposes the session before returning (one-shot by contract).
+
+    ``before_dispose`` is awaited in the teardown, after the last event and
+    BEFORE the session is disposed. It exists because the dispose is this
+    function's own contract and a caller therefore cannot sequence anything
+    ahead of it from the outside: ``exec --control`` needs its control surface
+    announced-and-closed while the session is still whole, so an attached
+    supervisor reads a deliberate end rather than a dropped socket, and the
+    runtime's heartbeat is not still reading through a handle into a session
+    being torn down. Awaited on every exit path including a raising prompt,
+    and its own failure must not mask that error — the callable owns swallowing
+    what it can (see ``ExecControl.aclose``).
     """
     renderer = PrintRenderer(stream_text=False, json_mode=json_mode)
     unsubscribe = renderer.attach(session)
@@ -351,4 +365,6 @@ async def run_print_mode(
     finally:
         if callable(unsubscribe):
             unsubscribe()
+        if before_dispose is not None:
+            await before_dispose()
         await session.dispose()

--- a/local_operator/headless_print.py
+++ b/local_operator/headless_print.py
@@ -126,13 +126,37 @@ class PrintRenderer:
         #: provider in its recovery hint. ``None`` until :meth:`attach`.
         self._session: SessionProtocol | None = None
 
+    @property
+    def session_id(self) -> str | None:
+        """The attached session's id, or ``None`` before :meth:`attach`.
+
+        Read defensively: a test double satisfying only the parts of
+        ``SessionProtocol`` a renderer touches may not carry an id, and a
+        missing id must degrade to an unstamped line rather than break the
+        stream that is the run's only output.
+        """
+        session = self._session
+        if session is None:
+            return None
+        value = getattr(session, "session_id", None)
+        return value if isinstance(value, str) and value else None
+
     # -- subscription entry point -------------------------------------------
 
     def handle(self, event: AgentEvent) -> None:
         """Event handler for ``session.subscribe`` (sync; the harness accepts
         sync or async handlers)."""
         if self.json_mode:
-            sys.stdout.write(json.dumps(printable_event(event), ensure_ascii=False) + "\n")
+            payload = printable_event(event)
+            # Stamp the session on EVERY line rather than once in a header.
+            # External supervisors parse this stream line-by-line and
+            # statelessly (Minerva's sentinel runner is a per-line jq filter),
+            # so a header they happened to start after is unrecoverable — and
+            # the id is what lets them resume the session later.
+            session_id = self.session_id
+            if session_id:
+                payload.setdefault("session_id", session_id)
+            sys.stdout.write(json.dumps(payload, ensure_ascii=False) + "\n")
             sys.stdout.flush()
             self._track_outcome(event)
             return

--- a/local_operator/mobile/types.py
+++ b/local_operator/mobile/types.py
@@ -154,6 +154,16 @@ def validate_control_frame(frame: dict[str, Any]) -> None:
                     "images": images,
                 }
             )
+    elif op == "cancel":
+        # An unknown mode is REFUSED rather than defaulted. The two modes differ
+        # in whether a running tool is cut in half, so a typo ("gracefull",
+        # "soft") silently resolving to either one is a wrong-semantics bug on
+        # the exact op whose reason for existing is that the distinction
+        # matters. Absent is fine and means graceful — the safe default that a
+        # caller who has not thought about it should get.
+        mode = frame.get("mode", "graceful")
+        if mode not in ("graceful", "immediate"):
+            raise ValueError("mode must be 'graceful' or 'immediate'")
     elif op == "complete_aside":
         turns = frame.get("turns")
         if not isinstance(turns, list) or not all(isinstance(item, dict) for item in turns):
@@ -218,6 +228,18 @@ ControlOp = Literal[
     "prompt",  # {command_id, text, images?} — durable idempotent user turn
     "steer",  # {command_id, text, images?} — idempotent mid-turn injection
     "abort",  # {} — the stop button; never kills the session
+    # The supervised-agent counterpart of ``abort``, and the reason both exist.
+    # ``abort`` fires the turn's AbortSignal immediately, cancelling the running
+    # tool task — right for a human at a keyboard, who wants it to stop NOW and
+    # can see and repair whatever was left half-done. A machine supervisor has
+    # neither of those: its agent's tools push commits, open merge requests and
+    # write rows, and a cut mid-``git push`` leaves damage nobody is watching
+    # for. ``cancel`` defaults to the boundary-respecting mode, which lands
+    # after the in-flight tool batch has produced its results and before the
+    # next model request is spent (``Session.request_graceful_cancel``).
+    # ``mode: "immediate"`` is the explicit opt-in to ``abort`` semantics, so a
+    # caller only cuts a tool in half by asking for it in those words.
+    "cancel",  # {mode?: graceful|immediate}
     "set_model",  # {provider, model_id} — the model sheet's choice
     "set_effort",  # {effort} — one rung from the model's ladder
     "slash",  # {command, args} — execute a TUI slash command

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -45,6 +45,7 @@ from local_operator.harness.types import (
     ModelSpec,
     StreamEndEvent,
     StreamEvent,
+    StreamStartEvent,
     StreamTextDelta,
     StreamToolCallDelta,
     StreamUsageEvent,
@@ -154,6 +155,21 @@ def _usage_token(raw_usage: Mapping[str, Any], *names: str) -> int:
                 # stream; treating it as absent preserves the authoritative totals.
                 continue
     return 0
+
+
+def _stream_id(value: Any) -> str | None:
+    """Normalize a provider's native turn id for ``StreamStartEvent``.
+
+    An external runtime commits this value as no-replay proof, so the only
+    honest answers are a non-empty string or ``None``. A blank or whitespace-
+    only id is coerced to ``None`` rather than forwarded: a consumer that sees
+    an empty string cannot tell "the provider gave no id" from "the provider
+    gave one and it was lost", and the first must fail closed as indeterminate.
+    """
+    if not isinstance(value, str):
+        return None
+    trimmed = value.strip()
+    return trimmed or None
 
 
 def _compat_cache_usage(raw_usage: Mapping[str, Any]) -> tuple[int, int]:
@@ -2140,6 +2156,14 @@ class OpenAICompatClient:
         # reading as if the model replied normally.
         refusal_parts: list[str] = []
         streamed_text = False
+        #: Whether the on-the-wire acceptance boundary has been announced, and
+        #: the provider's native turn id once it is known. An OpenAI-compatible
+        #: stream carries ``id`` on its first chunk, so the two are usually set
+        #: together; ``started`` is tracked separately because a provider that
+        #: omits ``id`` must still produce the boundary (with a null id) rather
+        #: than none at all.
+        started = False
+        response_id: str | None = None
 
         async with self._http.stream(
             "POST",
@@ -2163,6 +2187,14 @@ class OpenAICompatClient:
                     # Raise it NAMED; swallowing it left turns dying as
                     # wordless interruptions (see _compat_stream_error).
                     raise _compat_stream_error(chunk)
+                if not started:
+                    # First decoded chunk: the request is on the wire and the
+                    # provider is generating. Announce the boundary HERE rather
+                    # than at the end, because a supervisor commits no-replay
+                    # proof against it (see StreamStartEvent) and must not learn
+                    # the turn was accepted only once it has already finished.
+                    started = True
+                    yield StreamStartEvent(response_id=_stream_id(chunk.get("id")))
                 if isinstance(chunk.get("usage"), Mapping):
                     raw = chunk["usage"]
                     cache_read, cache_write = _compat_cache_usage(raw)
@@ -2227,6 +2259,8 @@ class OpenAICompatClient:
                         "id": chunk.get("id"),
                         "system_fingerprint": chunk.get("system_fingerprint"),
                     }
+                    if not response_id:
+                        response_id = _stream_id(chunk.get("id"))
 
         stop_reason = _FINISH_TO_STOP_REASON.get(finish_reason or "", finish_reason or "stop")
         # A refusal delta with a non-filter finish (OpenAI sends
@@ -2310,6 +2344,15 @@ class OpenAICompatClient:
                 except json.JSONDecodeError:
                     continue
                 event_type = payload.get("type", "")
+                if event_type == "response.created":
+                    # The Responses API names the turn as soon as it opens it.
+                    # Capture the boundary HERE, not at ``response.completed``:
+                    # a supervisor keying no-replay proof on completion would
+                    # learn the turn was accepted only after it had already
+                    # produced its whole answer, which defeats the purpose.
+                    yield StreamStartEvent(
+                        response_id=_stream_id((payload.get("response") or {}).get("id"))
+                    )
                 # Requesting ``include: ["reasoning.encrypted_content"]`` (defect
                 # #2) makes the stream carry ``reasoning`` output items and their
                 # ``response.reasoning*`` deltas that a non-reasoning include
@@ -3025,6 +3068,15 @@ class AnthropicClient:
                     continue
                 event_type = event.get("type")
                 if event_type == "message_start":
+                    # Anthropic names the turn on its own ``message_start``,
+                    # which is the moment it began generating for this request.
+                    # The id was previously read past for usage alone, leaving
+                    # an Anthropic-pinned run with NO native turn identity on
+                    # any event — and therefore no way for an external runtime
+                    # to commit no-replay proof.
+                    yield StreamStartEvent(
+                        response_id=_stream_id((event.get("message") or {}).get("id"))
+                    )
                     raw_usage = (event.get("message") or {}).get("usage") or {}
                     usage.input_tokens = int(raw_usage.get("input_tokens", usage.input_tokens))
                     usage.cache_read_tokens = int(raw_usage.get("cache_read_input_tokens", 0))

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -3340,11 +3340,22 @@ class GoogleClient:
             if response.status_code >= 400:
                 await response.aread()
                 raise_for_status(response)
+            started = False
             async for data in _iter_sse_lines(response):
                 try:
                     chunk = json.loads(data)
                 except json.JSONDecodeError:
                     continue
+                if not started:
+                    # Gemini's streaming surface exposes no stable per-response
+                    # id, so the boundary carries ``None``. It is still emitted:
+                    # a supervisor needs to know the provider began generating,
+                    # and a MISSING boundary is worse than an id-less one — it
+                    # cannot be distinguished from "the request never went out",
+                    # so a consumer waits forever instead of failing closed on an
+                    # indeterminate acceptance (which is the documented contract).
+                    started = True
+                    yield StreamStartEvent(response_id=None)
                 for candidate in chunk.get("candidates") or []:
                     for part in (candidate.get("content") or {}).get("parts") or []:
                         text = part.get("text")
@@ -3445,6 +3456,10 @@ class MockClient:
         api_key: str | None,
         oauth_access: "OAuthAccess | None" = None,
     ) -> AsyncIterator[StreamEvent]:
+        # Mirror the real clients: the boundary leads every stream, including
+        # the refusal path, so anything exercised against the mock sees the
+        # same event shape a provider produces.
+        yield StreamStartEvent(response_id="mock-response-id")
         if any("[refuse]" in message.text for message in request.messages):
             yield StreamUsageEvent(usage=Usage(input_tokens=10, output_tokens=0))
             yield StreamEndEvent(

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -34,6 +34,7 @@ from local_operator.harness.types import (
     ModelSpec,
     RenderedStreamError,
     StreamEvent,
+    StreamStartEvent,
 )
 from local_operator.model.effort import EFFORT_ORDER, resolve_effort_in
 
@@ -2437,7 +2438,21 @@ async def stream_with_failover(
                     if buffered is not None:
                         buffered.append(stamped)
                         continue
-                    forwarded_any = True
+                    # ``forwarded_any`` gates retry, and it means exactly one
+                    # thing: the caller has SEEN output that cannot be un-shown,
+                    # so replaying this attempt would stream deltas twice.
+                    # A ``StreamStartEvent`` shows the user nothing — it is a
+                    # boundary marker announcing that the provider began — so
+                    # counting it would make every failure that lands after
+                    # acceptance but before the first token non-retryable
+                    # (Anthropic 529s, in-band error chunks on a 200 stream),
+                    # bypassing credential rotation and the whole fallback
+                    # chain. It would also misreport a pre-content transport
+                    # death as a MID-STREAM loss, which is what
+                    # ``is_mid_stream_connectivity_loss`` infers from this very
+                    # flag. Nothing has been rendered, so nothing blocks a retry.
+                    if not isinstance(event, StreamStartEvent):
+                        forwarded_any = True
                     yield stamped
                 if route_state is not None and target == primary_target:
                     # Settled, not silent: while a fallback was pinned the front

--- a/local_operator/server/utils/sse.py
+++ b/local_operator/server/utils/sse.py
@@ -128,6 +128,21 @@ class EventName:
     #: Tool finished, with its result and error flag. Maps to
     #: ``runtime.agent.item.completed`` / ``failed``.
     TOOL_END = "tool.end"
+    #: The provider began generating for the request that is ON THE WIRE,
+    #: carrying its native ``response_id``. This is the acceptance boundary an
+    #: external supervisor commits as no-replay proof (see
+    #: ``harness.types.ProviderTurnStartEvent``), which is why it is a distinct
+    #: name rather than a flag on ``turn.start``: ``turn.start`` is the loop's
+    #: own iteration boundary and is emitted before any request exists, so a
+    #: consumer keying "accepted" on it would mark a prompt un-retryable that
+    #: DNS, auth or a rate limit could still reject. ``response_id`` is ``None``
+    #: on providers that expose none (Google); a consumer needing proof must
+    #: fail closed on that rather than substitute an id of its own.
+    #:
+    #: Named ``provider.start`` and not ``provider.turn_start`` to hold the
+    #: taxonomy's shape - every name here is ``<subject>.<single lifecycle
+    #: word>``, and a two-word second segment would be the first exception.
+    PROVIDER_START = "provider.start"
     #: Turn boundaries. Map to ``runtime.agent.turn.started`` / ``completed``.
     TURN_START = "turn.start"
     TURN_END = "turn.end"
@@ -136,6 +151,13 @@ class EventName:
     AGENT_END = "agent.end"
     #: Human-facing notice (info/warning/error) surfaced in the transcript.
     NOTICE = "notice"
+    #: Queued steering messages entered the model's context. A STATE TRANSITION
+    #: a client reconciles the "queued" row it already painted against, not a
+    #: line to print - which is why it is not folded into ``notice``, where it
+    #: would append a second row saying the first row is now wrong. ``count`` is
+    #: how many messages were delivered at that one boundary (see
+    #: ``harness.types.SteeringDeliveredEvent``).
+    STEERING_DELIVERED = "steering.delivered"
     #: Context compaction began/finished - the UI may show a marker.
     COMPACTION_START = "compaction.start"
     COMPACTION_END = "compaction.end"

--- a/local_operator/server/utils/sse_bridge.py
+++ b/local_operator/server/utils/sse_bridge.py
@@ -1,0 +1,137 @@
+"""Attach a plain harness session to an :class:`EventBroker`.
+
+WHY THIS EXISTS
+---------------
+Until now the only producer of SSE events was the ``lop serve`` job pipeline:
+:mod:`local_operator.server.utils.job_processor_queue` drains a
+``multiprocessing.Queue`` filled by an :class:`AgentEventBridge` running in the
+child process, and dispatches each tuple to
+:mod:`local_operator.server.utils.sse_publisher`. Every other host of a session
+- headless ``exec``, an embedded supervisor, anything driving
+``Session.prompt`` directly - produced **zero** SSE events, even though the
+whole transport (framing, replay buffer, ``Last-Event-ID`` resume, the
+endpoints, and a UI that already speaks all of it) was sitting right there.
+
+This module is the missing seam, and it is deliberately thin: the projection
+from ``AgentEvent`` to the wire is NOT reimplemented here. A second projection
+is how two hosts start disagreeing about what ``message.delta`` means, and the
+one in ``AgentEventBridge`` already carries hard-won behaviour a reimplementation
+would silently drop - the running ``snapshot`` on delta frames, the per-string
+:data:`STREAM_VALUE_LIMIT` cap that stops a megabyte tool result from stalling
+every listener, and the record shape the legacy WebSocket consumer expects.
+
+So instead of a new projection, this supplies a new *destination* for the
+existing one. ``AgentEventBridge`` talks to a ``StatusQueue`` - a protocol whose
+entire surface is ``put(obj)`` - so an in-process object that implements ``put``
+and publishes straight to the broker reuses the projection verbatim while
+skipping the process hop the server needs and a single-process host does not.
+
+WHAT THIS IS NOT
+----------------
+It does not start a server, open a socket, or own a broker. The caller supplies
+the :class:`EventBroker` it already has, which keeps the dependency pointing one
+way: a host decides it wants a stream, rather than the stream reaching into
+hosts. A host with no broker calls nothing and pays nothing.
+
+IMPORT COST
+-----------
+``tests/unit/test_import_graph.py`` pins what the CLI drags in at startup, so
+the heavy import (``server.utils.operator``, which pulls the whole legacy
+adapter plus yaml/dotenv/pickle) is function-local inside :func:`attach_broker`.
+Importing this module costs the publisher and the broker only, and a host that
+never attaches a stream never loads the adapter at all.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Mapping, Optional
+
+from local_operator.server.utils.event_broker import EventBroker
+from local_operator.server.utils.sse_publisher import (
+    publish_agent_event,
+    publish_job_status,
+    publish_record,
+)
+
+logger = logging.getLogger("local_operator.server.utils.sse_bridge")
+
+
+class BrokerStatusSink:
+    """A ``StatusQueue`` that publishes to a broker instead of crossing a pipe.
+
+    The server's queue exists because its turn runs in a *child process*; the
+    parent-side pump is what turns each tuple into broker events. A host that
+    runs the turn in its own process has no such boundary, so this collapses the
+    pump into the queue: the same tuples arrive, and are dispatched by the same
+    publisher functions the pump uses. The tuple vocabulary is therefore not a
+    private detail of this class - it is the one defined by ``AgentEventBridge``
+    and consumed in ``job_processor_queue``, and the two must be changed
+    together.
+
+    ``put`` never raises. It is called from inside the event handler on the
+    turn's own task, so an exception here would abort the turn - the same
+    failure posture the publisher documents, one step earlier in the chain.
+    """
+
+    def __init__(self, broker: EventBroker, job_id: str) -> None:
+        self._broker = broker
+        # Required, not optional: every frame this sink emits lands on the
+        # job-keyed channel, which is the only channel a consumer can open
+        # before a record id has been minted. A sink without one would publish
+        # to nowhere and look like a broken stream rather than a missing id.
+        self._job_id = job_id
+
+    def put(self, obj: object, /) -> None:
+        try:
+            if not isinstance(obj, tuple) or len(obj) != 3:
+                return
+            kind, _ident, payload = obj
+            if kind == "message_update":
+                publish_record(self._broker, self._job_id, payload)  # type: ignore[arg-type]
+            elif kind == "agent_event" and isinstance(payload, Mapping):
+                publish_agent_event(self._broker, self._job_id, payload)
+            # "execution_update" is deliberately dropped. It carries the legacy
+            # "Thinking about my next action" placeholder record that exists to
+            # drive the old UI's spinner off the job ledger; the pump routes it
+            # to the JobManager and never to the broker, and inventing a stream
+            # frame for it here would put a record on the wire that the server
+            # path does not emit.
+        except Exception:  # noqa: BLE001 - a stream must never kill the turn
+            logger.warning("failed to publish session event to SSE broker", exc_info=True)
+
+
+def attach_broker(
+    session: Any,
+    broker: Optional[EventBroker],
+    job_id: str,
+) -> Callable[[], None]:
+    """Stream ``session``'s events to ``broker`` on ``job_channel(job_id)``.
+
+    Returns the unsubscribe callable, which the caller MUST invoke when the run
+    ends: the handler holds the bridge's per-message record state, so leaving it
+    attached to a reused session leaks a record dict per message and keeps
+    republishing to a channel nobody reads.
+
+    A ``None`` broker returns a no-op, so a host can wire this unconditionally
+    and let configuration decide whether a stream exists - the same shape
+    ``SchedulerService`` uses for its optional broker.
+
+    Terminal framing is the caller's job, via
+    :func:`~local_operator.server.utils.sse_publisher.publish_job_status`: only
+    the host knows whether the run completed, failed, or was cancelled, and a
+    stream that never receives a terminal frame keepalives until the client
+    gives up - the exact defect the transport was built to remove.
+    """
+    if broker is None:
+        return lambda: None
+
+    # Function-local: see the module docstring's IMPORT COST note. The adapter
+    # is only needed once a host has actually decided to stream.
+    from local_operator.server.utils.operator import AgentEventBridge
+
+    bridge = AgentEventBridge(status_queue=BrokerStatusSink(broker, job_id), job_id=job_id)
+    return session.subscribe(bridge.handle)
+
+
+__all__ = ["BrokerStatusSink", "attach_broker", "publish_job_status"]

--- a/local_operator/server/utils/sse_bridge.py
+++ b/local_operator/server/utils/sse_bridge.py
@@ -33,6 +33,26 @@ the :class:`EventBroker` it already has, which keeps the dependency pointing one
 way: a host decides it wants a stream, rather than the stream reaching into
 hosts. A host with no broker calls nothing and pays nothing.
 
+WHO CALLS THIS (and who deliberately does not)
+----------------------------------------------
+The broker is created by, and lives inside, the ``lop serve`` process
+(``server/app.py``), and the SSE routes are read-only — there is no ingest
+endpoint. So this seam is for a host that owns a session **in the same process
+as a broker**, and it is the seam any such host should use rather than growing
+a second projection.
+
+A separate ``lop exec`` process is therefore NOT a caller and cannot be one
+without new ingest surface. That is deliberate rather than an oversight: a
+headless run's events already leave the process as NDJSON on stdout, and the
+supervisors that drive lop as a subprocess (Minerva's ``agent-runtime-svc``)
+parse that stream and own the UI-facing SSE fan-out — with the auth,
+heartbeating and ``Last-Event-ID`` resume — one layer up. Adding an ingest
+route here would put a second, public-ish streaming surface on the workload
+process to duplicate a fan-out that already exists and already works.
+
+So: in-process host with a broker -> call this. Out-of-process supervisor ->
+read stdout, and relay from wherever you already serve UIs.
+
 IMPORT COST
 -----------
 ``tests/unit/test_import_graph.py`` pins what the CLI drags in at startup, so

--- a/local_operator/server/utils/sse_publisher.py
+++ b/local_operator/server/utils/sse_publisher.py
@@ -49,6 +49,7 @@ TERMINAL_JOB_STATUSES = frozenset({JobStatus.COMPLETED, JobStatus.FAILED, JobSta
 _AGENT_EVENT_NAMES: Dict[str, str] = {
     "agent_start": EventName.AGENT_START,
     "agent_end": EventName.AGENT_END,
+    "provider_turn_start": EventName.PROVIDER_START,
     "turn_start": EventName.TURN_START,
     "turn_end": EventName.TURN_END,
     "message_update": EventName.MESSAGE_DELTA,
@@ -56,6 +57,7 @@ _AGENT_EVENT_NAMES: Dict[str, str] = {
     "tool_execution_update": EventName.TOOL_DELTA,
     "tool_execution_end": EventName.TOOL_END,
     "notice": EventName.NOTICE,
+    "steering_delivered": EventName.STEERING_DELIVERED,
     "compaction_start": EventName.COMPACTION_START,
     "compaction_end": EventName.COMPACTION_END,
     "retry_start": EventName.RETRY_START,

--- a/local_operator/session/runtime/exec_control.py
+++ b/local_operator/session/runtime/exec_control.py
@@ -1,0 +1,217 @@
+"""The opt-in control surface for a headless ``lop exec`` run.
+
+``exec`` is the harness's machine-driven entry point: a supervisor composes a
+prompt, runs one turn, and parses NDJSON off stdout. Until this module that run
+was also UNREACHABLE — it published no discovery record and served no control
+socket — so a supervisor watching a sentinel drift had only process signals to
+answer with, and a signal cannot say *"stop after this ``git push`` finishes"*.
+
+This is the composition root that closes the gap, and it is deliberately the
+SAME one the daemon's phone-started sessions use: an
+:class:`~local_operator.session.runtime.owned.OwnedSessionHandle` over the exec
+session, wrapped in a :class:`~local_operator.session.runtime.server.RuntimeServer`
+that publishes the record and serves the authenticated loopback socket. Nothing
+here is a third ``SessionHandle`` implementation — the whole control vocabulary
+(``steer``, ``abort``, ``cancel``, ``set_model``, ``set_effort``,
+``approval_answer``, ``ask_answer``, ``stop``) is the one the phone daemon and
+``lop attach`` already speak, so a supervisor written against either drives an
+exec run with no new client.
+
+**Why it is opt-in** (``exec --control``) rather than always on. Every reason
+below is a cost paid by runs that would never use the surface, which is the
+overwhelming majority of them:
+
+- ``lop sessions`` (``cli.sessions_command``) filters on nothing, so every
+  scripted exec and every CI loop would land in the operator's session list and
+  become a ``lop send`` target. A one-shot run is not a peer.
+- the mobile daemon adopts published records, so short-lived exec runs would
+  flicker in and out of the phone's session list.
+- :data:`~local_operator.session.runtime.types.HEARTBEAT_INTERVAL_S` is a 15 s
+  cadence sized for long-lived hosts; most exec runs are shorter than one
+  interval, so the record's whole liveness story would be its publish and its
+  unpublish.
+- the socket, the record and the owned handle pull the asyncio control stack
+  onto a path whose import weight ``tests/unit/test_import_graph.py`` pins,
+  which is why every import into this module is made from inside a function on
+  the CLI path and never at ``exec_mode`` scope.
+
+**What ``--control`` changes about the run itself.** The owned handle installs
+its own approval/ask gates (``OwnedSessionHandle._install_gates``), replacing
+the CLI's headless gate. A tool approval therefore PARKS for an attached
+supervisor to answer — up to
+:data:`~local_operator.session.runtime.owned.PENDING_REQUEST_TIMEOUT_S` — where
+an ordinary headless exec denies instantly for want of a tty. That is the point
+of the surface (a supervisor can now answer), but it is a real behavioural
+difference, so it is opt-in with the flag and ``--yolo`` still short-circuits
+it via ``auto_approve``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, never imported at runtime
+    from local_operator.session.runtime.owned import OwnedSessionHandle
+    from local_operator.session.runtime.server import RuntimeServer
+
+logger = logging.getLogger(__name__)
+
+#: The record's ``kind``. ``SessionRecord.kind`` already admitted ``"exec"``
+#: before anything constructed one — this is the first producer of it, and it
+#: is what lets a reader of ``lop sessions --json`` tell a supervised one-shot
+#: apart from a terminal a human is sitting at.
+EXEC_RECORD_KIND = "exec"
+
+
+@dataclass
+class ExecControl:
+    """A live control surface bound to one foreground exec run.
+
+    Held by the caller for exactly as long as the run: built before the prompt
+    (so a supervisor can attach to the very first tool call) and closed in the
+    run's teardown BEFORE the session is disposed — see :meth:`aclose` for why
+    that ordering is load-bearing rather than tidy.
+    """
+
+    handle: "OwnedSessionHandle"
+    runtime: "RuntimeServer"
+    session_id: str
+    pid: int
+    port: int
+    record_path: str
+
+    @property
+    def endpoint_line(self) -> str:
+        """The one line the run prints so a supervisor can find this session.
+
+        Goes to STDERR at every call site, never stdout: stdout is the
+        machine-readable payload stream (``--json``'s NDJSON, or the final
+        assistant text), and a chrome line in it corrupts the only output the
+        run has. Same rule ``headless_print`` states for progress chrome.
+
+        The control KEY is deliberately absent. It lives in the record, mode
+        0600 under a 0700 directory, and those permissions are the entire
+        authorization model (see :mod:`.registry`): anything that can read the
+        key is already the owning account. Printing it into a supervisor's log
+        would move the credential somewhere the permissions do not reach, so
+        the line names the record instead and the supervisor reads it there.
+        """
+        return (
+            f"lop exec control: session_id={self.session_id} pid={self.pid} "
+            f"port={self.port} record={self.record_path}"
+        )
+
+    async def aclose(self) -> None:
+        """Announce the deliberate end, then tear the surface down.
+
+        MUST run before the session is disposed. Two reasons, both observed
+        rather than theoretical:
+
+        1. ``announce_stop`` is what tells an attached supervisor the socket
+           close it is about to see is a finished run and not a dropped
+           connection — the same distinction ``RuntimeServer.announce_stop``
+           documents for the TUI's ``/stop``. A supervisor that cannot make it
+           has to treat every clean exit as a crash and retry the prompt.
+        2. The runtime reads through the handle into the session on every
+           heartbeat and every push. Disposing the session first leaves those
+           reads racing a torn-down session for as long as teardown takes.
+
+        Non-raising by contract: this runs in the run's ``finally``, and a
+        control surface that fails to close must not change the run's exit
+        code, which is the supervisor's actual result.
+        """
+        try:
+            self.runtime.announce_stop()
+        except Exception:  # noqa: BLE001 — announcing is best-effort courtesy
+            logger.debug("exec control: stop announcement failed", exc_info=True)
+        try:
+            await self.runtime.aclose()
+        except Exception:  # noqa: BLE001 — teardown must not fail the run
+            logger.warning("exec control: runtime shutdown failed", exc_info=True)
+
+
+async def start_exec_control(
+    session: Any,
+    *,
+    cwd: str,
+    yolo: bool = False,
+) -> ExecControl:
+    """Publish a record and serve the control socket for ``session``.
+
+    ``start_in_process`` rather than ``start``: the exec session already lives
+    on the caller's running loop, so a second loop on its own thread (what the
+    TUI needs, because Textual owns its loop) would force every control request
+    through a cross-thread hop for no benefit. This mirrors
+    ``session.runtime.process.amain``, the daemon child that made the same
+    choice for the same reason.
+
+    ``yolo`` maps to the handle's ``auto_approve``, so ``exec --control --yolo``
+    keeps approving every tier inline instead of parking a card no supervisor
+    may be watching. Without it the gates park for an attached supervisor —
+    the behavioural difference this module's header calls out.
+
+    Imports are function-local by contract, not by habit: ``owned`` pulls the
+    composition root and ``server`` pulls asyncio, and this package sits on the
+    CLI startup path (see the module header and :mod:`.owned`).
+    """
+    import asyncio
+
+    from local_operator.paths import config_dir
+    from local_operator.session.runtime import registry
+    from local_operator.session.runtime.owned import OwnedSessionHandle
+    from local_operator.session.runtime.server import RuntimeServer
+
+    loop = asyncio.get_running_loop()
+    handle = OwnedSessionHandle(session, loop, cwd=cwd, auto_approve=yolo)
+    # The ``stop`` control op (and therefore `lop stop`, which can now see this
+    # run because it publishes a record) reaches ``request_stop`` -> this hook.
+    # Without one the handle falls back to disposing in place, UNDER the prompt
+    # that is still running — a torn session mid-turn. Aborting instead ends
+    # the turn, so the run returns through its own teardown and the surface is
+    # closed and unpublished in the ordering :meth:`ExecControl.aclose` owns.
+    handle.on_stop_requested = lambda: session.abort("stopped by supervisor")
+    runtime = RuntimeServer(handle, kind=EXEC_RECORD_KIND)
+    await runtime.start_in_process()
+    record = runtime.record
+    return ExecControl(
+        handle=handle,
+        runtime=runtime,
+        session_id=record.session_id,
+        pid=record.pid,
+        port=record.control_port,
+        record_path=str(registry.record_path(record.pid, config_dir())),
+    )
+
+
+async def maybe_start_exec_control(
+    session: Any,
+    *,
+    enabled: bool,
+    cwd: str,
+    yolo: bool = False,
+) -> ExecControl | None:
+    """Start the surface when asked, disposing the session if it cannot start.
+
+    Shared by both headless entry points — the foreground ``exec`` runner and
+    the detached ``exec_worker`` — so ``--control`` means exactly one thing on
+    either side of the ``--background`` process boundary.
+
+    A failure here is FATAL rather than degraded, and that is the whole reason
+    this wrapper exists. ``--control`` is a supervisor saying "I need to be able
+    to steer and cancel this run"; continuing without the surface would give it
+    an agent it cannot stop, while reporting success. The session is disposed
+    first because it is already built by this point, and re-raising past a live
+    session would leak its claim and its provider connections.
+    """
+    if not enabled:
+        return None
+    try:
+        return await start_exec_control(session, cwd=cwd, yolo=yolo)
+    except BaseException:
+        try:
+            await session.dispose()
+        except Exception:  # noqa: BLE001 — the start failure is the real error
+            logger.debug("exec control: dispose after failed start failed", exc_info=True)
+        raise

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -839,6 +839,34 @@ class OwnedSessionHandle(SessionHandle):
         self._session.abort("stopped from mobile")
         return "stopping"
 
+    async def cancel_gracefully(self, reason: str = "cancelled by supervisor") -> str:
+        """Stop at the next post-tool boundary, leaving in-flight work intact.
+
+        The optional capability behind the ``cancel`` op's default mode (see
+        the SessionHandle contract). Where :meth:`abort` fires the turn's
+        AbortSignal and cancels the running tool task, this only SETS a sticky
+        request the harness loop reads once every call in the batch has
+        produced a paired result — so a ``git push`` or a merge-request write
+        that is already on the wire completes, and the turn then ends as
+        aborted with that work in the transcript.
+
+        Returns immediately, and the receipt says so: the boundary may be one
+        long tool away, and a caller that needs the process GONE by a deadline
+        wants the stop ladder (``lop stop``), not this. Reporting "cancelled"
+        here would claim a completion this cannot observe.
+
+        Probed with getattr on a session too: an older ``SessionProtocol``
+        implementation (or a test double) that predates
+        ``request_graceful_cancel`` gets a clear error rather than a silent
+        no-op that would leave a supervisor believing its cancel landed.
+        """
+        self._check_loop_thread()
+        request = getattr(self._session, "request_graceful_cancel", None)
+        if not callable(request):
+            raise ValueError("this session cannot cancel at a tool boundary")
+        request(reason)
+        return "cancelling at the next tool boundary"
+
     async def set_model(self, provider: str, model_id: str) -> str:
         self._check_loop_thread()
         from local_operator.model.configure import build_model_spec

--- a/local_operator/session/runtime/registry.py
+++ b/local_operator/session/runtime/registry.py
@@ -42,6 +42,22 @@ def run_dir(root: Path | None = None) -> Path:
     return path
 
 
+def record_path(pid: int, root: Path | None = None) -> Path:
+    """Where one session's record lives. Keyed by pid, like every reader here.
+
+    The ``<pid>.json`` spelling was inline in three places (publish, unpublish,
+    and every caller that wanted to NAME the file). It is named once now
+    because a host that publishes a record may need to tell an external
+    supervisor where to read it — ``exec --control`` prints exactly this path
+    on stderr so the supervisor can pick the control key out of a file only
+    the owning account can open, rather than being handed the key in a log.
+
+    Creating the directory is :func:`run_dir`'s job and happens here too, so
+    the returned path's parent always exists with the right mode.
+    """
+    return run_dir(root) / f"{pid}.json"
+
+
 def publish(record: SessionRecord, root: Path | None = None) -> Path:
     """Write (or refresh) a session's record, staged so scanners see either
     the old file or the new one, never a half-written one."""
@@ -67,7 +83,7 @@ def unpublish(pid: int, root: Path | None = None) -> None:
     """Remove a session's record on clean exit. Best-effort: an exit path
     must never raise over a missing file."""
     try:
-        (run_dir(root) / f"{pid}.json").unlink()
+        record_path(pid, root).unlink()
     except OSError:
         pass
 

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -248,6 +248,14 @@ class SessionHandle(Protocol):
     #   Optional (getattr-probed in _dispatch) so reduced test handles and
     #   non-interactive exec hosts that never wired it keep working — a handle
     #   lacking it answers "this session cannot receive peer messages".
+    # cancel_gracefully() -> str: stop the turn at the POST-TOOL boundary
+    #   instead of cutting the running tool (Session.request_graceful_cancel).
+    #   Serves the ``cancel`` op's default mode. Deliberately distinct from
+    #   ``abort`` rather than a parameter on it: abort's contract is "stop now,
+    #   the human will repair the mess", and a supervised agent has no human to
+    #   repair a half-finished push. Optional and getattr-probed so hosts that
+    #   cannot honour a boundary (a reduced handle, an older bridge) say so
+    #   plainly instead of silently doing the destructive thing.
 
 
 class ProjectionSink(Protocol):
@@ -1200,6 +1208,27 @@ class RuntimeServer:
             return await h.steer(frame["text"], **fields)
         if op == "abort":
             return await h.abort()
+        if op == "cancel":
+            # Two rungs, one op, because the CHOICE is the feature. The default
+            # is graceful: a supervisor cancelling a sentinel mid-``git push``
+            # must not tear the push in half, and defaulting the other way makes
+            # the dangerous behaviour the one you get by not thinking. Asking
+            # for ``immediate`` is asking for ``abort``, so it routes there
+            # rather than growing a second implementation of "stop now".
+            #
+            # Optional capability, getattr-probed like every other addition to
+            # this dispatch: a reduced test handle or an older bridge answers
+            # the unknown-op error, and a caller that needs a stop regardless
+            # falls back to ``abort`` (or to the stop ladder). Additive on the
+            # wire for the same reason ``peer_message`` and ``stop`` were, so
+            # no PROTOCOL_VERSION bump.
+            if str(frame.get("mode", "graceful")) == "immediate":
+                return await h.abort()
+            cancel = getattr(h, "cancel_gracefully", None)
+            if not callable(cancel):
+                raise ValueError("this session cannot cancel at a tool boundary")
+            typed_cancel = cast(Callable[[], Awaitable[str]], cancel)
+            return await typed_cancel()
         if op == "set_model":
             return await h.set_model(str(frame.get("provider", "")), str(frame.get("model_id", "")))
         if op == "set_effort":
@@ -1647,6 +1676,24 @@ class RuntimeServer:
                 self._record.session_id,
             )
         return sink
+
+    @property
+    def record(self) -> SessionRecord:
+        """The discovery record this runtime publishes.
+
+        Read-only by intent — the runtime owns every mutation (the port is
+        stamped when the listener binds, the heartbeat rewrites the liveness
+        fields), and a caller that reassigned it would leave the publisher
+        writing a record nobody else holds.
+
+        Exposed because a host that starts a runtime and must then TELL
+        someone where it is (``exec --control`` prints the endpoint to stderr)
+        otherwise has to re-read the file the runtime just wrote, or reach for
+        ``_record``. Deliberately not the control key by a separate accessor:
+        the key rides the record, and the record's 0600 file is the whole
+        authorization model, so nothing should be encouraged to copy it out.
+        """
+        return self._record
 
     @property
     def projection_sink(self) -> ProjectionSink | None:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1848,6 +1848,12 @@ class Session:
         # usage objects that lifetime cost and analytics still need.
         self._held_context_tokens: int | None = None
         self._abort_requested = False  # sticky across the continuation gap
+        # Boundary-respecting cancel (see request_graceful_cancel). Sticky like
+        # ``_abort_requested`` and cleared on the same edges, but honoured at
+        # the loop's post-tool boundary instead of by firing the abort signal,
+        # so a tool with external side effects is never cut mid-flight.
+        self._graceful_cancel_requested = False
+        self._graceful_cancel_reason = "cancelled"
         # --- Speculative compaction advisor (BETA; inert unless the config
         # opts in via values.compaction.advisor_enabled). All of it is session
         # state rather than plan state because the advisor runs OFF the turn:
@@ -4200,6 +4206,10 @@ class Session:
             self._flush_context_journal()
             # A fresh user prompt supersedes any earlier interrupt request.
             self._abort_requested = False
+            # ...and any earlier boundary cancel, for the same reason: the
+            # request applied to the turn the caller was stopping, not to the
+            # one they have just submitted.
+            self._graceful_cancel_requested = False
             if self._is_streaming:
                 raise RuntimeError("session is already streaming; use steer() to inject mid-turn")
             # INLINE a pending wake catch-up ahead of the user's message, in
@@ -4716,6 +4726,36 @@ class Session:
         self.cancel_fork()
         if self._signal is not None:
             self._signal.abort(reason)
+
+    def request_graceful_cancel(self, reason: str = "cancelled") -> None:
+        """Stop after the current tool call finishes, not in the middle of it.
+
+        The difference from :meth:`abort` is what happens to work already in
+        flight. ``abort`` fires the turn's :class:`AbortSignal` immediately,
+        which cancels the running tool task — correct for a human pressing Esc,
+        who wants the thing to stop NOW and can see and repair whatever was
+        half-done.
+
+        A supervised agent is the opposite case. Its tools have external side
+        effects a machine operator cannot see or repair: a ``git push`` cut
+        mid-transfer, a merge request half-created, a row written without its
+        companion. Minerva's sentinel runner defends against exactly this today
+        by holding SIGTERM until a boundary, and this method is the in-process
+        equivalent so an external supervisor gets the same guarantee through
+        the control socket instead of through process signals.
+
+        The request is sticky and is honoured at the loop's post-tool boundary
+        — after every call in the batch has produced a paired result, before
+        the next model request is spent. The turn then ends as ``aborted``,
+        with the completed work intact in the transcript.
+        """
+        self._graceful_cancel_requested = True
+        self._graceful_cancel_reason = reason
+
+    @property
+    def graceful_cancel_requested(self) -> bool:
+        """Whether a boundary-respecting cancel is pending for this turn."""
+        return self._graceful_cancel_requested
 
     def cancel_subagents(self, reason: str = "interrupted") -> int:
         """Cancel every running SUBAGENT and report how many were stopped.
@@ -5349,6 +5389,7 @@ class Session:
                 stream_fn=self._stream_fn,
                 get_steering_messages=self._drain_steering,
                 has_steering_messages=lambda: not self._steering_queue.empty(),
+                graceful_cancel_requested=lambda: self._graceful_cancel_requested,
                 has_urgent_steering_messages=self._has_urgent_steering,
                 # Rides the SAME interrupt poll steering uses, so a fork
                 # requested mid-tool reaches its boundary in ~250 ms instead of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.46.0"
+version = "0.46.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/exec_control_probe.py
+++ b/scripts/exec_control_probe.py
@@ -1,0 +1,83 @@
+"""Attach to a `lop exec --control` run and drive one control op.
+
+A hand-driven supervisor stand-in used to exercise the exec control surface
+end to end: it resolves the run's record by session id, reads the control key
+out of the 0600 file (the whole authorization model — see
+session/runtime/registry.py), dials the loopback socket, and speaks one op.
+
+Not a test fixture and not part of the product: this is the operator-side tool
+for the evidence a change to the control surface has to produce, kept next to
+the other scripts/ helpers so the next person verifying this path does not
+rewrite it from the protocol docs.
+
+    python scripts/exec_control_probe.py <session-id> steer "text"
+    python scripts/exec_control_probe.py <session-id> cancel [graceful|immediate]
+    python scripts/exec_control_probe.py <session-id> ping
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from local_operator.paths import config_dir  # noqa: E402
+from local_operator.session.runtime import registry  # noqa: E402
+
+
+def find(session_id: str):
+    for record, state in registry.scan(config_dir()):
+        if record.session_id == session_id:
+            return record, state
+    raise SystemExit(f"no record for session {session_id!r}")
+
+
+async def main() -> int:
+    session_id, op = sys.argv[1], sys.argv[2]
+    arg = sys.argv[3] if len(sys.argv) > 3 else ""
+    record, state = find(session_id)
+    print(
+        f"[probe] record: pid={record.pid} kind={record.kind} state={state} "
+        f"port={record.control_port}",
+        flush=True,
+    )
+
+    reader, writer = await asyncio.open_connection("127.0.0.1", record.control_port)
+    # Dial daemon-class (the default when `client` is omitted) like peer_client:
+    # a fire-and-forget supervisor wants no attach accounting.
+    writer.write(json.dumps({"key": record.control_key}).encode() + b"\n")
+    await writer.drain()
+
+    frame: dict[str, Any] = {"op": op, "req": "probe-1"}
+    if op == "steer":
+        frame["text"] = arg
+    elif op == "cancel" and arg:
+        frame["mode"] = arg
+    writer.write(json.dumps(frame).encode() + b"\n")
+    await writer.drain()
+    print(f"[probe] sent: {json.dumps(frame)}", flush=True)
+
+    # The first frame back is the unsolicited welcome projection; read until the
+    # ack/error carrying our req id.
+    while True:
+        line = await asyncio.wait_for(reader.readline(), timeout=20.0)
+        if not line:
+            print("[probe] connection closed before ack", flush=True)
+            return 1
+        try:
+            got = json.loads(line)
+        except ValueError:
+            continue
+        if got.get("op") in ("ack", "error") and got.get("req") == "probe-1":
+            print(f"[probe] reply: {json.dumps(got)}", flush=True)
+            writer.close()
+            return 0 if got["op"] == "ack" else 1
+        print(f"[probe] ...{got.get('op')}", flush=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/unit/harness/test_graceful_cancel.py
+++ b/tests/unit/harness/test_graceful_cancel.py
@@ -26,12 +26,13 @@ from local_operator.harness.types import (
     ToolExecutionEndEvent,
     ToolResult,
 )
-
 from tests.unit.harness.test_loop import make_config
 
 
 def _tool(name: str = "touch", on_execute: Any = None) -> AgentTool:
-    async def execute(tool_call_id, args, signal, on_update, context):  # type: ignore[no-untyped-def]
+    async def execute(  # type: ignore[no-untyped-def]
+        tool_call_id, args, signal, on_update, context
+    ):
         if on_execute is not None:
             on_execute()
         return ToolResult(
@@ -65,9 +66,7 @@ async def _events(tool: AgentTool, **config_kwargs: Any) -> tuple[list[Any], _Sc
     stream = _Scripted()
     context = LoopContext(tools=[tool])
     config = make_config(stream, **config_kwargs)
-    events = [
-        event async for event in AgentLoop().run([Message.user("go")], context, config, None)
-    ]
+    events = [event async for event in AgentLoop().run([Message.user("go")], context, config, None)]
     return events, stream
 
 

--- a/tests/unit/harness/test_graceful_cancel.py
+++ b/tests/unit/harness/test_graceful_cancel.py
@@ -1,0 +1,134 @@
+"""Boundary-respecting cancel: stop after the tool finishes, not mid-tool.
+
+The distinction these tests defend is the whole reason the feature exists. An
+``abort`` fires the turn's signal and cancels the running tool task, which is
+right for a human pressing Esc. A supervised agent's tools have external side
+effects a machine operator cannot repair — a half-transferred ``git push``, a
+partly-created merge request — so a supervisor's cancel must land at the
+boundary where every call has ALREADY produced a paired result, and before the
+next model request is spent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from local_operator.harness.loop import AgentLoop, LoopContext
+from local_operator.harness.types import (
+    AgentEndEvent,
+    AgentTool,
+    Message,
+    StreamEndEvent,
+    StreamToolCallDelta,
+    TextContent,
+    ToolExecutionEndEvent,
+    ToolResult,
+)
+
+from tests.unit.harness.test_loop import make_config
+
+
+def _tool(name: str = "touch", on_execute: Any = None) -> AgentTool:
+    async def execute(tool_call_id, args, signal, on_update, context):  # type: ignore[no-untyped-def]
+        if on_execute is not None:
+            on_execute()
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name=name, content=[TextContent(text="ok")]
+        )
+
+    return AgentTool(name=name, parameters={"type": "object"}, execute=execute)
+
+
+class _Scripted:
+    """One tool call on the first model call, plain text on any later one.
+
+    ``calls`` is the assertion that matters: it proves whether the loop spent
+    another provider request after the cancel.
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(self, request: Any, signal: Any) -> Any:
+        self.calls += 1
+        if self.calls == 1:
+            yield StreamToolCallDelta(index=0, id="call_1", name="touch")
+            yield StreamToolCallDelta(index=0, argument_delta="{}")
+            yield StreamEndEvent(stop_reason="toolUse")
+            return
+        yield StreamEndEvent(stop_reason="stop")
+
+
+async def _events(tool: AgentTool, **config_kwargs: Any) -> tuple[list[Any], _Scripted]:
+    stream = _Scripted()
+    context = LoopContext(tools=[tool])
+    config = make_config(stream, **config_kwargs)
+    events = [
+        event async for event in AgentLoop().run([Message.user("go")], context, config, None)
+    ]
+    return events, stream
+
+
+@pytest.mark.asyncio
+async def test_cancel_lands_after_the_tool_completes_not_during() -> None:
+    """The in-flight tool RUNS TO COMPLETION and no second model call is made.
+
+    This is the property that protects an external side effect: the tool body
+    finishes even though the cancel becomes pending while it is running.
+    """
+    completed: list[str] = []
+    pending = {"cancel": False}
+
+    def during_tool() -> None:
+        # The supervisor cancels WHILE the tool is in flight, mirroring a
+        # cancel pressed during a push.
+        pending["cancel"] = True
+        completed.append("tool finished")
+
+    events, stream = await _events(
+        _tool(on_execute=during_tool),
+        graceful_cancel_requested=lambda: pending["cancel"],
+    )
+
+    assert completed == ["tool finished"], "the tool must not be cut mid-flight"
+    assert stream.calls == 1, "no model request may be spent after the cancel"
+    ends = [event for event in events if isinstance(event, AgentEndEvent)]
+    assert ends and ends[-1].aborted is True, "the turn must end as aborted"
+    # The finished work stays in the transcript as a paired tool result.
+    assert any(isinstance(event, ToolExecutionEndEvent) for event in events)
+
+
+@pytest.mark.asyncio
+async def test_no_cancel_runs_to_normal_completion() -> None:
+    """Control: with no cancel pending the loop takes its second model call."""
+    events, stream = await _events(_tool(), graceful_cancel_requested=lambda: False)
+
+    assert stream.calls == 2
+    ends = [event for event in events if isinstance(event, AgentEndEvent)]
+    assert ends and not ends[-1].aborted
+
+
+@pytest.mark.asyncio
+async def test_absent_hook_preserves_existing_behaviour() -> None:
+    """``None`` — every existing host — must behave exactly as before."""
+    events, stream = await _events(_tool())
+
+    assert stream.calls == 2
+    ends = [event for event in events if isinstance(event, AgentEndEvent)]
+    assert ends and not ends[-1].aborted
+
+
+@pytest.mark.asyncio
+async def test_a_raising_hook_does_not_strand_the_turn() -> None:
+    """A broken host hook degrades to "no cancel", never kills the run."""
+
+    def explode() -> bool:
+        raise RuntimeError("host is broken")
+
+    events, stream = await _events(_tool(), graceful_cancel_requested=explode)
+
+    assert stream.calls == 2, "a raising hook must not stop the turn"
+    ends = [event for event in events if isinstance(event, AgentEndEvent)]
+    assert ends and not ends[-1].aborted

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -19,6 +19,7 @@ from local_operator.harness.types import (
     ChatRequest,
     ModelSpec,
     StreamEndEvent,
+    StreamStartEvent,
     StreamTextDelta,
     StreamUsageEvent,
     Usage,
@@ -4449,3 +4450,59 @@ def test_a_model_answers_the_same_way_however_it_is_reached() -> None:
     assert seeded_base.reasoning_effort == seeded_base.reasoning_default_effort, "fixture drifted"
 
     assert _hop_wire_effort(seeded_base, selector) == direct_wire
+
+
+class _StartThenFail:
+    """Announces the acceptance boundary, then dies BEFORE any content.
+
+    The exact shape of a real Anthropic 529 or an in-band error chunk on an
+    HTTP-200 stream: the provider accepted the request and said so, then failed
+    with nothing rendered.
+    """
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+        self.calls = 0
+
+    async def stream(
+        self, request: ChatRequest, api_key: str | None, oauth_access: Any = None
+    ) -> AsyncIterator[Any]:
+        self.calls += 1
+        yield StreamStartEvent(response_id=f"resp-{self.calls}")
+        raise self._exc
+
+
+async def test_a_content_free_start_event_does_not_block_the_retry() -> None:
+    """A boundary event must not count as "output the user has already seen".
+
+    ``forwarded_any`` exists to stop a retry replaying deltas someone has read.
+    ``StreamStartEvent`` renders nothing, so a failure landing after acceptance
+    but before the first token has to stay retryable — otherwise every
+    pre-content provider failure silently bypasses credential rotation and the
+    whole fallback chain.
+    """
+    failing = _StartThenFail(ProviderError(401, "invalid api key", auth_error=True))
+    succeeding = ScriptedClient([StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")])
+
+    async def client_for(spec: ModelSpec) -> Any:
+        def wrapper(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            return (failing if api_key == "bad-key" else succeeding).stream(request, api_key)
+
+        return _FnClient(wrapper)
+
+    got = [
+        event
+        async for event in stream_with_failover(
+            _request(), FakeAuth({"openai": ["bad-key", "good-key"]}), None, client_for
+        )
+    ]
+
+    # The retry happened: the good key served the turn.
+    assert any(isinstance(event, StreamTextDelta) for event in got), (
+        "a pre-content failure must still rotate the credential and retry; "
+        "a content-free boundary event must not gate it"
+    )
+    # The failing key was actually tried (the retry is real, not vacuous).
+    assert failing.calls >= 1

--- a/tests/unit/server/test_sse_bridge.py
+++ b/tests/unit/server/test_sse_bridge.py
@@ -1,0 +1,292 @@
+"""Streaming a plain harness session into the SSE broker.
+
+``publish_agent_event`` had exactly one caller - the ``lop serve`` job pump - so
+a host that drives ``Session.prompt`` directly (headless ``exec``, an external
+supervisor) produced no SSE events at all while the entire transport sat
+unused. These tests pin the seam that closes that gap, and the two properties
+that make it worth having rather than a second projection to keep in sync:
+
+* the wire shape is the one the pump already produces, because the same
+  ``AgentEventBridge`` produces it;
+* ``provider.start`` reaches a subscriber with its provider-native
+  ``response_id`` intact, which is the whole reason an external runtime attaches
+  at all - it is the token it commits as no-replay proof.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, List
+
+import pytest
+
+from local_operator.harness.types import (
+    AgentEvent,
+    Message,
+    MessageStartEvent,
+    MessageUpdateEvent,
+    ProviderTurnStartEvent,
+    SteeringDeliveredEvent,
+)
+from local_operator.jobs import JobStatus
+from local_operator.server.utils.event_broker import (
+    EventBroker,
+    job_channel,
+    message_channel,
+)
+from local_operator.server.utils.sse import EventName
+from local_operator.server.utils.sse_bridge import BrokerStatusSink, attach_broker
+from local_operator.server.utils.sse_publisher import publish_job_status
+
+
+class _FakeSession:
+    """Just the ``subscribe`` half of ``SessionProtocol``.
+
+    The bridge only ever calls ``subscribe`` and the callable it returns, so a
+    stub keeps these tests on the seam under test instead of on a real session's
+    provider, transcript and tool wiring.
+    """
+
+    def __init__(self) -> None:
+        self.handlers: List[Callable[[AgentEvent], Any]] = []
+        self.unsubscribed = 0
+
+    def subscribe(self, handler: Callable[[AgentEvent], Any]) -> Callable[[], None]:
+        self.handlers.append(handler)
+
+        def _unsubscribe() -> None:
+            self.unsubscribed += 1
+            self.handlers.remove(handler)
+
+        return _unsubscribe
+
+    def emit(self, event: AgentEvent) -> None:
+        for handler in list(self.handlers):
+            handler(event)
+
+
+def _names(broker: EventBroker, channel: str) -> List[str]:
+    return [event.name for event in broker.retained(channel)]
+
+
+# ---------------------------------------------------------------------------
+# the sink
+# ---------------------------------------------------------------------------
+
+
+def test_sink_publishes_records_and_agent_events_to_the_job_channel() -> None:
+    """The sink stands in for the parent-side pump, tuple vocabulary included."""
+    broker = EventBroker()
+    sink = BrokerStatusSink(broker, "job-1")
+
+    sink.put(("agent_event", "job-1", {"type": "turn_start"}))
+    sink.put(("agent_event", "job-1", {"type": "notice", "level": "info"}))
+
+    assert _names(broker, job_channel("job-1")) == [EventName.TURN_START, EventName.NOTICE]
+
+
+def test_sink_drops_the_legacy_execution_placeholder() -> None:
+    """``execution_update`` is job-ledger bookkeeping, not a stream frame.
+
+    The pump routes it to the JobManager and never to the broker; emitting one
+    here would put a record on the wire that the server path does not.
+    """
+    broker = EventBroker()
+    BrokerStatusSink(broker, "job-1").put(("execution_update", "job-1", object()))
+    assert broker.retained(job_channel("job-1")) == []
+
+
+def test_sink_ignores_malformed_traffic_instead_of_raising() -> None:
+    """``put`` runs on the turn's own task, so it must never abort the turn."""
+    broker = EventBroker()
+    sink = BrokerStatusSink(broker, "job-1")
+    sink.put("not-a-tuple")
+    sink.put(("agent_event", "job-1"))
+    # A payload that is not a mapping cannot be published, and must not escape.
+    sink.put(("agent_event", "job-1", None))
+    assert broker.retained(job_channel("job-1")) == []
+
+
+def test_sink_never_raises_when_publishing_fails() -> None:
+    """Same failure posture as the publisher, one step earlier in the chain."""
+
+    class _Exploding(EventBroker):
+        def publish_with(self, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError("broker down")
+
+    BrokerStatusSink(_Exploding(), "job-1").put(("agent_event", "job-1", {"type": "turn_start"}))
+
+
+# ---------------------------------------------------------------------------
+# attach_broker
+# ---------------------------------------------------------------------------
+
+
+def test_attach_broker_streams_session_events_without_a_server() -> None:
+    """The gap this closes: a session with no job pump now reaches the wire."""
+    broker = EventBroker()
+    session = _FakeSession()
+    unsubscribe = attach_broker(session, broker, "job-1")
+
+    message = Message(id="m1", role="assistant")
+    session.emit(MessageStartEvent(message=message))
+    session.emit(MessageUpdateEvent(message=message, delta="hi"))
+
+    names = _names(broker, job_channel("job-1"))
+    # Both taxonomies, from one subscription: the richer engine event AND the
+    # legacy record frame the existing UI renders.
+    assert EventName.MESSAGE_DELTA in names
+    assert EventName.RECORD_UPDATE in names
+
+    unsubscribe()
+    assert session.unsubscribed == 1
+    assert session.handlers == []
+
+
+def test_attach_broker_reuses_the_record_projection_verbatim() -> None:
+    """A delta frame keeps its running ``snapshot`` and the legacy record body.
+
+    This is why the bridge reuses ``AgentEventBridge`` rather than projecting
+    again: the snapshot guarantee and the legacy-compatible record keys are
+    behaviour a second implementation would quietly lose.
+    """
+    broker = EventBroker()
+    session = _FakeSession()
+    attach_broker(session, broker, "job-1")
+
+    message = Message(id="m1", role="assistant")
+    session.emit(MessageStartEvent(message=message))
+    session.emit(MessageUpdateEvent(message=message, delta="Hello"))
+    session.emit(MessageUpdateEvent(message=message, delta=" world"))
+
+    deltas = [
+        event.data
+        for event in broker.retained(job_channel("job-1"))
+        if event.name == EventName.MESSAGE_DELTA
+    ]
+    assert [d["delta"] for d in deltas] == ["Hello", " world"]
+    assert [d["snapshot"] for d in deltas] == ["Hello", "Hello world"]
+
+    records = [
+        event.data["record"]
+        for event in broker.retained(job_channel("job-1"))
+        if event.name == EventName.RECORD_UPDATE
+    ]
+    assert records[-1]["message"] == "Hello world"
+    # The legacy injections the WebSocket transport made are still present.
+    assert records[-1]["message_id"] == "m1"
+    assert records[-1]["connection_type"]
+
+    # And the record-keyed channel gets the same fan-out the pump produces.
+    assert EventName.MESSAGE_DELTA in _names(broker, message_channel("m1"))
+
+
+def test_attach_broker_without_a_broker_is_a_no_op() -> None:
+    """A host wires this unconditionally; configuration decides if it streams."""
+    session = _FakeSession()
+    unsubscribe = attach_broker(session, None, "job-1")
+    assert session.handlers == []
+    unsubscribe()
+
+
+def test_terminal_framing_stays_the_hosts_decision() -> None:
+    """Only the host knows the outcome, so it publishes the terminal frame.
+
+    Without one the client keepalives until it gives up - the exact hang the
+    transport exists to remove.
+    """
+    broker = EventBroker()
+    session = _FakeSession()
+    attach_broker(session, broker, "job-1")
+    session.emit(MessageStartEvent(message=Message(id="m1", role="assistant")))
+    assert not broker.is_terminal(job_channel("job-1"))
+
+    publish_job_status(broker, "job-1", JobStatus.COMPLETED)
+    assert broker.is_terminal(job_channel("job-1"))
+    assert _names(broker, job_channel("job-1"))[-1] == EventName.TERMINAL
+
+
+# ---------------------------------------------------------------------------
+# the two new event types
+# ---------------------------------------------------------------------------
+
+
+def test_provider_start_carries_the_native_response_id_to_the_wire() -> None:
+    """The point of the whole exercise.
+
+    An external supervisor commits ``response_id`` as no-replay proof, so it has
+    to survive the projection, the sink and the envelope - not just be emitted
+    by the harness.
+    """
+    broker = EventBroker()
+    session = _FakeSession()
+    attach_broker(session, broker, "job-1")
+
+    session.emit(
+        ProviderTurnStartEvent(
+            response_id="msg_01ABC",
+            provider="anthropic",
+            model_id="claude-opus-5",
+        )
+    )
+
+    events = [
+        event for event in broker.retained(job_channel("job-1")) if event.name == "provider.start"
+    ]
+    assert len(events) == 1
+    data = events[0].data
+    assert data["response_id"] == "msg_01ABC"
+    assert data["provider"] == "anthropic"
+    assert data["model_id"] == "claude-opus-5"
+    # The dual discriminator the taxonomy promises: event name and inner type
+    # always agree, so a client may switch on either.
+    assert data["type"] == EventName.PROVIDER_START
+
+
+def test_provider_start_without_a_native_id_stays_indeterminate() -> None:
+    """Google exposes no per-response id; the frame must say so rather than
+    invent one, so a consumer requiring proof can fail closed."""
+    broker = EventBroker()
+    session = _FakeSession()
+    attach_broker(session, broker, "job-1")
+
+    session.emit(ProviderTurnStartEvent(response_id=None, provider="google"))
+
+    data = broker.retained(job_channel("job-1"))[0].data
+    assert data["response_id"] is None
+
+
+def test_steering_delivered_reaches_the_wire_with_its_count() -> None:
+    """The transition a UI reconciles its "queued" row against.
+
+    ``count`` is load-bearing: three lines sent while a tool ran are delivered
+    at one boundary, and a receipt per message would claim three deliveries.
+    """
+    broker = EventBroker()
+    session = _FakeSession()
+    attach_broker(session, broker, "job-1")
+
+    session.emit(SteeringDeliveredEvent(count=3))
+
+    events = broker.retained(job_channel("job-1"))
+    assert [e.name for e in events] == [EventName.STEERING_DELIVERED]
+    assert events[0].data["count"] == 3
+
+
+@pytest.mark.parametrize(
+    "raw_type, expected",
+    [
+        ("provider_turn_start", EventName.PROVIDER_START),
+        ("steering_delivered", EventName.STEERING_DELIVERED),
+    ],
+)
+def test_new_event_types_are_no_longer_dropped(raw_type: str, expected: str) -> None:
+    """An unmapped type is DISCARDED by ``publish_agent_event``, silently.
+
+    That is the correct default - a consumer cannot render an event it was never
+    told about - which is exactly why adding an event type means adding it here.
+    """
+    from local_operator.server.utils.sse_publisher import publish_agent_event
+
+    broker = EventBroker()
+    publish_agent_event(broker, "job-1", {"type": raw_type})
+    assert _names(broker, job_channel("job-1")) == [expected]

--- a/tests/unit/session/runtime/test_exec_control.py
+++ b/tests/unit/session/runtime/test_exec_control.py
@@ -1,0 +1,285 @@
+"""The opt-in control surface for headless ``exec`` runs.
+
+Covers the composition root (``exec_control``), the ``cancel`` op's two modes
+on the real socket, and the lifecycle ordering ``run_print_mode`` now owns —
+close-and-announce BEFORE dispose, so a short run that ends inside the first
+heartbeat still leaves no record behind.
+
+The socket tests run against a REAL RuntimeServer for the same reason
+``test_server.py`` does: the failure modes here (a record that outlives the
+run, a cancel routed to the wrong rung) only exist on a live connection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.session.runtime import registry
+from local_operator.session.runtime.exec_control import (
+    EXEC_RECORD_KIND,
+    maybe_start_exec_control,
+    start_exec_control,
+)
+
+
+class FakeSession:
+    """The slice of Session the owned handle and the runtime touch here."""
+
+    def __init__(self, *, graceful: bool = True) -> None:
+        self.session_id = "exec-sess"
+        self.model_label = "test/model"
+        self.effective_model_label = "test/model"
+        self.model = None
+        self.conversation_name = ""
+        self.is_streaming = False
+        self.disposed = False
+        self.aborts: list[str] = []
+        self.graceful_cancels: list[str] = []
+        self._handlers: list[Any] = []
+        # A session predating the boundary-cancel seam has no callable there.
+        # Shadowing the class method with None on the instance is exactly what
+        # the handle's ``callable(getattr(...))`` probe tests for, and unlike
+        # ``del`` it works against a method defined on the class.
+        if not graceful:
+            self.request_graceful_cancel = None  # type: ignore[assignment]
+
+        from local_operator.harness.jobs import AsyncJobManager
+
+        self.jobs = AsyncJobManager()
+
+    # -- the seams the handle reads at construction ---------------------------
+    def set_approval_handler(self, handler) -> None:  # noqa: ANN001
+        self._approval_handler = handler
+
+    def set_ask_handler(self, handler) -> None:  # noqa: ANN001
+        self._ask_handler = handler
+
+    def subscribe(self, handler):  # noqa: ANN001, ANN201
+        self._handlers.append(handler)
+        return lambda: self._handlers.remove(handler)
+
+    def history(self) -> list[Any]:
+        return []
+
+    # -- what the control ops drive -------------------------------------------
+    def abort(self, reason: str = "") -> None:
+        self.aborts.append(reason)
+
+    def request_graceful_cancel(self, reason: str = "cancelled") -> None:
+        self.graceful_cancels.append(reason)
+
+    async def dispose(self) -> None:
+        self.disposed = True
+
+
+@pytest.fixture()
+def isolated_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the record directory at a tmp dir.
+
+    Never the operator's real config dir: these tests publish live records, and
+    one escaping into ``~/.local-operator/run/mobile`` would show up in the
+    developer's own ``lop sessions`` as a session that does not exist. The env
+    var is enough because ``paths.config_dir`` re-reads it on every call.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    return tmp_path
+
+
+async def _dial(record) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:  # noqa: ANN001
+    reader, writer = await asyncio.open_connection("127.0.0.1", record.control_port)
+    writer.write(json.dumps({"key": record.control_key}).encode() + b"\n")
+    await writer.drain()
+    return reader, writer
+
+
+async def _request(reader, writer, frame: dict[str, Any]) -> dict[str, Any]:  # noqa: ANN001
+    frame = {"req": "t1", **frame}
+    writer.write(json.dumps(frame).encode() + b"\n")
+    await writer.drain()
+    while True:
+        line = await asyncio.wait_for(reader.readline(), timeout=5.0)
+        assert line, "socket closed before a reply"
+        got = json.loads(line)
+        if got.get("op") in ("ack", "error") and got.get("req") == "t1":
+            return got
+
+
+@pytest.mark.asyncio
+async def test_start_publishes_an_exec_record(isolated_config: Path) -> None:
+    session = FakeSession()
+    control = await start_exec_control(session, cwd="/tmp")
+    try:
+        # The record's kind is the whole point: `lop sessions` and the daemon
+        # can now tell a supervised one-shot from a terminal a human owns.
+        records = registry.scan(isolated_config)
+        assert [(r.kind, r.session_id) for r, _ in records] == [(EXEC_RECORD_KIND, "exec-sess")]
+        assert control.port > 0
+        # The endpoint line names the record rather than carrying the key: the
+        # 0600 file IS the authorization model, so the credential must not be
+        # copied into a supervisor's log.
+        assert control.session_id in control.endpoint_line
+        assert str(control.port) in control.endpoint_line
+        assert control.record_path in control.endpoint_line
+        assert control.runtime.record.control_key not in control.endpoint_line
+    finally:
+        await control.aclose()
+
+
+@pytest.mark.asyncio
+async def test_aclose_unpublishes_the_record(isolated_config: Path) -> None:
+    """A run shorter than one heartbeat still cleans up after itself."""
+    control = await start_exec_control(FakeSession(), cwd="/tmp")
+    assert registry.scan(isolated_config)
+    await control.aclose()
+    assert registry.scan(isolated_config) == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_defaults_to_the_tool_boundary(isolated_config: Path) -> None:
+    """The default mode must never cut a running tool.
+
+    This is the guarantee a supervisor cancelling mid-``git push`` depends on,
+    so the assertion is on WHICH session method ran: ``request_graceful_cancel``
+    sets a sticky flag the loop honours at the post-tool boundary, while
+    ``abort`` fires the AbortSignal and cancels the tool task outright.
+    """
+    session = FakeSession()
+    control = await start_exec_control(session, cwd="/tmp")
+    try:
+        reader, writer = await _dial(control.runtime.record)
+        reply = await _request(reader, writer, {"op": "cancel"})
+        assert reply["op"] == "ack"
+        assert "boundary" in reply["detail"]
+        assert session.graceful_cancels == ["cancelled by supervisor"]
+        assert session.aborts == []
+        writer.close()
+    finally:
+        await control.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cancel_immediate_routes_to_abort(isolated_config: Path) -> None:
+    """``mode: immediate`` is the explicit opt-in to cutting a tool in half."""
+    session = FakeSession()
+    control = await start_exec_control(session, cwd="/tmp")
+    try:
+        reader, writer = await _dial(control.runtime.record)
+        reply = await _request(reader, writer, {"op": "cancel", "mode": "immediate"})
+        assert reply["op"] == "ack"
+        assert session.aborts and session.graceful_cancels == []
+        writer.close()
+    finally:
+        await control.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cancel_rejects_an_unknown_mode(isolated_config: Path) -> None:
+    """A typo must not silently resolve to either rung.
+
+    The two modes differ in whether external side effects get cut, so guessing
+    is worse than refusing on the one op whose reason to exist is that
+    distinction.
+    """
+    session = FakeSession()
+    control = await start_exec_control(session, cwd="/tmp")
+    try:
+        reader, writer = await _dial(control.runtime.record)
+        reply = await _request(reader, writer, {"op": "cancel", "mode": "soft"})
+        assert reply["op"] == "error"
+        assert "graceful" in reply["message"]
+        assert session.aborts == [] and session.graceful_cancels == []
+        writer.close()
+    finally:
+        await control.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cancel_on_a_session_without_the_seam_errors(isolated_config: Path) -> None:
+    """An older session says so rather than silently ignoring the cancel."""
+    session = FakeSession(graceful=False)
+    control = await start_exec_control(session, cwd="/tmp")
+    try:
+        reader, writer = await _dial(control.runtime.record)
+        reply = await _request(reader, writer, {"op": "cancel"})
+        assert reply["op"] == "error"
+        assert "boundary" in reply["message"]
+        writer.close()
+    finally:
+        await control.aclose()
+
+
+@pytest.mark.asyncio
+async def test_steer_reaches_the_session(isolated_config: Path) -> None:
+    """The existing control vocabulary works unchanged over an exec runtime."""
+    session = FakeSession()
+    steered: list[str] = []
+
+    def _steer(text: str, images: Any = None, **kwargs: Any) -> None:
+        steered.append(text)
+
+    session.steer = _steer  # type: ignore[attr-defined]
+    session.has_admitted_command = lambda cid: False  # type: ignore[attr-defined]
+    control = await start_exec_control(session, cwd="/tmp")
+    try:
+        reader, writer = await _dial(control.runtime.record)
+        reply = await _request(reader, writer, {"op": "steer", "text": "change course"})
+        assert reply["op"] == "ack"
+        assert steered == ["change course"]
+        writer.close()
+    finally:
+        await control.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stop_op_aborts_rather_than_disposing_under_the_run(
+    isolated_config: Path,
+) -> None:
+    """`lop stop` on an exec run ends the turn; the run's own teardown does
+    the disposing, in the ordering ``aclose`` owns."""
+    session = FakeSession()
+    control = await start_exec_control(session, cwd="/tmp")
+    try:
+        reader, writer = await _dial(control.runtime.record)
+        reply = await _request(reader, writer, {"op": "stop"})
+        assert reply["op"] == "ack"
+        assert session.aborts == ["stopped by supervisor"]
+        # The session must NOT have been torn down out from under the prompt
+        # that is still running.
+        assert session.disposed is False
+        writer.close()
+    finally:
+        await control.aclose()
+
+
+@pytest.mark.asyncio
+async def test_maybe_start_is_a_no_op_when_disabled(isolated_config: Path) -> None:
+    session = FakeSession()
+    assert await maybe_start_exec_control(session, enabled=False, cwd="/tmp") is None
+    # No record, and nothing torn down: an ordinary exec run is unaffected.
+    assert registry.scan(isolated_config) == []
+    assert session.disposed is False
+
+
+@pytest.mark.asyncio
+async def test_maybe_start_disposes_and_raises_when_it_cannot_start(
+    isolated_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A supervisor that asked to be able to steer must not get an agent it
+    cannot stop — the failure is fatal, and the built session is released."""
+    session = FakeSession()
+
+    def boom(*args: Any, **kwargs: Any) -> Any:
+        raise OSError("no port")
+
+    monkeypatch.setattr(
+        "local_operator.session.runtime.server.RuntimeServer.start_in_process",
+        boom,
+    )
+    with pytest.raises(OSError):
+        await maybe_start_exec_control(session, enabled=True, cwd="/tmp")
+    assert session.disposed is True

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -955,6 +955,46 @@ def test_yolo_parses_on_every_subcommand(parser: argparse.ArgumentParser, argv: 
     assert parser.parse_args(argv).yolo is True
 
 
+# --- run-shaping flags are position-independent too -----------------------------
+
+
+def test_run_shaping_flags_parse_after_the_subcommand(parser: argparse.ArgumentParser) -> None:
+    """`exec - --model X --hosting Y --run-in Z` parses instead of exiting 2.
+
+    An external supervisor composes argv programmatically and naturally writes
+    the flags after the subcommand. Before this, that form died with
+    "unrecognized arguments" and an exit 2 that reads like a broken install.
+    """
+    args = parser.parse_args(
+        ["exec", "-", "--hosting", "anthropic", "--model", "claude-opus-5", "--run-in", "/tmp"]
+    )
+    assert args.subcommand == "exec"
+    assert args.hosting == "anthropic"
+    assert args.model == "claude-opus-5"
+    assert args.run_in == "/tmp"
+
+
+def test_run_shaping_flags_still_parse_before_the_subcommand(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """The documented root-position form keeps working \u2014 this is additive."""
+    args = parser.parse_args(
+        ["--hosting", "anthropic", "--model", "claude-opus-5", "--run-in", "/tmp", "exec", "-"]
+    )
+    assert args.hosting == "anthropic"
+    assert args.model == "claude-opus-5"
+    assert args.run_in == "/tmp"
+
+
+def test_a_subcommand_does_not_clobber_a_root_run_shaping_flag(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """The argparse re-default quirk must not swallow a value set BEFORE the
+    subcommand \u2014 the exact failure ``--resume`` documents having hit."""
+    args = parser.parse_args(["--model", "claude-opus-5", "exec", "task"])
+    assert args.model == "claude-opus-5"
+
+
 # --- CL-06: startup preflight ---------------------------------------------------
 
 

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -314,9 +314,106 @@ def test_build_worker_argv_omits_unset_flags() -> None:
     assert parsed.json_mode is False
     assert parsed.agent is None
     assert parsed.hosting is None
+    # Opt-in: a detached run publishes no record unless asked.
+    assert "--control" not in argv
+    assert parsed.control is False
+
+
+def test_build_worker_argv_threads_control_to_the_worker() -> None:
+    """`--background --control` is the same request run elsewhere.
+
+    A detached run is the one that most needs steering — nobody is watching its
+    log — so a flag dropped at this process boundary would be accepted by the
+    front end and silently lost, the failure the ``resume`` field records.
+    """
+    argv = build_worker_argv("do it", ExecArgs(control=True))
+    assert "--control" in argv
+    parsed = exec_worker.build_parser().parse_args(argv[3:])
+    assert parsed.control is True
 
 
 # --- exec_mode foreground -------------------------------------------------------
+
+
+def test_run_exec_starts_no_control_surface_by_default(fake_factory, monkeypatch, capsys) -> None:
+    """The default exec run stays invisible: no record, no socket, no line.
+
+    Opt-in is the whole design (`lop sessions` filters on nothing, so every
+    scripted run would otherwise become a `lop send` target), and this is the
+    pin on it.
+    """
+    started: list[bool] = []
+    monkeypatch.setattr(
+        "local_operator.session.runtime.exec_control.start_exec_control",
+        lambda *a, **k: started.append(True),
+    )
+    session = FakeSession([_success_script()])
+    fake_factory(session)
+    assert exec_mode.run_exec("say hello", ExecArgs()) == 0
+    assert started == []
+    assert "lop exec control" not in capsys.readouterr().err
+
+
+def test_run_exec_control_prints_the_endpoint_on_stderr(fake_factory, monkeypatch, capsys) -> None:
+    """stdout is the payload stream; chrome that lands in it corrupts the only
+    output the run has."""
+
+    class _Control:
+        endpoint_line = "lop exec control: session_id=x pid=1 port=2 record=/r"
+
+        async def aclose(self) -> None:
+            closed.append(True)
+
+    closed: list[bool] = []
+
+    async def fake_start(session, *, enabled, cwd, yolo=False):  # noqa: ANN001
+        assert enabled is True
+        return _Control()
+
+    monkeypatch.setattr(
+        "local_operator.session.runtime.exec_control.maybe_start_exec_control", fake_start
+    )
+    session = FakeSession([_success_script()])
+    fake_factory(session)
+    assert exec_mode.run_exec("say hello", ExecArgs(control=True)) == 0
+    captured = capsys.readouterr()
+    assert "lop exec control:" in captured.err
+    assert "lop exec control:" not in captured.out
+    assert closed == [True]
+
+
+def test_run_exec_control_closes_before_the_session_is_disposed(fake_factory, monkeypatch) -> None:
+    """The ordering that lets an attached supervisor see a deliberate end.
+
+    Closing after the dispose would leave the runtime reading through its handle
+    into a session being torn down, and the supervisor would see a bare EOF it
+    cannot tell from a crash.
+    """
+    order: list[str] = []
+
+    class _Control:
+        endpoint_line = "endpoint"
+
+        async def aclose(self) -> None:
+            order.append("control-closed")
+
+    async def fake_start(session, *, enabled, cwd, yolo=False):  # noqa: ANN001
+        return _Control()
+
+    monkeypatch.setattr(
+        "local_operator.session.runtime.exec_control.maybe_start_exec_control", fake_start
+    )
+    session = FakeSession([_success_script()])
+    original_dispose = session.dispose
+
+    async def tracking_dispose() -> None:
+        order.append("session-disposed")
+        await original_dispose()
+
+    session.dispose = tracking_dispose  # type: ignore[method-assign]
+    fake_factory(session)
+    assert exec_mode.run_exec("say hello", ExecArgs(control=True)) == 0
+    assert order == ["control-closed", "session-disposed"]
 
 
 def test_run_exec_foreground_success(fake_factory, capsys) -> None:
@@ -574,6 +671,49 @@ async def test_run_print_mode_prompts_sequentially(capsys) -> None:
     code = await run_print_mode(session, ["first", "second"])
     assert code == 0
     assert session.prompts == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_run_print_mode_runs_before_dispose_ahead_of_the_dispose() -> None:
+    """The hook exists because the dispose is this function's own contract, so
+    a caller cannot sequence anything ahead of it from the outside."""
+    order: list[str] = []
+    session = FakeSession([_success_script()])
+    original = session.dispose
+
+    async def tracking() -> None:
+        order.append("disposed")
+        await original()
+
+    session.dispose = tracking  # type: ignore[method-assign]
+
+    async def hook() -> None:
+        order.append("hook")
+
+    assert await run_print_mode(session, ["go"], before_dispose=hook) == 0
+    assert order == ["hook", "disposed"]
+
+
+@pytest.mark.asyncio
+async def test_run_print_mode_runs_before_dispose_when_the_prompt_raises() -> None:
+    """A control surface must be closed on the failure path too, or a crashed
+    run leaves a published record for a scanner to reap."""
+    order: list[str] = []
+
+    class Exploding(FakeSession):
+        async def prompt(self, text, images=None):  # noqa: ANN001, ANN201
+            raise RuntimeError("boom")
+
+        async def dispose(self) -> None:
+            order.append("disposed")
+            await super().dispose()
+
+    async def hook() -> None:
+        order.append("hook")
+
+    with pytest.raises(RuntimeError):
+        await run_print_mode(Exploding([_success_script()]), ["go"], before_dispose=hook)
+    assert order == ["hook", "disposed"]
 
 
 # --- exec_mode background --------------------------------------------------------

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -365,13 +365,18 @@ def test_run_exec_foreground_json_mode(fake_factory, capsys) -> None:
         "agent_end",
     ]
     # Quadratic-growth fix: message_update keeps ONLY the delta — plus the
-    # message_id so JSON consumers can attribute deltas (CL-15).
+    # message_id so JSON consumers can attribute deltas (CL-15), and the
+    # session_id every json-mode line carries for stateless per-line parsers.
+    # Asserted as an exact shape (minus the session stamp, which the fake
+    # session supplies) because the property under test is what is ABSENT:
+    # no full-message snapshot may creep back in.
     update = lines[2]
-    assert update == {
+    assert {key: value for key, value in update.items() if key != "session_id"} == {
         "type": "message_update",
         "message_id": reply.id,
         "delta": "streamed",
     }
+    assert "message" not in update, "the full message snapshot must not return"
 
 
 def test_printable_event_strips_provider_payload() -> None:


### PR DESCRIPTION
## Summary

Minerva's Sentinels — autonomous supervised engineering agents — run on the `omp` CLI harness today. This adds what `lop` needs to be a first-class harness in its place: a supervisor can drive a headless run, take a durable acceptance boundary from it, stream it to a UI, steer it mid-turn, and cancel it **without tearing a `git push` in half**.

Four gaps, one of which was a correctness bug waiting to happen rather than a missing feature.

### 1. `message_start` cannot mean "the provider accepted this prompt"

An external runtime commits **no-replay proof** at the moment the provider demonstrably began generating: past that point, resubmitting the prompt can duplicate real side effects — a pushed commit, an opened MR, a sent message. The obvious hook is the first assistant `message_start`, which is exactly what the existing `omp` adapter keys on.

In `lop` that would be **wrong, and silently so**. `loop.py` yields `MessageStartEvent` from a bare placeholder `Message(role="assistant")` *before* the `ChatRequest` is constructed and long before it reaches the wire:

```
assistant = Message(role="assistant")   # empty placeholder
yield TurnStartEvent()
yield MessageStartEvent(message=assistant)
...
request = ChatRequest(...)              # only built here
stream = _abortable_stream(...)         # only sent here
```

A supervisor keying acceptance there marks a prompt un-retryable that DNS, auth, or a rate limit can still reject. The work is dropped while the runtime records it as accepted — a failure that stays invisible until a provider outage produces a run of them.

So the boundary is a **new event, emitted only once the request is on the wire**: `StreamStartEvent` from the wire clients → `provider_turn_start` from the loop, carrying the provider's native turn id.

**A dedicated typed field, not a hole in the payload stripper.** The tempting fix — stop stripping `provider_payload`, or retain its `"id"` — was rejected. `strip_provider_payload` exists because that payload is transport-native replay state, opaque outside the producing process, and potentially enormous; its recursive walk would leak `"id"` from *every* nested dict it visits (tool results, compaction markers, `provider_payload["details"]`), which is a bloat and privacy regression in the exact function written to prevent one. `response_id` sits outside `provider_payload`, so the stripper is untouched and pyright checks the field.

**Anthropic had no turn identity at all.** Only the two OpenAI-compatible paths populated `provider_payload`; `AnthropicClient` and `GoogleClient` passed none. Anthropic *does* send `message.id` on its `message_start` SSE event — it was being read past for usage and discarded. A Claude-pinned sentinel therefore had **no native id on any event**. Now captured, alongside a Responses-API capture moved from `response.completed` to `response.created` (waiting for completion to learn a turn was accepted defeats the purpose). Google exposes no stable per-response id here and honestly reports `None`, which a consumer must treat as indeterminate and fail closed on.

### 2. Cancel cut tools mid-flight

`abort` fires the turn's `AbortSignal`, which cancels the running tool task. That is right for a human pressing Esc — they can see and repair whatever was half-done. It is wrong for a supervised agent whose tools have external side effects a machine operator cannot see: a `git push` cut mid-transfer, a merge request half-created.

`Session.request_graceful_cancel()` is sticky and honoured at the loop's **post-tool boundary** — after every call in the batch has produced a paired result, before the next model request is spent. The turn ends `aborted` with the completed work intact. Opt-in through `LoopConfig.graceful_cancel_requested`; an absent hook (every existing host) behaves exactly as before, and a hook that *raises* degrades to "no cancel" rather than stranding the turn.

This preserves a guarantee the sentinel runner currently implements by holding `SIGTERM` until a boundary — now available in-process, through the control socket, instead of through process signals.

### 3. A headless run could not be reached at all

`SessionRecord.kind` already admitted `"exec"`, but only the TUI and the mobile daemon ever constructed a `RuntimeServer`, so a headless run published no discovery record and no control socket. The whole control vocabulary — `steer`, `abort`, `set_model`, `approval_answer` — already existed and worked.

`exec --control` registers one, reusing `OwnedSessionHandle` rather than adding a third `SessionHandle`. **Off by default**, deliberately: `lop sessions` filters on nothing, so every scripted `exec` and CI loop would pollute the operator's session list and become a `lop send` target; the mobile daemon would adopt short-lived records; `RuntimeServer` heartbeats on a 15s cadence built for long-lived hosts while most exec runs are shorter than that.

`cancel` takes a `mode`, defaulting to graceful; `mode: "immediate"` routes to `abort`. An unknown mode is **refused, not defaulted** — the two differ in whether external side effects get torn in half, so guessing is worse than erroring.

### 4. SSE existed but nothing fed it

The transport, broker, cursor-resume, keepalive and event taxonomy were all already here, and `local-operator-ui` already speaks them. But `publish_agent_event` had exactly **one** caller — the `lop serve` job pipeline — and a headless run never enters that path. A sentinel produced **zero** SSE events despite the whole transport being present.

`sse_bridge.attach_broker()` lets a non-server host publish into an `EventBroker`, reusing `AgentEventBridge`'s projection rather than writing a second one. Two taxonomy entries were added because unmapped types are *discarded*: `provider.start` (the acceptance boundary, carrying `response_id`) and `steering.delivered` (a state transition a UI reconciles its "queued" row against — not a `notice`, which would append a second row saying the first is now wrong).

### 5. Flags that only parsed before the subcommand

`--hosting`, `--model` and `--run-in` were global-only, so the form a supervisor naturally composes — `lop exec - --json --model X --run-in DIR` — died with `unrecognized arguments` and an exit 2 that reads like a broken install. They now use the same `_propagate_global_flags` mechanism that already makes `--yolo` and `--resume` position-independent, including its `SUPPRESS` default so a value set *before* the subcommand is never clobbered. `-` as the prompt positional reads from stdin (resolved *before* the `--background` branch, so a detached worker cannot receive a literal `-`), and `--json` stamps `session_id` on every line for the stateless per-line parsers external supervisors use.

## Testing

**End-to-end, in a fully isolated `HOME` with credentials supplied only through the environment — the container model a sentinel actually runs under**, on OpenRouter (the provider Sentinels use):

```
printf 'Create a file called result.txt containing exactly the text HARNESS-E2E, using bash. Then reply with exactly DONE.' \
  | env HOME=/tmp/e2e-lop/home LOCAL_OPERATOR_CONFIG_DIR=... OPENROUTER_API_KEY=... \
    local-operator exec - --json --yolo --hosting openrouter --model openai/gpt-5-mini --run-in /tmp/e2e-lop
```

Exit 0. `result.txt` contains `HARNESS-E2E` — the agent really used its tools. Three model turns, each with its own boundary:

```json
{"response_id":"gen-1788500469-FohOXvVb2Lw8rWXrisCc","provider":"openrouter","model_id":"openai/gpt-5-mini","session_id":"0cb045c9a95b"}
{"response_id":"gen-1788500476-MJS2bEPIneTekvU4GaeF","provider":"openrouter","model_id":"openai/gpt-5-mini","session_id":"0cb045c9a95b"}
{"response_id":"gen-1788500478-Ba9bGDElOQyLmz8rhiZx","provider":"openrouter","model_id":"openai/gpt-5-mini","session_id":"0cb045c9a95b"}
```

Distinct native ids per turn, one stable `session_id` on every line, and `usd_cost` populated (`0.00043925`, `0.000377`) so a supervisor can bill from the stream. Verified separately on Anthropic direct, where the id (`msg_011Cehi…`) was previously unobtainable.

**Both cancel rungs, proven to differ** (real runs, control socket, isolated config dir):

- graceful, requested while a tool was in flight → `tool calls started: 5 / ended: 5 / UNPAIRED: []`, `agent_end aborted=True`. Nothing cut; the steered instruction landed.
- `mode: "immediate"` against a 120s sleep → the tool's output file was **never written**. The tool was cut, as intended.

**SSE, against the real endpoint.** A session built with **no job pump** — the gap itself — attached via `attach_broker` streamed 25 frames to `/v1/sse/jobs/{id}`: two `provider.start` with distinct ids and a `steering.delivered` `{"count":1}` from a real mid-turn `steer()`. That path previously produced nothing. Reconnecting with `Last-Event-ID: 6` replayed from exactly `id: 7`; `record.update`/`record.complete`/`message.delta` key sets are byte-identical between pump and bridge.

**Control surface off by default** — no record, no endpoint line, no directory entry; the operator's real `~/.local-operator/run/mobile/` was untouched throughout.

**Mutation-tested, not just green.** Reverting the loop's boundary check makes `test_cancel_lands_after_the_tool_completes_not_during` fail with `no model request may be spent after the cancel — assert 2 == 1`, so the test proves the property rather than passing vacuously.

**Gates:** flake8, black, isort clean tree-wide; **pyright 0 errors**; `tests/unit` **12,167 passed**.

One unrelated pre-existing flake, `tui/test_subagent_view.py::test_a_narrow_viewport_opens_on_a_row_head_not_a_wrap_fragment`: it reproduces at ~1-in-3 under xdist on this branch, passes isolated (124/124), passes on unmodified `origin/main`, and this diff touches no TUI code. Reported, not fixed.

## Compatibility

Additive throughout: a new stream-event member (the loop's dispatch is an `isinstance` chain that ignores unknown members), a new harness event, a new typed field, a json-mode-only key, two new SSE names, an opt-in flag, and a new meaning for a positional that is currently a nonsense prompt. No existing wire shape changes. `provider_payload` stays stripped.

Downstream: this is the contract Minerva's `agent-runtime-svc` `lopcli` adapter is written against, so it must ship before that adapter deploys.
