### PR TITLE
fix(tui): serve teams and agents from the viewer's own config dir

### DIFF
--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -284,6 +284,17 @@ class RemoteSession:
         # session that never types `/team` must not pay at boot.
         self._team_registry_cache: Any | None = None
         self._agent_registry_cache: Any | None = None
+        # FAILURE is latched as well as success (R3). Returning None out of the
+        # `except` without recording it left the cache empty, so the next read
+        # re-entered the whole constructor: 25 property reads against a raising
+        # constructor measured 25 constructions. The picker re-derives its rows
+        # on EVERY keystroke, so an unreadable registry would put a directory
+        # walk plus a recovery probe on the typing path — the exact cost
+        # `teams.py` keeps off that loop ("a reader that waited turned an
+        # ordinary keystroke into a multi-second freeze"). Construct at most
+        # once per session, whichever way it goes.
+        self._team_registry_failed = False
+        self._agent_registry_failed = False
 
     @property
     def team_registry(self) -> Any | None:
@@ -301,11 +312,14 @@ class RemoteSession:
         half-truth (see ``TeamRegistry._raise_if_recovery_failed``).
         """
         if self._team_registry_cache is None:
+            if self._team_registry_failed:
+                return None
             from local_operator.teams import TeamRegistry
 
             try:
                 self._team_registry_cache = TeamRegistry(self._config_dir)
             except Exception:  # noqa: BLE001 — one feature must not break the session
+                self._team_registry_failed = True
                 return None
         return self._team_registry_cache
 
@@ -316,14 +330,34 @@ class RemoteSession:
         The sibling of :attr:`team_registry`, and broken by the same
         mechanism: ``/agent``'s listing and launch both read this off the
         session (``_agent_profile_rows``, ``_cmd_agent``). Same lazy
-        construction and same degrade-one-feature guard.
+        construction, same degrade-one-feature guard, same failure latch.
+
+        NOT symmetric with :attr:`team_registry` in one respect, which is
+        recorded here rather than silently inherited (R4):
+        ``AgentRegistry.__init__`` creates ``<config_dir>`` and
+        ``<config_dir>/agents`` and runs its two migrations, so READING this
+        property writes to disk. ``TeamRegistry`` deliberately does the
+        opposite ("No mkdir here: every interactive session constructs a
+        registry, and an unused feature must not litter the config dir").
+
+        The asymmetry is pre-existing and left alone on purpose: every other
+        host that offers `/agent` — the CLI, `exec`, the server, the mobile
+        daemon — constructs the same registry the same way, so the directory a
+        viewer creates is one every other entry point would have created
+        anyway. Changing the constructor to match ``TeamRegistry`` is a change
+        to shared behaviour with its own blast radius, not a fix belonging to
+        this regression. What is new here is only that the construction now
+        also happens on a viewer.
         """
         if self._agent_registry_cache is None:
+            if self._agent_registry_failed:
+                return None
             from local_operator.agents import AgentRegistry
 
             try:
                 self._agent_registry_cache = AgentRegistry(self._config_dir)
             except Exception:  # noqa: BLE001 — one feature must not break the session
+                self._agent_registry_failed = True
                 return None
         return self._agent_registry_cache
 

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -291,10 +291,39 @@ class RemoteSession:
         # on EVERY keystroke, so an unreadable registry would put a directory
         # walk plus a recovery probe on the typing path — the exact cost
         # `teams.py` keeps off that loop ("a reader that waited turned an
-        # ordinary keystroke into a multi-second freeze"). Construct at most
-        # once per session, whichever way it goes.
-        self._team_registry_failed = False
-        self._agent_registry_failed = False
+        # ordinary keystroke into a multi-second freeze").
+        #
+        # The latch is a COOLDOWN, not a tombstone (R7). A permanent latch
+        # makes any transient failure — a full disk that clears, a directory
+        # being rewritten by a concurrent `lop team` — cost `/team` and
+        # `/agent` for the entire life of the session, silently and with no way
+        # back short of restarting. Timestamps rather than a bool, so a burst
+        # of keystrokes still pays exactly one construction while a genuinely
+        # repaired registry heals on its own.
+        #
+        # Same shape and the same budget as `TeamRegistry`'s own read-path
+        # recovery cooldown (`_READ_RECOVERY_COOLDOWN_S`), deliberately: one
+        # retry convention in the codebase, not a second one invented here.
+        self._team_registry_failed_at: float | None = None
+        self._agent_registry_failed_at: float | None = None
+
+    def _within_registry_cooldown(self, failed_at: float | None) -> bool:
+        """Whether a failed registry construction is still too recent to retry.
+
+        Keeps a burst of keystrokes to ONE construction (the picker re-derives
+        its rows per character) while letting a repaired registry recover
+        without restarting the session — see the constructor's note on why a
+        permanent latch is the wrong trade.
+
+        ``monotonic`` because this is an elapsed-time question: a wall-clock
+        source would let an NTP correction either suppress the retry for hours
+        or defeat the cooldown entirely.
+        """
+        if failed_at is None:
+            return False
+        from local_operator.teams import _READ_RECOVERY_COOLDOWN_S
+
+        return (time.monotonic() - failed_at) < _READ_RECOVERY_COOLDOWN_S
 
     @property
     def team_registry(self) -> Any | None:
@@ -312,14 +341,14 @@ class RemoteSession:
         half-truth (see ``TeamRegistry._raise_if_recovery_failed``).
         """
         if self._team_registry_cache is None:
-            if self._team_registry_failed:
+            if self._within_registry_cooldown(self._team_registry_failed_at):
                 return None
             from local_operator.teams import TeamRegistry
 
             try:
                 self._team_registry_cache = TeamRegistry(self._config_dir)
             except Exception:  # noqa: BLE001 — one feature must not break the session
-                self._team_registry_failed = True
+                self._team_registry_failed_at = time.monotonic()
                 return None
         return self._team_registry_cache
 
@@ -350,14 +379,14 @@ class RemoteSession:
         also happens on a viewer.
         """
         if self._agent_registry_cache is None:
-            if self._agent_registry_failed:
+            if self._within_registry_cooldown(self._agent_registry_failed_at):
                 return None
             from local_operator.agents import AgentRegistry
 
             try:
                 self._agent_registry_cache = AgentRegistry(self._config_dir)
             except Exception:  # noqa: BLE001 — one feature must not break the session
-                self._agent_registry_failed = True
+                self._agent_registry_failed_at = time.monotonic()
                 return None
         return self._agent_registry_cache
 

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -263,6 +263,69 @@ class RemoteSession:
         # optimistic notice through this app-installed callback.
         self._cancel_resolution: Callable[[int], None] | None = None
         self._cancel_task: asyncio.Task[None] | None = None
+        # Teams and agent profiles are LOCAL CONFIG, not runtime state: they
+        # live in `<config_dir>/teams` and `<config_dir>/agents`, the same
+        # files `lop team`/`lop agents` read with no session at all. So a
+        # viewer answers them from its OWN config dir rather than asking a
+        # runtime — which is what makes `/team` and `/agent` work on a COLD
+        # session, where there is no runtime to ask and never will be until
+        # the first message engages one.
+        #
+        # This is the invariant that regressed in the viewer transition: the
+        # TUI reads both registries off the SESSION object
+        # (`_team_registry()`, `_agent_profile_rows()`), and `Session`
+        # supplied them while `RemoteSession` did not, so every `/team` and
+        # `/agent` surface silently answered "unavailable" once `lop` stopped
+        # building a `Session`. Anything the TUI reads off the session has to
+        # exist on BOTH implementations or it fails only on the viewer path.
+        #
+        # Built lazily and cached: constructing a registry walks the config
+        # tree (and `TeamRegistry.__init__` runs crash recovery), which a
+        # session that never types `/team` must not pay at boot.
+        self._team_registry_cache: Any | None = None
+        self._agent_registry_cache: Any | None = None
+
+    @property
+    def team_registry(self) -> Any | None:
+        """The teams on this machine, read from the viewer's own config dir.
+
+        Mirrors the attribute ``Session`` carries so the TUI's
+        ``_team_registry()`` — a plain ``getattr(session, "team_registry")`` —
+        resolves identically whichever session implementation it holds.
+
+        Failure degrades ONE feature rather than the session, the same
+        discipline ``session_factory`` applies to its own construction: a
+        stranded backup or an unreadable ``teams`` directory leaves ``/team``
+        reporting "teams are unavailable" instead of taking the conversation
+        down with it. The registry itself still refuses to answer with a
+        half-truth (see ``TeamRegistry._raise_if_recovery_failed``).
+        """
+        if self._team_registry_cache is None:
+            from local_operator.teams import TeamRegistry
+
+            try:
+                self._team_registry_cache = TeamRegistry(self._config_dir)
+            except Exception:  # noqa: BLE001 — one feature must not break the session
+                return None
+        return self._team_registry_cache
+
+    @property
+    def agent_registry(self) -> Any | None:
+        """The agent profiles on this machine, from the viewer's own config dir.
+
+        The sibling of :attr:`team_registry`, and broken by the same
+        mechanism: ``/agent``'s listing and launch both read this off the
+        session (``_agent_profile_rows``, ``_cmd_agent``). Same lazy
+        construction and same degrade-one-feature guard.
+        """
+        if self._agent_registry_cache is None:
+            from local_operator.agents import AgentRegistry
+
+            try:
+                self._agent_registry_cache = AgentRegistry(self._config_dir)
+            except Exception:  # noqa: BLE001 — one feature must not break the session
+                return None
+        return self._agent_registry_cache
 
     @classmethod
     async def connect(

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -1588,7 +1588,7 @@ class OwnedSessionHandle(SessionHandle):
             (
                 team.name,
                 f"Led by {team.manager} · {team.member_count()} "
-                f"{'role' if team.member_count() == 1 else 'roles'}",
+                f"{'member' if team.member_count() == 1 else 'members'}",
                 (team.description or "").strip(),
             )
             for team in teams

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -1578,11 +1578,17 @@ class OwnedSessionHandle(SessionHandle):
             return SlashResult(
                 kind="notice", text="no teams yet. Ask the agent to create one.", style="info"
             )
+        # ``member_count()``, matching the TUI's own producer (D2). The old
+        # `len(members) + 1` assumed the manager is not on the roster — false
+        # for real teams — and collapsed multi-count slots; the plural was also
+        # keyed to a different number than the one displayed. A detached
+        # runtime and an in-process one must answer the same question with the
+        # same number.
         items = [
             (
                 team.name,
-                f"Led by {team.manager} · {len(team.members) + 1} "
-                f"{'role' if len(team.members) == 0 else 'roles'}",
+                f"Led by {team.manager} · {team.member_count()} "
+                f"{'role' if team.member_count() == 1 else 'roles'}",
                 (team.description or "").strip(),
             )
             for team in teams

--- a/local_operator/tools/team_tool.py
+++ b/local_operator/tools/team_tool.py
@@ -105,7 +105,12 @@ def _registry(context: ToolContext | None) -> TeamRegistry | None:
 
 
 def _row(team: Any) -> str:
-    slots = len(team.members) + 1
+    # ``member_count()`` for the same reason every other listing uses it (D2):
+    # `len(members) + 1` assumes the manager is not on the roster, which is
+    # false for real teams, and collapses a multi-count slot to one. This row
+    # is what the MODEL reads when it lists teams, so a wrong count here is a
+    # wrong count in the agent's own reasoning about a roster it may staff.
+    slots = team.member_count()
     summary = (team.description or "").strip() or "(no description)"
     role_word = "role" if slots == 1 else "roles"
     row = f"- {team.name} [{slots} {role_word}, led by {team.manager}]: {summary}"

--- a/local_operator/tools/team_tool.py
+++ b/local_operator/tools/team_tool.py
@@ -112,8 +112,11 @@ def _row(team: Any) -> str:
     # wrong count in the agent's own reasoning about a roster it may staff.
     slots = team.member_count()
     summary = (team.description or "").strip() or "(no description)"
-    role_word = "role" if slots == 1 else "roles"
-    row = f"- {team.name} [{slots} {role_word}, led by {team.manager}]: {summary}"
+    # "members", matching the number (R6): `member_count()` excludes the
+    # manager, whom this row names separately, so "roles" implied he was
+    # counted and put the model one ahead of the roster it can actually staff.
+    member_word = "member" if slots == 1 else "members"
+    row = f"- {team.name} [{slots} {member_word}, led by {team.manager}]: {summary}"
     return row if len(row) <= _ROW_CAP else row[: _ROW_CAP - 1].rstrip() + "…"
 
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -6354,7 +6354,22 @@ class OperatorApp(App[None]):
                 ArgumentChoice(
                     team.name,
                     description,
-                    # ROLES ONLY, no manager (D1). The picker reserves the
+                    # "MEMBERS", not "roles" (R6). The word has to match the
+                    # NUMBER: `member_count()` excludes the manager, and the
+                    # org chart's own badge (`org_render._member_badge`) counts
+                    # exactly the same leaves the same way and calls them
+                    # members, as do `org_chart._team_detail` and `lop teams`.
+                    # Labelling that number "roles" implied the manager was in
+                    # it, so a manager-off-roster team read one short against
+                    # the boxes the chart draws — D2's contradiction pointing
+                    # the other way.
+                    #
+                    # Count and label are taken from the same place on purpose:
+                    # this is the second defect in this arithmetic, and both
+                    # came from a producer answering a slightly different
+                    # question than the surface it sits beside.
+                    #
+                    # No manager in the detail (D1). The picker reserves the
                     # detail column BEFORE the description and drops the
                     # description first, so a 44-cell
                     # "<n> roles · led by <manager>" silenced the description
@@ -6362,7 +6377,7 @@ class OperatorApp(App[None]):
                     # ordinary terminal sits in. The manager is one keystroke
                     # away in the listing and the chart; the description is the
                     # only thing telling the user which team this IS.
-                    detail=f"{slots} {'role' if slots == 1 else 'roles'}",
+                    detail=f"{slots} {'member' if slots == 1 else 'members'}",
                 )
             )
         return choices
@@ -6633,10 +6648,14 @@ class OperatorApp(App[None]):
             # picker and the org chart must agree.
             slots = team.member_count()
             rows.append(Padding(Text(team.name, style=heading), (0, 0, 0, 2)))
-            role_word = "role" if slots == 1 else "roles"
+            # "members", matching the number (R6) — see the picker's note. This
+            # row names the manager separately ("Led by <manager> · N
+            # members"), so calling the roster count "roles" also double-counted
+            # him in the reader's head.
+            member_word = "member" if slots == 1 else "members"
             rows.append(
                 Padding(
-                    Text(f"Led by {team.manager} · {slots} {role_word}", style=body),
+                    Text(f"Led by {team.manager} · {slots} {member_word}", style=body),
                     (0, 0, 0, 4),
                 )
             )
@@ -7007,13 +7026,20 @@ class OperatorApp(App[None]):
             out.append(Padding(Text(facts, style=body), (0, 0, 0, 4)))
             if summary:
                 out.append(Padding(Text(summary, style=body), (0, 0, 0, 4)))
-        out.append(Text())
         # D6, same rule as the team listing: only offer what THIS session can
         # do. Both of these lines name the attach seam, so on a viewer they
         # invited the user into the refusal the listing sits above. The detach
         # verb goes with them — there is nothing to detach where nothing can
         # attach.
+        #
+        # The SPACER is inside the guard too (D7). Left outside, the viewer's
+        # listing ended on a blank row separating the entries from nothing at
+        # all — measured block-local as 29 rows against 28 of content, where
+        # the owner's listing and both `/team` cases are flush. A spacer that
+        # outlives the thing it was spacing is the same drift D6 is about, so
+        # it is keyed to the same seam rather than left to be re-noticed.
         if callable(getattr(self._session, "attach_agent_profile", None)):
+            out.append(Text())
             out.append(Text("Send: /agent <name> <message>", style=body))
             # The detach verb belongs in the listing so a user who attached a
             # profile can find their way back to base instructions without
@@ -19712,7 +19738,7 @@ class OperatorApp(App[None]):
                 (
                     team.name,
                     f"Led by {team.manager} · {team.member_count()} "
-                    f"{'role' if team.member_count() == 1 else 'roles'}",
+                    f"{'member' if team.member_count() == 1 else 'members'}",
                     (team.description or "").strip(),
                 )
                 for team in teams

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -6355,40 +6355,51 @@ class OperatorApp(App[None]):
         filled frames geometrically identical: the placeholder is REPLACED
         in place by the first real row, so nothing moves.
 
-        Scoped to the windows where the roster is genuinely still ARRIVING, on
-        purpose (the reviewer's constraint, not a guess):
+        The reserve is owed to exactly ONE question — *is a roster still
+        arriving?* — so the gate asks that question rather than enumerating the
+        states that happen to answer it. Enumerating is what made this wrong
+        twice: the old gate reserved a row for ``self._session is None`` and
+        then subtracted the single terminal state it knew about, so every LATER
+        way to sit without a session silently inherited an eternal "loading…".
 
-        * ``_session_transition_pending`` — a resume/attach the user just asked
-          for. Set by ``_run_session_transition`` and cleared on BOTH success
-          and refusal, so the placeholder cannot outlive the transition.
-        * ``self._session is None`` — no session has been adopted yet. That is
-          the original reported boot race: ``/team lop`` typed while the boot
-          worker was still constructing. The transition flag is False during
-          initial boot, so without this explicit readiness check the race this
-          PR fixes would reserve nothing. This is deliberately NOT keyed to the
-          welcome/boot LAYOUT: an adopted but empty session keeps the welcome
-          visible, while its empty roster is already authoritative and must not
-          leave an eternal placeholder hole.
+        Three cases, in the order they are asked:
 
-        An ADOPTED session past both windows with an empty roster is a real
-        answer ("no teams yet"), and holding a blank hole there forever would
-        read as a stuck list, so it gets no row. No timer drives any of this:
-        the editor re-syncs the picker on every keystroke and the app refills
-        at adoption, so the placeholder retires the moment a window closes.
+        * ``_session_transition_pending`` — a resume/attach/new the user just
+          asked for. Set by ``_run_session_transition`` and cleared on BOTH
+          success and refusal, so the placeholder cannot outlive the
+          transition. Asked FIRST because it promises rows regardless of what
+          the app's state was before it.
+        * an ADOPTED session — its roster is authoritative, empty or not. "No
+          teams yet" is a real answer and must not be dressed up as a wait.
+        * no session and no transition — a roster is genuinely arriving only
+          while the BOOT WORKER is still constructing one. Every other
+          sessionless state is TERMINAL: nothing further arrives until the user
+          acts, and that act is itself a transition, which the first branch
+          already covers.
 
-        A FAILED boot closes the window too (U7-1). ``self._session is None`` is
-        permanently true after ``_on_boot_failed``, so the reserve promised
-        "loading teams…" forever and — because ``is_loading()`` gates Tab/Enter
-        — swallowed every Enter with no feedback, where the same key on an
-        unfixed app at least answered "session is still starting…". A boot
-        failure is as AUTHORITATIVE as an empty roster: nothing is arriving any
-        more, so no row is reserved and Enter reaches the ordinary submit path
-        that reports the session state.
+        The terminal states are named rather than inferred because there is no
+        "boot worker is running" flag to read: ``_boot_failed``
+        (``_on_boot_failed``), ``_setup_state`` (``_enter_setup_state``, which
+        returns BEFORE setting ``_boot_failed`` and so is not covered by it),
+        and ``_stopped_session_id`` (``_stop_local_session``, which detaches the
+        session deliberately). A future way to sit sessionless must be added
+        here; the regression tests pin each one.
+
+        Why an eternal reserve is worse than a blank row: ``is_loading()`` GATES
+        Tab/Enter, so a stuck reserve does not merely withhold the rows the app
+        already has — it also swallows the keys that would dismiss the list or
+        submit the line, with no feedback (U7-1). That is what makes a stranded
+        placeholder read as "this command is broken" rather than "this list is
+        empty".
         """
-        if self._boot_failed and not self._session_transition_pending:
-            return ""
-        if not self._session_transition_pending and self._session is not None:
-            return ""
+        if not self._session_transition_pending:
+            if self._session is not None:
+                # Adopted: its roster is authoritative, empty or not.
+                return ""
+            # Terminal sessionless states: nothing is arriving, so answer with
+            # the real rows (or an honest empty list) rather than a reserve.
+            if self._boot_failed or self._setup_state or self._stopped_session_id:
+                return ""
         # Same voice as every other picker notice (the `/effort` and `/logout`
         # rows): lowercase, no period, says why the list is empty. The registry
         # is named in the text because `/team` and `/agent` share this row and
@@ -6726,12 +6737,36 @@ class OperatorApp(App[None]):
             )
             return
         attach = getattr(session, "attach_team", None)
-        if callable(attach):
-            try:
-                attach(team)
-            except Exception as exc:
-                self._system_notice(f"could not attach team {name!r}: {exc}", "warning")
-                return
+        if not callable(attach):
+            # REFUSE rather than half-execute. This branch used to fall through
+            # to `_submit_command_prompt` below, so a session whose
+            # implementation cannot attach a team still sent the request — and
+            # the receipt said "<manager> is coordinating" while the turn ran
+            # with no roster, no collaboration brief and no project brief. A
+            # wrong persona answering confidently is worse than a refusal,
+            # because nothing on screen tells the user which one they got.
+            #
+            # Reachable on a viewer (`RemoteSession`), which serves the teams
+            # LISTING from local config but has no seam to stamp an attachment
+            # onto the runtime that will build the turn. The wording says
+            # exactly that: the teams are fine, attaching them here is what is
+            # not available — "teams are unavailable" would now be a lie, since
+            # `/team` lists them one line earlier.
+            #
+            # Mirrors the `/agent` guard's shape and voice deliberately: the
+            # asymmetry between the two (that one returned and this one did
+            # not) is what let the silent path ship.
+            self._system_notice(
+                "teams cannot be attached in this session yet. "
+                "Send a message first, then run /team again.",
+                "warning",
+            )
+            return
+        try:
+            attach(team)
+        except Exception as exc:
+            self._system_notice(f"could not attach team {name!r}: {exc}", "warning")
+            return
         # U2: the band names the roster now managed by this session. Synced from
         # the session after the attach, so the segment matches what was actually
         # stamped rather than the name the user typed.
@@ -6994,8 +7029,19 @@ class OperatorApp(App[None]):
         # falls through to normal resolution, which reports the unknown name.
         if name.lower() in ("clear", "none") and not request:
             detach = getattr(session, "clear_agent_profile", None)
-            if callable(detach):
-                detach()
+            if not callable(detach):
+                # Same silent-skip shape as the team attach above, and the same
+                # refusal: without this the notice below reported the persona
+                # detached ("this session uses its base instructions") on a
+                # session that never cleared anything, so a user trying to shed
+                # a role kept talking to it while being told they had not.
+                self._system_notice(
+                    "agents cannot be detached in this session yet. "
+                    "Send a message first, then run /agent clear again.",
+                    "warning",
+                )
+                return
+            detach()
             # U2: the band's active-agent segment disappears on detach. Synced
             # from the session (the source of truth `clear_agent_profile` just
             # blanked), not by pushing "" directly, so the band and session can

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -6332,14 +6332,37 @@ class OperatorApp(App[None]):
             return []
         choices: list[ArgumentChoice] = []
         for team in teams:
-            slots = len(getattr(team, "members", ()) or ()) + 1
-            manager = getattr(team, "manager", "manager")
+            # ``member_count()``, never ``len(members) + 1`` (D2). The old
+            # arithmetic assumed the manager is not itself on the roster, which
+            # is false for real teams — two of the three on the reference
+            # machine list their manager as a member, so the picker reported 8
+            # roles for a 7-role team. It also collapsed a ``reviewer x2`` slot
+            # to one, understating the roster the user assembled.
+            #
+            # This is the count `org_chart.py` and `lop teams` already use, and
+            # the chart is TWO KEYSTROKES from this row — a picker that
+            # disagrees with the boxes it opens is worse than one that says
+            # nothing.
+            # Defensive access kept from the original: this list is built from
+            # whatever the session's registry yields, and a reduced double
+            # without the method must degrade to a row rather than break the
+            # picker mid-keystroke.
+            counter = getattr(team, "member_count", None)
+            slots = counter() if callable(counter) else len(getattr(team, "members", ()) or ())
             description = (getattr(team, "description", "") or "").strip() or "no description"
             choices.append(
                 ArgumentChoice(
                     team.name,
                     description,
-                    detail=f"{slots} roles · led by {manager}",
+                    # ROLES ONLY, no manager (D1). The picker reserves the
+                    # detail column BEFORE the description and drops the
+                    # description first, so a 44-cell
+                    # "<n> roles · led by <manager>" silenced the description
+                    # outright between 76 and 123 columns — the band an
+                    # ordinary terminal sits in. The manager is one keystroke
+                    # away in the listing and the chart; the description is the
+                    # only thing telling the user which team this IS.
+                    detail=f"{slots} {'role' if slots == 1 else 'roles'}",
                 )
             )
         return choices
@@ -6604,7 +6627,11 @@ class OperatorApp(App[None]):
         body = Style(color=theme_mod.semantic_color("dim"))
         rows: list[Any] = [Text("teams", style=section)]
         for team in teams:
-            slots = len(team.members) + 1
+            # ``member_count()`` for the D2 reason the picker documents: the
+            # manager is often ON the roster, so `len(members) + 1` overcounts,
+            # and a multi-count slot was collapsed to one. The listing, the
+            # picker and the org chart must agree.
+            slots = team.member_count()
             rows.append(Padding(Text(team.name, style=heading), (0, 0, 0, 2)))
             role_word = "role" if slots == 1 else "roles"
             rows.append(
@@ -6617,8 +6644,24 @@ class OperatorApp(App[None]):
             if summary:
                 rows.append(Padding(Text(summary, style=body), (0, 0, 0, 4)))
         rows.append(Text())
-        rows.append(Text("Send: /team <name> <message>", style=body))
+        rows.append(Text(self._team_listing_footer(), style=body))
         return RichBlock(Group(*rows))
+
+    def _team_listing_footer(self) -> str:
+        """The next-step line under a `/team` listing, true for THIS session.
+
+        D6: the footer read ``Send: /team <name> <message>`` unconditionally,
+        which on a viewer walks the user straight into the refusal the listing
+        sits above — the listing invites the one action this session cannot
+        perform. Keyed to the same seam the guard checks (``attach_team``), so
+        the invitation and the refusal can never disagree: where running a team
+        works the footer offers it, and where it does not the footer offers
+        charting, which does work.
+        """
+        session = self._session
+        if callable(getattr(session, "attach_team", None)):
+            return "Send: /team <name> <message>"
+        return "Chart: /team chart <name>"
 
     def _submit_command_prompt(
         self, request: str, attachments: Mapping[int, Marked] | None
@@ -6756,9 +6799,28 @@ class OperatorApp(App[None]):
             # Mirrors the `/agent` guard's shape and voice deliberately: the
             # asymmetry between the two (that one returned and this one did
             # not) is what let the silent path ship.
+            #
+            # NO RETRY ADVICE, and NO "yet" (R1, D3). The obvious next step —
+            # "send a message first, then run /team again" — is FALSE and lands
+            # the user somewhere worse than here. Sending a message BINDS the
+            # viewer, and a bound viewer adopts the owner's
+            # `slash_capabilities`, where `team` is scoped
+            # `authoritative_session`. The retry therefore never reaches this
+            # method: it routes to the owner's `_team_slash_result`, which
+            # returns `noop {"type": "team_mutate"}` for the mutating form, and
+            # `_render_authoritative_slash` returns without printing on a noop.
+            # Measured on a bound viewer: routed to owner, 0 prompts sent, 0
+            # transcript rows, no notice — total silence.
+            #
+            # "Run it in the session's own terminal" is false too, and "yet"
+            # promises a wait that never ends: `attach_team` exists only on
+            # `Session`, which `lop` no longer builds at all, so this is
+            # unfollowable BY CONSTRUCTION rather than merely unavailable
+            # today. So the notice names what this session CAN do — list and
+            # chart — instead of gesturing at a capability that is not coming.
             self._system_notice(
-                "teams cannot be attached in this session yet. "
-                "Send a message first, then run /team again.",
+                "this session can list and chart teams, but not run one. "
+                "/team chart <name> shows a roster",
                 "warning",
             )
             return
@@ -6946,10 +7008,17 @@ class OperatorApp(App[None]):
             if summary:
                 out.append(Padding(Text(summary, style=body), (0, 0, 0, 4)))
         out.append(Text())
-        out.append(Text("Send: /agent <name> <message>", style=body))
-        # The detach verb belongs in the listing so a user who attached a
-        # profile can find their way back to base instructions without guessing.
-        out.append(Text("Detach: /agent clear", style=body))
+        # D6, same rule as the team listing: only offer what THIS session can
+        # do. Both of these lines name the attach seam, so on a viewer they
+        # invited the user into the refusal the listing sits above. The detach
+        # verb goes with them — there is nothing to detach where nothing can
+        # attach.
+        if callable(getattr(self._session, "attach_agent_profile", None)):
+            out.append(Text("Send: /agent <name> <message>", style=body))
+            # The detach verb belongs in the listing so a user who attached a
+            # profile can find their way back to base instructions without
+            # guessing.
+            out.append(Text("Detach: /agent clear", style=body))
         return RichBlock(Group(*out))
 
     def _sync_agent_band(self) -> None:
@@ -7035,9 +7104,15 @@ class OperatorApp(App[None]):
                 # detached ("this session uses its base instructions") on a
                 # session that never cleared anything, so a user trying to shed
                 # a role kept talking to it while being told they had not.
+                # Same no-retry rule as the team guard above (R1), but a
+                # different SHAPE (D3): this states the situation rather than
+                # refusing an action. A viewer never attached a profile in the
+                # first place, so "cannot detach" answers a question the user
+                # did not ask; "nothing to detach" is both true and the end of
+                # the matter, and it kills the old lie ("no agent active…")
+                # without inventing a capability.
                 self._system_notice(
-                    "agents cannot be detached in this session yet. "
-                    "Send a message first, then run /agent clear again.",
+                    "no agent is attached in this session, so there is nothing to detach",
                     "warning",
                 )
                 return
@@ -7054,9 +7129,22 @@ class OperatorApp(App[None]):
             return
         attach = getattr(session, "attach_agent_profile", None)
         if not callable(attach):
+            # STALE AFTER THE REGISTRY FIX (Q2). This said "agents are
+            # unavailable in this session" — true when the registry was also
+            # missing, and false now: `/agent` lists this machine's profiles
+            # one line earlier, so the old wording contradicts the rows the
+            # user is looking at. That is precisely the defect this PR fixes
+            # for `/team`, and the registry fix is what made this copy wrong.
+            #
+            # What is missing is the attach seam, not the agents, so the notice
+            # names what this session CAN do — and, per R1/D3, promises no
+            # retry and says no "yet": `agent` is scoped
+            # `authoritative_session`, so a retry after binding routes to the
+            # owner and answers with `agent_mutate` silence, and
+            # `attach_agent_profile` exists only on the `Session` that `lop`
+            # no longer builds.
             self._system_notice(
-                # D4: "agents", matching /team's "teams are unavailable".
-                "agents are unavailable in this session.",
+                "this session can list agents, but not attach one. /agent shows the roster",
                 "warning",
             )
             return
@@ -13855,7 +13943,10 @@ class OperatorApp(App[None]):
             if summary:
                 rows.append(Padding(Text(str(summary), style=body), (0, 0, 0, 4)))
         rows.append(Text())
-        rows.append(Text("Send: /team <name> <message>", style=body))
+        # Same session-aware footer as the local listing (D6): this renders a
+        # FOLLOWER's routed listing, which is exactly the case that cannot run
+        # a team, so the unconditional "Send:" line was wrong most often here.
+        rows.append(Text(self._team_listing_footer(), style=body))
         return RichBlock(Group(*rows))
 
     def _run_slash_command(
@@ -19612,11 +19703,16 @@ class OperatorApp(App[None]):
                 return SlashResult(
                     kind="notice", text="no teams yet. Ask the agent to create one.", style="info"
                 )
+            # ``member_count()`` here too (D2): this producer feeds a FOLLOWER's
+            # listing over the wire, so a different count here would make one
+            # terminal disagree with another about the same team. The plural
+            # is keyed to the number actually shown, which `len(members) == 0`
+            # was not.
             items = [
                 (
                     team.name,
-                    f"Led by {team.manager} · {len(team.members) + 1} "
-                    f"{'role' if len(team.members) == 0 else 'roles'}",
+                    f"Led by {team.manager} · {team.member_count()} "
+                    f"{'role' if team.member_count() == 1 else 'roles'}",
                     (team.description or "").strip(),
                 )
                 for team in teams

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.46.6"
+version = "0.46.7"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/session/test_remote_registries.py
+++ b/tests/unit/session/test_remote_registries.py
@@ -213,17 +213,24 @@ async def test_every_session_attribute_the_tui_reads_exists_on_the_viewer(
     # absence caused the bug, and the guard would pass while blind to its own
     # subject. Parsed rather than instantiated because building a real Session
     # needs a model, a transcript and a config tree.
-    assigned_in_init = set(
+    # Scans the WHOLE class, not just `__init__` (R8). Restricting the scan to
+    # the constructor is the same class of blindness as the class-level
+    # `hasattr` this test was first written with: an attribute assigned in any
+    # other method — a lazy cache, a late-wired handle — would be invisible to
+    # the guard while being perfectly reachable from `app.py`. No public
+    # attribute is assigned outside `__init__` today, so this is latent rather
+    # than live, which is exactly when it is cheap to close.
+    assigned_on_self = set(
         re.findall(
             r"^\s+self\.([a-z_][a-z_0-9]*)\s*(?:[:=])",
-            inspect.getsource(Session.__init__),
+            inspect.getsource(Session),
             re.M,
         )
     )
-    session_surface = assigned_in_init | {
+    session_surface = assigned_on_self | {
         name for name in dir(Session) if not name.startswith("__")
     }
-    assert "team_registry" in session_surface, "the __init__ scan missed a known attribute"
+    assert "team_registry" in session_surface, "the self-assignment scan missed a known attribute"
 
     # Private names are implementation details of one side or the other, and
     # the shared contract is what this guards.
@@ -289,5 +296,52 @@ async def test_a_failed_registry_is_constructed_once_not_once_per_keystroke(
 
     assert constructions["count"] == 1, (
         f"a broken registry was rebuilt {constructions['count']} times for 25 reads; "
-        "the failure must be latched so it costs one construction per session"
+        "the failure must be latched so a keystroke burst costs one construction"
     )
+
+
+@pytest.mark.asyncio
+async def test_a_transient_registry_failure_recovers_without_a_restart(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The latch is a COOLDOWN, not a tombstone (R7).
+
+    A permanent latch means any transient failure — a full disk that clears, a
+    directory momentarily being rewritten by a concurrent `lop team` — costs
+    `/team` and `/agent` for the whole life of the session, silently, with no
+    way back short of restarting. The cooldown keeps R3's guarantee (a burst of
+    keystrokes pays one construction) while letting a repaired registry heal.
+    """
+    import time as _time
+
+    from local_operator.teams import _READ_RECOVERY_COOLDOWN_S
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    real = TeamRegistry
+    attempts = {"count": 0}
+
+    def _flaky(*args, **kwargs):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise OSError("a transient blip")
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr("local_operator.teams.TeamRegistry", _flaky)
+
+    viewer = await RemoteSession.cold(
+        SESSION_ID, config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=_never
+    )
+    try:
+        assert viewer.team_registry is None
+        # Still inside the cooldown: no re-entry, so typing stays cheap.
+        for _ in range(25):
+            assert viewer.team_registry is None
+        assert attempts["count"] == 1, "the cooldown must absorb a keystroke burst"
+
+        _time.sleep(_READ_RECOVERY_COOLDOWN_S + 0.05)
+        assert viewer.team_registry is not None, (
+            "a repaired registry must recover on a later read rather than staying "
+            "dead for the life of the session"
+        )
+    finally:
+        await viewer.dispose()

--- a/tests/unit/session/test_remote_registries.py
+++ b/tests/unit/session/test_remote_registries.py
@@ -1,0 +1,127 @@
+"""A viewer answers `/team` and `/agent` from its OWN config dir.
+
+Teams and agent profiles are LOCAL CONFIG — files under ``<config_dir>/teams``
+and ``<config_dir>/agents`` — not runtime state. The TUI reads both registries
+off the SESSION object (``_team_registry()``, ``_agent_profile_rows()``), so
+when ``lop`` stopped building a ``Session`` and started handing the app a
+``RemoteSession``, both surfaces silently went empty: every team the user had
+vanished from `/team`, and `/agent` fell back to the packaged starters.
+
+That is what these tests pin. The regression is invisible to any test that
+drives a ``Session`` or a ``FakeSession``, because the only broken thing was
+the attribute the viewer did NOT carry — which is exactly why it shipped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from local_operator.session.remote import RemoteSession
+from local_operator.teams import TeamEditFields, TeamRegistry
+
+SESSION_ID = "registryviewer1"
+
+
+async def _never():
+    raise AssertionError("takeover was not expected")
+
+
+def _seed_team(config_dir: Path, name: str) -> None:
+    """Write one real team through the registry's own writer."""
+    TeamRegistry(config_dir).create_team(
+        TeamEditFields(name=name, description=f"{name} description", manager="manager")
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_cold_viewer_lists_the_teams_on_this_machine(tmp_path: Path, monkeypatch) -> None:
+    """The reported bug: three teams on disk, none of them in `/team`.
+
+    A cold viewer has no runtime to ask and — until the first message — never
+    will, so a registry served from the owner would leave `/team` permanently
+    empty. Reading the viewer's own config dir is what makes the listing
+    answerable at all in this state.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    for name in ("alpha", "beta", "gamma"):
+        _seed_team(tmp_path, name)
+
+    viewer = await RemoteSession.cold(
+        SESSION_ID, config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=_never
+    )
+    try:
+        registry = viewer.team_registry
+        assert registry is not None, "a viewer must serve teams from its own config dir"
+        assert sorted(team.name for team in registry.list_teams()) == ["alpha", "beta", "gamma"]
+    finally:
+        await viewer.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_cold_viewer_serves_the_agent_registry_too(tmp_path: Path, monkeypatch) -> None:
+    """`/agent` reads `agent_registry` off the session by the same route.
+
+    One root cause, two user-visible surfaces: a fix that restored only teams
+    would ship a half-fixed picker.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    viewer = await RemoteSession.cold(
+        SESSION_ID, config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=_never
+    )
+    try:
+        registry = viewer.agent_registry
+        assert registry is not None, "a viewer must serve agent profiles from its own config dir"
+        # The registry is rooted at the viewer's config dir, not at some
+        # process-global default — that is what makes it the USER's agents.
+        assert Path(registry.config_dir) == tmp_path
+    finally:
+        await viewer.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_registries_are_built_once_and_cached(tmp_path: Path, monkeypatch) -> None:
+    """Constructing a registry walks the config tree; a repaint must not.
+
+    ``TeamRegistry.__init__`` also runs crash recovery, and the picker
+    re-derives its rows on EVERY keystroke, so an uncached property would put
+    a directory walk plus a recovery probe on the typing path.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _seed_team(tmp_path, "alpha")
+
+    viewer = await RemoteSession.cold(
+        SESSION_ID, config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=_never
+    )
+    try:
+        assert viewer.team_registry is viewer.team_registry
+        assert viewer.agent_registry is viewer.agent_registry
+    finally:
+        await viewer.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_unusable_registry_degrades_one_feature_not_the_session(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A broken teams dir costs `/team`, never the conversation.
+
+    Same discipline ``session_factory`` applies to its own construction: the
+    session must still open, and `/team` reports teams are unavailable rather
+    than taking the whole session down with it.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+
+    def _explode(*_args, **_kwargs):
+        raise OSError("teams directory is unreadable")
+
+    monkeypatch.setattr("local_operator.teams.TeamRegistry", _explode)
+
+    viewer = await RemoteSession.cold(
+        SESSION_ID, config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=_never
+    )
+    try:
+        assert viewer.team_registry is None
+    finally:
+        await viewer.dispose()

--- a/tests/unit/session/test_remote_registries.py
+++ b/tests/unit/session/test_remote_registries.py
@@ -116,6 +116,12 @@ async def test_an_unusable_registry_degrades_one_feature_not_the_session(
     def _explode(*_args, **_kwargs):
         raise OSError("teams directory is unreadable")
 
+    # Patching the MODULE attribute works only because the property imports
+    # `TeamRegistry` inside its own body, so each call re-reads the patched
+    # name (R6). Hoisting that import to module scope for performance would
+    # make this test silently stop exercising the guard while still passing
+    # green — if you move the import, patch `local_operator.session.remote`'s
+    # binding instead.
     monkeypatch.setattr("local_operator.teams.TeamRegistry", _explode)
 
     viewer = await RemoteSession.cold(
@@ -125,3 +131,163 @@ async def test_an_unusable_registry_degrades_one_feature_not_the_session(
         assert viewer.team_registry is None
     finally:
         await viewer.dispose()
+
+
+@pytest.mark.asyncio
+async def test_every_session_attribute_the_tui_reads_exists_on_the_viewer(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The durable guard for the CLASS of bug this file's other tests fix (R5).
+
+    `/team` and `/agent` broke because `app.py` reads local machine config off
+    whatever object happens to be in ``self._session``, through ~50 unchecked
+    ``getattr`` calls, and ``RemoteSession`` silently lacked two of the names
+    ``Session`` provides. Nothing raised: every surface degraded quietly, which
+    is why it reached a user rather than a test.
+
+    So this asserts PRESENCE, not behaviour: every public attribute the TUI
+    reads off a session, which ``Session`` provides, must also exist on a cold
+    ``RemoteSession`` — or be named in ``KNOWN_VIEWER_GAPS`` below with the
+    reason. A NEW divergence fails here, at the seam, instead of as an empty
+    picker on the reporter's machine.
+
+    The allowlist is deliberately explicit rather than a blanket skip. Each
+    entry is a real user-visible or quiet degradation on the viewer path,
+    catalogued during this fix and scoped to their own follow-up work; the
+    point of listing them is that adding a fifteenth requires a deliberate
+    edit here rather than passing unnoticed.
+    """
+    import inspect
+    import re
+
+    from local_operator.session.session import Session
+
+    # Attributes the viewer genuinely cannot serve today. Shrinking this list is
+    # the follow-up work; GROWING it must be a conscious decision.
+    known_viewer_gaps = {
+        # Attach/detach seam: needs a control op or engage-path routing. The
+        # `/team` and `/agent` guards refuse loudly rather than half-execute.
+        "attach_team",
+        "attach_agent_profile",
+        "clear_agent_profile",
+        "agent_brief",
+        # `/credential`'s store: the picker resolves an empty name list, so
+        # stored credentials are invisible on a viewer. Its own follow-up.
+        "variables",
+        "journal_credential_change",
+        # Guarded fallbacks in app.py that degrade to a documented default
+        # (fork clones from disk, routing reads config.yml, usage/context
+        # measurement is skipped, bang-mode results are not journalled).
+        "request_fork",
+        "has_pending_fork",
+        "routing_settings",
+        "record_shell",
+        "measure_preloaded_context",
+        "preflight_usage",
+        "refresh_frontend_usage",
+        "wears_inherited_title",
+        # The attached team OBJECT. The viewer reports the attached roster by
+        # name through `active_team_name` (which it does provide) and cannot
+        # hold the Team itself without the attach seam above.
+        "active_team",
+        # Set by `Session._restore_attachment` to report a team/agent that
+        # could not be re-resolved on resume. A viewer performs no restore, so
+        # it has nothing to report; `app.py` reads it with a "" default.
+        "attachment_restore_notice",
+    }
+
+    source = (Path(__file__).parents[3] / "local_operator" / "tui" / "app.py").read_text(
+        encoding="utf-8"
+    )
+    read_by_tui = {
+        match.group(1)
+        for match in re.finditer(
+            r'getattr\(\s*(?:self\._session|session)\s*,\s*["\']([a-z_][a-z_0-9]*)["\']',
+            source,
+        )
+    }
+    # `Session`'s surface includes the attributes it assigns in `__init__`, not
+    # just class-level ones. That distinction is load-bearing: `team_registry`
+    # and `agent_registry` — the two this PR restored — are INSTANCE attributes,
+    # so a plain `hasattr(Session, name)` excludes exactly the names whose
+    # absence caused the bug, and the guard would pass while blind to its own
+    # subject. Parsed rather than instantiated because building a real Session
+    # needs a model, a transcript and a config tree.
+    assigned_in_init = set(
+        re.findall(
+            r"^\s+self\.([a-z_][a-z_0-9]*)\s*(?:[:=])",
+            inspect.getsource(Session.__init__),
+            re.M,
+        )
+    )
+    session_surface = assigned_in_init | {
+        name for name in dir(Session) if not name.startswith("__")
+    }
+    assert "team_registry" in session_surface, "the __init__ scan missed a known attribute"
+
+    # Private names are implementation details of one side or the other, and
+    # the shared contract is what this guards.
+    shared = {name for name in read_by_tui if not name.startswith("_") and name in session_surface}
+    assert shared, "the getattr scan found nothing — the pattern has drifted"
+
+    viewer = await RemoteSession.cold(
+        SESSION_ID, config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=_never
+    )
+    try:
+        missing = {name for name in shared if not hasattr(viewer, name)}
+    finally:
+        await viewer.dispose()
+
+    new_gaps = missing - known_viewer_gaps
+    assert not new_gaps, (
+        f"the TUI reads {sorted(new_gaps)} off the session and a viewer does not provide "
+        "it, so that surface fails only on the viewer path — the exact shape of the "
+        "/team and /agent regression. Implement it on RemoteSession, or add it to "
+        "known_viewer_gaps with the reason."
+    )
+    # The registries this PR restored must never reappear as gaps.
+    assert "team_registry" not in missing
+    assert "agent_registry" not in missing
+
+    stale = known_viewer_gaps - missing
+    assert not stale, (
+        f"{sorted(stale)} is listed as a viewer gap but the viewer now provides it — "
+        "remove it from known_viewer_gaps so the list keeps meaning something."
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_failed_registry_is_constructed_once_not_once_per_keystroke(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The FAILURE path is latched too, not just the success path (R3).
+
+    Returning ``None`` out of the ``except`` without recording it left the
+    cache empty, so the next read re-entered the constructor: 25 property
+    reads measured 25 constructions. ``_team_choices`` runs on every keystroke
+    while the picker is open, so an unreadable registry put a directory walk
+    plus a recovery probe on the typing path — the cost ``teams.py`` is
+    explicit about keeping off that loop.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    constructions = {"count": 0}
+
+    def _explode(*_args, **_kwargs):
+        constructions["count"] += 1
+        raise OSError("teams directory is unreadable")
+
+    monkeypatch.setattr("local_operator.teams.TeamRegistry", _explode)
+
+    viewer = await RemoteSession.cold(
+        SESSION_ID, config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=_never
+    )
+    try:
+        for _ in range(25):
+            assert viewer.team_registry is None
+    finally:
+        await viewer.dispose()
+
+    assert constructions["count"] == 1, (
+        f"a broken registry was rebuilt {constructions['count']} times for 25 reads; "
+        "the failure must be latched so it costs one construction per session"
+    )

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -346,7 +346,9 @@ async def test_bare_team_lists_without_a_user_row() -> None:
         painted = _painted(app)
     assert rows == [], rows
     assert "feature-release" in painted, painted
-    assert "Led by manager · 2 roles" in painted, painted
+    # D2: `member_count()` — one member is one role. The old assertion pinned
+    # `len(members) + 1`, which counted a manager that is not on this roster.
+    assert "Led by manager · 1 role" in painted, painted
     assert "Ship a change" in painted, painted
     assert "Send: /team <name> <message>" in painted, painted
     assert "manager=" not in painted, painted
@@ -1871,6 +1873,261 @@ async def test_team_launch_refuses_instead_of_sending_without_the_briefs(tmp_pat
         rendered = " ".join(
             str(getattr(block, "_text", "") or "") for block in app._transcript_view().children
         )
-        assert "teams cannot be attached in this session" in rendered, rendered
+        assert "but not run one" in rendered, rendered
         # The old wording would now be a lie: `/team` lists them one line up.
         assert "teams are unavailable" not in rendered, rendered
+        # It names a capability this session HAS rather than one it lacks (D3).
+        assert "/team chart" in rendered, rendered
+
+
+@pytest.mark.asyncio
+async def test_agent_clear_refuses_instead_of_reporting_a_detach_that_did_not_happen() -> None:
+    """The symmetric half of the anti-asymmetry fix, pinned (R2).
+
+    ``/agent clear`` had the same shape the team guard was fixed for:
+    ``if callable(detach): detach()`` with no else, then the notice below it
+    announced "no agent active; this session uses its base instructions" —
+    on a session where nothing had cleared. A user shedding a role kept
+    talking to it while being told they had not.
+
+    This PR's own argument is that the team/agent asymmetry is what let the
+    silent path ship, so the agent half must be pinned or the same refactor
+    can reintroduce it with nothing objecting.
+    """
+
+    class NoDetachSession(FakeSession):
+        # The viewer's shape: no local detach seam.
+        clear_agent_profile = None  # type: ignore[assignment]
+
+    session = NoDetachSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(40):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        assert app._session is session
+        assert not callable(getattr(app._session, "clear_agent_profile", None))
+
+        app._cmd_agent("clear", app._notice, None)
+        await pilot.pause()
+
+        rendered = " ".join(
+            str(getattr(block, "_text", "") or "") for block in app._transcript_view().children
+        )
+        # D3: states the SITUATION rather than refusing an action — a viewer
+        # never attached a profile, so there is genuinely nothing to detach.
+        assert "nothing to detach" in rendered, rendered
+        # The lie the unguarded path told must not appear.
+        assert "no agent active" not in rendered, rendered
+
+
+@pytest.mark.asyncio
+async def test_neither_refusal_promises_a_retry_that_answers_with_silence() -> None:
+    """R1: the guards must not send the user somewhere worse than here.
+
+    "Send a message first, then run /team again" was false. Sending a message
+    BINDS the viewer, and a bound viewer adopts the owner's
+    ``slash_capabilities`` where `team`/`agent` are scoped
+    ``authoritative_session`` — so the retry never reaches these guards. It
+    routes to the owner, which answers the mutating form with
+    ``noop {"type": "team_mutate"}``, and ``_render_authoritative_slash``
+    returns without printing on a noop: zero prompts, zero transcript rows,
+    no notice at all.
+
+    A guard whose purpose is to stop the app claiming something happened must
+    not itself promise a remedy that does nothing, so it makes no promise.
+    """
+    from local_operator.session.frontend_state import _slash_capabilities
+
+    # The states the old advice named are BOTH authoritative, which is the
+    # mechanism that made the retry silent. Pin it so the wording cannot drift
+    # back to promising one.
+    scopes = {
+        capability.command: getattr(capability.scope, "value", capability.scope)
+        for capability in _slash_capabilities()
+    }
+    assert scopes["team"] == "authoritative_session"
+    assert scopes["agent"] == "authoritative_session"
+
+    class NoAttachSession(FakeSession):
+        attach_team = None  # type: ignore[assignment]
+        clear_agent_profile = None  # type: ignore[assignment]
+
+    from local_operator.teams import TeamEditFields, TeamRegistry
+
+    with tempfile.TemporaryDirectory() as directory:
+        registry = TeamRegistry(Path(directory))
+        registry.create_team(TeamEditFields(name="alpha", description="d", manager="manager"))
+
+        session = NoAttachSession()
+        session.team_registry = registry
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(40):
+                await pilot.pause()
+                if app._session is not None:
+                    break
+
+            app._cmd_team("alpha do the thing", app._notice, None)
+            app._cmd_agent("clear", app._notice, None)
+            await pilot.pause()
+
+            rendered = " ".join(
+                str(getattr(block, "_text", "") or "") for block in app._transcript_view().children
+            )
+            # No retry instruction of any shape.
+            assert "run /team again" not in rendered, rendered
+            assert "run /agent clear again" not in rendered, rendered
+            assert "Send a message first" not in rendered, rendered
+            # No open-ended "yet" either: `attach_team` exists only on the
+            # `Session` `lop` no longer builds, so a wait would never end (D3).
+            assert "yet" not in rendered, rendered
+            # It still says what IS true.
+            assert "but not run one" in rendered, rendered
+            assert "nothing to detach" in rendered, rendered
+
+
+@pytest.mark.asyncio
+async def test_no_notice_calls_a_registry_unavailable_while_its_rows_are_listed(tmp_path) -> None:
+    """Q2: restoring the registries made the old attach copy false.
+
+    `/agent <name> <message>` answered "agents are unavailable in this
+    session" on a session whose `/agent ` list had just rendered 13 profiles.
+    That wording was true only while the REGISTRY was also missing; once the
+    registry resolves, the sentence contradicts the rows the user is looking
+    at — the same defect this PR fixes for `/team`, introduced by this PR's
+    own fix and closed in the same commit.
+
+    The distinction the copy must keep: the agents are fine and listable; the
+    ATTACH SEAM is what a viewer lacks.
+    """
+    from local_operator.agents import AgentRegistry
+
+    class NoAttachSession(FakeSession):
+        # A viewer's shape: registries resolve, attach seams do not.
+        attach_agent_profile = None  # type: ignore[assignment]
+
+    session = NoAttachSession()
+    session.agent_registry = AgentRegistry(tmp_path)
+
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(40):
+            await pilot.pause()
+            if app._session is not None:
+                break
+
+        # The listing resolves — that is what makes "unavailable" a lie.
+        assert app._agent_profile_rows(), "the fixture must offer rows for this to be a lie"
+
+        app._cmd_agent("reviewer hello", app._notice, None)
+        await pilot.pause()
+
+        rendered = " ".join(
+            str(getattr(block, "_text", "") or "") for block in app._transcript_view().children
+        )
+        assert "but not attach one" in rendered, rendered
+        assert "agents are unavailable" not in rendered, rendered
+        # Points at the surface that DOES work in this session (D3).
+        assert "/agent shows the roster" in rendered, rendered
+        # And no retry promise, for the R1 reason.
+        assert "Send a message first" not in rendered, rendered
+
+
+@pytest.mark.asyncio
+async def test_the_roster_count_matches_the_chart_it_opens(tmp_path) -> None:
+    """D2: `len(members) + 1` overcounts every team whose manager is a member.
+
+    The old arithmetic assumed the manager sits OUTSIDE the roster. On real
+    teams it often does not — two of the three on the reference machine list
+    their manager as a member — so the picker advertised 8 roles for a 7-role
+    team. The org chart is TWO KEYSTROKES from that row and counts with
+    ``member_count()``, so the picker contradicted the boxes it opens.
+
+    ``member_count()`` also sums slot counts, so a ``reviewer x2`` slot stops
+    being reported as one member.
+    """
+    from local_operator.org_chart import _team_detail
+    from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
+
+    registry = TeamRegistry(tmp_path)
+    # The shape that broke: the manager is ALSO on the roster.
+    registry.create_team(
+        TeamEditFields(
+            name="onroster",
+            manager="manager",
+            members=[TeamMember(role="manager"), TeamMember(role="coder")],
+        )
+    )
+    # And a multi-count slot, which the old count collapsed to one.
+    registry.create_team(
+        TeamEditFields(
+            name="doubled",
+            manager="boss",
+            members=[TeamMember(role="reviewer", count=2)],
+        )
+    )
+
+    session = FakeSession()
+    session.team_registry = registry
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(40):
+            await pilot.pause()
+            if app._session is not None:
+                break
+
+        details = {choice.name: choice.detail for choice in app._team_choices()}
+
+    for name, expected in (("onroster", 2), ("doubled", 2)):
+        team = registry.get_team_by_name(name)
+        assert team is not None
+        assert team.member_count() == expected
+        # The picker's number and the chart's number are the SAME number.
+        assert details[name] == f"{expected} roles", details[name]
+        assert f"{expected} members" in _team_detail(team), _team_detail(team)
+
+
+@pytest.mark.asyncio
+async def test_the_detail_column_leaves_room_for_the_description(tmp_path) -> None:
+    """D1: a wide detail silences the description at ordinary widths.
+
+    The picker reserves the detail column BEFORE the description and drops the
+    description first, so a 44-cell ``<n> roles · led by <manager>`` blanked
+    the description outright between roughly 76 and 123 columns — the band an
+    ordinary terminal sits in, including the 100-column frame this PR's own
+    first evidence was captured at. The manager is one keystroke away in the
+    listing and the chart; the description is the only thing telling the user
+    which team a row IS.
+    """
+    from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
+
+    registry = TeamRegistry(tmp_path)
+    registry.create_team(
+        TeamEditFields(
+            name="data-investigations",
+            manager="data-investigations-manager",
+            description="Investigates global-public subjects and turns them into records",
+            members=[TeamMember(role="coder")],
+        )
+    )
+
+    session = FakeSession()
+    session.team_registry = registry
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(40):
+            await pilot.pause()
+            if app._session is not None:
+                break
+
+        choices = app._team_choices()
+
+    detail = choices[0].detail
+    # The manager's name is what made this column wide, and it is not a fact
+    # the row needs to carry.
+    assert "led by" not in detail, detail
+    assert detail == "1 role", detail
+    # Comfortably inside `/agent`'s 15-cell detail, which never had this bug.
+    assert len(detail) <= 15, detail

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -1715,3 +1715,162 @@ async def test_genuine_still_starting_keeps_its_wording() -> None:
         assert app._no_session_notice() == ("session is still starting…", "warning")
         release.set()
         await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_a_stopped_session_shows_real_rows_not_an_eternal_placeholder() -> None:
+    """`/stop` is TERMINAL: nothing is arriving, so the list must answer.
+
+    The reserve was keyed to ``self._session is None`` with a single
+    subtraction for the failed boot, so every LATER way to sit without a
+    session inherited "loading teams…" forever. ``/stop`` detaches the session
+    on purpose (``_stop_local_session``), which is exactly that shape: the user
+    ended the session, no roster is on its way, and the picker promised one
+    anyway. Worse than a blank row, because ``is_loading()`` gates Tab/Enter.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        # Exactly what `_stop_local_session` leaves behind.
+        app._session = None
+        app._stopped_session_id = "sess-abc123"
+
+        assert app._name_list_pending_notice("team") == ""
+        assert app._name_list_pending_notice("agent") == ""
+
+
+@pytest.mark.asyncio
+async def test_the_setup_state_shows_real_rows_not_an_eternal_placeholder() -> None:
+    """First-run setup is TERMINAL too, and is NOT covered by `_boot_failed`.
+
+    ``_enter_setup_state`` returns from ``_on_boot_failed`` BEFORE the
+    ``_boot_failed = True`` assignment — deliberately, because "no hosting
+    configured" is guidance rather than a crash. So the one subtraction the old
+    gate made did not apply here, and a user who opened `lop` with nothing
+    configured got a permanent "loading teams…" with Tab and Enter swallowed.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._session = None
+        app._setup_state = True
+        # The flag the old gate keyed on is explicitly NOT set in this state.
+        assert app._boot_failed is False
+
+        assert app._name_list_pending_notice("team") == ""
+        assert app._name_list_pending_notice("agent") == ""
+
+
+@pytest.mark.asyncio
+async def test_a_stopped_session_does_not_swallow_tab_and_enter() -> None:
+    """The other half of the reported breakage, through the real surface.
+
+    ``is_loading()`` gates Tab/Enter, so a stranded reserve does not merely
+    withhold rows — it eats the keys that would dismiss the list or submit the
+    line. That is what makes an empty list read as "the command is broken".
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._session = None
+        app._stopped_session_id = "sess-abc123"
+
+        editor = app._editor()
+        editor.focus()
+        await pilot.pause()
+        for ch in "/team ":
+            await pilot.press(ch if ch != " " else "space")
+        await pilot.pause()
+
+        # No latch, so accept keys reach their ordinary handlers.
+        assert editor.picker.is_loading() is False
+
+        await pilot.press("enter")
+        await pilot.pause()
+        assert editor.text == "", "Enter was swallowed by a stranded loading reserve"
+
+
+@pytest.mark.asyncio
+async def test_a_genuinely_arriving_roster_still_reserves_its_row() -> None:
+    """The reserve must survive for the window it was written for (D1).
+
+    Both real windows: the boot worker still constructing, and a transition the
+    user just asked for. Removing the placeholder from these would bring back
+    the one-row dock jump the reserve exists to prevent.
+    """
+    release = asyncio.Event()
+
+    async def delayed_factory() -> FakeSession:
+        await release.wait()
+        return FakeSession()
+
+    app = OperatorApp(delayed_factory)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        # Boot worker still running: no session, and no terminal state set.
+        assert app._session is None
+        assert app._boot_failed is False
+        assert app._setup_state is False
+        assert app._stopped_session_id == ""
+        assert app._name_list_pending_notice("team") == "loading teams…"
+        assert app._name_list_pending_notice("agent") == "loading agent roster…"
+
+        # A transition promises rows even from a terminal state.
+        app._stopped_session_id = "sess-abc123"
+        app._session_transition_pending = True
+        assert app._name_list_pending_notice("team") == "loading teams…"
+
+        app._session_transition_pending = False
+        app._stopped_session_id = ""
+        release.set()
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_team_launch_refuses_instead_of_sending_without_the_briefs(tmp_path) -> None:
+    """A session that cannot attach a team must not run the request anyway.
+
+    The guard was ``if callable(attach):`` with NO else, so a session whose
+    implementation has no ``attach_team`` fell through to the prompt: the
+    receipt said "<manager> is coordinating" while the turn ran with no roster
+    and no briefs. A confidently wrong persona is worse than a refusal, because
+    nothing on screen distinguishes the two.
+
+    Reachable on the viewer (`RemoteSession`), which lists teams from local
+    config but has no seam to stamp an attachment onto the runtime that builds
+    the turn.
+    """
+    from local_operator.teams import TeamEditFields, TeamRegistry
+
+    registry = TeamRegistry(tmp_path)
+    registry.create_team(TeamEditFields(name="alpha", description="d", manager="manager"))
+
+    # Exactly the viewer's shape: the LISTING resolves, the ATTACH does not.
+    # A subclass rather than `del type(session).attach_team`, which would strip
+    # the method from the SHARED FakeSession class for every later test.
+    class NoAttachSession(FakeSession):
+        attach_team = None  # type: ignore[assignment]
+
+    session = NoAttachSession()
+    session.team_registry = registry
+
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(40):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        assert app._session is session
+        assert not callable(getattr(app._session, "attach_team", None))
+
+        app._cmd_team("alpha do the thing", app._notice, None)
+        await pilot.pause()
+
+        # The request was NOT sent: no briefs, no turn.
+        assert session.prompts == [], "the request ran without the team briefs"
+        rendered = " ".join(
+            str(getattr(block, "_text", "") or "") for block in app._transcript_view().children
+        )
+        assert "teams cannot be attached in this session" in rendered, rendered
+        # The old wording would now be a lie: `/team` lists them one line up.
+        assert "teams are unavailable" not in rendered, rendered

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -346,9 +346,13 @@ async def test_bare_team_lists_without_a_user_row() -> None:
         painted = _painted(app)
     assert rows == [], rows
     assert "feature-release" in painted, painted
-    # D2: `member_count()` — one member is one role. The old assertion pinned
-    # `len(members) + 1`, which counted a manager that is not on this roster.
-    assert "Led by manager · 1 role" in painted, painted
+    # D2/R6: `member_count()` with the label that matches it. One roster member
+    # is "1 member" — the manager is named by "Led by" in the same line and is
+    # deliberately not in the count, exactly as the org chart badges it. The
+    # original assertion pinned `len(members) + 1` ("2 roles"), which counted
+    # the manager twice over; calling the corrected number "roles" then read
+    # one short against the chart.
+    assert "Led by manager · 1 member" in painted, painted
     assert "Ship a change" in painted, painted
     assert "Send: /team <name> <message>" in painted, painted
     assert "manager=" not in painted, painted
@@ -2085,7 +2089,7 @@ async def test_the_roster_count_matches_the_chart_it_opens(tmp_path) -> None:
         assert team is not None
         assert team.member_count() == expected
         # The picker's number and the chart's number are the SAME number.
-        assert details[name] == f"{expected} roles", details[name]
+        assert details[name] == f"{expected} members", details[name]
         assert f"{expected} members" in _team_detail(team), _team_detail(team)
 
 
@@ -2128,6 +2132,120 @@ async def test_the_detail_column_leaves_room_for_the_description(tmp_path) -> No
     # The manager's name is what made this column wide, and it is not a fact
     # the row needs to carry.
     assert "led by" not in detail, detail
-    assert detail == "1 role", detail
+    assert detail == "1 member", detail
     # Comfortably inside `/agent`'s 15-cell detail, which never had this bug.
     assert len(detail) <= 15, detail
+
+
+@pytest.mark.asyncio
+async def test_the_picker_count_equals_the_boxes_the_chart_draws(tmp_path) -> None:
+    """The invariant BOTH count bugs violated, pinned directly.
+
+    D2 counted `len(members) + 1`, which overcounted a team whose manager is
+    also a roster member. R6 then labelled `member_count()` "roles", which read
+    one SHORT for a team whose manager is not — the same contradiction pointing
+    the other way. Neither existing test expressed the property the two
+    surfaces actually have to share, so each fix could satisfy its own test
+    while disagreeing with the chart.
+
+    The property: the number `/team ` renders for a team is the number of
+    member boxes `/team chart <name>` draws for it — the manager excluded from
+    both, because the chart draws him as a structural node and badges the rest
+    (`org_render._member_badge`). Exercised with the manager ON the roster and
+    OFF it, which is exactly the pair that separates the two arithmetics.
+    """
+    from local_operator.org_chart import resolve_org
+    from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
+    from local_operator.tui.org_render import _member_badge
+
+    registry = TeamRegistry(tmp_path)
+    # manager NOT on the roster — the shape R6 got wrong.
+    registry.create_team(
+        TeamEditFields(name="mgr-off", manager="boss", members=[TeamMember(role="coder")])
+    )
+    # manager ALSO on the roster — the shape D2 got wrong.
+    registry.create_team(
+        TeamEditFields(
+            name="mgr-on",
+            manager="manager",
+            members=[TeamMember(role="manager"), TeamMember(role="coder")],
+        )
+    )
+    # A multi-count slot, which `len(members)` collapses either way.
+    registry.create_team(
+        TeamEditFields(
+            name="doubled", manager="boss", members=[TeamMember(role="reviewer", count=2)]
+        )
+    )
+
+    session = FakeSession()
+    session.team_registry = registry
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(40):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        details = {choice.name: choice.detail for choice in app._team_choices()}
+
+    for name, expected in (("mgr-off", 1), ("mgr-on", 2), ("doubled", 2)):
+        # What the picker row says.
+        word = "member" if expected == 1 else "members"
+        assert details[name] == f"{expected} {word}", details[name]
+
+        # What the chart actually draws for the same team, counted from the
+        # resolved tree rather than restated from the same helper — otherwise
+        # this asserts a function equals itself.
+        root = resolve_org(name, teams=registry, agents=None)
+        leaf_kinds = ("role", "specialist", "seed", "unresolved", "cycle", "depth")
+        drawn = sum(child.count for child in root.children if child.kind in leaf_kinds)
+        assert drawn == expected, f"{name}: picker says {expected}, chart draws {drawn}"
+        # And the badge the collapsed box carries agrees too.
+        assert _member_badge(root).strip() == f"·{expected}", _member_badge(root)
+
+
+@pytest.mark.asyncio
+async def test_the_agent_listing_does_not_end_on_a_dangling_spacer(tmp_path) -> None:
+    """D7: the blank row must go with the footer it was spacing.
+
+    The D6 remediation made the `Send:`/`Detach:` footer conditional on the
+    attach seam but left the `Text()` spacer above it unconditional, so a
+    viewer's `/agent` listing ended on a blank row separating the entries from
+    nothing at all. The owner's listing and both `/team` listings are flush;
+    only this one drifted, because it is the only listing whose footer can be
+    absent.
+    """
+    from rich.console import Console
+
+    from local_operator.agents import AgentRegistry
+
+    class NoAttachSession(FakeSession):
+        attach_agent_profile = None  # type: ignore[assignment]
+
+    def _trailing_blanks(app: OperatorApp) -> tuple[int, list[str]]:
+        block = app._agent_list_block([("architect", "role", "Decide how")])
+        console = Console(width=100, no_color=True)
+        with console.capture() as captured:
+            console.print(getattr(block, "_renderable", None) or block.renderable)
+        lines = captured.get().rstrip("\n").split("\n")
+        blanks = 0
+        for line in reversed(lines):
+            if line.strip():
+                break
+            blanks += 1
+        return blanks, lines
+
+    for session_cls, expects_footer in ((FakeSession, True), (NoAttachSession, False)):
+        session = session_cls()
+        session.agent_registry = AgentRegistry(tmp_path)
+        app = OperatorApp(lambda s=session: _factory(s))
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(40):
+                await pilot.pause()
+                if app._session is not None:
+                    break
+            blanks, lines = _trailing_blanks(app)
+
+        assert blanks == 0, f"{session_cls.__name__} listing ends on {blanks} blank row(s): {lines}"
+        # The spacer is only correct when it is actually spacing something.
+        assert ("Send: /agent <name> <message>" in "\n".join(lines)) is expects_footer, lines

--- a/tests/unit/tui/test_team_chart.py
+++ b/tests/unit/tui/test_team_chart.py
@@ -259,14 +259,15 @@ async def test_picker_first_slot_offers_teams_first_then_chart_subcommand() -> N
     # U3: a team literally named `chart` still appears, completing to the `=chart`
     # ESCAPE (not the bare name, which would route to the subcommand); its detail
     # names the talk path, so the collision is resolvable from the picker.
-    # Detail is the D1/D2 shape: roster size only (`member_count()`, manager
-    # excluded), no "led by" — the manager's name is what made this column wide
-    # enough to silence descriptions at ordinary widths.
-    assert ("=chart", "talk to team · 1 role") in rows
+    # Detail is the D1/D2/R6 shape: roster size only (`member_count()`, manager
+    # excluded) labelled "member(s)" to match that number, and no "led by" —
+    # the manager's name is what made this column wide enough to silence
+    # descriptions at ordinary widths.
+    assert ("=chart", "talk to team · 1 member") in rows
     # A non-colliding team keeps its plain name.
     assert any(name == "org" for name, _ in rows)
     # The bare `chart` name is NOT offered as a team row (it would mis-route).
-    assert ("chart", "1 role") not in rows
+    assert ("chart", "1 member") not in rows
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_team_chart.py
+++ b/tests/unit/tui/test_team_chart.py
@@ -259,11 +259,14 @@ async def test_picker_first_slot_offers_teams_first_then_chart_subcommand() -> N
     # U3: a team literally named `chart` still appears, completing to the `=chart`
     # ESCAPE (not the bare name, which would route to the subcommand); its detail
     # names the talk path, so the collision is resolvable from the picker.
-    assert ("=chart", "talk to team · 2 roles · led by m") in rows
+    # Detail is the D1/D2 shape: roster size only (`member_count()`, manager
+    # excluded), no "led by" — the manager's name is what made this column wide
+    # enough to silence descriptions at ordinary widths.
+    assert ("=chart", "talk to team · 1 role") in rows
     # A non-colliding team keeps its plain name.
     assert any(name == "org" for name, _ in rows)
     # The bare `chart` name is NOT offered as a team row (it would mis-route).
-    assert ("chart", "2 roles · led by m") not in rows
+    assert ("chart", "1 role") not in rows
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## `/team` lists nothing and `/agent` shows only the packaged starters

Reported as "/team is no longer working, my teams are not showing up" on
v0.46.0. Reproduced against the real `OperatorApp`, driven with the real
cold-viewer factory and the reporter's own config dir, typing `/team ` as
keystrokes:

| probe | v0.46.0 | this PR |
|---|---|---|
| session the TUI holds | `RemoteSession` | `RemoteSession` |
| `_team_choices()` | `[]` | `['data-investigations', 'lopdev', 'minervadev']` |
| `_agent_profile_rows()` | 6 (packaged only) | 13 (incl. authored specialists) |
| `_name_list_pending_notice("team")` | `''` | `''` |
| `picker.is_loading()` | `False` | `False` |

The last two rows matter because they rule out the obvious suspect. The picker
was **not** stuck on a `loading teams…` placeholder and Tab/Enter were **not**
being swallowed — a session *was* adopted, so the reserve correctly retired.
The rows were simply empty.

## Root cause

PR #576 made `lop`'s TUI a **viewer**. `cli.py`'s session factory now only ever
returns a `RemoteSession` — attached when a runtime record exists,
`RemoteSession.cold(...)` otherwise — and says so in as many words:

> THE OWNER PATH IS GONE FROM `lop`. This factory only ever returns a
> RemoteSession … the TUI process never builds a `Session`.

But the TUI reads both registries **off the session object**:

```python
def _team_registry(self):        # app.py
    return getattr(session, "team_registry", None)   # _team_choices() feeds /team

registry = getattr(session, "agent_registry", None)  # _agent_profile_rows() feeds /agent
```

`Session` carried both. `RemoteSession` carried neither — verified on a live
cold instance, not just the class. So both resolved to `None`, `_team_choices()`
returned `[]`, and `/agent` fell back to the packaged seeds. Nothing raised;
every surface degraded quietly, which is why it shipped.

**Regression window** — `RemoteSession.cold` appears in `cli.py` for the first
time in v0.46.0:

```
v0.45.7:local_operator/cli.py   0 occurrences
v0.46.0:local_operator/cli.py   1 occurrence     <- e589db7b (#576)
```

## The fix

Teams and agent profiles are **local config, not runtime state** — files under
`<config_dir>/teams` and `<config_dir>/agents`, the same ones `lop team` and
`lop agents` read with no session at all. So the viewer serves them from its
own `_config_dir` rather than asking a runtime.

That framing is the point, and it is written into the code comments: it is what
makes the registries answerable on a **cold** session, where there is no
runtime and none arrives until the first message. Anything the TUI reads off
the session must exist on *both* implementations, or it fails only on the
viewer path.

Built lazily and cached — `TeamRegistry.__init__` runs crash recovery, and the
picker re-derives its rows on every keystroke. Construction failure degrades
one feature rather than the session, matching `session_factory`'s own
discipline.

## Launch deliberately fails LOUDLY (not an oversight)

`/team <name> <request>` is **still refused** on a viewer, on purpose. This is
the one part of the report a listing fix alone would have made *worse*.

`_cmd_team` guarded with `if callable(attach):` and **no else**, so a session
without `attach_team` fell straight through to `_submit_command_prompt`.
Measured on the cold viewer with the registry fix applied but the guard
untouched:

```
/team lopdev do the thing
  notice        : "sending to lopdev. manager is coordinating."
  prompt SENT   : "do the thing"
  active_team   : ''            <- no roster, no collaboration brief, no project brief
```

The user is told the manager is coordinating while the turn runs as a plain
agent. Before this PR that path failed loudly ("teams are unavailable");
restoring only the listing would have converted a loud failure into a **silent
wrong-persona turn**. So the guard now refuses and sends nothing, matching the
`/agent` sibling's shape and voice — that asymmetry (one returned, one did not)
is precisely what let the silent path ship.

`/agent clear` had the identical silent-skip shape: it reported the persona
detached while nothing had cleared. It refuses too.

The wording is deliberately *not* "teams are unavailable" — that is now false,
since `/team` lists them one line earlier. It says they cannot be **attached**
in this session yet.

**Follow-up (not attempted here):** attaching on a viewer needs the mutation to
reach the runtime that will build the turn, and on a cold viewer no runtime
exists until `_ensure_bound` engages one. There is no wire op for it —
`run_slash_authoritative`'s `_team_slash` returns `noop {"type": "team_mutate"}`
and leaves the mutation to the invoking terminal, which is exactly the terminal
that can no longer perform it. Either a new control op or routing the attach
through the engage path; that is a protocol surface, not a patch.

## The placeholder gate, fixed at the source

`_name_list_pending_notice` reserved a row whenever `_session is None` and then
subtracted the single terminal state it knew about, so every *later* way to sit
sessionless inherited an eternal `loading teams…`:

| state | before | after |
|---|---|---|
| boot worker still constructing | `loading teams…` | `loading teams…` |
| transition pending | `loading teams…` | `loading teams…` |
| adopted session | `''` | `''` |
| boot failed (U7-1) | `''` | `''` |
| **`/stop`** | **`loading teams…`** | `''` |
| **first-run setup** | **`loading teams…`** | `''` |

`_enter_setup_state` returns *before* `_boot_failed` is set, so the one
subtraction never covered it. The gate now asks the question it was written for
— *is a roster still arriving?* — instead of enumerating states, and the
docstring is true again.

This half also swallowed keys: a stranded reserve makes `is_loading()` true,
which gates Tab/Enter, so the list withheld the rows it had **and** ate the
keys that would dismiss it. That is what makes an empty list read as "the
command is broken".

## Evidence

Rendered frames, real `OperatorApp` (loads `local_operator.tcss`), real
cold-viewer factory, `/team ` and `/agent ` typed as keystrokes.

**`/team ` — before:** only the synthetic `chart` row. Zero teams.
**`/team ` — after:** all three real teams with their roles and managers.

**`/agent ` — before:** 6 rows, all `role · packaged`.
**`/agent ` — after:** 13 rows including the authored specialists
(`copy-reviewer`, `qa-tester`, `ux-reviewer`, `data-entry`,
`data-investigations-manager`, `data-qa`).

Bare `/team` end to end through the real dispatch now renders the listing block
with all three teams and their descriptions.

Refusal verified to send nothing:

```
/team lopdev do the thing -> "teams cannot be attached in this session yet…"
                             prompt SENT: []
/agent clear              -> "agents cannot be detached in this session yet…"
```

**Regression tests are mutation-tested** — each fix reverted, tests confirmed
red:

- registry properties removed → 4 failed (`'RemoteSession' object has no
  attribute 'team_registry'`)
- gate reverted to v0.46.0 logic → 3 failed (incl. `is_loading()` assertion)
- attach guard reverted to the silent skip → 1 failed, showing the leak
  directly: `prompts: [] -> ['do the thing']`


## Also restored: `/team chart`

The org chart was entirely unreachable on a viewer — it resolves through the
same registry, so `/team chart <name>` did nothing. It now works end to end:
the second-slot picker offers team names, and the chart view mounts and draws
the roster. Verified on a cold viewer (`_org_chart_view` non-None, target
`lopdev`, zero notices) with the frame rendered and inspected.

## Why the loud refusal is load-bearing rather than defensive padding

On `main` the silent-send is **masked** by the missing registry: `_cmd_team`
returns at the `registry is None` gate before it ever reaches the attach.
Measured on unmodified `main` with a cold viewer — the notice fires and
`prompt sent = []`.

So the silent wrong-persona path only becomes **reachable once registries
exist**. This PR creates that exposure and closes it in the same commit, which
is why the guard ships with the fix rather than after it.

## Roster counts and picker width

`len(members) + 1` assumed the manager is not on the roster. Two of the three
teams on the reference machine list theirs as a member, so the picker
advertised **8 roles for a 7-role team** while the org chart — two keystrokes
from that row — drew 7 boxes. It also collapsed a `reviewer x2` slot to one.
All listings now use `Team.member_count()`, the count `org_chart.py` and
`lop teams` already used: 6/8/9 → **6/7/8**, matching the chart.

The `/team ` detail column was 44 cells (`<n> roles · led by <manager>`). The
picker reserves detail before description and drops description first, so
descriptions vanished between roughly 76 and 123 columns — including the
100-column frame in this PR's own first evidence, which contained the defect
and was read as success. Detail is now the roster size alone.

## Version

**0.46.2**, not 0.46.1: #605 merged mid-review and shipped 0.46.1.

## Deferred

- **Corrupt `team.yml` is silent** — a malformed file drops a team from the UI
  with no signal (the `logger.warning` goes to the log file while Textual owns
  the terminal), making it indistinguishable from deletion. `deferred —
  pre-existing in TeamRegistry, not introduced by this diff`.
- **`variables` / `/credential`** — broken on the viewer by the same
  getattr-off-session mechanism, but a live `CredentialStore` with
  process-lifetime and secret-handling concerns is not a config-dir read, so it
  does not share the "local config, not runtime state" invariant that justifies
  the lazy-property shape here. Its own workstream.

## Gates

`flake8`, `black --check` (26.1.0), `isort --check` (5.13.2), `pyright`: all
clean over the whole tree. Unit suite green.

One environment note, per AGENTS.md's "a local failure CI does not have is
usually your shell": 18 pre-existing `tests/unit/test_session_factory.py`
failures reproduce identically on unmodified `origin/main` and are caused by
ambient `LOP_RUNTIME_ADOPT_SESSION` / `LOP_RUNTIME_DEFER_MATERIALISE` /
`LOP_MOBILE_CHILD_*` exported by the agent session running the tests. Scrubbing
them gives `111 passed` on both trees. Unrelated to this change and not fixed
here; flagged for the fixture's scrub list.

