### PR TITLE
chore(release): 0.46.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.46.7"
+version = "0.46.8"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Version-only bump.

`#608` merged carrying `0.46.7`, but `#607` published that version while `#608` was still in review. This takes the next free patch so the release tag and the published artifact agree.

No code change.