### PR TITLE
fix(evaluation): survive a transient observation failure instead of losing the episode

### DIFF
--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
@@ -70,6 +70,7 @@ from local_operator.evaluation.adapters.api import (
     ExecuteResult,
     ExecutionReceipt,
     InspectRequirementsParams,
+    ObservationPhaseError,
     ObservationResult,
     ObserveParams,
     PrepareParams,
@@ -639,7 +640,13 @@ class OSWorldV2Adapter:
         statements = actions.compile_batch(params.action_batch, geometry)
         guest_lines = [s for s in statements if not s.startswith("WAIT ")]
         waits = [int(s.split(" ", 1)[1]) for s in statements if s.startswith("WAIT ")]
-        if guest_lines or waits:
+        # RESUME: the parent is re-reading the state THIS batch already
+        # produced, after a previous attempt committed the actions and then
+        # failed to read the screen back. Re-running the guest statements here
+        # would apply the click or the keystroke a second time, so the mutation
+        # is skipped and only the read-back below runs. The parent sets this
+        # flag solely after we declared the commit via ObservationPhaseError.
+        if not params.resume_observation and (guest_lines or waits):
             if guest_lines:
                 await self._provider.execute(guest_lines)
             for wait_ms in waits:
@@ -648,14 +655,25 @@ class OSWorldV2Adapter:
                 # A pure-wait batch still advances the environment's clock.
                 await self._provider.execute([])
 
-        raw = await self._provider.observe()
+        # PAST THE POINT OF NO RETURN. The guest has moved; from here every
+        # failure is a failure to READ, and saying so is what lets the parent
+        # re-read instead of destroying an episode that has already cost money
+        # and completed many valid steps. The sequence is deliberately NOT
+        # advanced before the build: a build that raises must leave the adapter
+        # exactly where it was, or the resumed attempt would skip a sequence
+        # number and the parent's "exact next sequence" check would reject the
+        # very observation it asked for.
+        try:
+            raw = await self._provider.observe()
+            output = self._observation_builder.build(
+                raw,
+                task_id=params.action_batch.task_id,
+                episode_id=params.action_batch.episode_id,
+                sequence=self._sequence + 1,
+            )
+        except Exception as error:
+            raise ObservationPhaseError(str(error)) from error
         self._sequence += 1
-        output = self._observation_builder.build(
-            raw,
-            task_id=params.action_batch.task_id,
-            episode_id=params.action_batch.episode_id,
-            sequence=self._sequence,
-        )
         receipt = ExecutionReceipt(
             operation_id=params.operation_id,
             action_batch_id=params.action_batch_id,

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/fake.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/fake.py
@@ -42,11 +42,24 @@ class FakeProvider:
         *,
         scripted_score: float = 1.0,
         fail_evaluate: bool = False,
+        blind_observations: int = 0,
+        blind_after_observe_calls: int = 0,
         has_user_simulator: bool = False,
         simulator_answer: str = "simulated user answer",
     ) -> None:
         self._scripted_score = scripted_score
         self._fail_evaluate = fail_evaluate
+        # How many upcoming observe() calls return NO frame, reproducing a
+        # guest whose screenshot server is starved (the burstable-instance
+        # failure that destroyed five paid episodes). OSWorld's own
+        # ``_get_obs`` returns None for the screenshot after exhausting its
+        # internal retries rather than raising, so the fake does the same.
+        self._blind_observations = blind_observations
+        # Which observe() call the blindness STARTS at. The real outage began
+        # mid-episode, after reset_start had already produced a good frame, so
+        # a test that blinded the very first read would exercise a different
+        # (and easier) failure than the one that cost five paid episodes.
+        self._blind_after_observe_calls = blind_after_observe_calls
         self._has_user_simulator = has_user_simulator
         self._simulator_answer = simulator_answer
         # The in-memory registry stands in for EC2: ref -> state. Teardown
@@ -96,6 +109,14 @@ class FakeProvider:
 
     async def observe(self) -> dict[str, Any]:
         self.observe_calls += 1
+        if self._blind_observations > 0 and self.observe_calls > self._blind_after_observe_calls:
+            self._blind_observations -= 1
+            return {
+                "screenshot": None,
+                "accessibility_tree": None,
+                "terminal": None,
+                "instruction": "fake instruction",
+            }
         return {
             "screenshot": self._frame(),
             "accessibility_tree": None,

--- a/local_operator/evaluation/adapters/api.py
+++ b/local_operator/evaluation/adapters/api.py
@@ -63,10 +63,25 @@ from local_operator.evaluation.receipts import (
 # error path, which is the worst possible place to discover a mismatch. The
 # exact-version pin in ``AdapterSelector`` turns that into a refusal at
 # selection time, before a worker is spawned or a resource allocated.
-ADAPTER_SCHEMA_VERSION = "1.3"
+#
+# 1.4 adds the OBSERVATION-PHASE RECOVERY contract: ``phase`` on
+# ``RpcErrorDetail`` (rpc.py) and ``resume_observation`` on ``ExecuteParams``.
+# Together they let an adapter say "my mutation committed; only the read-back
+# failed", which is the one case where a repeat call is safe -- see
+# ``ObservationPhaseError`` below for why the harness cannot infer this on its
+# own. Five paid episodes died at steps 9-32 because a burstable benchmark VM
+# starved its screenshot server for ~25s and the adapter, correctly, refused to
+# build a frameless observation.
+#
+# The bump is required for exactly the reason 1.3's was, in both directions: a
+# 1.3 worker's error line carries no ``phase`` key and fails a 1.4 parent's
+# canonicality check, and a 1.4 worker's ``"phase":"unknown"`` fails a 1.3
+# parent's ``extra="forbid"``. ``resume_observation`` is the same story on the
+# request side.
+ADAPTER_SCHEMA_VERSION = "1.4"
 # One alias for the three models that pin the version, so a future bump cannot
 # move the constant while leaving a model silently accepting the older literal.
-SchemaVersion: TypeAlias = Literal["1.3"]
+SchemaVersion: TypeAlias = Literal["1.4"]
 ADAPTER_ENTRY_POINT_GROUP = "local_operator.evaluation_adapters.v1"
 MAX_RESCUE_REFS = 256
 MAX_REQUIREMENTS = 256
@@ -513,9 +528,62 @@ class ObservationResult(ProtocolModel):
     observation: Observation
 
 
+class ObservationPhaseError(Exception):
+    """The mutation COMMITTED; only reading the resulting state failed.
+
+    An adapter raises this from ``execute`` to state a fact only it can know:
+    the guest actions were applied and the environment moved, and the failure
+    happened afterwards, while reading the new state back. That distinction is
+    the whole safety argument for recovery -- ``execute`` is otherwise treated
+    as an AMBIGUOUS mutation, where a repeat call could apply the actions a
+    second time, and that treatment must not be weakened.
+
+    WHY A DECLARED CONTRACT AND NOT INFERENCE. The parent's only other evidence
+    is ``RpcErrorDetail``: an exception type name, a message, and file/line
+    frames. Keying recovery off any of those would hard-code one benchmark's
+    private internals into a benchmark-neutral harness -- adapter exception
+    names are adapter-owned, unversioned, and free to change in a patch
+    release. The adapter is the code that ordered the two phases, so it is the
+    only honest source of the fact, and it says so in a type the boundary
+    defines. ``AdapterRescueUnsupported`` (worker.py) is the same pattern.
+
+    Raising this WITHOUT having committed the mutation is a contract violation
+    that can double-apply an action. It is safe to raise only from after the
+    point of no return -- typically ``raise ObservationPhaseError(...) from
+    error`` around the read-back that follows the guest call.
+
+    An adapter that never raises it is completely unaffected: the phase
+    defaults to ``unknown`` and every failure poisons exactly as before.
+    """
+
+
 class ExecuteParams(OperationParams):
+    """One action batch to apply, or one committed batch's read-back to resume.
+
+    ``resume_observation`` is set ONLY by the parent, and only after this exact
+    batch already failed with ``phase == "observation"`` -- that is, after the
+    adapter declared the mutation committed. It carries one obligation, which is
+    the contract an adapter accepts by ever raising ``ObservationPhaseError``:
+
+        The adapter MUST NOT apply ``action_batch`` again. It must only re-read
+        the environment and return the observation the failed call could not
+        build, as the exact next sequence after the parent's current one.
+
+    The batch still rides along because the receipt binds to it
+    (``validate_execution`` checks ``action_batch_id``, the input observation,
+    and that the sequence is fresh), so the parent's verification of a resumed
+    call is identical to that of a normal one -- nothing is relaxed to let
+    recovery through.
+
+    Each attempt carries a FRESH ``operation_id`` derived from the original.
+    Reusing the original key would replay the worker's cached error verbatim,
+    which is precisely what the operation cache is for and precisely wrong
+    here: a resumed read is a new call whose outcome is not yet decided.
+    """
+
     action_batch: ActionBatch
     action_batch_id: Digest
+    resume_observation: bool = False
 
     @model_validator(mode="after")
     def _bind_batch(self) -> "ExecuteParams":

--- a/local_operator/evaluation/adapters/rpc.py
+++ b/local_operator/evaluation/adapters/rpc.py
@@ -7,7 +7,7 @@ import errno
 import json
 import os
 from collections.abc import Callable
-from typing import Any, Literal
+from typing import Any, Literal, TypeAlias
 
 from pydantic import Field, field_validator, model_validator
 
@@ -88,6 +88,18 @@ class RpcErrorCause(ProtocolModel):
     message: str = Field(max_length=MAX_DETAIL_MESSAGE)
 
 
+#: Which phase of a mutating call failed, as the ADAPTER declares it.
+#:
+#: ``observation`` means the mutation committed and only the read-back of the
+#: resulting state failed -- the one shape of failure a repeat call cannot
+#: double-apply. ``unknown`` is the default and means exactly what the boundary
+#: assumed before this field existed: the call may or may not have applied, so
+#: it is not safe to repeat. A worker only ever writes ``observation`` when the
+#: adapter raised ``ObservationPhaseError``; nothing is inferred from an
+#: exception type, a message, or a traceback.
+ErrorPhase: TypeAlias = Literal["unknown", "observation"]
+
+
 class RpcErrorDetail(ProtocolModel):
     """Bounded, worker-redacted cause travelling inside the existing envelope.
 
@@ -109,6 +121,12 @@ class RpcErrorDetail(ProtocolModel):
     # operation replay cache returns this error again under a NEW request ID,
     # so the request ID alone does not identify the originating operation.
     operation_id: str | None = Field(default=None, max_length=MAX_DETAIL_NAME)
+    # A CLOSED enum rather than free text, because the parent makes a safety
+    # decision on it: this is the only field in this model that changes what
+    # the harness DOES rather than what it records. Defaulting to "unknown"
+    # keeps every adapter that does not participate on the pre-existing
+    # poison-on-any-mutating-failure path.
+    phase: ErrorPhase = "unknown"
     causes: tuple[RpcErrorCause, ...] = Field(default=(), max_length=MAX_DETAIL_CAUSES)
     frames: tuple[RpcErrorFrame, ...] = Field(default=(), max_length=MAX_DETAIL_FRAMES)
 
@@ -124,6 +142,11 @@ class RpcErrorDetail(ProtocolModel):
         parts.append(f"method={self.method}")
         if self.operation_id is not None:
             parts.append(f"operation_id={self.operation_id}")
+        # Rendered only when it is load-bearing. An "unknown" phase is the
+        # default and adds noise to every pre-existing diagnostic; naming the
+        # observation phase explains why the harness then retried.
+        if self.phase != "unknown":
+            parts.append(f"phase={self.phase}")
         for cause in self.causes:
             parts.append(
                 f"caused by {cause.exception_type}: {cause.message}"

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -54,7 +54,7 @@ from local_operator.evaluation.adapters.discovery import (
     validate_resolved_launch,
     worker_argv,
 )
-from local_operator.evaluation.adapters.rpc import RpcClient
+from local_operator.evaluation.adapters.rpc import RpcClient, RpcRemoteError
 from local_operator.evaluation.evidence.media import (
     MediaValidationError,
     validate_media,
@@ -89,6 +89,39 @@ _DENIED_MARKERS = ("OPENAI", "OPENROUTER", "ANTHROPIC", "MODEL", "PROVIDER")
 
 class SupervisionError(RuntimeError):
     pass
+
+
+def _mutation_committed(error: BaseException) -> bool:
+    """Did the ADAPTER declare that its mutation applied and only the read failed?
+
+    This is the single predicate that decides whether a failed mutating call
+    keeps its session alive, so it is deliberately narrow. It is true only for
+    an answered ``adapter_error`` whose worker-built detail carries
+    ``phase == "observation"`` -- meaning the adapter raised
+    ``ObservationPhaseError`` from ``execute`` after the guest actions
+    committed.
+
+    Everything else stays ambiguous and keeps poisoning, and the exclusions
+    matter more than the inclusion:
+
+    * A TIMEOUT or a CANCELLED call answers nothing. The worker may still be
+      mid-mutation, and ``RpcClient`` has already poisoned the channel.
+    * A PROCESS DEATH, a protocol error, or any ``SupervisionError`` raised by
+      the parent's own verification arrives as a different exception type and
+      never reaches this branch.
+    * A ``phase`` of ``"unknown"`` -- the default, and what every adapter that
+      has not adopted the contract emits -- is ambiguous by definition.
+
+    A session kept alive here is NOT trusted further than before: the resume
+    call re-enters ``_mutating_call``, so a second failure poisons normally.
+    """
+
+    return (
+        isinstance(error, RpcRemoteError)
+        and error.code == "adapter_error"
+        and error.detail is not None
+        and error.detail.phase == "observation"
+    )
 
 
 class _Tail:
@@ -600,8 +633,9 @@ class VerifiedAdapterSession:
             result = await self._supervisor._call_raw(method, params, result_type, timeout=timeout)
             validate(result)
             return result
-        except BaseException:
-            await self._poison_after_ambiguous_mutation()
+        except BaseException as error:
+            if not _mutation_committed(error):
+                await self._poison_after_ambiguous_mutation()
             raise
 
     async def inspect_requirements(
@@ -728,6 +762,57 @@ class VerifiedAdapterSession:
         )
         assert isinstance(result, ExecuteResult)
         self.verifier.accept_execution(params, result)
+        return result
+
+    async def resume_observation(self, params: ExecuteParams, *, timeout: float) -> ExecuteResult:
+        """Re-read the state a COMMITTED batch produced. Never re-applies it.
+
+        Callable only after that same batch failed with ``phase ==
+        "observation"``, i.e. after the adapter declared the mutation committed
+        and only the read-back lost. The caller (``episode._execute_batch``)
+        owns that gate; this method owns the verification, which is not
+        weakened by one clause:
+
+        * ``resume_observation=True`` is set here rather than accepted from the
+          caller, so the obligation "do not apply this batch again" is stated
+          by the boundary that guarantees it.
+        * A fresh ``operation_id`` per attempt. The original key would replay
+          the worker's cached ERROR verbatim -- correct behaviour for the
+          operation cache, and exactly wrong for a read whose outcome is not
+          yet decided.
+        * The result is checked by the ordinary ``validate_execution`` +
+          ``_validate_output`` path: exact next sequence, content-derived
+          identity, receipt bound to this batch and this input observation, and
+          every frame artifact re-opened by digest under the parent's own root
+          with ``O_NOFOLLOW``. A resumed observation clears the same bar as a
+          normal one.
+
+        Still a ``_mutating_call``: a failure here poisons and requires rescue
+        exactly as before. Recovery adds attempts, never a weaker failure mode.
+        """
+
+        current = self.verifier.current_observation
+        if current is None:
+            raise SupervisionError("resume has no current observation")
+        # The batch must still bind to the observation the model acted on. A
+        # resume that arrived after the verifier moved on would be reading for
+        # a step that is already closed.
+        params.action_batch.validate_for(current)
+        self._ensure_usable()
+        resumed = params.model_copy(update={"resume_observation": True})
+        result = await self._mutating_call(
+            "execute",
+            resumed,
+            ExecuteResult,
+            timeout=timeout,
+            validate=lambda value: (
+                self.verifier.validate_execution_result(resumed, value)
+                if isinstance(value, ExecuteResult)
+                else (_ for _ in ()).throw(SupervisionError("execute returned the wrong result"))
+            ),
+        )
+        assert isinstance(result, ExecuteResult)
+        self.verifier.accept_execution(resumed, result)
         return result
 
     def begin_ask(self, params: AskUserExchangeParams) -> None:

--- a/local_operator/evaluation/adapters/worker.py
+++ b/local_operator/evaluation/adapters/worker.py
@@ -24,6 +24,7 @@ from local_operator.evaluation.adapters.api import (
     EvaluationAdapter,
     Handshake,
     HelloParams,
+    ObservationPhaseError,
     PythonRuntime,
     RescuableAdapter,
     RescueDescriptor,
@@ -44,6 +45,7 @@ from local_operator.evaluation.adapters.rpc import (
     WITHHELD,
     AsyncIncrementalReader,
     CancelRequest,
+    ErrorPhase,
     IncrementalWriter,
     RpcError,
     RpcErrorCause,
@@ -164,6 +166,28 @@ def _redacted(value: str, limit: int, redactions: RedactionSet | None) -> str:
     return _control_safe(value, limit)
 
 
+def _error_phase(error: BaseException, method: AdapterMethod) -> ErrorPhase:
+    """Read the failure phase the adapter DECLARED, never one inferred from it.
+
+    An ``isinstance`` check against a type this boundary owns is the whole
+    mechanism, deliberately. The tempting alternatives -- matching an exception
+    name, a message substring, or a traceback filename -- would each turn one
+    adapter's private internals into harness behaviour, and would silently
+    start or stop recovering when that adapter renamed something.
+
+    Only ``execute`` may claim the observation phase. The claim's safety rests
+    on the parent being able to re-read state without re-applying anything,
+    which is a property of the step loop's execute path alone; an adapter that
+    raised it from ``prepare`` or ``cleanup`` would be asking for a repeat of a
+    call the parent has no safe way to resume, so the claim is dropped rather
+    than honoured.
+    """
+
+    if method == "execute" and isinstance(error, ObservationPhaseError):
+        return "observation"
+    return "unknown"
+
+
 def _error_detail(
     error: BaseException,
     method: AdapterMethod,
@@ -219,6 +243,7 @@ def _error_detail(
                 )
             )
         return RpcErrorDetail(
+            phase=_error_phase(error, method),
             exception_type=_redacted(type(error).__name__, MAX_DETAIL_TYPE, redactions)
             or "Exception",
             message=_redacted(str(error), MAX_DETAIL_MESSAGE, redactions),

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -27,6 +27,7 @@ Run-level budget aggregation across episodes is deliberately out of scope.
 
 from __future__ import annotations
 
+import asyncio
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -41,6 +42,7 @@ from local_operator.evaluation.adapters.api import (
     CleanupParams,
     CloseParams,
     ExecuteParams,
+    ExecuteResult,
     Handshake,
     InspectRequirementsParams,
     PrepareParams,
@@ -52,7 +54,7 @@ from local_operator.evaluation.adapters.api import (
     ScoreParams,
     SecretRef,
 )
-from local_operator.evaluation.adapters.rpc import WITHHELD
+from local_operator.evaluation.adapters.rpc import WITHHELD, RpcRemoteError
 from local_operator.evaluation.adapters.supervisor import (
     AdapterSupervisor,
     HostVerifier,
@@ -236,6 +238,23 @@ class EpisodeConfig:
     another; beyond that the model is not converging and every further call
     is money spent on a batch that can never execute. ``0`` restores the old
     one-strike behaviour.
+
+    ``observation_retry_attempts``/``observation_retry_delay`` bound recovery
+    from a transient failure to READ the environment after a step's actions
+    already committed (``_execute_with_observation_recovery``). The defaults --
+    3 attempts, 5s apart -- come from the observed failure: a burstable VM
+    starved its screenshot server for ~25s while the adapter's own upstream
+    already spent ~25s retrying, so ~15s of additional patience covers the
+    credit-recovery window without holding a paid episode open indefinitely.
+    ``0`` attempts restores the previous behaviour, where any such failure
+    destroyed the episode.
+
+    They are ON by default rather than opt-in because the path is unreachable
+    unless an adapter explicitly raises ``ObservationPhaseError``: an adapter
+    that says nothing is bit-for-bit unaffected. The conservatism therefore
+    lives in the adapter's declaration, and a second config gate would only add
+    a way for the feature to be silently off during the paid run it exists to
+    save.
     The frame policy (``keep_recent_frames``) is deliberately NOT here: the
     model client owns its context and is built before the runner
     (``create_provider_model_client(keep_recent_frames=...)``), so a copy on
@@ -256,6 +275,8 @@ class EpisodeConfig:
     max_cycle_cost_micros: int | None = None
     guards: tuple[EpisodeGuard, ...] | None = None
     max_decision_retries: int = 2
+    observation_retry_attempts: int = 3
+    observation_retry_delay: float = 5.0
 
 
 @dataclass(frozen=True)
@@ -931,7 +952,7 @@ class EpisodeRunner:
             action_batch=batch,
             action_batch_id=_adapter_batch_id(batch),
         )
-        result = await session.execute(params, timeout=self._config.step_timeout)
+        result = await self._execute_with_observation_recovery(session, params)
         self._append_batch(batch, terminal=None)
         self._steps_taken += 1
         self._guest_actions += len(batch.actions)
@@ -978,6 +999,91 @@ class EpisodeRunner:
         self._truncation_reason = reason if truncated else None
         self._last_step_terminated = truncated
         self._record_observation(result.observation)
+
+    async def _execute_with_observation_recovery(
+        self, session: VerifiedAdapterSession, params: ExecuteParams
+    ) -> ExecuteResult:
+        """Execute a batch, re-reading state if the environment briefly went blind.
+
+        WHAT THIS EXISTS FOR. Five paid episodes died between steps 9 and 32,
+        each costing $0.12-$0.32, on the same failure: a burstable benchmark VM
+        exhausted its CPU credits, its guest screenshot server stopped
+        answering for ~25s, and the adapter -- correctly -- refused to build a
+        frameless observation for a computer-use model. The actions had already
+        landed. Only the read-back was lost, and the episode was destroyed
+        along with every valid step before it.
+
+        WHY THIS IS SAFE WHEN RETRYING ``execute`` IS NOT. It does not retry
+        the mutation. The adapter declares, by raising
+        ``ObservationPhaseError``, that the batch committed and only the
+        observation phase failed; the supervisor honours that declaration
+        alone, and ``resume_observation`` carries an explicit obligation not to
+        re-apply the batch. Every other failure -- a timeout, a dead worker, a
+        plain adapter error, anything from an adapter that never adopted the
+        contract -- is ambiguous, poisons the session, and ends the episode
+        exactly as it did before.
+
+        HONESTY. Each failed attempt is journalled as an ``error`` event with
+        the adapter's rendered cause, so a bundle shows the environment
+        degrading rather than a suspiciously clean run. Smoothing this over
+        silently would make the benchmark's scores dishonest, since a harness
+        that hides flaky infrastructure reports it as capability.
+        """
+
+        attempts = max(0, self._config.observation_retry_attempts)
+        for attempt in range(attempts + 1):
+            try:
+                if attempt == 0:
+                    return await session.execute(params, timeout=self._config.step_timeout)
+                # Each attempt is its own operation: the worker's replay cache
+                # is keyed by operation_id and would hand back the cached
+                # FAILURE for a reused key.
+                return await session.resume_observation(
+                    params.model_copy(
+                        update={"operation_id": f"{params.operation_id}-obs{attempt}"}
+                    ),
+                    timeout=self._config.step_timeout,
+                )
+            except Exception as error:
+                # Exhausted, or a failure whose mutation is ambiguous: let it
+                # end the episode. The ORIGINAL error propagates on the last
+                # attempt, so the recorded diagnostic names the real fault
+                # rather than the recovery that could not fix it.
+                if attempt == attempts or not _observation_phase_failure(error):
+                    raise
+                self._record_observation_retry(error, attempt + 1, attempts)
+                if self._config.observation_retry_delay > 0:
+                    await asyncio.sleep(self._config.observation_retry_delay)
+        raise AssertionError("unreachable: the loop returns or raises on every path")
+
+    def _record_observation_retry(self, error: Exception, attempt: int, attempts: int) -> None:
+        """Journal one degraded read, before the delay rather than after it.
+
+        Written first so a bundle sealed by a crash DURING the backoff still
+        carries the evidence of why the harness was waiting. ``retryable`` is
+        true because it describes this event, not the episode's fate: an
+        exhausted final attempt propagates and is recorded separately by the
+        fatal-error path.
+        """
+
+        detail = self._publish(
+            f"observation-phase failure, attempt {attempt} of {attempts}: "
+            f"{_diagnostic(error, self._redactions)}".encode("utf-8"),
+            media_type="text/plain",
+        )
+        self._append(
+            "error",
+            ErrorPayload(
+                error_id=f"err-{uuid.uuid4().hex[:12]}",
+                # The environment failed to answer, not the adapter's logic and
+                # not the model. Miscategorising this would let an infrastructure
+                # outage be read as an adapter defect.
+                category="environment",
+                diagnostic_code="observation-phase-retry",
+                detail_artifact=detail,
+                retryable=True,
+            ),
+        )
 
     def _close_turn(self, batch: ActionBatch, *, ask_answer: str | None = None) -> None:
         """Attach the batch just executed to the turn it was decided on.
@@ -1910,6 +2016,28 @@ def _diagnostic(error: BaseException, redactions: RedactionSet | None) -> str:
             # at all -- losing it would undo this PR's own purpose.
             return f"{type(error).__name__}: {WITHHELD}"
     return rendered[:500]
+
+
+def _observation_phase_failure(error: BaseException) -> bool:
+    """Is this the one failure a re-read can recover -- as the ADAPTER declared it?
+
+    Mirrors ``supervisor._mutation_committed`` and must keep mirroring it: the
+    supervisor decides whether the session SURVIVES the failure, and this
+    decides whether the runner tries again. If the runner ever retried a case
+    the supervisor poisoned, every attempt would fail on the poison gate and
+    the episode would pay the full backoff before dying anyway.
+
+    Kept as a separate predicate rather than imported so each module states the
+    condition it depends on, and both are pinned by tests that break if one
+    drifts.
+    """
+
+    return (
+        isinstance(error, RpcRemoteError)
+        and error.code == "adapter_error"
+        and error.detail is not None
+        and error.detail.phase == "observation"
+    )
 
 
 def _diagnostic_code(error: BaseException) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.46.4"
+version = "0.46.6"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
+++ b/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
@@ -91,7 +91,7 @@ def runner_descriptor(tmp_path: Path, episode_id: str, *, secret_refs: Any = ())
 
     tmp_path.mkdir(parents=True, exist_ok=True)
     return RescueDescriptor(
-        schema_version="1.3",
+        schema_version="1.4",
         selector=selector(tmp_path),
         handshake=handshake(tmp_path),
         episode_id=episode_id,

--- a/tests/unit/evaluation/adapters/osworld/test_fake_end_to_end.py
+++ b/tests/unit/evaluation/adapters/osworld/test_fake_end_to_end.py
@@ -25,7 +25,7 @@ asserted only in ``test_spawn.py``, and none of them are asserted here.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from lop_osworld_v2_adapter.adapter import OSWorldV2Adapter
@@ -33,6 +33,7 @@ from lop_osworld_v2_adapter.providers.fake import FakeProvider
 
 from local_operator.evaluation.adapters.api import (
     ADAPTER_SCHEMA_VERSION,
+    AdapterMethod,
     AdapterSelector,
     Handshake,
     PrepareParams,
@@ -40,6 +41,8 @@ from local_operator.evaluation.adapters.api import (
     ResetStartParams,
     ScopedInfraValue,
 )
+from local_operator.evaluation.adapters.rpc import RpcRemoteError
+from local_operator.evaluation.adapters.worker import _error_detail
 from local_operator.evaluation.evidence.verify import verify_bundle
 from local_operator.evaluation.runner.episode import EpisodeRunner
 from tests.unit.evaluation.adapters.osworld import fixtures
@@ -97,7 +100,25 @@ class _AdapterSupervisorShim:
     async def _call_raw(self, method: str, params: Any, result_type: Any, *, timeout: float) -> Any:
         del timeout
         handler = getattr(self._adapter, method)
-        return await handler(params)
+        try:
+            return await handler(params)
+        except Exception as error:
+            # Translate exactly as the worker does. Letting the adapter's own
+            # exception escape raw would be a LIE about this boundary: out of
+            # process the parent never sees an adapter exception type, only an
+            # answered ``adapter_error`` carrying the worker-built detail. The
+            # phase the parent acts on lives in that detail, so a shim that
+            # skipped this step would test a path production does not have.
+            raise RpcRemoteError(
+                "adapter_error",
+                "adapter operation failed",
+                _error_detail(
+                    error,
+                    cast(AdapterMethod, method),
+                    getattr(params, "operation_id", None),
+                    None,
+                ),
+            ) from error
 
 
 def _selector(tmp_path: Path, workspace: Path, adapter: OSWorldV2Adapter) -> AdapterSelector:
@@ -317,3 +338,57 @@ async def test_an_infeasible_task_is_refused_before_anything_is_allocated(
         )
     # Nothing was allocated, so there is nothing to leak.
     assert provider.allocated is False
+
+
+@pytest.mark.asyncio
+async def test_a_blind_guest_costs_a_re_read_not_the_episode(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """The REAL adapter, blinded mid-episode, must recover without re-acting.
+
+    This is the failure that killed five paid episodes: the guest's screenshot
+    server stops answering, ``_get_obs`` yields no frame, and the adapter
+    refuses to build a frameless observation for a computer-use model. The
+    actions had already landed, so the correct outcome is a re-read, not a
+    destroyed episode.
+    """
+
+    # Blind AFTER reset_start's good frame, so the outage starts mid-episode
+    # as the real one did. Two blind reads: the first step's read-back fails,
+    # its first resume fails, the second resume succeeds -- inside the default
+    # 3-attempt bound.
+    provider = FakeProvider(scripted_score=1.0, blind_observations=2, blind_after_observe_calls=1)
+    adapter = _adapter(tmp_path, provider)
+    selector = _selector(tmp_path, adapter._workspace_root, adapter)
+    shim = _AdapterSupervisorShim(adapter, selector)
+
+    runner = EpisodeRunner(
+        _spec_with_task(episode_id),
+        build_config(tmp_path, observation_retry_delay=0.0),
+        selector=selector,
+        # "type" rather than "step": a wait compiles to no guest statements,
+        # so it could not show whether a resume re-applied the batch. A typed
+        # keystroke is a real mutation, and re-applying it would be visible.
+        model=ScriptedModel(["type", "type", "finish"]),
+        launch=lambda _selector: shim,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "completed", outcome.diagnostic
+    assert outcome.score is not None and outcome.score.binary == 1
+    assert outcome.rescue_required is False
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+    assert report.counters is not None
+    assert report.counters.environment_step_count == 2
+
+    # THE SAFETY PROPERTY, at the adapter's own boundary: a resumed call must
+    # re-read WITHOUT re-issuing the guest statements. Each step types once, so
+    # a re-applied batch would type the same keystrokes again.
+    assert len(provider.executed_statements) == 2
+
+    # The re-reads really happened: 1 reset + 2 failed + 2 successful.
+    assert provider.observe_calls == 5

--- a/tests/unit/evaluation/adapters/osworld/test_secrets_and_rescue.py
+++ b/tests/unit/evaluation/adapters/osworld/test_secrets_and_rescue.py
@@ -419,7 +419,7 @@ async def test_rescue_without_aws_secrets_fails_closed(
 
 
 def test_schema_is_1_2_and_secrets_live_only_on_reset_and_rescue() -> None:
-    assert ADAPTER_SCHEMA_VERSION == "1.3"
+    assert ADAPTER_SCHEMA_VERSION == "1.4"
     assert "secrets" in ResetStartParams.model_fields
     assert "secrets" in BeginRescueParams.model_fields
     assert "secrets" not in PrepareParams.model_fields

--- a/tests/unit/evaluation/adapters/test_api.py
+++ b/tests/unit/evaluation/adapters/test_api.py
@@ -27,7 +27,7 @@ def selector(tmp_path: Path) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return AdapterSelector(
-        schema_version="1.3",
+        schema_version="1.4",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.2.3",
@@ -49,7 +49,7 @@ def metadata() -> AdapterMetadata:
         entry_point="tiny_adapter:create",
         package_digest=DIGEST,
         release_digest="b" * 64,
-        schema_version="1.3",
+        schema_version="1.4",
         capabilities=AdapterCapabilities(routes=("computer",), ask_user=True, scoring=True),
     )
 
@@ -133,7 +133,7 @@ def test_scoped_infra_has_no_provider_or_model_purpose() -> None:
 def test_rescue_descriptor_is_content_bound_and_has_refs_not_secrets(tmp_path: Path) -> None:
     selected = selector(tmp_path)
     descriptor = RescueDescriptor(
-        schema_version="1.3",
+        schema_version="1.4",
         selector=selected,
         handshake=handshake(tmp_path),
         episode_id="episode",

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -101,7 +101,7 @@ def selected(tmp_path: Path, digest: str) -> AdapterSelector:
         shutil.copy2(Path(sys.executable).resolve(), executable)
         executable.chmod(0o755)
     return AdapterSelector(
-        schema_version="1.3",
+        schema_version="1.4",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.0",

--- a/tests/unit/evaluation/adapters/test_launch.py
+++ b/tests/unit/evaluation/adapters/test_launch.py
@@ -75,7 +75,7 @@ def create():
             entry_point="tiny_e2e_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="%s",
-            schema_version="1.3",
+            schema_version="1.4",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=False
             ),
@@ -170,7 +170,7 @@ def create():
             entry_point="rescue_e2e_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="{release}",
-            schema_version="1.3",
+            schema_version="1.4",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=False
             ),
@@ -272,7 +272,7 @@ async def test_supervisor_launch_completes_real_handshake_and_reaps(tmp_path: Pa
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     selector = AdapterSelector(
-        schema_version="1.3",
+        schema_version="1.4",
         adapter_id="tiny-e2e",
         distribution="tiny-e2e-adapter",
         version="1.0",
@@ -317,7 +317,7 @@ def _rescue_selector(tmp_path: Path) -> AdapterSelector:
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     return AdapterSelector(
-        schema_version="1.3",
+        schema_version="1.4",
         adapter_id="rescue-e2e",
         distribution="rescue-e2e-adapter",
         version="1.0",
@@ -348,7 +348,7 @@ def _rescue_descriptor(selector: AdapterSelector, handshake: Handshake, root: Pa
         ),
     )
     return RescueDescriptor(
-        schema_version="1.3",
+        schema_version="1.4",
         selector=selector,
         handshake=handshake,
         episode_id="episode",
@@ -422,7 +422,7 @@ async def test_spawned_rescue_worker_refuses_an_adapter_without_begin_rescue(
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     selector = AdapterSelector(
-        schema_version="1.3",
+        schema_version="1.4",
         adapter_id="tiny-e2e",
         distribution="tiny-e2e-adapter",
         version="1.0",
@@ -513,7 +513,7 @@ def create():
             entry_point="failing_e2e_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="{release}",
-            schema_version="1.3",
+            schema_version="1.4",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=False
             ),
@@ -540,7 +540,7 @@ def _failing_selector(tmp_path: Path) -> AdapterSelector:
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     return AdapterSelector(
-        schema_version="1.3",
+        schema_version="1.4",
         adapter_id="failing-e2e",
         distribution="failing-e2e-adapter",
         version="1.0",
@@ -697,7 +697,7 @@ def create():
             entry_point="leaky_e2e_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="{release}",
-            schema_version="1.3",
+            schema_version="1.4",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=False
             ),
@@ -724,7 +724,7 @@ def _leaky_selector(tmp_path: Path) -> AdapterSelector:
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     return AdapterSelector(
-        schema_version="1.3",
+        schema_version="1.4",
         adapter_id="leaky-e2e",
         distribution="leaky-e2e-adapter",
         version="1.0",

--- a/tests/unit/evaluation/adapters/test_supervisor.py
+++ b/tests/unit/evaluation/adapters/test_supervisor.py
@@ -22,6 +22,7 @@ from local_operator.evaluation.adapters.api import (
     CleanupOutcome,
     CleanupParams,
     CleanupResult,
+    ExecuteParams,
     Handshake,
     ObservationResult,
     ObserveParams,
@@ -34,6 +35,7 @@ from local_operator.evaluation.adapters.api import (
     ScoreResult,
     observation_content_id,
 )
+from local_operator.evaluation.adapters.rpc import RpcErrorDetail, RpcRemoteError
 from local_operator.evaluation.adapters.supervisor import (
     MAX_DIAGNOSTIC_TAIL,
     HostVerifier,
@@ -47,16 +49,25 @@ from local_operator.evaluation.adapters.supervisor import (
     run_rescue,
     verify_artifact,
 )
-from local_operator.evaluation.evidence.models import EvidenceArtifactRef, ScoreArtifact
+from local_operator.evaluation.evidence.models import (
+    EvidenceArtifactRef,
+    ScoreArtifact,
+    canonical_digest,
+)
 from local_operator.evaluation.lifecycle import CleanupAction, CleanupPlan
-from local_operator.evaluation.protocol import ArtifactRef, Observation
+from local_operator.evaluation.protocol import (
+    ActionBatch,
+    ArtifactRef,
+    Observation,
+    WaitAction,
+)
 
 
 def selector(tmp_path: Path) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return AdapterSelector(
-        schema_version="1.3",
+        schema_version="1.4",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.0",
@@ -78,7 +89,7 @@ def metadata() -> AdapterMetadata:
         entry_point="tiny_adapter:create",
         package_digest="a" * 64,
         release_digest="b" * 64,
-        schema_version="1.3",
+        schema_version="1.4",
         capabilities=AdapterCapabilities(routes=("computer",), ask_user=False, scoring=True),
     )
 
@@ -110,7 +121,7 @@ def plan() -> CleanupPlan:
 
 def descriptor(tmp_path: Path) -> RescueDescriptor:
     return RescueDescriptor(
-        schema_version="1.3",
+        schema_version="1.4",
         selector=selector(tmp_path),
         handshake=handshake(tmp_path),
         episode_id="episode",
@@ -525,3 +536,129 @@ async def test_rescue_rejects_duplicate_receipts_and_reaps(tmp_path: Path) -> No
     with pytest.raises(SupervisionError, match="missing or duplicate"):
         await run_rescue(rescue, launch=lambda _: fake)  # type: ignore[arg-type]
     assert fake.terminated
+
+
+def _execute_params(current: Any) -> ExecuteParams:
+    """A batch bound to ``current``, as the runner builds one."""
+
+    batch = ActionBatch(
+        protocol_version="1.0",
+        task_id=current.task_id,
+        episode_id=current.episode_id,
+        observation_id=current.observation_id,
+        actions=(WaitAction(observation_id=current.observation_id, duration_ms=1),),
+    )
+    return ExecuteParams(
+        operation_id="exec-0",
+        action_batch=batch,
+        action_batch_id=canonical_digest("adapter-action-batch-v1", batch),
+    )
+
+
+def _adapter_error(phase: str) -> RpcRemoteError:
+    """The wire error a worker answers with, at the given declared phase."""
+
+    return RpcRemoteError(
+        "adapter_error",
+        "adapter operation failed",
+        RpcErrorDetail(
+            exception_type="ObservationPhaseError",
+            message="environment returned no screenshot frame",
+            method="execute",
+            operation_id="exec-0",
+            phase=phase,  # pyright: ignore[reportArgumentType]
+        ),
+    )
+
+
+def test_declared_observation_phase_failure_keeps_the_session_usable(
+    tmp_path: Path,
+) -> None:
+    """The recovery precondition: a declared observation failure must NOT poison.
+
+    Without this the runner's retry is dead code -- every attempt would hit the
+    poison gate, and the episode would pay the full backoff before dying anyway.
+    """
+
+    verifier = HostVerifier("task", "episode", tmp_path)
+    verifier.accept_initial(observation("task", "episode", 0))
+    raw = RawSupervisor([_adapter_error("observation")])
+    rescue_required: list[bool] = []
+    session = VerifiedAdapterSession(
+        raw,  # pyright: ignore[reportArgumentType]
+        verifier,
+        rescue_required=lambda: rescue_required.append(True),
+    )
+
+    async def run() -> None:
+        with pytest.raises(RpcRemoteError):
+            await session.execute(_execute_params(verifier.current_observation), timeout=1)
+        # Usable, not poisoned: the very next call must reach the adapter.
+        session._ensure_usable()
+
+    import asyncio
+
+    asyncio.run(run())
+    # The worker was left ALIVE and no rescue was demanded, which is what makes
+    # a subsequent re-read possible at all.
+    assert not raw.terminated and rescue_required == []
+
+
+@pytest.mark.parametrize("phase", ["unknown", "observation"])
+def test_only_a_declared_observation_phase_escapes_the_poison(tmp_path: Path, phase: str) -> None:
+    """An UNDECLARED failure stays ambiguous and must poison exactly as before.
+
+    This is the safety boundary of the whole feature: an adapter that says
+    nothing about its phase -- every adapter that has not adopted the contract
+    -- must keep the pre-existing poison-on-any-mutating-failure behaviour,
+    because a repeat call there could apply the mutation a second time.
+    """
+
+    verifier = HostVerifier("task", "episode", tmp_path)
+    verifier.accept_initial(observation("task", "episode", 0))
+    raw = RawSupervisor([_adapter_error(phase)])
+    rescue_required: list[bool] = []
+    session = VerifiedAdapterSession(
+        raw,  # pyright: ignore[reportArgumentType]
+        verifier,
+        rescue_required=lambda: rescue_required.append(True),
+    )
+
+    async def run() -> None:
+        with pytest.raises(RpcRemoteError):
+            await session.execute(_execute_params(verifier.current_observation), timeout=1)
+
+    import asyncio
+
+    asyncio.run(run())
+    poisoned = phase == "unknown"
+    assert raw.terminated is poisoned
+    assert rescue_required == ([True] if poisoned else [])
+
+
+def test_a_timeout_never_claims_the_observation_phase(tmp_path: Path) -> None:
+    """A call that was never ANSWERED is ambiguous whatever its phase would be.
+
+    A timeout is the case where the worker may still be mid-mutation, so it
+    must poison. It reaches ``_mutating_call`` as a bare ``TimeoutError`` with
+    no detail at all, and the predicate must not be tempted to guess.
+    """
+
+    verifier = HostVerifier("task", "episode", tmp_path)
+    verifier.accept_initial(observation("task", "episode", 0))
+    raw = RawSupervisor([TimeoutError("adapter call timed out")])
+    rescue_required: list[bool] = []
+    session = VerifiedAdapterSession(
+        raw,  # pyright: ignore[reportArgumentType]
+        verifier,
+        rescue_required=lambda: rescue_required.append(True),
+    )
+
+    async def run() -> None:
+        with pytest.raises(TimeoutError):
+            await session.execute(_execute_params(verifier.current_observation), timeout=1)
+
+    import asyncio
+
+    asyncio.run(run())
+    assert raw.terminated and rescue_required == [True]

--- a/tests/unit/evaluation/adapters/test_worker.py
+++ b/tests/unit/evaluation/adapters/test_worker.py
@@ -279,7 +279,7 @@ def rescue_selector(tmp_path: Path) -> AdapterSelector:
     release_digest = "b" * 64
     (workspace / "adapter-release.json").write_text(f'{{"release_digest":"{release_digest}"}}')
     return AdapterSelector(
-        schema_version="1.3",
+        schema_version="1.4",
         adapter_id="rescue",
         distribution="rescue-adapter",
         version="1.0",
@@ -301,7 +301,7 @@ def rescue_metadata() -> AdapterMetadata:
         entry_point="rescue_adapter:create",
         package_digest="a" * 64,
         release_digest="b" * 64,
-        schema_version="1.3",
+        schema_version="1.4",
         capabilities=AdapterCapabilities(routes=("computer",), ask_user=False, scoring=False),
     )
 
@@ -348,7 +348,7 @@ async def test_real_worker_rescue_invokes_each_cleanup_once_and_blocks_normal_fl
             ),
         )
         descriptor = RescueDescriptor(
-            schema_version="1.3",
+            schema_version="1.4",
             selector=selected,
             handshake=handshake,
             episode_id="episode",
@@ -470,7 +470,7 @@ def test_rescue_cleanup_rejects_forged_episode_and_action_without_losing_pin(
         selected_route="computer",
     )
     descriptor = RescueDescriptor(
-        schema_version="1.3",
+        schema_version="1.4",
         selector=selected,
         handshake=pinned_handshake,
         episode_id="episode",
@@ -535,3 +535,53 @@ async def test_worker_rejects_cancel_without_inflight_call() -> None:
                     os.close(fd)
             except OSError:
                 pass
+
+
+def test_error_phase_is_declared_by_the_adapter_and_only_for_execute() -> None:
+    """The worker REPORTS a declared phase; it never infers one.
+
+    The parent makes a safety decision on this field -- whether a failed
+    mutating call may keep its session -- so the two ways to get it wrong are
+    pinned here:
+
+    * A phase is stamped only for an ``ObservationPhaseError``. An ordinary
+      adapter exception, however much its text looks like a screenshot
+      failure, stays ``unknown`` and keeps poisoning.
+    * Only ``execute`` may claim it. The recovery path re-reads state after a
+      committed step; there is no equivalent for ``prepare`` or ``cleanup``,
+      so a claim from one of those is dropped rather than honoured.
+    """
+
+    from local_operator.evaluation.adapters.api import ObservationPhaseError
+    from local_operator.evaluation.adapters.worker import _error_detail
+
+    declared = _error_detail(
+        ObservationPhaseError("environment returned no screenshot frame"),
+        "execute",
+        "exec-0",
+        None,
+    )
+    assert declared is not None and declared.phase == "observation"
+    # It renders, so a bundle reader can see why the harness retried.
+    assert "phase=observation" in declared.render()
+
+    # An undeclared failure whose message names the same symptom.
+    undeclared = _error_detail(
+        RuntimeError("environment returned no screenshot frame"),
+        "execute",
+        "exec-0",
+        None,
+    )
+    assert undeclared is not None and undeclared.phase == "unknown"
+    assert "phase=" not in undeclared.render()
+
+    # The same declared exception raised from a method that cannot be resumed.
+    for method in ("prepare", "reset_start", "score", "cleanup"):
+        wrong_method = _error_detail(
+            ObservationPhaseError("no screenshot"),
+            method,  # pyright: ignore[reportArgumentType]
+            "op-0",
+            None,
+        )
+        assert wrong_method is not None
+        assert wrong_method.phase == "unknown", method

--- a/tests/unit/evaluation/runner/conftest.py
+++ b/tests/unit/evaluation/runner/conftest.py
@@ -73,7 +73,7 @@ def selector(tmp_path: Path) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return AdapterSelector(
-        schema_version="1.3",
+        schema_version="1.4",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.0",
@@ -97,7 +97,7 @@ def handshake(tmp_path: Path) -> Handshake:
             entry_point="tiny_adapter:create",
             package_digest="a" * 64,
             release_digest="b" * 64,
-            schema_version="1.3",
+            schema_version="1.4",
             capabilities=AdapterCapabilities(routes=("computer",), ask_user=True, scoring=True),
         ),
         python=PythonRuntime.current(),

--- a/tests/unit/evaluation/runner/test_episode_subprocess.py
+++ b/tests/unit/evaluation/runner/test_episode_subprocess.py
@@ -57,6 +57,7 @@ from local_operator.evaluation.adapters.api import (
     CleanupResult,
     ExecuteResult,
     ExecutionReceipt,
+    ObservationPhaseError,
     ObservationResult,
     PrepareResult,
     RequirementsResult,
@@ -143,6 +144,42 @@ def _frame_mode():
             return handle.read().strip()
     except OSError:
         return ""
+
+
+# How many times the OBSERVATION phase of execute should fail before it starts
+# succeeding, armed the same adapter-owned way as the cutpoint. This reproduces
+# the paid-episode failure exactly: the guest actions land, and the read-back
+# that follows raises. The countdown lives in a FILE because it must survive
+# across separate execute calls and be observable from the parent.
+def _observation_failures():
+    import os
+
+    path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "tiny_observation_failures"
+    )
+    try:
+        with open(path) as handle:
+            return int(handle.read().strip() or "0")
+    except (OSError, ValueError):
+        return 0
+
+
+# Burn one armed failure and report whether this call should fail. Decrementing
+# on disk is what makes the failure TRANSIENT rather than permanent: the
+# exhausted-retries test arms more failures than the runner has attempts, and
+# the recovery test arms fewer.
+def _consume_observation_failure():
+    import os
+
+    path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "tiny_observation_failures"
+    )
+    remaining = _observation_failures()
+    if remaining <= 0:
+        return False
+    with open(path, "w") as handle:
+        handle.write(str(remaining - 1))
+    return True
 
 
 # Whether reset_start should import a task module from the WORKSPACE (the
@@ -256,6 +293,13 @@ class TinyAdapter:
         # Learned ONLY from reset_start; the stripped environment offers no
         # other route to it, which is exactly what this fixture proves.
         self.artifact_root = None
+        # How many times a batch was actually APPLIED, published beside the
+        # module so the parent can assert a resumed call did not re-apply one.
+        self.applied = 0
+        self.applied_path = __import__("os").path.join(
+            __import__("os").path.dirname(__import__("os").path.abspath(__file__)),
+            "tiny_applied_count",
+        )
 
     def _maybe_die(self, name):
         if _cutpoint() == name:
@@ -300,10 +344,25 @@ class TinyAdapter:
 
     async def execute(self, params):
         self._maybe_die("execute")
-        self.sequence += 1
+        # The MUTATION. Recorded so a test can prove a resumed call did not
+        # apply the batch a second time -- the safety property the whole
+        # observation-phase contract rests on.
+        if not params.resume_observation:
+            self.applied += 1
+            with open(self.applied_path, "w") as handle:
+                handle.write(str(self.applied))
+
+        # PAST THE POINT OF NO RETURN: from here a failure is a failure to
+        # READ, which is what ObservationPhaseError declares. The sequence is
+        # advanced only after the observation is built, so a failed attempt
+        # leaves the adapter where it was and the resumed attempt yields the
+        # sequence the parent expects.
+        if _consume_observation_failure():
+            raise ObservationPhaseError("environment returned no screenshot frame")
         output = _observation(
-            self.task_id, self.episode_id, self.sequence, self.artifact_root
+            self.task_id, self.episode_id, self.sequence + 1, self.artifact_root
         )
+        self.sequence += 1
         receipt = ExecutionReceipt(
             operation_id=params.operation_id,
             action_batch_id=params.action_batch_id,
@@ -349,7 +408,7 @@ def create():
             entry_point="tiny_runner_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="%s",
-            schema_version="1.3",
+            schema_version="1.4",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=True
             ),
@@ -420,7 +479,7 @@ def real_selector(tmp_path: Path, adapter_site: Path) -> AdapterSelector:
     (workspace / "tasks" / "pkg").mkdir(exist_ok=True)
     (workspace / "tasks" / "pkg" / "mod.py").write_text("MARK = 'nested'\n")
     return AdapterSelector(
-        schema_version="1.3",
+        schema_version="1.4",
         adapter_id="tiny-runner",
         distribution="tiny-runner-adapter",
         version="1.0",
@@ -434,7 +493,7 @@ def real_selector(tmp_path: Path, adapter_site: Path) -> AdapterSelector:
     )
 
 
-def _subprocess_config(tmp_path: Path) -> Any:
+def _subprocess_config(tmp_path: Path, **overrides: Any) -> Any:
     """Config with timeouts sized for a REAL interpreter spawn.
 
     The in-process default of 5s is ample for a fake adapter but marginal here:
@@ -453,6 +512,7 @@ def _subprocess_config(tmp_path: Path) -> Any:
         step_timeout=60.0,
         score_timeout=60.0,
         cleanup_timeout=60.0,
+        **overrides,
     )
 
 
@@ -505,6 +565,155 @@ def _arm_frames(site: Path, mode: str | None) -> None:
         marker.unlink(missing_ok=True)
     else:
         marker.write_text(mode)
+
+
+def _arm_observation_failures(site: Path, count: int) -> None:
+    """Arm N consecutive observation-phase failures in the installed adapter.
+
+    Armed through a file for the same reason the cutpoint is: the worker's
+    environment is built from a closed allowlist, so a test cannot hand it a
+    mode any other way without weakening the policy under test.
+    """
+
+    marker = site / "tiny_observation_failures"
+    if count <= 0:
+        marker.unlink(missing_ok=True)
+    else:
+        marker.write_text(str(count))
+
+
+def _applied_count(site: Path) -> int:
+    """How many times the adapter actually APPLIED a batch."""
+
+    marker = site / "tiny_applied_count"
+    try:
+        return int(marker.read_text().strip())
+    except (OSError, ValueError):
+        return 0
+
+
+def _retry_events(root: Path) -> list[dict[str, Any]]:
+    """Every journalled observation-phase retry in a sealed bundle."""
+
+    events = [json.loads(line) for line in (root / "events.jsonl").read_text().splitlines() if line]
+    return [
+        event
+        for event in events
+        if event["kind"] == "error"
+        and event["payload"]["diagnostic_code"] == "observation-phase-retry"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transient_observation_failure_does_not_destroy_the_episode(
+    tmp_path: Path,
+    episode_id: str,
+    real_selector: AdapterSelector,
+    adapter_site: Path,
+) -> None:
+    """The paid-episode failure, reproduced end to end against a real worker.
+
+    Five real episodes died between steps 9 and 32 like this: a burstable VM
+    starved its guest screenshot server, the read-back after a committed step
+    failed, and the whole episode was destroyed along with every valid step
+    before it. Here the first step's observation phase fails twice and then
+    recovers; the episode must reach a normal scored ending.
+    """
+
+    _arm_cutpoint(adapter_site, None)
+    _arm_frames(adapter_site, "honest")
+    _arm_observation_failures(adapter_site, 2)
+    # No sleeping in a unit test; the bound under test is the ATTEMPT count.
+    config = _subprocess_config(tmp_path, observation_retry_delay=0.0)
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        config,
+        selector=real_selector,
+        model=ScriptedModel(["step", "step", "finish"]),
+        launch=AdapterSupervisor.launch,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "completed", outcome.diagnostic
+    assert outcome.score is not None and outcome.score.status == "scored"
+    # Never poisoned, so no rescue was demanded and no VM was abandoned.
+    assert outcome.rescue_required is False
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+    assert report.counters is not None
+    assert report.counters.environment_step_count == 2
+
+    # THE SAFETY PROPERTY: two steps ran, so the batch was applied exactly
+    # twice. A resumed call that re-applied its batch would show more.
+    assert _applied_count(adapter_site) == 2
+
+    # THE HONESTY PROPERTY: both degraded reads are in the evidence, so a
+    # reader sees the environment faltered rather than a suspiciously clean run.
+    retries = _retry_events(root)
+    assert len(retries) == 2
+    assert all(event["payload"]["category"] == "environment" for event in retries)
+    assert all(event["payload"]["retryable"] is True for event in retries)
+
+
+@pytest.mark.asyncio
+async def test_exhausted_observation_retries_still_fail_and_seal_the_bundle(
+    tmp_path: Path,
+    episode_id: str,
+    real_selector: AdapterSelector,
+    adapter_site: Path,
+) -> None:
+    """Recovery is BOUNDED: past the bound the episode still dies cleanly.
+
+    A harness that retried forever would hold a paid VM open against a dead
+    environment. The bundle must still seal and verify, so an unrecoverable
+    outage stays auditable rather than merely survived.
+    """
+
+    _arm_cutpoint(adapter_site, None)
+    _arm_frames(adapter_site, "honest")
+    # One more failure than the runner has attempts.
+    _arm_observation_failures(adapter_site, 5)
+    config = _subprocess_config(tmp_path, observation_retry_delay=0.0)
+    rescued: list[Any] = []
+
+    async def recording_rescue(descriptor: Any, **kwargs: Any) -> Any:
+        del kwargs
+        rescued.append(descriptor)
+
+        class _Aggregate:
+            complete = True
+            descriptor_id = descriptor.descriptor_id
+
+        return _Aggregate()
+
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        config,
+        selector=real_selector,
+        model=ScriptedModel(["step", "step", "finish"]),
+        launch=AdapterSupervisor.launch,
+        rescue=recording_rescue,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "failed", outcome.diagnostic
+    # The ORIGINAL cause is recorded, not the recovery that could not fix it.
+    assert outcome.diagnostic is not None
+    assert "no screenshot frame" in outcome.diagnostic
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+
+    # Exactly the configured bound: 3 retries, then the failure propagates.
+    assert len(_retry_events(root)) == 3
+    # The step never completed, so no step event was written for it.
+    assert report.counters is not None
+    assert report.counters.environment_step_count == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Five paid OSWorld episodes died between steps 9 and 32, each costing $0.12-$0.32, on the same failure:

```
ObservationError: environment returned no screenshot frame; method=execute;
operation_id=exec-19-2c29bfece6b6; at worker.py:402 in _handle <- worker.py:610
in _dispatch <- adapter.py:653 in execute <- observation.py:121 in build
```

Root cause (instrumented on a real run): the benchmark VM is a **burstable** `t3.xlarge`, and at the failure moment CloudWatch showed `CPUCreditBalance 4.2` with `CPUSurplusCreditBalance 0.0` and CPU throttled to 10.3%, while AWS status checks stayed `ok`. The guest's screenshot HTTP server was starved and stopped answering. Upstream OSWorld already retries 3 times at 5s intervals (~25s, matching the observed 24s delay exactly) and then returns `None`; the adapter then correctly refused to build a frameless observation, because a computer-use model cannot act on one.

**The actions had already landed.** Only the read-back was lost — and the episode was destroyed along with every valid step before it. This is the harness half of the fix (the instance type is handled separately in #610).

## The design question, and why the answer is a contract

`execute` is a MUTATING call, and the supervisor deliberately poisons on any mutating-call failure because retrying a possibly-applied mutation is unsafe. **That reasoning is sound and is not weakened here.** A previous agent correctly declined to make mutating calls retryable.

The insight is that this failure is not in *applying* the action but in *reading the result*. So: can the harness distinguish "the mutation may not have applied" from "the mutation applied but the observation could not be read"?

**By itself, no — and it must not try.** The parent's only evidence is `RpcErrorDetail`: an exception type name, a message, and file/line frames. Keying recovery off `exception_type == "ObservationError"`, or off `observation.py` appearing in the frames, would hard-code one benchmark's private internals into a benchmark-neutral harness. Adapter exception names are adapter-owned and unversioned; that recovery would start or stop working when an adapter renamed something.

The **adapter** knows exactly, because it is the code that ordered the two phases. So the fact is obtained by contract, not inference:

- **`ObservationPhaseError`** (`adapters/api.py`) — a benchmark-neutral exception any adapter may raise from `execute` to state that the mutation committed and only the read-back failed. Precedent: `AdapterRescueUnsupported` is already a named worker-recognised exception at this boundary.
- The worker stamps **`RpcErrorDetail.phase`** — a closed enum, default `unknown` — only for that exception type and only from `execute`. A claim from `prepare` or `cleanup` is dropped rather than honoured, because there is no safe resume for those.
- **`_mutation_committed`** (supervisor) lets a session survive exactly that case. Timeouts, cancellations, process death, protocol errors, parent-side `SupervisionError`s, and every `unknown` phase keep poisoning exactly as before.
- **`resume_observation`** re-reads through `execute` with `resume_observation=True` — an explicit obligation not to re-apply the batch — and a **fresh `operation_id` per attempt**, since the worker's replay cache is keyed by operation id and would otherwise hand back the cached *failure*.

`observe` was evaluated first and cannot do this job: `verify_current_snapshot` requires the returned observation to equal the one the parent already holds, so a loop over `observe` returns the stale pre-action observation forever.

Nothing is relaxed to let recovery through. A resumed result clears the ordinary bar: exact next sequence, content-derived identity, receipt bound to this batch and input observation, and every frame artifact re-opened by digest under the parent's own root with `O_NOFOLLOW`.

## Bounded, observable, honest

- **Bounded**: `observation_retry_attempts` (3) and `observation_retry_delay` (5.0s). The adapter's upstream already spends ~25s retrying, so ~15s more covers the credit-recovery window without holding a paid VM open on a dead environment. `0` restores the old one-strike behaviour.
- **Observable**: every attempt is journalled as an `error` event, `category="environment"`, `retryable=true`, with the adapter's rendered cause as a detail artifact. **A benchmark that hides flaky infrastructure produces dishonest scores**, so the bundle shows the environment degrading rather than a suspiciously clean run.
- **Exhaustion**: re-raises the ORIGINAL error (not the recovery that failed) and falls through to the existing poison → rescue → sealed-bundle path.

**On by default rather than behind a flag**, deliberately: the path is unreachable unless an adapter explicitly raises `ObservationPhaseError`, so every adapter that exists today is bit-for-bit unaffected. The conservatism lives in the adapter's declaration, and a second config gate would only add a way for the feature to be silently off during the paid run it exists to save.

## Adapter changes

The OSWorld adapter declares the phase and skips re-issuing guest statements on a resume. Its sequence counter now advances **only after** the observation is successfully built — previously `self._sequence += 1` ran before `build()`, so a failed read would skip a sequence number and the parent's "exact next sequence" check would reject the very observation it asked for.

## Schema 1.3 → 1.4

Required for the same reason 1.3's bump was, in both directions: every RPC line must round-trip byte-identically, and a model serialises its full field set. A 1.3 worker's error line (no `phase`) fails a 1.4 parent's canonicality check; a 1.4 worker's `"phase":"unknown"` fails a 1.3 parent's `extra="forbid"`. The exact-version pin in `AdapterSelector` turns that into a refusal at selection time, before a worker is spawned or a resource allocated.

## Testing evidence

Reproduced end to end with a **real adapter subprocess** (a genuine interpreter running a genuine installed adapter distribution, spawned by the real supervisor over the real pipe), not a unit mock.

**BEFORE** — recovery disabled (`observation_retry_attempts=0`), the same transient failure, verbatim:

```
$ .venv/bin/python -m pytest tests/unit/evaluation/runner/test_episode_subprocess.py -q -n0 -k transient
E       AssertionError: RpcRemoteError: adapter_error: adapter operation failed
        [ObservationPhaseError: environment returned no screenshot frame; method=execute;
         operation_id=exec-0-19b65a79e76c; phase=observation;
         at worker.py:427 in _handle <- worker.py:635 in _dispatch
         <- tiny_runner_adapter.py:313 in execute]
E       assert 'failed' == 'completed'
E         + failed
FAILED ... test_transient_observation_failure_does_not_destroy_the_episode
```

That is the production failure signature, reproduced.

**AFTER** — default 3 attempts:

```
$ .venv/bin/python -m pytest tests/unit/evaluation/runner/test_episode_subprocess.py -q -n0 -k observation
..                                                                       [100%]
2 passed, 14 deselected in 18.87s
```

The surviving episode is asserted to be genuinely healthy, not merely non-crashing:

- `status == "completed"`, scored, `rescue_required is False` (session never poisoned, no VM abandoned)
- `verify_bundle(root).valid` and `environment_step_count == 2`
- **applied exactly twice** across two steps — a resumed call that re-applied its batch would show more
- **both degraded reads present** in `events.jsonl` as `observation-phase-retry` / `category=environment`

The exhausted case still fails cleanly with a verifiable sealed bundle: `status == "failed"`, the diagnostic names the original cause, `verify_bundle(...).valid`, exactly 3 retry events, and `environment_step_count == 0` (the step never completed, so no step event was written).

A second end-to-end test drives the **real OSWorld adapter** over `FakeProvider` with the guest blinded mid-episode (after `reset_start`'s good frame, as the real outage began), using a `type` action so a re-applied batch would be visible: the episode completes and `executed_statements == 2`.

### Mutation testing

Every new test was verified to fail against the bug it guards. Two mutations initially **survived** and the tests were strengthened until they did not:

| Mutation | Result |
|---|---|
| `observation_retry_attempts = 0` | FAILS — both proof tests, with the verbatim production error |
| resume sets `resume_observation=False` (re-applies) | FAILS — `assert 4 == 2` applications |
| supervisor drops the phase gate (any `adapter_error` survives) | initially SURVIVED → added `test_only_a_declared_observation_phase_escapes_the_poison`; now FAILS |
| worker stamps phase for any method | initially SURVIVED → added `test_error_phase_is_declared_by_the_adapter_and_only_for_execute`; now FAILS |
| worker stamps phase for any exception type | FAILS |
| runner retries any error (drops phase check) | FAILS — 4 tests, poisoned-session errors |
| OSWorld adapter re-applies batch on resume | FAILS — `assert 4 == 2` typed statements |
| OSWorld adapter advances sequence before build | FAILS — "adapter output must be the exact next sequence" |
| OSWorld adapter does not declare the phase | FAILS — episode dies as before |

### Gates (whole tree, exactly as CI, each exit code checked directly)

```
flake8=0    black=0 (26.1.0)    isort=0 (5.13.2)    pyright=0
12354 passed, 15 skipped in 868.70s
```

One earlier full-suite run showed a single failure in `test_run_episode_script.py`; that was **my own interference** — I ran `git stash` on the source tree for the before/after capture while the suite was running in the background, so a worker briefly imported main's 1.3 code. Confirmed by re-running the file (6 passed), the module (786 passed) and the whole suite undisturbed (12354 passed, 0 failed).

## Not addressed

- The burstable-instance root cause itself is out of scope here and handled in #610.
- `observe`'s own poison-on-failure behaviour is left exactly as documented in its docstring; it still has no caller in the step loop, so relaxing it would rescue nothing today.
