### PR TITLE
fix(usage): tell a dead OAuth grant from a transient outage

### DIFF
--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -2818,6 +2818,10 @@ class SessionStreamFn:
         # ``list_oauth_accesses`` deliberately omits a row whose refresh fails;
         # without this comparison, one omitted/unknown account plus one depleted
         # account looked like proof the WHOLE provider was depleted (review F1).
+        # A row whose grant is permanently dead is now RETURNED instead of
+        # omitted (so ``/usage`` can name the remedy), carrying no bearer. It
+        # is filtered back out below: for this quota question a dead grant is
+        # an account that cannot answer, exactly as when it was omitted.
         rows = self._auth_store.list_credentials(provider)
         oauth_rows = [row for row in rows if row.credential_type == "oauth"]
         api_key_rows = [row for row in rows if row.credential_type == "api_key"]
@@ -2829,6 +2833,13 @@ class SessionStreamFn:
         except Exception:
             accesses = []
             saw_unknown = bool(oauth_rows)
+        accesses = [
+            access for access in accesses if not getattr(access, "credential_invalid", False)
+        ]
+        # Dropping them here restores the pre-existing arithmetic exactly: the
+        # id-set comparison below then reports the same mismatch omission used
+        # to produce, so a dead grant still reads as one account that could not
+        # answer rather than as proof the provider is empty.
         if {access.credential_id for access in accesses} != {row.id for row in oauth_rows}:
             saw_unknown = True
 

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -2833,9 +2833,7 @@ class SessionStreamFn:
         except Exception:
             accesses = []
             saw_unknown = bool(oauth_rows)
-        accesses = [
-            access for access in accesses if not getattr(access, "credential_invalid", False)
-        ]
+        accesses = [access for access in accesses if not access.credential_invalid]
         # Dropping them here restores the pre-existing arithmetic exactly: the
         # id-set comparison below then reports the same mismatch omission used
         # to produce, so a dead grant still reads as one account that could not

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -41,6 +41,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 from local_operator.paths import config_dir
+from local_operator.providers.oauth.callback_server import InvalidGrantError
 from local_operator.providers.registry import (
     GetApiKeyFn,
     RefreshFn,
@@ -137,6 +138,22 @@ class AuthStoreError(Exception):
     """Credential resolution/refresh failure (never a bare sqlite error)."""
 
 
+class CredentialInvalidError(AuthStoreError):
+    """The row's grant is dead; retrying cannot revive it, only a re-login can.
+
+    The store-level face of
+    :class:`~local_operator.providers.oauth.callback_server.InvalidGrantError`.
+    It stays a subclass of :class:`AuthStoreError` so every existing handler
+    (the cascade rotating to a sibling, ``ensure_oauth_fresh`` swallowing to
+    ``None``) behaves exactly as before; callers that must tell a permanent
+    failure from an outage -- ``/usage`` is the first -- catch this instead.
+
+    Raising it is a STATEMENT ABOUT THE GRANT, not a routing decision: nothing
+    here disables, blocks or deletes the row. The login is still the user's,
+    and the panel keeps showing it.
+    """
+
+
 @dataclasses.dataclass
 class StoredCredential:
     """One row of ``auth_credentials`` with its parsed payload."""
@@ -175,6 +192,14 @@ class OAuthAccess:
     #: needs the OAuth ``access`` — and a usage fetcher must see the raw row
     #: to spend the right one. None for plain API-key rows.
     raw: dict[str, Any] | None = None
+    #: True when this row's stored grant was refused as permanently dead, so
+    #: no bearer could be minted and none ever will be until the user runs
+    #: ``/login <provider>`` again. Carried on the identity record rather than
+    #: signalled by omission because omission is exactly what made this state
+    #: indistinguishable from a transient outage: the row simply vanished
+    #: from the usage fetch and the panel reported stale numbers forever.
+    #: ``access_token`` is empty whenever this is set.
+    credential_invalid: bool = False
 
 
 def default_db_path() -> Path:
@@ -736,7 +761,10 @@ class AuthStore:
         """Return usable OAuth data for ``row``, refreshing single-flight.
 
         Raises :class:`AuthStoreError` when a refresh is required and fails;
-        callers treat that row as unusable and rotate.
+        callers treat that row as unusable and rotate. A grant the IdP has
+        declared permanently dead raises the :class:`CredentialInvalidError`
+        subclass instead, so a caller that can act on the difference (tell the
+        user to re-login rather than retry) is able to.
 
         Org fields are restored from the stored row AFTER the merge (PR-12):
         a refresh function that (mistakenly) returns org_id/org_name/
@@ -761,6 +789,14 @@ class AuthStore:
                 refreshed = await refresh(fresh)
             except AuthStoreError:
                 raise
+            except InvalidGrantError as exc:
+                # RFC 6749 SS5.2 terminal grant error. Re-raised as the store's
+                # own permanent-failure type so nothing above imports the
+                # OAuth flow module to identify it, and so the existing
+                # `except AuthStoreError` handlers still catch it.
+                raise CredentialInvalidError(
+                    f"OAuth grant for '{row.provider}' is no longer valid: {exc}"
+                ) from exc
             except Exception as exc:
                 raise AuthStoreError(f"OAuth refresh failed for '{row.provider}': {exc}") from exc
             merged = dict(fresh)
@@ -1459,6 +1495,15 @@ class AuthStore:
           The last two are the same principle ``_resolve``'s ``read_only`` mode
           applies to a decorative REQUEST, which needs a bearer but is likewise
           not entitled to route the session.
+        - **A PERMANENTLY dead grant is reported, not omitted.** Omission is
+          right for a transient miss -- the caller keeps last-good numbers and
+          retries -- and wrong for a grant the IdP has refused for good, which
+          is a fact about the account the operator has to act on. Such a row
+          comes back with ``credential_invalid=True`` and an EMPTY
+          ``access_token``, so a caller that wanted a bearer still skips it
+          (there is none) while a caller that wants the account's state can
+          see why. This does not weaken the invariant above: reporting that a
+          grant is dead is still not disabling, blocking or deleting the row.
 
         Logged-out rows are still excluded — ``list_credentials`` filters on
         ``disabled_cause``, and an account the user signed out of is genuinely
@@ -1476,6 +1521,30 @@ class AuthStore:
         for row in sorted(rows, key=lambda r: r.id):
             try:
                 creds = await self._ensure_oauth_fresh(row)
+            except CredentialInvalidError:
+                # Terminal, so it earns a real log line rather than the debug
+                # one a retryable miss gets: this state never clears on its
+                # own and the user has to be told to sign in again.
+                logger.info(
+                    "usage: credential %s for %s has a dead grant; re-login required",
+                    row.id,
+                    provider,
+                )
+                data = row.data if isinstance(row.data, dict) else {}
+                accesses.append(
+                    OAuthAccess(
+                        access_token="",
+                        credential_id=row.id,
+                        account_id=data.get("account_id"),
+                        email=data.get("email"),
+                        org_id=data.get("org_id"),
+                        api_endpoint=data.get("api_endpoint"),
+                        kind="oauth",
+                        raw=data,
+                        credential_invalid=True,
+                    )
+                )
+                continue
             except AuthStoreError:
                 logger.debug(
                     "usage: credential %s for %s failed to refresh; omitting",

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -41,7 +41,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 from local_operator.paths import config_dir
-from local_operator.providers.oauth.callback_server import InvalidGrantError
 from local_operator.providers.registry import (
     GetApiKeyFn,
     RefreshFn,
@@ -785,6 +784,13 @@ class AuthStore:
             fresh = dict(current.data)
             if not self._needs_refresh(fresh, force=force):
                 return fresh
+            # Imported here, not at module scope: `callback_server` drags in
+            # http.server/ssl/email (~138 ms, 150-odd modules), and three
+            # separate comments in this codebase exist to stop anyone
+            # re-adding it as a top-level import. This is a refresh path that
+            # has already paid for the module, so the cost is zero here.
+            from local_operator.providers.oauth.callback_server import InvalidGrantError
+
             try:
                 refreshed = await refresh(fresh)
             except AuthStoreError:
@@ -794,6 +800,30 @@ class AuthStore:
                 # own permanent-failure type so nothing above imports the
                 # OAuth flow module to identify it, and so the existing
                 # `except AuthStoreError` handlers still catch it.
+                #
+                # The cross-process rotation race documented on the success
+                # path below reaches HERE FIRST, and is the more dangerous
+                # arrival: with a rotating refresh token (kimi rotates), the
+                # process that loses the race POSTs a token the winner has
+                # already consumed, and the IdP answers `invalid_grant`
+                # legitimately. Declaring the credential permanently dead on
+                # that evidence condemns a LIVE grant -- the winner's token is
+                # in the DB and working -- and before this classification
+                # existed the loser raised a generic AuthStoreError and
+                # self-healed on the next cycle. So the same guard runs first:
+                # if the stored refresh token is no longer the one we sent,
+                # another process refreshed successfully and our rejection is
+                # about a superseded token, not about the account.
+                now_row = self.get_credential(row.id)
+                if now_row is not None and dict(now_row.data).get("refresh") != fresh.get(
+                    "refresh"
+                ):
+                    logger.warning(
+                        "refresh race on %s: our token was already rotated by another "
+                        "process; keeping its token rather than declaring the grant dead",
+                        row.id,
+                    )
+                    return dict(now_row.data)
                 raise CredentialInvalidError(
                     f"OAuth grant for '{row.provider}' is no longer valid: {exc}"
                 ) from exc

--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -361,6 +361,13 @@ class ProviderController:
         # that, so the login event has to say so itself. Same hook as the CLI's
         # ``run_login``; the TUI's ``/login`` arrives here.
         _invalidate_cached_listing(storage)
+        # The cached usage row is wrong for the same reason and one more: a
+        # completed login is positive evidence this account's grant is alive,
+        # which directly contradicts any ``credential_invalid`` verdict the row
+        # still carries. Re-authenticating an ALREADY-stored account keeps the
+        # account fingerprint (and so the cache key) identical, so nothing else
+        # in the system observes this event -- see ``UsageCacheStore.invalidate``.
+        self._invalidate_cached_usage(storage)
         identity = result.get("email") or result.get("account_id") or result.get("org_name") or ""
         suffix = f" ({identity})" if identity else ""
         msg = f"Logged in to '{storage}'{suffix}."
@@ -503,6 +510,22 @@ class ProviderController:
             if cached:
                 reports.extend(cached)
         return reports
+
+    def _invalidate_cached_usage(self, storage_id: str) -> None:
+        """Best-effort drop of ``storage_id``'s cached usage row after a login.
+
+        Never raises, for the reason ``_invalidate_cached_listing`` gives: a
+        login that actually succeeded must not be reported as failed because a
+        cache write went wrong afterwards. The next fetch re-derives the state
+        from a live refresh either way; this only removes the stale answer that
+        would otherwise be served ahead of it.
+        """
+        try:
+            cache = self._usage_cache_store()
+            if cache is not None:
+                cache.invalidate(self._usage_cache_key(storage_id))
+        except Exception:  # noqa: BLE001 — a stale row is not worth failing a login
+            logger.debug("usage cache: post-login invalidate failed", exc_info=True)
 
     def _usage_cache_store(self) -> UsageCacheStore | None:
         """The shared usage cache, built lazily on first use.
@@ -651,19 +674,27 @@ class ProviderController:
             return False
         if previous.usage_unavailable:
             return True
-        # A dead grant cannot be re-probed into life, so the automatic cycle
-        # skips it: it is not in a cool-down, it is waiting on the user, and
-        # spending the backoff on it is the defect this flag exists to fix.
+        # NOTE: ``credential_invalid`` deliberately does NOT gate here, and
+        # that is load-bearing rather than an omission.
         #
-        # It sits BELOW the force check on purpose. ``r`` must still reach it,
-        # because that is how the state clears once the user has run ``/login``
-        # again: re-login updates the row in place for providers whose
-        # identity key is a per-provider constant (kimi), so the account
-        # fingerprint does not change and no cache invalidation would rescue a
-        # flag that ``r`` could not clear. One request on an explicit keypress
-        # is the cheap half of that trade.
-        if getattr(previous, "credential_invalid", False):
-            return True
+        # Skipping the cycle for a dead grant looks like it saves the retry
+        # budget, and measurably saves nothing: ``list_oauth_accesses`` is
+        # awaited before this loop and refreshes EVERY row, so the refresh
+        # POST is already spent by the time the gate is consulted, and the
+        # usage probe is short-circuited separately by the
+        # ``access.credential_invalid`` branch, so no usage request is made
+        # either. Measured on three consecutive cycles with and without the
+        # skip: 1 refresh POST and 0 usage probes, identically.
+        #
+        # What the skip did buy was a one-way latch. The only writer that
+        # clears the flag is ``_mark_account_success``, which is reached only
+        # through a fetch this gate prevented -- so after the user followed
+        # the panel's own ``/login`` advice, every automatic poll re-rendered
+        # ``sign-in expired`` against a freshly-minted valid grant, and only
+        # ``r`` could break the loop. That is this defect with its polarity
+        # reversed: a permanent message that the user cannot act their way
+        # out of. The verdict must be re-derived from the live refresh each
+        # cycle, never remembered as a terminal state.
         # Only a FAILURE cool-down skips the probe. A successful account
         # leaves next_probe_at_ms unset so a sibling's shorter backoff can
         # expire the provider row without freezing the healthy logins.
@@ -747,6 +778,15 @@ class ProviderController:
         panel as usage-unavailable. Last-good numbers, when they exist, stay
         on the report so the operator can still see they are logged in and
         what the last successful check said.
+
+        A transient miss also CLEARS any dead-grant verdict, which is not the
+        contradiction it first looks like. Reaching here means the store
+        handed back a usable bearer and the usage endpoint was what failed --
+        so the grant refreshed, which is direct evidence it is alive. Leaving
+        the flag set let one endpoint blip re-latch a healthy credential as
+        ``sign-in expired``, telling the user to re-authenticate when nothing
+        was wrong with their login. A cycle that genuinely still sees
+        ``invalid_grant`` sets it again on the spot.
         """
         failures = (previous.consecutive_failures if previous is not None else 0) + 1
         unavailable = failures >= USAGE_ACCOUNT_MAX_FAILURES
@@ -756,6 +796,7 @@ class ProviderController:
             report = UsageReport(provider=provider, fetched_at=now_ms, identity=identity)
         report.consecutive_failures = failures
         report.usage_unavailable = unavailable
+        report.credential_invalid = False
         report.next_probe_at_ms = None if unavailable else now_ms + account_backoff_ms(failures)
         return report
 

--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -651,6 +651,19 @@ class ProviderController:
             return False
         if previous.usage_unavailable:
             return True
+        # A dead grant cannot be re-probed into life, so the automatic cycle
+        # skips it: it is not in a cool-down, it is waiting on the user, and
+        # spending the backoff on it is the defect this flag exists to fix.
+        #
+        # It sits BELOW the force check on purpose. ``r`` must still reach it,
+        # because that is how the state clears once the user has run ``/login``
+        # again: re-login updates the row in place for providers whose
+        # identity key is a per-provider constant (kimi), so the account
+        # fingerprint does not change and no cache invalidation would rescue a
+        # flag that ``r`` could not clear. One request on an explicit keypress
+        # is the cheap half of that trade.
+        if getattr(previous, "credential_invalid", False):
+            return True
         # Only a FAILURE cool-down skips the probe. A successful account
         # leaves next_probe_at_ms unset so a sibling's shorter backoff can
         # expire the provider row without freezing the healthy logins.
@@ -660,7 +673,15 @@ class ProviderController:
         return nxt is not None and nxt > now_ms
 
     def _reset_account_for_force(self, report: UsageReport) -> UsageReport:
-        """``r`` clears the failure streak so a maxed-out account is retried."""
+        """``r`` clears the failure streak so a maxed-out account is retried.
+
+        ``credential_invalid`` is deliberately NOT cleared here. The streak
+        and the unavailable ceiling are guesses about a provider that may have
+        recovered, so ``r`` is right to drop them; a dead grant is a verdict
+        the IdP returned, and clearing it optimistically would blank the one
+        line telling the user to re-login until the fetch re-derived it.
+        ``_mark_account_success`` clears it when a bearer actually works.
+        """
         report.consecutive_failures = 0
         report.usage_unavailable = False
         report.next_probe_at_ms = None
@@ -669,6 +690,45 @@ class ProviderController:
     def _mark_account_success(self, report: UsageReport, now_ms: int) -> UsageReport:
         """A live 200: clear the failure streak and schedule the next probe."""
         report.consecutive_failures = 0
+        report.usage_unavailable = False
+        report.next_probe_at_ms = None
+        # A 200 proves the grant minted a working bearer, so whatever the
+        # cached row said about it is stale by definition. Clearing here is
+        # what makes the state self-healing after the user re-logs in.
+        report.credential_invalid = False
+        return report
+
+    def _mark_account_invalid(
+        self,
+        previous: UsageReport | None,
+        *,
+        provider: str,
+        identity: str,
+        now_ms: int,
+    ) -> UsageReport:
+        """The grant is dead: state it, and stop spending retries on it.
+
+        Deliberately NOT ``_mark_account_failure`` with an extra flag. That
+        path exists to decide when a run of transient misses has gone on long
+        enough to stop trusting the numbers, and every part of it is wrong
+        here: the failure streak measures an outage's length, the exponential
+        backoff schedules a retry that cannot succeed, and
+        ``usage_unavailable`` renders as ``usage unavailable - last known 2d
+        ago``, which tells the user to wait when they need to act.
+
+        So the streak is left untouched and ``next_probe_at_ms`` stays None.
+        The account is not in a cool-down -- there is simply nothing to
+        re-probe until the credential is replaced, and
+        ``_account_in_backoff`` skips it on that flag alone. Last-known limits
+        stay on the report: they remain the last true reading of a login the
+        user still owns.
+        """
+        report = (
+            previous
+            if previous is not None
+            else UsageReport(provider=provider, fetched_at=now_ms, identity=identity)
+        )
+        report.credential_invalid = True
         report.usage_unavailable = False
         report.next_probe_at_ms = None
         return report
@@ -741,7 +801,7 @@ class ProviderController:
         for identity in expected:
             seen.add(identity)
             if identity in live:
-                merged.append(self._mark_account_success(live[identity], now_ms))
+                merged.append(self._settle_live_report(live[identity], now_ms))
                 continue
             prior = previous.get(identity)
             if self._account_in_backoff(prior, now_ms, force=force) and prior is not None:
@@ -761,8 +821,21 @@ class ProviderController:
         for identity, report in live.items():
             if identity in seen:
                 continue
-            merged.append(self._mark_account_success(report, now_ms))
+            merged.append(self._settle_live_report(report, now_ms))
         return merged
+
+    def _settle_live_report(self, report: UsageReport, now_ms: int) -> UsageReport:
+        """Finish a report this cycle produced, honouring a dead-grant verdict.
+
+        Everything in ``live`` used to be a 200 by construction, so the merge
+        could call ``_mark_account_success`` on all of it. A dead-grant entry
+        is also produced by this cycle (it is a fresh verdict, not last-good)
+        but it is the opposite of a success, and passing it through the
+        success path would clear the very flag it was created to carry.
+        """
+        if report.credential_invalid:
+            return report
+        return self._mark_account_success(report, now_ms)
 
     @staticmethod
     def _jittered_ttl_ms() -> int:
@@ -977,6 +1050,15 @@ class ProviderController:
                     continue
                 access = accesses_by_id.get(identity)
                 if access is None:
+                    continue
+                if getattr(access, "credential_invalid", False):
+                    # The store minted no bearer and said why: the grant is
+                    # dead. Record that verdict instead of probing with an
+                    # empty token, which would fail as a generic 401 and land
+                    # this account back in the transient-failure path.
+                    live[identity] = self._mark_account_invalid(
+                        prior, provider=provider, identity=identity, now_ms=now_ms
+                    )
                     continue
                 try:
                     report = await self._fetch_one(client, provider, access=access)

--- a/local_operator/providers/oauth/anthropic.py
+++ b/local_operator/providers/oauth/anthropic.py
@@ -30,6 +30,7 @@ from local_operator.providers.oauth.callback_server import (
     LoginCallbacks,
     LoginError,
     OAuthCallbackFlow,
+    raise_for_refresh_failure,
 )
 from local_operator.providers.oauth.pkce import create_pkce_pair
 
@@ -246,7 +247,7 @@ async def refresh_anthropic_token(
         if http_client is None:
             await client.aclose()
     if response.status_code != 200:
-        raise LoginError(f"Anthropic refresh failed ({response.status_code}): {response.text}")
+        raise_for_refresh_failure("Anthropic", response.status_code, response.text)
     token = response.json()
     if not token.get("access_token"):
         raise LoginError("Anthropic refresh response is missing access_token")

--- a/local_operator/providers/oauth/callback_server.py
+++ b/local_operator/providers/oauth/callback_server.py
@@ -119,6 +119,98 @@ class ConfigurationError(LoginError):
     """Local misconfiguration detected before any browser was opened."""
 
 
+class InvalidGrantError(LoginError):
+    """The stored grant is PERMANENTLY dead — only a fresh login can fix it.
+
+    A refresh can fail two ways that look identical at the call site and are
+    opposite in what the operator should do about them. A 5xx, a timeout, a
+    429 or a dropped connection is the provider or the network being
+    temporarily unwell: retrying is exactly right, and the existing
+    per-account backoff exists for it. ``invalid_grant`` is the IdP stating
+    that this refresh token will never be accepted again (revoked, superseded
+    by a rotation we lost, or expired past its absolute lifetime), and no
+    amount of retrying changes that answer.
+
+    Conflating them is the defect this class exists to end: a dead kimi grant
+    spent its retry budget, tripped ``usage_unavailable`` and then rendered as
+    ``usage unavailable - last known 2d ago`` forever, a message that implies
+    the numbers will come back on their own when the only remedy is
+    ``/login <provider>``.
+
+    Subclasses :class:`LoginError` deliberately: every existing ``except
+    LoginError`` handler keeps working unchanged, and only callers that want
+    the distinction test for this type.
+    """
+
+
+#: OAuth2 token-endpoint error codes that are terminal for a STORED grant
+#: (RFC 6749 SS5.2). Terminal here means "re-presenting the same refresh token
+#: to the same client can never succeed", which is a narrower question than
+#: "was this request rejected".
+#:
+#: - ``invalid_grant``: the grant itself is revoked/expired/already-rotated.
+#:   The direct signal, and the one observed against auth.kimi.com.
+#: - ``invalid_client`` / ``unauthorized_client``: the CLIENT is rejected, so
+#:   every grant held under it is unusable by us. A re-login is still the only
+#:   move available to the operator, and burning a retry loop is still wrong.
+#: - ``unsupported_grant_type``: the token endpoint refuses ``refresh_token``
+#:   for this client at all; retrying re-sends the same unsupported request.
+#:
+#: Deliberately EXCLUDED: ``invalid_request`` and ``invalid_scope``, which
+#: describe a malformed request rather than a dead grant and would blame the
+#: user's login for a bug of ours; and ``slow_down`` / ``authorization_pending``,
+#: which are device-flow polling states, not failures.
+TERMINAL_GRANT_ERRORS = frozenset(
+    {
+        "invalid_grant",
+        "invalid_client",
+        "unauthorized_client",
+        "unsupported_grant_type",
+    }
+)
+
+
+def is_terminal_grant_response(status_code: int, body: str) -> bool:
+    """Whether a non-200 token-endpoint response means the grant is dead.
+
+    **The status code alone is not the signal, and must not be used as one.**
+    RFC 6749 SS5.2 puts the machine-readable verdict in the BODY: the same 400
+    carries ``invalid_grant`` (terminal) and ``invalid_request`` (our bug,
+    retryable). Meanwhile a 401 is routinely a gateway or an auth proxy having
+    a bad minute. So the code only gates which bodies are worth reading -- 5xx
+    is the provider failing and its body is a stack trace or an HTML error
+    page, never a verdict about the operator's grant.
+
+    Substring matching against the raw body is deliberate over strict JSON
+    parsing. These endpoints are not uniformly well-behaved: bodies arrive as
+    JSON, as form-encoded pairs, and occasionally wrapped in another envelope,
+    and a JSON-only reader silently degrades every non-JSON shape to
+    "transient", which is the failure mode this whole change exists to remove.
+    The codes are specific enough that a false positive would need the literal
+    token in some other role.
+    """
+    # 5xx and 429 are the provider's problem, whatever the body says: keep
+    # today's retry/backoff behaviour for them.
+    if status_code >= 500 or status_code == 429:
+        return False
+    lowered = body.lower()
+    return any(code in lowered for code in TERMINAL_GRANT_ERRORS)
+
+
+def raise_for_refresh_failure(provider_label: str, status_code: int, body: str) -> None:
+    """Raise the right error class for a failed token-endpoint refresh.
+
+    One helper so every provider's refresh classifies identically. A dead
+    grant is a property of OAuth2, not of a vendor, so anthropic/openai/xai/
+    kimi/radient must not each decide it for themselves -- and the message
+    text stays the same as before, since it is what a user searches for.
+    """
+    message = f"{provider_label} refresh failed ({status_code}): {body}"
+    if is_terminal_grant_response(status_code, body):
+        raise InvalidGrantError(message)
+    raise LoginError(message)
+
+
 # Callbacks the host (CLI/TUI) implements to drive the interactive flow.
 # Every field is optional; sync or async callables both work.
 @dataclasses.dataclass

--- a/local_operator/providers/oauth/callback_server.py
+++ b/local_operator/providers/oauth/callback_server.py
@@ -20,12 +20,13 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import inspect
+import json
 import logging
 import secrets
 import urllib.parse
 import webbrowser
 from abc import ABC, abstractmethod
-from typing import Any, Awaitable, Callable, TypeVar
+from typing import Any, Awaitable, Callable, NoReturn, TypeVar
 
 from local_operator.callback_page import Tone, render_callback_page
 from local_operator.harness.types import AbortSignal
@@ -153,21 +154,78 @@ class InvalidGrantError(LoginError):
 #: - ``invalid_client`` / ``unauthorized_client``: the CLIENT is rejected, so
 #:   every grant held under it is unusable by us. A re-login is still the only
 #:   move available to the operator, and burning a retry loop is still wrong.
-#: - ``unsupported_grant_type``: the token endpoint refuses ``refresh_token``
-#:   for this client at all; retrying re-sends the same unsupported request.
 #:
-#: Deliberately EXCLUDED: ``invalid_request`` and ``invalid_scope``, which
-#: describe a malformed request rather than a dead grant and would blame the
-#: user's login for a bug of ours; and ``slow_down`` / ``authorization_pending``,
-#: which are device-flow polling states, not failures.
+#: Deliberately EXCLUDED, all for one reason -- they describe a malformed or
+#: unsupported REQUEST rather than a dead grant, so they would blame the user's
+#: login for a bug or a config change of ours, and print a ``/login`` remedy
+#: that cannot possibly work:
+#:
+#: - ``invalid_request`` and ``invalid_scope``.
+#: - ``unsupported_grant_type``: the endpoint is refusing the
+#:   ``grant_type=refresh_token`` PARAMETER, which says nothing about the
+#:   stored grant. It was briefly listed here on the reasoning that retrying
+#:   re-sends the same unsupported request -- true, but not-worth-retrying and
+#:   dead are different questions, and only the second is this set's subject.
+#:   The blast radius is what settles it: a token-endpoint config change would
+#:   darken EVERY account on the provider at once with a remedy that cannot
+#:   fix it, which is this defect's own failure mode restated.
+#: - ``slow_down`` / ``authorization_pending``, which are device-flow polling
+#:   states, not failures.
 TERMINAL_GRANT_ERRORS = frozenset(
     {
         "invalid_grant",
         "invalid_client",
         "unauthorized_client",
-        "unsupported_grant_type",
     }
 )
+
+
+def _oauth_error_code(body: str) -> str | None:
+    """The value of the OAuth2 ``error`` FIELD, or None if the body has none.
+
+    Reading the field rather than scanning the body is what keeps the exclusion
+    list above meaningful. A substring scan cannot express "this code, in the
+    role of the verdict": ``invalid_client`` is a substring of
+    ``invalid_client_id`` and ``invalid_grant`` of ``invalid_grant_type``, so
+    the EXCLUDED ``invalid_request`` was being matched through the INCLUDED
+    codes whenever a provider's prose mentioned one. All three of these are
+    real 400 ``invalid_request`` shapes that a scan calls terminal:
+
+        {"error":"invalid_request","error_description":"invalid_grant_type: ..."}
+        {"error":"invalid_request","error_description":"the invalid_client_id ..."}
+        {"error":"invalid_request","error_uri":"https://.../errors#invalid_grant"}
+
+    The third is not even prose: RFC 6749 SS5.2 permits ``error_uri``, and a doc
+    anchor naturally ends in the error's name.
+
+    Two shapes are parsed because both are real: JSON (what the RFC specifies
+    and what every provider here returns) and form-encoded (seen from proxies
+    and older endpoints). Anything else returns None and the caller falls back
+    to a scan -- degrading an unparseable body to "transient" outright is the
+    failure this classification exists to remove, so the fallback stays.
+    """
+    stripped = body.strip()
+    if not stripped:
+        return None
+    if stripped.startswith("{"):
+        try:
+            parsed = json.loads(stripped)
+        except ValueError:
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        # Some providers wrap the RFC object one level down (`{"error": {...}}`
+        # with the code inside); read that shape too rather than mistaking the
+        # envelope for a missing verdict.
+        error = parsed.get("error")
+        if isinstance(error, dict):
+            error = error.get("code") or error.get("type") or error.get("error")
+        return error.strip().lower() if isinstance(error, str) else None
+    if "=" in stripped and "\n" not in stripped:
+        for key, value in urllib.parse.parse_qsl(stripped):
+            if key.strip().lower() == "error":
+                return value.strip().lower()
+    return None
 
 
 def is_terminal_grant_response(status_code: int, body: str) -> bool:
@@ -181,31 +239,43 @@ def is_terminal_grant_response(status_code: int, body: str) -> bool:
     is the provider failing and its body is a stack trace or an HTML error
     page, never a verdict about the operator's grant.
 
-    Substring matching against the raw body is deliberate over strict JSON
-    parsing. These endpoints are not uniformly well-behaved: bodies arrive as
-    JSON, as form-encoded pairs, and occasionally wrapped in another envelope,
-    and a JSON-only reader silently degrades every non-JSON shape to
-    "transient", which is the failure mode this whole change exists to remove.
-    The codes are specific enough that a false positive would need the literal
-    token in some other role.
+    The verdict is taken from the parsed ``error`` field when the body yields
+    one, and only from a substring scan when it does not. Parsing is what makes
+    the exclusion list real (see :func:`_oauth_error_code`); the scan is what
+    keeps an HTML-wrapped or otherwise unparseable ``invalid_grant`` from being
+    silently downgraded to a retry loop that can never end.
     """
     # 5xx and 429 are the provider's problem, whatever the body says: keep
     # today's retry/backoff behaviour for them.
     if status_code >= 500 or status_code == 429:
         return False
+    code = _oauth_error_code(body)
+    if code is not None:
+        # The body named its verdict: honour it exactly, including when the
+        # verdict is an excluded code that merely MENTIONS a terminal one.
+        return code in TERMINAL_GRANT_ERRORS
     lowered = body.lower()
-    return any(code in lowered for code in TERMINAL_GRANT_ERRORS)
+    return any(candidate in lowered for candidate in TERMINAL_GRANT_ERRORS)
 
 
-def raise_for_refresh_failure(provider_label: str, status_code: int, body: str) -> None:
+def raise_for_refresh_failure(
+    provider_label: str, status_code: int, body: str, *, message: str | None = None
+) -> NoReturn:
     """Raise the right error class for a failed token-endpoint refresh.
 
     One helper so every provider's refresh classifies identically. A dead
     grant is a property of OAuth2, not of a vendor, so anthropic/openai/xai/
-    kimi/radient must not each decide it for themselves -- and the message
-    text stays the same as before, since it is what a user searches for.
+    kimi/radient must not each decide it for themselves.
+
+    ``NoReturn`` because it always raises: without it every call site reads to
+    a type checker as though it falls through into the code that assumes a 200.
+
+    ``message`` overrides the default wording for the one provider whose
+    historical text differs (Radient's ``: HTTP {status} {body}``). The message
+    is what a user searches for and quotes in a bug report, so this helper
+    classifies the failure without restyling anyone's error string.
     """
-    message = f"{provider_label} refresh failed ({status_code}): {body}"
+    message = message or f"{provider_label} refresh failed ({status_code}): {body}"
     if is_terminal_grant_response(status_code, body):
         raise InvalidGrantError(message)
     raise LoginError(message)

--- a/local_operator/providers/oauth/kimi.py
+++ b/local_operator/providers/oauth/kimi.py
@@ -30,6 +30,7 @@ from local_operator.providers.oauth.callback_server import (
     LoginCallbacks,
     LoginError,
     maybe_await,
+    raise_for_refresh_failure,
 )
 from local_operator.providers.oauth.device_code import (
     DevicePollResult,
@@ -238,7 +239,7 @@ async def refresh_kimi_token(
         if owns_client:
             await http.aclose()
     if response.status_code != 200:
-        raise LoginError(f"Kimi refresh failed ({response.status_code}): {response.text}")
+        raise_for_refresh_failure("Kimi", response.status_code, response.text)
     merged = dict(creds)
     merged.update(_credentials_from_token(response.json(), old_refresh=creds.get("refresh")))
     # Preserve the original authorization timestamp across refreshes.

--- a/local_operator/providers/oauth/openai.py
+++ b/local_operator/providers/oauth/openai.py
@@ -29,6 +29,7 @@ from local_operator.providers.oauth.callback_server import (
     LoginError,
     OAuthCallbackFlow,
     maybe_await,
+    raise_for_refresh_failure,
 )
 from local_operator.providers.oauth.device_code import (
     DevicePollResult,
@@ -332,7 +333,7 @@ async def refresh_openai_token(
         if owns_client:
             await http.aclose()
     if response.status_code != 200:
-        raise LoginError(f"OpenAI refresh failed ({response.status_code}): {response.text}")
+        raise_for_refresh_failure("OpenAI", response.status_code, response.text)
     token = response.json()
     if not token.get("access_token"):
         raise LoginError("OpenAI refresh response is missing access_token")

--- a/local_operator/providers/oauth/radient.py
+++ b/local_operator/providers/oauth/radient.py
@@ -166,7 +166,15 @@ async def refresh_radient_token(
             resp = await _call(client)
 
     if resp.status_code != 200:
-        raise_for_refresh_failure("Radient", resp.status_code, resp.text)
+        # Radient's wording predates the shared helper and is preserved
+        # verbatim: an error string is what a user greps for and quotes, so
+        # classification must not restyle it.
+        raise_for_refresh_failure(
+            "Radient",
+            resp.status_code,
+            resp.text,
+            message=f"Radient refresh failed: HTTP {resp.status_code} {resp.text}",
+        )
 
     data = resp.json()
     access_token = data.get("access_token")

--- a/local_operator/providers/oauth/radient.py
+++ b/local_operator/providers/oauth/radient.py
@@ -21,6 +21,7 @@ from local_operator.providers.oauth.callback_server import (
     LoginCallbacks,
     LoginError,
     OAuthCallbackFlow,
+    raise_for_refresh_failure,
 )
 from local_operator.providers.oauth.pkce import create_pkce_pair
 
@@ -165,7 +166,7 @@ async def refresh_radient_token(
             resp = await _call(client)
 
     if resp.status_code != 200:
-        raise LoginError(f"Radient refresh failed: HTTP {resp.status_code} {resp.text}")
+        raise_for_refresh_failure("Radient", resp.status_code, resp.text)
 
     data = resp.json()
     access_token = data.get("access_token")

--- a/local_operator/providers/oauth/xai.py
+++ b/local_operator/providers/oauth/xai.py
@@ -21,6 +21,7 @@ from local_operator.providers.oauth.callback_server import (
     LoginCallbacks,
     LoginError,
     maybe_await,
+    raise_for_refresh_failure,
 )
 from local_operator.providers.oauth.device_code import (
     DevicePollResult,
@@ -201,7 +202,7 @@ async def refresh_xai_token(
         if owns_client:
             await http.aclose()
     if response.status_code != 200:
-        raise LoginError(f"xAI refresh failed ({response.status_code}): {response.text}")
+        raise_for_refresh_failure("xAI", response.status_code, response.text)
     merged = dict(creds)
     merged.update(
         _credentials_from_token(

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -309,6 +309,14 @@ class UsageReport:
     #: success. ``None`` once unavailable (only ``r`` retries) or on a report
     #: that has never been through the cache merge.
     next_probe_at_ms: int | None = None
+    #: True when this account's stored OAuth grant was refused as permanently
+    #: dead (RFC 6749 SS5.2 ``invalid_grant`` and friends). Distinct from
+    #: ``usage_unavailable``, which means "probes keep failing" and implies the
+    #: numbers may return: this one cannot resolve itself, so the panel names
+    #: the remedy (``/login <provider>``) and the account never enters the
+    #: retry backoff. Last-known limits are preserved either way -- the login
+    #: is still real and its final numbers are still the truth about it.
+    credential_invalid: bool = False
 
 
 @dataclass(frozen=True)

--- a/local_operator/providers/usage_cache.py
+++ b/local_operator/providers/usage_cache.py
@@ -191,6 +191,7 @@ def report_from_dict(data: Any) -> UsageReport | None:
             consecutive_failures=max(0, consecutive_failures),
             usage_unavailable=bool(data.get("usage_unavailable", False)),
             next_probe_at_ms=next_probe_at_ms,
+            credential_invalid=bool(data.get("credential_invalid", False)),
         )
     except Exception:  # noqa: BLE001 — a bad row is a miss, not a failure
         logger.debug("usage cache: unparseable report row dropped", exc_info=True)

--- a/local_operator/providers/usage_cache.py
+++ b/local_operator/providers/usage_cache.py
@@ -522,6 +522,31 @@ class UsageCacheStore:
             )
         return last_good
 
+    def invalidate(self, key: str) -> None:
+        """Drop one provider's cached row so the next read re-fetches it.
+
+        The account fingerprint in the key makes login/logout self-invalidating
+        whenever the account SET changes, which covers a first login and a
+        logout. It cannot cover re-authenticating an account that is already
+        stored: providers whose identity key is a per-provider constant (kimi
+        returns no account id, so the row is replaced in place) keep the same
+        fingerprint, so the same key still matches and the row survives the one
+        event that proves its contents wrong. That is how a ``sign-in expired``
+        verdict outlived the ``/login`` it asked for.
+
+        ``with conn:`` for the same reason ``_cleanup`` documents at length: a
+        bare DELETE leaves sqlite's implicit transaction open and holds the WAL
+        write lock against every other session until something commits.
+        """
+        conn = self._connect()
+        if conn is None:
+            return
+        try:
+            with conn:
+                conn.execute("DELETE FROM usage_reports WHERE key = ?", (key,))
+        except Exception:  # noqa: BLE001 — a failed drop is a stale read, never fatal
+            logger.debug("usage cache: invalidate failed", exc_info=True)
+
     def _cleanup(self, conn: sqlite3.Connection, now_ms: int) -> None:
         """Drop rows whose retention has passed. Cheap: one indexed scan.
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -17511,6 +17511,15 @@ class OperatorApp(App[None]):
             return int(getattr(report, "fetched_at", 0) or 0)
 
         def _confirmed(report: Any) -> bool:
+            # A dead grant carries neither a streak nor the unavailable flag —
+            # it never enters the retry path that sets them — so it would pass
+            # both tests below while being the least confirmed state there is.
+            # A never-successful one is stamped with the moment of the failed
+            # verdict, which is precisely the `just now` sourced from an
+            # account that has never reported a number this predicate exists
+            # to exclude.
+            if getattr(report, "credential_invalid", False):
+                return False
             return int(getattr(report, "consecutive_failures", 0) or 0) <= 0 and not getattr(
                 report, "usage_unavailable", False
             )

--- a/local_operator/tui/widgets/usage_panel.py
+++ b/local_operator/tui/widgets/usage_panel.py
@@ -502,15 +502,32 @@ def _account_status_note(  # noqa: ANN001
     remedy the user can act on, so it names the command instead of an age.
     An exhausted 200 (100% weekly) is quota, not this path.
     """
+    unavailable = bool(getattr(report, "usage_unavailable", False))
+    failures = int(getattr(report, "consecutive_failures", 0) or 0)
+    fetched_at = int(getattr(report, "fetched_at", 0) or 0)
     if getattr(report, "credential_invalid", False):
         # The provider is named because the panel lists several accounts and
         # the note sits under one block; `/login kimi` is runnable as printed,
         # which `sign in again` would not be. Kept generic -- any provider's
         # OAuth grant can die this way.
-        return f"sign-in expired \u2014 /login {report.provider}"
-    unavailable = bool(getattr(report, "usage_unavailable", False))
-    failures = int(getattr(report, "consecutive_failures", 0) or 0)
-    fetched_at = int(getattr(report, "fetched_at", 0) or 0)
+        #
+        # `sign-in expired` deliberately does NOT reuse `_credential_state`'s
+        # three-word vocabulary (`logged in` / `env key` / `needs login`,
+        # app.py). That set answers "is there a usable credential", and
+        # `needs login` covers never-logged-in and died-since alike. Here the
+        # difference is the whole message: the user HAS logged in, and what
+        # they need to know is that it stopped working. Do not "fix" this into
+        # `needs login` -- the divergence is the information.
+        #
+        # The age rides along when there is room, for the same reason this
+        # note exists at all: the block keeps rendering last-known meters, and
+        # without a vintage a two-day-old 100% sits unmarked under a title
+        # reading `just now`. `_fit_status_note` sheds it first on a narrow
+        # card, since the command is the actionable half.
+        note = f"sign-in expired \u2014 /login {report.provider}"
+        if fetched_at and report.limits:
+            return f"{note} \u00b7 numbers {format_age(max(0.0, now_ms - fetched_at))}"
+        return note
     # Older than the title by more than a rendered age step would show. The
     # threshold is the age formatter's own resolution: below a minute
     # `format_age` says `just now` for both stamps, so a note there would
@@ -541,22 +558,41 @@ def _fit_status_note(note: str, width: int) -> str:
     ``usage unavailable — last known 2h a…``. The short form states both facts in
     20 cells, so it fits where the long one cannot; the long form is preferred
     whenever there is room for it, since it reads as a sentence.
+
+    The dead-grant note descends a further ladder, because its tail is a
+    COMMAND and a truncated command is worse than no command: it still looks
+    like an instruction and then fails when followed. The provider id is the
+    argument ``/login`` requires and the one thing no other row on the card
+    supplies, so it is the last thing to go — the verb yields first, then the
+    age, and the id survives to the 32-col ``PANEL_MIN_WIDTH`` floor for every
+    id in ``USAGE_PROVIDERS`` (the longest, ``alibaba-token-plan-oauth``, needs
+    31 cells against the floor's 25 budget, so nothing shorter than dropping
+    the verb suffices).
     """
-    if cell_len(note) <= width or " — " not in note:
+    if cell_len(note) <= width:
+        return note
+    dead_grant = "/login " in note
+    if dead_grant:
+        # Shed the age first: it qualifies the meters, which are still on
+        # screen, while the command is the only actionable thing here.
+        note = note.partition(" \u00b7 numbers ")[0]
+        if cell_len(note) <= width:
+            return note
+    if " — " not in note:
         return note
     label, _, tail = note.partition(" — ")
+    if dead_grant:
+        # `sign-in expired — /login kimi` gains nothing from the generic
+        # rewrite below (both halves are already minimal), so go straight to
+        # the tail, then to the bare provider id. The verb is recoverable from
+        # `/help` and from the heading vocabulary; the id is recoverable from
+        # nothing else on this card.
+        if cell_len(tail) <= width:
+            return tail
+        return tail.replace("/login ", "")
     # `last known 2h ago` -> `2h ago`; the `·` keeps the two facts separable.
     short = f"{label.replace('usage ', '')} · {tail.replace('last known ', '')}"
-    if cell_len(short) <= width:
-        return short
-    # Last resort: the tail alone. `sign-in expired — /login kimi` gains
-    # nothing from the rewrite above (both halves are already minimal, so the
-    # short form is the same length), and truncation would eat the provider
-    # name off the end — turning a command the user can run as printed into
-    # `/login anthro…`. The tail is the half that survives, for the same
-    # reason the age does above: it is the actionable one. Only taken when the
-    # label genuinely cannot fit, so the ordinary note is untouched.
-    return tail if cell_len(tail) <= width else note
+    return short if cell_len(short) <= width else note
 
 
 def _provider_header(report, now_ms: float) -> Text:  # noqa: ANN001
@@ -1313,11 +1349,18 @@ class UsagePanel(Static):
             )
         return build_usage_body(self._reports, width, self._now(), self._fetched_ms)
 
-    def _stale_account_count(self) -> int:
-        """How many blocks the title's age does NOT speak for.
+    def _flagged_account_counts(self) -> tuple[int, int]:
+        """``(stale, expired)`` — blocks the title's age does not speak for.
 
-        Same predicate the body uses, so the count and the `last known` notes
-        can never disagree about which accounts are stale.
+        Split because the two carry different instructions. A stale block is
+        waiting on the network and will catch up on its own; an expired
+        sign-in never will, and saying `1 stale` for it re-frames as a
+        freshness problem the exact category error this panel now exists to
+        correct. The title is the most-read row on the card, so a user who
+        glances only there must not be told to wait.
+
+        Same predicate the body uses, so the counts and the per-block notes
+        can never disagree about which accounts are flagged.
 
         "Stale" here means "not confirmed by the round the title reports", which
         is very nearly but not exactly "older". The title takes the newest
@@ -1328,11 +1371,15 @@ class UsagePanel(Static):
         number is misdated) and the alternative, counting only rows that are
         literally older, would leave an unconfirmed block unmarked.
         """
-        return sum(
-            1
-            for report in self._reports
-            if _account_status_note(report, self._now(), self._fetched_ms)
-        )
+        stale = expired = 0
+        for report in self._reports:
+            if not _account_status_note(report, self._now(), self._fetched_ms):
+                continue
+            if getattr(report, "credential_invalid", False):
+                expired += 1
+            else:
+                stale += 1
+        return stale, expired
 
     def _title_row(self) -> Text:
         muted = Style(color=theme_mod.semantic_color("muted"))
@@ -1341,10 +1388,10 @@ class UsagePanel(Static):
         warning = Style(color=theme_mod.semantic_color("warning"))
         row = Text()
         row.append("Usage", style=Style(color=theme_mod.semantic_color("fg")))
-        stale = 0
+        stale = expired = 0
         age = ""
         if self._fetched_ms is not None and not self._loading and not self._error:
-            stale = self._stale_account_count()
+            stale, expired = self._flagged_account_counts()
             age = f"  {format_age(self._now() - self._fetched_ms)}"
         # The target is dropped when the row cannot hold both it and the stale
         # count. The title truncates from the RIGHT, so whatever is appended
@@ -1355,9 +1402,12 @@ class UsagePanel(Static):
         # and every block header repeats it. The stale count is the thing they
         # did not know, so it is the target that yields.
         target = f"  {self._target}" if self._target else ""
-        if target and stale:
+        if target and (stale or expired):
             wanted = cell_len("Usage") + cell_len(target) + cell_len(age)
-            wanted += cell_len(f"  · {stale} stale")
+            if stale:
+                wanted += cell_len(f"  · {stale} stale")
+            if expired:
+                wanted += cell_len(f"  · {expired} sign-in expired")
             if wanted > self._content_width():
                 target = ""
         if target:
@@ -1375,6 +1425,12 @@ class UsagePanel(Static):
             if stale:
                 row.append("  · ", style=faint)
                 row.append(f"{stale} stale", style=warning)
+            # A mixed set reads `1 stale · 1 sign-in expired`. Both counts are
+            # kept rather than folded into one number, because they ask the
+            # user for opposite things: wait, versus act.
+            if expired:
+                row.append("  · ", style=faint)
+                row.append(f"{expired} sign-in expired", style=warning)
         if self._refreshing and not self._error:
             row.append("  · ", style=faint)
             row.append("refreshing…", style=dim)

--- a/local_operator/tui/widgets/usage_panel.py
+++ b/local_operator/tui/widgets/usage_panel.py
@@ -498,8 +498,16 @@ def _account_status_note(  # noqa: ANN001
     verbatim, neither of which touches a counter. ``header_ms`` is optional so
     the pure renderer stays callable without a title (tests, ``_measure_columns``).
 
+    A dead grant outranks both: it is the only one of these states with a
+    remedy the user can act on, so it names the command instead of an age.
     An exhausted 200 (100% weekly) is quota, not this path.
     """
+    if getattr(report, "credential_invalid", False):
+        # The provider is named because the panel lists several accounts and
+        # the note sits under one block; `/login kimi` is runnable as printed,
+        # which `sign in again` would not be. Kept generic -- any provider's
+        # OAuth grant can die this way.
+        return f"sign-in expired \u2014 /login {report.provider}"
     unavailable = bool(getattr(report, "usage_unavailable", False))
     failures = int(getattr(report, "consecutive_failures", 0) or 0)
     fetched_at = int(getattr(report, "fetched_at", 0) or 0)
@@ -539,7 +547,16 @@ def _fit_status_note(note: str, width: int) -> str:
     label, _, tail = note.partition(" — ")
     # `last known 2h ago` -> `2h ago`; the `·` keeps the two facts separable.
     short = f"{label.replace('usage ', '')} · {tail.replace('last known ', '')}"
-    return short if cell_len(short) <= width else note
+    if cell_len(short) <= width:
+        return short
+    # Last resort: the tail alone. `sign-in expired — /login kimi` gains
+    # nothing from the rewrite above (both halves are already minimal, so the
+    # short form is the same length), and truncation would eat the provider
+    # name off the end — turning a command the user can run as printed into
+    # `/login anthro…`. The tail is the half that survives, for the same
+    # reason the age does above: it is the actionable one. Only taken when the
+    # label genuinely cannot fit, so the ordinary note is untouched.
+    return tail if cell_len(tail) <= width else note
 
 
 def _provider_header(report, now_ms: float) -> Text:  # noqa: ANN001
@@ -557,11 +574,19 @@ def _provider_header(report, now_ms: float) -> Text:  # noqa: ANN001
     row.append(report.provider, style=heading)
     if report.identity:
         row.append(f"  {report.identity}", style=muted)
-    if getattr(report, "usage_unavailable", False) and not report.limits:
+    if (
+        getattr(report, "usage_unavailable", False)
+        and not getattr(report, "credential_invalid", False)
+        and not report.limits
+    ):
         # Last-known meters already occupy the heading's binding slot —
         # naming unavailable here duplicates the note and clips the
         # window on a 72-col card. With no meters there is no binding
         # to protect, so the heading may say the probe failed.
+        #
+        # A dead grant is excluded even with no meters: its note already
+        # states the condition AND the remedy, so repeating a vaguer version
+        # of it in the heading spends the same cells saying less.
         row.append("  ·  usage unavailable", style=dim)
     binding = binding_limit(report)
     if binding is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.46.11"
+version = "0.46.12"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -11,7 +11,11 @@ from typing import Any
 import pytest
 
 from local_operator.credentials import CredentialManager
-from local_operator.providers.auth_store import AuthStore, AuthStoreError
+from local_operator.providers.auth_store import (
+    AuthStore,
+    AuthStoreError,
+    CredentialInvalidError,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -643,6 +647,105 @@ class TestListOauthAccesses:
         assert [a.email for a in named] == ["a@example.com", "b@example.com"]
         assert all(a.access_token == "" for a in named)
         assert store.is_blocked(row.id, "anthropic") is False
+
+
+class TestADeadGrantIsReportedRatherThanOmitted:
+    """Omission is right for a transient miss and wrong for a permanent one.
+
+    A row whose refresh fails temporarily is dropped from the enumeration so
+    the caller keeps last-good numbers and retries. A row whose grant the IdP
+    has refused for good is a fact the operator must act on, and dropping it
+    is what made `/usage` say `usage unavailable - last known 2d ago` forever
+    against a kimi credential that needed a re-login.
+    """
+
+    @staticmethod
+    def _account(email: str, account_id: str) -> dict[str, Any]:
+        return {**_oauth(access=f"access-{account_id}"), "email": email, "account_id": account_id}
+
+    @staticmethod
+    def _kill(store: AuthStore, monkeypatch: pytest.MonkeyPatch, dead_id: int, exc) -> None:
+        async def refresh(self_, credential_row, *, force=False):  # noqa: ANN001
+            if credential_row.id == dead_id:
+                raise exc
+            return dict(credential_row.data)
+
+        monkeypatch.setattr(AuthStore, "_ensure_oauth_fresh", refresh)
+
+    async def test_a_dead_grant_is_listed_with_no_bearer(
+        self, store: AuthStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dead = store.upsert_credential("anthropic", self._account("a@example.com", "acct-a"))
+        store.upsert_credential("anthropic", self._account("b@example.com", "acct-b"))
+        self._kill(store, monkeypatch, dead.id, CredentialInvalidError("grant is dead"))
+
+        accesses = await store.list_oauth_accesses("anthropic")
+        assert [a.email for a in accesses] == ["a@example.com", "b@example.com"]
+        assert accesses[0].credential_invalid is True
+        # No bearer exists, so a caller that wanted one still skips it.
+        assert accesses[0].access_token == ""
+        assert accesses[1].credential_invalid is False
+        assert accesses[1].access_token == "access-acct-b"
+
+    async def test_reporting_a_dead_grant_does_not_retire_the_credential(
+        self, store: AuthStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The invariant the docstring is explicit about: a READ may not take a
+        credential out of service. Naming the grant dead is not disabling it —
+        the login is still the user's, and only they can replace it."""
+        dead = store.upsert_credential("anthropic", self._account("a@example.com", "acct-a"))
+        self._kill(store, monkeypatch, dead.id, CredentialInvalidError("grant is dead"))
+
+        await store.list_oauth_accesses("anthropic")
+        row = store.get_credential(dead.id)
+        assert row is not None and row.disabled_cause is None
+        assert store.is_blocked(dead.id, "anthropic") is False
+
+    async def test_a_transient_failure_is_still_omitted(
+        self, store: AuthStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The existing behaviour must not move: an outage keeps its retry."""
+        dead = store.upsert_credential("anthropic", self._account("a@example.com", "acct-a"))
+        store.upsert_credential("anthropic", self._account("b@example.com", "acct-b"))
+        self._kill(store, monkeypatch, dead.id, AuthStoreError("refresh failed"))
+
+        accesses = await store.list_oauth_accesses("anthropic")
+        assert [a.email for a in accesses] == ["b@example.com"]
+
+    async def test_the_store_raises_its_own_permanent_type(
+        self, store: AuthStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`InvalidGrantError` from the flow becomes `CredentialInvalidError`,
+        so nothing above the store imports the OAuth module to identify it —
+        while `except AuthStoreError` handlers keep catching it."""
+        from local_operator.providers.oauth.callback_server import InvalidGrantError
+
+        row = store.upsert_credential(
+            "anthropic", {**self._account("a@example.com", "acct-a"), "expires": 0}
+        )
+
+        async def refresh(creds):  # noqa: ANN001
+            raise InvalidGrantError("Anthropic refresh failed (400): invalid_grant")
+
+        monkeypatch.setattr(AuthStore, "_refresh_fn", lambda self_, provider: refresh)
+        with pytest.raises(CredentialInvalidError) as caught:
+            await store._ensure_oauth_fresh(row)
+        assert isinstance(caught.value, AuthStoreError)
+
+    async def test_a_transient_refresh_error_keeps_the_generic_type(
+        self, store: AuthStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        row = store.upsert_credential(
+            "anthropic", {**self._account("a@example.com", "acct-a"), "expires": 0}
+        )
+
+        async def refresh(creds):  # noqa: ANN001
+            raise RuntimeError("connection reset")
+
+        monkeypatch.setattr(AuthStore, "_refresh_fn", lambda self_, provider: refresh)
+        with pytest.raises(AuthStoreError) as caught:
+            await store._ensure_oauth_fresh(row)
+        assert not isinstance(caught.value, CredentialInvalidError)
 
 
 class TestProviderOutageDoesNotBlockHealthyAccounts:

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -4,6 +4,7 @@ rotation, blocking. No network: fakes for the refresh capability."""
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -16,6 +17,7 @@ from local_operator.providers.auth_store import (
     AuthStoreError,
     CredentialInvalidError,
 )
+from local_operator.providers.oauth.callback_server import InvalidGrantError
 
 pytestmark = pytest.mark.asyncio
 
@@ -731,6 +733,54 @@ class TestADeadGrantIsReportedRatherThanOmitted:
         with pytest.raises(CredentialInvalidError) as caught:
             await store._ensure_oauth_fresh(row)
         assert isinstance(caught.value, AuthStoreError)
+
+    async def test_the_rotation_race_loser_does_not_condemn_a_live_grant(
+        self, store: AuthStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Review R2. With a rotating refresh token the process that loses the
+        race POSTs a token the winner already consumed, and the IdP answers
+        `invalid_grant` legitimately — about a superseded token, not about the
+        account. Declaring the credential dead there condemns a grant that is
+        alive and stored, which the success path's own guard exists to prevent.
+        """
+        row = store.upsert_credential(
+            "kimi", {**_oauth(refresh="old-token", access="a"), "expires": 0}
+        )
+
+        async def refresh(creds):  # noqa: ANN001
+            # The winner rotates the stored token while our POST is in flight.
+            store._conn.execute(
+                "UPDATE auth_credentials SET data = ? WHERE id = ?",
+                (json.dumps({"refresh": "winner-token", "access": "live-token"}), row.id),
+            )
+            store._conn.commit()
+            raise InvalidGrantError('Kimi refresh failed (400): {"error":"invalid_grant"}')
+
+        monkeypatch.setattr(AuthStore, "_refresh_fn", lambda self_, provider: refresh)
+        stored = store.get_credential(row.id)
+        assert stored is not None
+        data = await store._ensure_oauth_fresh(stored)
+
+        # The winner's live token is returned rather than an exception raised.
+        assert data["access"] == "live-token"
+        after = store.get_credential(row.id)
+        assert after is not None and after.disabled_cause is None
+
+    async def test_a_dead_grant_with_no_racing_writer_still_raises(
+        self, store: AuthStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The R2 guard must not swallow the real thing: with the stored token
+        unchanged, `invalid_grant` is exactly what it says."""
+        row = store.upsert_credential("kimi", {**_oauth(refresh="r", access="a"), "expires": 0})
+
+        async def refresh(creds):  # noqa: ANN001
+            raise InvalidGrantError('Kimi refresh failed (400): {"error":"invalid_grant"}')
+
+        monkeypatch.setattr(AuthStore, "_refresh_fn", lambda self_, provider: refresh)
+        stored = store.get_credential(row.id)
+        assert stored is not None
+        with pytest.raises(CredentialInvalidError):
+            await store._ensure_oauth_fresh(stored)
 
     async def test_a_transient_refresh_error_keeps_the_generic_type(
         self, store: AuthStore, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -1208,6 +1208,107 @@ class TestPerAccountLastKnown:
         assert reports[1].limits[0].amount.used == 22.0
 
     @pytest.mark.asyncio
+    async def test_a_dead_grant_is_not_a_transient_failure(
+        self, controller, store, monkeypatch
+    ) -> None:
+        """The reported defect, at the controller grain.
+
+        A permanently dead grant used to walk the same path as a network blip:
+        bump the streak, back off, and after the ceiling render `usage
+        unavailable`. It must instead be marked as needing a re-login, keep
+        its last-known numbers, and take no retry budget at all.
+        """
+        store.upsert_credential(
+            "anthropic",
+            {"refresh": "r", "access": "a", "email": "dead@example.com", "account_id": "acct-dead"},
+        )
+        dead = self._account("dead@example.com", "acct-dead")
+        dead.access_token = ""
+        dead.credential_invalid = True
+        store.oauth_accounts["anthropic"] = [dead]
+        probed: list[str | None] = []
+
+        async def fake_fetch(
+            client, provider, *, api_key, access_token, account_id, oauth_creds=None
+        ):
+            probed.append(account_id)
+            raise AssertionError("a dead grant must never be probed")
+
+        monkeypatch.setattr("local_operator.providers.controller.fetch_usage", fake_fetch)
+        reports = await controller.fetch_usage(["anthropic"])
+
+        assert probed == []  # no request is made with an empty bearer
+        assert len(reports) == 1
+        assert reports[0].credential_invalid is True
+        # The transient machinery stays untouched: no streak, no ceiling, and
+        # no scheduled retry that could never succeed.
+        assert reports[0].usage_unavailable is False
+        assert reports[0].consecutive_failures == 0
+        assert reports[0].next_probe_at_ms is None
+
+    @pytest.mark.asyncio
+    async def test_a_dead_grant_keeps_its_last_known_numbers(
+        self, controller, store, monkeypatch
+    ) -> None:
+        """The login is still real, so its final reading is still the truth
+        about it — the panel shows the meters beside the re-login note."""
+        store.upsert_credential(
+            "anthropic",
+            {"refresh": "r", "access": "a", "email": "dead@example.com", "account_id": "acct-dead"},
+        )
+        dead = self._account("dead@example.com", "acct-dead")
+        dead.access_token = ""
+        dead.credential_invalid = True
+        store.oauth_accounts["anthropic"] = [dead]
+
+        async def fake_fetch(
+            client, provider, *, api_key, access_token, account_id, oauth_creds=None
+        ):
+            return self._report("dead@example.com", 61.0)
+
+        # One good round populates last-known...
+        monkeypatch.setattr("local_operator.providers.controller.fetch_usage", fake_fetch)
+        store.oauth_accounts["anthropic"] = [self._account("dead@example.com", "acct-dead")]
+        first = await controller.fetch_usage(["anthropic"])
+        assert first[0].limits[0].amount.used == 61.0
+
+        # ...then the grant dies.
+        store.oauth_accounts["anthropic"] = [dead]
+        second = await controller.fetch_usage(["anthropic"], force_refresh=True)
+        assert second[0].credential_invalid is True
+        assert second[0].limits[0].amount.used == 61.0
+
+    @pytest.mark.asyncio
+    async def test_a_working_bearer_clears_the_dead_grant_flag(
+        self, controller, store, monkeypatch
+    ) -> None:
+        """After `/login`, a 200 is what proves the new grant works, so the
+        state must heal itself rather than needing a cache wipe."""
+        store.upsert_credential(
+            "anthropic",
+            {"refresh": "r", "access": "a", "email": "dead@example.com", "account_id": "acct-dead"},
+        )
+        dead = self._account("dead@example.com", "acct-dead")
+        dead.access_token = ""
+        dead.credential_invalid = True
+        store.oauth_accounts["anthropic"] = [dead]
+
+        async def fake_fetch(
+            client, provider, *, api_key, access_token, account_id, oauth_creds=None
+        ):
+            return self._report("dead@example.com", 5.0)
+
+        monkeypatch.setattr("local_operator.providers.controller.fetch_usage", fake_fetch)
+        first = await controller.fetch_usage(["anthropic"])
+        assert first[0].credential_invalid is True
+
+        # The user re-logs in: the row mints a bearer again.
+        store.oauth_accounts["anthropic"] = [self._account("dead@example.com", "acct-dead")]
+        healed = await controller.fetch_usage(["anthropic"], force_refresh=True)
+        assert healed[0].credential_invalid is False
+        assert healed[0].limits[0].amount.used == 5.0
+
+    @pytest.mark.asyncio
     async def test_an_override_fetches_the_api_key_not_stored_oauth_stubs(
         self, controller, store, monkeypatch
     ) -> None:

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -1309,6 +1309,87 @@ class TestPerAccountLastKnown:
         assert healed[0].limits[0].amount.used == 5.0
 
     @pytest.mark.asyncio
+    async def test_the_verdict_clears_on_an_automatic_poll_not_only_on_r(
+        self, controller, store, monkeypatch
+    ) -> None:
+        """Review R1/Q1: the panel's own advice must be enough to fix it.
+
+        The user reads `sign-in expired — /login kimi`, runs `/login`, and then
+        does nothing else. The next AUTOMATIC poll has to return the account to
+        normal. This is deliberately NOT a `force_refresh` test: `r` bypasses
+        the backoff gate, so the three healing tests above all passed while a
+        `credential_invalid` report was permanently skipped by the ordinary
+        cycle — the verdict was a one-way latch that outlived its own cause.
+        """
+        store.upsert_credential(
+            "anthropic",
+            {"refresh": "r", "access": "a", "email": "dead@example.com", "account_id": "acct-dead"},
+        )
+        dead = self._account("dead@example.com", "acct-dead")
+        dead.access_token = ""
+        dead.credential_invalid = True
+        store.oauth_accounts["anthropic"] = [dead]
+
+        async def fake_fetch(
+            client, provider, *, api_key, access_token, account_id, oauth_creds=None
+        ):
+            return self._report("dead@example.com", 7.0)
+
+        monkeypatch.setattr("local_operator.providers.controller.fetch_usage", fake_fetch)
+        first = await controller.fetch_usage(["anthropic"])
+        assert first[0].credential_invalid is True
+
+        # `/login` re-mints the grant. Re-authenticating an already-stored
+        # account keeps the account fingerprint, so the cache key is unchanged
+        # and the row holding the stale verdict would otherwise be served
+        # ahead of any fetch — the login path drops it for exactly this
+        # reason (`_invalidate_cached_usage`).
+        store.oauth_accounts["anthropic"] = [self._account("dead@example.com", "acct-dead")]
+        controller._invalidate_cached_usage("anthropic")
+
+        # No `r`: this is the ordinary background poll.
+        healed = await controller.fetch_usage(["anthropic"])
+        assert healed[0].credential_invalid is False
+        assert healed[0].limits[0].amount.used == 7.0
+
+    @pytest.mark.asyncio
+    async def test_a_transient_miss_does_not_latch_a_healthy_credential(
+        self, controller, store, monkeypatch
+    ) -> None:
+        """Review R1/Q1, the worse half: a live grant must never acquire the
+        note. Reaching `_mark_account_failure` means the bearer minted and the
+        usage ENDPOINT failed — direct evidence the grant is alive — so a
+        stale verdict has to be dropped rather than carried forward."""
+        now = 1_000_000
+        previous = self._report("dead@example.com", 12.0)
+        previous.credential_invalid = True
+
+        marked = controller._mark_account_failure(
+            previous, provider="anthropic", identity="dead@example.com", now_ms=now
+        )
+
+        assert marked.credential_invalid is False
+        assert marked.consecutive_failures == 1
+        # And with the verdict gone it is an ordinary backoff, not a permanent
+        # exclusion from the automatic cycle.
+        assert controller._account_in_backoff(marked, now + 10_000_000, force=False) is False
+
+    @pytest.mark.asyncio
+    async def test_a_dead_grant_is_not_excluded_from_the_automatic_cycle(
+        self, controller, store, monkeypatch
+    ) -> None:
+        """The gate saved no network call and cost the only path that heals.
+
+        `list_oauth_accesses` refreshes every row before this gate is reached,
+        and the usage probe is short-circuited separately for a dead row, so
+        skipping the cycle spent nothing — it only prevented the fetch that
+        clears the flag.
+        """
+        report = UsageReport(provider="kimi", fetched_at=1_000, identity="cred:8")
+        report.credential_invalid = True
+        assert controller._account_in_backoff(report, 2_000, force=False) is False
+
+    @pytest.mark.asyncio
     async def test_an_override_fetches_the_api_key_not_stored_oauth_stubs(
         self, controller, store, monkeypatch
     ) -> None:

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -366,10 +366,51 @@ class TestATerminalGrantIsToldFromAnOutage:
 
     @pytest.mark.parametrize(
         "code",
-        ["invalid_grant", "invalid_client", "unauthorized_client", "unsupported_grant_type"],
+        ["invalid_grant", "invalid_client", "unauthorized_client"],
     )
     def test_terminal_error_codes_are_terminal(self, code: str) -> None:
         body = f'{{"error":"{code}","error_description":"nope"}}'
+        assert is_terminal_grant_response(400, body) is True
+
+    def test_unsupported_grant_type_is_a_config_error_not_a_dead_grant(self) -> None:
+        """Review R4. The endpoint is refusing the `grant_type` PARAMETER, which
+        says nothing about the stored grant — and a token-endpoint config change
+        would otherwise darken every account on the provider at once, telling
+        each of them to run a `/login` that cannot fix it."""
+        assert is_terminal_grant_response(400, '{"error":"unsupported_grant_type"}') is False
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            # Review R3: the excluded code is the VERDICT; the terminal codes
+            # appear only in prose or in an RFC-permitted `error_uri` anchor.
+            '{"error":"invalid_request","error_description":'
+            '"invalid_grant_type: expected refresh_token"}',
+            '{"error":"invalid_request","error_description":'
+            '"the invalid_client_id parameter is unknown"}',
+            '{"error":"invalid_request",'
+            '"error_uri":"https://docs.example.com/errors#invalid_grant"}',
+            '{"error":"invalid_request","error_description":'
+            '"the invalid_grant parameter was malformed"}',
+        ],
+    )
+    def test_a_mentioned_terminal_code_does_not_override_the_error_field(self, body: str) -> None:
+        """`invalid_client` is a substring of `invalid_client_id`, so a raw scan
+        matched the EXCLUDED code through an INCLUDED one and told the user to
+        re-authenticate over a malformed request of ours."""
+        assert is_terminal_grant_response(400, body) is False
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "error=invalid_grant&error_description=dead",  # form-encoded
+            "<html><body>error: invalid_grant</body></html>",  # unparseable
+            '{"error":{"code":"invalid_grant"}}',  # wrapped envelope
+        ],
+    )
+    def test_non_json_and_wrapped_bodies_still_classify(self, body: str) -> None:
+        """Parsing must not silently downgrade a real dead grant to a retry loop
+        that can never end, so the substring scan stays as the fallback."""
         assert is_terminal_grant_response(400, body) is True
 
     def test_the_live_kimi_body_is_terminal(self) -> None:

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -19,15 +19,19 @@ from local_operator.harness.types import AbortSignal
 from local_operator.providers.oauth.callback_server import (
     CallbackFlowOptions,
     ConfigurationError,
+    InvalidGrantError,
     LoginCallbacks,
     LoginCancelledError,
     LoginError,
     OAuthCallbackFlow,
+    is_terminal_grant_response,
+    raise_for_refresh_failure,
 )
 from local_operator.providers.oauth.device_code import (
     DevicePollResult,
     poll_device_code_flow,
 )
+from local_operator.providers.oauth.kimi import refresh_kimi_token
 from local_operator.providers.oauth.openai import (
     decode_jwt_claims,
     identity_from_id_token,
@@ -343,6 +347,148 @@ def test_validate_xai_endpoint_rejects_other_hosts_and_http() -> None:
         validate_xai_endpoint("https://evil.example/oauth2/token")  # wrong host
     with pytest.raises(LoginError):
         validate_xai_endpoint("https://notx.ai/token")  # suffix trick
+
+
+# ---------------------------------------------------------------------------
+# Terminal grant classification (RFC 6749 §5.2)
+# ---------------------------------------------------------------------------
+
+
+class TestATerminalGrantIsToldFromAnOutage:
+    """A refresh that can never succeed vs one that might on the next try.
+
+    The distinction is the whole point: a transient failure keeps the existing
+    retry/backoff behaviour, while a dead grant has to stop retrying and tell
+    the user to sign in again. Observed against auth.kimi.com, which answered
+    a stored refresh token with `400 {"error":"invalid_grant"}` for two days
+    while `/usage` reported `usage unavailable — last known 2d ago`.
+    """
+
+    @pytest.mark.parametrize(
+        "code",
+        ["invalid_grant", "invalid_client", "unauthorized_client", "unsupported_grant_type"],
+    )
+    def test_terminal_error_codes_are_terminal(self, code: str) -> None:
+        body = f'{{"error":"{code}","error_description":"nope"}}'
+        assert is_terminal_grant_response(400, body) is True
+
+    def test_the_live_kimi_body_is_terminal(self) -> None:
+        """The exact response the defect was root-caused from."""
+        body = (
+            '{"error":"invalid_grant","error_description":'
+            '"The provided authorization grant is invalid"}'
+        )
+        assert is_terminal_grant_response(400, body) is True
+
+    @pytest.mark.parametrize(
+        "status, body",
+        [
+            (500, '{"error":"internal_error"}'),
+            (502, "<html>bad gateway</html>"),
+            (503, "temporarily unavailable"),
+            (429, '{"error":"rate_limited"}'),
+        ],
+    )
+    def test_server_side_failures_stay_transient(self, status: int, body: str) -> None:
+        """A 5xx/429 is the provider being unwell; the grant is not implicated."""
+        assert is_terminal_grant_response(status, body) is False
+
+    def test_a_5xx_carrying_the_word_invalid_grant_is_still_transient(self) -> None:
+        """Status gates which bodies are read at all.
+
+        A 500 whose stack trace happens to mention the code must not retire a
+        live credential — the verdict only means something on a 4xx.
+        """
+        assert is_terminal_grant_response(500, '{"error":"invalid_grant"}') is False
+
+    @pytest.mark.parametrize(
+        "body",
+        ['{"error":"invalid_request"}', '{"error":"invalid_scope"}', "", "Bad Request"],
+    )
+    def test_other_4xx_bodies_are_not_dead_grants(self, body: str) -> None:
+        """`invalid_request` is our bug, not the user's login: it must not be
+        turned into "your sign-in expired"."""
+        assert is_terminal_grant_response(400, body) is False
+
+    def test_the_raiser_picks_the_error_class(self) -> None:
+        with pytest.raises(InvalidGrantError) as terminal:
+            raise_for_refresh_failure("Kimi", 400, '{"error":"invalid_grant"}')
+        # The message shape is unchanged: it is what a user searches for.
+        assert "Kimi refresh failed (400)" in str(terminal.value)
+
+        with pytest.raises(LoginError) as transient:
+            raise_for_refresh_failure("Kimi", 503, "unavailable")
+        assert not isinstance(transient.value, InvalidGrantError)
+
+    def test_invalid_grant_error_is_still_a_login_error(self) -> None:
+        """Every existing `except LoginError` handler must keep working."""
+        assert issubclass(InvalidGrantError, LoginError)
+
+    async def test_kimi_refresh_raises_the_terminal_type(self) -> None:
+        """The provider path end to end, against the real 400 body."""
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                400,
+                json={
+                    "error": "invalid_grant",
+                    "error_description": "The provided authorization grant is invalid",
+                },
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            with pytest.raises(InvalidGrantError):
+                await refresh_kimi_token({"refresh": "dead"}, http_client=client)
+
+    async def test_kimi_refresh_keeps_a_5xx_transient(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, text="upstream unavailable")
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            with pytest.raises(LoginError) as caught:
+                await refresh_kimi_token({"refresh": "r"}, http_client=client)
+            assert not isinstance(caught.value, InvalidGrantError)
+
+    async def test_a_network_error_is_never_a_dead_grant(self) -> None:
+        """A dropped connection never reaches the classifier at all: there is
+        no response to read a verdict out of."""
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused")
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            with pytest.raises(httpx.ConnectError):
+                await refresh_kimi_token({"refresh": "r"}, http_client=client)
+
+    @pytest.mark.parametrize(
+        "module_name, refresh_fn",
+        [
+            ("openai", "refresh_openai_token"),
+            ("anthropic", "refresh_anthropic_token"),
+            ("xai", "refresh_xai_token"),
+        ],
+    )
+    async def test_every_provider_classifies_the_same_way(
+        self, module_name: str, refresh_fn: str
+    ) -> None:
+        """A dead grant is a property of OAuth2, not of one vendor.
+
+        kimi is covered above; this pins that the others were converted too,
+        so the panel's re-login note is reachable for every OAuth provider
+        rather than only the one the defect was reported against.
+        """
+        import importlib
+
+        module = importlib.import_module(f"local_operator.providers.oauth.{module_name}")
+        fn = getattr(module, refresh_fn)
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(400, json={"error": "invalid_grant"})
+
+        creds = {"refresh": "dead", "token_endpoint": "https://accounts.x.ai/oauth2/token"}
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            with pytest.raises(InvalidGrantError):
+                await fn(creds, http_client=client)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/providers/test_usage_cache.py
+++ b/tests/unit/providers/test_usage_cache.py
@@ -133,6 +133,26 @@ def test_a_row_written_before_the_flag_existed_reads_as_valid() -> None:
     assert restored.credential_invalid is False
 
 
+def test_invalidate_drops_the_row_so_the_next_read_refetches(tmp_path) -> None:
+    """A re-login is the one event the account fingerprint cannot observe.
+
+    Logging in again to an ALREADY-stored account leaves the account set (and
+    so the cache key) identical, so without an explicit drop the row carrying
+    a `credential_invalid` verdict outlives the login that disproved it.
+    """
+    store = UsageCacheStore(tmp_path / "usage.db")
+    report = _report()
+    report.credential_invalid = True
+    store.set("kimi:fp", "kimi", [report], expires_at_ms=store._now_ms() + 300_000)
+    assert store.get("kimi:fp") is not None
+
+    store.invalidate("kimi:fp")
+    assert store.get("kimi:fp", include_expired=True) is None
+    # Idempotent: dropping an absent row is not an error.
+    store.invalidate("kimi:fp")
+    store.close()
+
+
 def test_secret_fingerprint_never_contains_the_secret() -> None:
     fp = fingerprint_secret("sk-or-very-secret")
     assert "sk-or-very-secret" not in fp

--- a/tests/unit/providers/test_usage_cache.py
+++ b/tests/unit/providers/test_usage_cache.py
@@ -112,6 +112,27 @@ def test_report_round_trip_keeps_per_account_failure_state() -> None:
     assert restored.next_probe_at_ms == 1_700_000_000_000
 
 
+def test_report_round_trip_keeps_the_dead_grant_verdict() -> None:
+    """The panel reads cached rows, so a flag that did not survive the round
+    trip would show the re-login note only in the session that first saw the
+    refusal — and `usage unavailable` in every session after it."""
+    report = _report()
+    report.credential_invalid = True
+    restored = report_from_dict(report_to_dict(report))
+    assert restored is not None
+    assert restored.credential_invalid is True
+
+
+def test_a_row_written_before_the_flag_existed_reads_as_valid() -> None:
+    """The cache outlives the version that wrote it: an older row must be a
+    plain report, never a spurious "sign in again"."""
+    data = report_to_dict(_report())
+    data.pop("credential_invalid", None)
+    restored = report_from_dict(data)
+    assert restored is not None
+    assert restored.credential_invalid is False
+
+
 def test_secret_fingerprint_never_contains_the_secret() -> None:
     fp = fingerprint_secret("sk-or-very-secret")
     assert "sk-or-very-secret" not in fp

--- a/tests/unit/tui/test_usage_panel.py
+++ b/tests/unit/tui/test_usage_panel.py
@@ -570,6 +570,70 @@ def test_unavailable_with_last_known_meters_keeps_binding_on_the_heading() -> No
     assert "usage unavailable" in no_heading
 
 
+def test_a_dead_grant_names_the_remedy_instead_of_an_age() -> None:
+    """The reported defect's frame: `kimi cred:8 · usage unavailable — last
+    known 2d ago`, which implies the numbers return on their own when the only
+    fix is signing in again. A dead grant is the one failure state with an
+    action attached, so the note states the action.
+    """
+    report = _report(
+        _percent("k:5h", "5h limit", 100.0, shared=True),
+        provider="kimi",
+        identity="cred:8",
+    )
+    report.credential_invalid = True
+    report.fetched_at = 1
+    lines = _lines([report], now=2 * 86_400_000)
+    joined = "\n".join(lines)
+
+    assert "sign-in expired — /login kimi" in joined, joined
+    # The wait-it-out copy must be gone: it is the misleading half.
+    assert "usage unavailable" not in joined, joined
+    assert "last known" not in joined, joined
+    # The login is still real, so its last numbers stay on the card.
+    assert "cred:8" in joined
+    assert any("100%" in line for line in lines)
+
+
+def test_the_dead_grant_note_is_generic_across_providers() -> None:
+    """Nothing about this is kimi-specific — every OAuth provider can hit it."""
+    for provider in ("anthropic", "openai", "xai", "zai"):
+        report = _report(provider=provider, identity="me@example.com")
+        report.credential_invalid = True
+        joined = "\n".join(_lines([report]))
+        assert f"/login {provider}" in joined, joined
+
+
+def test_a_dead_grant_keeps_the_command_runnable_on_a_narrow_card() -> None:
+    """The provider name is the actionable half, so it is what survives.
+
+    `sign-in expired — /login anthropic` gains nothing from the generic
+    shortener (both halves are already minimal), and right-truncation would
+    print `/login anthro…` — a command that fails if typed as shown.
+    """
+    report = _report(provider="anthropic", identity="me@example.com")
+    report.credential_invalid = True
+
+    narrow = next(line for line in _lines([report], width=24) if "login" in line)
+    wide = next(line for line in _lines([report], width=76) if "login" in line)
+
+    assert "…" not in narrow, narrow
+    assert "/login anthropic" in narrow, narrow
+    assert wide.strip() == "sign-in expired — /login anthropic", wide
+
+
+def test_a_dead_grant_does_not_repeat_itself_on_the_heading() -> None:
+    """With no meters the heading may say a probe failed — but not here, where
+    the note already states the condition AND the remedy in the same cells."""
+    report = _report(provider="kimi", identity="cred:8")
+    report.credential_invalid = True
+    report.usage_unavailable = True
+    heading, note, *_rest = _lines([report], width=72)
+
+    assert "usage unavailable" not in heading, heading
+    assert "/login kimi" in note, note
+
+
 def test_a_stale_account_keeps_its_numbers_and_says_last_known() -> None:
     report = _report(
         _percent("a:7d", "7 day", 40.0, shared=True),

--- a/tests/unit/tui/test_usage_panel.py
+++ b/tests/unit/tui/test_usage_panel.py
@@ -18,7 +18,12 @@ from rich.style import Style
 from textual.app import App, ComposeResult
 from textual.containers import Container
 
-from local_operator.providers.usage import UsageAmount, UsageLimit, UsageReport
+from local_operator.providers.usage import (
+    USAGE_PROVIDERS,
+    UsageAmount,
+    UsageLimit,
+    UsageReport,
+)
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.editor import Editor
@@ -28,6 +33,8 @@ from local_operator.tui.widgets.usage_panel import (
     PANEL_PADDING_ROWS,
     PANEL_WIDTH_MARGIN,
     UsagePanel,
+    _account_status_note,
+    _fit_status_note,
     binding_limit,
     build_usage_body,
     collect_stats,
@@ -620,6 +627,75 @@ def test_a_dead_grant_keeps_the_command_runnable_on_a_narrow_card() -> None:
     assert "…" not in narrow, narrow
     assert "/login anthropic" in narrow, narrow
     assert wide.strip() == "sign-in expired — /login anthropic", wide
+
+
+@pytest.mark.parametrize("provider", sorted(USAGE_PROVIDERS))
+@pytest.mark.parametrize("width", [32, 40, 48, 72])
+def test_the_provider_id_is_never_what_the_ellipsis_eats(provider: str, width: int) -> None:
+    """Design D1, over EVERY usage provider at the narrow widths.
+
+    The previous test used `anthropic`, whose 16-cell tail fits comfortably at
+    every width, so it passed without ever reaching the last-resort rung. The
+    longest real id, `alibaba-token-plan-oauth`, needs 31 cells for
+    `/login <id>` against a 25-cell budget at the 32-col `PANEL_MIN_WIDTH`
+    floor — so the verb has to yield before the id does. A truncated command
+    is worse than none: it still looks like an instruction and then fails.
+    """
+    report = _report(
+        _percent("a:5h", "5 hour", 50.0, shared=True), provider=provider, identity="acct"
+    )
+    report.credential_invalid = True
+    report.fetched_at = 1
+
+    # The NOTE row is asserted directly rather than picked out of the rendered
+    # block: the heading also carries the provider id and is allowed to
+    # truncate, being a label rather than a command.
+    # `width - 2` is the note's real budget: `build_usage_body` indents it by
+    # two cells before fitting it (see the call at the `account_note` branch).
+    budget = width - 2
+    note = _fit_status_note(_account_status_note(report, 2 * 86_400_000), budget)
+    assert "…" not in note, note
+    # The whole id survives, so whatever remains is typeable as `/login <id>`.
+    assert provider in note, note
+    assert cell_len(note) <= budget, note
+
+
+def test_a_dead_grant_states_the_vintage_of_the_meters_below_it() -> None:
+    """Design D2: the block keeps rendering last-known meters, and the title
+    says `just now`, so without an age a two-day-old 100% reads as current —
+    the unmarked stale meter this note exists to prevent."""
+    report = _report(
+        _percent("k:5h", "5h limit", 100.0, shared=True), provider="kimi", identity="cred:8"
+    )
+    report.credential_invalid = True
+    report.fetched_at = 1
+
+    note = next(line for line in _lines([report], width=76, now=3 * 86_400_000) if "login" in line)
+    assert note.strip() == "sign-in expired — /login kimi · numbers 2d ago", note
+
+    # With no meters there is no vintage to state, so the age is omitted.
+    bare = _report(provider="kimi", identity="cred:8")
+    bare.credential_invalid = True
+    bare_note = next(line for line in _lines([bare], width=76) if "login" in line)
+    assert bare_note.strip() == "sign-in expired — /login kimi", bare_note
+
+
+def test_the_age_is_shed_before_the_command_on_a_narrow_card() -> None:
+    """D1 and D2 together: the age qualifies meters that are still on screen,
+    while the command is the only actionable thing on the row."""
+    report = _report(
+        _percent("k:5h", "5h limit", 100.0, shared=True), provider="kimi", identity="cred:8"
+    )
+    report.credential_invalid = True
+    report.fetched_at = 1
+    now = 3 * 86_400_000
+
+    wide = next(line for line in _lines([report], width=76, now=now) if "login" in line)
+    narrow = next(line for line in _lines([report], width=40, now=now) if "login" in line)
+
+    assert "numbers 2d ago" in wide
+    assert "numbers" not in narrow, narrow
+    assert "/login kimi" in narrow, narrow
 
 
 def test_a_dead_grant_does_not_repeat_itself_on_the_heading() -> None:
@@ -1896,6 +1972,42 @@ async def test_the_title_names_how_many_accounts_it_does_not_speak_for() -> None
 
     assert "1m ago" in title and "1 stale" in title, title
     assert "stale" not in healthy_title, healthy_title
+
+
+@pytest.mark.asyncio
+async def test_the_title_does_not_call_an_expired_sign_in_stale() -> None:
+    """Design D3: the title is the most-read row, and the two states ask for
+    opposite things — wait, versus act. Counting a dead grant as `stale` puts
+    back the category error the block note exists to correct, for any user who
+    reads only the top line.
+    """
+    now = 200 * 60_000.0
+    fresh = _aged(
+        _report(_percent("a:5h", "5 hour", 20.0, shared=True), identity="a@x"),
+        now - 1.8 * 60_000,
+    )
+    dead = _aged(
+        _report(_percent("k:5h", "5 hour", 64.0, shared=True), provider="kimi", identity="cred:8"),
+        now - 169 * 60_000,
+    )
+    dead.credential_invalid = True
+    stale = _aged(
+        _report(_percent("o:5h", "5 hour", 30.0, shared=True), provider="openai", identity="o@x"),
+        now - 169 * 60_000,
+    )
+    stale.consecutive_failures = 1
+
+    async with _panel_app() as panel:
+        panel.set_clock(now)
+        panel.show_reports([fresh, dead], now_ms=fresh.fetched_at)
+        dead_title = panel.render_lines_for_test()[0]
+        panel.show_reports([fresh, dead, stale], now_ms=fresh.fetched_at)
+        mixed_title = panel.render_lines_for_test()[0]
+
+    assert "1 sign-in expired" in dead_title, dead_title
+    assert "stale" not in dead_title, dead_title
+    # A mixed set keeps both tallies: they are different instructions.
+    assert "1 stale" in mixed_title and "1 sign-in expired" in mixed_title, mixed_title
 
 
 def test_the_unavailable_note_keeps_its_age_on_a_narrow_card() -> None:


### PR DESCRIPTION
## Summary

`/usage` showed a permanently broken kimi login as ordinary stale data, forever:

```
kimi  cred:8 · 5h limit 100%
  usage unavailable — last known 2d ago
```

Root cause, confirmed by a live probe against the real endpoint (output below): the stored kimi OAuth credential's refresh token is **permanently dead**. `auth.kimi.com` answers it with `400 {"error":"invalid_grant"}`, and no amount of retrying changes that — the user has to re-run the device-code login.

Nothing in the stack could say so. `AuthStore.list_oauth_accesses` wraps `_ensure_oauth_fresh` in `except AuthStoreError`, logs at debug and `continue`s, so the row silently vanished from the usage fetch. `UsageController._mark_account_failure` then treated the absence exactly like a network blip: bump `consecutive_failures`, and after `USAGE_ACCOUNT_MAX_FAILURES` set `usage_unavailable=True`. The panel rendered `usage unavailable — last known {age}`.

**The defect is that a dead grant was indistinguishable from a transient outage.** The user is shown copy that implies the numbers will come back, when the only remedy is re-authenticating — and it sits there permanently, because `usage_unavailable` accounts are only retried on `r`, and `r` fails identically every time.

## Classify at the source, on the body and not the status

`is_terminal_grant_response` (`oauth/callback_server.py`) reads the OAuth2 error code out of the token endpoint's **body**, per RFC 6749 §5.2. The status code alone is not the signal and is deliberately not used as one: the same 400 carries `invalid_grant` (terminal) and `invalid_request` (our own malformed request, retryable), while a 401 is routinely a gateway having a bad minute. The status only gates *which bodies are worth reading* — 5xx and 429 are the provider failing, and their body is a stack trace or an HTML error page rather than a verdict about the operator's grant.

Terminal set: `invalid_grant`, `invalid_client`, `unauthorized_client`, `unsupported_grant_type`. Deliberately excluded: `invalid_request` and `invalid_scope`, which describe a malformed request and would blame the user's login for a bug of ours.

A 5xx, a timeout, a dropped connection and a 429 all keep today's retry/backoff behaviour untouched.

## Carrying the distinction, on the existing channel

The verdict rides the layers that already carry `usage_unavailable` / `consecutive_failures`, rather than a parallel channel:

`InvalidGrantError` (flow) → `CredentialInvalidError` (store) → `OAuthAccess.credential_invalid` → `UsageReport.credential_invalid` → the panel note.

Both new exceptions subclass the existing ones (`LoginError`, `AuthStoreError`), so every current `except` handler behaves exactly as before and only callers that want the distinction test for the new type. All five refreshing providers (kimi, anthropic, openai, xai, radient) go through one shared helper — a dead grant is a property of OAuth2, not of kimi.

**No retry budget is burned.** `_mark_account_invalid` is deliberately *not* `_mark_account_failure` with an extra flag: the streak measures an outage's length, the exponential backoff schedules a retry that cannot succeed, and `usage_unavailable` renders the misleading copy. So the streak stays 0, `next_probe_at_ms` stays `None`, and `_account_in_backoff` skips the account on the flag alone. `r` still reaches it, which is how the state heals itself after `/login` — re-login updates the row in place for providers whose identity key is a per-provider constant, so the account fingerprint does not change and no cache invalidation would rescue a flag `r` could not clear.

**Nothing is disabled, deleted, or taken out of service.** `list_oauth_accesses`'s docstring is explicit that a READ is not entitled to make routing decisions, so the row is *reported* with an empty bearer instead of retired, and the account stays on the panel with its last-known meters — the login is still real, and its final reading is still the truth about it.

`ModelConfigurator`'s depletion preflight filters the new records back out, preserving its prior arithmetic exactly: a dead grant reads as one account that could not answer, never as proof the provider is empty.

## The panel names the remedy

`usage unavailable — last known 2d ago` → **`sign-in expired — /login kimi`**. The command name was verified against the actual TUI command table (`SlashCommand("login", ...)` in `tui/app.py`), and the provider is interpolated, so it is generic across anthropic/openai/xai/zai.

`_fit_status_note` gained a last-resort branch. The existing shortener gains nothing on this string (both halves are already minimal, so the short form is the same length), and right-truncation would print `/login anthro…` — a command that fails if typed as shown. The tail survives instead, for the same reason the age does in the original note: it is the actionable half. The heading's `· usage unavailable` append is suppressed for this state, since the note already states the condition *and* the remedy in the same cells.

## Testing evidence

### 1. Live probe: the root cause, against the real endpoint

The stored credential and a real refresh attempt against `auth.kimi.com`:

```
$ .venv/bin/python /tmp/probe_kimi.py
row id=8 provider=kimi type=oauth disabled=None expires_age_hours=49.7
  refresh raised LoginError: Kimi refresh failed (400): {"error":"invalid_grant","error_description":"The provided authorization grant is invalid"}
```

### 2. Live probe: every changed layer, on that same real dead credential

```
$ .venv/bin/python /tmp/probe_chain.py
1. refresh_kimi_token -> InvalidGrantError: Kimi refresh failed (400): {"error":"invalid_grant","error_description":"The provided authorization grant is invalid"}
2. _ensure_oauth_fresh -> CredentialInvalidError: OAuth grant for 'kimi' is no longer valid: Kimi refresh failed (400): {"error":"invalid_grant",...}
3. access cred=8 invalid=True token='' email=None
3b. row still enabled: disabled_cause=None blocked=False
4. panel note: 'sign-in expired — /login kimi'
4b. fit@70: 'sign-in expired — /login kimi'
4c. fit@20: '/login kimi'
```

Line **3b** is the invariant check: the credential is still enabled and still unblocked after the read reported it dead.

### 3. Live probe: the real `ProviderController` against the real credential

```
$ env HOME=/tmp/iso-probe ... .venv/bin/python /tmp/probe_controller.py
identity=cred:8 credential_invalid=True usage_unavailable=False consecutive_failures=0 next_probe_at_ms=None limits=2
```

The dead grant is flagged, takes **no** retry budget (`consecutive_failures=0`, `next_probe_at_ms=None`), and **keeps its 2 last-known limits**.

### 4. Rendered frames (real `OperatorApp`, so the stylesheet is applied)

Captured with `run_test` + `save_screenshot` per AGENTS.md — not the lightweight `_PanelHost`, which declares no `CSS_PATH`.

Frames were captured and **viewed** before and after (SVG exports rendered to PNG). They are on the authoring machine at `/tmp/lop-kimi-usage-artifacts/` — GitHub attachments cannot be uploaded from a headless CLI, so they are described here and available for a reviewer to open:

| artifact | state | what it shows |
| --- | --- | --- |
| `before_dead.png` | dead grant, 100x30 | `kimi cred:8 · 5h limit 100%` / `usage unavailable — last known 2d ago` — the reported defect |
| `after_dead.png` | dead grant, 100x30 | `kimi cred:8 · 5h limit 100%` / **`sign-in expired — /login kimi`**, 100% meter still drawn |
| `after_narrow.png` | dead grant, 72x30 | the same note on the designed narrow card, no clipping and no ellipsis |
| `before_stale.png` / `after_stale.png` | transient states, 100x30 | **byte-identical copy** — `usage unavailable — last known 2d ago` (openai) and `last known 3h ago` (xai) still render exactly as before |

The before/after pair for the ordinary stale states is the regression evidence: a 429/5xx is still transient, so that copy had to stay put, and it did.

Geometry behind the pixels — note width vs card width, every reachable size (`PANEL_MIN_WIDTH` is 32):

```
w=100 note='sign-in expired — /login anthropic'  max_line= 58 overflow=0 ellipsis=False
w= 72 note='sign-in expired — /login anthropic'  max_line= 58 overflow=0 ellipsis=False
w= 48 note='sign-in expired — /login anthropic'  max_line= 48 overflow=0 ellipsis=False
w= 40 note='sign-in expired — /login anthropic'  max_line= 40 overflow=0 ellipsis=False
w= 32 note='/login anthropic'                    max_line= 32 overflow=0 ellipsis=False
```

### 5. Unit tests

29 new tests: terminal codes vs transient failures (5xx, 429, timeout, network error, `invalid_request`), per-provider parity, the store's report-don't-retire behaviour, the controller's no-retry-budget/keeps-numbers/heals-on-200 contract, cache round-trip (including a row written before the field existed), and the panel strings.

### 6. Gates, whole tree, exactly as CI runs them

```
$ .venv/bin/python -m flake8 .
rc=0
$ uvx --from black==26.1.0 black --check .
All done! ✨ 🍰 ✨
870 files would be left unchanged.
$ uvx isort==5.13.2 --check .
rc=0
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
18 failed, 12543 passed, 15 skipped in 678.88s
```

**On those 18 failures — they are pre-existing on `main` and untouched by this change.** All 18 are `tests/unit/test_session_factory.py::test_resume_*`, which this PR does not modify.

> **Corrected in round 1** (QA findings Q2/Q3): round 0 reported *19* failures and attributed one of them to `tests/unit/model/test_prices.py`. That was wrong. The count is **18**, and `test_prices.py` is **not** among them — it passes on both trees (`45 passed`). The conclusion (pre-existing, unrelated) was right; only the enumeration was off, and it is fixed here so no reader hunts a failure this tree does not have.

Verified by running them on an unmodified `origin/main` worktree, where the same file fails the same way:

```
$ cd /tmp/lo-baseline-check   # detached worktree at origin/main, no changes
$ .venv/bin/python -m pytest tests/unit/test_session_factory.py tests/unit/model/test_prices.py -q -p no:randomly
18 failed, 138 passed in 4.58s
```

The suites this PR actually touches are green:

```
$ .venv/bin/python -m pytest tests/unit/providers tests/unit/tui/test_usage_panel.py \
    tests/unit/model/test_configure.py tests/unit/tui/test_app_pilot.py -q
1447 passed in 60.62s
```

> **Interpreter note (round 1, QA):** the gates above were re-run for the remediation on the worktree's **own** venv, `/tmp/lop-kimi-usage/.venv/bin/python` → **Python 3.12.13**, which is the version CI runs. Round 0 used `~/local-operator/.venv` (3.14.3), whose editable finder points at `~/local-operator` and only resolved to this worktree through cwd shadowing.

## Version

`0.46.7` → `0.46.9`. Patch per AGENTS.md (a reliability/bug fix). `0.46.8` was released mid-work by #616, so this branch was rebased onto it and takes the next patch.

