### PR TITLE
chore(release): 0.45.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.45.3"
+version = "0.45.4"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Version-only bump. `main` carries `0.45.3` in `pyproject.toml`, but v0.45.3 was already published from #596 while #600 was in review, so the router-metadata fix has no free version to release under.

No source change — `pyproject.toml` only.

## Verification
```
$ gh release view v0.45.3 --json tagName -q .tagName
v0.45.3          # already taken
```
Publishing #600 under 0.45.3 would collide with an existing tag and PyPI artifact.