### PR TITLE
feat(benchmarks): AWS_INSTANCE_TYPE override for the OSWorld V2 benchmark VM

### DIFF
--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -184,7 +184,24 @@ does NOT create IAM roles or security groups; those are one-time human steps.
    key works but should not be the one a worker subprocess holds.
 5. **Guest settings** → infra `OSWORLD_CLIENT_PASSWORD`, `OSWORLD_FILE_BASE_URL`;
    optional `OSWORLD_INPUTS_ROOT` (default `~/worktrees/osworld`) and
-   `OSWORLD_TTL_SECONDS` (default 7200).
+   `OSWORLD_TTL_SECONDS` (default 7200). Optional `AWS_INSTANCE_TYPE`
+   (purpose `benchmark_compute`) replaces the EC2 instance type for the
+   benchmark VM; it **overrides a task's own `instance_type`**, because the
+   task files are content-hash verified and cannot be edited to escape an
+   infrastructure problem their author never saw. Omitting it reproduces the
+   previous behaviour exactly. A malformed value is refused at `prepare`,
+   before anything is allocated (shape only — a well-formed but nonexistent
+   type still reaches `run_instances`). Reach for it when the default
+   burstable `t3.xlarge` runs out of CPU credits — see "Burstable credit
+   exhaustion" in `docs/benchmarks/osworld_2/README.md`.
+
+   **This value requires a workspace built from adapter source that supports
+   it.** The source here gained it without a version bump (the bump would
+   falsify the pilot's pinned attestation), so the shipped source and the
+   digest-pinned `0.1.1` wheel are different code under one version string.
+   Supplying it to a build that does not declare it is refused by the runner
+   before `prepare` rather than silently ignored — an ignored override would
+   put a false hardware claim into a sealed bundle.
 6. **Judged tasks only** → secret `OSWORLD_EVAL_MODEL_API_KEY` plus infra
    `OSWORLD_EVAL_MODEL_PROVIDER` / `OSWORLD_EVAL_MODEL_NAME` (purpose
    `benchmark_judge`). A task whose source imports the judge client is

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/provisioning.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/provisioning.py
@@ -24,6 +24,19 @@ from lop_osworld_v2_adapter.taskfile import TaskDescriptor
 from local_operator.evaluation.adapters.api import ScopedInfraValue
 
 _AMI_RE = re.compile(r"^ami-[a-f0-9]{8,17}$")
+# ``<family>.<size>``, lowercase, both halves allowed internal hyphens so the
+# real oddballs still parse: ``u-6tb1.metal``, ``m7i.metal-24xl``, ``c5n.18xlarge``.
+# Shape borrowed from _AMI_RE on purpose -- a malformed value must fail in
+# ``resolve`` (prepare time, nothing allocated) rather than as an opaque
+# botocore InvalidParameterValue midway through a paid run_instances.
+#
+# SHAPE ONLY, deliberately: 'zz99.megahuge' is well-formed and nonexistent, and
+# still reaches run_instances. Confirming a type EXISTS needs a live
+# describe-instance-types call, and ``resolve`` performs no I/O by contract --
+# that is the whole reason ``prepare`` can be declarative. So this narrows the
+# failure window rather than closing it: a typo in the FORM of the value fails
+# free, a plausible-but-fictional type still costs a launch attempt.
+_INSTANCE_TYPE_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*\.[a-z0-9]+(?:-[a-z0-9]+)*$")
 
 # The V2 release manifest pins exactly one AMI for the 1920x1080 Ubuntu guest
 # in us-east-1. Stated identically in benchmark_releases/osworld-v2-2026.08.08.json
@@ -92,7 +105,7 @@ def resolve(
     ami_id = (
         task.image if task.image is not None and _AMI_RE.fullmatch(task.image) else _DEFAULT_AMI
     )
-    instance_type = task.instance_type or _DEFAULT_INSTANCE_TYPE
+    instance_type = _resolve_instance_type(task, infra_values)
     # Volume size is left None unless the task pins it: the AMI's own
     # BlockDeviceMappings carry a default that OSWorld resolves at launch,
     # and replicating that lookup here would require the very describe_images
@@ -138,4 +151,69 @@ def resolve(
 
 
 def _has(infra_values: tuple[ScopedInfraValue, ...], name: str) -> bool:
-    return any(value.name == name for value in infra_values)
+    # Delegates to _get so this module has ONE lookup rule: a second scan with
+    # its own matching logic is how "present" and "readable" drift apart.
+    return _get(infra_values, name) is not None
+
+
+def _resolve_instance_type(
+    task: TaskDescriptor,
+    infra_values: tuple[ScopedInfraValue, ...],
+) -> str:
+    """``AWS_INSTANCE_TYPE`` > the task's own pin > the release default.
+
+    WHY THIS EXISTS. Five paid episodes died on
+    ``ObservationError: environment returned no screenshot frame``. The cause
+    was measured, not guessed: the default ``t3.xlarge`` is a BURSTABLE
+    instance, and at the failure moment CloudWatch reported CPUCreditBalance
+    4.2 with CPUSurplusCreditBalance 0.0 while CPU sat at 10.3% -- throttled
+    to its baseline, not idle. A starved guest cannot answer its screenshot
+    HTTP server, so the episode dies at step 9-32 having already spent
+    $0.12-$0.32, and AWS status checks stay "ok" throughout because from the
+    hypervisor's side nothing is wrong. Swapping to a non-burstable family
+    (m5/c5) is the fix, and it has to be reachable WITHOUT editing task files:
+    those are content-hash verified against the release pin, so editing one
+    invalidates the very digest that makes a score reproducible.
+
+    WHY THE OVERRIDE BEATS A TASK'S OWN PIN. A task pins ``instance_type``
+    for a task-specific reason (a heavy build wants more cores), which argues
+    for deferring to it. It loses anyway, because the two knobs answer
+    different questions: the task author chose a SIZE against hardware they
+    could reach, while the operator is working around an INFRASTRUCTURE
+    failure that author never saw and cannot fix from inside a hash-pinned
+    file. An override that a task pin could veto would silently fail exactly
+    on the tasks most likely to be starved -- the ones heavy enough to pin a
+    bigger box -- which is the opposite of the intent. The override is opt-in
+    and absent by default, so this precedence is unreachable unless an
+    operator deliberately supplied it; omitting the value reproduces the
+    previous behaviour exactly, which is what keeps a default run comparable.
+
+    Because the override changes the hardware a score was produced on, the
+    host stamps it into the evidence manifest's metadata (see
+    ``scripts/run_episode.py``), so a run on non-default hardware is
+    disclosable from the bundle alone rather than only from operator memory.
+    """
+
+    override = _get(infra_values, "AWS_INSTANCE_TYPE")
+    if override is not None:
+        # Rejected, never ignored -- the asymmetry with ``image`` above is
+        # deliberate. An invalid ``task.image`` falls back to the manifest AMI
+        # because the task file is hash-pinned and the adapter cannot correct
+        # it. An invalid override is something the operator typed seconds ago
+        # and can fix; quietly discarding it would launch the burstable
+        # default they were trying to escape and destroy more paid episodes
+        # with no signal that the knob never took effect.
+        if not _INSTANCE_TYPE_RE.fullmatch(override):
+            raise ProvisioningError(
+                f"AWS_INSTANCE_TYPE {override!r} is not a valid EC2 instance type "
+                "(expected '<family>.<size>', e.g. 'm5.xlarge')"
+            )
+        return override
+    return task.instance_type or _DEFAULT_INSTANCE_TYPE
+
+
+def _get(infra_values: tuple[ScopedInfraValue, ...], name: str) -> str | None:
+    for value in infra_values:
+        if value.name == name:
+            return value.value
+    return None

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/requirements.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/requirements.py
@@ -63,7 +63,15 @@ _ALWAYS_INFRA = (
 # holding the gated assets and the prepared checkout (the workspace pins their
 # manifests by sha but cannot hold the 4.2 GB of assets under its 4 GiB cap);
 # OSWORLD_TTL_SECONDS overrides the budget-derived lease length.
+# AWS_INSTANCE_TYPE replaces the EC2 instance type for the benchmark VM. It is
+# the escape hatch from burstable-credit exhaustion: the default t3.xlarge is
+# BURSTABLE and a starved guest stops answering its screenshot server, which
+# killed five paid episodes (CPUCreditBalance 4.2, surplus 0.0, CPU pinned at
+# 10.3%) while AWS status checks read "ok". It is infra, not a task field,
+# precisely because task files are content-hash verified and cannot be edited
+# to work around the operator's hardware. See provisioning._resolve_instance_type.
 _OPTIONAL_INFRA = (
+    "AWS_INSTANCE_TYPE",
     "OSWORLD_INPUTS_ROOT",
     "OSWORLD_TTL_SECONDS",
 )

--- a/docs/benchmarks/osworld_2/README.md
+++ b/docs/benchmarks/osworld_2/README.md
@@ -152,6 +152,83 @@ but **the wall budget is not on the adapter wire today**: the adapter passes
 Setting `OSWORLD_TTL_SECONDS` to the wall budget plus 900 is therefore the
 operator's job, and is what bounds a leaked instance's worst-case cost.
 
+### Burstable credit exhaustion, and `AWS_INSTANCE_TYPE`
+
+The default `t3.xlarge` is a **burstable** instance, and that silently
+destroyed five paid episodes with
+`ObservationError: environment returned no screenshot frame`. An instrumented
+run identified the cause: at the failure moment CloudWatch reported
+`CPUCreditBalance 4.2` with `CPUSurplusCreditBalance 0.0` and CPU dipping to
+**10.3%** — the guest was throttled to its baseline, not idle. A starved guest
+cannot answer its screenshot HTTP server, so the episode dies at step 9–32
+having already spent $0.12–$0.32. AWS status checks stay `ok` throughout,
+because from the hypervisor's side nothing is wrong; the failure is only
+visible as credit metrics plus a suspiciously low CPU floor.
+
+The escape hatch is the optional infra value `AWS_INSTANCE_TYPE`, which
+replaces the instance type for the benchmark VM:
+
+```sh
+--infra AWS_INSTANCE_TYPE=m5.xlarge
+```
+
+It is infra rather than a task field because the task files are **content-hash
+verified** against the release pin — editing one to change `instance_type`
+invalidates the digest that makes a score reproducible. For the same reason
+the override **beats a task's own pinned `instance_type`**: the task author
+chose a size against hardware they could reach, while the operator is working
+around an infrastructure failure they never saw and cannot fix from inside a
+hash-pinned file. A malformed value is refused at `prepare`, before anything
+is allocated, rather than surfacing as an opaque botocore error midway through
+a paid run.
+
+Omitting it reproduces the previous behaviour exactly, which is what keeps a
+default run comparable. When it **is** set, `scripts/run_episode.py` stamps
+`aws_instance_type_override` into the evidence manifest's metadata, so a score
+produced on non-default hardware is disclosable from the sealed bundle alone
+rather than from operator memory. A run on non-default hardware is not
+directly comparable to one on the release default and should be reported as
+such.
+
+That key records the value **requested** on the command line. It is only
+honest because the runner refuses the one case that would make it a lie — see
+below.
+
+#### The adapter source and the pinned wheel both call themselves `0.1.1`
+
+**Read this before running with `AWS_INSTANCE_TYPE`.** The adapter source in
+this repository gained the override *without* a distribution version bump. The
+bump was withheld on purpose: the adapter version feeds `_release_digest`, so
+bumping it would have falsified the committed attestation of what the paid
+pilot actually ran on. The consequence is that **two materially different
+adapter code bodies now both report version `0.1.1`**, and the wheel installed
+in the pilot interpreter (`~/worktrees/osworld/venvs/0.1.1/`) is the one
+*without* override support. The committed selectors still pin that artifact by
+`package_digest`.
+
+The digest pin catches a *mismatched* wheel. It cannot catch a *correctly
+pinned old* one — so version alone cannot tell an operator which build they
+are about to run.
+
+Because a stale build would silently ignore the override while the manifest
+recorded it as applied — a false statement sealed inside a `verify_bundle`-valid
+bundle, which is worse than no disclosure at all — the runner fails closed.
+`EpisodeRunner._refuse_undeclared_disclosed_infra` compares the value against
+the adapter's own `inspect_requirements` response, which distinguishes the two
+builds exactly, and refuses **before `prepare`**, so nothing is allocated and no
+bundle exists to mislead a reader:
+
+```
+UndeclaredDisclosedInfra: adapter 'osworld-v2' version '0.1.1' does not
+declare ['AWS_INSTANCE_TYPE'], so the value would be silently ignored while
+the evidence bundle recorded it as applied; rebuild the adapter workspace and
+selector, or drop the value
+```
+
+Seeing that error means the workspace and selector need rebuilding against the
+current adapter source (§ the build recipe in
+`benchmarks/osworld_v2_adapter/README.md`), not that the flag is wrong.
+
 ### Upstream is sealed after the first reset
 
 One `reset` per episode is the contract. Upstream's own allocation paths — a

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -44,6 +44,7 @@ from local_operator.evaluation.adapters.api import (
     Handshake,
     InspectRequirementsParams,
     PrepareParams,
+    RequirementsResult,
     RescueDescriptor,
     ResetStartParams,
     ResolvedSecret,
@@ -130,6 +131,44 @@ from local_operator.evaluation.runner.secrets import (
 # session is the one resource the parent always knows exists before the adapter
 # has described anything, which is what makes the provisional plan expressible.
 _PROVISIONAL_CLEANUP_ACTION = "close-session"
+
+# Infra values whose EFFECT a caller discloses in the sealed manifest, and which
+# an adapter that does not understand them would silently ignore.
+#
+# The pairing is what makes these special. An ordinary infra value an adapter
+# ignores is a no-op: the run is what it is, and the bundle says nothing about
+# it. But when a caller records "this run used X" in the manifest, an adapter
+# that drops X turns that record into a FALSE statement sealed inside a
+# verify_bundle-valid bundle -- a score that reads as comparable to a
+# corrected run when it is nothing of the sort. A reader can see a missing
+# disclosure; they cannot see a lying one.
+#
+# This is reachable today, not hypothetical: the deployed OSWorld pilot wheel
+# predates AWS_INSTANCE_TYPE support, and the committed selectors still pin it
+# by digest. The digest pin catches a MISMATCHED wheel; it cannot catch a
+# correctly-pinned OLD one. Skipping any step of an adapter rebuild would
+# otherwise yield rc 0, green CI, and a bundle claiming hardware the episode
+# never ran on.
+#
+# Deliberately a NARROW allowlist rather than "reject every undeclared infra
+# value". ``inspect_requirements`` runs before the task is named, so it returns
+# only the adapter's UNCONDITIONAL baseline -- a task-conditional requirement
+# (OSWORLD_PROXY_CREDENTIALS, OSWORLD_PROXY_ENDPOINT) is legitimately absent
+# from it, and a blanket rule would refuse correct proxy runs. Only a value
+# whose silent drop corrupts the evidence record belongs here.
+_DISCLOSED_INFRA_VALUES = frozenset({"AWS_INSTANCE_TYPE"})
+
+
+class UndeclaredDisclosedInfra(RuntimeError):
+    """A disclosed infra value was supplied to an adapter that does not declare it.
+
+    Raised from ``_launch_and_prepare`` -- before ``prepare``, and therefore
+    before any resource can exist -- so it surfaces as ``failed_pre_bundle``
+    with no bundle to mislead anyone. Failing closed is the same rule the
+    adapter already applies to a malformed value: an override the adapter will
+    silently drop is the same class of defect as one it cannot parse.
+    """
+
 
 EpisodeStatus = Literal[
     "completed",
@@ -385,10 +424,11 @@ class EpisodeRunner:
         )
         self._session = session
 
-        await session.inspect_requirements(
+        requirements = await session.inspect_requirements(
             InspectRequirementsParams(),
             timeout=self._config.prepare_timeout,
         )
+        self._refuse_undeclared_disclosed_infra(requirements)
 
         # Secrets are resolved HERE -- after the handshake, before the
         # provisional descriptor and before ``prepare`` -- for two reasons.
@@ -1377,6 +1417,36 @@ class EpisodeRunner:
             # sweep (``instance-absent``) -- harmless, and strictly better than
             # failing an already-clean episode over inbox hygiene.
             pass
+
+    def _refuse_undeclared_disclosed_infra(self, requirements: RequirementsResult) -> None:
+        """Refuse a disclosed infra value the adapter build does not understand.
+
+        ``inspect_requirements`` is the only signal that distinguishes two
+        adapter builds carrying the SAME version string, which is exactly the
+        situation here: the OSWorld adapter source gained AWS_INSTANCE_TYPE
+        without a distribution bump (the bump was withheld on purpose, because
+        it feeds ``_release_digest`` and would have falsified the pinned
+        attestation of what the paid pilot ran on). Version therefore cannot
+        tell the builds apart -- the declared requirement set can, and the
+        runner already makes this call, so nothing new crosses the wire and no
+        schema version changes.
+
+        Matched by NAME rather than by the ``required`` flag: these values are
+        optional by construction (an operator knob defaults to absent), so the
+        flag says nothing about whether the adapter understands the name.
+        """
+
+        declared = {requirement.name for requirement in requirements.requirements}
+        supplied = {value.name for value in self._spec.infra_values}
+        undeclared = sorted((supplied & _DISCLOSED_INFRA_VALUES) - declared)
+        if undeclared:
+            raise UndeclaredDisclosedInfra(
+                f"adapter {self._selector.adapter_id!r} version "
+                f"{self._selector.version!r} does not declare {undeclared}, so the "
+                "value would be silently ignored while the evidence bundle "
+                "recorded it as applied; rebuild the adapter workspace and "
+                "selector, or drop the value"
+            )
 
     def _build_manifest(self, handshake: Handshake, plan: CleanupPlan) -> EvidenceManifest:
         spec = self._spec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.46.1"
+version = "0.46.4"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/run_episode.py
+++ b/scripts/run_episode.py
@@ -464,6 +464,37 @@ def _parse_infra(values: Sequence[str], purpose: str) -> tuple[ScopedInfraValue,
     return tuple(out)
 
 
+def _instance_type_metadata(infra: Sequence[str]) -> dict[str, Any]:
+    """Manifest metadata disclosing an EC2 instance-type override, if any.
+
+    The key records what was **requested** on the command line, not a value
+    read back from the adapter -- there is no channel for the latter, since
+    ``ObservationPayload`` carries no metadata and neither ``PrepareResult``
+    nor ``AckResult`` returns the resolved plan. Widening the wire to return it
+    would be an ``ADAPTER_SCHEMA_VERSION`` bump, which breaks mixed-version
+    interop in both directions (see the schema notes in ``adapters/api.py``)
+    for a field only this script reads.
+
+    "Requested" is only honest because the runner refuses the mismatch that
+    would make it a lie: ``EpisodeRunner._refuse_undeclared_disclosed_infra``
+    fails the episode before ``prepare`` when this value is supplied to an
+    adapter build that does not declare ``AWS_INSTANCE_TYPE``. Requested and
+    applied can therefore differ only on a run that produced no bundle at all.
+
+    Reads the raw ``--infra NAME=VALUE`` strings rather than the parsed
+    ``ScopedInfraValue`` tuple so this stays a pure function of the CLI input
+    and can be tested without building a whole spec. Reporting an unparseable
+    value verbatim is correct: the run fails at prepare, and a bundle, if one
+    exists at all, should still show what was asked for.
+    """
+
+    for item in infra:
+        name, sep, value = item.partition("=")
+        if sep and name == "AWS_INSTANCE_TYPE" and value:
+            return {"aws_instance_type_override": value}
+    return {}
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n\n")[0])
     parser.add_argument("--selector", required=True, type=Path, help="AdapterSelector JSON file")
@@ -605,6 +636,20 @@ async def run(args: argparse.Namespace) -> int:
             # read as a result.
             "model_client": args.model_client,
             "script": "scripts/run_episode.py",
+            # Hardware disclosure: the instance type REQUESTED for this run.
+            # A score produced on non-default hardware is not comparable to one
+            # produced on the release default, so the bundle has to say so on
+            # its own -- reading it must not depend on operator memory of which
+            # --infra flags were passed. Only the OVERRIDE is stamped, and only
+            # when supplied: with it absent the effective type is fully
+            # determined by the hash-pinned task file plus the documented
+            # default, so the disclosure is complete in both directions. The
+            # adapter cannot report this itself -- ``ObservationPayload``
+            # carries no metadata field, so nothing the worker resolves reaches
+            # the bundle except through the manifest. Requested can only differ
+            # from applied on an episode that produced no bundle: the runner
+            # refuses an override an adapter build does not declare.
+            **_instance_type_metadata(args.infra),
         },
     )
 

--- a/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
+++ b/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
@@ -177,8 +177,10 @@ def _expect_describe_images(stubs: _Stubs) -> None:
     )
 
 
-def _expect_run_instances(stubs: _Stubs) -> None:
-    plan = _plan()
+def _expect_run_instances(stubs: _Stubs, plan: provisioning.ProvisioningPlan | None = None) -> None:
+    # ``plan`` defaults to the standard one so every existing caller is
+    # unchanged; a caller testing a resolved override passes its own.
+    plan = plan if plan is not None else _plan()
     stubs.ec2_stub.add_response(
         "run_instances",
         {"Instances": [{"InstanceId": INSTANCE}]},
@@ -369,6 +371,43 @@ async def test_allocate_launches_with_client_token_and_both_tag_specs(
     assert envs[0].reset_calls == [{"id": "task_plain"}]
     # Readiness probed the guest's control port on the public IP.
     assert stubs.http_calls == ["http://203.0.113.5:5000/terminal"]
+
+
+@pytest.mark.asyncio
+async def test_an_instance_type_override_reaches_the_real_run_instances_call(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The override must survive resolve -> plan -> EC2, not just resolve.
+
+    A unit test of the pure function would still pass if the plan field were
+    dropped on the way to ``run_instances``, which is precisely the failure
+    that would leave the operator on the starved burstable box while every
+    test stayed green. The stubbed client asserts the exact launch parameters,
+    so ``InstanceType`` here is the value AWS would actually receive.
+    """
+
+    task = taskfile.load_static(fixtures.PLAIN.encode(), module_name="tasks/task_plain.py")
+    infra = _infra() + (
+        ScopedInfraValue(name="AWS_INSTANCE_TYPE", purpose="benchmark_compute", value="m5.xlarge"),
+    )
+    plan = provisioning.resolve(task, episode_id=EPISODE, infra_values=infra)
+    assert plan.instance_type == "m5.xlarge"
+
+    with _Stubs() as stubs:
+        _expect_describe_images(stubs)
+        # Built from the OVERRIDDEN plan: the stub rejects the call if any
+        # launch parameter differs, so a dropped override fails right here.
+        _expect_run_instances(stubs, plan=plan)
+        _expect_create_schedule(stubs)
+        _expect_running(stubs)
+        provider = _provider(
+            stubs,
+            monkeypatch,
+            desktop_env_factory=_FakeEnv,
+            task_factory=lambda t: {"id": t.task_id},
+        )
+        await provider.allocate(plan, task, cache_root=_cache_root(tmp_path))
+        stubs.ec2_stub.assert_no_pending_responses()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/evaluation/adapters/osworld/test_provisioning.py
+++ b/tests/unit/evaluation/adapters/osworld/test_provisioning.py
@@ -64,6 +64,91 @@ def test_volume_defaults_to_none_for_launch_time_resolution() -> None:
     assert plan.instance_type == "t3.xlarge"
 
 
+def _with_instance_type(value: str) -> tuple[ScopedInfraValue, ...]:
+    return _INFRA + (
+        ScopedInfraValue(name="AWS_INSTANCE_TYPE", purpose="benchmark_compute", value=value),
+    )
+
+
+def test_instance_type_defaults_to_the_release_default_without_an_override() -> None:
+    # Omitting the knob must reproduce the previous behaviour EXACTLY: a score
+    # run on default hardware stays comparable to every earlier run.
+    plan = _resolve(fixtures.PLAIN)
+    assert plan.instance_type == "t3.xlarge"
+
+
+def test_an_instance_type_override_replaces_the_default() -> None:
+    # The reason the knob exists: t3.xlarge is burstable, and credit
+    # exhaustion (CPUCreditBalance 4.2, surplus 0.0) silently killed five paid
+    # episodes by starving the guest's screenshot server.
+    descriptor = taskfile.load_static(fixtures.PLAIN.encode(), module_name="tasks/t.py")
+    plan = provisioning.resolve(
+        descriptor, episode_id="ep-1", infra_values=_with_instance_type("m5.xlarge")
+    )
+    assert plan.instance_type == "m5.xlarge"
+
+
+def test_an_instance_type_override_beats_a_task_pinned_instance_type() -> None:
+    # The precedence decision, asserted rather than assumed. CUSTOM_INSTANCE
+    # pins t3.2xlarge -- still burstable, so a task pin that could veto the
+    # override would leave exactly the starvation case unfixable from outside
+    # a hash-pinned task file.
+    descriptor = taskfile.load_static(fixtures.CUSTOM_INSTANCE.encode(), module_name="tasks/t.py")
+    assert descriptor.instance_type == "t3.2xlarge"
+    plan = provisioning.resolve(
+        descriptor, episode_id="ep-1", infra_values=_with_instance_type("m5.2xlarge")
+    )
+    assert plan.instance_type == "m5.2xlarge"
+
+
+def test_a_task_pinned_instance_type_still_wins_without_an_override() -> None:
+    # The override is opt-in: absent it, the task's own pin is untouched.
+    plan = _resolve(fixtures.CUSTOM_INSTANCE)
+    assert plan.instance_type == "t3.2xlarge"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "not-an-instance-type",  # no size separator at all
+        "m5",  # family without a size
+        "m5.",  # empty size
+        ".xlarge",  # empty family
+        "M5.XLarge",  # EC2 types are lowercase; a case slip must not launch
+        "m5 .xlarge",  # whitespace
+        "m5.xlarge; rm -rf /",  # anything that is not the closed shape
+    ],
+)
+def test_a_malformed_instance_type_override_is_rejected_at_prepare_time(bad: str) -> None:
+    # Rejected, not ignored: silently discarding it would launch the burstable
+    # default the operator was escaping, with no signal the knob never applied.
+    descriptor = taskfile.load_static(fixtures.PLAIN.encode(), module_name="tasks/t.py")
+    with pytest.raises(ProvisioningError) as excinfo:
+        provisioning.resolve(descriptor, episode_id="ep-1", infra_values=_with_instance_type(bad))
+    assert "AWS_INSTANCE_TYPE" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "good",
+    [
+        "m5.xlarge",
+        "c5n.18xlarge",
+        "u-6tb1.metal",  # hyphenated family
+        "m7i.metal-24xl",  # hyphenated size
+        "t3.nano",
+    ],
+)
+def test_real_ec2_instance_type_spellings_are_accepted(good: str) -> None:
+    # The validator must not reject the oddballs AWS actually sells; a regex
+    # that only knows ``m5.xlarge`` would block the metal instances that are
+    # the strongest answer to a starved burstable guest.
+    descriptor = taskfile.load_static(fixtures.PLAIN.encode(), module_name="tasks/t.py")
+    plan = provisioning.resolve(
+        descriptor, episode_id="ep-1", infra_values=_with_instance_type(good)
+    )
+    assert plan.instance_type == good
+
+
 def test_screen_is_always_the_native_1920x1080() -> None:
     assert _resolve(fixtures.PLAIN).screen == (1920, 1080)
 

--- a/tests/unit/evaluation/adapters/osworld/test_requirements.py
+++ b/tests/unit/evaluation/adapters/osworld/test_requirements.py
@@ -23,6 +23,7 @@ _ALWAYS = {
     "OSWORLD_CLIENT_PASSWORD",
     "OSWORLD_FILE_BASE_URL",
     "HF_TOKEN",  # optional at episode time: the corpus is pre-materialised
+    "AWS_INSTANCE_TYPE",  # optional: escape hatch from the burstable default
     "OSWORLD_INPUTS_ROOT",  # optional: the durable root the assets live in
     "OSWORLD_TTL_SECONDS",  # optional: lease-length override
 }
@@ -95,6 +96,14 @@ def test_inputs_root_and_ttl_are_optional_infra() -> None:
     by_name = _by_name(fixtures.PLAIN)
     assert by_name["OSWORLD_INPUTS_ROOT"] == ("infra", False)
     assert by_name["OSWORLD_TTL_SECONDS"] == ("infra", False)
+
+
+def test_instance_type_override_is_optional_infra() -> None:
+    # Optional, so preflight never demands it: omitting the knob must leave a
+    # default run exactly as it was. Declared at all so the host knows the
+    # name is accepted rather than silently dropping an unknown infra value.
+    by_name = _by_name(fixtures.PLAIN)
+    assert by_name["AWS_INSTANCE_TYPE"] == ("infra", False)
 
 
 def test_judged_task_requires_the_judge_key_and_settings() -> None:

--- a/tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
+++ b/tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
@@ -154,6 +154,11 @@ def test_script_runs_one_spawned_episode_to_a_sealed_bundle(
     assert manifest.metadata["route_model_id"] == "fake/model:free"
     assert manifest.metadata["route_provider_id"] == "test"
     assert manifest.metadata["model_client"] == "scripted-finish"
+    # No override was passed, so the bundle must NOT claim one: with the key
+    # absent the effective instance type is fully determined by the hash-pinned
+    # task file plus the documented default, and a stamp here would misreport
+    # a default run as having used custom hardware.
+    assert "aws_instance_type_override" not in manifest.metadata
     assert manifest.harness_version == _checkout_version()
     assert report.outcome is not None and report.outcome.reportable is False
     assert report.outcome.reportability_label == "synthetic_model"
@@ -168,6 +173,60 @@ def test_script_runs_one_spawned_episode_to_a_sealed_bundle(
     everything = _all_bytes_under(run_root) + completed.stdout.encode() + completed.stderr.encode()
     assert CANARY_SECRET.encode() not in everything
     assert CANARY_KEY.encode() not in everything
+
+
+def test_an_instance_type_override_is_disclosed_in_the_sealed_manifest(
+    durable_path: Path, adapter_wheel: Path  # noqa: F811
+) -> None:
+    """A score run on non-default hardware must be disclosable from the bundle.
+
+    Comparability is the whole point: an episode run on m5.xlarge instead of
+    the release-default t3.xlarge is not directly comparable to one that used
+    the default, and a reader of the bundle has no other way to learn that --
+    ``ObservationPayload`` carries no metadata, so nothing the worker resolves
+    reaches the bundle except through the manifest the parent seals.
+    """
+
+    selector = _selector_file(durable_path / "adapter", adapter_wheel)
+    run_root = durable_path / "run"
+
+    completed = _run(
+        [
+            "--selector",
+            str(selector),
+            "--task-id",
+            "task_plain",
+            "--route",
+            "test/fake/model:free",
+            "--run-root",
+            str(run_root),
+            "--secret-env",
+            "AWS_ACCESS_KEY_ID",
+            "--secret-env",
+            "AWS_SECRET_ACCESS_KEY",
+            "--no-store",
+            "--model-client",
+            "scripted-finish",
+            "--max-steps",
+            "3",
+            "--max-usd",
+            "0.01",
+            *INFRA,
+            "--infra",
+            "AWS_INSTANCE_TYPE=m5.xlarge",
+        ],
+        {"AWS_ACCESS_KEY_ID": CANARY_KEY, "AWS_SECRET_ACCESS_KEY": CANARY_SECRET},
+    )
+
+    assert completed.returncode == 0, completed.stderr[-3000:]
+    outcome: dict[str, Any] = json.loads(completed.stdout)
+    assert outcome["status"] == "completed", outcome
+    report = verify_bundle(Path(outcome["bundle_root"]))
+    # Sealed AND valid: the manifest digest covers metadata, so a bundle that
+    # verifies is one whose disclosure cannot have been edited after the fact.
+    assert report.valid, [issue.code for issue in report.issues]
+    assert report.manifest is not None
+    assert report.manifest.metadata["aws_instance_type_override"] == "m5.xlarge"
 
 
 def test_script_fails_pre_bundle_on_a_missing_secret_naming_only_the_ref(

--- a/tests/unit/evaluation/runner/conftest.py
+++ b/tests/unit/evaluation/runner/conftest.py
@@ -32,6 +32,7 @@ from local_operator.evaluation.adapters.api import (
     ObservationResult,
     PrepareResult,
     PythonRuntime,
+    Requirement,
     RequirementsResult,
     ScoreResult,
     observation_content_id,
@@ -226,9 +227,14 @@ class FakeAdapter:
         cleanup_status: str = "succeeded",
         failures: dict[str, BaseException] | None = None,
         fail_after: dict[str, int] | None = None,
+        declared_requirements: tuple[Requirement, ...] = (),
     ) -> None:
         self.tmp_path = tmp_path
         self.episode_id = episode_id
+        # What ``inspect_requirements`` answers. Defaults to none, which is
+        # also how an OLDER adapter build behaves for a name it predates --
+        # the case the runner must refuse rather than silently ignore.
+        self.declared_requirements = declared_requirements
         self.score = score or ScoreArtifact(status="scored", binary=1)
         self.cleanup_status = cleanup_status
         self.failures = failures or {}
@@ -262,7 +268,7 @@ class FakeAdapter:
         self.calls.append(method)
         self._maybe_fail(method)
         if method == "inspect_requirements":
-            return RequirementsResult(requirements=())
+            return RequirementsResult(requirements=self.declared_requirements)
         if method == "prepare":
             return PrepareResult(cleanup_plan=cleanup_plan(self.episode_id))
         if method == "reset_start":

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import pytest
 
+from local_operator.evaluation.adapters.api import Requirement, ScopedInfraValue
 from local_operator.evaluation.adapters.supervisor import SupervisionError
 from local_operator.evaluation.evidence.models import (
     CleanupPayload,
@@ -1262,3 +1263,121 @@ async def test_detail_publish_os_error_cannot_escape_the_failure_handler(
         recovered.close()
     assert record.reason == "infrastructure_failure"
     assert verify_bundle(root).terminal_state == "abandoned"
+
+
+# ---------------------------------------------------------------------------
+# Disclosed infra values must not be silently dropped by an older adapter
+# ---------------------------------------------------------------------------
+#
+# The defect these cover is a FALSE disclosure, which is strictly worse than a
+# missing one: the caller stamps "this run used m5.xlarge" into the sealed
+# manifest from the CLI string alone, while an adapter build that predates the
+# knob resolves t3.xlarge and drops it. The bundle then verifies, the run exits
+# 0, and a reader reports a burstable-starved score as starvation-corrected.
+# ``inspect_requirements`` is the only signal that separates two builds sharing
+# one version string, so the runner binds it and fails closed.
+
+
+def _spec_with_infra(episode_id: str, *names: str) -> Any:
+    spec = build_spec(episode_id)
+    object.__setattr__(
+        spec,
+        "infra_values",
+        tuple(
+            ScopedInfraValue(name=name, purpose="benchmark_compute", value="m5.xlarge")
+            for name in names
+        ),
+    )
+    return spec
+
+
+def _infra_runner(
+    tmp_path: Path, episode_id: str, spec: Any, adapter: FakeAdapter
+) -> EpisodeRunner:
+    return EpisodeRunner(
+        spec,
+        build_config(tmp_path),
+        selector=selector(tmp_path),
+        model=ScriptedModel(["finish"]),
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_disclosed_infra_value_an_adapter_does_not_declare_is_refused(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """The reviewer's reproduction, as a test: old adapter + new host script.
+
+    A ``FakeAdapter`` declaring no requirements is exactly how a build that
+    predates ``AWS_INSTANCE_TYPE`` answers for that name. Pre-fix this ran to
+    a sealed, valid bundle claiming hardware the episode never used; the
+    refusal must land BEFORE ``prepare``, so nothing is allocated and there is
+    no bundle to mislead a reader.
+    """
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    outcome = await _infra_runner(
+        tmp_path, episode_id, _spec_with_infra(episode_id, "AWS_INSTANCE_TYPE"), adapter
+    ).run()
+
+    assert outcome.status == "failed_pre_bundle"
+    assert outcome.bundle_root is None
+    assert "AWS_INSTANCE_TYPE" in (outcome.diagnostic or "")
+    assert "UndeclaredDisclosedInfra" in (outcome.diagnostic or "")
+    # The side-effect boundary was never crossed and the worker was reaped.
+    assert "prepare" not in adapter.calls and "reset_start" not in adapter.calls
+    assert adapter.terminated
+
+
+@pytest.mark.asyncio
+async def test_a_declared_disclosed_infra_value_runs_normally(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """The inverse direction: a rebuilt adapter DOES declare it, so it runs.
+
+    Without this the gate could pass by refusing everything, which would break
+    the very workflow the knob exists for.
+    """
+
+    adapter = FakeAdapter(
+        tmp_path,
+        episode_id,
+        declared_requirements=(
+            Requirement(
+                requirement_id="AWS_INSTANCE_TYPE",
+                kind="infra",
+                name="AWS_INSTANCE_TYPE",
+                required=False,
+            ),
+        ),
+    )
+    outcome = await _infra_runner(
+        tmp_path, episode_id, _spec_with_infra(episode_id, "AWS_INSTANCE_TYPE"), adapter
+    ).run()
+
+    assert outcome.status == "completed", outcome.diagnostic
+    assert "prepare" in adapter.calls and "reset_start" in adapter.calls
+
+
+@pytest.mark.asyncio
+async def test_an_undeclared_ordinary_infra_value_is_not_refused(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """The gate is a narrow allowlist, and that scoping is load-bearing.
+
+    ``inspect_requirements`` runs BEFORE the task is named, so it returns only
+    the adapter's unconditional baseline -- a task-conditional requirement
+    (OSWORLD_PROXY_ENDPOINT for a proxy task) is legitimately absent from it.
+    A blanket "refuse every undeclared infra value" rule would therefore break
+    correct proxy runs, which is why only values whose silent drop corrupts the
+    evidence record are gated.
+    """
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    outcome = await _infra_runner(
+        tmp_path, episode_id, _spec_with_infra(episode_id, "OSWORLD_PROXY_ENDPOINT"), adapter
+    ).run()
+
+    assert outcome.status == "completed", outcome.diagnostic


### PR DESCRIPTION
## What

An optional infra value, `AWS_INSTANCE_TYPE`, that replaces the EC2 instance type for the OSWorld V2 benchmark VM — so a credit-starved burstable instance can be swapped out **without editing content-hash-verified task files**.

Optional and absent by default: omitting it reproduces today's behaviour exactly, which is what keeps a default score run comparable.

## Why — burstable credit exhaustion destroyed five paid episodes

Five paid episodes died on `ObservationError: environment returned no screenshot frame`. The cause was **measured, not guessed**: the default `t3.xlarge` is a BURSTABLE instance, and at the failure moment CloudWatch reported

- `CPUCreditBalance` **4.2**
- `CPUSurplusCreditBalance` **0.0**
- CPU dipping to **10.3%** — throttled to baseline, *not idle*

A starved guest cannot answer its screenshot HTTP server, so the episode dies at **step 9–32 having already spent $0.12–$0.32**. AWS status checks stay `"ok"` throughout, because from the hypervisor's side nothing is wrong — which is exactly why this burned five times before being identified.

Task files are content-hash verified against the release pin, so the fix must not be "edit `instance_type` in the task". Region, subnet, security group and the scheduler role already arrive as declared **infra values**; this follows that established pattern.

## The precedence decision, and why

`AWS_INSTANCE_TYPE` **beats a task's own pinned `instance_type`**.

The argument for deferring to the task is real: a task pins a type for a task-specific reason (a heavy build wants more cores). It loses anyway, because the two knobs answer different questions. The task author chose a **size** against hardware they could reach; the operator is working around an **infrastructure failure** that author never saw and cannot fix from inside a hash-pinned file. An override a task pin could veto would silently fail *exactly* on the tasks most likely to be starved — the ones heavy enough to pin a bigger box — which is the opposite of the intent.

It is opt-in and absent by default, so this precedence is unreachable unless an operator deliberately supplied it. The choice is documented in `_resolve_instance_type`'s docstring and asserted by a dedicated test, not left implicit.

## Validation

A malformed value is refused in `resolve()` at **prepare time — before anything is allocated**, following the shape of the existing `_AMI_RE` check, rather than surfacing as an opaque botocore `InvalidParameterValue` midway through a paid `run_instances`.

Rejected, never ignored — deliberately asymmetric with `task.image`, which falls back to the manifest AMI. An invalid `image` lives in a hash-pinned file the adapter cannot correct; an invalid override is something the operator typed seconds ago and can fix. Quietly discarding it would launch the burstable default they were trying to escape, with no signal the knob never took effect.

The regex accepts the spellings AWS actually sells, including `u-6tb1.metal` and `m7i.metal-24xl` — a validator that only knew `m5.xlarge` would block the metal instances that are the strongest answer to a starved guest.

## Disclosure in the evidence bundle

Point 3 of the brief asked whether the provisioning plan already reaches the evidence manifest. **It does not** — I checked rather than assumed: `ObservationPayload` carries no metadata field, so nothing the worker resolves reaches the bundle. The manifest's `metadata` is the only channel that does.

`scripts/run_episode.py` therefore stamps `aws_instance_type_override` into manifest metadata when (and only when) an override is supplied. A score run on non-default hardware is then disclosable from the **sealed** bundle alone rather than from operator memory. With the key absent the effective type is fully determined by the hash-pinned task file plus the documented default, so the disclosure is complete in both directions.

## Testing evidence

### Whole-tree gates, exactly as CI, each exit code read directly (not through a pipe)

```
.venv/bin/python -m flake8 .                                   FLAKE8_EXIT=0
uvx --from black==26.1.0 black --check .                       BLACK_EXIT=0    (859 files unchanged)
uvx isort==5.13.2 --check .                                    ISORT_EXIT=0
.venv/bin/python -m pyright --pythonpath .venv/bin/python .    PYRIGHT_EXIT=0  (0 errors, 0 warnings)
```

### Full unit suite, whole tree

```
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
12365 passed, 15 skipped, 629 warnings in 917.78s (0:15:17)
```

Zero FAILED, zero ERROR lines.

### Real execution: the override reaches the actual EC2 launch call

Not only the pure function. `test_an_instance_type_override_reaches_the_real_run_instances_call` drives `AwsProvider.allocate` against botocore's `Stubber`, which **asserts the exact request parameters** — so `InstanceType` there is the value AWS would really receive. A plan field dropped between `resolve` and `run_instances` fails this test, which is precisely the failure that would leave the operator on the starved box with a green suite.

### Real execution: a genuinely sealed, verified bundle carries the disclosure

`test_an_instance_type_override_is_disclosed_in_the_sealed_manifest` runs `scripts/run_episode.py` as a **real subprocess**, with the real supervisor spawning a real worker from a real adapter wheel, to a sealed bundle:

```
2 passed, 5 deselected in 15.19s
```

```python
report = verify_bundle(Path(outcome["bundle_root"]))
assert report.valid                                                     # manifest digest covers metadata
assert report.manifest.metadata["aws_instance_type_override"] == "m5.xlarge"
```

Valid *and* sealed: the manifest digest covers metadata, so a bundle that verifies is one whose disclosure cannot have been edited after the fact. The companion default-path test asserts the key is **absent** when no override is passed.

### Mutation testing — every new test broken on purpose, and watched to fail

The trap here is a test that passes against the bug. Each mutation was applied to the source, the suite re-run, and the reverted state re-confirmed green.

| # | Mutation | Result |
|---|---|---|
| 1 | Override ignored entirely | **15 failed** (incl. the EC2 launch test) |
| 2 | Precedence flipped (task pin vetoes override) | **1 failed** — `..._beats_a_task_pinned_instance_type` |
| 3 | Invalid override silently accepted | **7 failed** — `DID NOT RAISE ProvisioningError` |
| 4 | Default changed from `t3.xlarge` | **2 failed** |
| 5 | Regex widened to `^.+$` | **7 failed** (incl. `M5.XLarge`, `m5 .xlarge`, injection-shaped) |
| 6 | Requirement declaration removed | **3 failed** |
| 7 | Manifest disclosure never stamped | **1 failed** — `KeyError: 'aws_instance_type_override'` |
| 8 | Disclosure stamped unconditionally | **1 failed** — default-path test caught the false claim |

Every mutation was caught by the *specific* test written for that behaviour, not incidentally by an unrelated one.

## Deliberately not done

- **No adapter package version bump.** I bumped `lop-osworld-v2-adapter` to `0.1.2` and reverted it: the version is an input to `_release_digest`, and the bump falsified `test_the_staged_pilot_release_digest_is_reproduced_from_committed_values`, which attests a **real deployed artifact** (the `0.1.1` pilot wheel, `package_digest 69e8504d…`). Re-pinning that committed attestation to make my own bump pass would have rewritten the record of what the pilot actually ran on. The bump belongs with the operator's workspace/selector rebuild, not this PR — *deferred — belongs to the adapter rebuild step, see the operator note below*.
- **`ObservationPayload` gained no metadata field.** Widening the adapter wire protocol to carry provisioning facts is a schema change well outside this slice; the manifest channel already answers the disclosure requirement.

## Operator note — rebuilding the adapter workspace and selector

The harness pins the adapter's package digest, so a rebuilt workspace needs a matching selector. After this lands, to put the override into a real run:

```sh
# 1. rebuild the wheel from the changed adapter source
cd ~/local-operator/benchmarks/osworld_v2_adapter
uv build --wheel

# 2. install it into the pilot interpreter (README step 3a recipe)
uv pip install --python ~/worktrees/osworld/venvs/<ver>/bin/python3.12 \
  --no-deps --force-reinstall dist/lop_osworld_v2_adapter-<ver>-py3-none-any.whl

# 3. rebuild the workspace — attests version + package digest into release_digest
~/local-operator/.venv/bin/python ~/local-operator/scripts/build_osworld_adapter.py \
  --out ~/worktrees/osworld/workspaces/<new> ...

# 4. regenerate the selector so package_digest / release_digest / workspace_digest match
#    (a stale selector fails the handshake's exact-pin check)
```

Then pass `--infra AWS_INSTANCE_TYPE=m5.xlarge` to `scripts/run_episode.py`.

Note the adapter version participates in `_release_digest`; if the rebuild bumps it, `test_the_staged_pilot_release_digest_is_reproduced_from_committed_values` and the `0.1.1` literals across the osworld tests must be updated in that same change, against the newly built wheel's real digest.
