### PR TITLE
chore(release): 0.46.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.46.9"
+version = "0.46.10"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Cuts the release carrying the `ask` restraint change (#617).

#617 merged as `5fc44146` carrying `0.46.9` in `pyproject.toml` — but `0.46.9` was **already published to PyPI and tagged `v0.46.9`** (19:19 UTC, for #611) while #617 was still in its review rounds. Releasing on it would mean the tag and the published artifact disagree. Bump to the next free patch.

This is the same situation, and the same fix, as #616.

## Version choice

**Patch, per the materiality rule in `AGENTS.md`** ("Versioning: choose the bump by materiality, not commit type"):

> if you cannot name the step-function capability in the release title (`X.Y.0: <the new thing>`), it is a patch, not a minor

#617 changes how an existing tool is described and when the agent reaches for it. No new surface or subsystem, nothing to adopt, nothing a user installs differently. There is no step-function capability to put in a title, so it is a patch. The guidance also says to err toward patch here, since an over-called minor permanently misreports how much changed.

## What is being released

`fix(prompts): make deciding the default and \`ask\` the exception` (#617) — makes agent judgement the default and `ask` the exception, after measuring 156 `ask` calls across 600 local session transcripts (worst session: 35 calls, most on already-authorized work).

It carries three agent-review rounds plus a recorded re-pin: round 1 found a real authorization leak (an irreversible step could be authorized *by implication* — "…and clean up afterwards" reaching a table drop), round 2 found a latent probe bug that would have fired on first use post-merge, round 3 approved as TERMINAL.

## Change class

**C1/C2 — standard, pre-authorized.** A version-string bump; no runtime path.

## Testing evidence

Version bumps have **no runtime path**, so per the standard there is nothing to exercise end to end. What was validated instead:

```
$ git diff origin/main..chore-release-0-46-10
-version = "0.46.9"
+version = "0.46.10"
```

That is the complete diff: one line, no dependency pin, script, or entry point moved beside it.

Verified the target version is genuinely free before choosing it:

```
$ gh release list --limit 5
0.46.9: attach frames that fit    Latest    v0.46.9
0.46.8: Teams and agents list again        v0.46.8

$ curl -s https://pypi.org/pypi/local-operator/json | ... 'latest'
latest: 0.46.9
```

`0.46.10` is unpublished and untagged. The substance of the release was validated on #617, which was CI-green across all 13 checks on its merged head.