### PR TITLE
feat(instructions): read a user-scope AGENTS.md alongside system_prompt.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,6 +737,31 @@ and falls back to `/bin/sh` only on a host with no bash — so process
 substitution and other bash syntax work as the tool's name promises. Every
 option is browsable in `/settings`.
 
+### Standing instructions
+
+Your machine-wide preferences — output style, commit conventions, safety
+rules — live in `~/.local-operator/system_prompt.md`, editable from
+Settings → Instructions, `PATCH /v1/config/system-prompt`, or your editor.
+They ride every session and every subagent.
+
+If you also run Claude Code, Codex, opencode or droid, Local Operator reads
+`~/.agents/AGENTS.md` too — the tool-neutral file those ecosystems have
+converged on, in the directory Local Operator already scans for skills. It is
+**read-only** (`system_prompt.md` stays the only file Local Operator writes),
+it is placed *before* your own instructions so those win on conflict, and
+content identical to `system_prompt.md` is dropped rather than sent twice.
+
+```bash
+# read a different set of shared files instead (colon-separated)
+export LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS=~/.config/AGENTS.md:~/team/AGENTS.md
+# or turn the import off entirely
+export LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS=
+```
+
+Project-level `AGENTS.md` / `CLAUDE.md` files are discovered separately by
+walking up from your working directory, and can be disabled with
+`LOCAL_OPERATOR_CONTEXT_FILES=0`.
+
 Credentials are stored in `~/.local-operator/credentials.env` and never
 echoed:
 

--- a/local_operator/analytics/model.py
+++ b/local_operator/analytics/model.py
@@ -44,10 +44,12 @@ from typing import Any, Mapping
 #: Why these boundaries and not finer ones: they are exactly the seams that are
 #: RECOVERABLE from the wire ``ChatRequest`` without the session having to hand
 #: the recorder a parallel structure. ``custom_instructions`` is the operator's
-#: ``system_prompt.md`` PLUS any selected agent/team profile prompt — the
-#: harness appends the profile inside the ``<user_instructions>`` span
-#: (``prompts_api.build_system_blocks``), so on the wire they are one tagged
-#: region and splitting them further would be a guess. ``system_prompt`` is the
+#: ``system_prompt.md``, PLUS any imported user-scope file
+#: (``~/.agents/AGENTS.md``, see ``local_operator.ecosystem_instructions``),
+#: PLUS any selected agent/team profile prompt — the harness joins all three
+#: inside the ``<user_instructions>`` span (``prompts_api.build_system_blocks``),
+#: so on the wire they are one tagged region and splitting them further would
+#: be a guess. ``system_prompt`` is the
 #: packaged persona plus repo guidance (AGENTS.md/CLAUDE.md), which share block
 #: 0's stable head with the persona and carry no wire delimiter of their own.
 #: ``images`` is APPENDED, never inserted, so the CREATE TABLE / docs /

--- a/local_operator/analytics/model.py
+++ b/local_operator/analytics/model.py
@@ -86,8 +86,9 @@ COMPONENT_LABELS: dict[str, str] = {
 
 #: Marks the operator's custom-instructions section inside system block 0. Kept
 #: in sync with ``prompts_api.build_system_blocks``: the header text is the
-#: seam analytics uses to separate the operator's standing instructions (and
-#: the agent/team profile appended to them) from the packaged persona above.
+#: seam analytics uses to separate the operator's standing instructions (any
+#: imported user-scope file, then ``system_prompt.md``, then the agent/team
+#: profile) from the packaged persona above.
 _CUSTOM_INSTRUCTIONS_HEADER = "## User's custom instructions"
 
 
@@ -99,8 +100,12 @@ def split_system_prompt(block0: str) -> tuple[int, int]:
     instructions`` section wrapping ``<user_instructions>…</user_instructions>``
     (see ``prompts_api.build_system_blocks``). The header is the only seam that
     survives onto the wire, so everything from it onward is attributed to
-    ``custom_instructions`` (the operator prompt plus any agent/team profile),
-    and everything before it to ``system_prompt`` (persona + repo guidance).
+    ``custom_instructions`` — which is all three standing-instruction sources
+    the harness joins inside that one span: any imported user-scope file
+    (``~/.agents/AGENTS.md``), the operator's ``system_prompt.md``, and any
+    agent/team profile. Everything before it is ``system_prompt`` (persona +
+    repo guidance). See ``COMPONENT_KEYS`` above for why the three are not
+    split further: the span carries no wire delimiter between them.
 
     Best-effort: a block with no custom section attributes the whole thing to
     ``system_prompt``, which is exactly right — there were no custom

--- a/local_operator/ecosystem_instructions.py
+++ b/local_operator/ecosystem_instructions.py
@@ -119,10 +119,25 @@ def _read_bounded(path: Path) -> str:
     """Read one regular file, following links, without exceeding the cap.
 
     Symlinks are followed (see the module docstring), but a non-regular target
-    is still refused: a fifo at this path would otherwise block session startup
-    forever, which is a strictly worse failure than having no instructions.
+    is still refused: this runs on the synchronous session-construction path
+    with no timeout above it, so a fifo here would block startup forever —
+    a strictly worse failure than having no instructions.
+
+    ``ecosystem_instruction_files`` already drops non-regular paths via
+    ``is_file()``, so in the ordinary arrangement this guard never fires. It
+    exists for the TOCTOU window: a regular file swapped for a fifo between
+    that listing and this open, which is precisely the case that would hang
+    rather than raise.
+
+    ``O_NONBLOCK`` is what makes the guard reachable at all, and is load-
+    bearing rather than defensive tidiness. Opening a fifo ``O_RDONLY`` blocks
+    in the kernel until a writer appears, so control would never reach the
+    ``fstat`` below — the check would be ordered after the syscall it exists to
+    protect. With the flag, the open returns a descriptor immediately and
+    ``S_ISREG`` refuses it. Regular files are unaffected: ``O_NONBLOCK`` has no
+    meaning for them, and the read below returns the same bytes either way.
     """
-    descriptor = os.open(path, os.O_RDONLY)
+    descriptor = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
     try:
         if not stat.S_ISREG(os.fstat(descriptor).st_mode):
             raise OSError(f"not a regular file: {path}")
@@ -170,6 +185,16 @@ def load_ecosystem_instructions(skip_digests: frozenset[str] = frozenset()) -> s
             logger.debug("skipping %s: identical to instructions already loaded", path)
             continue
         seen.add(digest)
-        logger.debug("loaded ecosystem instructions from %s (%d chars)", path, len(stripped))
+        # INFO, not DEBUG: this file is written by another tool and named in no
+        # lop-owned setting, yet it changes the system prompt of every session
+        # and every subagent — the one import whose provenance an operator
+        # cannot otherwise recover. It is not startup chatter: the record is
+        # emitted only when a file actually EXISTS and actually contributed, so
+        # the default install (no ``~/.agents/AGENTS.md``) stays silent, and on
+        # the TUI it lands in the rotating log file rather than on screen
+        # because ``file_logging`` detaches the console handlers. The dedup
+        # skip above stays at DEBUG: nothing reached the prompt, so there is
+        # nothing to account for.
+        logger.info("loaded ecosystem instructions from %s (%d chars)", path, len(stripped))
         parts.append(stripped)
     return "\n\n".join(parts)

--- a/local_operator/ecosystem_instructions.py
+++ b/local_operator/ecosystem_instructions.py
@@ -1,0 +1,175 @@
+"""User-scope instruction files shared with other agent tools.
+
+``<config_dir>/system_prompt.md`` is lop's own machine-wide instructions file
+and the only one lop WRITES. But an operator running lop next to Claude Code,
+Codex, opencode or droid keeps one set of standing preferences — output style,
+commit conventions, safety rules — and before this module the only way to get
+them into lop was to maintain a second copy under a lop-specific filename.
+
+lop already imports two other categories from other tools' user-scope
+directories: skills are scanned out of ``~/.omp/agent/skills``,
+``~/.claude/skills``, ``~/.codex/skills`` and ``~/.agents/skills``
+(``skills/api.py``), and MCP servers are read from ``~/.claude.json``,
+``~/.cursor/mcp.json`` and ``~/.codex/config.toml`` (``mcp/config.py``).
+Instructions were the one category left out — lop loaded skills from
+``~/.agents/skills`` while ignoring an ``AGENTS.md`` sitting directly beside
+them. This module closes that asymmetry.
+
+Contract, mirroring the skills loader deliberately:
+
+- A fixed-order tuple of paths (:data:`ECOSYSTEM_INSTRUCTION_PATHS`), read in
+  order, so two machines with the same files compute the same result.
+- **Read-only.** ``system_prompt.md`` remains the sole write target for
+  Settings → Instructions and ``GET``/``PATCH /v1/config/system-prompt``, so
+  those surfaces cannot drift and lop never writes into another tool's file.
+- Placed BEFORE ``system_prompt.md`` in the prompt, so lop's own instructions
+  are read last and win on conflict — the same ranking native skills have over
+  imported ones, and the same reason the MCP loader appends Codex last.
+- Identical content collapses (:func:`content_digest`). An operator whose
+  ``system_prompt.md`` was generated from the ecosystem file by a sync script
+  has two byte-identical sources; paying context for both, on every cached
+  request of every session, would be the worst possible outcome of adding this.
+- :data:`ECOSYSTEM_INSTRUCTIONS_ENV` replaces the default set with a
+  colon-separated path list, and an EMPTY value disables the feature outright —
+  the same override shape as ``LOCAL_OPERATOR_SKILL_EXTRA_ROOTS``, which gives
+  "point it somewhere else" and "turn it off" in one variable instead of two.
+
+Why ``~/.agents/AGENTS.md`` and nothing else by default. There is no standard
+for user-scope agent instructions — the agents.md spec covers repository files
+only — but the FILENAME has converged, and two tool-neutral directories have
+more than one independent implementation: ``~/.agents/`` (Cline, Factory droid)
+and ``~/.config/`` (Amp, Crush). ``~/.agents/`` is chosen because lop already
+reads that exact directory for skills, so this requires no new relationship
+with a path lop does not already know. A bare ``AGENTS.md`` at the XDG config
+root is a materially bigger namespace claim and is left to the override; the
+tuple exists so adding it later is one line rather than a refactor.
+
+``~/.local-operator/AGENTS.md`` is deliberately NOT read. It would gain no
+interoperability (no other tool reads that directory) and would create a
+write-path ambiguity: with both it and ``system_prompt.md`` present, what
+``GET /v1/config/system-prompt`` returns and where ``PATCH`` writes stop having
+one answer. Keeping every ecosystem file read-only avoids the question.
+
+Symlinks ARE followed here, unlike :mod:`local_operator.context_files`. The two
+policies differ because the trust boundaries do: repo guidance is discovered by
+walking into directories cloned from anywhere, so it refuses links under
+``O_NOFOLLOW``, while these are fixed paths in the operator's own home
+directory — the same trust domain as ``system_prompt.md``, whose loader follows
+links for the express purpose of pointing the file at a dotfiles checkout.
+Versioning shared instructions in dotfiles is the main reason this feature is
+wanted at all, so refusing the link would refuse the use case.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import stat
+from pathlib import Path
+
+logger = logging.getLogger("local_operator.ecosystem_instructions")
+
+#: User-scope instruction files imported from the shared agent-tool namespace,
+#: read in this fixed order. Relative to the home directory; see the module
+#: docstring for why this is ``~/.agents/`` and why it is a tuple of one.
+ECOSYSTEM_INSTRUCTION_PATHS: tuple[Path, ...] = (Path(".agents") / "AGENTS.md",)
+
+#: Replaces the default set when set. Colon-separated paths (``~`` expanded);
+#: an EMPTY value disables ecosystem instructions entirely, so an operator who
+#: wants only ``system_prompt.md`` gets exactly that. Shaped after
+#: ``LOCAL_OPERATOR_SKILL_EXTRA_ROOTS`` rather than the on/off
+#: ``LOCAL_OPERATOR_CONTEXT_FILES``, because a path list needs to be
+#: redirectable and not merely switchable.
+ECOSYSTEM_INSTRUCTIONS_ENV = "LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS"
+
+#: Per-file byte cap. The joined result is bounded again on the instructions
+#: budget by the caller; this one exists so a single pathological file is never
+#: read into memory whole just to be discarded a moment later.
+MAX_FILE_BYTES = 64 * 1024
+
+
+def content_digest(text: str) -> str:
+    """Stable digest of instruction content, for collapsing duplicates.
+
+    Whitespace-stripped before hashing so a trailing newline — the difference
+    between a hand-edited file and one written by a sync script — does not
+    defeat the dedup and charge the operator twice for one set of rules.
+    """
+    return hashlib.sha256(text.strip().encode("utf-8", errors="replace")).hexdigest()
+
+
+def ecosystem_instruction_files() -> list[Path]:
+    """The instruction paths to read, in order. Empty when disabled or absent.
+
+    Missing files are filtered HERE rather than left for the reader to skip,
+    because this list is also the user-facing answer to "what is lop reading",
+    and an answer naming files that do not exist is not one. Override paths are
+    filtered the same way so the override behaves like the set it replaces.
+    """
+    raw = os.environ.get(ECOSYSTEM_INSTRUCTIONS_ENV)
+    if raw is None:
+        candidates = [Path.home() / relative for relative in ECOSYSTEM_INSTRUCTION_PATHS]
+    else:
+        candidates = [Path(part).expanduser() for part in raw.split(":") if part.strip()]
+    return [candidate for candidate in candidates if candidate.is_file()]
+
+
+def _read_bounded(path: Path) -> str:
+    """Read one regular file, following links, without exceeding the cap.
+
+    Symlinks are followed (see the module docstring), but a non-regular target
+    is still refused: a fifo at this path would otherwise block session startup
+    forever, which is a strictly worse failure than having no instructions.
+    """
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise OSError(f"not a regular file: {path}")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            probe = stream.read(MAX_FILE_BYTES + 1)
+    finally:
+        os.close(descriptor)
+    if len(probe) > MAX_FILE_BYTES:
+        logger.warning(
+            "ecosystem instructions at %s exceed %d bytes; reading the first %d",
+            path,
+            MAX_FILE_BYTES,
+            MAX_FILE_BYTES,
+        )
+    # ``utf-8-sig`` for the same reason the native loader uses it: a BOM from a
+    # Windows editor would otherwise survive into the prompt ahead of rule one.
+    return probe[:MAX_FILE_BYTES].decode("utf-8-sig", errors="replace")
+
+
+def load_ecosystem_instructions(skip_digests: frozenset[str] = frozenset()) -> str:
+    """Imported user-scope instructions, joined in order. ``""`` when there are none.
+
+    ``skip_digests`` carries the digests of content the caller has ALREADY
+    taken — in practice ``system_prompt.md`` — so an operator who generates the
+    native file from the ecosystem one does not pay for both copies on every
+    cached request.
+
+    Failures degrade rather than breaking startup, matching
+    ``load_user_instructions``: an unreadable file is skipped and undecodable
+    bytes are replaced, because a bad byte in a shared instructions file should
+    cost one glyph, never a session.
+    """
+    parts: list[str] = []
+    seen = set(skip_digests)
+    for path in ecosystem_instruction_files():
+        try:
+            text = _read_bounded(path)
+        except OSError:
+            continue
+        stripped = text.strip()
+        if not stripped:
+            continue
+        digest = content_digest(stripped)
+        if digest in seen:
+            logger.debug("skipping %s: identical to instructions already loaded", path)
+            continue
+        seen.add(digest)
+        logger.debug("loaded ecosystem instructions from %s (%d chars)", path, len(stripped))
+        parts.append(stripped)
+    return "\n\n".join(parts)

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -39,6 +39,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from local_operator.ansi import sanitize_prompt_line
+
+# Stdlib-only and tiny, like ``paths`` below: safe at module level on the
+# startup path that ``test_import_graph`` guards.
+from local_operator.ecosystem_instructions import (
+    content_digest,
+    load_ecosystem_instructions,
+)
 from local_operator.harness.types import AgentMessage, Message
 
 # Imported as an alias: ``config_dir`` is a parameter/local name in other
@@ -83,6 +90,15 @@ MAX_USER_INSTRUCTIONS_CHARS = 64_000
 #: slice: whichever source is smaller than its share leaves the remainder to
 #: the other, so neither is taxed for room the other never uses.
 _AGENT_INSTRUCTIONS_RESERVE = 16_000
+
+#: Floor held for imported user-scope instructions (``~/.agents/AGENTS.md``;
+#: see :mod:`local_operator.ecosystem_instructions`). Its OWN share, because
+#: adding a third source to a two-way split silently converts one of the two
+#: existing guarantees into a shared one — the operator's file and the selected
+#: profile would start evicting each other because of a file neither of them
+#: knows about. Sized to match the profile's reserve: an imported file is
+#: standing preference of the same kind and the same order of magnitude.
+_ECOSYSTEM_INSTRUCTIONS_RESERVE = 16_000
 
 
 #: Modules whose import dominates :func:`create_session`, measured rather than
@@ -728,6 +744,15 @@ def load_user_instructions(agent_prompt: str = "") -> str:
     operator's machine-wide preferences, and a profile that genuinely must
     override one can say so in its own text.
 
+    Instructions shared with other agent tools (``~/.agents/AGENTS.md``, see
+    :mod:`local_operator.ecosystem_instructions`) are read too, PREPENDED so
+    the operator's own file is read last and wins on conflict, and skipped
+    entirely when their content is identical to ``system_prompt.md`` — the
+    common case for anyone who currently generates the native file from the
+    shared one with a sync script. Those files are never written by lop, so
+    ``system_prompt.md`` remains the single write target of Settings →
+    Instructions and ``GET``/``PATCH /v1/config/system-prompt``.
+
     Failures degrade instead of breaking startup: an unreadable file is
     skipped, and undecodable bytes are REPLACED rather than dropping the whole
     file, because a stray bad byte in a long instructions file should cost the
@@ -770,25 +795,47 @@ def load_user_instructions(agent_prompt: str = "") -> str:
     # down to its own guaranteed share.
     global_raw = "\n\n".join(part.strip() for part in parts if part.strip())
     agent_raw = agent_prompt.strip()
-    # The "\n\n" join is only emitted when BOTH sources survive, so the two
+    # The digest is handed down so a shared file byte-identical to the native
+    # one is dropped rather than duplicated into every cached request.
+    ecosystem_raw = load_ecosystem_instructions(
+        skip_digests=frozenset({content_digest(global_raw)} if global_raw else ())
+    ).strip()
+
+    # The "\n\n" joins are only emitted between sources that SURVIVE, so the
     # characters are only withheld then. Keyed off the agent text alone, a
     # profile that fits the documented cap exactly was truncated by two
     # characters while a global file of the same size passed whole.
-    separator = 2 if (agent_raw and global_raw) else 0
+    present = sum(1 for raw in (ecosystem_raw, global_raw, agent_raw) if raw)
+    separator = 2 * max(0, present - 1)
+    # Bounded in ascending order of ownership: the imported file first, then
+    # the profile, and the operator's own file takes the remainder. Each may
+    # spend what the others leave, down to its own floor — so a lone 64k source
+    # is still whole, and no source is taxed for room the others never use.
+    ecosystem_text = _bound_instructions(
+        ecosystem_raw,
+        "imported user-scope instructions",
+        max(
+            _ECOSYSTEM_INSTRUCTIONS_RESERVE,
+            MAX_USER_INSTRUCTIONS_CHARS - len(global_raw) - len(agent_raw) - separator,
+        ),
+    )
     agent_text = _bound_instructions(
         agent_raw,
         "the selected agent's profile",
         max(
             _AGENT_INSTRUCTIONS_RESERVE,
-            MAX_USER_INSTRUCTIONS_CHARS - len(global_raw) - separator,
+            MAX_USER_INSTRUCTIONS_CHARS - len(ecosystem_text) - len(global_raw) - separator,
         ),
     )
     global_text = _bound_instructions(
         global_raw,
         str(path),
-        MAX_USER_INSTRUCTIONS_CHARS - len(agent_text) - separator,
+        MAX_USER_INSTRUCTIONS_CHARS - len(ecosystem_text) - len(agent_text) - separator,
     )
-    return "\n\n".join(part for part in (global_text, agent_text) if part)
+    # Imported first, native second, profile last: later text is read as the
+    # more specific instruction, so lop's own file outranks the shared one and
+    # the chosen profile outranks both.
+    return "\n\n".join(part for part in (ecosystem_text, global_text, agent_text) if part)
 
 
 def _bound_instructions(text: str, source: str, limit: int) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,11 @@ _AMBIENT_VARS = (
     "HERDR_SOCKET_PATH",
     "HERDR_TAB_ID",
     "HERDR_WORKSPACE_ID",
+    # Redirects the imported user-scope instruction paths. HOME is already
+    # scrubbed below, which covers the DEFAULT ``~/.agents/AGENTS.md``, but the
+    # override names absolute paths and would survive that — a developer who
+    # exports it gets a different prompt than CI from the same tree.
+    "LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS",
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
     # The provider registry's ONLY callable ``env_keys`` resolver prefers this

--- a/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
+++ b/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
@@ -57,9 +57,15 @@ def _hermetic_aws(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
     and dropping the profile makes the tests hermetic AND pins the property
     the provider relies on: it is built from explicit values, not the
     environment.
+
+    ``AWS_DEFAULT_PROFILE`` is in the list because botocore reads it as well
+    as ``AWS_PROFILE``, and a docstring promising "no ambient AWS
+    configuration" is simply wrong until it covers every variable the client
+    reads: a developer with only that one exported got 24 ``ProfileNotFound``
+    failures on a tree that is green on CI.
     """
 
-    for name in ("AWS_PROFILE", "AWS_DEFAULT_REGION", "AWS_REGION"):
+    for name in ("AWS_PROFILE", "AWS_DEFAULT_PROFILE", "AWS_DEFAULT_REGION", "AWS_REGION"):
         monkeypatch.delenv(name, raising=False)
     monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "no-config"))
     monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "no-credentials"))

--- a/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
+++ b/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
@@ -552,7 +552,11 @@ def test_the_committed_release_pin_carries_the_known_hashes() -> None:
 
 @pytest.fixture
 def stubbed_clients(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
-    for name in ("AWS_PROFILE", "AWS_DEFAULT_REGION", "AWS_REGION"):
+    # ``AWS_DEFAULT_PROFILE`` too: botocore reads it alongside ``AWS_PROFILE``,
+    # so omitting it leaves the fixture non-hermetic for any developer who
+    # exports that spelling instead (see ``_hermetic_aws`` in
+    # ``test_aws_provider.py``).
+    for name in ("AWS_PROFILE", "AWS_DEFAULT_PROFILE", "AWS_DEFAULT_REGION", "AWS_REGION"):
         monkeypatch.delenv(name, raising=False)
     monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "no-config"))
     ec2 = boto3.client(

--- a/tests/unit/test_ecosystem_instructions.py
+++ b/tests/unit/test_ecosystem_instructions.py
@@ -13,7 +13,11 @@ the developer's own preferences into every assertion here.
 
 from __future__ import annotations
 
+import json
 import os
+import signal
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -152,6 +156,79 @@ def test_a_symlinked_file_is_followed(tmp_path: Path, monkeypatch: pytest.Monkey
     assert eco.load_ecosystem_instructions() == "- Versioned in dotfiles."
 
 
+@pytest.mark.skipif(not hasattr(signal, "SIGALRM"), reason="POSIX alarm only")
+def test_a_fifo_reaching_the_reader_is_refused_instead_of_blocking(tmp_path: Path) -> None:
+    """The guard ``_read_bounded`` documents, exercised where it actually runs.
+
+    ``ecosystem_instruction_files`` filters fifos out via ``is_file()``, so the
+    ordinary arrangement never reaches this code — which is exactly why the
+    guard needs its own test rather than riding on the loader-level one below.
+    The case it defends is the TOCTOU window: a regular file swapped for a fifo
+    after that listing, reproduced here by calling the reader directly.
+
+    Guarded by ``SIGALRM``, matching ``test_a_fifo_is_refused_without_being_opened``
+    in the composer's suite, because the regression is an INFINITE BLOCK inside
+    a synchronous ``os.open`` on the session-construction path, which has no
+    timeout above it. Without the alarm, dropping ``O_NONBLOCK`` would not fail
+    this test — it would hang CI with no report and nothing to read.
+    """
+    fifo = tmp_path / "AGENTS.md"
+    os.mkfifo(fifo)
+
+    def _blocked(signum, frame):  # noqa: ANN001 - signal handler signature
+        raise AssertionError("the reader blocked on a fifo instead of refusing it")
+
+    previous = signal.signal(signal.SIGALRM, _blocked)
+    signal.alarm(10)
+    try:
+        with pytest.raises(OSError, match="not a regular file"):
+            eco._read_bounded(fifo)
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous)
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGALRM"), reason="POSIX alarm only")
+def test_a_fifo_at_the_path_costs_no_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole-loader view of the same hazard: a named pipe left at the
+    shared path degrades to no imported instructions, and startup proceeds.
+
+    Alarmed for the same reason as the test above — the failure being pinned is
+    a hang, not a wrong return value.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".agents").mkdir(parents=True)
+    os.mkfifo(tmp_path / ".agents" / "AGENTS.md")
+
+    def _blocked(signum, frame):  # noqa: ANN001 - signal handler signature
+        raise AssertionError("load_ecosystem_instructions blocked on a fifo")
+
+    previous = signal.signal(signal.SIGALRM, _blocked)
+    signal.alarm(10)
+    try:
+        assert eco.load_ecosystem_instructions() == ""
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous)
+
+
+def test_the_nonblocking_open_does_not_short_read_a_regular_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``O_NONBLOCK`` is set for the fifo guard above, so pin that it costs the
+    ordinary case nothing. It has no meaning for regular files, but a partial
+    read here would silently truncate everyone's instructions rather than
+    fail — the kind of regression a fifo test would never catch."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    body = "".join(f"- Rule {n}.\n" for n in range(4000))
+    assert len(body.encode("utf-8")) > 32 * 1024, "too small to exercise a multi-chunk read"
+    _write_agents_md(tmp_path, body)
+
+    assert eco.load_ecosystem_instructions() == body.strip()
+
+
 def test_a_directory_at_the_path_degrades_instead_of_raising(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -247,7 +324,40 @@ def test_the_default_path_sits_beside_the_skills_directory_lop_already_reads(
 def test_the_module_stays_stdlib_only() -> None:
     """It is imported at module level by ``session_factory``, the composition
     root every host funnels through, so a third-party import here lands on the
-    startup path of every invocation."""
-    source = Path(eco.__file__).read_text(encoding="utf-8")
-    assert "import httpx" not in source
-    assert "from local_operator" not in source, "no intra-package imports on this path"
+    startup path of every invocation.
+
+    Asserted as the PROPERTY — what actually landed in ``sys.modules`` — rather
+    than by scanning the source for known spellings, which would pass for any
+    third-party package not named in the scan and for anything reached
+    indirectly. Run in a FRESH SUBPROCESS for the reason
+    ``tests/unit/test_import_graph.py`` documents: by the time a test body runs
+    pytest has imported half the tree, so an in-process check would find a
+    wrongly-imported module already present and report nothing.
+    """
+    probe = (
+        "import json, sys;"
+        "before = set(sys.modules);"
+        "__import__('local_operator.ecosystem_instructions');"
+        "print(json.dumps(sorted(set(sys.modules) - before)))"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        cwd=str(Path(eco.__file__).resolve().parent.parent),
+    )
+    assert proc.returncode == 0, f"probe failed:\n{proc.stderr[-3000:]}"
+
+    added = json.loads(proc.stdout.strip().splitlines()[-1])
+    # Top-level names only: ``sys.stdlib_module_names`` lists roots, not
+    # submodules, so ``collections.abc`` has to be tested as ``collections``.
+    # ``local_operator`` itself is the package being imported, not a dependency.
+    top_level = {name.split(".")[0] for name in added} - {"local_operator"}
+    offenders = sorted(top_level - sys.stdlib_module_names)
+
+    assert not offenders, f"non-stdlib imports on the startup path: {offenders}"
+    assert "local_operator.ecosystem_instructions" in added, "probe never imported the module"
+    intra = sorted(n for n in added if n.startswith("local_operator."))
+    assert intra == [
+        "local_operator.ecosystem_instructions"
+    ], f"no intra-package imports on this path; saw {intra}"

--- a/tests/unit/test_ecosystem_instructions.py
+++ b/tests/unit/test_ecosystem_instructions.py
@@ -1,0 +1,253 @@
+"""Imported user-scope instructions (``~/.agents/AGENTS.md``).
+
+The loader's job is small; the properties that matter are the ones a
+regression would make invisible — that lop never WRITES these files, that a
+duplicate of ``system_prompt.md`` is not paid for twice on every cached
+request, and that a bad file costs no session.
+
+``HOME`` is redirected to ``tmp_path`` by the autouse ``isolate_environment``
+fixture, so these tests reach a scratch home rather than the developer's real
+``~/.agents`` — which on a machine that has one would otherwise inject 7k of
+the developer's own preferences into every assertion here.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from local_operator import ecosystem_instructions as eco
+
+
+def _write_agents_md(home: Path, text: str) -> Path:
+    path = home / ".agents" / "AGENTS.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_reads_the_shared_agents_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The feature in one line: instructions kept for other agent tools reach
+    lop without being copied into a lop-specific filename."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_agents_md(tmp_path, "- Use conventional commits.")
+
+    assert eco.load_ecosystem_instructions() == "- Use conventional commits."
+
+
+def test_no_shared_file_is_not_an_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    assert eco.load_ecosystem_instructions() == ""
+    assert eco.ecosystem_instruction_files() == []
+
+
+def test_the_env_override_replaces_the_default_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Redirectable, not merely switchable — the shape
+    ``LOCAL_OPERATOR_SKILL_EXTRA_ROOTS`` established."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_agents_md(tmp_path, "- DEFAULT PATH")
+    elsewhere = tmp_path / "dotfiles" / "shared.md"
+    elsewhere.parent.mkdir(parents=True)
+    elsewhere.write_text("- OVERRIDE PATH", encoding="utf-8")
+    monkeypatch.setenv(eco.ECOSYSTEM_INSTRUCTIONS_ENV, str(elsewhere))
+
+    out = eco.load_ecosystem_instructions()
+
+    assert out == "- OVERRIDE PATH"
+    assert "DEFAULT PATH" not in out, "the override REPLACES the set, never extends it"
+
+
+def test_the_env_override_reads_several_paths_in_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    first = tmp_path / "first.md"
+    second = tmp_path / "second.md"
+    first.write_text("- FIRST", encoding="utf-8")
+    second.write_text("- SECOND", encoding="utf-8")
+    monkeypatch.setenv(eco.ECOSYSTEM_INSTRUCTIONS_ENV, f"{first}:{second}")
+
+    assert eco.load_ecosystem_instructions() == "- FIRST\n\n- SECOND"
+
+
+def test_an_empty_override_disables_the_feature(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An operator who wants ONLY ``system_prompt.md`` gets exactly that,
+    without needing a second on/off variable."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_agents_md(tmp_path, "- Shared rule.")
+    monkeypatch.setenv(eco.ECOSYSTEM_INSTRUCTIONS_ENV, "")
+
+    assert eco.load_ecosystem_instructions() == ""
+
+
+def test_a_tilde_in_the_override_is_expanded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_agents_md(tmp_path, "- Shared rule.")
+    monkeypatch.setenv(eco.ECOSYSTEM_INSTRUCTIONS_ENV, "~/.agents/AGENTS.md")
+
+    assert eco.load_ecosystem_instructions() == "- Shared rule."
+
+
+def test_content_identical_to_the_native_file_is_dropped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The sync-script case, which is the CURRENT workaround this replaces.
+    Both copies surviving would double the cost of the thing being fixed, on
+    every cached request of every session."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_agents_md(tmp_path, "- Shared rule.\n")
+
+    out = eco.load_ecosystem_instructions(
+        skip_digests=frozenset({eco.content_digest("- Shared rule.")})
+    )
+
+    assert out == "", "trailing-whitespace drift must not defeat the dedup"
+
+
+def test_different_content_survives_the_dedup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_agents_md(tmp_path, "- Shared rule.")
+
+    out = eco.load_ecosystem_instructions(skip_digests=frozenset({eco.content_digest("- Other.")}))
+
+    assert out == "- Shared rule."
+
+
+def test_duplicate_override_paths_collapse(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two entries whose content matches contribute once — the same rule the
+    native comparison uses, applied within the set."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    first = tmp_path / "a.md"
+    second = tmp_path / "b.md"
+    first.write_text("- Same rule.", encoding="utf-8")
+    second.write_text("- Same rule.", encoding="utf-8")
+    monkeypatch.setenv(eco.ECOSYSTEM_INSTRUCTIONS_ENV, f"{first}:{second}")
+
+    assert eco.load_ecosystem_instructions() == "- Same rule."
+
+
+def test_a_symlinked_file_is_followed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deliberately the OPPOSITE of ``context_files``' O_NOFOLLOW policy: this
+    path is in the operator's own home, and pointing it at a dotfiles checkout
+    is the main reason to want shared instructions at all."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    real = tmp_path / "dotfiles" / "AGENTS.md"
+    real.parent.mkdir(parents=True)
+    real.write_text("- Versioned in dotfiles.", encoding="utf-8")
+    link = tmp_path / ".agents" / "AGENTS.md"
+    link.parent.mkdir(parents=True)
+    link.symlink_to(real)
+
+    assert eco.load_ecosystem_instructions() == "- Versioned in dotfiles."
+
+
+def test_a_directory_at_the_path_degrades_instead_of_raising(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".agents" / "AGENTS.md").mkdir(parents=True)
+
+    assert eco.load_ecosystem_instructions() == ""
+
+
+def test_an_unreadable_file_degrades_instead_of_raising(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bad file must never cost the operator their session."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = _write_agents_md(tmp_path, "- Shared rule.")
+    path.chmod(0o000)
+    try:
+        if os.access(path, os.R_OK):  # pragma: no cover — root ignores the mode
+            pytest.skip("running as root; the mode is not enforced")
+        assert eco.load_ecosystem_instructions() == ""
+    finally:
+        path.chmod(0o644)
+
+
+def test_undecodable_bytes_cost_a_glyph_not_the_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = tmp_path / ".agents" / "AGENTS.md"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"- Keep \xff this rule.")
+
+    assert "Keep" in eco.load_ecosystem_instructions()
+    assert "this rule." in eco.load_ecosystem_instructions()
+
+
+def test_a_bom_never_reaches_the_prompt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without ``utf-8-sig`` the ``\\ufeff`` survives ahead of the first rule."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = tmp_path / ".agents" / "AGENTS.md"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"\xef\xbb\xbf- First rule.")
+
+    assert eco.load_ecosystem_instructions() == "- First rule."
+
+
+def test_a_whitespace_only_file_contributes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_agents_md(tmp_path, "\n\n   \n")
+
+    assert eco.load_ecosystem_instructions() == ""
+
+
+def test_one_pathological_file_is_bounded_at_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_agents_md(tmp_path, "z" * (eco.MAX_FILE_BYTES * 4))
+
+    assert len(eco.load_ecosystem_instructions()) == eco.MAX_FILE_BYTES
+
+
+def test_the_loader_never_writes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Read-only is the guarantee that keeps ``system_prompt.md`` the single
+    write target of Settings and ``PATCH /v1/config/system-prompt``. Asserted
+    against the filesystem, because "we simply do not call write" is exactly
+    the kind of claim a later refactor invalidates silently."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = _write_agents_md(tmp_path, "- Shared rule.")
+    before = (path.read_bytes(), path.stat().st_mtime_ns)
+    listing_before = sorted(p.name for p in (tmp_path / ".agents").iterdir())
+
+    eco.load_ecosystem_instructions()
+
+    assert (path.read_bytes(), path.stat().st_mtime_ns) == before
+    assert sorted(p.name for p in (tmp_path / ".agents").iterdir()) == listing_before
+
+
+def test_the_default_path_sits_beside_the_skills_directory_lop_already_reads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pins the CHOICE of directory, which is the whole argument of the issue:
+    ``~/.agents/skills`` is already an ecosystem skill root, so the AGENTS.md
+    beside it needs no new relationship with a path lop does not know."""
+    from local_operator.skills.api import _ECOSYSTEM_SKILL_SUBDIRS
+
+    assert eco.ECOSYSTEM_INSTRUCTION_PATHS == (Path(".agents") / "AGENTS.md",)
+    assert Path(".agents") / "skills" in _ECOSYSTEM_SKILL_SUBDIRS
+
+
+def test_the_module_stays_stdlib_only() -> None:
+    """It is imported at module level by ``session_factory``, the composition
+    root every host funnels through, so a third-party import here lands on the
+    startup path of every invocation."""
+    source = Path(eco.__file__).read_text(encoding="utf-8")
+    assert "import httpx" not in source
+    assert "from local_operator" not in source, "no intra-package imports on this path"

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -2163,6 +2163,253 @@ def test_truncation_marker_is_counted_inside_the_budget() -> None:
     assert "truncated" not in tiny
 
 
+# --- Imported user-scope instructions (~/.agents/AGENTS.md) -----------------
+
+
+def _write_ecosystem_file(home: Path, text: str) -> Path:
+    path = home / ".agents" / "AGENTS.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_ecosystem_instructions_reach_the_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The issue in one assertion: instructions kept for other agent tools no
+    longer have to be copied into a lop-specific filename to be seen."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_ecosystem_file(tmp_path, "- Shared with every agent tool.")
+
+    assert session_factory.load_user_instructions() == "- Shared with every agent tool."
+
+
+def test_the_native_file_is_read_after_the_imported_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Order IS the precedence rule. lop's own file lands last so it is read
+    as the more specific instruction and wins on conflict — the same ranking
+    native skills have over imported ones."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "system_prompt.md").write_text("- NATIVE", encoding="utf-8")
+    _write_ecosystem_file(tmp_path, "- IMPORTED")
+
+    out = session_factory.load_user_instructions()
+
+    assert out.index("- IMPORTED") < out.index("- NATIVE")
+
+
+def test_all_three_sources_layer_imported_native_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "system_prompt.md").write_text("- NATIVE", encoding="utf-8")
+    _write_ecosystem_file(tmp_path, "- IMPORTED")
+
+    assert session_factory.load_user_instructions("- PROFILE") == (
+        "- IMPORTED\n\n- NATIVE\n\n- PROFILE"
+    )
+
+
+def test_an_imported_copy_of_the_native_file_is_not_paid_for_twice(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The sync-script workaround this feature replaces leaves both files on
+    disk with identical content. Injecting both would double the cost of the
+    exact thing being fixed, on every cached request of every session."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "system_prompt.md").write_text("- One rule.\n", encoding="utf-8")
+    _write_ecosystem_file(tmp_path, "- One rule.")
+
+    assert session_factory.load_user_instructions() == "- One rule."
+
+
+def test_ecosystem_instructions_can_be_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "system_prompt.md").write_text("- NATIVE", encoding="utf-8")
+    _write_ecosystem_file(tmp_path, "- IMPORTED")
+    monkeypatch.setenv("LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS", "")
+
+    assert session_factory.load_user_instructions() == "- NATIVE"
+
+
+def test_a_huge_imported_file_cannot_crowd_out_the_other_two_sources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A third source must not be able to evict the two that already had
+    guarantees — least of all a file lop imported rather than one the operator
+    pointed it at."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "system_prompt.md").write_text(
+        "- NATIVE RULE MUST SURVIVE", encoding="utf-8"
+    )
+    _write_ecosystem_file(tmp_path, "e" * 64_000)
+
+    out = session_factory.load_user_instructions("- PROFILE RULE MUST SURVIVE")
+
+    assert "NATIVE RULE MUST SURVIVE" in out
+    assert "PROFILE RULE MUST SURVIVE" in out
+    assert len(out) <= session_factory.MAX_USER_INSTRUCTIONS_CHARS
+
+
+def test_a_huge_native_file_cannot_crowd_out_the_imported_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The mirror: the imported file holds its own floor, so a full-size
+    native file cannot silently discard it."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "system_prompt.md").write_text("n" * 64_000, encoding="utf-8")
+    _write_ecosystem_file(tmp_path, "- IMPORTED RULE MUST SURVIVE")
+
+    out = session_factory.load_user_instructions()
+
+    assert "IMPORTED RULE MUST SURVIVE" in out
+    assert len(out) <= session_factory.MAX_USER_INSTRUCTIONS_CHARS
+
+
+def test_no_imported_file_leaves_the_whole_budget_to_the_other_two(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The flat-tax bug this loader has already been fixed for twice: a
+    reserve subtracted unconditionally hands a slice to nobody. With no
+    imported file present, a full-size native file must still pass whole."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config").mkdir()
+    text = "z" * session_factory.MAX_USER_INSTRUCTIONS_CHARS
+    (tmp_path / "config" / "system_prompt.md").write_text(text, encoding="utf-8")
+
+    out = session_factory.load_user_instructions()
+
+    assert len(out) == session_factory.MAX_USER_INSTRUCTIONS_CHARS
+    assert "truncated" not in out
+
+
+def test_a_broken_imported_file_does_not_cost_the_native_instructions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "system_prompt.md").write_text("- NATIVE", encoding="utf-8")
+    (tmp_path / ".agents" / "AGENTS.md").mkdir(parents=True)  # a directory, not a file
+
+    assert session_factory.load_user_instructions() == "- NATIVE"
+
+
+def test_lop_never_writes_the_imported_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``system_prompt.md`` stays the SOLE write target of Settings →
+    Instructions and ``GET``/``PATCH /v1/config/system-prompt``; loading an
+    imported file must not create a second, ambiguous one."""
+    from local_operator.server.routes.config import system_prompt_file
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = _write_ecosystem_file(tmp_path, "- Shared rule.")
+    before = (path.read_bytes(), path.stat().st_mtime_ns)
+
+    session_factory.load_user_instructions()
+
+    assert (path.read_bytes(), path.stat().st_mtime_ns) == before
+    assert system_prompt_file() == tmp_path / "config" / "system_prompt.md"
+
+
+@pytest.mark.asyncio
+async def test_a_real_session_carries_imported_instructions(
+    tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pins the WIRING, not just the loader — the same reason the native
+    file's own end-to-end test exists. Drives the real composition root and
+    reads the blocks the provider actually returns."""
+    from local_operator.agents import AgentRegistry
+    from local_operator.config import ConfigManager
+    from local_operator.credentials import CredentialManager
+
+    # The fixture points LOCAL_OPERATOR_CONFIG_DIR at tmp_path while returning
+    # tmp_path/.local-operator; HOME follows it so the imported path resolves
+    # under the same scratch tree.
+    monkeypatch.setenv("HOME", str(tmp_config_dir.parent))
+    _write_ecosystem_file(tmp_config_dir.parent, "- IMPORTED RULE REACHES THE PROMPT")
+
+    session = await create_session(
+        _args(hosting="test", model="test", yolo=True),
+        ConfigManager(tmp_config_dir),
+        CredentialManager(tmp_config_dir),
+        AgentRegistry(tmp_config_dir),
+    )
+    assert isinstance(session, Session)
+    try:
+        produced = session._system_blocks_provider()
+        blocks = await produced if inspect.isawaitable(produced) else produced
+    finally:
+        await session.dispose()
+
+    assert "IMPORTED RULE REACHES THE PROMPT" in blocks[0]
+    assert "<user_instructions>" in blocks[0]
+    assert not any("IMPORTED RULE" in block for block in blocks[1:])
+
+
+@pytest.mark.asyncio
+async def test_a_subagent_inherits_imported_instructions(
+    tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A child must behave like the thing the imported file extends. It gets
+    this for free by re-reading through the same loader — which is exactly why
+    it needs pinning: a future split of the ecosystem read out of
+    ``load_user_instructions`` would silently give children a different set of
+    standing rules than their parent, with the suite green."""
+    from local_operator.agents import AgentRegistry
+    from local_operator.config import ConfigManager
+    from local_operator.credentials import CredentialManager
+    from local_operator.harness.subagent import _build_child_session
+
+    monkeypatch.setenv("HOME", str(tmp_config_dir.parent))
+    _write_ecosystem_file(tmp_config_dir.parent, "- IMPORTED RULE BINDS CHILDREN TOO")
+
+    parent = await create_session(
+        _args(hosting="test", model="test", yolo=True),
+        ConfigManager(tmp_config_dir),
+        CredentialManager(tmp_config_dir),
+        AgentRegistry(tmp_config_dir),
+    )
+    assert isinstance(parent, Session)
+    try:
+        child = await _build_child_session(
+            label="probe",
+            prompt="do a thing",
+            parent_session=parent,
+            model_spec=None,
+            job_id="probe-job",
+        )
+        try:
+            blocks = child._system_blocks_provider()
+            if inspect.isawaitable(blocks):
+                blocks = await blocks
+        finally:
+            await child.dispose()
+    finally:
+        await parent.dispose()
+
+    assert "- IMPORTED RULE BINDS CHILDREN TOO" in blocks[0]
+
+
 @pytest.mark.asyncio
 async def test_a_non_utf8_agent_prompt_does_not_kill_startup(
     tmp_config_dir: Path,


### PR DESCRIPTION
## Summary

`lop` already imports two categories of user-scope config from other agent tools' directories, and ignored the third.

- **Skills** — `~/.omp/agent/skills`, `~/.claude/skills`, `~/.codex/skills`, `~/.agents/skills` (`skills/api.py:57`)
- **MCP servers** — `~/.claude.json`, `~/.cursor/mcp.json`, `~/.codex/config.toml` (`mcp/config.py:374`)
- **Instructions** — exactly one file, `<config_dir>/system_prompt.md` (`session_factory.py:694`)

So `lop` loaded skills out of `~/.agents/skills` while ignoring an `AGENTS.md` sitting directly beside them. An operator running `lop` next to Claude Code and Codex with one set of standing preferences — output style, commit conventions, safety rules — had to maintain a second copy under a `lop`-specific filename, typically via a sync script.

This reads `~/.agents/AGENTS.md` at user scope, mirroring the skills loader: a fixed-order tuple of paths, read-only, with an env override.

### Why `~/.agents/AGENTS.md` and nothing else by default

There is no standard for user-scope agent instructions — the agents.md spec covers repository files only, and [agentsmd/agents.md#91](https://github.com/agentsmd/agents.md/issues/91) has been open since Oct 2025 with no maintainer response. So this is not a compliance change.

But the filename has converged, and two *tool-neutral* directories have more than one independent implementation: `~/.agents/` (Cline, Factory droid) and `~/.config/` (Amp, Crush). `~/.agents/` is chosen because **`lop` already reads that exact directory for skills**, so this needs no new relationship with a path `lop` does not know. A bare `AGENTS.md` at the XDG config root is a materially bigger namespace claim; the tuple exists so adding it later is one line.

`~/.local-operator/AGENTS.md` is deliberately **not** read. It gains no interop (no other tool reads that directory) and creates a write-path ambiguity: with both it and `system_prompt.md` present, what `GET /v1/config/system-prompt` returns and where `PATCH` writes stop having one answer.

### The four open questions from the issue

**Budget.** The imported file gets its **own** 16k floor (`_ECOSYSTEM_INSTRUCTIONS_RESERVE`) rather than sharing one of the existing two. Adding a third source to a two-way split silently converts a guarantee into a shared one: the operator's file and the selected profile would start evicting each other because of a file neither of them knows about. Each source still spends whatever the others leave, so a lone 64k source is unaffected — the flat-tax bug this loader has already been fixed for twice does not come back, and there is a regression test pinning it.

**Dedup.** Content is SHA-256'd whitespace-insensitively against `system_prompt.md` and dropped when identical. Anyone currently generating the native file from the shared one with a sync script — the workaround this replaces — would otherwise pay for both copies on every cached request of every session, doubling the cost of the exact thing being fixed. Whitespace-insensitive because a trailing newline is the difference between a hand-edited file and one a script wrote.

**Symlinks.** Followed, matching `load_user_instructions` rather than `context_files`' `O_NOFOLLOW`. The two policies differ because the trust boundaries do: repo guidance is discovered by walking into directories cloned from anywhere, while this is a fixed path in the operator's own home — the same trust domain as `system_prompt.md`, whose loader already follows links so the file can point at a dotfiles checkout. Versioning shared instructions in dotfiles is a main reason to want this feature, so refusing the link would refuse the use case. A non-regular target is still refused, so a fifo at that path cannot hang startup.

**Subagents.** Inherited, because children re-read through the same loader. That makes it free, which is exactly why it is pinned by a test: a later split of the ecosystem read out of `load_user_instructions` would otherwise give a child a different set of standing rules than its parent, with the suite green.

### Ordering and the write path

Imported → native → profile. `lop`'s own file is read last and wins on conflict — the same ranking native skills have over imported ones, and the same reason the MCP loader appends Codex last.

`system_prompt.md` remains the **sole write target** of Settings → Instructions and `GET`/`PATCH /v1/config/system-prompt`. Every imported file is read-only, so the four-surface guarantee is untouched and `lop` never writes into another tool's file.

`LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS` replaces the path set (colon-separated, `~` expanded); an **empty** value disables the import entirely. That shape follows `LOCAL_OPERATOR_SKILL_EXTRA_ROOTS` rather than the on/off `LOCAL_OPERATOR_CONTEXT_FILES`, because a path list needs to be redirectable and not merely switchable — one variable instead of two.

## Related Issue(s)

- Closes #523

## Impact

No breaking changes, no dependency updates.

- **Behaviour change for one group only**: operators who already have `~/.agents/AGENTS.md`. Their file now reaches the prompt — which is the request. Anyone else sees byte-identical prompts, and the disable switch is one env var.
- **Context cost** is bounded by the existing 64k `MAX_USER_INSTRUCTIONS_CHARS` cap, now split three ways with a floor each, plus a 64KiB per-file read bound. The dedup means the sync-script population pays nothing extra.
- **New module is stdlib-only.** `ecosystem_instructions.py` is imported at module level by `session_factory`, the composition root every host funnels through, so a third-party import there would land on the startup path of every invocation. A test asserts it stays stdlib-only, and `test_import_graph` is unaffected.
- **Security**: read-only by construction, with a filesystem-level test asserting bytes and mtime are unchanged. `utf-8-sig` and `errors="replace"` mean a bad byte costs one glyph, never a session.

## Testing Details

All four CI gates clean over the whole tree, exactly as `.github/workflows/ci.yml` runs them:

```
.venv/bin/python -m flake8 .                                   # 0 findings
uvx --from black==26.1.0 black --check .                       # 867 files unchanged
uvx isort==5.13.2 --check .                                    # clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .    # 0 errors, 0 warnings
```

Both test stages:

```
.venv/bin/python -m pytest tests/unit -q
12411 passed, 18 skipped in 425.18s

env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
9 passed in 14.54s
```

**35 new tests** — 19 in `tests/unit/test_ecosystem_instructions.py` (loader contract, override, dedup, symlink, degradation, read-only) and 16 in `tests/unit/test_session_factory.py` (layering, precedence, budget floors both directions, disable, and two end-to-end tests driving the real composition root for the parent and the subagent).

### Exercised against real files, not only in tests

A green suite is not evidence the feature works, so the assembled product was driven directly. Verified the venv resolves *this* worktree first (`local_operator.__file__` → `lo-issue-523/...`), since a symlinked venv would have tested `main`.

```
$ HOME=$SANDBOX/home LOCAL_OPERATOR_CONFIG_DIR=$SANDBOX/config \
    .venv/bin/python -c "from local_operator.session_factory import load_user_instructions; print(repr(load_user_instructions()))"

both files present  '- SHARED: use conventional commits.\n\n- NATIVE: lop-specific preference.'
identical content   '- Shared rule: always use conventional commits.'     # dedup: one copy, not two
disabled (empty env)'- NATIVE: lop-specific preference.'                  # import off, native intact
redirected override '- ELSEWHERE: from an override path.\n\n- NATIVE: lop-specific preference.'
symlink → dotfiles  '- FROM DOTFILES: versioned instructions.\n\n- NATIVE: lop-specific preference.'
```

The assembled system prompt, confirming it lands inside the tagged span in the right order with block arity unchanged:

```
## User's custom instructions
...
<user_instructions>
- SHARED: use conventional commits.

- NATIVE: lop-specific preference.
</user_instructions>
---- arity: 4
```

The write-path guarantee, driven through the real HTTP endpoints with `TestClient`:

```
GET   /v1/config/system-prompt  → 200  '- NATIVE: original.\n'      # native only
PATCH /v1/config/system-prompt  → 200
native file now: '- NATIVE: edited via API.'
shared file now: '- SHARED: imported, must never be written.\n'
shared unchanged (sha256): True
```

### An unrelated fixture bug fixed on the way (separate commit)

The first full run reported **24 failures + 2 errors** in `tests/unit/evaluation` — `ProfileNotFound: The config profile (sandbox) could not be found`. Not caused by this change: the OSWorld AWS fixtures scrub `AWS_PROFILE`, `AWS_DEFAULT_REGION` and `AWS_REGION`, but botocore also reads **`AWS_DEFAULT_PROFILE`**, which the list missed. Any developer exporting that spelling gets 24 failures on a tree that is green on CI, and the fixture's docstring promising "no ambient AWS configuration may reach these tests" was wrong until it covered every variable the client reads.

Fixed in the fixtures (`88ddc529`) rather than worked around locally. Verified with the variable *still* exported:

```
$ echo $AWS_DEFAULT_PROFILE
sandbox
$ .venv/bin/python -m pytest tests/unit/evaluation -q
775 passed, 3 skipped in 58.21s
```

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.

## Notes for review

- **Version**: bumped `0.46.1` → `0.46.2`. A patch by AGENTS.md's materiality test — a small self-contained feature, not a step-function capability that could title a release.
- **Open to a second default path.** `~/.config/AGENTS.md` (Amp, Crush) is the other two-implementation candidate and is one tuple entry away. Left out because a bare `AGENTS.md` at the XDG config root is a bigger namespace claim than a directory `lop` already reads; happy to add it if you would rather ship both.

Release: patch — lop reads a user-scope `~/.agents/AGENTS.md` alongside `system_prompt.md`, so instructions shared with other agent tools reach the prompt without a sync script.
