### PR TITLE
feat(benchmarks): AWS_ROOT_VOLUME_SIZE override for the OSWorld V2 benchmark VM

### DIFF
--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -195,11 +195,24 @@ does NOT create IAM roles or security groups; those are one-time human steps.
    burstable `t3.xlarge` runs out of CPU credits — see "Burstable credit
    exhaustion" in `docs/benchmarks/osworld_2/README.md`.
 
-   **This value requires a workspace built from adapter source that supports
-   it.** The source here gained it without a version bump (the bump would
+   Optional `AWS_ROOT_VOLUME_SIZE` (purpose `benchmark_compute`, a whole
+   number of GiB) replaces the root volume size for the benchmark VM. It
+   follows `AWS_INSTANCE_TYPE` exactly: it **overrides a task's own
+   `volume_size`**, for the same content-hash reason, and omitting it
+   reproduces the previous behaviour exactly (the task's pin, else the AMI's
+   own size resolved at launch). A non-integer, zero, negative, or
+   out-of-range value is refused at `prepare` before anything is allocated;
+   a size smaller than the AMI's own snapshot is refused at launch, with both
+   numbers named, because establishing that floor needs a `describe_images`
+   call `prepare` may not make. Reach for it when episodes die at a
+   consistent wall-clock time — see "Disk exhaustion" in
+   `docs/benchmarks/osworld_2/README.md`.
+
+   **Both values require a workspace built from adapter source that supports
+   them.** The source here gained them without a version bump (the bump would
    falsify the pilot's pinned attestation), so the shipped source and the
    digest-pinned `0.1.1` wheel are different code under one version string.
-   Supplying it to a build that does not declare it is refused by the runner
+   Supplying one to a build that does not declare it is refused by the runner
    before `prepare` rather than silently ignored — an ignored override would
    put a false hardware claim into a sealed bundle.
 6. **Judged tasks only** → secret `OSWORLD_EVAL_MODEL_API_KEY` plus infra

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
@@ -368,6 +368,19 @@ class AwsProvider:
         volume_gb = plan.volume_gb
         if volume_gb is None:
             volume_gb = self._resolve_root_volume_size(plan.ami_id)
+        else:
+            # A pinned size is checked against the AMI's OWN snapshot before
+            # run_instances. AWS refuses a root volume smaller than the
+            # snapshot it is restored from, and does it with an
+            # InvalidBlockDeviceMapping message that names neither the AMI's
+            # size nor the one asked for -- so the operator learns only that
+            # something was wrong, mid-launch. Checking here costs one
+            # read-only describe_images on the path that already issues one in
+            # the None branch, and turns that into a message carrying both
+            # numbers. It cannot move to ``provisioning.resolve``: prepare is
+            # declarative and issues no I/O at all, which is exactly what lets
+            # it run before anything is allocated.
+            self._refuse_volume_smaller_than_ami(plan.ami_id, volume_gb)
         tags = [{"Key": key, "Value": value} for key, value in plan.tags]
         response = ec2.run_instances(
             MaxCount=1,
@@ -421,13 +434,31 @@ class AwsProvider:
         """
 
         default = 40
+        return max(default, self._ami_root_volume_size(ami_id))
+
+    def _ami_root_volume_size(self, ami_id: str) -> int:
+        """The AMI's root BlockDeviceMapping size in GiB, with no floor applied.
+
+        Split out from ``_resolve_root_volume_size`` because the two callers
+        need different numbers from the same lookup. The default path wants
+        OSWorld's 40 GiB floor; the override check wants the AMI's REAL size,
+        since that -- not the floor -- is what AWS refuses to shrink below. One
+        function returning max(40, ami) would accept a 35 GiB override against
+        a 30 GiB AMI and reject one against a 45 GiB AMI with the wrong number
+        in the message.
+
+        Returns 0 when the image declares no EBS root mapping, which makes the
+        floor check vacuous rather than wrong: an AMI whose size cannot be read
+        must not manufacture a constraint the operator cannot satisfy.
+        """
+
         response = self._clients.ec2.describe_images(ImageIds=[ami_id])
         images = response.get("Images", [])
         if not images:
             raise AllocationError(f"AMI {ami_id} is not visible in {self._region}")
         image = images[0]
         root = image.get("RootDeviceName")
-        size = default
+        size = 0
         for mapping in image.get("BlockDeviceMappings", []):
             ebs = mapping.get("Ebs")
             if not ebs:
@@ -436,6 +467,23 @@ class AwsProvider:
                 size = max(size, int(ebs.get("VolumeSize", 0)))
                 break
         return size
+
+    def _refuse_volume_smaller_than_ami(self, ami_id: str, volume_gb: int) -> None:
+        """Fail a root volume smaller than the AMI's snapshot, naming both sizes.
+
+        EBS cannot restore a snapshot into a volume smaller than itself, so
+        this launch is doomed; the only question is whether the operator finds
+        out from a message naming the two numbers or from botocore's
+        InvalidBlockDeviceMapping, which names neither.
+        """
+
+        ami_gb = self._ami_root_volume_size(ami_id)
+        if ami_gb and volume_gb < ami_gb:
+            raise AllocationError(
+                f"root volume {volume_gb} GiB is smaller than AMI {ami_id}'s own "
+                f"snapshot ({ami_gb} GiB); EBS cannot restore a snapshot into a "
+                f"smaller volume, so raise AWS_ROOT_VOLUME_SIZE to at least {ami_gb}"
+            )
 
     def _create_lease(self, instance_id: str, role_arn: str) -> None:
         fire_at = datetime.now(timezone.utc) + timedelta(seconds=self._ttl_seconds)

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/provisioning.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/provisioning.py
@@ -44,6 +44,21 @@ _INSTANCE_TYPE_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*\.[a-z0-9]+(?:-[a
 # ``image`` field when that field is a valid AMI id.
 _DEFAULT_AMI = "ami-01017272139e01feb"
 _DEFAULT_INSTANCE_TYPE = "t3.xlarge"
+
+# Root volume bounds for AWS_ROOT_VOLUME_SIZE, checked at prepare time.
+#
+# The UPPER bound is AWS's own hard ceiling for a gp3 volume (16 TiB); the
+# provider pins VolumeType "gp3", so anything above this is refused by
+# run_instances no matter what. The LOWER bound is 1 because that is the
+# smallest positive size the API accepts -- the value that actually matters is
+# the AMI's own snapshot size, which is strictly larger and cannot be known
+# here, since establishing it costs the describe_images call ``resolve`` is
+# forbidden to make. That floor is enforced at launch instead (see
+# ``AwsProvider._run_instance``). Bounding the obviously absurd is still worth
+# doing at prepare time: it is free, and it catches a fat-fingered value
+# before anything is allocated.
+_MIN_ROOT_VOLUME_GB = 1
+_MAX_ROOT_VOLUME_GB = 16384
 # Public: the adapter's rescue path needs the same default when a descriptor
 # predates AWS_REGION being supplied.
 DEFAULT_REGION = "us-east-1"
@@ -106,11 +121,7 @@ def resolve(
         task.image if task.image is not None and _AMI_RE.fullmatch(task.image) else _DEFAULT_AMI
     )
     instance_type = _resolve_instance_type(task, infra_values)
-    # Volume size is left None unless the task pins it: the AMI's own
-    # BlockDeviceMappings carry a default that OSWorld resolves at launch,
-    # and replicating that lookup here would require the very describe_images
-    # call prepare must not make.
-    volume_gb = task.volume_size
+    volume_gb = _resolve_root_volume_gb(task, infra_values)
 
     region = (
         _infra(infra_values, "AWS_REGION") if _has(infra_values, "AWS_REGION") else _DEFAULT_REGION
@@ -210,6 +221,80 @@ def _resolve_instance_type(
             )
         return override
     return task.instance_type or _DEFAULT_INSTANCE_TYPE
+
+
+def _resolve_root_volume_gb(
+    task: TaskDescriptor,
+    infra_values: tuple[ScopedInfraValue, ...],
+) -> int | None:
+    """Root volume size in GiB: operator override, else the task's pin, else None.
+
+    WHY THIS KNOB EXISTS. Every OSWorld episode died at roughly the same
+    WALL-CLOCK time -- 7 of 8 runs first failed in a 424-466s window --
+    regardless of how much work the agent had done (16-32 steps) and on both
+    t3.xlarge and m5.xlarge. Instrumenting the guest's own control server
+    showed the root filesystem filling on a clock rather than on workload:
+
+        t+54s .. t+342s : 93% used, 2.2 GB free   (stable)
+        t+363s          : 95%
+        t+383s          : 100% used, 0 bytes free
+        t+424s          : first ObservationPhaseError, "no screenshot frame"
+
+    OSWorld starts an ``x11grab`` ffmpeg screen recorder in the guest on reset.
+    Its measured fill rate is ~6.8 MB/s (~410 MB/min) against only ~2.2 GB free
+    at launch, so the disk exhausts in ~330s on every run. A disk at 0 bytes
+    cannot write a screenshot, which is exactly the observed failure. This also
+    explains why AWS_INSTANCE_TYPE changed nothing: the recorder's rate does not
+    depend on CPU, and the volume is identical on either instance type.
+
+    WHY IT IS INFRA RATHER THAN A TASK FIELD. Same reason as AWS_INSTANCE_TYPE:
+    task files are content-hash verified against the release pin, so growing
+    ``volume_size`` there invalidates the very digest that makes a score
+    reproducible. The operator needs a knob reachable from outside the pin.
+
+    WHY THE OVERRIDE BEATS A TASK'S OWN PIN. Deliberately identical to
+    ``_resolve_instance_type``, and for the same reason rather than merely for
+    symmetry: the task author sized a volume against the workload they could
+    see, while the operator is working around an INFRASTRUCTURE failure -- a
+    recorder filling the disk on a clock -- that the author never saw and
+    cannot fix from inside a hash-pinned file. An override a task pin could
+    veto would silently fail on exactly the tasks most likely to run long
+    enough to hit the wall. A single precedence rule across both knobs is also
+    the one an operator can predict without reading the source.
+
+    Absent, this returns the previous value unchanged (the task's pin, else
+    None so OSWorld's own launch-time resolution from the AMI's
+    BlockDeviceMappings runs), so omitting the knob reproduces today's
+    behaviour exactly.
+    """
+
+    override = _get(infra_values, "AWS_ROOT_VOLUME_SIZE")
+    if override is None:
+        return task.volume_size
+
+    # Rejected, never ignored -- the same asymmetry with ``image`` that
+    # _resolve_instance_type documents. Quietly discarding a malformed value
+    # would launch the 2.2 GB-free default the operator was escaping and lose
+    # another paid episode at t+424s with no signal the knob never took effect.
+    #
+    # Validated by PARSING rather than by a regex: for an integer the parser is
+    # the validator, and a bare int() is too permissive on its own -- it accepts
+    # "+40", " 40 ", "4_0" and non-ASCII digits, none of which an operator meant
+    # to type. Requiring the string to be exactly its own ASCII digits rejects
+    # those along with "40.5", "1e3", "0x28" and "-1", and leaves int() total.
+    if not (override.isascii() and override.isdigit()):
+        raise ProvisioningError(
+            f"AWS_ROOT_VOLUME_SIZE {override!r} is not a whole number of GiB "
+            "(expected a plain positive integer, e.g. '80')"
+        )
+    size = int(override)
+    if not _MIN_ROOT_VOLUME_GB <= size <= _MAX_ROOT_VOLUME_GB:
+        raise ProvisioningError(
+            f"AWS_ROOT_VOLUME_SIZE {size} GiB is out of range "
+            f"({_MIN_ROOT_VOLUME_GB}-{_MAX_ROOT_VOLUME_GB} GiB); the provider pins "
+            "gp3, whose maximum volume size is 16384 GiB"
+        )
+    return size
 
 
 def _get(infra_values: tuple[ScopedInfraValue, ...], name: str) -> str | None:

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/requirements.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/requirements.py
@@ -70,8 +70,17 @@ _ALWAYS_INFRA = (
 # 10.3%) while AWS status checks read "ok". It is infra, not a task field,
 # precisely because task files are content-hash verified and cannot be edited
 # to work around the operator's hardware. See provisioning._resolve_instance_type.
+# AWS_ROOT_VOLUME_SIZE replaces the root volume size (GiB) for the benchmark VM.
+# It is the escape hatch from the OTHER failure that presents identically: the
+# guest's x11grab screen recorder fills the root filesystem at ~6.8 MB/s against
+# ~2.2 GB free, so the disk hits 0 bytes at ~t+383s and the next screenshot
+# request fails -- which is why 7 of 8 runs died in a 424-466s window on a clock
+# rather than on workload, and why changing the instance type fixed nothing.
+# Infra rather than a task field for the same content-hash reason.
+# See provisioning._resolve_root_volume_gb.
 _OPTIONAL_INFRA = (
     "AWS_INSTANCE_TYPE",
+    "AWS_ROOT_VOLUME_SIZE",
     "OSWORLD_INPUTS_ROOT",
     "OSWORLD_TTL_SECONDS",
 )

--- a/docs/benchmarks/osworld_2/README.md
+++ b/docs/benchmarks/osworld_2/README.md
@@ -229,6 +229,75 @@ Seeing that error means the workspace and selector need rebuilding against the
 current adapter source (§ the build recipe in
 `benchmarks/osworld_v2_adapter/README.md`), not that the flag is wrong.
 
+### Disk exhaustion by the screen recorder, and `AWS_ROOT_VOLUME_SIZE`
+
+`AWS_INSTANCE_TYPE` fixed a *starved* guest. A second failure presents
+**identically** — `ObservationPhaseError: environment returned no screenshot
+frame` — and has nothing to do with CPU. Episodes died at roughly the same
+**wall-clock time** regardless of how much work the agent had done: 7 of 8 runs
+first failed in a **424–466s window**, at 16–32 steps, on both `t3.xlarge`
+*and* `m5.xlarge`. That the instance-type fix changed nothing was the clue.
+
+Instrumenting the guest's own control server showed the root filesystem
+filling on a clock rather than on workload:
+
+| time | root filesystem |
+|------|-----------------|
+| t+54s … t+342s | 93% used, 2.2 GB free (stable) |
+| t+363s | 95% |
+| t+383s | **100% used, 0 bytes free** |
+| t+424s | first `ObservationPhaseError` |
+
+OSWorld starts an `x11grab` **ffmpeg screen recorder** in the guest on reset.
+Its measured fill rate is **~6.8 MB/s (~410 MB/min)** against only ~2.2 GB free
+at launch, so the disk exhausts in **~330s on every run**. A disk at 0 bytes
+cannot write a screenshot, which is exactly the observed failure — and the rate
+is constant regardless of agent activity, which is why the wall is a clock
+rather than a workload. The volume is identical on either instance type, which
+is why changing the hardware family did not move it.
+
+The escape hatch is the optional infra value `AWS_ROOT_VOLUME_SIZE`, a whole
+number of GiB:
+
+```sh
+--infra AWS_ROOT_VOLUME_SIZE=120
+```
+
+At ~410 MB/min, each extra GiB buys roughly 2.5 minutes of recording, so size
+it against the wall budget rather than against disk cost.
+
+It is infra rather than a task field for the same reason as the instance type:
+task files are **content-hash verified**, so editing `volume_size` invalidates
+the digest that makes a score reproducible. For the same reason it **beats a
+task's own pinned `volume_size`** — the task author sized a volume against the
+workload they could see, not against a recorder filling the disk on a clock.
+
+Validation runs in two places, deliberately:
+
+- **At `prepare`, before anything is allocated** — non-integers (`40.5`,
+  `1e3`, `+40`, `4_0`, whitespace), zero, negatives, and anything outside
+  1–16384 GiB (the gp3 maximum, since the provider pins gp3).
+- **At launch, before `run_instances`** — a size smaller than the AMI's own
+  snapshot. EBS cannot restore a snapshot into a smaller volume, and AWS
+  refuses it with an `InvalidBlockDeviceMapping` naming neither size; the
+  adapter's message names both plus the knob to change. This check cannot move
+  to `prepare`, which by contract issues no I/O at all — not even a read-only
+  `describe_images` — because that is what lets it run before allocation.
+
+Omitting the value reproduces the previous behaviour exactly: the task's pin,
+else the AMI's own root size resolved at launch (OSWorld's 40 GiB floor). When
+it **is** set, `scripts/run_episode.py` stamps `aws_root_volume_size_override`
+into the evidence manifest's metadata, so a run that survived past the
+exhaustion wall is not silently compared against truncated ones.
+
+Like `AWS_INSTANCE_TYPE`, this value is **gated**: supplying it to an adapter
+build that does not declare it fails the episode before `prepare` with
+`UndeclaredDisclosedInfra`, because a silently dropped override plus a stamped
+disclosure is a false statement sealed in a `verify_bundle`-valid bundle. Both
+the gate and the stamp derive from a single table
+(`DISCLOSED_INFRA_METADATA_KEYS` in `local_operator/evaluation/runner/episode.py`),
+so a future third value cannot be gated without being disclosed or vice versa.
+
 ### Upstream is sealed after the first reset
 
 One `reset` per episode is the contract. Upstream's own allocation paths — a

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -32,6 +32,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, Literal, Mapping
 
 from pydantic import ValidationError
@@ -158,7 +159,27 @@ _PROVISIONAL_CLEANUP_ACTION = "close-session"
 # (OSWORLD_PROXY_CREDENTIALS, OSWORLD_PROXY_ENDPOINT) is legitimately absent
 # from it, and a blanket rule would refuse correct proxy runs. Only a value
 # whose silent drop corrupts the evidence record belongs here.
-_DISCLOSED_INFRA_VALUES = frozenset({"AWS_INSTANCE_TYPE"})
+#
+# ONE TABLE, TWO CONSUMERS. The infra name is mapped to the manifest metadata
+# key that discloses it, because the gate below and the stamp in
+# ``scripts/run_episode.py`` are the two halves of a single guarantee and used
+# to be two independent hardcoded lists. A value present in the stamp but
+# absent here is disclosed with NO gate protecting it -- precisely the false
+# disclosure the gate exists to prevent -- and one present here but absent
+# there is gated but never disclosed. Neither mistake is detectable by reading
+# either file alone, so the pairing is expressed once and both sides derive
+# from it: adding a third value is one entry, and cannot be half-added.
+DISCLOSED_INFRA_METADATA_KEYS: Mapping[str, str] = MappingProxyType(
+    {
+        "AWS_INSTANCE_TYPE": "aws_instance_type_override",
+        # The root volume the guest's x11grab recorder fills at ~6.8 MB/s. A
+        # score run on a larger disk survives past the ~t+383s exhaustion wall
+        # that truncated earlier runs, so it is not comparable to one that hit
+        # it, and the bundle has to say so on its own.
+        "AWS_ROOT_VOLUME_SIZE": "aws_root_volume_size_override",
+    }
+)
+_DISCLOSED_INFRA_VALUES = frozenset(DISCLOSED_INFRA_METADATA_KEYS)
 
 
 class UndeclaredDisclosedInfra(RuntimeError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.46.10"
+version = "0.46.11"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/run_episode.py
+++ b/scripts/run_episode.py
@@ -86,6 +86,7 @@ from local_operator.evaluation.runner.durable_root import (
     refuse_volatile_root,
 )
 from local_operator.evaluation.runner.episode import (
+    DISCLOSED_INFRA_METADATA_KEYS,
     EpisodeConfig,
     EpisodeOutcome,
     EpisodeRunner,
@@ -464,11 +465,21 @@ def _parse_infra(values: Sequence[str], purpose: str) -> tuple[ScopedInfraValue,
     return tuple(out)
 
 
-def _instance_type_metadata(infra: Sequence[str]) -> dict[str, Any]:
-    """Manifest metadata disclosing an EC2 instance-type override, if any.
+def _infra_disclosure_metadata(infra: Sequence[str]) -> dict[str, Any]:
+    """Manifest metadata disclosing every infra override that changes the hardware.
 
-    The key records what was **requested** on the command line, not a value
-    read back from the adapter -- there is no channel for the latter, since
+    Driven by ``DISCLOSED_INFRA_METADATA_KEYS`` rather than by a list of names
+    repeated here. That table is also what
+    ``EpisodeRunner._refuse_undeclared_disclosed_infra`` gates on, and the two
+    are halves of one guarantee: the gate makes "requested" honest, and the
+    stamp is the only thing that records it. Hardcoding the names in both
+    places let a value be stamped without a gate (a disclosure nothing checks)
+    or gated without a stamp (a check nothing discloses), neither visible from
+    either file alone. Deriving both from the shared mapping makes a
+    half-added value impossible instead of merely unlikely.
+
+    The keys record what was **requested** on the command line, not values read
+    back from the adapter -- there is no channel for the latter, since
     ``ObservationPayload`` carries no metadata and neither ``PrepareResult``
     nor ``AckResult`` returns the resolved plan. Widening the wire to return it
     would be an ``ADAPTER_SCHEMA_VERSION`` bump, which breaks mixed-version
@@ -476,23 +487,25 @@ def _instance_type_metadata(infra: Sequence[str]) -> dict[str, Any]:
     for a field only this script reads.
 
     "Requested" is only honest because the runner refuses the mismatch that
-    would make it a lie: ``EpisodeRunner._refuse_undeclared_disclosed_infra``
-    fails the episode before ``prepare`` when this value is supplied to an
-    adapter build that does not declare ``AWS_INSTANCE_TYPE``. Requested and
-    applied can therefore differ only on a run that produced no bundle at all.
+    would make it a lie: the episode fails before ``prepare`` when one of these
+    values is supplied to an adapter build that does not declare it. Requested
+    and applied can therefore differ only on a run that produced no bundle.
 
     Reads the raw ``--infra NAME=VALUE`` strings rather than the parsed
     ``ScopedInfraValue`` tuple so this stays a pure function of the CLI input
     and can be tested without building a whole spec. Reporting an unparseable
     value verbatim is correct: the run fails at prepare, and a bundle, if one
-    exists at all, should still show what was asked for.
+    exists at all, should still show what was asked for. First occurrence wins,
+    matching ``_parse_infra``'s own left-to-right handling of a repeated name.
     """
 
+    metadata: dict[str, Any] = {}
     for item in infra:
         name, sep, value = item.partition("=")
-        if sep and name == "AWS_INSTANCE_TYPE" and value:
-            return {"aws_instance_type_override": value}
-    return {}
+        key = DISCLOSED_INFRA_METADATA_KEYS.get(name)
+        if sep and key is not None and value and key not in metadata:
+            metadata[key] = value
+    return metadata
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -636,20 +649,21 @@ async def run(args: argparse.Namespace) -> int:
             # read as a result.
             "model_client": args.model_client,
             "script": "scripts/run_episode.py",
-            # Hardware disclosure: the instance type REQUESTED for this run.
-            # A score produced on non-default hardware is not comparable to one
-            # produced on the release default, so the bundle has to say so on
-            # its own -- reading it must not depend on operator memory of which
-            # --infra flags were passed. Only the OVERRIDE is stamped, and only
-            # when supplied: with it absent the effective type is fully
-            # determined by the hash-pinned task file plus the documented
-            # default, so the disclosure is complete in both directions. The
-            # adapter cannot report this itself -- ``ObservationPayload``
-            # carries no metadata field, so nothing the worker resolves reaches
-            # the bundle except through the manifest. Requested can only differ
-            # from applied on an episode that produced no bundle: the runner
-            # refuses an override an adapter build does not declare.
-            **_instance_type_metadata(args.infra),
+            # Hardware disclosure: the infra overrides REQUESTED for this run
+            # (instance type, root volume size). A score produced on
+            # non-default hardware is not comparable to one produced on the
+            # release default, so the bundle has to say so on its own --
+            # reading it must not depend on operator memory of which --infra
+            # flags were passed. Only OVERRIDES are stamped, and only when
+            # supplied: with one absent the effective value is fully determined
+            # by the hash-pinned task file plus the documented default, so the
+            # disclosure is complete in both directions. The adapter cannot
+            # report this itself -- ``ObservationPayload`` carries no metadata
+            # field, so nothing the worker resolves reaches the bundle except
+            # through the manifest. Requested can only differ from applied on
+            # an episode that produced no bundle: the runner refuses an
+            # override an adapter build does not declare.
+            **_infra_disclosure_metadata(args.infra),
         },
     )
 

--- a/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
+++ b/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
@@ -177,10 +177,21 @@ def _expect_describe_images(stubs: _Stubs) -> None:
     )
 
 
-def _expect_run_instances(stubs: _Stubs, plan: provisioning.ProvisioningPlan | None = None) -> None:
+def _expect_run_instances(
+    stubs: _Stubs,
+    plan: provisioning.ProvisioningPlan | None = None,
+    *,
+    volume_gb: int | None = None,
+) -> None:
     # ``plan`` defaults to the standard one so every existing caller is
     # unchanged; a caller testing a resolved override passes its own.
     plan = plan if plan is not None else _plan()
+    # ``volume_gb`` is separate from ``plan`` because the size AWS receives is
+    # not always the plan's: with ``plan.volume_gb`` None the provider resolves
+    # it from the AMI (40 = OSWorld's floor, which the AMI's 30 does not
+    # lower). Defaulting to that keeps every existing caller unchanged while
+    # letting an override test assert the size actually sent.
+    expected_volume = volume_gb if volume_gb is not None else (plan.volume_gb or 40)
     stubs.ec2_stub.add_response(
         "run_instances",
         {"Instances": [{"InstanceId": INSTANCE}]},
@@ -204,8 +215,7 @@ def _expect_run_instances(stubs: _Stubs, plan: provisioning.ProvisioningPlan | N
                 {
                     "DeviceName": "/dev/sda1",
                     "Ebs": {
-                        # 40 = OSWorld's floor; the AMI's 30 does not lower it.
-                        "VolumeSize": 40,
+                        "VolumeSize": expected_volume,
                         "VolumeType": "gp3",
                         "Throughput": 1000,
                         "Iops": 4000,
@@ -1049,3 +1059,152 @@ def test_ttl_seconds_derivation() -> None:
 def test_credentials_repr_never_echoes_the_secret() -> None:
     assert "marker-secret" not in repr(CREDS)
     assert "marker-secret" not in str(CREDS)
+
+
+def _volume_infra(value: str) -> tuple[ScopedInfraValue, ...]:
+    return _infra() + (
+        ScopedInfraValue(name="AWS_ROOT_VOLUME_SIZE", purpose="benchmark_compute", value=value),
+    )
+
+
+def _describe_images_response(size_gb: int) -> dict[str, Any]:
+    return {
+        "Images": [
+            {
+                "ImageId": _plan().ami_id,
+                "RootDeviceName": "/dev/sda1",
+                "BlockDeviceMappings": [
+                    {"DeviceName": "/dev/sda1", "Ebs": {"VolumeSize": size_gb}},
+                ],
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_a_resolved_root_volume_override_reaches_run_instances(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The override must reach the actual API call, not merely the plan.
+
+    A unit test of the pure function would still pass if ``volume_gb`` were
+    dropped on the way to ``run_instances`` -- which is exactly the failure
+    that would leave the guest on the 2.2 GB-free disk its recorder exhausts
+    at ~t+383s, while every test stayed green. The stubbed client asserts the
+    exact launch parameters, so ``VolumeSize`` here is the number AWS would
+    actually receive.
+    """
+
+    task = taskfile.load_static(fixtures.PLAIN.encode(), module_name="tasks/task_plain.py")
+    plan = provisioning.resolve(task, episode_id=EPISODE, infra_values=_volume_infra("120"))
+    assert plan.volume_gb == 120
+
+    with _Stubs() as stubs:
+        # The floor check reads the AMI, so the lookup still happens -- but now
+        # to validate rather than to supply the size.
+        _expect_describe_images(stubs)
+        _expect_run_instances(stubs, plan=plan, volume_gb=120)
+        _expect_create_schedule(stubs)
+        _expect_running(stubs)
+        provider = _provider(
+            stubs,
+            monkeypatch,
+            desktop_env_factory=_FakeEnv,
+            task_factory=lambda t: {"id": t.task_id},
+        )
+        await provider.allocate(plan, task, cache_root=_cache_root(tmp_path))
+        stubs.ec2_stub.assert_no_pending_responses()
+
+
+@pytest.mark.asyncio
+async def test_a_root_volume_smaller_than_the_ami_snapshot_is_refused_before_launch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """EBS cannot restore a snapshot into a smaller volume, so this is doomed.
+
+    AWS refuses it with an InvalidBlockDeviceMapping that names neither size.
+    Failing here instead produces a message carrying both numbers and the name
+    of the knob to change -- and does it before run_instances, so no instance
+    and no volume are ever created.
+    """
+
+    task = taskfile.load_static(fixtures.PLAIN.encode(), module_name="tasks/task_plain.py")
+    plan = provisioning.resolve(task, episode_id=EPISODE, infra_values=_volume_infra("20"))
+    assert plan.volume_gb == 20
+
+    with _Stubs() as stubs:
+        # The release AMI's own root snapshot is 30 GiB; 20 cannot hold it.
+        stubs.ec2_stub.add_response(
+            "describe_images", _describe_images_response(30), {"ImageIds": [_plan().ami_id]}
+        )
+        provider = _provider(
+            stubs,
+            monkeypatch,
+            desktop_env_factory=_FakeEnv,
+            task_factory=lambda t: {"id": t.task_id},
+        )
+        with pytest.raises(AllocationError) as excinfo:
+            await provider.allocate(plan, task, cache_root=_cache_root(tmp_path))
+        message = str(excinfo.value)
+        # Both numbers and the remedy, which is the entire point of the check.
+        assert "20" in message and "30" in message
+        assert "AWS_ROOT_VOLUME_SIZE" in message
+        # No run_instances was queued, and none was attempted.
+        stubs.ec2_stub.assert_no_pending_responses()
+
+
+@pytest.mark.asyncio
+async def test_a_root_volume_equal_to_the_ami_snapshot_is_accepted(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The floor is >=, not >. Rejecting an exact match would refuse a size AWS
+    accepts, and would be invisible until an operator picked exactly 30."""
+
+    task = taskfile.load_static(fixtures.PLAIN.encode(), module_name="tasks/task_plain.py")
+    plan = provisioning.resolve(task, episode_id=EPISODE, infra_values=_volume_infra("30"))
+
+    with _Stubs() as stubs:
+        stubs.ec2_stub.add_response(
+            "describe_images", _describe_images_response(30), {"ImageIds": [_plan().ami_id]}
+        )
+        _expect_run_instances(stubs, plan=plan, volume_gb=30)
+        _expect_create_schedule(stubs)
+        _expect_running(stubs)
+        provider = _provider(
+            stubs,
+            monkeypatch,
+            desktop_env_factory=_FakeEnv,
+            task_factory=lambda t: {"id": t.task_id},
+        )
+        await provider.allocate(plan, task, cache_root=_cache_root(tmp_path))
+        stubs.ec2_stub.assert_no_pending_responses()
+
+
+@pytest.mark.asyncio
+async def test_the_default_path_still_applies_osworlds_forty_gib_floor(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Splitting the AMI lookup must not change the no-override behaviour.
+
+    ``_resolve_root_volume_size`` keeps OSWorld's 40 GiB floor while the new
+    floor CHECK needs the AMI's real 30; a single function serving both would
+    have to pick one and be wrong for the other. This pins the default half.
+    """
+
+    task = taskfile.load_static(fixtures.PLAIN.encode(), module_name="tasks/task_plain.py")
+    plan = _plan()
+    assert plan.volume_gb is None
+
+    with _Stubs() as stubs:
+        _expect_describe_images(stubs)  # AMI declares 30
+        _expect_run_instances(stubs, plan=plan, volume_gb=40)  # floor wins
+        _expect_create_schedule(stubs)
+        _expect_running(stubs)
+        provider = _provider(
+            stubs,
+            monkeypatch,
+            desktop_env_factory=_FakeEnv,
+            task_factory=lambda t: {"id": t.task_id},
+        )
+        await provider.allocate(plan, task, cache_root=_cache_root(tmp_path))
+        stubs.ec2_stub.assert_no_pending_responses()

--- a/tests/unit/evaluation/adapters/osworld/test_provisioning.py
+++ b/tests/unit/evaluation/adapters/osworld/test_provisioning.py
@@ -182,3 +182,111 @@ def test_tags_carry_the_episode_and_adapter() -> None:
 def test_proxy_flag_comes_from_the_task() -> None:
     assert _resolve(fixtures.PROXY).enable_proxy is True
     assert _resolve(fixtures.PLAIN).enable_proxy is False
+
+
+# ---------------------------------------------------------------------------
+# AWS_ROOT_VOLUME_SIZE: the disk-exhaustion escape hatch
+# ---------------------------------------------------------------------------
+#
+# The failure this knob answers is a CLOCK, not a workload: the guest's x11grab
+# recorder fills the root filesystem at ~6.8 MB/s against ~2.2 GB free, so the
+# disk reaches 0 bytes at ~t+383s and the next screenshot request fails. 7 of 8
+# runs first failed in a 424-466s window regardless of agent activity (16-32
+# steps) and on both t3.xlarge and m5.xlarge -- the volume is identical either
+# way, which is why the instance-type knob changed nothing.
+
+
+def _with_volume_size(value: str) -> tuple[ScopedInfraValue, ...]:
+    return _INFRA + (
+        ScopedInfraValue(name="AWS_ROOT_VOLUME_SIZE", purpose="benchmark_compute", value=value),
+    )
+
+
+def test_a_root_volume_override_replaces_the_launch_time_default() -> None:
+    descriptor = taskfile.load_static(fixtures.PLAIN.encode(), module_name="tasks/t.py")
+    plan = provisioning.resolve(
+        descriptor, episode_id="ep-1", infra_values=_with_volume_size("120")
+    )
+    assert plan.volume_gb == 120
+
+
+def test_a_root_volume_override_beats_a_task_pinned_volume_size() -> None:
+    # The precedence decision, asserted rather than assumed, and deliberately
+    # the same rule AWS_INSTANCE_TYPE uses: an override a task pin could veto
+    # would fail on exactly the tasks that run long enough to hit the wall.
+    descriptor = taskfile.load_static(fixtures.CUSTOM_INSTANCE.encode(), module_name="tasks/t.py")
+    assert descriptor.volume_size == 100
+    plan = provisioning.resolve(
+        descriptor, episode_id="ep-1", infra_values=_with_volume_size("250")
+    )
+    assert plan.volume_gb == 250
+
+
+def test_a_task_pinned_volume_size_still_wins_without_an_override() -> None:
+    # The override is opt-in: absent it, the task's own pin is untouched.
+    assert _resolve(fixtures.CUSTOM_INSTANCE).volume_gb == 100
+
+
+def test_volume_stays_none_without_an_override_or_a_task_pin() -> None:
+    # Omitting the knob must reproduce today's behaviour EXACTLY -- None, so
+    # OSWorld's own launch-time resolution from the AMI's BDM still runs.
+    assert _resolve(fixtures.PLAIN).volume_gb is None
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        # No empty-string case: ``ScopedInfraValue`` rejects it upstream with a
+        # min_length constraint, so it cannot reach ``resolve`` at all.
+        "eighty",  # not a number at all
+        "40.5",  # fractional GiB do not exist
+        "1e3",  # scientific notation
+        "0x28",  # hex
+        " 40",  # leading whitespace int() would silently accept
+        "40 ",  # trailing whitespace
+        "+40",  # signed, which int() would also accept
+        "4_0",  # PEP 515 underscore int() would read as 40
+        "\uff14\uff10",  # full-width digits str.isdigit() alone accepts
+        "40; rm -rf /",  # anything outside the closed shape
+    ],
+)
+def test_a_malformed_root_volume_override_is_rejected_at_prepare_time(bad: str) -> None:
+    # Rejected, not ignored: silently discarding it would launch the 2.2 GB-free
+    # default the operator was escaping and lose another paid episode at t+424s.
+    descriptor = taskfile.load_static(fixtures.PLAIN.encode(), module_name="tasks/t.py")
+    with pytest.raises(ProvisioningError) as excinfo:
+        provisioning.resolve(descriptor, episode_id="ep-1", infra_values=_with_volume_size(bad))
+    assert "AWS_ROOT_VOLUME_SIZE" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("bad", ["0", "-1", "-100", "16385", "999999"])
+def test_an_out_of_range_root_volume_override_is_rejected(bad: str) -> None:
+    # Zero and negatives are meaningless; above 16384 GiB is refused by AWS
+    # itself because the provider pins gp3. Catching them here costs nothing
+    # and beats an opaque botocore error midway through a paid launch.
+    descriptor = taskfile.load_static(fixtures.PLAIN.encode(), module_name="tasks/t.py")
+    with pytest.raises(ProvisioningError) as excinfo:
+        provisioning.resolve(descriptor, episode_id="ep-1", infra_values=_with_volume_size(bad))
+    assert "AWS_ROOT_VOLUME_SIZE" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("good", ["1", "40", "80", "120", "16384"])
+def test_root_volume_sizes_at_and_inside_the_bounds_are_accepted(good: str) -> None:
+    # The bounds are INCLUSIVE; an off-by-one here would reject the largest
+    # gp3 volume AWS sells, and 1 is the smallest the API accepts.
+    descriptor = taskfile.load_static(fixtures.PLAIN.encode(), module_name="tasks/t.py")
+    plan = provisioning.resolve(descriptor, episode_id="ep-1", infra_values=_with_volume_size(good))
+    assert plan.volume_gb == int(good)
+
+
+def test_the_two_infra_overrides_apply_independently() -> None:
+    # Both knobs answer the same symptom (a frameless observation) from
+    # different causes, so an operator hitting both applies both at once.
+    descriptor = taskfile.load_static(fixtures.PLAIN.encode(), module_name="tasks/t.py")
+    infra = _INFRA + (
+        ScopedInfraValue(name="AWS_INSTANCE_TYPE", purpose="benchmark_compute", value="m5.2xlarge"),
+        ScopedInfraValue(name="AWS_ROOT_VOLUME_SIZE", purpose="benchmark_compute", value="150"),
+    )
+    plan = provisioning.resolve(descriptor, episode_id="ep-1", infra_values=infra)
+    assert plan.instance_type == "m5.2xlarge"
+    assert plan.volume_gb == 150

--- a/tests/unit/evaluation/adapters/osworld/test_requirements.py
+++ b/tests/unit/evaluation/adapters/osworld/test_requirements.py
@@ -24,6 +24,7 @@ _ALWAYS = {
     "OSWORLD_FILE_BASE_URL",
     "HF_TOKEN",  # optional at episode time: the corpus is pre-materialised
     "AWS_INSTANCE_TYPE",  # optional: escape hatch from the burstable default
+    "AWS_ROOT_VOLUME_SIZE",  # optional: escape hatch from recorder disk exhaustion
     "OSWORLD_INPUTS_ROOT",  # optional: the durable root the assets live in
     "OSWORLD_TTL_SECONDS",  # optional: lease-length override
 }
@@ -104,6 +105,15 @@ def test_instance_type_override_is_optional_infra() -> None:
     # name is accepted rather than silently dropping an unknown infra value.
     by_name = _by_name(fixtures.PLAIN)
     assert by_name["AWS_INSTANCE_TYPE"] == ("infra", False)
+
+
+def test_root_volume_size_override_is_optional_infra() -> None:
+    # Optional, so preflight never demands it: omitting the knob must leave a
+    # default run exactly as it was. Declared at all because the runner's
+    # disclosure gate reads this declaration to tell an adapter build that
+    # understands the value from one that would silently drop it.
+    by_name = _by_name(fixtures.PLAIN)
+    assert by_name["AWS_ROOT_VOLUME_SIZE"] == ("infra", False)
 
 
 def test_judged_task_requires_the_judge_key_and_settings() -> None:

--- a/tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
+++ b/tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
@@ -159,6 +159,7 @@ def test_script_runs_one_spawned_episode_to_a_sealed_bundle(
     # task file plus the documented default, and a stamp here would misreport
     # a default run as having used custom hardware.
     assert "aws_instance_type_override" not in manifest.metadata
+    assert "aws_root_volume_size_override" not in manifest.metadata
     assert manifest.harness_version == _checkout_version()
     assert report.outcome is not None and report.outcome.reportable is False
     assert report.outcome.reportability_label == "synthetic_model"
@@ -433,3 +434,66 @@ def test_script_refuses_an_over_long_secret_naming_only_the_ref(
     assert completed.stderr.strip() == outcome["diagnostic"]
     everything = _all_bytes_under(run_root) + completed.stdout.encode() + completed.stderr.encode()
     assert b"SECRETVALUE" not in everything and b"zzzz" not in everything
+
+
+def test_a_root_volume_override_is_disclosed_in_the_sealed_manifest(
+    durable_path: Path, adapter_wheel: Path  # noqa: F811
+) -> None:
+    """A run on a resized disk must be disclosable from the bundle alone.
+
+    Comparability is the whole point. An episode on a larger root volume
+    survives past the ~t+383s exhaustion wall where the guest's x11grab
+    recorder fills the default 2.2 GB of free space, so its score is not
+    comparable to a truncated default run -- and a reader has no other way to
+    learn that, since ``ObservationPayload`` carries no metadata and nothing
+    the worker resolves reaches the bundle except through the manifest the
+    parent seals.
+
+    Both overrides are passed together because that is what an operator
+    escaping both failure modes actually runs, and it proves the two
+    disclosures coexist rather than one clobbering the other.
+    """
+
+    selector = _selector_file(durable_path / "adapter", adapter_wheel)
+    run_root = durable_path / "run"
+
+    completed = _run(
+        [
+            "--selector",
+            str(selector),
+            "--task-id",
+            "task_plain",
+            "--route",
+            "test/fake/model:free",
+            "--run-root",
+            str(run_root),
+            "--secret-env",
+            "AWS_ACCESS_KEY_ID",
+            "--secret-env",
+            "AWS_SECRET_ACCESS_KEY",
+            "--no-store",
+            "--model-client",
+            "scripted-finish",
+            "--max-steps",
+            "3",
+            "--max-usd",
+            "0.01",
+            *INFRA,
+            "--infra",
+            "AWS_ROOT_VOLUME_SIZE=120",
+            "--infra",
+            "AWS_INSTANCE_TYPE=m5.xlarge",
+        ],
+        {"AWS_ACCESS_KEY_ID": CANARY_KEY, "AWS_SECRET_ACCESS_KEY": CANARY_SECRET},
+    )
+
+    assert completed.returncode == 0, completed.stderr[-3000:]
+    outcome: dict[str, Any] = json.loads(completed.stdout)
+    assert outcome["status"] == "completed", outcome
+    report = verify_bundle(Path(outcome["bundle_root"]))
+    # Sealed AND valid: the manifest digest covers metadata, so a bundle that
+    # verifies is one whose disclosure cannot have been edited after the fact.
+    assert report.valid, [issue.code for issue in report.issues]
+    assert report.manifest is not None
+    assert report.manifest.metadata["aws_root_volume_size_override"] == "120"
+    assert report.manifest.metadata["aws_instance_type_override"] == "m5.xlarge"

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -27,7 +27,10 @@ from local_operator.evaluation.evidence.models import (
 from local_operator.evaluation.evidence.store import EvidenceWriter
 from local_operator.evaluation.evidence.verify import verify_bundle
 from local_operator.evaluation.receipts import RedactionSet
-from local_operator.evaluation.runner.episode import EpisodeRunner
+from local_operator.evaluation.runner.episode import (
+    DISCLOSED_INFRA_METADATA_KEYS,
+    EpisodeRunner,
+)
 from tests.unit.evaluation.runner.conftest import (
     FakeAdapter,
     RecordingResponder,
@@ -1381,3 +1384,104 @@ async def test_an_undeclared_ordinary_infra_value_is_not_refused(
     ).run()
 
     assert outcome.status == "completed", outcome.diagnostic
+
+
+@pytest.mark.asyncio
+async def test_a_root_volume_override_an_adapter_does_not_declare_is_refused(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """The second disclosed value inherits the gate, not just the allowlist.
+
+    Adding a value to the disclosure mechanism is exactly the drift a reviewer
+    predicted when the stamp and the allowlist were two hardcoded lists: a
+    value stamped into the manifest but ungated is a FALSE disclosure sealed
+    in a bundle that verifies. The refusal must land before ``prepare``, so
+    nothing is allocated and no bundle exists to mislead a reader.
+    """
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    outcome = await _infra_runner(
+        tmp_path, episode_id, _spec_with_infra(episode_id, "AWS_ROOT_VOLUME_SIZE"), adapter
+    ).run()
+
+    assert outcome.status == "failed_pre_bundle"
+    assert outcome.bundle_root is None
+    assert "AWS_ROOT_VOLUME_SIZE" in (outcome.diagnostic or "")
+    assert "UndeclaredDisclosedInfra" in (outcome.diagnostic or "")
+    assert "prepare" not in adapter.calls and "reset_start" not in adapter.calls
+    assert adapter.terminated
+
+
+@pytest.mark.asyncio
+async def test_a_declared_root_volume_override_runs_normally(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """The inverse: a rebuilt adapter declares it, so the knob is usable.
+
+    Without this the gate could pass by refusing everything, which would break
+    the very workflow the override exists for.
+    """
+
+    adapter = FakeAdapter(
+        tmp_path,
+        episode_id,
+        declared_requirements=(
+            Requirement(
+                requirement_id="AWS_ROOT_VOLUME_SIZE",
+                kind="infra",
+                name="AWS_ROOT_VOLUME_SIZE",
+                required=False,
+            ),
+        ),
+    )
+    outcome = await _infra_runner(
+        tmp_path, episode_id, _spec_with_infra(episode_id, "AWS_ROOT_VOLUME_SIZE"), adapter
+    ).run()
+
+    assert outcome.status == "completed", outcome.diagnostic
+    assert "prepare" in adapter.calls and "reset_start" in adapter.calls
+
+
+def test_every_disclosed_infra_value_is_gated_and_stamped_from_one_table() -> None:
+    """The gate and the stamp must not drift apart, and this is what binds them.
+
+    ``scripts/run_episode.py`` used to repeat the disclosed names in its own
+    hardcoded branch. Nothing tied the two lists together, so a third value
+    could be stamped without a gate (a disclosure nothing verifies) or gated
+    without a stamp (a check nothing records) -- neither visible by reading
+    either file alone. Both now derive from ``DISCLOSED_INFRA_METADATA_KEYS``;
+    this asserts the derivation rather than the current contents, so it keeps
+    holding when a fourth value is added.
+    """
+
+    import scripts.run_episode as run_episode
+    from local_operator.evaluation.runner.episode import _DISCLOSED_INFRA_VALUES
+
+    # The gate's allowlist is exactly the table's keys -- not a copy of them.
+    assert _DISCLOSED_INFRA_VALUES == frozenset(DISCLOSED_INFRA_METADATA_KEYS)
+
+    # And every gated name reaches the manifest under its declared key, which
+    # is the half a reviewer cannot see from episode.py alone.
+    for name, key in DISCLOSED_INFRA_METADATA_KEYS.items():
+        metadata = run_episode._infra_disclosure_metadata([f"{name}=some-value"])
+        assert metadata == {key: "some-value"}, name
+
+    # The keys are distinct: two values sharing one key would have the second
+    # silently overwrite the first's disclosure.
+    keys = list(DISCLOSED_INFRA_METADATA_KEYS.values())
+    assert len(keys) == len(set(keys))
+
+
+def test_an_undisclosed_infra_value_is_never_stamped() -> None:
+    """The stamp is an allowlist too: an ordinary infra value must not leak
+    into the manifest, and a value with no ``=`` must not be stamped empty."""
+
+    import scripts.run_episode as run_episode
+
+    assert run_episode._infra_disclosure_metadata(["OSWORLD_TTL_SECONDS=900"]) == {}
+    assert run_episode._infra_disclosure_metadata(["AWS_ROOT_VOLUME_SIZE"]) == {}
+    assert run_episode._infra_disclosure_metadata([]) == {}
+    # Both at once, each under its own key.
+    assert run_episode._infra_disclosure_metadata(
+        ["AWS_INSTANCE_TYPE=m5.xlarge", "AWS_ROOT_VOLUME_SIZE=120", "OSWORLD_TTL_SECONDS=900"]
+    ) == {"aws_instance_type_override": "m5.xlarge", "aws_root_volume_size_override": "120"}


### PR DESCRIPTION
## What

An optional infra value, `AWS_ROOT_VOLUME_SIZE` (a whole number of GiB), that sets the launched instance's root volume size for the OSWorld V2 benchmark VM — so a disk the guest's screen recorder exhausts can be enlarged **without editing content-hash-verified task files**.

Optional and absent by default: omitting it reproduces today's behaviour exactly (the task's own `volume_size` pin, else `None` so the AMI's BlockDeviceMappings resolve at launch), which is what keeps a default score run comparable.

Mirrors the `AWS_INSTANCE_TYPE` override from #610: same resolution shape, same validation posture, same optionality, same declaration in `requirements.py`, same precedence, same disclosure machinery.

## Why — the wall is a clock, not a workload

Every episode died at roughly the same **wall-clock time**: 7 of 8 runs first failed in a **424–466s window**, regardless of how much work the agent had done (16–32 steps), on **both `t3.xlarge` and `m5.xlarge`**. That the #610 instance-type fix changed nothing was the clue — this is a different failure wearing the same error message.

Root cause proven **from inside the guest**, not inferred. Instrumenting the guest's own control server and watching its root filesystem:

| time | root filesystem |
|------|-----------------|
| t+54s … t+342s | 93% used, 2.2 GB free (stable) |
| t+363s | 95% |
| t+383s | **100% used, 0 bytes free** |
| t+424s | first `ObservationPhaseError` — "environment returned no screenshot frame" |

OSWorld starts an `x11grab` **ffmpeg screen recorder** in the guest on reset. Measured fill rate **~6.8 MB/s (~410 MB/min)** against only **~2.2 GB free** at launch ⇒ exhaustion in **~330s, every run**. A disk at 0 bytes cannot write a screenshot, which is exactly the observed failure. The rate is constant regardless of agent activity, which is why the wall is a clock rather than a workload — and why changing the instance type changed nothing: the volume is identical.

At ~410 MB/min each extra GiB buys roughly 2.5 minutes of recording, so the knob is sized against the wall budget, not against disk cost.

## Precedence, and why it matches #610

`AWS_ROOT_VOLUME_SIZE` **beats a task's own pinned `volume_size`** — the same choice #610 made for the instance type, and adopted here for the same reason rather than merely for symmetry.

The task author sized a volume against the **workload** they could see; the operator is working around an **infrastructure** failure — a recorder filling the disk on a clock — that the author never saw and cannot fix from inside a hash-pinned file. An override a task pin could veto would silently fail on exactly the tasks likely to run long enough to hit the wall. A single precedence rule across both knobs is also the one an operator can predict without reading the source.

Justified in `_resolve_root_volume_gb`'s docstring and pinned by a dedicated test (`test_a_root_volume_override_beats_a_task_pinned_volume_size`), not left implicit.

## Validation, deliberately split across two sites

**At `prepare`, before anything is allocated** — non-integers, zero, negatives, and anything outside 1–16384 GiB (the gp3 maximum; the provider pins gp3).

Validated by **parsing** rather than by a regex, which is what fits an integer: a bare `int()` is too permissive on its own (it accepts `+40`, `" 40 "`, `4_0` and non-ASCII digits), so the value must be exactly its own ASCII digits, which also rejects `40.5`, `1e3` and `0x28` and leaves `int()` total.

**At launch, before `run_instances`** — a size **smaller than the AMI's own snapshot**. EBS cannot restore a snapshot into a smaller volume, and AWS refuses it with an `InvalidBlockDeviceMapping` naming *neither* size; the adapter's message names both plus the knob to change.

This check **cannot** move to `resolve()`: that function is pure by contract and issues no I/O at all — not even a read-only `describe_images` — which is the whole reason `prepare` can be declarative. It rides the lookup the launch path already performs in the default branch, so it costs no extra API call. `_ami_root_volume_size` is split out from `_resolve_root_volume_size` because the two callers need different numbers from one lookup: the default path wants OSWorld's 40 GiB floor, the floor check wants the AMI's real size. One function returning `max(40, ami)` would accept a 35 GiB override against a 30 GiB AMI and reject one against a 45 GiB AMI with the wrong number in the message.

## Disclosure — and the drift a reviewer predicted

#610's reviewer flagged that `_DISCLOSED_INFRA_VALUES` and the stamp in `scripts/run_episode.py` were **two hardcoded places with nothing binding them**, and that adding a second value was exactly the drift risk. That prediction was correct, so this PR fixes the mechanism rather than adding a second value to it.

Both sides now derive from one table, `DISCLOSED_INFRA_METADATA_KEYS`, mapping infra name → manifest metadata key:

- the gate's allowlist is `frozenset(DISCLOSED_INFRA_METADATA_KEYS)`, not a copy;
- `_instance_type_metadata` became `_infra_disclosure_metadata`, which iterates the table instead of branching on a literal name.

A value stamped but ungated is a **false disclosure sealed in a `verify_bundle`-valid bundle** — the exact defect the gate exists to prevent; one gated but unstamped is a check nothing records. Neither is visible by reading either file alone. Now a third value is one entry and **cannot be half-added** — asserted by `test_every_disclosed_infra_value_is_gated_and_stamped_from_one_table`, which checks the derivation (and that the keys are distinct) rather than the current contents, so it keeps holding as values are added.

Kept proportionate: one mapping and two derivations, no registry or plugin machinery.

## Testing evidence

### Whole-tree gates, exactly as CI, each exit code read directly

CI pins `flake8==7.1.0 black==26.1.0 isort==5.13.2` (`.github/workflows/ci.yml:100`). The shared dev venv has drifted to black 26.5.1 / isort 9.0.1, so lint ran in a **dedicated venv at CI's pins** — the drift is real and would have produced a misleading local result either way.

| gate | version | exit code |
|------|---------|-----------|
| `flake8 .` | 7.1.0 (CI pin) | **0** |
| `black --check .` | 26.1.0 (CI pin) | **0** — 870 files unchanged |
| `isort --check-only .` | 5.13.2 (CI pin) | **0** |
| `pyright .` | pyproject dev pin | **0** — `0 errors, 0 warnings, 0 informations` |
| `pytest tests/unit` | — | **0** — `12521 passed, 15 skipped in 552.51s` |

Exit codes captured with `cmd > file; echo "EXIT=$?"` — never through a pipe, so no `tail` status masked a failure. Black initially flagged one file (my own test file's line wrapping); it was fixed and re-verified to exit 0, not waived.

### The plan field actually reaches the API call

A unit test of the pure function would still pass if `volume_gb` were dropped on the way to `run_instances` — precisely the failure that would leave the guest on the 2.2 GB-free disk while every test stayed green. `test_a_resolved_root_volume_override_reaches_run_instances` resolves a real plan and asserts the **exact** `run_instances` parameters through a botocore `Stubber`, so `VolumeSize: 120` is the number AWS would actually receive. `_expect_run_instances` no longer hardcodes `VolumeSize: 40`; it derives the expectation, so the assertion cannot pass vacuously.

**No AWS writes anywhere** — botocore `Stubber` and fakes only; no instance was ever launched.

### Sealed bundle, end to end, in a real subprocess

`test_a_root_volume_override_is_disclosed_in_the_sealed_manifest` runs `scripts/run_episode.py` as a **real subprocess** with both overrides, then calls `verify_bundle` on the result:

```
report.valid                                          -> True
report.manifest.metadata["aws_root_volume_size_override"] -> "120"
report.manifest.metadata["aws_instance_type_override"]    -> "m5.xlarge"
```

Sealed **and** valid: the manifest digest covers metadata, so a bundle that verifies is one whose disclosure cannot have been edited after the fact. Both disclosures coexist rather than one clobbering the other. The default-run test additionally asserts `aws_root_volume_size_override` is **absent** when no override is passed — a stamp there would misreport a default run as custom hardware.

The undeclared-adapter gate is covered in both directions: refused before `prepare` with no bundle and the worker reaped (`status == "failed_pre_bundle"`, `bundle_root is None`, `"prepare" not in adapter.calls`), and running normally once the adapter declares it — without which the gate could pass by refusing everything.

### Real path exercised directly

```
1. default (no override)      volume_gb = None   (AMI resolves at launch)
2. override 120               volume_gb = 120
3. task pins 100, no override volume_gb = 100
4. task pins 100 + override   volume_gb = 250    (override wins)
5. '40.5'  -> refused: not a whole number of GiB
   '0'     -> refused: out of range (1-16384 GiB)
   '-5'    -> refused: not a whole number of GiB
   '16385' -> refused: out of range (1-16384 GiB)
   '+40'   -> refused: not a whole number of GiB
   ' 40'   -> refused: not a whole number of GiB
6. table: {'AWS_INSTANCE_TYPE': 'aws_instance_type_override',
           'AWS_ROOT_VOLUME_SIZE': 'aws_root_volume_size_override'}
7. stamp both: {'aws_root_volume_size_override': '120',
                'aws_instance_type_override': 'm5.xlarge'}
8. stamp none (ordinary infra value): {}
```

### Mutation testing — 11 mutants, all killed by their specific test

A test that passes against the bug is worthless, so every new behaviour was broken and the *specific* test written for it watched to fail. `__pycache__` was purged between mutations (stale bytecode has confounded mutation results here).

| # | mutation | killed by |
|---|----------|-----------|
| M1 | override ignored when a task pins a size | `..._beats_a_task_pinned_volume_size` (`assert 100 == 250`) |
| M2 | digit validation removed | `..._malformed_root_volume_override_is_rejected...` (`DID NOT RAISE`) |
| M3 | range check removed | `..._out_of_range_root_volume_override_is_rejected[16385]` |
| M4 | bounds `<` instead of `<=` (off-by-one) | `..._at_and_inside_the_bounds_are_accepted[1]`, `[16384]` |
| M5 | plan size never reaches `run_instances` | `..._reaches_run_instances` (passed clean, failed mutated) |
| M6 | snapshot floor check removed | `..._smaller_than_the_ami_snapshot_is_refused_before_launch` |
| M7 | floor `<=` instead of `<` (rejects an exact match) | `..._equal_to_the_ami_snapshot_is_accepted` |
| M8 | 40 GiB floor lost on the default path | `..._still_applies_osworlds_forty_gib_floor` |
| M9 | value dropped from the disclosure gate | `..._an_adapter_does_not_declare_is_refused` + `..._from_one_table` |
| M10 | stamp drops the new key (gated, never disclosed) | `..._from_one_table` + `..._never_stamped` |
| M11 | requirements declaration removed | `..._is_optional_infra` (`KeyError`) |

M5 was verified against a clean baseline (`1 passed` unmutated → `1 failed` mutated) so the kill is attributable to the mutation. Source restored and re-verified clean afterwards.

## Deliberately not done

- **No adapter package version bump.** Same reasoning #610 recorded: the version feeds `_release_digest`, and bumping it falsifies `test_the_staged_pilot_release_digest_is_reproduced_from_committed_values`, which attests the real deployed `0.1.1` pilot wheel. The bump belongs with the operator's workspace/selector rebuild — *deferred — belongs to the adapter rebuild step, see the operator note below*.
- **`ObservationPayload` gained no metadata field.** Widening the adapter wire to carry provisioning facts is an `ADAPTER_SCHEMA_VERSION` change well outside this slice; the manifest channel already answers the disclosure requirement.
- **No live-AWS validation of the fix's effect.** That the larger volume actually outlasts the recorder needs a paid run on rebuilt adapter artifacts, which is the operator step below. The arithmetic (~410 MB/min against the chosen size) is stated so the sizing can be checked.

## Operator note — rebuilding the adapter wheel, workspace and selector

The harness pins the adapter's package digest, so a rebuilt workspace needs a matching selector. After this lands, to put the override into a real run:

```sh
# 1. rebuild the wheel from the changed adapter source
cd ~/local-operator/benchmarks/osworld_v2_adapter
uv build --wheel

# 2. install it into the pilot interpreter (README step 3a recipe)
uv pip install --python ~/worktrees/osworld/venvs/<ver>/bin/python3.12 \
  --no-deps --force-reinstall dist/lop_osworld_v2_adapter-<ver>-py3-none-any.whl

# 3. rebuild the workspace — attests version + package digest into release_digest
~/local-operator/.venv/bin/python ~/local-operator/scripts/build_osworld_adapter.py \
  --out ~/worktrees/osworld/workspaces/<new> ...

# 4. regenerate the selector so package_digest / release_digest / workspace_digest match
#    (a stale selector fails the handshake's exact-pin check)
```

Then pass `--infra AWS_ROOT_VOLUME_SIZE=120` to `scripts/run_episode.py`.

Skipping any step yields `UndeclaredDisclosedInfra` before `prepare` rather than a silently ignored override — that refusal is the gate working, not a bug. As with #610: the adapter version participates in `_release_digest`, so if the rebuild bumps it, `test_the_staged_pilot_release_digest_is_reproduced_from_committed_values` and the `0.1.1` literals across the osworld tests must be updated in that same change, against the newly built wheel's real digest.
