### PR TITLE
fix(tests): reclaim the TUI suite's abandoned temp directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.46.6"
+version = "0.46.7"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tui/conftest.py
+++ b/tests/unit/tui/conftest.py
@@ -5,11 +5,20 @@ that exports NO_COLOR (a common developer default) would otherwise fail all
 three snapshots for reasons that have nothing to do with the code under
 test. The pins live in fixtures — scoped and reverted — instead of module
 import time, so collection order never leaks environment into other suites.
+
+This file also reclaims the temporary directories this suite allocates; see
+``_reclaim_bare_mkdtemp`` for why the cleanup lives here rather than at the
+~30 call sites that create them.
 """
 
 from __future__ import annotations
 
+import os
+import shutil
+import tempfile
+from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 import pytest
 from textual.app import App, ComposeResult
@@ -19,9 +28,160 @@ from local_operator.tui import theme as theme_mod
 from local_operator.tui.settings import settings_reload
 from local_operator.tui.widgets.transcript import TranscriptView
 
+#: Whatever occupied ``tempfile.mkdtemp`` when this conftest was imported — in
+#: practice the CPython original, since nothing in this venv patches it before
+#: import, but the guarantee is "the import-time binding", not "the stdlib
+#: function". If a plugin ever did patch it earlier, delegating here would
+#: preserve that plugin's semantics rather than bypass them, which is the
+#: behaviour we want either way.
+#:
+#: ``_reclaim_bare_mkdtemp`` delegates to THIS rather than to whatever occupies
+#: the slot at setup time, which is what keeps wrappers from stacking: a test
+#: that patches ``mkdtemp`` itself has its ``monkeypatch`` undone AFTER this
+#: fixture (pytest resolves ``monkeypatch`` first, so it tears down later),
+#: leaving OUR wrapper in the slot for the next test to capture as its "real"
+#: function. Reading the live slot per test therefore grows the chain by one
+#: layer per patching test — measured 2, 3, 4, 5, 6, 7 across six such tests,
+#: and depth 60 on a 60-test storm; anchoring here holds it flat. Behaviour
+#: survived the stack (every layer delegates), but the growth was unbounded
+#: within a session.
+_STDLIB_MKDTEMP = tempfile.mkdtemp
+
 #: The real stylesheet, so styled tests exercise the shipped rules rather
 #: than a convenient approximation of them.
 TCSS_PATH = str(Path(theme_mod.__file__).parent / "local_operator.tcss")
+
+
+@pytest.fixture(autouse=True)
+def _reclaim_bare_mkdtemp() -> Iterator[None]:
+    """Remove the ``tempfile.mkdtemp()`` dirs this suite abandons, per test.
+
+    WHY THIS EXISTS. Five files here (``test_slash_echo``, ``test_team_chart``,
+    ``test_slash_command_images``, ``test_paste_collapse``,
+    ``test_credential_command``) build ``TeamRegistry``/``AgentRegistry`` roots
+    from a bare ``tempfile.mkdtemp()`` and never remove them: 65 directories
+    per serial run of ``tests/unit/tui``, unbounded in COUNT across runs. It is
+    the residue of #564, which fixed the unbounded-in-SIZE evidence bundles
+    (43,627 abandoned dirs / ~30 GB filled the operator's disk) and explicitly
+    deferred this one.
+
+    WHY IT IS A WRAPPER HERE AND NOT A FIXTURE AT THE CALL SITES. This leak has
+    been fixed and reverted twice, both times for the same reason. Migrating
+    the five files to a ``tmp_path``-backed ``scratch_dir`` fixture added
+    fixture dependencies to those modules and perturbed xdist's ``worksteal``
+    scheduling, landing an unrelated timing-sensitive pilot test
+    (``test_app_pilot.py`` ::
+    ``test_a_swap_leaves_the_ledger_matching_the_new_sessions_history``) in a
+    failing window 4/4 in CI. A second attempt using a plain-function helper in
+    ``tests/unit/tui/_scratch.py`` destabilised a different shard
+    (``test_word_caret``, 2/2). Both were reverted.
+
+    So the constraint this fix is written against is: **do not change what
+    pytest collects, schedules, or resolves.** This fixture is autouse with no
+    parameters, so it introduces no new fixture-graph edges and no per-test
+    dependency on ``tmp_path``; the suite's other autouse fixture already makes
+    every test in this package carry one. Collection, ordering, test ids and
+    the per-test fixture closure are unchanged from the pre-fix tree — the only
+    difference is that ``mkdtemp`` is a different function object while a test
+    body runs.
+
+    WHAT IT RECLAIMS, AND WHAT IT DELIBERATELY DOES NOT. The rule is by PARENT
+    PATH, not by keyword: only allocations whose parent is the system temp root
+    are tracked, which is exactly the bare ``mkdtemp()`` shape that leaks. That
+    is what leaves ``dir=``-staged directories alone —
+    ``TeamRegistry._save_team_locked`` stages a row under ``teams_dir`` and its
+    backup under ``target.parent``, both outside the temp root, and sweeping
+    either would delete a live registry's staging directory mid-write. Note the
+    rule is deliberately about WHERE the directory landed rather than HOW it was
+    asked for: an explicit ``mkdtemp(dir=<the temp root>)`` IS swept, because it
+    is indistinguishable on disk from the bare call this reclaims, and a caller
+    staging into the shared temp root has not opted out of cleanup.
+    ``tempfile.TemporaryDirectory`` routes through ``mkdtemp`` and so is seen,
+    but it removes itself first and the sweep below is then a no-op.
+    ``tmp_path`` does not route through ``mkdtemp`` at all (pytest uses
+    ``make_numbered_dir``), so it is untouched and keeps its own rotation.
+
+    Sweeping per test rather than at process exit keeps the disk flat during a
+    long run instead of only at the end of one, and attributes nothing across
+    tests: the list is per-test state, so a directory is only ever removed by
+    the test that allocated it.
+
+    WHY THIS RECLAIMS RATHER THAN DETECTS, unlike the evidence suite's guard in
+    ``tests/unit/evaluation/evidence/conftest.py``. That one can only DETECT: its
+    leaks are created inside embedded subprocess scripts, which no in-process
+    finalizer can reach, so failing the test is the only lever it has. These
+    leaks are ordinary in-process allocations, so they can simply be reclaimed —
+    and prevention beats detection here, because a new call site added later is
+    cleaned up automatically instead of failing a test that a future author then
+    has to remediate. There is deliberately no new detector test file to go with
+    this: CI shards by ``sorted(glob('tests/unit/**/test_*.py'))`` with
+    ``i % 5``, so adding ONE file re-indexes the files sorting after it into
+    different shards (30 of 349 for a plausibly-named file here, up to ~100 for
+    one sorting to the front) — scheduling churn this fix exists to avoid. The
+    decisive reason, though, is that reclaiming PREVENTS by construction where a
+    detector only reports: a bare ``mkdtemp()`` added later is cleaned up with
+    no new test to maintain, and a detector folded into this conftest would have
+    to assert on a temp root that concurrent sibling worktrees also write to,
+    making it flaky by construction.
+
+    To re-measure the leak (serial and private, so sibling worktrees cannot
+    pollute the count). The expected count is whatever the CONTROL arm reports,
+    not a number pinned here — it moves as call sites come and go; it was 65
+    directories / 724 KB when this landed, and the invariant that matters is
+    that this arm reports zero::
+
+        T=/tmp/leakprobe; rm -rf $T; mkdir -p $T
+        env -u NO_COLOR TERM=xterm-256color TMPDIR=$T \\
+            .venv/bin/python -m pytest tests/unit/tui -q -p no:randomly -n0
+        ls -1 $T | grep -v '^pytest-\\|data-gym-cache' | wc -l   # 0 here
+
+    The ``grep -v`` is load-bearing, not decoration: pytest's own ``pytest-of-*``
+    basetemp and tiktoken's ``data-gym-cache`` both live in the same directory
+    and are not leaks. Dropping the filter when retyping the command is the
+    fastest way to get a wrong answer out of it.
+    """
+    # Anchored to the import-time original, never to the live slot — see
+    # ``_STDLIB_MKDTEMP`` for the stacking this avoids.
+    real_mkdtemp = _STDLIB_MKDTEMP
+    # Resolved once per test: comparing REAL paths keeps macOS's
+    # /var -> /private/var symlink from making every parent comparison false.
+    temp_root = os.path.realpath(tempfile.gettempdir())
+    created: list[str] = []
+
+    def tracking_mkdtemp(*args: Any, **kwargs: Any) -> str:
+        path = real_mkdtemp(*args, **kwargs)
+        if os.path.realpath(os.path.dirname(path)) == temp_root:
+            created.append(path)
+        return path
+
+    # Not `monkeypatch`: this fixture takes no parameters on purpose (see the
+    # docstring), and `try`/`finally` restores on every exit path anyway.
+    tempfile.mkdtemp = tracking_mkdtemp  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        # Restore only while we still own the slot: a test that patched
+        # `mkdtemp` and has not yet had its own `monkeypatch` undone is holding
+        # the slot legitimately, and clobbering it here would strip a patch the
+        # test still expects to be in force.
+        #
+        # KNOWN LIMIT (review round 2, MINOR 2), latent and deliberately not
+        # designed around: if a test that patches `mkdtemp` is the LAST one in
+        # this package, this declines to restore, its `monkeypatch` then
+        # reinstates our wrapper, and nothing afterwards removes it — an
+        # out-of-package test would allocate into a `created` list nobody
+        # sweeps. No test in `tests/unit/tui` patches `mkdtemp` today (the only
+        # one in the repo is `tests/unit/test_agents.py`, another package), so
+        # this is unreachable. The fix, should it ever bite, is to restore when
+        # the slot is not ours but our wrapper is still reachable in the chain;
+        # it is not applied now because it trades a real, measured guarantee for
+        # a hypothetical one.
+        if tempfile.mkdtemp is tracking_mkdtemp:
+            tempfile.mkdtemp = real_mkdtemp  # type: ignore[assignment]
+        for path in created:
+            # A test that cleaned up after itself, or handed the directory to
+            # something that did, is the normal case rather than an error.
+            shutil.rmtree(path, ignore_errors=True)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

The residue deliberately deferred from #564. Five TUI test files build `TeamRegistry` / `AgentRegistry` roots from a bare `tempfile.mkdtemp()` and never remove them: **65 directories / 724 KB per serial run of `tests/unit/tui`**, unbounded in COUNT across runs. #564 fixed the unbounded-in-SIZE contributors (the 64 MiB evidence bundles behind 43,627 dirs / ~30 GB) and left this one, because fixing it must not perturb an unrelated timing-sensitive pilot test under xdist.

**Measured, paired on one base with a private `TMPDIR`, serial (`-n0`): control 65 dirs / 724 KB → branch 0 / 0.**

## The constraint, and why this shape

This leak has been fixed and reverted **twice**, both times for the same reason:

- **Attempt 1 (fixture-based).** Migrating the five files to a `tmp_path`-backed `scratch_dir` fixture added fixture dependencies to those modules, perturbed xdist worksteal scheduling, and failed `test_app_pilot.py::test_a_swap_leaves_the_ledger_matching_the_new_sessions_history` 4/4 in CI. Reverted.
- **Attempt 2 (plain-function helper).** A tracked `TemporaryDirectory` in `tests/unit/tui/_scratch.py`, no signature changes — still destabilised a different shard (`test_word_caret`, 2/2). Reverted.

So this fix changes **nothing pytest collects, schedules, or resolves.** One autouse fixture in the TUI conftest wraps `tempfile.mkdtemp` for the duration of each test and removes what that test allocated.

- It takes **no parameters**, so it adds no fixture-graph edges and no new `tmp_path` dependency. The suite's existing autouse `hermetic_tui_env` already puts a fixture on every test in this package.
- **No test file changes at all.** `test_app_pilot.py` is untouched, as required.
- Collection is identical: **4826 tests collected** on both sides (TUI scope), and byte-identical across all of `tests/unit` (**12,361 ids**, `diff` clean).

The only observable difference is that `mkdtemp` is a different function object while a test body runs.

## What it reclaims, and what it deliberately does not

Only allocations landing **directly in the system temp root** are tracked — exactly the bare `mkdtemp()` shape that leaks. A call passing `dir=` is somebody managing their own location: `TeamRegistry._save_team_locked` stages a row under `teams_dir` that way (42 calls in one probe), and sweeping it would delete a live registry's staging directory mid-write. `tempfile.TemporaryDirectory` routes through `mkdtemp` and is seen, but removes itself first, so the sweep is a no-op. `tmp_path` does not route through `mkdtemp` at all (pytest uses `make_numbered_dir`), so it keeps its own rotation.

## Leak, before and after

Paired runs on the same base, private `TMPDIR`, `-n0`, arms in separate worktrees:

| | dirs / run | bytes / run | result |
|---|---|---|---|
| control (`origin/main`) | **65** | **724 KB** | 1 failed, 4791 passed |
| this branch | **0** | **0** | 4792 passed, exit 0 |

The control arm's one failure (`test_stream_anchor.py::test_paging_the_subagent_body_by_its_hint_arrow_releases_the_anchor`, `assert 25.0 == 26.0`) is a pre-existing order-dependent flake on unmodified main — it passes 5/5 in isolation there.

## Scheduling stability — CI's exact config

`-n 4 --dist worksteal`, Python 3.12, **with `--cov`**, over CI's real shard file lists (`sorted(glob('tests/unit/**/test_*.py'))`, `i % 5`). Arms live in **separate worktrees** and runs are **interleaved** (control, branch, control, …) so machine-load drift hits both equally.

| shard | contains | rounds/arm | control failures | branch failures |
|---|---|---|---|---|
| **3** | `test_app_pilot.py` | 6 | **2** | **2** |
| **2** | `test_slash_echo.py`, `test_word_caret.py` | 5 | **0** | **0** |

> **Corrected after review/QA.** Shard *indices* drift as test files are added — on the tree these runs used, the at-risk files sat in shards 3 and 2; reviewer and QA re-ran them at 0/4, and post-rebase all three sit in shard 2. The *files* exercised were the right ones in every case. Across the reviewer's 24 runs and QA's 16 CI-exact runs there were **zero failures on either arm**, `test_app_pilot` and `test_word_caret` included.

- Shard 3, both arms: the failures are the same ambient pilot tests (`test_boot_typing_sends_prompt`, `test_a_replayed_bang_card_opens_and_ordinary_calls_stay_shut`), 2 on each side — the branch is **no worse than control**.
- Shard 2: **0 failures either arm across 5 rounds**, `2240 passed` every run, and the leak goes **37 → 0** every round.

**~~`test_app_pilot.py` alone fails 3/12 under `-n 4 --dist worksteal` on unmodified `origin/main`.~~ WITHDRAWN.** Both gates independently measured **0/12** on pristine main and could not reproduce it; the figure is unsupported and should not be relied on. The load-dependent shard failures I observed were real but are not evidence of a standing `test_app_pilot` flake rate. `main`'s own CI is red **9 of its last 12** runs (QA's count from the CI record), chiefly `test_subagent_view` — that part stands, corroborated on four distinct main commits.

Also confirmed: `test_a_swap_leaves_the_ledger_matching_the_new_sessions_history` — the test that killed attempt 1 — passes, and the `test_word_caret` tests are clean across all of shard 2.

## On widening the #564 guard to the TUI suite — decided against, with reasons

**No detector test accompanies this, deliberately.** CI shards by `sorted(glob('tests/unit/**/test_*.py'))` with `i % 5`, so adding **one** new test file re-indexes **100 of 347 files** into different shards — a *larger* scheduling perturbation than the fixture edges that broke both previous attempts. Adding a guard that way would risk exactly the failure this ticket exists to avoid.

The two mechanisms also answer different problems. The evidence guard can only **detect**: its leaks are born inside embedded subprocess scripts no in-process finalizer can reach, so failing the test is its only lever. These leaks are ordinary in-process allocations, so they can simply be **reclaimed** — and prevention is strictly better here, because a new call site added later is cleaned up automatically instead of failing a test a future author must then remediate. A tree-wide `tempfile.tempdir` redirect was already measured and rejected in #564 (AF_UNIX paths past darwin's 104-byte limit); this fix never redirects `tempdir`, so paths keep their normal length.

**What would catch a regression:** the reproduction recipe is committed in the fixture docstring —

```sh
T=/tmp/leakprobe; rm -rf $T; mkdir -p $T
env -u NO_COLOR TERM=xterm-256color TMPDIR=$T \
    .venv/bin/python -m pytest tests/unit/tui -q -p no:randomly -n0
ls -1 $T | grep -v '^pytest-\|data-gym-cache' | wc -l   # 65 before, 0 after
```

A regression would have to be a *new* leak shape (a `dir=`-passing call, or a subprocess), since every in-process bare `mkdtemp()` in this package is now reclaimed by construction.

## Testing evidence

```
flake8 .                                          rc=0
black --check .           836 files unchanged     rc=0
isort --check .                                   rc=0
pyright                   0 errors, 0 warnings, 0 informations
tests/unit (full suite)   12133 passed, 15 skipped, exit=0
tests/unit/evaluation/evidence (the #564 guard)   153 passed
tests/unit/tui serial     4792 passed, 0 leaked dirs, exit=0
```

Lint pins match CI (`flake8==7.1.0`, `black==26.1.0`, `isort==5.13.2`); pyright run as `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` per AGENTS.md.

## Deferred (pre-existing, unrelated to this diff)

- `deferred — pre-existing ambient TUI timing flakes on main (test_subagent_view::test_a_narrow_viewport..., confirmed on 4 distinct main commits; main red 9 of its last 12 CI runs). Not tempfile-related and not this PR's to fix. My earlier 'test_app_pilot fails 3/12 on main' figure is WITHDRAWN — both gates measured 0/12.`
- `deferred — pre-existing flake: tests/unit/model/test_prices.py::test_a_background_revalidation_gets_the_full_default_timeout, reproduced 1/15 serially on unmodified main (thread-visibility race). Deselected from both arms of the scheduling A/B so it could not be mistaken for a scheduling effect.`
- `deferred — pre-existing order-dependent flake: test_stream_anchor.py::test_paging_the_subagent_body_by_its_hint_arrow_releases_the_anchor failed on the CONTROL serial run and passes 5/5 in isolation there.`

## Version

`0.46.2` — a patch: test-only cleanup, no user-facing behaviour change. Rebased onto `5e4670b6`. `0.46.1` was published to PyPI **during review round 2**, and because main and this branch then declared the **same string**, `git merge-tree` reported **zero conflict markers** — the merge would have silently landed an already-published version and failed only as a rejected PyPI upload *after* the tag and Release were public. Verified free on **both sides of the push** (PyPI JSON **404**, `git ls-remote --tags origin v0.46.2` **empty**). **main releases every ~25 minutes, so the merge step must re-verify the version is still free at merge time.**


